### PR TITLE
Add new remote execution options

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -204,7 +204,11 @@ Scheduler* scheduler_create(Tasks*,
                             BufferBuffer,
                             TypeIdBuffer,
                             Buffer,
-                            Buffer);
+                            Buffer,
+                            uint64_t,
+                            uint64_t,
+                            uint64_t,
+                            uint64_t);
 void scheduler_pre_fork(Scheduler*);
 Value scheduler_metrics(Scheduler*, Session*);
 RawNodes* scheduler_execute(Scheduler*, Session*, ExecutionRequest*);
@@ -720,8 +724,7 @@ class Native(object):
                     build_root,
                     work_dir,
                     ignore_patterns,
-                    remote_store_server,
-                    remote_execution_server,
+                    execution_options,
                     construct_directory_digest,
                     construct_snapshot,
                     construct_file_content,
@@ -786,8 +789,13 @@ class Native(object):
         self.context.utf8_buf_buf(ignore_patterns),
         self.to_ids_buf(root_subject_types),
         # Remote execution config.
-        self.context.utf8_buf(remote_store_server),
-        self.context.utf8_buf(remote_execution_server),
+        # We can't currently pass Options to the rust side, so we pass empty strings for None.
+        self.context.utf8_buf(execution_options.remote_store_server or ""),
+        self.context.utf8_buf(execution_options.remote_execution_server or ""),
+        execution_options.remote_store_thread_count,
+        execution_options.remote_store_chunk_size,
+        execution_options.remote_store_chunk_upload_timeout,
+        execution_options.process_execution_parallelism,
       )
     return self.gc(scheduler, self.lib.scheduler_destroy)
 

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -794,7 +794,7 @@ class Native(object):
         self.context.utf8_buf(execution_options.remote_execution_server or ""),
         execution_options.remote_store_thread_count,
         execution_options.remote_store_chunk_bytes,
-        execution_options.remote_store_chunk_upload_timeout,
+        execution_options.remote_store_chunk_upload_timeout_seconds,
         execution_options.process_execution_parallelism,
       )
     return self.gc(scheduler, self.lib.scheduler_destroy)

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -793,7 +793,7 @@ class Native(object):
         self.context.utf8_buf(execution_options.remote_store_server or ""),
         self.context.utf8_buf(execution_options.remote_execution_server or ""),
         execution_options.remote_store_thread_count,
-        execution_options.remote_store_chunk_size,
+        execution_options.remote_store_chunk_bytes,
         execution_options.remote_store_chunk_upload_timeout,
         execution_options.process_execution_parallelism,
       )

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -78,8 +78,7 @@ class Scheduler(object):
     project_tree,
     work_dir,
     rules,
-    remote_store_server,
-    remote_execution_server,
+    execution_options,
     include_trace_on_error=True,
     validate=True,
   ):
@@ -88,16 +87,14 @@ class Scheduler(object):
     :param project_tree: An instance of ProjectTree for the current build root.
     :param work_dir: The pants work dir.
     :param rules: A set of Rules which is used to compute values in the graph.
+    :param execution_options: Execution options for (remote) processes.
     :param include_trace_on_error: Include the trace through the graph upon encountering errors.
     :type include_trace_on_error: bool
     :param validate: True to assert that the ruleset is valid.
     """
 
-    if remote_execution_server and not remote_store_server:
+    if execution_options.remote_execution_server and not execution_options.remote_store_server:
       raise ValueError("Cannot set remote execution server without setting remote store server")
-    # We can't currently pass Options to the rust side, so we pass empty strings for None:
-    remote_execution_server = remote_execution_server or ""
-    remote_store_server = remote_store_server or ""
 
     self._native = native
     self.include_trace_on_error = include_trace_on_error
@@ -121,8 +118,7 @@ class Scheduler(object):
       project_tree.build_root,
       work_dir,
       project_tree.ignore_patterns,
-      remote_store_server,
-      remote_execution_server,
+      execution_options,
       DirectoryDigest,
       Snapshot,
       FileContent,

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -28,7 +28,8 @@ from pants.engine.parser import SymbolTable
 from pants.engine.rules import SingletonRule
 from pants.engine.scheduler import Scheduler
 from pants.init.options_initializer import BuildConfigInitializer
-from pants.option.global_options import GlobMatchErrorBehavior
+from pants.option.global_options import (DEFAULT_EXECUTION_OPTIONS, ExecutionOptions,
+                                         GlobMatchErrorBehavior)
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.objects import datatype
 
@@ -134,8 +135,7 @@ class EngineInitializer(object):
       exclude_target_regexps=bootstrap_options.exclude_target_regexp,
       subproject_roots=bootstrap_options.subproject_roots,
       include_trace_on_error=bootstrap_options.print_exception_stacktrace,
-      remote_store_server=bootstrap_options.remote_store_server,
-      remote_execution_server=bootstrap_options.remote_execution_server,
+      execution_options=ExecutionOptions.from_bootstrap_options(bootstrap_options),
     )
 
   @staticmethod
@@ -152,8 +152,7 @@ class EngineInitializer(object):
     exclude_target_regexps=None,
     subproject_roots=None,
     include_trace_on_error=True,
-    remote_store_server=None,
-    remote_execution_server=None
+    execution_options=None,
   ):
     """Construct and return the components necessary for LegacyBuildGraph construction.
 
@@ -177,6 +176,8 @@ class EngineInitializer(object):
                                   under the current build root.
     :param bool include_trace_on_error: If True, when an error occurs, the error message will
                 include the graph trace.
+    :param execution_options: Option values for (remote) process execution.
+    :type execution_options: :class:`pants.option.global_options.ExecutionOptions`
     :returns: A LegacyGraphScheduler.
     """
 
@@ -188,6 +189,8 @@ class EngineInitializer(object):
     symbol_table = LegacySymbolTable(build_file_aliases)
 
     project_tree = FileSystemProjectTree(build_root, pants_ignore_patterns)
+
+    execution_options = execution_options or DEFAULT_EXECUTION_OPTIONS
 
     # Register "literal" subjects required for these rules.
     parser = LegacyPythonCallbacksParser(
@@ -223,8 +226,7 @@ class EngineInitializer(object):
       project_tree,
       workdir,
       rules,
-      remote_store_server,
-      remote_execution_server,
+      execution_options,
       include_trace_on_error=include_trace_on_error,
     )
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -64,7 +64,7 @@ class ExecutionOptions(datatype([
   'remote_store_server',
   'remote_store_thread_count',
   'remote_execution_server',
-  'remote_store_chunk_size',
+  'remote_store_chunk_bytes',
   'remote_store_chunk_upload_timeout',
   'process_execution_parallelism',
 ])):
@@ -80,7 +80,7 @@ class ExecutionOptions(datatype([
       remote_store_server=bootstrap_options.remote_store_server,
       remote_execution_server=bootstrap_options.remote_execution_server,
       remote_store_thread_count=bootstrap_options.remote_store_thread_count,
-      remote_store_chunk_size=bootstrap_options.remote_store_chunk_size,
+      remote_store_chunk_bytes=bootstrap_options.remote_store_chunk_bytes,
       remote_store_chunk_upload_timeout=bootstrap_options.remote_store_chunk_upload_timeout,
       process_execution_parallelism=bootstrap_options.process_execution_parallelism,
     )
@@ -90,7 +90,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_store_server=None,
     remote_store_thread_count=1,
     remote_execution_server=None,
-    remote_store_chunk_size=1024*1024,
+    remote_store_chunk_bytes=1024*1024,
     remote_store_chunk_upload_timeout=60,
     process_execution_parallelism=multiprocessing.cpu_count()*2,
   )
@@ -293,17 +293,15 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--build-file-imports', choices=['allow', 'warn', 'error'], default='warn',
       help='Whether to allow import statements in BUILD files')
 
-    remote_store_server = '--remote-store-server'
-    remote_execution_server = '--remote-execution-server'
-    register(remote_store_server, advanced=True,
+    register('--remote-store-server', advanced=True,
              help='host:port of grpc server to use as remote execution file store.')
     register('--remote-store-thread-count', type=int, advanced=True,
              default=DEFAULT_EXECUTION_OPTIONS.remote_store_thread_count,
              help='Thread count to use for the pool that interacts with the remote file store.')
-    register(remote_execution_server, advanced=True,
+    register('--remote-execution-server', advanced=True,
              help='host:port of grpc server to use as remote execution scheduler.')
-    register('--remote-store-chunk-size', type=int, advanced=True,
-             default=DEFAULT_EXECUTION_OPTIONS.remote_store_chunk_size,
+    register('--remote-store-chunk-bytes', type=int, advanced=True,
+             default=DEFAULT_EXECUTION_OPTIONS.remote_store_chunk_bytes,
              help='Size in bytes of chunks transferred to/from the remote file store.')
     register('--remote-store-chunk-upload-timeout', type=int, advanced=True,
              default=DEFAULT_EXECUTION_OPTIONS.remote_store_chunk_upload_timeout,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -92,7 +92,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_execution_server=None,
     remote_store_chunk_size=1024*1024,
     remote_store_chunk_upload_timeout=60,
-    process_execution_parallelism=multiprocessing.cpu_count(),
+    process_execution_parallelism=multiprocessing.cpu_count()*2,
   )
 
 
@@ -297,13 +297,16 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     remote_execution_server = '--remote-execution-server'
     register(remote_store_server, advanced=True,
              help='host:port of grpc server to use as remote execution file store.')
-    register('--remote-store-thread-count', type=int, default=1, advanced=True,
+    register('--remote-store-thread-count', type=int, advanced=True,
+             default=DEFAULT_EXECUTION_OPTIONS.remote_store_thread_count,
              help='Thread count to use for the pool that interacts with the remote file store.')
     register(remote_execution_server, advanced=True,
              help='host:port of grpc server to use as remote execution scheduler.')
-    register('--remote-store-chunk-size', type=int, default=1024*1024, advanced=True,
+    register('--remote-store-chunk-size', type=int, advanced=True,
+             default=DEFAULT_EXECUTION_OPTIONS.remote_store_chunk_size,
              help='Size in bytes of chunks transferred to/from the remote file store.')
-    register('--remote-store-chunk-upload-timeout', type=int, default=60, advanced=True,
+    register('--remote-store-chunk-upload-timeout', type=int, advanced=True,
+             default=DEFAULT_EXECUTION_OPTIONS.remote_store_chunk_upload_timeout,
              help='Timeout (in seconds) for uploads of individual chunks to the remote file store.')
 
     # This should eventually deprecate the RunTracker worker count, which is used for legacy cache

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import logging
+import multiprocessing
 import os
 import sys
 
@@ -57,6 +58,42 @@ class GlobMatchErrorBehavior(datatype(['failure_behavior'])):
                                 .format(this_object.failure_behavior, cls.allowed_values))
 
     return this_object
+
+
+class ExecutionOptions(datatype([
+  'remote_store_server',
+  'remote_store_thread_count',
+  'remote_execution_server',
+  'remote_store_chunk_size',
+  'remote_store_chunk_upload_timeout',
+  'process_execution_parallelism',
+])):
+  """A collection of all options related to (remote) execution of processes.
+
+  TODO: These options should move to a Subsystem once we add support for "bootstrap" Subsystems (ie,
+  allowing Subsystems to be consumed before the Scheduler has been created).
+  """
+
+  @classmethod
+  def from_bootstrap_options(cls, bootstrap_options):
+    cls(
+      remote_store_server=bootstrap_options.remote_store_server,
+      remote_execution_server=bootstrap_options.remote_execution_server,
+      remote_store_thread_count=bootstrap_options.remote_store_thread_count,
+      remote_store_chunk_size=bootstrap_options.remote_store_chunk_size,
+      remote_store_chunk_upload_timeout=bootstrap_options.remote_store_chunk_upload_timeout,
+      process_execution_parallelism=bootstrap_options.process_execution_parallelism,
+    )
+
+
+DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
+    remote_store_server=None,
+    remote_store_thread_count=1,
+    remote_execution_server=None,
+    remote_store_chunk_size=1024*1024,
+    remote_store_chunk_upload_timeout=60,
+    process_execution_parallelism=multiprocessing.cpu_count(),
+  )
 
 
 class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
@@ -256,10 +293,23 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--build-file-imports', choices=['allow', 'warn', 'error'], default='warn',
       help='Whether to allow import statements in BUILD files')
 
-    register('--remote-store-server',
-             help='host:port of grpc server to use as remote execution file store')
-    register('--remote-execution-server',
-             help='host:port of grpc server to use as remote execution scheduler')
+    remote_store_server = '--remote-store-server'
+    remote_execution_server = '--remote-execution-server'
+    register(remote_store_server, advanced=True,
+             help='host:port of grpc server to use as remote execution file store.')
+    register('--remote-store-thread-count', type=int, default=1, advanced=True,
+             help='Thread count to use for the pool that interacts with the remote file store.')
+    register(remote_execution_server, advanced=True,
+             help='host:port of grpc server to use as remote execution scheduler.')
+    register('--remote-store-chunk-size', type=int, default=1024*1024, advanced=True,
+             help='Size in bytes of chunks transferred to/from the remote file store.')
+    register('--remote-store-chunk-upload-timeout', type=int, default=60, advanced=True,
+             help='Timeout (in seconds) for uploads of individual chunks to the remote file store.')
+
+    # This should eventually deprecate the RunTracker worker count, which is used for legacy cache
+    # lookups via CacheSetup in TaskBase.
+    register('--process-execution-parallelism', type=int, default=multiprocessing.cpu_count(),
+             help='Number of concurrent processes that may be executed either locally and remotely.')
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -65,7 +65,7 @@ class ExecutionOptions(datatype([
   'remote_store_thread_count',
   'remote_execution_server',
   'remote_store_chunk_bytes',
-  'remote_store_chunk_upload_timeout',
+  'remote_store_chunk_upload_timeout_seconds',
   'process_execution_parallelism',
 ])):
   """A collection of all options related to (remote) execution of processes.
@@ -81,7 +81,7 @@ class ExecutionOptions(datatype([
       remote_execution_server=bootstrap_options.remote_execution_server,
       remote_store_thread_count=bootstrap_options.remote_store_thread_count,
       remote_store_chunk_bytes=bootstrap_options.remote_store_chunk_bytes,
-      remote_store_chunk_upload_timeout=bootstrap_options.remote_store_chunk_upload_timeout,
+      remote_store_chunk_upload_timeout_seconds=bootstrap_options.remote_store_chunk_upload_timeout_seconds,
       process_execution_parallelism=bootstrap_options.process_execution_parallelism,
     )
 
@@ -91,7 +91,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_store_thread_count=1,
     remote_execution_server=None,
     remote_store_chunk_bytes=1024*1024,
-    remote_store_chunk_upload_timeout=60,
+    remote_store_chunk_upload_timeout_seconds=60,
     process_execution_parallelism=multiprocessing.cpu_count()*2,
   )
 
@@ -303,8 +303,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--remote-store-chunk-bytes', type=int, advanced=True,
              default=DEFAULT_EXECUTION_OPTIONS.remote_store_chunk_bytes,
              help='Size in bytes of chunks transferred to/from the remote file store.')
-    register('--remote-store-chunk-upload-timeout', type=int, advanced=True,
-             default=DEFAULT_EXECUTION_OPTIONS.remote_store_chunk_upload_timeout,
+    register('--remote-store-chunk-upload-timeout-seconds', type=int, advanced=True,
+             default=DEFAULT_EXECUTION_OPTIONS.remote_store_chunk_upload_timeout_seconds,
              help='Timeout (in seconds) for uploads of individual chunks to the remote file store.')
 
     # This should eventually deprecate the RunTracker worker count, which is used for legacy cache

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -87,7 +87,8 @@ impl Core {
       match remote_execution_server {
         Some(address) => Box::new(process_execution::remote::CommandRunner::new(
           address,
-          1,
+          // Allow for some overhead for bookkeeping threads (if any).
+          process_execution_parallelism + 2,
           store.clone(),
         )),
         None => Box::new(process_execution::local::CommandRunner::new(

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -51,7 +51,7 @@ impl Core {
     remote_store_server: Option<String>,
     remote_execution_server: Option<String>,
     remote_store_thread_count: usize,
-    remote_store_chunk_size: usize,
+    remote_store_chunk_bytes: usize,
     remote_store_chunk_upload_timeout: Duration,
     process_execution_parallelism: usize,
   ) -> Core {
@@ -76,7 +76,7 @@ impl Core {
           fs_pool.clone(),
           address,
           remote_store_thread_count,
-          remote_store_chunk_size,
+          remote_store_chunk_bytes,
           remote_store_chunk_upload_timeout,
         ),
         None => Store::local_only(store_path, fs_pool.clone()),

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -221,7 +221,7 @@ pub extern "C" fn scheduler_create(
   remote_execution_server: Buffer,
   remote_store_thread_count: u64,
   remote_store_chunk_bytes: u64,
-  remote_store_chunk_upload_timeout: u64,
+  remote_store_chunk_upload_timeout_seconds: u64,
   process_execution_parallelism: u64,
 ) -> *const Scheduler {
   let root_type_ids = root_type_ids.to_vec();
@@ -282,7 +282,7 @@ pub extern "C" fn scheduler_create(
     },
     remote_store_thread_count as usize,
     remote_store_chunk_bytes as usize,
-    Duration::from_secs(remote_store_chunk_upload_timeout),
+    Duration::from_secs(remote_store_chunk_upload_timeout_seconds),
     process_execution_parallelism as usize,
   ))))
 }

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -220,7 +220,7 @@ pub extern "C" fn scheduler_create(
   remote_store_server: Buffer,
   remote_execution_server: Buffer,
   remote_store_thread_count: u64,
-  remote_store_chunk_size: u64,
+  remote_store_chunk_bytes: u64,
   remote_store_chunk_upload_timeout: u64,
   process_execution_parallelism: u64,
 ) -> *const Scheduler {
@@ -281,7 +281,7 @@ pub extern "C" fn scheduler_create(
       Some(remote_execution_server_string)
     },
     remote_store_thread_count as usize,
-    remote_store_chunk_size as usize,
+    remote_store_chunk_bytes as usize,
     Duration::from_secs(remote_store_chunk_upload_timeout),
     process_execution_parallelism as usize,
   ))))

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -39,6 +39,7 @@ use std::mem;
 use std::os::raw;
 use std::panic;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use context::Core;
 use core::{Failure, Function, Key, TypeConstraint, TypeId, Value};
@@ -218,6 +219,10 @@ pub extern "C" fn scheduler_create(
   root_type_ids: TypeIdBuffer,
   remote_store_server: Buffer,
   remote_execution_server: Buffer,
+  remote_store_thread_count: u64,
+  remote_store_chunk_size: u64,
+  remote_store_chunk_upload_timeout: u64,
+  process_execution_parallelism: u64,
 ) -> *const Scheduler {
   let root_type_ids = root_type_ids.to_vec();
   let ignore_patterns = ignore_patterns_buf
@@ -275,6 +280,10 @@ pub extern "C" fn scheduler_create(
     } else {
       Some(remote_execution_server_string)
     },
+    remote_store_thread_count as usize,
+    remote_store_chunk_size as usize,
+    Duration::from_secs(remote_store_chunk_upload_timeout),
+    process_execution_parallelism as usize,
   ))))
 }
 

--- a/tests/python/pants_test/engine/examples/planners.py
+++ b/tests/python/pants_test/engine/examples/planners.py
@@ -24,6 +24,7 @@ from pants.engine.rules import SingletonRule, TaskRule, rule
 from pants.engine.scheduler import Scheduler
 from pants.engine.selectors import Get, Select, SelectVariant
 from pants.engine.struct import HasProducts, Struct, StructWithDeps, Variants
+from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS
 from pants.util.meta import AbstractClass
 from pants.util.objects import SubclassesOf, datatype
 from pants_test.engine.examples.parsers import JsonParser
@@ -473,6 +474,7 @@ def setup_json_scheduler(build_root, native):
                         project_tree,
                         work_dir,
                         rules,
+                        DEFAULT_EXECUTION_OPTIONS,
                         None,
                         None)
   return scheduler.new_session()

--- a/tests/python/pants_test/engine/scheduler_test_base.py
+++ b/tests/python/pants_test/engine/scheduler_test_base.py
@@ -11,6 +11,7 @@ import shutil
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.engine.nodes import Return, Throw
 from pants.engine.scheduler import Scheduler
+from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS
 from pants.util.contextutil import temporary_file_path
 from pants.util.dirutil import safe_mkdtemp, safe_rmtree
 from pants_test.engine.util import init_native
@@ -56,8 +57,7 @@ class SchedulerTestBase(object):
                           project_tree,
                           work_dir,
                           rules,
-                          remote_store_server=None,
-                          remote_execution_server=None,
+                          DEFAULT_EXECUTION_OPTIONS,
                           include_trace_on_error=include_trace_on_error)
     return scheduler.new_session()
 

--- a/tests/python/pants_test/engine/util.py
+++ b/tests/python/pants_test/engine/util.py
@@ -17,6 +17,7 @@ from pants.engine.parser import SymbolTable
 from pants.engine.scheduler import Scheduler
 from pants.engine.selectors import Get
 from pants.engine.struct import HasProducts, Struct
+from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS
 from pants.util.objects import SubclassesOf
 from pants_test.option.util.fakes import create_options_for_optionables
 from pants_test.subsystem.subsystem_util import init_subsystem
@@ -97,8 +98,7 @@ def create_scheduler(rules, validate=True):
     FileSystemProjectTree(os.getcwd()),
     './.pants.d',
     rules,
-    remote_store_server=None,
-    remote_execution_server=None,
+    execution_options=DEFAULT_EXECUTION_OPTIONS,
     validate=validate,
   )
 


### PR DESCRIPTION
### Problem

As described in #5904, a few configuration values that are important to testing of remote execution are currently hardcoded.

### Solution

Extract existing options to a `ExecutionOptions` collection (which should become a `Subsystem` whenever we add support for consuming `Subsystems` during bootstrap), and add the new options.

### Result

Fixes #5904.