### PR TITLE
Use target not make_target in some tests

### DIFF
--- a/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
+++ b/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
@@ -12,7 +12,7 @@ from textwrap import dedent
 import bs4
 import mock
 
-from pants.backend.docgen.targets.doc import Page
+from pants.backend.docgen.register import build_file_aliases
 from pants.backend.docgen.tasks import markdown_to_html_utils
 from pants.backend.docgen.tasks.markdown_to_html import MarkdownToHtml
 from pants.base.exceptions import TaskError
@@ -105,9 +105,14 @@ class MarkdownToHtmlTest(TaskTestBase):
   def task_type(cls):
     return MarkdownToHtml
 
+  @classmethod
+  def alias_groups(cls):
+    return build_file_aliases()
+
   def test_rst_render_empty(self):
     self.create_file('empty.rst')
-    empty_rst = self.make_target(':empty_rst', target_type=Page, source='empty.rst')
+    self.add_to_build_file('', 'page(name = "empty_rst", source = "empty.rst")')
+    empty_rst = self.target(':empty_rst')
     task = self.create_task(self.context(target_roots=[empty_rst]))
     task.execute()
 
@@ -117,7 +122,8 @@ class MarkdownToHtmlTest(TaskTestBase):
 
     * `RB #2363 https://rbcommons.com/s/twitter/r/2363/>`_
     """))
-    bad_rst = self.make_target(':bad_rst', target_type=Page, source='bad.rst')
+    self.add_to_build_file('', 'page(name = "bad_rst", source = "bad.rst")')
+    bad_rst = self.target(':bad_rst')
     task = self.create_task(self.context(target_roots=[bad_rst]))
     with self.assertRaises(TaskError):
       task.execute()
@@ -138,8 +144,9 @@ class MarkdownToHtmlTest(TaskTestBase):
 
     * `RB #2363 https://rbcommons.com/s/twitter/r/2363/>`_
     """))
-    bad_rst = self.make_target(':bad_rst', target_type=Page, source='bad.rst')
+    self.add_to_build_file('', 'page(name = "bad_rst", source = "bad.rst")')
     self.set_options(ignore_failure=True)
+    bad_rst = self.target(':bad_rst')
     context = self.context(target_roots=[bad_rst])
     context.log.warn = mock.Mock()
     task = self.create_task(context)
@@ -163,7 +170,8 @@ class MarkdownToHtmlTest(TaskTestBase):
 
     * `RB #2363 <https://rbcommons.com/s/twitter/r/2363/>`_
     """))
-    good_rst = self.make_target(':good_rst', target_type=Page, source='good.rst')
+    self.add_to_build_file('', 'page(name = "good_rst", source = "good.rst")')
+    good_rst = self.target(':good_rst')
     context = self.context(target_roots=[good_rst])
     task = self.create_task(context)
     task.execute()

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
@@ -7,13 +7,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import unittest
 
-from pants.backend.jvm.targets.jvm_binary import (Duplicate, JarRules, JvmBinary, ManifestEntries,
-                                                  Skip)
+from pants.backend.jvm.register import build_file_aliases
+from pants.backend.jvm.targets.jvm_binary import Duplicate, JarRules, ManifestEntries, Skip
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload_field import FingerprintedField
+from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
 from pants.java.jar.exclude import Exclude
-from pants.java.jar.jar_dependency import JarDependency
 from pants_test.test_base import TestBase
 
 
@@ -57,8 +57,22 @@ class JarRulesTest(unittest.TestCase):
 
 class JvmBinaryTest(TestBase):
 
+  @classmethod
+  def alias_groups(cls):
+    return build_file_aliases().merge(
+      BuildFileAliases(
+        objects={
+          'duplicate': Duplicate,
+        },
+      )
+    )
+
   def test_simple(self):
-    target = self.make_target(':foo', JvmBinary, main='com.example.Foo', basename='foo-base')
+    self.add_to_build_file(
+      '',
+      'jvm_binary(name = "foo", main = "com.example.Foo", basename = "foo-base")',
+    )
+    target = self.target(':foo')
     self.assertEquals('com.example.Foo', target.main)
     self.assertEquals('com.example.Foo', target.payload.main)
     self.assertEquals('foo-base', target.basename)
@@ -70,23 +84,34 @@ class JvmBinaryTest(TestBase):
     self.assertEquals({}, target.payload.manifest_entries.entries)
 
   def test_default_base(self):
-    target = self.make_target(':foo', JvmBinary, main='com.example.Foo')
+    self.add_to_build_file('', 'jvm_binary(name = "foo", main = "com.example.Foo")')
+    target = self.target(':foo')
     self.assertEquals('foo', target.basename)
 
   def test_deploy_jar_excludes(self):
-    target = self.make_target(':foo',
-                              JvmBinary,
-                              main='com.example.Foo',
-                              deploy_excludes=[Exclude(org='example.com', name='foo-lib')])
+    self.add_to_build_file(
+      '',
+      '''jvm_binary(
+  name = "foo",
+  main = "com.example.Foo",
+  deploy_excludes=[exclude(org = "example.com", name = "foo-lib")],
+)''')
+    target = self.target(':foo')
     self.assertEquals([Exclude(org='example.com', name='foo-lib')],
                       target.deploy_excludes)
 
   def test_deploy_jar_rules(self):
-    target = self.make_target(':foo',
-                              JvmBinary,
-                              main='com.example.Foo',
-                              deploy_jar_rules=JarRules([Duplicate('foo', Duplicate.SKIP)],
-                                                        default_dup_action=Duplicate.FAIL))
+    self.add_to_build_file(
+      '',
+      '''jvm_binary(
+  name = "foo",
+  main = "com.example.Foo",
+  deploy_jar_rules = jar_rules(
+    [duplicate("foo", duplicate.SKIP)],
+    default_dup_action = duplicate.FAIL,
+  ),
+)''')
+    target = self.target(':foo')
     jar_rules = target.deploy_jar_rules
     self.assertEquals(1, len(jar_rules.rules))
     self.assertEquals('foo', jar_rules.rules[0].apply_pattern.pattern)
@@ -95,25 +120,39 @@ class JvmBinaryTest(TestBase):
     self.assertEquals(Duplicate.FAIL, jar_rules.default_dup_action)
 
   def test_bad_source_declaration(self):
+    self.add_to_build_file(
+      '',
+      'jvm_binary(name = "foo", main = "com.example.Foo", source = ["foo.py"])',
+    )
     with self.assertRaisesRegexp(TargetDefinitionException,
                                  r'Invalid target JvmBinary.*foo.*source must be a single'):
-      self.make_target(':foo', JvmBinary, main='com.example.Foo', source=['foo.py'])
+      self.target(':foo')
 
   def test_bad_sources_declaration(self):
+    self.add_to_build_file(
+      'foo',
+      'jvm_binary(name = "foo", main = "com.example.Foo", sources = ["foo.py"])',
+    )
     with self.assertRaisesRegexp(Target.IllegalArgument,
                                  r'jvm_binary only supports a single "source" argument'):
-      self.make_target('foo:foo', target_type=JvmBinary, main='com.example.Foo', sources=['foo.py'])
+      self.target('foo:foo')
 
   def test_bad_main_declaration(self):
+    self.add_to_build_file('', 'jvm_binary(name = "bar", main = ["com.example.Bar"])')
     with self.assertRaisesRegexp(TargetDefinitionException,
                                  r'Invalid target JvmBinary.*bar.*main must be a fully'):
-      self.make_target(':bar', JvmBinary, main=['com.example.Bar'])
+      self.target(':bar')
 
   def test_bad_jar_rules(self):
+    self.add_to_build_file(
+      '',
+      'jvm_binary(name = "foo", main = "com.example.Foo", deploy_jar_rules="invalid")',
+    )
     with self.assertRaisesRegexp(TargetDefinitionException,
                                  r'Invalid target JvmBinary.*foo.*'
-                                 r'deploy_jar_rules must be a JarRules specification. got unicode'):
-      self.make_target(':foo', JvmBinary, main='com.example.Foo', deploy_jar_rules='invalid')
+                                 r'deploy_jar_rules must be a JarRules specification. '
+                                 r'got (str|unicode)'):
+      self.target(':foo')
 
   def _assert_fingerprints_not_equal(self, fields):
     for field in fields:
@@ -144,31 +183,43 @@ class JvmBinaryTest(TestBase):
     self._assert_fingerprints_not_equal([field1, field2, field3, field4, field5, field6, field7])
 
   def test_manifest_entries(self):
-    target = self.make_target(':foo',
-                              JvmBinary,
-                              main='com.example.Foo',
-                              manifest_entries={'Foo-Field': 'foo'})
+    self.add_to_build_file(
+      '',
+      '''jvm_binary(
+  name = "foo",
+  main = "com.example.Foo",
+  manifest_entries = {"Foo-Field": "foo"},
+)''')
+    target = self.target(":foo")
     self.assertTrue(isinstance(target.payload.manifest_entries, ManifestEntries))
     entries = target.payload.manifest_entries.entries
     self.assertEquals({'Foo-Field': 'foo'}, entries)
 
   def test_manifest_not_dict(self):
+    self.add_to_build_file(
+      '',
+      '''jvm_binary(
+  name = "foo",
+  main = "com.example.Foo",
+  manifest_entries = "foo",
+)''')
     with self.assertRaisesRegexp(TargetDefinitionException,
                                  r'Invalid target JvmBinary.*foo.*: manifest_entries must be a '
-                                 r'dict. got unicode'):
-      self.make_target(':foo',
-                       JvmBinary,
-                       main='com.example.Foo',
-                       manifest_entries='foo')
+                                 r'dict. got (str|unicode)'):
+      self.target(':foo')
 
   def test_manifest_bad_key(self):
-    with self.assertRaisesRegexp(ManifestEntries.ExpectedDictionaryError,
-                                 r'^entries must be dictionary of strings, got key .* '
-                                 r'type JarDependency$'):
-      self.make_target(':foo',
-                       JvmBinary,
-                       main='com.example.Foo',
-                       manifest_entries={JarDependency('bad', 'bad', 'bad'): 'foo'})
+    self.add_to_build_file(
+      '',
+      '''jvm_binary(
+  name = "foo",
+  main = "com.example.Foo",
+  manifest_entries = {jar("bad", "bad", "bad"): "foo"},
+)''')
+    with self.assertRaisesRegexp(TargetDefinitionException,
+                                 r'entries must be dictionary of strings, got key .* '
+                                 r'type JarDependency'):
+      self.target(':foo')
 
   def test_manifest_entries_fingerprint(self):
     field1 = ManifestEntries()

--- a/tests/python/pants_test/backend/jvm/tasks/test_binary_create.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_binary_create.py
@@ -7,11 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
-from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.tasks.binary_create import BinaryCreate
-from pants.java.jar.exclude import Exclude
-from pants.java.jar.jar_dependency import JarDependency
 from pants.util.contextutil import open_zip
 from pants_test.backend.jvm.tasks.jvm_binary_task_test_base import JvmBinaryTaskTestBase
 
@@ -23,9 +19,8 @@ class TestBinaryCreate(JvmBinaryTaskTestBase):
     return BinaryCreate
 
   def test_jvm_binaries_products(self):
-    binary_target = self.make_target(spec='//bar:bar-binary',
-                                     target_type=JvmBinary,
-                                     source='Bar.java')
+    self.add_to_build_file('bar', 'jvm_binary(name = "bar-binary", source = "Bar.java")')
+    binary_target = self.target('//bar:bar-binary')
     context = self.context(target_roots=[binary_target])
     classpath_products = self.ensure_classpath_products(context)
 
@@ -56,16 +51,25 @@ class TestBinaryCreate(JvmBinaryTaskTestBase):
                        sorted(jar.namelist()))
 
   def test_jvm_binaries_deploy_excludes(self):
-    foo_jar_lib = self.make_target(spec='3rdparty/jvm/org/example:foo',
-                                   target_type=JarLibrary,
-                                   jars=[JarDependency(org='org.example', name='foo', rev='1.0.0')])
-    binary_target = self.make_target(spec='//bar:bar-binary',
-                                     target_type=JvmBinary,
-                                     source='Bar.java',
-                                     dependencies=[foo_jar_lib],
-                                     deploy_excludes=[Exclude(org='org.pantsbuild')])
+    self.add_to_build_file(
+      '3rdparty/jvm/org/example',
+      'jar_library(name = "foo", jars = [jar(org = "org.example", name = "foo", rev = "1.0.0")])',
+    )
+    foo_jar_lib = self.target('3rdparty/jvm/org/example:foo')
+
+    self.add_to_build_file(
+      'bar',
+      '''jvm_binary(
+  name = "bar-binary",
+  source = "Bar.java",
+  dependencies = ["3rdparty/jvm/org/example:foo"],
+  deploy_excludes = [exclude(org = "org.pantsbuild")],
+)'''
+    )
+    binary_target = self.target('//bar:bar-binary')
     context = self.context(target_roots=[binary_target])
     classpath_products = self.ensure_classpath_products(context)
+
 
     foo_artifact = self.create_artifact(org='org.example', name='foo', rev='1.0.0')
     with open_zip(foo_artifact.pants_path, 'w') as jar:

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -14,8 +14,6 @@ import coverage
 from six.moves import configparser
 
 from pants.backend.python.register import build_file_aliases as register_python
-from pants.backend.python.targets.python_library import PythonLibrary
-from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.gather_sources import GatherSources
 from pants.backend.python.tasks.pytest_prep import PytestPrep
 from pants.backend.python.tasks.pytest_run import PytestResult, PytestRun
@@ -253,9 +251,10 @@ class PytestTest(PytestTestBase):
           def two():  # line 5
             return 2  # line 6
         """).strip())
-    core_lib = self.make_target(spec='lib:core',
-                                target_type=PythonLibrary,
-                                sources=['core.py'])
+    self.add_to_build_file(
+      'lib',
+      'python_library(name = "core", sources = ["core.py"])',
+    )
 
     self.create_file(
         'app/app.py',
@@ -266,10 +265,10 @@ class PytestTest(PytestTestBase):
           def use_two():       # line 4
             return core.two()  # line 5
         """).strip())
-    app_lib = self.make_target(spec='app',
-                               target_type=PythonLibrary,
-                               sources=['app.py'],
-                               dependencies=[core_lib])
+    self.add_to_build_file(
+      'app',
+      'python_library(name = "app", sources = ["app.py"], dependencies = ["lib:core"])'
+    )
 
     # Test targets.
     self.create_file(
@@ -283,10 +282,69 @@ class PytestTest(PytestTestBase):
             def test_use_two(self):
               self.assertEqual(2, app.use_two())
         """))
-    self.app = self.make_target(spec='tests:app',
-                                target_type=PythonTests,
-                                sources=['test_app.py'],
-                                dependencies=[app_lib])
+    self.add_to_build_file(
+      'tests',
+      'python_tests(name = "app", sources = ["test_app.py"], dependencies = ["app"])\n'
+    )
+
+    for name in ['green', 'green2', 'green3', 'red', 'red_in_class']:
+      content = '''python_tests(
+  name = "{name}",
+  sources = ["test_core_{name}.py"],
+  dependencies = ["lib:core"],
+  coverage = ["core"],
+)
+'''.format(name=name)
+      self.add_to_build_file('tests', content)
+
+    self.add_to_build_file(
+      'tests',
+      '''python_tests(
+  name = "sleep_no_timeout",
+  sources = ["test_core_sleep.py"],
+  dependencies = ["lib:core"],
+  coverage = ["core"],
+  timeout = 0,
+)
+
+python_tests(
+  name = "sleep_timeout",
+  sources = ["test_core_sleep.py"],
+  dependencies = ["lib:core"],
+  coverage = ["core"],
+  timeout = 1,
+)
+
+python_tests(
+  name = "error",
+  sources = ["test_error.py"],
+)
+
+python_tests(
+  name = "failure_outside_function",
+  sources = ["test_failure_outside_function.py"],
+)
+
+python_tests(
+  name = "green-with-conftest",
+  sources = ["conftest.py", "test_core_green.py"],
+  dependencies = ["lib:core"],
+)
+
+python_tests(
+  name = "all",
+  sources = ["test_core_green.py", "test_core_red.py"],
+  dependencies = ["lib:core"],
+)
+
+python_tests(
+  name = "all-with-coverage",
+  sources = ["test_core_green.py", "test_core_red.py"],
+  dependencies = ["lib:core"],
+  coverage = ["core"],
+)
+'''
+    )
 
     self.create_file(
         'tests/test_core_green.py',
@@ -299,11 +357,6 @@ class PytestTest(PytestTestBase):
             def test_one(self):
               self.assertEqual(1, core.one())
         """))
-    self.green = self.make_target(spec='tests:green',
-                                  target_type=PythonTests,
-                                  sources=['test_core_green.py'],
-                                  dependencies=[core_lib],
-                                  coverage=['core'])
 
     self.create_file(
         'tests/test_core_green2.py',
@@ -316,11 +369,6 @@ class PytestTest(PytestTestBase):
             def test_one(self):
               self.assertEqual(1, core.one())
         """))
-    self.green2 = self.make_target(spec='tests:green2',
-                                   target_type=PythonTests,
-                                   sources=['test_core_green2.py'],
-                                   dependencies=[core_lib],
-                                   coverage=['core'])
 
     self.create_file(
         'tests/test_core_green3.py',
@@ -333,11 +381,6 @@ class PytestTest(PytestTestBase):
             def test_one(self):
               self.assertEqual(1, core.one())
         """))
-    self.green3 = self.make_target(spec='tests:green3',
-                                   target_type=PythonTests,
-                                   sources=['test_core_green3.py'],
-                                   dependencies=[core_lib],
-                                   coverage=['core'])
 
     self.create_file(
         'tests/test_core_red.py',
@@ -347,11 +390,6 @@ class PytestTest(PytestTestBase):
           def test_two():
             assert 1 == core.two()
         """))
-    self.red = self.make_target(spec='tests:red',
-                                target_type=PythonTests,
-                                sources=['test_core_red.py'],
-                                dependencies=[core_lib],
-                                coverage=['core'])
 
     self.create_file(
         'tests/test_core_red_in_class.py',
@@ -364,32 +402,15 @@ class PytestTest(PytestTestBase):
             def test_one_in_class(self):
               self.assertEqual(1, core.two())
         """))
-    self.red_in_class = self.make_target(spec='tests:red_in_class',
-                                         target_type=PythonTests,
-                                         sources=['test_core_red_in_class.py'],
-                                         dependencies=[core_lib],
-                                         coverage=['core'])
 
     self.create_file(
-        'tests/test_core_sleep.py',
-        dedent("""
+      'tests/test_core_sleep.py',
+      dedent("""
           import core
 
           def test_three():
             assert 1 == core.one()
         """))
-    self.sleep_no_timeout = self.make_target(spec='tests:sleep_no_timeout',
-                                             target_type=PythonTests,
-                                             sources=['test_core_sleep.py'],
-                                             dependencies=[core_lib],
-                                             coverage=['core'],
-                                             timeout=0)
-    self.sleep_timeout = self.make_target(spec='tests:sleep_timeout',
-                                          target_type=PythonTests,
-                                          sources=['test_core_sleep.py'],
-                                          dependencies=[core_lib],
-                                          coverage=['core'],
-                                          timeout=1)
 
     self.create_file(
         'tests/test_error.py',
@@ -397,9 +418,6 @@ class PytestTest(PytestTestBase):
           def test_error(bad_fixture):
             pass
         """))
-    self.error = self.make_target(spec='tests:error',
-                                  target_type=PythonTests,
-                                  sources=['test_error.py'])
 
     self.create_file(
         'tests/test_failure_outside_function.py',
@@ -409,27 +427,22 @@ class PytestTest(PytestTestBase):
 
         assert(False)
         """))
-    self.failure_outside_function = self.make_target(spec='tests:failure_outside_function',
-                                                     target_type=PythonTests,
-                                                     sources=['test_failure_outside_function.py'])
 
     self.create_file('tests/conftest.py', self._CONFTEST_CONTENT)
-    self.green_with_conftest = self.make_target(spec='tests:green-with-conftest',
-                                                target_type=PythonTests,
-                                                sources=['conftest.py', 'test_core_green.py'],
-                                                dependencies=[core_lib])
 
-    self.all = self.make_target(spec='tests:all',
-                                target_type=PythonTests,
-                                sources=['test_core_green.py',
-                                         'test_core_red.py'],
-                                dependencies=[core_lib])
-
-    self.all_with_cov = self.make_target(spec='tests:all-with-coverage',
-                                         target_type=PythonTests,
-                                         sources=['test_core_green.py', 'test_core_red.py'],
-                                         dependencies=[core_lib],
-                                         coverage=['core'])
+    self.app = self.target('tests:app')
+    self.green = self.target('tests:green')
+    self.green2 = self.target('tests:green2')
+    self.green3 = self.target('tests:green3')
+    self.red = self.target('tests:red')
+    self.red_in_class = self.target('tests:red_in_class')
+    self.sleep_no_timeout = self.target('tests:sleep_no_timeout')
+    self.sleep_timeout = self.target('tests:sleep_timeout')
+    self.error = self.target('tests:error')
+    self.failure_outside_function = self.target('tests:failure_outside_function')
+    self.green_with_conftest = self.target('tests:green-with-conftest')
+    self.all = self.target('tests:all')
+    self.all_with_cov = self.target('tests:all-with-coverage')
 
   @ensure_cached(PytestRun, expected_num_artifacts=0)
   def test_error(self):
@@ -609,14 +622,16 @@ class PytestTest(PytestTestBase):
     init_subsystem(Target.Arguments)
     init_subsystem(SourceRootConfig)
 
+    self.add_to_build_file('src/python/util', 'python_library()')
+
     self.create_file(
       'src/python/util/math.py',
       dedent("""
           def one():  # line 1
             return 1  # line 2
         """).strip())
-    util = self.make_target(spec='src/python/util',
-                            target_type=PythonLibrary)
+
+    self.add_to_build_file('test/python/util', 'python_tests(dependencies = ["src/python/util"])')
 
     self.create_file(
       'test/python/util/test_math.py',
@@ -629,9 +644,7 @@ class PytestTest(PytestTestBase):
             def test_one(self):
               self.assertEqual(1, math.one())
         """))
-    test = self.make_target(spec='test/python/util',
-                            target_type=PythonTests,
-                            dependencies=[util])
+    test = self.target('test/python/util')
     covered_path = os.path.join(self.build_root, 'src/python/util/math.py')
 
     all_statements, not_run_statements = self.run_coverage_auto(targets=[test],
@@ -646,14 +659,16 @@ class PytestTest(PytestTestBase):
     init_subsystem(Target.Arguments)
     init_subsystem(SourceRootConfig)
 
+    self.add_to_build_file('src/python/util', 'python_library()')
+
     self.create_file(
       'src/python/util/math.py',
       dedent("""
           def one():  # line 1
             return 1  # line 2
         """).strip())
-    util = self.make_target(spec='src/python/util',
-                            target_type=PythonLibrary)
+
+    self.add_to_build_file('test/python/util_tests', 'python_tests(dependencies = ["src/python/util"])')
 
     self.create_file(
       'test/python/util_tests/test_math.py',
@@ -666,9 +681,7 @@ class PytestTest(PytestTestBase):
             def test_one(self):
               self.assertEqual(1, math.one())
         """))
-    test = self.make_target(spec='test/python/util_tests',
-                            target_type=PythonTests,
-                            dependencies=[util])
+    test = self.target('test/python/util_tests')
     covered_path = os.path.join(self.build_root, 'src/python/util/math.py')
     all_statements, not_run_statements = self.run_coverage_auto(targets=[test],
                                                                 covered_path=covered_path)
@@ -839,7 +852,8 @@ class PytestTest(PytestTestBase):
         marker_file = os.path.join(marker_dir, name)
         self.assertEqual(exists, os.path.exists(marker_file), message)
 
-      test = self.make_target(spec='test/python/passthru', target_type=PythonTests)
+      self.add_to_build_file('test/python/passthru', 'python_tests()')
+      test = self.target('test/python/passthru')
       yield test, functools.partial(assert_mark, True), functools.partial(assert_mark, False)
 
   def test_passthrough_args_facility_single_style(self):

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -8,16 +8,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import shutil
 
+from pants.backend.jvm.register import build_file_aliases
 from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
-from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.backend.jvm.targets.scala_jar_dependency import ScalaJarDependency
 from pants.backend.jvm.tasks.bootstrap_jvm_tools import BootstrapJvmTools
 from pants.base.build_environment import get_pants_cachedir
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
 from pants.ivy.bootstrapper import Bootstrapper
-from pants.java.jar.exclude import Exclude
-from pants.java.jar.jar_dependency import JarDependency
 from pants.util.dirutil import safe_mkdir
 from pants_test.jvm.jvm_task_test_base import JvmTaskTestBase
 
@@ -34,17 +31,7 @@ class JvmToolTaskTestBase(JvmTaskTestBase):
     :API: public
     """
     # Aliases appearing in our real BUILD.tools.
-    return BuildFileAliases(
-      targets={
-        'jar_library': JarLibrary,
-        'target': Target,
-      },
-      objects={
-        'exclude': Exclude,
-        'jar': JarDependency,
-        'scala_jar': ScalaJarDependency,
-      },
-    )
+    return build_file_aliases().merge(BuildFileAliases(targets={'target': Target}))
 
   def setUp(self):
     """


### PR DESCRIPTION
This pushes parsing of the targets through the engine, rather than
bypassing it.

This is important because I'm about to make these targets require an
EagerFilesetWithSpec as their source/sources arg, rather than being
happy with a list of strings.