### PR TITLE
Add extra_compile_args option to jvm targets so you can add additional compile arg per java library target

### DIFF
--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -49,6 +49,7 @@ class JvmTarget(Target, Jarable):
                javac_plugin_args=None,
                scalac_plugins=None,
                scalac_plugin_args=None,
+               extra_compile_args=None,
                **kwargs):
     """
     :API: public
@@ -91,6 +92,9 @@ class JvmTarget(Target, Jarable):
     :param dict javac_plugin_args: Map from javac plugin name to list of arguments for that plugin.
     :param scalac_plugins: names of compiler plugins to use when compiling this target with scalac.
     :param dict scalac_plugin_args: Map from scalac plugin name to list of arguments for that plugin.
+    :param list extra_compile_args: A list of args that will be added to the default compile args
+                                    when compiling the sources of this target.
+                                    Example: ['--add-modules=java.xml.bind']
     """
 
     self.address = address  # Set in case a TargetDefinitionException is thrown early
@@ -109,6 +113,7 @@ class JvmTarget(Target, Jarable):
       'javac_plugin_args': PrimitiveField(javac_plugin_args),
       'scalac_plugins': SetOfPrimitivesField(scalac_plugins),
       'scalac_plugin_args': PrimitiveField(scalac_plugin_args),
+      'extra_compile_args': PrimitiveField(tuple(extra_compile_args or ())),
     })
 
     super(JvmTarget, self).__init__(address=address, payload=payload, **kwargs)

--- a/testprojects/src/java/org/pantsbuild/testproject/extracompileargs/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/extracompileargs/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(name='main',
+  sources=globs('Main.java'),
+  extra_compile_args=["-Werror"]
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/extracompileargs/Main.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/extracompileargs/Main.java
@@ -1,0 +1,8 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.extracompileargs;
+
+public class Main {
+
+}

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/javac/test_javac_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/javac/test_javac_compile_integration.py
@@ -24,3 +24,20 @@ class JavacCompileIntegration(BaseCompileIT):
            ],
           workdir, config)
         self.assert_success(pants_run)
+
+  def test_extra_compile_args(self):
+    with temporary_dir() as cache_dir:
+      config = {
+        'cache.compile.javac': {'write_to': [cache_dir]},
+        'jvm-platform': {'compiler': 'javac'}
+      }
+
+      with self.temporary_workdir() as workdir:
+        pants_run = self.run_pants_with_workdir(
+          ['compile',
+           'testprojects/src/java/org/pantsbuild/testproject/extracompileargs:main',
+           '-ldebug',
+           ],
+          workdir, config)
+        self.assert_success(pants_run)
+        self.assertIn('-Werror testprojects/src/java/org/pantsbuild/testproject/extracompileargs/Main.java', pants_run.stdout_data)


### PR DESCRIPTION
### Problem

Currently you can only specify compile args in pants.ini which means all java targets get the same list of javac options.  In java 9 and above they have added options to add modules for compilation such as `--add-modules module , module` from https://docs.oracle.com/javase/9/tools/javac.htm#JSWOR627
In general most developers probably won't want add this module for every java library in their system

You could also use this to add additional compiler warnings to a jvm target. 

### Solution

Add and extra_compile_args option to jvm targets that allow you specify extra javac options for that jvm target.

### Result

You can now add per jvm library compile arguments. 