### PR TITLE
Enable fromfile support for --owner-of and increase test coverage

### DIFF
--- a/src/docs/target_addresses.md
+++ b/src/docs/target_addresses.md
@@ -44,8 +44,10 @@ The following target addresses all specify the same single target.
         $ ./pants --owner-of=examples/src/java/org/pantsbuild/example/hello/main/HelloMain.java list
         examples/src/java/org/pantsbuild/example/hello/main:main
     
-    It's also worth noting that multiple passes of `owner-of=` are accepted in order to work with multiple 
-    files and pants will execute the goal on all the targets that own those files.
+    It's also worth noting that multiple instances of `--owner-of=` are accepted in order to work with multiple
+    files and pants will execute the goal on all the targets that own those files. Additionally, `fromfile`
+    support is enabled for this option, so passing `--owner-of=@file` (where "file" is a filename
+    containing a list of filenames to look up owners for) is supported.
 
 -   Relative paths and trailing forward slashes are ignored on the
     command-line to accommodate tab completion:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -220,7 +220,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--subproject-roots', type=list, advanced=True, fromfile=True, default=[],
              help='Paths that correspond with build roots for any subproject that this '
                   'project depends on.')
-    register('--owner-of', type=list, default=[], metavar='<path>',
+    register('--owner-of', type=list, default=[], fromfile=True, metavar='<path>',
              help='Select the targets that own these files. '
                   'This is the third target calculation strategy along with the --changed '
                   'options and specifying the targets directly. These three types of target '

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -174,7 +174,7 @@ class SchedulerService(PantsService):
     with self.fork_lock:
       target_roots = target_roots_calculator.create(
         options,
-        session,
+        session.scheduler_session,
         session.symbol_table,
       )
       session.warm_product_graph(target_roots)

--- a/tests/python/pants_test/engine/legacy/test_changed_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_changed_integration.py
@@ -14,7 +14,7 @@ from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import safe_delete, safe_mkdir, safe_open, touch
 from pants_test.base_test import TestGenerator
-from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
 from pants_test.testutils.git_util import initialize_repo
 
 
@@ -352,6 +352,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
       self.assert_success(pants_run)
       self.assertEqual(pants_run.stdout_data.strip(), '')
 
+  @ensure_daemon
   def test_list_changed(self):
     deleted_file = 'src/python/sources/sources.py'
 

--- a/tests/python/pants_test/engine/legacy/test_owners_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_owners_integration.py
@@ -5,10 +5,11 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
 
 
 class ListOwnersIntegrationTest(PantsRunIntegrationTest):
+  @ensure_daemon
   def test_owner_of_success(self):
     pants_run = self.do_command('--owner-of=testprojects/tests/python/pants/dummies/test_pass.py',
                                 'list',


### PR DESCRIPTION
### Problem

The new `--owner-of` option was broken in the context of `pantsd`, but didn't have test coverage due to the `--changed` and `--owner-of` tests not running under `pantsd`. Additionally, `fromfile` support is useful for this option, but was not enabled. 

### Solution

Mark some integration tests as needing to run under the daemon, and enable `fromfile` support for `--owner-of`.