### PR TITLE
Re-shade zinc to avoid classpath collisions with annotation processors.

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -49,13 +49,17 @@ class Zinc(object):
           Shader.exclude_package('scala', recursive=True),
           Shader.exclude_package('xsbt', recursive=True),
           Shader.exclude_package('xsbti', recursive=True),
+          # Unfortunately, is loaded reflectively by the compiler.
+          Shader.exclude_package('org.apache.logging.log4j', recursive=True),
         ]
 
       cls.register_jvm_tool(register,
                             Zinc.ZINC_COMPILER_TOOL_NAME,
                             classpath=[
                               JarDependency('org.pantsbuild', 'zinc-compiler_2.11', '0.0.5'),
-                            ])
+                            ],
+                            main=Zinc.ZINC_COMPILE_MAIN,
+                            custom_rules=shader_rules)
 
       cls.register_jvm_tool(register,
                             'compiler-bridge',
@@ -85,7 +89,7 @@ class Zinc(object):
 
     @classmethod
     def _zinc(cls, products):
-      return cls.tool_classpath_from_products(products, Zinc.ZINC_COMPILER_TOOL_NAME, cls.options_scope)
+      return cls.tool_jar_from_products(products, Zinc.ZINC_COMPILER_TOOL_NAME, cls.options_scope)
 
     @classmethod
     def _compiler_bridge(cls, products):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -268,7 +268,7 @@ class BaseZincCompile(JvmCompile):
     than compiling it.
     """
     hasher = sha1()
-    for cp_entry in self._zinc.zinc + [self._zinc.compiler_interface, self._zinc.compiler_bridge]:
+    for cp_entry in [self._zinc.zinc, self._zinc.compiler_interface, self._zinc.compiler_bridge]:
       hasher.update(os.path.relpath(cp_entry, self.get_options().pants_workdir))
     key = hasher.hexdigest()[:12]
     return os.path.join(self.get_options().pants_bootstrapdir, 'zinc', key)
@@ -353,7 +353,7 @@ class BaseZincCompile(JvmCompile):
         fp.write(arg)
         fp.write(b'\n')
 
-    if self.runjava(classpath=self._zinc.zinc,
+    if self.runjava(classpath=[self._zinc.zinc],
                     main=Zinc.ZINC_COMPILE_MAIN,
                     jvm_options=jvm_options,
                     args=zinc_args,

--- a/testprojects/3rdparty/com/google/guava/BUILD
+++ b/testprojects/3rdparty/com/google/guava/BUILD
@@ -1,0 +1,7 @@
+# NB: This is an intentionally ancient guava to attempt to flush out classpath collisions
+# with the compiler.
+jar_library(name='ancient-guava',
+            jars=[
+              jar('com.google.guava', 'guava', '10.0')
+            ])
+

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processor/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processor/BUILD
@@ -7,7 +7,9 @@ annotation_processor(
   sources=globs('*.java'),
   processors=['org.pantsbuild.testproject.annotation.processor.ResourceMappingProcessor'],
   dependencies=[
-    '3rdparty:guava',
+    # NB: We use the oldest guava we can stomach here, in order to flush out classpath
+    # collisions between the compiler and annotation processors.
+    'testprojects/3rdparty/com/google/guava:ancient-guava',
   ],
 )
 


### PR DESCRIPTION
### Problem

Zinc used to be shaded before the `1.x.y` upgrade (#4729), but shading was removed due to an overabundance of optimism. When testing the zinc upgrade internally, we experienced a classpath collision between an annotation processor and zinc (in guava, although zinc has many other dependencies that could cause issues).

### Solution

Shade zinc, and ensure that our annotation processor uses a very old guava in order to attempt to force collisions in future.