### PR TITLE
Construct rule_graph recursively

### DIFF
--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -190,7 +190,7 @@ impl<'t> GraphMaker<'t> {
     if let Some(beginning_root) = self.gen_root_entry(subject_type, product_type) {
       self._construct_graph(vec![beginning_root])
     } else {
-      Default::default()
+      RuleGraph::default()
     }
   }
 
@@ -273,7 +273,7 @@ impl<'t> GraphMaker<'t> {
       (hash_map::Entry::Vacant(_), hash_map::Entry::Vacant(re)) => {
         // When a rule has not been visited before, we visit it by storing a placeholder in the
         // rule dependencies map (to prevent infinite recursion).
-        re.insert(Default::default());
+        re.insert(RuleEdges::default());
       },
       (hash_map::Entry::Vacant(_), hash_map::Entry::Occupied(_)) =>
         // Rule has been visited before and been found to be valid, or is currently being

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -82,7 +82,7 @@ class RulesetValidatorTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                      Rules with errors: 1
                        (A, (Select(B),), noop):
-                         no rule was available to compute B for SubA with subject types: SubA
+                         no rule was available to compute B for subject type SubA
                      """).strip(),
                                     str(cm.exception))
 
@@ -94,8 +94,8 @@ class RulesetValidatorTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                      Rules with errors: 1
                        (A, (Select(B), Select(C)), noop):
-                         no rule was available to compute B for SubA with subject types: SubA
-                         no rule was available to compute C for SubA with subject types: SubA
+                         no rule was available to compute B for subject type SubA
+                         no rule was available to compute C for subject type SubA
                      """).strip(),
       str(cm.exception))
 
@@ -115,9 +115,9 @@ class RulesetValidatorTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       Rules with errors: 2
                                         (A, (Select(B),), noop):
-                                          no rule was available to compute B for C with subject types: C
+                                          no rule was available to compute B for subject type C
                                         (B, (Select(SubA),), noop):
-                                          no rule was available to compute SubA for C with subject types: C
+                                          no rule was available to compute SubA for subject type C
                                       """).strip(),
                                     str(cm.exception))
 
@@ -142,7 +142,7 @@ class RulesetValidatorTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       Rules with errors: 1
                                         (D, (Select(C),), noop):
-                                          no rule was available to compute C for A with subject types: A
+                                          no rule was available to compute C for subject type A
                                       """).strip(),
                                     str(cm.exception))
 
@@ -161,9 +161,9 @@ class RulesetValidatorTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                       Rules with errors: 2
                         (B, (Select(D),), noop):
-                          no rule was available to compute D for SubA with subject types: SubA
+                          no rule was available to compute D for subject type SubA
                         (D, (Select(A), Select(SubA)), [Get(A, C)], noop):
-                          no rule was available to compute A for C with subject types: C
+                          no rule was available to compute A for subject type C
                       """).strip(),
         str(cm.exception))
 

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -82,7 +82,7 @@ class RulesetValidatorTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                      Rules with errors: 1
                        (A, (Select(B),), noop):
-                         no matches for Select(B) with subject types: SubA
+                         no rule was available to compute B for SubA with subject types: SubA
                      """).strip(),
                                     str(cm.exception))
 
@@ -94,8 +94,8 @@ class RulesetValidatorTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                      Rules with errors: 1
                        (A, (Select(B), Select(C)), noop):
-                         no matches for Select(B) with subject types: SubA
-                         no matches for Select(C) with subject types: SubA
+                         no rule was available to compute B for SubA with subject types: SubA
+                         no rule was available to compute C for SubA with subject types: SubA
                      """).strip(),
       str(cm.exception))
 
@@ -115,9 +115,9 @@ class RulesetValidatorTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       Rules with errors: 2
                                         (A, (Select(B),), noop):
-                                          depends on unfulfillable (B, (Select(SubA),), noop) of C with subject types: C
+                                          no rule was available to compute B for C with subject types: C
                                         (B, (Select(SubA),), noop):
-                                          no matches for Select(SubA) with subject types: C
+                                          no rule was available to compute SubA for C with subject types: C
                                       """).strip(),
                                     str(cm.exception))
 
@@ -142,7 +142,7 @@ class RulesetValidatorTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       Rules with errors: 1
                                         (D, (Select(C),), noop):
-                                          no matches for Select(C) with subject types: A
+                                          no rule was available to compute C for A with subject types: A
                                       """).strip(),
                                     str(cm.exception))
 
@@ -161,9 +161,9 @@ class RulesetValidatorTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                       Rules with errors: 2
                         (B, (Select(D),), noop):
-                          depends on unfulfillable (D, (Select(A), Select(SubA)), [Get(A, C)], noop) of SubA with subject types: SubA
+                          no rule was available to compute D for SubA with subject types: SubA
                         (D, (Select(A), Select(SubA)), [Get(A, C)], noop):
-                          depends on unfulfillable (A, (Select(SubA),), noop) of C with subject types: SubA
+                          no rule was available to compute A for C with subject types: C
                       """).strip(),
         str(cm.exception))
 


### PR DESCRIPTION
### Problem

The `RuleGraph` is currently constructed iteratively, but can be more-easily constructed recursively.

### Solution

Switch to constructing the `RuleGraph` recursively, and unify a few disparate diagnostic messages.

### Result

Helps to prepare for further refactoring in #5788.