### PR TITLE
Allow manylinux wheels when resolving plugins.

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -75,6 +75,9 @@ class PythonSetup(Subsystem):
               'NOTE: this keyword is a temporary fix and will be reverted per: '
               'https://github.com/pantsbuild/pants/issues/5696. The long term '
               'solution is tracked by: https://github.com/pantsbuild/pex/issues/456.')
+    register('--resolver-use-manylinux', advanced=True, type=bool, default=True, fingerprint=True,
+             help='Whether to consider manylinux wheels when resolving requirements for linux '
+                  'platforms.')
 
   @property
   def interpreter_constraints(self):
@@ -123,6 +126,10 @@ class PythonSetup(Subsystem):
   @property
   def resolver_blacklist(self):
     return self.get_options().resolver_blacklist
+
+  @property
+  def use_manylinux(self):
+    return self.get_options().resolver_use_manylinux
 
   @property
   def artifact_cache_dir(self):

--- a/src/python/pants/backend/python/tasks/pex_build_util.py
+++ b/src/python/pants/backend/python/tasks/pex_build_util.py
@@ -218,6 +218,7 @@ def _resolve_multi(interpreter, requirements, platforms, find_links):
       cache=requirements_cache_dir,
       cache_ttl=python_setup.resolver_cache_ttl,
       allow_prereleases=python_setup.resolver_allow_prereleases,
-      pkg_blacklist=python_setup.resolver_blacklist)
+      pkg_blacklist=python_setup.resolver_blacklist,
+      use_manylinux=python_setup.use_manylinux)
 
   return distributions

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -112,7 +112,10 @@ class PluginResolver(object):
                             context=self._python_repos.get_network_context(),
                             cache=self.plugin_cache_dir,
                             cache_ttl=10 * 365 * 24 * 60 * 60,  # Effectively never expire.
-                            allow_prereleases=PANTS_SEMVER.is_prerelease)
+                            allow_prereleases=PANTS_SEMVER.is_prerelease,
+                            # Plugins will all depend on `pantsbuild.pants` which is distributed as
+                            # a manylinux wheel.
+                            use_manylinux=True)
 
   @memoized_property
   def plugin_cache_dir(self):


### PR DESCRIPTION
Also plumb manylinux resolution support for the python backend, on by
default, but configurable via `python_setup.resolver_use_manylinux`.

Fixes #5958