### PR TITLE
adding more documentation for python_app

### DIFF
--- a/src/python/pants/backend/python/targets/python_app.py
+++ b/src/python/pants/backend/python/targets/python_app.py
@@ -10,6 +10,13 @@ from pants.build_graph.app_base import AppBase
 
 
 class PythonApp(AppBase):
+  """A deployable Python application.
+  Invoking the ``bundle`` goal on one of these targets creates a
+  self-contained artifact suitable for deployment on some other machine.
+  The artifact contains the executable pex, its dependencies, and
+  extra files like config files, startup scripts, etc.
+  :API: public
+  """
   @classmethod
   def alias(cls):
     return 'python_app'

--- a/src/python/pants/backend/python/targets/python_app.py
+++ b/src/python/pants/backend/python/targets/python_app.py
@@ -11,12 +11,15 @@ from pants.build_graph.app_base import AppBase
 
 class PythonApp(AppBase):
   """A deployable Python application.
+
   Invoking the ``bundle`` goal on one of these targets creates a
   self-contained artifact suitable for deployment on some other machine.
   The artifact contains the executable pex, its dependencies, and
   extra files like config files, startup scripts, etc.
+
   :API: public
   """
+
   @classmethod
   def alias(cls):
     return 'python_app'

--- a/src/python/pants/build_graph/app_base.py
+++ b/src/python/pants/build_graph/app_base.py
@@ -212,8 +212,8 @@ class AppBase(Target):
                archive=None,
                **kwargs):
     """
-    :param string binary: Target spec of the ``jvm_binary`` that contains the
-      app main.
+    :param string binary: Target spec of the ``jvm_binary`` or the ``python-binary``
+      that contains the app main.
     :param bundles: One or more ``bundle``\s
       describing "extra files" that should be included with this app
       (e.g.: config files, startup scripts).

--- a/src/python/pants/build_graph/app_base.py
+++ b/src/python/pants/build_graph/app_base.py
@@ -212,7 +212,7 @@ class AppBase(Target):
                archive=None,
                **kwargs):
     """
-    :param string binary: Target spec of the ``jvm_binary`` or the ``python-binary``
+    :param string binary: Target spec of the ``jvm_binary`` or the ``python_binary``
       that contains the app main.
     :param bundles: One or more ``bundle``\s
       describing "extra files" that should be included with this app


### PR DESCRIPTION
### Problem

The python_app target doesn't have the documentation specific for it and has a documentation that is specific to jvm_app.

### Solution

Added a few lines of documentation.

### Result

There is no system-wide change, only a documentation change.