### PR TITLE
Shorten safe filenames further, and combine codepaths to make them readable.

### DIFF
--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -23,6 +23,7 @@ from pants.build_graph.address import Address
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.target_addressable import TargetAddressable
 from pants.build_graph.target_scopes import Scope
+from pants.fs.fs import safe_filename
 from pants.source.payload_fields import SourcesField
 from pants.source.wrapped_globs import Files, FilesetWithSpec, Globs
 from pants.subsystem.subsystem import Subsystem
@@ -173,11 +174,7 @@ class Target(AbstractTarget):
   @classmethod
   def compute_target_id(cls, address):
     """Computes a target id from the given address."""
-    id_candidate = address.path_safe_spec
-    if len(id_candidate) >= 200:
-      # two dots + 79 char head + 79 char tail + 40 char sha1
-      return '{}.{}.{}'.format(id_candidate[:79], sha1(id_candidate).hexdigest(), id_candidate[-79:])
-    return id_candidate
+    return safe_filename(address.path_safe_spec)
 
   @staticmethod
   def combine_ids(ids):

--- a/src/python/pants/fs/fs.py
+++ b/src/python/pants/fs/fs.py
@@ -9,10 +9,9 @@ import hashlib
 import os
 
 
-# This is the max filename length for HFS+, extX and NTFS - the most likely filesystems pants will
-# be run under.
-# TODO(John Sirois): consider a better isolation layer
-_MAX_FILENAME_LENGTH = 255
+# The max filename length for HFS+, extX and NTFS is 255, but many systems also have limits on the
+# total path length (made up of multiple filenames), so we include some additional buffer.
+_MAX_FILENAME_LENGTH = 100
 
 
 def safe_filename(name, extension=None, digest=None, max_length=_MAX_FILENAME_LENGTH):
@@ -43,8 +42,17 @@ def safe_filename(name, extension=None, digest=None, max_length=_MAX_FILENAME_LE
     return filename
   else:
     digest = digest or hashlib.sha1()
-    digest.update(name)
-    safe_name = digest.hexdigest() + ext
+    digest.update(filename)
+    hexdigest = digest.hexdigest()[:16]
+
+    # Prefix and suffix length: max length less 2 periods, the extension length, and the digest length.
+    ps_len = max(0, (max_length - (2 + len(ext) + len(hexdigest))) // 2)
+    print('prefix/suffix len is: {}'.format(ps_len))
+    sep = '.' if ps_len > 0 else ''
+    prefix = name[:ps_len]
+    suffix = name[-ps_len:] if ps_len > 0 else ''
+
+    safe_name = '{}{}{}{}{}{}'.format(prefix, sep, hexdigest, sep, suffix, ext)
     if len(safe_name) > max_length:
       raise ValueError('Digest {} failed to produce a filename <= {} '
                        'characters for {} - got {}'.format(digest, max_length, filename, safe_name))

--- a/src/python/pants/fs/fs.py
+++ b/src/python/pants/fs/fs.py
@@ -47,7 +47,6 @@ def safe_filename(name, extension=None, digest=None, max_length=_MAX_FILENAME_LE
 
     # Prefix and suffix length: max length less 2 periods, the extension length, and the digest length.
     ps_len = max(0, (max_length - (2 + len(ext) + len(hexdigest))) // 2)
-    print('prefix/suffix len is: {}'.format(ps_len))
     sep = '.' if ps_len > 0 else ''
     prefix = name[:ps_len]
     suffix = name[-ps_len:] if ps_len > 0 else ''

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_bundle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_bundle_integration.py
@@ -28,9 +28,8 @@ class BundleIntegrationTest(PantsRunIntegrationTest):
       target = ('testprojects/maven_layout/resource_collision/example_{name}/'
                 'src/main/java/org/pantsbuild/duplicateres/example{name}/'
                 .format(name=name))
-      bundle_name = ('testprojects.maven_layout.resource_collision.example_{name}.'
-                     'src.main.java.org.pantsbuild.duplicateres.example{name}.example{name}'
-                     .format(name=name))
-      bundle_jar_name = 'example{proj}'.format(proj=name)
-      stdout = self.bundle_and_run(target, bundle_name, bundle_jar_name=bundle_jar_name)
+      bundle_name = 'example{name}'.format(name=name)
+      stdout = self.bundle_and_run(target, bundle_name, bundle_jar_name=bundle_name, bundle_options=[
+          '--bundle-jvm-use-basename-prefix',
+        ])
       self.assertEquals(stdout, 'Hello world!: resource from example {name}\n'.format(name=name))

--- a/tests/python/pants_test/build_graph/test_target.py
+++ b/tests/python/pants_test/build_graph/test_target.py
@@ -115,11 +115,9 @@ class TargetTest(TestBase):
       long_path = os.path.join(long_path, 'dummy{}'.format(i))
     long_target = self.make_target('{}:foo'.format(long_path), Target)
     long_id = long_target.id
-    self.assertEqual(len(long_id), 200)
-    self.assertEqual(long_id,
-      'dummy.dummy1.dummy2.dummy3.dummy4.dummy5.dummy6.dummy7.dummy8.dummy9.dummy10.du.'
-      'c582ce0f60008b3dc8196ae9e6ff5e8c40096974.y20.dummy21.dummy22.dummy23.dummy24.dummy25.'
-      'dummy26.dummy27.dummy28.dummy29.foo')
+    self.assertEqual(len(long_id), 100)
+    self.assertTrue(long_id.startswith('dummy.dummy1.'))
+    self.assertTrue(long_id.endswith('.dummy28.dummy29.foo'))
 
   def test_target_id_short(self):
     short_path = 'dummy'

--- a/tests/python/pants_test/fs/test_safe_filename.py
+++ b/tests/python/pants_test/fs/test_safe_filename.py
@@ -34,6 +34,10 @@ class SafeFilenameTest(unittest.TestCase):
     self.assertEqual('**.jill',
                      safe_filename('jack', '.jill', digest=self.FixedDigest(2), max_length=8))
 
+  def test_shorten_readable(self):
+    self.assertEqual('j.**.e.jill',
+                     safe_filename('jackalope', '.jill', digest=self.FixedDigest(2), max_length=11))
+
   def test_shorten_fail(self):
     with self.assertRaises(ValueError):
       safe_filename('jack', '.beanstalk', digest=self.FixedDigest(3), max_length=12)


### PR DESCRIPTION
### Problem

#5587 describes a case where our 255 character limit on path _component_ lengths (note, not the entire path) still results in someone hitting a path length limit.

### Solution

Lower the `safe_filename` path component length limit to 100 characters, since the previous 255 value did not account for the fact that many filesystems also have a limit on total path length. This "fixes" the issue described in #5587, which was caused by using this method via `build_invalidator.py`.

Additionally, merge the codepath from `Target.compute_target_id` which computes a readable shortened filename into `safe_filename`, and expand tests. This removes some duplication, and ensure that we don't run into a similar issue with target ids.

### Result

The specific error from #5587 should be prevented, and consumers of `safe_filename` should have safe and readable filenames.

Fixes #5587.