### PR TITLE
Override get_sources for pants plugins

### DIFF
--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -183,7 +183,6 @@ class PantsPlugin(PythonLibrary):
 
     super(PantsPlugin, self).__init__(address,
                                       payload,
-                                      sources=['register.py'],
                                       provides=setup_py,
                                       **kwargs)
 

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -329,6 +329,11 @@ class GoTargetAdaptor(TargetAdaptor):
     return ('BUILD', 'BUILD.*')
 
 
+class PantsPluginAdaptor(TargetAdaptor):
+  def get_sources(self):
+    return ['register.py']
+
+
 class BaseGlobs(Locatable, AbstractClass):
   """An adaptor class to allow BUILD file parsing from ContextAwareObjectFactories."""
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -19,9 +19,9 @@ from pants.engine.legacy.options_parsing import create_options_parsing_rules
 from pants.engine.legacy.parser import LegacyPythonCallbacksParser
 from pants.engine.legacy.structs import (AppAdaptor, GoTargetAdaptor, JavaLibraryAdaptor,
                                          JunitTestsAdaptor, JvmBinaryAdaptor, PageAdaptor,
-                                         PythonBinaryAdaptor, PythonLibraryAdaptor,
-                                         PythonTestsAdaptor, RemoteSourcesAdaptor,
-                                         ScalaLibraryAdaptor, TargetAdaptor)
+                                         PantsPluginAdaptor, PythonBinaryAdaptor,
+                                         PythonLibraryAdaptor, PythonTestsAdaptor,
+                                         RemoteSourcesAdaptor, ScalaLibraryAdaptor, TargetAdaptor)
 from pants.engine.mapper import AddressMapper
 from pants.engine.native import Native
 from pants.engine.parser import SymbolTable
@@ -69,6 +69,8 @@ class LegacySymbolTable(SymbolTable):
     self._table['python_binary'] = PythonBinaryAdaptor
     self._table['remote_sources'] = RemoteSourcesAdaptor
     self._table['page'] = PageAdaptor
+    self._table['pants_plugin'] = PantsPluginAdaptor
+    self._table['contrib_plugin'] = PantsPluginAdaptor
 
   def aliases(self):
     return self._build_file_aliases


### PR DESCRIPTION
This pushes sources parsing through the engine (in parallel with other parsing), rather than doing it later in Python.