### PR TITLE
Deprecate legacy default sources API

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/targets/go_library.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_library.py
@@ -11,8 +11,6 @@ from pants.contrib.go.targets.go_local_source import GoLocalSource
 class GoLibrary(GoLocalSource):
   """A local Go package."""
 
-  default_sources_globs = '*.go'
-
   @classmethod
   def alias(cls):
     return 'go_library'

--- a/contrib/go/src/python/pants/contrib/go/targets/go_protobuf_library.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_protobuf_library.py
@@ -15,8 +15,6 @@ from pants.contrib.go.targets.go_target import GoTarget
 class GoProtobufLibrary(Target):
   """A Go library generated from Protobuf IDL files."""
 
-  default_sources_globs = '*.proto'
-
   def __init__(self,
                address=None,
                payload=None,

--- a/contrib/thrifty/src/python/pants/contrib/thrifty/java_thrifty_library.py
+++ b/contrib/thrifty/src/python/pants/contrib/thrifty/java_thrifty_library.py
@@ -16,4 +16,4 @@ class JavaThriftyLibrary(JvmTarget):
 
   For details, see https://github.com/Microsoft/thrifty
   """
-  default_sources_globs = '*.thrift'
+  pass

--- a/src/python/pants/backend/jvm/targets/java_library.py
+++ b/src/python/pants/backend/jvm/targets/java_library.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
-from pants.backend.jvm.targets.junit_tests import JUnitTests
 
 
 class JavaLibrary(ExportableJvmLibrary):
@@ -20,9 +19,6 @@ class JavaLibrary(ExportableJvmLibrary):
 
   :API: public
   """
-
-  default_sources_globs = '*.java'
-  default_sources_exclude_globs = JUnitTests.java_test_globs
 
   @classmethod
   def subsystems(cls):

--- a/src/python/pants/backend/jvm/targets/junit_tests.py
+++ b/src/python/pants/backend/jvm/targets/junit_tests.py
@@ -19,12 +19,6 @@ class JUnitTests(JvmTarget):
   :API: public
   """
 
-  java_test_globs = ('*Test.java',)
-  scala_test_globs = ('*Test.scala', '*Spec.scala')
-
-  default_sources_globs = java_test_globs + scala_test_globs
-
-
   CONCURRENCY_SERIAL = 'SERIAL'
   CONCURRENCY_PARALLEL_CLASSES = 'PARALLEL_CLASSES'
   CONCURRENCY_PARALLEL_METHODS = 'PARALLEL_METHODS'

--- a/src/python/pants/backend/jvm/targets/scala_library.py
+++ b/src/python/pants/backend/jvm/targets/scala_library.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
-from pants.backend.jvm.targets.junit_tests import JUnitTests
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
@@ -25,9 +24,6 @@ class ScalaLibrary(ExportableJvmLibrary):
 
   :API: public
   """
-
-  default_sources_globs = '*.scala'
-  default_sources_exclude_globs = JUnitTests.scala_test_globs
 
   @classmethod
   def subsystems(cls):

--- a/src/python/pants/backend/python/targets/python_distribution.py
+++ b/src/python/pants/backend/python/targets/python_distribution.py
@@ -17,8 +17,6 @@ from pants.build_graph.target import Target
 class PythonDistribution(Target):
   """A Python distribution target that accepts a user-defined setup.py."""
 
-  default_sources_globs = '*.py'
-
   @classmethod
   def alias(cls):
     return 'python_dist'

--- a/src/python/pants/backend/python/targets/python_library.py
+++ b/src/python/pants/backend/python/targets/python_library.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.python.targets.python_target import PythonTarget
-from pants.backend.python.targets.python_tests import PythonTests
 
 
 class PythonLibrary(PythonTarget):
@@ -18,6 +17,3 @@ class PythonLibrary(PythonTarget):
   @classmethod
   def alias(cls):
     return 'python_library'
-
-  default_sources_globs = '*.py'
-  default_sources_exclude_globs = PythonTests.default_sources_globs

--- a/src/python/pants/backend/python/targets/python_tests.py
+++ b/src/python/pants/backend/python/targets/python_tests.py
@@ -16,9 +16,6 @@ class PythonTests(PythonTarget):
   :API: public
   """
 
-  # These are the patterns matched by pytest's test discovery.
-  default_sources_globs = ('test_*.py', '*_test.py')
-
   @classmethod
   def alias(cls):
     return 'python_tests'

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -868,6 +868,13 @@ class Target(AbstractTarget):
       # This is so that tests don't need to set up the subsystem when creating targets that
       # legitimately do not require sources.
       if (key_arg is None or key_arg == 'sources') and self.supports_default_sources():
+        deprecated_conditional(
+          lambda: True,
+          '1.10.0.dev0',
+          ('Specifying default sources on Targets is deprecated, and now takes a slow path. '
+           'Instead, class {} should have a TargetAdaptor installed specifying default sources to '
+           'the v2 engine.').format(self.__class__.__name__)
+        )
         sources = self.default_sources(sources_rel_path)
       else:
         sources = FilesetWithSpec.empty(sources_rel_path)

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -312,6 +312,16 @@ class PythonTestsAdaptor(PythonTargetAdaptor):
     return self.python_test_globs
 
 
+class PythonDistributionAdaptor(TargetAdaptor):
+  @property
+  def default_sources(self):
+    return True
+
+  @property
+  def default_sources_globs(self):
+    return ('*.py',)
+
+
 class GoTargetAdaptor(TargetAdaptor):
 
   @property
@@ -332,6 +342,26 @@ class GoTargetAdaptor(TargetAdaptor):
 class PantsPluginAdaptor(TargetAdaptor):
   def get_sources(self):
     return ['register.py']
+
+
+class ProtobufLibraryAdaptor(TargetAdaptor):
+  @property
+  def default_sources(self):
+    return True
+
+  @property
+  def default_sources_globs(self):
+    return ('*.proto',)
+
+
+class ThriftLibraryAdaptor(TargetAdaptor):
+  @property
+  def default_sources(self):
+    return True
+
+  @property
+  def default_sources_globs(self):
+    return ('*.thrift',)
 
 
 class BaseGlobs(Locatable, AbstractClass):

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -19,9 +19,11 @@ from pants.engine.legacy.options_parsing import create_options_parsing_rules
 from pants.engine.legacy.parser import LegacyPythonCallbacksParser
 from pants.engine.legacy.structs import (AppAdaptor, GoTargetAdaptor, JavaLibraryAdaptor,
                                          JunitTestsAdaptor, JvmBinaryAdaptor, PageAdaptor,
-                                         PantsPluginAdaptor, PythonBinaryAdaptor,
+                                         PantsPluginAdaptor, ProtobufLibraryAdaptor,
+                                         PythonBinaryAdaptor, PythonDistributionAdaptor,
                                          PythonLibraryAdaptor, PythonTestsAdaptor,
-                                         RemoteSourcesAdaptor, ScalaLibraryAdaptor, TargetAdaptor)
+                                         RemoteSourcesAdaptor, ScalaLibraryAdaptor, TargetAdaptor,
+                                         ThriftLibraryAdaptor)
 from pants.engine.mapper import AddressMapper
 from pants.engine.native import Native
 from pants.engine.parser import SymbolTable
@@ -54,12 +56,15 @@ class LegacySymbolTable(SymbolTable):
     # territory.
     for alias in ['java_library', 'java_agent', 'javac_plugin']:
       self._table[alias] = JavaLibraryAdaptor
+    self._table['java_thrifty_library'] = ThriftLibraryAdaptor
     for alias in ['scala_library', 'scalac_plugin']:
       self._table[alias] = ScalaLibraryAdaptor
     for alias in ['python_library', 'pants_plugin']:
       self._table[alias] = PythonLibraryAdaptor
+    self._table['python_distribution'] = PythonDistributionAdaptor
     for alias in ['go_library', 'go_binary']:
       self._table[alias] = GoTargetAdaptor
+    self._table['go_protobuf_library'] = ProtobufLibraryAdaptor
 
     self._table['junit_tests'] = JunitTestsAdaptor
     self._table['jvm_app'] = AppAdaptor

--- a/tests/python/pants_test/build_graph/test_target.py
+++ b/tests/python/pants_test/build_graph/test_target.py
@@ -128,7 +128,7 @@ class TargetTest(TestBase):
     self.assertEqual(short_id,
                      'dummy.dummy1.dummy2.dummy3.dummy4.dummy5.dummy6.dummy7.dummy8.dummy9.foo')
 
-  def test_implicit_sources(self):
+  def test_legacy_implicit_sources(self):
     options = {Target.Arguments.options_scope: {'implicit_sources': True}}
     init_subsystem(Target.Arguments, options)
     target = self.make_target(':a', ImplicitSourcesTestingTarget)


### PR DESCRIPTION
Instead, fill in defaults during the engine parsing phase.

This means that default sources are eager parsed in parallel alongside the rest of BUILD file parsing, rather than lazily done synchronously later on.