### PR TITLE
Fix TestSetupPyInterpreter.test_setuptools_version

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -16,6 +16,7 @@ from twitter.common.collections import OrderedSet
 from twitter.common.dirutil.chroot import Chroot
 
 from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants.backend.python.tasks.setup_py import SetupPy
 from pants.base.exceptions import TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -43,7 +44,9 @@ class SetupPyTestBase(PythonTaskTestBase):
   @contextmanager
   def run_execute(self, target, recursive=False):
     self.set_options(recursive=recursive)
-    context = self.context(target_roots=[target])
+    si_task_type = self.synthesize_task_subtype(SelectInterpreter, 'si_scope')
+    context = self.context(for_task_types=[si_task_type], target_roots=[target])
+    si_task_type(context, os.path.join(self.pants_workdir, 'si')).execute()
     setup_py = self.create_task(context)
     setup_py.execute()
     yield context.products.get_data(SetupPy.PYTHON_DISTS_PRODUCT)


### PR DESCRIPTION
Previously the test failed to populate the `PythonInterpreter` data
product leading to a fallback to the current non-bare interpreter which
allowed `setuptools` from `site-packages` to leak in.

Fixes #5467