### PR TITLE
Context always has a scheduler in tests

### DIFF
--- a/tests/python/pants_test/backend/graph_info/tasks/test_cloc.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_cloc.py
@@ -47,7 +47,6 @@ class ClocTest(ConsoleTaskTestBase, SchedulerTestBase):
     res = self.execute_console_task(
       targets=[py_tgt, java_tgt],
       options={'transitive': True},
-      scheduler=self.scheduler,
     )
     assert_counts(res, 'Python', files=3, blank=2, comment=3, code=3)
     assert_counts(res, 'Java', files=1, blank=0, comment=1, code=1)
@@ -55,7 +54,6 @@ class ClocTest(ConsoleTaskTestBase, SchedulerTestBase):
     res = self.execute_console_task(
       targets=[py_tgt, java_tgt],
       options={'transitive': False},
-      scheduler=self.scheduler,
     )
     assert_counts(res, 'Python', files=2, blank=2, comment=3, code=2)
     assert_counts(res, 'Java', files=1, blank=0, comment=1, code=1)
@@ -68,7 +66,6 @@ class ClocTest(ConsoleTaskTestBase, SchedulerTestBase):
     res = self.execute_console_task(
       targets=[py_tgt],
       options={'ignored': True},
-      scheduler=self.scheduler,
     )
     self.assertEquals(['Ignored the following files:',
                        'src/py/foo/empty.py: zero sized file'],

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -458,6 +458,8 @@ class TestBase(unittest.TestCase):
     Subsystem.reset(reset_options=True)
     Subsystem.set_options(fake_options)
 
+    scheduler = scheduler or self.scheduler
+
     context = create_context_from_options(fake_options,
                                           target_roots=target_roots,
                                           build_graph=self.build_graph,


### PR DESCRIPTION
We're starting to rely on this in more places, and it's always present
in production code, so these tests become more faithful.