### PR TITLE
[engine] Selecting for ExecuteProcessResult will Throw on non-zero exit

### DIFF
--- a/src/python/pants/backend/graph_info/tasks/cloc.py
+++ b/src/python/pants/backend/graph_info/tasks/cloc.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants.backend.graph_info.subsystems.cloc_binary import ClocBinary
-from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.engine.fs import FilesContent, PathGlobs, PathGlobsAndRoot, Snapshot
 from pants.engine.isolated_process import ExecuteProcessRequest
@@ -87,10 +86,6 @@ class CountLinesOfCode(ConsoleTask):
       'cloc'
     )
     exec_result = self.context.execute_process_synchronously(req, 'cloc', (WorkUnitLabel.TOOL,))
-
-    # TODO: Remove this check when https://github.com/pantsbuild/pants/issues/5719 is resolved.
-    if exec_result.exit_code != 0:
-      raise TaskError('{} ... exited non-zero ({}).'.format(' '.join(cmd), exec_result.exit_code))
 
     files_content_tuple = self.context._scheduler.product_request(
       FilesContent,

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -10,7 +10,8 @@ import logging
 import six
 
 from pants.engine.fs import EMPTY_SNAPSHOT, DirectoryDigest
-from pants.engine.rules import RootRule
+from pants.engine.rules import RootRule, rule
+from pants.engine.selectors import Select
 from pants.util.objects import Exactly, SubclassesOf, TypeCheckError, datatype
 
 
@@ -86,11 +87,61 @@ class ExecuteProcessRequest(datatype([
 
 
 class ExecuteProcessResult(datatype(['stdout', 'stderr', 'exit_code', 'output_directory_digest'])):
-  pass
+  """Result of executing a process. Will raise an exception if the exit code is non-zero."""
+
+
+class FallibleExecuteProcessResult(datatype(['stdout', 'stderr', 'exit_code', 'output_directory_digest'])):
+  """An ExecuteProcessResult that will not raise an exception if the exit code is non-zero."""
+
+
+class ProcessExecutionFailure(Exception):
+  """Used to denote that a process exited, but was unsuccessful in some way.
+
+  For example, exiting with a non-zero code.
+  """
+
+  MSG_FMT = """process '{desc}' failed with code {code}.
+stdout:
+{stdout}
+stderr:
+{stderr}
+"""
+
+  def __init__(self, exit_code, stdout, stderr, process_description):
+    # These are intentionally "public" members.
+    self.exit_code = exit_code
+    self.stdout = stdout
+    self.stderr = stderr
+
+    msg = self.MSG_FMT.format(
+      desc=process_description, code=exit_code, stdout=stdout, stderr=stderr)
+
+    super(ProcessExecutionFailure, self).__init__(msg)
+
+
+@rule(ExecuteProcessResult, [Select(FallibleExecuteProcessResult), Select(ExecuteProcessRequest)])
+def fallible_to_exec_result_or_raise(fallible_result, request):
+  """Converts a FallibleExecuteProcessResult to a ExecuteProcessResult or raises an error."""
+
+  if fallible_result.exit_code == 0:
+    return ExecuteProcessResult(
+      fallible_result.stdout,
+      fallible_result.stderr,
+      fallible_result.exit_code,
+      fallible_result.output_directory_digest
+    )
+  else:
+    raise ProcessExecutionFailure(
+      fallible_result.exit_code,
+      fallible_result.stdout,
+      fallible_result.stderr,
+      request.description
+    )
 
 
 def create_process_rules():
   """Creates rules that consume the intrinsic filesystem types."""
   return [
     RootRule(ExecuteProcessRequest),
+    fallible_to_exec_result_or_raise
   ]

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -86,12 +86,16 @@ class ExecuteProcessRequest(datatype([
       )
 
 
-class ExecuteProcessResult(datatype(['stdout', 'stderr', 'exit_code', 'output_directory_digest'])):
-  """Result of executing a process. Will raise an exception if the exit code is non-zero."""
+class ExecuteProcessResult(datatype(['stdout', 'stderr', 'output_directory_digest'])):
+  """Result of successfully executing a process.
+
+  Requesting one of these will raise an exception if the exit code is non-zero."""
 
 
 class FallibleExecuteProcessResult(datatype(['stdout', 'stderr', 'exit_code', 'output_directory_digest'])):
-  """An ExecuteProcessResult that will not raise an exception if the exit code is non-zero."""
+  """Result of executing a process.
+
+  Requesting one of these will not raise an exception if the exit code is non-zero."""
 
 
 class ProcessExecutionFailure(Exception):
@@ -100,7 +104,7 @@ class ProcessExecutionFailure(Exception):
   For example, exiting with a non-zero code.
   """
 
-  MSG_FMT = """process '{desc}' failed with code {code}.
+  MSG_FMT = """process '{desc}' failed with exit code {code}.
 stdout:
 {stdout}
 stderr:
@@ -127,7 +131,6 @@ def fallible_to_exec_result_or_raise(fallible_result, request):
     return ExecuteProcessResult(
       fallible_result.stdout,
       fallible_result.stderr,
-      fallible_result.exit_code,
       fallible_result.output_directory_digest
     )
   else:

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -16,7 +16,7 @@ from pants.base.project_tree import Dir, File, Link
 from pants.build_graph.address import Address
 from pants.engine.fs import (DirectoryDigest, FileContent, FilesContent, Path, PathGlobs,
                              PathGlobsAndRoot, Snapshot)
-from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.engine.native import Function, TypeConstraint, TypeId
 from pants.engine.nodes import Return, State, Throw
 from pants.engine.rules import RuleIndex, SingletonRule, TaskRule
@@ -127,7 +127,7 @@ class Scheduler(object):
       Dir,
       File,
       Link,
-      ExecuteProcessResult,
+      FallibleExecuteProcessResult,
       has_products_constraint,
       constraint_for(Address),
       constraint_for(Variants),
@@ -139,7 +139,7 @@ class Scheduler(object):
       constraint_for(File),
       constraint_for(Link),
       constraint_for(ExecuteProcessRequest),
-      constraint_for(ExecuteProcessResult),
+      constraint_for(FallibleExecuteProcessResult),
       constraint_for(GeneratorType),
     )
 

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -16,7 +16,7 @@ from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.worker_pool import SubprocPool
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target
-from pants.engine.isolated_process import ExecuteProcessResult
+from pants.engine.isolated_process import FallibleExecuteProcessResult
 from pants.goal.products import Products
 from pants.goal.workspace import ScmWorkspace
 from pants.process.lock import OwnerPrintingInterProcessFileLock
@@ -394,7 +394,7 @@ class Context(object):
       labels=labels,
       cmd=' '.join(execute_process_request.argv),
     ) as workunit:
-      result = self._scheduler.product_request(ExecuteProcessResult, [execute_process_request])[0]
+      result = self._scheduler.product_request(FallibleExecuteProcessResult, [execute_process_request])[0]
       workunit.output("stdout").write(result.stdout)
       workunit.output("stderr").write(result.stderr)
       return result

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -70,7 +70,7 @@ pub struct ExecuteProcessRequest {
 /// The result of running a process.
 ///
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ExecuteProcessResult {
+pub struct FallibleExecuteProcessResult {
   pub stdout: Bytes,
   pub stderr: Bytes,
   pub exit_code: i32,
@@ -81,7 +81,7 @@ pub struct ExecuteProcessResult {
 }
 
 pub trait CommandRunner: Send + Sync {
-  fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<ExecuteProcessResult, String>;
+  fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<FallibleExecuteProcessResult, String>;
 
   fn reset_prefork(&self);
 }
@@ -104,7 +104,7 @@ impl BoundedCommandRunner {
 }
 
 impl CommandRunner for BoundedCommandRunner {
-  fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<ExecuteProcessResult, String> {
+  fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<FallibleExecuteProcessResult, String> {
     let inner = self.inner.clone();
     self.sema.with_acquired(move || inner.run(req))
   }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use tokio_process::CommandExt;
 
-use super::{ExecuteProcessRequest, ExecuteProcessResult};
+use super::{ExecuteProcessRequest, FallibleExecuteProcessResult};
 
 use bytes::Bytes;
 
@@ -74,7 +74,7 @@ impl super::CommandRunner for CommandRunner {
   ///
   /// Runs a command on this machine in the passed working directory.
   ///
-  fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<ExecuteProcessResult, String> {
+  fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<FallibleExecuteProcessResult, String> {
     let workdir = try_future!(
       tempfile::Builder::new()
         .prefix("process-execution")
@@ -141,7 +141,7 @@ impl super::CommandRunner for CommandRunner {
         };
 
         output_snapshot
-          .map(|snapshot| ExecuteProcessResult {
+          .map(|snapshot| FallibleExecuteProcessResult {
             stdout: Bytes::from(output.stdout),
             stderr: Bytes::from(output.stderr),
             exit_code: output.status.code().unwrap(),
@@ -165,7 +165,7 @@ mod tests {
 
   use fs;
   use futures::Future;
-  use super::{ExecuteProcessRequest, ExecuteProcessResult};
+  use super::{ExecuteProcessRequest, FallibleExecuteProcessResult};
   use super::super::CommandRunner as CommandRunnerTrait;
   use std;
   use std::collections::{BTreeMap, BTreeSet};
@@ -193,7 +193,7 @@ mod tests {
 
     assert_eq!(
       result.unwrap(),
-      ExecuteProcessResult {
+      FallibleExecuteProcessResult {
         stdout: as_bytes("foo"),
         stderr: as_bytes(""),
         exit_code: 0,
@@ -217,7 +217,7 @@ mod tests {
 
     assert_eq!(
       result.unwrap(),
-      ExecuteProcessResult {
+      FallibleExecuteProcessResult {
         stdout: as_bytes("foo"),
         stderr: as_bytes("bar"),
         exit_code: 1,
@@ -315,7 +315,7 @@ mod tests {
     });
     assert_eq!(
       result.unwrap(),
-      ExecuteProcessResult {
+      FallibleExecuteProcessResult {
         stdout: as_bytes(""),
         stderr: as_bytes(""),
         exit_code: 0,
@@ -342,7 +342,7 @@ mod tests {
 
     assert_eq!(
       result.unwrap(),
-      ExecuteProcessResult {
+      FallibleExecuteProcessResult {
         stdout: as_bytes(""),
         stderr: as_bytes(""),
         exit_code: 0,
@@ -374,7 +374,7 @@ mod tests {
 
     assert_eq!(
       result.unwrap(),
-      ExecuteProcessResult {
+      FallibleExecuteProcessResult {
         stdout: as_bytes(""),
         stderr: as_bytes(""),
         exit_code: 0,
@@ -407,7 +407,7 @@ mod tests {
 
     assert_eq!(
       result.unwrap(),
-      ExecuteProcessResult {
+      FallibleExecuteProcessResult {
         stdout: as_bytes(""),
         stderr: as_bytes(""),
         exit_code: 0,
@@ -438,7 +438,7 @@ mod tests {
 
     assert_eq!(
       result.unwrap(),
-      ExecuteProcessResult {
+      FallibleExecuteProcessResult {
         stdout: as_bytes(""),
         stderr: as_bytes(""),
         exit_code: 1,
@@ -467,7 +467,7 @@ mod tests {
 
     assert_eq!(
       result.unwrap(),
-      ExecuteProcessResult {
+      FallibleExecuteProcessResult {
         stdout: as_bytes(""),
         stderr: as_bytes(""),
         exit_code: 0,
@@ -476,13 +476,15 @@ mod tests {
     )
   }
 
-  fn run_command_locally(req: ExecuteProcessRequest) -> Result<ExecuteProcessResult, String> {
+  fn run_command_locally(
+    req: ExecuteProcessRequest,
+  ) -> Result<FallibleExecuteProcessResult, String> {
     run_command_locally_in_dir(req)
   }
 
   fn run_command_locally_in_dir(
     req: ExecuteProcessRequest,
-  ) -> Result<ExecuteProcessResult, String> {
+  ) -> Result<FallibleExecuteProcessResult, String> {
     let store_dir = TempDir::new().unwrap();
     let pool = Arc::new(fs::ResettablePool::new("test-pool-".to_owned()));
     let store = fs::Store::local_only(store_dir.path(), pool.clone()).unwrap();

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -522,7 +522,7 @@ impl ExecuteProcess {
 }
 
 #[derive(Clone, Debug)]
-pub struct ProcessResult(process_execution::ExecuteProcessResult);
+pub struct ProcessResult(process_execution::FallibleExecuteProcessResult);
 
 impl Node for ExecuteProcess {
   type Output = ProcessResult;


### PR DESCRIPTION
This patch renames ExecuteProcessResult to FallibleExecuteProcessResult, and adds a rule to convert that to an ExecuteProcessResult. If the exit code is not zero, it raises ProcessExecutionFailure.

It moves ProcessExecutionFailure into `isolated_process.py`

Fixes #5719