### PR TITLE
Extract and genericize Graph for easier testing

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -236,10 +236,10 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "graph 0.0.1",
  "hashing 0.0.1",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "process_execution 0.0.1",
  "resettable 0.0.1",
  "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -431,6 +431,17 @@ dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "graph"
+version = "0.0.1"
+dependencies = [
+ "boxfuture 0.0.1",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
+ "petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -30,6 +30,7 @@ members = [
   "fs",
   "fs/brfs",
   "fs/fs_util",
+  "graph",
   "hashing",
   "process_execution",
   "process_execution/bazel_protos",
@@ -53,6 +54,7 @@ default-members = [
   "boxfuture",
   "fs",
   "fs/fs_util",
+  "graph",
   "hashing",
   "process_execution",
   "process_execution/bazel_protos",
@@ -69,10 +71,10 @@ enum_primitive = "0.1.1"
 fnv = "1.0.5"
 fs = { path = "fs" }
 futures = "^0.1.16"
+graph = { path = "graph" }
 hashing = { path = "hashing" }
 lazy_static = "0.2.2"
 log = "0.4"
-petgraph = "0.4.5"
 process_execution = { path = "process_execution" }
 resettable = { path = "resettable" }
 tokio = "0.1"

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+version = "0.0.1"
+name = "graph"
+authors = [ "Pants Build <pantsbuild@gmail.com>" ]
+
+[dependencies]
+boxfuture = { path = "../boxfuture" }
+fnv = "1.0.5"
+futures = "^0.1.16"
+hashing = { path = "../hashing" }
+petgraph = "0.4.5"

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -1,64 +1,56 @@
-// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+extern crate boxfuture;
+extern crate fnv;
+extern crate futures;
+extern crate hashing;
+extern crate petgraph;
+
+mod node;
+
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::fs::File;
-use std::fs::OpenOptions;
+use std::hash::BuildHasherDefault;
+use std::fs::{File, OpenOptions};
 use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use std::collections::binary_heap::BinaryHeap;
 
+use fnv::FnvHasher;
+
 use petgraph::Direction;
-use petgraph::stable_graph::{NodeIndex, StableDiGraph, StableGraph};
+use petgraph::stable_graph::{StableDiGraph, StableGraph};
 use futures::future::{self, Future};
 
-use externs;
-use boxfuture::Boxable;
-use context::ContextFactory;
-use core::{Failure, Noop, FNV};
-use hashing;
-use nodes::{DigestFile, Node, NodeFuture, NodeKey, NodeResult, TryInto};
+use boxfuture::{BoxFuture, Boxable};
+pub use node::{EntryId, Node, NodeContext, NodeError, NodeTracer, NodeVisualizer};
 
-// 2^32 Nodes ought to be more than enough for anyone!
-pub type EntryId = NodeIndex<u32>;
+type FNV = BuildHasherDefault<FnvHasher>;
 
-type PGraph = StableDiGraph<Entry, (), u32>;
+type PGraph<N> = StableDiGraph<Entry<N>, (), u32>;
 
-type EntryStateField = future::Shared<NodeFuture<NodeResult>>;
+type EntryStateField<Item, Error> = future::Shared<BoxFuture<Item, Error>>;
 
-trait EntryStateGetter {
-  fn get<N: Node>(&self) -> NodeFuture<N::Output>;
-}
-
-impl EntryStateGetter for EntryStateField {
-  fn get<N: Node>(&self) -> NodeFuture<N::Output> {
-    self
-      .clone()
-      .then(|node_result| Entry::unwrap::<N>(node_result))
-      .to_boxed()
-  }
-}
-
-struct EntryState {
-  field: EntryStateField,
+struct EntryState<N: Node> {
+  field: EntryStateField<N::Item, N::Error>,
   start_time: Instant,
 }
 
 ///
 /// Because there are guaranteed to be more edges than nodes in Graphs, we mark cyclic
-/// dependencies via a wrapper around the NodeKey (rather than adding a byte to every
+/// dependencies via a wrapper around the Node (rather than adding a byte to every
 /// valid edge).
 ///
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-enum EntryKey {
-  Valid(NodeKey),
-  Cyclic(NodeKey),
+enum EntryKey<N: Node> {
+  Valid(N),
+  Cyclic(N),
 }
 
-impl EntryKey {
-  fn content(&self) -> &NodeKey {
+impl<N: Node> EntryKey<N> {
+  fn content(&self) -> &N {
     match self {
       &EntryKey::Valid(ref v) => v,
       &EntryKey::Cyclic(ref v) => v,
@@ -66,48 +58,46 @@ impl EntryKey {
   }
 }
 
+fn unwrap_entry_res<N: Node>(
+  res: Result<future::SharedItem<N::Item>, future::SharedError<N::Error>>,
+) -> Result<N::Item, N::Error> {
+  match res {
+    Ok(nr) => Ok((*nr).clone()),
+    Err(failure) => Err((*failure).clone()),
+  }
+}
+
 ///
 /// An Entry and its adjacencies.
 ///
-pub struct Entry {
+pub struct Entry<N: Node> {
   // TODO: This is a clone of the Node, which is also kept in the `nodes` map. It would be
   // nice to avoid keeping two copies of each Node, but tracking references between the two
   // maps is painful.
-  node: EntryKey,
-  state: Option<EntryState>,
+  node: EntryKey<N>,
+  state: Option<EntryState<N>>,
 }
 
-impl Entry {
+impl<N: Node> Entry<N> {
   ///
   /// Creates an Entry, wrapping its execution in `future::lazy` to defer execution until a
   /// a caller actually pulls on it. This indirection exists in order to allow Nodes to start
   /// outside of the Graph lock.
   ///
-  fn new(node: EntryKey) -> Entry {
+  fn new(node: EntryKey<N>) -> Entry<N> {
     Entry {
       node: node,
       state: None,
     }
   }
 
-  fn unwrap<N: Node>(
-    res: Result<future::SharedItem<NodeResult>, future::SharedError<Failure>>,
-  ) -> Result<N::Output, Failure> {
-    match res {
-      Ok(nr) => Ok(
-        (*nr)
-          .clone()
-          .try_into()
-          .unwrap_or_else(|_| panic!("A Node implementation was ambiguous.")),
-      ),
-      Err(failure) => Err((*failure).clone()),
-    }
-  }
-
   ///
   /// Returns a reference to the Node's Future, starting it if need be.
   ///
-  fn state(&mut self, context_factory: &ContextFactory, entry_id: EntryId) -> EntryStateField {
+  fn state<C>(&mut self, context: &C, entry_id: EntryId) -> EntryStateField<N::Item, N::Error>
+  where
+    C: NodeContext<CloneFor = N::Context>,
+  {
     if let Some(ref state) = self.state {
       state.field.clone()
     } else {
@@ -115,29 +105,29 @@ impl Entry {
       let state = match &self.node {
         &EntryKey::Valid(ref n) => {
           // Wrap the launch in future::lazy to defer it until after we're outside the Graph lock.
-          let context = context_factory.create(entry_id);
+          let context = context.clone_for(entry_id);
           let node = n.clone();
           future::lazy(move || node.run(context)).to_boxed()
         }
-        &EntryKey::Cyclic(_) => future::err(Failure::Noop(Noop::Cycle)).to_boxed(),
+        &EntryKey::Cyclic(_) => future::err(N::Error::cyclic()).to_boxed(),
       };
 
       self.state = Some(EntryState {
         field: state.shared(),
         start_time,
       });
-      self.state(context_factory, entry_id)
+      self.state(context, entry_id)
     }
   }
 
   ///
   /// If the Future for this Node has already completed, returns a clone of its result.
   ///
-  fn peek<N: Node>(&self) -> Option<Result<N::Output, Failure>> {
+  fn peek(&self) -> Option<Result<N::Item, N::Error>> {
     self
       .state
       .as_ref()
-      .and_then(|state| state.field.peek().map(|nr| Entry::unwrap::<N>(nr)))
+      .and_then(|state| state.field.peek().map(unwrap_entry_res::<N>))
   }
 
   ///
@@ -158,10 +148,9 @@ impl Entry {
     self.state = None;
   }
 
-  fn format<N: Node>(&self) -> String {
-    let state = match self.peek::<N>() {
+  fn format(&self) -> String {
+    let state = match self.peek() {
       Some(Ok(ref nr)) => format!("{:?}", nr),
-      Some(Err(Failure::Throw(ref v, _))) => externs::val_to_str(v),
       Some(Err(ref x)) => format!("{:?}", x),
       None => "<None>".to_string(),
     };
@@ -169,42 +158,46 @@ impl Entry {
   }
 }
 
-type Nodes = HashMap<EntryKey, EntryId>;
+type Nodes<N> = HashMap<EntryKey<N>, EntryId>;
 
-struct InnerGraph {
-  nodes: Nodes,
-  pg: PGraph,
+struct InnerGraph<N: Node> {
+  nodes: Nodes<N>,
+  pg: PGraph<N>,
 }
 
-impl InnerGraph {
-  fn entry(&self, node: &EntryKey) -> Option<&Entry> {
+impl<N: Node> InnerGraph<N> {
+  fn entry(&self, node: &EntryKey<N>) -> Option<&Entry<N>> {
     self.entry_id(node).and_then(|&id| self.entry_for_id(id))
   }
 
-  fn entry_id(&self, node: &EntryKey) -> Option<&EntryId> {
+  fn entry_id(&self, node: &EntryKey<N>) -> Option<&EntryId> {
     self.nodes.get(node)
   }
 
-  fn entry_for_id(&self, id: EntryId) -> Option<&Entry> {
+  fn entry_for_id(&self, id: EntryId) -> Option<&Entry<N>> {
     self.pg.node_weight(id)
   }
 
-  fn entry_for_id_mut(&mut self, id: EntryId) -> Option<&mut Entry> {
+  fn entry_for_id_mut(&mut self, id: EntryId) -> Option<&mut Entry<N>> {
     self.pg.node_weight_mut(id)
   }
 
-  fn unsafe_entry_for_id(&self, id: EntryId) -> &Entry {
+  fn unsafe_entry_for_id(&self, id: EntryId) -> &Entry<N> {
     self
       .pg
       .node_weight(id)
       .expect("The unsafe_entry_for_id method should only be used in read-only methods!")
   }
 
-  fn ensure_entry(&mut self, node: EntryKey) -> EntryId {
+  fn ensure_entry(&mut self, node: EntryKey<N>) -> EntryId {
     InnerGraph::ensure_entry_internal(&mut self.pg, &mut self.nodes, node)
   }
 
-  fn ensure_entry_internal<'a>(pg: &mut PGraph, nodes: &mut Nodes, node: EntryKey) -> EntryId {
+  fn ensure_entry_internal<'a>(
+    pg: &mut PGraph<N>,
+    nodes: &mut Nodes<N>,
+    node: EntryKey<N>,
+  ) -> EntryId {
     if let Some(&id) = nodes.get(&node) {
       return id;
     }
@@ -244,7 +237,7 @@ impl InnerGraph {
   ///
   /// Begins a topological Walk from the given roots.
   ///
-  fn walk(&self, roots: VecDeque<EntryId>, direction: Direction) -> Walk {
+  fn walk(&self, roots: VecDeque<EntryId>, direction: Direction) -> Walk<N> {
     Walk {
       graph: self,
       direction: direction,
@@ -262,7 +255,7 @@ impl InnerGraph {
     roots: Vec<EntryId>,
     predicate: P,
     direction: Direction,
-  ) -> LeveledWalk<P>
+  ) -> LeveledWalk<N, P>
   where
     P: Fn(EntryId, Level) -> bool,
   {
@@ -315,7 +308,7 @@ impl InnerGraph {
     result
   }
 
-  fn invalidate_internal(pg: &mut PGraph, nodes: &mut Nodes, ids: HashSet<EntryId, FNV>) {
+  fn invalidate_internal(pg: &mut PGraph<N>, nodes: &mut Nodes<N>, ids: HashSet<EntryId, FNV>) {
     if ids.is_empty() {
       return;
     }
@@ -332,7 +325,7 @@ impl InnerGraph {
     }
 
     // Filter the Nodes to delete any with matching ids.
-    let filtered: Vec<(EntryKey, EntryId)> = nodes
+    let filtered: Vec<(EntryKey<N>, EntryId)> = nodes
       .drain()
       .filter(|&(_, id)| !ids.contains(&id))
       .collect();
@@ -346,40 +339,34 @@ impl InnerGraph {
     );
   }
 
-  fn visualize(&self, roots: &[NodeKey], path: &Path) -> io::Result<()> {
+  fn visualize<V: NodeVisualizer<N>>(
+    &self,
+    mut visualizer: V,
+    roots: &[N],
+    path: &Path,
+  ) -> io::Result<()> {
     let file = try!(File::create(path));
     let mut f = BufWriter::new(file);
-    let mut viz_colors = HashMap::new();
-    let viz_color_scheme = "set312";
-    let viz_max_colors = 12;
-    let mut format_color = |entry: &Entry| match entry.peek::<NodeKey>() {
-      None | Some(Err(Failure::Noop(_))) => "white".to_string(),
-      Some(Err(Failure::Throw(..))) => "4".to_string(),
-      Some(Err(Failure::Invalidated)) => "12".to_string(),
-      Some(Ok(_)) => {
-        let viz_colors_len = viz_colors.len();
-        viz_colors
-          .entry(entry.node.content().product_str())
-          .or_insert_with(|| format!("{}", viz_colors_len % viz_max_colors + 1))
-          .clone()
-      }
-    };
 
     try!(f.write_all(b"digraph plans {\n"));
-    try!(f.write_fmt(format_args!("  node[colorscheme={}];\n", viz_color_scheme),));
+    try!(f.write_fmt(format_args!(
+      "  node[colorscheme={}];\n",
+      visualizer.color_scheme()
+    ),));
     try!(f.write_all(b"  concentrate=true;\n"));
     try!(f.write_all(b"  rankdir=TB;\n"));
+
+    let mut format_color = |entry: &Entry<N>| visualizer.color(entry.node.content(), entry.peek());
 
     let root_entries = roots
       .iter()
       .filter_map(|n| self.entry_id(&EntryKey::Valid(n.clone())))
       .map(|&eid| eid)
       .collect();
-    let predicate = |_| true;
 
     for eid in self.walk(root_entries, Direction::Outgoing) {
       let entry = self.unsafe_entry_for_id(eid);
-      let node_str = entry.format::<NodeKey>();
+      let node_str = entry.format();
 
       // Write the node header.
       try!(f.write_fmt(format_args!(
@@ -390,12 +377,9 @@ impl InnerGraph {
 
       for dep_id in self.pg.neighbors(eid) {
         let dep_entry = self.unsafe_entry_for_id(dep_id);
-        if !predicate(dep_entry) {
-          continue;
-        }
 
         // Write an entry per edge.
-        let dep_str = dep_entry.format::<NodeKey>();
+        let dep_str = dep_entry.format();
         try!(f.write_fmt(format_args!("    \"{}\" -> \"{}\"\n", node_str, dep_str),));
       }
     }
@@ -404,24 +388,11 @@ impl InnerGraph {
     Ok(())
   }
 
-  fn trace(&self, root: &NodeKey, path: &Path) -> io::Result<()> {
+  fn trace<T: NodeTracer<N>>(&self, root: &N, path: &Path) -> io::Result<()> {
     let file = try!(OpenOptions::new().append(true).open(path));
     let mut f = BufWriter::new(file);
 
-    let is_bottom = |eid: EntryId| -> bool {
-      match self.unsafe_entry_for_id(eid).peek::<NodeKey>() {
-        Some(Err(Failure::Invalidated)) => false,
-        Some(Err(Failure::Noop(..))) => true,
-        Some(Err(Failure::Throw(..))) => false,
-        Some(Ok(_)) => true,
-        None => {
-          // A Node with no state is either still running, or effectively cancelled
-          // because a dependent failed. In either case, it's not useful to render
-          // them, as we don't know whether they would have succeeded or failed.
-          true
-        }
-      }
-    };
+    let is_bottom = |eid: EntryId| -> bool { T::is_bottom(self.unsafe_entry_for_id(eid).peek()) };
 
     let is_one_level_above_bottom =
       |eid: EntryId| -> bool { self.pg.neighbors(eid).all(|d| is_bottom(d)) };
@@ -439,22 +410,12 @@ impl InnerGraph {
       let indent = _indent(level);
       let output = format!("{}Computing {}", indent, entry.node.content().format());
       if is_one_level_above_bottom(eid) {
-        let state_str = match entry.peek::<NodeKey>() {
-          None => "<None>".to_string(),
-          Some(Ok(ref x)) => format!("{:?}", x),
-          Some(Err(Failure::Throw(ref x, ref traceback))) => format!(
-            "Throw({})\n{}",
-            externs::val_to_str(x),
-            traceback
-              .split("\n")
-              .map(|l| format!("{}    {}", indent, l))
-              .collect::<Vec<_>>()
-              .join("\n")
-          ),
-          Some(Err(Failure::Noop(ref x))) => format!("Noop({:?})", x),
-          Some(Err(Failure::Invalidated)) => "Invalidated".to_string(),
-        };
-        format!("{}\n{}  {}", output, indent, state_str)
+        format!(
+          "{}\n{}  {}",
+          output,
+          indent,
+          T::state_str(&indent, entry.peek())
+        )
       } else {
         output
       }
@@ -476,7 +437,7 @@ impl InnerGraph {
   ///
   /// Computes the K longest running entries in a Graph-aware fashion.
   ///
-  fn heavy_hitters(&self, roots: &[NodeKey], k: usize) -> Vec<(String, Duration)> {
+  fn heavy_hitters(&self, roots: &[N], k: usize) -> Vec<(String, Duration)> {
     let now = Instant::now();
     let queue_entry = |id| {
       self
@@ -527,7 +488,7 @@ impl InnerGraph {
     res
   }
 
-  fn reachable_digest_count(&self, roots: &[NodeKey]) -> usize {
+  fn reachable_digest_count(&self, roots: &[N]) -> usize {
     let root_ids = roots
       .iter()
       .cloned()
@@ -553,12 +514,8 @@ impl InnerGraph {
       entryids
         .into_iter()
         .filter_map(move |eid| self.entry_for_id(eid))
-        .filter_map(|entry| match entry.node.content() {
-          &NodeKey::DigestFile(_) => Some(entry.peek::<DigestFile>()),
-          _ => None,
-        })
-        .filter_map(|output| match output {
-          Some(Ok(digest)) => Some(digest),
+        .filter_map(|entry| match entry.peek() {
+          Some(Ok(item)) => N::digest(item),
           _ => None,
         }),
     )
@@ -568,12 +525,12 @@ impl InnerGraph {
 ///
 /// A DAG (enforced on mutation) of Entries.
 ///
-pub struct Graph {
-  inner: Mutex<InnerGraph>,
+pub struct Graph<N: Node> {
+  inner: Mutex<InnerGraph<N>>,
 }
 
-impl Graph {
-  pub fn new() -> Graph {
+impl<N: Node> Graph<N> {
+  pub fn new() -> Graph<N> {
     let inner = InnerGraph {
       nodes: HashMap::default(),
       pg: StableGraph::new(),
@@ -591,26 +548,20 @@ impl Graph {
   ///
   /// If the given Node has completed, returns a clone of its state.
   ///
-  pub fn peek<N: Node>(&self, node: N) -> Option<Result<N::Output, Failure>> {
+  pub fn peek(&self, node: N) -> Option<Result<N::Item, N::Error>> {
     let node = node.into();
     let inner = self.inner.lock().unwrap();
-    inner
-      .entry(&EntryKey::Valid(node))
-      .and_then(|e| e.peek::<N>())
+    inner.entry(&EntryKey::Valid(node)).and_then(|e| e.peek())
   }
 
   ///
   /// In the context of the given src Node, declare a dependency on the given dst Node and
   /// begin its execution if it has not already started.
   ///
-  pub fn get<N: Node>(
-    &self,
-    src_id: EntryId,
-    context: &ContextFactory,
-    dst_node: N,
-  ) -> NodeFuture<N::Output> {
-    let dst_node = dst_node.into();
-
+  pub fn get<C>(&self, src_id: EntryId, context: &C, dst_node: N) -> BoxFuture<N::Item, N::Error>
+  where
+    C: NodeContext<CloneFor = N::Context>,
+  {
     // Get or create the destination, and then insert the dep and return its state.
     let dst_state = {
       let mut inner = self.inner.lock().unwrap();
@@ -632,18 +583,21 @@ impl Graph {
       inner
         .entry_for_id_mut(dst_id)
         .map(|entry| entry.state(context, dst_id))
-        .unwrap_or_else(|| future::err(Failure::Invalidated).to_boxed().shared())
+        .unwrap_or_else(|| future::err(N::Error::invalidated()).to_boxed().shared())
     };
 
     // Got the destination's state. Now that we're outside the graph locks, we can safely
     // retrieve it.
-    dst_state.get::<N>()
+    dst_state.then(unwrap_entry_res::<N>).to_boxed()
   }
 
   ///
   /// Create the given Node if it does not already exist.
   ///
-  pub fn create<N: Node>(&self, node: N, context: &ContextFactory) -> NodeFuture<N::Output> {
+  pub fn create<C>(&self, node: N, context: &C) -> BoxFuture<N::Item, N::Error>
+  where
+    C: NodeContext<CloneFor = N::Context>,
+  {
     // Initialize the state while under the lock...
     let state = {
       let mut inner = self.inner.lock().unwrap();
@@ -651,10 +605,10 @@ impl Graph {
       inner
         .entry_for_id_mut(id)
         .map(|entry| entry.state(context, id))
-        .unwrap_or_else(|| future::err(Failure::Invalidated).to_boxed().shared())
+        .unwrap_or_else(|| future::err(N::Error::invalidated()).to_boxed().shared())
     };
     // ...but only `get` it outside the lock.
-    state.get::<N>()
+    state.then(unwrap_entry_res::<N>).to_boxed()
   }
 
   ///
@@ -670,23 +624,28 @@ impl Graph {
     inner.invalidate(paths)
   }
 
-  pub fn trace(&self, root: &NodeKey, path: &Path) -> io::Result<()> {
+  pub fn trace<T: NodeTracer<N>>(&self, root: &N, path: &Path) -> io::Result<()> {
     let inner = self.inner.lock().unwrap();
-    inner.trace(root, path)
+    inner.trace::<T>(root, path)
   }
 
-  pub fn visualize(&self, roots: &[NodeKey], path: &Path) -> io::Result<()> {
+  pub fn visualize<V: NodeVisualizer<N>>(
+    &self,
+    visualizer: V,
+    roots: &[N],
+    path: &Path,
+  ) -> io::Result<()> {
     let inner = self.inner.lock().unwrap();
-    inner.visualize(roots, path)
+    inner.visualize(visualizer, roots, path)
   }
 
   #[allow(dead_code)]
-  pub fn heavy_hitters(&self, roots: &[NodeKey], k: usize) -> Vec<(String, Duration)> {
+  pub fn heavy_hitters(&self, roots: &[N], k: usize) -> Vec<(String, Duration)> {
     let inner = self.inner.lock().unwrap();
     inner.heavy_hitters(roots, k)
   }
 
-  pub fn reachable_digest_count(&self, roots: &[NodeKey]) -> usize {
+  pub fn reachable_digest_count(&self, roots: &[N]) -> usize {
     let inner = self.inner.lock().unwrap();
     inner.reachable_digest_count(roots)
   }
@@ -701,14 +660,14 @@ impl Graph {
 /// Represents the state of a particular topological walk through a Graph. Implements Iterator and
 /// has the same lifetime as the Graph itself.
 ///
-struct Walk<'a> {
-  graph: &'a InnerGraph,
+struct Walk<'a, N: Node + 'a> {
+  graph: &'a InnerGraph<N>,
   direction: Direction,
   deque: VecDeque<EntryId>,
   walked: HashSet<EntryId, FNV>,
 }
 
-impl<'a> Iterator for Walk<'a> {
+impl<'a, N: Node + 'a> Iterator for Walk<'a, N> {
   type Item = EntryId;
 
   fn next(&mut self) -> Option<Self::Item> {
@@ -734,15 +693,15 @@ type Level = u32;
 /// Represents the state of a particular topological walk through a Graph. Implements Iterator and
 /// has the same lifetime as the Graph itself.
 ///
-struct LeveledWalk<'a, P: Fn(EntryId, Level) -> bool> {
-  graph: &'a InnerGraph,
+struct LeveledWalk<'a, N: Node + 'a, P: Fn(EntryId, Level) -> bool> {
+  graph: &'a InnerGraph<N>,
   direction: Direction,
   deque: VecDeque<(EntryId, Level)>,
   walked: HashSet<EntryId, FNV>,
   predicate: P,
 }
 
-impl<'a, P: Fn(EntryId, Level) -> bool> Iterator for LeveledWalk<'a, P> {
+impl<'a, N: Node + 'a, P: Fn(EntryId, Level) -> bool> Iterator for LeveledWalk<'a, N, P> {
   type Item = (EntryId, Level);
 
   fn next(&mut self) -> Option<Self::Item> {

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -1,0 +1,100 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::path::Path;
+
+use boxfuture::BoxFuture;
+use hashing::Digest;
+
+use petgraph::stable_graph;
+
+// 2^32 Nodes ought to be more than enough for anyone!
+pub type EntryId = stable_graph::NodeIndex<u32>;
+
+///
+/// Defines executing a cacheable/memoizable step within the given NodeContext.
+///
+pub trait Node: Clone + Eq + Hash + Send + 'static {
+  type Context: NodeContext;
+
+  type Item: Clone + Debug + Send + 'static;
+  type Error: NodeError;
+
+  fn run(self, context: Self::Context) -> BoxFuture<Self::Item, Self::Error>;
+
+  // TODO: Use a `Display` bound instead.
+  fn format(&self) -> String;
+
+  ///
+  /// If this Node represents an FS operation, returns its input Path.
+  ///
+  fn fs_subject(&self) -> Option<&Path>;
+
+  ///
+  /// If the given Node output represents an FS operation, returns its Digest.
+  ///
+  fn digest(result: Self::Item) -> Option<Digest>;
+}
+
+pub trait NodeError: Clone + Debug + Send {
+  ///
+  /// Creates an instance that represents that a Node was invalidated out of the
+  /// Graph (generally while running).
+  ///
+  fn invalidated() -> Self;
+
+  ///
+  /// Creates an instance that represents that a Node dependency was cyclic.
+  ///
+  fn cyclic() -> Self;
+}
+
+///
+/// A trait used to visualize Nodes in either DOT/GraphViz format.
+///
+pub trait NodeVisualizer<N: Node> {
+  ///
+  /// Returns a GraphViz color scheme name for this visualizer.
+  ///
+  fn color_scheme(&self) -> &str;
+
+  ///
+  /// Returns a GraphViz color name/id within Self::color_scheme for the given Node/result.
+  ///
+  fn color(&mut self, node: &N, result: Option<Result<N::Item, N::Error>>) -> String;
+}
+
+///
+/// A trait used to visualize Nodes for the purposes of CLI-output tracing.
+///
+pub trait NodeTracer<N: Node> {
+  ///
+  /// Returns true if the given Node Result represents the "bottom" of a trace.
+  ///
+  fn is_bottom(result: Option<Result<N::Item, N::Error>>) -> bool;
+
+  ///
+  /// Renders the given result for a trace. The trace will already be indented by `indent`, but
+  /// an implementer creating a multi-line output would need to indent them as well.
+  ///
+  fn state_str(indent: &str, result: Option<Result<N::Item, N::Error>>) -> String;
+}
+
+///
+/// A context passed between Nodes that also stores an EntryId to uniquely identify them.
+///
+pub trait NodeContext: Clone + Send + 'static {
+  ///
+  /// The type generated when this Context is cloned for another Node.
+  ///
+  type CloneFor: NodeContext;
+
+  ///
+  /// Creates a clone of this NodeContext to be used for a different Node.
+  ///
+  /// To clone a Context for use for the same Node, `Clone` is used directly.
+  ///
+  fn clone_for(&self, entry_id: EntryId) -> Self::CloneFor;
+}

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -10,6 +10,8 @@ use hashing::Digest;
 
 use petgraph::stable_graph;
 
+use Graph;
+
 // 2^32 Nodes ought to be more than enough for anyone!
 pub type EntryId = stable_graph::NodeIndex<u32>;
 
@@ -17,7 +19,7 @@ pub type EntryId = stable_graph::NodeIndex<u32>;
 /// Defines executing a cacheable/memoizable step within the given NodeContext.
 ///
 pub trait Node: Clone + Eq + Hash + Send + 'static {
-  type Context: NodeContext;
+  type Context: NodeContext<Node = Self>;
 
   type Item: Clone + Debug + Send + 'static;
   type Error: NodeError;
@@ -89,12 +91,17 @@ pub trait NodeContext: Clone + Send + 'static {
   ///
   /// The type generated when this Context is cloned for another Node.
   ///
-  type CloneFor: NodeContext;
+  type Node: Node;
 
   ///
   /// Creates a clone of this NodeContext to be used for a different Node.
   ///
   /// To clone a Context for use for the same Node, `Clone` is used directly.
   ///
-  fn clone_for(&self, entry_id: EntryId) -> Self::CloneFor;
+  fn clone_for(&self, entry_id: EntryId) -> <Self::Node as Node>::Context;
+
+  ///
+  /// Returns a reference to the Graph for this Context.
+  ///
+  fn graph(&self) -> &Graph<Self::Node>;
 }

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -69,6 +69,10 @@ pub trait NodeTracer<N: Node> {
   ///
   /// Returns true if the given Node Result represents the "bottom" of a trace.
   ///
+  /// A trace represents a sub-dag of the entire Graph, and a "bottom" Node result represents
+  /// a boundary that the trace stops before (ie, a bottom Node will not be rendered in the trace,
+  /// but anything that depends on a bottom Node will be).
+  ///
   fn is_bottom(result: Option<Result<N::Item, N::Error>>) -> bool;
 
   ///

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::path::Path;
 
 use boxfuture::BoxFuture;
 use hashing::Digest;
@@ -28,11 +27,6 @@ pub trait Node: Clone + Eq + Hash + Send + 'static {
 
   // TODO: Use a `Display` bound instead.
   fn format(&self) -> String;
-
-  ///
-  /// If this Node represents an FS operation, returns its input Path.
-  ///
-  fn fs_subject(&self) -> Option<&Path>;
 
   ///
   /// If the given Node output represents an FS operation, returns its Digest.

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -166,7 +166,7 @@ impl Context {
 }
 
 impl NodeContext for Context {
-  type CloneFor = Context;
+  type Node = NodeKey;
 
   ///
   /// Clones this Context for a new EntryId. Because the Core of the context is an Arc, this
@@ -177,5 +177,9 @@ impl NodeContext for Context {
       entry_id: entry_id,
       core: self.core.clone(),
     }
+  }
+
+  fn graph(&self) -> &Graph<NodeKey> {
+    &self.core.graph
   }
 }

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -434,7 +434,7 @@ pub extern "C" fn graph_invalidate(scheduler_ptr: *mut Scheduler, paths_buf: Buf
       .into_iter()
       .map(|os_str| PathBuf::from(os_str))
       .collect();
-    scheduler.core.graph.invalidate(paths) as u64
+    scheduler.invalidate(paths) as u64
   })
 }
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -5,7 +5,6 @@ pub mod cffi_externs;
 mod context;
 mod core;
 mod externs;
-mod graph;
 mod handles;
 mod interning;
 mod nodes;
@@ -22,12 +21,12 @@ extern crate enum_primitive;
 extern crate fnv;
 extern crate fs;
 extern crate futures;
+extern crate graph;
 extern crate hashing;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-extern crate petgraph;
 extern crate process_execution;
 extern crate resettable;
 extern crate tokio;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -3,9 +3,8 @@
 
 extern crate bazel_protos;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
-use std::fmt;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -24,6 +23,8 @@ use process_execution::{self, CommandRunner};
 use rule_graph;
 use selectors;
 use tasks::{self, Intrinsic, IntrinsicKind};
+
+use graph::{Node, NodeError, NodeTracer, NodeVisualizer};
 
 pub type NodeFuture<T> = BoxFuture<T, Failure>;
 
@@ -44,10 +45,6 @@ fn was_required(failure: Failure) -> Failure {
     Failure::Noop(noop) => throw(&format!("No source of required dependency: {:?}", noop)),
     f => f,
   }
-}
-
-pub trait GetNode {
-  fn get<N: Node>(&self, node: N) -> NodeFuture<N::Output>;
 }
 
 impl VFS<Failure> for Context {
@@ -78,18 +75,19 @@ impl StoreFileByDigest<Failure> for Context {
 }
 
 ///
-/// Defines executing a cacheable/memoizable step for the given context.
+/// A simplified implementation of graph::Node for members of the NodeKey enum to implement.
+/// NodeKey's impl of graph::Node handles the rest.
 ///
-/// The Output type of a Node is bounded to values that can be stored and retrieved from
-/// the NodeResult enum. Due to the semantics of memoization, retrieving the typed result
+/// The Item type of a WrappedNode is bounded to values that can be stored and retrieved
+/// from the NodeResult enum. Due to the semantics of memoization, retrieving the typed result
 /// stored inside the NodeResult requires an implementation of TryFrom<NodeResult>. But the
 /// combination of bounds at usage sites should mean that a failure to unwrap the result is
 /// exceedingly rare.
 ///
-pub trait Node: Into<NodeKey> {
-  type Output: Clone + fmt::Debug + Into<NodeResult> + TryFrom<NodeResult> + Send + 'static;
+pub trait WrappedNode: Into<NodeKey> {
+  type Item: TryFrom<NodeResult>;
 
-  fn run(self, context: Context) -> NodeFuture<Self::Output>;
+  fn run(self, context: Context) -> BoxFuture<Self::Item, Failure>;
 }
 
 ///
@@ -403,8 +401,8 @@ impl Select {
 
 // TODO: This is a Node only because it is used as a root in the graph, but it should never be
 // requested using context.get
-impl Node for Select {
-  type Output = Value;
+impl WrappedNode for Select {
+  type Item = Value;
 
   fn run(self, context: Context) -> NodeFuture<Value> {
     // TODO add back support for variants https://github.com/pantsbuild/pants/issues/4020
@@ -524,8 +522,8 @@ impl ExecuteProcess {
 #[derive(Clone, Debug)]
 pub struct ProcessResult(process_execution::ExecuteProcessResult);
 
-impl Node for ExecuteProcess {
-  type Output = ProcessResult;
+impl WrappedNode for ExecuteProcess {
+  type Item = ProcessResult;
 
   fn run(self, context: Context) -> NodeFuture<ProcessResult> {
     let request = self.0;
@@ -555,8 +553,8 @@ pub struct ReadLink(Link);
 #[derive(Clone, Debug)]
 pub struct LinkDest(PathBuf);
 
-impl Node for ReadLink {
-  type Output = LinkDest;
+impl WrappedNode for ReadLink {
+  type Item = LinkDest;
 
   fn run(self, context: Context) -> NodeFuture<LinkDest> {
     let link = self.0.clone();
@@ -582,8 +580,8 @@ impl From<ReadLink> for NodeKey {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DigestFile(pub File);
 
-impl Node for DigestFile {
-  type Output = hashing::Digest;
+impl WrappedNode for DigestFile {
+  type Item = hashing::Digest;
 
   fn run(self, context: Context) -> NodeFuture<hashing::Digest> {
     let file = self.0.clone();
@@ -625,8 +623,8 @@ pub struct Scandir(Dir);
 #[derive(Clone, Debug)]
 pub struct DirectoryListing(Vec<fs::Stat>);
 
-impl Node for Scandir {
-  type Output = DirectoryListing;
+impl WrappedNode for Scandir {
+  type Item = DirectoryListing;
 
   fn run(self, context: Context) -> NodeFuture<DirectoryListing> {
     let dir = self.0.clone();
@@ -758,8 +756,8 @@ impl Snapshot {
   }
 }
 
-impl Node for Snapshot {
-  type Output = fs::Snapshot;
+impl WrappedNode for Snapshot {
+  type Item = fs::Snapshot;
 
   fn run(self, context: Context) -> NodeFuture<fs::Snapshot> {
     let lifted_path_globs = Self::lift_path_globs(&externs::val_for(&self.0));
@@ -839,8 +837,8 @@ impl Task {
   }
 }
 
-impl Node for Task {
-  type Output = Value;
+impl WrappedNode for Task {
+  type Item = Value;
 
   fn run(self, context: Context) -> NodeFuture<Value> {
     let deps = {
@@ -891,6 +889,71 @@ impl From<Task> for NodeKey {
   }
 }
 
+#[derive(Default)]
+pub struct Visualizer {
+  viz_colors: HashMap<String, String>,
+}
+
+impl NodeVisualizer<NodeKey> for Visualizer {
+  fn color_scheme(&self) -> &str {
+    "set312"
+  }
+
+  fn color(&mut self, node: &NodeKey, result: Option<Result<NodeResult, Failure>>) -> String {
+    let max_colors = 12;
+    match result {
+      None | Some(Err(Failure::Noop(_))) => "white".to_string(),
+      Some(Err(Failure::Throw(..))) => "4".to_string(),
+      Some(Err(Failure::Invalidated)) => "12".to_string(),
+      Some(Ok(_)) => {
+        let viz_colors_len = self.viz_colors.len();
+        self
+          .viz_colors
+          .entry(node.product_str())
+          .or_insert_with(|| format!("{}", viz_colors_len % max_colors + 1))
+          .clone()
+      }
+    }
+  }
+}
+
+pub struct Tracer;
+
+impl NodeTracer<NodeKey> for Tracer {
+  fn is_bottom(result: Option<Result<NodeResult, Failure>>) -> bool {
+    match result {
+      Some(Err(Failure::Invalidated)) => false,
+      Some(Err(Failure::Noop(..))) => true,
+      Some(Err(Failure::Throw(..))) => false,
+      Some(Ok(_)) => true,
+      None => {
+        // A Node with no state is either still running, or effectively cancelled
+        // because a dependent failed. In either case, it's not useful to render
+        // them, as we don't know whether they would have succeeded or failed.
+        true
+      }
+    }
+  }
+
+  fn state_str(indent: &str, result: Option<Result<NodeResult, Failure>>) -> String {
+    match result {
+      None => "<None>".to_string(),
+      Some(Ok(ref x)) => format!("{:?}", x),
+      Some(Err(Failure::Throw(ref x, ref traceback))) => format!(
+        "Throw({})\n{}",
+        externs::val_to_str(x),
+        traceback
+          .split("\n")
+          .map(|l| format!("{}    {}", indent, l))
+          .collect::<Vec<_>>()
+          .join("\n")
+      ),
+      Some(Err(Failure::Noop(ref x))) => format!("Noop({:?})", x),
+      Some(Err(Failure::Invalidated)) => "Invalidated".to_string(),
+    }
+  }
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum NodeKey {
   DigestFile(DigestFile),
@@ -903,7 +966,41 @@ pub enum NodeKey {
 }
 
 impl NodeKey {
-  pub fn format(&self) -> String {
+  fn product_str(&self) -> String {
+    fn typstr(tc: &TypeConstraint) -> String {
+      externs::key_to_str(&tc.0)
+    }
+    match self {
+      &NodeKey::ExecuteProcess(..) => "ProcessResult".to_string(),
+      &NodeKey::Select(ref s) => typstr(&s.selector.product),
+      &NodeKey::Task(ref s) => typstr(&s.product),
+      &NodeKey::Snapshot(..) => "Snapshot".to_string(),
+      &NodeKey::DigestFile(..) => "DigestFile".to_string(),
+      &NodeKey::ReadLink(..) => "LinkDest".to_string(),
+      &NodeKey::Scandir(..) => "DirectoryListing".to_string(),
+    }
+  }
+}
+
+impl Node for NodeKey {
+  type Context = Context;
+
+  type Item = NodeResult;
+  type Error = Failure;
+
+  fn run(self, context: Context) -> NodeFuture<NodeResult> {
+    match self {
+      NodeKey::DigestFile(n) => n.run(context).map(|v| v.into()).to_boxed(),
+      NodeKey::ExecuteProcess(n) => n.run(context).map(|v| v.into()).to_boxed(),
+      NodeKey::ReadLink(n) => n.run(context).map(|v| v.into()).to_boxed(),
+      NodeKey::Scandir(n) => n.run(context).map(|v| v.into()).to_boxed(),
+      NodeKey::Select(n) => n.run(context).map(|v| v.into()).to_boxed(),
+      NodeKey::Snapshot(n) => n.run(context).map(|v| v.into()).to_boxed(),
+      NodeKey::Task(n) => n.run(context).map(|v| v.into()).to_boxed(),
+    }
+  }
+
+  fn format(&self) -> String {
     fn keystr(key: &Key) -> String {
       externs::key_to_str(&key)
     }
@@ -932,25 +1029,7 @@ impl NodeKey {
     }
   }
 
-  pub fn product_str(&self) -> String {
-    fn typstr(tc: &TypeConstraint) -> String {
-      externs::key_to_str(&tc.0)
-    }
-    match self {
-      &NodeKey::ExecuteProcess(..) => "ProcessResult".to_string(),
-      &NodeKey::Select(ref s) => typstr(&s.selector.product),
-      &NodeKey::Task(ref s) => typstr(&s.product),
-      &NodeKey::Snapshot(..) => "Snapshot".to_string(),
-      &NodeKey::DigestFile(..) => "DigestFile".to_string(),
-      &NodeKey::ReadLink(..) => "LinkDest".to_string(),
-      &NodeKey::Scandir(..) => "DirectoryListing".to_string(),
-    }
-  }
-
-  ///
-  /// If this NodeKey represents an FS operation, returns its Path.
-  ///
-  pub fn fs_subject(&self) -> Option<&Path> {
+  fn fs_subject(&self) -> Option<&Path> {
     match self {
       &NodeKey::DigestFile(ref s) => Some(s.0.path.as_path()),
       &NodeKey::ReadLink(ref s) => Some((s.0).0.as_path()),
@@ -966,39 +1045,37 @@ impl NodeKey {
       | &NodeKey::Task { .. } => None,
     }
   }
+
+  fn digest(res: NodeResult) -> Option<hashing::Digest> {
+    match res {
+      NodeResult::Digest(d) => Some(d),
+      NodeResult::DirectoryListing(_)
+      | NodeResult::LinkDest(_)
+      | NodeResult::ProcessResult(_)
+      | NodeResult::Snapshot(_)
+      | NodeResult::Value(_) => None,
+    }
+  }
 }
 
-impl Node for NodeKey {
-  type Output = NodeResult;
+impl NodeError for Failure {
+  fn invalidated() -> Failure {
+    Failure::Invalidated
+  }
 
-  fn run(self, context: Context) -> NodeFuture<NodeResult> {
-    match self {
-      NodeKey::DigestFile(n) => n.run(context).map(|v| v.into()).to_boxed(),
-      NodeKey::ExecuteProcess(n) => n.run(context).map(|v| v.into()).to_boxed(),
-      NodeKey::ReadLink(n) => n.run(context).map(|v| v.into()).to_boxed(),
-      NodeKey::Scandir(n) => n.run(context).map(|v| v.into()).to_boxed(),
-      NodeKey::Select(n) => n.run(context).map(|v| v.into()).to_boxed(),
-      NodeKey::Snapshot(n) => n.run(context).map(|v| v.into()).to_boxed(),
-      NodeKey::Task(n) => n.run(context).map(|v| v.into()).to_boxed(),
-    }
+  fn cyclic() -> Failure {
+    Failure::Noop(Noop::Cycle)
   }
 }
 
 #[derive(Clone, Debug)]
 pub enum NodeResult {
-  Unit,
   Digest(hashing::Digest),
   DirectoryListing(DirectoryListing),
   LinkDest(LinkDest),
   ProcessResult(ProcessResult),
   Snapshot(fs::Snapshot),
   Value(Value),
-}
-
-impl From<()> for NodeResult {
-  fn from(_: ()) -> Self {
-    NodeResult::Unit
-  }
 }
 
 impl From<Value> for NodeResult {
@@ -1065,17 +1142,6 @@ impl TryFrom<NodeResult> for NodeResult {
 
   fn try_from(nr: NodeResult) -> Result<Self, ()> {
     Ok(nr)
-  }
-}
-
-impl TryFrom<NodeResult> for () {
-  type Err = ();
-
-  fn try_from(nr: NodeResult) -> Result<Self, ()> {
-    match nr {
-      NodeResult::Unit => Ok(()),
-      _ => Err(()),
-    }
   }
 }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -980,6 +980,23 @@ impl NodeKey {
       &NodeKey::Scandir(..) => "DirectoryListing".to_string(),
     }
   }
+
+  pub fn fs_subject(&self) -> Option<&Path> {
+    match self {
+      &NodeKey::DigestFile(ref s) => Some(s.0.path.as_path()),
+      &NodeKey::ReadLink(ref s) => Some((s.0).0.as_path()),
+      &NodeKey::Scandir(ref s) => Some((s.0).0.as_path()),
+
+      // Not FS operations:
+      // Explicitly listed so that if people add new NodeKeys they need to consider whether their
+      // NodeKey represents an FS operation, and accordingly whether they need to add it to the
+      // above list or the below list.
+      &NodeKey::ExecuteProcess { .. }
+      | &NodeKey::Select { .. }
+      | &NodeKey::Snapshot { .. }
+      | &NodeKey::Task { .. } => None,
+    }
+  }
 }
 
 impl Node for NodeKey {
@@ -1026,23 +1043,6 @@ impl Node for NodeKey {
         typstr(&s.product)
       ),
       &NodeKey::Snapshot(ref s) => format!("Snapshot({})", keystr(&s.0)),
-    }
-  }
-
-  fn fs_subject(&self) -> Option<&Path> {
-    match self {
-      &NodeKey::DigestFile(ref s) => Some(s.0.path.as_path()),
-      &NodeKey::ReadLink(ref s) => Some((s.0).0.as_path()),
-      &NodeKey::Scandir(ref s) => Some((s.0).0.as_path()),
-
-      // Not FS operations:
-      // Explicitly listed so that if people add new NodeKeys they need to consider whether their
-      // NodeKey represents an FS operation, and accordingly whether they need to add it to the
-      // above list or the below list.
-      &NodeKey::ExecuteProcess { .. }
-      | &NodeKey::Select { .. }
-      | &NodeKey::Snapshot { .. }
-      | &NodeKey::Task { .. } => None,
     }
   }
 

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -13,7 +13,7 @@ use boxfuture::{BoxFuture, Boxable};
 use context::{Context, Core};
 use core::{Failure, Key, TypeConstraint, TypeId, Value};
 use fs::{self, GlobMatching, PosixFS};
-use graph::{EntryId, Node, NodeContext};
+use graph::{EntryId, Graph, Node, NodeContext};
 use nodes::{NodeKey, Select, Tracer, TryInto, Visualizer};
 use rule_graph;
 use selectors;
@@ -287,9 +287,13 @@ struct RootContext {
 }
 
 impl NodeContext for RootContext {
-  type CloneFor = Context;
+  type Node = NodeKey;
 
   fn clone_for(&self, entry_id: EntryId) -> Context {
     Context::new(entry_id, self.core.clone())
+  }
+
+  fn graph(&self) -> &Graph<NodeKey> {
+    &self.core.graph
   }
 }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -294,6 +294,11 @@ type Root = Select;
 
 pub type RootResult = Result<Value, Failure>;
 
+///
+/// NB: This basic wrapper exists to allow us to implement the `NodeContext` trait (which lives
+/// outside of this crate) for the `Arc` struct (which also lives outside our crate), which is not
+/// possible without the wrapper due to "trait coherence".
+///
 #[derive(Clone)]
 struct RootContext {
   core: Arc<Core>,

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use futures::future::{self, Future};
@@ -130,6 +130,19 @@ impl Scheduler {
           rule_graph::type_str(subject_type)
         )
       })
+  }
+
+  ///
+  /// Invalidate the invalidation roots represented by the given Paths.
+  ///
+  pub fn invalidate(&self, paths: HashSet<PathBuf>) -> usize {
+    self.core.graph.invalidate_from_roots(move |node| {
+      if let Some(fs_subject) = node.fs_subject() {
+        paths.contains(fs_subject)
+      } else {
+        false
+      }
+    })
   }
 
   ///


### PR DESCRIPTION
### Problem

#4558 involves some relatively fidgety logic, but `Graph` was built in-situ and does not have any tests of its own.

### Solution

Extract and genericize `Graph` to allow for adding unit tests of the new behaviour in #4558. Add a very basic test; more useful ones will follow.