### PR TITLE
Switch to a per-entry state machine in Graph

### DIFF
--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -23,7 +23,7 @@ use fnv::FnvHasher;
 
 use futures::future::{self, Future};
 use futures::sync::oneshot;
-use petgraph::stable_graph::{StableDiGraph, StableGraph};
+use petgraph::graph::DiGraph;
 use petgraph::Direction;
 
 use boxfuture::{BoxFuture, Boxable};
@@ -31,7 +31,7 @@ pub use node::{EntryId, Node, NodeContext, NodeError, NodeTracer, NodeVisualizer
 
 type FNV = BuildHasherDefault<FnvHasher>;
 
-type PGraph<N> = StableDiGraph<Entry<N>, (), u32>;
+type PGraph<N> = DiGraph<Entry<N>, (), u32>;
 
 type RunToken = usize;
 
@@ -572,7 +572,7 @@ impl<N: Node> Graph<N> {
   pub fn new() -> Graph<N> {
     let inner = InnerGraph {
       nodes: HashMap::default(),
-      pg: StableGraph::new(),
+      pg: DiGraph::new(),
     };
     Graph {
       inner: Mutex::new(inner),

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -7,6 +7,7 @@ use std::hash::Hash;
 use boxfuture::BoxFuture;
 use hashing::Digest;
 
+use futures::future::Future;
 use petgraph::stable_graph;
 
 use Graph;
@@ -102,4 +103,14 @@ pub trait NodeContext: Clone + Send + 'static {
   /// Returns a reference to the Graph for this Context.
   ///
   fn graph(&self) -> &Graph<Self::Node>;
+
+  ///
+  /// Spawns a Future on an Executor provided by the context.
+  ///
+  /// NB: Unlike the futures `Executor` trait itself, this implementation _must_ spawn the work
+  /// on another thread, as it is called from within the Graph lock.
+  ///
+  fn spawn<F>(&self, future: F)
+  where
+    F: Future<Item = (), Error = ()> + Send + 'static;
 }

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -181,4 +181,11 @@ impl NodeContext for Context {
   fn graph(&self) -> &Graph<NodeKey> {
     &self.core.graph
   }
+
+  fn spawn<F>(&self, future: F)
+  where
+    F: Future<Item = (), Error = ()> + Send + 'static,
+  {
+    self.core.runtime.get().executor().spawn(future);
+  }
 }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -314,4 +314,11 @@ impl NodeContext for RootContext {
   fn graph(&self) -> &Graph<NodeKey> {
     &self.core.graph
   }
+
+  fn spawn<F>(&self, future: F)
+  where
+    F: Future<Item = (), Error = ()> + Send + 'static,
+  {
+    self.core.runtime.get().executor().spawn(future);
+  }
 }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -91,10 +91,11 @@ impl Scheduler {
       .visualize(Visualizer::default(), &session.root_nodes(), path)
   }
 
-  pub fn trace(&self, request: &ExecutionRequest, path: &Path) -> io::Result<()> {
-    for root in request.root_nodes() {
-      self.core.graph.trace::<Tracer>(&root, path)?;
-    }
+  pub fn trace(&self, request: &ExecutionRequest, path: &Path) -> Result<(), String> {
+    self
+      .core
+      .graph
+      .trace::<Tracer>(&request.root_nodes(), path)?;
     Ok(())
   }
 

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -141,19 +141,14 @@ class GraphTargetScanFailureTests(GraphTestBase):
 class GraphInvalidationTest(GraphTestBase):
 
   def test_invalidate_fsnode(self):
+    # NB: Invalidation is now more directly tested in unit tests in the `graph` crate.
     with self.open_scheduler(['3rdparty/python::']) as (_, _, scheduler):
-      initial_node_count = scheduler.node_count()
-      self.assertGreater(initial_node_count, 0)
-
       invalidated_count = scheduler.invalidate_files(['3rdparty/python/BUILD'])
       self.assertGreater(invalidated_count, 0)
-      self.assertLess(scheduler.node_count(), initial_node_count)
 
   def test_invalidate_fsnode_incremental(self):
+    # NB: Invalidation is now more directly tested in unit tests in the `graph` crate.
     with self.open_scheduler(['//:', '3rdparty/::']) as (_, _, scheduler):
-      node_count = scheduler.node_count()
-      self.assertGreater(node_count, 0)
-
       # Invalidate the '3rdparty/python' DirectoryListing, the `3rdparty` DirectoryListing,
       # and then the root DirectoryListing by "touching" files/dirs.
       for filename in ('3rdparty/python/BUILD', '3rdparty/jvm', 'non_existing_file'):
@@ -161,8 +156,6 @@ class GraphInvalidationTest(GraphTestBase):
         self.assertGreater(invalidated_count,
                            0,
                            'File {} did not invalidate any Nodes.'.format(filename))
-        node_count, last_node_count = scheduler.node_count(), node_count
-        self.assertLess(node_count, last_node_count)
 
   def _ordering_test(self, spec, expected_sources=None):
     expected_sources = expected_sources or ['p', 'a', 'n', 't', 's', 'b', 'u', 'i', 'l', 'd']


### PR DESCRIPTION
### Problem

#4558 introduces a new state for a `Node`: it may be `dirty`, which requires that we remember the previous value of a `Node` while simultaneously computing its next value. I began implementing this state machine with our existing `future::Shared` usage, but ran into the need to either hide values in the closure of the running future, or store values atomically outside of the future's value. This complexity represents a classic case for a state machine.

Additionally, we have seen that `future::Shared` has a relatively high cost in terms of complexity and memory (see #5990).

### Solution

In order to make #4558 easier to implement correctly (and to reduce memory usage), implement the storage of a `Node`'s value in the `Graph` via a state machine.

One of the largest complexities of `Shared` is that it needs to elect one of the waiters of the `Shared` future as the one who will actually do the work of `poll`ing the wrapped future. To avoid that complexity, we introduce usage of the `tokio` `Runtime` for _all_ `Node` executions. This allows waiters to stay very simple, and receive the result value via a `oneshot::channel`.

### Result

#4558 should be much easier to implement. I'll likely wait to land this until #4558 is further along. 

This change reduces memory usage about 200MB further than the fix from #5990 (down to about 2.5GB for `./pants list ::` in Twitter's repo).  Unfortunately, in its current form it also represents a performance regression of about 10% for that same usecase. Although I believe I have a handle on why, I'd like to defer fixing that regression until after #4558 is implemented.

This also fixes #3695, as since we now fail slowly, we are able to render multiple distinct failures at once.