### PR TITLE
Release Pants as a pex.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Conditions are documented here: https://docs.travis-ci.com/user/conditions-v1
+conditions: v1
+
 env:
   global:
     - PANTS_CONFIG_FILES="${TRAVIS_BUILD_DIR}/pants.travis-ci.ini"
@@ -48,6 +51,12 @@ cache:
     - build-support/isort.venv
     - build-support/pants_dev_deps.venv
 
+# Stages are documented here: https://docs.travis-ci.com/user/build-stages
+stages:
+  - Test Pants
+  - name: Deploy Pants Pex
+    if: tag IS present AND tag =~ ^release_.*$
+
 # NB: There is much repetition in include elements, but there is no known current way to factor
 # this duplication up.
 matrix:
@@ -58,6 +67,7 @@ matrix:
       # for debugging native code issues.
       # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
       osx_image: xcode7.3
+      stage: Test Pants
       language: generic
       env:
         - SHARD="OSX Native Engine Binary Builder"
@@ -66,6 +76,7 @@ matrix:
         - ./pants --version && ./build-support/bin/release.sh -n
 
     - os: linux
+      stage: Test Pants
       language: generic
       services:
         - docker
@@ -91,6 +102,26 @@ matrix:
         - build-support/bin/ci-failure.sh
 
     - os: linux
+      language: python
+      stage: Deploy Pants Pex
+      env:
+        - PANTS_PEX_RELEASE=stable
+      script:
+        - ./build-support/bin/release.sh -p
+      deploy:
+        # See https://docs.travis-ci.com/user/deployment/releases/
+        provider: releases
+        api_key:
+          secure: "GH+on0frVmTZv0ZE/36ERktsucCkS2Z+KhOqQ/PGUiTOwYm+2D3EWUlaU0lXlIdEzqULXIhCi8ikfmwZMJF+6YxSD8CA+DrGQosgxVQ042OKndxy8IUsaiAezsXp94AGtgrPjIrzNFpUmps9r5hnLCzIK64NjTkZQJIH5LLGupY="
+        file_glob: true
+        file: dist/deploy/pex/*
+        skip_cleanup: true
+        on:
+          # We only release a pex for Pants releases, which are tagged.
+          tags: true
+          repo: pantsbuild/pants
+
+    - os: linux
       dist: trusty
       sudo: required
       addons:
@@ -103,6 +134,7 @@ matrix:
             - python-dev
             - openssl
             - libssl-dev
+      stage: Test Pants
       language: python
       python: "2.7.13"
       before_install:
@@ -129,6 +161,7 @@ matrix:
             - python-dev
             - openssl
             - libssl-dev
+      stage: Test Pants
       language: python
       python: "2.7.13"
       before_install:
@@ -155,6 +188,7 @@ matrix:
             - python-dev
             - openssl
             - libssl-dev
+      stage: Test Pants
       language: python
       python: "2.7.13"
       before_install:
@@ -181,6 +215,7 @@ matrix:
             - python-dev
             - openssl
             - libssl-dev
+      stage: Test Pants
       language: python
       python: "2.7.13"
       before_install:
@@ -207,6 +242,7 @@ matrix:
             - python-dev
             - openssl
             - libssl-dev
+      stage: Test Pants
       language: python
       python: "2.7.13"
       before_install:
@@ -233,6 +269,7 @@ matrix:
             - python-dev
             - openssl
             - libssl-dev
+      stage: Test Pants
       language: python
       python: "2.7.13"
       before_install:
@@ -259,6 +296,7 @@ matrix:
             - python-dev
             - openssl
             - libssl-dev
+      stage: Test Pants
       language: python
       python: "2.7.13"
       before_install:
@@ -285,6 +323,7 @@ matrix:
             - python-dev
             - openssl
             - libssl-dev
+      stage: Test Pants
       language: python
       python: "2.7.13"
       before_install:
@@ -311,6 +350,7 @@ matrix:
             - python-dev
             - openssl
             - libssl-dev
+      stage: Test Pants
       language: python
       python: "2.7.13"
       before_install:
@@ -337,6 +377,7 @@ matrix:
             - python-dev
             - openssl
             - libssl-dev
+      stage: Test Pants
       language: python
       python: "2.7.13"
       before_install:
@@ -363,6 +404,7 @@ matrix:
             - python-dev
             - openssl
             - libssl-dev
+      stage: Test Pants
       language: python
       python: "2.7.13"
       before_install:
@@ -389,6 +431,7 @@ matrix:
             - python-dev
             - openssl
             - libssl-dev
+      stage: Test Pants
       language: python
       python: "2.7.13"
       before_install:
@@ -406,6 +449,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      stage: Test Pants
       language: python
       python: "2.7.13"
       addons:
@@ -428,6 +472,7 @@ matrix:
     - os: osx
       # Fuse actually works on this image. It hangs on many others.
       osx_image: xcode8.3
+      stage: Test Pants
       language: generic
       env:
         - SHARD="Rust + Platform-specific Tests OSX"

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -561,10 +561,12 @@ function build_pex() {
       esac
       local platforms=("${platform}")
       local dest="${ROOT}/dist/pants.${PANTS_UNSTABLE_VERSION}.${platform}.pex"
+      local stable_dest="${DEPLOY_DIR}/pex/pants.${PANTS_STABLE_VERSION}.${platform}.pex"
       ;;
     fetch)
       local platforms=("${linux_platform}" "${osx_platform}")
       local dest="${ROOT}/dist/pants.${PANTS_UNSTABLE_VERSION}.pex"
+      local stable_dest="${DEPLOY_DIR}/pex/pants.${PANTS_STABLE_VERSION}.pex"
       ;;
     *)
       echo >&2 "Bad build_pex mode ${mode}"
@@ -604,6 +606,11 @@ function build_pex() {
     -f "${DEPLOY_PANTS_WHEEL_DIR}/${PANTS_UNSTABLE_VERSION}" \
     -f "${DEPLOY_3RDPARTY_WHEEL_DIR}/${PANTS_UNSTABLE_VERSION}" \
     "${requirements[@]}"
+
+  if [[ "${PANTS_PEX_RELEASE}" == "stable" ]]; then
+    mkdir -p "$(dirname "${stable_dest}")"
+    cp "${dest}" "${stable_dest}"
+  fi
 
   banner "Successfully built ${dest}"
 }


### PR DESCRIPTION
This adds release automation of a Pants pex to our Travis CI job when
run against a release_* tag. There is more to be done to consume the pex
in the setup script we point users to, but the actual release should now
be covered.

Fixes #4896