### PR TITLE
Expose `PATH` in hermetic ITs.

### DIFF
--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -110,6 +110,12 @@ class PantsRunIntegrationTest(unittest.TestCase):
     return [
         # Used in the wrapper script to locate a rust install.
         'HOME',
+
+        # Used in the wrapper script to locate a python 2.7 binary via `which`; also used in
+        # pants.pex for the same purpose via a pex header shebang of `#!/usr/bin/env python2.7`.
+        'PATH',
+
+        # Allow profiling of integration tests,
         'PANTS_PROFILE',
       ]
 


### PR DESCRIPTION
Without `PATH` there is no way for the `./pants` script (or a
`pants.pex` for that matter), to find a python 2.7 interpreter.