### PR TITLE
Add .vscode/ folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 .buildcache/
 .coverage*
 .idea
-.vscode/
+/.vscode/
 .cache
 .pants.d
 .pants.run


### PR DESCRIPTION
### Problem
Workspace-specific configuration on Visual Studio Code creates a `.vscode/` folder to store the `settings.json` to store said configuration. Since there were already some editor-specific ignores in `gitignore`, I figured I might as well include VSCode's.

### Solution
I added `.vscode/` to the `.gitignore` file.

### Result
Now VSCode users won't see a dirty workspace when using project-defined configs :)