### PR TITLE
Ignore the `logs/` dir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ out/
 /build-support/phab/
 /dist/
 /lib/
+# This is created by the very handy `build-support/bin/get_failing_travis_targets_for_pr.sha`.
+/logs/
 arc.sh
 BUILD.release*
 pants.ini.sitegen


### PR DESCRIPTION
This is created by the very handy
`build-support/bin/get_failing_travis_targets_for_pr.sh` and its
contents should not be checked in.