### PR TITLE
Upgrade to v2 of bazel protobuf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@
 .python
 .pydevproject
 .pytest_cache/
-build/
 codegen/classes/
 htmlcov/
 out/

--- a/3rdparty/protobuf/bazelbuild_remote-apis/LICENSE
+++ b/3rdparty/protobuf/bazelbuild_remote-apis/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/3rdparty/protobuf/bazelbuild_remote-apis/README.md
+++ b/3rdparty/protobuf/bazelbuild_remote-apis/README.md
@@ -1,0 +1,12 @@
+This is a dump of the .proto files from https://github.com/bazelbuild/remote-apis directory build.
+
+This dump was taken at git sha cbf6ada7f5b2a0ce14646bf983d03b49118f0ec8.
+
+The following script was run to enable Bytes fields for Rust:
+```
+sed -i '' '/^package /a\
+\
+import "rustproto.proto";\
+option (rustproto.carllerche_bytes_for_bytes_all) = true;\
+' build/bazel/remote/execution/v2/remote_execution.proto
+```

--- a/3rdparty/protobuf/bazelbuild_remote-apis/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/3rdparty/protobuf/bazelbuild_remote-apis/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 The Bazel Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package google.devtools.remoteexecution.v1test;
+package build.bazel.remote.execution.v2;
 
 import "rustproto.proto";
 option (rustproto.carllerche_bytes_for_bytes_all) = true;
@@ -22,18 +22,19 @@ option (rustproto.carllerche_bytes_for_bytes_all) = true;
 import "google/api/annotations.proto";
 import "google/longrunning/operations.proto";
 import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
 import "google/rpc/status.proto";
 
-option csharp_namespace = "Google.RemoteExecution.V1Test";
-option go_package = "google.golang.org/genproto/googleapis/devtools/remoteexecution/v1test;remoteexecution";
+option csharp_namespace = "Build.Bazel.Remote.Execution.V2";
+option go_package = "remoteexecution";
 option java_multiple_files = true;
 option java_outer_classname = "RemoteExecutionProto";
-option java_package = "com.google.devtools.remoteexecution.v1test";
+option java_package = "build.bazel.remote.execution.v2";
 option objc_class_prefix = "REX";
 
 
 // The Remote Execution API is used to execute an
-// [Action][google.devtools.remoteexecution.v1test.Action] on the remote
+// [Action][build.bazel.remote.execution.v2.Action] on the remote
 // workers.
 //
 // As with other services in the Remote Execution API, any call may return an
@@ -44,12 +45,12 @@ service Execution {
   // Execute an action remotely.
   //
   // In order to execute an action, the client must first upload all of the
-  // inputs, as well as the
-  // [Command][google.devtools.remoteexecution.v1test.Command] to run, into the
-  // [ContentAddressableStorage][google.devtools.remoteexecution.v1test.ContentAddressableStorage].
-  // It then calls `Execute` with an
-  // [Action][google.devtools.remoteexecution.v1test.Action] referring to them.
-  // The server will run the action and eventually return the result.
+  // inputs, the
+  // [Command][build.bazel.remote.execution.v2.Command] to run, and the
+  // [Action][build.bazel.remote.execution.v2.Action] into the
+  // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
+  // It then calls `Execute` with an `action_digest` referring to them. The
+  // server will run the action and eventually return the result.
   //
   // The input `Action`'s fields MUST meet the various canonicalization
   // requirements specified in the documentation for their types so that it has
@@ -60,26 +61,22 @@ service Execution {
   // verify the requirement, then it will treat the `Action` as distinct from
   // another logically equivalent action if they hash differently.
   //
-  // Returns a [google.longrunning.Operation][google.longrunning.Operation]
+  // Returns a stream of
+  // [google.longrunning.Operation][google.longrunning.Operation] messages
   // describing the resulting execution, with eventual `response`
-  // [ExecuteResponse][google.devtools.remoteexecution.v1test.ExecuteResponse].
-  // The `metadata` on the operation is of type
-  // [ExecuteOperationMetadata][google.devtools.remoteexecution.v1test.ExecuteOperationMetadata].
+  // [ExecuteResponse][build.bazel.remote.execution.v2.ExecuteResponse]. The
+  // `metadata` on the operation is of type
+  // [ExecuteOperationMetadata][build.bazel.remote.execution.v2.ExecuteOperationMetadata].
   //
-  // To query the operation, you can use the
-  // [Operations API][google.longrunning.Operations.GetOperation]. If you wish
-  // to allow the server to stream operations updates, rather than requiring
-  // client polling, you can use the
-  // [Watcher API][google.watcher.v1.Watcher.Watch] with the Operation's `name`
-  // as the `target`.
-  //
-  // When using the Watcher API, the initial `data` will be the `Operation` at
-  // the time of the request. Updates will be provided periodically by the
-  // server until the `Operation` completes, at which point the response message
-  // will (assuming no error) be at `data.response`.
+  // If the client remains connected after the first response is returned after
+  // the server, then updates are streamed as if the client had called
+  // [WaitExecution][build.bazel.remote.execution.v2.Execution.WaitExecution]
+  // until the execution completes or the request reaches an error. The
+  // operation can also be queried using [Operations
+  // API][google.longrunning.Operations.GetOperation].
   //
   // The server NEED NOT implement other methods or functionality of the
-  // Operation and Watcher APIs.
+  // Operations API.
   //
   // Errors discovered during creation of the `Operation` will be reported
   // as gRPC Status errors, while errors that occurred while running the
@@ -104,24 +101,34 @@ service Execution {
   // where, for each requested blob not present in the CAS, there is a
   // `Violation` with a `type` of `MISSING` and a `subject` of
   // `"blobs/{hash}/{size}"` indicating the digest of the missing blob.
-  rpc Execute(ExecuteRequest) returns (google.longrunning.Operation) {
-    option (google.api.http) = { post: "/v1test/{instance_name=**}/actions:execute" body: "*" };
+  rpc Execute(ExecuteRequest) returns (stream google.longrunning.Operation) {
+    option (google.api.http) = { post: "/v2/{instance_name=**}/actions:execute" body: "*" };
+  }
+
+  // Wait for an execution operation to complete. When the client initially
+  // makes the request, the server immediately responds with the current status
+  // of the execution. The server will leave the request stream open until the
+  // operation completes, and then respond with the completed operation. The
+  // server MAY choose to stream additional updates as execution progresses,
+  // such as to provide an update as to the state of the execution.
+  rpc WaitExecution(WaitExecutionRequest) returns (stream google.longrunning.Operation) {
+    option (google.api.http) = { post: "/v2/{name=operations/**}:waitExecution" body: "*" };
   }
 }
 
 // The action cache API is used to query whether a given action has already been
 // performed and, if so, retrieve its result. Unlike the
-// [ContentAddressableStorage][google.devtools.remoteexecution.v1test.ContentAddressableStorage],
+// [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage],
 // which addresses blobs by their own content, the action cache addresses the
-// [ActionResult][google.devtools.remoteexecution.v1test.ActionResult] by a
-// digest of the encoded [Action][google.devtools.remoteexecution.v1test.Action]
+// [ActionResult][build.bazel.remote.execution.v2.ActionResult] by a
+// digest of the encoded [Action][build.bazel.remote.execution.v2.Action]
 // which produced them.
 //
 // The lifetime of entries in the action cache is implementation-specific, but
 // the server SHOULD assume that more recently used entries are more likely to
 // be used again. Additionally, action cache implementations SHOULD ensure that
 // any blobs referenced in the
-// [ContentAddressableStorage][google.devtools.remoteexecution.v1test.ContentAddressableStorage]
+// [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage]
 // are still valid when returning a result.
 //
 // As with other services in the Remote Execution API, any call may return an
@@ -134,22 +141,29 @@ service ActionCache {
   // Errors:
   // * `NOT_FOUND`: The requested `ActionResult` is not in the cache.
   rpc GetActionResult(GetActionResultRequest) returns (ActionResult) {
-    option (google.api.http) = { get: "/v1test/{instance_name=**}/actionResults/{action_digest.hash}/{action_digest.size_bytes}" };
+    option (google.api.http) = { get: "/v2/{instance_name=**}/actionResults/{action_digest.hash}/{action_digest.size_bytes}" };
   }
 
   // Upload a new execution result.
   //
   // This method is intended for servers which implement the distributed cache
   // independently of the
-  // [Execution][google.devtools.remoteexecution.v1test.Execution] API. As a
+  // [Execution][build.bazel.remote.execution.v2.Execution] API. As a
   // result, it is OPTIONAL for servers to implement.
+  //
+  // In order to allow the server to perform access control based on the type of
+  // action, and to assist with client debugging, the client MUST first upload
+  // the [Action][build.bazel.remote.execution.v2.Execution] that produced the
+  // result, along with its
+  // [Command][build.bazel.remote.execution.v2.Command], into the
+  // `ContentAddressableStorage`.
   //
   // Errors:
   // * `NOT_IMPLEMENTED`: This method is not supported by the server.
   // * `RESOURCE_EXHAUSTED`: There is insufficient storage space to add the
   //   entry to the cache.
   rpc UpdateActionResult(UpdateActionResultRequest) returns (ActionResult) {
-    option (google.api.http) = { put: "/v1test/{instance_name=**}/actionResults/{action_digest.hash}/{action_digest.size_bytes}" body: "action_result" };
+    option (google.api.http) = { put: "/v2/{instance_name=**}/actionResults/{action_digest.hash}/{action_digest.size_bytes}" body: "action_result" };
   }
 }
 
@@ -159,23 +173,23 @@ service ActionCache {
 //
 // Most of the binary data stored in the CAS is opaque to the execution engine,
 // and is only used as a communication medium. In order to build an
-// [Action][google.devtools.remoteexecution.v1test.Action],
+// [Action][build.bazel.remote.execution.v2.Action],
 // however, the client will need to also upload the
-// [Command][google.devtools.remoteexecution.v1test.Command] and input root
-// [Directory][google.devtools.remoteexecution.v1test.Directory] for the Action.
+// [Command][build.bazel.remote.execution.v2.Command] and input root
+// [Directory][build.bazel.remote.execution.v2.Directory] for the Action.
 // The Command and Directory messages must be marshalled to wire format and then
 // uploaded under the hash as with any other piece of content. In practice, the
 // input root directory is likely to refer to other Directories in its
 // hierarchy, which must also each be uploaded on their own.
 //
 // For small file uploads the client should group them together and call
-// [BatchUpdateBlobs][google.devtools.remoteexecution.v1test.ContentAddressableStorage.BatchUpdateBlobs]
+// [BatchUpdateBlobs][build.bazel.remote.execution.v2.ContentAddressableStorage.BatchUpdateBlobs]
 // on chunks of no more than 10 MiB. For large uploads, the client must use the
 // [Write method][google.bytestream.ByteStream.Write] of the ByteStream API. The
 // `resource_name` is `{instance_name}/uploads/{uuid}/blobs/{hash}/{size}`,
 // where `instance_name` is as described in the next paragraph, `uuid` is a
 // version 4 UUID generated by the client, and `hash` and `size` are the
-// [Digest][google.devtools.remoteexecution.v1test.Digest] of the blob. The
+// [Digest][build.bazel.remote.execution.v2.Digest] of the blob. The
 // `uuid` is used only to avoid collisions when multiple clients try to upload
 // the same file (or the same client tries to upload the file multiple times at
 // once on different threads), so the client MAY reuse the `uuid` for uploading
@@ -199,7 +213,7 @@ service ActionCache {
 // a response whose `committed_size` is the full size of the uploaded file
 // (regardless of how much data was transmitted by the client). If the client
 // completes the upload but the
-// [Digest][google.devtools.remoteexecution.v1test.Digest] does not match, an
+// [Digest][build.bazel.remote.execution.v2.Digest] does not match, an
 // `INVALID_ARGUMENT` error will be returned. In either case, the client should
 // not attempt to retry the upload.
 //
@@ -207,12 +221,12 @@ service ActionCache {
 // [Read method][google.bytestream.ByteStream.Read] of the ByteStream API, with
 // a `resource_name` of `"{instance_name}/blobs/{hash}/{size}"`, where
 // `instance_name` is the instance name (see above), and `hash` and `size` are
-// the [Digest][google.devtools.remoteexecution.v1test.Digest] of the blob.
+// the [Digest][build.bazel.remote.execution.v2.Digest] of the blob.
 //
 // The lifetime of entries in the CAS is implementation specific, but it SHOULD
 // be long enough to allow for newly-added and recently looked-up entries to be
 // used in subsequent calls (e.g. to
-// [Execute][google.devtools.remoteexecution.v1test.Execution.Execute]).
+// [Execute][build.bazel.remote.execution.v2.Execution.Execute]).
 //
 // As with other services in the Remote Execution API, any call may return an
 // error with a [RetryInfo][google.rpc.RetryInfo] error detail providing
@@ -226,7 +240,7 @@ service ContentAddressableStorage {
   //
   // There are no method-specific errors.
   rpc FindMissingBlobs(FindMissingBlobsRequest) returns (FindMissingBlobsResponse) {
-    option (google.api.http) = { post: "/v1test/{instance_name=**}/blobs:findMissing" body: "*" };
+    option (google.api.http) = { post: "/v2/{instance_name=**}/blobs:findMissing" body: "*" };
   }
 
   // Upload many blobs at once.
@@ -236,8 +250,9 @@ service ContentAddressableStorage {
   // chunks or uploaded using the
   // [ByteStream API][google.bytestream.ByteStream], as appropriate.
   //
-  // This request is equivalent to calling [UpdateBlob][] on each individual
-  // blob, in parallel. The requests may succeed or fail independently.
+  // This request is equivalent to calling a hypothetical `UpdateBlob` request
+  // on each individual blob, in parallel. The requests may succeed or fail
+  // independently.
   //
   // Errors:
   // * `INVALID_ARGUMENT`: The client attempted to upload more than 10 MiB of
@@ -246,15 +261,50 @@ service ContentAddressableStorage {
   // Individual requests may return the following errors, additionally:
   // * `RESOURCE_EXHAUSTED`: There is insufficient disk quota to store the blob.
   // * `INVALID_ARGUMENT`: The
-  // [Digest][google.devtools.remoteexecution.v1test.Digest] does not match the
+  // [Digest][build.bazel.remote.execution.v2.Digest] does not match the
   // provided data.
   rpc BatchUpdateBlobs(BatchUpdateBlobsRequest) returns (BatchUpdateBlobsResponse) {
-    option (google.api.http) = { post: "/v1test/{instance_name=**}/blobs:batchUpdate" body: "*" };
+    option (google.api.http) = { post: "/v2/{instance_name=**}/blobs:batchUpdate" body: "*" };
   }
 
-  // DEPRECATED: This method is deprecated and should no longer be used.
-  rpc GetTree(GetTreeRequest) returns (GetTreeResponse) {
-    option (google.api.http) = { get: "/v1test/{instance_name=**}/blobs/{root_digest.hash}/{root_digest.size_bytes}:getTree" };
+  // Fetch the entire directory tree rooted at a node.
+  //
+  // This request must be targeted at a
+  // [Directory][build.bazel.remote.execution.v2.Directory] stored in the
+  // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage]
+  // (CAS). The server will enumerate the `Directory` tree recursively and
+  // return every node descended from the root.
+  //
+  // The GetTreeRequest.page_token parameter can be used to skip ahead in
+  // the stream (e.g. when retrying a partially completed and aborted request),
+  // by setting it to a value taken from GetTreeResponse.next_page_token of the
+  // last successfully processed GetTreeResponse).
+  //
+  // The exact traversal order is unspecified and, unless retrieving subsequent
+  // pages from an earlier request, is not guaranteed to be stable across
+  // multiple invocations of `GetTree`.
+  //
+  // If part of the tree is missing from the CAS, the server will return the
+  // portion present and omit the rest.
+  //
+  // * `NOT_FOUND`: The requested tree root is not present in the CAS.
+  rpc GetTree(GetTreeRequest) returns (stream GetTreeResponse) {
+    option (google.api.http) = { get: "/v2/{instance_name=**}/blobs/{root_digest.hash}/{root_digest.size_bytes}:getTree" };
+  }
+}
+
+// The Capabilities service may be used by remote execution clients to query
+// various server properties, in order to self-configure or return meaningful
+// error messages.
+//
+// The query may include a particular `instance_name`, in which case the values
+// returned will pertain to that instance.
+service Capabilities {
+  // GetCapabilities returns the server capabilities configuration.
+  rpc GetCapabilities(GetCapabilitiesRequest) returns (ServerCapabilities) {
+    option (google.api.http) = {
+      get: "/v2/{instance_name=**}/capabilities"
+    };
   }
 }
 
@@ -269,65 +319,32 @@ service ContentAddressableStorage {
 // rather than needing to run afresh.
 //
 // When a server completes execution of an
-// [Action][google.devtools.remoteexecution.v1test.Action], it MAY choose to
-// cache the [result][google.devtools.remoteexecution.v1test.ActionResult] in
-// the [ActionCache][google.devtools.remoteexecution.v1test.ActionCache] unless
+// [Action][build.bazel.remote.execution.v2.Action], it MAY choose to
+// cache the [result][build.bazel.remote.execution.v2.ActionResult] in
+// the [ActionCache][build.bazel.remote.execution.v2.ActionCache] unless
 // `do_not_cache` is `true`. Clients SHOULD expect the server to do so. By
-// default, future calls to [Execute][] the same `Action` will also serve their
-// results from the cache. Clients must take care to understand the caching
-// behaviour. Ideally, all `Action`s will be reproducible so that serving a
-// result from cache is always desirable and correct.
+// default, future calls to
+// [Execute][build.bazel.remote.execution.v2.Execution.Execute] the same
+// `Action` will also serve their results from the cache. Clients must take care
+// to understand the caching behaviour. Ideally, all `Action`s will be
+// reproducible so that serving a result from cache is always desirable and
+// correct.
 message Action {
-  // The digest of the [Command][google.devtools.remoteexecution.v1test.Command]
+  // The digest of the [Command][build.bazel.remote.execution.v2.Command]
   // to run, which MUST be present in the
-  // [ContentAddressableStorage][google.devtools.remoteexecution.v1test.ContentAddressableStorage].
+  // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
   Digest command_digest = 1;
 
   // The digest of the root
-  // [Directory][google.devtools.remoteexecution.v1test.Directory] for the input
+  // [Directory][build.bazel.remote.execution.v2.Directory] for the input
   // files. The files in the directory tree are available in the correct
   // location on the build machine before the command is executed. The root
   // directory, as well as every subdirectory and content blob referred to, MUST
   // be in the
-  // [ContentAddressableStorage][google.devtools.remoteexecution.v1test.ContentAddressableStorage].
+  // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
   Digest input_root_digest = 2;
 
-  // A list of the output files that the client expects to retrieve from the
-  // action. Only the listed files, as well as directories listed in
-  // `output_directories`, will be returned to the client as output.
-  // Other files that may be created during command execution are discarded.
-  //
-  // The paths are specified using forward slashes (`/`) as path separators,
-  // even if the execution platform natively uses a different separator. The
-  // path MUST NOT include a trailing slash.
-  //
-  // In order to ensure consistent hashing of the same Action, the output paths
-  // MUST be sorted lexicographically by code point (or, equivalently, by UTF-8
-  // bytes).
-  repeated string output_files = 3;
-
-  // A list of the output directories that the client expects to retrieve from
-  // the action. Only the contents of the indicated directories (recursively
-  // including the contents of their subdirectories) will be
-  // returned, as well as files listed in `output_files`. Other files that may
-  // be created during command execution are discarded.
-  //
-  // The paths are specified using forward slashes (`/`) as path separators,
-  // even if the execution platform natively uses a different separator. The
-  // path MUST NOT include a trailing slash, unless the path is `"/"` (which,
-  // although not recommended, can be used to capture the entire working
-  // directory tree, including inputs).
-  //
-  // In order to ensure consistent hashing of the same Action, the output paths
-  // MUST be sorted lexicographically by code point (or, equivalently, by UTF-8
-  // bytes).
-  repeated string output_directories = 4;
-
-  // The platform requirements for the execution environment. The server MAY
-  // choose to execute the action on any worker satisfying the requirements, so
-  // the client SHOULD ensure that running the action on any such worker will
-  // have the same result.
-  Platform platform = 5;
+  reserved 3 to 5; // Used for fields moved to [Command][build.bazel.remote.execution.v2.Command].
 
   // A timeout after which the execution should be killed. If the timeout is
   // absent, then the client is specifying that the execution should continue
@@ -337,7 +354,7 @@ message Action {
   // reject the request.
   //
   // The timeout is a part of the
-  // [Action][google.devtools.remoteexecution.v1test.Action] message, and
+  // [Action][build.bazel.remote.execution.v2.Action] message, and
   // therefore two `Actions` with different timeouts are different, even if they
   // are otherwise identical. This is because, if they were not, running an
   // `Action` with a lower timeout than is required might result in a cache hit
@@ -352,7 +369,8 @@ message Action {
 }
 
 // A `Command` is the actual command executed by a worker running an
-// [Action][google.devtools.remoteexecution.v1test.Action].
+// [Action][build.bazel.remote.execution.v2.Action] and specifications of its
+// environment.
 //
 // Except as otherwise required, the environment (such as which system
 // libraries or binaries are available, and what filesystems are mounted where)
@@ -370,11 +388,7 @@ message Command {
 
   // The arguments to the command. The first argument must be the path to the
   // executable, which must be either a relative path, in which case it is
-  // evaluated with respect to the input root, or an absolute path. The `PATH`
-  // environment variable, or similar functionality on other systems, is not
-  // used to determine which executable to run.
-  //
-  // The working directory will always be the input root.
+  // evaluated with respect to the input root, or an absolute path.
   repeated string arguments = 1;
 
   // The environment variables to set when running the program. The worker may
@@ -385,21 +399,72 @@ message Command {
   // value, the environment variables MUST be lexicographically sorted by name.
   // Sorting of strings is done by code point, equivalently, by the UTF-8 bytes.
   repeated EnvironmentVariable environment_variables = 2;
+
+  // A list of the output files that the client expects to retrieve from the
+  // action. Only the listed files, as well as directories listed in
+  // `output_directories`, will be returned to the client as output.
+  // Other files that may be created during command execution are discarded.
+  //
+  // The paths are relative to the working directory of the action execution.
+  // The paths are specified using a single forward slash (`/`) as a path
+  // separator, even if the execution platform natively uses a different
+  // separator. The path MUST NOT include a trailing slash, nor a leading slash,
+  // being a relative path.
+  //
+  // In order to ensure consistent hashing of the same Action, the output paths
+  // MUST be sorted lexicographically by code point (or, equivalently, by UTF-8
+  // bytes).
+  //
+  // An output file cannot be duplicated, be a parent of another output file, be
+  // a child of a listed output directory, or have the same path as any of the
+  // listed output directories.
+  repeated string output_files = 3;
+
+  // A list of the output directories that the client expects to retrieve from
+  // the action. Only the contents of the indicated directories (recursively
+  // including the contents of their subdirectories) will be
+  // returned, as well as files listed in `output_files`. Other files that may
+  // be created during command execution are discarded.
+  //
+  // The paths are relative to the working directory of the action execution.
+  // The paths are specified using a single forward slash (`/`) as a path
+  // separator, even if the execution platform natively uses a different
+  // separator. The path MUST NOT include a trailing slash, nor a leading slash,
+  // being a relative path. The special value of empty string is allowed,
+  // although not recommended, and can be used to capture the entire working
+  // directory tree, including inputs.
+  //
+  // In order to ensure consistent hashing of the same Action, the output paths
+  // MUST be sorted lexicographically by code point (or, equivalently, by UTF-8
+  // bytes).
+  //
+  // An output directory cannot be duplicated, be a parent of another output
+  // directory, be a parent of a listed output file, or have the same path as
+  // any of the listed output files.
+  repeated string output_directories = 4;
+
+  // The platform requirements for the execution environment. The server MAY
+  // choose to execute the action on any worker satisfying the requirements, so
+  // the client SHOULD ensure that running the action on any such worker will
+  // have the same result.
+  Platform platform = 5;
+
+  // The working directory, relative to the input root, for the command to run
+  // in. It must be a directory which exists in the input tree. If it is left
+  // empty, then the action is run in the input root.
+  string working_directory = 6;
 }
 
-// A `Platform` is a set of requirements, such as hardware, operation system, or
+// A `Platform` is a set of requirements, such as hardware, operating system, or
 // compiler toolchain, for an
-// [Action][google.devtools.remoteexecution.v1test.Action]'s execution
+// [Action][build.bazel.remote.execution.v2.Action]'s execution
 // environment. A `Platform` is represented as a series of key-value pairs
 // representing the properties that are required of the platform.
-//
-// This message is currently being redeveloped since it is an overly simplistic
-// model of platforms.
 message Platform {
   // A single property for the environment. The server is responsible for
   // specifying the property `name`s that it accepts. If an unknown `name` is
   // provided in the requirements for an
-  // [Action][google.devtools.remoteexecution.v1test.Action], the server SHOULD
+  // [Action][build.bazel.remote.execution.v2.Action], the server SHOULD
   // reject the execution request. If permitted by the server, the same `name`
   // may occur multiple times.
   //
@@ -429,8 +494,8 @@ message Platform {
 }
 
 // A `Directory` represents a directory node in a file tree, containing zero or
-// more children [FileNodes][google.devtools.remoteexecution.v1test.FileNode]
-// and [DirectoryNodes][google.devtools.remoteexecution.v1test.DirectoryNode].
+// more children [FileNodes][build.bazel.remote.execution.v2.FileNode]
+// and [DirectoryNodes][build.bazel.remote.execution.v2.DirectoryNode].
 // Each `Node` contains its name in the directory, the digest of its content
 // (either a file blob or a `Directory` proto), as well as possibly some
 // metadata about the file or directory.
@@ -504,20 +569,22 @@ message FileNode {
   // The digest of the file's content.
   Digest digest = 2;
 
+  reserved 3; // Reserved to ensure wire-compatibility with `OutputFile`.
+
   // True if file is executable, false otherwise.
   bool is_executable = 4;
 }
 
 // A `DirectoryNode` represents a child of a
-// [Directory][google.devtools.remoteexecution.v1test.Directory] which is itself
+// [Directory][build.bazel.remote.execution.v2.Directory] which is itself
 // a `Directory` and its associated metadata.
 message DirectoryNode {
   // The name of the directory.
   string name = 1;
 
   // The digest of the
-  // [Directory][google.devtools.remoteexecution.v1test.Directory] object
-  // represented. See [Digest][google.devtools.remoteexecution.v1test.Digest]
+  // [Directory][build.bazel.remote.execution.v2.Directory] object
+  // represented. See [Digest][build.bazel.remote.execution.v2.Digest]
   // for information about how to take the digest of a proto message.
   Digest digest = 2;
 }
@@ -562,12 +629,47 @@ message Digest {
   int64 size_bytes = 2;
 }
 
+// ExecutedActionMetadata contains details about a completed execution.
+message ExecutedActionMetadata {
+  // The name of the worker which ran the execution.
+  string worker = 1;
+
+  // When was the action added to the queue.
+  google.protobuf.Timestamp queued_timestamp = 2;
+
+  // When the worker received the action.
+  google.protobuf.Timestamp worker_start_timestamp = 3;
+
+  // When the worker completed the action, including all stages.
+  google.protobuf.Timestamp worker_completed_timestamp = 4;
+
+  // When the worker started fetching action inputs.
+  google.protobuf.Timestamp input_fetch_start_timestamp = 5;
+
+  // When the worker finished fetching action inputs.
+  google.protobuf.Timestamp input_fetch_completed_timestamp = 6;
+
+  // When the worker started executing the action command.
+  google.protobuf.Timestamp execution_start_timestamp = 7;
+
+  // When the worker completed executing the action command.
+  google.protobuf.Timestamp execution_completed_timestamp = 8;
+
+  // When the worker started uploading action outputs.
+  google.protobuf.Timestamp output_upload_start_timestamp = 9;
+
+  // When the worker finished uploading action outputs.
+  google.protobuf.Timestamp output_upload_completed_timestamp = 10;
+}
+
 // An ActionResult represents the result of an
-// [Action][google.devtools.remoteexecution.v1test.Action] being run.
+// [Action][build.bazel.remote.execution.v2.Action] being run.
 message ActionResult {
-  // The output files of the action. For each output file requested, if the
-  // corresponding file existed after the action completed, a single entry will
-  // be present in the output list.
+  reserved 1; // Reserved for use as the resource name.
+
+  // The output files of the action. For each output file requested in the
+  // `output_files` field of the Action, if the corresponding file existed after
+  // the action completed, a single entry will be present in the output list.
   //
   // If the action does not produce the requested output, or produces a
   // directory where a regular file is expected or vice versa, then that output
@@ -575,11 +677,65 @@ message ActionResult {
   // list as desired; clients MUST NOT assume that the output list is sorted.
   repeated OutputFile output_files = 2;
 
-  // The output directories of the action. For each output directory requested,
-  // if the corresponding directory existed after the action completed, a single
-  // entry will be present in the output list, which will contain the digest of
-  // a [Tree][google.devtools.remoteexecution.v1.test.Tree] message containing
-  // the directory tree.
+  // The output directories of the action. For each output directory requested
+  // in the `output_directories` field of the Action, if the corresponding
+  // directory existed after the action completed, a single entry will be
+  // present in the output list, which will contain the digest of a
+  // [Tree][build.bazel.remote.execution.v2.Tree] message containing the
+  // directory tree, and the path equal exactly to the corresponding Action
+  // output_directories member.
+  //
+  // As an example, suppose the Action had an output directory `a/b/dir` and the
+  // execution produced the following contents in `a/b/dir`: a file named `bar`
+  // and a directory named `foo` with an executable file named `baz`. Then,
+  // output_directory will contain (hashes shortened for readability):
+  //
+  // ```json
+  // // OutputDirectory proto:
+  // {
+  //   path: "a/b/dir"
+  //   tree_digest: {
+  //     hash: "4a73bc9d03...",
+  //     size: 55
+  //   }
+  // }
+  // // Tree proto with hash "4a73bc9d03..." and size 55:
+  // {
+  //   root: {
+  //     files: [
+  //       {
+  //         name: "bar",
+  //         digest: {
+  //           hash: "4a73bc9d03...",
+  //           size: 65534
+  //         }
+  //       }
+  //     ],
+  //     directories: [
+  //       {
+  //         name: "foo",
+  //         digest: {
+  //           hash: "4cf2eda940...",
+  //           size: 43
+  //         }
+  //       }
+  //     ]
+  //   }
+  //   children : {
+  //     // (Directory proto with hash "4cf2eda940..." and size 43)
+  //     files: [
+  //       {
+  //         name: "baz",
+  //         digest: {
+  //           hash: "b2c941073e...",
+  //           size: 1294,
+  //         },
+  //         is_executable: true
+  //       }
+  //     ]
+  //   }
+  // }
+  // ```
   repeated OutputDirectory output_directories = 3;
 
   // The exit code of the command.
@@ -595,7 +751,7 @@ message ActionResult {
 
   // The digest for a blob containing the standard output of the action, which
   // can be retrieved from the
-  // [ContentAddressableStorage][google.devtools.remoteexecution.v1test.ContentAddressableStorage].
+  // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
   // See `stdout_raw` for when this will be set.
   Digest stdout_digest = 6;
 
@@ -609,43 +765,37 @@ message ActionResult {
 
   // The digest for a blob containing the standard error of the action, which
   // can be retrieved from the
-  // [ContentAddressableStorage][google.devtools.remoteexecution.v1test.ContentAddressableStorage].
+  // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
   // See `stderr_raw` for when this will be set.
   Digest stderr_digest = 8;
+
+  // The details of the execution that originally produced this result.
+  ExecutedActionMetadata execution_metadata = 9;
 }
 
 // An `OutputFile` is similar to a
-// [FileNode][google.devtools.remoteexecution.v1test.FileNode], but it is
-// tailored for output as part of an `ActionResult`. It allows a full file path
-// rather than only a name, and allows the server to include content inline.
+// [FileNode][build.bazel.remote.execution.v2.FileNode], but it is used as an
+// output in an `ActionResult`. It allows a full file path rather than
+// only a name.
 //
 // `OutputFile` is binary-compatible with `FileNode`.
 message OutputFile {
   // The full path of the file relative to the input root, including the
-  // filename. The path separator is a forward slash `/`.
+  // filename. The path separator is a forward slash `/`. Since this is a
+  // relative path, it MUST NOT begin with a leading forward slash.
   string path = 1;
 
   // The digest of the file's content.
   Digest digest = 2;
 
-  // The raw content of the file.
-  //
-  // This field may be used by the server to provide the content of a file
-  // inline in an
-  // [ActionResult][google.devtools.remoteexecution.v1test.ActionResult] and
-  // avoid requiring that the client make a separate call to
-  // [ContentAddressableStorage.GetBlob] to retrieve it.
-  //
-  // The client SHOULD NOT assume that it will get raw content with any request,
-  // and always be prepared to retrieve it via `digest`.
-  bytes content = 3;
+  reserved 3; // Used for a removed field in an earlier version of the API.
 
   // True if file is executable, false otherwise.
   bool is_executable = 4;
 }
 
 // A `Tree` contains all the
-// [Directory][google.devtools.remoteexecution.v1test.Directory] protos in a
+// [Directory][build.bazel.remote.execution.v2.Directory] protos in a
 // single directory Merkle tree, compressed into one message.
 message Tree {
   // The root directory in the tree.
@@ -661,21 +811,50 @@ message Tree {
 // An `OutputDirectory` is the output in an `ActionResult` corresponding to a
 // directory's full contents rather than a single file.
 message OutputDirectory {
-  // The full path of the directory relative to the input root, including the
-  // filename. The path separator is a forward slash `/`.
+  // The full path of the directory relative to the working directory. The path
+  // separator is a forward slash `/`. Since this is a relative path, it MUST
+  // NOT begin with a leading forward slash. The empty string value is allowed,
+  // and it denotes the entire working directory.
   string path = 1;
 
-  // DEPRECATED: This field is deprecated and should no longer be used.
-  Digest digest = 2;
+  reserved 2; // Used for a removed field in an earlier version of the API.
 
   // The digest of the encoded
-  // [Tree][google.devtools.remoteexecution.v1test.Tree] proto containing the
+  // [Tree][build.bazel.remote.execution.v2.Tree] proto containing the
   // directory's contents.
   Digest tree_digest = 3;
 }
 
+// An `ExecutionPolicy` can be used to control the scheduling of the action.
+message ExecutionPolicy {
+  // The priority (relative importance) of this action. Generally, a lower value
+  // means that the action should be run sooner than actions having a greater
+  // priority value, but the interpretation of a given value is server-
+  // dependent. A priority of 0 means the *default* priority. Priorities may be
+  // positive or negative, and such actions should run later or sooner than
+  // actions having the default priority, respectively. The particular semantics
+  // of this field is up to the server. In particular, every server will have
+  // their own supported range of priorities, and will decide how these map into
+  // scheduling policy.
+  int32 priority = 1;
+}
+
+// A `ResultsCachePolicy` is used for fine-grained control over how action
+// outputs are stored in the CAS and Action Cache.
+message ResultsCachePolicy {
+  // The priority (relative importance) of this content in the overall cache.
+  // Generally, a lower value means a longer retention time or other advantage,
+  // but the interpretation of a given value is server-dependent. A priority of
+  // 0 means a *default* value, decided by the server.
+  //
+  // The particular semantics of this field is up to the server. In particular,
+  // every server will have their own supported range of priorities, and will
+  // decide how these map into retention/eviction policy.
+  int32 priority = 1;
+}
+
 // A request message for
-// [Execution.Execute][google.devtools.remoteexecution.v1test.Execution.Execute].
+// [Execution.Execute][build.bazel.remote.execution.v2.Execution.Execute].
 message ExecuteRequest {
   // The instance of the execution system to operate against. A server may
   // support multiple instances of the execution system (with their own workers,
@@ -684,21 +863,25 @@ message ExecuteRequest {
   // omitted.
   string instance_name = 1;
 
-  // The action to be performed.
-  Action action = 2;
-
   // If true, the action will be executed anew even if its result was already
   // present in the cache. If false, the result may be served from the
-  // [ActionCache][google.devtools.remoteexecution.v1test.ActionCache].
+  // [ActionCache][build.bazel.remote.execution.v2.ActionCache].
   bool skip_cache_lookup = 3;
 
-  // DEPRECATED: This field should be ignored by clients and servers and will be
-  // removed.
-  int32 total_input_file_count = 4;
+  reserved 2, 4, 5; // Used for removed fields in an earlier version of the API.
 
-  // DEPRECATED: This field should be ignored by clients and servers and will be
-  // removed.
-  int64 total_input_file_bytes = 5;
+  // The digest of the [Action][build.bazel.remote.execution.v2.Action] to
+  // execute.
+  Digest action_digest = 6;
+
+  // An optional policy for execution of the action.
+  // The server will have a default policy if this is not provided.
+  ExecutionPolicy execution_policy = 7;
+
+  // An optional policy for the results of this execution in the remote cache.
+  // The server will have a default policy if this is not provided.
+  // This may be applied to both the ActionResult and the associated blobs.
+  ResultsCachePolicy results_cache_policy = 8;
 }
 
 // A `LogFile` is a log stored in the CAS.
@@ -715,7 +898,7 @@ message LogFile {
 }
 
 // The response message for
-// [Execution.Execute][google.devtools.remoteexecution.v1test.Execution.Execute],
+// [Execution.Execute][build.bazel.remote.execution.v2.Execution.Execute],
 // which will be contained in the [response
 // field][google.longrunning.Operation.response] of the
 // [Operation][google.longrunning.Operation].
@@ -749,7 +932,7 @@ message ExecuteResponse {
 }
 
 // Metadata about an ongoing
-// [execution][google.devtools.remoteexecution.v1test.Execution.Execute], which
+// [execution][build.bazel.remote.execution.v2.Execution.Execute], which
 // will be contained in the [metadata
 // field][google.longrunning.Operation.response] of the
 // [Operation][google.longrunning.Operation].
@@ -773,7 +956,7 @@ message ExecuteOperationMetadata {
 
   Stage stage = 1;
 
-  // The digest of the [Action][google.devtools.remoteexecution.v1test.Action]
+  // The digest of the [Action][build.bazel.remote.execution.v2.Action]
   // being executed.
   Digest action_digest = 2;
 
@@ -789,7 +972,15 @@ message ExecuteOperationMetadata {
 }
 
 // A request message for
-// [ActionCache.GetActionResult][google.devtools.remoteexecution.v1test.ActionCache.GetActionResult].
+// [WaitExecution][build.bazel.remote.execution.v2.Execution.WaitExecution].
+message WaitExecutionRequest {
+  // The name of the [Operation][google.longrunning.operations.v1.Operation]
+  // returned by [Execute][build.bazel.remote.execution.v2.Execution.Execute].
+  string name = 1;
+}
+
+// A request message for
+// [ActionCache.GetActionResult][build.bazel.remote.execution.v2.ActionCache.GetActionResult].
 message GetActionResultRequest {
   // The instance of the execution system to operate against. A server may
   // support multiple instances of the execution system (with their own workers,
@@ -798,13 +989,13 @@ message GetActionResultRequest {
   // omitted.
   string instance_name = 1;
 
-  // The digest of the [Action][google.devtools.remoteexecution.v1test.Action]
+  // The digest of the [Action][build.bazel.remote.execution.v2.Action]
   // whose result is requested.
   Digest action_digest = 2;
 }
 
 // A request message for
-// [ActionCache.UpdateActionResult][google.devtools.remoteexecution.v1test.ActionCache.UpdateActionResult].
+// [ActionCache.UpdateActionResult][build.bazel.remote.execution.v2.ActionCache.UpdateActionResult].
 message UpdateActionResultRequest {
   // The instance of the execution system to operate against. A server may
   // support multiple instances of the execution system (with their own workers,
@@ -813,17 +1004,22 @@ message UpdateActionResultRequest {
   // omitted.
   string instance_name = 1;
 
-  // The digest of the [Action][google.devtools.remoteexecution.v1test.Action]
+  // The digest of the [Action][build.bazel.remote.execution.v2.Action]
   // whose result is being uploaded.
   Digest action_digest = 2;
 
-  // The [ActionResult][google.devtools.remoteexecution.v1test.ActionResult]
+  // The [ActionResult][build.bazel.remote.execution.v2.ActionResult]
   // to store in the cache.
   ActionResult action_result = 3;
+
+  // An optional policy for the results of this execution in the remote cache.
+  // The server will have a default policy if this is not provided.
+  // This may be applied to both the ActionResult and the associated blobs.
+  ResultsCachePolicy results_cache_policy = 4;
 }
 
 // A request message for
-// [ContentAddressableStorage.FindMissingBlobs][google.devtools.remoteexecution.v1test.ContentAddressableStorage.FindMissingBlobs].
+// [ContentAddressableStorage.FindMissingBlobs][build.bazel.remote.execution.v2.ContentAddressableStorage.FindMissingBlobs].
 message FindMissingBlobsRequest {
   // The instance of the execution system to operate against. A server may
   // support multiple instances of the execution system (with their own workers,
@@ -837,14 +1033,14 @@ message FindMissingBlobsRequest {
 }
 
 // A response message for
-// [ContentAddressableStorage.FindMissingBlobs][google.devtools.remoteexecution.v1test.ContentAddressableStorage.FindMissingBlobs].
+// [ContentAddressableStorage.FindMissingBlobs][build.bazel.remote.execution.v2.ContentAddressableStorage.FindMissingBlobs].
 message FindMissingBlobsResponse {
   // A list of the blobs requested *not* present in the storage.
   repeated Digest missing_blob_digests = 2;
 }
 
 // A single request message for
-// [ContentAddressableStorage.BatchUpdateBlobs][google.devtools.remoteexecution.v1test.ContentAddressableStorage.BatchUpdateBlobs].
+// [ContentAddressableStorage.BatchUpdateBlobs][build.bazel.remote.execution.v2.ContentAddressableStorage.BatchUpdateBlobs].
 message UpdateBlobRequest {
   // The digest of the blob. This MUST be the digest of `data`.
   Digest content_digest = 1;
@@ -854,7 +1050,7 @@ message UpdateBlobRequest {
 }
 
 // A request message for
-// [ContentAddressableStorage.BatchUpdateBlobs][google.devtools.remoteexecution.v1test.ContentAddressableStorage.BatchUpdateBlobs].
+// [ContentAddressableStorage.BatchUpdateBlobs][build.bazel.remote.execution.v2.ContentAddressableStorage.BatchUpdateBlobs].
 message BatchUpdateBlobsRequest {
   // The instance of the execution system to operate against. A server may
   // support multiple instances of the execution system (with their own workers,
@@ -868,7 +1064,7 @@ message BatchUpdateBlobsRequest {
 }
 
 // A response message for
-// [ContentAddressableStorage.BatchUpdateBlobs][google.devtools.remoteexecution.v1test.ContentAddressableStorage.BatchUpdateBlobs].
+// [ContentAddressableStorage.BatchUpdateBlobs][build.bazel.remote.execution.v2.ContentAddressableStorage.BatchUpdateBlobs].
 message BatchUpdateBlobsResponse {
   // A response corresponding to a single blob that the client tried to upload.
   message Response {
@@ -884,8 +1080,7 @@ message BatchUpdateBlobsResponse {
 }
 
 // A request message for
-// [ContentAddressableStorage.GetTree][google.devtools.remoteexecution.v1test.ContentAddressableStorage.GetTree].
-// This message is deprecated and should no longer be used.
+// [ContentAddressableStorage.GetTree][build.bazel.remote.execution.v2.ContentAddressableStorage.GetTree].
 message GetTreeRequest {
   // The instance of the execution system to operate against. A server may
   // support multiple instances of the execution system (with their own workers,
@@ -895,9 +1090,9 @@ message GetTreeRequest {
   string instance_name = 1;
 
   // The digest of the root, which must be an encoded
-  // [Directory][google.devtools.remoteexecution.v1test.Directory] message
+  // [Directory][build.bazel.remote.execution.v2.Directory] message
   // stored in the
-  // [ContentAddressableStorage][google.devtools.remoteexecution.v1test.ContentAddressableStorage].
+  // [ContentAddressableStorage][build.bazel.remote.execution.v2.ContentAddressableStorage].
   Digest root_digest = 2;
 
   // A maximum page size to request. If present, the server will request no more
@@ -907,23 +1102,94 @@ message GetTreeRequest {
   int32 page_size = 3;
 
   // A page token, which must be a value received in a previous
-  // [GetTreeResponse][google.devtools.remoteexecution.v1test.GetTreeResponse].
+  // [GetTreeResponse][build.bazel.remote.execution.v2.GetTreeResponse].
   // If present, the server will use it to return the following page of results.
   string page_token = 4;
 }
 
 // A response message for
-// [ContentAddressableStorage.GetTree][google.devtools.remoteexecution.v1test.ContentAddressableStorage.GetTree].
-// This message is deprecated and should no longer be used.
+// [ContentAddressableStorage.GetTree][build.bazel.remote.execution.v2.ContentAddressableStorage.GetTree].
 message GetTreeResponse {
   // The directories descended from the requested root.
   repeated Directory directories = 1;
 
   // If present, signifies that there are more results which the client can
   // retrieve by passing this as the page_token in a subsequent
-  // [request][google.devtools.remoteexecution.v1test.GetTreeRequest].
+  // [request][build.bazel.remote.execution.v2.GetTreeRequest].
   // If empty, signifies that this is the last page of results.
   string next_page_token = 2;
+}
+
+// A request message for
+// [Capabilities.GetCapabilities][google.devtools.remoteexecution.v2.Capabilities.GetCapabilities].
+message GetCapabilitiesRequest {
+  // The instance of the execution system to operate against. A server may
+  // support multiple instances of the execution system (with their own workers,
+  // storage, caches, etc.). The server MAY require use of this field to select
+  // between them in an implementation-defined fashion, otherwise it can be
+  // omitted.
+  string instance_name = 1;
+}
+
+// A response message for
+// [Capabilities.GetCapabilities][google.devtools.remoteexecution.v2.Capabilities.GetCapabilities].
+message ServerCapabilities {
+  // Capabilities of the remote cache system.
+  CacheCapabilities cache_capabilities = 1;
+
+  // Capabilities of the remote execution system.
+  ExecutionCapabilities execution_capabilities = 2;
+}
+
+// The digest function used for converting values into keys for CAS and Action
+// Cache.
+enum DigestFunction {
+  UNKNOWN = 0;
+  SHA256 = 1;
+  SHA1 = 2;
+  MD5 = 3;
+}
+
+// Describes the server/instance capabilities for updating the action cache.
+message ActionCacheUpdateCapabilities {
+  bool update_enabled = 1;
+}
+
+// Allowed values for priority in
+// [ResultsCachePolicy][google.devtools.remoteexecution.v2.ResultsCachePolicy]
+// Used for querying both cache and execution valid priority ranges.
+message PriorityCapabilities {
+  // Supported range of priorities, including boundaries.
+  message PriorityRange {
+    int32 min_priority = 1;
+    int32 max_priority = 2;
+  }
+  repeated PriorityRange priorities = 1;
+}
+
+// Capabilities of the remote cache system.
+message CacheCapabilities {
+  // All the digest functions supported by the remote cache.
+  // Remote cache may support multiple digest functions simultaneously.
+  repeated DigestFunction digest_function = 1;
+
+  // Capabilities for updating the action cache.
+  ActionCacheUpdateCapabilities action_cache_update_capabilities = 2;
+
+  // Supported cache priority range for both CAS and ActionCache.
+  PriorityCapabilities cache_priority_capabilities = 3;
+}
+
+// Capabilities of the remote execution system.
+message ExecutionCapabilities {
+  // Remote execution may only support a single digest function.
+  DigestFunction digest_function = 1;
+
+  // Whether remote execution is enabled for the particular server/instance.
+  bool exec_enabled = 2;
+
+  // Supported execution priority range.
+  PriorityCapabilities execution_priority_capabilities = 3;
 }
 
 // Details for the tool used to call the API.
@@ -939,7 +1205,7 @@ message ToolDetails {
 // external context of the request. The server may use this for logging or other
 // purposes. To use it, the client attaches the header to the call using the
 // canonical proto serialization:
-// name: google.devtools.remoteexecution.v1test.requestmetadata-bin
+// name: build.bazel.remote.execution.v2.requestmetadata-bin
 // contents: the base64 encoded binary RequestMetadata message.
 message RequestMetadata {
   // The details for the tool invoking the requests.

--- a/src/rust/engine/process_execution/bazel_protos/build.rs
+++ b/src/rust/engine/process_execution/bazel_protos/build.rs
@@ -23,7 +23,7 @@ fn main() {
 
   protoc_grpcio::compile_grpc_protos(
     &[
-      "google/devtools/remoteexecution/v1test/remote_execution.proto",
+      "build/bazel/remote/execution/v2/remote_execution.proto",
       "google/bytestream/bytestream.proto",
       "google/rpc/code.proto",
       "google/rpc/error_details.proto",
@@ -32,6 +32,7 @@ fn main() {
       "google/protobuf/empty.proto",
     ],
     &[
+      thirdpartyprotobuf.join("bazelbuild_remote-apis"),
       thirdpartyprotobuf.join("googleapis"),
       thirdpartyprotobuf.join("standard"),
       thirdpartyprotobuf.join("rust-protobuf"),

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use bazel_protos;
@@ -8,7 +8,7 @@ use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
 use digest::{Digest as DigestTrait, FixedOutput};
 use fs::{self, File, PathStat, Store};
-use futures::{future, Future};
+use futures::{future, Future, Stream};
 use futures_timer::Delay;
 use grpcio;
 use hashing::{Digest, Fingerprint};
@@ -38,6 +38,40 @@ enum ExecutionError {
   NotFinished(String),
 }
 
+impl CommandRunner {
+  // The Execute API used to be unary, and became streaming. The contract of the streaming API is
+  // that if the client disconnects after one request, it should continue to function exactly like
+  // the unary API.
+  // For maximal compatibility with servers, we fall back to this unary-like behavior, and control
+  // our own polling rates.
+  fn oneshot_execute(
+    &self,
+    execute_request: Arc<bazel_protos::remote_execution::ExecuteRequest>,
+  ) -> BoxFuture<bazel_protos::operations::Operation, String> {
+    let stream = try_future!(
+      self
+        .execution_client
+        .get()
+        .execute(&execute_request)
+        .map_err(rpcerror_to_string)
+    );
+    stream
+        .take(1)
+        .into_future()
+        // Drop the _stream to disconnect so that the server doesn't keep the connection alive and
+        // continue sending on it.
+        .map_err(|(error, _stream)| rpcerror_to_string(error))
+        .and_then(|(maybe_operation, _stream)| {
+          // Drop the _stream to disconnect so that the server doesn't keep the connection alive and
+          // continue sending on it.
+          maybe_operation.ok_or_else(|| {
+            "Didn't get proper stream response from server during remote execution".to_owned()
+          })
+        })
+        .to_boxed()
+  }
+}
+
 impl super::CommandRunner for CommandRunner {
   ///
   /// Runs a command via a gRPC service implementing the Bazel Remote Execution API
@@ -57,42 +91,44 @@ impl super::CommandRunner for CommandRunner {
   /// timeout: polls in a tight loop.
   ///
   fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<FallibleExecuteProcessResult, String> {
-    let execution_client = self.execution_client.clone();
-    let execution_client2 = execution_client.clone();
     let operations_client = self.operations_client.clone();
 
     let store = self.store.clone();
     let execute_request_result = make_execute_request(&req);
 
-    let req_description = req.description;
-    let req_timeout = req.timeout;
+    let ExecuteProcessRequest {
+      description,
+      timeout,
+      ..
+    } = req;
 
     match execute_request_result {
-      Ok((command, execute_request)) => {
+      Ok((action, command, execute_request)) => {
         let command_runner = self.clone();
-        let command_digest = try_future!(execute_request.get_action().get_command_digest().into());
+        let command_runner2 = self.clone();
+        let execute_request = Arc::new(execute_request);
+        let execute_request2 = execute_request.clone();
         self
-          .upload_command(&command, command_digest)
+          .upload_proto(&command)
+          .join(self.upload_proto(&action))
           .and_then(move |_| {
             debug!(
               "Executing remotely request: {:?} (command: {:?})",
               execute_request, command
             );
-
-            map_grpc_result(execution_client.get().execute(&execute_request))
-              .map(|result| (Arc::new(execute_request), result))
+            command_runner.oneshot_execute(execute_request)
           })
-          .and_then(move |(execute_request, operation)| {
+          .and_then(move |operation| {
             let start_time = Instant::now();
 
             future::loop_fn((operation, 0), move |(operation, iter_num)| {
-              let req_description = req_description.clone();
+              let description = description.clone();
 
-              let execute_request = execute_request.clone();
-              let execution_client2 = execution_client2.clone();
+              let execute_request2 = execute_request2.clone();
               let store = store.clone();
               let operations_client = operations_client.clone();
-              command_runner
+              let command_runner2 = command_runner2.clone();
+              command_runner2
                 .extract_execute_response(operation)
                 .map(future::Loop::Break)
                 .or_else(move |value| {
@@ -103,15 +139,10 @@ impl super::CommandRunner for CommandRunner {
                         "Server reported missing digests; trying to upload: {:?}",
                         missing_digests
                       );
-                      let execute_request = execute_request.clone();
-                      let execution_client2 = execution_client2.clone();
+                      let execute_request = execute_request2.clone();
                       store.ensure_remote_has_recursive(missing_digests)
                               .and_then(move |()| {
-                                map_grpc_result(
-                                  execution_client2.get().execute(
-                                    &execute_request.clone()
-                                  )
-                                )
+                                command_runner2.oneshot_execute(execute_request)
                               })
                               // Reset `iter_num` on `MissingDigests`
                               .map(|operation| future::Loop::Continue((operation, 0)))
@@ -130,10 +161,10 @@ impl super::CommandRunner for CommandRunner {
                       // take the grpc result and cancel the op if too much time has passed.
                       let elapsed = start_time.elapsed();
 
-                      if elapsed > req_timeout {
+                      if elapsed > timeout {
                         future::err(format!(
                           "Exceeded time out of {:?} with {:?} for operation {}, {}",
-                          req_timeout, elapsed, operation_name, req_description
+                          timeout, elapsed, operation_name, description
                         )).to_boxed()
                       } else {
                         // maybe the delay here should be the min of remaining time and the backoff period
@@ -141,13 +172,16 @@ impl super::CommandRunner for CommandRunner {
                           .map_err(move |e| {
                             format!(
                               "Future-Delay errored at operation result polling for {}, {}: {}",
-                              operation_name, req_description, e
+                              operation_name, description, e
                             )
                           })
                           .and_then(move |_| {
-                            future::done(map_grpc_result(
-                              operations_client.get().get_operation(&operation_request),
-                            )).map(move |operation| {
+                            future::done(
+                              operations_client
+                                .get()
+                                .get_operation(&operation_request)
+                                .map_err(rpcerror_to_string),
+                            ).map(move |operation| {
                               future::Loop::Continue((operation, iter_num + 1))
                             })
                               .to_boxed()
@@ -204,24 +238,20 @@ impl CommandRunner {
     }
   }
 
-  fn upload_command(
-    &self,
-    command: &bazel_protos::remote_execution::Command,
-    command_digest: Digest,
-  ) -> BoxFuture<(), String> {
+  fn upload_proto<P: protobuf::Message>(&self, proto: &P) -> BoxFuture<(), String> {
     let store = self.store.clone();
     let store2 = store.clone();
     future::done(
-      command
+      proto
         .write_to_bytes()
-        .map_err(|e| format!("Error serializing command {:?}", e)),
+        .map_err(|e| format!("Error serializing proto {:?}", e)),
     ).and_then(move |command_bytes| store.store_file_bytes(Bytes::from(command_bytes), true))
       .map_err(|e| format!("Error saving digest to local store: {:?}", e))
-      .and_then(move |_| {
-        // TODO: Tune when we upload the command.
+      .and_then(move |digest| {
+        // TODO: Tune when we upload the proto.
         store2
-          .ensure_remote_has_recursive(vec![command_digest])
-          .map_err(|e| format!("Error uploading command {:?}", e))
+          .ensure_remote_has_recursive(vec![digest])
+          .map_err(|e| format!("Error uploading proto {:?}", e))
           .map(|_| ())
       })
       .to_boxed()
@@ -433,44 +463,19 @@ impl CommandRunner {
     &self,
     execute_response: &bazel_protos::remote_execution::ExecuteResponse,
   ) -> BoxFuture<Digest, ExecutionError> {
-    let mut futures = vec![];
-    let path_map = Arc::new(Mutex::new(HashMap::new()));
-    let path_map_2 = path_map.clone();
+    let mut path_map = HashMap::new();
     let path_stats_result: Result<Vec<PathStat>, String> = execute_response
       .get_result()
       .get_output_files()
       .into_iter()
       .map(|output_file| {
         let output_file_path_buf = PathBuf::from(output_file.get_path());
-        if output_file.has_digest() {
-          let digest: Result<Digest, String> = output_file.get_digest().into();
-          let mut underlying_path_map = path_map.lock().unwrap();
-          underlying_path_map.insert(output_file_path_buf.clone(), digest?);
-        } else {
-          let raw_content = output_file.content.clone();
-          let path_map_3 = path_map.clone();
-          let output_file_path_buf_2 = output_file_path_buf.clone();
-          let output_file_path_buf_3 = output_file_path_buf_2.clone();
-          futures.push(
-            self
-              .store
-              .store_file_bytes(raw_content, false)
-              .map_err(move |error| {
-                ExecutionError::Fatal(format!(
-                  "Error storing raw content for output file {:?}: {:?}",
-                  output_file_path_buf_3, error
-                ))
-              })
-              .map(move |digest| {
-                let mut underlying_path_map = path_map_3.lock().unwrap();
-                underlying_path_map.insert(output_file_path_buf_2, digest);
-              }),
-          );
-        }
+        let digest: Result<Digest, String> = output_file.get_digest().into();
+        path_map.insert(output_file_path_buf.clone(), digest?);
         Ok(PathStat::file(
           output_file_path_buf.clone(),
           File {
-            path: output_file_path_buf.clone(),
+            path: output_file_path_buf,
             is_executable: output_file.get_is_executable(),
           },
         ))
@@ -504,23 +509,16 @@ impl CommandRunner {
       }
     }
 
-    let store = self.store.clone();
-    future::join_all(futures)
-      .and_then(move |_| {
-        // The unwrap() below is safe because we have joined any futures that had references to the Arc
-        let path_wrap_mutex = Arc::try_unwrap(path_map_2).unwrap();
-        let underlying_path_map = path_wrap_mutex.into_inner().unwrap();
-        fs::Snapshot::digest_from_path_stats(
-          store,
-          StoreOneOffRemoteDigest::new(underlying_path_map),
-          &path_stats,
-        ).map_err(move |error| {
-          ExecutionError::Fatal(format!(
-            "Error when storing the output file directory info in the remote CAS: {:?}",
-            error
-          ))
-        })
-      })
+    fs::Snapshot::digest_from_path_stats(
+      self.store.clone(),
+      StoreOneOffRemoteDigest::new(path_map),
+      &path_stats,
+    ).map_err(move |error| {
+      ExecutionError::Fatal(format!(
+        "Error when storing the output file directory info in the remote CAS: {:?}",
+        error
+      ))
+    })
       .to_boxed()
   }
 }
@@ -529,6 +527,7 @@ fn make_execute_request(
   req: &ExecuteProcessRequest,
 ) -> Result<
   (
+    bazel_protos::remote_execution::Action,
     bazel_protos::remote_execution::Command,
     bazel_protos::remote_execution::ExecuteRequest,
   ),
@@ -542,10 +541,6 @@ fn make_execute_request(
     env.set_value(value.to_string());
     command.mut_environment_variables().push(env);
   }
-
-  let mut action = bazel_protos::remote_execution::Action::new();
-  action.set_command_digest(digest(&command)?);
-  action.set_input_root_digest((&req.input_files).into());
   let mut output_files = req
     .output_files
     .iter()
@@ -556,12 +551,16 @@ fn make_execute_request(
     })
     .collect::<Result<Vec<String>, String>>()?;
   output_files.sort();
-  action.set_output_files(protobuf::repeated::RepeatedField::from_vec(output_files));
+  command.set_output_files(protobuf::repeated::RepeatedField::from_vec(output_files));
+
+  let mut action = bazel_protos::remote_execution::Action::new();
+  action.set_command_digest(digest(&command)?);
+  action.set_input_root_digest((&req.input_files).into());
 
   let mut execute_request = bazel_protos::remote_execution::ExecuteRequest::new();
-  execute_request.set_action(action);
+  execute_request.set_action_digest(digest(&action)?);
 
-  Ok((command, execute_request))
+  Ok((action, command, execute_request))
 }
 
 fn format_error(error: &bazel_protos::status::Status) -> String {
@@ -573,15 +572,14 @@ fn format_error(error: &bazel_protos::status::Status) -> String {
   format!("{}: {}", error_code, error.get_message())
 }
 
-fn map_grpc_result<T>(result: grpcio::Result<T>) -> Result<T, String> {
-  match result {
-    Ok(value) => Ok(value),
-    Err(grpcio::Error::RpcFailure(status)) => Err(format!(
+fn rpcerror_to_string(error: grpcio::Error) -> String {
+  match error {
+    grpcio::Error::RpcFailure(status) => format!(
       "{:?}: {:?}",
       status.status,
       status.details.unwrap_or_else(|| "[no message]".to_string())
-    )),
-    Err(err) => Err(format!("{:?}", err)),
+    ),
+    err => format!("{:?}", err),
   }
 }
 
@@ -662,24 +660,38 @@ mod tests {
       env.set_value("value".to_owned());
       env
     });
-    let mut want_execute_request = bazel_protos::remote_execution::ExecuteRequest::new();
-    want_execute_request.set_action({
-      let mut action = bazel_protos::remote_execution::Action::new();
-      action.set_command_digest(
-        (&Digest(
-          Fingerprint::from_hex_string(
-            "7e487b414ca637093673c010eaacc56c6ffd573035133338ca282e952158d0f4",
-          ).unwrap(),
-          30,
-        )).into(),
-      );
-      action.set_input_root_digest((&input_directory.digest()).into());
-      action.mut_output_files().push("other/file".to_owned());
-      action.mut_output_files().push("path/to/file".to_owned());
-      action
-    });
+    want_command
+      .mut_output_files()
+      .push("other/file".to_owned());
+    want_command
+      .mut_output_files()
+      .push("path/to/file".to_owned());
 
-    assert_eq!(result, Ok((want_command, want_execute_request)));
+    let mut want_action = bazel_protos::remote_execution::Action::new();
+    want_action.set_command_digest(
+      (&Digest(
+        Fingerprint::from_hex_string(
+          "fb09aa134e9d84aed9c35a9dadb128ab6924285fbcb7e4bec0f65b5c08988a5f",
+        ).unwrap(),
+        56,
+      )).into(),
+    );
+    want_action.set_input_root_digest((&input_directory.digest()).into());
+
+    let mut want_execute_request = bazel_protos::remote_execution::ExecuteRequest::new();
+    want_execute_request.set_action_digest(
+      (&Digest(
+        Fingerprint::from_hex_string(
+          "736c7aca28d63a5b09c4549e0e70bf8cb1645070a038a51abd7283f611cbd6c6",
+        ).unwrap(),
+        140,
+      )).into(),
+    );
+
+    assert_eq!(
+      result,
+      Ok((want_action, want_command, want_execute_request))
+    );
   }
 
   #[test]
@@ -698,7 +710,7 @@ mod tests {
           timeout: Duration::from_millis(1000),
           description: "wrong command".to_string(),
         }).unwrap()
-          .1,
+          .2,
         vec![],
       ))
     };
@@ -719,7 +731,7 @@ mod tests {
 
       mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
         op_name.clone(),
-        super::make_execute_request(&execute_request).unwrap().1,
+        super::make_execute_request(&execute_request).unwrap().2,
         vec![
           make_incomplete_operation(&op_name),
           make_successful_operation(
@@ -803,7 +815,7 @@ mod tests {
         op_name.clone(),
         super::make_execute_request(&echo_roland_request())
           .unwrap()
-          .1,
+          .2,
         vec![make_successful_operation(
           &op_name.clone(),
           StdoutType::Raw(test_stdout.string()),
@@ -869,7 +881,7 @@ mod tests {
 
       mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
         op_name.clone(),
-        super::make_execute_request(&execute_request).unwrap().1,
+        super::make_execute_request(&execute_request).unwrap().2,
         Vec::from_iter(
           iter::repeat(make_incomplete_operation(&op_name))
             .take(4)
@@ -916,7 +928,7 @@ mod tests {
 
       mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
         op_name.clone(),
-        super::make_execute_request(&execute_request).unwrap().1,
+        super::make_execute_request(&execute_request).unwrap().2,
         vec![
           make_incomplete_operation(&op_name),
           make_delayed_incomplete_operation(&op_name, delayed_operation_time),
@@ -939,7 +951,7 @@ mod tests {
 
       mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
         op_name.clone(),
-        super::make_execute_request(&execute_request).unwrap().1,
+        super::make_execute_request(&execute_request).unwrap().2,
         vec![make_incomplete_operation(&op_name), {
           let mut op = bazel_protos::operations::Operation::new();
           op.set_name(op_name.clone());
@@ -972,7 +984,7 @@ mod tests {
 
       mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
         op_name.clone(),
-        super::make_execute_request(&execute_request).unwrap().1,
+        super::make_execute_request(&execute_request).unwrap().2,
         vec![{
           let mut op = bazel_protos::operations::Operation::new();
           op.set_name(op_name.to_string());
@@ -1002,7 +1014,7 @@ mod tests {
 
       mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
         op_name.clone(),
-        super::make_execute_request(&execute_request).unwrap().1,
+        super::make_execute_request(&execute_request).unwrap().2,
         vec![make_incomplete_operation(&op_name), {
           let mut op = bazel_protos::operations::Operation::new();
           op.set_name(op_name.to_string());
@@ -1032,7 +1044,7 @@ mod tests {
 
       mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
         op_name.clone(),
-        super::make_execute_request(&execute_request).unwrap().1,
+        super::make_execute_request(&execute_request).unwrap().2,
         vec![{
           let mut op = bazel_protos::operations::Operation::new();
           op.set_name(op_name.to_string());
@@ -1056,7 +1068,7 @@ mod tests {
 
       mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
         op_name.clone(),
-        super::make_execute_request(&execute_request).unwrap().1,
+        super::make_execute_request(&execute_request).unwrap().2,
         vec![make_incomplete_operation(&op_name), {
           let mut op = bazel_protos::operations::Operation::new();
           op.set_name(op_name.to_string());
@@ -1082,7 +1094,7 @@ mod tests {
         op_name.clone(),
         super::make_execute_request(&cat_roland_request())
           .unwrap()
-          .1,
+          .2,
         vec![
           make_incomplete_operation(&op_name),
           make_precondition_failure_operation(vec![missing_preconditionfailure_violation(
@@ -1142,7 +1154,7 @@ mod tests {
         op_name.clone(),
         super::make_execute_request(&cat_roland_request())
           .unwrap()
-          .1,
+          .2,
         vec![
           make_incomplete_operation(&op_name),
           make_precondition_failure_operation(vec![missing_preconditionfailure_violation(
@@ -1363,7 +1375,7 @@ mod tests {
         let op_name = "gimme-foo".to_string();
         mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&execute_request).unwrap().1,
+          super::make_execute_request(&execute_request).unwrap().2,
           vec![
             make_incomplete_operation(&op_name),
             make_successful_operation(
@@ -1394,7 +1406,7 @@ mod tests {
         let op_name = "gimme-foo".to_string();
         mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&execute_request).unwrap().1,
+          super::make_execute_request(&execute_request).unwrap().2,
           vec![
             make_incomplete_operation(&op_name),
             make_incomplete_operation(&op_name),

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -392,16 +392,12 @@ impl bazel_protos::remote_execution_grpc::ContentAddressableStorage for StubCASR
       None,
     ));
   }
-
   fn get_tree(
     &self,
     _ctx: grpcio::RpcContext,
     _req: bazel_protos::remote_execution::GetTreeRequest,
-    sink: grpcio::UnarySink<bazel_protos::remote_execution::GetTreeResponse>,
+    _sink: grpcio::ServerStreamingSink<bazel_protos::remote_execution::GetTreeResponse>,
   ) {
-    sink.fail(grpcio::RpcStatus::new(
-      grpcio::RpcStatusCode::Unimplemented,
-      None,
-    ));
+    unimplemented!()
   }
 }

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -398,6 +398,8 @@ impl bazel_protos::remote_execution_grpc::ContentAddressableStorage for StubCASR
     _req: bazel_protos::remote_execution::GetTreeRequest,
     _sink: grpcio::ServerStreamingSink<bazel_protos::remote_execution::GetTreeResponse>,
   ) {
+    // Our client doesn't currently use get_tree, so we don't bother implementing it.
+    // We will need to if the client starts wanting to use it.
     unimplemented!()
   }
 }


### PR DESCRIPTION
Key differences:
 * Execute is a streaming RPC - we only support a single response per
   stream.
 * Action is now a separate proto addressed by digest, rather than
   inlined.
 * Inline output files are no longer supported.
 * Output files are now specified on Command not Action.