### PR TITLE
Fix bad exclusion introduced during rushed change.

### DIFF
--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -67,7 +67,7 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/tests/java/org/pantsbuild/testproject/depman:old-tests',
       'testprojects/tests/java/org/pantsbuild/testproject/htmlreport:htmlreport',
       'testprojects/tests/java/org/pantsbuild/testproject/parallel.*',
-      'testprojects/src/python/python_distribution/fasthello_with_install_requires.*u',
+      'testprojects/src/python/python_distribution/fasthello_with_install_requires.*',
       'testprojects/src/python/unicode/compilation_failure',
     ]
 


### PR DESCRIPTION
In a hurry while landing #6032, I introduced a bug in the exclusions list for testprojects. I waited until Travis completed, but assumed that the failure I saw was spurious. Narrator: "The error was NOT spurious."