### PR TITLE
Fix go-import meta tag ends with /> #6036

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py
@@ -34,7 +34,7 @@ class GoImportMetaTagReader(Subsystem):
           \s+
           content=['"](?P<root>[^\s]+)\s+(?P<vcs>[^\s]+)\s+(?P<url>[^\s]+)['"]
           \s*
-      >""", flags=re.VERBOSE)
+      /?>""", flags=re.VERBOSE)
 
   @classmethod
   def find_meta_tags(cls, page_html):

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_go_import_meta_tag_reader.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_go_import_meta_tag_reader.py
@@ -105,3 +105,24 @@ class FetchersTest(unittest.TestCase):
 
     meta_tag_content = GoImportMetaTagReader.find_meta_tags(test_html)
     self.assertEqual(meta_tag_content, [])
+
+  def test_meta_tag_end_with_forward_slash(self):
+    test_html = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <meta name="go-import"
+          content="google.golang.org/notapi
+                   git
+                   https://code.googlesource.com/google-notapi-go-client" />
+    </head>
+    <body>
+    Nothing to see here.
+    Please <a href="https://godoc.org/google.golang.org/api/googleapi">move along</a>.
+    </body>
+    </html>
+    """
+
+    meta_tag_content = GoImportMetaTagReader.find_meta_tags(test_html)
+    self.assertEqual(meta_tag_content, [('google.golang.org/notapi', 'git',
+                      'https://code.googlesource.com/google-notapi-go-client')])


### PR DESCRIPTION
### Problem

Fix #6036 

### Solution

Modify regex.

### Result

Now some repo with <meta xxx /> can be discovered