### PR TITLE
Skip pyprep and pytest-prep if there are no python targest

### DIFF
--- a/src/python/pants/backend/python/tasks/gather_sources.py
+++ b/src/python/pants/backend/python/tasks/gather_sources.py
@@ -71,7 +71,7 @@ class GatherSources(Task):
     if versioned_targets:
       target_set_id = VersionedTargetSet.from_versioned_targets(versioned_targets).cache_key.hash
     else:
-      raise TaskError('Tried to get pex for no targets in gather_sources')
+      raise TaskError("Can't create pex in gather_sources: No python targets provided")
     source_pex_path = os.path.realpath(os.path.join(self.workdir, target_set_id))
     # Note that we check for the existence of the directory, instead of for invalid_vts,
     # to cover the empty case.

--- a/src/python/pants/backend/python/tasks/gather_sources.py
+++ b/src/python/pants/backend/python/tasks/gather_sources.py
@@ -44,10 +44,10 @@ class GatherSources(Task):
     round_manager.require_data('python')  # For codegen.
 
   def execute(self):
-    interpreter = self.context.products.get_data(PythonInterpreter)
     targets = self._collect_source_targets()
     if not targets:
       return
+    interpreter = self.context.products.get_data(PythonInterpreter)
 
     with self.invalidated(targets) as invalidation_check:
       pex = self._get_pex_for_versioned_targets(interpreter, invalidation_check.all_vts)

--- a/src/python/pants/backend/python/tasks/pytest_prep.py
+++ b/src/python/pants/backend/python/tasks/pytest_prep.py
@@ -11,6 +11,7 @@ import pkg_resources
 from pex.pex_info import PexInfo
 
 from pants.backend.python.subsystems.pytest import PyTest
+from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.python_execution_task_base import PythonExecutionTaskBase
 
 
@@ -70,6 +71,8 @@ class PytestPrep(PythonExecutionTaskBase):
                          content=pkg_resources.resource_string(__name__, 'coverage/plugin.py'))
 
   def execute(self):
+    if not self.context.targets(lambda t: isinstance(t, PythonTests)):
+      return
     pex_info = PexInfo.default()
     pex_info.entry_point = 'pytest'
     pytest_binary = self.create_pex(pex_info)

--- a/src/python/pants/backend/python/tasks/resolve_requirements.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pex.interpreter import PythonInterpreter
 
-from pants.backend.python.tasks.pex_build_util import has_python_requirements
+from pants.backend.python.tasks.pex_build_util import has_python_requirements, is_python_target
 from pants.backend.python.tasks.resolve_requirements_task_base import ResolveRequirementsTaskBase
 
 
@@ -24,6 +24,8 @@ class ResolveRequirements(ResolveRequirementsTaskBase):
     round_manager.require_data(PythonInterpreter)
 
   def execute(self):
+    if not self.context.targets(is_python_target):
+      return
     interpreter = self.context.products.get_data(PythonInterpreter)
     pex = self.resolve_requirements(interpreter, self.context.targets(has_python_requirements))
     self.context.products.register_data(self.REQUIREMENTS_PEX, pex)

--- a/src/python/pants/backend/python/tasks/resolve_requirements.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements.py
@@ -24,7 +24,7 @@ class ResolveRequirements(ResolveRequirementsTaskBase):
     round_manager.require_data(PythonInterpreter)
 
   def execute(self):
-    if not self.context.targets(is_python_target):
+    if not self.context.targets(lambda t: is_python_target(t) or has_python_requirements(t)):
       return
     interpreter = self.context.products.get_data(PythonInterpreter)
     pex = self.resolve_requirements(interpreter, self.context.targets(has_python_requirements))

--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -14,6 +14,7 @@ from pants.backend.python.interpreter_cache import PythonInterpreterCache
 from pants.backend.python.pex_util import create_bare_interpreter
 from pants.backend.python.subsystems.python_repos import PythonRepos
 from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.base.fingerprint_strategy import DefaultFingerprintHashingMixin, FingerprintStrategy
 from pants.invalidation.cache_manager import VersionedTargetSet
@@ -55,9 +56,12 @@ class SelectInterpreter(Task):
     return [PythonInterpreter]
 
   def execute(self):
-    python_tgts = self.context.targets(lambda tgt: isinstance(tgt, PythonTarget))
-    if not python_tgts:
+    python_tgts_and_reqs = self.context.targets(
+      lambda tgt: isinstance(tgt, (PythonTarget, PythonRequirementLibrary))
+    )
+    if not python_tgts_and_reqs:
       return
+    python_tgts = filter(lambda tgt: isinstance(tgt, PythonTarget), python_tgts_and_reqs)
     fs = PythonInterpreterFingerprintStrategy()
     with self.invalidated(python_tgts, fingerprint_strategy=fs) as invalidation_check:
       if (PythonSetup.global_instance().interpreter_search_paths

--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -56,6 +56,8 @@ class SelectInterpreter(Task):
 
   def execute(self):
     python_tgts = self.context.targets(lambda tgt: isinstance(tgt, PythonTarget))
+    if not python_tgts:
+      return
     fs = PythonInterpreterFingerprintStrategy()
     with self.invalidated(python_tgts, fingerprint_strategy=fs) as invalidation_check:
       if (PythonSetup.global_instance().interpreter_search_paths

--- a/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
+++ b/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
@@ -75,7 +75,6 @@ class SelectInterpreterTest(TaskTestBase):
                             dependencies=dependencies, compatibility=compatibility)
 
   def _select_interpreter(self, target_roots, should_invalidate=None):
-    """Return the version string of the interpreter selected for the target roots."""
     context = self.context(target_roots=target_roots)
     task = self.create_task(context)
     if should_invalidate is not None:
@@ -96,24 +95,29 @@ class SelectInterpreterTest(TaskTestBase):
       else:
         task._create_interpreter_path_file.assert_not_called()
 
-    interpreter = context.products.get_data(PythonInterpreter)
+    return context.products.get_data(PythonInterpreter)
+
+  def _select_interpreter_and_get_version(self, target_roots, should_invalidate=None):
+    """Return the version string of the interpreter selected for the target roots."""
+    interpreter = self._select_interpreter(target_roots, should_invalidate)
     self.assertTrue(isinstance(interpreter, PythonInterpreter))
     return interpreter.version_string
 
   def test_interpreter_selection(self):
-    self.assertEquals('IronPython-2.77.777', self._select_interpreter([self.reqtgt]))
-    self.assertEquals('IronPython-2.77.777', self._select_interpreter([self.tgt1]))
-    self.assertEquals('IronPython-2.88.888', self._select_interpreter([self.tgt2]))
-    self.assertEquals('IronPython-2.99.999', self._select_interpreter([self.tgt3]))
-    self.assertEquals('IronPython-2.77.777', self._select_interpreter([self.tgt4]))
-    self.assertEquals('IronPython-2.88.888', self._select_interpreter([self.tgt20]))
-    self.assertEquals('IronPython-2.99.999', self._select_interpreter([self.tgt30]))
-    self.assertEquals('IronPython-2.77.777', self._select_interpreter([self.tgt40]))
-    self.assertEquals('IronPython-2.99.999', self._select_interpreter([self.tgt2, self.tgt3]))
-    self.assertEquals('IronPython-2.88.888', self._select_interpreter([self.tgt2, self.tgt4]))
+    self.assertIsNone(self._select_interpreter([]))
+    self.assertEquals('IronPython-2.77.777', self._select_interpreter_and_get_version([self.reqtgt]))
+    self.assertEquals('IronPython-2.77.777', self._select_interpreter_and_get_version([self.tgt1]))
+    self.assertEquals('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt2]))
+    self.assertEquals('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt3]))
+    self.assertEquals('IronPython-2.77.777', self._select_interpreter_and_get_version([self.tgt4]))
+    self.assertEquals('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt20]))
+    self.assertEquals('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt30]))
+    self.assertEquals('IronPython-2.77.777', self._select_interpreter_and_get_version([self.tgt40]))
+    self.assertEquals('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt2, self.tgt3]))
+    self.assertEquals('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt2, self.tgt4]))
 
     with self.assertRaises(TaskError) as cm:
-      self._select_interpreter([self.tgt3, self.tgt4])
+      self._select_interpreter_and_get_version([self.tgt3, self.tgt4])
     self.assertIn('Unable to detect a suitable interpreter for compatibilities: '
                   'IronPython<2.99.999 && IronPython>2.88.888', str(cm.exception))
 
@@ -121,31 +125,31 @@ class SelectInterpreterTest(TaskTestBase):
     tgta = self._fake_target('tgta', compatibility=['IronPython>2.77.777'],
                              dependencies=[self.tgt3])
     self.assertEquals('IronPython-2.99.999',
-                      self._select_interpreter([tgta], should_invalidate=True))
+                      self._select_interpreter_and_get_version([tgta], should_invalidate=True))
 
     # A new target with different sources, but identical compatibility, shouldn't invalidate.
     self.create_file('tgtb/foo/bar/baz.py', 'fake content')
     tgtb = self._fake_target('tgtb', compatibility=['IronPython>2.77.777'],
                              dependencies=[self.tgt3], sources=['foo/bar/baz.py'])
     self.assertEquals('IronPython-2.99.999',
-                      self._select_interpreter([tgtb], should_invalidate=False))
+                      self._select_interpreter_and_get_version([tgtb], should_invalidate=False))
 
   def test_compatibility_AND(self):
     tgt = self._fake_target('tgt5', compatibility=['IronPython>2.77.777,<2.99.999'])
-    self.assertEquals('IronPython-2.88.888', self._select_interpreter([tgt]))
+    self.assertEquals('IronPython-2.88.888', self._select_interpreter_and_get_version([tgt]))
 
   def test_compatibility_AND_impossible(self):
     tgt = self._fake_target('tgt5', compatibility=['IronPython>2.77.777,<2.88.888'])
 
     with self.assertRaises(PythonInterpreterCache.UnsatisfiableInterpreterConstraintsError):
-      self._select_interpreter([tgt])
+      self._select_interpreter_and_get_version([tgt])
 
   def test_compatibility_OR(self):
     tgt = self._fake_target('tgt6', compatibility=['IronPython>2.88.888', 'IronPython<2.7'])
-    self.assertEquals('IronPython-2.99.999', self._select_interpreter([tgt]))
+    self.assertEquals('IronPython-2.99.999', self._select_interpreter_and_get_version([tgt]))
 
   def test_compatibility_OR_impossible(self):
     tgt = self._fake_target('tgt6', compatibility=['IronPython>2.99.999', 'IronPython<2.77.777'])
 
     with self.assertRaises(PythonInterpreterCache.UnsatisfiableInterpreterConstraintsError):
-      self._select_interpreter([tgt])
+      self._select_interpreter_and_get_version([tgt])

--- a/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
+++ b/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
@@ -14,6 +14,7 @@ from pex.interpreter import PythonInterpreter
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants.base.exceptions import TaskError
 from pants.util.dirutil import chmod_plus_x, safe_mkdtemp
@@ -56,6 +57,11 @@ class SelectInterpreterTest(TaskTestBase):
       fake_interpreter('ip ip2 2 2 99 999')
     ]
 
+    self.reqtgt = self.make_target(
+      spec='req',
+      target_type=PythonRequirementLibrary,
+      requirements=[],
+    )
     self.tgt1 = self._fake_target('tgt1')
     self.tgt2 = self._fake_target('tgt2', compatibility=['IronPython>2.77.777'])
     self.tgt3 = self._fake_target('tgt3', compatibility=['IronPython>2.88.888'])
@@ -95,7 +101,7 @@ class SelectInterpreterTest(TaskTestBase):
     return interpreter.version_string
 
   def test_interpreter_selection(self):
-    self.assertEquals('IronPython-2.77.777', self._select_interpreter([]))
+    self.assertEquals('IronPython-2.77.777', self._select_interpreter([self.reqtgt]))
     self.assertEquals('IronPython-2.77.777', self._select_interpreter([self.tgt1]))
     self.assertEquals('IronPython-2.88.888', self._select_interpreter([self.tgt2]))
     self.assertEquals('IronPython-2.99.999', self._select_interpreter([self.tgt3]))


### PR DESCRIPTION
This saves 4.75s from a simple junit test run.

Fixes #5158

We could fix this in a more principled way by modifying how `prepare` works. If we assume that a `BuildGraph` is always constructed by the engine, and never mutated (or is only mutated up until a known point), we could pass a `BuildGraph` (or possibly an index of `{TargetType: target_count}`) into `prepare`, and not require products which won't actually be needed based on the `BuildGraph`. This probably isn't worth a lot of effort, because v2 should also solve this problem, but if we can easily make the no-mutation guarantee, may be worthwhile. There are a lot of these surprisingly-expensive landmines which occasionally add up to multiple seconds of unnecessary work.