### PR TITLE
Clean up process execution python API

### DIFF
--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -71,12 +71,12 @@ class ExecuteProcessRequest(datatype([
   ):
     return cls.create_from_snapshot(
       argv,
-      env,
       EMPTY_SNAPSHOT,
+      description,
+      env,
       output_files,
       output_directories,
       timeout_seconds,
-      description
     )
 
   @classmethod

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -36,17 +36,22 @@ class ExecuteProcessRequest(datatype([
   def create_from_snapshot(
     cls,
     argv,
-    env,
     snapshot,
+    description,
+    env=None,
     output_files=(),
     output_directories=(),
     timeout_seconds=_default_timeout_seconds,
-    description='process'
   ):
-    cls._verify_env_is_dict(env)
+    if env is None:
+      env = ()
+    else:
+      cls._verify_env_is_dict(env)
+      env = tuple(env.items())
+
     return ExecuteProcessRequest(
       argv=argv,
-      env=tuple(env.items()),
+      env=env,
       input_files=snapshot.directory_digest,
       output_files=output_files,
       output_directories=output_directories,
@@ -58,11 +63,11 @@ class ExecuteProcessRequest(datatype([
   def create_with_empty_snapshot(
     cls,
     argv,
-    env,
+    description,
+    env=None,
     output_files=(),
     output_directories=(),
     timeout_seconds=_default_timeout_seconds,
-    description='process'
   ):
     return cls.create_from_snapshot(
       argv,

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -14,8 +14,8 @@ from types import GeneratorType
 from pants.base.exceptions import TaskError
 from pants.base.project_tree import Dir, File, Link
 from pants.build_graph.address import Address
-from pants.engine.fs import (DirectoryDigest, DirectoryToMaterialize,FileContent, FilesContent, Path, PathGlobs,
-                             PathGlobsAndRoot, Snapshot)
+from pants.engine.fs import (DirectoryDigest, DirectoryToMaterialize, FileContent, FilesContent,
+                             Path, PathGlobs, PathGlobsAndRoot, Snapshot)
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.engine.native import Function, TypeConstraint, TypeId
 from pants.engine.nodes import Return, State, Throw

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -14,7 +14,7 @@ from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.worker_pool import SubprocPool
-from pants.base.workunit import WorkUnitLabel
+from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.build_graph.target import Target
 from pants.engine.isolated_process import FallibleExecuteProcessResult
 from pants.goal.products import Products
@@ -379,7 +379,7 @@ class Context(object):
       build_graph.inject_address_closure(address)
     return build_graph
 
-  def execute_process_synchronously(self, execute_process_request, name, labels):
+  def execute_process_synchronously(self, execute_process_request, name, labels=None):
     """Executes a process (possibly remotely), and returns information about its output.
 
     :param execute_process_request: The ExecuteProcessRequest to run.
@@ -397,4 +397,5 @@ class Context(object):
       result = self._scheduler.product_request(FallibleExecuteProcessResult, [execute_process_request])[0]
       workunit.output("stdout").write(result.stdout)
       workunit.output("stderr").write(result.stderr)
+      workunit.set_outcome(WorkUnit.FAILURE if result.exit_code else WorkUnit.SUCCESS)
       return result

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -71,7 +71,6 @@ def cat_files_process_result_concatted(cat_exe_req):
   cat_files_snapshot = yield Get(Snapshot, PathGlobs, cat_exe_req.path_globs)
   process_request = ExecuteProcessRequest.create_from_snapshot(
     argv=cat_bin.argv_from_snapshot(cat_files_snapshot),
-    env=dict(),
     snapshot=cat_files_snapshot,
     output_files=(),
   )
@@ -102,9 +101,8 @@ class JavacVersionExecutionRequest(datatype([('binary_location', BinaryLocation)
 def process_request_from_javac_version(javac_version_exe_req):
   yield ExecuteProcessRequest.create_with_empty_snapshot(
     argv=javac_version_exe_req.gen_argv(),
-    env=dict(),
-    output_files=(),
-    description=javac_version_exe_req.description)
+    description=javac_version_exe_req.description,
+  )
 
 
 class JavacVersionOutput(datatype([('value', str)])): pass
@@ -169,7 +167,6 @@ def javac_compile_process_result(javac_compile_req):
   output_dirs = tuple({os.path.dirname(java_file) for java_file in java_files})
   process_request = ExecuteProcessRequest.create_from_snapshot(
     argv=javac_compile_req.argv_from_source_snapshot(sources_snapshot),
-    env=dict(),
     snapshot=sources_snapshot,
     output_directories=output_dirs,
     description='javac compilation'
@@ -198,6 +195,7 @@ class ExecuteProcessRequestTest(SchedulerTestBase, unittest.TestCase):
     env = env or dict()
     return ExecuteProcessRequest.create_with_empty_snapshot(
       argv=argv,
+      description='',
       env=env,
       output_files=(),
     )
@@ -296,9 +294,9 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     scheduler = self.mk_scheduler_in_example_fs(())
 
     request = ExecuteProcessRequest.create_with_empty_snapshot(
-      ("/bin/bash", "-c", "echo -n 'European Burmese' > roland"),
-      dict(),
-      ("roland",)
+      argv=("/bin/bash", "-c", "echo -n 'European Burmese' > roland"),
+      description="echo roland",
+      output_files=("roland",)
     )
 
     execute_process_result = self.execute_expecting_one_result(scheduler, ExecuteProcessResult, request).value
@@ -329,9 +327,7 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     scheduler = self.mk_scheduler_in_example_fs(())
 
     request = ExecuteProcessRequest.create_with_empty_snapshot(
-      ("/bin/bash", "-c", "/bin/sleep 1; echo -n 'European Burmese'"),
-      dict(),
-      tuple(),
+      argv=("/bin/bash", "-c", "/bin/sleep 1; echo -n 'European Burmese'"),
       timeout_seconds=0.1,
       description='sleepy-cat',
     )
@@ -378,9 +374,7 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     scheduler = self.mk_scheduler_in_example_fs(())
 
     request = ExecuteProcessRequest.create_with_empty_snapshot(
-      ("/bin/bash", "-c", "exit 1"),
-      dict(),
-      tuple(),
+      argv=("/bin/bash", "-c", "exit 1"),
       description='one-cat',
     )
 
@@ -392,9 +386,7 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     scheduler = self.mk_scheduler_in_example_fs(())
 
     request = ExecuteProcessRequest.create_with_empty_snapshot(
-      ("/bin/bash", "-c", "exit 1"),
-      dict(),
-      tuple(),
+      argv=("/bin/bash", "-c", "exit 1"),
       description='one-cat',
     )
 

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -72,7 +72,7 @@ def cat_files_process_result_concatted(cat_exe_req):
   process_request = ExecuteProcessRequest.create_from_snapshot(
     argv=cat_bin.argv_from_snapshot(cat_files_snapshot),
     snapshot=cat_files_snapshot,
-    output_files=(),
+    description='cat some files',
   )
   cat_process_result = yield Get(ExecuteProcessResult, ExecuteProcessRequest, process_request)
   yield Concatted(str(cat_process_result.stdout))


### PR DESCRIPTION
* Descriptions are important, so no longer optional.
* Env should be empty where possible, so default it thus.
* Set WorkUnit outcome