### PR TITLE
Add support for reusing Graph node values if their inputs haven't changed

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -224,6 +224,7 @@ void execution_request_destroy(ExecutionRequest*);
 
 uint64_t graph_len(Scheduler*);
 uint64_t graph_invalidate(Scheduler*, BufferBuffer);
+uint64_t graph_invalidate_all_paths(Scheduler*);
 PyResult graph_visualize(Scheduler*, Session*, char*);
 void graph_trace(Scheduler*, ExecutionRequest*, char*);
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -296,6 +296,11 @@ class Scheduler(object):
     logger.info('invalidated %d nodes for: %s', invalidated, filenames)
     return invalidated
 
+  def invalidate_all_files(self):
+    invalidated =  self._native.lib.graph_invalidate_all_paths(self._scheduler)
+    logger.info('invalidated all %d nodes', invalidated)
+    return invalidated
+
   def graph_len(self):
     return self._native.lib.graph_len(self._scheduler)
 
@@ -453,8 +458,14 @@ class SchedulerSession(object):
     return self.execution_request_literal(roots)
 
   def invalidate_files(self, direct_filenames):
-    """Calls `Graph.invalidate_files()` against an internal product Graph instance."""
+    """Invalidates the given filenames in an internal product Graph instance."""
     invalidated = self._scheduler.invalidate_files(direct_filenames)
+    self._maybe_visualize()
+    return invalidated
+
+  def invalidate_all_files(self):
+    """Invalidates all filenames in an internal product Graph instance."""
+    invalidated = self._scheduler.invalidate_all_files()
     self._maybe_visualize()
     return invalidated
 

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -169,6 +169,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +446,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -837,6 +846,23 @@ dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rand"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "redox_syscall"
@@ -1318,6 +1344,7 @@ dependencies = [
 "checksum cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0ebb87d1116151416c0cf66a0e3fb6430cccd120fd6300794b4dfaa050ac40ba"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
 "checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
 "checksum crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe8153ef04a7594ded05b427ffad46ddeaf22e63fd48d42b3e1e3bb4db07cae7"
@@ -1384,6 +1411,8 @@ dependencies = [
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6802c0e883716383777e147b7c21323d5de7527257c8b6dc1365a7f2983e90f6"
+"checksum rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -9,3 +9,6 @@ fnv = "1.0.5"
 futures = "^0.1.16"
 hashing = { path = "../hashing" }
 petgraph = "0.4.5"
+
+[dev-dependencies]
+rand = "0.5.3"

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -21,7 +21,7 @@ pub type EntryId = stable_graph::NodeIndex<u32>;
 pub trait Node: Clone + Eq + Hash + Send + 'static {
   type Context: NodeContext<Node = Self>;
 
-  type Item: Clone + Debug + Send + 'static;
+  type Item: Clone + Debug + Eq + Send + 'static;
   type Error: NodeError;
 
   fn run(self, context: Self::Context) -> BoxFuture<Self::Item, Self::Error>;
@@ -35,7 +35,7 @@ pub trait Node: Clone + Eq + Hash + Send + 'static {
   fn digest(result: Self::Item) -> Option<Digest>;
 }
 
-pub trait NodeError: Clone + Debug + Send {
+pub trait NodeError: Clone + Debug + Eq + Send {
   ///
   /// Creates an instance that represents that a Node was invalidated out of the
   /// Graph (generally while running).

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -18,7 +18,7 @@ pub type EntryId = stable_graph::NodeIndex<u32>;
 ///
 /// Defines executing a cacheable/memoizable step within the given NodeContext.
 ///
-pub trait Node: Clone + Eq + Hash + Send + 'static {
+pub trait Node: Clone + Debug + Eq + Hash + Send + 'static {
   type Context: NodeContext<Node = Self>;
 
   type Item: Clone + Debug + Eq + Send + 'static;

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -137,6 +137,14 @@ impl Value {
   }
 }
 
+impl PartialEq for Value {
+  fn eq(&self, other: &Value) -> bool {
+    externs::equals(self, other)
+  }
+}
+
+impl Eq for Value {}
+
 ///
 /// Implemented by calling back to python to clone the underlying Handle.
 ///
@@ -152,7 +160,7 @@ impl fmt::Debug for Value {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Failure {
   /// A Node failed because a filesystem change invalidated it or its inputs.
   /// A root requestor should usually immediately retry their request.

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -443,6 +443,13 @@ pub extern "C" fn graph_invalidate(scheduler_ptr: *mut Scheduler, paths_buf: Buf
 }
 
 #[no_mangle]
+pub extern "C" fn graph_invalidate_all_paths(scheduler_ptr: *mut Scheduler) -> u64 {
+  with_scheduler(scheduler_ptr, |scheduler| {
+    scheduler.invalidate_all_paths() as u64
+  })
+}
+
+#[no_mangle]
 pub extern "C" fn graph_len(scheduler_ptr: *mut Scheduler) -> u64 {
   with_scheduler(scheduler_ptr, |scheduler| scheduler.core.graph.len() as u64)
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -518,7 +518,7 @@ impl ExecuteProcess {
   }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProcessResult(process_execution::FallibleExecuteProcessResult);
 
 impl WrappedNode for ExecuteProcess {
@@ -549,7 +549,7 @@ impl From<ExecuteProcess> for NodeKey {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ReadLink(Link);
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LinkDest(PathBuf);
 
 impl WrappedNode for ReadLink {
@@ -613,7 +613,7 @@ impl From<DigestFile> for NodeKey {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Scandir(Dir);
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DirectoryListing(Vec<fs::Stat>);
 
 impl WrappedNode for Scandir {
@@ -1060,7 +1060,7 @@ impl NodeError for Failure {
   }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum NodeResult {
   Digest(hashing::Digest),
   DirectoryListing(DirectoryListing),

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -137,13 +137,15 @@ impl Scheduler {
   /// Invalidate the invalidation roots represented by the given Paths.
   ///
   pub fn invalidate(&self, paths: &HashSet<PathBuf>) -> usize {
-    self.core.graph.invalidate_from_roots(move |node| {
+    let invalidation_result = self.core.graph.invalidate_from_roots(move |node| {
       if let Some(fs_subject) = node.fs_subject() {
         paths.contains(fs_subject)
       } else {
         false
       }
-    })
+    });
+    // TODO: Expose.
+    invalidation_result.cleared + invalidation_result.dirtied
   }
 
   ///

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -149,6 +149,18 @@ impl Scheduler {
   }
 
   ///
+  /// Invalidate all filesystem dependencies in the graph.
+  ///
+  pub fn invalidate_all_paths(&self) -> usize {
+    let invalidation_result = self
+      .core
+      .graph
+      .invalidate_from_roots(|node| node.fs_subject().is_some());
+    // TODO: Expose.
+    invalidation_result.cleared + invalidation_result.dirtied
+  }
+
+  ///
   /// Return Scheduler and per-Session metrics.
   ///
   pub fn metrics(&self, session: &Session) -> HashMap<&str, i64> {

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -331,6 +331,7 @@ class TestBase(unittest.TestCase):
   def _reset_engine(self):
     if self._scheduler is not None:
       self._build_graph.reset()
+      self._scheduler.invalidate_all_files()
       # Eagerly free file handles, threads, connections, etc, held by the scheduler. In theory,
       # dropping the scheduler is equivalent, but it's easy for references to the scheduler to leak.
       self._scheduler.pre_fork()


### PR DESCRIPTION
### Problem

As described in #4558, we currently completely delete `Node`s from the `Graph` when their inputs have changed.

One concrete case where this is problematic is that all `Snapshots` in the graph end up with a dependency on the `scandir` outputs of all of their parent directories, because we need to expand symlinks recursively from the root when consuming a `Path` (in order to see whether any path component on the way down is a symlink). This means that changes anywhere above a `Snapshot` invalidate that `Snapshot`, and changes at the root of the repo invalidate _all_ `Snapshots` (although 99% of the syscalls they depend on are not invalidated, having no dependencies of their own).

But this case is just one of many cases affected by the current implementation: there are many other times where we re-compute more than we should due to the current `Node` invalidation strategy.

### Solution

Implement node "dirtying", as described on #4558.

There are a few components to this work:

* In addition to being `Entry::clear`ed (which will force a `Node` to re-run), a `Node` may be `Entry::dirty`ed. A "dirty" `Node` is eligible to be "cleaned" if its dependencies have not changed since it was dirtied.
* Each `Node` records a `Generation` value that acts as proxy for "my output has changed". The `Node` locally maintains this value, and when a Node re-runs for any reason (either due to being `dirtied` or `cleared`), it compares its new output value to its old output value to determine whether to increment the `Generation`.
* Each `Node` records the `Generation` values of the dependencies that it used to run, at the point when it runs. When a dirtied `Node` is deciding whether to re-run, it compares the previous generation values of its dependencies to their current dependency values: if they are equal, then the `Node` can be "cleaned": ie, its previous value can be used without re-running it.

This patch also expands the testing of `Graph` to differentiate dirtying a `Node` from clearing it, and confirms that the correct `Nodes` re-run in each of those cases.

### Result

Cleaning all `Nodes` involved in `./pants list ::` after touching `pants.ini` completes 6 times faster than recomputing them from scratch (56 seconds vs 336 seconds in our repository). More gains are likely possible by implementing the performance improvement(s) described on #6013. 

Fixes #4558 and fixes #4394.