### PR TITLE
Log more in rust tests

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -223,8 +223,8 @@ if [[ "${skip_rust_tests:-false}" == "false" ]]; then
       test_threads_flag="--test-threads=1"
     fi
 
-    RUST_BACKTRACE=all "${REPO_ROOT}/build-support/bin/native/cargo" test --all --nocapture \
-      --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" -- "${test_threads_flag}"
+    RUST_BACKTRACE=all "${REPO_ROOT}/build-support/bin/native/cargo" test --all \
+      --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" -- "${test_threads_flag}" --nocapture
   ) || die "Pants rust test failure"
   end_travis_section
 fi

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -223,7 +223,7 @@ if [[ "${skip_rust_tests:-false}" == "false" ]]; then
       test_threads_flag="--test-threads=1"
     fi
 
-    RUST_BACKTRACE=1 "${REPO_ROOT}/build-support/bin/native/cargo" test --all \
+    RUST_BACKTRACE=all "${REPO_ROOT}/build-support/bin/native/cargo" test --all --nocapture \
       --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" -- "${test_threads_flag}"
   ) || die "Pants rust test failure"
   end_travis_section


### PR DESCRIPTION
This should expose recursive backtraces when we see:
'thread panicked while panicking'