### PR TITLE
Remove and prevent inaccurate __eq__ implementations on datatype

### DIFF
--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -72,14 +72,6 @@ class UnhydratedStruct(datatype(['address', 'struct', 'dependencies'])):
   the `dependencies` field of StructWithDeps.
   """
 
-  def __eq__(self, other):
-    if type(self) != type(other):
-      return NotImplemented
-    return self.struct == other.struct
-
-  def __ne__(self, other):
-    return not (self == other)
-
   def __hash__(self):
     return hash(self.struct)
 

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -280,14 +280,6 @@ class HydratedTarget(datatype(['address', 'adaptor', 'dependencies'])):
   def addresses(self):
     return self.dependencies
 
-  def __eq__(self, other):
-    if type(self) != type(other):
-      return False
-    return self.address == other.address
-
-  def __ne__(self, other):
-    return not (self == other)
-
   def __hash__(self):
     return hash(self.address)
 

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -139,14 +139,6 @@ class AddressFamily(datatype(['namespace', 'objects_by_name'])):
       for name, (path, obj) in self.objects_by_name.items()
     }
 
-  def __eq__(self, other):
-    if not type(other) == type(self):
-      return NotImplemented
-    return self.namespace == other.namespace
-
-  def __ne__(self, other):
-    return not (self == other)
-
   def __hash__(self):
     return hash(self.namespace)
 
@@ -159,15 +151,21 @@ class ResolveError(MappingError):
   """Indicates an error resolving targets."""
 
 
-class AddressMapper(object):
+class AddressMapper(datatype([
+  'parser',
+  'build_patterns',
+  'build_ignore_patterns',
+  'exclude_target_regexps',
+  'subproject_roots',
+])):
   """Configuration to parse build files matching a filename pattern."""
 
-  def __init__(self,
-               parser,
-               build_patterns=None,
-               build_ignore_patterns=None,
-               exclude_target_regexps=None,
-               subproject_roots=None):
+  def __new__(cls,
+              parser,
+              build_patterns=None,
+              build_ignore_patterns=None,
+              exclude_target_regexps=None,
+              subproject_roots=None):
     """Create an AddressMapper.
 
     Both the set of files that define a mappable BUILD files and the parser used to parse those
@@ -180,27 +178,22 @@ class AddressMapper(object):
     :param list build_ignore_patterns: A list of path ignore patterns used when searching for BUILD files.
     :param list exclude_target_regexps: A list of regular expressions for excluding targets.
     """
-    self.parser = parser
-    self.build_patterns = tuple(build_patterns or [b'BUILD', b'BUILD.*'])
-    self.build_ignore_patterns = tuple(build_ignore_patterns or [])
-    self._exclude_target_regexps = exclude_target_regexps or []
-    self.exclude_patterns = [re.compile(pattern) for pattern in self._exclude_target_regexps]
-    self.subproject_roots = subproject_roots or []
+    build_patterns = tuple(build_patterns or [b'BUILD', b'BUILD.*'])
+    build_ignore_patterns = tuple(build_ignore_patterns or [])
+    exclude_target_regexps = tuple(exclude_target_regexps or [])
+    subproject_roots = tuple(subproject_roots or [])
+    return super(AddressMapper, cls).__new__(
+        cls,
+        parser,
+        build_patterns,
+        build_ignore_patterns,
+        exclude_target_regexps,
+        subproject_roots
+      )
 
-  def __eq__(self, other):
-    if self is other:
-      return True
-    if type(other) != type(self):
-      return NotImplemented
-    return (other.build_patterns == self.build_patterns and
-            other.parser == self.parser)
-
-  def __ne__(self, other):
-    return not (self == other)
-
-  def __hash__(self):
-    # Compiled regexes are not hashable.
-    return hash(self.parser)
+  @memoized_property
+  def exclude_patterns(self):
+    return tuple(re.compile(pattern) for pattern in self.exclude_target_regexps)
 
   def __repr__(self):
     return 'AddressMapper(parser={}, build_patterns={})'.format(self.parser, self.build_patterns)

--- a/src/python/pants/engine/struct.py
+++ b/src/python/pants/engine/struct.py
@@ -260,18 +260,15 @@ class Struct(Serializable, SerializableFactory, Validatable):
     return object.__getattribute__(self, item)
 
   def _key(self):
-    if self.address:
-      return self.address
-    else:
-      def hashable(value):
-        if isinstance(value, dict):
-          return tuple(sorted((k, hashable(v)) for k, v in value.items()))
-        elif isinstance(value, list):
-          return tuple(hashable(v) for v in value)
-        else:
-          return value
-      return tuple(sorted((k, hashable(v)) for k, v in self._kwargs.items()
-                          if k not in self._INHERITANCE_FIELDS))
+    def hashable(value):
+      if isinstance(value, dict):
+        return tuple(sorted((k, hashable(v)) for k, v in value.items()))
+      elif isinstance(value, list):
+        return tuple(hashable(v) for v in value)
+      else:
+        return value
+    return tuple(sorted((k, hashable(v)) for k, v in self._kwargs.items()
+                        if k not in self._INHERITANCE_FIELDS))
 
   def __hash__(self):
     return hash(self._key())

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -262,6 +262,14 @@ class DatatypeTest(BaseTest):
     with self.assertRaises(ValueError):
       datatype(['0isntanallowedfirstchar'])
 
+  def test_override_eq_disallowed(self):
+    class OverridesEq(datatype(['myval'])):
+      def __eq__(self, other):
+        return other.myval == self.myval
+    with self.assertRaises(TypeCheckError) as tce:
+      OverridesEq(1)
+    self.assertIn('Should not override __eq__.', str(tce.exception))
+
   def test_subclass_pickleable(self):
     before = ExportedDatatype(1)
     dumps = pickle.dumps(before, protocol=2)


### PR DESCRIPTION
### Problem

Overriding `__eq__` on `datatype` violates structural equality, and the assumptions that people have about `datatype` instances. Moreover, it is very error prone in the presence of #6059, which will be using `__eq__` to determine whether objects have changed.

### Solution

Make it impossible to override `__eq__` accidentally on `datatype` by attaching a canary to the `__eq__` method definition on the generated class. Remove a few `__eq__` implementations that violated structural equality and were thus causing issues in #6059.

### Result

`datatypes` behave as expected more frequently, and bugs are avoided. There is no noticeable impact on performance in my testing (likely these were overridden back when _every_ object ended up memoized, rather than just `Key` instances).