### PR TITLE
Run `futurize --stage1` to make safe changes for python 3 compatibility.

### DIFF
--- a/build-support/bin/check_header_helper.py
+++ b/build-support/bin/check_header_helper.py
@@ -8,6 +8,8 @@
 #
 # usage: check_header_helper.py dir1 [ dir2 [ ... ] ]
 
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 import os
 import re
 import sys
@@ -61,12 +63,12 @@ def main():
   for directory in dirs:
     failed_files.extend(check_dir(directory))
   if failed_files:
-    print 'ERROR: All .py files other than __init__.py should start with the following header:'
-    print
-    print EXPECTED_HEADER
-    print '---'
-    print 'The following {} file(s) do not conform:'.format(len(failed_files))
-    print '  {}'.format('\n  '.join(failed_files))
+    print('ERROR: All .py files other than __init__.py should start with the following header:')
+    print()
+    print(EXPECTED_HEADER)
+    print('---')
+    print('The following {} file(s) do not conform:'.format(len(failed_files)))
+    print('  {}'.format('\n  '.join(failed_files)))
     sys.exit(1)
 
 if __name__ == '__main__':

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -58,7 +58,7 @@ class MypyTask(ResolveRequirementsTaskBase):
 
   @staticmethod
   def is_python_target(target):
-    return isinstance(target, (PythonTarget,))
+    return isinstance(target, PythonTarget)
 
   def _calculate_python_sources(self, targets):
     """Generate a set of source files from the given targets."""

--- a/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/npm_resolver.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/npm_resolver.py
@@ -77,13 +77,13 @@ class NpmResolver(Subsystem, NodeResolverBase):
     else:
       package = {}
 
-    if not package.has_key('name'):
+    if 'name' not in package:
       package['name'] = target.package_name
     elif package['name'] != target.package_name:
       raise TaskError('Package name in the corresponding package.json is not the same '
                       'as the BUILD target name for {}'.format(target.address.reference()))
 
-    if not package.has_key('version'):
+    if 'version' not in package:
       package['version'] = '0.0.0'
 
     # TODO(Chris Pesto): Preserve compatibility with normal package.json files by dropping existing

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/trailing_whitespace.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/trailing_whitespace.py
@@ -27,9 +27,9 @@ class TrailingWhitespace(CheckstylePlugin):
         if token_start[0] == token_end[0]:
           exception_ranges[token_start[0]].append((token_start[1], token_end[1]))
         else:
-          exception_ranges[token_start[0]].append((token_start[1], sys.maxint))
+          exception_ranges[token_start[0]].append((token_start[1], sys.maxsize))
           for line in range(token_start[0] + 1, token_end[0]):
-            exception_ranges[line].append((0, sys.maxint))
+            exception_ranges[line].append((0, sys.maxsize))
           exception_ranges[token_end[0]].append((0, token_end[1]))
     return exception_ranges
 

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -138,7 +138,7 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
   def implementation_version(cls):
     return super(JUnitRun, cls).implementation_version() + [('JUnitRun', 3)]
 
-  _BATCH_ALL = sys.maxint
+  _BATCH_ALL = sys.maxsize
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -186,7 +186,7 @@ class JvmDependencyUsage(Task):
         try:
           with open(self.nodes_json(vt.results_dir)) as fp:
             return Node.from_cacheable_dict(json.load(fp),
-                                            lambda spec: self.context.resolve(spec).__iter__().next())
+                                            lambda spec: next(self.context.resolve(spec).__iter__()))
         except Exception:
           self.context.log.warn("Can't deserialize json for target {}".format(target))
           return Node(target.concrete_derived_from)

--- a/src/python/pants/backend/jvm/tasks/reports/junit_html_report.py
+++ b/src/python/pants/backend/jvm/tasks/reports/junit_html_report.py
@@ -76,7 +76,7 @@ class ReportTestSuite(object):
                            'using first result:\n -> {}'.format(suite_name,
                                                                 ', '.join(s.file for s in suites),
                                                                 '\n    '.join(map(str, cases))))
-        case = iter(cases).next()
+        case = next(iter(cases))
         tests += 1
         time += case.time
         if case.error:

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -276,9 +276,9 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
         if hasattr(current_target, 'test_platform'):
           info['test_platform'] = current_target.test_platform.name
 
-      info['roots'] = map(lambda (source_root, package_prefix): {
-        'source_root': source_root,
-        'package_prefix': package_prefix
+      info['roots'] = map(lambda source_root_package_prefix: {
+        'source_root': source_root_package_prefix[0],
+        'package_prefix': source_root_package_prefix[1]
       }, self._source_roots_for_target(current_target))
 
       if classpath_products:

--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -84,9 +84,9 @@ class Exiter(object):
 
   def handle_unhandled_exception(self, exc_class=None, exc=None, tb=None, add_newline=False):
     """Default sys.excepthook implementation for unhandled exceptions."""
-    exc_class = exc_class or sys.exc_type
-    exc = exc or sys.exc_value
-    tb = tb or sys.exc_traceback
+    exc_class = exc_class or sys.exc_info()[0]
+    exc = exc or sys.exc_info()[1]
+    tb = tb or sys.exc_info()[2]
 
     def format_msg(print_backtrace=True):
       msg = 'Exception caught: ({})\n'.format(type(exc))

--- a/src/python/pants/base/worker_pool.py
+++ b/src/python/pants/base/worker_pool.py
@@ -107,7 +107,7 @@ class WorkerPool(object):
 
     def submit_next():
       try:
-        self.submit_async_work(work_iter.next(), workunit_parent=workunit_parent,
+        self.submit_async_work(next(work_iter), workunit_parent=workunit_parent,
                                on_success=lambda x: submit_next(), on_failure=error)
       except StopIteration:
         done()  # The success case.

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -366,7 +366,7 @@ def _eager_fileset_with_spec(spec_path, filespec, snapshot, include_dirs=False):
   rel_include_globs = filespec['globs']
 
   relpath_adjusted_filespec = FilesetRelPathWrapper.to_filespec(rel_include_globs, spec_path)
-  if filespec.has_key('exclude'):
+  if 'exclude' in filespec:
     relpath_adjusted_filespec['exclude'] = [FilesetRelPathWrapper.to_filespec(e['globs'], spec_path)
                                             for e in filespec['exclude']]
 

--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import logging
 import os
-
+from functools import reduce
 
 logger = logging.getLogger(__name__)
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from collections import defaultdict
 from contextlib import contextmanager
+from functools import reduce
 
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatformSettings
 from pants.backend.jvm.targets.java_library import JavaLibrary

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_task.py
@@ -33,7 +33,7 @@ class JvmTaskTest(JvmTaskTestBase):
 
     context = self.context(target_roots=[self.t1, self.t2, self.t3])
 
-    self.classpath = [os.path.join(self.pants_workdir, entry) for entry in 'a', 'b']
+    self.classpath = [os.path.join(self.pants_workdir, entry) for entry in ('a', 'b')]
     self.populate_runtime_classpath(context, self.classpath)
 
     self.task = self.create_task(context)

--- a/tests/python/pants_test/net/http/test_fetcher.py
+++ b/tests/python/pants_test/net/http/test_fetcher.py
@@ -11,6 +11,7 @@ import os
 import SocketServer
 import unittest
 from contextlib import closing, contextmanager
+from functools import reduce
 from threading import Thread
 
 import mock

--- a/tests/python/pants_test/scm/test_git.py
+++ b/tests/python/pants_test/scm/test_git.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import types
 import unittest
 from contextlib import contextmanager
 from textwrap import dedent
@@ -144,7 +143,7 @@ class GitTest(unittest.TestCase):
     self.assertEquals(reader.Symlink, lstat('not-a-dir'))
     self.assertEquals(reader.File, lstat('README'))
     self.assertEquals(reader.Dir, lstat('dir'))
-    self.assertEquals(types.NoneType, lstat('nope-not-here'))
+    self.assertEquals(type(None), lstat('nope-not-here'))
 
   def test_readlink(self):
     reader = self.git.repo_reader(self.initial_rev)

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -194,7 +194,7 @@ class ContextutilTest(unittest.TestCase):
     falsey = (None, '', False)
     for invalid in falsey:
       with self.assertRaises(InvalidZipPath):
-        open_zip(invalid).gen.next()
+        next(open_zip(invalid).gen)
 
   def test_open_zip_returns_realpath_on_badzipfile(self):
     # In case of file corruption, deleting a Pants-constructed symlink would not resolve the error.
@@ -204,7 +204,7 @@ class ContextutilTest(unittest.TestCase):
         os.symlink(not_zip.name, file_symlink)
         self.assertEquals(os.path.realpath(file_symlink), os.path.realpath(not_zip.name))
         with self.assertRaisesRegexp(zipfile.BadZipfile, r'{}'.format(not_zip.name)):
-          open_zip(file_symlink).gen.next()
+          next(open_zip(file_symlink).gen)
 
   @contextmanager
   def _stdio_as_tempfiles(self):
@@ -295,11 +295,11 @@ class ContextutilTest(unittest.TestCase):
     ])
 
   def test_permissions(self):
-    with temporary_file(permissions=0700) as f:
-      self.assertEquals(0700, os.stat(f.name)[0] & 0777)
+    with temporary_file(permissions=0o700) as f:
+      self.assertEquals(0o700, os.stat(f.name)[0] & 0o777)
 
-    with temporary_dir(permissions=0644) as path:
-      self.assertEquals(0644, os.stat(path)[0] & 0777)
+    with temporary_dir(permissions=0o644) as path:
+      self.assertEquals(0o644, os.stat(path)[0] & 0o777)
 
   def test_exception_logging(self):
     fake_logger = mock.Mock()


### PR DESCRIPTION
### Problem
First stage of [Python 3 port](https://github.com/pantsbuild/pants/issues/6062)

### Solution
Stage 1 of the futurize tool only makes safe changes, and it keeps the code base at Python 2. See http://python-future.org/futurize.html#forwards-conversion-stage1. Stage 2 will later convert this to actual Python 3 code.

This command was ran on
- src/python
- test/python
- contrib
- examples
- pants-plugins
- build-support/bin/check-header-helper.py

(not ran on testprojects)