### PR TITLE
Add future library to dependencies for python2-3 compatibility.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -6,6 +6,7 @@ coverage>=4.5,<4.6
 docutils>=0.12,<0.13
 fasteners==0.14.1
 faulthandler==2.6
+future==0.16.0
 futures==3.0.5
 isort==4.2.5
 Markdown==2.1.1


### PR DESCRIPTION
### Problem
Stage 2 of [Python 3 port](https://github.com/pantsbuild/pants/issues/6062)

### Solution
The `future` library provides tools to write cross-compatible py2/py3 code. It provides several imports similar to `six`, along with the `futurize` script to go py2->py3 and the `pasteurize` script to go py3->py2.

See http://python-future.org/overview.html for features and more context.

### Result
`./pants` correctly adds the module to the virtual env (`./build-support/pants_dev_deps.venv/bin/futurize`) and allows for importing `future`