### PR TITLE
Add future lib and port src/base

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,11 +1,13 @@
 ansicolors==1.0.2
 beautifulsoup4>=4.3.2,<4.4
 cffi==1.11.1
+configparser==3.5.0
 contextlib2==0.5.5
 coverage>=4.5,<4.6
 docutils>=0.12,<0.13
 fasteners==0.14.1
 faulthandler==2.6
+future==0.16.0
 futures==3.0.5
 isort==4.2.5
 Markdown==2.1.1

--- a/pants-plugins/src/python/internal_backend/sitegen/tasks/sitegen.py
+++ b/pants-plugins/src/python/internal_backend/sitegen/tasks/sitegen.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import cgi
 import collections
 import json
 import os
@@ -354,7 +355,9 @@ def generate_generated(config, here):
 
 def render_html(dst, config, soups, precomputed, template):
   soup = soups[dst]
-  renderer = Renderer()
+  renderer = Renderer(escape=cgi.escape)  # TODO(python3port): cgi.escape is deprecated in favor html.escape
+                                          # (the default used by Pystache on Python3). html.escape() escapes single
+                                          # quotes, whereas cgi.escape() does not. This will need to be addressed.
   title = precomputed.page[dst].title
   topdots = ('../' * dst.count('/'))
   if soup.body:

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -5,6 +5,7 @@ python_library(
   name = 'build_environment',
   sources = ['build_environment.py'],
   dependencies = [
+    '3rdparty/python:future',
     ':build_root',
     'src/python/pants/scm',
     'src/python/pants/scm:git',
@@ -75,6 +76,7 @@ python_library(
   name = 'fingerprint_strategy',
   sources = ['fingerprint_strategy.py'],
   dependencies = [
+    '3rdparty/python:future',
     ':deprecated',
     'src/python/pants/util:meta',
   ]
@@ -85,6 +87,7 @@ python_library(
   sources = ['generator.py'],
   dependencies = [
     ':mustache',
+    '3rdparty/python:future',
     '3rdparty/python:pystache',
   ]
 )
@@ -92,12 +95,16 @@ python_library(
 python_library(
   name = 'hash_utils',
   sources = ['hash_utils.py'],
+  dependencies = [
+    '3rdparty/python:future',
+  ]
 )
 
 python_library(
   name = 'mustache',
   sources = ['mustache.py'],
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python:pystache',
     '3rdparty/python:six',
   ]
@@ -106,17 +113,24 @@ python_library(
 python_library(
   name = 'parse_context',
   sources = ['parse_context.py'],
+  dependencies = [
+    '3rdparty/python:future',
+  ]
 )
 
 python_library(
   name = 'payload',
   sources = ['payload.py'],
+  dependencies = [
+    '3rdparty/python:future',
+  ]
 )
 
 python_library(
   name = 'payload_field',
   sources = ['payload_field.py'],
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':deprecated',
     ':hash_utils',
@@ -136,12 +150,16 @@ python_library(
 python_library(
   name = 'revision',
   sources = ['revision.py'],
+  dependencies = [
+    '3rdparty/python:future',
+  ]
 )
 
 python_library(
   name = 'run_info',
   sources = ['run_info.py'],
   dependencies = [
+    '3rdparty/python:future',
     ':build_environment',
     'src/python/pants/util:dirutil',
     'src/python/pants:version',
@@ -152,6 +170,7 @@ python_library(
   name = 'cmd_line_spec_parser',
   sources = ['cmd_line_spec_parser.py'],
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':build_file',
     ':specs',
@@ -171,6 +190,7 @@ python_library(
   name = 'worker_pool',
   sources = ['worker_pool.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/reporting:report', # TODO(pl): Bust this out
   ],
 )
@@ -179,7 +199,7 @@ python_library(
   name = 'workunit',
   sources = ['workunit.py'],
   dependencies = [
-    '3rdparty/python:six',
+    '3rdparty/python:future',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
     'src/python/pants/util:rwbuf',
@@ -200,6 +220,7 @@ python_library(
   name='exiter',
   sources=['exiter.py'],
   dependencies=[
+    '3rdparty/python:future',
     '3rdparty/python:faulthandler',
     'src/python/pants/util:dirutil'
   ]

--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import os
 import sys
+from builtins import str
 
 from pants.base.build_root import BuildRoot
 from pants.scm.scm import Scm

--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+from builtins import object
 
 from pants.base.specs import DescendantAddresses, SiblingAddresses, SingleAddress
 

--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -11,6 +11,7 @@ import os
 import signal
 import sys
 import traceback
+from builtins import object
 
 import faulthandler
 import six

--- a/src/python/pants/base/fingerprint_strategy.py
+++ b/src/python/pants/base/fingerprint_strategy.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import logging
 from abc import abstractmethod
+from builtins import object
 
 from pants.util.meta import AbstractClass
 

--- a/src/python/pants/base/generator.py
+++ b/src/python/pants/base/generator.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import pprint
+from builtins import object
 
 import pystache
 

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import hashlib
 import json
+from builtins import object
 
 
 def hash_all(strs, digest=None):

--- a/src/python/pants/base/mustache.py
+++ b/src/python/pants/base/mustache.py
@@ -35,7 +35,7 @@ class MustacheRenderer(object):
         return [convert_val(e) for e in x]
       else:
         return x
-    items = [(key, convert_val(val)) for (key, val) in list(args.items())]
+    items = [(key, convert_val(val)) for (key, val) in args.items()]
     ret = dict([(key + '?', True) for (key, val) in items if val and not key.endswith('?')])
     ret.update(dict(items))
     return ret

--- a/src/python/pants/base/mustache.py
+++ b/src/python/pants/base/mustache.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import pkgutil
+from builtins import object
 
 import pystache
 import six
@@ -34,7 +35,7 @@ class MustacheRenderer(object):
         return [convert_val(e) for e in x]
       else:
         return x
-    items = [(key, convert_val(val)) for (key, val) in args.items()]
+    items = [(key, convert_val(val)) for (key, val) in list(args.items())]
     ret = dict([(key + '?', True) for (key, val) in items if val and not key.endswith('?')])
     ret.update(dict(items))
     return ret

--- a/src/python/pants/base/parse_context.py
+++ b/src/python/pants/base/parse_context.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import functools
 import threading
+from builtins import object
 
 
 class Storage(threading.local):

--- a/src/python/pants/base/payload.py
+++ b/src/python/pants/base/payload.py
@@ -71,7 +71,7 @@ class Payload(object):
 
     :API: public
     """
-    for key, field in list(field_dict.items()):
+    for key, field in field_dict.items():
       self.add_field(key, field)
 
   def add_field(self, key, field):
@@ -106,7 +106,7 @@ class Payload(object):
     :param iterable<string> field_keys: A subset of fields to use for the fingerprint.  Defaults
                                         to all fields.
     """
-    field_keys = frozenset(field_keys or list(self._fields.keys()))
+    field_keys = frozenset(field_keys or self._fields.keys())
     if field_keys not in self._fingerprint_memo_map:
       self._fingerprint_memo_map[field_keys] = self._compute_fingerprint(field_keys)
     return self._fingerprint_memo_map[field_keys]
@@ -135,7 +135,7 @@ class Payload(object):
     :API: public
     """
     self._fingerprint_memo_map = {}
-    for field in list(self._fields.values()):
+    for field in self._fields.values():
       field.mark_dirty()
 
   def __getattr__(self, attr):

--- a/src/python/pants/base/payload.py
+++ b/src/python/pants/base/payload.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from builtins import object
 from hashlib import sha1
 
 
@@ -30,7 +31,7 @@ class Payload(object):
 
   @property
   def fields(self):
-    return self._fields.items()
+    return list(self._fields.items())
 
   def as_dict(self):
     """Return the Payload object as a dict."""
@@ -70,7 +71,7 @@ class Payload(object):
 
     :API: public
     """
-    for key, field in field_dict.items():
+    for key, field in list(field_dict.items()):
       self.add_field(key, field)
 
   def add_field(self, key, field):
@@ -105,7 +106,7 @@ class Payload(object):
     :param iterable<string> field_keys: A subset of fields to use for the fingerprint.  Defaults
                                         to all fields.
     """
-    field_keys = frozenset(field_keys or self._fields.keys())
+    field_keys = frozenset(field_keys or list(self._fields.keys()))
     if field_keys not in self._fingerprint_memo_map:
       self._fingerprint_memo_map[field_keys] = self._compute_fingerprint(field_keys)
     return self._fingerprint_memo_map[field_keys]
@@ -134,7 +135,7 @@ class Payload(object):
     :API: public
     """
     self._fingerprint_memo_map = {}
-    for field in self._fields.values():
+    for field in list(self._fields.values()):
       field.mark_dirty()
 
   def __getattr__(self, attr):

--- a/src/python/pants/base/payload_field.py
+++ b/src/python/pants/base/payload_field.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from abc import abstractmethod
+from builtins import object
 from hashlib import sha1
 
 from twitter.common.collections import OrderedSet

--- a/src/python/pants/base/revision.py
+++ b/src/python/pants/base/revision.py
@@ -99,12 +99,14 @@ class Revision(object):
 
   def __eq__(self, other):
     if not self._is_valid_operand(other):
-      return False  # TODO: typically this should return NotImplemented. Returning False to avoid changing prior API.
+      return False  # TODO(python3port): typically this should return NotImplemented.
+                    # Returning False for now to avoid changing prior API.
     return tuple(self._components) == tuple(other._components)
 
   def __lt__(self, other):
     if not self._is_valid_operand(other):
-      return NotImplemented
+      return AttributeError  # TODO(python3port): typically this should return NotImplemented.
+                             # Returning AttributeError for now to avoid changing prior API.
     for ours, theirs in zip_longest(self._components, other._components, fillvalue=0):
       if ours != theirs:
         return ours < theirs

--- a/src/python/pants/base/revision.py
+++ b/src/python/pants/base/revision.py
@@ -99,7 +99,7 @@ class Revision(object):
 
   def __eq__(self, other):
     if not self._is_valid_operand(other):
-      return NotImplemented
+      return False  # TODO: typically this should return NotImplemented. Returning False to avoid changing prior API.
     return tuple(self._components) == tuple(other._components)
 
   def __lt__(self, other):

--- a/src/python/pants/base/run_info.py
+++ b/src/python/pants/base/run_info.py
@@ -10,6 +10,7 @@ import os
 import re
 import socket
 import time
+from builtins import object, str
 
 from pants import version
 from pants.base.build_environment import get_buildroot, get_scm
@@ -55,7 +56,7 @@ class RunInfo(object):
     """Adds the given info and returns a dict composed of just this added info."""
     infos = dict(keyvals)
     kv_pairs = []
-    for key, val in infos.items():
+    for key, val in list(infos.items()):
       key = key.strip()
       val = str(val).strip()
       if ':' in key:

--- a/src/python/pants/base/run_info.py
+++ b/src/python/pants/base/run_info.py
@@ -56,7 +56,7 @@ class RunInfo(object):
     """Adds the given info and returns a dict composed of just this added info."""
     infos = dict(keyvals)
     kv_pairs = []
-    for key, val in list(infos.items()):
+    for key, val in infos.items():
       key = key.strip()
       val = str(val).strip()
       if ':' in key:

--- a/src/python/pants/base/worker_pool.py
+++ b/src/python/pants/base/worker_pool.py
@@ -105,7 +105,7 @@ class WorkerPool(object):
 
     # We filter out Nones defensively. There shouldn't be any, but if a bug causes one,
     # Pants might hang indefinitely without this filtering.
-    work_iter = iter([_f for _f in work_chain if _f])
+    work_iter = (_f for _f in work_chain if _f)
 
     def submit_next():
       try:

--- a/src/python/pants/base/worker_pool.py
+++ b/src/python/pants/base/worker_pool.py
@@ -8,9 +8,11 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import multiprocessing
 import signal
 import sys
-import thread
 import threading
+from builtins import next, object
 from multiprocessing.pool import ThreadPool
+
+from future.moves import _thread
 
 from pants.reporting.report import Report
 
@@ -103,7 +105,7 @@ class WorkerPool(object):
 
     # We filter out Nones defensively. There shouldn't be any, but if a bug causes one,
     # Pants might hang indefinitely without this filtering.
-    work_iter = iter(filter(None, work_chain))
+    work_iter = iter([_f for _f in work_chain if _f])
 
     def submit_next():
       try:
@@ -149,7 +151,7 @@ class WorkerPool(object):
     except KeyboardInterrupt:
       # If a worker thread intercepts a KeyboardInterrupt, we want to propagate it to the main
       # thread.
-      thread.interrupt_main()
+      _thread.interrupt_main()
       raise
     except Exception as e:
       if on_failure:

--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -147,7 +147,7 @@ class WorkUnit(object):
   def end(self):
     """Mark the time at which this workunit ended."""
     self.end_time = time.time()
-    for output in list(self._outputs.values()):
+    for output in self._outputs.values():
       output.close()
     return self.path(), self.duration(), self._self_time(), self.has_label(WorkUnitLabel.TOOL)
 
@@ -164,7 +164,7 @@ class WorkUnit(object):
     We can set the outcome on a work unit directly, but that outcome will also be affected by
     those of its subunits. The right thing happens: The outcome of a work unit is the
     worst outcome of any of its subunits and any outcome set on it directly."""
-    if outcome not in list(range(0, 5)):
+    if outcome not in range(0, 5):
       raise Exception('Invalid outcome: {}'.format(outcome))
 
     if outcome < self._outcome:

--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -9,9 +9,8 @@ import os
 import re
 import time
 import uuid
+from builtins import object, range
 from collections import namedtuple
-
-from six.moves import range
 
 from pants.util.dirutil import safe_mkdir_for
 from pants.util.memo import memoized_method
@@ -148,7 +147,7 @@ class WorkUnit(object):
   def end(self):
     """Mark the time at which this workunit ended."""
     self.end_time = time.time()
-    for output in self._outputs.values():
+    for output in list(self._outputs.values()):
       output.close()
     return self.path(), self.duration(), self._self_time(), self.has_label(WorkUnitLabel.TOOL)
 
@@ -165,7 +164,7 @@ class WorkUnit(object):
     We can set the outcome on a work unit directly, but that outcome will also be affected by
     those of its subunits. The right thing happens: The outcome of a work unit is the
     worst outcome of any of its subunits and any outcome set on it directly."""
-    if outcome not in range(0, 5):
+    if outcome not in list(range(0, 5)):
       raise Exception('Invalid outcome: {}'.format(outcome))
 
     if outcome < self._outcome:

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -36,6 +36,7 @@ python_tests(
   name = 'exclude_target_regexp_integration',
   sources = [ 'test_exclude_target_regexp_integration.py' ],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/util:process_handler',
     'tests/python/pants_test:int-test',
   ],
@@ -58,6 +59,7 @@ python_library(
   name = 'context_utils',
   sources = ['context_utils.py'],
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:workunit',
     'src/python/pants/build_graph',
@@ -70,6 +72,7 @@ python_tests(
   name = 'deprecated',
   sources = ['test_deprecated.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/base:deprecated',
     'src/python/pants:version',
   ]
@@ -109,6 +112,7 @@ python_tests(
   name = 'hash_utils',
   sources = ['test_hash_utils.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/base:hash_utils',
     'src/python/pants/util:contextutil',
   ]
@@ -185,6 +189,7 @@ python_tests(
   name = 'worker_pool',
   sources = ['test_worker_pool.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/base:worker_pool',
     'src/python/pants/util:contextutil',
   ]

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import logging
 import sys
+from builtins import map, object
 from contextlib import contextmanager
 
 from twitter.common.collections import maybe_list
@@ -107,7 +108,7 @@ class TestContext(Context):
     :API: public
     """
     # Just execute in-process.
-    return map(f, items)
+    return list(map(f, items))
 
 
 def create_context_from_options(options, target_roots=None, build_graph=None,

--- a/tests/python/pants_test/base/test_deprecated.py
+++ b/tests/python/pants_test/base/test_deprecated.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import unittest
 import warnings
+from builtins import object, str
 from contextlib import contextmanager
 
 from pants.base.deprecated import (BadDecoratorNestingError, BadRemovalVersionError,

--- a/tests/python/pants_test/base/test_exclude_target_regexp_integration.py
+++ b/tests/python/pants_test/base/test_exclude_target_regexp_integration.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+from builtins import object, zip
 from contextlib import contextmanager
 
 from pants.base.build_environment import get_buildroot

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import hashlib
 import math
 import unittest
+from builtins import range, str
 
 from pants.base.hash_utils import Sharder, hash_all, hash_file
 from pants.util.contextutil import temporary_file

--- a/tests/python/pants_test/base/test_worker_pool.py
+++ b/tests/python/pants_test/base/test_worker_pool.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import threading
 import unittest
+from builtins import object
 
 from pants.base.worker_pool import Work, WorkerPool
 from pants.base.workunit import WorkUnit


### PR DESCRIPTION
### Description
Implements stage 2 of [porting plan](https://github.com/pantsbuild/pants/issues/6062), which is adding the future library.

Also ports the `src/pants/base` and `tests/python/pants_test/base` as a demo of how this tool works.

At this stage, we aren't testing things yet with the Python 3 interpreter, even though technically it's Python 3 code. The goal for now is to make sure things still work on Python 2. 

#### FYI - how the backports work
The `future` library adds several modules: `future`, `builtins`, `past`, and individual ports like `queue` (instead of `Queue`). 

These added names all correspond exactly to Python 3 code. When running Python 3, it will simply use the native Python 3 version. When using Python 2, it will use the library implementation, which is semantically equivalent to Python 3.

#### FYI - using old `moves` interface
Typically `futurize` will try to use this idiom for certain backports

```python
from future import standard_library
standard_library.install_aliases()

import [backports]
```

This however does not work in our codebase, because all imports must appear above code with iSort, so the `install_aliases()` line gets moved below the relevant imports. 

Instead, we are using the legacy `future.moves` library. Once we remove Python 2 support we'll want to convert this type of import `from future.moves.itertools import x` to `from itertools import x`.

### Testing
I ran the tests for everything with the normal Python 2 interpreter - is that enough, or should I hand test any behavior?
 
### Open question - remaining pull requests
The next stage is to run this tool on all remaining source code, which will lead to a **huge** pull request. How should I split this up? Do you prefer everything being together, one folder at a time, or something else? 

I'm using [this spreadsheet](https://docs.google.com/spreadsheets/d/1i4xFUrgejVFp6NSwT9aGBQWyjbiDIuqMqGEIxcSMCC0/edit#gid=0) to track progress.

All of these changes will be generated by futurize, unless otherwise noted where I have to manually fix things. I'm restraining myself from refactors etc to minimize complexity.

#### FYI - script to automate running tool
I made this [helper script](https://pastebin.com/MDC63A7W) to automate the 5 steps it takes to port a file with `futurize`. It's not very robust but you can use to experiment with this tool.