### PR TITLE
Add `-ltrace` and requests debug logging.

### DIFF
--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -6,9 +6,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.native.config.environment import (Assembler, CCompiler, CppCompiler,
-                                                     GCCCCompiler, GCCCppCompiler,
-                                                     Linker, LLVMCCompiler, LLVMCppCompiler,
-                                                     Platform)
+                                                     GCCCCompiler, GCCCppCompiler, Linker,
+                                                     LLVMCCompiler, LLVMCppCompiler, Platform)
 from pants.backend.native.subsystems.binaries.binutils import Binutils
 from pants.backend.native.subsystems.binaries.gcc import GCC
 from pants.backend.native.subsystems.binaries.llvm import LLVM

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -6,6 +6,7 @@ python_library(
     ':plugins',
     '3rdparty/python:pex',
     '3rdparty/python:setuptools',
+    '3rdparty/python:requests',
     '3rdparty/python:wheel',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/python/subsystems',

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -4,9 +4,9 @@
 python_library(
   dependencies=[
     ':plugins',
+    '3rdparty/python:six',
     '3rdparty/python:pex',
     '3rdparty/python:setuptools',
-    '3rdparty/python:requests',
     '3rdparty/python:wheel',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/python/subsystems',

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -6,7 +6,6 @@ python_library(
     ':plugins',
     '3rdparty/python:pex',
     '3rdparty/python:setuptools',
-    '3rdparty/python:six',
     '3rdparty/python:wheel',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/python/subsystems',

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -4,9 +4,9 @@
 python_library(
   dependencies=[
     ':plugins',
-    '3rdparty/python:six',
     '3rdparty/python:pex',
     '3rdparty/python:setuptools',
+    '3rdparty/python:six',
     '3rdparty/python:wheel',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/python/subsystems',

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -37,8 +37,8 @@ def _configure_requests_debug_logging():
   requests_logger.propagate = True
 
 
-def _maybe_configure_extended_logging(level):
-  if logging.getLogger().isEnabledFor(TRACE):
+def _maybe_configure_extended_logging(logger):
+  if logger.isEnabledFor(TRACE):
     _configure_requests_debug_logging()
 
 
@@ -131,6 +131,6 @@ def setup_logging(level, console_stream=None, log_dir=None, scope=None, log_name
   # This routes warnings through our loggers instead of straight to raw stderr.
   logging.captureWarnings(True)
 
-  _maybe_configure_extended_logging(level)
+  _maybe_configure_extended_logging(logger)
 
   return LoggingSetupResult(log_filename, file_handler)

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -13,8 +13,6 @@ import time
 from collections import namedtuple
 from logging import FileHandler, Formatter, StreamHandler
 
-import six
-
 from pants.util.dirutil import safe_mkdir
 
 

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -128,7 +128,6 @@ def setup_logging(level, console_stream=None, log_dir=None, scope=None, log_name
   # This routes warnings through our loggers instead of straight to raw stderr.
   logging.captureWarnings(True)
 
-  if v:
-    _maybe_configure_extended_logging(v)
+  _maybe_configure_extended_logging(v)
 
   return LoggingSetupResult(log_filename, file_handler)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import logging
 import multiprocessing
 import os
 import sys

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -128,6 +128,10 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     logging.addLevelName(logging.WARNING, 'WARN')
     register('-l', '--level', choices=['debug', 'info', 'warn'], default='info', recursive=True,
              help='Set the logging level.')
+    # TODO: make `-v -v -v` -> options.verbosity == 3.
+    register('-v', '--verbosity', type=int, default=0, advanced=True,
+             help='Set the verbosity level for e.g. extended debug logging. Can be passed '
+                  'multiple times to increase verbosity from 0 (none) to 10 (max).')
     register('-q', '--quiet', type=bool, recursive=True, daemon=False,
              help='Squelches most console output. NOTE: Some tasks default to behaving quietly: '
                   'inverting this option supports making them noisier than they would be otherwise.')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -122,15 +122,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     default_distdir = os.path.join(buildroot, default_distdir_name)
     default_rel_distdir = '/{}/'.format(default_distdir_name)
 
-    # Although logging supports the WARN level, its not documented and could conceivably be yanked.
-    # Since pants has supported 'warn' since inception, leave the 'warn' choice as-is but explicitly
-    # setup a 'WARN' logging level name that maps to 'WARNING'.
-    logging.addLevelName(logging.WARNING, 'WARN')
-    register('-l', '--level', choices=['debug', 'info', 'warn'], default='info', recursive=True,
-             help='Set the logging level.')
-    # TODO: make `-v -v -v` -> options.verbosity == 3.
-    register('-v', '--verbosity', type=int, default=0, advanced=True,
-             help='Set the verbosity level for extended debug logging.')
+    register('-l', '--level', choices=['trace', 'debug', 'info', 'warn'], default='info',
+             recursive=True, help='Set the logging level.')
     register('-q', '--quiet', type=bool, recursive=True, daemon=False,
              help='Squelches most console output. NOTE: Some tasks default to behaving quietly: '
                   'inverting this option supports making them noisier than they would be otherwise.')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -130,8 +130,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help='Set the logging level.')
     # TODO: make `-v -v -v` -> options.verbosity == 3.
     register('-v', '--verbosity', type=int, default=0, advanced=True,
-             help='Set the verbosity level for e.g. extended debug logging. Can be passed '
-                  'multiple times to increase verbosity from 0 (none) to 10 (max).')
+             help='Set the verbosity level for extended debug logging.')
     register('-q', '--quiet', type=bool, recursive=True, daemon=False,
              help='Squelches most console output. NOTE: Some tasks default to behaving quietly: '
                   'inverting this option supports making them noisier than they would be otherwise.')

--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -9,6 +9,7 @@ import logging
 import os
 from functools import reduce
 
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
this PR adds a new `-ltrace` log level and enables requests HTTP session logging if enabled.

```
[omerta pants2 (kwlzn/requests_logging)]$ rm -rf ~/.cache/pants/bin/cloc; ./pants -ltrace cloc src/python/pants/scm 2>&1 |grep -A14 ^"send: "
send: 'GET /bin/cloc/1.66/cloc HTTP/1.1\r\nHost: binaries.pantsbuild.org\r\nConnection: keep-alive\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nUser-Agent: python-requests/2.18.4\r\n\r\n'
reply: 'HTTP/1.1 200 OK\r\n'
header: Date: Fri, 06 Jul 2018 19:23:23 GMT
header: Content-Type: binary/octet-stream
header: Content-Length: 425558
header: Connection: keep-alive
...
header: Last-Modified: Tue, 12 Jun 2018 01:11:59 GMT
header: ETag: "201e32c3aff9b485a5baa81155349029"
header: Accept-Ranges: bytes
header: Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
header: Server: cloudflare
...
```