### PR TITLE
Port util metaprogramming files to Python3

### DIFF
--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -73,6 +73,9 @@ python_library(
 python_library(
   name = 'meta',
   sources = ['meta.py'],
+  dependencies = [
+    '3rdparty/python:future',
+  ]
 )
 
 python_library(

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -87,6 +87,7 @@ python_library(
   name = 'objects',
   sources = ['objects.py'],
   dependencies = [
+    '3rdparty/python:future',
     ':memo',
     ':meta',
   ],

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from abc import ABCMeta
+from builtins import object
 
 
 class SingletonMetaclass(type):
@@ -95,8 +96,14 @@ def staticproperty(func):
 
 
 # Extend Singleton and your class becomes a singleton, each construction returns the same instance.
-Singleton = SingletonMetaclass(str('Singleton'), (object,), {})
+try:  # Python3
+  Singleton = SingletonMetaclass(u'Singleton', (object,), {})
+except TypeError:  # Python2
+  Singleton = SingletonMetaclass(b'Singleton', (object,), {})
 
 
 # Abstract base classes w/o __metaclass__ or meta =, just extend AbstractClass.
-AbstractClass = ABCMeta(str('AbstractClass'), (object,), {})
+try:  # Python3
+  AbstractClass = ABCMeta(u'AbstractClass', (object,), {})
+except TypeError:  # Python2
+  AbstractClass = ABCMeta(b'AbstractClass', (object,), {})

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import sys
 from abc import abstractmethod
+from builtins import map, object, zip
 from collections import OrderedDict, namedtuple
 
 from pants.util.memo import memoized
@@ -50,7 +51,6 @@ def datatype(field_decls, superclass_name=None, **kwargs):
 
   if not superclass_name:
     superclass_name = '_anonymous_namedtuple_subclass'
-  superclass_name = str(superclass_name)
 
   namedtuple_cls = namedtuple(superclass_name, field_names, **kwargs)
 
@@ -162,7 +162,10 @@ def datatype(field_decls, superclass_name=None, **kwargs):
 
   # Return a new type with the given name, inheriting from the DataType class
   # just defined, with an empty class body.
-  return type(superclass_name, (DataType,), {})
+  try:  # Python3
+    return type(superclass_name, (DataType,), {})
+  except TypeError:  # Python2
+    return type(superclass_name.encode('utf-8'), (DataType,), {})
 
 
 class TypedDatatypeClassConstructionError(Exception):

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -82,6 +82,7 @@ python_tests(
   name = 'meta',
   sources = ['test_meta.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/util:meta',
     'tests/python/pants_test:test_base',
   ]
@@ -101,6 +102,7 @@ python_tests(
   sources = ['test_objects.py'],
   coverage = ['pants.util.objects'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/util:objects',
     'tests/python/pants_test:base_test',
   ]

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from abc import abstractmethod, abstractproperty
+from builtins import object
 
 from pants.util.meta import AbstractClass, Singleton, classproperty, staticproperty
 from pants_test.test_base import TestBase


### PR DESCRIPTION
Part of https://github.com/pantsbuild/pants/issues/6062 

## Problem
`ABCMeta` expects `unicode` on Python3, but `bytes` on Python2. 

## Solution
We use feature detection to try with idiomatic Py3 and fall back on Py2. This is [preferred over version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection) (i.e. checking which Python interpreter is used).

Note that the source of this file, [`twitter.commons.lang`](https://github.com/twitter/commons/blob/master/src/python/twitter/common/lang/__init__.py#L179), did not have to do this because they don't use `from __future__ import unicode_literals`.