### PR TITLE
Use impl Future where relevant

### DIFF
--- a/src/rust/engine/boxfuture/src/lib.rs
+++ b/src/rust/engine/boxfuture/src/lib.rs
@@ -39,3 +39,11 @@ macro_rules! try_future {
     }
   }};
 }
+
+///
+/// A trait alias specifically for _avoiding_ `BoxFuture` via `impl IFuture`.
+///
+#[cfg_attr(rustfmt, rustfmt_skip)]
+pub trait IFuture<T, E>: Future<Item=T, Error=E> {}
+#[cfg_attr(rustfmt, rustfmt_skip)]
+impl<T, E, I> IFuture<T, E> for I where I: Future<Item=T, Error=E> {}

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -53,7 +53,7 @@ use futures::future::{self, Future};
 use glob::Pattern;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 
-use boxfuture::{BoxFuture, Boxable};
+use boxfuture::{BoxFuture, Boxable, IFuture};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Stat {
@@ -543,49 +543,43 @@ impl PosixFS {
     self.ignore.is_ignored(stat)
   }
 
-  pub fn read_file(&self, file: &File) -> BoxFuture<FileContent, io::Error> {
+  pub fn read_file(&self, file: &File) -> impl IFuture<FileContent, io::Error> {
     let path = file.path.clone();
     let path_abs = self.root.0.join(&file.path);
-    self
-      .pool
-      .spawn_fn(move || {
-        std::fs::File::open(&path_abs).and_then(|mut f| {
-          let mut content = Vec::new();
-          f.read_to_end(&mut content)?;
-          Ok(FileContent {
-            path: path,
-            content: Bytes::from(content),
-          })
+    self.pool.spawn_fn(move || {
+      std::fs::File::open(&path_abs).and_then(|mut f| {
+        let mut content = Vec::new();
+        f.read_to_end(&mut content)?;
+        Ok(FileContent {
+          path: path,
+          content: Bytes::from(content),
         })
       })
-      .to_boxed()
+    })
   }
 
-  pub fn read_link(&self, link: &Link) -> BoxFuture<PathBuf, io::Error> {
+  pub fn read_link(&self, link: &Link) -> impl IFuture<PathBuf, io::Error> {
     let link_parent = link.0.parent().map(|p| p.to_owned());
     let link_abs = self.root.0.join(link.0.as_path()).to_owned();
-    self
-      .pool
-      .spawn_fn(move || {
-        link_abs.read_link().and_then(|path_buf| {
-          if path_buf.is_absolute() {
-            Err(io::Error::new(
-              io::ErrorKind::InvalidData,
-              format!("Absolute symlink: {:?}", link_abs),
-            ))
-          } else {
-            link_parent
-              .map(|parent| parent.join(path_buf))
-              .ok_or_else(|| {
-                io::Error::new(
-                  io::ErrorKind::InvalidData,
-                  format!("Symlink without a parent?: {:?}", link_abs),
-                )
-              })
-          }
-        })
+    self.pool.spawn_fn(move || {
+      link_abs.read_link().and_then(|path_buf| {
+        if path_buf.is_absolute() {
+          Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Absolute symlink: {:?}", link_abs),
+          ))
+        } else {
+          link_parent
+            .map(|parent| parent.join(path_buf))
+            .ok_or_else(|| {
+              io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Symlink without a parent?: {:?}", link_abs),
+              )
+            })
+        }
       })
-      .to_boxed()
+    })
   }
 
   ///
@@ -649,23 +643,22 @@ impl PosixFS {
     PosixFS::stat_internal(relative_path, metadata.file_type(), &root, || Ok(metadata))
   }
 
-  pub fn scandir(&self, dir: &Dir) -> BoxFuture<Vec<Stat>, io::Error> {
+  pub fn scandir(&self, dir: &Dir) -> impl IFuture<Vec<Stat>, io::Error> {
     let dir = dir.to_owned();
     let root = self.root.0.clone();
     self
       .pool
       .spawn_fn(move || PosixFS::scandir_sync(root, &dir))
-      .to_boxed()
   }
 }
 
 impl VFS<io::Error> for Arc<PosixFS> {
   fn read_link(&self, link: Link) -> BoxFuture<PathBuf, io::Error> {
-    PosixFS::read_link(self, &link)
+    PosixFS::read_link(self, &link).to_boxed()
   }
 
   fn scandir(&self, dir: Dir) -> BoxFuture<Vec<Stat>, io::Error> {
-    PosixFS::scandir(self, &dir)
+    PosixFS::scandir(self, &dir).to_boxed()
   }
 
   fn is_ignored(&self, stat: &Stat) -> bool {

--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use bazel_protos;
-use boxfuture::{BoxFuture, Boxable};
+use boxfuture::{BoxFuture, Boxable, IFuture};
 use futures::future::{self, join_all};
 use futures::Future;
 use hashing::{Digest, Fingerprint};
@@ -42,12 +42,11 @@ impl Snapshot {
     store: Store,
     file_digester: S,
     path_stats: Vec<PathStat>,
-  ) -> BoxFuture<Snapshot, String> {
+  ) -> impl IFuture<Snapshot, String> {
     let mut sorted_path_stats = path_stats.clone();
     sorted_path_stats.sort_by(|a, b| a.path().cmp(b.path()));
     Snapshot::ingest_directory_from_sorted_path_stats(store, &file_digester, &sorted_path_stats)
       .map(|digest| Snapshot { digest, path_stats })
-      .to_boxed()
   }
 
   pub fn digest_from_path_stats<
@@ -57,7 +56,7 @@ impl Snapshot {
     store: Store,
     file_digester: S,
     path_stats: &[PathStat],
-  ) -> BoxFuture<Digest, String> {
+  ) -> impl IFuture<Digest, String> {
     let mut sorted_path_stats = path_stats.to_owned();
     sorted_path_stats.sort_by(|a, b| a.path().cmp(b.path()));
     Snapshot::ingest_directory_from_sorted_path_stats(store, &file_digester, &sorted_path_stats)

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -27,7 +27,7 @@ use petgraph::graph::DiGraph;
 use petgraph::visit::EdgeRef;
 use petgraph::Direction;
 
-use boxfuture::{BoxFuture, Boxable};
+use boxfuture::{BoxFuture, Boxable, IFuture};
 pub use node::{EntryId, Node, NodeContext, NodeError, NodeTracer, NodeVisualizer};
 
 type FNV = BuildHasherDefault<FnvHasher>;
@@ -1036,7 +1036,7 @@ impl<N: Node> Graph<N> {
     &self,
     entry_id: EntryId,
     context: &C,
-  ) -> BoxFuture<Vec<Generation>, N::Error>
+  ) -> impl IFuture<Vec<Generation>, N::Error>
   where
     C: NodeContext<Node = N>,
   {
@@ -1059,7 +1059,7 @@ impl<N: Node> Graph<N> {
             .to_boxed()
         })
         .collect::<Vec<_>>(),
-    ).to_boxed()
+    )
   }
 
   ///

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -22,7 +22,7 @@ extern crate tempfile;
 extern crate testutil;
 extern crate tokio_process;
 
-use boxfuture::BoxFuture;
+use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
@@ -106,7 +106,7 @@ impl BoundedCommandRunner {
 impl CommandRunner for BoundedCommandRunner {
   fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<FallibleExecuteProcessResult, String> {
     let inner = self.inner.clone();
-    self.sema.with_acquired(move || inner.run(req))
+    self.sema.with_acquired(move || inner.run(req)).to_boxed()
   }
 
   fn reset_prefork(&self) {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use bazel_protos;
-use boxfuture::{BoxFuture, Boxable};
+use boxfuture::{BoxFuture, Boxable, IFuture};
 use bytes::Bytes;
 use digest::{Digest as DigestTrait, FixedOutput};
 use fs::{self, File, PathStat, Store};
@@ -208,7 +208,7 @@ impl CommandRunner {
     &self,
     command: &bazel_protos::remote_execution::Command,
     command_digest: Digest,
-  ) -> BoxFuture<(), String> {
+  ) -> impl IFuture<(), String> {
     let store = self.store.clone();
     let store2 = store.clone();
     future::done(
@@ -224,7 +224,6 @@ impl CommandRunner {
           .map_err(|e| format!("Error uploading command {:?}", e))
           .map(|_| ())
       })
-      .to_boxed()
   }
 
   fn extract_execute_response(

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -10,7 +10,7 @@ use tokio::runtime::Runtime;
 
 use futures::Future;
 
-use boxfuture::{BoxFuture, Boxable};
+use boxfuture::IFuture;
 use core::{Failure, TypeId};
 use externs;
 use fs::{safe_create_dir_all_ioerror, PosixFS, ResettablePool, Store};
@@ -146,7 +146,7 @@ impl Context {
   ///
   /// Get the future value for the given Node implementation.
   ///
-  pub fn get<N: WrappedNode>(&self, node: N) -> BoxFuture<N::Item, Failure> {
+  pub fn get<N: WrappedNode>(&self, node: N) -> impl IFuture<N::Item, Failure> {
     // TODO: Odd place for this... could do it periodically in the background?
     if let Some(handles) = maybe_drain_handles() {
       externs::drop_handles(&handles);
@@ -160,7 +160,6 @@ impl Context {
           .try_into()
           .unwrap_or_else(|_| panic!("A Node implementation was ambiguous."))
       })
-      .to_boxed()
   }
 }
 


### PR DESCRIPTION
### Problem

Use of `impl Trait` (in this case, for `Future`) allows an "abstract" instance of a trait to be returned from a function, without the allocation required to `Box` a type (generally accomplished via `BoxFuture` in our codebase). In theory, this allows for reduced memory allocation and more concise code. 

### Solution

Use `impl Future` in all positions where it is feasible, and introduce a "trait alias" named `IFuture` that allows us to use generic parameters rather than associated types (which would have required additional rewriting of return types from `-> BoxFuture<Item, Error>` to `-> impl Future<Item=Item, Error=Error>`).

### Result

No appreciable difference in performance; removal of many calls to `Boxable::to_boxed()`.