### PR TITLE
Add PrimitivesSetField and deprecate SetOfPrimitivesField

### DIFF
--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -12,7 +12,7 @@ from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jarable import Jarable
 from pants.base.payload import Payload
-from pants.base.payload_field import ExcludesField, PrimitiveField, SetOfPrimitivesField
+from pants.base.payload_field import ExcludesField, PrimitiveField, PrimitivesSetField
 from pants.build_graph.resources import Resources
 from pants.build_graph.target import Target
 from pants.java.jar.exclude import Exclude
@@ -102,12 +102,12 @@ class JvmTarget(Target, Jarable):
       'excludes': excludes,
       'platform': PrimitiveField(platform),
       'strict_deps': PrimitiveField(strict_deps),
-      'exports': SetOfPrimitivesField(exports),
+      'exports': PrimitivesSetField(exports or []),
       'fatal_warnings': PrimitiveField(fatal_warnings),
       'zinc_file_manager': PrimitiveField(zinc_file_manager),
-      'javac_plugins': SetOfPrimitivesField(javac_plugins),
+      'javac_plugins': PrimitivesSetField(javac_plugins or []),
       'javac_plugin_args': PrimitiveField(javac_plugin_args),
-      'scalac_plugins': SetOfPrimitivesField(scalac_plugins),
+      'scalac_plugins': PrimitivesSetField(scalac_plugins or []),
       'scalac_plugin_args': PrimitiveField(scalac_plugin_args),
     })
 

--- a/src/python/pants/base/payload_field.py
+++ b/src/python/pants/base/payload_field.py
@@ -11,6 +11,7 @@ from hashlib import sha1
 
 from twitter.common.collections import OrderedSet
 
+from pants.base.deprecated import deprecated
 from pants.base.hash_utils import stable_json_hash
 from pants.util.meta import AbstractClass
 
@@ -164,6 +165,27 @@ class PrimitiveField(PayloadField):
     return stable_json_hash(self._underlying)
 
 
+class PrimitivesSetField(PayloadField):
+  """A general field for order-insensitive sets of primitive, ordered types.
+
+  As long as the underlying elements are JSON representable and have a consistent sort order,
+  their hash can be stably inferred. An underlying value of `None` is preserved to allow for
+  "unset" fields: to default to an empty list/set instead, pass one to the constructor.
+
+  :API: public
+  """
+
+  def __init__(self, underlying=None):
+    self._underlying = tuple(sorted(set(underlying))) if underlying is not None else None
+
+  @property
+  def value(self):
+    return self._underlying
+
+  def _compute_fingerprint(self):
+    return stable_json_hash(self._underlying)
+
+
 class SetOfPrimitivesField(PayloadField):
   """A general field for order-insensitive sets of primitive, ordered types.
 
@@ -173,6 +195,8 @@ class SetOfPrimitivesField(PayloadField):
   :API: public
   """
 
+  @deprecated(removal_version='1.11.0.dev0',
+              hint_message='Use PrimitivesSetField, which preserves `None`/unset fields.')
   def __init__(self, underlying=None):
     self._underlying = tuple(sorted(set(underlying or [])))
 

--- a/tests/python/pants_test/base/test_payload_field.py
+++ b/tests/python/pants_test/base/test_payload_field.py
@@ -143,6 +143,10 @@ class PayloadTest(TestBase):
       sopf(None),
       sopf(['one']),
     )
+    self.assertNotEqual(
+      sopf(None),
+      sopf([]),
+    )
 
   def test_unimplemented_fingerprinted_field(self):
     class TestUnimplementedValue(FingerprintedMixin):

--- a/tests/python/pants_test/base/test_payload_field.py
+++ b/tests/python/pants_test/base/test_payload_field.py
@@ -9,7 +9,8 @@ from hashlib import sha1
 
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.base.payload_field import (ExcludesField, FingerprintedField, FingerprintedMixin,
-                                      JarsField, PrimitiveField, PythonRequirementsField)
+                                      JarsField, PrimitiveField, PrimitivesSetField,
+                                      PythonRequirementsField)
 from pants.java.jar.exclude import Exclude
 from pants.java.jar.jar_dependency import JarDependency
 from pants_test.test_base import TestBase
@@ -119,6 +120,29 @@ class PayloadTest(TestBase):
     fingerprinted_field2 = FingerprintedField(field2)
     self.assertEquals(fingerprinted_field1.fingerprint(), fingerprinted_field1_same.fingerprint())
     self.assertNotEquals(fingerprinted_field1.fingerprint(), fingerprinted_field2.fingerprint())
+
+  def test_set_of_primitives_field(self):
+    # Should preserve `None` values.
+    self.assertEqual(PrimitivesSetField(None).value, None)
+
+    def sopf(underlying):
+      return PrimitivesSetField(underlying).fingerprint()
+    self.assertEqual(
+      sopf({'one', 'two'}),
+      sopf({'two', 'one'}),
+    )
+    self.assertEqual(
+      sopf(['one', 'two']),
+      sopf(['two', 'one']),
+    )
+    self.assertEqual(
+      sopf(None),
+      sopf(None),
+    )
+    self.assertNotEqual(
+      sopf(None),
+      sopf(['one']),
+    )
 
   def test_unimplemented_fingerprinted_field(self):
     class TestUnimplementedValue(FingerprintedMixin):

--- a/tests/python/pants_test/build_graph/test_target.py
+++ b/tests/python/pants_test/build_graph/test_target.py
@@ -13,7 +13,7 @@ import mock
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
 from pants.base.payload import Payload
-from pants.base.payload_field import SetOfPrimitivesField
+from pants.base.payload_field import PrimitivesSetField
 from pants.build_graph.address import Address
 from pants.build_graph.target import Target
 from pants.build_graph.target_scopes import Scopes
@@ -37,7 +37,7 @@ class SourcesTarget(Target):
     payload.add_field('sources', self.create_sources_field(sources,
                                                            sources_rel_path=address.spec_path,
                                                            key_arg='sources'))
-    payload.add_field('exports', SetOfPrimitivesField(exports))
+    payload.add_field('exports', PrimitivesSetField(exports or []))
     super(SourcesTarget, self).__init__(address=address, payload=payload, **kwargs)
 
   @property


### PR DESCRIPTION
### Problem

Using `SetOfPrimitivesField`, it is not currently possible to default a field to `None`, which is important in situations where you need to differentiate "not set" from "empty".

### Solution

Add `PrimitivesSetField` which allows a field to default to `None`, and deprecate `SetOfPrimitivesField`.