### PR TITLE
Fix test_objects handling of dataclass() py2-py3 compatibility

### DIFF
--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -9,7 +9,7 @@ import pickle
 from abc import abstractmethod
 from builtins import object, str
 
-from future.utils import PY2, native, text_type
+from future.utils import PY2, text_type
 
 from pants.util.objects import (Exactly, SubclassesOf, SuperclassesOf, TypeCheckError,
                                 TypedDatatypeInstanceConstructionError, datatype)
@@ -374,7 +374,7 @@ class TypedDatatypeTest(BaseTest):
     self.assertEqual(repr(some_val), "SomeTypedDatatype(val=3)")
     self.assertEqual(str(some_val), "SomeTypedDatatype(val<=int>=3)")
 
-    some_object = WithExplicitTypeConstraint(native(str('asdf')), 45)
+    some_object = WithExplicitTypeConstraint(text_type('asdf'), 45)
     self.assertEqual(some_object.a_string, 'asdf')
     self.assertEqual(some_object.an_int, 45)
     def compare_repr(include_unicode = False):
@@ -406,7 +406,7 @@ class TypedDatatypeTest(BaseTest):
       str(wrapped_nonneg_int),
       "CamelCaseWrapper(nonneg_int<=NonNegativeInt>=NonNegativeInt(an_int<=int>=45))")
 
-    mixed_type_obj = MixedTyping(value=3, name=native(str('asdf')))
+    mixed_type_obj = MixedTyping(value=3, name=text_type('asdf'))
     self.assertEqual(3, mixed_type_obj.value)
     def compare_repr(include_unicode = False):
       expected_message = "MixedTyping(value=3, name={unicode_literal}'asdf')" \
@@ -431,7 +431,7 @@ class TypedDatatypeTest(BaseTest):
       "WithSubclassTypeConstraint(some_value<+SomeBaseClass>=SomeDatatypeClass())")
 
   def test_mixin_type_construction(self):
-    obj_with_mixin = TypedWithMixin(native(str(' asdf ')))
+    obj_with_mixin = TypedWithMixin(text_type(' asdf '))
     def compare_repr(include_unicode = False):
       expected_message = "TypedWithMixin(val={unicode_literal}' asdf ')" \
         .format(unicode_literal='u' if include_unicode else '')
@@ -490,7 +490,7 @@ field 'val' was invalid: value [] (with type 'list') must satisfy this type cons
 
     # type checking failure with multiple arguments (one is correct)
     with self.assertRaises(TypeCheckError) as cm:
-      AnotherTypedDatatype(native(str('correct')), native(str('should be list')))
+      AnotherTypedDatatype(text_type('correct'), text_type('should be list'))
     def compare_str(unicode_type_name, include_unicode=False):
       expected_message = (
         """error: in constructor of type AnotherTypedDatatype: type check error:
@@ -504,7 +504,7 @@ field 'elements' was invalid: value {unicode_literal}'should be list' (with type
 
     # type checking failure on both arguments
     with self.assertRaises(TypeCheckError) as cm:
-      AnotherTypedDatatype(3, native(str('should be list')))
+      AnotherTypedDatatype(3, text_type('should be list'))
     def compare_str(unicode_type_name, include_unicode=False):
       expected_message = (
         """error: in constructor of type AnotherTypedDatatype: type check error:
@@ -518,7 +518,7 @@ field 'elements' was invalid: value {unicode_literal}'should be list' (with type
       compare_str('str')
 
     with self.assertRaises(TypeCheckError) as cm:
-      NonNegativeInt(native(str('asdf')))
+      NonNegativeInt(text_type('asdf'))
     def compare_str(unicode_type_name, include_unicode=False):
       expected_message = (
         """error: in constructor of type NonNegativeInt: type check error:


### PR DESCRIPTION
Followup from https://github.com/pantsbuild/pants/pull/6072, which was an incorrect representation of the changes made to metaprogramming with Python 3 port. Part of https://github.com/pantsbuild/pants/issues/6062.

## Problem
`object.py`'s `datatype()` function expects exactly one type. This poses an issue when we add `from builtins import str` to files - in Py2, the type will become `newstr`, whereas in Py3 the type will become `str`. `type(newstr) != type(str)`, even though the behavior is similar, so `datatype()` will raise an exception.

We ran into this issue originally with `test_objects.py`. The original solution only fixed the tests, it didn't actually fix the underlying problem, which I realized when `engine/fs.py` starting breaking with PRs that touched it like the [`backend/jvm` port](https://github.com/pantsbuild/pants/pull/6092).

## Solution
The solution has two parts:
1) Wherever we define a class using the metaclass of `datatype`, set the parameter to `future.utils.text_type`, rather than `str`. This means in Py2 the type will be `unicode` and in Py3 the type will be `str`. Both have the same unicode semantics, which is a good thing.

```python
from future.utils import text_type

class Foo(datatype([('val', text_type)])): pass
```

2) When instantiating a class that uses `dataclass` as its metaclass, wrap the parameter calls with `text_type(x)`. This will call `unicode(x)` in Py2 and `str()` in Py3, resulting in the correct type for the class definition from the first step. 

```python
from future.utils import text_type

example = Foo(text_type('🐍'))
```

## What this impacts
Anywhere we create a class with `datatype()` that sets a parameter to `str`, we'll have to make this change to both the class definition and all of its instantiations. 

The biggest example of this is in `engine/fs.py`