### PR TITLE
Use extended platform specification for `current` platform in `resolve_multi`.

### DIFF
--- a/src/python/pants/backend/python/pex_util.py
+++ b/src/python/pants/backend/python/pex_util.py
@@ -32,3 +32,13 @@ def get_local_platform():
   # is fixed.
   current_platform = Platform.current()
   return current_platform.platform
+
+
+def get_extended_local_platform():
+  """Returns the extended form of the local platform; eg: 'linux_x86_64-cp-27-cp27mu'.
+
+  :returns: The local extended platform name.
+  :rtype: str
+  """
+  current_platform = Platform.current()
+  return str(current_platform)

--- a/src/python/pants/backend/python/tasks/pex_build_util.py
+++ b/src/python/pants/backend/python/tasks/pex_build_util.py
@@ -11,7 +11,7 @@ from pex.fetcher import Fetcher
 from pex.resolver import resolve
 from twitter.common.collections import OrderedSet
 
-from pants.backend.python.pex_util import get_local_platform
+from pants.backend.python.pex_util import get_extended_local_platform
 from pants.backend.python.subsystems.python_repos import PythonRepos
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_binary import PythonBinary
@@ -155,7 +155,7 @@ def resolve_multi(interpreter, requirements, platforms, find_links):
       requirements=[req.requirement for req in requirements],
       interpreter=interpreter,
       fetchers=fetchers,
-      platform=get_local_platform() if platform == 'current' else platform,
+      platform=get_extended_local_platform() if platform == 'current' else platform,
       context=python_repos.get_network_context(),
       cache=requirements_cache_dir,
       cache_ttl=python_setup.resolver_cache_ttl,


### PR DESCRIPTION
Improves ABI selection for resolved dists to avoid cases like e.g.

```
Exception message: /home/travis/.pex/install/cffi-1.11.1-cp27-cp27m-manylinux1_x86_64.whl.c29d7079f1a3cf615b80ce0420ced57c9facc7b1/cffi-1.11.1-cp27-cp27m-manylinux1_x86_64.whl/_cffi_backend.so: undefined symbol: PyUnicodeUCS2_FromUnicode
```

where the platform=current ABI type is `cp27mu` vs `cp27m`.