### PR TITLE
Fix local execution of hermetic integration tests

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -7,7 +7,7 @@ set -e
 ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
 source ${ROOT}/build-support/common.sh
 
-PY=$(which python2.7)
+PY=$(which python2.7 || exit 0)
 [[ -n "${PY}" ]] || die "You must have python2.7 installed and on the path to release."
 export PY
 

--- a/pants
+++ b/pants
@@ -47,7 +47,7 @@ source ${HERE}/build-support/bin/native/bootstrap_code.sh
 
 PANTS_EXE="${HERE}/src/python/pants/bin/pants_loader.py"
 
-PY=${PY:-$(which python2.7)}
+PY=${PY:-$(which python2.7 || exit 0)}
 
 if [[ ! -z "${WRAPPER_REQUIREMENTS}" ]]; then
   REQUIREMENTS=(

--- a/pants
+++ b/pants
@@ -47,8 +47,6 @@ source ${HERE}/build-support/bin/native/bootstrap_code.sh
 
 PANTS_EXE="${HERE}/src/python/pants/bin/pants_loader.py"
 
-PY=${PY:-$(which python2.7 || exit 0)}
-
 if [[ ! -z "${WRAPPER_REQUIREMENTS}" ]]; then
   REQUIREMENTS=(
     $(echo ${WRAPPER_REQUIREMENTS} | tr : ' ')

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -254,7 +254,9 @@ class PantsRunIntegrationTest(unittest.TestCase):
     if self.hermetic():
       env = dict()
       for h in self.hermetic_env_whitelist():
-        env[h] = os.getenv(h) or ''
+        value = os.getenv(h)
+        if value is not None:
+          env[h] = value
       hermetic_env = os.getenv('HERMETIC_ENV')
       if hermetic_env:
         for h in hermetic_env.strip(',').split(','):


### PR DESCRIPTION
### Problem

Post #5742, `def hermetic(cls): True` integration tests fail in environments where `PATH` or `PY` are not set due to a non-zero exit code from `which python2.7`, which causes a failure of the script due to `set -e`.

### Solution

Exit the subshell cleanly if `python2.7` cannot be located.

### Result

Hermetic integration tests work locally and/or on OSX.