### PR TITLE
Switch from output_async to spawn_async, and buffer output.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
+ "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1094,12 +1095,22 @@ dependencies = [
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-codec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1116,13 +1127,13 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-io"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1139,7 +1150,7 @@ dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1155,7 +1166,7 @@ dependencies = [
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1168,7 +1179,7 @@ dependencies = [
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1182,7 +1193,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1217,7 +1228,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1439,9 +1450,10 @@ dependencies = [
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d00555353b013e170ed8bc4e13f648a317d1fd12157dbcae13f7013f6cf29f5"
+"checksum tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "881e9645b81c2ce95fcb799ded2c29ffb9f25ef5bef909089a420e5961dd8ccb"
 "checksum tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cac2a7883ff3567e9d66bb09100d09b33d90311feca0206c7ca034bc0c55113"
 "checksum tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76766830bbf9a2d5bfb50c95350d56a2e79e2c80f675967fff448bc615899708"
-"checksum tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6af9eb326f64b2d6b68438e1953341e00ab3cf54de7e35d92bfc73af8555313a"
+"checksum tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a5c9635ee806f26d302b8baa1e145689a280d8f5aa8d0552e7344808da54cc21"
 "checksum tokio-process 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de38febefe683adab7070c0f705afd6247582d0b1780d9eb745c77a0d4e88b"
 "checksum tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3cedc8e5af5131dc3423ffa4f877cce78ad25259a9a62de0613735a13ebc64b"
 "checksum tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6a5bf935a0151cc8899aa806ce6a425bdaec79ed4034de1a1e6bfa247e2def"

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -19,6 +19,7 @@ resettable = { path = "../resettable" }
 sha2 = "0.6.0"
 tempfile = "3"
 futures-timer = "0.1"
+tokio-codec = "0.1"
 tokio-process = "0.2.1"
 
 [dev-dependencies]

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -20,6 +20,7 @@ extern crate sha2;
 extern crate tempfile;
 #[cfg(test)]
 extern crate testutil;
+extern crate tokio_codec;
 extern crate tokio_process;
 
 use boxfuture::BoxFuture;

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -3,17 +3,18 @@ extern crate tempfile;
 
 use boxfuture::{BoxFuture, Boxable};
 use fs::{self, GlobMatching, PathGlobs, PathStatGetter, Snapshot, StrictGlobMatching};
-use futures::{future, Future};
+use futures::{future, Future, Stream};
 use std::collections::BTreeSet;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 
-use tokio_process::CommandExt;
+use tokio_codec::{Decoder, FramedRead};
+use tokio_process::{Child, CommandExt};
 
 use super::{ExecuteProcessRequest, FallibleExecuteProcessResult};
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 
 pub struct CommandRunner {
   store: fs::Store,
@@ -35,6 +36,25 @@ impl CommandRunner {
       work_dir,
       cleanup_local_dirs,
     }
+  }
+
+  fn outputs_stream_for_child(
+    mut child: Child,
+  ) -> Box<Stream<Item = ChildOutput, Error = String> + Send> {
+    // TODO: This assumes that the Child was launched with stdout/stderr `Stdio::piped`.
+    let stdout_stream = FramedRead::new(child.stdout().take().unwrap(), IdentityDecoder)
+      .map(|bytes| ChildOutput::Stdout(bytes.into()));
+    let stderr_stream = FramedRead::new(child.stderr().take().unwrap(), IdentityDecoder)
+      .map(|bytes| ChildOutput::Stderr(bytes.into()));
+    let exit_stream = child
+      .into_stream()
+      .map(|exit_status| ChildOutput::Exit(exit_status.code()));
+    Box::new(
+      stdout_stream
+        .select(stderr_stream)
+        .chain(exit_stream)
+        .map_err(|e| format!("Failed to consume process outputs: {:?}", e)),
+    )
   }
 
   fn construct_output_snapshot(
@@ -120,11 +140,35 @@ impl super::CommandRunner for CommandRunner {
                   // to stop automatic PATH searching.
                   .env("PATH", "")
                   .envs(env)
-                  .output_async()
-                  .map_err(|e| format!("Error executing process: {:?}", e))
-                  .map(|output| (output, workdir))
+                  .stdin(Stdio::null())
+                  .stdout(Stdio::piped())
+                  .stderr(Stdio::piped())
+                  .spawn_async()
+                  .map_err(|e| format!("Error launching process: {:?}", e))
+                  .map(|child| (child, workdir))
       })
-      .and_then(move |(output, workdir)| {
+      .and_then(|(child, workdir)| {
+        // Consume the stream of ChildOutputs incrementally.
+        let init = (
+          BytesMut::with_capacity(8192),
+          BytesMut::with_capacity(8192),
+          None,
+        );
+        Self::outputs_stream_for_child(child)
+          .fold(
+            init,
+            |(mut stdout, mut stderr, mut exit_code), child_output| {
+              match child_output {
+                ChildOutput::Stdout(bytes) => stdout.extend_from_slice(&bytes),
+                ChildOutput::Stderr(bytes) => stderr.extend_from_slice(&bytes),
+                ChildOutput::Exit(code) => exit_code = code,
+              };
+              Ok((stdout, stderr, exit_code)) as Result<_, String>
+            },
+          )
+          .map(|output| (output, workdir))
+      })
+      .and_then(move |((stdout, stderr, exit_code), workdir)| {
         let output_snapshot = if output_file_paths.is_empty() && output_dir_paths.is_empty() {
           future::ok(fs::Snapshot::empty()).to_boxed()
         } else {
@@ -170,10 +214,10 @@ impl super::CommandRunner for CommandRunner {
         };
 
         output_snapshot
-          .map(|snapshot| FallibleExecuteProcessResult {
-            stdout: Bytes::from(output.stdout),
-            stderr: Bytes::from(output.stderr),
-            exit_code: output.status.code().unwrap(),
+          .map(move |snapshot| FallibleExecuteProcessResult {
+            stdout: stdout.freeze(),
+            stderr: stderr.freeze(),
+            exit_code: exit_code.unwrap_or(-1),
             output_directory: snapshot.digest,
           })
           .to_boxed()
@@ -185,6 +229,34 @@ impl super::CommandRunner for CommandRunner {
     self.store.reset_prefork();
     self.fs_pool.reset();
   }
+}
+
+///
+/// A Decoder that emits bytes immediately for any non-empty buffer.
+///
+struct IdentityDecoder;
+
+impl Decoder for IdentityDecoder {
+  type Item = Bytes;
+  type Error = ::std::io::Error;
+
+  fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+    if buf.len() == 0 {
+      Ok(None)
+    } else {
+      Ok(Some(buf.take().freeze()))
+    }
+  }
+}
+
+///
+/// An enum of the possible outputs from a child process.
+///
+#[derive(Debug)]
+enum ChildOutput {
+  Stdout(Bytes),
+  Stderr(Bytes),
+  Exit(Option<i32>),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Problem

See #6089.

### Solution

Switch to `spawn_async` and `fold` over a stream of outputs. To stream/duplicate output elsewhere, we'd add logic in the `fold`.

### Result

Fixes #6089.