### PR TITLE
Make RUST_BACKTRACE sniffing less specific

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -809,7 +809,7 @@ class Native(object):
     return self.gc(scheduler, self.lib.scheduler_destroy)
 
   def set_panic_handler(self):
-    if os.getenv("RUST_BACKTRACE", "0") != "1":
+    if os.getenv("RUST_BACKTRACE", "0") == "0":
       # The panic handler hides a lot of rust tracing which may be useful.
       # Don't activate it when the user explicitly asks for rust backtraces.
       self.lib.set_panic_handler()


### PR DESCRIPTION
We set it to 'all' now on CI, so otherwise lose information