### PR TITLE
Allow Rust to store `unicode` as well as `bytes`

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -11,11 +11,13 @@ import os
 import sys
 import sysconfig
 import traceback
+from builtins import str
 from contextlib import closing
 
 import cffi
 import pkg_resources
 import six
+from future.utils import native
 
 from pants.engine.selectors import Get, constraint_for
 from pants.util.contextutil import temporary_dir
@@ -111,6 +113,7 @@ typedef _Bool               (*extern_ptr_satisfied_by)(ExternContext*, Handle*, 
 typedef _Bool               (*extern_ptr_satisfied_by_type)(ExternContext*, Handle*, TypeId*);
 typedef Handle              (*extern_ptr_store_tuple)(ExternContext*, Handle**, uint64_t);
 typedef Handle              (*extern_ptr_store_bytes)(ExternContext*, uint8_t*, uint64_t);
+typedef Handle              (*extern_ptr_store_utf8)(ExternContext*, uint8_t*, uint64_t);
 typedef Handle              (*extern_ptr_store_i64)(ExternContext*, int64_t);
 typedef HandleBuffer        (*extern_ptr_project_multi)(ExternContext*, Handle*, uint8_t*, uint64_t);
 typedef Handle              (*extern_ptr_project_ignoring_type)(ExternContext*, Handle*, uint8_t*, uint64_t);
@@ -156,6 +159,7 @@ void externs_set(ExternContext*,
                  extern_ptr_satisfied_by_type,
                  extern_ptr_store_tuple,
                  extern_ptr_store_bytes,
+                 extern_ptr_store_utf8,
                  extern_ptr_store_i64,
                  extern_ptr_project_ignoring_type,
                  extern_ptr_project_multi,
@@ -265,6 +269,7 @@ extern "Python" {
   _Bool               extern_satisfied_by_type(ExternContext*, Handle*, TypeId*);
   Handle              extern_store_tuple(ExternContext*, Handle**, uint64_t);
   Handle              extern_store_bytes(ExternContext*, uint8_t*, uint64_t);
+  Handle              extern_store_utf8(ExternContext*, uint8_t*, uint64_t);
   Handle              extern_store_i64(ExternContext*, int64_t);
   Handle              extern_project_ignoring_type(ExternContext*, Handle*, uint8_t*, uint64_t);
   HandleBuffer        extern_project_multi(ExternContext*, Handle*, uint8_t*, uint64_t);
@@ -424,6 +429,12 @@ def _initialize_externs(ffi):
     """Given a context and raw bytes, return a new Handle to represent the content."""
     c = ffi.from_handle(context_handle)
     return c.to_value(bytes(ffi.buffer(bytes_ptr, bytes_len)))
+
+  @ffi.def_extern()
+  def extern_store_utf8(context_handle, utf8_ptr, utf8_len):
+    """Given a context and UTF8 bytes, return a new Handle to represent the content."""
+    c = ffi.from_handle(context_handle)
+    return c.to_value(native(str(ffi.buffer(utf8_ptr, utf8_len))))
 
   @ffi.def_extern()
   def extern_store_i64(context_handle, i64):
@@ -688,6 +699,7 @@ class Native(object):
                            self.ffi_lib.extern_satisfied_by_type,
                            self.ffi_lib.extern_store_tuple,
                            self.ffi_lib.extern_store_bytes,
+                           self.ffi_lib.extern_store_utf8,
                            self.ffi_lib.extern_store_i64,
                            self.ffi_lib.extern_project_ignoring_type,
                            self.ffi_lib.extern_project_multi,

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -68,8 +68,18 @@ pub fn store_tuple(values: &[Value]) -> Value {
   with_externs(|e| (e.store_tuple)(e.context, handles.as_ptr(), handles.len() as u64).into())
 }
 
+///
+/// Store an opqaue buffer of bytes to pass to Python. This will end up as a Python `bytes`.
+///
 pub fn store_bytes(bytes: &[u8]) -> Value {
   with_externs(|e| (e.store_bytes)(e.context, bytes.as_ptr(), bytes.len() as u64).into())
+}
+
+///
+/// Store an buffer of utf8 bytes to pass to Python. This will end up as a Python `unicode`.
+///
+pub fn store_utf8(utf8: &str) -> Value {
+  with_externs(|e| (e.store_utf8)(e.context, utf8.as_ptr(), utf8.len() as u64).into())
 }
 
 pub fn store_i64(val: i64) -> Value {
@@ -262,6 +272,7 @@ pub struct Externs {
   pub satisfied_by_type: SatisfiedByTypeExtern,
   pub store_tuple: StoreTupleExtern,
   pub store_bytes: StoreBytesExtern,
+  pub store_utf8: StoreUtf8Extern,
   pub store_i64: StoreI64Extern,
   pub project_ignoring_type: ProjectIgnoringTypeExtern,
   pub project_multi: ProjectMultiExtern,
@@ -296,6 +307,9 @@ pub type StoreTupleExtern =
   extern "C" fn(*const ExternContext, *const *const Handle, u64) -> Handle;
 
 pub type StoreBytesExtern = extern "C" fn(*const ExternContext, *const u8, u64) -> Handle;
+
+pub type StoreUtf8Extern = extern "C" fn(*const ExternContext, *const u8, u64) -> Handle;
+
 
 pub type StoreI64Extern = extern "C" fn(*const ExternContext, i64) -> Handle;
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -46,8 +46,8 @@ use externs::{
   Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionExtern, DropHandlesExtern,
   EqualsExtern, EvalExtern, ExternContext, Externs, GeneratorSendExtern, IdentifyExtern, LogExtern,
   ProjectIgnoringTypeExtern, ProjectMultiExtern, PyResult, SatisfiedByExtern,
-  SatisfiedByTypeExtern, StoreBytesExtern, StoreI64Extern, StoreTupleExtern, TypeIdBuffer,
-  TypeToStrExtern, ValToStrExtern,
+  SatisfiedByTypeExtern, StoreBytesExtern, StoreI64Extern, StoreTupleExtern, StoreUtf8Extern,
+  TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
 };
 use futures::Future;
 use handles::Handle;
@@ -141,6 +141,7 @@ pub extern "C" fn externs_set(
   satisfied_by_type: SatisfiedByTypeExtern,
   store_tuple: StoreTupleExtern,
   store_bytes: StoreBytesExtern,
+  store_utf8: StoreUtf8Extern,
   store_i64: StoreI64Extern,
   project_ignoring_type: ProjectIgnoringTypeExtern,
   project_multi: ProjectMultiExtern,
@@ -164,6 +165,7 @@ pub extern "C" fn externs_set(
     satisfied_by_type,
     store_tuple,
     store_bytes,
+    store_utf8,
     store_i64,
     project_ignoring_type,
     project_multi,


### PR DESCRIPTION
This is currently unused, but will be used to land
https://github.com/pantsbuild/pants/pull/6103 with
DirectoryDigest.fingerprint being a `unicode` not a `bytes`.

/cc @Eric-Arellano