### PR TITLE
Use PrimitivesSetField in ScalaJs target and minor help text fixup

### DIFF
--- a/contrib/scalajs/src/python/pants/contrib/scalajs/targets/scala_js_target.py
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/targets/scala_js_target.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.base.payload import Payload
-from pants.base.payload_field import PrimitiveField, SetOfPrimitivesField
+from pants.base.payload_field import PrimitiveField, PrimitivesSetField
 
 from pants.contrib.scalajs.subsystems.scala_js_platform import ScalaJSPlatform
 
@@ -23,7 +23,7 @@ class ScalaJSTarget(object):
     payload = payload or Payload()
     payload.add_fields({
       'platform': PrimitiveField(None),
-      'compiler_option_sets': SetOfPrimitivesField(None)
+      'compiler_option_sets': PrimitivesSetField(None)
     })
     super(ScalaJSTarget, self).__init__(address=address, payload=payload, **kwargs)
 

--- a/src/python/pants/backend/jvm/subsystems/zinc_language_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc_language_mixin.py
@@ -27,7 +27,8 @@ class ZincLanguageMixin(object):
 
     register('--compiler-option-sets', advanced=True, default=[], type=list,
              fingerprint=True,
-             help='The option sets to be enabled for the compilation of this target.')
+             help='The default for the "compiler_option_sets" argument'
+                  'for targets of this language.')
 
     register('--zinc-file-manager', advanced=True, default=True, type=bool,
              fingerprint=True,


### PR DESCRIPTION
### Problem

Fixup the things requested at #6065

### Solution

s/SetOfPrimitivesField/PrimitivesSetField

and a change to the wording in the help text of the `compiler_option_sets` default options.