### PR TITLE
port cpp to py3

### DIFF
--- a/contrib/cpp/src/python/pants/contrib/cpp/toolchain/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/toolchain/BUILD
@@ -7,4 +7,5 @@ python_library(
     'cpp_toolchain.py',
   ],
   dependencies=[],
+    '3rdparty/python:future',
 )

--- a/contrib/cpp/src/python/pants/contrib/cpp/toolchain/cpp_toolchain.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/toolchain/cpp_toolchain.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import object
 import os
 
 


### PR DESCRIPTION
### Problem

Porting contrib/cpp to py3

### Solution

just added an import
