### PR TITLE
Fix edge removal in Graph that could make invalidation inaccurate

### DIFF
--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -1075,12 +1075,13 @@ impl<N: Node> Graph<N> {
     }
 
     // Otherwise, clear the deps.
-    let dep_edges: Vec<_> = inner
+    // NB: Because `remove_edge` changes EdgeIndex values, we remove edges one at a time.
+    while let Some(dep_edge) = inner
       .pg
       .edges_directed(entry_id, Direction::Outgoing)
+      .next()
       .map(|edge| edge.id())
-      .collect();
-    for dep_edge in dep_edges {
+    {
       inner.pg.remove_edge(dep_edge);
     }
   }

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -310,7 +310,6 @@ pub type StoreBytesExtern = extern "C" fn(*const ExternContext, *const u8, u64) 
 
 pub type StoreUtf8Extern = extern "C" fn(*const ExternContext, *const u8, u64) -> Handle;
 
-
 pub type StoreI64Extern = extern "C" fn(*const ExternContext, i64) -> Handle;
 
 ///


### PR DESCRIPTION
### Problem

Removing edges with `Graph` (note, not `StableGraph`) causes their `EdgeIndex`es to change. So collecting all outbound edges and then removing them one by one could remove the wrong edges (or be a noop).

### Solution

Lookup and remove edges one at a time.