### PR TITLE
Impose a consistent sort on CONTRIBUTORS.md.

### DIFF
--- a/build-support/bin/contributors.sh
+++ b/build-support/bin/contributors.sh
@@ -67,6 +67,6 @@ Alyssa Pohahau
 FIXED_LIST
 ) | grep -v -E "^[[:space:]]*#" | \
     grep -v -E "^[[:space:]]*$" | \
-    sort -u | \
+    LC_ALL=C sort -u | \
     sed -E -e "s|^|+ |" >> CONTRIBUTORS.md
 fi


### PR DESCRIPTION
The sort provided by `LC_ALL=C` appears to match the sort that ships with
OSX or else every developer except me configures their machine for the C
locale.

Previously I was always getting spurious diffs under my setup:
```
$ locale
LANG=en_US.UTF-8
LC_CTYPE="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_PAPER="en_US.UTF-8"
LC_NAME="en_US.UTF-8"
LC_ADDRESS="en_US.UTF-8"
LC_TELEPHONE="en_US.UTF-8"
LC_MEASUREMENT="en_US.UTF-8"
LC_IDENTIFICATION="en_US.UTF-8"
LC_ALL=en_US.UTF-8
```