### PR TITLE
Add --output-dir flag to ScalaFmt task

### DIFF
--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -679,6 +679,7 @@ python_library(
     'src/python/pants/java/jar',
     'src/python/pants/option',
     'src/python/pants/task',
+    'src/python/pants/util:dirutil',
   ]
 )
 

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -687,6 +687,7 @@ python_library(
   sources = ['rewrite_base.py'],
   dependencies = [
     'src/python/pants/backend/jvm/tasks:nailgun_task',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
     'src/python/pants/option',

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -679,7 +679,6 @@ python_library(
     'src/python/pants/java/jar',
     'src/python/pants/option',
     'src/python/pants/task',
-    'src/python/pants/util:dirutil',
   ]
 )
 
@@ -690,6 +689,8 @@ python_library(
     'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
+    'src/python/pants/option',
+    'src/python/pants/util:dirutil',
     'src/python/pants/util:meta',
     'src/python/pants/util:memo',
   ]

--- a/src/python/pants/backend/jvm/tasks/rewrite_base.py
+++ b/src/python/pants/backend/jvm/tasks/rewrite_base.py
@@ -5,12 +5,15 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+import shutil
 from abc import abstractmethod, abstractproperty
 
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
+from pants.option.custom_types import dir_option
 from pants.process.xargs import Xargs
+from pants.util.dirutil import fast_relpath, safe_mkdir_for_all
 from pants.util.memo import memoized_property
 from pants.util.meta import AbstractClass
 
@@ -25,6 +28,9 @@ class RewriteBase(NailgunTask, AbstractClass):
              default=cls.target_types(),
              advanced=True, type=list,
              help='The target types to apply formatting to.')
+    register('--output-dir', advanced=True, type=dir_option, fingerprint=True,
+             help='Path to scalafmt output directory. Any updated files will be written here. '
+             'If not specified, files will be modified in-place.')
 
   @classmethod
   def target_types(cls):
@@ -65,14 +71,27 @@ class RewriteBase(NailgunTask, AbstractClass):
     if not target_sources:
       return
 
-    result = Xargs(self._invoke_tool_in_place).execute(target_sources)
+    result = Xargs(self._invoke_tool_in_or_out_of_place).execute(target_sources)
     if result != 0:
       raise TaskError('{} is improperly implemented: a failed process '
                       'should raise an exception earlier.'.format(type(self).__name__))
 
-  def _invoke_tool_in_place(self, target_sources):
-    # Invoke in place.
-    result = self.invoke_tool(get_buildroot(), target_sources)
+  def _invoke_tool_in_or_out_of_place(self, target_sources):
+    buildroot = get_buildroot()
+    toolroot = buildroot
+    if self.get_options().output_dir:
+      toolroot = self.get_options().output_dir
+      new_sources = [
+        (target, os.path.join(toolroot, fast_relpath(source, buildroot)))
+        for target, source in target_sources
+      ]
+      old_file_paths = [source for _, source in target_sources]
+      new_file_paths = [source for _, source in new_sources]
+      safe_mkdir_for_all(new_file_paths)
+      for old, new in zip(old_file_paths, new_file_paths):
+        shutil.copyfile(old, new)
+      target_sources = new_sources
+    result = self.invoke_tool(toolroot, target_sources)
     self.process_result(result)
     return result
 

--- a/src/python/pants/backend/jvm/tasks/rewrite_base.py
+++ b/src/python/pants/backend/jvm/tasks/rewrite_base.py
@@ -41,7 +41,7 @@ class RewriteBase(NailgunTask, AbstractClass):
       sideeffecting = False
     if sideeffecting:
       register('--output-dir', advanced=True, type=dir_option, fingerprint=True,
-               help='Path to scalafmt output directory. Any updated files will be written here. '
+               help='Path to output directory. Any updated files will be written here. '
                'If not specified, files will be modified in-place.')
 
   @classmethod
@@ -83,12 +83,12 @@ class RewriteBase(NailgunTask, AbstractClass):
     if not target_sources:
       return
 
-    result = Xargs(self._invoke_tool_in_or_out_of_place).execute(target_sources)
+    result = Xargs(self._invoke_tool).execute(target_sources)
     if result != 0:
       raise TaskError('{} is improperly implemented: a failed process '
                       'should raise an exception earlier.'.format(type(self).__name__))
 
-  def _invoke_tool_in_or_out_of_place(self, target_sources):
+  def _invoke_tool(self, target_sources):
     buildroot = get_buildroot()
     toolroot = buildroot
     if self.sideeffecting and self.get_options().output_dir:

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -4,17 +4,17 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os.path
+import os
+import shutil
 from abc import abstractproperty
 
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
-from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.java.jar.jar_dependency import JarDependency
 from pants.option.custom_types import dir_option, file_option
 from pants.task.fmt_task_mixin import FmtTaskMixin
 from pants.task.lint_task_mixin import LintTaskMixin
-from pants.util.dirutil import fast_relpath
+from pants.util.dirutil import fast_relpath, safe_mkdir_for_all
 
 
 class ScalaFmt(RewriteBase):
@@ -31,7 +31,7 @@ class ScalaFmt(RewriteBase):
               help='Path to scalafmt config file, if not specified default scalafmt config used')
     register('--output-dir', advanced=True, type=dir_option, fingerprint=True,
               help='Path to scalafmt output directory. Any updated files will be written here. '
-                   'If not specified, files will be modified in-place')
+                   'If not specified, files will be modified in-place.')
 
     cls.register_jvm_tool(register,
                           'scalafmt',
@@ -53,50 +53,31 @@ class ScalaFmt(RewriteBase):
   def implementation_version(cls):
     return super(ScalaFmt, cls).implementation_version() + [('ScalaFmt', 5)]
 
-  def invoke_tool(self, _, target_sources):
+  def invoke_tool(self, buildroot, target_sources):
     # If no config file is specified use default scalafmt config.
     config_file = self.get_options().configuration
     args = list(self.additional_args)
     if config_file is not None:
       args.extend(['--config', config_file])
+
+    files = [source for _, source in target_sources]
+
     if self.get_options().output_dir:
-      args.append('--stdout')
+      moved_files = [
+        os.path.join(self.get_options().output_dir, fast_relpath(source, buildroot))
+        for _, source in target_sources
+      ]
+      safe_mkdir_for_all(moved_files)
+      for src, dst in zip(files, moved_files):
+        shutil.copyfile(src, dst)
+      files = moved_files
 
-    result = 0
-    created_dirs = set()
 
-    for _, source in target_sources:
-      res, workunit = self.runjava(classpath=self.tool_classpath('scalafmt'),
-                                   main='org.scalafmt.cli.Cli',
-                                   args=args + ['--files', source],
-                                   workunit_name='scalafmt',
-                                   jvm_options=self.get_options().jvm_options,
-                                   return_workunit=True)
-      result |= res
-
-      if self.get_options().output_dir is not None:
-        with open(workunit.output_paths()['stdout'], 'r') as f:
-          formatted_file = f.read()
-
-        with open(source, 'r') as f:
-          unformatted_file = f.read()
-
-        if formatted_file != unformatted_file:
-          path = os.path.join(
-            self.get_options().output_dir,
-            fast_relpath(source, get_buildroot())
-          )
-
-          dir_to_create = os.path.dirname(path)
-
-          if dir_to_create not in created_dirs:
-            os.makedirs(os.path.dirname(path))
-            created_dirs.add(dir_to_create)
-
-          with open(path, 'w') as f:
-            f.write(formatted_file)
-
-    return result
+    return self.runjava(classpath=self.tool_classpath('scalafmt'),
+                        main='org.scalafmt.cli.Cli',
+                        args=args + files,
+                        workunit_name='scalafmt',
+                        jvm_options=self.get_options().jvm_options)
 
   @abstractproperty
   def additional_args(self):

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -47,7 +47,7 @@ class ScalaFmt(RewriteBase):
   def implementation_version(cls):
     return super(ScalaFmt, cls).implementation_version() + [('ScalaFmt', 5)]
 
-  def invoke_tool(self, _root, target_sources):
+  def invoke_tool(self, absolute_root, target_sources):
     # If no config file is specified use default scalafmt config.
     config_file = self.get_options().configuration
     args = list(self.additional_args)

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -4,14 +4,17 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import os.path
 from abc import abstractproperty
 
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
+from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.java.jar.jar_dependency import JarDependency
-from pants.option.custom_types import file_option
+from pants.option.custom_types import dir_option, file_option
 from pants.task.fmt_task_mixin import FmtTaskMixin
 from pants.task.lint_task_mixin import LintTaskMixin
+from pants.util.dirutil import fast_relpath
 
 
 class ScalaFmt(RewriteBase):
@@ -26,6 +29,10 @@ class ScalaFmt(RewriteBase):
     super(ScalaFmt, cls).register_options(register)
     register('--configuration', advanced=True, type=file_option, fingerprint=True,
               help='Path to scalafmt config file, if not specified default scalafmt config used')
+    register('--output-dir', advanced=True, type=dir_option, fingerprint=True,
+              help='Path to scalafmt output directory. Any updated files will be written here. '
+                   'If not specified, files will be modified in-place')
+
     cls.register_jvm_tool(register,
                           'scalafmt',
                           classpath=[
@@ -50,15 +57,46 @@ class ScalaFmt(RewriteBase):
     # If no config file is specified use default scalafmt config.
     config_file = self.get_options().configuration
     args = list(self.additional_args)
-    args.extend(['--files', ','.join(source for _, source in target_sources)])
-    if config_file != None:
+    if config_file is not None:
       args.extend(['--config', config_file])
+    if self.get_options().output_dir:
+      args.append('--stdout')
 
-    return self.runjava(classpath=self.tool_classpath('scalafmt'),
-                        main='org.scalafmt.cli.Cli',
-                        args=args,
-                        workunit_name='scalafmt',
-                        jvm_options=self.get_options().jvm_options)
+    result = 0
+    created_dirs = set()
+
+    for _, source in target_sources:
+      res, workunit = self.runjava(classpath=self.tool_classpath('scalafmt'),
+                                   main='org.scalafmt.cli.Cli',
+                                   args=args + ['--files', source],
+                                   workunit_name='scalafmt',
+                                   jvm_options=self.get_options().jvm_options,
+                                   return_workunit=True)
+      result |= res
+
+      if self.get_options().output_dir is not None:
+        with open(workunit.output_paths()['stdout'], 'r') as f:
+          formatted_file = f.read()
+
+        with open(source, 'r') as f:
+          unformatted_file = f.read()
+
+        if formatted_file != unformatted_file:
+          path = os.path.join(
+            self.get_options().output_dir,
+            fast_relpath(source, get_buildroot())
+          )
+
+          dir_to_create = os.path.dirname(path)
+
+          if dir_to_create not in created_dirs:
+            os.makedirs(os.path.dirname(path))
+            created_dirs.add(dir_to_create)
+
+          with open(path, 'w') as f:
+            f.write(formatted_file)
+
+    return result
 
   @abstractproperty
   def additional_args(self):

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -83,6 +83,15 @@ def safe_mkdir_for(path, clean=False):
   safe_mkdir(os.path.dirname(path), clean=clean)
 
 
+def safe_mkdir_for_all(paths):
+  created_dirs = set()
+  for path in paths:
+    dir_to_make = os.path.dirname(path)
+    if dir_to_make not in created_dirs:
+      safe_mkdir(dir_to_make)
+      created_dirs.add(dir_to_make)
+
+
 def safe_file_dump(filename, payload):
   """Write a string to a file.
 

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -88,7 +88,8 @@ def safe_mkdir_for_all(paths):
 
   This avoids attempting to re-make the same directories, which may be noticeably expensive if many
   paths mostly fall in the same set of directories.
-  :type paths list<string>
+
+  :param list of str paths: The paths for which containing directories should be created.
   """
   created_dirs = set()
   for path in paths:

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -84,6 +84,12 @@ def safe_mkdir_for(path, clean=False):
 
 
 def safe_mkdir_for_all(paths):
+  """Make directories which would contain all of the passed paths.
+
+  This avoids attempting to re-make the same directories, which may be noticeably expensive if many
+  paths mostly fall in the same set of directories.
+  :type paths list<string>
+  """
   created_dirs = set()
   for path in paths:
     dir_to_make = os.path.dirname(path)

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -148,23 +148,22 @@ class ScalaFmtFormatTest(ScalaFmtTestBase):
 
   def test_output_dir(self):
     with temporary_dir() as output_dir:
-      with temporary_dir() as workunit_dir:
-        self.set_options(skip=False, output_dir=output_dir)
+      self.set_options(skip=False, output_dir=output_dir)
 
-        lint_options_scope = 'sfcf'
-        check_fmt_task_type = self.synthesize_task_subtype(ScalaFmtCheckFormat, lint_options_scope)
-        self.set_options_for_scope(lint_options_scope)
+      lint_options_scope = 'sfcf'
+      check_fmt_task_type = self.synthesize_task_subtype(ScalaFmtCheckFormat, lint_options_scope)
+      self.set_options_for_scope(lint_options_scope)
 
-        # format an incorrectly formatted file.
-        context = self.context(
-          for_task_types=[check_fmt_task_type],
-          target_roots=self.library,
-        )
-        self.execute(context)
+      # format an incorrectly formatted file.
+      context = self.context(
+        for_task_types=[check_fmt_task_type],
+        target_roots=self.library,
+      )
+      self.execute(context)
 
-        with open(self.test_file, 'rb') as fp:
-          self.assertEqual(self.test_file_contents, fp.read())
+      with open(self.test_file, 'rb') as fp:
+        self.assertEqual(self.test_file_contents, fp.read())
 
-        relative_test_file = fast_relpath(self.test_file, self.build_root)
-        with open(os.path.join(output_dir, relative_test_file), 'rb') as fp:
-          self.assertNotEqual(self.test_file_contents, fp.read())
+      relative_test_file = fast_relpath(self.test_file, self.build_root)
+      with open(os.path.join(output_dir, relative_test_file), 'rb') as fp:
+        self.assertNotEqual(self.test_file_contents, fp.read())

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -15,6 +15,8 @@ from pants.base.exceptions import TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.resources import Resources
 from pants.source.source_root import SourceRootConfig
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import fast_relpath
 from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 from pants_test.subsystem.subsystem_util import init_subsystem
 
@@ -143,3 +145,27 @@ class ScalaFmtFormatTest(ScalaFmtTestBase):
     check_fmt_workdir = os.path.join(self.pants_workdir, check_fmt_task_type.stable_name())
     check_fmt_task = check_fmt_task_type(context, check_fmt_workdir)
     check_fmt_task.execute()
+
+  def test_output_dir(self):
+    with temporary_dir() as output_dir:
+      with temporary_dir() as workunit_dir:
+        self.set_options(skip=False, output_dir=output_dir)
+
+        lint_options_scope = 'sfcf'
+        check_fmt_task_type = self.synthesize_task_subtype(ScalaFmtCheckFormat, lint_options_scope)
+        self.set_options_for_scope(lint_options_scope)
+
+        # format an incorrectly formatted file.
+        context = self.context(
+          for_task_types=[check_fmt_task_type],
+          target_roots=self.library,
+          workunit_output_dir=workunit_dir,
+        )
+        self.execute(context)
+
+        with open(self.test_file, 'rb') as fp:
+          self.assertEqual(self.test_file_contents, fp.read())
+
+        relative_test_file = fast_relpath(self.test_file, self.build_root)
+        with open(os.path.join(output_dir, relative_test_file), 'rb') as fp:
+          self.assertNotEqual(self.test_file_contents, fp.read())

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -159,7 +159,6 @@ class ScalaFmtFormatTest(ScalaFmtTestBase):
         context = self.context(
           for_task_types=[check_fmt_task_type],
           target_roots=self.library,
-          workunit_output_dir=workunit_dir,
         )
         self.execute(context)
 


### PR DESCRIPTION
### Problem

The Scalafmt task currently modifies files in-place. In some circumstances it more useful to put updated files in a separate output directory.

### Solution

This patch adds an --output-dir flag to the ScalaFmt task which causes scalafmt to write updates to stdout instead of modifying in-place, then captures this and writes it to a mirrored directory structure in the user-specified output directory.