### PR TITLE
Port buildgen - add missing future dependency to BUILD

### DIFF
--- a/contrib/buildgen/src/python/pants/contrib/buildgen/BUILD
+++ b/contrib/buildgen/src/python/pants/contrib/buildgen/BUILD
@@ -21,6 +21,7 @@ python_library(
   name = 'build_file_manipulator',
   sources = ['build_file_manipulator.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/build_graph',
   ]
 )


### PR DESCRIPTION
Fixing issue from the port of buildgen of missing dependency in BUILD file from https://github.com/pantsbuild/pants/pull/6110.

While technically everything runs correctly without this declaration, that is an implementation detail that should not be relied upon.