### PR TITLE
Add Python3 standard library imports to isort.cfg known_standard_library

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,5 +6,6 @@ line_length=100
 indent=2
 lines_after_imports=2
 known_first_party=internal_backend,pants,pants_test
+known_standard_library=_dummy_thread,_markupbase,_thread,builtins,copyreg,html,http,queue,reprlib,socketserver,tkinter,xmlrpc
 default_section=THIRDPARTY
 not_skip=__init__.py

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,6 +6,7 @@ line_length=100
 indent=2
 lines_after_imports=2
 known_first_party=internal_backend,pants,pants_test
+# TODO(python3port): remove below line once isort upgraded to 4.3.4 (https://github.com/pantsbuild/pants/issues/6149)
 known_standard_library=_dummy_thread,_markupbase,_thread,builtins,copyreg,html,http,queue,reprlib,socketserver,tkinter,xmlrpc
 default_section=THIRDPARTY
 not_skip=__init__.py

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -2,7 +2,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-set -e
+set -ex
 
 ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
 source ${ROOT}/build-support/common.sh

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -4,10 +4,10 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import http.server
 import json
 import threading
 
-import http.server
 from future.moves.urllib.parse import parse_qs
 
 from pants.goal.run_tracker import RunTracker


### PR DESCRIPTION
Add backported Python3 standard library modules to known section of isort.cfg.

## Background
isort has an environment leak somehow between some local usages of `isort.sh` vs. CI's usage, as discussed in #6092.

While this PR does not solve the underlying leakage, it fixes the results of that bug and will fix the breaking CI for #6136, #6129, and #6092.
