### PR TITLE
Port contrib/node to py3

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/BUILD
@@ -3,6 +3,7 @@
 
 python_library(
   dependencies=[
+    '3rdparty/python:future',
     'src/python/pants/base:deprecated',
     'src/python/pants/binaries',
     'src/python/pants/subsystem',

--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -77,7 +77,7 @@ class NodeDistribution(NativeTool):
     if not package_manager_obj:
       raise TaskError(
         'Unknown package manager: {}.\nValid values are {}.'.format(
-          package_manager, NodeDistribution.VALID_PACKAGE_MANAGER_LIST.keys()
+          package_manager, list(NodeDistribution.VALID_PACKAGE_MANAGER_LIST.keys())
       ))
     return package_manager_obj
 

--- a/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+from builtins import object
 
 from pants.contrib.node.subsystems.command import command_gen
 

--- a/contrib/node/src/python/pants/contrib/node/tasks/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/tasks/BUILD
@@ -15,7 +15,10 @@ target(
 
 python_library(
   name='node_paths',
-  sources=['node_paths.py']
+  sources=['node_paths.py'],
+  dependencies = [
+    '3rdparty/python:future',
+  ],
 )
 
 python_library(
@@ -58,6 +61,7 @@ python_library(
   name='node_task',
   sources=['node_task.py'],
   dependencies=[
+    '3rdparty/python:future',
     'contrib/node/src/python/pants/contrib/node/subsystems',
     'contrib/node/src/python/pants/contrib/node/targets:node_bundle',
     'contrib/node/src/python/pants/contrib/node/targets:node_module',

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -43,12 +43,10 @@ class JavascriptStyleBase(NodeTask):
     raise NotImplementedError()
 
   def get_lintable_node_targets(self, targets):
-    return filter(
-      lambda target: isinstance(target, NodeModule)
+    return [target for target in targets if isinstance(target, NodeModule)
                      and (target.has_sources(self._JS_SOURCE_EXTENSION)
                           or target.has_sources(self._JSX_SOURCE_EXTENSION))
-                     and (not target.is_synthetic),
-      targets)
+                     and (not target.is_synthetic)]
 
   def get_javascript_sources(self, target):
     sources = set()

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_paths.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_paths.py
@@ -4,10 +4,12 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-
 # TODO(John Sirois): UnionProducts? That seems broken though for ranged version constraints,
 # which npm has and are widely used in the community.  For now stay dumb simple (and slow) and
 # resolve each node_module individually.
+from builtins import object
+
+
 class NodePaths(object):
   """Maps NpmPackage targets to their resolved NODE_PATH chroot."""
 
@@ -38,4 +40,4 @@ class NodePaths(object):
 
     :rtype list string
     """
-    return self._paths_by_target.values()
+    return list(self._paths_by_target.values())

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_paths.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_paths.py
@@ -4,12 +4,12 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-# TODO(John Sirois): UnionProducts? That seems broken though for ranged version constraints,
-# which npm has and are widely used in the community.  For now stay dumb simple (and slow) and
-# resolve each node_module individually.
 from builtins import object
 
 
+# TODO(John Sirois): UnionProducts? That seems broken though for ranged version constraints,
+# which npm has and are widely used in the community.  For now stay dumb simple (and slow) and
+# resolve each node_module individually.
 class NodePaths(object):
   """Maps NpmPackage targets to their resolved NODE_PATH chroot."""
 

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import str
+
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.task.task import Task
 from pants.util.memo import memoized_property

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
@@ -73,6 +73,7 @@ python_tests(
   name='node_test_integration',
   sources=['test_node_test_integration.py'],
   dependencies=[
+    '3rdparty/python:future',
     'tests/python/pants_test:int-test',
   ],
   timeout=240,
@@ -83,6 +84,7 @@ python_tests(
   name='node_task',
   sources=['test_node_task.py'],
   dependencies=[
+    '3rdparty/python:future',
     'contrib/node/src/python/pants/contrib/node/targets:node_module',
     'contrib/node/src/python/pants/contrib/node/targets:node_remote_module',
     'contrib/node/src/python/pants/contrib/node/targets:node_test',

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_bundle.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_bundle.py
@@ -57,7 +57,7 @@ class TestNodeBundle(TaskTestBase):
 
       product_data = product.get(target)
       self.assertIsNotNone(product_data)
-      product_basedir = product_data.keys()[0]
+      product_basedir = list(product_data.keys())[0]
       self.assertEquals(product_data[product_basedir], ['{}.tar.gz'.format(self.target_name)])
 
   def test_no_dependencies_for_node_bundle(self):

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_task.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_task.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 import os
 import string
+from builtins import zip
 from textwrap import dedent
 
 from pants.build_graph.target import Target
@@ -76,10 +77,10 @@ class NodeTaskTest(TaskTestBase):
     target_names = [':' + letter for letter in list(string.ascii_lowercase)]
     types_with_target_names = zip(types, target_names)
 
-    type_check_results = [(type, type_check_function(self.make_target(target_name, type)))
-                          for (type, target_name) in types_with_target_names]
+    type_check_results = {type: type_check_function(self.make_target(target_name, type))
+                          for type, target_name in types_with_target_names}
 
-    return dict(type_check_results)
+    return type_check_results
 
   def test_execute_node(self):
     task = self.create_task(self.context())

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_test_integration.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_test_integration.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import range
+
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 


### PR DESCRIPTION
Mostly imports, an occasional cast to list.
Largest change perhaps was the dict comp in test_node_task.py

### Problem

port to py3

### Solution

only significant change:
   -- type_check_results = [(type, type_check_function(self.make_target(target_name, type)))
                          for (type, target_name) in types_with_target_names]
   ++ type_check_results = {type: type_check_function(self.make_target(target_name, type))
                          for type, target_name in types_with_target_names}

   -- return dict(type_check_results)
   ++ return type_check_results
