### PR TITLE
rustfmt check more reliably works

### DIFF
--- a/build-support/bin/check_rust_formatting.sh
+++ b/build-support/bin/check_rust_formatting.sh
@@ -15,7 +15,7 @@ function usage() {
   fi
 }
 
-write_mode=diff
+write_mode=check
 
 while getopts "hf" opt; do
   case ${opt} in
@@ -54,24 +54,21 @@ bad_files=(
     exit ${PIPESTATUS[0]}
   )
 )
-case $? in
-  4)
+exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+  if [[ "${write_mode}" == "check" ]]; then
     echo >&2 "The following rust files were incorrectly formatted, run \`$0 -f\` to reformat them:"
     for bad_file in ${bad_files[*]}; do
       echo >&2 ${bad_file}
     done
-    exit 1
-    ;;
-  0)
-    exit 0
-    ;;
-  *)
+  else
     cat << EOF >&2
 An error occurred while checking the formatting of rust files.
-Try running \`(cd "${NATIVE_ROOT}" && ${cmd[*]} --write-mode=diff)\` to investigate.
+Try running \`(cd "${NATIVE_ROOT}" && ${cmd[*]} --write-mode=${write_mode})\` to investigate.
 Its error is:
 EOF
-    cd "${NATIVE_ROOT}" && ${cmd[*]} --write-mode=diff >/dev/null
-    exit 1
-    ;;
-esac
+    cd "${NATIVE_ROOT}" && ${cmd[*]} --write-mode=${write_mode} >/dev/null
+  fi
+  exit 1
+fi

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -608,16 +608,27 @@ impl<N: Node> Graph<N> {
       // Get the Generations of all dependencies of the Node. We can trust that these have not changed
       // since we began executing, as long as we are not currently marked dirty (see the method doc).
       let dep_generations = inner
-          .pg
-          .neighbors_directed(entry_id, Direction::Outgoing)
-          .filter_map(|dep_id| inner.entry_for_id(dep_id))
-          .map(|entry| entry.generation())
-          .collect();
-      (inner.entry_for_id(entry_id).cloned(), entry_id, dep_generations)
+        .pg
+        .neighbors_directed(entry_id, Direction::Outgoing)
+        .filter_map(|dep_id| inner.entry_for_id(dep_id))
+        .map(|entry| entry.generation())
+        .collect();
+      (
+        inner.entry_for_id(entry_id).cloned(),
+        entry_id,
+        dep_generations,
+      )
     };
     if let Some(mut entry) = entry {
       let mut inner = self.inner.lock().unwrap();
-      entry.complete(context, entry_id, run_token, dep_generations, result, &mut inner);
+      entry.complete(
+        context,
+        entry_id,
+        run_token,
+        dep_generations,
+        result,
+        &mut inner,
+      );
     }
   }
 


### PR DESCRIPTION
We were running `--write-mode=diff` which used to exit 4 if your code as
incorrectly formatted, and now doesn't. It now only exits non-0 if
your code doesn't parse. `--write-mode=check` *does* exit non-zero if
your code isn't correctly formatted, but provides no way of
distinguishing "Your code is incorrectly formatted" from "your code
doesn't parse". So that's nice of it.