### PR TITLE
Fix isort issues

### DIFF
--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
+import faulthandler
 import logging
 import os
 import signal
@@ -12,7 +13,6 @@ import sys
 import traceback
 from builtins import object
 
-import faulthandler
 import six
 
 from pants.util.dirutil import safe_open

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -12,8 +12,8 @@ from builtins import object
 
 from pex import resolver
 from pex.base import requirement_is_exact
-from pkg_resources import working_set as global_working_set
 from pkg_resources import Requirement
+from pkg_resources import working_set as global_working_set
 from wheel.install import WheelFile
 
 from pants.backend.python.subsystems.python_repos import PythonRepos

--- a/src/python/pants/pantsd/service/fs_event_service.py
+++ b/src/python/pants/pantsd/service/fs_event_service.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import os
 import traceback
-
 from concurrent.futures import ThreadPoolExecutor
 
 from pants.pantsd.service.pants_service import PantsService

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -4,10 +4,10 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import http.server
 import json
 import threading
 
-import http.server
 from future.moves.urllib.parse import parse_qs
 
 from pants.goal.run_tracker import RunTracker

--- a/tests/python/pants_test/java/junit/test_junit_xml_parser.py
+++ b/tests/python/pants_test/java/junit/test_junit_xml_parser.py
@@ -8,10 +8,11 @@ import os
 import unittest
 from builtins import object
 
-from pants.java.junit.junit_xml_parser import Test as JUnitTest
 # NB: The Test -> JUnitTest import re-name above is needed to work around conflicts with pytest test
 # collection and a conflicting Test type in scope during that process.
-from pants.java.junit.junit_xml_parser import ParseError, RegistryOfTests, parse_failed_targets
+from pants.java.junit.junit_xml_parser import ParseError, RegistryOfTests
+from pants.java.junit.junit_xml_parser import Test as JUnitTest
+from pants.java.junit.junit_xml_parser import parse_failed_targets
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_open
 from pants.util.xml_parser import XmlParser

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -10,10 +10,10 @@ import os
 import signal
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 
 from colors import bold, cyan, magenta
-from concurrent.futures import ThreadPoolExecutor
 
 from pants.pantsd.process_manager import ProcessManager
 from pants.util.collections import recursively_update

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -16,10 +16,11 @@ import mock
 from pants.util import dirutil
 from pants.util.contextutil import pushd, temporary_dir
 from pants.util.dirutil import (ExistingDirError, ExistingFileError, _mkdtemp_unregister_cleaner,
-                                absolute_symlink, check_no_overlapping_paths, fast_relpath, get_basedir,
-                                longest_dir_prefix, mergetree, read_file, relative_symlink, relativize_paths,
-                                rm_rf, safe_concurrent_creation, safe_file_dump, safe_mkdir, safe_mkdtemp,
-                                safe_open, safe_rm_oldest_items_in_dir, safe_rmtree, touch)
+                                absolute_symlink, check_no_overlapping_paths, fast_relpath,
+                                get_basedir, longest_dir_prefix, mergetree, read_file,
+                                relative_symlink, relativize_paths, rm_rf, safe_concurrent_creation,
+                                safe_file_dump, safe_mkdir, safe_mkdtemp, safe_open,
+                                safe_rm_oldest_items_in_dir, safe_rmtree, touch)
 from pants.util.objects import datatype
 
 


### PR DESCRIPTION
#6166 correctly upgraded isort, but resulted in some files having issues that don't throw issues in CI until a related file is changed, e.g. the backend/jvm port complaining about init code.

## How changes generated
- `./pants fmt src/python/pants/::`
- `./pants fmt tests/python/pants_test/::`
- Running similar command on every contrib/src and contrib/tests folder

Let me know if there's a better way to do this! I'm not sure I caught every problem.



