### PR TITLE
Add basic native task unit tests.

### DIFF
--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -254,7 +254,6 @@ class EngineInitializer(object):
       build_configuration,
       native=native,
       glob_match_error_behavior=bootstrap_options.glob_expansion_failure,
-      rules=build_configuration.rules(),
       build_ignore_patterns=bootstrap_options.build_ignore,
       exclude_target_regexps=bootstrap_options.exclude_target_regexp,
       subproject_roots=bootstrap_options.subproject_roots,
@@ -271,7 +270,6 @@ class EngineInitializer(object):
     build_root=None,
     native=None,
     glob_match_error_behavior=None,
-    rules=None,
     build_ignore_patterns=None,
     exclude_target_regexps=None,
     subproject_roots=None,
@@ -308,7 +306,7 @@ class EngineInitializer(object):
     build_root = build_root or get_buildroot()
     build_configuration = build_configuration or BuildConfigInitializer.get(OptionsBootstrapper())
     build_file_aliases = build_configuration.registered_aliases()
-    rules = rules or build_configuration.rules() or []
+    rules = build_configuration.rules()
     console = Console()
 
     symbol_table = LegacySymbolTable(build_file_aliases)

--- a/tests/python/pants_test/backend/native/tasks/BUILD
+++ b/tests/python/pants_test/backend/native/tasks/BUILD
@@ -1,0 +1,18 @@
+python_tests(
+  dependencies=[
+    ':native_task_test_base',
+    'src/python/pants/backend/native/targets',
+    'src/python/pants/backend/native/tasks',
+  ],
+  tags={'platform_specific_behavior'},
+)
+
+python_library(
+  name='native_task_test_base',
+  sources=['native_task_test_base.py'],
+  dependencies=[
+    'src/python/pants/backend/native',
+    'src/python/pants/backend/native/targets',
+    'tests/python/pants_test:task_test_base',
+  ],
+)

--- a/tests/python/pants_test/backend/native/tasks/native_task_test_base.py
+++ b/tests/python/pants_test/backend/native/tasks/native_task_test_base.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+from textwrap import dedent
+
+from pants.backend.native import register
+from pants.backend.native.targets.native_library import CppLibrary
+from pants.backend.native.tasks.native_external_library_fetch import NativeExternalLibraryFetch
+from pants_test.task_test_base import TaskTestBase
+
+
+class NativeTaskTestBase(TaskTestBase):
+  @classmethod
+  def rules(cls):
+    return super(NativeTaskTestBase, cls).rules() + register.rules()
+
+
+class NativeCompileTestMixin(object):
+  def create_simple_cpp_library(self, **kwargs):
+    self.create_file('src/cpp/test/test.hpp', contents=dedent("""
+      #ifndef __TEST_HPP__
+      #define __TEST_HPP__
+
+      int test(int);
+
+      extern "C" int test_exported(int);
+
+      #endif
+    """))
+    self.create_file('src/cpp/test/test.cpp', contents=dedent("""
+      #include "test.hpp"
+
+      int test(int x) {
+        return x / 137;
+      }
+
+      extern "C" int test_exported(int x) {
+        return test(x * 42);
+      }
+    """))
+    return self.make_target(spec='src/cpp/test',
+                            target_type=CppLibrary,
+                            sources=['test.hpp', 'test.cpp'],
+                            **kwargs)
+
+  def prepare_context_for_compile(self, target_roots, for_task_types=None, **kwargs):
+    native_elf_fetch_task_type = self.synthesize_task_subtype(NativeExternalLibraryFetch,
+                                                              'native_elf_fetch_scope')
+
+    for_task_types = list(for_task_types or ()) + [native_elf_fetch_task_type]
+    context = self.context(target_roots=target_roots, for_task_types=for_task_types, **kwargs)
+
+    native_elf_fetch = native_elf_fetch_task_type(context,
+                                                  os.path.join(self.pants_workdir,
+                                                               'native_elf_fetch'))
+    native_elf_fetch.execute()
+    return context

--- a/tests/python/pants_test/backend/native/tasks/test_c_compile.py
+++ b/tests/python/pants_test/backend/native/tasks/test_c_compile.py
@@ -1,0 +1,47 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from textwrap import dedent
+
+from pants.backend.native.targets.native_library import CLibrary
+from pants.backend.native.tasks.c_compile import CCompile
+from pants_test.backend.native.tasks.native_task_test_base import (NativeCompileTestMixin,
+                                                                   NativeTaskTestBase)
+
+
+class CCompileTest(NativeTaskTestBase, NativeCompileTestMixin):
+  @classmethod
+  def task_type(cls):
+    return CCompile
+
+  def create_simple_c_library(self, **kwargs):
+    self.create_file('src/c/test/test.h', contents=dedent("""
+      #ifndef __TEST_H__
+      #define __TEST_H__
+
+      int test(int);
+
+      #endif
+    """))
+    self.create_file('src/c/test/test.c', contents=dedent("""
+      #include "test.h"
+
+      int test(int x) {
+        return x / 137;
+      }
+    """))
+    return self.make_target(spec='src/c/test',
+                            target_type=CLibrary,
+                            sources=['test.h', 'test.c'],
+                            **kwargs)
+
+  def test_caching(self):
+    c = self.create_simple_c_library()
+    context = self.prepare_context_for_compile(target_roots=[c])
+    c_compile = self.create_task(context)
+
+    c_compile.execute()
+    c_compile.execute()

--- a/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
+++ b/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
@@ -1,0 +1,23 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from pants.backend.native.tasks.cpp_compile import CppCompile
+from pants_test.backend.native.tasks.native_task_test_base import (NativeCompileTestMixin,
+                                                                   NativeTaskTestBase)
+
+
+class CppCompileTest(NativeTaskTestBase, NativeCompileTestMixin):
+  @classmethod
+  def task_type(cls):
+    return CppCompile
+
+  def test_caching(self):
+    cpp = self.create_simple_cpp_library()
+    context = self.prepare_context_for_compile(target_roots=[cpp])
+    cpp_compile = self.create_task(context)
+
+    cpp_compile.execute()
+    cpp_compile.execute()

--- a/tests/python/pants_test/backend/native/tasks/test_link_shared_libraries.py
+++ b/tests/python/pants_test/backend/native/tasks/test_link_shared_libraries.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+from pants.backend.native.targets.native_artifact import NativeArtifact
+from pants.backend.native.tasks.cpp_compile import CppCompile
+from pants.backend.native.tasks.link_shared_libraries import LinkSharedLibraries
+from pants_test.backend.native.tasks.native_task_test_base import (NativeCompileTestMixin,
+                                                                   NativeTaskTestBase)
+
+
+class LinkSharedLibrariesTest(NativeTaskTestBase, NativeCompileTestMixin):
+  @classmethod
+  def task_type(cls):
+    return LinkSharedLibraries
+
+  def test_caching(self):
+    cpp = self. create_simple_cpp_library(ctypes_native_library=NativeArtifact(lib_name='test'),)
+
+    cpp_compile_task_type = self.synthesize_task_subtype(CppCompile, 'cpp_compile_scope')
+    context = self.prepare_context_for_compile(target_roots=[cpp],
+                                               for_task_types=[cpp_compile_task_type])
+
+    cpp_compile = cpp_compile_task_type(context, os.path.join(self.pants_workdir, 'cpp_compile'))
+    cpp_compile.execute()
+
+    link_shared_libraries = self.create_task(context)
+
+    link_shared_libraries.execute()
+    link_shared_libraries.execute()

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -268,12 +268,12 @@ class ExecuteProcessRequestTest(unittest.TestCase):
 class IsolatedProcessTest(TestBase, unittest.TestCase):
 
   @classmethod
-  def extra_rules(cls):
-    return create_cat_stdout_rules() + create_javac_compile_rules() + [
+  def rules(cls):
+    return super(IsolatedProcessTest, cls).rules() + [
       RootRule(JavacVersionExecutionRequest),
       process_request_from_javac_version,
       get_javac_version_output,
-    ]
+    ] + create_cat_stdout_rules() + create_javac_compile_rules()
 
   def test_integration_concat_with_snapshots_stdout(self):
 

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -270,9 +270,15 @@ class TestBase(unittest.TestCase):
     return BuildFileAliases(targets={'target': Target})
 
   @classmethod
+  def rules(cls):
+    # Required for sources_for:
+    return [RootRule(SourcesField)]
+
+  @classmethod
   def build_config(cls):
     build_config = BuildConfiguration()
     build_config.register_aliases(cls.alias_groups())
+    build_config.register_rules(cls.rules())
     return build_config
 
   def setUp(self):
@@ -356,11 +362,6 @@ class TestBase(unittest.TestCase):
     return os.path.join(cls._build_root(), '.pants.d')
 
   @classmethod
-  def extra_rules(cls):
-    """Override this to register extra rules in this class's scheduler."""
-    return []
-
-  @classmethod
   def _init_engine(cls):
     if cls._scheduler is not None:
       return
@@ -374,8 +375,6 @@ class TestBase(unittest.TestCase):
       native=init_native(),
       build_configuration=cls.build_config(),
       build_ignore_patterns=None,
-      # Required for sources_for:
-      rules=cls.extra_rules() + [RootRule(SourcesField)],
     ).new_session()
     cls._scheduler = graph_session.scheduler_session
     cls._build_graph, cls._address_mapper = graph_session.create_build_graph(


### PR DESCRIPTION
Running a `./pants lint` across the whole repo revealed an issue
accessing a non-existant `self.linker.platform` attribute in
`LinkSharedLibraries`. Add basic unit tests to exercise task execution
with a full cache miss and then a full hit.