### PR TITLE
Fix incorrect use of bytes() when invoking the daemon in a tty

### DIFF
--- a/src/python/pants/java/nailgun_protocol.py
+++ b/src/python/pants/java/nailgun_protocol.py
@@ -6,9 +6,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import struct
-from builtins import object, zip
+from builtins import object, str, zip
 
 import six
+from future.utils import binary_type
 
 
 STDIO_DESCRIPTORS = (0, 1, 2)
@@ -245,7 +246,7 @@ class NailgunProtocol(object):
     def gen_env_vars():
       for fd_id, fd in zip(STDIO_DESCRIPTORS, (stdin, stdout, stderr)):
         is_atty = fd.isatty()
-        yield (cls.TTY_ENV_TMPL.format(fd_id), six.binary_type(str(int(is_atty))))
+        yield (cls.TTY_ENV_TMPL.format(fd_id), binary_type(str(int(is_atty))))
         if is_atty:
           yield (cls.TTY_PATH_ENV.format(fd_id), os.ttyname(fd.fileno()) or '')
     return dict(gen_env_vars())

--- a/src/python/pants/java/nailgun_protocol.py
+++ b/src/python/pants/java/nailgun_protocol.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import struct
-from builtins import bytes, object, zip
+from builtins import object, zip
 
 import six
 
@@ -245,7 +245,7 @@ class NailgunProtocol(object):
     def gen_env_vars():
       for fd_id, fd in zip(STDIO_DESCRIPTORS, (stdin, stdout, stderr)):
         is_atty = fd.isatty()
-        yield (cls.TTY_ENV_TMPL.format(fd_id), bytes([int(is_atty)]))
+        yield (cls.TTY_ENV_TMPL.format(fd_id), six.binary_type(str(int(is_atty))))
         if is_atty:
           yield (cls.TTY_PATH_ENV.format(fd_id), os.ttyname(fd.fileno()) or '')
     return dict(gen_env_vars())

--- a/src/python/pants/java/nailgun_protocol.py
+++ b/src/python/pants/java/nailgun_protocol.py
@@ -245,7 +245,7 @@ class NailgunProtocol(object):
     def gen_env_vars():
       for fd_id, fd in zip(STDIO_DESCRIPTORS, (stdin, stdout, stderr)):
         is_atty = fd.isatty()
-        yield (cls.TTY_ENV_TMPL.format(fd_id), bytes(int(is_atty)))
+        yield (cls.TTY_ENV_TMPL.format(fd_id), bytes([int(is_atty)]))
         if is_atty:
           yield (cls.TTY_PATH_ENV.format(fd_id), os.ttyname(fd.fileno()) or '')
     return dict(gen_env_vars())

--- a/tests/python/pants_test/java/test_nailgun_protocol.py
+++ b/tests/python/pants_test/java/test_nailgun_protocol.py
@@ -211,9 +211,11 @@ class TestNailgunProtocol(unittest.TestCase):
     mock_stream.fileno.return_value = fileno
     return mock_stream
 
+  _fake_ttyname = '/this/is/not/a/real/tty'
+
   @mock.patch('os.ttyname', autospec=True, spec_set=True)
   def test_isatty_to_env_with_mock_tty(self, mock_ttyname):
-    mock_ttyname.return_value = '/dev/ttys000'
+    mock_ttyname.return_value = self._fake_ttyname
     mock_stdin = self._make_mock_stream(True, 0)
     mock_stdout = self._make_mock_stream(True, 1)
     mock_stderr = self._make_mock_stream(True, 2)
@@ -221,12 +223,12 @@ class TestNailgunProtocol(unittest.TestCase):
     self.assertEquals(
       NailgunProtocol.isatty_to_env(mock_stdin, mock_stdout, mock_stderr),
       {
-        'NAILGUN_TTY_0': b'\x01',
-        'NAILGUN_TTY_1': b'\x01',
-        'NAILGUN_TTY_2': b'\x01',
-        'NAILGUN_TTY_PATH_0': '/dev/ttys000',
-        'NAILGUN_TTY_PATH_1': '/dev/ttys000',
-        'NAILGUN_TTY_PATH_2': '/dev/ttys000',
+        'NAILGUN_TTY_0': b'1',
+        'NAILGUN_TTY_1': b'1',
+        'NAILGUN_TTY_2': b'1',
+        'NAILGUN_TTY_PATH_0': self._fake_ttyname,
+        'NAILGUN_TTY_PATH_1': self._fake_ttyname,
+        'NAILGUN_TTY_PATH_2': self._fake_ttyname,
       })
 
   def test_isatty_to_env_without_tty(self):
@@ -237,9 +239,9 @@ class TestNailgunProtocol(unittest.TestCase):
     self.assertEquals(
       NailgunProtocol.isatty_to_env(mock_stdin, mock_stdout, mock_stderr),
       {
-        'NAILGUN_TTY_0': b'\x00',
-        'NAILGUN_TTY_1': b'\x00',
-        'NAILGUN_TTY_2': b'\x00',
+        'NAILGUN_TTY_0': b'0',
+        'NAILGUN_TTY_1': b'0',
+        'NAILGUN_TTY_2': b'0',
       })
 
   def test_construct_chunk(self):

--- a/tests/python/pants_test/java/test_nailgun_protocol.py
+++ b/tests/python/pants_test/java/test_nailgun_protocol.py
@@ -205,18 +205,18 @@ class TestNailgunProtocol(unittest.TestCase):
       (False, True, False)
     )
 
+  def _make_mock_stream(self, isatty, fileno):
+    mock_stream = mock.Mock()
+    mock_stream.isatty.return_value = isatty
+    mock_stream.fileno.return_value = fileno
+    return mock_stream
+
   @mock.patch('os.ttyname', autospec=True, spec_set=True)
   def test_isatty_to_env_with_mock_tty(self, mock_ttyname):
     mock_ttyname.return_value = '/dev/ttys000'
-    mock_stdin = mock.Mock()
-    mock_stdin.isatty.return_value = True
-    mock_stdin.fileno.return_value = 0
-    mock_stdout = mock.Mock()
-    mock_stdout.isatty.return_value = True
-    mock_stdout.fileno.return_value = 1
-    mock_stderr = mock.Mock()
-    mock_stderr.isatty.return_value = True
-    mock_stderr.fileno.return_value = 2
+    mock_stdin = self._make_mock_stream(True, 0)
+    mock_stdout = self._make_mock_stream(True, 1)
+    mock_stderr = self._make_mock_stream(True, 2)
 
     self.assertEquals(
       NailgunProtocol.isatty_to_env(mock_stdin, mock_stdout, mock_stderr),
@@ -230,15 +230,9 @@ class TestNailgunProtocol(unittest.TestCase):
       })
 
   def test_isatty_to_env_without_tty(self):
-    mock_stdin = mock.Mock()
-    mock_stdin.isatty.return_value = False
-    mock_stdin.fileno.return_value = 0
-    mock_stdout = mock.Mock()
-    mock_stdout.isatty.return_value = False
-    mock_stdout.fileno.return_value = 1
-    mock_stderr = mock.Mock()
-    mock_stderr.isatty.return_value = False
-    mock_stderr.fileno.return_value = 2
+    mock_stdin = self._make_mock_stream(False, 0)
+    mock_stdout = self._make_mock_stream(False, 1)
+    mock_stderr = self._make_mock_stream(False, 2)
 
     self.assertEquals(
       NailgunProtocol.isatty_to_env(mock_stdin, mock_stdout, mock_stderr),


### PR DESCRIPTION
### Problem

`pkill -f "pantsd \[" pantsd-runner && ./pants --enable-pantsd help` fails on master when run within a tty because we incorrectly try to pass an `int` directly to a `bytes`. This was introduced during #6159.

### Solution

- Wrap the `bytes()` argument in a list in `NailgunProtocol.isatty_to_env()`.
- Add unit testing which mocks out the tty querying to ensure the environment we return is valid.

### Result

No more crashing when trying to create a pantsd in a tty.

#### Thoughts

This may be another argument for something like #6157. There may also be room for an integration test which opens up a "real" pty to catch issues like these in the future, but it's not clear to me how to do that right now.