### PR TITLE
update contrib/python with py3 compat

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/BUILD
@@ -3,6 +3,7 @@
 
 python_library(
   dependencies=[
+    '3rdparty/python:future',
     ':resources',
     'src/python/pants/backend/python:interpreter_cache',
     'src/python/pants/backend/python/targets:python',

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/BUILD
@@ -5,6 +5,7 @@ python_library(
   name='all',
   sources=rglobs('*.py'),
   dependencies=[
+    '3rdparty/python:future',
     '3rdparty/python:pycodestyle',
     '3rdparty/python:pyflakes',
     '3rdparty/python:pex',

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/common.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/common.py
@@ -198,7 +198,7 @@ class PythonFile(object):
         yield self.translate_logical_line(
             line_number_start,
             token_start[0] + (1 if token_type is tokenize.NEWLINE else -1),
-            list([_f for _f in contents if _f]),
+            [_f for _f in contents if _f],
             indent_stack,
             endmarker=token_type == tokenize.ENDMARKER)
         contents = []
@@ -260,7 +260,7 @@ class Nit(object):
 
   def __init__(self, code, severity, filename, message, line_range=None, lines=None):
     if severity not in self.SEVERITY:
-      raise ValueError('Severity should be one of {}'.format(' '.join(list(self.SEVERITY.values()))))
+      raise ValueError('Severity should be one of {}'.format(' '.join(self.SEVERITY.values())))
     if not re.match(r'[A-Z]\d{3}', code):
       raise ValueError('Code must contain a prefix letter followed by a 3 digit number')
     self.filename = filename

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/common.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/common.py
@@ -12,6 +12,7 @@ import re
 import textwrap
 import tokenize
 from abc import abstractmethod
+from builtins import object
 from collections import Sequence
 
 import six
@@ -197,7 +198,7 @@ class PythonFile(object):
         yield self.translate_logical_line(
             line_number_start,
             token_start[0] + (1 if token_type is tokenize.NEWLINE else -1),
-            list(filter(None, contents)),
+            list([_f for _f in contents if _f]),
             indent_stack,
             endmarker=token_type == tokenize.ENDMARKER)
         contents = []
@@ -259,7 +260,7 @@ class Nit(object):
 
   def __init__(self, code, severity, filename, message, line_range=None, lines=None):
     if severity not in self.SEVERITY:
-      raise ValueError('Severity should be one of {}'.format(' '.join(self.SEVERITY.values())))
+      raise ValueError('Severity should be one of {}'.format(' '.join(list(self.SEVERITY.values()))))
     if not re.match(r'[A-Z]\d{3}', code):
       raise ValueError('Code must contain a prefix letter followed by a 3 digit number')
     self.filename = filename

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/file_excluder.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/file_excluder.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import re
+from builtins import object
 
 from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
@@ -29,11 +30,17 @@ class FileExcluder(object):
               'The pep8 check has been renamed to pycodestyle. '
               'Please update your suppression file: "{}". The pep8 option'.format(excludes_path)
             )
-            map(lambda p:p if p != 'pep8' else 'pycodestyle', plugins)
+
+            style_plugins = []
+            for p in plugins:
+              if p == 'pep8':
+                style_plugins.append('pycodestyle')
+              else:
+                style_plugins.append(p)
 
             self.excludes[pattern] = {
               'regex': re.compile(pattern),
-              'plugins': plugins
+              'plugins': style_plugins
             }
             log.debug('Exclude pattern: {pattern}'.format(pattern=pattern))
     else:

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/import_order.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/import_order.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import ast
 import os
+from builtins import object
 from distutils import sysconfig
 
 from pants.contrib.python.checks.tasks.checkstyle.common import CheckstylePlugin

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/trailing_whitespace.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/trailing_whitespace.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 import tokenize
+from builtins import range
 from collections import defaultdict
 
 from pants.contrib.python.checks.tasks.checkstyle.common import CheckstylePlugin

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import hashlib
 import os
 import pkgutil
+from builtins import str
 
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
 from pants.backend.python.subsystems.python_repos import PythonRepos
@@ -156,7 +157,7 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
           builder.freeze()
 
       exec_pex = PEX(exec_pex_path, interpreter)
-      extra_pex_paths = [pex.path() for pex in filter(None, [reqs_pex, srcs_pex])]
+      extra_pex_paths = [pex.path() for pex in [_f for _f in [reqs_pex, srcs_pex] if _f]]
       pex = WrappedPEX(exec_pex, extra_pex_paths)
 
       with self.context.new_workunit(name='eval',
@@ -213,7 +214,7 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
     reqs_pex_path = os.path.realpath(os.path.join(self.workdir, str(interpreter.identity),
                                                   vt.cache_key.hash))
     if not os.path.isdir(reqs_pex_path):
-      req_libs = filter(has_python_requirements, vt.target.closure())
+      req_libs =  [t for t in vt.target.closure() if has_python_requirements(t)]
       with safe_concurrent_creation(reqs_pex_path) as safe_path:
         builder = PEXBuilder(safe_path, interpreter=interpreter, copy=True)
         dump_requirement_libs(builder, interpreter, req_libs, self.context.log)

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
@@ -2,7 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='lib'
+  name='lib',
+  dependencies = [
+    '3rdparty/python:future',
+  ],
 )
 
 python_tests(

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checker.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checker.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import str
 from textwrap import dedent
 
 from pants.backend.python.targets.python_library import PythonLibrary

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_common.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_common.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import ast
 import textwrap
 import unittest
+from builtins import range, str
 
 from pants_test.option.util.fakes import create_options
 

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_import_order.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_import_order.py
@@ -49,7 +49,7 @@ IMPORT_CHUNKS = {
 
 
 def strip_newline(stmt):
-  return textwrap.dedent('\n'.join([_f for _f in stmt.splitlines() if _f]))
+  return textwrap.dedent('\n'.join(_f for _f in stmt.splitlines() if _f))
 
 
 def stitch_chunks(newlines, *chunks):

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_import_order.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_import_order.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import ast
 import textwrap
+from builtins import map
 
 from pants_test.contrib.python.checks.tasks.checkstyle.plugin_test_base import \
   CheckstylePluginTestBase
@@ -48,7 +49,7 @@ IMPORT_CHUNKS = {
 
 
 def strip_newline(stmt):
-  return textwrap.dedent('\n'.join(filter(None, stmt.splitlines())))
+  return textwrap.dedent('\n'.join([_f for _f in stmt.splitlines() if _f]))
 
 
 def stitch_chunks(newlines, *chunks):


### PR DESCRIPTION
### Problem
Upgrading to py3

Only substantive change: 
original:
            list(map(lambda p:p if p != 'pep8' else 'pycodestyle', plugins))

For loop should have replaced pep8 with pycodestyle.

### Solution

This is the same PR as previous only cleaning up the accidental merge w/o rebase.
