### PR TITLE
[missing-deps-suggest] move buildozer cli to a new line

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -598,12 +598,11 @@ class JvmCompile(NailgunTaskBase):
 
         path_to_buildozer = self.get_options().buildozer
         if path_to_buildozer:
-          suggestion_msg += ("\nYou can do this by running {buildozer} "
-                             "'add dependencies {deps}' {target}".format(
-                                 buildozer=path_to_buildozer,
-                                 deps=" ".join(sorted(suggested_deps)),
-                                 target=target.address.spec
-                             )
+          suggestion_msg += ("\nYou can do this by running:\n"
+                             "  {buildozer} 'add dependencies {deps}' {target}".format(
+                               buildozer=path_to_buildozer,
+                               deps=" ".join(sorted(suggested_deps)),
+                               target=target.address.spec)
                             )
 
         self.context.log.info(suggestion_msg)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
@@ -33,7 +33,7 @@ class MissingDependencyFinderIntegrationTest(PantsRunIntegrationTest):
       '--compile-zinc-buildozer=path/to/buildozer',
     ])
     self.assert_failure(run)
-    self.assertTrue(re.search("\n +path/to/buildozer 'add dependencies 3rdparty:guava' " + target,
+    self.assertTrue(re.search("\n *path/to/buildozer 'add dependencies 3rdparty:guava' " + target,
                               run.stdout_data,
                               re.DOTALL))
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
@@ -33,7 +33,7 @@ class MissingDependencyFinderIntegrationTest(PantsRunIntegrationTest):
       '--compile-zinc-buildozer=path/to/buildozer',
     ])
     self.assert_failure(run)
-    self.assertTrue(re.search("path/to/buildozer 'add dependencies 3rdparty:guava' " + target,
+    self.assertTrue(re.search("\n +path/to/buildozer 'add dependencies 3rdparty:guava' " + target,
                               run.stdout_data,
                               re.DOTALL))
 


### PR DESCRIPTION
Currently, the buildozer command is on the same line as the rest of the message. This makes it harder to select, particularly when the command is long.

Putting the buildozer command on a new line will make it easier to copy / paste.