### PR TITLE
Use SubclassesOf instead of Exactly to fix native source detection 

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -15,7 +15,7 @@ from pants.backend.python.targets.python_distribution import PythonDistribution
 from pants.base.exceptions import IncompatiblePlatformsError
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
-from pants.util.objects import Exactly
+from pants.util.objects import Exactly, SubclassesOf
 
 
 class PythonNativeCode(Subsystem):
@@ -64,7 +64,7 @@ class PythonNativeCode(Subsystem):
   def _native_target_matchers(self):
     return {
       Exactly(PythonDistribution): self.pydist_has_native_sources,
-      Exactly(NativeLibrary): self.native_target_has_native_sources,
+      SubclassesOf(NativeLibrary): self.native_target_has_native_sources,
     }
 
   def _any_targets_have_native_sources(self, targets):

--- a/testprojects/src/python/python_distribution/ctypes/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes/BUILD
@@ -31,4 +31,5 @@ python_binary(
   dependencies=[
     ':ctypes',
   ],
+  platforms=("current")
 )

--- a/testprojects/src/python/python_distribution/ctypes/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes/BUILD
@@ -31,5 +31,5 @@ python_binary(
   dependencies=[
     ':ctypes',
   ],
-  platforms=("current")
+  platforms="current"
 )

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -196,12 +196,8 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
     # we need to setup a pants.ini that contains two platform defauts:
     # (1) "current" and (2) a different platform than the one we are currently
     # running on. The test target below has `platforms=("current")`.
-    non_current_platform = None
     platform_string = Platform.create().normalized_os_name
-    if platform_string == 'darwin':
-      non_current_platform_string = 'linux-x86_64'
-    else:
-      non_current_platform_string = 'macosx-10.12-x86_64-x86_64'
+    non_current_platform_string = 'macosx-10.12-x86_64-x86_64' if platform_string == 'darwin' else 'linux-x86_64'
     pants_ini_config = {'python-setup': {'platforms': ["current", non_current_platform_string]}}
 
     # Clean all to rebuild requirements pex.

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -190,6 +190,29 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       pants_run = self.run_pants(command=command, config=pants_ini_config)
       self.assert_success(pants_run)
 
+  def test_pants_native_source_detection_when_running_local_dists_for_current_platform_only(self):
+    # Test that `./pants run` respects python_binary platforms
+    # arguments when the closure contains native sources. To do this,
+    # we need to setup a pants.ini that contains two platform defauts:
+    # (1) "current" and (2) a different platform than the one we are currently
+    # running on. The test target below has `platforms=("current")`.
+    non_current_platform = None
+    platform_string = Platform.create().normalized_os_name
+    if platform_string == 'darwin':
+      non_current_platform_string = 'linux-x86_64'
+    else:
+      non_current_platform_string = 'macosx-10.12-x86_64-x86_64'
+    pants_ini_config = {'python-setup': {'platforms': ["current", non_current_platform_string]}}
+
+    # Clean all to rebuild requirements pex.
+    command = [
+      'clean-all',
+      'run',
+      'testprojects/src/python/python_distribution/ctypes:bin'
+    ]
+    pants_run = self.run_pants(command=command, config=pants_ini_config)
+    self.assert_success(pants_run)
+
   def test_python_distribution_with_setup_requires(self):
     # Validate that setup_requires dependencies are present and functional.
     # PANTS_TEST_SETUP_REQUIRES triggers test functionality in this particular setup.py.


### PR DESCRIPTION
### Problem
When a pants.ini file contains both "current" and a non-current platform string, running (./pants run) python_binary targets that depend on native sources will throw a resolver exception during the resolve_requirements task because native source detection for the current target closure is broken.

### Solution
Fix native source detection by matching targets against `SubclassesOf` `NativeLibrary`, rather than `Exactly` `NativeLibrary`.

### Result
Users can build python_dist targets that depend on ctypes-based cpp libraries in codebases that set a conflicting default platform constraint set in pants.ini. The user simply needs to add `platforms=("current")` to the consuming python_binary target.

#### Verify
Test these changes against master by running: `./pants test tests/python/pants_test/backend/python/tasks:: -- -k test_pants_runs_local_dists_for_current_platform_only`