### PR TITLE
Fix pydist native sources selection

### DIFF
--- a/src/python/pants/backend/native/tasks/c_compile.py
+++ b/src/python/pants/backend/native/tasks/c_compile.py
@@ -15,6 +15,8 @@ from pants.util.objects import SubclassesOf
 
 class CCompile(NativeCompile):
 
+  options_scope = 'c-compile'
+
   # Compile only C library targets.
   source_target_constraint = SubclassesOf(CLibrary)
 

--- a/src/python/pants/backend/native/tasks/cpp_compile.py
+++ b/src/python/pants/backend/native/tasks/cpp_compile.py
@@ -15,6 +15,8 @@ from pants.util.objects import SubclassesOf
 
 class CppCompile(NativeCompile):
 
+  options_scope = 'cpp-compile'
+
   # Compile only C++ library targets.
   source_target_constraint = SubclassesOf(CppLibrary)
 

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 
-from pants.backend.native.config.environment import LLVMCppToolchain, Platform
+from pants.backend.native.config.environment import Linker, LLVMCppToolchain, Platform
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_artifact import NativeArtifact
 from pants.backend.native.targets.native_library import NativeLibrary

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -12,7 +12,6 @@ from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.native_compile import NativeTargetDependencies, ObjectFiles
 from pants.backend.native.tasks.native_external_library_fetch import NativeExternalLibraryFetch
 from pants.backend.native.tasks.native_task import NativeTask
-from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.util.collections import assert_single_element
@@ -186,7 +185,6 @@ class LinkSharedLibraries(NativeTask):
                                              native_artifact.as_shared_lib(self.platform))
     self.context.log.debug("resulting_shared_lib_path: {}".format(resulting_shared_lib_path))
     # We are executing in the results_dir, so get absolute paths for everything.
-    buildroot = get_buildroot()
     cmd = ([linker.exe_filename] +
            self.platform.resolve_platform_specific(self._SHARED_CMDLINE_ARGS) +
            linker.extra_args +

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 
 from pants.backend.native.config.environment import Executable
 from pants.backend.native.targets.native_library import NativeLibrary
-from pants.backend.native.tasks.native_external_library_fetch import NativeExternalLibraryFetch
+from pants.backend.native.tasks.native_external_library_fetch import NativeExternalLibraryFiles
 from pants.backend.native.tasks.native_task import NativeTask
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
@@ -64,7 +64,7 @@ class NativeCompile(NativeTask, AbstractClass):
   @classmethod
   def prepare(cls, options, round_manager):
     super(NativeCompile, cls).prepare(options, round_manager)
-    round_manager.optional_data(NativeExternalLibraryFetch.NativeExternalLibraryFiles)
+    round_manager.optional_data(NativeExternalLibraryFiles)
 
   @property
   def cache_target_dirs(self):
@@ -124,9 +124,7 @@ class NativeCompile(NativeTask, AbstractClass):
   def execute(self):
     object_files_product = self.context.products.get(ObjectFiles)
     native_deps_product = self.context.products.get(NativeTargetDependencies)
-    external_libs_product = self.context.products.get_data(
-      NativeExternalLibraryFetch.NativeExternalLibraryFiles
-    )
+    external_libs_product = self.context.products.get_data(NativeExternalLibraryFiles)
     source_targets = self.context.targets(self.source_target_constraint.satisfied_by)
 
     with self.invalidated(source_targets, invalidate_dependents=True) as invalidation_check:

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -64,7 +64,7 @@ class NativeCompile(NativeTask, AbstractClass):
   @classmethod
   def prepare(cls, options, round_manager):
     super(NativeCompile, cls).prepare(options, round_manager)
-    round_manager.require(NativeExternalLibraryFetch.NativeExternalLibraryFiles)
+    round_manager.optional_data(NativeExternalLibraryFetch.NativeExternalLibraryFiles)
 
   @property
   def cache_target_dirs(self):
@@ -195,6 +195,9 @@ class NativeCompile(NativeTask, AbstractClass):
     return self.get_compiler()
 
   def _get_third_party_include_dirs(self, external_libs_product):
+    if not external_libs_product:
+      return []
+
     directory = external_libs_product.include_dir
     return [directory] if directory else []
 
@@ -221,13 +224,17 @@ class NativeCompile(NativeTask, AbstractClass):
 
     # We are going to execute in the target output, so get absolute paths for everything.
     # TODO: If we need to produce static libs, don't add -fPIC! (could use Variants -- see #5788).
+    buildroot = get_buildroot()
     argv = (
       [compiler.exe_filename] +
       compiler.extra_args +
       err_flags +
       ['-c', '-fPIC'] +
-      ['-I{}'.format(os.path.abspath(inc_dir)) for inc_dir in compile_request.include_dirs] +
-      [os.path.abspath(src) for src in compile_request.sources])
+      [
+        '-I{}'.format(os.path.join(buildroot, inc_dir))
+        for inc_dir in compile_request.include_dirs
+      ] +
+      [os.path.join(buildroot, src) for src in compile_request.sources])
 
     self.context.log.debug("compile argv: {}".format(argv))
 

--- a/src/python/pants/backend/native/tasks/native_external_library_fetch.py
+++ b/src/python/pants/backend/native/tasks/native_external_library_fetch.py
@@ -61,30 +61,20 @@ class ConanRequirement(datatype(['pkg_spec'])):
     return args
 
 
+class NativeExternalLibraryFiles(datatype([
+    'include_dir',
+    # TODO: we shouldn't have any `lib_names` if `lib_dir` is not set!
+    'lib_dir',
+    ('lib_names', tuple),
+])): pass
+
+
 class NativeExternalLibraryFetch(Task):
   options_scope = 'native-external-library-fetch'
   native_library_constraint = Exactly(ExternalNativeLibrary)
 
   class NativeExternalLibraryFetchError(TaskError):
     pass
-
-  class NativeExternalLibraryFiles(object):
-    def __init__(self):
-      self.include_dir = None
-      self.lib_dir = None
-      self.lib_names = []
-
-    def add_lib_name(self, lib_name):
-      self.lib_names.append(lib_name)
-
-    def get_third_party_lib_args(self):
-      lib_args = []
-      if self.lib_names:
-        for lib_name in self.lib_names:
-          lib_args.append('-l{}'.format(lib_name))
-        lib_dir_arg = '-L{}'.format(self.lib_dir)
-        lib_args.append(lib_dir_arg)
-      return lib_args
 
   @classmethod
   def _parse_lib_name_from_library_filename(cls, filename):
@@ -105,7 +95,7 @@ class NativeExternalLibraryFetch(Task):
 
   @classmethod
   def product_types(cls):
-    return [cls.NativeExternalLibraryFiles]
+    return [NativeExternalLibraryFiles]
 
   @property
   def cache_target_dirs(self):
@@ -116,9 +106,6 @@ class NativeExternalLibraryFetch(Task):
     return Conan.scoped_instance(self).bootstrap_conan()
 
   def execute(self):
-    task_product = self.context.products.get_data(self.NativeExternalLibraryFiles,
-                                                  self.NativeExternalLibraryFiles)
-
     native_lib_tgts = self.context.targets(self.native_library_constraint.satisfied_by)
     if native_lib_tgts:
       with self.invalidated(native_lib_tgts,
@@ -128,7 +115,10 @@ class NativeExternalLibraryFetch(Task):
         if invalidation_check.invalid_vts or not resolve_vts.valid:
           for vt in invalidation_check.all_vts:
             self._fetch_packages(vt, vts_results_dir)
-        self._populate_task_product(vts_results_dir, task_product)
+
+        native_external_libs_product = self._collect_external_libs(vts_results_dir)
+        self.context.products.register_data(NativeExternalLibraryFiles,
+                                            native_external_libs_product)
 
   def _prepare_vts_results_dir(self, vts):
     """
@@ -138,22 +128,23 @@ class NativeExternalLibraryFetch(Task):
     safe_mkdir(vt_set_results_dir)
     return vt_set_results_dir
 
-  def _populate_task_product(self, results_dir, task_product):
+  def _collect_external_libs(self, results_dir):
     """
     Sets the relevant properties of the task product (`NativeExternalLibraryFiles`) object.
     """
-    lib = os.path.join(results_dir, 'lib')
-    include = os.path.join(results_dir, 'include')
+    lib_dir = os.path.join(results_dir, 'lib')
+    include_dir = os.path.join(results_dir, 'include')
 
-    if os.path.exists(lib):
-      task_product.lib_dir = lib
-      for filename in os.listdir(lib):
+    lib_names = []
+    if os.path.isdir(lib_dir):
+      for filename in os.listdir(lib_dir):
         lib_name = self._parse_lib_name_from_library_filename(filename)
         if lib_name:
-          task_product.add_lib_name(lib_name)
+          lib_names.append(lib_name)
 
-    if os.path.exists(include):
-      task_product.include_dir = include
+    return NativeExternalLibraryFiles(include_dir=include_dir,
+                                      lib_dir=lib_dir,
+                                      lib_names=tuple(lib_names))
 
   def _get_conan_data_dir_path_for_package(self, pkg_dir_path, pkg_sha):
     return os.path.join(self.workdir,

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -70,7 +70,7 @@ class PythonNativeCode(Subsystem):
   @memoized_property
   def _native_target_matchers(self):
     return {
-      Exactly(PythonDistribution): self.pydist_has_native_sources,
+      SubclassesOf(PythonDistribution): self.pydist_has_native_sources,
       SubclassesOf(NativeLibrary): self.native_target_has_native_sources,
     }
 
@@ -104,7 +104,7 @@ class PythonNativeCode(Subsystem):
                                           '--platforms option or a pants.ini file.']
     return targets_by_platforms
 
-  _PYTHON_PLATFORM_TARGETS_CONSTRAINT = Exactly(PythonBinary, PythonDistribution)
+  _PYTHON_PLATFORM_TARGETS_CONSTRAINT = SubclassesOf(PythonBinary, PythonDistribution)
 
   def check_build_for_current_platform_only(self, targets):
     """

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -21,7 +21,7 @@ from pants.backend.python.tasks.pex_build_util import resolve_multi
 from pants.base.exceptions import IncompatiblePlatformsError
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
-from pants.util.objects import Exactly, SubclassesOf, datatype
+from pants.util.objects import SubclassesOf, datatype
 from pants.util.strutil import create_path_env_var, safe_shlex_join
 
 

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -21,7 +21,7 @@ from pants.backend.python.tasks.pex_build_util import resolve_multi
 from pants.base.exceptions import IncompatiblePlatformsError
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
-from pants.util.objects import Exactly, datatype
+from pants.util.objects import Exactly, SubclassesOf, datatype
 from pants.util.strutil import create_path_env_var, safe_shlex_join
 
 
@@ -71,7 +71,7 @@ class PythonNativeCode(Subsystem):
   def _native_target_matchers(self):
     return {
       Exactly(PythonDistribution): self.pydist_has_native_sources,
-      Exactly(NativeLibrary): self.native_target_has_native_sources,
+      SubclassesOf(NativeLibrary): self.native_target_has_native_sources,
     }
 
   def _any_targets_have_native_sources(self, targets):

--- a/src/python/pants/backend/python/targets/python_distribution.py
+++ b/src/python/pants/backend/python/targets/python_distribution.py
@@ -4,15 +4,18 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import str
+
+from pex.interpreter import PythonIdentity
 from twitter.common.collections import maybe_list
 
-from pants.backend.python.targets.python_target import PythonTarget
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
+from pants.build_graph.target import Target
 
 
-class PythonDistribution(PythonTarget):
+class PythonDistribution(Target):
   """A Python distribution target that accepts a user-defined setup.py."""
 
   default_sources_globs = '*.py'
@@ -25,6 +28,7 @@ class PythonDistribution(PythonTarget):
                address=None,
                payload=None,
                sources=None,
+               compatibility=None,
                setup_requires=None,
                **kwargs):
     """
@@ -35,23 +39,31 @@ class PythonDistribution(PythonTarget):
     :type payload: :class:`pants.base.payload.Payload`
     :param sources: Files to "include". Paths are relative to the
       BUILD file's directory.
-    :type sources: :class:`twitter.common.dirutil.Fileset` or list of strings. Must include
-                   setup.py.
-    :param list setup_requires: A list of python requirements to provide during the invocation of
-                                setup.py.
+    :type sources: ``Fileset`` or list of strings. Must include setup.py.
+    :param compatibility: either a string or list of strings that represents
+      interpreter compatibility for this target, using the Requirement-style
+      format, e.g. ``'CPython>=3', or just ['>=2.7','<3']`` for requirements
+      agnostic to interpreter class.
     """
-    if not 'setup.py' in sources:
-      raise TargetDefinitionException(
-        self,
-        'A file named setup.py must be in the same '
-        'directory as the BUILD file containing this target.')
-
     payload = payload or Payload()
     payload.add_fields({
+      'sources': self.create_sources_field(sources, address.spec_path, key_arg='sources'),
+      'compatibility': PrimitiveField(maybe_list(compatibility or ())),
       'setup_requires': PrimitiveField(maybe_list(setup_requires or ()))
     })
-    super(PythonDistribution, self).__init__(
-      address=address, payload=payload, sources=sources, **kwargs)
+    super(PythonDistribution, self).__init__(address=address, payload=payload, **kwargs)
+
+    if not 'setup.py' in sources:
+      raise TargetDefinitionException(
+        self, 'A setup.py in the top-level directory relative to the target definition is required.'
+      )
+
+    # Check that the compatibility requirements are well-formed.
+    for req in self.payload.compatibility:
+      try:
+        PythonIdentity.parse_requirement(req)
+      except ValueError as e:
+        raise TargetDefinitionException(self, str(e))
 
   @property
   def has_native_sources(self):

--- a/testprojects/src/python/python_distribution/ctypes/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes/BUILD
@@ -31,4 +31,5 @@ python_binary(
   dependencies=[
     ':ctypes',
   ],
+  platforms=("current")
 )

--- a/testprojects/src/python/python_distribution/ctypes/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes/BUILD
@@ -31,5 +31,5 @@ python_binary(
   dependencies=[
     ':ctypes',
   ],
-  platforms="current"
+  platforms=['current'],
 )

--- a/testprojects/src/python/python_distribution/ctypes/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes/BUILD
@@ -31,5 +31,5 @@ python_binary(
   dependencies=[
     ':ctypes',
   ],
-  platforms=("current")
+  platforms="current"
 )

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -24,6 +24,7 @@ python_library(
 python_native_code_test_files = [
   'test_build_local_python_distributions.py',
   'test_python_distribution_integration.py',
+  'test_ctypes.py',
   'test_ctypes_integration.py',
 ]
 
@@ -35,12 +36,14 @@ python_tests(
     '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/native',
+    'src/python/pants/backend/native/targets',
     'src/python/pants/backend/python:plugin',
     'src/python/pants/backend/python/targets',
     'src/python/pants/backend/python/tasks',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:process_handler',
     'tests/python/pants_test:int-test',
+    'tests/python/pants_test/backend/python/tasks/util',
     'tests/python/pants_test/engine:scheduler_test_base',
   ],
   tags={'platform_specific_behavior', 'integration'},

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -33,6 +33,7 @@ python_tests(
   dependencies=[
     ':python_task_test_base',
     '3rdparty/python:future',
+    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/native',
     'src/python/pants/backend/python:plugin',
     'src/python/pants/backend/python/targets',

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -32,7 +32,6 @@ python_tests(
   name='python_native_code_testing',
   sources=python_native_code_test_files,
   dependencies=[
-    ':python_task_test_base',
     '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/native',

--- a/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
+++ b/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
@@ -8,7 +8,15 @@ import re
 from builtins import next, str
 from textwrap import dedent
 
+from twitter.common.collections import OrderedDict
+
 from pants.backend.native.register import rules as native_backend_rules
+from pants.backend.native.targets.native_artifact import NativeArtifact
+from pants.backend.native.targets.native_library import CLibrary, CppLibrary
+from pants.backend.native.tasks.c_compile import CCompile
+from pants.backend.native.tasks.cpp_compile import CppCompile
+from pants.backend.native.tasks.link_shared_libraries import LinkSharedLibraries
+from pants.backend.python.register import rules as python_backend_rules
 from pants.backend.python.targets.python_distribution import PythonDistribution
 from pants.backend.python.tasks.build_local_python_distributions import \
   BuildLocalPythonDistributions
@@ -20,62 +28,13 @@ from pants_test.engine.scheduler_test_base import SchedulerTestBase
 
 
 class TestBuildLocalPythonDistributions(PythonTaskTestBase, SchedulerTestBase):
+
   @classmethod
   def task_type(cls):
     return BuildLocalPythonDistributions
 
-  _dist_specs = {
-    'src/python/dist:universal_dist': {
-      'key': 'universal',
-      'sources': ['foo.py', 'bar.py', '__init__.py', 'setup.py'],
-      'filemap': {
-        'src/python/dist/__init__.py': '',
-        'src/python/dist/foo.py': 'print("foo")',
-        'src/python/dist/bar.py': 'print("bar")',
-        'src/python/dist/setup.py': dedent("""
-        from setuptools import setup, find_packages
-        setup(
-          name='universal_dist',
-          version='0.0.0',
-          packages=find_packages()
-        )
-      """)
-      }
-    },
-    'src/python/plat_specific_dist:plat_specific_dist': {
-      'key': 'platform_specific',
-      'sources': ['__init__.py', 'setup.py', 'native_source.c'],
-      'filemap': {
-        'src/python/plat_specific_dist/__init__.py': '',
-        'src/python/plat_specific_dist/setup.py': dedent("""
-        from distutils.core import Extension
-        from setuptools import setup, find_packages
-        setup(
-          name='platform_specific_dist',
-          version='0.0.0',
-          packages=find_packages(),
-          extensions=[Extension('native_source', sources=['native_source.c'])]
-        )
-      """),
-        'src/python/plat_specific_dist/native_source.c': dedent("""
-        #include <Python.h>
-
-        static PyObject * native_source(PyObject *self, PyObject *args) {
-          return Py_BuildValue("s", "Hello from C!");
-        }
-
-        static PyMethodDef Methods[] = {
-          {"native_source", native_source, METH_VARARGS, ""},
-          {NULL, NULL, 0, NULL}
-        };
-
-        PyMODINIT_FUNC initnative_source(void) {
-          (void) Py_InitModule("native_source", Methods);
-        }
-      """),
-      }
-    },
-  }
+  _dist_specs = None
+  _extra_relevant_task_types = None
 
   def setUp(self):
     super(TestBuildLocalPythonDistributions, self).setUp()
@@ -84,18 +43,20 @@ class TestBuildLocalPythonDistributions(PythonTaskTestBase, SchedulerTestBase):
 
     # Create a python_dist() target from each specification and insert it into `self.target_dict`.
     for target_spec, file_spec in self._dist_specs.items():
-      filemap = file_spec['filemap']
+      file_spec = file_spec.copy()
+      filemap = file_spec.pop('filemap')
       for rel_path, content in filemap.items():
         self.create_file(rel_path, content)
 
-      sources = file_spec['sources']
-      python_dist_tgt = self.make_target(spec=target_spec,
-                                         target_type=PythonDistribution,
-                                         sources=sources)
-      key = file_spec['key']
+      key = file_spec.pop('key')
+      dep_targets = []
+      for dep_spec in file_spec.pop('dependencies', []):
+        existing_tgt_key = self._dist_specs[dep_spec]['key']
+        dep_targets.append(self.target_dict[existing_tgt_key])
+      python_dist_tgt = self.make_target(spec=target_spec, dependencies=dep_targets, **file_spec)
       self.target_dict[key] = python_dist_tgt
 
-  def _all_dist_targets(self):
+  def _all_specified_targets(self):
     return list(self.target_dict.values())
 
   def _scheduling_context(self, **kwargs):
@@ -133,14 +94,26 @@ class TestBuildLocalPythonDistributions(PythonTaskTestBase, SchedulerTestBase):
     # --tag-build option.
     return re.sub(r'[^a-zA-Z0-9]', '.', versioned_target_fingerprint.lower())
 
-  def _create_distribution_synthetic_target(self, python_dist_target):
+  def _create_task(self, task_type, context):
+    return task_type(context, self.test_workdir)
+
+  def _create_distribution_synthetic_target(self, python_dist_target, extra_targets=[]):
     context = self._scheduling_context(
-      target_roots=[python_dist_target],
-      for_task_types=[BuildLocalPythonDistributions])
-    self.assertEquals(set(self._all_dist_targets()), set(context.build_graph.targets()))
+      target_roots=([python_dist_target] + extra_targets),
+      for_task_types=([self.task_type()] + self._extra_relevant_task_types))
+    self.assertEquals(set(self._all_specified_targets()), set(context.build_graph.targets()))
+
     python_create_distributions_task = self.create_task(context)
+    extra_tasks = [
+      self._create_task(task_type, context)
+      for task_type in self._extra_relevant_task_types
+    ]
+    for tsk in extra_tasks:
+      tsk.execute()
+
     python_create_distributions_task.execute()
-    synthetic_tgts = set(context.build_graph.targets()) - set(self._all_dist_targets())
+
+    synthetic_tgts = set(context.build_graph.targets()) - set(self._all_specified_targets())
     self.assertEquals(1, len(synthetic_tgts))
     synthetic_target = next(iter(synthetic_tgts))
 
@@ -148,6 +121,69 @@ class TestBuildLocalPythonDistributions(PythonTaskTestBase, SchedulerTestBase):
       python_create_distributions_task, python_dist_target)
 
     return context, synthetic_target, snapshot_version
+
+
+class TestBuildLocalDistsNativeSources(TestBuildLocalPythonDistributions):
+
+  _extra_relevant_task_types = []
+
+  _dist_specs = OrderedDict([
+
+    ('src/python/dist:universal_dist', {
+      'key': 'universal',
+      'target_type': PythonDistribution,
+      'sources': ['foo.py', 'bar.py', '__init__.py', 'setup.py'],
+      'filemap': {
+        'src/python/dist/__init__.py': '',
+        'src/python/dist/foo.py': 'print("foo")',
+        'src/python/dist/bar.py': 'print("bar")',
+        'src/python/dist/setup.py': dedent("""
+        from setuptools import setup, find_packages
+        setup(
+          name='universal_dist',
+          version='0.0.0',
+          packages=find_packages()
+        )
+      """)
+      }
+    }),
+
+    ('src/python/plat_specific_dist:plat_specific_dist', {
+      'key': 'platform_specific',
+      'target_type': PythonDistribution,
+      'sources': ['__init__.py', 'setup.py', 'native_source.c'],
+      'filemap': {
+        'src/python/plat_specific_dist/__init__.py': '',
+        'src/python/plat_specific_dist/setup.py': dedent("""
+        from distutils.core import Extension
+        from setuptools import setup, find_packages
+        setup(
+          name='platform_specific_dist',
+          version='0.0.0',
+          packages=find_packages(),
+          extensions=[Extension('native_source', sources=['native_source.c'])]
+        )
+      """),
+        'src/python/plat_specific_dist/native_source.c': dedent("""
+        #include <Python.h>
+
+        static PyObject * native_source(PyObject *self, PyObject *args) {
+          return Py_BuildValue("s", "Hello from C!");
+        }
+
+        static PyMethodDef Methods[] = {
+          {"native_source", native_source, METH_VARARGS, ""},
+          {NULL, NULL, 0, NULL}
+        };
+
+        PyMODINIT_FUNC initnative_source(void) {
+          (void) Py_InitModule("native_source", Methods);
+        }
+      """),
+      }
+    }),
+
+  ])
 
   def test_python_create_universal_distribution(self):
     universal_dist = self.target_dict['universal']
@@ -166,6 +202,103 @@ class TestBuildLocalPythonDistributions(PythonTaskTestBase, SchedulerTestBase):
     context, synthetic_target, snapshot_version = self._create_distribution_synthetic_target(
       platform_specific_dist)
     self.assertEquals(['platform_specific_dist==0.0.0+{}'.format(snapshot_version)],
+                      [str(x.requirement) for x in synthetic_target.requirements.value])
+
+    local_wheel_products = context.products.get('local_wheels')
+    local_wheel = self._retrieve_single_product_at_target_base(
+      local_wheel_products, platform_specific_dist)
+    self.assertTrue(check_wheel_platform_matches_host(local_wheel))
+
+
+class TestBuildLocalDistsWithCtypesNativeSources(TestBuildLocalPythonDistributions):
+
+  _extra_relevant_task_types = [CCompile, CppCompile, LinkSharedLibraries]
+
+  _dist_specs = OrderedDict([
+
+    ('src/python/plat_specific_c_dist:ctypes_c_library', {
+      'key': 'ctypes_c_library',
+      'target_type': CLibrary,
+      'ctypes_native_library': NativeArtifact(lib_name='c-math-lib'),
+      'sources': ['c_math_lib.c', 'c_math_lib.h'],
+      'filemap': {
+        'src/python/plat_specific_c_dist/c_math_lib.c': dedent("""
+        #include "c_math_lib.h"
+        int add_two(int x) { return x + 2; }
+"""),
+        'src/python/plat_specific_c_dist/c_math_lib.h': dedent("""
+        int add_two(int);
+"""),
+      }
+    }),
+
+    ('src/python/plat_specific_c_dist:plat_specific_ctypes_c_dist', {
+      'key': 'platform_specific_ctypes_c_dist',
+      'target_type': PythonDistribution,
+      'sources': ['__init__.py', 'setup.py'],
+      'dependencies': ['src/python/plat_specific_c_dist:ctypes_c_library'],
+      'filemap': {
+        'src/python/plat_specific_c_dist/__init__.py': '',
+        'src/python/plat_specific_c_dist/setup.py': dedent("""
+        from setuptools import setup, find_packages
+        setup(
+          name='platform_specific_ctypes_c_dist',
+          version='0.0.0',
+          packages=find_packages(),
+          data_files=[('', ['libc-math-lib.so'])],
+        )
+      """),
+      }
+    }),
+
+    ('src/python/plat_specific_cpp_dist:ctypes_cpp_library', {
+      'key': 'ctypes_cpp_library',
+      'target_type': CppLibrary,
+      'ctypes_native_library': NativeArtifact(lib_name='cpp-math-lib'),
+      'sources': ['cpp_math_lib.cpp', 'cpp_math_lib.hpp'],
+      'filemap': {
+        'src/python/plat_specific_cpp_dist/cpp_math_lib.cpp': '',
+        'src/python/plat_specific_cpp_dist/cpp_math_lib.hpp': '',
+      },
+    }),
+
+    ('src/python/plat_specific_cpp_dist:plat_specific_ctypes_cpp_dist', {
+      'key': 'platform_specific_ctypes_cpp_dist',
+      'target_type': PythonDistribution,
+      'sources': ['__init__.py', 'setup.py'],
+      'dependencies': ['src/python/plat_specific_cpp_dist:ctypes_cpp_library'],
+      'filemap': {
+        'src/python/plat_specific_cpp_dist/__init__.py': '',
+        'src/python/plat_specific_cpp_dist/setup.py': dedent("""
+        from setuptools import setup, find_packages
+        setup(
+          name='platform_specific_ctypes_cpp_dist',
+          version='0.0.0',
+          packages=find_packages(),
+          data_files=[('', ['libcpp-math-lib.so'])],
+        )
+      """),
+      }
+    }),
+
+  ])
+
+  def test_ctypes_c_dist(self):
+    platform_specific_dist = self.target_dict['platform_specific_ctypes_c_dist']
+    context, synthetic_target, snapshot_version = self._create_distribution_synthetic_target(
+      platform_specific_dist, extra_targets=[self.target_dict['ctypes_c_library']])
+    self.assertEquals(['platform_specific_ctypes_c_dist==0.0.0+{}'.format(snapshot_version)],
+                      [str(x.requirement) for x in synthetic_target.requirements.value])
+    local_wheel_products = context.products.get('local_wheels')
+    local_wheel = self._retrieve_single_product_at_target_base(
+      local_wheel_products, platform_specific_dist)
+    self.assertTrue(check_wheel_platform_matches_host(local_wheel))
+
+  def test_ctypes_cpp_dist(self):
+    platform_specific_dist = self.target_dict['platform_specific_ctypes_cpp_dist']
+    context, synthetic_target, snapshot_version = self._create_distribution_synthetic_target(
+      platform_specific_dist, extra_targets=[self.target_dict['ctypes_cpp_library']])
+    self.assertEquals(['platform_specific_ctypes_cpp_dist==0.0.0+{}'.format(snapshot_version)],
                       [str(x.requirement) for x in synthetic_target.requirements.value])
 
     local_wheel_products = context.products.get('local_wheels')

--- a/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
+++ b/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
@@ -4,126 +4,19 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import re
-from builtins import next, str
+from builtins import str
 from textwrap import dedent
 
 from twitter.common.collections import OrderedDict
 
-from pants.backend.native.register import rules as native_backend_rules
-from pants.backend.native.targets.native_artifact import NativeArtifact
-from pants.backend.native.targets.native_library import CLibrary, CppLibrary
-from pants.backend.native.tasks.c_compile import CCompile
-from pants.backend.native.tasks.cpp_compile import CppCompile
-from pants.backend.native.tasks.link_shared_libraries import LinkSharedLibraries
-from pants.backend.python.register import rules as python_backend_rules
 from pants.backend.python.targets.python_distribution import PythonDistribution
-from pants.backend.python.tasks.build_local_python_distributions import \
-  BuildLocalPythonDistributions
-from pants.util.collections import assert_single_element
-from pants_test.backend.python.tasks.python_task_test_base import (PythonTaskTestBase,
-                                                                   check_wheel_platform_matches_host,
+from pants_test.backend.python.tasks.python_task_test_base import (check_wheel_platform_matches_host,
                                                                    name_and_platform)
-from pants_test.engine.scheduler_test_base import SchedulerTestBase
+from pants_test.backend.python.tasks.util.build_local_dists_test_base import \
+  BuildLocalPythonDistributionsTestBase
 
 
-class TestBuildLocalPythonDistributions(PythonTaskTestBase, SchedulerTestBase):
-
-  @classmethod
-  def task_type(cls):
-    return BuildLocalPythonDistributions
-
-  _dist_specs = None
-  _extra_relevant_task_types = None
-
-  def setUp(self):
-    super(TestBuildLocalPythonDistributions, self).setUp()
-
-    self.target_dict = {}
-
-    # Create a python_dist() target from each specification and insert it into `self.target_dict`.
-    for target_spec, file_spec in self._dist_specs.items():
-      file_spec = file_spec.copy()
-      filemap = file_spec.pop('filemap')
-      for rel_path, content in filemap.items():
-        self.create_file(rel_path, content)
-
-      key = file_spec.pop('key')
-      dep_targets = []
-      for dep_spec in file_spec.pop('dependencies', []):
-        existing_tgt_key = self._dist_specs[dep_spec]['key']
-        dep_targets.append(self.target_dict[existing_tgt_key])
-      python_dist_tgt = self.make_target(spec=target_spec, dependencies=dep_targets, **file_spec)
-      self.target_dict[key] = python_dist_tgt
-
-  def _all_specified_targets(self):
-    return list(self.target_dict.values())
-
-  def _scheduling_context(self, **kwargs):
-    scheduler = self.mk_scheduler(rules=native_backend_rules())
-    return self.context(scheduler=scheduler, **kwargs)
-
-  def _retrieve_single_product_at_target_base(self, product_mapping, target):
-    product = product_mapping.get(target)
-    base_dirs = list(product.keys())
-    self.assertEqual(1, len(base_dirs))
-    single_base_dir = base_dirs[0]
-    all_products = product[single_base_dir]
-    self.assertEqual(1, len(all_products))
-    single_product = all_products[0]
-    return single_product
-
-  def _get_dist_snapshot_version(self, task, python_dist_target):
-    """Get the target's fingerprint, and guess the resulting version string of the built dist.
-
-    Local python_dist() builds are tagged with the versioned target's fingerprint using the
-    --tag-build option in the egg_info command. This fingerprint string is slightly modified by
-    distutils to ensure a valid version string, and this method finds what that modified version
-    string is so we can verify that the produced local dist is being tagged with the correct
-    snapshot version.
-
-    The argument we pass to that option begins with a +, which is unchanged. See
-    https://www.python.org/dev/peps/pep-0440/ for further information.
-    """
-    with task.invalidated([python_dist_target], invalidate_dependents=True) as invalidation_check:
-      versioned_dist_target = assert_single_element(invalidation_check.all_vts)
-
-    versioned_target_fingerprint = versioned_dist_target.cache_key.hash
-
-    # This performs the normalization that distutils performs to the version string passed to the
-    # --tag-build option.
-    return re.sub(r'[^a-zA-Z0-9]', '.', versioned_target_fingerprint.lower())
-
-  def _create_task(self, task_type, context):
-    return task_type(context, self.test_workdir)
-
-  def _create_distribution_synthetic_target(self, python_dist_target, extra_targets=[]):
-    context = self._scheduling_context(
-      target_roots=([python_dist_target] + extra_targets),
-      for_task_types=([self.task_type()] + self._extra_relevant_task_types))
-    self.assertEquals(set(self._all_specified_targets()), set(context.build_graph.targets()))
-
-    python_create_distributions_task = self.create_task(context)
-    extra_tasks = [
-      self._create_task(task_type, context)
-      for task_type in self._extra_relevant_task_types
-    ]
-    for tsk in extra_tasks:
-      tsk.execute()
-
-    python_create_distributions_task.execute()
-
-    synthetic_tgts = set(context.build_graph.targets()) - set(self._all_specified_targets())
-    self.assertEquals(1, len(synthetic_tgts))
-    synthetic_target = next(iter(synthetic_tgts))
-
-    snapshot_version = self._get_dist_snapshot_version(
-      python_create_distributions_task, python_dist_target)
-
-    return context, synthetic_target, snapshot_version
-
-
-class TestBuildLocalDistsNativeSources(TestBuildLocalPythonDistributions):
+class TestBuildLocalDistsNativeSources(BuildLocalPythonDistributionsTestBase):
 
   _extra_relevant_task_types = []
 
@@ -202,103 +95,6 @@ class TestBuildLocalDistsNativeSources(TestBuildLocalPythonDistributions):
     context, synthetic_target, snapshot_version = self._create_distribution_synthetic_target(
       platform_specific_dist)
     self.assertEquals(['platform_specific_dist==0.0.0+{}'.format(snapshot_version)],
-                      [str(x.requirement) for x in synthetic_target.requirements.value])
-
-    local_wheel_products = context.products.get('local_wheels')
-    local_wheel = self._retrieve_single_product_at_target_base(
-      local_wheel_products, platform_specific_dist)
-    self.assertTrue(check_wheel_platform_matches_host(local_wheel))
-
-
-class TestBuildLocalDistsWithCtypesNativeSources(TestBuildLocalPythonDistributions):
-
-  _extra_relevant_task_types = [CCompile, CppCompile, LinkSharedLibraries]
-
-  _dist_specs = OrderedDict([
-
-    ('src/python/plat_specific_c_dist:ctypes_c_library', {
-      'key': 'ctypes_c_library',
-      'target_type': CLibrary,
-      'ctypes_native_library': NativeArtifact(lib_name='c-math-lib'),
-      'sources': ['c_math_lib.c', 'c_math_lib.h'],
-      'filemap': {
-        'src/python/plat_specific_c_dist/c_math_lib.c': dedent("""
-        #include "c_math_lib.h"
-        int add_two(int x) { return x + 2; }
-"""),
-        'src/python/plat_specific_c_dist/c_math_lib.h': dedent("""
-        int add_two(int);
-"""),
-      }
-    }),
-
-    ('src/python/plat_specific_c_dist:plat_specific_ctypes_c_dist', {
-      'key': 'platform_specific_ctypes_c_dist',
-      'target_type': PythonDistribution,
-      'sources': ['__init__.py', 'setup.py'],
-      'dependencies': ['src/python/plat_specific_c_dist:ctypes_c_library'],
-      'filemap': {
-        'src/python/plat_specific_c_dist/__init__.py': '',
-        'src/python/plat_specific_c_dist/setup.py': dedent("""
-        from setuptools import setup, find_packages
-        setup(
-          name='platform_specific_ctypes_c_dist',
-          version='0.0.0',
-          packages=find_packages(),
-          data_files=[('', ['libc-math-lib.so'])],
-        )
-      """),
-      }
-    }),
-
-    ('src/python/plat_specific_cpp_dist:ctypes_cpp_library', {
-      'key': 'ctypes_cpp_library',
-      'target_type': CppLibrary,
-      'ctypes_native_library': NativeArtifact(lib_name='cpp-math-lib'),
-      'sources': ['cpp_math_lib.cpp', 'cpp_math_lib.hpp'],
-      'filemap': {
-        'src/python/plat_specific_cpp_dist/cpp_math_lib.cpp': '',
-        'src/python/plat_specific_cpp_dist/cpp_math_lib.hpp': '',
-      },
-    }),
-
-    ('src/python/plat_specific_cpp_dist:plat_specific_ctypes_cpp_dist', {
-      'key': 'platform_specific_ctypes_cpp_dist',
-      'target_type': PythonDistribution,
-      'sources': ['__init__.py', 'setup.py'],
-      'dependencies': ['src/python/plat_specific_cpp_dist:ctypes_cpp_library'],
-      'filemap': {
-        'src/python/plat_specific_cpp_dist/__init__.py': '',
-        'src/python/plat_specific_cpp_dist/setup.py': dedent("""
-        from setuptools import setup, find_packages
-        setup(
-          name='platform_specific_ctypes_cpp_dist',
-          version='0.0.0',
-          packages=find_packages(),
-          data_files=[('', ['libcpp-math-lib.so'])],
-        )
-      """),
-      }
-    }),
-
-  ])
-
-  def test_ctypes_c_dist(self):
-    platform_specific_dist = self.target_dict['platform_specific_ctypes_c_dist']
-    context, synthetic_target, snapshot_version = self._create_distribution_synthetic_target(
-      platform_specific_dist, extra_targets=[self.target_dict['ctypes_c_library']])
-    self.assertEquals(['platform_specific_ctypes_c_dist==0.0.0+{}'.format(snapshot_version)],
-                      [str(x.requirement) for x in synthetic_target.requirements.value])
-    local_wheel_products = context.products.get('local_wheels')
-    local_wheel = self._retrieve_single_product_at_target_base(
-      local_wheel_products, platform_specific_dist)
-    self.assertTrue(check_wheel_platform_matches_host(local_wheel))
-
-  def test_ctypes_cpp_dist(self):
-    platform_specific_dist = self.target_dict['platform_specific_ctypes_cpp_dist']
-    context, synthetic_target, snapshot_version = self._create_distribution_synthetic_target(
-      platform_specific_dist, extra_targets=[self.target_dict['ctypes_cpp_library']])
-    self.assertEquals(['platform_specific_ctypes_cpp_dist==0.0.0+{}'.format(snapshot_version)],
                       [str(x.requirement) for x in synthetic_target.requirements.value])
 
     local_wheel_products = context.products.get('local_wheels')

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes.py
@@ -1,0 +1,117 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from builtins import str
+from textwrap import dedent
+
+from twitter.common.collections import OrderedDict
+
+from pants.backend.native.targets.native_artifact import NativeArtifact
+from pants.backend.native.targets.native_library import CLibrary, CppLibrary
+from pants.backend.native.tasks.c_compile import CCompile
+from pants.backend.native.tasks.cpp_compile import CppCompile
+from pants.backend.native.tasks.link_shared_libraries import LinkSharedLibraries
+from pants.backend.python.targets.python_distribution import PythonDistribution
+from pants_test.backend.python.tasks.python_task_test_base import check_wheel_platform_matches_host
+from pants_test.backend.python.tasks.util.build_local_dists_test_base import \
+  BuildLocalPythonDistributionsTestBase
+
+
+class TestBuildLocalDistsWithCtypesNativeSources(BuildLocalPythonDistributionsTestBase):
+
+  _extra_relevant_task_types = [CCompile, CppCompile, LinkSharedLibraries]
+
+  _dist_specs = OrderedDict([
+
+    ('src/python/plat_specific_c_dist:ctypes_c_library', {
+      'key': 'ctypes_c_library',
+      'target_type': CLibrary,
+      'ctypes_native_library': NativeArtifact(lib_name='c-math-lib'),
+      'sources': ['c_math_lib.c', 'c_math_lib.h'],
+      'filemap': {
+        'src/python/plat_specific_c_dist/c_math_lib.c': dedent("""
+        #include "c_math_lib.h"
+        int add_two(int x) { return x + 2; }
+"""),
+        'src/python/plat_specific_c_dist/c_math_lib.h': dedent("""
+        int add_two(int);
+"""),
+      }
+    }),
+
+    ('src/python/plat_specific_c_dist:plat_specific_ctypes_c_dist', {
+      'key': 'platform_specific_ctypes_c_dist',
+      'target_type': PythonDistribution,
+      'sources': ['__init__.py', 'setup.py'],
+      'dependencies': ['src/python/plat_specific_c_dist:ctypes_c_library'],
+      'filemap': {
+        'src/python/plat_specific_c_dist/__init__.py': '',
+        'src/python/plat_specific_c_dist/setup.py': dedent("""
+        from setuptools import setup, find_packages
+        setup(
+          name='platform_specific_ctypes_c_dist',
+          version='0.0.0',
+          packages=find_packages(),
+          data_files=[('', ['libc-math-lib.so'])],
+        )
+      """),
+      }
+    }),
+
+    ('src/python/plat_specific_cpp_dist:ctypes_cpp_library', {
+      'key': 'ctypes_cpp_library',
+      'target_type': CppLibrary,
+      'ctypes_native_library': NativeArtifact(lib_name='cpp-math-lib'),
+      'sources': ['cpp_math_lib.cpp', 'cpp_math_lib.hpp'],
+      'filemap': {
+        'src/python/plat_specific_cpp_dist/cpp_math_lib.cpp': '',
+        'src/python/plat_specific_cpp_dist/cpp_math_lib.hpp': '',
+      },
+    }),
+
+    ('src/python/plat_specific_cpp_dist:plat_specific_ctypes_cpp_dist', {
+      'key': 'platform_specific_ctypes_cpp_dist',
+      'target_type': PythonDistribution,
+      'sources': ['__init__.py', 'setup.py'],
+      'dependencies': ['src/python/plat_specific_cpp_dist:ctypes_cpp_library'],
+      'filemap': {
+        'src/python/plat_specific_cpp_dist/__init__.py': '',
+        'src/python/plat_specific_cpp_dist/setup.py': dedent("""
+        from setuptools import setup, find_packages
+        setup(
+          name='platform_specific_ctypes_cpp_dist',
+          version='0.0.0',
+          packages=find_packages(),
+          data_files=[('', ['libcpp-math-lib.so'])],
+        )
+      """),
+      }
+    }),
+
+  ])
+
+  def test_ctypes_c_dist(self):
+    platform_specific_dist = self.target_dict['platform_specific_ctypes_c_dist']
+    context, synthetic_target, snapshot_version = self._create_distribution_synthetic_target(
+      platform_specific_dist, extra_targets=[self.target_dict['ctypes_c_library']])
+    self.assertEquals(['platform_specific_ctypes_c_dist==0.0.0+{}'.format(snapshot_version)],
+                      [str(x.requirement) for x in synthetic_target.requirements.value])
+    local_wheel_products = context.products.get('local_wheels')
+    local_wheel = self._retrieve_single_product_at_target_base(
+      local_wheel_products, platform_specific_dist)
+    self.assertTrue(check_wheel_platform_matches_host(local_wheel))
+
+  def test_ctypes_cpp_dist(self):
+    platform_specific_dist = self.target_dict['platform_specific_ctypes_cpp_dist']
+    context, synthetic_target, snapshot_version = self._create_distribution_synthetic_target(
+      platform_specific_dist, extra_targets=[self.target_dict['ctypes_cpp_library']])
+    self.assertEquals(['platform_specific_ctypes_cpp_dist==0.0.0+{}'.format(snapshot_version)],
+                      [str(x.requirement) for x in synthetic_target.requirements.value])
+
+    local_wheel_products = context.products.get('local_wheels')
+    local_wheel = self._retrieve_single_product_at_target_base(
+      local_wheel_products, platform_specific_dist)
+    self.assertTrue(check_wheel_platform_matches_host(local_wheel))

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -153,8 +153,11 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
     # or running a target that depends on native (c or cpp) sources.
     with temporary_dir() as tmp_dir:
       pex = os.path.join(tmp_dir, 'main.pex')
-      pants_ini_config = {'python-setup': {'platforms': ['current', 'linux-x86_64']}}
-      # Clean all to rebuild requirements pex.
+      pants_ini_config = {
+        'python-setup': {
+          'platforms': ['current', 'this-platform-does_not-exist'],
+        },
+      }
       command=[
         '--pants-distdir={}'.format(tmp_dir),
         'run',
@@ -171,11 +174,14 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       output = subprocess.check_output(pex)
       self._assert_native_greeting(output)
 
-  def test_pants_tests_local_dists_for_current_platform_only(self):
-    platform_string = Platform.create().resolve_platform_specific({
+  def _get_current_platform_string(self):
+    return Platform.create().resolve_platform_specific({
       'darwin': lambda: 'macosx-10.12-x86_64',
       'linux': lambda: 'linux-x86_64',
     })
+
+  def test_pants_tests_local_dists_for_current_platform_only(self):
+    platform_string = self._get_current_platform_string()
     # Use a platform-specific string for testing because the test goal
     # requires the coverage package and the pex resolver raises an Untranslatable error when
     # attempting to translate the coverage sdist for incompatible platforms.
@@ -189,25 +195,6 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
         '{}:fasthello'.format(self.fasthello_tests)]
       pants_run = self.run_pants(command=command, config=pants_ini_config)
       self.assert_success(pants_run)
-
-  def test_pants_native_source_detection_when_running_local_dists_for_current_platform_only(self):
-    # Test that `./pants run` respects python_binary platforms
-    # arguments when the closure contains native sources. To do this,
-    # we need to setup a pants.ini that contains two platform defauts:
-    # (1) "current" and (2) a different platform than the one we are currently
-    # running on. The test target below has `platforms=("current")`.
-    platform_string = Platform.create().normalized_os_name
-    non_current_platform_string = 'macosx-10.12-x86_64-x86_64' if platform_string == 'darwin' else 'linux-x86_64'
-    pants_ini_config = {'python-setup': {'platforms': ["current", non_current_platform_string]}}
-
-    # Clean all to rebuild requirements pex.
-    command = [
-      'clean-all',
-      'run',
-      'testprojects/src/python/python_distribution/ctypes:bin'
-    ]
-    pants_run = self.run_pants(command=command, config=pants_ini_config)
-    self.assert_success(pants_run)
 
   def test_python_distribution_with_setup_requires(self):
     # Validate that setup_requires dependencies are present and functional.

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -196,12 +196,8 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
     # we need to setup a pants.ini that contains two platform defauts:
     # (1) "current" and (2) a different platform than the one we are currently
     # running on. The test target below has `platforms=("current")`.
-    non_current_platform = None
     platform_string = Platform.create().normalized_os_name
-    if platform_string == 'darwin':
-      non_current_platform_string = 'linux-x86_64'
-    else:
-      non_current_platform_string = 'macosx-10.12-x86_64-x86_64'
+    non_current_platform_string = 'macosx-10.12-x86_64-x86_64' if platform_string == 'darwin' else 'linux-x86_64'
     pants_ini_config = {'python-setup': {'platforms': ["current", non_current_platform_string]}}
 
     # Clean all to rebuild requirements pex.

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -190,6 +190,29 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       pants_run = self.run_pants(command=command, config=pants_ini_config)
       self.assert_success(pants_run)
 
+  def test_pants_native_source_detection_when_running_local_dists_for_current_platform_only(self):
+    # Test that `./pants run` respects python_binary platforms
+    # arguments when the closure contains native sources. To do this,
+    # we need to setup a pants.ini that contains two platform defauts:
+    # (1) "current" and (2) a different platform than the one we are currently
+    # running on. The test target below has `platforms=("current")`.
+    non_current_platform = None
+    platform_string = Platform.create().normalized_os_name
+    if platform_string == 'darwin':
+      non_current_platform_string = 'linux-x86_64'
+    else:
+      non_current_platform_string = 'macosx-10.12-x86_64-x86_64'
+    pants_ini_config = {'python-setup': {'platforms': ["current", non_current_platform_string]}}
+
+    # Clean all to rebuild requirements pex.
+    command = [
+      'clean-all',
+      'run',
+      'testprojects/src/python/python_distribution/ctypes:bin'
+    ]
+    pants_run = self.run_pants(command=command, config=pants_ini_config)
+    self.assert_success(pants_run)
+
   def test_python_distribution_with_setup_requires(self):
     # Validate that setup_requires dependencies are present and functional.
     # PANTS_TEST_SETUP_REQUIRES triggers test functionality in this particular setup.py.

--- a/tests/python/pants_test/backend/python/tasks/util/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/util/BUILD
@@ -1,7 +1,6 @@
 python_library(
   dependencies=[
     'src/python/pants/backend/native',
-    'src/python/pants/backend/python:plugin',
     'src/python/pants/backend/python/tasks',
     'tests/python/pants_test/backend/python/tasks:python_task_test_base',
     'tests/python/pants_test/engine:scheduler_test_base',

--- a/tests/python/pants_test/backend/python/tasks/util/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/util/BUILD
@@ -1,0 +1,16 @@
+python_library(
+  dependencies=[
+    '3rdparty/python:future',
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/backend/native',
+    'src/python/pants/backend/native/targets',
+    'src/python/pants/backend/python:plugin',
+    'src/python/pants/backend/python/targets',
+    'src/python/pants/backend/python/tasks',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:process_handler',
+    'tests/python/pants_test:int-test',
+    'tests/python/pants_test/backend/python/tasks:python_task_test_base',
+    'tests/python/pants_test/engine:scheduler_test_base',
+  ]
+)

--- a/tests/python/pants_test/backend/python/tasks/util/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/util/BUILD
@@ -1,15 +1,8 @@
 python_library(
   dependencies=[
-    '3rdparty/python:future',
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/native',
-    'src/python/pants/backend/native/targets',
     'src/python/pants/backend/python:plugin',
-    'src/python/pants/backend/python/targets',
     'src/python/pants/backend/python/tasks',
-    'src/python/pants/util:contextutil',
-    'src/python/pants/util:process_handler',
-    'tests/python/pants_test:int-test',
     'tests/python/pants_test/backend/python/tasks:python_task_test_base',
     'tests/python/pants_test/engine:scheduler_test_base',
   ]

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -22,7 +22,15 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBas
   def task_type(cls):
     return BuildLocalPythonDistributions
 
+  # This is an informally-specified nested dict -- see ../test_ctypes.py for an example. Special
+  # keys are 'key' (used to index into `self.target_dict`) and 'filemap' (creates files at the
+  # specified relative paths). The rest of the keys are fed into `self.make_target()`. An
+  # `OrderedDict` of 2-tuples may be used if targets need to be created in a specific order (e.g. if
+  # they have dependencies on each other).
   _dist_specs = None
+  # By default, we just use a `BuildLocalPythonDistributions` task. When testing with C/C++ targets,
+  # we want to compile and link them as well to get the resulting dist to build, so we add those
+  # task types here and execute them beforehand.
   _extra_relevant_task_types = None
 
   def setUp(self):

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -8,7 +8,6 @@ import re
 from builtins import next
 
 from pants.backend.native.register import rules as native_backend_rules
-from pants.backend.python.register import rules as python_backend_rules
 from pants.backend.python.tasks.build_local_python_distributions import \
   BuildLocalPythonDistributions
 from pants.util.collections import assert_single_element
@@ -57,11 +56,7 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBas
     return list(self.target_dict.values())
 
   def _scheduling_context(self, **kwargs):
-    rules = (
-      native_backend_rules() +
-      python_backend_rules()
-    )
-    scheduler = self.mk_scheduler(rules=rules)
+    scheduler = self.mk_scheduler(rules=native_backend_rules())
     return self.context(scheduler=scheduler, **kwargs)
 
   def _retrieve_single_product_at_target_base(self, product_mapping, target):

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -1,0 +1,116 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import re
+from builtins import next
+
+from pants.backend.native.register import rules as native_backend_rules
+from pants.backend.python.register import rules as python_backend_rules
+from pants.backend.python.tasks.build_local_python_distributions import \
+  BuildLocalPythonDistributions
+from pants.util.collections import assert_single_element
+from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
+from pants_test.engine.scheduler_test_base import SchedulerTestBase
+
+
+class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBase):
+
+  @classmethod
+  def task_type(cls):
+    return BuildLocalPythonDistributions
+
+  _dist_specs = None
+  _extra_relevant_task_types = None
+
+  def setUp(self):
+    super(BuildLocalPythonDistributionsTestBase, self).setUp()
+
+    self.target_dict = {}
+
+    # Create a python_dist() target from each specification and insert it into `self.target_dict`.
+    for target_spec, file_spec in self._dist_specs.items():
+      file_spec = file_spec.copy()
+      filemap = file_spec.pop('filemap')
+      for rel_path, content in filemap.items():
+        self.create_file(rel_path, content)
+
+      key = file_spec.pop('key')
+      dep_targets = []
+      for dep_spec in file_spec.pop('dependencies', []):
+        existing_tgt_key = self._dist_specs[dep_spec]['key']
+        dep_targets.append(self.target_dict[existing_tgt_key])
+      python_dist_tgt = self.make_target(spec=target_spec, dependencies=dep_targets, **file_spec)
+      self.target_dict[key] = python_dist_tgt
+
+  def _all_specified_targets(self):
+    return list(self.target_dict.values())
+
+  def _scheduling_context(self, **kwargs):
+    rules = (
+      native_backend_rules() +
+      python_backend_rules()
+    )
+    scheduler = self.mk_scheduler(rules=rules)
+    return self.context(scheduler=scheduler, **kwargs)
+
+  def _retrieve_single_product_at_target_base(self, product_mapping, target):
+    product = product_mapping.get(target)
+    base_dirs = list(product.keys())
+    self.assertEqual(1, len(base_dirs))
+    single_base_dir = base_dirs[0]
+    all_products = product[single_base_dir]
+    self.assertEqual(1, len(all_products))
+    single_product = all_products[0]
+    return single_product
+
+  def _get_dist_snapshot_version(self, task, python_dist_target):
+    """Get the target's fingerprint, and guess the resulting version string of the built dist.
+
+    Local python_dist() builds are tagged with the versioned target's fingerprint using the
+    --tag-build option in the egg_info command. This fingerprint string is slightly modified by
+    distutils to ensure a valid version string, and this method finds what that modified version
+    string is so we can verify that the produced local dist is being tagged with the correct
+    snapshot version.
+
+    The argument we pass to that option begins with a +, which is unchanged. See
+    https://www.python.org/dev/peps/pep-0440/ for further information.
+    """
+    with task.invalidated([python_dist_target], invalidate_dependents=True) as invalidation_check:
+      versioned_dist_target = assert_single_element(invalidation_check.all_vts)
+
+    versioned_target_fingerprint = versioned_dist_target.cache_key.hash
+
+    # This performs the normalization that distutils performs to the version string passed to the
+    # --tag-build option.
+    return re.sub(r'[^a-zA-Z0-9]', '.', versioned_target_fingerprint.lower())
+
+  def _create_task(self, task_type, context):
+    return task_type(context, self.test_workdir)
+
+  def _create_distribution_synthetic_target(self, python_dist_target, extra_targets=[]):
+    context = self._scheduling_context(
+      target_roots=([python_dist_target] + extra_targets),
+      for_task_types=([self.task_type()] + self._extra_relevant_task_types))
+    self.assertEquals(set(self._all_specified_targets()), set(context.build_graph.targets()))
+
+    python_create_distributions_task = self.create_task(context)
+    extra_tasks = [
+      self._create_task(task_type, context)
+      for task_type in self._extra_relevant_task_types
+    ]
+    for tsk in extra_tasks:
+      tsk.execute()
+
+    python_create_distributions_task.execute()
+
+    synthetic_tgts = set(context.build_graph.targets()) - set(self._all_specified_targets())
+    self.assertEquals(1, len(synthetic_tgts))
+    synthetic_target = next(iter(synthetic_tgts))
+
+    snapshot_version = self._get_dist_snapshot_version(
+      python_create_distributions_task, python_dist_target)
+
+    return context, synthetic_target, snapshot_version


### PR DESCRIPTION
### Problem

This adds a few more unit tests on top of #6201 -- specifically, testing in isolation that the platform is correctly set on a `python_dist()` which has no native sources itself, but depends on a `ctypes_compatible_c(pp)?_library()` (which is what #6201 fixes). It also moves all testing related to the `ctypes_compatible_c(pp)?_library()` targets into separate testing files to separate functionality more clearly.

Resolves #6201.