### PR TITLE
Re-structure CI flow.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -228,7 +228,8 @@ matrix:
     # Run OSX platform-specific tests.
     - stage: Test Pants
       os: osx
-      language: generic
+      language: python
+      python: "2.7.13"
       env:
         - SHARD="Platform-specific tests for OSX"
         # Specifically avoid the OSX provided 2.7.10 under xcode8.3 since it returns a platform
@@ -245,8 +246,7 @@ matrix:
       os: linux
       dist: trusty
       sudo: required
-      language: python
-      python: "2.7.13"
+      language: generic
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ cache:
     - ${HOME}/.npm
     - build-support/isort.venv
     - build-support/pants_dev_deps.venv
+    - src/rust/engine/target
 
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,14 @@ cache:
 
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
+  - Build Wheels
+  - Build Pants Pex
   - Test Pants
   - name: Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
 
 default_test_config: &default_test_config
+  stage: Test Pants
   os: linux
   dist: trusty
   sudo: required
@@ -71,7 +74,6 @@ default_test_config: &default_test_config
         - python-dev
         - openssl
         - libssl-dev
-  stage: Test Pants
   language: python
   python: "2.7.13"
   before_install:
@@ -81,32 +83,49 @@ default_test_config: &default_test_config
     - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
     - jdk_switcher use oraclejdk8
 
+s3_deploy_config: &s3_deploy_config
+  language: generic
+  deploy:
+    # See: https://docs.travis-ci.com/user/deployment/s3/
+    provider: s3
+    access_key_id: AKIAIWOKBXVU3JLY6EGQ
+    secret_access_key:
+      secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
+    bucket: binaries.pantsbuild.org
+    local_dir: dist/deploy
+    # Otherwise travis will stash dist/deploy and the deploy will fail.
+    skip_cleanup: true
+    acl: public_read
+    on:
+      # NB: We mainly want deploys for `master` commits; but we also need new binaries for stable
+      # release branches; eg `1.3.x`
+      all_branches: true
+      repo: pantsbuild/pants
+
 matrix:
   include:
 
-    # Build macOS engine
-    - os: osx
+    # Build and deploy macOS wheels to S3.
+    - <<: *s3_deploy_config
+      stage: Build Wheels
+      os: osx
       # We request the oldest image we can (corresponding to OSX 10.11) for maximum compatibility.
       # We use 10.11 as a minimum to avoid https://github.com/rust-lang/regex/issues/489.
       # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
       osx_image: xcode8
-      stage: Test Pants
-      language: generic
       env:
         - SHARD="OSX Native Engine Binary Builder"
-        - PREPARE_DEPLOY=1
       script:
         - ./pants --version && ./build-support/bin/release.sh -n
 
-    # Build Linux engine
-    - os: linux
-      stage: Test Pants
-      language: generic
+    # Build and deploy Linux wheels to S3.
+    - <<: *s3_deploy_config
+      stage: Build Wheels
+      os: linux
       services:
         - docker
       env:
         - SHARD="Linux Native Engine Binary Builder"
-        - PREPARE_DEPLOY=1
       before_script:
         - ulimit -c unlimited
       script:
@@ -125,105 +144,95 @@ matrix:
       after_failure:
         - build-support/bin/ci-failure.sh
 
-    # Deploy Pex
-    - os: linux
+    # Build and deploy an OSX / Linux Pants pex to S3.
+    - <<: *s3_deploy_config
+      stage: Build Pants Pex
+      os: linux
       language: python
-      stage: Deploy Pants Pex
-      env:
-        - PANTS_PEX_RELEASE=stable
       script:
         - ./build-support/bin/release.sh -p
-      deploy:
-        # See https://docs.travis-ci.com/user/deployment/releases/
-        provider: releases
-        # The pantsbuild-ci-bot OAuth token, see the pantsbuild vault for details.
-        api_key:
-          secure: "u0aCsiuVGOg28YxG0sQUovuUm29kKwQfFgHbNz2TT5L+cGoHxGl4aoVOCtuwWYEtbNGmYc8/3WRS3C/jOiqQj6JEgHUzWOsnfKUObEqNhisAmXbzBbKc0wPQTL8WNK+DKFh32sD3yPYcw+a5PTLO56+o7rqlI25LK7A17WesHC4="
-        file_glob: true
-        file: dist/deploy/pex/*
-        skip_cleanup: true
-        on:
-          # We only release a pex for Pants releases, which are tagged.
-          tags: true
-          repo: pantsbuild/pants
+      before_deploy:
+        # Wheels were downloaded to dist/deploy from S3 and we don't to re-upload them to S3, but
+        # we do want to upload the pex so shuffle dist/deploy/ contents pre-deploy.
+        - "rm -rf dist/deploy && mkdir -p dist/deploy && mv dist/pants.*.pex dist/deploy/"
 
     - <<: *default_test_config
       env:
         - SHARD="Various pants self checks and lint"
       script:
-        - ./build-support/bin/ci.sh -x -cejlpn 'Various pants self checks and lint'
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -cejlpn"
 
     - <<: *default_test_config
       env:
         - SHARD="Unit tests for pants and pants-plugins - shard 1"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrcnt -u 0/2 "${SHARD}"
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -efkmrcnt -u 0/2"
 
     - <<: *default_test_config
       env:
         - SHARD="Unit tests for pants and pants-plugins - shard 2"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrcnt -u 1/2 "${SHARD}"
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -efkmrcnt -u 1/2"
 
     - <<: *default_test_config
       env:
         - SHARD="Python contrib tests - shard 1"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrcjlpt -y 0/2 "${SHARD}"
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -efkmrcjlpt -y 0/2"
 
     - <<: *default_test_config
       env:
         - SHARD="Python contrib tests - shard 2"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrcjlpt -y 1/2 "${SHARD}"
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -efkmrcjlpt -y 1/2"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 1"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 0/7 "${SHARD}"
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -efkmrjlpnt -i 0/7"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 2"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 1/7 "${SHARD}"
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -efkmrjlpnt -i 1/7"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 3"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 2/7 "${SHARD}"
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -efkmrjlpnt -i 2/7"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 4"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 3/7 "${SHARD}"
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -efkmrjlpnt -i 3/7"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 5"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 4/7 "${SHARD}"
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -efkmrjlpnt -i 4/7"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 6"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 5/7 "${SHARD}"
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -efkmrjlpnt -i 5/7"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 7"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 6/7 "${SHARD}"
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -efkmrjlpnt -i 6/7"
 
-    # Rust on linux
-    - os: linux
+    # Test rust code on Linux.
+    - stage: Test Pants
+      os: linux
       dist: trusty
       sudo: required
-      stage: Test Pants
       language: python
       python: "2.7.13"
       addons:
@@ -241,13 +250,13 @@ matrix:
         - ulimit -c unlimited
         - ulimit -n 8192
       script:
-        - ./build-support/bin/ci.sh -bcfjklmnprtx
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -bcfjklmnprtx"
 
-    # Rust on macOS
-    - os: osx
+    # Test rust code on OSX and runn OSX platform-specific tests.
+    - stage: Test Pants
+      os: osx
       # Fuse actually works on this image. It hangs on many others.
       osx_image: xcode8.3
-      stage: Test Pants
       language: generic
       env:
         - SHARD="Rust + Platform-specific Tests OSX"
@@ -263,25 +272,29 @@ matrix:
         - ulimit -n 8192
       script:
         # Platform-specific tests currently need a pants pex, so we bootstrap here (no -b) and set -z to run the platform-specific tests.
-        - ./build-support/bin/ci.sh -cfjklmnprtxz
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -cfjklmnprtxz"
 
-deploy:
-  # See: https://docs.travis-ci.com/user/deployment/s3/
-  provider: s3
-  access_key_id: AKIAIWOKBXVU3JLY6EGQ
-  secret_access_key:
-    secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
-  bucket: binaries.pantsbuild.org
-  local_dir: dist/deploy
-  # Otherwise travis will stash dist/deploy and the deploy will fail.
-  skip_cleanup: true
-  acl: public_read
-  on:
-    condition: $PREPARE_DEPLOY = 1
-    # NB: We mainly want deploys for `master` commits; but we also need new binaries for stable
-    # release branches; eg `1.3.x`
-    all_branches: true
-    repo: pantsbuild/pants
+    # Deploy the OSX / Linux Pants pex saved in S3 to Github releases.
+    - stage: Deploy Pants Pex
+      os: linux
+      language: generic
+      env:
+        - PANTS_PEX_RELEASE=stable
+      script:
+        - ./build-support/bin/release.sh -f
+      deploy:
+        # See https://docs.travis-ci.com/user/deployment/releases/
+        provider: releases
+        # The pantsbuild-ci-bot OAuth token, see the pantsbuild vault for details.
+        api_key:
+          secure: "u0aCsiuVGOg28YxG0sQUovuUm29kKwQfFgHbNz2TT5L+cGoHxGl4aoVOCtuwWYEtbNGmYc8/3WRS3C/jOiqQj6JEgHUzWOsnfKUObEqNhisAmXbzBbKc0wPQTL8WNK+DKFh32sD3yPYcw+a5PTLO56+o7rqlI25LK7A17WesHC4="
+        file_glob: true
+        file: dist/deploy/pex/*
+        skip_cleanup: true
+        on:
+          # We only release a pex for Pants releases, which are tagged.
+          tags: true
+          repo: pantsbuild/pants
 
 # We accept the default travis-ci email author+committer notification
 # for now which is enabled even with no `notifications` config.

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,30 @@ stages:
   - name: Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
 
+default_test_config: &default_test_config
+  stage: Test Pants
+  os: linux
+  dist: trusty
+  sudo: required
+  addons:
+    apt:
+      packages:
+        - lib32stdc++6
+        - lib32z1
+        - lib32z1-dev
+        - gcc-multilib
+        - python-dev
+        - openssl
+        - libssl-dev
+  language: python
+  python: "2.7.13"
+  before_install:
+    # Remove bad openjdk6 from trusty image, so
+    # Pants will pick up oraclejdk6 from `packages` above.
+    - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
+    - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
+    - jdk_switcher use oraclejdk8
+
 matrix:
   include:
 
@@ -130,34 +154,11 @@ matrix:
         - "rm -rf dist/deploy && mkdir -p dist/deploy && mv dist/pants.*.pex dist/deploy/"
       deploy: *s3_deploy
 
-    # Various pants self checks and lint.
-    - <<: &default_test_config
-        stage: Test Pants
-        os: linux
-        dist: trusty
-        sudo: required
-        addons:
-          apt:
-            packages:
-              - lib32stdc++6
-              - lib32z1
-              - lib32z1-dev
-              - gcc-multilib
-              - python-dev
-              - openssl
-              - libssl-dev
-        language: python
-        python: "2.7.13"
-        before_install:
-          # Remove bad openjdk6 from trusty image, so
-          # Pants will pick up oraclejdk6 from `packages` above.
-          - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
-          - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
-          - jdk_switcher use oraclejdk8
-        env:
-          - SHARD="Various pants self checks and lint"
-        script:
-          - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -cejlpn"
+    - <<: *default_test_config
+      env:
+        - SHARD="Various pants self checks and lint"
+      script:
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -cejlpn"
 
     - <<: *default_test_config
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,8 +93,7 @@ jobs:
       # We use 10.11 as a minimum to avoid https://github.com/rust-lang/regex/issues/489.
       # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
       osx_image: xcode8
-      language: python
-      python: "2.7.13"
+      language: generic
       before_install:
         - brew update && brew install bash
       env:
@@ -257,8 +256,7 @@ jobs:
     # Run OSX platform-specific tests.
     - stage: Test Pants
       os: osx
-      language: python
-      python: "2.7.13"
+      language: generic
       before_install:
         - brew update && brew install bash
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,7 @@ jobs:
       # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
       osx_image: xcode8
       language: ruby
+      rvm: 2.5.1
       before_install:
         - brew install bash
       env:
@@ -257,6 +258,7 @@ jobs:
     - stage: Test Pants
       os: osx
       language: ruby
+      rvm: 2.5.1
       before_install:
         - brew install bash
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,30 +57,6 @@ stages:
   - name: Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
 
-default_test_config: &default_test_config
-  stage: Test Pants
-  os: linux
-  dist: trusty
-  sudo: required
-  addons:
-    apt:
-      packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-  language: python
-  python: "2.7.13"
-  before_install:
-    # Remove bad openjdk6 from trusty image, so
-    # Pants will pick up oraclejdk6 from `packages` above.
-    - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
-    - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
-    - jdk_switcher use oraclejdk8
-
 jobs:
   include:
 
@@ -99,12 +75,12 @@ jobs:
         - S3_DEPLOY = 1
       script:
         - ./pants --version && ./build-support/bin/release.sh -s
-      deploy:
+      deploy: &s3_deploy
         # See: https://docs.travis-ci.com/user/deployment/s3/
         provider: s3
         access_key_id: AKIAIWOKBXVU3JLY6EGQ
         secret_access_key:
-          secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
+          secure: "UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM="
         bucket: binaries.pantsbuild.org
         local_dir: dist/deploy
         # Otherwise travis will stash dist/deploy and the deploy will fail.
@@ -137,19 +113,7 @@ jobs:
           -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
           travis_ci:latest
           sh -c "./pants --version && ./build-support/bin/release.sh -s"
-      deploy:
-        # See: https://docs.travis-ci.com/user/deployment/s3/
-        provider: s3
-        access_key_id: AKIAIWOKBXVU3JLY6EGQ
-        secret_access_key:
-          secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
-        bucket: binaries.pantsbuild.org
-        local_dir: dist/deploy
-        # Otherwise travis will stash dist/deploy and the deploy will fail.
-        skip_cleanup: true
-        acl: public_read
-        on:
-          condition: $S3_DEPLOY = 1
+      deploy: *s3_deploy
 
     # Build and deploy an OSX & Linux multi-platform Pants pex to S3.
     - stage: Build Pants Pex
@@ -164,22 +128,31 @@ jobs:
         # Wheels were downloaded to dist/deploy from S3 and we don't want to re-upload them to S3,
         # but we do want to upload the pex so shuffle dist/deploy/ contents pre-deploy.
         - "rm -rf dist/deploy && mkdir -p dist/deploy && mv dist/pants.*.pex dist/deploy/"
-      deploy:
-        # See: https://docs.travis-ci.com/user/deployment/s3/
-        provider: s3
-        access_key_id: AKIAIWOKBXVU3JLY6EGQ
-        secret_access_key:
-          secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
-        bucket: binaries.pantsbuild.org
-        local_dir: dist/deploy
-        # Otherwise travis will stash dist/deploy and the deploy will fail.
-        skip_cleanup: true
-        acl: public_read
-        on:
-          condition: $S3_DEPLOY = 1
+      deploy: *s3_deploy
 
-
-    - <<: *default_test_config
+    - &default_test_config
+      stage: Test Pants
+      os: linux
+      dist: trusty
+      sudo: required
+      addons:
+        apt:
+          packages:
+            - lib32stdc++6
+            - lib32z1
+            - lib32z1-dev
+            - gcc-multilib
+            - python-dev
+            - openssl
+            - libssl-dev
+      language: python
+      python: "2.7.13"
+      before_install:
+        # Remove bad openjdk6 from trusty image, so
+        # Pants will pick up oraclejdk6 from `packages` above.
+        - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
+        - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
+        - jdk_switcher use oraclejdk8
       env:
         - SHARD="Various pants self checks and lint"
       script:
@@ -292,20 +265,7 @@ jobs:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
       before_deploy:
         - ./build-support/bin/release.sh -u
-      deploy:
-        # See: https://docs.travis-ci.com/user/deployment/s3/
-        provider: s3
-        access_key_id: AKIAIWOKBXVU3JLY6EGQ
-        secret_access_key:
-          secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
-        bucket: binaries.pantsbuild.org
-        local_dir: dist/deploy
-        # Otherwise travis will stash dist/deploy and the deploy will fail.
-        skip_cleanup: true
-        acl: public_read
-        on:
-          condition: $S3_DEPLOY = 1
-
+      deploy: *s3_deploy
 
     # Test rust code on OSX.
     - os: osx
@@ -324,19 +284,7 @@ jobs:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
       before_deploy:
         - ./build-support/bin/release.sh -u
-      deploy:
-        # See: https://docs.travis-ci.com/user/deployment/s3/
-        provider: s3
-        access_key_id: AKIAIWOKBXVU3JLY6EGQ
-        secret_access_key:
-          secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
-        bucket: binaries.pantsbuild.org
-        local_dir: dist/deploy
-        # Otherwise travis will stash dist/deploy and the deploy will fail.
-        skip_cleanup: true
-        acl: public_read
-        on:
-          condition: $S3_DEPLOY = 1
+      deploy: *s3_deploy
 
     # Deploy the OSX / Linux Pants pex saved in S3 to Github releases.
     - stage: Deploy Pants Pex

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,20 +83,6 @@ default_test_config: &default_test_config
     - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
     - jdk_switcher use oraclejdk8
 
-deploy:
-  # See: https://docs.travis-ci.com/user/deployment/s3/
-  provider: s3
-  access_key_id: AKIAIWOKBXVU3JLY6EGQ
-  secret_access_key:
-    secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
-  bucket: binaries.pantsbuild.org
-  local_dir: dist/deploy
-  # Otherwise travis will stash dist/deploy and the deploy will fail.
-  skip_cleanup: true
-  acl: public_read
-  on:
-    condition: $S3_DEPLOY = 1
-
 matrix:
   include:
 
@@ -305,6 +291,20 @@ matrix:
           # We only release a pex for Pants releases, which are tagged.
           tags: true
           repo: pantsbuild/pants
+
+deploy:
+  # See: https://docs.travis-ci.com/user/deployment/s3/
+  provider: s3
+  access_key_id: AKIAIWOKBXVU3JLY6EGQ
+  secret_access_key:
+    secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
+  bucket: binaries.pantsbuild.org
+  local_dir: dist/deploy
+  # Otherwise travis will stash dist/deploy and the deploy will fail.
+  skip_cleanup: true
+  acl: public_read
+  on:
+    condition: $S3_DEPLOY = 1
 
 # We accept the default travis-ci email author+committer notification
 # for now which is enabled even with no `notifications` config.

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ default_test_config: &default_test_config
     - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
     - jdk_switcher use oraclejdk8
 
-s3_deploy_config: &s3_deploy_config
+sss_deploy_config: &sss_deploy_config
   language: generic
   deploy:
     # See: https://docs.travis-ci.com/user/deployment/s3/
@@ -101,7 +101,7 @@ matrix:
   include:
 
     # Build and deploy OSX wheels to S3.
-    - <<: *s3_deploy_config
+    - <<: *sss_deploy_config
       stage: Build Wheels
       os: osx
       # We request the oldest image we can (corresponding to OSX 10.11) for maximum compatibility.
@@ -111,10 +111,10 @@ matrix:
       env:
         - SHARD="OSX Wheel Builder"
       script:
-        - ./pants --version && ./build-support/bin/release.sh -n
+        - ./pants --version && ./build-support/bin/release.sh -s
 
     # Build and deploy Linux wheels to S3.
-    - <<: *s3_deploy_config
+    - <<: *sss_deploy_config
       stage: Build Wheels
       os: linux
       services:
@@ -135,12 +135,10 @@ matrix:
           -v "${HOME}:/travis/home"
           -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
           travis_ci:latest
-          sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -n"
-      after_failure:
-        - build-support/bin/ci-failure.sh
+          sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -s"
 
     # Build and deploy an OSX & Linux multi-platform Pants pex to S3.
-    - <<: *s3_deploy_config
+    - <<: *sss_deploy_config
       stage: Build Pants Pex
       os: linux
       language: python
@@ -238,10 +236,10 @@ matrix:
         # https://github.com/pantsbuild/pex/issues/523
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>2.7.10,<3']"
       script:
-        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -cfjklmnprtxz"
+        - CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -cfjklmnprtxz
 
     # Test rust code on Linux.
-    - <<: *s3_deploy_config
+    - <<: *sss_deploy_config
       stage: Test Pants
       os: linux
       dist: trusty
@@ -262,11 +260,12 @@ matrix:
         - ulimit -c unlimited
         - ulimit -n 8192
       script:
-        - "./build-support/bin/ci.sh -bcfjklmnprtx"
-        - "./build-support/bin/release.sh -u"
+        - ./build-support/bin/ci.sh -bcfjklmnprtx
+      before_deploy:
+        - ./build-support/bin/release.sh -u
 
     # Test rust code on OSX.
-    - <<: *s3_deploy_config
+    - <<: *sss_deploy_config
       os: osx
       # Fuse actually works on this image. It hangs on many others.
       osx_image: xcode8.3
@@ -279,8 +278,9 @@ matrix:
         - ulimit -c unlimited
         - ulimit -n 8192
       script:
-        - "./build-support/bin/ci.sh -bcfjklmnprtx"
-        - "./build-support/bin/release.sh -u"
+        - ./build-support/bin/ci.sh -bcfjklmnprtx
+      before_deploy:
+        - ./build-support/bin/release.sh -u
 
     # Deploy the OSX / Linux Pants pex saved in S3 to Github releases.
     - stage: Deploy Pants Pex

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,8 @@ jobs:
       # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
       osx_image: xcode8
       language: generic
+      before_install:
+        - brew update && brew install bash
       env:
         - SHARD="OSX Wheel Builder"
         - S3_DEPLOY = 1
@@ -256,6 +258,8 @@ jobs:
       os: osx
       language: python
       python: "2.7.13"
+      before_install:
+        - brew update && brew install bash
       env:
         - SHARD="Platform-specific tests for OSX"
         # Specifically avoid the OSX provided 2.7.10 under xcode8.3 since it returns a platform
@@ -311,11 +315,11 @@ jobs:
       # Fuse actually works on this image. It hangs on many others.
       osx_image: xcode8.3
       language: generic
+      before_install:
+        - brew tap caskroom/cask && brew update && brew cask install osxfuse && brew install bash
       env:
         - SHARD="Rust tests for OSX & fs_util deploy"
         - S3_DEPLOY = 1
-      before_install:
-        - brew tap caskroom/cask && brew update && brew cask install osxfuse
       before_script:
         - ulimit -c unlimited
         - ulimit -n 8192

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ jobs:
           -v "${HOME}:/travis/home"
           -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
           travis_ci:latest
-          sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -s"
+          sh -c "./pants --version && ./build-support/bin/release.sh -s"
       deploy:
         # See: https://docs.travis-ci.com/user/deployment/s3/
         provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,16 +96,11 @@ s3_deploy_config: &s3_deploy_config
     # Otherwise travis will stash dist/deploy and the deploy will fail.
     skip_cleanup: true
     acl: public_read
-    on:
-      # NB: We mainly want deploys for `master` commits; but we also need new binaries for stable
-      # release branches; eg `1.3.x`
-      all_branches: true
-      repo: pantsbuild/pants
 
 matrix:
   include:
 
-    # Build and deploy macOS wheels to S3.
+    # Build and deploy OSX wheels to S3.
     - <<: *s3_deploy_config
       stage: Build Wheels
       os: osx
@@ -152,8 +147,8 @@ matrix:
       script:
         - ./build-support/bin/release.sh -p
       before_deploy:
-        # Wheels were downloaded to dist/deploy from S3 and we don't to re-upload them to S3, but
-        # we do want to upload the pex so shuffle dist/deploy/ contents pre-deploy.
+        # Wheels were downloaded to dist/deploy from S3 and we don't want to re-upload them to S3,
+        # but we do want to upload the pex so shuffle dist/deploy/ contents pre-deploy.
         - "rm -rf dist/deploy && mkdir -p dist/deploy && mv dist/pants.*.pex dist/deploy/"
 
     - <<: *default_test_config
@@ -271,7 +266,6 @@ matrix:
         - ulimit -c unlimited
         - ulimit -n 8192
       script:
-        # Platform-specific tests currently need a pants pex, so we bootstrap here (no -b) and set -z to run the platform-specific tests.
         - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -cfjklmnprtxz"
 
     # Deploy the OSX / Linux Pants pex saved in S3 to Github releases.

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
         - S3_DEPLOY = 1
       script:
         - ./pants --version && ./build-support/bin/release.sh -s
-      deploy: &s3_deploy
+      deploy:
         # See: https://docs.travis-ci.com/user/deployment/s3/
         provider: s3
         access_key_id: AKIAIWOKBXVU3JLY6EGQ
@@ -137,7 +137,19 @@ jobs:
           -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
           travis_ci:latest
           sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -s"
-      deploy: *s3_deploy
+      deploy:
+        # See: https://docs.travis-ci.com/user/deployment/s3/
+        provider: s3
+        access_key_id: AKIAIWOKBXVU3JLY6EGQ
+        secret_access_key:
+          secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
+        bucket: binaries.pantsbuild.org
+        local_dir: dist/deploy
+        # Otherwise travis will stash dist/deploy and the deploy will fail.
+        skip_cleanup: true
+        acl: public_read
+        on:
+          condition: $S3_DEPLOY = 1
 
     # Build and deploy an OSX & Linux multi-platform Pants pex to S3.
     - stage: Build Pants Pex
@@ -152,7 +164,20 @@ jobs:
         # Wheels were downloaded to dist/deploy from S3 and we don't want to re-upload them to S3,
         # but we do want to upload the pex so shuffle dist/deploy/ contents pre-deploy.
         - "rm -rf dist/deploy && mkdir -p dist/deploy && mv dist/pants.*.pex dist/deploy/"
-      deploy: *s3_deploy
+      deploy:
+        # See: https://docs.travis-ci.com/user/deployment/s3/
+        provider: s3
+        access_key_id: AKIAIWOKBXVU3JLY6EGQ
+        secret_access_key:
+          secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
+        bucket: binaries.pantsbuild.org
+        local_dir: dist/deploy
+        # Otherwise travis will stash dist/deploy and the deploy will fail.
+        skip_cleanup: true
+        acl: public_read
+        on:
+          condition: $S3_DEPLOY = 1
+
 
     - <<: *default_test_config
       env:
@@ -266,7 +291,20 @@ jobs:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
       before_deploy:
         - ./build-support/bin/release.sh -u
-      deploy: *s3_deploy
+      deploy:
+        # See: https://docs.travis-ci.com/user/deployment/s3/
+        provider: s3
+        access_key_id: AKIAIWOKBXVU3JLY6EGQ
+        secret_access_key:
+          secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
+        bucket: binaries.pantsbuild.org
+        local_dir: dist/deploy
+        # Otherwise travis will stash dist/deploy and the deploy will fail.
+        skip_cleanup: true
+        acl: public_read
+        on:
+          condition: $S3_DEPLOY = 1
+
 
     # Test rust code on OSX.
     - os: osx
@@ -285,7 +323,19 @@ jobs:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
       before_deploy:
         - ./build-support/bin/release.sh -u
-      deploy: *s3_deploy
+      deploy:
+        # See: https://docs.travis-ci.com/user/deployment/s3/
+        provider: s3
+        access_key_id: AKIAIWOKBXVU3JLY6EGQ
+        secret_access_key:
+          secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
+        bucket: binaries.pantsbuild.org
+        local_dir: dist/deploy
+        # Otherwise travis will stash dist/deploy and the deploy will fail.
+        skip_cleanup: true
+        acl: public_read
+        on:
+          condition: $S3_DEPLOY = 1
 
     # Deploy the OSX / Linux Pants pex saved in S3 to Github releases.
     - stage: Deploy Pants Pex

--- a/.travis.yml
+++ b/.travis.yml
@@ -223,8 +223,23 @@ matrix:
       script:
         - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -efkmrjlpnt -i 6/7"
 
-    # Test rust code on Linux.
+    # Run OSX platform-specific tests.
     - stage: Test Pants
+      os: osx
+      language: generic
+      env:
+        - SHARD="Platform-specific Tests OSX"
+        # Specifically avoid the OSX provided 2.7.10 under xcode8.3 since it returns a platform
+        # of `macosx-*-intel` where the `intel` suffix is bogus but pex has not yet been taught to
+        # deal with this. Can be removed when this issue is resolved:
+        # https://github.com/pantsbuild/pex/issues/523
+        - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>2.7.10,<3']"
+      script:
+        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -cfjklmnprtxz"
+
+    # Test rust code on Linux.
+    - <<: *s3_deploy_config
+      stage: Test Pants
       os: linux
       dist: trusty
       sudo: required
@@ -240,33 +255,30 @@ matrix:
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf
       env:
-        - SHARD="Rust Tests Linux"
+        - SHARD="Rust Tests Linux & fs_util S3 deploy"
       before_script:
         - ulimit -c unlimited
         - ulimit -n 8192
       script:
-        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -bcfjklmnprtx"
+        - "./build-support/bin/ci.sh -bcfjklmnprtx"
+        - "./build-support/bin/release.sh -u"
 
-    # Test rust code on OSX and runn OSX platform-specific tests.
-    - stage: Test Pants
+    # Test rust code on OSX.
+    - <<: *s3_deploy_config
       os: osx
       # Fuse actually works on this image. It hangs on many others.
       osx_image: xcode8.3
       language: generic
       env:
-        - SHARD="Rust + Platform-specific Tests OSX"
-        # Specifically avoid the OSX provided 2.7.10 under xcode8.3 since it returns a platform
-        # of `macosx-*-intel` where the `intel` suffix is bogus but pex has not yet been taught to
-        # deal with this. Can be removed when this issue is resolved:
-        # https://github.com/pantsbuild/pex/issues/523
-        - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>2.7.10,<3']"
+        - SHARD="Rust Tests OSX & fs_util S3 deploy"
       before_install:
         - brew tap caskroom/cask && brew update && brew cask install osxfuse
       before_script:
         - ulimit -c unlimited
         - ulimit -n 8192
       script:
-        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -cfjklmnprtxz"
+        - "./build-support/bin/ci.sh -bcfjklmnprtx"
+        - "./build-support/bin/release.sh -u"
 
     # Deploy the OSX / Linux Pants pex saved in S3 to Github releases.
     - stage: Deploy Pants Pex

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ jobs:
       osx_image: xcode8
       language: generic
       before_install:
-        - brew install bash
+        - brew upgrade ruby && brew install bash
       env:
         - SHARD="OSX Wheel Builder"
         - S3_DEPLOY = 1
@@ -259,7 +259,7 @@ jobs:
       language: python
       python: "2.7.13"
       before_install:
-        - brew install bash
+        - brew upgrade ruby && brew install bash
       env:
         - SHARD="Platform-specific tests for OSX"
         # Specifically avoid the OSX provided 2.7.10 under xcode8.3 since it returns a platform

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,10 +93,10 @@ jobs:
       # We use 10.11 as a minimum to avoid https://github.com/rust-lang/regex/issues/489.
       # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
       osx_image: xcode8
-      language: ruby
-      rvm: 2.5.1
+      language: python
+      python: "2.7.13"
       before_install:
-        - brew install bash
+        - brew update && brew install bash
       env:
         - SHARD="OSX Wheel Builder"
         - S3_DEPLOY = 1
@@ -257,10 +257,10 @@ jobs:
     # Run OSX platform-specific tests.
     - stage: Test Pants
       os: osx
-      language: ruby
-      rvm: 2.5.1
+      language: python
+      python: "2.7.13"
       before_install:
-        - brew install bash
+        - brew update && brew install bash
       env:
         - SHARD="Platform-specific tests for OSX"
         # Specifically avoid the OSX provided 2.7.10 under xcode8.3 since it returns a platform

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ jobs:
       osx_image: xcode8
       language: generic
       before_install:
-        - brew update && brew install bash
+        - brew install bash
       env:
         - SHARD="OSX Wheel Builder"
         - S3_DEPLOY = 1
@@ -259,7 +259,7 @@ jobs:
       language: python
       python: "2.7.13"
       before_install:
-        - brew update && brew install bash
+        - brew install bash
       env:
         - SHARD="Platform-specific tests for OSX"
         # Specifically avoid the OSX provided 2.7.10 under xcode8.3 since it returns a platform

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,9 +93,9 @@ jobs:
       # We use 10.11 as a minimum to avoid https://github.com/rust-lang/regex/issues/489.
       # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
       osx_image: xcode8
-      language: generic
+      language: ruby
       before_install:
-        - brew upgrade ruby && brew install bash
+        - brew install bash
       env:
         - SHARD="OSX Wheel Builder"
         - S3_DEPLOY = 1
@@ -256,10 +256,9 @@ jobs:
     # Run OSX platform-specific tests.
     - stage: Test Pants
       os: osx
-      language: python
-      python: "2.7.13"
+      language: ruby
       before_install:
-        - brew upgrade ruby && brew install bash
+        - brew install bash
       env:
         - SHARD="Platform-specific tests for OSX"
         # Specifically avoid the OSX provided 2.7.10 under xcode8.3 since it returns a platform

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ matrix:
       # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
       osx_image: xcode8
       env:
-        - SHARD="OSX Native Engine Binary Builder"
+        - SHARD="OSX Wheel Builder"
       script:
         - ./pants --version && ./build-support/bin/release.sh -n
 
@@ -120,7 +120,7 @@ matrix:
       services:
         - docker
       env:
-        - SHARD="Linux Native Engine Binary Builder"
+        - SHARD="Linux Wheel Builder"
       before_script:
         - ulimit -c unlimited
       script:
@@ -139,11 +139,13 @@ matrix:
       after_failure:
         - build-support/bin/ci-failure.sh
 
-    # Build and deploy an OSX / Linux Pants pex to S3.
+    # Build and deploy an OSX & Linux multi-platform Pants pex to S3.
     - <<: *s3_deploy_config
       stage: Build Pants Pex
       os: linux
       language: python
+      env:
+        - SHARD="Multiplatform Pants pex Builder"
       script:
         - ./build-support/bin/release.sh -p
       before_deploy:
@@ -228,7 +230,7 @@ matrix:
       os: osx
       language: generic
       env:
-        - SHARD="Platform-specific Tests OSX"
+        - SHARD="Platform-specific tests for OSX"
         # Specifically avoid the OSX provided 2.7.10 under xcode8.3 since it returns a platform
         # of `macosx-*-intel` where the `intel` suffix is bogus but pex has not yet been taught to
         # deal with this. Can be removed when this issue is resolved:
@@ -255,7 +257,7 @@ matrix:
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf
       env:
-        - SHARD="Rust Tests Linux & fs_util S3 deploy"
+        - SHARD="Rust tests for Linux & fs_util S3 deploy"
       before_script:
         - ulimit -c unlimited
         - ulimit -n 8192
@@ -270,7 +272,7 @@ matrix:
       osx_image: xcode8.3
       language: generic
       env:
-        - SHARD="Rust Tests OSX & fs_util S3 deploy"
+        - SHARD="Rust tests for OSX & fs_util S3 deploy"
       before_install:
         - brew tap caskroom/cask && brew update && brew cask install osxfuse
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,10 @@ before_cache:
   # The stats cache contains timestamped reports unused by CI but that
   # thrash the cache.  Skip caching these.
   - rm -rf ${HOME}/.cache/pants/stats
-  # While the bin directory and rust toolchains are relatively large, they're also very quick to
-  # restore/install: prune them to keep the total cache size down.
-  #   see https://docs.travis-ci.com/user/caching/#Things-not-to-cache
-  # NB: We do _not_ prune the cargo cache, since that holds compiled tools and outputs, and
-  # individually resolved artifacts.
+  # While the bin directory is relatively large, it's also very quick to restore/install;
+  # so prune it to keep the total cache size down. See:
+  #   https://docs.travis-ci.com/user/caching/#Things-not-to-cache
   - rm -rf ${HOME}/.cache/pants/bin
-  - rm -rf ${HOME}/.cache/pants/rust/rustup
   - rm -rf ${HOME}/.cache/pants/lmdb_store
   # Render a summary of what is left in the home directory, to assist with further pruning of
   # the cache.

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ default_test_config: &default_test_config
     - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
     - jdk_switcher use oraclejdk8
 
-matrix:
+jobs:
   include:
 
     # Build and deploy OSX wheels to S3.

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,30 +59,6 @@ stages:
   - name: Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
 
-default_test_config: &default_test_config
-  stage: Test Pants
-  os: linux
-  dist: trusty
-  sudo: required
-  addons:
-    apt:
-      packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-  language: python
-  python: "2.7.13"
-  before_install:
-    # Remove bad openjdk6 from trusty image, so
-    # Pants will pick up oraclejdk6 from `packages` above.
-    - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
-    - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
-    - jdk_switcher use oraclejdk8
-
 matrix:
   include:
 
@@ -99,6 +75,19 @@ matrix:
         - S3_DEPLOY = 1
       script:
         - ./pants --version && ./build-support/bin/release.sh -s
+      deploy: &s3_deploy
+        # See: https://docs.travis-ci.com/user/deployment/s3/
+        provider: s3
+        access_key_id: AKIAIWOKBXVU3JLY6EGQ
+        secret_access_key:
+          secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
+        bucket: binaries.pantsbuild.org
+        local_dir: dist/deploy
+        # Otherwise travis will stash dist/deploy and the deploy will fail.
+        skip_cleanup: true
+        acl: public_read
+        on:
+          condition: $S3_DEPLOY = 1
 
     # Build and deploy Linux wheels to S3.
     - stage: Build Wheels
@@ -124,6 +113,7 @@ matrix:
           -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
           travis_ci:latest
           sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -s"
+      deploy: *s3_deploy
 
     # Build and deploy an OSX & Linux multi-platform Pants pex to S3.
     - stage: Build Pants Pex
@@ -138,12 +128,36 @@ matrix:
         # Wheels were downloaded to dist/deploy from S3 and we don't want to re-upload them to S3,
         # but we do want to upload the pex so shuffle dist/deploy/ contents pre-deploy.
         - "rm -rf dist/deploy && mkdir -p dist/deploy && mv dist/pants.*.pex dist/deploy/"
+      deploy: *s3_deploy
 
-    - <<: *default_test_config
-      env:
-        - SHARD="Various pants self checks and lint"
-      script:
-        - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -cejlpn"
+    # Various pants self checks and lint.
+    - <<: &default_test_config
+        stage: Test Pants
+        os: linux
+        dist: trusty
+        sudo: required
+        addons:
+          apt:
+            packages:
+              - lib32stdc++6
+              - lib32z1
+              - lib32z1-dev
+              - gcc-multilib
+              - python-dev
+              - openssl
+              - libssl-dev
+        language: python
+        python: "2.7.13"
+        before_install:
+          # Remove bad openjdk6 from trusty image, so
+          # Pants will pick up oraclejdk6 from `packages` above.
+          - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
+          - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
+          - jdk_switcher use oraclejdk8
+        env:
+          - SHARD="Various pants self checks and lint"
+        script:
+          - "CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -x -cejlpn"
 
     - <<: *default_test_config
       env:
@@ -251,6 +265,7 @@ matrix:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
       before_deploy:
         - ./build-support/bin/release.sh -u
+      deploy: *s3_deploy
 
     # Test rust code on OSX.
     - os: osx
@@ -269,6 +284,7 @@ matrix:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
       before_deploy:
         - ./build-support/bin/release.sh -u
+      deploy: *s3_deploy
 
     # Deploy the OSX / Linux Pants pex saved in S3 to Github releases.
     - stage: Deploy Pants Pex
@@ -291,20 +307,6 @@ matrix:
           # We only release a pex for Pants releases, which are tagged.
           tags: true
           repo: pantsbuild/pants
-
-deploy:
-  # See: https://docs.travis-ci.com/user/deployment/s3/
-  provider: s3
-  access_key_id: AKIAIWOKBXVU3JLY6EGQ
-  secret_access_key:
-    secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
-  bucket: binaries.pantsbuild.org
-  local_dir: dist/deploy
-  # Otherwise travis will stash dist/deploy and the deploy will fail.
-  skip_cleanup: true
-  acl: public_read
-  on:
-    condition: $S3_DEPLOY = 1
 
 # We accept the default travis-ci email author+committer notification
 # for now which is enabled even with no `notifications` config.

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,44 +83,46 @@ default_test_config: &default_test_config
     - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
     - jdk_switcher use oraclejdk8
 
-sss_deploy_config: &sss_deploy_config
-  language: generic
-  deploy:
-    # See: https://docs.travis-ci.com/user/deployment/s3/
-    provider: s3
-    access_key_id: AKIAIWOKBXVU3JLY6EGQ
-    secret_access_key:
-      secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
-    bucket: binaries.pantsbuild.org
-    local_dir: dist/deploy
-    # Otherwise travis will stash dist/deploy and the deploy will fail.
-    skip_cleanup: true
-    acl: public_read
+deploy:
+  # See: https://docs.travis-ci.com/user/deployment/s3/
+  provider: s3
+  access_key_id: AKIAIWOKBXVU3JLY6EGQ
+  secret_access_key:
+    secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
+  bucket: binaries.pantsbuild.org
+  local_dir: dist/deploy
+  # Otherwise travis will stash dist/deploy and the deploy will fail.
+  skip_cleanup: true
+  acl: public_read
+  on:
+    condition: $S3_DEPLOY = 1
 
 matrix:
   include:
 
     # Build and deploy OSX wheels to S3.
-    - <<: *sss_deploy_config
-      stage: Build Wheels
+    - stage: Build Wheels
       os: osx
       # We request the oldest image we can (corresponding to OSX 10.11) for maximum compatibility.
       # We use 10.11 as a minimum to avoid https://github.com/rust-lang/regex/issues/489.
       # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
       osx_image: xcode8
+      language: generic
       env:
         - SHARD="OSX Wheel Builder"
+        - S3_DEPLOY = 1
       script:
         - ./pants --version && ./build-support/bin/release.sh -s
 
     # Build and deploy Linux wheels to S3.
-    - <<: *sss_deploy_config
-      stage: Build Wheels
+    - stage: Build Wheels
       os: linux
+      language: generic
       services:
         - docker
       env:
         - SHARD="Linux Wheel Builder"
+        - S3_DEPLOY = 1
       before_script:
         - ulimit -c unlimited
       script:
@@ -138,12 +140,12 @@ matrix:
           sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -s"
 
     # Build and deploy an OSX & Linux multi-platform Pants pex to S3.
-    - <<: *sss_deploy_config
-      stage: Build Pants Pex
+    - stage: Build Pants Pex
       os: linux
       language: python
       env:
         - SHARD="Multiplatform Pants pex Builder"
+        - S3_DEPLOY = 1
       script:
         - ./build-support/bin/release.sh -p
       before_deploy:
@@ -239,8 +241,7 @@ matrix:
         - CI_USE_PREBUILT_PANTS_PEX=1 ./build-support/bin/ci.sh -cfjklmnprtxz
 
     # Test rust code on Linux.
-    - <<: *sss_deploy_config
-      stage: Test Pants
+    - stage: Test Pants
       os: linux
       dist: trusty
       sudo: required
@@ -255,7 +256,8 @@ matrix:
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf
       env:
-        - SHARD="Rust tests for Linux & fs_util S3 deploy"
+        - SHARD="Rust tests for Linux & fs_util deploy"
+        - S3_DEPLOY = 1
       before_script:
         - ulimit -c unlimited
         - ulimit -n 8192
@@ -265,13 +267,13 @@ matrix:
         - ./build-support/bin/release.sh -u
 
     # Test rust code on OSX.
-    - <<: *sss_deploy_config
-      os: osx
+    - os: osx
       # Fuse actually works on this image. It hangs on many others.
       osx_image: xcode8.3
       language: generic
       env:
-        - SHARD="Rust tests for OSX & fs_util S3 deploy"
+        - SHARD="Rust tests for OSX & fs_util deploy"
+        - S3_DEPLOY = 1
       before_install:
         - brew tap caskroom/cask && brew update && brew cask install osxfuse
       before_script:

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -687,9 +687,9 @@ function usage() {
   echo "       and can be installed in an ephemeral virtualenv."
   echo " -l  Lists all pantsbuild packages that this script releases."
   echo " -o  Lists all pantsbuild package owners."
-  echo " -e  Check that wheels are prebuilt for this release."
-  echo " -f  Fetch the prebuilt pex for this release and print its path."
-  echo " -p  Build a pex from prebuilt wheels for this release."
+  echo " -e  Check that wheels are prebuilt for HEAD."
+  echo " -f  Fetch the prebuilt pex for HEAD and print its path."
+  echo " -p  Build a pex from prebuilt wheels for HEAD."
   echo " -q  Build a pex which only works on the host platform, using the code as exists on disk."
   echo
   echo "All options (except for '-d') are mutually exclusive."

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -221,6 +221,25 @@ function build_pants_packages() {
   pants_version_reset
 }
 
+function build_fs_util() {
+  start_travis_section "fs_util" "Building fs_util binary"
+  # fs_util is a standalone tool which can be used to inspect and manipulate
+  # Pants's engine's file store, and interact with content addressable storage
+  # services which implement the Bazel remote execution API.
+  # It is a useful standalone tool which people may want to consume, for
+  # instance when debugging pants issues, or if they're implementing a remote
+  # execution API.
+  (
+    set -e
+    RUST_BACKTRACE=1 "${ROOT}/build-support/bin/native/cargo" build --release \
+      --manifest-path="${ROOT}/src/rust/engine/fs/fs_util/Cargo.toml"
+    dst_dir="${DEPLOY_DIR}/bin/fs_util/$("${ROOT}/build-support/bin/get_os.sh")/${version}"
+    mkdir -p "${dst_dir}"
+    cp "${ROOT}/src/rust/engine/target/release/fs_util" "${dst_dir}/"
+  ) || die "Failed to build fs_util"
+  end_travis_section
+}
+
 function activate_tmp_venv() {
   VENV_DIR=$(mktemp -d -t pants.XXXXX) && \
   ${ROOT}/build-support/virtualenv $VENV_DIR && \
@@ -653,9 +672,10 @@ function usage() {
   echo "PyPi.  Credentials are needed for this as described in the"
   echo "release docs: http://pantsbuild.org/release.html"
   echo
-  echo "Usage: $0 [-d] [-c] (-h|-s|-n|-t|-l|-o|-e|-f|-p)"
+  echo "Usage: $0 [-d] [-c] (-h|-u|-s|-n|-t|-l|-o|-e|-f|-p)"
   echo " -d  Enables debug mode (verbose output, script pauses after venv creation)"
   echo " -h  Prints out this help message."
+  echo " -u  Build fs_util."
   echo " -s  Performs a release dry run."
   echo "       All package distributions will be built."
   echo " -n  Performs a release dry run with sanity checks that dists install and run."
@@ -681,10 +701,11 @@ function usage() {
   fi
 }
 
-while getopts "hdsntcloefpqw" opt; do
+while getopts "hdusntcloefpqw" opt; do
   case ${opt} in
     h) usage ;;
     d) debug="true" ;;
+    u) do_build_fs_util="true" ;;
     s) do_dry_run="true" ;;
     n) do_dry_run_install="true" ;;
     t) test_release="true" ;;
@@ -719,6 +740,12 @@ elif [[ "${do_dry_run_install}" == "true" ]]; then
     dry_run_install && \
     banner "Dry run release and install succeeded"
   ) || die "Dry run release and install failed."
+elif [[ "${do_build_fs_util}" == "true" ]]; then
+  banner "Building fs_util" && \
+  (
+    build_fs_util && \
+    banner "Building fs_util succeeded"
+  ) || die "Building fs_util failed."
 elif [[ "${test_release}" == "true" ]]; then
   banner "Installing and testing the latest released packages" && \
   (

--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -18,6 +18,9 @@ RUN groupadd --gid ${TRAVIS_GID} ${TRAVIS_GROUP} || true
 RUN useradd -d /travis/home -g ${TRAVIS_GROUP} --uid ${TRAVIS_UID} ${TRAVIS_USER}
 USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 
+# Make sure our non-standard home directory sticks.
+ENV HOME /travis/home
+
 # Ensure Pants runs under the 2.7.13 interpreter.
 ENV PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==2.7.13']"
 


### PR DESCRIPTION
First build a multiplatform pex in two stages and then use that pex to
run all tests and finally for the GitHub release.

Fixes #6016
