### PR TITLE
Port examples

### DIFF
--- a/examples/src/python/example/python_distribution/hello/fasthello/setup.py
+++ b/examples/src/python/example/python_distribution/hello/fasthello/setup.py
@@ -8,8 +8,8 @@ from setuptools import setup, find_packages
 from distutils.core import Extension
 
 
-c_module = Extension(str('c_greet'), sources=[str('c_greet.c')])
-cpp_module = Extension(str('cpp_greet'), sources=[str('cpp_greet.cpp')])
+c_module = Extension(b'c_greet', sources=[b'c_greet.c'])
+cpp_module = Extension(b'cpp_greet', sources=[b'cpp_greet.cpp'])
 
 setup(
   name='fasthello',

--- a/examples/src/python/example/python_distribution/hello/setup_requires/setup.py
+++ b/examples/src/python/example/python_distribution/hello/setup_requires/setup.py
@@ -14,7 +14,7 @@ import pycountry
 # This is for testing purposes so we can assert that setup_requires is functioning
 # correctly (because Pants swallows print statements).
 if os.getenv('PANTS_TEST_SETUP_REQUIRES', ''):
-  output = [str(pycountry)]
+  output = [bytes(pycountry)]
   output.extend(os.listdir(os.getenv('PYTHONPATH', '')))
   raise Exception(str(output))
 


### PR DESCRIPTION
Part of #6062 

This folder was unlike any we've worked with. Because it's a dist, you aren't allowed to include `future` as a 3rd party library. So we unfortunately can't use the backports. 

I also couldn't find tests for the particular folder

cc @CMLivingston if you could help review please.