### PR TITLE
Fix imports of future.utils

### DIFF
--- a/src/python/pants/backend/jvm/ossrh_publication_metadata.py
+++ b/src/python/pants/backend/jvm/ossrh_publication_metadata.py
@@ -6,14 +6,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from builtins import object
 
-import future
+from future.utils import string_types
 
 from pants.backend.jvm.artifact import PublicationMetadata
 from pants.base.validation import assert_list
 
 
 def _validate_maybe_string(name, item):
-  if item and not isinstance(item, future.utils.string_types):
+  if item and not isinstance(item, string_types):
     raise ValueError('{} was expected to be of type {} but given {}'.format(name, type(item), item))
   return item
 

--- a/src/python/pants/backend/jvm/targets/import_jars_mixin.py
+++ b/src/python/pants/backend/jvm/targets/import_jars_mixin.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import future
+from future.utils import string_types
 
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.build_graph.address_lookup_error import AddressLookupError
@@ -52,7 +52,7 @@ class ImportJarsMixin(Target):
         for item in target_representation.get(fields_tuple[field_pos], ()):
           # For better error handling, this simply skips over non-strings, but we catch them
           # with a WrongTargetType in JarLibrary.to_jar_dependencies.
-          if not isinstance(item, future.utils.string_types):
+          if not isinstance(item, string_types):
             raise JarLibrary.ExpectedAddressError(
               'expected imports to contain string addresses, got {found_class} instead.'
               .format(found_class=type(item).__name__)

--- a/src/python/pants/backend/jvm/targets/jar_library.py
+++ b/src/python/pants/backend/jvm/targets/jar_library.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import future
+from future.utils import string_types
 from twitter.common.collections import OrderedSet
 
 from pants.base.exceptions import TargetDefinitionException
@@ -98,7 +98,7 @@ class JarLibrary(Target):
     """
     jar_deps = OrderedSet()
     for spec in jar_library_specs:
-      if not isinstance(spec, future.utils.string_types):
+      if not isinstance(spec, string_types):
         raise JarLibrary.ExpectedAddressError(
           "{address}: expected imports to contain string addresses, got {found_class}."
           .format(address=relative_to.spec,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_analysis.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from builtins import str
 
-import future
+from future.utils import text_type
 
 from pants.backend.jvm.tasks.jvm_compile.analysis import Analysis
 from pants.backend.jvm.zinc.zinc_analysis import ZincAnalysis as UnderlyingAnalysis
@@ -49,4 +49,4 @@ class ZincAnalysis(Analysis):
     return str(self.underlying_analysis)
 
   def __unicode__(self):
-    return future.utils.text_type(self.underlying_analysis)
+    return text_type(self.underlying_analysis)

--- a/src/python/pants/build_graph/intermediate_target_factory.py
+++ b/src/python/pants/build_graph/intermediate_target_factory.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from builtins import str
 from hashlib import sha1
 
-import future
+from future.utils import string_types
 
 from pants.base.exceptions import TargetDefinitionException
 from pants.build_graph.address import Address
@@ -41,7 +41,7 @@ class IntermediateTargetFactoryBase(AbstractClass):
     :param string suffix: A string used as a suffix of the intermediate target name.
     :returns: The address of a synthetic intermediary target.
     """
-    if not isinstance(address, future.utils.string_types):
+    if not isinstance(address, string_types):
       raise self.ExpectedAddressError("Expected string address argument, got type {type}"
                                       .format(type=type(address)))
 

--- a/src/python/pants/build_graph/target_scopes.py
+++ b/src/python/pants/build_graph/target_scopes.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from builtins import object, str
 
-import future
+from future.utils import string_types
 
 from pants.build_graph.intermediate_target_factory import IntermediateTargetFactoryBase
 
@@ -28,7 +28,7 @@ class Scope(frozenset):
     """
     if not scope:
       return ('default',)
-    if isinstance(scope, future.utils.string_types):
+    if isinstance(scope, string_types):
       scope = scope.split(' ')
     scope = {str(s).lower() for s in scope if s}
     return scope or ('default',)

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -9,7 +9,7 @@ import inspect
 from builtins import object
 from functools import update_wrapper
 
-import future
+from future.utils import string_types
 
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.objects import Resolvable, Serializable
@@ -154,7 +154,7 @@ class AddressableDescriptor(object):
     if value is None:
       return None
 
-    if isinstance(value, (future.utils.string_types, Address, Resolvable)):
+    if isinstance(value, (string_types, Address, Resolvable)):
       return value
 
     # Support untyped dicts that we deserialize on-demand here into the required type.

--- a/src/python/pants/engine/struct.py
+++ b/src/python/pants/engine/struct.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from abc import abstractproperty
 from collections import MutableMapping, MutableSequence
 
-import future
+from future.utils import binary_type, text_type
 
 from pants.engine.addressable import addressable, addressable_list
 from pants.engine.objects import Serializable, SerializableFactory, Validatable, ValidationError
@@ -17,10 +17,10 @@ from pants.util.objects import SubclassesOf, SuperclassesOf
 
 def _normalize_utf8_keys(kwargs):
   """When kwargs are passed literally in a source file, their keys are ascii: normalize."""
-  if any(type(key) is future.utils.binary_type for key in kwargs.keys()):
+  if any(type(key) is binary_type for key in kwargs.keys()):
     # This is to preserve the original dict type for kwargs.
     dict_type = type(kwargs)
-    return dict_type([(future.utils.text_type(k), v) for k, v in kwargs.items()])
+    return dict_type([(text_type(k), v) for k, v in kwargs.items()])
   return kwargs
 
 

--- a/src/python/pants/util/eval.py
+++ b/src/python/pants/util/eval.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from builtins import range, str
 from textwrap import dedent
 
-import future
+from future.utils import string_types
 
 
 def parse_expression(val, acceptable_types, name=None, raise_type=ValueError):
@@ -26,7 +26,7 @@ def parse_expression(val, acceptable_types, name=None, raise_type=ValueError):
   def format_type(typ):
     return typ.__name__
 
-  if not isinstance(val, future.utils.string_types):
+  if not isinstance(val, string_types):
     raise raise_type('The raw `val` is not a string.  Given {} of type {}.'
                      .format(val, format_type(type(val))))
 

--- a/src/python/pants/util/process_handler.py
+++ b/src/python/pants/util/process_handler.py
@@ -10,7 +10,7 @@ import os
 import sys
 from abc import abstractmethod
 
-import future
+from future.utils import PY2
 
 from pants.util.meta import AbstractClass
 
@@ -19,7 +19,7 @@ from pants.util.meta import AbstractClass
 # NB: As recommended here: https://github.com/google/python-subprocess32/blob/master/README.md
 # which accounts for non-posix, ie: Windows. Although we don't support Windows yet, this sets the
 # pattern up in anticipation.
-if os.name == 'posix' and future.utils.PY2:
+if os.name == 'posix' and PY2:
   import subprocess32 as subprocess3
 else:
   import subprocess as subprocess3

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -7,29 +7,29 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import re
 import shlex
 
-import future
+from future.utils import binary_type, text_type
 
 
 def ensure_binary(text_or_binary):
-  if isinstance(text_or_binary, future.utils.binary_type):
+  if isinstance(text_or_binary, binary_type):
     return text_or_binary
-  elif isinstance(text_or_binary, future.utils.text_type):
+  elif isinstance(text_or_binary, text_type):
     return text_or_binary.encode('utf8')
   else:
     raise TypeError('Argument is neither text nor binary type.({})'.format(type(text_or_binary)))
 
 
 def ensure_text(text_or_binary):
-  if isinstance(text_or_binary, future.utils.binary_type):
+  if isinstance(text_or_binary, binary_type):
     return text_or_binary.decode('utf-8')
-  elif isinstance(text_or_binary, future.utils.text_type):
+  elif isinstance(text_or_binary, text_type):
     return text_or_binary
   else:
     raise TypeError('Argument is neither text nor binary type ({})'.format(type(text_or_binary)))
 
 
 def is_text_or_binary(obj):
-  return isinstance(obj, (future.utils.text_type, future.utils.binary_type))
+  return isinstance(obj, (text_type, binary_type))
 
 
 def safe_shlex_split(text_or_binary):

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -10,8 +10,8 @@ import time
 import unittest
 from contextlib import contextmanager
 
-import future
 import mock
+from future.utils import text_type
 
 from pants.util import dirutil
 from pants.util.contextutil import pushd, temporary_dir
@@ -120,10 +120,10 @@ class DirutilTest(unittest.TestCase):
     # unicode constructor.
     with temporary_dir() as tmpdir:
       safe_mkdir(os.path.join(tmpdir, '中文'))
-      if isinstance(tmpdir, future.utils.text_type):
+      if isinstance(tmpdir, text_type):
         tmpdir = tmpdir.encode('utf-8')
       for _, dirs, _ in dirutil.safe_walk(tmpdir):
-        self.assertTrue(all(isinstance(dirname, future.utils.text_type) for dirname in dirs))
+        self.assertTrue(all(isinstance(dirname, text_type) for dirname in dirs))
 
   @contextmanager
   def tree(self):

--- a/tests/python/pants_test/util/test_eval.py
+++ b/tests/python/pants_test/util/test_eval.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import unittest
 
-import future
+from future.utils import string_types
 
 from pants.util.eval import parse_expression
 
@@ -14,7 +14,7 @@ from pants.util.eval import parse_expression
 class ParseLiteralTest(unittest.TestCase):
 
   def test_success_simple(self):
-    literal = parse_expression("'42'", acceptable_types=future.utils.string_types)
+    literal = parse_expression("'42'", acceptable_types=string_types)
     self.assertEqual('42', literal)
 
   def test_success_mixed(self):


### PR DESCRIPTION
In Py2, it's acceptable to directly refer to members of `future.utils`, e.g. `if future.utils.PY2`. In Py3, this fails for some reason, and you must instead use `from future.utils import x`.

Part of #6062 