### PR TITLE
Associate cli arguments with executables and refactor llvm/gcc c/c++ toolchain selection

### DIFF
--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -8,7 +8,7 @@ import os
 from abc import abstractproperty
 from builtins import object
 
-from pants.engine.rules import RootRule, SingletonRule
+from pants.engine.rules import SingletonRule
 from pants.util.objects import datatype
 from pants.util.osutil import all_normalized_os_names, get_normalized_os_name
 from pants.util.strutil import create_path_env_var, safe_shlex_join
@@ -262,9 +262,5 @@ class HostLibcDev(datatype(['crti_object', 'fingerprint'])):
 
 def create_native_environment_rules():
   return [
-    RootRule(LLVMCToolchain),
-    RootRule(GCCCToolchain),
-    RootRule(LLVMCppToolchain),
-    RootRule(LLVMCppToolchain),
     SingletonRule(Platform, Platform.create()),
   ]

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -90,15 +90,9 @@ class Linker(datatype([
     'extra_args',
 ]), Executable):
 
-  # FIXME(#5951): We need a way to compose executables more hygienically. This could be done
-  # declaratively -- something like: { 'LIBRARY_PATH': DelimitedPathDirectoryEnvVar(...) }.  We
-  # could also just use safe_shlex_join() and create_path_env_var() and keep all the state in the
-  # environment -- but then we have to remember to use those each time we specialize.
   def get_invocation_environment_dict(self, platform):
     ret = super(Linker, self).get_invocation_environment_dict(platform).copy()
 
-    # TODO: set all LDFLAGS in here or in further specializations of Linker instead of in individual
-    # tasks.
     all_ldflags_for_platform = platform.resolve_platform_specific({
       'darwin': lambda: ['-mmacosx-version-min=10.11'],
       'linux': lambda: [],
@@ -118,8 +112,6 @@ class CompilerMixin(Executable):
   def include_dirs(self):
     """Directories to search for header files to #include during compilation."""
 
-  # FIXME: LIBRARY_PATH and (DY)?LD_LIBRARY_PATH are used for entirely different purposes, but are
-  # both sourced from the same `self.library_dirs`!
   def get_invocation_environment_dict(self, platform):
     ret = super(CompilerMixin, self).get_invocation_environment_dict(platform).copy()
 

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -165,7 +165,10 @@ class CppCompiler(datatype([
     return ret
 
 
-# TODO(#4020): These classes are performing the work of variants.
+# NB: These wrapper classes for LLVM and GCC toolchains are performing the work of variants. A
+# CToolchain cannot be requested directly, but native_toolchain.py provides an LLVMCToolchain,
+# which contains a CToolchain representing the clang compiler and a linker paired to work with
+# objects compiled by that compiler.
 class CToolchain(datatype([('c_compiler', CCompiler), ('c_linker', Linker)])): pass
 
 

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -160,96 +160,22 @@ class CppCompiler(datatype([
 
 
 # TODO(#4020): These classes are performing the work of variants.
-class GCCCCompiler(datatype([('c_compiler', CCompiler)])): pass
-
-
-class GCCCLinker(datatype([('c_linker', Linker)])): pass
-
-
-class GCCCppCompiler(datatype([('cpp_compiler', CppCompiler)])): pass
-
-
-class GCCCppLinker(datatype([('cpp_linker', Linker)])): pass
-
-
-class LLVMCCompiler(datatype([('c_compiler', CCompiler)])): pass
-
-
-class LLVMCLinker(datatype([('c_linker', Linker)])): pass
-
-
-class LLVMCppCompiler(datatype([('cpp_compiler', CppCompiler)])): pass
-
-
-class LLVMCppLinker(datatype([('cpp_linker', Linker)])): pass
-
-
 class CToolchain(datatype([('c_compiler', CCompiler), ('c_linker', Linker)])): pass
 
 
-class CToolchainProvider(object):
-
-  @abstractproperty
-  def as_c_toolchain(self):
-    """???"""
+class LLVMCToolchain(datatype([('c_toolchain', CToolchain)])): pass
 
 
-class LLVMCToolchain(datatype([
-    ('llvm_c_compiler', LLVMCCompiler),
-    ('llvm_c_linker', LLVMCLinker),
-]), CToolchainProvider):
-
-  @property
-  def as_c_toolchain(self):
-    return CToolchain(
-      c_compiler=self.llvm_c_compiler.c_compiler,
-      c_linker=self.llvm_c_linker.c_linker)
-
-
-class GCCCToolchain(datatype([
-    ('gcc_c_compiler', GCCCCompiler),
-    ('gcc_c_linker', GCCCLinker),
-]), CToolchainProvider):
-
-  @property
-  def as_c_toolchain(self):
-    return CToolchain(
-      c_compiler=self.gcc_c_compiler.c_compiler,
-      c_linker=self.gcc_c_linker.c_linker)
+class GCCCToolchain(datatype([('c_toolchain', CToolchain)])): pass
 
 
 class CppToolchain(datatype([('cpp_compiler', CppCompiler), ('cpp_linker', Linker)])): pass
 
 
-class CppToolchainProvider(object):
-
-  @abstractproperty
-  def as_cpp_toolchain(self):
-    """???"""
+class LLVMCppToolchain(datatype([('cpp_toolchain', CppToolchain)])): pass
 
 
-class LLVMCppToolchain(datatype([
-    ('llvm_cpp_compiler', LLVMCppCompiler),
-    ('llvm_cpp_linker', LLVMCppLinker),
-]), CppToolchainProvider):
-
-  @property
-  def as_cpp_toolchain(self):
-    return CppToolchain(
-      cpp_compiler=self.llvm_cpp_compiler.cpp_compiler,
-      cpp_linker=self.llvm_cpp_linker.cpp_linker)
-
-
-class GCCCppToolchain(datatype([
-    ('gcc_cpp_compiler', GCCCppCompiler),
-    ('gcc_cpp_linker', GCCCppLinker),
-]), CppToolchainProvider):
-
-  @property
-  def as_cpp_toolchain(self):
-    return CppToolchain(
-      cpp_compiler=self.gcc_cpp_compiler.cpp_compiler,
-      cpp_linker=self.gcc_cpp_linker.cpp_linker)
+class GCCCppToolchain(datatype([('cpp_toolchain', CppToolchain)])): pass
 
 
 # FIXME: make this an @rule, after we can automatically produce LibcDev and other subsystems in the

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -59,6 +59,10 @@ class Executable(object):
   def exe_filename(self):
     """The "entry point" -- which file to invoke when PATH is set to `path_entries()`."""
 
+  @property
+  def extra_args(self):
+    return []
+
   def get_invocation_environment_dict(self, platform):
     lib_env_var = platform.resolve_platform_specific({
       'darwin': lambda: 'DYLD_LIBRARY_PATH',
@@ -83,6 +87,7 @@ class Linker(datatype([
     'exe_filename',
     'library_dirs',
     'linking_library_dirs',
+    'extra_args',
 ]), Executable):
 
   # FIXME(#5951): We need a way to compose executables more hygienically. This could be done
@@ -135,6 +140,7 @@ class CCompiler(datatype([
     'exe_filename',
     'library_dirs',
     'include_dirs',
+    'extra_args',
 ]), CompilerMixin):
 
   def get_invocation_environment_dict(self, platform):
@@ -150,6 +156,7 @@ class CppCompiler(datatype([
     'exe_filename',
     'library_dirs',
     'include_dirs',
+    'extra_args',
 ]), CompilerMixin):
 
   def get_invocation_environment_dict(self, platform):

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -121,6 +121,15 @@ class CompilerMixin(Executable):
   def include_dirs(self):
     """Directories to search for header files to #include during compilation."""
 
+  @property
+  def as_invocation_environment_dict(self):
+    ret = super(CompilerMixin, self).as_invocation_environment_dict.copy()
+
+    if self.include_dirs:
+      ret['CPATH'] = create_path_env_var(self.include_dirs)
+
+    return ret
+
 
 class CCompiler(datatype([
     'path_entries',
@@ -132,10 +141,7 @@ class CCompiler(datatype([
 
   @property
   def as_invocation_environment_dict(self):
-    ret = super(CompilerMixin, self).as_invocation_environment_dict.copy()
-
-    if self.include_dirs:
-      ret['C_INCLUDE_PATH'] = create_path_env_var(self.include_dirs)
+    ret = super(CCompiler, self).as_invocation_environment_dict.copy()
 
     ret['CC'] = self.exe_filename
 
@@ -152,10 +158,7 @@ class CppCompiler(datatype([
 
   @property
   def as_invocation_environment_dict(self):
-    ret = super(CompilerMixin, self).as_invocation_environment_dict.copy()
-
-    if self.include_dirs:
-      ret['CPLUS_INCLUDE_PATH'] = create_path_env_var(self.include_dirs)
+    ret = super(CppCompiler, self).as_invocation_environment_dict.copy()
 
     ret['CXX'] = self.exe_filename
 

--- a/src/python/pants/backend/native/subsystems/binaries/binutils.py
+++ b/src/python/pants/backend/native/subsystems/binaries/binutils.py
@@ -31,7 +31,8 @@ class Binutils(NativeTool):
       path_entries=self.path_entries(),
       exe_filename='ld',
       library_dirs=[],
-      linking_library_dirs=[])
+      linking_library_dirs=[],
+      extra_args=[])
 
 
 @rule(Assembler, [Select(Binutils)])

--- a/src/python/pants/backend/native/subsystems/binaries/binutils.py
+++ b/src/python/pants/backend/native/subsystems/binaries/binutils.py
@@ -30,7 +30,8 @@ class Binutils(NativeTool):
     return Linker(
       path_entries=self.path_entries(),
       exe_filename='ld',
-      library_dirs=[])
+      library_dirs=[],
+      linking_library_dirs=[])
 
 
 @rule(Assembler, [Select(Binutils)])

--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -14,10 +14,6 @@ from pants.engine.selectors import Select
 from pants.util.memo import memoized_method
 
 
-def _raise_empty_exception():
-  raise Exception("???")
-
-
 class GCC(NativeTool):
   options_scope = 'gcc'
   default_version = '7.3.0'
@@ -28,7 +24,7 @@ class GCC(NativeTool):
     return [os.path.join(self.select(), 'bin')]
 
   _PLATFORM_INTERMEDIATE_DIRNAME = {
-    'darwin': _raise_empty_exception,
+    'darwin': lambda: 'x86_64-apple-darwin17.5.0',
     'linux': lambda: 'x86_64-pc-linux-gnu',
   }
 

--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -7,8 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import glob
 import os
 
-from pants.backend.native.config.environment import (CCompiler, CppCompiler, GCCCCompiler,
-                                                     GCCCppCompiler, Platform)
+from pants.backend.native.config.environment import CCompiler, CppCompiler, Platform
 from pants.binaries.binary_tool import NativeTool
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Select
@@ -95,14 +94,14 @@ class GCC(NativeTool):
       extra_args=[])
 
 
-@rule(GCCCCompiler, [Select(GCC), Select(Platform)])
+@rule(CCompiler, [Select(GCC), Select(Platform)])
 def get_gcc(gcc, platform):
-  yield GCCCCompiler(gcc.c_compiler(platform))
+  return gcc.c_compiler(platform)
 
 
-@rule(GCCCppCompiler, [Select(GCC), Select(Platform)])
+@rule(CppCompiler, [Select(GCC), Select(Platform)])
 def get_gplusplus(gcc, platform):
-  yield GCCCppCompiler(gcc.cpp_compiler(platform))
+  return gcc.cpp_compiler(platform)
 
 
 def create_gcc_rules():

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -72,9 +72,6 @@ class LLVM(NativeTool):
       linking_library_dirs=[],
       extra_args=[])
 
-  # FIXME: use ParseSearchDirs for this and other include directories -- we shouldn't be trying to
-  # guess the path here.
-  # https://github.com/pantsbuild/pants/issues/6143
   @memoized_property
   def _common_include_dirs(self):
     return [os.path.join(self.select(), 'lib/clang', self.version(), 'include')]

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 
 from pants.backend.native.config.environment import CCompiler, CppCompiler, Linker, Platform
+from pants.backend.native.subsystems.utils.archive_file_mapper import ArchiveFileMapper
 from pants.binaries.binary_tool import NativeTool
 from pants.binaries.binary_util import BinaryToolUrlGenerator
 from pants.engine.rules import RootRule, rule
@@ -35,6 +36,16 @@ class LLVMReleaseUrlGenerator(BinaryToolUrlGenerator):
 
 
 class LLVM(NativeTool):
+  """Subsystem wrapping an archive providing an LLVM distribution.
+
+  This subsystem provides the clang and clang++ compilers. It also provides lld, which is not
+  currently used.
+
+  NB: The lib and include dirs provided by this distribution are produced by using known relative
+  paths into the distribution of LLVM from LLVMReleaseUrlGenerator. If LLVM changes the structure of
+  their release archives, these methods may have to change. They should be stable to version
+  upgrades, however.
+  """
   options_scope = 'llvm'
   default_version = '6.0.0'
   archive_type = 'txz'
@@ -46,7 +57,7 @@ class LLVM(NativeTool):
   def select(self):
     unpacked_path = super(LLVM, self).select()
     # The archive from releases.llvm.org wraps the extracted content into a directory one level
-    # deeper, but the one from our S3 does not.
+    # deeper, but the one from our S3 does not. We account for both here.
     children = os.listdir(unpacked_path)
     if len(children) == 1:
       llvm_base_dir = os.path.join(unpacked_path, children[0])
@@ -54,8 +65,22 @@ class LLVM(NativeTool):
       return llvm_base_dir
     return unpacked_path
 
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(LLVM, cls).subsystem_dependencies() + (ArchiveFileMapper.scoped(cls),)
+
+  @memoized_property
+  def _file_mapper(self):
+    return ArchiveFileMapper.scoped_instance(self)
+
+  def _filemap(self, all_components_list):
+    return self._file_mapper.map_files(self.select(), all_components_list)
+
+  _bin_paths = [('bin',)]
+
+  @memoized_property
   def path_entries(self):
-    return [os.path.join(self.select(), 'bin')]
+    return self._filemap(self._bin_paths)
 
   _PLATFORM_SPECIFIC_LINKER_NAME = {
     'darwin': lambda: 'ld64.lld',
@@ -64,7 +89,7 @@ class LLVM(NativeTool):
 
   def linker(self, platform):
     return Linker(
-      path_entries=self.path_entries(),
+      path_entries=self.path_entries,
       exe_filename=platform.resolve_platform_specific(
         self._PLATFORM_SPECIFIC_LINKER_NAME),
       library_dirs=[],
@@ -73,15 +98,15 @@ class LLVM(NativeTool):
 
   @memoized_property
   def _common_include_dirs(self):
-    return [os.path.join(self.select(), 'lib/clang', self.version(), 'include')]
+    return self._filemap([('lib/clang', self.version(), 'include')])
 
   @memoized_property
   def _common_lib_dirs(self):
-    return [os.path.join(self.select(), 'lib')]
+    return self._filemap([('lib',)])
 
   def c_compiler(self):
     return CCompiler(
-      path_entries=self.path_entries(),
+      path_entries=self.path_entries,
       exe_filename='clang',
       library_dirs=self._common_lib_dirs,
       include_dirs=self._common_include_dirs,
@@ -89,11 +114,11 @@ class LLVM(NativeTool):
 
   @memoized_property
   def _cpp_include_dirs(self):
-    return [os.path.join(self.select(), 'include/c++/v1')]
+    return self._filemap([('include/c++/v1',)])
 
   def cpp_compiler(self):
     return CppCompiler(
-      path_entries=self.path_entries(),
+      path_entries=self.path_entries,
       exe_filename='clang++',
       library_dirs=self._common_lib_dirs,
       include_dirs=(self._cpp_include_dirs + self._common_include_dirs),

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -76,11 +76,9 @@ class LLVM(NativeTool):
   def _filemap(self, all_components_list):
     return self._file_mapper.map_files(self.select(), all_components_list)
 
-  _bin_paths = [('bin',)]
-
   @memoized_property
   def path_entries(self):
-    return self._filemap(self._bin_paths)
+    return self._filemap([('bin',)])
 
   _PLATFORM_SPECIFIC_LINKER_NAME = {
     'darwin': lambda: 'ld64.lld',

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -6,8 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 
-from pants.backend.native.config.environment import (CCompiler, CppCompiler, Linker, LLVMCCompiler,
-                                                     LLVMCppCompiler, Platform)
+from pants.backend.native.config.environment import CCompiler, CppCompiler, Linker, Platform
 from pants.binaries.binary_tool import NativeTool
 from pants.binaries.binary_util import BinaryToolUrlGenerator
 from pants.engine.rules import RootRule, rule
@@ -107,14 +106,14 @@ def get_lld(platform, llvm):
   return llvm.linker(platform)
 
 
-@rule(LLVMCCompiler, [Select(LLVM)])
+@rule(CCompiler, [Select(LLVM)])
 def get_clang(llvm):
-  yield LLVMCCompiler(llvm.c_compiler())
+  return llvm.c_compiler()
 
 
-@rule(LLVMCppCompiler, [Select(LLVM)])
+@rule(CppCompiler, [Select(LLVM)])
 def get_clang_plusplus(llvm):
-  yield LLVMCppCompiler(llvm.cpp_compiler())
+  return llvm.cpp_compiler()
 
 
 def create_llvm_rules():

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -69,7 +69,8 @@ class LLVM(NativeTool):
       exe_filename=platform.resolve_platform_specific(
         self._PLATFORM_SPECIFIC_LINKER_NAME),
       library_dirs=[],
-      linking_library_dirs=[])
+      linking_library_dirs=[],
+      extra_args=[])
 
   # FIXME: use ParseSearchDirs for this and other include directories -- we shouldn't be trying to
   # guess the path here.
@@ -87,7 +88,8 @@ class LLVM(NativeTool):
       path_entries=self.path_entries(),
       exe_filename='clang',
       library_dirs=self._common_lib_dirs,
-      include_dirs=self._common_include_dirs)
+      include_dirs=self._common_include_dirs,
+      extra_args=[])
 
   @memoized_property
   def _cpp_include_dirs(self):
@@ -98,7 +100,8 @@ class LLVM(NativeTool):
       path_entries=self.path_entries(),
       exe_filename='clang++',
       library_dirs=self._common_lib_dirs,
-      include_dirs=(self._cpp_include_dirs + self._common_include_dirs))
+      include_dirs=(self._cpp_include_dirs + self._common_include_dirs),
+      extra_args=[])
 
 
 # FIXME(#5663): use this over the XCode linker!

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -68,7 +68,8 @@ class LLVM(NativeTool):
       path_entries=self.path_entries(),
       exe_filename=platform.resolve_platform_specific(
         self._PLATFORM_SPECIFIC_LINKER_NAME),
-      library_dirs=[])
+      library_dirs=[],
+      linking_library_dirs=[])
 
   # FIXME: use ParseSearchDirs for this and other include directories -- we shouldn't be trying to
   # guess the path here.

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -111,16 +111,22 @@ def select_llvm_c_toolchain(platform, native_toolchain):
       path_entries=(provided_clang.path_entries + xcode_clang.path_entries),
       exe_filename=provided_clang.exe_filename,
       library_dirs=(provided_clang.library_dirs + xcode_clang.library_dirs),
-      include_dirs=(xcode_clang.include_dirs + provided_clang.include_dirs))
+      include_dirs=(xcode_clang.include_dirs + provided_clang.include_dirs),
+      extra_args=(['-x', 'c', '-std=c11'] + xcode_clang.extra_args))
   else:
     gcc_c_compiler = yield Get(GCCCCompiler, GCC, native_toolchain._gcc)
     provided_gcc = gcc_c_compiler.c_compiler
     working_c_compiler = CCompiler(
       path_entries=provided_clang.path_entries,
       exe_filename=provided_clang.exe_filename,
-      # We need this version of GLIBCXX to be able to run, unfortunately.
+      # We need g++'s version of the GLIBCXX library to be able to run, unfortunately.
       library_dirs=(provided_gcc.library_dirs + provided_clang.library_dirs),
-      include_dirs=(provided_clang.include_dirs + provided_gcc.include_dirs))
+      include_dirs=provided_gcc.include_dirs,
+      extra_args=[
+        '-x', 'c', '-std=c11',
+        # These mean we don't use any of the headers from our LLVM distribution.
+        '-nobuiltininc',
+      ])
 
   base_linker_wrapper = yield Get(BaseLinker, NativeToolchain, native_toolchain)
   base_linker = base_linker_wrapper.linker
@@ -129,7 +135,8 @@ def select_llvm_c_toolchain(platform, native_toolchain):
     path_entries=(base_linker.path_entries + working_c_compiler.path_entries),
     exe_filename=working_c_compiler.exe_filename,
     library_dirs=(base_linker.library_dirs + working_c_compiler.library_dirs),
-    linking_library_dirs=libc_dev.get_libc_dirs(platform))
+    linking_library_dirs=libc_dev.get_libc_dirs(platform),
+    extra_args=[])
 
   yield LLVMCToolchain(llvm_c_compiler=LLVMCCompiler(working_c_compiler),
                        llvm_c_linker=LLVMCLinker(working_linker))
@@ -146,25 +153,41 @@ def select_llvm_cpp_toolchain(platform, native_toolchain):
       path_entries=(provided_clang.path_entries + xcode_clang.path_entries),
       exe_filename=provided_clang.exe_filename,
       library_dirs=(provided_clang.library_dirs + xcode_clang.library_dirs),
-      include_dirs=(xcode_clang.include_dirs + provided_clang.include_dirs))
+      include_dirs=(xcode_clang.include_dirs + provided_clang.include_dirs),
+      # On OSX, this uses the libc++ (LLVM) C++ standard library implementation. This is
+      # feature-complete for OSX. <FIXME: insert link citation for that fact here!>
+      extra_args=(['-x', 'c++', '-std=c++11'] + xcode_clang.extra_args))
+    linking_library_dirs = []
+    linker_extra_args = []
   else:
     gcc_cpp_compiler = yield Get(GCCCppCompiler, GCC, native_toolchain._gcc)
     provided_gpp = gcc_cpp_compiler.cpp_compiler
     working_cpp_compiler = CppCompiler(
       path_entries=provided_clang.path_entries,
       exe_filename=provided_clang.exe_filename,
-      # We need this version of GLIBCXX to be able to run, unfortunately.
+      # We need g++'s version of the GLIBCXX library to be able to run, unfortunately.
       library_dirs=(provided_gpp.library_dirs + provided_clang.library_dirs),
-      include_dirs=(provided_clang.include_dirs + provided_gpp.include_dirs))
+      # NB: we use g++'s headers on Linux, and therefore their C++ standard library.
+      include_dirs=provided_gpp.include_dirs,
+      extra_args=[
+        '-x', 'c++', '-std=c++11',
+        # These mean we don't use any of the headers from our LLVM distribution.
+        '-nobuiltininc',
+        '-nostdinc++',
+      ])
+    linking_library_dirs = provided_gpp.library_dirs + provided_clang.library_dirs
+    # Ensure we use libstdc++, provided by g++, during the linking stage.
+    linker_extra_args=['-stdlib=libstdc++']
 
+  libc_dev = yield Get(LibcDev, NativeToolchain, native_toolchain)
   base_linker_wrapper = yield Get(BaseLinker, NativeToolchain, native_toolchain)
   base_linker = base_linker_wrapper.linker
-  libc_dev = yield Get(LibcDev, NativeToolchain, native_toolchain)
   working_linker = Linker(
     path_entries=(base_linker.path_entries + working_cpp_compiler.path_entries),
     exe_filename=working_cpp_compiler.exe_filename,
     library_dirs=(base_linker.library_dirs + working_cpp_compiler.library_dirs),
-    linking_library_dirs=libc_dev.get_libc_dirs(platform))
+    linking_library_dirs=(linking_library_dirs + libc_dev.get_libc_dirs(platform)),
+    extra_args=linker_extra_args)
 
   yield LLVMCppToolchain(llvm_cpp_compiler=LLVMCppCompiler(working_cpp_compiler),
                          llvm_cpp_linker=LLVMCppLinker(working_linker))
@@ -193,7 +216,8 @@ def select_gcc_c_toolchain(platform, native_toolchain):
     path_entries=(provided_gcc.path_entries + assembler.path_entries),
     exe_filename=provided_gcc.exe_filename,
     library_dirs=provided_gcc.library_dirs,
-    include_dirs=new_include_dirs)
+    include_dirs=new_include_dirs,
+    extra_args=['-x', 'c', '-std=c11'])
 
   base_linker_wrapper = yield Get(BaseLinker, NativeToolchain, native_toolchain)
   base_linker = base_linker_wrapper.linker
@@ -202,7 +226,8 @@ def select_gcc_c_toolchain(platform, native_toolchain):
     path_entries=(base_linker.path_entries + working_c_compiler.path_entries),
     exe_filename=working_c_compiler.exe_filename,
     library_dirs=(base_linker.library_dirs + working_c_compiler.library_dirs),
-    linking_library_dirs=libc_dev.get_libc_dirs(platform))
+    linking_library_dirs=libc_dev.get_libc_dirs(platform),
+    extra_args=[])
 
   yield GCCCToolchain(gcc_c_compiler=GCCCCompiler(working_c_compiler),
                       gcc_c_linker=GCCCLinker(working_linker))
@@ -231,7 +256,8 @@ def select_gcc_cpp_toolchain(platform, native_toolchain):
     path_entries=(provided_gpp.path_entries + assembler.path_entries),
     exe_filename=provided_gpp.exe_filename,
     library_dirs=provided_gpp.library_dirs,
-    include_dirs=new_include_dirs)
+    include_dirs=new_include_dirs,
+    extra_args=['-x', 'c++', '-std=c++11'])
 
   base_linker_wrapper = yield Get(BaseLinker, NativeToolchain, native_toolchain)
   base_linker = base_linker_wrapper.linker
@@ -240,7 +266,8 @@ def select_gcc_cpp_toolchain(platform, native_toolchain):
     path_entries=(base_linker.path_entries + working_cpp_compiler.path_entries),
     exe_filename=working_cpp_compiler.exe_filename,
     library_dirs=(base_linker.library_dirs + working_cpp_compiler.library_dirs),
-    linking_library_dirs=libc_dev.get_libc_dirs(platform))
+    linking_library_dirs=libc_dev.get_libc_dirs(platform),
+    extra_args=[])
 
   yield GCCCppToolchain(gcc_cpp_compiler=GCCCppCompiler(working_cpp_compiler),
                         gcc_cpp_linker=GCCCppLinker(working_linker))

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -166,7 +166,7 @@ def select_llvm_cpp_toolchain(platform, native_toolchain):
       library_dirs=(provided_clang.library_dirs + xcode_clang.library_dirs),
       include_dirs=(provided_clang.include_dirs + xcode_clang.include_dirs),
       # On OSX, this uses the libc++ (LLVM) C++ standard library implementation. This is
-      # feature-complete for OSX. <FIXME: insert link citation for that fact here!>
+      # feature-complete for OSX, but not for Linux (see https://libcxx.llvm.org/ for more info).
       extra_args=(llvm_cpp_compiler_args + xcode_clang.extra_args))
     linking_library_dirs = []
     linker_extra_args = []

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -120,7 +120,8 @@ def select_llvm_c_toolchain(platform, native_toolchain):
   llvm_c_compiler_args = [
     '-x', 'c', '-std=c11',
     # This means we don't use any of the C standard library headers from our packaged LLVM
-    # distribution. Instead, we use include dirs from the XCodeCLITools or GCC.
+    # distribution, or any from the host system. Instead, we use include dirs from the XCodeCLITools
+    # or GCC.
     '-nostdinc',
   ] + gcc_install.as_clang_argv
 
@@ -165,8 +166,9 @@ def select_llvm_cpp_toolchain(platform, native_toolchain):
   llvm_cpp_compiler_args = [
     '-x', 'c++', '-std=c++11',
     # This mean we don't use any of the headers from our LLVM distribution's C++ stdlib
-    # implementation. Instead, we use include dirs from the XCodeCLITools or GCC.
-    # TODO: why does -nostdinc work for LLVMCToolchain but not LLVMCppToolchain?
+    # implementation, or any from the host system. Instead, we use include dirs from the
+    # XCodeCLITools or GCC.
+    # TODO: why does -nostdinc work for LLVMCToolchain but not LLVMCppToolchain (on Linux)?
     '-nostdinc++',
   ] + gcc_install.as_clang_argv
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -119,10 +119,6 @@ def select_llvm_c_toolchain(platform, native_toolchain):
   # These arguments are shared across platforms.
   llvm_c_compiler_args = [
     '-x', 'c', '-std=c11',
-    # This means we don't use any of the C standard library headers from our packaged LLVM
-    # distribution, or any from the host system. Instead, we use include dirs from the XCodeCLITools
-    # or GCC.
-    '-nostdinc',
   ] + gcc_install.as_clang_argv
 
   if platform.normalized_os_name == 'darwin':
@@ -168,7 +164,6 @@ def select_llvm_cpp_toolchain(platform, native_toolchain):
     # This mean we don't use any of the headers from our LLVM distribution's C++ stdlib
     # implementation, or any from the host system. Instead, we use include dirs from the
     # XCodeCLITools or GCC.
-    # TODO: why does -nostdinc work for LLVMCToolchain but not LLVMCppToolchain (on Linux)?
     '-nostdinc++',
   ] + gcc_install.as_clang_argv
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -5,8 +5,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants.backend.native.config.environment import (Assembler, CCompiler, CppCompiler,
-                                                     GCCCCompiler, GCCCppCompiler, Linker,
-                                                     LLVMCCompiler, LLVMCppCompiler, Platform)
+                                                     GCCCCompiler, GCCCLinker, GCCCppCompiler,
+                                                     GCCCppLinker, GCCCppToolchain, GCCCToolchain,
+                                                     Linker, LLVMCCompiler, LLVMCLinker,
+                                                     LLVMCppCompiler, LLVMCppLinker,
+                                                     LLVMCppToolchain, LLVMCToolchain, Platform)
 from pants.backend.native.subsystems.binaries.binutils import Binutils
 from pants.backend.native.subsystems.binaries.gcc import GCC
 from pants.backend.native.subsystems.binaries.llvm import LLVM
@@ -16,6 +19,7 @@ from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, Select
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
+from pants.util.objects import datatype
 
 
 class NativeToolchain(Subsystem):
@@ -63,211 +67,193 @@ class NativeToolchain(Subsystem):
     return LibcDev.scoped_instance(self)
 
 
-@rule(Linker, [Select(Platform), Select(NativeToolchain)])
-def select_linker(platform, native_toolchain):
-  # TODO(#5933): make it possible to yield Get with a non-static
-  # subject type and use `platform.resolve_platform_specific()`, something like:
-  # linker = platform.resolve_platform_specific({
-  #   'darwin': lambda: Get(Linker, XCodeCLITools, native_toolchain._xcode_cli_tools),
-  #   'linux': lambda: Get(Linker, Binutils, native_toolchain._binutils),
-  # })
-  #
-  # NB: We need to link through a provided compiler's frontend, and we need to know where all the
-  # compiler's libraries/etc are, so we set the executable name to the C++ compiler, which can find
-  # its own set of C++-specific files for the linker if necessary. Using e.g. 'g++' as the linker
-  # appears to produce byte-identical output when linking even C-only object files, and also
-  # happens to work when C++ is used.
-  # Currently, OSX links through the clang++ frontend, and Linux links through the g++ frontend.
+@rule(LibcDev, [Select(NativeToolchain)])
+def select_libc_dev(native_toolchain):
+  yield native_toolchain._libc_dev
+
+
+@rule(Assembler, [Select(Platform), Select(NativeToolchain)])
+def select_assembler(platform, native_toolchain):
+  if platform.normalized_os_name == 'darwin':
+    assembler = yield Get(Assembler, XCodeCLITools, native_toolchain._xcode_cli_tools)
+  else:
+    assembler = yield Get(Assembler, Binutils, native_toolchain._binutils)
+  yield assembler
+
+
+class BaseLinker(datatype([('linker', Linker)])):
+  """A Linker which is not specific to any compiler yet.
+
+  This represents Linker objects provided by subsystems, but may need additional information to be
+  usable by a specific compiler."""
+
+
+# TODO: select the appropriate `Platform` in the `@rule` decl using variants!
+@rule(BaseLinker, [Select(Platform), Select(NativeToolchain)])
+def select_base_linker(platform, native_toolchain):
   if platform.normalized_os_name == 'darwin':
     # TODO(#5663): turn this into LLVM when lld works.
     linker = yield Get(Linker, XCodeCLITools, native_toolchain._xcode_cli_tools)
-    llvm_c_compiler = yield Get(LLVMCCompiler, NativeToolchain, native_toolchain)
-    c_compiler = llvm_c_compiler.c_compiler
-    llvm_cpp_compiler = yield Get(LLVMCppCompiler, NativeToolchain, native_toolchain)
-    cpp_compiler = llvm_cpp_compiler.cpp_compiler
   else:
     linker = yield Get(Linker, Binutils, native_toolchain._binutils)
-    gcc_c_compiler = yield Get(GCCCCompiler, NativeToolchain, native_toolchain)
-    c_compiler = gcc_c_compiler.c_compiler
-    gcc_cpp_compiler = yield Get(GCCCppCompiler, NativeToolchain, native_toolchain)
-    cpp_compiler = gcc_cpp_compiler.cpp_compiler
-
-  libc_dirs = native_toolchain._libc_dev.get_libc_dirs(platform)
-
-  # NB: If needing to create an environment for process invocation that could use either a compiler
-  # or a linker (e.g. when we compile native code from `python_dist()`s), use the environment from
-  # the linker object (in addition to any further customizations), which has the paths from the C
-  # and C++ compilers baked in.
-  # FIXME(#5951): we need a way to compose executables more hygienically.
-  linker = Linker(
-    path_entries=(
-      cpp_compiler.path_entries +
-      c_compiler.path_entries +
-      linker.path_entries),
-    exe_filename=cpp_compiler.exe_filename,
-    library_dirs=(
-      libc_dirs +
-      cpp_compiler.library_dirs +
-      c_compiler.library_dirs +
-      linker.library_dirs))
-
-  yield linker
+  base_linker = BaseLinker(linker=linker)
+  yield base_linker
 
 
-@rule(LLVMCCompiler, [Select(Platform), Select(NativeToolchain)])
-def select_llvm_c_compiler(platform, native_toolchain):
+@rule(LLVMCToolchain, [Select(Platform), Select(NativeToolchain)])
+def select_llvm_c_toolchain(platform, native_toolchain):
   original_llvm_c_compiler = yield Get(LLVMCCompiler, LLVM, native_toolchain._llvm)
   provided_clang = original_llvm_c_compiler.c_compiler
 
   if platform.normalized_os_name == 'darwin':
     xcode_clang = yield Get(CCompiler, XCodeCLITools, native_toolchain._xcode_cli_tools)
-    clang_with_xcode_paths = CCompiler(
+    working_c_compiler = CCompiler(
       path_entries=(provided_clang.path_entries + xcode_clang.path_entries),
       exe_filename=provided_clang.exe_filename,
       library_dirs=(provided_clang.library_dirs + xcode_clang.library_dirs),
       include_dirs=(xcode_clang.include_dirs + provided_clang.include_dirs))
-    final_llvm_c_compiler = LLVMCCompiler(clang_with_xcode_paths)
   else:
     gcc_c_compiler = yield Get(GCCCCompiler, GCC, native_toolchain._gcc)
     provided_gcc = gcc_c_compiler.c_compiler
-    clang_with_gcc_libs = CCompiler(
+    working_c_compiler = CCompiler(
       path_entries=provided_clang.path_entries,
       exe_filename=provided_clang.exe_filename,
       # We need this version of GLIBCXX to be able to run, unfortunately.
       library_dirs=(provided_gcc.library_dirs + provided_clang.library_dirs),
       include_dirs=(provided_clang.include_dirs + provided_gcc.include_dirs))
-    final_llvm_c_compiler = LLVMCCompiler(clang_with_gcc_libs)
 
-  yield final_llvm_c_compiler
+  base_linker_wrapper = yield Get(BaseLinker, NativeToolchain, native_toolchain)
+  base_linker = base_linker_wrapper.linker
+  libc_dev = yield Get(LibcDev, NativeToolchain, native_toolchain)
+  working_linker = Linker(
+    path_entries=(base_linker.path_entries + working_c_compiler.path_entries),
+    exe_filename=working_c_compiler.exe_filename,
+    library_dirs=(base_linker.library_dirs + working_c_compiler.library_dirs),
+    linking_library_dirs=libc_dev.get_libc_dirs(platform))
+
+  yield LLVMCToolchain(llvm_c_compiler=LLVMCCompiler(working_c_compiler),
+                       llvm_c_linker=LLVMCLinker(working_linker))
 
 
-@rule(LLVMCppCompiler, [Select(Platform), Select(NativeToolchain)])
-def select_llvm_cpp_compiler(platform, native_toolchain):
+@rule(LLVMCppToolchain, [Select(Platform), Select(NativeToolchain)])
+def select_llvm_cpp_toolchain(platform, native_toolchain):
   original_llvm_cpp_compiler = yield Get(LLVMCppCompiler, LLVM, native_toolchain._llvm)
-  provided_clangpp = original_llvm_cpp_compiler.cpp_compiler
+  provided_clang = original_llvm_cpp_compiler.cpp_compiler
 
   if platform.normalized_os_name == 'darwin':
     xcode_clang = yield Get(CppCompiler, XCodeCLITools, native_toolchain._xcode_cli_tools)
-    clang_with_xcode_paths = CppCompiler(
-      path_entries=(provided_clangpp.path_entries + xcode_clang.path_entries),
-      exe_filename=provided_clangpp.exe_filename,
-      library_dirs=(provided_clangpp.library_dirs + xcode_clang.library_dirs),
-      include_dirs=(provided_clangpp.include_dirs + xcode_clang.include_dirs))
-    final_llvm_cpp_compiler = LLVMCppCompiler(clang_with_xcode_paths)
+    working_cpp_compiler = CppCompiler(
+      path_entries=(provided_clang.path_entries + xcode_clang.path_entries),
+      exe_filename=provided_clang.exe_filename,
+      library_dirs=(provided_clang.library_dirs + xcode_clang.library_dirs),
+      include_dirs=(xcode_clang.include_dirs + provided_clang.include_dirs))
   else:
     gcc_cpp_compiler = yield Get(GCCCppCompiler, GCC, native_toolchain._gcc)
-    provided_gpp = gcc_cpp_compiler.cpp_compiler
-    clang_with_gpp_libs = CppCompiler(
-      path_entries=provided_clangpp.path_entries,
-      exe_filename=provided_clangpp.exe_filename,
+    provided_gcc = gcc_cpp_compiler.cpp_compiler
+    working_cpp_compiler = CppCompiler(
+      path_entries=provided_clang.path_entries,
+      exe_filename=provided_clang.exe_filename,
       # We need this version of GLIBCXX to be able to run, unfortunately.
-      library_dirs=(provided_gpp.library_dirs + provided_clangpp.library_dirs),
-      include_dirs=(provided_clangpp.include_dirs + provided_gpp.include_dirs))
-    final_llvm_cpp_compiler = LLVMCppCompiler(clang_with_gpp_libs)
+      library_dirs=(provided_gcc.library_dirs + provided_clang.library_dirs),
+      include_dirs=(provided_clang.include_dirs + provided_gcc.include_dirs))
 
-  yield final_llvm_cpp_compiler
+  base_linker_wrapper = yield Get(BaseLinker, NativeToolchain, native_toolchain)
+  base_linker = base_linker_wrapper.linker
+  libc_dev = yield Get(LibcDev, NativeToolchain, native_toolchain)
+  working_linker = Linker(
+    path_entries=(base_linker.path_entries + working_cpp_compiler.path_entries),
+    exe_filename=working_cpp_compiler.exe_filename,
+    library_dirs=(base_linker.library_dirs + working_cpp_compiler.library_dirs),
+    linking_library_dirs=libc_dev.get_libc_dirs(platform))
+
+  yield LLVMCppToolchain(llvm_cpp_compiler=LLVMCppCompiler(working_cpp_compiler),
+                         llvm_cpp_linker=LLVMCppLinker(working_linker))
 
 
-@rule(GCCCCompiler, [Select(Platform), Select(NativeToolchain)])
-def select_gcc_c_compiler(platform, native_toolchain):
+@rule(GCCCToolchain, [Select(Platform), Select(NativeToolchain)])
+def select_gcc_c_toolchain(platform, native_toolchain):
   original_gcc_c_compiler = yield Get(GCCCCompiler, GCC, native_toolchain._gcc)
   provided_gcc = original_gcc_c_compiler.c_compiler
 
   # GCC needs an assembler, so we provide that (platform-specific) tool here.
-  if platform.normalized_os_name == 'darwin':
-    xcode_tools_assembler = yield Get(Assembler, XCodeCLITools, native_toolchain._xcode_cli_tools)
-    assembler_paths = xcode_tools_assembler.path_entries
+  assembler = yield Get(Assembler, NativeToolchain, native_toolchain)
 
+  if platform.normalized_os_name == 'darwin':
     # GCC needs access to some headers that are only provided by the XCode toolchain
     # currently (e.g. "_stdio.h"). These headers are unlikely to change across versions, so this is
     # probably safe.
     # TODO: we should be providing all of these (so we can eventually phase out XCodeCLITools
     # entirely).
-    # This mutual recursion with select_llvm_c_compiler() works because we only pull in gcc in that
-    # method if we are on Linux.
     xcode_clang = yield Get(CCompiler, XCodeCLITools, native_toolchain._xcode_cli_tools)
-
-    new_library_dirs = provided_gcc.library_dirs + xcode_clang.library_dirs
     new_include_dirs = xcode_clang.include_dirs + provided_gcc.include_dirs
   else:
-    binutils_assembler = yield Get(Assembler, Binutils, native_toolchain._binutils)
-    assembler_paths = binutils_assembler.path_entries
-
-    new_library_dirs = provided_gcc.library_dirs
     new_include_dirs = provided_gcc.include_dirs
 
-  gcc_with_assembler = CCompiler(
-    path_entries=(provided_gcc.path_entries + assembler_paths),
+  working_c_compiler = CCompiler(
+    path_entries=(provided_gcc.path_entries + assembler.path_entries),
     exe_filename=provided_gcc.exe_filename,
-    library_dirs=new_library_dirs,
+    library_dirs=provided_gcc.library_dirs,
     include_dirs=new_include_dirs)
 
-  final_gcc_c_compiler = GCCCCompiler(gcc_with_assembler)
-  yield final_gcc_c_compiler
+  base_linker_wrapper = yield Get(BaseLinker, NativeToolchain, native_toolchain)
+  base_linker = base_linker_wrapper.linker
+  libc_dev = yield Get(LibcDev, NativeToolchain, native_toolchain)
+  working_linker = Linker(
+    path_entries=(base_linker.path_entries + working_c_compiler.path_entries),
+    exe_filename=working_c_compiler.exe_filename,
+    library_dirs=(base_linker.library_dirs + working_c_compiler.library_dirs),
+    linking_library_dirs=libc_dev.get_libc_dirs(platform))
+
+  yield GCCCToolchain(gcc_c_compiler=GCCCCompiler(working_c_compiler),
+                      gcc_c_linker=GCCCLinker(working_linker))
 
 
-@rule(GCCCppCompiler, [Select(Platform), Select(NativeToolchain)])
-def select_gcc_cpp_compiler(platform, native_toolchain):
+@rule(GCCCppToolchain, [Select(Platform), Select(NativeToolchain)])
+def select_gcc_cpp_toolchain(platform, native_toolchain):
   original_gcc_cpp_compiler = yield Get(GCCCppCompiler, GCC, native_toolchain._gcc)
   provided_gpp = original_gcc_cpp_compiler.cpp_compiler
 
+  # GCC needs an assembler, so we provide that (platform-specific) tool here.
+  assembler = yield Get(Assembler, NativeToolchain, native_toolchain)
+
   if platform.normalized_os_name == 'darwin':
-    xcode_tools_assembler = yield Get(Assembler, XCodeCLITools, native_toolchain._xcode_cli_tools)
-    assembler_paths = xcode_tools_assembler.path_entries
-
+    # GCC needs access to some headers that are only provided by the XCode toolchain
+    # currently (e.g. "_stdio.h"). These headers are unlikely to change across versions, so this is
+    # probably safe.
+    # TODO: we should be providing all of these (so we can eventually phase out XCodeCLITools
+    # entirely).
     xcode_clangpp = yield Get(CppCompiler, XCodeCLITools, native_toolchain._xcode_cli_tools)
-
-    new_library_dirs = provided_gpp.library_dirs + xcode_clangpp.library_dirs
     new_include_dirs = xcode_clangpp.include_dirs + provided_gpp.include_dirs
   else:
-    binutils_assembler = yield Get(Assembler, Binutils, native_toolchain._binutils)
-    assembler_paths = binutils_assembler.path_entries
-
-    new_library_dirs = provided_gpp.library_dirs
     new_include_dirs = provided_gpp.include_dirs
 
-  gcc_with_assembler = CppCompiler(
-    path_entries=(provided_gpp.path_entries + assembler_paths),
+  working_cpp_compiler = CppCompiler(
+    path_entries=(provided_gpp.path_entries + assembler.path_entries),
     exe_filename=provided_gpp.exe_filename,
-    library_dirs=new_library_dirs,
+    library_dirs=provided_gpp.library_dirs,
     include_dirs=new_include_dirs)
 
-  final_gcc_cpp_compiler = GCCCppCompiler(gcc_with_assembler)
-  yield final_gcc_cpp_compiler
+  base_linker_wrapper = yield Get(BaseLinker, NativeToolchain, native_toolchain)
+  base_linker = base_linker_wrapper.linker
+  libc_dev = yield Get(LibcDev, NativeToolchain, native_toolchain)
+  working_linker = Linker(
+    path_entries=(base_linker.path_entries + working_cpp_compiler.path_entries),
+    exe_filename=working_cpp_compiler.exe_filename,
+    library_dirs=(base_linker.library_dirs + working_cpp_compiler.library_dirs),
+    linking_library_dirs=libc_dev.get_libc_dirs(platform))
 
-
-@rule(CCompiler, [Select(NativeToolchain), Select(Platform)])
-def select_c_compiler(native_toolchain, platform):
-  if platform.normalized_os_name == 'darwin':
-    llvm_c_compiler = yield Get(LLVMCCompiler, NativeToolchain, native_toolchain)
-    c_compiler = llvm_c_compiler.c_compiler
-  else:
-    gcc_c_compiler = yield Get(GCCCCompiler, NativeToolchain, native_toolchain)
-    c_compiler = gcc_c_compiler.c_compiler
-
-  yield c_compiler
-
-
-@rule(CppCompiler, [Select(NativeToolchain), Select(Platform)])
-def select_cpp_compiler(native_toolchain, platform):
-  if platform.normalized_os_name == 'darwin':
-    llvm_cpp_compiler = yield Get(LLVMCppCompiler, NativeToolchain, native_toolchain)
-    cpp_compiler = llvm_cpp_compiler.cpp_compiler
-  else:
-    gcc_cpp_compiler = yield Get(GCCCppCompiler, NativeToolchain, native_toolchain)
-    cpp_compiler = gcc_cpp_compiler.cpp_compiler
-
-  yield cpp_compiler
+  yield GCCCppToolchain(gcc_cpp_compiler=GCCCppCompiler(working_cpp_compiler),
+                        gcc_cpp_linker=GCCCppLinker(working_linker))
 
 
 def create_native_toolchain_rules():
   return [
-    select_linker,
-    select_llvm_c_compiler,
-    select_llvm_cpp_compiler,
-    select_gcc_c_compiler,
-    select_gcc_cpp_compiler,
-    select_c_compiler,
-    select_cpp_compiler,
+    select_libc_dev,
+    select_assembler,
+    select_base_linker,
+    select_llvm_c_toolchain,
+    select_llvm_cpp_toolchain,
+    select_gcc_c_toolchain,
+    select_gcc_cpp_toolchain,
     RootRule(NativeToolchain),
   ]

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -267,6 +267,18 @@ def select_gcc_cpp_toolchain(platform, native_toolchain):
   yield GCCCppToolchain(CppToolchain(working_cpp_compiler, working_linker))
 
 
+@rule(CToolchain, [Select(NativeToolchain)])
+def select_default_c_toolchain(native_toolchain):
+  llvm_c_toolchain = yield Get(LLVMCToolchain, NativeToolchain, native_toolchain)
+  yield llvm_c_toolchain.c_toolchain
+
+
+@rule(CppToolchain, [Select(NativeToolchain)])
+def select_default_cpp_toolchain(native_toolchain):
+  llvm_cpp_toolchain = yield Get(LLVMCppToolchain, NativeToolchain, native_toolchain)
+  yield llvm_cpp_toolchain.cpp_toolchain
+
+
 def create_native_toolchain_rules():
   return [
     select_libc_dev,
@@ -276,5 +288,7 @@ def create_native_toolchain_rules():
     select_llvm_cpp_toolchain,
     select_gcc_c_toolchain,
     select_gcc_cpp_toolchain,
+    select_default_c_toolchain,
+    select_default_cpp_toolchain,
     RootRule(NativeToolchain),
   ]

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -291,18 +291,6 @@ def select_gcc_cpp_toolchain(platform, native_toolchain):
   yield GCCCppToolchain(CppToolchain(working_cpp_compiler, working_linker))
 
 
-@rule(CToolchain, [Select(NativeToolchain)])
-def select_default_c_toolchain(native_toolchain):
-  llvm_c_toolchain = yield Get(LLVMCToolchain, NativeToolchain, native_toolchain)
-  yield llvm_c_toolchain.c_toolchain
-
-
-@rule(CppToolchain, [Select(NativeToolchain)])
-def select_default_cpp_toolchain(native_toolchain):
-  llvm_cpp_toolchain = yield Get(LLVMCppToolchain, NativeToolchain, native_toolchain)
-  yield llvm_cpp_toolchain.cpp_toolchain
-
-
 def create_native_toolchain_rules():
   return [
     select_libc_dev,
@@ -313,7 +301,5 @@ def create_native_toolchain_rules():
     select_llvm_cpp_toolchain,
     select_gcc_c_toolchain,
     select_gcc_cpp_toolchain,
-    select_default_c_toolchain,
-    select_default_cpp_toolchain,
     RootRule(NativeToolchain),
   ]

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -149,13 +149,13 @@ def select_llvm_cpp_toolchain(platform, native_toolchain):
       include_dirs=(xcode_clang.include_dirs + provided_clang.include_dirs))
   else:
     gcc_cpp_compiler = yield Get(GCCCppCompiler, GCC, native_toolchain._gcc)
-    provided_gcc = gcc_cpp_compiler.cpp_compiler
+    provided_gpp = gcc_cpp_compiler.cpp_compiler
     working_cpp_compiler = CppCompiler(
       path_entries=provided_clang.path_entries,
       exe_filename=provided_clang.exe_filename,
       # We need this version of GLIBCXX to be able to run, unfortunately.
-      library_dirs=(provided_gcc.library_dirs + provided_clang.library_dirs),
-      include_dirs=(provided_clang.include_dirs + provided_gcc.include_dirs))
+      library_dirs=(provided_gpp.library_dirs + provided_clang.library_dirs),
+      include_dirs=(provided_clang.include_dirs + provided_gpp.include_dirs))
 
   base_linker_wrapper = yield Get(BaseLinker, NativeToolchain, native_toolchain)
   base_linker = base_linker_wrapper.linker

--- a/src/python/pants/backend/native/subsystems/utils/BUILD
+++ b/src/python/pants/backend/native/subsystems/utils/BUILD
@@ -1,5 +1,6 @@
 python_library(
   dependencies=[
+    'src/python/pants/binaries',
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',

--- a/src/python/pants/backend/native/subsystems/utils/archive_file_mapper.py
+++ b/src/python/pants/backend/native/subsystems/utils/archive_file_mapper.py
@@ -15,7 +15,9 @@ class ArchiveFileMapper(Subsystem):
   """Index into known paths relative to a base directory.
 
   This is used with `NativeTool`s that wrap a compressed archive, which may have slightly different
-  paths across platforms. The helper methods from this class """
+  paths across platforms. The helper methods from this class make it concise to express searching
+  for a single exact match for each of a set of directory path globs.
+  """
 
   options_scope = 'archive-file-mapper'
 
@@ -26,7 +28,8 @@ class ArchiveFileMapper(Subsystem):
 
     The matched path may be a file or a directory. This method is used to avoid having to guess
     platform-specific intermediate directory names, e.g. 'x86_64-linux-gnu' or
-    'x86_64-apple-darwin17.5.0'."""
+    'x86_64-apple-darwin17.5.0'.
+    """
     glob_path_string = os.path.join(*components)
     expanded_glob = glob.glob(glob_path_string)
 

--- a/src/python/pants/backend/native/subsystems/utils/archive_file_mapper.py
+++ b/src/python/pants/backend/native/subsystems/utils/archive_file_mapper.py
@@ -1,0 +1,63 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import glob
+import os
+
+from pants.subsystem.subsystem import Subsystem
+from pants.util.collections import assert_single_element
+
+
+class ArchiveFileMapper(Subsystem):
+  """Index into known paths relative to a base directory.
+
+  This is used with `NativeTool`s that wrap a compressed archive, which may have slightly different
+  paths across platforms. The helper methods from this class """
+
+  options_scope = 'archive-file-mapper'
+
+  class ArchiveFileMappingError(Exception): pass
+
+  def assert_single_path_by_glob(self, components):
+    """Assert that the path components (which are joined into a glob) match exactly one path.
+
+    The matched path may be a file or a directory. This method is used to avoid having to guess
+    platform-specific intermediate directory names, e.g. 'x86_64-linux-gnu' or
+    'x86_64-apple-darwin17.5.0'."""
+    glob_path_string = os.path.join(*components)
+    expanded_glob = glob.glob(glob_path_string)
+
+    try:
+      return assert_single_element(expanded_glob)
+    except StopIteration as e:
+      raise self.ArchiveFileMappingError(
+        "No elements for glob '{}' -- expected exactly one."
+        .format(glob_path_string),
+        e)
+    except ValueError as e:
+      raise self.ArchiveFileMappingError(
+        "Should have exactly one path matching expansion of glob '{}'."
+        .format(glob_path_string),
+        e)
+
+  def map_files(self, base_dir, all_components_list):
+    """Apply `assert_single_path_by_glob()` to all elements of `all_components_list`.
+
+    Each element of `all_components_list` should be a tuple of path components, including
+    wildcards. The elements of each tuple are joined, and interpreted as a glob expression relative
+    to `base_dir`. The resulting glob should match exactly one path.
+
+    :return: List of matched paths, one per element of `all_components_list`.
+    :raises: :class:`ArchiveFileMapper.ArchiveFileMappingError` if more or less than one path was
+             matched by one of the glob expressions interpreted from `all_components_list`.
+    """
+    mapped_paths = []
+    for components_tupled in all_components_list:
+      with_base = [base_dir] + list(components_tupled)
+      # Results are known to exist, since they match a glob.
+      mapped_paths.append(self.assert_single_path_by_glob(with_base))
+
+    return mapped_paths

--- a/src/python/pants/backend/native/subsystems/utils/parse_search_dirs.py
+++ b/src/python/pants/backend/native/subsystems/utils/parse_search_dirs.py
@@ -37,24 +37,30 @@ class ParseSearchDirs(Subsystem):
   def _search_dirs_libraries_regex(cls):
     return re.compile('^libraries: =(.*)$', flags=re.MULTILINE)
 
-  def _parse_libraries_from_compiler_search_dirs(self, compiler_exe, env):
-    # This argument is supported by at least gcc and clang.
-    cmd = [compiler_exe, '-print-search-dirs']
-
+  def _invoke_compiler_exe(self, cmd, env):
     try:
       # Get stderr interspersed in the error message too -- this should not affect output parsing.
       compiler_output = subprocess.check_output(cmd, env=env, stderr=subprocess.STDOUT)
     except OSError as e:
       # We use `safe_shlex_join` here to pretty-print the command.
       raise self.ParseSearchDirsError(
-        "Invocation of '{}' with argv '{}' failed."
-        .format(compiler_exe, safe_shlex_join(cmd)),
+        "Process invocation with argv '{}' and environment {!r} failed."
+        .format(safe_shlex_join(cmd), env),
         e)
     except subprocess.CalledProcessError as e:
       raise self.ParseSearchDirsError(
-        "Invocation of '{}' with argv '{}' exited with non-zero code {}. output:\n{}"
-        .format(compiler_exe, safe_shlex_join(cmd), e.returncode, e.output),
+        "Process invocation with argv '{}' and environment {!r} exited with non-zero code {}. "
+        "output:\n{}"
+        .format(safe_shlex_join(cmd), env, e.returncode, e.output),
         e)
+
+    return compiler_output
+
+  def _parse_libraries_from_compiler_search_dirs(self, compiler_exe, env):
+    # This argument is supported by at least gcc and clang.
+    cmd = [compiler_exe, '-print-search-dirs']
+
+    compiler_output = self._invoke_compiler_exe(cmd, env)
 
     libs_line = self._search_dirs_libraries_regex.search(compiler_output)
     if not libs_line:
@@ -63,18 +69,20 @@ class ParseSearchDirs(Subsystem):
         .format(safe_shlex_join(cmd), compiler_output))
     return libs_line.group(1).split(':')
 
+  def _filter_existing_dirs(self, dir_candidates, compiler_exe):
+    real_dirs = OrderedSet()
+
+    for maybe_existing_dir in dir_candidates:
+      # Could use a `seen_dir_paths` set if we want to avoid pinging the fs for duplicate entries.
+      if is_readable_dir(maybe_existing_dir):
+        real_dirs.add(os.path.realpath(maybe_existing_dir))
+      else:
+        logger.debug("non-existent or non-accessible directory at {} while "
+                     "parsing directories from {}"
+                     .format(maybe_existing_dir, compiler_exe))
+
+    return list(real_dirs)
+
   def get_compiler_library_dirs(self, compiler_exe, env=None):
     all_dir_candidates = self._parse_libraries_from_compiler_search_dirs(compiler_exe, env=env)
-
-    real_lib_dirs = OrderedSet()
-
-    for lib_dir_path in all_dir_candidates:
-      # Could use a `seen_dir_paths` set if we want to avoid pinging the fs for duplicate entries.
-      if is_readable_dir(lib_dir_path):
-        real_lib_dirs.add(os.path.realpath(lib_dir_path))
-      else:
-        logger.debug("non-existent or non-accessible program directory at {} while "
-                     "parsing libraries from {}"
-                     .format(lib_dir_path, compiler_exe))
-
-    return list(real_lib_dirs)
+    return self._filter_existing_dirs(all_dir_candidates, compiler_exe)

--- a/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
+++ b/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
@@ -14,6 +14,12 @@ from pants.util.dirutil import is_readable_dir
 from pants.util.memo import memoized_method, memoized_property
 
 
+MIN_OSX_SUPPORTED_VERSION = '10.11'
+
+
+MIN_OSX_VERSION_ARG = '-mmacosx-version-min={}'.format(MIN_OSX_SUPPORTED_VERSION)
+
+
 class XCodeCLITools(Subsystem):
   """Subsystem to detect and provide the XCode command line developer tools.
 
@@ -143,7 +149,7 @@ class XCodeCLITools(Subsystem):
       exe_filename='ld',
       library_dirs=[],
       linking_library_dirs=[],
-      extra_args=['-mmacosx-version-min=10.11'])
+      extra_args=[MIN_OSX_VERSION_ARG])
 
   @memoized_method
   def c_compiler(self):
@@ -152,7 +158,7 @@ class XCodeCLITools(Subsystem):
       exe_filename='clang',
       library_dirs=self.lib_dirs(),
       include_dirs=self.include_dirs(),
-      extra_args=['-mmacosx-version-min=10.11'])
+      extra_args=[MIN_OSX_VERSION_ARG])
 
   @memoized_method
   def cpp_compiler(self):
@@ -161,7 +167,7 @@ class XCodeCLITools(Subsystem):
       exe_filename='clang++',
       library_dirs=self.lib_dirs(),
       include_dirs=self.include_dirs(),
-      extra_args=['-mmacosx-version-min=10.11'])
+      extra_args=[MIN_OSX_VERSION_ARG])
 
 
 @rule(Assembler, [Select(XCodeCLITools)])

--- a/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
+++ b/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
@@ -122,6 +122,7 @@ class XCodeCLITools(Subsystem):
 
     all_inc_dirs = base_inc_dirs
     for d in base_inc_dirs:
+      # FIXME: what does this directory do?
       secure_inc_dir = os.path.join(d, 'secure')
       if is_readable_dir(secure_inc_dir):
         all_inc_dirs.append(secure_inc_dir)

--- a/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
+++ b/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
@@ -141,7 +141,8 @@ class XCodeCLITools(Subsystem):
       path_entries=self.path_entries(),
       exe_filename='ld',
       library_dirs=[],
-      linking_library_dirs=[])
+      linking_library_dirs=[],
+      extra_args=['-mmacosx-version-min=10.11'])
 
   @memoized_method
   def c_compiler(self):
@@ -149,7 +150,8 @@ class XCodeCLITools(Subsystem):
       path_entries=self.path_entries(),
       exe_filename='clang',
       library_dirs=self.lib_dirs(),
-      include_dirs=self.include_dirs())
+      include_dirs=self.include_dirs(),
+      extra_args=['-mmacosx-version-min=10.11'])
 
   @memoized_method
   def cpp_compiler(self):
@@ -157,7 +159,8 @@ class XCodeCLITools(Subsystem):
       path_entries=self.path_entries(),
       exe_filename='clang++',
       library_dirs=self.lib_dirs(),
-      include_dirs=self.include_dirs())
+      include_dirs=self.include_dirs(),
+      extra_args=['-mmacosx-version-min=10.11'])
 
 
 @rule(Assembler, [Select(XCodeCLITools)])

--- a/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
+++ b/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
@@ -140,7 +140,8 @@ class XCodeCLITools(Subsystem):
     return Linker(
       path_entries=self.path_entries(),
       exe_filename='ld',
-      library_dirs=[])
+      library_dirs=[],
+      linking_library_dirs=[])
 
   @memoized_method
   def c_compiler(self):

--- a/src/python/pants/backend/native/tasks/c_compile.py
+++ b/src/python/pants/backend/native/tasks/c_compile.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.native.config.environment import CCompiler
+from pants.backend.native.config.environment import LLVMCToolchain
 from pants.backend.native.subsystems.native_compile_settings import CCompileSettings
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import CLibrary
@@ -32,14 +32,19 @@ class CCompile(NativeCompile):
     )
 
   @memoized_property
-  def _toolchain(self):
+  def _native_toolchain(self):
     return NativeToolchain.scoped_instance(self)
 
   def get_compile_settings(self):
     return CCompileSettings.scoped_instance(self)
 
+  @memoized_property
+  def _c_toolchain(self):
+    llvm_c_toolchain = self._request_single(LLVMCToolchain, self._native_toolchain)
+    return llvm_c_toolchain.as_c_toolchain
+
   def get_compiler(self):
-    return self._request_single(CCompiler, self._toolchain)
+    return self._c_toolchain.c_compiler
 
   # FIXME(#5951): don't have any command-line args in the task or in the subsystem -- rather,
   # subsystem options should be used to populate an `Executable` which produces its own arguments.

--- a/src/python/pants/backend/native/tasks/c_compile.py
+++ b/src/python/pants/backend/native/tasks/c_compile.py
@@ -45,8 +45,3 @@ class CCompile(NativeCompile):
 
   def get_compiler(self):
     return self._c_toolchain.c_compiler
-
-  # FIXME(#5951): don't have any command-line args in the task or in the subsystem -- rather,
-  # subsystem options should be used to populate an `Executable` which produces its own arguments.
-  def extra_compile_args(self):
-    return ['-x', 'c', '-std=c11']

--- a/src/python/pants/backend/native/tasks/c_compile.py
+++ b/src/python/pants/backend/native/tasks/c_compile.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.native.config.environment import LLVMCToolchain
+from pants.backend.native.config.environment import CToolchain
 from pants.backend.native.subsystems.native_compile_settings import CCompileSettings
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import CLibrary
@@ -40,8 +40,7 @@ class CCompile(NativeCompile):
 
   @memoized_property
   def _c_toolchain(self):
-    llvm_c_toolchain = self._request_single(LLVMCToolchain, self._native_toolchain)
-    return llvm_c_toolchain.as_c_toolchain
+    return self._request_single(CToolchain, self._native_toolchain)
 
   def get_compiler(self):
     return self._c_toolchain.c_compiler

--- a/src/python/pants/backend/native/tasks/c_compile.py
+++ b/src/python/pants/backend/native/tasks/c_compile.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.native.config.environment import CToolchain
+from pants.backend.native.config.environment import LLVMCToolchain
 from pants.backend.native.subsystems.native_compile_settings import CCompileSettings
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import CLibrary
@@ -40,7 +40,7 @@ class CCompile(NativeCompile):
 
   @memoized_property
   def _c_toolchain(self):
-    return self._request_single(CToolchain, self._native_toolchain)
+    return self._request_single(LLVMCToolchain, self._native_toolchain).c_toolchain
 
   def get_compiler(self):
     return self._c_toolchain.c_compiler

--- a/src/python/pants/backend/native/tasks/cpp_compile.py
+++ b/src/python/pants/backend/native/tasks/cpp_compile.py
@@ -45,19 +45,3 @@ class CppCompile(NativeCompile):
 
   def get_compiler(self):
     return self._cpp_toolchain.cpp_compiler
-
-  def _make_compile_argv(self, compile_request):
-    # FIXME: this is a temporary fix, do not do any of this kind of introspection.
-    # https://github.com/pantsbuild/pants/issues/5951
-    prev_argv = super(CppCompile, self)._make_compile_argv(compile_request)
-
-    if compile_request.compiler.exe_filename == 'clang++':
-      new_argv = [prev_argv[0], '-nobuiltininc', '-nostdinc++'] + prev_argv[1:]
-    else:
-      new_argv = prev_argv
-    return new_argv
-
-  # FIXME(#5951): don't have any command-line args in the task or in the subsystem -- rather,
-  # subsystem options should be used to populate an `Executable` which produces its own arguments.
-  def extra_compile_args(self):
-    return ['-x', 'c++', '-std=c++11']

--- a/src/python/pants/backend/native/tasks/cpp_compile.py
+++ b/src/python/pants/backend/native/tasks/cpp_compile.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.native.config.environment import CppCompiler
+from pants.backend.native.config.environment import LLVMCppToolchain
 from pants.backend.native.subsystems.native_compile_settings import CppCompileSettings
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import CppLibrary
@@ -32,14 +32,19 @@ class CppCompile(NativeCompile):
     )
 
   @memoized_property
-  def _toolchain(self):
+  def _native_toolchain(self):
     return NativeToolchain.scoped_instance(self)
 
   def get_compile_settings(self):
     return CppCompileSettings.scoped_instance(self)
 
+  @memoized_property
+  def _cpp_toolchain(self):
+    llvm_cpp_toolchain = self._request_single(LLVMCppToolchain, self._native_toolchain)
+    return llvm_cpp_toolchain.as_cpp_toolchain
+
   def get_compiler(self):
-    return self._request_single(CppCompiler, self._toolchain)
+    return self._cpp_toolchain.cpp_compiler
 
   def _make_compile_argv(self, compile_request):
     # FIXME: this is a temporary fix, do not do any of this kind of introspection.

--- a/src/python/pants/backend/native/tasks/cpp_compile.py
+++ b/src/python/pants/backend/native/tasks/cpp_compile.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.native.config.environment import LLVMCppToolchain
+from pants.backend.native.config.environment import CppToolchain
 from pants.backend.native.subsystems.native_compile_settings import CppCompileSettings
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import CppLibrary
@@ -40,8 +40,7 @@ class CppCompile(NativeCompile):
 
   @memoized_property
   def _cpp_toolchain(self):
-    llvm_cpp_toolchain = self._request_single(LLVMCppToolchain, self._native_toolchain)
-    return llvm_cpp_toolchain.as_cpp_toolchain
+    return self._request_single(CppToolchain, self._native_toolchain)
 
   def get_compiler(self):
     return self._cpp_toolchain.cpp_compiler

--- a/src/python/pants/backend/native/tasks/cpp_compile.py
+++ b/src/python/pants/backend/native/tasks/cpp_compile.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.native.config.environment import CppToolchain
+from pants.backend.native.config.environment import LLVMCppToolchain
 from pants.backend.native.subsystems.native_compile_settings import CppCompileSettings
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import CppLibrary
@@ -40,7 +40,7 @@ class CppCompile(NativeCompile):
 
   @memoized_property
   def _cpp_toolchain(self):
-    return self._request_single(CppToolchain, self._native_toolchain)
+    return self._request_single(LLVMCppToolchain, self._native_toolchain).cpp_toolchain
 
   def get_compiler(self):
     return self._cpp_toolchain.cpp_compiler

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -178,7 +178,7 @@ class LinkSharedLibraries(NativeTask):
            [os.path.abspath(obj) for obj in object_files])
     self.context.log.debug("linker command: {}".format(cmd))
 
-    env = linker.get_invocation_environment_dict(platform)
+    env = linker.as_invocation_environment_dict
     self.context.log.debug("linker invocation environment: {}".format(env))
 
     with self.context.new_workunit(name='link-shared-libraries',

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 
-from pants.backend.native.config.environment import LLVMCppToolchain, Platform
+from pants.backend.native.config.environment import CppToolchain, Platform
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.native_compile import NativeTargetDependencies, ObjectFiles
@@ -64,8 +64,7 @@ class LinkSharedLibraries(NativeTask):
 
   @memoized_property
   def _cpp_toolchain(self):
-    llvm_cpp_toolchain = self._request_single(LLVMCppToolchain, self._native_toolchain)
-    return llvm_cpp_toolchain.as_cpp_toolchain
+    return self._request_single(CppToolchain, self._native_toolchain)
 
   @memoized_property
   def linker(self):

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 
-from pants.backend.native.config.environment import CppToolchain, Platform
+from pants.backend.native.config.environment import LLVMCppToolchain, Platform
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.native_compile import NativeTargetDependencies, ObjectFiles
@@ -64,7 +64,7 @@ class LinkSharedLibraries(NativeTask):
 
   @memoized_property
   def _cpp_toolchain(self):
-    return self._request_single(CppToolchain, self._native_toolchain)
+    return self._request_single(LLVMCppToolchain, self._native_toolchain).cpp_toolchain
 
   @memoized_property
   def linker(self):

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 
-from pants.backend.native.config.environment import Linker, Platform
+from pants.backend.native.config.environment import LLVMCppToolchain, Platform
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.native_compile import NativeTargetDependencies, ObjectFiles
@@ -59,12 +59,17 @@ class LinkSharedLibraries(NativeTask):
     return super(LinkSharedLibraries, cls).subsystem_dependencies() + (NativeToolchain.scoped(cls),)
 
   @memoized_property
-  def _toolchain(self):
+  def _native_toolchain(self):
     return NativeToolchain.scoped_instance(self)
 
   @memoized_property
+  def _cpp_toolchain(self):
+    llvm_cpp_toolchain = self._request_single(LLVMCppToolchain, self._native_toolchain)
+    return llvm_cpp_toolchain.as_cpp_toolchain
+
+  @memoized_property
   def linker(self):
-    return self._request_single(Linker, self._toolchain)
+    return self._cpp_toolchain.cpp_linker
 
   def _retrieve_single_product_at_target_base(self, product_mapping, target):
     self.context.log.debug("product_mapping: {}".format(product_mapping))

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -154,12 +154,9 @@ class LinkSharedLibraries(NativeTask):
       external_libs_info=external_libs_product)
 
   _SHARED_CMDLINE_ARGS = {
-    'darwin': lambda: ['-mmacosx-version-min=10.11', '-Wl,-dylib'],
+    'darwin': lambda: ['-Wl,-dylib'],
     'linux': lambda: ['-shared'],
   }
-
-  def _get_shared_lib_cmdline_args(self, platform):
-    return platform.resolve_platform_specific(self._SHARED_CMDLINE_ARGS)
 
   def _execute_link_request(self, link_request):
     object_files = link_request.object_files
@@ -175,7 +172,7 @@ class LinkSharedLibraries(NativeTask):
     resulting_shared_lib_path = os.path.join(output_dir, native_artifact.as_shared_lib(platform))
     # We are executing in the results_dir, so get absolute paths for everything.
     cmd = ([linker.exe_filename] +
-           self._get_shared_lib_cmdline_args(platform) +
+           platform.resolve_platform_specific(self._SHARED_CMDLINE_ARGS) +
            linker.extra_args +
            link_request.external_libs_info.get_third_party_lib_args() +
            ['-o', os.path.abspath(resulting_shared_lib_path)] +

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -193,15 +193,17 @@ class LinkSharedLibraries(NativeTask):
       except OSError as e:
         workunit.set_outcome(WorkUnit.FAILURE)
         raise self.LinkSharedLibrariesError(
-          "Error invoking the native linker with command {} for request {}: {}"
-          .format(cmd, link_request, e),
+          "Error invoking the native linker with command {cmd} and environment {env} "
+          "for request {req}: {err}."
+          .format(cmd=cmd, env=env, req=link_request, err=e),
           e)
 
       rc = process.wait()
       if rc != 0:
         workunit.set_outcome(WorkUnit.FAILURE)
         raise self.LinkSharedLibrariesError(
-          "Error linking native objects with command {} for request {}. Exit code was: {}."
-          .format(cmd, link_request, rc))
+          "Error linking native objects with command {cmd} and environment {env} "
+          "for request {req}. Exit code was: {rc}."
+          .format(cmd=cmd, env=env, req=link_request, rc=rc))
 
     return SharedLibrary(name=native_artifact.lib_name, path=resulting_shared_lib_path)

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -208,10 +208,6 @@ class NativeCompile(NativeTask, AbstractClass):
         'fatal_warnings', target),
       output_dir=versioned_target.results_dir)
 
-  @abstractmethod
-  def extra_compile_args(self):
-    """Return a list of task-specific arguments to use to compile sources."""
-
   def _make_compile_argv(self, compile_request):
     """Return a list of arguments to use to compile sources. Subclasses can override and append."""
     compiler = compile_request.compiler
@@ -229,11 +225,13 @@ class NativeCompile(NativeTask, AbstractClass):
     argv = (
       [compiler.exe_filename] +
       platform_specific_flags +
-      self.extra_compile_args() +
+      compiler.extra_args +
       err_flags +
       ['-c', '-fPIC'] +
       ['-I{}'.format(os.path.abspath(inc_dir)) for inc_dir in compile_request.include_dirs] +
       [os.path.abspath(src) for src in compile_request.sources])
+
+    self.context.log.debug("compile argv: {}".format(argv))
 
     return argv
 

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -8,6 +8,7 @@ from pants.backend.python.pants_requirement import PantsRequirement
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.python_requirements import PythonRequirements
+from pants.backend.python.subsystems.python_native_code import create_python_native_code_rules
 from pants.backend.python.targets.python_app import PythonApp
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_distribution import PythonDistribution
@@ -29,7 +30,7 @@ from pants.backend.python.tasks.python_repl import PythonRepl
 from pants.backend.python.tasks.python_run import PythonRun
 from pants.backend.python.tasks.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks.select_interpreter import SelectInterpreter
-from pants.backend.python.tasks.setup_py import SetupPy, create_setup_py_rules
+from pants.backend.python.tasks.setup_py import SetupPy
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.resources import Resources
 from pants.goal.task_registrar import TaskRegistrar as task
@@ -76,4 +77,4 @@ def register_goals():
 
 
 def rules():
-  return create_setup_py_rules()
+  return create_python_native_code_rules()

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -8,7 +8,6 @@ from pants.backend.python.pants_requirement import PantsRequirement
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.python_requirements import PythonRequirements
-from pants.backend.python.subsystems.python_native_code import create_python_native_code_rules
 from pants.backend.python.targets.python_app import PythonApp
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_distribution import PythonDistribution
@@ -74,7 +73,3 @@ def register_goals():
   task(name='isort-prep', action=IsortPrep).install('fmt')
   task(name='isort', action=IsortRun).install('fmt')
   task(name='py', action=PythonBundle).install('bundle')
-
-
-def rules():
-  return create_python_native_code_rules()

--- a/src/python/pants/backend/python/subsystems/BUILD
+++ b/src/python/pants/backend/python/subsystems/BUILD
@@ -6,8 +6,6 @@ python_library(
     '3rdparty/python:future',
     '3rdparty/python:pex',
     '3rdparty/python:setuptools',
-    'src/python/pants/engine:rules',
-    'src/python/pants/engine:selectors',
     'src/python/pants/option',
     'src/python/pants/subsystem',
   ],

--- a/src/python/pants/backend/python/subsystems/BUILD
+++ b/src/python/pants/backend/python/subsystems/BUILD
@@ -6,6 +6,8 @@ python_library(
     '3rdparty/python:future',
     '3rdparty/python:pex',
     '3rdparty/python:setuptools',
+    'src/python/pants/engine:rules',
+    'src/python/pants/engine:selectors',
     'src/python/pants/option',
     'src/python/pants/subsystem',
   ],

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -208,7 +208,9 @@ class SetupPyExecutionEnvironment(datatype([
     # only creating an environment at the very end.
     native_tools = self.setup_py_native_tools
     if native_tools:
-      # TODO: an as_tuple() method for datatypes could make this destructuring cleaner!
+      # An as_tuple() method for datatypes could make this destructuring cleaner!  Alternatively,
+      # constructing this environment could be done more compositionally instead of requiring all of
+      # these disparate fields together at once.
       plat = native_tools.platform
       c_toolchain = native_tools.c_toolchain
       c_compiler = c_toolchain.c_compiler

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -15,11 +15,13 @@ from pex.interpreter import PythonInterpreter
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.link_shared_libraries import SharedLibrary
 from pants.backend.python.python_requirement import PythonRequirement
-from pants.backend.python.subsystems.python_native_code import PythonNativeCode
+from pants.backend.python.subsystems.python_native_code import (PythonNativeCode,
+                                                                SetupPyExecutionEnvironment,
+                                                                SetupPyNativeTools,
+                                                                ensure_setup_requires_site_dir)
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.tasks.pex_build_util import is_local_python_dist
-from pants.backend.python.tasks.setup_py import (SetupPyExecutionEnvironment, SetupPyNativeTools,
-                                                 SetupPyRunner, ensure_setup_requires_site_dir)
+from pants.backend.python.tasks.setup_py import SetupPyRunner
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException, TaskError
 from pants.build_graph.address import Address
@@ -81,8 +83,7 @@ class BuildLocalPythonDistributions(Task):
 
   @memoized_property
   def _setup_py_native_tools(self):
-    native_toolchain = self._python_native_code_settings.native_toolchain
-    return self._request_single(SetupPyNativeTools, native_toolchain)
+    return self._request_single(SetupPyNativeTools, self._python_native_code_settings)
 
   # TODO: This should probably be made into an @classproperty (see PR #5901).
   @property

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -194,8 +194,8 @@ class SetupPyExecutionEnvironment(datatype([
       ret['CPATH'] = create_path_env_var(all_include_dirs)
 
       all_cflags_for_platform = plat.resolve_platform_specific({
-        'darwin': lambda: ['-mmacosx-version-min=10.11'],
-        'linux': lambda: [],
+        'darwin': lambda: ['-mmacosx-version-min=10.11', '-nostdinc++'],
+        'linux': lambda: ['-nostdinc++'],
       })
       ret['CFLAGS'] = safe_shlex_join(all_cflags_for_platform)
 

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -158,7 +158,7 @@ class SetupPyExecutionEnvironment(datatype([
     # only creating an environment at the very end.
     native_tools = self.setup_py_native_tools
     if native_tools:
-      # TODO: an as_tuple() method for datatypes would make this destructuring cleaner!
+      # TODO: an as_tuple() method for datatypes could make this destructuring cleaner!
       plat = native_tools.platform
       c_toolchain = native_tools.c_toolchain
       c_compiler = c_toolchain.c_compiler

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -18,28 +18,22 @@ from pex.installer import InstallerBase, Packager
 from pex.interpreter import PythonInterpreter
 from twitter.common.collections import OrderedSet
 from twitter.common.dirutil.chroot import Chroot
-from wheel.install import WheelFile
 
-from pants.backend.native.config.environment import (CppToolchain, CToolchain, LLVMCppToolchain,
-                                                     LLVMCToolchain, Platform)
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
-from pants.backend.python.tasks.pex_build_util import is_local_python_dist, resolve_multi
+from pants.backend.python.tasks.pex_build_util import is_local_python_dist
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException, TaskError
 from pants.base.specs import SiblingAddresses
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.build_graph import sort_targets
 from pants.build_graph.resources import Resources
-from pants.engine.rules import rule
-from pants.engine.selectors import Select
 from pants.task.task import Task
 from pants.util.dirutil import safe_rmtree, safe_walk
 from pants.util.memo import memoized_property
 from pants.util.meta import AbstractClass
-from pants.util.objects import datatype
-from pants.util.strutil import create_path_env_var, safe_shlex_join, safe_shlex_split
+from pants.util.strutil import safe_shlex_split
 
 
 SETUP_BOILERPLATE = """
@@ -79,134 +73,6 @@ class SetupPyRunner(InstallerBase):
 
   def _setup_command(self):
     return self.__setup_command
-
-
-class SetupPyNativeTools(datatype([
-    ('c_toolchain', CToolchain),
-    ('cpp_toolchain', CppToolchain),
-    ('platform', Platform),
-])):
-  """The native tools needed for a setup.py invocation.
-
-  This class exists because `SetupPyExecutionEnvironment` is created manually, one per target.
-  """
-
-
-@rule(SetupPyNativeTools, [Select(LLVMCToolchain), Select(LLVMCppToolchain), Select(Platform)])
-def get_setup_py_native_tools(llvm_c_toolchain, llvm_cpp_toolchain, platform):
-  yield SetupPyNativeTools(
-    c_toolchain=llvm_c_toolchain.as_c_toolchain,
-    cpp_toolchain=llvm_cpp_toolchain.as_cpp_toolchain,
-    platform=platform)
-
-
-class SetupRequiresSiteDir(datatype(['site_dir'])): pass
-
-
-# TODO: This could be formulated as an @rule if targets and `PythonInterpreter` are made available
-# to the v2 engine.
-def ensure_setup_requires_site_dir(reqs_to_resolve, interpreter, site_dir,
-                                   platforms=None):
-  if not reqs_to_resolve:
-    return None
-
-  setup_requires_dists = resolve_multi(interpreter, reqs_to_resolve, platforms, None)
-
-  # FIXME: there's no description of what this does or why it's necessary.
-  overrides = {
-    'purelib': site_dir,
-    'headers': os.path.join(site_dir, 'headers'),
-    'scripts': os.path.join(site_dir, 'bin'),
-    'platlib': site_dir,
-    'data': site_dir
-  }
-
-  # The `python_dist` target builds for the current platform only.
-  # FIXME: why does it build for the current platform only?
-  for obj in setup_requires_dists['current']:
-    wf = WheelFile(obj.location)
-    wf.install(overrides=overrides, force=True)
-
-  return SetupRequiresSiteDir(site_dir)
-
-
-class SetupPyExecutionEnvironment(datatype([
-    # TODO: It might be pretty useful to have an Optional TypeConstraint.
-    'setup_requires_site_dir',
-    # If None, don't execute in the toolchain environment.
-    'setup_py_native_tools',
-])):
-
-  _SHARED_CMDLINE_ARGS = {
-    'darwin': lambda: [
-      '-mmacosx-version-min=10.11',
-      '-Wl,-dylib',
-      '-undefined',
-      'dynamic_lookup',
-    ],
-    'linux': lambda: ['-shared'],
-  }
-
-  def as_environment(self):
-    ret = {}
-
-    if self.setup_requires_site_dir:
-      ret['PYTHONPATH'] = self.setup_requires_site_dir.site_dir
-
-    # FIXME(#5951): the below is a lot of error-prone repeated logic -- we need a way to compose
-    # executables more hygienically. We should probably be composing each datatype's members, and
-    # only creating an environment at the very end.
-    native_tools = self.setup_py_native_tools
-    if native_tools:
-      # TODO: an as_tuple() method for datatypes could make this destructuring cleaner!
-      plat = native_tools.platform
-      c_toolchain = native_tools.c_toolchain
-      c_compiler = c_toolchain.c_compiler
-      c_linker = c_toolchain.c_linker
-
-      cpp_toolchain = native_tools.cpp_toolchain
-      cpp_compiler = cpp_toolchain.cpp_compiler
-      cpp_linker = cpp_toolchain.cpp_linker
-
-      all_path_entries = (
-        c_compiler.path_entries +
-        c_linker.path_entries +
-        cpp_compiler.path_entries +
-        cpp_linker.path_entries)
-      ret['PATH'] = create_path_env_var(all_path_entries)
-
-      all_library_dirs = (
-        c_compiler.library_dirs +
-        c_linker.library_dirs +
-        cpp_compiler.library_dirs +
-        cpp_linker.library_dirs)
-      joined_library_dirs = create_path_env_var(all_library_dirs)
-      dynamic_lib_env_var = plat.resolve_platform_specific({
-        'darwin': lambda: 'DYLD_LIBRARY_PATH',
-        'linux': lambda: 'LD_LIBRARY_PATH',
-      })
-      ret[dynamic_lib_env_var] = joined_library_dirs
-
-      all_linking_library_dirs = (c_linker.linking_library_dirs + cpp_linker.linking_library_dirs)
-      ret['LIBRARY_PATH'] = create_path_env_var(all_linking_library_dirs)
-
-      all_include_dirs = c_compiler.include_dirs + cpp_compiler.include_dirs
-      ret['CPATH'] = create_path_env_var(all_include_dirs)
-
-      all_cflags_for_platform = plat.resolve_platform_specific({
-        'darwin': lambda: ['-mmacosx-version-min=10.11', '-nostdinc++'],
-        'linux': lambda: ['-nostdinc++'],
-      })
-      ret['CFLAGS'] = safe_shlex_join(all_cflags_for_platform)
-
-      ret['CC'] = c_compiler.exe_filename
-      ret['CXX'] = cpp_compiler.exe_filename
-      ret['LDSHARED'] = cpp_linker.exe_filename
-
-      all_new_ldflags = plat.resolve_platform_specific(self._SHARED_CMDLINE_ARGS)
-      ret['LDFLAGS'] = safe_shlex_join(all_new_ldflags)
-
-    return ret
 
 
 class TargetAncestorIterator(object):
@@ -776,9 +642,3 @@ class SetupPy(Task):
           setup_runner = SetupPyRunner(setup_dir, split_command, interpreter=interpreter)
           setup_runner.run()
           python_dists[exported_python_target] = setup_dir
-
-
-def create_setup_py_rules():
-  return [
-    get_setup_py_native_tools,
-  ]

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -20,7 +20,8 @@ from twitter.common.collections import OrderedSet
 from twitter.common.dirutil.chroot import Chroot
 from wheel.install import WheelFile
 
-from pants.backend.native.config.environment import CCompiler, CppCompiler, Linker, Platform
+from pants.backend.native.config.environment import (CppToolchain, CToolchain, LLVMCppToolchain,
+                                                     LLVMCToolchain, Platform)
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
@@ -81,9 +82,8 @@ class SetupPyRunner(InstallerBase):
 
 
 class SetupPyNativeTools(datatype([
-    ('c_compiler', CCompiler),
-    ('cpp_compiler', CppCompiler),
-    ('linker', Linker),
+    ('c_toolchain', CToolchain),
+    ('cpp_toolchain', CppToolchain),
     ('platform', Platform),
 ])):
   """The native tools needed for a setup.py invocation.
@@ -92,12 +92,11 @@ class SetupPyNativeTools(datatype([
   """
 
 
-@rule(SetupPyNativeTools, [Select(CCompiler), Select(CppCompiler), Select(Linker), Select(Platform)])
-def get_setup_py_native_tools(c_compiler, cpp_compiler, linker, platform):
+@rule(SetupPyNativeTools, [Select(LLVMCToolchain), Select(LLVMCppToolchain), Select(Platform)])
+def get_setup_py_native_tools(llvm_c_toolchain, llvm_cpp_toolchain, platform):
   yield SetupPyNativeTools(
-    c_compiler=c_compiler,
-    cpp_compiler=cpp_compiler,
-    linker=linker,
+    c_toolchain=llvm_c_toolchain.as_c_toolchain,
+    cpp_toolchain=llvm_cpp_toolchain.as_cpp_toolchain,
     platform=platform)
 
 
@@ -161,37 +160,48 @@ class SetupPyExecutionEnvironment(datatype([
     if native_tools:
       # TODO: an as_tuple() method for datatypes would make this destructuring cleaner!
       plat = native_tools.platform
-      cc = native_tools.c_compiler
-      cxx = native_tools.cpp_compiler
-      linker = native_tools.linker
+      c_toolchain = native_tools.c_toolchain
+      c_compiler = c_toolchain.c_compiler
+      c_linker = c_toolchain.c_linker
 
-      all_path_entries = cc.path_entries + cxx.path_entries + linker.path_entries
+      cpp_toolchain = native_tools.cpp_toolchain
+      cpp_compiler = cpp_toolchain.cpp_compiler
+      cpp_linker = cpp_toolchain.cpp_linker
+
+      all_path_entries = (
+        c_compiler.path_entries +
+        c_linker.path_entries +
+        cpp_compiler.path_entries +
+        cpp_linker.path_entries)
       ret['PATH'] = create_path_env_var(all_path_entries)
 
-      all_library_dirs = cc.library_dirs + cxx.library_dirs + linker.library_dirs
-      if all_library_dirs:
-        joined_library_dirs = create_path_env_var(all_library_dirs)
-        ret['LIBRARY_PATH'] = joined_library_dirs
-        dynamic_lib_env_var = plat.resolve_platform_specific({
-          'darwin': lambda: 'DYLD_LIBRARY_PATH',
-          'linux': lambda: 'LD_LIBRARY_PATH',
-        })
-        ret[dynamic_lib_env_var] = joined_library_dirs
+      all_library_dirs = (
+        c_compiler.library_dirs +
+        c_linker.library_dirs +
+        cpp_compiler.library_dirs +
+        cpp_linker.library_dirs)
+      joined_library_dirs = create_path_env_var(all_library_dirs)
+      dynamic_lib_env_var = plat.resolve_platform_specific({
+        'darwin': lambda: 'DYLD_LIBRARY_PATH',
+        'linux': lambda: 'LD_LIBRARY_PATH',
+      })
+      ret[dynamic_lib_env_var] = joined_library_dirs
 
-      all_include_dirs = cc.include_dirs + cxx.include_dirs
-      if all_include_dirs:
-        ret['CPATH'] = create_path_env_var(all_include_dirs)
+      all_linking_library_dirs = (c_linker.linking_library_dirs + cpp_linker.linking_library_dirs)
+      ret['LIBRARY_PATH'] = create_path_env_var(all_linking_library_dirs)
+
+      all_include_dirs = c_compiler.include_dirs + cpp_compiler.include_dirs
+      ret['CPATH'] = create_path_env_var(all_include_dirs)
 
       all_cflags_for_platform = plat.resolve_platform_specific({
         'darwin': lambda: ['-mmacosx-version-min=10.11'],
         'linux': lambda: [],
       })
-      if all_cflags_for_platform:
-        ret['CFLAGS'] = safe_shlex_join(all_cflags_for_platform)
+      ret['CFLAGS'] = safe_shlex_join(all_cflags_for_platform)
 
-      ret['CC'] = cc.exe_filename
-      ret['CXX'] = cxx.exe_filename
-      ret['LDSHARED'] = linker.exe_filename
+      ret['CC'] = c_compiler.exe_filename
+      ret['CXX'] = cpp_compiler.exe_filename
+      ret['LDSHARED'] = cpp_linker.exe_filename
 
       all_new_ldflags = plat.resolve_platform_specific(self._SHARED_CMDLINE_ARGS)
       ret['LDFLAGS'] = safe_shlex_join(all_new_ldflags)

--- a/tests/python/pants_test/backend/native/subsystems/test_libc_resolution.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_libc_resolution.py
@@ -74,6 +74,6 @@ class TestLibcCompilerSearchFailure(TestBase):
     with self.assertRaises(ParseSearchDirs.ParseSearchDirsError) as cm:
       self.libc.get_libc_dirs(self.platform)
     expected_msg = (
-      "Invocation of 'this_executable_does_not_exist' with argv "
-      "'this_executable_does_not_exist -print-search-dirs' failed.")
+      "Process invocation with argv "
+      "'this_executable_does_not_exist -print-search-dirs' and environment None failed.")
     self.assertIn(expected_msg, str(cm.exception))

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -52,7 +52,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     gcc_c_toolchain = self.execute_expecting_one_result(
       scheduler, GCCCToolchain, self.toolchain).value
 
-    gcc = gcc_c_toolchain.gcc_c_compiler.c_compiler
+    gcc = gcc_c_toolchain.c_toolchain.c_compiler
     gcc_version_out = self._invoke_capturing_output(
       [gcc.exe_filename, '--version'],
       env=gcc.get_invocation_environment_dict(self.platform))
@@ -66,7 +66,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     gcc_cpp_toolchain = self.execute_expecting_one_result(
       scheduler, GCCCppToolchain, self.toolchain).value
 
-    gpp = gcc_cpp_toolchain.gcc_cpp_compiler.cpp_compiler
+    gpp = gcc_cpp_toolchain.cpp_toolchain.cpp_compiler
     gpp_version_out = self._invoke_capturing_output(
       [gpp.exe_filename, '--version'],
       env=gpp.get_invocation_environment_dict(self.platform))
@@ -80,7 +80,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     llvm_c_toolchain = self.execute_expecting_one_result(
       scheduler, LLVMCToolchain, self.toolchain).value
 
-    clang = llvm_c_toolchain.llvm_c_compiler.c_compiler
+    clang = llvm_c_toolchain.c_toolchain.c_compiler
     clang_version_out = self._invoke_capturing_output(
       [clang.exe_filename, '--version'],
       env=clang.get_invocation_environment_dict(self.platform))
@@ -96,7 +96,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
 
     llvm_cpp_toolchain = self.execute_expecting_one_result(
       scheduler, LLVMCppToolchain, self.toolchain).value
-    clangpp = llvm_cpp_toolchain.llvm_cpp_compiler.cpp_compiler
+    clangpp = llvm_cpp_toolchain.cpp_toolchain.cpp_compiler
     clanggpp_version_out = self._invoke_capturing_output(
       [clangpp.exe_filename, '--version'],
       env=clangpp.get_invocation_environment_dict(self.platform))
@@ -112,11 +112,10 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
       with safe_open(source_file_path, mode='wb') as fp:
         fp.write(contents)
 
-      execution_request = scheduler.execution_request_literal(
-        [(self.toolchain, toolchain_type)])
+      toolchain = self.execute_expecting_one_result(scheduler, toolchain_type, self.toolchain).value
 
       with pushd(tmpdir):
-        yield tuple(self.execute_literal(scheduler, execution_request))
+        yield toolchain
 
   def _invoke_compiler(self, compiler, args):
     cmd = [compiler.exe_filename] + compiler.extra_args + args
@@ -171,12 +170,11 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
 int main() {
   printf("%s\\n", "I C the world!");
 }
-""") as products:
+""") as gcc_c_toolchain:
 
-      gcc_c_toolchain, = products
-
-      compiler = gcc_c_toolchain.gcc_c_compiler.c_compiler
-      linker = gcc_c_toolchain.gcc_c_linker.c_linker
+      c_toolchain = gcc_c_toolchain.c_toolchain
+      compiler = c_toolchain.c_compiler
+      linker = c_toolchain.c_linker
 
       self._do_compile_link(compiler, linker, 'hello.c', 'hello_gcc', "I C the world!")
 
@@ -187,12 +185,11 @@ int main() {
 int main() {
   printf("%s\\n", "I C the world!");
 }
-""") as products:
+""") as llvm_c_toolchain:
 
-      llvm_c_toolchain, = products
-
-      compiler = llvm_c_toolchain.llvm_c_compiler.c_compiler
-      linker = llvm_c_toolchain.llvm_c_linker.c_linker
+      c_toolchain = llvm_c_toolchain.c_toolchain
+      compiler = c_toolchain.c_compiler
+      linker = c_toolchain.c_linker
 
       self._do_compile_link(compiler, linker, 'hello.c', 'hello_clang', "I C the world!")
 
@@ -203,12 +200,11 @@ int main() {
 int main() {
   std::cout << "I C the world, ++ more!" << std::endl;
 }
-""") as products:
+""") as gcc_cpp_toolchain:
 
-      gcc_cpp_toolchain, = products
-
-      compiler = gcc_cpp_toolchain.gcc_cpp_compiler.cpp_compiler
-      linker = gcc_cpp_toolchain.gcc_cpp_linker.cpp_linker
+      cpp_toolchain = gcc_cpp_toolchain.cpp_toolchain
+      compiler = cpp_toolchain.cpp_compiler
+      linker = cpp_toolchain.cpp_linker
 
       self._do_compile_link(compiler, linker, 'hello.cpp', 'hello_gpp', "I C the world, ++ more!")
 
@@ -219,11 +215,11 @@ int main() {
 int main() {
   std::cout << "I C the world, ++ more!" << std::endl;
 }
-""") as products:
+""") as llvm_cpp_toolchain:
 
-      llvm_cpp_toolchain, = products
+      cpp_toolchain = llvm_cpp_toolchain.cpp_toolchain
+      compiler = cpp_toolchain.cpp_compiler
+      linker = cpp_toolchain.cpp_linker
 
-      compiler = llvm_cpp_toolchain.llvm_cpp_compiler.cpp_compiler
-      linker = llvm_cpp_toolchain.llvm_cpp_linker.cpp_linker
-
-      self._do_compile_link(compiler, linker, 'hello.cpp', 'hello_clangpp', "I C the world, ++ more!")
+      self._do_compile_link(compiler, linker, 'hello.cpp', 'hello_clangpp',
+                            "I C the world, ++ more!")

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -160,6 +160,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
       linker,
       [intermediate_obj_file_name, '-o', outfile])
     self.assertTrue(is_executable(outfile))
+
     program_out = self._invoke_capturing_output([os.path.abspath(outfile)])
     self.assertEqual((output + '\n'), program_out)
 

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -55,7 +55,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     gcc = gcc_c_toolchain.c_toolchain.c_compiler
     gcc_version_out = self._invoke_capturing_output(
       [gcc.exe_filename, '--version'],
-      env=gcc.get_invocation_environment_dict(self.platform))
+      env=gcc.as_invocation_environment_dict)
 
     gcc_version_regex = re.compile('^gcc.*{}$'.format(re.escape(self.gcc_version)),
                                    flags=re.MULTILINE)
@@ -69,7 +69,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     gpp = gcc_cpp_toolchain.cpp_toolchain.cpp_compiler
     gpp_version_out = self._invoke_capturing_output(
       [gpp.exe_filename, '--version'],
-      env=gpp.get_invocation_environment_dict(self.platform))
+      env=gpp.as_invocation_environment_dict)
 
     gpp_version_regex = re.compile(r'^g\+\+.*{}$'.format(re.escape(self.gcc_version)),
                                    flags=re.MULTILINE)
@@ -83,7 +83,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     clang = llvm_c_toolchain.c_toolchain.c_compiler
     clang_version_out = self._invoke_capturing_output(
       [clang.exe_filename, '--version'],
-      env=clang.get_invocation_environment_dict(self.platform))
+      env=clang.as_invocation_environment_dict)
 
     clang_version_regex = re.compile('^clang version {}'.format(re.escape(self.llvm_version)),
                                      flags=re.MULTILINE)
@@ -99,7 +99,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     clangpp = llvm_cpp_toolchain.cpp_toolchain.cpp_compiler
     clanggpp_version_out = self._invoke_capturing_output(
       [clangpp.exe_filename, '--version'],
-      env=clangpp.get_invocation_environment_dict(self.platform))
+      env=clangpp.as_invocation_environment_dict)
 
     self.assertIsNotNone(clangpp_version_regex.search(clanggpp_version_out))
 
@@ -121,13 +121,13 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     cmd = [compiler.exe_filename] + compiler.extra_args + args
     return self._invoke_capturing_output(
       cmd,
-      compiler.get_invocation_environment_dict(self.platform))
+      compiler.as_invocation_environment_dict)
 
   def _invoke_linker(self, linker, args):
     cmd = [linker.exe_filename] + linker.extra_args + args
     return self._invoke_capturing_output(
       cmd,
-      linker.get_invocation_environment_dict(self.platform))
+      linker.as_invocation_environment_dict)
 
   def _invoke_capturing_output(self, cmd, env=None):
     if env is None:

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -226,20 +226,4 @@ int main() {
       compiler = llvm_cpp_toolchain.llvm_cpp_compiler.cpp_compiler
       linker = llvm_cpp_toolchain.llvm_cpp_linker.cpp_linker
 
-      # lib_path_var = self.platform.resolve_platform_specific({
-      #   'darwin': lambda: 'DYLD_LIBRARY_PATH',
-      #   'linux': lambda: 'LD_LIBRARY_PATH',
-      # })
-      # runtime_libs_path = {lib_path_var: create_path_env_var(compiler.library_dirs)}
-      # Otherwise we get some header errors on Linux because clang++ will prefer the system
-      # headers if they are allowed, and we provide our own already in the LLVM subsystem (and
-      # pass them in through CPATH).
-      # extra_compile_args=['-nostdinc++'],
-      # # LLVM will prefer LLVM's libc++ on OSX, and seemingly requires it even if it does not use
-      # # its own C++ library implementation, and uses libstdc++, which we provide in the linker's
-      # # LIBRARY_PATH. See https://libcxx.llvm.org/ for more info.
-      # extra_link_args=['-lc++'],
-      # # We need to provide libc++ on the runtime library path as well on Linux (OSX will have it
-      # # already).
-      # extra_invocation_env=runtime_libs_path
       self._do_compile_link(compiler, linker, 'hello.cpp', 'hello_clangpp', "I C the world, ++ more!")

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -18,7 +18,7 @@ from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.util.contextutil import environment_as, pushd, temporary_dir
 from pants.util.dirutil import is_executable, safe_open
 from pants.util.process_handler import subprocess
-from pants.util.strutil import create_path_env_var, safe_shlex_join
+from pants.util.strutil import safe_shlex_join
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
 from pants_test.subsystem.subsystem_util import global_subsystem_instance, init_subsystems
 from pants_test.test_base import TestBase
@@ -119,13 +119,13 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
         yield tuple(self.execute_literal(scheduler, execution_request))
 
   def _invoke_compiler(self, compiler, args):
-    cmd = [compiler.exe_filename] + args
+    cmd = [compiler.exe_filename] + compiler.extra_args + args
     return self._invoke_capturing_output(
       cmd,
       compiler.get_invocation_environment_dict(self.platform))
 
   def _invoke_linker(self, linker, args):
-    cmd = [linker.exe_filename] + args
+    cmd = [linker.exe_filename] + linker.extra_args + args
     return self._invoke_capturing_output(
       cmd,
       linker.get_invocation_environment_dict(self.platform))
@@ -149,22 +149,19 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
                 out=e.output),
         e)
 
-  def _do_compile_link(self, compiler, linker, source_file, outfile, output,
-                       extra_compile_args=None, extra_link_args=None,
-                       extra_invocation_env=None):
+  def _do_compile_link(self, compiler, linker, source_file, outfile, output):
 
     intermediate_obj_file_name = '{}.o'.format(outfile)
     self._invoke_compiler(
       compiler,
-      ['-c', source_file, '-o', intermediate_obj_file_name] + (extra_compile_args or []))
+      ['-c', source_file, '-o', intermediate_obj_file_name])
     self.assertTrue(os.path.isfile(intermediate_obj_file_name))
 
     self._invoke_linker(
       linker,
-      [intermediate_obj_file_name, '-o', outfile] + (extra_link_args or []))
+      [intermediate_obj_file_name, '-o', outfile])
     self.assertTrue(is_executable(outfile))
-    program_out = self._invoke_capturing_output([os.path.abspath(outfile)],
-                                                env=extra_invocation_env)
+    program_out = self._invoke_capturing_output([os.path.abspath(outfile)])
     self.assertEqual((output + '\n'), program_out)
 
   def test_hello_c_gcc(self):
@@ -229,22 +226,20 @@ int main() {
       compiler = llvm_cpp_toolchain.llvm_cpp_compiler.cpp_compiler
       linker = llvm_cpp_toolchain.llvm_cpp_linker.cpp_linker
 
-      lib_path_var = self.platform.resolve_platform_specific({
-        'darwin': lambda: 'DYLD_LIBRARY_PATH',
-        'linux': lambda: 'LD_LIBRARY_PATH',
-      })
-      runtime_libs_path = {lib_path_var: create_path_env_var(compiler.library_dirs)}
-      self._do_compile_link(
-        compiler, linker, 'hello.cpp', 'hello_clangpp',
-        "I C the world, ++ more!",
-        # Otherwise we get some header errors on Linux because clang++ will prefer the system
-        # headers if they are allowed, and we provide our own already in the LLVM subsystem (and
-        # pass them in through CPATH).
-        extra_compile_args=['-nostdinc++'],
-        # LLVM will prefer LLVM's libc++ on OSX, and seemingly requires it even if it does not use
-        # its own C++ library implementation, and uses libstdc++, which we provide in the linker's
-        # LIBRARY_PATH. See https://libcxx.llvm.org/ for more info.
-        extra_link_args=['-lc++'],
-        # We need to provide libc++ on the runtime library path as well on Linux (OSX will have it
-        # already).
-        extra_invocation_env=runtime_libs_path)
+      # lib_path_var = self.platform.resolve_platform_specific({
+      #   'darwin': lambda: 'DYLD_LIBRARY_PATH',
+      #   'linux': lambda: 'LD_LIBRARY_PATH',
+      # })
+      # runtime_libs_path = {lib_path_var: create_path_env_var(compiler.library_dirs)}
+      # Otherwise we get some header errors on Linux because clang++ will prefer the system
+      # headers if they are allowed, and we provide our own already in the LLVM subsystem (and
+      # pass them in through CPATH).
+      # extra_compile_args=['-nostdinc++'],
+      # # LLVM will prefer LLVM's libc++ on OSX, and seemingly requires it even if it does not use
+      # # its own C++ library implementation, and uses libstdc++, which we provide in the linker's
+      # # LIBRARY_PATH. See https://libcxx.llvm.org/ for more info.
+      # extra_link_args=['-lc++'],
+      # # We need to provide libc++ on the runtime library path as well on Linux (OSX will have it
+      # # already).
+      # extra_invocation_env=runtime_libs_path
+      self._do_compile_link(compiler, linker, 'hello.cpp', 'hello_clangpp', "I C the world, ++ more!")

--- a/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
+++ b/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
@@ -9,7 +9,6 @@ from builtins import next, str
 from textwrap import dedent
 
 from pants.backend.native.register import rules as native_backend_rules
-from pants.backend.python.register import rules as python_backend_rules
 from pants.backend.python.targets.python_distribution import PythonDistribution
 from pants.backend.python.tasks.build_local_python_distributions import \
   BuildLocalPythonDistributions
@@ -100,11 +99,7 @@ class TestBuildLocalPythonDistributions(PythonTaskTestBase, SchedulerTestBase):
     return list(self.target_dict.values())
 
   def _scheduling_context(self, **kwargs):
-    rules = (
-      native_backend_rules() +
-      python_backend_rules()
-    )
-    scheduler = self.mk_scheduler(rules=rules)
+    scheduler = self.mk_scheduler(rules=native_backend_rules())
     return self.context(scheduler=scheduler, **kwargs)
 
   def _retrieve_single_product_at_target_base(self, product_mapping, target):


### PR DESCRIPTION
### Problem

#5951 explains the problem addressed by moving CLI arguments to individual `Executable` objects -- this reduces greatly the difficulty in generating appropriate command lines for the executables invoked. In this PR, it can be seen to remove a significant amount of repeated boilerplate.

Additionally, we weren't distinguishing between a `Linker` to link the compiled object files of `gcc` or `g++` vs `clang` or `clang++`. We were attempting to generate a linker object which would work with *any of* `gcc`, `g++`, `clang`, or `clang++`, and this wasn't really feasible. Along with the above, this made it extremely difficult and error-prone to generate correct command lines / environments for executing the linker, which led to e.g. not being able to find `crti.o` (as one symptom addressed by this problem).

### Solution

- Introduce `CToolchain` and `CppToolchain` in `environment.py`, which can be generated from `LLVMCToolchain`, `LLVMCppToolchain`, `GCCCToolchain`, or `GCCCppToolchain`. These toolchain datatypes are created in `native_toolchain.py`, where a single `@rule` for each ensures that no C or C++ compiler that someone can request was made without an accompanying linker, which will be configured to work with the compiler.
- Introduce the `extra_args` property to the `Executable` mixin in `environment.py`, which `Executable` subclasses can just declare a datatype field named `extra_args` in order to override. This is used in `native_toolchain.py` to ensure platform-specific arguments and environment variables are set in the same `@rule` which produces a paired compiler and linker -- there is a single place to look at to see where all the process invocation environment variables and command-line arguments are set for a given toolchain.
- Introduce the `ArchiveFileMapper` subsystem and use it to declare sets of directories to resolve within our BinaryTool archives `GCC` and `LLVM`. This subsystem allows globbing (and checks that there is a unique expansion), which makes it robust to e.g. platform-specific paths to things like include or lib directories.

### Result

Removes several FIXMEs, including heavily-commented parts of `test_native_toolchain.py`. Partially addresses #5951 -- `setup_py.py` still generates its own execution environment from scratch, and this could be made more hygienic in the future. As noted in #6179 and #6205, this PR seems to immediately fix the CI failures in those PRs.