### PR TITLE
Python 3 issues - os.environ bytes vs unicode

### DIFF
--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -17,7 +17,7 @@ from builtins import object
 from contextlib import closing, contextmanager
 
 from colors import green
-from future.utils import string_types
+from future.utils import PY3, string_types
 
 from pants.util.dirutil import safe_delete
 from pants.util.tarutil import TarFile
@@ -50,7 +50,7 @@ def environment_as(**kwargs):
 
   def setenv(key, val):
     if val is not None:
-      os.environ[key] = _os_encode(val)
+      os.environ[key] = val if PY3 else _os_encode(val)
     else:
       if key in os.environ:
         del os.environ[key]
@@ -80,13 +80,13 @@ def _purge_env():
 
 def _restore_env(env):
   for k, v in env.items():
-    os.environ[k] = _os_encode(v)
+    os.environ[k] = v if PY3 else _os_encode(v)
 
 
 @contextmanager
 def hermetic_environment_as(**kwargs):
   """Set the environment to the supplied values from an empty state."""
-  old_environment = _copy_and_decode_env(os.environ)
+  old_environment = os.environ.copy() if PY3 else _copy_and_decode_env(os.environ)
   _purge_env()
   try:
     with environment_as(**kwargs):


### PR DESCRIPTION
### Problem
In Py2, `os.environ` expects either bytes or ASCII strings. So, to pass it unicode, you must encode into bytes and pass the bytes, which is why we have several helper functions.

In Py3, it expects unicode and will crash upon receiving bytes.

We didn't catch this because there is no backport for the `os` module, and this is the first time running `contextutil` with Py3.

### Solution
If Py2, keep existing conversion from unicode to bytes. If Py3, don't modify the passed in unicode.

### Testing
CI is only going to prove this doesn't break Py2. It has no guarantees Py3 will work.. I got the unit tests to work, but there may still be other issues I don't know how to detect because we can't yet run CI in Py3 (too many other issues that have to be resolved)