### PR TITLE
Python 3 fixes - specify binary vs unicode behavior of temporary_file() and stdio_as()

### DIFF
--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -11,6 +11,8 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from zipfile import ZIP_DEFLATED
 
+from future.utils import PY2
+
 from pants.util.contextutil import open_tar, open_zip, temporary_dir
 from pants.util.dirutil import is_executable, safe_concurrent_rename, safe_walk
 from pants.util.meta import AbstractClass
@@ -67,7 +69,17 @@ class TarArchiver(Archiver):
 
   def _extract(self, path_or_file, outdir, **kwargs):
     with open_tar(path_or_file, errorlevel=1, **kwargs) as tar:
-      tar.extractall(outdir)
+      if PY2:
+        # TarFile in Py2 grabs files as byte strings and doesn't store the encoding.
+        # Unicode will thus fail, as it tries to coerce it through Ascii.
+        # See https://superuser.com/questions/60379/how-can-i-create-a-zip-tgz-in-linux-such-that-windows-has-proper-filenames/190786#190786.
+        decoded_members = []
+        for m in tar.getmembers():
+          m.name = m.name.decode('utf-8')
+          decoded_members.append(m)
+        tar.extractall(outdir, members=decoded_members)
+      else:
+        tar.extractall(outdir)
 
   def __init__(self, mode, extension):
     """

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -11,8 +11,6 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from zipfile import ZIP_DEFLATED
 
-from future.utils import PY2
-
 from pants.util.contextutil import open_tar, open_zip, temporary_dir
 from pants.util.dirutil import is_executable, safe_concurrent_rename, safe_walk
 from pants.util.meta import AbstractClass
@@ -69,17 +67,7 @@ class TarArchiver(Archiver):
 
   def _extract(self, path_or_file, outdir, **kwargs):
     with open_tar(path_or_file, errorlevel=1, **kwargs) as tar:
-      if PY2:
-        # TarFile in Py2 grabs files as byte strings and doesn't store the encoding.
-        # Unicode will thus fail, as it tries to coerce it through Ascii.
-        # See https://superuser.com/questions/60379/how-can-i-create-a-zip-tgz-in-linux-such-that-windows-has-proper-filenames/190786#190786.
-        decoded_members = []
-        for m in tar.getmembers():
-          m.name = m.name.decode('utf-8')
-          decoded_members.append(m)
-        tar.extractall(outdir, members=decoded_members)
-      else:
-        tar.extractall(outdir)
+      tar.extractall(outdir)
 
   def __init__(self, mode, extension):
     """

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -123,7 +123,7 @@ def _stdio_stream_as(src_fd, dst_fd, dst_sys_attribute, mode):
 
 
 @contextmanager
-def stdio_as(stdout_fd, stderr_fd, stdin_fd, binary_mode=False):
+def stdio_as(stdout_fd, stderr_fd, stdin_fd):
   """Redirect sys.{stdout, stderr, stdin} to alternate file descriptors.
 
   As a special case, if a given destination fd is `-1`, we will replace it with an open file handle
@@ -133,13 +133,12 @@ def stdio_as(stdout_fd, stderr_fd, stdin_fd, binary_mode=False):
   possible that the OS has repurposed fds `0, 1, 2` to represent other files or sockets. It's
   impossible for this method to locate all python objects which refer to those fds, so it's up
   to the caller to guarantee that `0, 1, 2` are safe to replace.
+
+  In Python3, the streams expect unicode. To write and read bytes, access their buffer, e.g. `stdin.buffer.read()`.
   """
-  # Python3 streams default to unicode, and access bytes by calling stream.buffer
-  read_mode = 'r' if not binary_mode else 'rb'
-  write_mode = 'w' if not binary_mode else 'wb'
-  with _stdio_stream_as(stdin_fd,  0, 'stdin',  read_mode),\
-       _stdio_stream_as(stdout_fd, 1, 'stdout', write_mode),\
-       _stdio_stream_as(stderr_fd, 2, 'stderr', write_mode):
+  with _stdio_stream_as(stdin_fd,  0, 'stdin',  'r'),\
+       _stdio_stream_as(stdout_fd, 1, 'stdout', 'w'),\
+       _stdio_stream_as(stderr_fd, 2, 'stderr', 'w'):
     yield
 
 

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -158,7 +158,7 @@ def signal_handler_as(sig, handler):
 
 
 @contextmanager
-def temporary_dir(root_dir=None, cleanup=True, suffix='', permissions=None, prefix=tempfile.template):
+def temporary_dir(root_dir=None, cleanup=True, suffix=b'', permissions=None, prefix=tempfile.template):
   """
     A with-context that creates a temporary directory.
 

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -223,9 +223,9 @@ class ContextutilTest(unittest.TestCase):
     stdout_data = u('stdout')
     stderr_data = u('stderr')
 
-    with temporary_file() as tmp_stdin,\
-         temporary_file() as tmp_stdout,\
-         temporary_file() as tmp_stderr:
+    with temporary_file(binary_mode=False) as tmp_stdin,\
+         temporary_file(binary_mode=False) as tmp_stdout,\
+         temporary_file(binary_mode=False) as tmp_stderr:
       print(stdin_data, file=tmp_stdin)
       tmp_stdin.seek(0)
       # Read prepared content from stdin, and write content to stdout/stderr.
@@ -274,7 +274,7 @@ class ContextutilTest(unittest.TestCase):
       # Read/write from/to `/dev/null`, which will be validated by the harness as not
       # affecting the tempfiles.
       with stdio_as(stdout_fd=-1, stderr_fd=-1, stdin_fd=-1):
-        self.assertEquals(b'', sys.stdin.read())
+        self.assertEquals('', sys.stdin.read())
         print('garbage', file=sys.stdout)
         print('garbage', file=sys.stderr)
 


### PR DESCRIPTION
## Problem
Python 2 allows us to freely mix bytes and unicode with IO. Python 3 forces us to choose between bytes vs unicode.

This led to failing unit tests for `contextutil`.

## Solution
Our code base has mixed use of `stdio_as()` and `temporary_file()`. In some instances, we write unicode and it clearly seems to be a good case for text. In others, like downloads, bytes make sense.

Hence, I think the best approach is to enable turning on or off binary mode, with a default given. 

The defaults should emulate Python 3's native implementation (principle of least surprise), as discussed below.

### temporary_file()
In both Py2 and Py3, `tempfile` defaults to `w+b`, as it does not presume what you are writing to the file ([docs](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryFile)). E.g. with our contrib code for downloads, bytes makes sense.

So, I kept the default to bytes.

### stdio_as()
In Py3, `stdin`, `stderr`, and `stdout` are unicode streams, meaning `stdin.write(b'hi')` will fail. If you want to access bytes, you use buffer, e.g. `stdin.buffer.write(b'hi')` ([docs](https://docs.python.org/3/library/sys.html#sys.stderr)). 

So, I changed `stdio_as()` to default to writing unicode with the option to write in binary mode.

## Incremental port
This change shouldn't break anything in Python 2, because it allows for intermixing string types. That's great, because it means that we can incrementally choose whether something should be text vs bytes. 