### PR TITLE
Python 3 fixes - fix various TestBase issues

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -140,6 +140,7 @@ python_library(
   name='rules',
   sources=['rules.py'],
   dependencies=[
+    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':selectors',
     'src/python/pants/base:specs',

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -70,7 +70,7 @@ def _make_rule(output_type, input_selectors, for_goal=None):
 
     def resolve_type(name):
       resolved = caller_frame.f_globals.get(name) or caller_frame.f_builtins.get(name)
-      if not isinstance(resolved, (TypeType, Exactly)):
+      if not isinstance(resolved, (type, Exactly)):
         # TODO: should this say "...or Exactly instance;"?
         raise ValueError('Expected either a `type` constructor or TypeConstraint instance; '
                          'got: {}'.format(name))

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -9,9 +9,8 @@ import inspect
 import logging
 from abc import abstractproperty
 from collections import OrderedDict
-from types import TypeType
 
-import six
+from future.utils import PY2
 from twitter.common.collections import OrderedSet
 
 from pants.engine.selectors import Get, type_or_constraint_repr
@@ -39,7 +38,9 @@ class GoalProduct(object):
   @staticmethod
   def _synthesize_goal_product(name):
     product_type_name = '{}GoalExecution'.format(name.capitalize())
-    return type(six.binary_type(product_type_name), (datatype(['result']),), {})
+    if PY2:
+      product_type_name = product_type_name.encode('utf-8')
+    return type(product_type_name, (datatype(['result']),), {})
 
   @classmethod
   def for_name(cls, name):

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -8,6 +8,7 @@ import ast
 import inspect
 import logging
 from abc import abstractproperty
+from builtins import bytes, str
 from collections import OrderedDict
 
 from future.utils import PY2
@@ -44,8 +45,9 @@ class GoalProduct(object):
 
   @classmethod
   def for_name(cls, name):
-    assert isinstance(name, six.string_types)
-    name = six.text_type(name)
+    assert isinstance(name, (bytes, str))
+    if name is bytes:
+      name = name.decode('utf-8')
     if name not in cls.PRODUCT_MAP:
       cls.PRODUCT_MAP[name] = cls._synthesize_goal_product(name)
     return cls.PRODUCT_MAP[name]

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -72,7 +72,7 @@ class NailgunExecutor(Executor, FingerprintedProcessManager):
   FINGERPRINT_CMD_KEY = b'-Dpants.nailgun.fingerprint'
   _PANTS_NG_ARG_PREFIX = b'-Dpants.buildroot'
   _PANTS_OWNER_ARG_PREFIX = b'-Dpants.nailgun.owner'
-  _PANTS_NG_BUILDROOT_ARG = '='.join((_PANTS_NG_ARG_PREFIX, get_buildroot()))
+  _PANTS_NG_BUILDROOT_ARG = b'='.join((_PANTS_NG_ARG_PREFIX, get_buildroot().encode('utf-8')))
 
   _NAILGUN_SPAWN_LOCK = threading.Lock()
   _SELECT_WAIT = 1

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -100,6 +100,9 @@ def datatype(field_decls, superclass_name=None, **kwargs):
     def __ne__(self, other):
       return not (self == other)
 
+    def __hash__(self):
+      return super(DataType, self).__hash__()
+
     # NB: As datatype is not iterable, we need to override both __iter__ and all of the
     # namedtuple methods that expect self to be iterable.
     def __iter__(self):

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -9,6 +9,8 @@ from abc import abstractmethod
 from builtins import map, object, zip
 from collections import OrderedDict, namedtuple
 
+from future.utils import PY2
+
 from pants.util.memo import memoized
 from pants.util.meta import AbstractClass
 
@@ -332,7 +334,9 @@ class Collection(object):
   @memoized
   def of(cls, *element_types):
     union = '|'.join(element_type.__name__ for element_type in element_types)
-    type_name = b'{}.of({})'.format(cls.__name__, union)
+    type_name = '{}.of({})'.format(cls.__name__, union)
+    if PY2:
+      type_name = type_name.encode('utf-8')
     # TODO: could we allow type checking in the datatype() invocation here?
     supertypes = (cls, datatype(['dependencies'], superclass_name='Collection'))
     properties = {'element_types': element_types}

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -9,6 +9,6 @@ import pkgutil
 from packaging.version import Version
 
 
-VERSION = pkgutil.get_data(__name__, 'VERSION').strip()
+VERSION = pkgutil.get_data(__name__, 'VERSION').strip().decode('utf-8')
 
 PANTS_SEMVER = Version(VERSION)


### PR DESCRIPTION
Running any test suite that extends `TestBase` will fail due to ~5 different problems.

To reproduce, add `compatibility='CPython>=3.5',` to `pants_test/util/BUILD` entry of `meta`, then run
```
./pants test tests/python/pants_test/util:meta
```