### PR TITLE
Python 3 fixes - use unicode with temporary_directory() file path

### DIFF
--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -70,16 +70,8 @@ class TarArchiver(Archiver):
   def _extract(self, path_or_file, outdir, **kwargs):
     with open_tar(path_or_file, errorlevel=1, **kwargs) as tar:
       if PY2:
-        # TarFile in Py2 grabs files as byte strings and doesn't store the encoding.
-        # Unicode will thus fail, as it tries to coerce it through Ascii.
-        # See https://superuser.com/questions/60379/how-can-i-create-a-zip-tgz-in-linux-such-that-windows-has-proper-filenames/190786#190786.
-        decoded_members = []
-        for m in tar.getmembers():
-          m.name = m.name.decode('utf-8')
-          decoded_members.append(m)
-        tar.extractall(outdir, members=decoded_members)
-      else:
-        tar.extractall(outdir)
+        outdir = outdir.encode('utf-8')
+      tar.extractall(outdir)
 
   def __init__(self, mode, extension):
     """

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -11,6 +11,8 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from zipfile import ZIP_DEFLATED
 
+from future.utils import PY2
+
 from pants.util.contextutil import open_tar, open_zip, temporary_dir
 from pants.util.dirutil import is_executable, safe_concurrent_rename, safe_walk
 from pants.util.meta import AbstractClass
@@ -67,7 +69,17 @@ class TarArchiver(Archiver):
 
   def _extract(self, path_or_file, outdir, **kwargs):
     with open_tar(path_or_file, errorlevel=1, **kwargs) as tar:
-      tar.extractall(outdir)
+      if PY2:
+        # TarFile in Py2 grabs files as byte strings and doesn't store the encoding.
+        # Unicode will thus fail, as it tries to coerce it through Ascii.
+        # See https://superuser.com/questions/60379/how-can-i-create-a-zip-tgz-in-linux-such-that-windows-has-proper-filenames/190786#190786.
+        decoded_members = []
+        for m in tar.getmembers():
+          m.name = m.name.decode('utf-8')
+          decoded_members.append(m)
+        tar.extractall(outdir, members=decoded_members)
+      else:
+        tar.extractall(outdir)
 
   def __init__(self, mode, extension):
     """

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -155,7 +155,7 @@ def signal_handler_as(sig, handler):
 
 
 @contextmanager
-def temporary_dir(root_dir=None, cleanup=True, suffix=b'', permissions=None, prefix=tempfile.template):
+def temporary_dir(root_dir=None, cleanup=True, suffix='', permissions=None, prefix=tempfile.template):
   """
     A with-context that creates a temporary directory.
 


### PR DESCRIPTION
For `temporary_directory()`, we were using a mix of bytes and unicode in the arguments, which fails in Py3 because it does not allow mixing the two.

The arguments could be either, but unicode makes more sense and requires less changes in our codebase. This changes the return type to be a `str`, not `bytes`, which impacted the TarFile logic.