### PR TITLE
[WIP] Add --interpreter-compatibility option to repl goal

### DIFF
--- a/src/python/pants/backend/python/tasks/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks/python_execution_task_base.py
@@ -111,9 +111,8 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
           # Add the extra requirements first, so they take precedence over any colliding version
           # in the target set's dependency closure.
           pexes = [extra_requirements_pex] + pexes
-        constraints = {constraint for rt in relevant_targets if is_python_target(rt)
-                       for constraint in rt.compatibility}
-
+        constraints = pex_info.interpreter_constraints
+        print(constraints)
         with self.merged_pex(path, pex_info, interpreter, pexes, constraints) as builder:
           for extra_file in self.extra_files():
             extra_file.add_to(builder)

--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -114,9 +114,9 @@ class ResolveRequirementsTaskBase(Task):
 
     with safe_concurrent_creation(path) as safe_path:
       builder = PEXBuilder(safe_path, interpreter, pex_info=pex_info)
-      if interpeter_constraints:
-        for constraint in interpeter_constraints:
-          builder.add_interpreter_constraint(constraint)
+      # if interpeter_constraints:
+      #   for constraint in interpeter_constraints:
+      #     builder.add_interpreter_constraint(constraint)
       yield builder
 
   @classmethod

--- a/testprojects/src/python/interpreter_selection/repl_testing/BUILD
+++ b/testprojects/src/python/interpreter_selection/repl_testing/BUILD
@@ -1,0 +1,59 @@
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# This BUILD file is intended to be an example of python 3 compatible targets and
+# to serve as a set of test cases for interpreter selection based on different targets.
+# To successfully build and run this binary target, the user will need to define a 
+# .pexrc file in /etx/pexrc, ~/.pexrc, or in a .pexrc in the pants root dir. The pexrc 
+# will need to contain a PEX_PYTHON_PATH variable containing an absolute path to a 
+# python 3 interpreter.
+#
+# An example of a PEX_PYTHON_PATH variable in a pexrc:
+# 	PEX_PYTHON_PATH=/path/to/python2.7:/path/to/python3.6
+#
+# Note that the basename of the python binaries specified must either be 'python' or 
+# 'pythonX.Y'. Specifing only major version (i.e. python3) will be ignored by Pants 
+# interpreter filtration.
+# 
+
+python_binary(
+  name='main_py3',
+  source='main_py3.py',
+  compatibility=['CPython>3'],
+  dependencies=[
+    ':lib_py3'
+  ]
+)
+
+python_library(
+  name='lib_py3',
+  sources=['lib_py3.py'],
+  compatibility=['CPython>3']
+)
+
+python_binary(
+  name='main_py2',
+  source='main_py2.py',
+  compatibility=['CPython>2.7.6,<3'],
+  dependencies=[
+    ':lib_py2'
+  ]
+)
+
+python_library(
+  name='lib_py2',
+  sources=['lib_py2.py'],
+  compatibility=['CPython>2.7.6,<3']
+)
+
+python_binary(
+  name='main_py23',
+  source='main_py23.py',
+  compatibility=['CPython>2.7.6,<4']
+)
+
+python_library(
+  name='lib_py23',
+  sources=['lib_py23.py'],
+  compatibility=['CPython>=2.7,<4']
+)

--- a/testprojects/src/python/interpreter_selection/repl_testing/lib_py2.py
+++ b/testprojects/src/python/interpreter_selection/repl_testing/lib_py2.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+
+# A simple example to include in a python 2 binary target
+
+def say_something():
+  print('I am a python 2 library method.')
+  # Note that ascii exists as a built-in in Python 3 and
+  # does not exist in Python 2.
+  try:
+    ret = ascii
+  except NameError:
+    ret = None
+  assert ret is None
+  return ret

--- a/testprojects/src/python/interpreter_selection/repl_testing/lib_py23.py
+++ b/testprojects/src/python/interpreter_selection/repl_testing/lib_py23.py
@@ -1,0 +1,9 @@
+def say_something():
+  print('I am a python 2/3 library method.')
+  # Note that ascii exists as a built-in in Python 3 and
+  # does not exist in Python 2.
+  try:
+    ret = ascii
+  except NameError:
+    ret = None
+  return 'Python2' if ret is None else 'Python3'

--- a/testprojects/src/python/interpreter_selection/repl_testing/lib_py3.py
+++ b/testprojects/src/python/interpreter_selection/repl_testing/lib_py3.py
@@ -1,0 +1,9 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# A simple example to include in a python 3 binary target
+
+def say_something():
+  print('I am a python 3 library method.')
+  return ascii

--- a/testprojects/src/python/interpreter_selection/repl_testing/main_py2.py
+++ b/testprojects/src/python/interpreter_selection/repl_testing/main_py2.py
@@ -1,0 +1,23 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import sys
+
+from interpreter_selection.python_3_selection_testing.lib_py2 import say_something
+
+
+# A simple example to test building/running/testing a python 2 binary target
+
+
+def main():
+  v = sys.version_info
+  print(sys.executable)
+  print('%d.%d.%d' % v[0:3])
+  return say_something()
+
+if __name__ == '__main__':
+  main()

--- a/testprojects/src/python/interpreter_selection/repl_testing/main_py3.py
+++ b/testprojects/src/python/interpreter_selection/repl_testing/main_py3.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import sys
+
+from interpreter_selection.python_3_selection_testing.lib_py3 import say_something
+
+
+# A simple example to test building/running/testing a python 3 binary target
+
+
+def main():
+  v = sys.version_info
+  print(sys.executable)
+  print('%d.%d.%d' % v[0:3])
+  return say_something()
+
+if __name__ == '__main__':
+  main()

--- a/testprojects/src/python/interpreter_selection/repl_testing/test_py2.py
+++ b/testprojects/src/python/interpreter_selection/repl_testing/test_py2.py
@@ -1,0 +1,18 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import sys
+
+from interpreter_selection.python_3_selection_testing.main_py2 import main
+
+
+def test_main():
+  print(sys.executable)
+  # Note that ascii exists as a built-in in Python 3 and
+  # does not exist in Python 2
+  ret = main()
+  assert ret == None

--- a/testprojects/src/python/interpreter_selection/repl_testing/test_py3.py
+++ b/testprojects/src/python/interpreter_selection/repl_testing/test_py3.py
@@ -1,0 +1,15 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import sys
+
+from interpreter_selection.python_3_selection_testing.main_py3 import main
+
+
+def test_main():
+  print(sys.executable)
+  # Note that ascii exists as a built-in in Python 3 and
+  # does not exist in Python 2
+  ret = main()
+  assert ret == ascii


### PR DESCRIPTION
### Problem
As explained in #6081, currently there isn't a way to further constrain the python interpreter version selection when firing up a repl session.

### Solution
This PR includes the addition of a new option under the repl goal scope, and also the merging of the three ways of specifying interpreter version constraints (`pants.ini`, by-target, by options).