### PR TITLE
Fix spurious deprecation warning for fatal_warnings

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/zinc_language_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc_language_mixin.py
@@ -58,7 +58,7 @@ class ZincLanguageMixin(object):
     :rtype: list
     """
     option_sets = self.get_options().compiler_option_sets
-    if 'fatal_warnings' not in option_sets and self.fatal_warnings:
+    if 'fatal_warnings' not in option_sets and self.get_options().fatal_warnings:
       option_sets.append('fatal_warnings')
     return option_sets
 


### PR DESCRIPTION
### Problem

`zinc_language_mixin.py` accesses its own deprecated property to get the fatal_warnings option value, which triggers a guaranteed warning.

### Solution

Directly consume the fatal_warnings option value to avoid triggering the deprecation warning for the property access.