### PR TITLE
Add a debug dump flag to the zinc analysis extractor

### DIFF
--- a/src/scala/org/pantsbuild/zinc/extractor/BUILD
+++ b/src/scala/org/pantsbuild/zinc/extractor/BUILD
@@ -12,6 +12,7 @@ scala_library(
     '3rdparty/jvm/com/fasterxml/jackson/module:scala',
     '3rdparty/jvm/org/scala-lang/modules:scala-java8-compat',
     '3rdparty/jvm/org/scala-sbt:zinc',
+    '3rdparty:guava',
     'src/scala/org/pantsbuild/zinc/analysis',
     'src/scala/org/pantsbuild/zinc/options',
   ],

--- a/src/scala/org/pantsbuild/zinc/extractor/Extractor.scala
+++ b/src/scala/org/pantsbuild/zinc/extractor/Extractor.scala
@@ -9,21 +9,21 @@ import java.io.File
 
 import scala.collection.mutable
 
-import sbt.internal.inc.{Analysis, FileAnalysisStore, Locate}
+import sbt.internal.inc.{Analysis, Locate}
 
-import xsbti.compile.CompileAnalysis
+import xsbti.compile.AnalysisContents
 
 import org.pantsbuild.zinc.analysis.AnalysisMap
 
 /**
  * Class to encapsulate extracting information from zinc analysis.
  */
-class Extractor(
+case class Extractor(
   classpath: Seq[File],
-  analysis: CompileAnalysis,
+  analysis: AnalysisContents,
   analysisMap: AnalysisMap
 ) {
-  private val relations = analysis.asInstanceOf[Analysis].relations
+  private val relations = analysis.getAnalysis.asInstanceOf[Analysis].relations
 
   // A lookup from classname to defining classpath entry File.
   private val definesClass = Locate.entry(classpath, analysisMap.getPCELookup)

--- a/src/scala/org/pantsbuild/zinc/extractor/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/extractor/Settings.scala
@@ -15,6 +15,7 @@ import org.pantsbuild.zinc.analysis.AnalysisOptions
 case class Settings(
   help: Boolean             = false,
   summaryJson: Option[File] = None,
+  debugDump: Option[File]   = None,
   classpath: Seq[File]      = Seq(),
   analysis: AnalysisOptions = AnalysisOptions()
 )
@@ -26,6 +27,8 @@ object Settings extends OptionSet[Settings] {
     header("Output options:"),
     boolean(  ("-help", "-h"),                 "Print this usage message",
       (s: Settings) => s.copy(help = true)),
+    file(      "-debug-dump", "file",          "A destination file to write a human readable analysis dump to.",
+      (s: Settings, f: File) => s.copy(debugDump = Some(f))),
     file(      "-summary-json", "file",        "Output file to write an analysis summary to.",
       (s: Settings, f: File) => s.copy(summaryJson = Some(f))),
 


### PR DESCRIPTION
### Problem

Testing analysis portability externally to zinc is not straightforward, because individual fields not being made portable do not necessarily cause loud failures, or even actual failures to compile incrementally. 

This test confirms one type of portability: https://github.com/pantsbuild/pants/blob/master/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py#L167, but there are other forms that can cause silent failures. See #6239 for an example.

### Solution

Re-introduce the ability to dump analysis as text, to be used for integration tests that confirm that no references to previous workspaces are included.