### PR TITLE
Python 3 fixes - fix tarutil and contextutil_test

### DIFF
--- a/src/python/pants/util/tarutil.py
+++ b/src/python/pants/util/tarutil.py
@@ -7,10 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import tarfile
 from builtins import str
 
-from future.utils import implements_iterator
 
-
-@implements_iterator
 class TarFile(tarfile.TarFile):
 
   def __next__(self):
@@ -79,3 +76,5 @@ class TarFile(tarfile.TarFile):
       self._loaded = True
 
     return tarinfo
+
+  next = __next__  # Still needed for Py3 because stdlib using next() instead of __next__().

--- a/src/python/pants/util/tarutil.py
+++ b/src/python/pants/util/tarutil.py
@@ -10,8 +10,11 @@ from builtins import str
 
 class TarFile(tarfile.TarFile):
 
-  def __next__(self):
+  def next(self):
     """A copy and modification of the next() method in tarfile module.
+
+    Note: this function should stay named next(), not __next__(), to reflect CPython.
+    See https://github.com/python/cpython/blob/master/Lib/tarfile.py#L2255.
 
     The copy is from tarfile.py of CPython @102457:95df96aa2f5a
 
@@ -76,5 +79,3 @@ class TarFile(tarfile.TarFile):
       self._loaded = True
 
     return tarinfo
-
-  next = __next__  # Still needed for Py3 because stdlib using next() instead of __next__().

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -35,7 +35,7 @@ class ContextutilTest(unittest.TestCase):
       pass
 
   def test_override_single_variable(self):
-    with temporary_file() as output:
+    with temporary_file(binary_mode=False) as output:
       # test that the override takes place
       with environment_as(HORK='BORK'):
         subprocess.Popen([sys.executable, '-c', 'import os; print(os.environ["HORK"])'],
@@ -44,14 +44,14 @@ class ContextutilTest(unittest.TestCase):
         self.assertEquals('BORK\n', output.read())
 
       # test that the variable is cleared
-      with temporary_file() as new_output:
+      with temporary_file(binary_mode=False) as new_output:
         subprocess.Popen([sys.executable, '-c', 'import os; print("HORK" in os.environ)'],
                          stdout=new_output).wait()
         new_output.seek(0)
         self.assertEquals('False\n', new_output.read())
 
   def test_environment_negation(self):
-    with temporary_file() as output:
+    with temporary_file(binary_mode=False) as output:
       with environment_as(HORK='BORK'):
         with environment_as(HORK=None):
           # test that the variable is cleared

--- a/tests/python/pants_test/util/test_tarutil.py
+++ b/tests/python/pants_test/util/test_tarutil.py
@@ -30,11 +30,12 @@ class TarutilTest(unittest.TestCase):
     safe_rmtree(self.basedir)
 
   def inject_corruption(self):
-    with open(self.file_tar, 'r+w') as fp:
+    with open(self.file_tar, 'r+b') as fp:
       content = fp.read()
       fp.seek(0)
       # Replace 8 bytes of good data with garbage.
-      fp.write(content[:512+148] + 'aaaaaaaa' + content[512+156:])
+      fp.write(content[:512+148] + b'aaaaaaaa' + content[512+156:])
+      fp.truncate()
 
   def extract_tar(self, path, **kwargs):
     with TarFile.open(self.file_tar, mode='r', **kwargs) as tar:


### PR DESCRIPTION
Spoke too soon when saying util was all ported.

Tarutil was failing due to a quirk in Py3's implementation of `__next__`. Usually, iterators in Py3 implement `__next__` and in Py2 implement `next()`. For some reason, Tarutil does not have the dunder `__next__` and uses the legacy `next()`. So, we were failing to use our override of this function.

_Now_ util passes 100% on Python 2 and 3!