### PR TITLE
Python 3 fixes - exclude faulthandler and futures if Py3

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -6,9 +6,9 @@ contextlib2==0.5.5
 coverage>=4.5,<4.6
 docutils>=0.12,<0.13
 fasteners==0.14.1
-faulthandler==2.6
+faulthandler==2.6 ; python_version<'3'
 future==0.16.0
-futures==3.0.5
+futures==3.0.5 ; python_version<'3'
 Markdown==2.1.1
 mock==2.0.0
 packaging==16.8

--- a/pants.ini
+++ b/pants.ini
@@ -369,7 +369,11 @@ verify_commit: False
 interpreter_constraints: ["CPython>=2.7,<3"]
 interpreter_cache_dir: %(pants_bootstrapdir)s/python_cache/interpreters
 resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
-resolver_blacklist: {'subprocess32': 'CPython >= 3'}
+resolver_blacklist: {
+    'subprocess32': 'CPython >= 3',
+    'faulthandler': 'CPython >= 3',
+    'futures': 'CPython >= 3',
+  }
 
 
 [test.pytest]


### PR DESCRIPTION
Both these libraries are not supported in Py3, as they are backports.
