### PR TITLE
Python 3 fixes - fix invalid ABCMeta comparison

### DIFF
--- a/src/python/pants/engine/parser.py
+++ b/src/python/pants/engine/parser.py
@@ -24,7 +24,7 @@ class SymbolTable(AbstractClass):
   def constraint(self):
     """Returns the typeconstraint for the symbol table"""
     # NB Sort types so that multiple calls get the same tuples.
-    symbol_table_types = sorted(set(self.table().values()), key=hash)
+    symbol_table_types = sorted(set(self.table().values()), key=repr)
     return Exactly(*symbol_table_types, description='symbol table types')
 
 

--- a/src/python/pants/engine/parser.py
+++ b/src/python/pants/engine/parser.py
@@ -24,7 +24,7 @@ class SymbolTable(AbstractClass):
   def constraint(self):
     """Returns the typeconstraint for the symbol table"""
     # NB Sort types so that multiple calls get the same tuples.
-    symbol_table_types = sorted(set(self.table().values()))
+    symbol_table_types = sorted(set(self.table().values()), key=hash)
     return Exactly(*symbol_table_types, description='symbol table types')
 
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -107,7 +107,7 @@ class Scheduler(object):
 
     # Validate and register all provided and intrinsic tasks.
     rule_index = RuleIndex.create(list(rules))
-    self._root_subject_types = sorted(rule_index.roots, key=hash)
+    self._root_subject_types = sorted(rule_index.roots, key=repr)
 
     # Create the native Scheduler and Session.
     # TODO: This `_tasks` reference could be a local variable, since it is not used
@@ -155,7 +155,7 @@ class Scheduler(object):
       self._assert_ruleset_valid()
 
   def _root_type_ids(self):
-    return self._to_ids_buf(sorted(self._root_subject_types, key=hash))
+    return self._to_ids_buf(sorted(self._root_subject_types, key=repr))
 
   def graph_trace(self, execution_request):
     with temporary_file_path() as path:

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -107,7 +107,7 @@ class Scheduler(object):
 
     # Validate and register all provided and intrinsic tasks.
     rule_index = RuleIndex.create(list(rules))
-    self._root_subject_types = sorted(rule_index.roots)
+    self._root_subject_types = sorted(rule_index.roots, key=hash)
 
     # Create the native Scheduler and Session.
     # TODO: This `_tasks` reference could be a local variable, since it is not used
@@ -155,7 +155,7 @@ class Scheduler(object):
       self._assert_ruleset_valid()
 
   def _root_type_ids(self):
-    return self._to_ids_buf(sorted(self._root_subject_types))
+    return self._to_ids_buf(sorted(self._root_subject_types, key=hash))
 
   def graph_trace(self, execution_request):
     with temporary_file_path() as path:


### PR DESCRIPTION
Calls to `sorted()` would fail in Py3 with some of the engine code, because Py3 doesn't allow relational comparisons for objects that don't implement `__lt__`, unlike Py2. It was complaining `ABCMeta < ABCMeta` is an invalid comparison.

Solution is to set the key as hash function. I believe this is how Py2 was doing this implicitly.

cc @mateor - much better solution than what we discussed IRL.