### PR TITLE
Python 3 fixes - test root unicode vs bytes

### DIFF
--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -14,6 +14,8 @@ from contextlib import contextmanager
 from tempfile import mkdtemp
 from textwrap import dedent
 
+from future.utils import PY2
+
 from pants.base.build_file import BuildFile
 from pants.base.build_root import BuildRoot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
@@ -303,11 +305,13 @@ class BaseTest(unittest.TestCase):
       # If task is expected to inherit goal-level options, register those directly on the task,
       # by subclassing the goal options registrar and settings its scope to the task scope.
       if issubclass(task_type, GoalOptionsMixin):
-        subclass_name = b'test_{}_{}_{}'.format(
+        subclass_name = 'test_{}_{}_{}'.format(
           task_type.__name__, task_type.goal_options_registrar_cls.options_scope,
           task_type.options_scope)
+        if PY2:
+          subclass_name = subclass_name.encode('utf-8')
         optionables.add(type(subclass_name, (task_type.goal_options_registrar_cls, ),
-                             {b'options_scope': task_type.options_scope}))
+                             {'options_scope': task_type.options_scope}))
 
     # Now expand to all deps.
     all_optionables = set()

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -274,7 +274,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
       env['PANTS_PROFILE'] = prof
       # Make a note the subprocess command, so the user can correctly interpret the profile files.
       with open('{}.cmd'.format(prof), 'w') as fp:
-        fp.write(b' '.join(pants_command))
+        fp.write(' '.join(pants_command))
 
     return pants_command, subprocess.Popen(pants_command, env=env, stdin=subprocess.PIPE,
       stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)

--- a/tests/python/pants_test/task_test_base.py
+++ b/tests/python/pants_test/task_test_base.py
@@ -9,6 +9,8 @@ import os
 from contextlib import closing, contextmanager
 from io import BytesIO
 
+from future.utils import PY2
+
 from pants.goal.goal import Goal
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.task.console_task import ConsoleTask
@@ -103,7 +105,9 @@ class TaskTestBase(TestBase):
     :param options_scope: The scope to give options on the generated task type.
     :return: A pair (type, options_scope)
     """
-    subclass_name = b'test_{0}_{1}'.format(task_type.__name__, options_scope)
+    subclass_name = 'test_{0}_{1}'.format(task_type.__name__, options_scope)
+    if PY2:
+      subclass_name = subclass_name.encode('utf-8')
     return type(subclass_name, (task_type,), {'_stable_name': task_type._compute_stable_name(),
                                               'options_scope': options_scope})
 

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -142,7 +142,7 @@ class TestBase(unittest.TestCase):
     relative_symlink(src, dst)
     self._invalidate_for(reldst)
 
-  def create_file(self, relpath, contents='', mode='wb'):
+  def create_file(self, relpath, contents=b'', mode='wb'):
     """Writes to a file under the buildroot.
 
     :API: public
@@ -168,7 +168,7 @@ class TestBase(unittest.TestCase):
     for f in files:
       self.create_file(os.path.join(path, f), contents=f)
 
-  def create_workdir_file(self, relpath, contents='', mode='wb'):
+  def create_workdir_file(self, relpath, contents=b'', mode='wb'):
     """Writes to a file under the work directory.
 
     :API: public

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -14,6 +14,8 @@ from contextlib import contextmanager
 from tempfile import mkdtemp
 from textwrap import dedent
 
+from future.utils import PY2
+
 from pants.base.build_root import BuildRoot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.exceptions import TaskError
@@ -439,11 +441,13 @@ class TestBase(unittest.TestCase):
       # If task is expected to inherit goal-level options, register those directly on the task,
       # by subclassing the goal options registrar and settings its scope to the task scope.
       if issubclass(task_type, GoalOptionsMixin):
-        subclass_name = b'test_{}_{}_{}'.format(
+        subclass_name = 'test_{}_{}_{}'.format(
           task_type.__name__, task_type.goal_options_registrar_cls.options_scope,
           task_type.options_scope)
+        if PY2:
+          subclass_name = subclass_name.encode('utf-8')
         optionables.add(type(subclass_name, (task_type.goal_options_registrar_cls, ),
-                             {b'options_scope': task_type.options_scope}))
+                             {'options_scope': task_type.options_scope}))
 
     # Now expand to all deps.
     all_optionables = set()


### PR DESCRIPTION
We have to decide if we want `create_file()` to still default to bytes instead of unicode. 

It has API public, so I think it's not really open to discussion, right?

If it's open to discussion, we may want to go back to defaulting to unicode, as most use cases seem to use unicode and this would correspond to the default way of opening files. 

Otherwise not a big deal, and the below fixes the default call to `create_file()` from breaking.