### PR TITLE
Python 3 fixes - bump beautifulsoup4 to 4.6 

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,5 +1,5 @@
 ansicolors==1.0.2
-beautifulsoup4>=4.3.2,<4.4
+beautifulsoup4>=4.6.0,<4.7
 cffi==1.11.1
 configparser==3.5.0
 contextlib2==0.5.5

--- a/pants-plugins/3rdparty/python/requirements.txt
+++ b/pants-plugins/3rdparty/python/requirements.txt
@@ -1,1 +1,1 @@
-beautifulsoup4>=4.3.2,<4.4
+beautifulsoup4>=4.6.0,<4.7


### PR DESCRIPTION
## Problem
Beautifulsoup4 version 4.3 doesn't run on Python 3.5+, due to a change made to the standard library.  

See https://stackoverflow.com/questions/28745153/importing-bs4-in-python-3-5.

## Solution
Bumping from 4.3 to 4.6, the newest version. We can technically get away with 4.4 if we want to reduce the scope of bump, although the [changelog](https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/NEWS.txt) looks fairly innocuous.

## Testing
Ran below in Py2 and Py3 mode (by changing BUILD's compatibility). Py3 still fails due to issues I'll address in another PR, but it no longer gives the beautifulsoup problem.
```
./pants run src/python/pants/releases:packages -- list
./pants run src/python/pants/releases:packages -- list-owners
./pants run src/python/pants/releases:packages -- check-my-ownership
```