### PR TITLE
Python 3 fixes - fix unicode and __hash__ issues with release folder

### DIFF
--- a/src/python/pants/releases/packages.py
+++ b/src/python/pants/releases/packages.py
@@ -38,6 +38,9 @@ class Package(object):
   def __eq__(self, other):
     return self.name == other.name
 
+  def __hash__(self):
+    return super(Package, self).__hash__()
+
   def __str__(self):
     return self.name
 
@@ -79,7 +82,9 @@ core_packages = {
 
 
 def contrib_packages():
-  output = subprocess.check_output(('bash', '-c', 'source contrib/release_packages.sh ; for pkg in "${CONTRIB_PACKAGES[@]}"; do echo "${!pkg}"; done'))
+  output = subprocess.check_output(
+    ('bash', '-c', 'source contrib/release_packages.sh ; for pkg in "${CONTRIB_PACKAGES[@]}"; do echo "${!pkg}"; done')
+  ).decode('utf-8')
   return set(Package(name) for name in output.strip().split('\n'))
 
 


### PR DESCRIPTION
Tested with
```
./pants run src/python/pants/releases:packages -- list
./pants run src/python/pants/releases:packages -- list-owners
./pants run src/python/pants/releases:packages -- check-my-ownership
```

Requires https://github.com/pantsbuild/pants/pull/6260 to work with Py3, although they can be merged independently because we only support 2.7 at the moment.