### PR TITLE
Python 3 fixes - fix test_base.create_files() unicode issue

### DIFF
--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -168,7 +168,7 @@ class TestBase(unittest.TestCase):
      files: List of file names.
     """
     for f in files:
-      self.create_file(os.path.join(path, f), contents=f)
+      self.create_file(os.path.join(path, f), contents=f, mode='w')
 
   def create_workdir_file(self, relpath, contents=b'', mode='wb'):
     """Writes to a file under the work directory.


### PR DESCRIPTION
Same thing happened while testing docgen - found an issue with an unrelated folder so breaking this out into separate PR. Let me know if these are too small and I should just combine with the PR for where I found the issue, e.g. https://github.com/pantsbuild/pants/pull/6265