### PR TITLE
Add a `--loop` flag, to allow for running continuously

### DIFF
--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -171,8 +171,8 @@ class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'goal_ma
   def warm_product_graph(self, target_roots):
     """Warm the scheduler's `ProductGraph` with `TransitiveHydratedTargets` products.
 
-    This method raises only fatal errors, and does not cosider failed roots: in the v1 codepath,
-    failed roots are accounted for post-fork.
+    This method raises only fatal errors, and does not consider failed roots in the execution
+    graph: in the v1 codepath, failed roots are accounted for post-fork.
 
     :param TargetRoots target_roots: The targets root of the request.
     """

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -168,20 +168,20 @@ class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'goal_ma
     """
     return target_roots.specs or []
 
-  def _execute(self, *args, **kwargs):
-    request = self.scheduler_session.execution_request(*args, **kwargs)
-    result = self.scheduler_session.execute(request)
-    if result.error:
-      raise result.error
-
   def warm_product_graph(self, target_roots):
     """Warm the scheduler's `ProductGraph` with `TransitiveHydratedTargets` products.
+
+    This method raises only fatal errors, and does not cosider failed roots: in the v1 codepath,
+    failed roots are accounted for post-fork.
 
     :param TargetRoots target_roots: The targets root of the request.
     """
     logger.debug('warming target_roots for: %r', target_roots)
     subjects = self._determine_subjects(target_roots)
-    self._execute([TransitiveHydratedTargets], subjects)
+    request = self.scheduler_session.execution_request([TransitiveHydratedTargets], subjects)
+    result = self.scheduler_session.execute(request)
+    if result.error:
+      raise result.error
 
   def validate_goals(self, goals):
     """Checks for @console_rules that satisfy requested goals.
@@ -195,6 +195,8 @@ class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'goal_ma
   def run_console_rules(self, goals, target_roots):
     """Runs @console_rules sequentially and interactively by requesting their implicit Goal products.
 
+    For retryable failures, raises scheduler.ExecutionError.
+
     :param list goals: The list of requested goal names as passed on the commandline.
     :param TargetRoots target_roots: The targets root of the request.
     """
@@ -204,7 +206,7 @@ class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'goal_ma
     for goal in goals:
       goal_product = self.goal_map[goal]
       logger.debug('requesting {} to satisfy execution of `{}` goal'.format(goal_product, goal))
-      self._execute([goal_product], subjects)
+      self.scheduler_session.product_request(goal_product, subjects)
 
   def create_build_graph(self, target_roots, build_root=None):
     """Construct and return a `BuildGraph` given a set of input specs.

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -118,6 +118,8 @@ class OptionsInitializer(object):
     # Parse and register options.
     options = cls._construct_options(options_bootstrapper, build_configuration)
 
+    GlobalOptionsRegistrar.validate_instance(options.for_global_scope())
+
     if init_subsystems:
       Subsystem.set_options(options)
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -125,6 +125,12 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('-q', '--quiet', type=bool, recursive=True, daemon=False,
              help='Squelches most console output. NOTE: Some tasks default to behaving quietly: '
                   'inverting this option supports making them noisier than they would be otherwise.')
+
+    register('--loop', type=bool, daemon=True,
+             help='Run continuously as file changes are detected.')
+    register('--loop-max', type=int, default=2**32, daemon=True, advanced=True,
+             help='The maximum number of times to loop.')
+
     # Not really needed in bootstrap options, but putting it here means it displays right
     # after -l and -q in help output, which is conveniently contextual.
     register('--colors', type=bool, default=sys.stdout.isatty(), recursive=True, daemon=False,

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -182,6 +182,7 @@ class SchedulerService(PantsService):
       return session, self._prefork_body(session, options)
 
   def _prefork_loop(self, session, options):
+    # TODO: See https://github.com/pantsbuild/pants/issues/6288 regarding Ctrl+C handling.
     iterations = options.for_global_scope().loop_max
     target_roots = None
     while iterations and not self.is_killed:

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import os
 import queue
+import sys
 import threading
 from builtins import open
 
@@ -184,7 +185,11 @@ class SchedulerService(PantsService):
     iterations = options.for_global_scope().loop_max
     target_roots = None
     while iterations and not self.is_killed:
-      target_roots = self._prefork_body(session, options)
+      try:
+        target_roots = self._prefork_body(session, options)
+      except session.scheduler_session.execution_error_type as e:
+        # Render retryable exceptions raised by the Scheduler.
+        print(e, file=sys.stderr)
 
       iterations -= 1
       while iterations and not self.is_killed and not self._loop_condition.wait(timeout=1):

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -69,7 +69,7 @@ python_tests(
   name = 'console_rule_integration',
   sources = [ 'test_console_rule_integration.py' ],
   dependencies = [
-    'tests/python/pants_test:int-test',
+    'tests/python/pants_test/pantsd:pantsd_integration_test_base',
   ],
   tags = {'integration'},
   timeout = 300,

--- a/tests/python/pants_test/engine/legacy/test_console_rule_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_console_rule_integration.py
@@ -4,10 +4,17 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
+import os
+import time
+
+from pants.base.build_environment import get_buildroot
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import fast_relpath, safe_file_dump
+from pants_test.pants_run_integration_test import ensure_daemon
+from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 
 
-class TestConsoleRuleIntegration(PantsRunIntegrationTest):
+class TestConsoleRuleIntegration(PantsDaemonIntegrationTestBase):
 
   # TODO: Running this command a second time with the daemon will result in no output because
   # of product caching. See #6146.
@@ -49,3 +56,46 @@ class TestConsoleRuleIntegration(PantsRunIntegrationTest):
       ':',
       success=True
     )
+
+  def test_v2_list_loop(self):
+    # Create a BUILD file in a nested temporary directory, and add additional targets to it.
+    with self.pantsd_test_context() as (workdir, config, checker), \
+        temporary_dir(root_dir=get_buildroot()) as tmpdir:
+      rel_tmpdir = fast_relpath(tmpdir, get_buildroot())
+
+      def dump(content):
+        safe_file_dump(os.path.join(tmpdir, 'BUILD'), content)
+
+      # Dump an initial target before starting the loop.
+      dump('target(name="one")')
+
+      # Launch the loop as a background process.
+      handle = self.run_pants_with_workdir_without_waiting(
+        [
+          '--no-v1',
+          '--v2',
+          '--loop',
+          '--loop-max=3',
+          'list',
+          '{}:'.format(tmpdir),
+        ],
+        workdir,
+        config,
+      )
+
+      # Wait for the loop to stabilize.
+      time.sleep(10)
+      checker.assert_started()
+
+      # Replace the BUILD file content twice.
+      dump('target(name="two")')
+      time.sleep(5)
+      dump('target(name="three")')
+
+      # Verify that the three different target states were listed, and that the process exited.
+      pants_result = handle.join()
+      self.assert_success(pants_result)
+      self.assertEquals(
+          ['{}:{}'.format(rel_tmpdir, name) for name in ('one', 'two', 'three')],
+          list(pants_result.stdout_data.splitlines())
+        )

--- a/tests/python/pants_test/engine/legacy/test_console_rule_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_console_rule_integration.py
@@ -10,7 +10,7 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensur
 class TestConsoleRuleIntegration(PantsRunIntegrationTest):
 
   # TODO: Running this command a second time with the daemon will result in no output because
-  # of product caching.
+  # of product caching. See #6146.
   @ensure_daemon
   def test_v2_list(self):
     result = self.do_command(

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -12,6 +12,7 @@ from textwrap import dedent
 from pants.build_graph.address import Address
 from pants.engine.nodes import Return
 from pants.engine.rules import RootRule, TaskRule, rule
+from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Get, Select
 from pants.util.contextutil import temporary_dir
 from pants.util.objects import datatype
@@ -111,10 +112,10 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
     scheduler = self.scheduler(rules, include_trace_on_error=False)
 
-    with self.assertRaises(Exception) as cm:
+    with self.assertRaises(ExecutionError) as cm:
       list(scheduler.product_request(A, subjects=[(B())]))
 
-    self.assert_equal_with_printing('An exception for B', str(cm.exception))
+    self.assert_equal_with_printing('1 Exception encountered:\n  Exception: An exception for B', str(cm.exception))
 
   def test_no_include_trace_error_multiple_paths_raises_executionerror(self):
     rules = [
@@ -124,11 +125,11 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
     scheduler = self.scheduler(rules, include_trace_on_error=False)
 
-    with self.assertRaises(Exception) as cm:
+    with self.assertRaises(ExecutionError) as cm:
       list(scheduler.product_request(A, subjects=[B(), B()]))
 
     self.assert_equal_with_printing(dedent('''
-      Multiple exceptions encountered:
+      2 Exceptions encountered:
         Exception: An exception for B
         Exception: An exception for B''').lstrip(),
       str(cm.exception))
@@ -140,11 +141,11 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     ]
 
     scheduler = self.scheduler(rules, include_trace_on_error=True)
-    with self.assertRaises(Exception) as cm:
+    with self.assertRaises(ExecutionError) as cm:
       list(scheduler.product_request(A, subjects=[(B())]))
 
     self.assert_equal_with_printing(dedent('''
-      Received unexpected Throw state(s):
+      1 Exception encountered:
       Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
         Computing Task(nested_raise, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
           Throw(An exception for B)
@@ -169,11 +170,11 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     ]
 
     scheduler = self.scheduler(rules, include_trace_on_error=True)
-    with self.assertRaises(Exception) as cm:
+    with self.assertRaises(ExecutionError) as cm:
       list(scheduler.product_request(A, subjects=[(B())]))
 
     self.assert_equal_with_printing(dedent('''
-      Received unexpected Throw state(s):
+      1 Exception encountered:
       Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
         Computing Task(A, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
           Computing Task(nested_raise, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =D)

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -8,13 +8,22 @@ import unittest
 
 from pants.base.exceptions import BuildConfigurationError
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
+from pants.option.errors import OptionsError
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
 
 class OptionsInitializerTest(unittest.TestCase):
   def test_invalid_version(self):
     options_bootstrapper = OptionsBootstrapper(args=['--pants-version=99.99.9999'])
-    build_config = BuildConfigInitializer(options_bootstrapper)
+    build_config = BuildConfigInitializer.get(options_bootstrapper)
 
     with self.assertRaises(BuildConfigurationError):
       OptionsInitializer.create(options_bootstrapper, build_config)
+
+  def test_global_options_validation(self):
+    # Specify an invalid combination of options.
+    ob = OptionsBootstrapper(args=['--loop', '--v1'])
+    build_config = BuildConfigInitializer.get(ob)
+    with self.assertRaises(OptionsError) as exc:
+      OptionsInitializer.create(ob, build_config)
+    self.assertIn('loop option only works with', exc.exception.message)

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -67,10 +67,11 @@ python_library(
   name = 'pantsd_integration_test_base',
   sources = ['pantsd_integration_test_base.py'],
   dependencies = [
+    '3rdparty/python:ansicolors',
     'src/python/pants/pantsd:process_manager',
     'src/python/pants/util:collections',
+    'tests/python/pants_test/testutils:process_test_util',
     'tests/python/pants_test:int-test',
-    '3rdparty/python:ansicolors'
   ],
 )
 

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(
+target(
   name = 'test_deps',
   dependencies = [
     '3rdparty/python:mock',
@@ -63,16 +63,25 @@ python_tests(
   ]
 )
 
+python_library(
+  name = 'pantsd_integration_test_base',
+  sources = ['pantsd_integration_test_base.py'],
+  dependencies = [
+    'src/python/pants/pantsd:process_manager',
+    'src/python/pants/util:collections',
+    'tests/python/pants_test:int-test',
+    '3rdparty/python:ansicolors'
+  ],
+)
+
 python_tests(
   name = 'pantsd_integration',
   sources = ['test_pantsd_integration.py'],
   dependencies = [
+    ':pantsd_integration_test_base',
     '3rdparty/python:futures',
-    'src/python/pants/pantsd:process_manager',
-    'src/python/pants/util:collections',
     'tests/python/pants_test:int-test',
     'tests/python/pants_test/testutils:process_test_util',
-    '3rdparty/python:ansicolors'
   ],
   tags = {'integration'},
   timeout = 900

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -1,0 +1,153 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import functools
+import os
+import time
+from builtins import open
+from contextlib import contextmanager
+
+from colors import bold, cyan, magenta
+
+from pants.pantsd.process_manager import ProcessManager
+from pants.util.collections import recursively_update
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.testutils.process_test_util import no_lingering_process_by_command
+
+
+def banner(s):
+  print(cyan('=' * 63))
+  print(cyan('- {} {}'.format(s, '-' * (60 - len(s)))))
+  print(cyan('=' * 63))
+
+
+def read_pantsd_log(workdir):
+  # Surface the pantsd log for easy viewing via pytest's `-s` (don't capture stdio) option.
+  with open('{}/pantsd/pantsd.log'.format(workdir), 'r') as f:
+    for line in f:
+      yield line.strip()
+
+
+def full_pantsd_log(workdir):
+  return '\n'.join(read_pantsd_log(workdir))
+
+
+class PantsDaemonMonitor(ProcessManager):
+  def __init__(self, metadata_base_dir=None):
+    super(PantsDaemonMonitor, self).__init__(name='pantsd', metadata_base_dir=metadata_base_dir)
+
+  def _log(self):
+    print(magenta(
+      'PantsDaemonMonitor: pid is {} is_alive={}'.format(self._pid, self.is_alive()))
+    )
+
+  def assert_started(self, timeout=.1):
+    self._process = None
+    self._pid = self.await_pid(timeout)
+    self.assert_running()
+    return self._pid
+
+  def assert_running(self):
+    self._log()
+    assert self._pid is not None and self.is_alive(), 'pantsd should be running!'
+    return self._pid
+
+  def assert_stopped(self):
+    self._log()
+    assert self._pid is not None, 'cant assert stoppage on an unknown pid!'
+    assert self.is_dead(), 'pantsd should be stopped!'
+    return self._pid
+
+
+class PantsDaemonIntegrationTestBase(PantsRunIntegrationTest):
+  @contextmanager
+  def pantsd_test_context(self, log_level='info', extra_config=None, expected_runs=1):
+    with no_lingering_process_by_command('pantsd-runner'):
+      with self.temporary_workdir() as workdir_base:
+        pid_dir = os.path.join(workdir_base, '.pids')
+        workdir = os.path.join(workdir_base, '.workdir.pants.d')
+        print('\npantsd log is {}/pantsd/pantsd.log'.format(workdir))
+        pantsd_config = {
+          'GLOBAL': {
+            'enable_pantsd': True,
+            # The absolute paths in CI can exceed the UNIX socket path limitation
+            # (>104-108 characters), so we override that here with a shorter path.
+            'watchman_socket_path': '/tmp/watchman.{}.sock'.format(os.getpid()),
+            'level': log_level,
+            'pants_subprocessdir': pid_dir,
+          }
+        }
+        if extra_config:
+          recursively_update(pantsd_config, extra_config)
+        print('>>> config: \n{}\n'.format(pantsd_config))
+        checker = PantsDaemonMonitor(pid_dir)
+        self.assert_success_runner(workdir, pantsd_config, ['kill-pantsd'])
+        try:
+          yield workdir, pantsd_config, checker
+        finally:
+          banner('BEGIN pantsd.log')
+          for line in read_pantsd_log(workdir):
+            print(line)
+          banner('END pantsd.log')
+          self.assert_success_runner(
+            workdir,
+            pantsd_config,
+            ['kill-pantsd'],
+            expected_runs=expected_runs,
+          )
+          checker.assert_stopped()
+
+  @contextmanager
+  def pantsd_successful_run_context(self, log_level='info', extra_config=None, extra_env=None):
+    with self.pantsd_test_context(log_level, extra_config) as (workdir, pantsd_config, checker):
+      yield (
+        functools.partial(
+          self.assert_success_runner,
+          workdir,
+          pantsd_config,
+          extra_env=extra_env,
+        ),
+        checker,
+        workdir,
+        pantsd_config,
+      )
+
+  def _run_count(self, workdir):
+    run_tracker_dir = os.path.join(workdir, 'run-tracker')
+    if os.path.isdir(run_tracker_dir):
+      return len([f for f in os.listdir(run_tracker_dir) if f != 'latest'])
+    else:
+      return 0
+
+  def assert_success_runner(self, workdir, config, cmd, extra_config={}, extra_env={}, expected_runs=1):
+    combined_config = config.copy()
+    recursively_update(combined_config, extra_config)
+    print(bold(cyan('\nrunning: ./pants {} (config={}) (extra_env={})'
+                    .format(' '.join(cmd), combined_config, extra_env))))
+    run_count = self._run_count(workdir)
+    start_time = time.time()
+    run = self.run_pants_with_workdir(
+      cmd,
+      workdir,
+      combined_config,
+      extra_env=extra_env,
+      # TODO: With this uncommented, `test_pantsd_run` fails.
+      # tee_output=True
+    )
+    elapsed = time.time() - start_time
+    print(bold(cyan('\ncompleted in {} seconds'.format(elapsed))))
+
+    runs_created = self._run_count(workdir) - run_count
+    self.assertEqual(
+        runs_created,
+        expected_runs,
+        'Expected {} RunTracker run to be created per pantsd run: was {}'.format(
+          expected_runs,
+          runs_created,
+        )
+    )
+    self.assert_success(run)
+    return run

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import functools
 import itertools
 import os
 import signal
@@ -12,60 +11,13 @@ import threading
 import time
 from builtins import open, range, zip
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
 
-from colors import bold, cyan, magenta
-
-from pants.pantsd.process_manager import ProcessManager
-from pants.util.collections import recursively_update
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, touch
-from pants_test.pants_run_integration_test import PantsResult, PantsRunIntegrationTest
+from pants_test.pants_run_integration_test import PantsResult
+from pants_test.pantsd.pantsd_integration_test_base import (PantsDaemonIntegrationTestBase,
+                                                            full_pantsd_log, read_pantsd_log)
 from pants_test.testutils.process_test_util import no_lingering_process_by_command
-
-
-class PantsDaemonMonitor(ProcessManager):
-  def __init__(self, metadata_base_dir=None):
-    super(PantsDaemonMonitor, self).__init__(name='pantsd', metadata_base_dir=metadata_base_dir)
-
-  def _log(self):
-    print(magenta(
-      'PantsDaemonMonitor: pid is {} is_alive={}'.format(self._pid, self.is_alive()))
-    )
-
-  def assert_started(self, timeout=.1):
-    self._process = None
-    self._pid = self.await_pid(timeout)
-    self.assert_running()
-    return self._pid
-
-  def assert_running(self):
-    self._log()
-    assert self._pid is not None and self.is_alive(), 'pantsd should be running!'
-    return self._pid
-
-  def assert_stopped(self):
-    self._log()
-    assert self._pid is not None, 'cant assert stoppage on an unknown pid!'
-    assert self.is_dead(), 'pantsd should be stopped!'
-    return self._pid
-
-
-def banner(s):
-  print(cyan('=' * 63))
-  print(cyan('- {} {}'.format(s, '-' * (60 - len(s)))))
-  print(cyan('=' * 63))
-
-
-def read_pantsd_log(workdir):
-  # Surface the pantsd log for easy viewing via pytest's `-s` (don't capture stdio) option.
-  with open('{}/pantsd/pantsd.log'.format(workdir), 'r') as f:
-    for line in f:
-      yield line.strip()
-
-
-def full_pantsd_log(workdir):
-  return '\n'.join(read_pantsd_log(workdir))
 
 
 def launch_file_toucher(f):
@@ -87,95 +39,7 @@ def launch_file_toucher(f):
   return join
 
 
-class TestPantsDaemonIntegration(PantsRunIntegrationTest):
-  @contextmanager
-  def pantsd_test_context(self, log_level='info', extra_config=None, expected_runs=1):
-    with no_lingering_process_by_command('pantsd-runner'):
-      with self.temporary_workdir() as workdir_base:
-        pid_dir = os.path.join(workdir_base, '.pids')
-        workdir = os.path.join(workdir_base, '.workdir.pants.d')
-        print('\npantsd log is {}/pantsd/pantsd.log'.format(workdir))
-        pantsd_config = {
-          'GLOBAL': {
-            'enable_pantsd': True,
-            # The absolute paths in CI can exceed the UNIX socket path limitation
-            # (>104-108 characters), so we override that here with a shorter path.
-            'watchman_socket_path': '/tmp/watchman.{}.sock'.format(os.getpid()),
-            'level': log_level,
-            'pants_subprocessdir': pid_dir,
-          }
-        }
-        if extra_config:
-          recursively_update(pantsd_config, extra_config)
-        print('>>> config: \n{}\n'.format(pantsd_config))
-        checker = PantsDaemonMonitor(pid_dir)
-        self.assert_success_runner(workdir, pantsd_config, ['kill-pantsd'])
-        try:
-          yield workdir, pantsd_config, checker
-        finally:
-          banner('BEGIN pantsd.log')
-          for line in read_pantsd_log(workdir):
-            print(line)
-          banner('END pantsd.log')
-          self.assert_success_runner(
-            workdir,
-            pantsd_config,
-            ['kill-pantsd'],
-            expected_runs=expected_runs,
-          )
-          checker.assert_stopped()
-
-  @contextmanager
-  def pantsd_successful_run_context(self, log_level='info', extra_config=None, extra_env=None):
-    with self.pantsd_test_context(log_level, extra_config) as (workdir, pantsd_config, checker):
-      yield (
-        functools.partial(
-          self.assert_success_runner,
-          workdir,
-          pantsd_config,
-          extra_env=extra_env,
-        ),
-        checker,
-        workdir,
-        pantsd_config,
-      )
-
-  def _run_count(self, workdir):
-    run_tracker_dir = os.path.join(workdir, 'run-tracker')
-    if os.path.isdir(run_tracker_dir):
-      return len([f for f in os.listdir(run_tracker_dir) if f != 'latest'])
-    else:
-      return 0
-
-  def assert_success_runner(self, workdir, config, cmd, extra_config={}, extra_env={}, expected_runs=1):
-    combined_config = config.copy()
-    recursively_update(combined_config, extra_config)
-    print(bold(cyan('\nrunning: ./pants {} (config={}) (extra_env={})'
-                    .format(' '.join(cmd), combined_config, extra_env))))
-    run_count = self._run_count(workdir)
-    start_time = time.time()
-    run = self.run_pants_with_workdir(
-      cmd,
-      workdir,
-      combined_config,
-      extra_env=extra_env,
-      # TODO: With this uncommented, `test_pantsd_run` fails.
-      # tee_output=True
-    )
-    elapsed = time.time() - start_time
-    print(bold(cyan('\ncompleted in {} seconds'.format(elapsed))))
-
-    runs_created = self._run_count(workdir) - run_count
-    self.assertEqual(
-        runs_created,
-        expected_runs,
-        'Expected {} RunTracker run to be created per pantsd run: was {}'.format(
-          expected_runs,
-          runs_created,
-        )
-    )
-    self.assert_success(run)
-    return run
+class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
 
   def test_pantsd_compile(self):
     with self.pantsd_successful_run_context('debug') as (pantsd_run, checker, _, _):


### PR DESCRIPTION
### Problem

The ability to run a command continuously as files change has been a long-standing feature request, and something which is implemented in competing tools. It is very useful for low-latency compiler and test feedback.

### Solution

Builds atop @kwlzn 's work in #6088 and adds a `--loop` flag which re-runs all `@console_rule`s whenever input files have changed.

Adds a covering integration test (and refactors the pantsd test harness a bit to do so). 

### Result

```
./pants --enable-pantsd --v2 --no-v1 --loop list ${dir}::
```
... will continuously list the contents of a directory when files under the directory are invalidated.