### PR TITLE
Python 3 fixes - fix contrib folders problems

### DIFF
--- a/contrib/avro/tests/python/pants_test/contrib/avro/tasks/test_avro_gen.py
+++ b/contrib/avro/tests/python/pants_test/contrib/avro/tasks/test_avro_gen.py
@@ -58,7 +58,7 @@ class AvroJavaGenTest(NailgunTaskTestBase):
       )
     '''))
 
-    self.create_file(relpath='avro-build/src/avro/schema.avsc', contents=dedent('''
+    self.create_file(relpath='avro-build/src/avro/schema.avsc', mode='w', contents=dedent('''
       {
         "namespace": "",
         "type": "record",
@@ -70,7 +70,7 @@ class AvroJavaGenTest(NailgunTaskTestBase):
       }
     '''))
 
-    self.create_file(relpath='avro-build/src/avro/record.avdl', contents=dedent('''
+    self.create_file(relpath='avro-build/src/avro/record.avdl', mode='w', contents=dedent('''
       protocol Test {
         void test();
       }

--- a/contrib/confluence/src/python/pants/contrib/confluence/util/confluence_util.py
+++ b/contrib/confluence/src/python/pants/contrib/confluence/util/confluence_util.py
@@ -9,6 +9,9 @@ import logging
 import mimetypes
 from builtins import object, str
 from os.path import basename
+from xmlrpc.client import Binary
+from xmlrpc.client import Error as XMLRPCError
+from xmlrpc.client import ServerProxy
 
 from future.moves.urllib.parse import quote_plus
 
@@ -21,10 +24,6 @@ log = logging.getLogger(__name__)
 
 """Code to ease publishing text to Confluence wikis."""
 
-try:
-  from xmlrpc.client import ServerProxy, Error as XMLRPCError, Binary
-except ImportError:
-  from xmlrpclib import ServerProxy, Error as XMLRPCError, Binary
 
 mimetypes.init()
 

--- a/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/test_findbugs_integration.py
+++ b/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/test_findbugs_integration.py
@@ -79,7 +79,7 @@ class FindBugsTest(PantsRunIntegrationTest):
 
   def test_exclude(self):
     cmd = ['compile', 'contrib/findbugs/tests/java/org/pantsbuild/contrib/findbugs::']
-    with temporary_file(root_dir=get_buildroot()) as exclude_file:
+    with temporary_file(root_dir=get_buildroot(), binary_mode=False) as exclude_file:
       exclude_file.write(dedent("""\
         <?xml version="1.0" encoding="UTF-8"?>
         <FindBugsFilter>
@@ -102,7 +102,7 @@ class FindBugsTest(PantsRunIntegrationTest):
 
   def test_error(self):
     cmd = ['compile', 'contrib/findbugs/tests/java/org/pantsbuild/contrib/findbugs:high']
-    with temporary_file(root_dir=get_buildroot()) as exclude_file:
+    with temporary_file(root_dir=get_buildroot(), binary_mode=False) as exclude_file:
       exclude_file.write(dedent("""\
         <?xml version="1.0" encoding="UTF-8"?>
         <FindBugsFilter>

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_go_distribution.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_go_distribution.py
@@ -23,8 +23,8 @@ class GoDistributionTest(unittest.TestCase):
   def test_bootstrap(self):
     go_distribution = self.distribution()
     go_cmd = go_distribution.create_go_cmd(cmd='env', args=['GOROOT'])
-    output = go_cmd.check_output()
-    self.assertEqual(go_distribution.goroot, output.strip())
+    output = go_cmd.check_output().decode('utf-8').strip()
+    self.assertEqual(go_distribution.goroot, output)
 
   def assert_no_gopath(self):
     go_distribution = self.distribution()
@@ -39,7 +39,7 @@ class GoDistributionTest(unittest.TestCase):
     cmd = [os.path.join(go_distribution.goroot, 'bin', 'go'), 'env', 'GOPATH']
     env = os.environ.copy()
     env.update(go_env)
-    default_gopath = subprocess.check_output(cmd, env=env).strip()
+    default_gopath = subprocess.check_output(cmd, env=env).decode('utf-8').strip()
 
     go_cmd = go_distribution.create_go_cmd(cmd='env', args=['GOPATH'])
 
@@ -48,7 +48,7 @@ class GoDistributionTest(unittest.TestCase):
     self.assertEqual(['env', 'GOPATH'], go_cmd.cmdline[1:])
     self.assertRegexpMatches(str(go_cmd),
                              r'^GOROOT=[^ ]+ GOPATH={} .*/go env GOPATH'.format(default_gopath))
-    self.assertEqual(default_gopath, go_cmd.check_output().strip())
+    self.assertEqual(default_gopath, go_cmd.check_output().decode('utf-8').strip())
 
   def test_go_command_no_gopath(self):
     self.assert_no_gopath()

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_binary_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_binary_integration.py
@@ -19,4 +19,4 @@ class GoBinaryIntegrationTest(PantsRunIntegrationTest):
             'contrib/go/examples/src/go/hello']
     pants_run = self.run_pants(args, extra_env={"GOOS": "windows"})
     self.assert_success(pants_run)
-    self.assertIn("for MS Windows", subprocess.check_output(["file", output_file]))
+    self.assertIn(b"for MS Windows", subprocess.check_output(["file", output_file]))

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_buildgen.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_buildgen.py
@@ -93,7 +93,7 @@ class GoBuildgenTest(TaskTestBase):
       task.execute()
 
   def test_existing_targets_wrong_type(self):
-    self.create_file(relpath='src/go/src/fred/foo.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/fred/foo.go', mode='w', contents=dedent("""
       package main
 
       import "fmt"
@@ -109,7 +109,7 @@ class GoBuildgenTest(TaskTestBase):
     self.assertEqual(GoTargetGenerator.WrongLocalSourceTargetTypeError, type(exc.exception.cause))
 
   def test_noop_applicable_targets_simple(self):
-    self.create_file(relpath='src/go/src/fred/foo.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/fred/foo.go', mode='w', contents=dedent("""
       package main
 
       import "fmt"
@@ -125,13 +125,13 @@ class GoBuildgenTest(TaskTestBase):
     self.assertEqual(expected, context.targets())
 
   def test_noop_applicable_targets_complete_graph(self):
-    self.create_file(relpath='src/go/src/jane/bar.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/jane/bar.go', mode='w', contents=dedent("""
       package jane
 
       var PublicConstant = 42
     """))
     jane = self.make_target('src/go/src/jane', GoLibrary)
-    self.create_file(relpath='src/go/src/fred/foo.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/fred/foo.go', mode='w', contents=dedent("""
       package main
 
       import (
@@ -157,12 +157,12 @@ class GoBuildgenTest(TaskTestBase):
       # We need physical directories on disk for `--materialize` since it does scans.
       self.create_dir('src/go/src')
 
-    self.create_file(relpath='src/go/src/jane/bar.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/jane/bar.go', mode='w', contents=dedent("""
         package jane
 
         var PublicConstant = 42
       """))
-    self.create_file(relpath='src/go/src/fred/foo.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/fred/foo.go', mode='w', contents=dedent("""
         package main
 
         import (
@@ -218,14 +218,14 @@ class GoBuildgenTest(TaskTestBase):
       self.create_dir('3rdparty/go')
       self.create_dir('src/go/src')
 
-    self.create_file(relpath='src/go/src/jane/bar.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/jane/bar.go', mode='w', contents=dedent("""
         package jane
 
         import "pantsbuild.org/fake/prod"
 
         var PublicConstant = prod.DoesNotExistButWeShouldNotCareWhenCheckingDepsAndNotInstalling
       """))
-    self.create_file(relpath='src/go/src/fred/foo.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/fred/foo.go', mode='w', contents=dedent("""
         package main
 
         import (
@@ -318,7 +318,7 @@ class GoBuildgenTest(TaskTestBase):
     self.add_to_build_file(relpath='3rdparty/go/pantsbuild.org/fake',
                            target='go_remote_library(rev="v4.5.6")')
 
-    self.create_file(relpath='src/go/src/jane/bar.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/jane/bar.go', mode='w', contents=dedent("""
         package jane
 
         import "pantsbuild.org/fake"
@@ -339,12 +339,12 @@ class GoBuildgenTest(TaskTestBase):
   def test_issues_2616(self):
     self.set_options(remote=False)
 
-    self.create_file(relpath='src/go/src/jane/bar.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/jane/bar.go', mode='w', contents=dedent("""
         package jane
 
         var PublicConstant = 42
       """))
-    self.create_file(relpath='src/go/src/fred/foo.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/fred/foo.go', mode='w', contents=dedent("""
         package main
 
         /*
@@ -379,19 +379,19 @@ class GoBuildgenTest(TaskTestBase):
 
     self.set_options(remote=False, materialize=False)
 
-    self.create_file(relpath='src/go/src/helper/helper.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/helper/helper.go', mode='w', contents=dedent("""
         package helper
 
         const PublicConstant = 42
       """))
 
-    self.create_file(relpath='src/go/src/lib/lib.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/lib/lib.go', mode='w', contents=dedent("""
         package lib
 
         const privateConstant = 42
       """))
 
-    self.create_file(relpath='src/go/src/lib/lib_test.go', contents=dedent("""
+    self.create_file(relpath='src/go/src/lib/lib_test.go', mode='w', contents=dedent("""
         package lib_test
 
         import (

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
@@ -27,7 +27,7 @@ class GoFetchTest(TaskTestBase):
 
   def test_get_remote_import_paths(self):
     go_fetch = self.create_task(self.context())
-    self.create_file('src/github.com/u/a/a.go', contents="""
+    self.create_file('src/github.com/u/a/a.go', mode='w', contents="""
       package a
 
       import (
@@ -77,7 +77,7 @@ class GoFetchTest(TaskTestBase):
     """Creates a Go package inside dirpath named 'name' importing deps."""
     imports = ['import "localzip/{}"'.format(d) for d in deps]
     f = os.path.join(dirpath, '{name}/{name}.go'.format(name=name))
-    self.create_file(f, contents=
+    self.create_file(f, mode='w', contents=
       """package {name}
         {imports}
       """.format(name=name, imports='\n'.join(imports)))
@@ -192,7 +192,7 @@ class GoFetchTest(TaskTestBase):
 
   def test_issues_2616(self):
     go_fetch = self.create_task(self.context())
-    self.create_file('src/github.com/u/a/a.go', contents="""
+    self.create_file('src/github.com/u/a/a.go', mode='w', contents="""
       package a
 
       import (
@@ -203,7 +203,7 @@ class GoFetchTest(TaskTestBase):
         "bitbucket.org/u/b"
       )
     """)
-    self.create_file('src/github.com/u/a/b.go', contents="""
+    self.create_file('src/github.com/u/a/b.go', mode='w', contents="""
       package a
 
       /*

--- a/contrib/googlejavaformat/tests/python/pants_test/contrib/googlejavaformat/test_googlejavaformat.py
+++ b/contrib/googlejavaformat/tests/python/pants_test/contrib/googlejavaformat/test_googlejavaformat.py
@@ -53,6 +53,7 @@ class GoogleJavaFormatTests(TestBase):
   def test_googlejavaformat(self):
     javafile = self.create_file(
       relpath='src/java/org/pantsbuild/contrib/googlejavaformat/MyClass.java',
+      mode='w',
       contents=self._BADFORMAT)
     target = self.make_target(
       spec='src/java/org/pantsbuild/contrib/googlejavaformat',
@@ -75,6 +76,7 @@ class GoogleJavaFormatCheckFormatTests(TestBase):
   def test_lint_badformat(self):
     self.create_file(
       relpath='src/java/org/pantsbuild/contrib/googlejavaformat/MyClass.java',
+      mode='w',
       contents=self._BADFORMAT)
     target = self.make_target(
       spec='src/java/org/pantsbuild/contrib/googlejavaformat',
@@ -92,6 +94,7 @@ class GoogleJavaFormatCheckFormatTests(TestBase):
   def test_lint_goodformat(self):
     self.create_file(
       relpath='src/java/org/pantsbuild/contrib/googlejavaformat/MyClass.java',
+      mode='w',
       contents=self._GOODFORMAT)
     target = self.make_target(
       spec='src/java/org/pantsbuild/contrib/googlejavaformat',

--- a/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_node_distribution.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_node_distribution.py
@@ -21,12 +21,12 @@ class NodeDistributionTest(unittest.TestCase):
 
   def test_bootstrap(self):
     node_cmd = self.distribution.node_command(args=['--version'])
-    output = node_cmd.check_output()
-    self.assertEqual(self.distribution.version(), output.strip())
+    output = node_cmd.check_output().decode('utf-8').strip()
+    self.assertEqual(self.distribution.version(), output)
 
   def test_node(self):
     node_command = self.distribution.node_command(args=['--interactive'])  # Force a REPL session.
-    repl = node_command.run(stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    repl = node_command.run(stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
 
     out, err = repl.communicate('console.log("Hello World!")')
     self.assertEqual('', err)
@@ -42,7 +42,7 @@ class NodeDistributionTest(unittest.TestCase):
   def test_npm(self):
     npm_version_flag = self.distribution.get_package_manager('npm').run_command(
       args=['--version'])
-    raw_version = npm_version_flag.check_output().strip()
+    raw_version = npm_version_flag.check_output().decode('utf-8').strip()
 
     npm_version_cmd = self.distribution.get_package_manager('npm').run_command(
       args=['version', '--json'])
@@ -54,7 +54,7 @@ class NodeDistributionTest(unittest.TestCase):
   def test_yarnpkg(self):
     yarnpkg_version_command = self.distribution.get_package_manager('yarn').run_command(
       args=['--version'])
-    yarnpkg_version = yarnpkg_version_command.check_output().strip()
+    yarnpkg_version = yarnpkg_version_command.check_output().decode('utf-8').strip()
     yarnpkg_versions_command = self.distribution.get_package_manager('yarn').run_command(
       args=['versions', '--json'])
     yarnpkg_versions = json.loads(yarnpkg_versions_command.check_output())
@@ -67,7 +67,7 @@ class NodeDistributionTest(unittest.TestCase):
 
     # Test the case in which we do not pass in env,
     # which should fall back to env=os.environ.copy()
-    injected_paths = node_path_cmd.check_output().strip().split(os.pathsep)
+    injected_paths = node_path_cmd.check_output().decode('utf-8').strip().split(os.pathsep)
     self.assertEqual(node_bin_path, injected_paths[0])
 
   def test_node_command_path_injection_with_overrided_path(self):
@@ -76,7 +76,7 @@ class NodeDistributionTest(unittest.TestCase):
     node_bin_path = self.distribution._install_node()
     injected_paths = node_path_cmd.check_output(
       env={'PATH': '/test/path'}
-    ).strip().split(os.pathsep)
+    ).decode('utf-8').strip().split(os.pathsep)
     self.assertEqual(node_bin_path, injected_paths[0])
     self.assertListEqual([node_bin_path, '/test/path'], injected_paths)
 
@@ -86,5 +86,5 @@ class NodeDistributionTest(unittest.TestCase):
     node_bin_path = self.distribution._install_node()
     injected_paths = node_path_cmd.check_output(
       env={'PATH': ''}
-    ).strip().split(os.pathsep)
+    ).decode('utf-8').strip().split(os.pathsep)
     self.assertListEqual([node_bin_path, ''], injected_paths)

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_build.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_build.py
@@ -102,6 +102,7 @@ class TestNodeBuild(TaskTestBase):
   def test_run_build_script(self):
     package_json_file = self.create_file(
       'src/node/build_test/package.json',
+      mode='w',
       contents=dedent("""
         {
           "scripts": {
@@ -131,7 +132,7 @@ class TestNodeBuild(TaskTestBase):
 
   def test_run_non_existing_script(self):
     package_json_file = self.create_file(
-      'src/node/build_test/package.json', contents='{}')
+      'src/node/build_test/package.json', mode='w', contents='{}')
     build_script = 'my_non_existing_build_scirpt'
     target = self.make_target(
       spec='src/node/build_test',
@@ -144,6 +145,7 @@ class TestNodeBuild(TaskTestBase):
   def test_run_no_output_dir(self):
     package_json_file = self.create_file(
       'src/node/build_test/package.json',
+      mode='w',
       contents=dedent("""
         {
           "scripts": {

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_bundle_integration.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_bundle_integration.py
@@ -136,7 +136,7 @@ class NodeBundleIntegrationTest(PantsRunIntegrationTest):
   def _extract_archive(self, archive_path):
     with temporary_dir() as temp_dir:
       _, extension = os.path.splitext(archive_path)
-      print (extension)
+      print(extension)
       if extension == '.jar':
         extraction_archiver = create_archiver('zip')
       else:

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_lint_integration.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_lint_integration.py
@@ -20,7 +20,7 @@ class NodeLintIntegrationTest(PantsRunIntegrationTest):
     path = 'contrib/node/examples/src/node/javascriptstyle-empty/index.js'
     content = 'const console = require(\'console\');\nconsole.log("Double Quotes");\n'
 
-    with self.temporary_file_content(path, content):
+    with self.temporary_file_content(path, content, binary_mode=False):
       command = ['lint',
                  'contrib/node/examples/src/node/javascriptstyle-empty']
       pants_run = self.run_pants(command=command)
@@ -31,7 +31,7 @@ class NodeLintIntegrationTest(PantsRunIntegrationTest):
     path = 'contrib/node/examples/src/node/javascriptstyle-empty/not_ignored_index.js'
     content = 'const console = require(\'console\');\nconsole.log("Double Quotes");\n'
 
-    with self.temporary_file_content(path, content):
+    with self.temporary_file_content(path, content, binary_mode=False):
       command = ['lint',
                  'contrib/node/examples/src/node/javascriptstyle-empty']
       pants_run = self.run_pants(command=command)

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_repl_integration.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_repl_integration.py
@@ -57,7 +57,7 @@ class NodeReplIntegrationTest(PantsRunIntegrationTest):
         var calc = new Calculator(0);
         calc.add(1);
         console.log('React: ' + reactElem + ', Calc + 1: ' + calc.number);
-      """)
+      """).encode('utf-8')
     pants_run = self.run_pants(command=command, stdin_data=program)
 
     self.assert_success(pants_run)

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve.py
@@ -181,7 +181,7 @@ class NodeResolveTest(TaskTestBase):
     self.assertIn('type of bool is: boolean', lines)
 
   def test_resolve_preserves_package_json(self):
-    self.create_file('src/node/util/package.json', contents=dedent("""
+    self.create_file('src/node/util/package.json', mode='w', contents=dedent("""
       {
         "name": "util",
         "version": "0.0.1"
@@ -192,7 +192,7 @@ class NodeResolveTest(TaskTestBase):
                             sources=['package.json'],
                             dependencies=[])
 
-    self.create_file('src/node/scripts_project/package.json', contents=dedent("""
+    self.create_file('src/node/scripts_project/package.json', mode='w', contents=dedent("""
       {
         "name": "scripts_project",
         "version": "1.2.3",
@@ -239,18 +239,18 @@ class NodeResolveTest(TaskTestBase):
 
   def _test_resolve_optional_install_helper(
       self, install_optional, package_manager, expected_params):
-    self.create_file('src/node/util/package.json', contents=dedent("""
+    self.create_file('src/node/util/package.json', mode='w', contents=dedent("""
       {
         "name": "util",
         "version": "0.0.1"
       }
     """))
-    self.create_file('src/node/util/util.js', contents=dedent("""
+    self.create_file('src/node/util/util.js', mode='w', contents=dedent("""
       var typ = require('typ');
       console.log("type of boolean is: " + typ.BOOLEAN);
     """))
     # yarn execution path requires yarn.lock
-    self.create_file('src/node/util/yarn.lock', contents='')
+    self.create_file('src/node/util/yarn.lock')
     target = self.make_target(spec='src/node/util',
                               target_type=NodeModule,
                               sources=['util.js', 'package.json', 'yarn.lock'],

--- a/contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks/test_scalajs_repl_integration.py
+++ b/contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks/test_scalajs_repl_integration.py
@@ -22,7 +22,7 @@ class ScalaJSReplIntegrationTest(PantsRunIntegrationTest):
         var _ = require('factfinder');
         var tenFactorial = org.pantsbuild.scalajs.example.factfinder.Factfinder().fact(10);
         console.log(tenFactorial)
-      """)
+      """).encode('utf-8')
     pants_run = self.run_pants(command=command, stdin_data=program)
 
     self.assert_success(pants_run)

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -110,7 +110,7 @@ class ScroogeGenTest(NailgunTaskTestBase):
       }
     ''')
 
-    self.create_file(relpath='test_smoke/a.thrift', contents=contents)
+    self.create_file(relpath='test_smoke/a.thrift', mode='w', contents=contents)
     build_string = self._test_create_build_str(language, compiler_args)
     self.add_to_build_file('test_smoke', build_string)
 
@@ -171,6 +171,6 @@ class ScroogeGenTest(NailgunTaskTestBase):
 
   def _test_dependencies_help(self, contents, declares_service, declares_exception):
     source = 'test_smoke/a.thrift'
-    self.create_file(relpath=source, contents=contents)
+    self.create_file(relpath=source, mode='w', contents=contents)
     self.assertEquals(ScroogeGen._declares_service(source), declares_service)
     self.assertEquals(ScroogeGen._declares_exception(source), declares_exception)

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -152,7 +152,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
   class InvalidShardSpecification(TaskError):
     """Indicates an invalid `--test-shard` option."""
 
-  DEFAULT_COVERAGE_CONFIG = dedent(b"""
+  DEFAULT_COVERAGE_CONFIG = dedent("""
     [run]
     branch = True
     timid = False

--- a/src/python/pants/engine/legacy/parser.py
+++ b/src/python/pants/engine/legacy/parser.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import inspect
 import logging
 import os
 import tokenize
@@ -64,7 +65,7 @@ class LegacyPythonCallbacksParser(Parser):
       def __init__(self, parse_context, type_alias, object_type):
         self._parse_context = parse_context
         self._type_alias = type_alias
-        self._object_type = object_type
+        self._object_type = object_type if inspect.isclass(object_type) else type(object_type)
         self._serializable = Serializable.is_serializable_type(self._object_type)
 
       @memoized_property

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -175,7 +175,7 @@ class ZipArchiver(Archiver):
     with open_zip(path) as archive_file:
       for name in archive_file.namelist():
         # While we're at it, we also perform this safety test.
-        if name.startswith(b'/') or name.startswith(b'..'):
+        if name.startswith('/') or name.startswith('..'):
           raise ValueError('Zip file contains unsafe path: {}'.format(name))
         if (not filter_func or filter_func(name)):
           archive_file.extract(name, outdir)

--- a/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
@@ -74,7 +74,7 @@ class PythonTaskTestBase(InterpreterCacheTestMixin, TaskTestBase):
     if source_contents_map:
       self.create_file(relpath=os.path.join(relpath, '__init__.py'))
       for source, contents in source_contents_map.items():
-        self.create_file(relpath=os.path.join(relpath, source), contents=contents)
+        self.create_file(relpath=os.path.join(relpath, source), mode='w', contents=contents)
     return self.target(Address(relpath, name).spec)
 
   def create_python_binary(self, relpath, name, entry_point, dependencies=(), provides=None, shebang=None):

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -429,13 +429,14 @@ class PantsRunIntegrationTest(unittest.TestCase):
       os.rename(real_path, test_path)
 
   @contextmanager
-  def temporary_file_content(self, path, content):
+  def temporary_file_content(self, path, content, binary_mode=True):
     """Temporarily write content to a file for the purpose of an integration test."""
     path = os.path.realpath(path)
     assert path.startswith(
       os.path.realpath(get_buildroot())), 'cannot write paths outside of the buildroot!'
     assert not os.path.exists(path), 'refusing to overwrite an existing path!'
-    with open(path, 'wb') as fh:
+    mode = 'wb' if binary_mode else 'w'
+    with open(path, mode) as fh:
       fh.write(content)
     try:
       yield

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -219,7 +219,7 @@ class TestBase(unittest.TestCase):
     if make_missing_sources and 'sources' in kwargs:
       for source in kwargs['sources']:
         if '*' not in source:
-          self.create_file(os.path.join(address.spec_path, source), mode='a')
+          self.create_file(os.path.join(address.spec_path, source), mode='a', contents='')
       kwargs['sources'] = self.sources_for(kwargs['sources'], address.spec_path)
 
     target = target_type(name=address.target_name,


### PR DESCRIPTION
Most folders are still failing due to the Rust ImportError, but this fixes a lot of their issues.

I'll be submitting a separate PR for porting contrib/python, because it involves major changes resulting from changes in the AST grammar that are better reviewed independently from this.

## Questions
1. There are no tests for confluence. Is there a way to test for Py3 compatibility?
2. Node has several functions to interface directly with subprocess, e.g. `node/subsystems/command.py`. I didn't change any of the source code for node, but fixed the unit tests to deal with bytes vs unicode. Should I be changing instead the underlying implementation? There is already logic in some places around bytes vs unicode, so I figured it's safer to leave as intended. This means uses of node may break in Py3, and the responsibility will be on the library user to fix their use.