### PR TITLE
satisfy python_dist setup_requires with a pex to resolve transitive deps, and some other unrelated native toolchain changes

### DIFF
--- a/examples/src/python/example/python_distribution/hello/pants_setup_requires/BUILD
+++ b/examples/src/python/example/python_distribution/hello/pants_setup_requires/BUILD
@@ -1,0 +1,10 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_dist(
+  sources=globs('*.py'),
+  setup_requires=[
+    # FIXME: this currently fails because setup_requires doesn't fetch transitive deps!
+    'testprojects/pants-plugins/3rdparty/python/pants',
+  ],
+)

--- a/examples/src/python/example/python_distribution/hello/pants_setup_requires/BUILD
+++ b/examples/src/python/example/python_distribution/hello/pants_setup_requires/BUILD
@@ -1,10 +1,18 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+main_file = 'main.py'
+
 python_dist(
-  sources=globs('*.py'),
+  sources=rglobs('*.py', exclude=[main_file]),
   setup_requires=[
     # FIXME: this currently fails because setup_requires doesn't fetch transitive deps!
     'testprojects/pants-plugins/3rdparty/python/pants',
   ],
+)
+
+python_binary(
+  name='bin',
+  sources=[main_file],
+  dependencies=[':pants_setup_requires'],
 )

--- a/examples/src/python/example/python_distribution/hello/pants_setup_requires/BUILD
+++ b/examples/src/python/example/python_distribution/hello/pants_setup_requires/BUILD
@@ -10,6 +10,8 @@ python_dist(
   ],
 )
 
+# TODO: add another python_binary() with compatibility=['CPython>=3.5'] once pants is released using
+# python 3.
 python_binary(
   name='bin',
   sources=[main_file],

--- a/examples/src/python/example/python_distribution/hello/pants_setup_requires/BUILD
+++ b/examples/src/python/example/python_distribution/hello/pants_setup_requires/BUILD
@@ -6,7 +6,6 @@ main_file = 'main.py'
 python_dist(
   sources=rglobs('*.py', exclude=[main_file]),
   setup_requires=[
-    # FIXME: this currently fails because setup_requires doesn't fetch transitive deps!
     'testprojects/pants-plugins/3rdparty/python/pants',
   ],
 )

--- a/examples/src/python/example/python_distribution/hello/pants_setup_requires/main.py
+++ b/examples/src/python/example/python_distribution/hello/pants_setup_requires/main.py
@@ -4,13 +4,10 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from setuptools import setup, find_packages
+import pkg_resources
 
-from pants.version import VERSION as pants_version
 
-setup(
-  name='hello_again',
-  # FIXME: test the wheel version in a unit test!
-  version=pants_version,
-  packages=find_packages(),
-)
+hello_module_version = pkg_resources.get_distribution('hello_again').version
+
+if __name__ == '__main__':
+  print(hello_module_version)

--- a/examples/src/python/example/python_distribution/hello/pants_setup_requires/setup.py
+++ b/examples/src/python/example/python_distribution/hello/pants_setup_requires/setup.py
@@ -10,7 +10,6 @@ from pants.version import VERSION as pants_version
 
 setup(
   name='hello_again',
-  # FIXME: test the wheel version in a unit test!
   version=pants_version,
   packages=find_packages(),
 )

--- a/examples/src/python/example/python_distribution/hello/pants_setup_requires/setup.py
+++ b/examples/src/python/example/python_distribution/hello/pants_setup_requires/setup.py
@@ -1,0 +1,17 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+from setuptools import setup, find_packages
+
+from pants.version import VERSION as pants_version
+
+setup(
+  name='hello',
+  # FIXME: test the wheel version in a unit test!
+  version=pants_version,
+  packages=find_packages(),
+)

--- a/examples/src/python/example/python_distribution/hello/setup_requires/setup.py
+++ b/examples/src/python/example/python_distribution/hello/setup_requires/setup.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 from setuptools import setup, find_packages
 
-# We require pycountry with setup_requires argument to this setup script's 
+# We require pycountry with setup_requires argument to this setup script's
 # corresponding python_dist.
 import pycountry
 

--- a/src/python/pants/backend/native/subsystems/BUILD
+++ b/src/python/pants/backend/native/subsystems/BUILD
@@ -7,6 +7,7 @@ python_library(
     'src/python/pants/backend/native/config',
     'src/python/pants/backend/native/subsystems/binaries',
     'src/python/pants/backend/native/subsystems/utils',
+    'src/python/pants/binaries',
     'src/python/pants/engine:rules',
     'src/python/pants/engine:selectors',
     'src/python/pants/subsystem',

--- a/src/python/pants/backend/native/subsystems/conan.py
+++ b/src/python/pants/backend/native/subsystems/conan.py
@@ -5,20 +5,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-import os
-
-from pex.interpreter import PythonInterpreter
-from pex.pex import PEX
-from pex.pex_builder import PEXBuilder
-from pex.pex_info import PexInfo
 
 from pants.backend.python.python_requirement import PythonRequirement
-from pants.backend.python.subsystems.python_repos import PythonRepos
-from pants.backend.python.subsystems.python_setup import PythonSetup
-from pants.backend.python.tasks.pex_build_util import dump_requirements
-from pants.base.build_environment import get_pants_cachedir
 from pants.binaries.executable_pex_tool import ExecutablePexTool
-from pants.util.dirutil import safe_concurrent_creation
 from pants.util.memo import memoized_property
 
 
@@ -50,19 +39,15 @@ class Conan(ExecutablePexTool):
   )
 
   @classmethod
-  def implementation_version(cls):
-    return super(Conan, cls).implementation_version() + [('Conan', 0)]
-
-  @classmethod
-  def subsystem_dependencies(cls):
-    return super(Conan, cls).subsystem_dependencies() + (PythonRepos, PythonSetup)
-
-  @classmethod
   def register_options(cls, register):
     super(Conan, cls).register_options(register)
     register('--conan-requirements', type=list, default=cls.default_conan_requirements,
              advanced=True, help='The requirements used to build the conan client pex.')
 
+  @classmethod
+  def implementation_version(cls):
+    return super(Conan, cls).implementation_version() + [('Conan', 0)]
+
   @memoized_property
-  def pex_tool_requirements(self):
+  def base_requirements(self):
     return [PythonRequirement(req) for req in self.get_options().conan_requirements]

--- a/src/python/pants/backend/native/subsystems/conan.py
+++ b/src/python/pants/backend/native/subsystems/conan.py
@@ -20,6 +20,8 @@ class Conan(ExecutablePexTool):
 
   entry_point = 'conans.conan'
 
+  # TODO: It would be great if these requirements could be drawn from a BUILD file (potentially with
+  # a special target specified in BUILD.tools)?
   default_conan_requirements = (
     'conan==1.4.4',
     'PyJWT>=1.4.0, <2.0.0',

--- a/src/python/pants/backend/native/subsystems/conan.py
+++ b/src/python/pants/backend/native/subsystems/conan.py
@@ -17,17 +17,20 @@ from pants.backend.python.subsystems.python_repos import PythonRepos
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.tasks.pex_build_util import dump_requirements
 from pants.base.build_environment import get_pants_cachedir
-from pants.subsystem.subsystem import Subsystem
+from pants.binaries.executable_pex_tool import ExecutablePexTool
 from pants.util.dirutil import safe_concurrent_creation
-from pants.util.objects import datatype
+from pants.util.memo import memoized_property
 
 
 logger = logging.getLogger(__name__)
 
 
-class Conan(Subsystem):
+class Conan(ExecutablePexTool):
   """Pex binary for the conan package manager."""
   options_scope = 'conan'
+
+  entry_point = 'conans.conan'
+
   default_conan_requirements = (
     'conan==1.4.4',
     'PyJWT>=1.4.0, <2.0.0',
@@ -60,20 +63,6 @@ class Conan(Subsystem):
     register('--conan-requirements', type=list, default=cls.default_conan_requirements,
              advanced=True, help='The requirements used to build the conan client pex.')
 
-  class ConanBinary(datatype(['pex'])):
-    """A `conan` PEX binary."""
-
-  def bootstrap_conan(self):
-    pex_info = PexInfo.default()
-    pex_info.entry_point = 'conans.conan'
-    conan_bootstrap_dir = os.path.join(get_pants_cachedir(), 'conan_support')
-    conan_pex_path = os.path.join(conan_bootstrap_dir, 'conan_binary')
-    interpreter = PythonInterpreter.get()
-    if not os.path.exists(conan_pex_path):
-      with safe_concurrent_creation(conan_pex_path) as safe_path:
-        builder = PEXBuilder(safe_path, interpreter, pex_info=pex_info)
-        reqs = [PythonRequirement(req) for req in self.get_options().conan_requirements]
-        dump_requirements(builder, interpreter, reqs, logger)
-        builder.freeze()
-    conan_binary = PEX(conan_pex_path, interpreter)
-    return self.ConanBinary(pex=conan_binary)
+  @memoized_property
+  def pex_tool_requirements(self):
+    return [PythonRequirement(req) for req in self.get_options().conan_requirements]

--- a/src/python/pants/backend/native/tasks/native_external_library_fetch.py
+++ b/src/python/pants/backend/native/tasks/native_external_library_fetch.py
@@ -13,7 +13,6 @@ from pex.interpreter import PythonInterpreter
 from pants.backend.native.config.environment import Platform
 from pants.backend.native.subsystems.conan import Conan
 from pants.backend.native.targets.external_native_library import ExternalNativeLibrary
-from pants.backend.python.tasks.wrapped_pex import WrappedPEX
 from pants.base.build_environment import get_pants_cachedir
 from pants.base.exceptions import TaskError
 from pants.invalidation.cache_manager import VersionedTargetSet
@@ -120,10 +119,9 @@ class NativeExternalLibraryFetch(Task):
 
   @memoized_property
   def _conan_binary(self):
-    conan_pex = Conan.scoped_instance(self).bootstrap(
+    return Conan.scoped_instance(self).bootstrap(
       self._conan_python_interpreter,
       self._conan_pex_path)
-    return WrappedPEX(conan_pex)
 
   def execute(self):
     native_lib_tgts = self.context.targets(self.native_library_constraint.satisfied_by)

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -213,6 +213,9 @@ class SetupPyExecutionEnvironment(datatype([
         c_linker.path_entries +
         cpp_compiler.path_entries +
         cpp_linker.path_entries)
+      # NB: We need to be able to access the python interpreter, so we need the rest of the PATH
+      # entries (after the ones from our native toolchain). This alone is not sufficient to force
+      # setup.py to use only our tools.
       ret['PATH'] = create_path_env_var(all_path_entries, env=os.environ.copy(), prepend=True)
 
       # GCC will output smart quotes in a variety of situations (leading to decoding errors

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -215,37 +215,4 @@ class SetupPyExecutionEnvironment(datatype([
         cpp_linker.path_entries)
       ret['PATH'] = create_path_env_var(all_path_entries)
 
-      all_library_dirs = (
-        c_compiler.library_dirs +
-        c_linker.library_dirs +
-        cpp_compiler.library_dirs +
-        cpp_linker.library_dirs)
-      joined_library_dirs = create_path_env_var(all_library_dirs)
-      dynamic_lib_env_var = plat.resolve_platform_specific({
-        'darwin': lambda: 'DYLD_LIBRARY_PATH',
-        'linux': lambda: 'LD_LIBRARY_PATH',
-      })
-      ret[dynamic_lib_env_var] = joined_library_dirs
-
-      all_linking_library_dirs = (c_linker.linking_library_dirs + cpp_linker.linking_library_dirs)
-      ret['LIBRARY_PATH'] = create_path_env_var(all_linking_library_dirs)
-
-      all_include_dirs = cpp_compiler.include_dirs + c_compiler.include_dirs
-      ret['CPATH'] = create_path_env_var(all_include_dirs)
-
-      shared_compile_flags = safe_shlex_join(plat.resolve_platform_specific({
-        'darwin': lambda: [MIN_OSX_VERSION_ARG],
-        'linux': lambda: [],
-      }))
-      ret['CFLAGS'] = shared_compile_flags
-      ret['CXXFLAGS'] = shared_compile_flags
-
-      ret['CC'] = c_compiler.exe_filename
-      ret['CXX'] = cpp_compiler.exe_filename
-      ret['LDSHARED'] = cpp_linker.exe_filename
-
-      all_new_ldflags = cpp_linker.extra_args + plat.resolve_platform_specific(
-        self._SHARED_CMDLINE_ARGS)
-      ret['LDFLAGS'] = safe_shlex_join(all_new_ldflags)
-
     return ret

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import os
 from builtins import str
 from collections import defaultdict
 
@@ -22,7 +23,7 @@ from pants.binaries.executable_pex_tool import ExecutablePexTool
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
 from pants.util.objects import SubclassesOf, datatype
-from pants.util.strutil import create_path_env_var, safe_shlex_join
+from pants.util.strutil import create_path_env_var
 
 
 class PythonNativeCode(Subsystem):
@@ -199,7 +200,6 @@ class SetupPyExecutionEnvironment(datatype([
       # An as_tuple() method for datatypes could make this destructuring cleaner!  Alternatively,
       # constructing this environment could be done more compositionally instead of requiring all of
       # these disparate fields together at once.
-      plat = native_tools.platform
       c_toolchain = native_tools.c_toolchain
       c_compiler = c_toolchain.c_compiler
       c_linker = c_toolchain.c_linker

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -188,7 +188,7 @@ class SetupPyExecutionEnvironment(datatype([
   def as_environment(self):
     ret = {}
 
-    # FIXME(#5951): the below is a lot of error-prone repeated logic -- we need a way to compose
+    # TODO(#5951): the below is a lot of error-prone repeated logic -- we need a way to compose
     # executables more hygienically. We should probably be composing each datatype's members, and
     # only creating an environment at the very end.
     native_tools = self.setup_py_native_tools

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -213,7 +213,7 @@ class SetupPyExecutionEnvironment(datatype([
         c_linker.path_entries +
         cpp_compiler.path_entries +
         cpp_linker.path_entries)
-      ret['PATH'] = create_path_env_var(all_path_entries)
+      ret['PATH'] = create_path_env_var(all_path_entries, env=os.environ.copy(), prepend=True)
 
       # GCC will output smart quotes in a variety of situations (leading to decoding errors
       # downstream) unless we set this environment variable.

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -213,9 +213,6 @@ class SetupPyExecutionEnvironment(datatype([
         c_linker.path_entries +
         cpp_compiler.path_entries +
         cpp_linker.path_entries)
-      # NB: We need to be able to access the python interpreter, so we need the rest of the PATH
-      # entries (after the ones from our native toolchain). This alone is not sufficient to force
-      # setup.py to use only our tools.
       ret['PATH'] = create_path_env_var(all_path_entries, env=os.environ.copy(), prepend=True)
 
       # GCC will output smart quotes in a variety of situations (leading to decoding errors

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -175,8 +175,6 @@ class SetupPyExecutionEnvironment(datatype([
     'setup_py_native_tools',
 ])):
 
-
-
   _SHARED_CMDLINE_ARGS = {
     'darwin': lambda: [
       MIN_OSX_VERSION_ARG,
@@ -211,6 +209,9 @@ class SetupPyExecutionEnvironment(datatype([
         c_linker.path_entries +
         cpp_compiler.path_entries +
         cpp_linker.path_entries)
+      # TODO(#6273): We prepend our toolchain to the PATH instead of overwriting it -- we need
+      # better control of the distutils compilation environment if we want to actually isolate the
+      # PATH (distutils does lots of sneaky things).
       ret['PATH'] = create_path_env_var(all_path_entries, env=os.environ.copy(), prepend=True)
 
       # GCC will output smart quotes in a variety of situations (leading to decoding errors

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -215,4 +215,8 @@ class SetupPyExecutionEnvironment(datatype([
         cpp_linker.path_entries)
       ret['PATH'] = create_path_env_var(all_path_entries)
 
+      # GCC will output smart quotes in a variety of situations (leading to decoding errors
+      # downstream) unless we set this environment variable.
+      ret['LC_ALL'] = 'C'
+
     return ret

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -242,7 +242,11 @@ class BuildLocalPythonDistributions(Task):
       setup_requires_dir,
       'setup-requires-{}.pex'.format(versioned_target_fingerprint))
     setup_requires_pex = self._build_setup_requires_pex_settings.bootstrap(
-      interpreter, setup_reqs_pex_path, extra_reqs=setup_reqs_to_resolve)
+      interpreter, setup_reqs_pex_path,
+      # FIXME: remove this obvious hack!
+      extra_reqs=(list(setup_reqs_to_resolve or []) + [
+        PythonRequirement('setuptools==33.1.1'),
+      ]))
     self.context.log.debug('Using pex file as setup.py interpreter: {}'
                            .format(setup_requires_pex))
 

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -12,7 +12,8 @@ import shutil
 from pex import pep425tags
 from pex.interpreter import PythonInterpreter
 
-from pants.backend.native.config.environment import LLVMCppToolchain, LLVMCToolchain, Platform
+from pants.backend.native.config.environment import (GCCCppToolchain, GCCCToolchain,
+                                                     LLVMCppToolchain, LLVMCToolchain, Platform)
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.link_shared_libraries import SharedLibrary
 from pants.backend.python.python_requirement import PythonRequirement
@@ -62,6 +63,24 @@ class BuildLocalPythonDistributions(Task):
     round_manager.require_data(PythonInterpreter)
     round_manager.optional_product(SharedLibrary)
 
+  default_platform_toolchains = {
+    'darwin': 'llvm',
+    'linux': 'gcc',
+  }
+
+  @classmethod
+  def register_options(cls, register):
+    super(BuildLocalPythonDistributions, cls).register_options(register)
+
+    register('--platform-toolchains', type=dict, default=cls.default_platform_toolchains,
+             advanced=True,
+             help='TODO:???/Which toolchain to use for different host platforms pants runs on.')
+
+  @memoized_property
+  def _toolchain_type(self):
+    all_toolchains = self.get_options().platform_toolchains
+    return all_toolchains[self._platform.normalized_os_name]
+
   @classmethod
   def implementation_version(cls):
     return super(BuildLocalPythonDistributions, cls).implementation_version() + [('BuildLocalPythonDistributions', 3)]
@@ -95,15 +114,17 @@ class BuildLocalPythonDistributions(Task):
 
   @memoized_property
   def _c_toolchain(self):
-    llvm_c_toolchain = self._request_single(
-      LLVMCToolchain, self._python_native_code_settings.native_toolchain)
-    return llvm_c_toolchain.c_toolchain
+    c_toolchain_type = LLVMCToolchain if self._toolchain_type == 'llvm' else GCCCToolchain
+    c_toolchain_wrapper = self._request_single(
+      c_toolchain_type, self._python_native_code_settings.native_toolchain)
+    return c_toolchain_wrapper.c_toolchain
 
   @memoized_property
   def _cpp_toolchain(self):
-    llvm_cpp_toolchain = self._request_single(
-      LLVMCppToolchain, self._python_native_code_settings.native_toolchain)
-    return llvm_cpp_toolchain.cpp_toolchain
+    cpp_toolchain_type = LLVMCppToolchain if self._toolchain_type == 'llvm' else GCCCppToolchain
+    cpp_toolchain_wrapper = self._request_single(
+      cpp_toolchain_type, self._python_native_code_settings.native_toolchain)
+    return cpp_toolchain_wrapper.cpp_toolchain
 
   # TODO: This should probably be made into an @classproperty (see PR #5901).
   @property

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -264,7 +264,8 @@ class BuildLocalPythonDistributions(Task):
       'setup-requires-{}.pex'.format(versioned_target_fingerprint))
     setup_requires_pex = self._build_setup_requires_pex_settings.bootstrap(
       interpreter, setup_reqs_pex_path,
-      # FIXME: remove this obvious hack!
+      # FIXME: remove this obvious hack! Without this building the dist will fail complaining that
+      # it can't find the py31compat module?
       extra_reqs=(list(setup_reqs_to_resolve or []) + [
         PythonRequirement('setuptools==33.1.1'),
       ]))

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -241,13 +241,9 @@ class BuildLocalPythonDistributions(Task):
     setup_reqs_pex_path = os.path.join(
       setup_requires_dir,
       'setup-requires-{}.pex'.format(versioned_target_fingerprint))
+    extra_reqs = list(setup_reqs_to_resolve or [])
     setup_requires_pex = self._build_setup_requires_pex_settings.bootstrap(
-      interpreter, setup_reqs_pex_path,
-      # FIXME: remove this obvious hack! Without this building the dist will fail complaining that
-      # it can't find the py31compat module?
-      extra_reqs=(list(setup_reqs_to_resolve or []) + [
-        PythonRequirement('setuptools==33.1.1'),
-      ]))
+      interpreter, setup_reqs_pex_path, extra_reqs=extra_reqs)
     self.context.log.debug('Using pex file as setup.py interpreter: {}'
                            .format(setup_requires_pex))
 

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -88,7 +88,7 @@ class BuildLocalPythonDistributions(Task):
   def _build_setup_requires_pex_settings(self):
     return BuildSetupRequiresPex.scoped_instance(self)
 
-  # FIXME(#5869): delete this and get Subsystems from options, when that is possible.
+  # TODO(#5869): delete this and get Subsystems from options, when that is possible.
   def _request_single(self, product, subject):
     # NB: This is not supposed to be exposed to Tasks yet -- see #4769 to track the status of
     # exposing v2 products in v1 tasks.

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -307,7 +307,8 @@ class BuildLocalPythonDistributions(Task):
 
     setup_py_env = setup_py_execution_environment.as_environment()
     with environment_as(**setup_py_env):
-      # Build a whl using SetupPyRunner and return its absolute path.
+      # Build a whl using SetupPyRunner. If the install was unsuccessful,
+      # SetupPyRunner.SetupPyRunnerError will be thrown.
       try:
         setup_runner.run()
       except SetupPyRunner.SetupPyRunnerError as e:

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -298,6 +298,8 @@ class BuildLocalPythonDistributions(Task):
     setup_runner = SetupPyRunner(
       source_dir=dist_target_dir,
       setup_command=setup_py_snapshot_version_argv,
+      # TODO: explain why this is necessary!
+      explicit_setup_filename='setup.py',
       interpreter=setup_requires_interpreter)
 
     setup_py_env = setup_py_execution_environment.as_environment()

--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -41,6 +41,8 @@ class PythonInterpreterFingerprintStrategy(DefaultFingerprintHashingMixin, Finge
 class SelectInterpreter(Task):
   """Select an Python interpreter that matches the constraints of all targets in the working set."""
 
+  options_scope = 'select-python-interpreter'
+
   @classmethod
   def implementation_version(cls):
     # TODO(John Sirois): Fixup this task to use VTS results_dirs. Right now version bumps aren't

--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -41,8 +41,6 @@ class PythonInterpreterFingerprintStrategy(DefaultFingerprintHashingMixin, Finge
 class SelectInterpreter(Task):
   """Select an Python interpreter that matches the constraints of all targets in the working set."""
 
-  options_scope = 'select-python-interpreter'
-
   @classmethod
   def implementation_version(cls):
     # TODO(John Sirois): Fixup this task to use VTS results_dirs. Right now version bumps aren't

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -54,8 +54,9 @@ class SetupPyRunner(InstallerBase):
   _EXTRAS = ('setuptools', 'wheel')
 
   # `interpreter` is one of the kwargs often passed to this constructor.
-  def __init__(self, source_dir, setup_command, **kw):
+  def __init__(self, source_dir, setup_command, explicit_setup_filename=None, **kw):
     self.__setup_command = setup_command
+    self.explicit_setup_filename = explicit_setup_filename
     super(SetupPyRunner, self).__init__(source_dir, **kw)
 
   def mixins(self):
@@ -84,7 +85,10 @@ class SetupPyRunner(InstallerBase):
       return self._installed
 
     with TRACER.timed('Installing {}'.format(self._install_tmp), V=2):
-      command = [self._interpreter.binary, 'setup.py'] + self._setup_command()
+      if self.explicit_setup_filename:
+        command = [self._interpreter.binary, self.explicit_setup_filename] + self._setup_command()
+      else:
+        command = [self._interpreter.binary, '-'] + self._setup_command()
       try:
         Executor.execute(command,
                          env=self._interpreter.sanitized_environment(),

--- a/src/python/pants/binaries/executable_pex_tool.py
+++ b/src/python/pants/binaries/executable_pex_tool.py
@@ -5,23 +5,14 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-import os
-from abc import abstractproperty
-from builtins import str
 
-from future.utils import text_type
-from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 
 from pants.backend.python.tasks.pex_build_util import dump_requirements
-from pants.binaries.binary_util import BinaryRequest, BinaryUtil
-from pants.engine.fs import PathGlobs, PathGlobsAndRoot
-from pants.fs.archive import XZCompressedTarArchiver, create_archiver
 from pants.subsystem.subsystem import Subsystem
-from pants.util.dirutil import safe_concurrent_creation
-from pants.util.memo import memoized_method, memoized_property
+from pants.util.dirutil import is_executable, safe_concurrent_creation
 
 
 logger = logging.getLogger(__name__)
@@ -31,19 +22,18 @@ class ExecutablePexTool(Subsystem):
 
   entry_point = None
 
-  @abstractproperty
-  def pex_tool_requirements(self): pass
+  base_requirements = []
 
-  def bootstrap(self, interpreter, pex_file_path):
+  def bootstrap(self, interpreter, pex_file_path, extra_reqs=None):
     pex_info = PexInfo.default()
     if self.entry_point is not None:
       pex_info.entry_point = self.entry_point
-    if os.path.exists(pex_file_path):
+    if is_executable(pex_file_path):
       return PEX(pex_file_path, interpreter)
     else:
       with safe_concurrent_creation(pex_file_path) as safe_path:
-        builder = PEXBuilder(safe_path, interpreter, pex_info=pex_info)
-        reqs = self.pex_tool_requirements
-        dump_requirements(builder, interpreter, reqs, logger)
-        builder.freeze()
+        builder = PEXBuilder(interpreter=interpreter, pex_info=pex_info)
+        all_reqs = list(self.base_requirements) + list(extra_reqs or [])
+        dump_requirements(builder, interpreter, all_reqs, logger)
+        builder.build(safe_path)
       return PEX(pex_file_path, interpreter)

--- a/src/python/pants/binaries/executable_pex_tool.py
+++ b/src/python/pants/binaries/executable_pex_tool.py
@@ -25,12 +25,14 @@ class ExecutablePexTool(Subsystem):
   base_requirements = []
 
   def bootstrap(self, interpreter, pex_file_path, extra_reqs=None):
-    pex_info = PexInfo.default()
-    if self.entry_point is not None:
-      pex_info.entry_point = self.entry_point
+    # Caching is done just by checking if the file at the specified path is already executable.
     if is_executable(pex_file_path):
       return PEX(pex_file_path, interpreter)
     else:
+      pex_info = PexInfo.default()
+      if self.entry_point is not None:
+        pex_info.entry_point = self.entry_point
+
       with safe_concurrent_creation(pex_file_path) as safe_path:
         builder = PEXBuilder(interpreter=interpreter, pex_info=pex_info)
         all_reqs = list(self.base_requirements) + list(extra_reqs or [])

--- a/src/python/pants/binaries/executable_pex_tool.py
+++ b/src/python/pants/binaries/executable_pex_tool.py
@@ -10,6 +10,8 @@ from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 
+from pants.backend.python.subsystems.python_repos import PythonRepos
+from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.tasks.pex_build_util import dump_requirements
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import is_executable, safe_concurrent_creation
@@ -23,6 +25,13 @@ class ExecutablePexTool(Subsystem):
   entry_point = None
 
   base_requirements = []
+
+  # NB: The `dump_requirements` method uses PythonSetup and PythonRepos (the global instances)
+  # behind your back - you need to declare subsystem dependencies on these two as things stand to be
+  # safe.
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(ExecutablePexTool, cls).subsystem_dependencies() + (PythonRepos, PythonSetup)
 
   def bootstrap(self, interpreter, pex_file_path, extra_reqs=None):
     # Caching is done just by checking if the file at the specified path is already executable.

--- a/src/python/pants/binaries/executable_pex_tool.py
+++ b/src/python/pants/binaries/executable_pex_tool.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+import os
+from abc import abstractproperty
+from builtins import str
+
+from future.utils import text_type
+from pex.interpreter import PythonInterpreter
+from pex.pex import PEX
+from pex.pex_builder import PEXBuilder
+from pex.pex_info import PexInfo
+
+from pants.backend.python.tasks.pex_build_util import dump_requirements
+from pants.binaries.binary_util import BinaryRequest, BinaryUtil
+from pants.engine.fs import PathGlobs, PathGlobsAndRoot
+from pants.fs.archive import XZCompressedTarArchiver, create_archiver
+from pants.subsystem.subsystem import Subsystem
+from pants.util.dirutil import safe_concurrent_creation
+from pants.util.memo import memoized_method, memoized_property
+
+
+logger = logging.getLogger(__name__)
+
+
+class ExecutablePexTool(Subsystem):
+
+  entry_point = None
+
+  @abstractproperty
+  def pex_tool_requirements(self): pass
+
+  def bootstrap(self, interpreter, pex_file_path):
+    pex_info = PexInfo.default()
+    if self.entry_point is not None:
+      pex_info.entry_point = self.entry_point
+    if os.path.exists(pex_file_path):
+      return PEX(pex_file_path, interpreter)
+    else:
+      with safe_concurrent_creation(pex_file_path) as safe_path:
+        builder = PEXBuilder(safe_path, interpreter, pex_info=pex_info)
+        reqs = self.pex_tool_requirements
+        dump_requirements(builder, interpreter, reqs, logger)
+        builder.freeze()
+      return PEX(pex_file_path, interpreter)

--- a/src/python/pants/binaries/executable_pex_tool.py
+++ b/src/python/pants/binaries/executable_pex_tool.py
@@ -15,6 +15,7 @@ from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.tasks.pex_build_util import dump_requirements
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import is_executable, safe_concurrent_creation
+from pants.util.memo import memoized_property
 
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,10 @@ class ExecutablePexTool(Subsystem):
   @classmethod
   def subsystem_dependencies(cls):
     return super(ExecutablePexTool, cls).subsystem_dependencies() + (PythonRepos, PythonSetup)
+
+  @memoized_property
+  def python_setup(self):
+    return PythonSetup.global_instance()
 
   def bootstrap(self, interpreter, pex_file_path, extra_reqs=None):
     # Caching is done just by checking if the file at the specified path is already executable.

--- a/src/python/pants/binaries/executable_pex_tool.py
+++ b/src/python/pants/binaries/executable_pex_tool.py
@@ -40,9 +40,7 @@ class ExecutablePexTool(Subsystem):
 
   def bootstrap(self, interpreter, pex_file_path, extra_reqs=None):
     # Caching is done just by checking if the file at the specified path is already executable.
-    if is_executable(pex_file_path):
-      return PEX(pex_file_path, interpreter)
-    else:
+    if not is_executable(pex_file_path):
       pex_info = PexInfo.default(interpreter=interpreter)
       if self.entry_point is not None:
         pex_info.entry_point = self.entry_point
@@ -52,4 +50,5 @@ class ExecutablePexTool(Subsystem):
         all_reqs = list(self.base_requirements) + list(extra_reqs or [])
         dump_requirements(builder, interpreter, all_reqs, logger, platforms=['current'])
         builder.build(safe_path)
-      return PEX(pex_file_path, interpreter)
+
+    return PEX(pex_file_path, interpreter)

--- a/src/python/pants/binaries/executable_pex_tool.py
+++ b/src/python/pants/binaries/executable_pex_tool.py
@@ -50,6 +50,6 @@ class ExecutablePexTool(Subsystem):
       with safe_concurrent_creation(pex_file_path) as safe_path:
         builder = PEXBuilder(interpreter=interpreter, pex_info=pex_info)
         all_reqs = list(self.base_requirements) + list(extra_reqs or [])
-        dump_requirements(builder, interpreter, all_reqs, logger)
+        dump_requirements(builder, interpreter, all_reqs, logger, platforms=['current'])
         builder.build(safe_path)
       return PEX(pex_file_path, interpreter)

--- a/src/python/pants/binaries/executable_pex_tool.py
+++ b/src/python/pants/binaries/executable_pex_tool.py
@@ -43,7 +43,7 @@ class ExecutablePexTool(Subsystem):
     if is_executable(pex_file_path):
       return PEX(pex_file_path, interpreter)
     else:
-      pex_info = PexInfo.default()
+      pex_info = PexInfo.default(interpreter=interpreter)
       if self.entry_point is not None:
         pex_info.entry_point = self.entry_point
 

--- a/testprojects/src/python/python_distribution/ctypes_with_third_party/setup.py
+++ b/testprojects/src/python/python_distribution/ctypes_with_third_party/setup.py
@@ -9,9 +9,9 @@ from setuptools import setup, find_packages
 
 
 setup(
-  name='ctypes_test',
+  name='ctypes_third_party_test',
   version='0.0.1',
   packages=find_packages(),
-  # Declare two files at the top-level directory (denoted by '').
+  # Declare one shared lib at the top-level directory (denoted by '').
   data_files=[('', ['libasdf-cpp-tp.so'])],
 )

--- a/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
+++ b/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
@@ -18,8 +18,6 @@ from pants_test.backend.python.tasks.util.build_local_dists_test_base import \
 
 class TestBuildLocalDistsNativeSources(BuildLocalPythonDistributionsTestBase):
 
-  _extra_relevant_task_types = []
-
   _dist_specs = OrderedDict([
 
     ('src/python/dist:universal_dist', {

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes.py
@@ -22,12 +22,11 @@ from pants_test.backend.python.tasks.util.build_local_dists_test_base import \
 
 class TestBuildLocalDistsWithCtypesNativeSources(BuildLocalPythonDistributionsTestBase):
 
-  _extra_relevant_task_types = (
-    [
-      CCompile,
-      CppCompile,
-      LinkSharedLibraries,
-    ] + BuildLocalPythonDistributionsTestBase._extra_relevant_task_types)
+  _extra_relevant_task_types = ([
+    CCompile,
+    CppCompile,
+    LinkSharedLibraries,
+  ] + BuildLocalPythonDistributionsTestBase._extra_relevant_task_types)
 
   _dist_specs = OrderedDict([
 

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes.py
@@ -15,6 +15,7 @@ from pants.backend.native.tasks.c_compile import CCompile
 from pants.backend.native.tasks.cpp_compile import CppCompile
 from pants.backend.native.tasks.link_shared_libraries import LinkSharedLibraries
 from pants.backend.python.targets.python_distribution import PythonDistribution
+from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants_test.backend.python.tasks.python_task_test_base import check_wheel_platform_matches_host
 from pants_test.backend.python.tasks.util.build_local_dists_test_base import \
   BuildLocalPythonDistributionsTestBase
@@ -22,7 +23,12 @@ from pants_test.backend.python.tasks.util.build_local_dists_test_base import \
 
 class TestBuildLocalDistsWithCtypesNativeSources(BuildLocalPythonDistributionsTestBase):
 
-  _extra_relevant_task_types = [CCompile, CppCompile, LinkSharedLibraries]
+  _extra_relevant_task_types = (
+    [
+      CCompile,
+      CppCompile,
+      LinkSharedLibraries,
+    ] + BuildLocalPythonDistributionsTestBase._extra_relevant_task_types)
 
   _dist_specs = OrderedDict([
 

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes.py
@@ -15,7 +15,6 @@ from pants.backend.native.tasks.c_compile import CCompile
 from pants.backend.native.tasks.cpp_compile import CppCompile
 from pants.backend.native.tasks.link_shared_libraries import LinkSharedLibraries
 from pants.backend.python.targets.python_distribution import PythonDistribution
-from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants_test.backend.python.tasks.python_task_test_base import check_wheel_platform_matches_host
 from pants_test.backend.python.tasks.util.build_local_dists_test_base import \
   BuildLocalPythonDistributionsTestBase

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -13,6 +13,7 @@ from pants.backend.native.config.environment import Platform
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import is_executable
 from pants.util.process_handler import subprocess
+from pants.version import VERSION as pants_version
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -23,6 +24,7 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
   fasthello_tests = 'examples/tests/python/example/python_distribution/hello/test_fasthello'
   fasthello_install_requires_dir = 'testprojects/src/python/python_distribution/fasthello_with_install_requires'
   hello_setup_requires = 'examples/src/python/example/python_distribution/hello/setup_requires'
+  pants_setup_requires = 'examples/src/python/example/python_distribution/hello/pants_setup_requires'
 
   def _assert_native_greeting(self, output):
     self.assertIn('Hello from C!', output)
@@ -229,3 +231,12 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       # Check that the pex runs.
       output = subprocess.check_output(pex).decode('utf-8')
       self.assertEqual('Hello, world!\n', output)
+
+  def test_pants_requirement_setup_requires_version(self):
+    """Ensure that a pants_requirement() can be successfully used in setup_requires."""
+    pants_run = self.run_pants(['-q', 'run', '{}:bin'.format(self.pants_setup_requires)])
+    self.assert_success(pants_run)
+    # This testproject prints its own version string here, which is the current pants version plus
+    # the pants fingerprint (as defined in this project's setup.py).
+    self.assertRegexpMatches(pants_run.stdout_data,
+                             r'\A{}\+([a-z0-9\.])+\n\Z'.format(re.escape(pants_version)))

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -8,8 +8,10 @@ import re
 from builtins import next
 
 from pants.backend.native.register import rules as native_backend_rules
+from pants.backend.python.subsystems.python_repos import PythonRepos
 from pants.backend.python.tasks.build_local_python_distributions import \
   BuildLocalPythonDistributions
+from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants.util.collections import assert_single_element
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
@@ -30,7 +32,7 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBas
   # By default, we just use a `BuildLocalPythonDistributions` task. When testing with C/C++ targets,
   # we want to compile and link them as well to get the resulting dist to build, so we add those
   # task types here and execute them beforehand.
-  _extra_relevant_task_types = None
+  _extra_relevant_task_types = [SelectInterpreter]
 
   def setUp(self):
     super(BuildLocalPythonDistributionsTestBase, self).setUp()
@@ -96,7 +98,8 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBas
   def _create_distribution_synthetic_target(self, python_dist_target, extra_targets=[]):
     context = self._scheduling_context(
       target_roots=([python_dist_target] + extra_targets),
-      for_task_types=([self.task_type()] + self._extra_relevant_task_types))
+      for_task_types=([self.task_type()] + self._extra_relevant_task_types),
+      for_subsystems=[PythonRepos])
     self.assertEqual(set(self._all_specified_targets()), set(context.build_graph.targets()))
 
     python_create_distributions_task = self.create_task(context)

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -13,6 +13,7 @@ from pants.backend.python.tasks.build_local_python_distributions import \
   BuildLocalPythonDistributions
 from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants.util.collections import assert_single_element
+from pants.util.memo import memoized_property
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
 
@@ -33,6 +34,13 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBas
   # we want to compile and link them as well to get the resulting dist to build, so we add those
   # task types here and execute them beforehand.
   _extra_relevant_task_types = [SelectInterpreter]
+
+  @memoized_property
+  def _all_other_synthesized_task_types(self):
+    return [
+      self.synthesize_task_subtype(tsk, '__tmp_{}'.format(tsk.__name__))
+      for tsk in self._extra_relevant_task_types
+    ]
 
   def setUp(self):
     super(BuildLocalPythonDistributionsTestBase, self).setUp()
@@ -96,27 +104,36 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBas
     return task_type(context, self.test_workdir)
 
   def _create_distribution_synthetic_target(self, python_dist_target, extra_targets=[]):
+
+    python_create_distributions_task_type = self._testing_task_type
+    all_synthesized_task_types = self._all_other_synthesized_task_types + [
+      python_create_distributions_task_type,
+    ]
+
     context = self._scheduling_context(
       target_roots=([python_dist_target] + extra_targets),
-      for_task_types=([self.task_type()] + self._extra_relevant_task_types),
+      for_task_types=(all_synthesized_task_types),
       for_subsystems=[PythonRepos])
     self.assertEqual(set(self._all_specified_targets()), set(context.build_graph.targets()))
 
-    python_create_distributions_task = self.create_task(context)
-    extra_tasks = [
+    all_other_task_instances = [
       self._create_task(task_type, context)
-      for task_type in self._extra_relevant_task_types
+      for task_type in self._all_other_synthesized_task_types
     ]
-    for tsk in extra_tasks:
+    python_create_distributions_task_instance = self._create_task(
+      python_create_distributions_task_type,
+      context)
+
+    for tsk in all_other_task_instances:
       tsk.execute()
 
-    python_create_distributions_task.execute()
+    python_create_distributions_task_instance.execute()
 
     synthetic_tgts = set(context.build_graph.targets()) - set(self._all_specified_targets())
     self.assertEqual(1, len(synthetic_tgts))
     synthetic_target = next(iter(synthetic_tgts))
 
     snapshot_version = self._get_dist_snapshot_version(
-      python_create_distributions_task, python_dist_target)
+      python_create_distributions_task_instance, python_dist_target)
 
     return context, synthetic_target, snapshot_version


### PR DESCRIPTION
### Problem

This PR solves two separate problems at once. It should have been split into two separate PRs earlier, but has undergone significant review and it would be a significant amount of unnecessary effort to do that at this point.

#### Problem 1
The `setup_requires` kwarg of `python_dist()` holds addresses for `python_requirement_library()` targets. Currently, these requirements are fetched into a directory which is added to `PYTHONPATH`. This currently produces an invalid set of packages (for reasons I'm not quite sure of), which can cause errors on `import` statements within the `setup.py`.

#### Problem 2
*See #6273 for more context on this second issue:* `distutils` does all sorts of things with our environment variables (e.g. adding `CFLAGS` to `LDFLAGS`), so until #6273 is merged, trying to modify anything but the `PATH` in the environment in which we invoke `setup.py` in for `python_dist()` targets causes lots of failures in many scenarios.

### Solution

#### Solution 1:
- Extract out the pex-building logic from the `Conan` subsystem into an `ExecutablePexTool` base class.
- Collect `setup_requires` into a pex, using `ExecutablePexTool`.

#### Solution 2
- Only modify the `PATH` in the environment dict produced from `SetupPyExecutionEnvironment`, no other env vars relevant to compilation.
  - Also, prepend our toolchain to the current PATH (commented inline, with a TODO pointing to #6273).
- Add `LC_ALL=C` to the environment as well so compilation error output doesn't have decode errors on smart quotes.

### Result

#### Result 1
`setup_requires` now fetches all necessary transitive deps into a pex, which means you can reliably import python requirements declared in `setup_requires` in the `python_dist()`'s `setup.py`.

#### Result 2
Some of the native toolchain code is slightly simplified until #6273 is merged.