### PR TITLE
Modify the `alias` page to actually reference the `alias` target

### DIFF
--- a/src/docs/common_tasks/BUILD
+++ b/src/docs/common_tasks/BUILD
@@ -109,6 +109,11 @@ page(
 )
 
 page(
+  name='target_aggregate',
+  source='target_aggregate.md',
+)
+
+page(
   name='test',
   source='test.md',
 )

--- a/src/docs/common_tasks/alias.md
+++ b/src/docs/common_tasks/alias.md
@@ -8,7 +8,7 @@ definition (for example when specifying dependencies).
 
 ## Solution
 
-Specify a `target` definition that refers to a target deeper in the directory
+Specify an `alias` definition that refers to a target deeper in the directory
 tree and acts as a proxy for it.
 
 ## Discussion
@@ -32,16 +32,14 @@ In addition, Pants commands would be similarly verbose:
     
     $ ./pants compile myproject/src/main/scala/com/twitter/myproject:scala
 
-You can simplify this by creating a `target` definition in a `BUILD` file
+You can simplify this by creating an `alias` definition in a `BUILD` file
 stored in a more convenient location in the directory tree, for example in the root directory. Here's an example:
 
 
     :: python
     # myproject/BUILD
     target(name='myproject',
-      dependencies=[
-        'myproject/src/main/scala/com/twitter/myproject/subproject/util:scala'
-      ]
+      target='myproject/src/main/scala/com/twitter/myproject/subproject/util:scala'
     )
 
 Now, other projects can depend on the library target in a more concise manner:
@@ -53,17 +51,15 @@ Now, other projects can depend on the library target in a more concise manner:
       # ...
     ]
 
-Pants commands involving the target are simplified as well. Here's a comparison:
+Pants commands involving the alias are simplified as well. Here's a comparison:
 
     :: bash
     
-    # Without target alias
+    # Without an alias
     $ ./pants compile myproject/src/main/scala/com/twitter/myproject/subproject/util:scala
     
-    # With target alias
+    # With an alias
     $ ./pants compile myproject:myproject
-
-NOTE: Proper aliases always contain exactly one destination. Using them to combine multiple library targets introduces false dependencies between the dependent and the dependency. 
 
 See Also
 --------

--- a/src/docs/common_tasks/alias.md
+++ b/src/docs/common_tasks/alias.md
@@ -38,8 +38,9 @@ stored in a more convenient location in the directory tree, for example in the r
 
     :: python
     # myproject/BUILD
-    target(name='myproject',
-      target='myproject/src/main/scala/com/twitter/myproject/subproject/util:scala'
+    alias(
+        name='myproject',
+        target='myproject/src/main/scala/com/twitter/myproject/subproject/util:scala'
     )
 
 Now, other projects can depend on the library target in a more concise manner:

--- a/src/docs/common_tasks/dependencies.md
+++ b/src/docs/common_tasks/dependencies.md
@@ -27,8 +27,8 @@ Below is an example `scala_library` definition that specifies dependencies on ot
 In this example, we have two dependencies, both of which reside in the same repository as our code. They are referenced by the relative path from the root of the repository, to the location of the `BUILD` file that defines the buildable target you wish to depend on.
 
 You should always target dependencies through their `scala_library` or
-other library target definition. Many projects have set up target aliases that
-are shorter, but tend to cause false dependencies. For more info, see
+other library target definition. Many projects have set up aliases that
+are shorter. For more info, see
 [[Create an Alias for a Target|pants('src/docs/common_tasks:alias')]].
 
 NOTE: In many cases, you can specify a library target path without specifying a target name. In the example above, the `myproject/library-a` library is targeted without a target name. That's because the target name, in this case, is the same as that of the directory. Here's what that `BUILD` file might look like:

--- a/src/docs/common_tasks/index.md
+++ b/src/docs/common_tasks/index.md
@@ -11,6 +11,7 @@ This section of the Pants documentation describes the most common day-to-day Pan
 * [[Get an Overview of Your Recent Pants Activity|pants('src/docs/common_tasks:server')]]
 * [[Add a Dependency on Another Target|pants('src/docs/common_tasks:dependencies')]]
 * [[Create an Alias for a Target|pants('src/docs/common_tasks:alias')]]
+* [[Create a Target Aggregate|pants('src/docs/common_tasks:target_aggregate')]]
 * [[Pass Command-line Arguments to an Executable|pants('src/docs/common_tasks:cli_args')]]
 * [[Clean Cached Pants Artifacts|pants('src/docs/common_tasks:clean')]]
 * [[Run a Binary Target|pants('src/docs/common_tasks:run')]]

--- a/src/docs/common_tasks/jvm_library.md
+++ b/src/docs/common_tasks/jvm_library.md
@@ -40,11 +40,11 @@ That library can then be compiled (perhaps for debugging purposes):
     ::python
     $ ./pants compile myproject/src/main/scala
 
-You can combine library targets together into a single target using a **target alias**. More info can be found in [[Create an Alias for a Target|pants('src/docs/common_tasks:alias')]].
+You can combine library targets together into a single target using a **target aggregate**. More info can be found in [[Create a Target Aggregate|pants('src/docs/common_tasks:target_aggregate')]].
 
 ## See Also
 
 * [[Compile a Library Target|pants('src/docs/common_tasks:compile')]]
 * [[Define a JVM Executable|pants('src/docs/common_tasks:jvm_binary')]]
 * [[Create a Bundled zip or Other Archive|pants('src/docs/common_tasks:bundle')]]
-* [[Create an Alias for a Target|pants('src/docs/common_tasks:alias')]]
+* [[Create a Target Aggregate|pants('src/docs/common_tasks:target_aggregate')]]

--- a/src/docs/common_tasks/target_aggregate.md
+++ b/src/docs/common_tasks/target_aggregate.md
@@ -1,0 +1,28 @@
+# Create a Target Aggregate
+
+## Problem
+
+You want to create a common target that when run in turn run several other targets
+
+## Solution
+
+Use the `target` goal and specify an aggregate target that depends on all the targets you wish to run
+
+Here's an example `target` definition that creates a target names `agg` dependent on two modules `dep1` and `dep2`:
+
+    :: python
+    # agg/BUILD
+    target(name='agg',
+      dependencies=[
+        'myproject/src/main/scala/com/twitter/myproject/subproject/dep1:scala'
+        'myproject/src/main/scala/com/twitter/myproject/subproject/dep2:scala'
+      ]
+    )
+
+Triggering any goal for `agg` will trigger said goal for both `dep1` and `dep2`
+
+If you wish to create an alias for an existing target see [[Create an Alias for a Target|pants('src/docs/common_tasks:alias')]]
+
+## See Also
+
+* [[Create an Alias for a Target|pants('src/docs/common_tasks:alias')]]

--- a/src/docs/common_tasks/target_aggregate.md
+++ b/src/docs/common_tasks/target_aggregate.md
@@ -6,15 +6,15 @@ You want to create a common target that when run in turn run several other targe
 
 ## Solution
 
-Use the `target` goal and specify an aggregate target that depends on all the targets you wish to run
+Use a literal `target` definition in your BUILD file to specify an aggregate target that depends on all the targets you wish to run
 
-Here's an example `target` definition that creates a target names `agg` dependent on two modules `dep1` and `dep2`:
+Here's an example `target` definition that creates a target names `agg` dependent on two modules named `dep1` and `dep2`:
 
     :: python
     # agg/BUILD
     target(name='agg',
       dependencies=[
-        'myproject/src/main/scala/com/twitter/myproject/subproject/dep1:scala'
+        'myproject/src/main/scala/com/twitter/myproject/subproject/dep1:scala',
         'myproject/src/main/scala/com/twitter/myproject/subproject/dep2:scala'
       ]
     )

--- a/src/docs/howto_plugin.md
+++ b/src/docs/howto_plugin.md
@@ -26,7 +26,7 @@ Pants, you can use the following technique using sources stored directly in your
 All you need to do is name the package where the plugin is defined, and the pythonpath entry to
 load it from.
 
-In the example below, the stock `JvmBinary` target will subclassed so that a custom task (not shown)
+In the example below, the stock `JvmBinary` target is subclassed so that a custom task (not shown)
 can consume it specifically but disregard regular `JvmBinary` instances (using `isinstance()`).
 
 - Define a home for your plugins. In this example we'll use a top-level `plugins/` directory but


### PR DESCRIPTION
Modified the `alias` page and other pages referring it.
Introduced a new "target aggregate" concept (as opposed to "target alias")
for the `target` target.