### PR TITLE
Add Conjunction field to PathGlobs and use it to remove false positive glob expansion failure warnings

### DIFF
--- a/src/python/pants/backend/codegen/antlr/java/java_antlr_library.py
+++ b/src/python/pants/backend/codegen/antlr/java/java_antlr_library.py
@@ -31,6 +31,8 @@ class JavaAntlrLibrary(JvmTarget):
         the sources are spread among different files, this must be set as the package cannot be
         inferred.
     """
+    if compiler not in ('antlr3', 'antlr4'):
+      raise TargetDefinitionException(self, "Illegal value for 'compiler': {}.".format(compiler))
 
     if isinstance(sources, EagerFilesetWithSpec):
       if sources.snapshot.is_empty:
@@ -38,8 +40,6 @@ class JavaAntlrLibrary(JvmTarget):
                                         .format(sources))
     elif not sources:
       raise TargetDefinitionException(self, "Missing required 'sources' parameter.")
-    elif compiler not in ('antlr3', 'antlr4'):
-      raise TargetDefinitionException(self, "Illegal value for 'compiler': {}.".format(compiler))
 
     super(JavaAntlrLibrary, self).__init__(name=name,
                                            sources=sources,

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -8,7 +8,7 @@ from future.utils import binary_type, text_type
 
 from pants.base.project_tree import Dir, File
 from pants.engine.rules import RootRule
-from pants.option.custom_types import Conjunction
+from pants.option.custom_types import GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.util.objects import Collection, datatype
 
@@ -34,7 +34,7 @@ class PathGlobs(datatype([
     'include',
     'exclude',
     ('glob_match_error_behavior', GlobMatchErrorBehavior),
-    ('conjunction', Conjunction),
+    ('conjunction', GlobExpansionConjunction),
 ])):
   """A wrapper around sets of filespecs to include and exclude.
 
@@ -57,13 +57,7 @@ class PathGlobs(datatype([
       include=tuple(include),
       exclude=tuple(exclude),
       glob_match_error_behavior=GlobMatchErrorBehavior.create(glob_match_error_behavior),
-      conjunction=Conjunction.create(conjunction))
-
-  def with_match_error_behavior(self, glob_match_error_behavior):
-    return PathGlobs(
-      include=self.include,
-      exclude=self.exclude,
-      glob_match_error_behavior=glob_match_error_behavior)
+      conjunction=GlobExpansionConjunction.create(conjunction))
 
 
 class PathGlobsAndRoot(datatype([('path_globs', PathGlobs), ('root', text_type)])):

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -97,6 +97,10 @@ class Snapshot(datatype([('directory_digest', DirectoryDigest), ('path_stats', t
   """
 
   @property
+  def is_empty(self):
+    return self == EMPTY_SNAPSHOT
+
+  @property
   def dirs(self):
     return [p for p in self.path_stats if type(p.stat) == Dir]
 

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -8,8 +8,9 @@ from future.utils import binary_type, text_type
 
 from pants.base.project_tree import Dir, File
 from pants.engine.rules import RootRule
+from pants.option.custom_types import Conjunction
 from pants.option.global_options import GlobMatchErrorBehavior
-from pants.util.objects import Collection, datatype, enum
+from pants.util.objects import Collection, datatype
 
 
 class FileContent(datatype([('path', text_type), ('content', binary_type)])):
@@ -27,9 +28,6 @@ class Path(datatype([('path', text_type), 'stat'])):
 
   Both values are relative to the ProjectTree's buildroot.
   """
-
-
-class Conjunction(enum('conjunction', ['and', 'or'])): pass
 
 
 class PathGlobs(datatype([
@@ -65,7 +63,8 @@ class PathGlobs(datatype([
     return PathGlobs(
       include=self.include,
       exclude=self.exclude,
-      glob_match_error_behavior=glob_match_error_behavior)
+      glob_match_error_behavior=glob_match_error_behavior,
+    )
 
 
 class PathGlobsAndRoot(datatype([('path_globs', PathGlobs), ('root', text_type)])):

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -9,7 +9,7 @@ from future.utils import binary_type, text_type
 from pants.base.project_tree import Dir, File
 from pants.engine.rules import RootRule
 from pants.option.global_options import GlobMatchErrorBehavior
-from pants.util.objects import Collection, datatype
+from pants.util.objects import Collection, datatype, enum
 
 
 class FileContent(datatype([('path', text_type), ('content', binary_type)])):
@@ -29,10 +29,14 @@ class Path(datatype([('path', text_type), 'stat'])):
   """
 
 
+class Conjunction(enum('conjunction', ['and', 'or'])): pass
+
+
 class PathGlobs(datatype([
     'include',
     'exclude',
     ('glob_match_error_behavior', GlobMatchErrorBehavior),
+    ('conjunction', Conjunction),
 ])):
   """A wrapper around sets of filespecs to include and exclude.
 
@@ -42,7 +46,7 @@ class PathGlobs(datatype([
   be aware of any changes to this object's definition.
   """
 
-  def __new__(cls, include, exclude=(), glob_match_error_behavior=None):
+  def __new__(cls, include, exclude=(), glob_match_error_behavior=None, conjunction=None):
     """Given various file patterns create a PathGlobs object (without using filesystem operations).
 
     :param include: A list of filespecs to include.
@@ -52,9 +56,10 @@ class PathGlobs(datatype([
     """
     return super(PathGlobs, cls).__new__(
       cls,
-      tuple(include),
-      tuple(exclude),
-      GlobMatchErrorBehavior.create(glob_match_error_behavior))
+      include=tuple(include),
+      exclude=tuple(exclude),
+      glob_match_error_behavior=GlobMatchErrorBehavior.create(glob_match_error_behavior),
+      conjunction=Conjunction.create(conjunction))
 
   def with_match_error_behavior(self, glob_match_error_behavior):
     return PathGlobs(

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -63,8 +63,7 @@ class PathGlobs(datatype([
     return PathGlobs(
       include=self.include,
       exclude=self.exclude,
-      glob_match_error_behavior=glob_match_error_behavior,
-    )
+      glob_match_error_behavior=glob_match_error_behavior)
 
 
 class PathGlobsAndRoot(datatype([('path_globs', PathGlobs), ('root', text_type)])):

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -374,7 +374,7 @@ def hydrate_sources(sources_field, glob_match_error_behavior):
   """
   # TODO(#5864): merge the target's selection of --glob-expansion-failure (which doesn't exist yet)
   # with the global default!
-  path_globs = sources_field.path_globs.with_match_error_behavior(glob_match_error_behavior)
+  path_globs = sources_field.path_globs.copy(glob_match_error_behavior=glob_match_error_behavior)
   snapshot = yield Get(Snapshot, PathGlobs, path_globs)
   fileset_with_spec = _eager_fileset_with_spec(
     sources_field.address.spec_path,
@@ -388,7 +388,7 @@ def hydrate_sources(sources_field, glob_match_error_behavior):
 def hydrate_bundles(bundles_field, glob_match_error_behavior):
   """Given a BundlesField, request Snapshots for each of its filesets and create BundleAdaptors."""
   path_globs_with_match_errors = [
-    pg.with_match_error_behavior(glob_match_error_behavior)
+    pg.copy(glob_match_error_behavior=glob_match_error_behavior)
     for pg in bundles_field.path_globs_list
   ]
   snapshot_list = yield [Get(Snapshot, PathGlobs, pg) for pg in path_globs_with_match_errors]

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -234,7 +234,7 @@ class AppAdaptor(TargetAdaptor):
       # something set on the target. Should we move --glob-expansion-failure to be a bootstrap
       # option? See #5864.
       # FIXME: get the right value for `conjunction`!
-      path_globs = base_globs.to_path_globs(rel_root)
+      path_globs = base_globs.to_path_globs(rel_root, Conjunction('and'))
 
       filespecs_list.append(base_globs.filespecs)
       path_globs_list.append(path_globs)
@@ -263,7 +263,7 @@ class PythonTargetAdaptor(TargetAdaptor):
         return field_adaptors
       base_globs = BaseGlobs.from_sources_field(self.resources, self.address.spec_path)
       # FIXME: get the right value for `conjunction`!
-      path_globs = base_globs.to_path_globs(self.address.spec_path)
+      path_globs = base_globs.to_path_globs(self.address.spec_path, Conjunction('and'))
       sources_field = SourcesField(self.address,
                                    'resources',
                                    base_globs.filespecs,

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -60,11 +60,14 @@ class TargetAdaptor(StructWithDeps):
 
     # N.B. Here we check specifically for `sources is None`, as it's possible for sources
     # to be e.g. an explicit empty list (sources=[]).
-    if sources is None and self.default_sources_globs is not None:
-      globs = Globs(*self.default_sources_globs,
+    if sources is None:
+      if self.default_sources_globs is not None:
+        globs = Globs(*self.default_sources_globs,
                       spec_path=self.address.spec_path,
                       exclude=self.default_sources_exclude_globs or [])
-      conjunction_globs = GlobsWithConjunction(globs, Conjunction('or'))
+        conjunction_globs = GlobsWithConjunction(globs, Conjunction('or'))
+      else:
+        conjunction_globs = None
     else:
       globs = BaseGlobs.from_sources_field(sources, self.address.spec_path)
       conjunction_globs = GlobsWithConjunction(globs, Conjunction('and'))
@@ -76,6 +79,10 @@ class TargetAdaptor(StructWithDeps):
     """Returns a tuple of Fields for captured fields which need additional treatment."""
     with exception_logging(logger, 'Exception in `field_adaptors` property'):
       conjunction_globs = self.get_sources()
+
+      if conjunction_globs is None:
+        return tuple()
+
       sources = conjunction_globs.non_path_globs
       conjunction = conjunction_globs.conjunction
 

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -293,7 +293,7 @@ class PythonTestsAdaptor(PythonTargetAdaptor):
 
 class PantsPluginAdaptor(PythonTargetAdaptor):
   def get_sources(self):
-    return GlobsWithConjunction.for_literal_files(['register.py'], self.target_base)
+    return GlobsWithConjunction.for_literal_files(['register.py'], self.address.spec_path)
 
 
 class BaseGlobs(Locatable, AbstractClass):

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -67,6 +67,7 @@ class TargetAdaptor(StructWithDeps):
                       exclude=self.default_sources_exclude_globs or [])
         conjunction_globs = GlobsWithConjunction(globs, Conjunction('or'))
       else:
+        globs = None
         conjunction_globs = None
     else:
       globs = BaseGlobs.from_sources_field(sources, self.address.spec_path)
@@ -263,7 +264,7 @@ class PythonTargetAdaptor(TargetAdaptor):
         return field_adaptors
       base_globs = BaseGlobs.from_sources_field(self.resources, self.address.spec_path)
       # FIXME: get the right value for `conjunction`!
-      path_globs = base_globs.to_path_globs(self.address.spec_path, Conjunction('and'))
+      path_globs = base_globs.to_path_globs(self.address.spec_path)
       sources_field = SourcesField(self.address,
                                    'resources',
                                    base_globs.filespecs,

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -293,7 +293,7 @@ class PythonTestsAdaptor(PythonTargetAdaptor):
 
 class PantsPluginAdaptor(PythonTargetAdaptor):
   def get_sources(self):
-    return GlobsWithConjunction.for_literal_files(['register.py'])
+    return GlobsWithConjunction.for_literal_files(['register.py'], self.target_base)
 
 
 class BaseGlobs(Locatable, AbstractClass):
@@ -423,5 +423,5 @@ class GlobsWithConjunction(datatype([
 ])):
 
   @classmethod
-  def for_literal_files(cls, file_paths):
-    return cls(Files(*file_paths), GlobExpansionConjunction.create('all_match'))
+  def for_literal_files(cls, file_paths, spec_path):
+    return cls(Files(*file_paths, spec_path=spec_path), GlobExpansionConjunction.create('all_match'))

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -234,7 +234,6 @@ class AppAdaptor(TargetAdaptor):
       # TODO: we want to have this field set from the global option --glob-expansion-failure, or
       # something set on the target. Should we move --glob-expansion-failure to be a bootstrap
       # option? See #5864.
-      # FIXME: get the right value for `conjunction`!
       path_globs = base_globs.to_path_globs(rel_root, Conjunction('and'))
 
       filespecs_list.append(base_globs.filespecs)
@@ -263,8 +262,7 @@ class PythonTargetAdaptor(TargetAdaptor):
       if getattr(self, 'resources', None) is None:
         return field_adaptors
       base_globs = BaseGlobs.from_sources_field(self.resources, self.address.spec_path)
-      # FIXME: get the right value for `conjunction`!
-      path_globs = base_globs.to_path_globs(self.address.spec_path)
+      path_globs = base_globs.to_path_globs(self.address.spec_path, Conjunction('and'))
       sources_field = SourcesField(self.address,
                                    'resources',
                                    base_globs.filespecs,

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -422,7 +422,6 @@ class GlobsWithConjunction(datatype([
     ('non_path_globs', SubclassesOf(BaseGlobs)),
     ('conjunction', Conjunction),
 ])):
-  """"""
 
   @classmethod
   def for_literal_files(cls, file_paths):

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -309,6 +309,9 @@ class DictValueComponent(object):
     return '{} {}'.format(self.action, self.val)
 
 
-class Conjunction(enum('conjunction', ['or', 'and'])):
+class GlobExpansionConjunction(enum('conjunction', ['any_match', 'all_match'])):
 
-  default_option_value = 'or'
+  # NB: The `default_value` is automatically the first element of the value list, but can be
+  # overridden or made more explicit in the body of the class. We want to be explicit here about
+  # which behavior we have when merging globs, as that can affect performance.
+  default_value = 'any_match'

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -309,4 +309,6 @@ class DictValueComponent(object):
     return '{} {}'.format(self.action, self.val)
 
 
-class Conjunction(enum('conjunction', ['or', 'and'])): pass
+class Conjunction(enum('conjunction', ['or', 'and'])):
+
+  default_option_value = 'or'

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -12,6 +12,7 @@ import six
 from pants.option.errors import ParseError
 from pants.util.eval import parse_expression
 from pants.util.memo import memoized_method
+from pants.util.objects import enum
 from pants.util.strutil import ensure_text
 
 
@@ -306,3 +307,6 @@ class DictValueComponent(object):
 
   def __repr__(self):
     return '{} {}'.format(self.action, self.val)
+
+
+class Conjunction(enum('conjunction', ['or', 'and'])): pass

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -16,47 +16,17 @@ from pants.option.errors import OptionsError
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
-from pants.util.memo import memoized_classproperty
-from pants.util.objects import datatype
+from pants.util.objects import datatype, enum
 
 
-class GlobMatchErrorBehavior(datatype(['failure_behavior'])):
+class GlobMatchErrorBehavior(enum('failure_behavior', ['ignore', 'warn', 'error'])):
   """Describe the action to perform when matching globs in BUILD files to source files.
 
   NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
   be aware of any changes to this object's definition.
   """
 
-  IGNORE = 'ignore'
-  WARN = 'warn'
-  ERROR = 'error'
-
-  allowed_values = [IGNORE, WARN, ERROR]
-
-  default_value = IGNORE
-
-  default_option_value = WARN
-
-  @memoized_classproperty
-  def _singletons(cls):
-    return { behavior: cls(behavior) for behavior in cls.allowed_values }
-
-  @classmethod
-  def create(cls, value=None):
-    if isinstance(value, cls):
-      return value
-    if not value:
-      value = cls.default_value
-    return cls._singletons[value]
-
-  def __new__(cls, *args, **kwargs):
-    this_object = super(GlobMatchErrorBehavior, cls).__new__(cls, *args, **kwargs)
-
-    if this_object.failure_behavior not in cls.allowed_values:
-      raise cls.make_type_error("Value {!r} for failure_behavior must be one of: {!r}."
-                                .format(this_object.failure_behavior, cls.allowed_values))
-
-    return this_object
+  default_option_value = 'warn'
 
 
 class ExecutionOptions(datatype([

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -181,9 +181,10 @@ def enum(field_name, all_values):
                      NB: `all_values` must be a finite, non-empty iterable with unique values!
   """
 
-  # `OrderedSet` maintains the order of the input iterable, and will eagerly evaluate any input
-  # which would otherwise be lazy, such as a generator.
+  # This call to list() will eagerly evaluate any `all_values` which would otherwise be lazy, such
+  # as a generator.
   all_values_realized = list(all_values)
+  # `OrderedSet` maintains the order of the input iterable, but is faster to check membership.
   allowed_values_set = OrderedSet(all_values_realized)
 
   if len(allowed_values_set) < len(all_values_realized):
@@ -197,7 +198,7 @@ def enum(field_name, all_values):
 
     @memoized_classproperty
     def _singletons(cls):
-      """Generate memoized instances this enum wrapping each of this enum's allowed values."""
+      """Generate memoized instances of this enum wrapping each of this enum's allowed values."""
       return { value: cls(value) for value in cls.allowed_values }
 
     @classmethod

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -10,6 +10,7 @@ from builtins import object, zip
 from collections import OrderedDict, namedtuple
 
 from future.utils import PY2
+from twitter.common.collections import OrderedSet
 
 from pants.util.memo import memoized, memoized_classproperty
 from pants.util.meta import AbstractClass
@@ -169,11 +170,21 @@ def datatype(field_decls, superclass_name=None, **kwargs):
 
 
 def enum(field_name, all_values):
-  """???"""
+  """A datatype which can take on a finite set of values.
+
+  NB: `all_values` must be a finite, non-empty iterable with unique values!
+
+  An enum subclass can be constructed with its create() classmethod. This method will use the first
+  element of `all_values` as the enum value if none is specified.
+
+  :param all_values: An iterable of objects representing all possible values for the enum.
+  """
 
   class ChoiceDatatype(datatype([field_name])):
 
-    allowed_values = all_values
+    # `OrderedSet` maintains the order of the input iterable, and will eagerly evaluate any input
+    # which would otherwise be lazy, such as a generator.
+    allowed_values = OrderedSet(all_values)
     default_value = all_values[0]
 
     @memoized_classproperty

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -172,12 +172,13 @@ def datatype(field_decls, superclass_name=None, **kwargs):
 def enum(field_name, all_values):
   """A datatype which can take on a finite set of values. This method is experimental and unstable.
 
-  NB: `all_values` must be a finite, non-empty iterable with unique values!
-
-  An enum subclass can be constructed with its create() classmethod. This method will use the first
+  Any enum subclass can be constructed with its create() classmethod. This method will use the first
   element of `all_values` as the enum value if none is specified.
 
+  :param field_name: A string used as the field for the datatype. Note that enum does not yet
+                     support type checking as with datatype.
   :param all_values: An iterable of objects representing all possible values for the enum.
+                     NB: `all_values` must be a finite, non-empty iterable with unique values!
   """
 
   class ChoiceDatatype(datatype([field_name])):
@@ -185,7 +186,7 @@ def enum(field_name, all_values):
     # `OrderedSet` maintains the order of the input iterable, and will eagerly evaluate any input
     # which would otherwise be lazy, such as a generator.
     allowed_values = OrderedSet(all_values)
-    default_value = all_values[0]
+    default_value = iter(allowed_values).next()
 
     @memoized_classproperty
     def _singletons(cls):

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -170,7 +170,7 @@ def datatype(field_decls, superclass_name=None, **kwargs):
 
 
 def enum(field_name, all_values):
-  """A datatype which can take on a finite set of values.
+  """A datatype which can take on a finite set of values. This method is experimental and unstable.
 
   NB: `all_values` must be a finite, non-empty iterable with unique values!
 

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -190,6 +190,7 @@ def enum(field_name, all_values):
 
     @memoized_classproperty
     def _singletons(cls):
+      """Generate memoized instances this enum wrapping each of this enum's allowed values."""
       return {
         value: cls(value) for value in cls.allowed_values
       }

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -306,7 +306,7 @@ fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
             // By using `Ignore`, we assume all elements of the globs will definitely expand to
             // something here, or we don't care. Is that a valid assumption?
             fs::StrictGlobMatching::Ignore,
-            fs::Conjunction::And,
+            fs::GlobExpansionConjunction::AllMatch,
           )?)
           .map_err(|e| format!("Error expanding globs: {:?}", e))
           .and_then(move |paths| {

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -306,6 +306,7 @@ fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
             // By using `Ignore`, we assume all elements of the globs will definitely expand to
             // something here, or we don't care. Is that a valid assumption?
             fs::StrictGlobMatching::Ignore,
+            fs::Conjunction::And,
           )?)
           .map_err(|e| format!("Error expanding globs: {:?}", e))
           .and_then(move |paths| {

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -303,7 +303,7 @@ trait GlobMatchingImplementation<E: Send + Sync + 'static>: VFS<E> {
           // All must match.
           GlobExpansionConjunction::AllMatch => !non_matching_inputs.is_empty(),
           // Only one needs to match.
-          GlobExpansionConjunction::AnyMatch => &include.len() <= &non_matching_inputs.len(),
+          GlobExpansionConjunction::AnyMatch => include.len() <= non_matching_inputs.len(),
         };
 
         if match_failed {

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -322,7 +322,8 @@ trait GlobMatchingImplementation<E: Send + Sync + 'static>: VFS<E> {
           } else {
             // TODO(#5683): this doesn't have any useful context (the stack trace) without
             // being thrown -- this needs to be provided, otherwise this is unusable.
-            warn!("{}", msg);
+            // TODO: explain why warn!() here doesn't work!
+            eprintln!("WARN] {}", msg);
           }
         }
       }

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -321,9 +321,7 @@ trait GlobMatchingImplementation<E: Send + Sync + 'static>: VFS<E> {
             return future::err(Self::mk_error(&msg));
           } else {
             // TODO(#5683): this doesn't have any useful context (the stack trace) without
-            // being thrown -- this needs to be provided, otherwise this is unusable.
-            // NB: warn!() is blocked when using a console task e.g. list, so we print
-            // unconditionally to stderr here.
+            // being thrown -- this needs to be provided, otherwise this is far less useful.
             warn!("{}", msg);
           }
         }

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -324,7 +324,7 @@ trait GlobMatchingImplementation<E: Send + Sync + 'static>: VFS<E> {
             // being thrown -- this needs to be provided, otherwise this is unusable.
             // NB: warn!() is blocked when using a console task e.g. list, so we print
             // unconditionally to stderr here.
-            eprintln!("WARN] {}", msg);
+            warn!("{}", msg);
           }
         }
       }

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -322,7 +322,8 @@ trait GlobMatchingImplementation<E: Send + Sync + 'static>: VFS<E> {
           } else {
             // TODO(#5683): this doesn't have any useful context (the stack trace) without
             // being thrown -- this needs to be provided, otherwise this is unusable.
-            // TODO: explain why warn!() here doesn't work!
+            // NB: warn!() is blocked when using a console task e.g. list, so we print
+            // unconditionally to stderr here.
             eprintln!("WARN] {}", msg);
           }
         }

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -12,8 +12,8 @@ use glob::Pattern;
 use indexmap::{map::Entry::Occupied, IndexMap, IndexSet};
 
 use {
-  Dir, GitignoreStyleExcludes, GlobParsedSource, GlobSource, GlobWithSource, Link, PathGlob,
-  PathGlobs, PathStat, Stat, VFS,
+  Conjunction, Dir, GitignoreStyleExcludes, GlobParsedSource, GlobSource, GlobWithSource, Link,
+  PathGlob, PathGlobs, PathStat, Stat, VFS,
 };
 
 pub trait GlobMatching<E: Send + Sync + 'static>: VFS<E> {
@@ -148,6 +148,7 @@ trait GlobMatchingImplementation<E: Send + Sync + 'static>: VFS<E> {
       include,
       exclude,
       strict_match_behavior,
+      conjunction,
     } = path_globs;
 
     if include.is_empty() {
@@ -292,12 +293,20 @@ trait GlobMatchingImplementation<E: Send + Sync + 'static>: VFS<E> {
 
         // Get all the inputs which didn't transitively expand to any files.
         let non_matching_inputs: Vec<GlobParsedSource> = include
+          .clone()
           .into_iter()
           .map(|entry| entry.input)
           .filter(|parsed_source| !inputs_with_matches.contains(parsed_source))
           .collect();
 
-        if !non_matching_inputs.is_empty() {
+        let match_failed = match conjunction {
+          // All must match.
+          Conjunction::And => !non_matching_inputs.is_empty(),
+          // Only one needs to match.
+          Conjunction::Or => &include.len() <= &non_matching_inputs.len(),
+        };
+
+        if match_failed {
           // TODO(#5684): explain what global and/or target-specific option to set to
           // modify this behavior!
           let msg = format!(

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -12,8 +12,8 @@ use glob::Pattern;
 use indexmap::{map::Entry::Occupied, IndexMap, IndexSet};
 
 use {
-  Conjunction, Dir, GitignoreStyleExcludes, GlobParsedSource, GlobSource, GlobWithSource, Link,
-  PathGlob, PathGlobs, PathStat, Stat, VFS,
+  Dir, GitignoreStyleExcludes, GlobExpansionConjunction, GlobParsedSource, GlobSource,
+  GlobWithSource, Link, PathGlob, PathGlobs, PathStat, Stat, VFS,
 };
 
 pub trait GlobMatching<E: Send + Sync + 'static>: VFS<E> {
@@ -301,9 +301,9 @@ trait GlobMatchingImplementation<E: Send + Sync + 'static>: VFS<E> {
 
         let match_failed = match conjunction {
           // All must match.
-          Conjunction::And => !non_matching_inputs.is_empty(),
+          GlobExpansionConjunction::AllMatch => !non_matching_inputs.is_empty(),
           // Only one needs to match.
-          Conjunction::Or => &include.len() <= &non_matching_inputs.len(),
+          GlobExpansionConjunction::AnyMatch => &include.len() <= &non_matching_inputs.len(),
         };
 
         if match_failed {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -443,16 +443,16 @@ impl StrictGlobMatching {
 }
 
 #[derive(Debug)]
-pub enum Conjunction {
-  And,
-  Or,
+pub enum GlobExpansionConjunction {
+  AllMatch,
+  AnyMatch,
 }
 
-impl Conjunction {
+impl GlobExpansionConjunction {
   pub fn create(spec: &str) -> Result<Self, String> {
     match spec {
-      "and" => Ok(Conjunction::And),
-      "or" => Ok(Conjunction::Or),
+      "all_match" => Ok(GlobExpansionConjunction::AllMatch),
+      "any_match" => Ok(GlobExpansionConjunction::AnyMatch),
       _ => Err(format!("Unrecognized conjunction: {}.", spec)),
     }
   }
@@ -463,7 +463,7 @@ pub struct PathGlobs {
   include: Vec<PathGlobIncludeEntry>,
   exclude: Arc<GitignoreStyleExcludes>,
   strict_match_behavior: StrictGlobMatching,
-  conjunction: Conjunction,
+  conjunction: GlobExpansionConjunction,
 }
 
 impl PathGlobs {
@@ -471,7 +471,7 @@ impl PathGlobs {
     include: &[String],
     exclude: &[String],
     strict_match_behavior: StrictGlobMatching,
-    conjunction: Conjunction,
+    conjunction: GlobExpansionConjunction,
   ) -> Result<PathGlobs, String> {
     let include = PathGlob::spread_filespecs(include)?;
     Self::create_with_globs_and_match_behavior(include, exclude, strict_match_behavior, conjunction)
@@ -481,7 +481,7 @@ impl PathGlobs {
     include: Vec<PathGlobIncludeEntry>,
     exclude: &[String],
     strict_match_behavior: StrictGlobMatching,
-    conjunction: Conjunction,
+    conjunction: GlobExpansionConjunction,
   ) -> Result<PathGlobs, String> {
     let gitignore_excludes = GitignoreStyleExcludes::create(exclude)?;
     Ok(PathGlobs {
@@ -505,7 +505,7 @@ impl PathGlobs {
       include,
       &[],
       StrictGlobMatching::Ignore,
-      Conjunction::And,
+      GlobExpansionConjunction::AllMatch,
     )
   }
 }

--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -374,8 +374,8 @@ mod tests {
   use testutil::make_file;
 
   use super::super::{
-    Conjunction, Dir, File, GlobMatching, Path, PathGlobs, PathStat, PosixFS, ResettablePool,
-    Snapshot, Store, StrictGlobMatching,
+    Dir, File, GlobExpansionConjunction, GlobMatching, Path, PathGlobs, PathStat, PosixFS,
+    ResettablePool, Snapshot, Store, StrictGlobMatching,
   };
   use super::OneOffStoreFileByDigest;
 
@@ -692,7 +692,7 @@ mod tests {
           &["**".to_owned()],
           &[],
           StrictGlobMatching::Ignore,
-          Conjunction::And,
+          GlobExpansionConjunction::AllMatch,
         ).unwrap(),
       )
       .wait()

--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -374,8 +374,8 @@ mod tests {
   use testutil::make_file;
 
   use super::super::{
-    Dir, File, GlobMatching, Path, PathGlobs, PathStat, PosixFS, ResettablePool, Snapshot, Store,
-    StrictGlobMatching,
+    Conjunction, Dir, File, GlobMatching, Path, PathGlobs, PathStat, PosixFS, ResettablePool,
+    Snapshot, Store, StrictGlobMatching,
   };
   use super::OneOffStoreFileByDigest;
 
@@ -688,7 +688,12 @@ mod tests {
     let mut v = posix_fs
       .expand(
         // Don't error or warn if there are no paths matched -- that is a valid state.
-        PathGlobs::create(&["**".to_owned()], &[], StrictGlobMatching::Ignore).unwrap(),
+        PathGlobs::create(
+          &["**".to_owned()],
+          &[],
+          StrictGlobMatching::Ignore,
+          Conjunction::And,
+        ).unwrap(),
       )
       .wait()
       .unwrap();

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -2,7 +2,9 @@ extern crate log;
 extern crate tempfile;
 
 use boxfuture::{BoxFuture, Boxable};
-use fs::{self, GlobMatching, PathGlobs, PathStatGetter, Snapshot, StrictGlobMatching};
+use fs::{
+  self, Conjunction, GlobMatching, PathGlobs, PathStatGetter, Snapshot, StrictGlobMatching,
+};
 use futures::{future, Future, Stream};
 use std::collections::BTreeSet;
 use std::ffi::OsStr;
@@ -62,6 +64,7 @@ impl CommandRunner {
         &try_future!(output_dirs_glob_strings),
         &[],
         StrictGlobMatching::Ignore,
+        Conjunction::And,
       )))
       .map_err(|e| format!("Error stating output dirs: {}", e));
 

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -3,7 +3,8 @@ extern crate tempfile;
 
 use boxfuture::{BoxFuture, Boxable};
 use fs::{
-  self, Conjunction, GlobMatching, PathGlobs, PathStatGetter, Snapshot, StrictGlobMatching,
+  self, GlobExpansionConjunction, GlobMatching, PathGlobs, PathStatGetter, Snapshot,
+  StrictGlobMatching,
 };
 use futures::{future, Future, Stream};
 use std::collections::BTreeSet;
@@ -64,7 +65,7 @@ impl CommandRunner {
         &try_future!(output_dirs_glob_strings),
         &[],
         StrictGlobMatching::Ignore,
-        Conjunction::And,
+        GlobExpansionConjunction::AllMatch,
       )))
       .map_err(|e| format!("Error stating output dirs: {}", e));
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -13,8 +13,8 @@ use context::{Context, Core};
 use core::{throw, Failure, Key, Noop, TypeConstraint, Value, Variants};
 use externs;
 use fs::{
-  self, Dir, DirectoryListing, File, FileContent, GlobMatching, Link, PathGlobs, PathStat,
-  StoreFileByDigest, StrictGlobMatching, VFS,
+  self, Conjunction, Dir, DirectoryListing, File, FileContent, GlobMatching, Link, PathGlobs,
+  PathStat, StoreFileByDigest, StrictGlobMatching, VFS,
 };
 use hashing;
 use process_execution::{self, CommandRunner};
@@ -678,11 +678,17 @@ impl Snapshot {
   pub fn lift_path_globs(item: &Value) -> Result<PathGlobs, String> {
     let include = externs::project_multi_strs(item, "include");
     let exclude = externs::project_multi_strs(item, "exclude");
+
     let glob_match_error_behavior =
       externs::project_ignoring_type(item, "glob_match_error_behavior");
     let failure_behavior = externs::project_str(&glob_match_error_behavior, "failure_behavior");
     let strict_glob_matching = StrictGlobMatching::create(failure_behavior.as_str())?;
-    PathGlobs::create(&include, &exclude, strict_glob_matching).map_err(|e| {
+
+    let conjunction_obj = externs::project_ignoring_type(item, "conjunction");
+    let conjunction_string = externs::project_str(&conjunction_obj, "conjunction");
+    let conjunction = Conjunction::create(&conjunction_string)?;
+
+    PathGlobs::create(&include, &exclude, strict_glob_matching, conjunction).map_err(|e| {
       format!(
         "Failed to parse PathGlobs for include({:?}), exclude({:?}): {}",
         include, exclude, e

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -13,8 +13,8 @@ use context::{Context, Core};
 use core::{throw, Failure, Key, Noop, TypeConstraint, Value, Variants};
 use externs;
 use fs::{
-  self, Conjunction, Dir, DirectoryListing, File, FileContent, GlobMatching, Link, PathGlobs,
-  PathStat, StoreFileByDigest, StrictGlobMatching, VFS,
+  self, Dir, DirectoryListing, File, FileContent, GlobExpansionConjunction, GlobMatching, Link,
+  PathGlobs, PathStat, StoreFileByDigest, StrictGlobMatching, VFS,
 };
 use hashing;
 use process_execution::{self, CommandRunner};
@@ -686,7 +686,7 @@ impl Snapshot {
 
     let conjunction_obj = externs::project_ignoring_type(item, "conjunction");
     let conjunction_string = externs::project_str(&conjunction_obj, "conjunction");
-    let conjunction = Conjunction::create(&conjunction_string)?;
+    let conjunction = GlobExpansionConjunction::create(&conjunction_string)?;
 
     PathGlobs::create(&include, &exclude, strict_glob_matching, conjunction).map_err(|e| {
       format!(

--- a/testprojects/src/python/sources/BUILD
+++ b/testprojects/src/python/sources/BUILD
@@ -1,6 +1,10 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+scala_library(
+  name='missing-sources',
+)
+
 python_library(
   dependencies=[
     ':text',

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_java_antlr_library.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_java_antlr_library.py
@@ -19,20 +19,19 @@ class JavaAntlrLibraryTest(TestBase):
     return BuildFileAliases(targets={'java_antlr_library': JavaAntlrLibrary})
 
   def test_empty(self):
-    with self.assertRaises(TargetDefinitionException) as cm:
+    with self.assertRaisesRegexp(TargetDefinitionException,
+                                 "the sources parameter.*contains an empty snapshot."):
       self.add_to_build_file('BUILD', dedent('''
         java_antlr_library(name='foo',
           sources=[],
         )'''))
       self.foo = self.target('//:foo')
-    expected_msg = (
-      "Invalid target JavaAntlrLibrary(address not yet set): the sources parameter EagerFilesetWithSpec(rel_root=u'', snapshot=Snapshot(directory_digest=DirectoryDigest(fingerprint=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, serialized_bytes_length=0), path_stats=())) contains an empty snapshot.")
-    self.assertEqual(expected_msg, str(cm.exception))
 
   def test_valid(self):
+    self.create_file(self.build_path('something.txt'), contents='asdf', mode='w')
     self.add_to_build_file('BUILD', dedent('''
       java_antlr_library(name='foo',
-        sources=['foo'],
+        sources=['something.txt'],
       )'''))
     self.foo = self.target('//:foo')
     self.assertIsInstance(self.foo, JavaAntlrLibrary)

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_java_antlr_library.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_java_antlr_library.py
@@ -19,12 +19,15 @@ class JavaAntlrLibraryTest(TestBase):
     return BuildFileAliases(targets={'java_antlr_library': JavaAntlrLibrary})
 
   def test_empty(self):
-    with self.assertRaisesRegexp(TargetDefinitionException, "Missing required 'sources' parameter"):
+    with self.assertRaises(TargetDefinitionException) as cm:
       self.add_to_build_file('BUILD', dedent('''
         java_antlr_library(name='foo',
           sources=[],
         )'''))
       self.foo = self.target('//:foo')
+    expected_msg = (
+      "Invalid target JavaAntlrLibrary(address not yet set): the sources parameter EagerFilesetWithSpec(rel_root=u'', snapshot=Snapshot(directory_digest=DirectoryDigest(fingerprint=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, serialized_bytes_length=0), path_stats=())) contains an empty snapshot.")
+    self.assertEqual(expected_msg, str(cm.exception))
 
   def test_valid(self):
     self.add_to_build_file('BUILD', dedent('''

--- a/tests/python/pants_test/engine/legacy/test_graph_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_graph_integration.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
+import os
 
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.option.scope import GLOBAL_SCOPE_CONFIG_SECTION
@@ -24,11 +24,20 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       'nonexistent_test_file.txt',
       'another_nonexistent_file.txt',
     ]),
-    'some-missing-some-not': ("globs('*.txt', '*.rs')", ['*.rs']),
-    'overlapping-globs': ("globs('sources.txt', '*.txt')", ['*.txt']),
   }
 
-  _WARN_FMT = "WARN] In target {base}:{name} with {desc}={glob}: glob pattern '{as_zsh_glob}' did not match any files."
+  _WARN_FMT = """WARN] Globs did not match. Excludes were: {excludes}. Unmatched globs were: {unmatched}.\n\n"""
+  # _WARN_FMT = "WARN] In target {base}:{name} with {desc}={glob}: glob pattern '{as_zsh_glob}' did
+  # not match any files."
+
+  _BUNDLE_ERR_MSGS = [
+    ['*.aaaa'],
+    ['**/*.aaaa', '**/*.bbbb'],
+    ['**/*.abab'],
+    ['file1.aaaa', 'file2.aaaa'],
+  ]
+
+  _BUNDLE_TARGET_BASE = 'testprojects/src/java/org/pantsbuild/testproject/bundle'
 
   def _list_target_check_warnings_sources(self, target_name):
     target_full = '{}:{}'.format(self._SOURCES_TARGET_BASE, target_name)
@@ -41,19 +50,18 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
     })
     self.assert_success(pants_run)
 
-    for as_zsh_glob in expected_globs:
-      warning_msg = self._WARN_FMT.format(
-        base=self._SOURCES_TARGET_BASE,
-        name=target_name,
-        desc='sources',
-        glob=glob_str,
-        as_zsh_glob=as_zsh_glob)
-      self.assertIn(warning_msg, pants_run.stderr_data)
+    warning_msg = (
+      "WARN] Globs did not match. Excludes were: " +
+      '[]' +
+      ". Unmatched globs were: " +
+      "[{}]".format(', '.join('"{}"'.format(os.path.join(self._SOURCES_TARGET_BASE, g)) for g in expected_globs)) +
+      ".\n\n")
+    self.assertEqual(warning_msg, pants_run.stderr_data)
 
   _ERR_TARGETS = {
     'testprojects/src/python/sources:some-missing-some-not': [
       "globs('*.txt', '*.rs')",
-      "Snapshot(PathGlobs(include=(u\'testprojects/src/python/sources/*.txt\', u\'testprojects/src/python/sources/*.rs\'), exclude=(), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error)))",
+      "Snapshot(PathGlobs(include=(u\'testprojects/src/python/sources/*.txt\', u\'testprojects/src/python/sources/*.rs\'), exclude=(), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=Conjunction>=Conjunction(conjunction=and)))",
       "Globs did not match. Excludes were: []. Unmatched globs were: [\"testprojects/src/python/sources/*.rs\"].",
     ],
     'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-bundle-fileset': [
@@ -62,7 +70,7 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       "Globs('*.aaaa')",
       "ZGlobs('**/*.abab')",
       "['file1.aaaa', 'file2.aaaa']",
-      "Snapshot(PathGlobs(include=(u\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error)))",
+      "Snapshot(PathGlobs(include=(u\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=Conjunction>=Conjunction(conjunction=and)))",
       "Globs did not match. Excludes were: []. Unmatched globs were: [\"testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\"].",
     ]
   }
@@ -82,12 +90,10 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
     for excerpt in expected_excerpts:
       self.assertIn(excerpt, pants_run.stderr_data)
 
-  @unittest.skip('Skipped to expedite landing #5769: see #5863')
   def test_missing_sources_warnings(self):
     for target_name in self._SOURCES_ERR_MSGS.keys():
       self._list_target_check_warnings_sources(target_name)
 
-  @unittest.skip('Skipped to expedite landing #5769: see #5863')
   def test_existing_sources(self):
     target_full = '{}:text'.format(self._SOURCES_TARGET_BASE)
     pants_run = self.run_pants(['list', target_full], config={
@@ -98,9 +104,8 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
     self.assert_success(pants_run)
     self.assertNotIn("WARN]", pants_run.stderr_data)
 
-  @unittest.skip('Skipped to expedite landing #5769: see #5863')
   def test_missing_bundles_warnings(self):
-    target_full = '{}:{}'.format(self._BUNDLE_TARGET_BASE, self._BUNDLE_TARGET_NAME)
+    target_full = '{}:missing-bundle-fileset'.format(self._BUNDLE_TARGET_BASE)
     pants_run = self.run_pants(['list', target_full], config={
       GLOBAL_SCOPE_CONFIG_SECTION: {
         'glob_expansion_failure': 'warn',
@@ -109,17 +114,15 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
 
     self.assert_success(pants_run)
 
-    for glob_str, expected_globs in self._BUNDLE_ERR_MSGS:
-      for as_zsh_glob in expected_globs:
-        warning_msg = self._WARN_FMT.format(
-          base=self._BUNDLE_TARGET_BASE,
-          name=self._BUNDLE_TARGET_NAME,
-          desc='fileset',
-          glob=glob_str,
-          as_zsh_glob=as_zsh_glob)
-        self.assertIn(warning_msg, pants_run.stderr_data)
+    for msgs in self._BUNDLE_ERR_MSGS:
+      warning_msg = (
+        "WARN] Globs did not match. Excludes were: " +
+        "[]" +
+        ". Unmatched globs were: " +
+        "[{}]".format(', '.join(('"' + os.path.join(self._BUNDLE_TARGET_BASE, m) + '"') for m in msgs)) +
+        ".")
+      self.assertIn(warning_msg, pants_run.stderr_data)
 
-  @unittest.skip('Skipped to expedite landing #5769: see #5863')
   def test_existing_bundles(self):
     target_full = '{}:mapper'.format(self._BUNDLE_TARGET_BASE)
     pants_run = self.run_pants(['list', target_full], config={

--- a/tests/python/pants_test/engine/legacy/test_graph_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_graph_integration.py
@@ -56,18 +56,15 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       ".\n\n")
     self.assertEqual(warning_msg, pants_run.stderr_data)
 
-  _SUCCESS_TARGETS = {
+  _ERR_TARGETS = {
     'testprojects/src/python/sources:some-missing-some-not': [
       "globs('*.txt', '*.rs')",
-      "Snapshot(PathGlobs(include=(u\'testprojects/src/python/sources/*.txt\', u\'testprojects/src/python/sources/*.rs\'), exclude=(), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=Conjunction>=Conjunction(conjunction=and)))",
-      "Globs did not match. Excludes were: [\"testprojects/src/python/sources/*Test.scala\", \"testprojects/src/python/sources/*Spec.scala\"]. Unmatched globs were: [\"testprojects/src/python/sources/*.rs\"].",
+      "Snapshot(PathGlobs(include=(u\'testprojects/src/python/sources/*.txt\', u\'testprojects/src/python/sources/*.rs\'), exclude=(), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=GlobExpansionConjunction>=GlobExpansionConjunction(conjunction=all_match)))",
+      "Globs did not match. Excludes were: []. Unmatched globs were: [\"testprojects/src/python/sources/*.rs\"].",
     ],
-  }
-
-  _ERR_TARGETS = {
     'testprojects/src/python/sources:missing-sources': [
       "*.scala",
-      "Snapshot(PathGlobs(include=(u\'testprojects/src/python/sources/*.scala\',), exclude=(u\'testprojects/src/python/sources/*Test.scala\', u\'testprojects/src/python/sources/*Spec.scala\'), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=Conjunction>=Conjunction(conjunction=or)))",
+      "Snapshot(PathGlobs(include=(u\'testprojects/src/python/sources/*.scala\',), exclude=(u\'testprojects/src/python/sources/*Test.scala\', u\'testprojects/src/python/sources/*Spec.scala\'), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=GlobExpansionConjunction>=GlobExpansionConjunction(conjunction=any_match)))",
       "Globs did not match. Excludes were: [\"testprojects/src/python/sources/*Test.scala\", \"testprojects/src/python/sources/*Spec.scala\"]. Unmatched globs were: [\"testprojects/src/python/sources/*.scala\"].",
     ],
     'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-bundle-fileset': [
@@ -76,31 +73,25 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       "Globs('*.aaaa')",
       "ZGlobs('**/*.abab')",
       "['file1.aaaa', 'file2.aaaa']",
-      "Snapshot(PathGlobs(include=(u\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=Conjunction>=Conjunction(conjunction=or)))",
+      "Snapshot(PathGlobs(include=(u\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=GlobExpansionConjunction>=GlobExpansionConjunction(conjunction=all_match)))",
       "Globs did not match. Excludes were: []. Unmatched globs were: [\"testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\"].",
     ]
   }
 
-  def _list_target_check_error(self, target_name, success=False):
-    if success:
-      expected_excerpts = self._SUCCESS_TARGETS[target_name]
-    else:
-      expected_excerpts = self._ERR_TARGETS[target_name]
+  def _list_target_check_error(self, target_name):
+    expected_excerpts = self._ERR_TARGETS[target_name]
 
     pants_run = self.run_pants(['list', target_name], config={
       GLOBAL_SCOPE_CONFIG_SECTION: {
         'glob_expansion_failure': 'error',
       },
     })
-    if success:
-      self.assert_success(pants_run)
-    else:
-      self.assert_failure(pants_run)
+    self.assert_failure(pants_run)
 
-      self.assertIn(AddressLookupError.__name__, pants_run.stderr_data)
+    self.assertIn(AddressLookupError.__name__, pants_run.stderr_data)
 
-      for excerpt in expected_excerpts:
-        self.assertIn(excerpt, pants_run.stderr_data)
+    for excerpt in expected_excerpts:
+      self.assertIn(excerpt, pants_run.stderr_data)
 
   def test_missing_sources_warnings(self):
     for target_name in self._SOURCES_ERR_MSGS.keys():
@@ -146,8 +137,5 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
     self.assertNotIn("WARN]", pants_run.stderr_data)
 
   def test_error_message(self):
-    for k in self._SUCCESS_TARGETS:
-      self._list_target_check_error(k, success=True)
-
     for k in self._ERR_TARGETS:
       self._list_target_check_error(k)

--- a/tests/python/pants_test/engine/legacy/test_graph_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_graph_integration.py
@@ -58,11 +58,19 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       ".\n\n")
     self.assertEqual(warning_msg, pants_run.stderr_data)
 
-  _ERR_TARGETS = {
+  _SUCCESS_TARGETS = {
     'testprojects/src/python/sources:some-missing-some-not': [
       "globs('*.txt', '*.rs')",
       "Snapshot(PathGlobs(include=(u\'testprojects/src/python/sources/*.txt\', u\'testprojects/src/python/sources/*.rs\'), exclude=(), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=Conjunction>=Conjunction(conjunction=and)))",
-      "Globs did not match. Excludes were: []. Unmatched globs were: [\"testprojects/src/python/sources/*.rs\"].",
+      "Globs did not match. Excludes were: [\"testprojects/src/python/sources/*Test.scala\", \"testprojects/src/python/sources/*Spec.scala\"]. Unmatched globs were: [\"testprojects/src/python/sources/*.rs\"].",
+    ],
+  }
+
+  _ERR_TARGETS = {
+    'testprojects/src/python/sources:missing-sources': [
+      "*.scala",
+      "Snapshot(PathGlobs(include=(u\'testprojects/src/python/sources/*.scala\',), exclude=(u\'testprojects/src/python/sources/*Test.scala\', u\'testprojects/src/python/sources/*Spec.scala\'), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=Conjunction>=Conjunction(conjunction=or)))",
+      "Globs did not match. Excludes were: [\"testprojects/src/python/sources/*Test.scala\", \"testprojects/src/python/sources/*Spec.scala\"]. Unmatched globs were: [\"testprojects/src/python/sources/*.scala\"].",
     ],
     'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-bundle-fileset': [
       "['a/b/file1.txt']",
@@ -70,25 +78,31 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       "Globs('*.aaaa')",
       "ZGlobs('**/*.abab')",
       "['file1.aaaa', 'file2.aaaa']",
-      "Snapshot(PathGlobs(include=(u\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=Conjunction>=Conjunction(conjunction=and)))",
+      "Snapshot(PathGlobs(include=(u\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=Conjunction>=Conjunction(conjunction=or)))",
       "Globs did not match. Excludes were: []. Unmatched globs were: [\"testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\"].",
     ]
   }
 
-  def _list_target_check_error(self, target_name):
-    expected_excerpts = self._ERR_TARGETS[target_name]
+  def _list_target_check_error(self, target_name, success=False):
+    if success:
+      expected_excerpts = self._SUCCESS_TARGETS[target_name]
+    else:
+      expected_excerpts = self._ERR_TARGETS[target_name]
 
     pants_run = self.run_pants(['list', target_name], config={
       GLOBAL_SCOPE_CONFIG_SECTION: {
         'glob_expansion_failure': 'error',
       },
     })
-    self.assert_failure(pants_run)
+    if success:
+      self.assert_success(pants_run)
+    else:
+      self.assert_failure(pants_run)
 
-    self.assertIn(AddressLookupError.__name__, pants_run.stderr_data)
+      self.assertIn(AddressLookupError.__name__, pants_run.stderr_data)
 
-    for excerpt in expected_excerpts:
-      self.assertIn(excerpt, pants_run.stderr_data)
+      for excerpt in expected_excerpts:
+        self.assertIn(excerpt, pants_run.stderr_data)
 
   def test_missing_sources_warnings(self):
     for target_name in self._SOURCES_ERR_MSGS.keys():
@@ -134,7 +148,8 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
     self.assertNotIn("WARN]", pants_run.stderr_data)
 
   def test_error_message(self):
-    self._list_target_check_error('testprojects/src/python/sources:some-missing-some-not')
+    for k in self._SUCCESS_TARGETS:
+      self._list_target_check_error(k, success=True)
 
-    self._list_target_check_error(
-      'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-bundle-fileset')
+    for k in self._ERR_TARGETS:
+      self._list_target_check_error(k)

--- a/tests/python/pants_test/engine/legacy/test_graph_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_graph_integration.py
@@ -27,8 +27,6 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
   }
 
   _WARN_FMT = """WARN] Globs did not match. Excludes were: {excludes}. Unmatched globs were: {unmatched}.\n\n"""
-  # _WARN_FMT = "WARN] In target {base}:{name} with {desc}={glob}: glob pattern '{as_zsh_glob}' did
-  # not match any files."
 
   _BUNDLE_ERR_MSGS = [
     ['*.aaaa'],

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -618,6 +618,7 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
       SomeEnum(x=3)
 
     expected_rx_falsy_value = re.escape(
-      "Value u'' for 'x' must be one of: OrderedSet([1, 2]).")
+      "Value {}'' for 'x' must be one of: OrderedSet([1, 2])."
+      .format('u' if PY2 else ''))
     with self.assertRaisesRegexp(TypeCheckError, expected_rx_falsy_value):
       SomeEnum(x='')

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -6,13 +6,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import copy
 import pickle
+import re
 from abc import abstractmethod
 from builtins import object, str
 
 from future.utils import PY2, PY3, text_type
 
 from pants.util.objects import (Exactly, SubclassesOf, SuperclassesOf, TypeCheckError,
-                                TypedDatatypeInstanceConstructionError, datatype)
+                                TypedDatatypeInstanceConstructionError, datatype, enum)
 from pants_test.base_test import BaseTest
 
 
@@ -193,6 +194,9 @@ class CamelCaseWrapper(datatype([('nonneg_int', NonNegativeInt)])): pass
 class ReturnsNotImplemented(object):
   def __eq__(self, other):
     return NotImplemented
+
+
+class SomeEnum(enum('x', [1, 2])): pass
 
 
 class DatatypeTest(BaseTest):
@@ -589,3 +593,31 @@ __new__() got an unexpected keyword argument 'nonexistent_field'""")
       """error: in constructor of type AnotherTypedDatatype: type check error:
 field 'elements' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(list).""")
     self.assertEqual(str(cm.exception), expected_msg)
+
+  def test_enum_class_creation_errors(self):
+    expected_rx = re.escape(
+      "When converting all_values ([1, 2, 3, 1]) to a set, at least one duplicate "
+      "was detected. The unique elements of all_values were: OrderedSet([1, 2, 3]).")
+    with self.assertRaisesRegexp(ValueError, expected_rx):
+      class DuplicateAllowedValues(enum('x', [1, 2, 3, 1])): pass
+
+  def test_enum_instance_creation(self):
+    self.assertEqual(1, SomeEnum.create().x)
+    self.assertEqual(2, SomeEnum.create(2).x)
+    self.assertEqual(1, SomeEnum(1).x)
+    self.assertEqual(2, SomeEnum(x=2).x)
+
+  def test_enum_instance_creation_errors(self):
+    expected_rx = re.escape(
+      "Value 3 for 'x' must be one of: OrderedSet([1, 2]).")
+    with self.assertRaisesRegexp(TypeCheckError, expected_rx):
+      SomeEnum.create(3)
+    with self.assertRaisesRegexp(TypeCheckError, expected_rx):
+      SomeEnum(3)
+    with self.assertRaisesRegexp(TypeCheckError, expected_rx):
+      SomeEnum(x=3)
+
+    expected_rx_falsy_value = re.escape(
+      "Value u'' for 'x' must be one of: OrderedSet([1, 2]).")
+    with self.assertRaisesRegexp(TypeCheckError, expected_rx_falsy_value):
+      SomeEnum(x='')


### PR DESCRIPTION
### Problem

See #6236.

### Solution

- Introduce the `enum` wrapper for `datatype`s which have a known, finite set of values, and apply it to GlobMatchErrorBehavior.
- Add Conjunction `enum` to PathGlobs in python and rust.
- Print warnings unconditionally to stderr from rust.
- Decide whether the PathGlobs match succeeded or failed depending on the value of the `Conjunction` object.

### Result

- Warnings or errors don't display if a target doesn't match every one of its `default_sources_globs`.
- Resolves #6236.