### PR TITLE
Avoid pytest 3.7.0+.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -376,6 +376,10 @@ resolver_blacklist: {
   }
 
 
+[pytest]
+requirements: pytest>=3.0.7,<3.7
+
+
 [test.pytest]
 timeouts: true
 timeout_default: 60


### PR DESCRIPTION
This is an attempt to stop the bleeding noted in #6282.
