### PR TITLE
When python target compatibility is not set, use interpreter constraints.

### DIFF
--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -78,7 +78,7 @@ class PythonInterpreterCache(object):
     filters = set()
     for target in targets:
       if isinstance(target, PythonTarget):
-        c = self._python_setup.compatibility_or_constraintstar(target)
+        c = self._python_setup.compatibility_or_constraints(target)
         targets = tgts_by_compatibilities.get(c)
         if not targets:
           targets = tgts_by_compatibilities[c] = []

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -19,13 +19,6 @@ class PythonSetup(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(PythonSetup, cls).register_options(register)
-    # Note: This replaces two options:
-    # A) The global --interpreter option in the old python tasks.
-    #    That flag is only relevant in the python backend, and should never have been
-    #    global to begin with.
-    # B) The --interpreter-requirement option above.  That flag merely served to set the
-    #    effective default for when no other constraints were set, so we might as well
-    #    roll that into the more general constraints.
     register('--interpreter-constraints', advanced=True, default=['CPython>=2.7,<3'], type=list,
              metavar='<requirement>',
              help="Constrain the selected Python interpreter.  Specify with requirement syntax, "

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -80,8 +80,7 @@ class PythonSetup(Subsystem):
 
   @property
   def interpreter_constraints(self):
-    return (self.get_options().interpreter_constraints or self.get_options().interpreter or
-            [self.get_options().interpreter_requirement or b''])
+    return tuple(self.get_options().interpreter_constraints)
 
   @property
   def interpreter_search_paths(self):
@@ -139,6 +138,10 @@ class PythonSetup(Subsystem):
   @property
   def scratch_dir(self):
     return os.path.join(self.get_options().pants_workdir, *self.options_scope.split('.'))
+
+  def compatibility_or_constraints(self, target):
+    """Return either the compatibility of the given target, or the interpreter constraints."""
+    return target.compatibility or self.interpreter_constraints
 
   def setuptools_requirement(self):
     return self._failsafe_parse('setuptools=={0}'.format(self.setuptools_version))

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -134,7 +134,7 @@ class PythonSetup(Subsystem):
 
   def compatibility_or_constraints(self, target):
     """Return either the compatibility of the given target, or the interpreter constraints."""
-    return target.compatibility or self.interpreter_constraints
+    return tuple(target.compatibility or self.interpreter_constraints)
 
   def setuptools_requirement(self):
     return self._failsafe_parse('setuptools=={0}'.format(self.setuptools_version))

--- a/src/python/pants/backend/python/tasks/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks/python_execution_task_base.py
@@ -10,6 +10,7 @@ from builtins import str
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 
+from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_distribution import PythonDistribution
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
@@ -18,7 +19,6 @@ from pants.backend.python.tasks.pex_build_util import is_python_target
 from pants.backend.python.tasks.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks.resolve_requirements_task_base import ResolveRequirementsTaskBase
 from pants.backend.python.tasks.wrapped_pex import WrappedPEX
-from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.build_graph.files import Files
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.util.contextutil import temporary_file

--- a/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
@@ -126,25 +126,30 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
     os.remove(py3_pex)
 
   def test_target_constraints_with_no_sources(self):
+    if self.skip_if_no_python('3'):
+      return
+
     with temporary_dir() as interpreters_cache:
+      pants_ini_config = {
+          'python-setup': {
+            'interpreter_cache_dir': interpreters_cache,
+            'interpreter_constraints': ['CPython>3'],
+          }
+        }
       # Run task.
-      py3 = '3'
-      if not self.skip_if_no_python(py3):
-        pants_ini_config = {'python-setup': {'interpreter_cache_dir': interpreters_cache}}
-        pants_run_3 = self.run_pants(
-          command=['run', '{}:test_bin'.format(os.path.join(self.testproject, 'test_target_with_no_sources'))],
-          config=pants_ini_config
-        )
-        self.assert_success(pants_run_3)
-        self.assertIn('python3', pants_run_3.stdout_data)
+      pants_run = self.run_pants(
+        command=['run', '{}:test_bin'.format(os.path.join(self.testproject, 'test_target_with_no_sources'))],
+        config=pants_ini_config
+      )
+      self.assert_success(pants_run)
+      self.assertIn('python3', pants_run.stdout_data)
 
       # Binary task.
-      pants_ini_config = {'python-setup': {'interpreter_cache_dir': interpreters_cache}}
-      pants_run_27 = self.run_pants(
+      pants_run = self.run_pants(
         command=['binary', '{}:test_bin'.format(os.path.join(self.testproject, 'test_target_with_no_sources'))],
         config=pants_ini_config
       )
-      self.assert_success(pants_run_27)
+      self.assert_success(pants_run)
 
     # Ensure proper interpreter constraints were passed to built pexes.
     py2_pex = os.path.join(os.getcwd(), 'dist', 'test_bin.pex')

--- a/tests/python/pants_test/python/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/python/test_interpreter_selection_integration.py
@@ -14,11 +14,29 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
   testproject = 'testprojects/src/python/interpreter_selection'
 
-  def test_conflict(self):
+  def test_conflict_via_compatibility(self):
+    # Tests that targets with compatibility conflicts collide.
     binary_target = '{}:deliberately_conficting_compatibility'.format(self.testproject)
     pants_run = self._build_pex(binary_target)
     self.assert_failure(pants_run,
                         'Unexpected successful build of {binary}.'.format(binary=binary_target))
+    self.assertIn('Unable to detect a suitable interpreter for compatibilities',
+                  pants_run.stdout_data)
+
+  def test_conflict_via_config(self):
+    # Tests that targets with compatibility conflict with targets with default compatibility.
+    # NB: Passes empty `args` to avoid having the default CLI args override the config.
+    config = {
+        'python-setup': {
+          'interpreter_constraints': ['CPython<2.7'],
+        }
+      }
+    binary_target = '{}:echo_interpreter_version'.format(self.testproject)
+    pants_run = self._build_pex(binary_target, config=config, args=[])
+    self.assert_failure(pants_run,
+                        'Unexpected successful build of {binary}.'.format(binary=binary_target))
+    self.assertIn('Unable to detect a suitable interpreter for compatibilities',
+                  pants_run.stdout_data)
 
   def test_select_3(self):
     self._maybe_test_version('3')
@@ -56,10 +74,11 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
       (stdout_data, _) = proc.communicate()
       return stdout_data
 
-  def _build_pex(self, binary_target, config=None):
-    # Avoid some known-to-choke-on interpreters.
-    command = ['binary',
-               binary_target,
-               '--python-setup-interpreter-constraints=CPython>=2.7,<3',
-               '--python-setup-interpreter-constraints=CPython>=3.3']
+  def _build_pex(self, binary_target, config=None, args=None):
+    # By default, Avoid some known-to-choke-on interpreters.
+    args = list(args) if args is not None else [
+          '--python-setup-interpreter-constraints=CPython>=2.7,<3',
+          '--python-setup-interpreter-constraints=CPython>=3.3',
+        ]
+    command = ['binary', binary_target] + args
     return self.run_pants(command=command, config=config)


### PR DESCRIPTION
### Problem

Currently, `interpreter_constraints` are not used as the "default" value of `compatibility` for a python target, which means that:
```
./pants --python-setup-interpreter-constraints='["CPython>=3.5"]' test tests/python/pants_test/java:nailgun_io
```

...fails in an odd half-configured fashion (where the interpreter is bounded in some way, but not the dep resolution).

### Solution

Use `interpreter_constraints` as the default value of `compatibility` for a target. This aligns with #6250, and that patch should likely land as well.

### Result

```./pants --python-setup-interpreter-constraints='["CPython>=3.5"]' test tests/python/pants_test/java:nailgun_io```
...works, and uses python 3.

Fixes #5082.

----

Before this patch, in a repository with:
```
--python-setup-interpreter-constraints='["CPython>=2.7,CPython<3"]'
```
...individual targets were able to claim to be compatible with `CPython>3` while depending on targets with no declared compatibility, and things would just work.

After this patch, the default compatibility for a repository is specified via the constraints, and so rather than being completely unconstrained, a target with no compatibility argument would pick up the default. In the case above, that would cause a failure.

There are a few potential fixes for consumers:
1. don't pin interpreters in pants.ini, and only pin compatibility on binaries, or on targets where it is relevant
2. pin interpreters in pants.ini, but for a range wide enough to cover all of your binary and test target's compatibilities
3. pin interpreters for a "default" compatibility (ie, default to 2), and then explicitly clear the default on libraries to make them "agnostic": ie, `python_library(.., compatibility=[])` (or declare them to be wide enough to cover all consumers).