### PR TITLE
Bound pytest below 3.7 to avoid a ZipImportError

### DIFF
--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -13,7 +13,8 @@ class PyTest(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(PyTest, cls).register_options(register)
-    register('--requirements', advanced=True, default='pytest>=3.0.7,<4.0',
+    # TODO: This is currently bounded below `3.7` due to #6282.
+    register('--requirements', advanced=True, default='pytest>=3.0.7,<3.7',
              help='Requirements string for the pytest library.')
     register('--timeout-requirements', advanced=True, default='pytest-timeout>=1.2,<1.3',
              help='Requirements string for the pytest-timeout library.')


### PR DESCRIPTION
### Problem

As described in #6282, pytest `3.7` introduces a non-deterministic `ZipImportError`.

### Solution

Bound pants' usage of pytest below `3.7`. This subsumes #6283: the hypothesis is that because `tests/python/pants_test/backend/python/tasks/test_pytest_run.py` creates synthetic scopes for its tasks, options in `pants.ini` (as opposed to Subsystem defaults) are not applied. 

### Result

Works around #6282.