### PR TITLE
Rename deprecated assertions

### DIFF
--- a/contrib/avro/tests/python/pants_test/contrib/avro/tasks/test_avro_gen.py
+++ b/contrib/avro/tests/python/pants_test/contrib/avro/tasks/test_avro_gen.py
@@ -77,11 +77,11 @@ class AvroJavaGenTest(NailgunTaskTestBase):
     '''))
 
     task = self._test_avro('avro-build:avro-schema')
-    self.assertEquals(len(task._test_cmd_log), 1)
-    self.assertEquals(task._test_cmd_log[0][:-1], ['compile', 'schema', 'avro-build/src/avro/schema.avsc'])
+    self.assertEqual(len(task._test_cmd_log), 1)
+    self.assertEqual(task._test_cmd_log[0][:-1], ['compile', 'schema', 'avro-build/src/avro/schema.avsc'])
 
     task = self._test_avro('avro-build:avro-idl')
-    self.assertEquals(len(task._test_cmd_log), 2)
-    self.assertEquals(task._test_cmd_log[0][:-1], ['idl', 'avro-build/src/avro/record.avdl'])
+    self.assertEqual(len(task._test_cmd_log), 2)
+    self.assertEqual(task._test_cmd_log[0][:-1], ['idl', 'avro-build/src/avro/record.avdl'])
     generated_protocol_json_file = task._test_cmd_log[0][-1]
-    self.assertEquals(task._test_cmd_log[1][:-1], ['compile', 'protocol', generated_protocol_json_file])
+    self.assertEqual(task._test_cmd_log[1][:-1], ['compile', 'protocol', generated_protocol_json_file])

--- a/contrib/avro/tests/python/pants_test/contrib/avro/tasks/test_avro_gen_integration.py
+++ b/contrib/avro/tests/python/pants_test/contrib/avro/tasks/test_avro_gen_integration.py
@@ -54,7 +54,7 @@ class AvroJavaGenTest(PantsRunIntegrationTest):
 
       output_root = self.get_gen_root(pants_run.workdir, target_spec)
       actual_files = set(os.listdir(os.path.join(output_root, 'org', 'pantsbuild', 'contrib', 'avro')))
-      self.assertEquals(set(['User.java']), actual_files)
+      self.assertEqual(set(['User.java']), actual_files)
 
   def test_idl_gen(self):
     target_spec = self.avro_test_target('simple')
@@ -64,4 +64,4 @@ class AvroJavaGenTest(PantsRunIntegrationTest):
       output_root = self.get_gen_root(pants_run.workdir, target_spec)
       expected_files = set(['Kind.java', 'MD5.java', 'Simple.java', 'TestError.java', 'TestRecord.java'])
       actual_files = set(os.listdir(os.path.join(output_root, 'org', 'pantsbuild', 'contrib', 'avro')))
-      self.assertEquals(expected_files, actual_files)
+      self.assertEqual(expected_files, actual_files)

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/test_meta_rename_integration.py
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/test_meta_rename_integration.py
@@ -26,4 +26,4 @@ class MetaRenameIntegrationTest(PantsRunIntegrationTest):
       '--to=testprojects/tests/java/org/pantsbuild/testproject/buildrefactor:X',
       'testprojects/tests/java/org/pantsbuild/testproject/buildrefactor:Y'])
 
-    self.assertEquals(pre_dependees_run.stdout_data, post_dependees_run.stdout_data)
+    self.assertEqual(pre_dependees_run.stdout_data, post_dependees_run.stdout_data)

--- a/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/test_index_java_integration.py
+++ b/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/test_index_java_integration.py
@@ -24,7 +24,7 @@ class TestIndexJavaIntegration(PantsRunIntegrationTest):
         kindex_glob = os.path.join(
           workdir, 'index/kythe-java-extract/current/{}/current/*.kindex'.format(tgt))
         kindex_files = glob.glob(kindex_glob)
-        self.assertEquals(1, len(kindex_files))
+        self.assertEqual(1, len(kindex_files))
         kindex_file = kindex_files[0]
         self.assertTrue(os.path.isfile(kindex_file))
         self.assertGreater(os.path.getsize(kindex_file), 200)  # Make sure it's not trivial.

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_thrift_gen_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_thrift_gen_integration.py
@@ -108,7 +108,7 @@ class GoThriftGenIntegrationTest(PantsRunIntegrationTest):
         root = os.path.join(workdir, 'gen', 'go-thrift', hash_dir,
                             target_dir.replace(os.path.sep, '.'), 'current')
 
-        self.assertEquals(sorted(['src/go/thrifttest/duck/constants.go',
+        self.assertEqual(sorted(['src/go/thrifttest/duck/constants.go',
                                   'src/go/thrifttest/duck/ttypes.go',
                                   'src/go/thrifttest/duck/feeder.go',
                                   'src/go/thrifttest/duck/feeder-remote/feeder-remote.go']),

--- a/contrib/jax_ws/tests/python/pants_test/contrib/jax_ws/tasks/test_jax_ws_gen_integration.py
+++ b/contrib/jax_ws/tests/python/pants_test/contrib/jax_ws/tasks/test_jax_ws_gen_integration.py
@@ -51,7 +51,7 @@ class JaxWsGenTest(PantsRunIntegrationTest):
                           'contrib.jax_ws.tests.wsdl.org.pantsbuild.contrib.jax_ws.hello-service',
                           'current')
 
-      self.assertEquals(sorted(['com/example/HelloWorldServer.java',
+      self.assertEqual(sorted(['com/example/HelloWorldServer.java',
                                 'com/example/HelloWorldServerImplService.java']),
                         sorted(exact_files(root)))
 

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_build.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_build.py
@@ -59,24 +59,24 @@ class TestNodeBuild(TaskTestBase):
       [(target, None), (node_dependent_module, None)])
 
     node_dependent_paths = self._get_all_bundleable_js_path(bundleable_js, node_dependent_module)
-    self.assertEquals(1, len(node_dependent_paths))
-    self.assertEquals(
+    self.assertEqual(1, len(node_dependent_paths))
+    self.assertEqual(
       os.path.normpath(node_dependent_paths[0]),
       os.path.normpath(node_paths.node_path(node_dependent_module)))
     target_paths = self._get_all_bundleable_js_path(bundleable_js, target)
-    self.assertEquals(1, len(target_paths))
-    self.assertEquals(
+    self.assertEqual(1, len(target_paths))
+    self.assertEqual(
       os.path.normpath(target_paths[0]),
       os.path.normpath(node_paths.node_path(target)))
 
     node_dependent_classpath = runtime_classpath.get_for_target(node_dependent_module)
-    self.assertEquals(1, len(node_dependent_classpath))
-    self.assertEquals(
+    self.assertEqual(1, len(node_dependent_classpath))
+    self.assertEqual(
       os.path.realpath(os.path.join(node_dependent_classpath[0][1], node_dependent_module_name)),
       os.path.realpath(node_paths.node_path(node_dependent_module)))
     target_classpaths = runtime_classpath.get_for_target(target)
-    self.assertEquals(1, len(target_classpaths))
-    self.assertEquals(
+    self.assertEqual(1, len(target_classpaths))
+    self.assertEqual(
       os.path.realpath(os.path.join(target_classpaths[0][1], target_name)),
       os.path.realpath(node_paths.node_path(target)))
 
@@ -122,13 +122,13 @@ class TestNodeBuild(TaskTestBase):
     target_paths = self._get_all_bundleable_js_path(bundleable_js, target)
     target_classpaths = runtime_classpath.get_for_target(target)
 
-    self.assertEquals(
+    self.assertEqual(
       os.path.realpath(target_paths[0]),
       os.path.realpath(os.path.join(target_classpaths[0][1], 'build_test')))
     self.assertTrue(os.path.realpath(target_paths[0]).endswith('myOutput'))
-    self.assertEquals(set(os.listdir(target_paths[0])), set(['output_file']))
+    self.assertEqual(set(os.listdir(target_paths[0])), set(['output_file']))
     with open(os.path.join(target_paths[0], 'output_file')) as f:
-      self.assertEquals(f.read(), 'Hello, world!\n')
+      self.assertEqual(f.read(), 'Hello, world!\n')
 
   def test_run_non_existing_script(self):
     package_json_file = self.create_file(

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_bundle.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_bundle.py
@@ -58,7 +58,7 @@ class TestNodeBundle(TaskTestBase):
       product_data = product.get(target)
       self.assertIsNotNone(product_data)
       product_basedir = list(product_data.keys())[0]
-      self.assertEquals(product_data[product_basedir], ['{}.tar.gz'.format(self.target_name)])
+      self.assertEqual(product_data[product_basedir], ['{}.tar.gz'.format(self.target_name)])
 
   def test_no_dependencies_for_node_bundle(self):
     with temporary_dir() as tmp_dir:

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_bundle_integration.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_bundle_integration.py
@@ -71,7 +71,7 @@ class NodeBundleIntegrationTest(PantsRunIntegrationTest):
     self.assert_success(pants_run)
 
     with self._extract_archive(self.WEB_COMPONENT_BUTTON_PROCESSED_ARTIFACT) as temp_dir:
-      self.assertEquals(
+      self.assertEqual(
         set(os.listdir(temp_dir)),
         {'Button.js'}
       )
@@ -86,7 +86,7 @@ class NodeBundleIntegrationTest(PantsRunIntegrationTest):
     self.assert_success(pants_run)
 
     with self._extract_archive(self.JVM_PROJECT_ARTIFACT) as temp_dir:
-      self.assertEquals(
+      self.assertEqual(
         set(os.listdir(os.path.join(temp_dir, self.WEB_COMPONENT_BUTTON_PROCESSED_PROJECT))),
         {'Button.js'}
       )
@@ -106,7 +106,7 @@ class NodeBundleIntegrationTest(PantsRunIntegrationTest):
 
     with self._extract_archive(self.JVM_WITH_ARTIFACTS_ARTIFACT) as temp_dir:
       print (os.listdir(temp_dir))
-      self.assertEquals(
+      self.assertEqual(
         set(os.listdir(os.path.join(temp_dir, self.WITH_DEPENDENCY_ARTIFACTS_PROJECT))),
         {'Button.js'}
       )
@@ -122,7 +122,7 @@ class NodeBundleIntegrationTest(PantsRunIntegrationTest):
     self.assert_success(self.run_pants(command=command))
 
     with self._extract_archive(self.PREINSTALLED_ARTIFACT) as temp_dir:
-      self.assertEquals(
+      self.assertEqual(
         set(os.listdir(temp_dir)),
         {'src', 'test', 'node_modules', 'package.json'}
       )

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_java_thrift_library_fingerprint_strategy.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_java_thrift_library_fingerprint_strategy.py
@@ -33,7 +33,7 @@ class JavaThriftLibraryFingerprintStrategyTest(TestBase):
 
     fp1 = self.create_strategy(self.options1).compute_fingerprint(a)
     fp2 = self.create_strategy(option_values).compute_fingerprint(a)
-    self.assertNotEquals(fp1, fp2)
+    self.assertNotEqual(fp1, fp2)
 
   def test_fp_diffs_due_to_compiler_args_change(self):
     a = self.make_target(':a', target_type=JavaThriftLibrary, compiler_args=['--foo'])
@@ -41,7 +41,7 @@ class JavaThriftLibraryFingerprintStrategyTest(TestBase):
 
     fp1 = self.create_strategy(self.options1).compute_fingerprint(a)
     fp2 = self.create_strategy(self.options1).compute_fingerprint(b)
-    self.assertNotEquals(fp1, fp2)
+    self.assertNotEqual(fp1, fp2)
 
   def test_hash_and_equal(self):
     self.assertEqual(self.create_strategy(self.options1), self.create_strategy(self.options1))

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -127,17 +127,17 @@ class ScroogeGenTest(NailgunTaskTestBase):
       Context.add_new_target = mock
       task.execute()
 
-      self.assertEquals(1, mock.call_count)
+      self.assertEqual(1, mock.call_count)
       _, call_kwargs = mock.call_args
-      self.assertEquals(call_kwargs['target_type'], library_type)
-      self.assertEquals(call_kwargs['dependencies'], OrderedSet())
-      self.assertEquals(call_kwargs['provides'], None)
-      self.assertEquals(call_kwargs['derived_from'], target)
-      self.assertEquals(call_kwargs['strict_deps'], True)
-      self.assertEquals(call_kwargs['fatal_warnings'], False)
+      self.assertEqual(call_kwargs['target_type'], library_type)
+      self.assertEqual(call_kwargs['dependencies'], OrderedSet())
+      self.assertEqual(call_kwargs['provides'], None)
+      self.assertEqual(call_kwargs['derived_from'], target)
+      self.assertEqual(call_kwargs['strict_deps'], True)
+      self.assertEqual(call_kwargs['fatal_warnings'], False)
 
       sources = call_kwargs['sources']
-      self.assertEquals(sources.files, ())
+      self.assertEqual(sources.files, ())
 
     finally:
       Context.add_new_target = saved_add_new_target
@@ -172,5 +172,5 @@ class ScroogeGenTest(NailgunTaskTestBase):
   def _test_dependencies_help(self, contents, declares_service, declares_exception):
     source = 'test_smoke/a.thrift'
     self.create_file(relpath=source, mode='w', contents=contents)
-    self.assertEquals(ScroogeGen._declares_service(source), declares_service)
-    self.assertEquals(ScroogeGen._declares_exception(source), declares_exception)
+    self.assertEqual(ScroogeGen._declares_service(source), declares_service)
+    self.assertEqual(ScroogeGen._declares_exception(source), declares_exception)

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_util.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_util.py
@@ -35,7 +35,7 @@ class ThriftUtilTest(unittest.TestCase):
       b_included = self.write(os.path.join(b, 'b_included.thrift'), '# noop')
       c_included = self.write(os.path.join(b, 'c_included.thrift'), '# noop')
 
-      self.assertEquals({a_included, b_included, c_included},
+      self.assertEqual({a_included, b_included, c_included},
                         find_includes(basedirs={a, b}, source=main))
 
   def test_find_includes_exception(self):
@@ -53,7 +53,7 @@ class ThriftUtilTest(unittest.TestCase):
     with temporary_dir() as dir:
       root_1 = self.write(os.path.join(dir, 'root_1.thrift'), '# noop')
       root_2 = self.write(os.path.join(dir, 'root_2.thrift'), '# noop')
-      self.assertEquals({root_1, root_2},
+      self.assertEqual({root_1, root_2},
                         find_root_thrifts(basedirs=[], sources=[root_1, root_2]))
 
     with temporary_dir() as dir:
@@ -61,4 +61,4 @@ class ThriftUtilTest(unittest.TestCase):
       self.write(os.path.join(dir, 'mid_1.thrift'), 'include "leaf_1.thrift"')
       self.write(os.path.join(dir, 'leaf_1.thrift'), '# noop')
       root_2 = self.write(os.path.join(dir, 'root_2.thrift'), 'include "root_1.thrift"')
-      self.assertEquals({root_2}, find_root_thrifts(basedirs=[], sources=[root_1, root_2]))
+      self.assertEqual({root_2}, find_root_thrifts(basedirs=[], sources=[root_1, root_2]))

--- a/contrib/thrifty/tests/python/pants_test/pants/contrib/thrifty/test_thrifty_gen.py
+++ b/contrib/thrifty/tests/python/pants_test/pants/contrib/thrifty/test_thrifty_gen.py
@@ -36,7 +36,7 @@ class JavaThriftyGenTest(TaskTestBase):
                               sources=['foo.thrift'])
     context = self.context(target_roots=[target])
     task = self.create_task(context)
-    self.assertEquals([
+    self.assertEqual([
       '--out={}'.format(self.TARGET_WORKDIR),
       '--path={}/src/thrifty'.format(self.build_root),
       'src/thrifty/foo.thrift'],
@@ -50,7 +50,7 @@ class JavaThriftyGenTest(TaskTestBase):
                                   sources=['downstream.thrift'], dependencies=[upstream])
     context = self.context(target_roots=[upstream, downstream])
     task = self.create_task(context)
-    self.assertEquals([
+    self.assertEqual([
       '--out={}'.format(self.TARGET_WORKDIR),
       '--path={}/src/thrifty'.format(self.build_root),
       'src/thrifty/downstream.thrift'],

--- a/pants-plugins/tests/python/internal_backend_test/utilities/test_releases.py
+++ b/pants-plugins/tests/python/internal_backend_test/utilities/test_releases.py
@@ -18,18 +18,18 @@ def _branch_name(revision_str):
 class ReleasesTest(unittest.TestCase):
 
   def test_branch_name_master(self):
-    self.assertEquals('master', _branch_name('1.1.0-dev1'))
-    self.assertEquals('master', _branch_name('1.1.0dev1'))
+    self.assertEqual('master', _branch_name('1.1.0-dev1'))
+    self.assertEqual('master', _branch_name('1.1.0dev1'))
 
   def test_branch_name_stable(self):
-    self.assertEquals('1.1.x', _branch_name('1.1.0-rc1'))
-    self.assertEquals('1.1.x', _branch_name('1.1.0rc1'))
-    self.assertEquals('2.1.x', _branch_name('2.1.0'))
-    self.assertEquals('1.2.x', _branch_name('1.2.0rc0-12345'))
+    self.assertEqual('1.1.x', _branch_name('1.1.0-rc1'))
+    self.assertEqual('1.1.x', _branch_name('1.1.0rc1'))
+    self.assertEqual('2.1.x', _branch_name('2.1.0'))
+    self.assertEqual('1.2.x', _branch_name('1.2.0rc0-12345'))
 
     # A negative example: do not prepend `<number>.`, because
     # the first two numbers will be taken as branch name.
-    self.assertEquals('12345.1.x', _branch_name('12345.1.2.0rc0'))
+    self.assertEqual('12345.1.x', _branch_name('12345.1.2.0rc0'))
 
   def test_invalid_test_branch_name_stable_append_alphabet(self):
     with self.assertRaises(InvalidVersion):

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
@@ -81,7 +81,7 @@ class AntlrJavaGenTest(NailgunTaskTestBase):
 
     actual_sources = [s for s in Fileset.rglobs('*.java', root=target_workdir)]
     expected_sources = syn_target.sources_relative_to_source_root()
-    self.assertEquals(set(expected_sources), set(actual_sources))
+    self.assertEqual(set(expected_sources), set(actual_sources))
 
     # Check that the synthetic target has a valid source root and the generated sources have the
     # expected java package

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen_integration.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen_integration.py
@@ -14,11 +14,11 @@ class AntlrJavaGenIntegrationTest(PantsRunIntegrationTest):
                                       'examples.src.java.org.pantsbuild.example.antlr3.antlr3',
                                       bundle_jar_name='antlr3',
                                       args=['7*8'])
-    self.assertEquals('56.0', stdout_data.rstrip(), msg="got output:{0}".format(stdout_data))
+    self.assertEqual('56.0', stdout_data.rstrip(), msg="got output:{0}".format(stdout_data))
 
   def test_run_antlr4(self):
     stdout_data = self.bundle_and_run('examples/src/java/org/pantsbuild/example/antlr4',
                                       'examples.src.java.org.pantsbuild.example.antlr4.antlr4',
                                       bundle_jar_name='antlr4',
                                       args=['7*6'])
-    self.assertEquals('42.0', stdout_data.rstrip(), msg="got output:{0}".format(stdout_data))
+    self.assertEqual('42.0', stdout_data.rstrip(), msg="got output:{0}".format(stdout_data))

--- a/tests/python/pants_test/backend/codegen/jaxb/test_jaxb_gen.py
+++ b/tests/python/pants_test/backend/codegen/jaxb/test_jaxb_gen.py
@@ -87,7 +87,7 @@ class JaxbGenJavaTest(NailgunTaskTestBase):
       for filename in filenames:
         if filename.endswith('.java'):
           files.append(os.path.join(dirpath, filename))
-    self.assertEquals(sorted(['ObjectFactory.java', 'Vegetable.java']),
+    self.assertEqual(sorted(['ObjectFactory.java', 'Vegetable.java']),
                       sorted([os.path.basename(f) for f in files]))
 
     # Make sure there is no header with a timestamp in the generated file

--- a/tests/python/pants_test/backend/codegen/protobuf/java/test_java_protobuf_library.py
+++ b/tests/python/pants_test/backend/codegen/protobuf/java/test_java_protobuf_library.py
@@ -51,7 +51,7 @@ class JavaProtobufLibraryTest(TestBase):
     '''))
     target = self.target('//:foo')
     self.assertIsInstance(target, JavaProtobufLibrary)
-    self.assertEquals(1, len(target.imported_jars))
+    self.assertEqual(1, len(target.imported_jars))
     import_jar_dep = target.imported_jars[0]
     self.assertIsInstance(import_jar_dep, JarDependency)
 

--- a/tests/python/pants_test/backend/codegen/protobuf/java/test_protobuf_gen.py
+++ b/tests/python/pants_test/backend/codegen/protobuf/java/test_protobuf_gen.py
@@ -51,8 +51,8 @@ class ProtobufGenTest(TaskTestBase):
     context = self.context(target_roots=[self.target('test_proto:proto')])
     task = self.create_task(context)
     javadeps = task.javadeps
-    self.assertEquals(len(javadeps), 1)
-    self.assertEquals('protobuf-java', javadeps.pop().name)
+    self.assertEqual(len(javadeps), 1)
+    self.assertEqual('protobuf-java', javadeps.pop().name)
 
   def test_calculate_sources(self):
     self.create_file(relpath='proto-lib/foo.proto', contents='')
@@ -65,8 +65,8 @@ class ProtobufGenTest(TaskTestBase):
     context = self.context(target_roots=[target])
     task = self.create_task(context)
     result = task._calculate_sources(target)
-    self.assertEquals(1, len(result.keys()))
-    self.assertEquals(OrderedSet(['proto-lib/foo.proto']), result['proto-lib'])
+    self.assertEqual(1, len(result.keys()))
+    self.assertEqual(OrderedSet(['proto-lib/foo.proto']), result['proto-lib'])
 
   def test_calculate_sources_with_source_root(self):
     self.create_file(relpath='project/src/main/proto/proto-lib/foo.proto', contents='')
@@ -79,6 +79,6 @@ class ProtobufGenTest(TaskTestBase):
     context = self.context(target_roots=[target])
     task = self.create_task(context)
     result = task._calculate_sources(target)
-    self.assertEquals(1, len(result.keys()))
-    self.assertEquals(OrderedSet(['project/src/main/proto/proto-lib/foo.proto']),
+    self.assertEqual(1, len(result.keys()))
+    self.assertEqual(OrderedSet(['project/src/main/proto/proto-lib/foo.proto']),
                       result['project/src/main/proto'])

--- a/tests/python/pants_test/backend/codegen/protobuf/java/test_protobuf_integration.py
+++ b/tests/python/pants_test/backend/codegen/protobuf/java/test_protobuf_integration.py
@@ -36,7 +36,7 @@ class ProtobufIntegrationTest(PantsRunIntegrationTest):
                                   cwd=out_path)
       java_retcode = java_run.wait()
       java_out = java_run.stdout.read()
-      self.assertEquals(java_retcode, 0)
+      self.assertEqual(java_retcode, 0)
       self.assertIn("parsec", java_out)
 
   def test_bundle_protobuf_imports(self):
@@ -55,7 +55,7 @@ class ProtobufIntegrationTest(PantsRunIntegrationTest):
         cwd=out_path)
       java_retcode = java_run.wait()
       java_out = java_run.stdout.read()
-      self.assertEquals(java_retcode, 0)
+      self.assertEqual(java_retcode, 0)
       self.assertIn("very test", java_out)
 
   def test_bundle_protobuf_unpacked_jars(self):
@@ -63,7 +63,7 @@ class ProtobufIntegrationTest(PantsRunIntegrationTest):
                          '--deployjar',
                          'examples/src/java/org/pantsbuild/example/protobuf/unpacked_jars']
                         ) as pants_run:
-      self.assertEquals(pants_run.returncode, self.PANTS_SUCCESS_CODE,
+      self.assertEqual(pants_run.returncode, self.PANTS_SUCCESS_CODE,
                         "goal bundle run expected success, got {0}\n"
                         "got stderr:\n{1}\n"
                         "got stdout:\n{2}\n".format(pants_run.returncode,
@@ -77,7 +77,7 @@ class ProtobufIntegrationTest(PantsRunIntegrationTest):
       java_run = subprocess.Popen(args, stdout=subprocess.PIPE, cwd=out_path)
       java_retcode = java_run.wait()
       java_out = java_run.stdout.read()
-      self.assertEquals(java_retcode, 0)
+      self.assertEqual(java_retcode, 0)
       self.assertIn("Message is: Hello World!", java_out)
 
   def test_source_ordering(self):
@@ -105,7 +105,7 @@ class ProtobufIntegrationTest(PantsRunIntegrationTest):
     all_blocks = list(find_protoc_blocks([l.strip() for l in pants_run.stdout_data.split('\n')]))
     block_text = '\n\n'.join('[block {0}]\n{1}'.format(index, '\n'.join(block))
                               for index, block in enumerate(all_blocks))
-    self.assertEquals(len(all_blocks), 3,
+    self.assertEqual(len(all_blocks), 3,
         'Expected there to be exactly {expected} protoc compilation group! (Were {count}.)'
         '\n{out}\n\nBLOCKS:\n{blocks}'
         .format(expected=3, count=len(all_blocks),
@@ -134,4 +134,4 @@ class ProtobufIntegrationTest(PantsRunIntegrationTest):
           last_proto = number
       if last_proto > biggest_proto:
         biggest_proto = last_proto
-    self.assertEquals(biggest_proto, 6, 'Not all protos were seen!\n{}'.format(block_text))
+    self.assertEqual(biggest_proto, 6, 'Not all protos were seen!\n{}'.format(block_text))

--- a/tests/python/pants_test/backend/codegen/ragel/java/test_ragel_gen.py
+++ b/tests/python/pants_test/backend/codegen/ragel/java/test_ragel_gen.py
@@ -80,4 +80,4 @@ class RagelGenTest(TaskTestBase):
     with temporary_file() as fp:
       fp.write(ragel_file_contents)
       fp.flush()
-      self.assertEquals(calculate_genfile(fp.name), 'com/example/atoi/Parser.java')
+      self.assertEqual(calculate_genfile(fp.name), 'com/example/atoi/Parser.java')

--- a/tests/python/pants_test/backend/codegen/wire/java/test_java_wire_library.py
+++ b/tests/python/pants_test/backend/codegen/wire/java/test_java_wire_library.py
@@ -32,7 +32,7 @@ class JavaWireLibraryTest(TestBase):
     target = self.make_target('//:wire_service_options', JavaWireLibrary,
                               service_writer='com.squareup.wire.RetrofitServiceWriter',
                               service_writer_options=['foo', 'bar', 'baz'])
-    self.assertEquals(['foo', 'bar', 'baz'], target.payload.service_writer_options)
+    self.assertEqual(['foo', 'bar', 'baz'], target.payload.service_writer_options)
 
   def test_invalid_service_writer_opts(self):
     with self.assertRaisesRegexp(TargetDefinitionException,

--- a/tests/python/pants_test/backend/codegen/wire/java/test_wire_gen.py
+++ b/tests/python/pants_test/backend/codegen/wire/java/test_wire_gen.py
@@ -37,7 +37,7 @@ class WireGenTest(TaskTestBase):
                                           sources=['foo.proto'])
     context = self.context(target_roots=[simple_wire_target])
     task = self.create_task(context)
-    self.assertEquals([
+    self.assertEqual([
       '--java_out={}'.format(self.TARGET_WORKDIR),
       '--proto_path={}/src/wire'.format(self.build_root),
       'foo.proto'],
@@ -50,7 +50,7 @@ class WireGenTest(TaskTestBase):
                                      service_writer='org.pantsbuild.DummyServiceWriter',
                                      service_writer_options=['opt1', 'opt2'])
     task = self.create_task(self.context(target_roots=[wire_targetv1]))
-    self.assertEquals([
+    self.assertEqual([
       '--java_out={}'.format(self.TARGET_WORKDIR),
       '--service_writer=org.pantsbuild.DummyServiceWriter',
       '--service_writer_opt', 'opt1',
@@ -69,7 +69,7 @@ class WireGenTest(TaskTestBase):
                                     roots=['root1', 'root2', 'root3'],
                                     enum_options=['enum1', 'enum2', 'enum3'],)
     task = self.create_task(self.context(target_roots=[kitchen_sink]))
-    self.assertEquals([
+    self.assertEqual([
       '--java_out={}'.format(self.TARGET_WORKDIR),
       '--no_options',
       '--service_writer=org.pantsbuild.DummyServiceWriter',
@@ -90,7 +90,7 @@ class WireGenTest(TaskTestBase):
                                           sources=['foo.proto'], dependencies=[parent_target])
     context = self.context(target_roots=[parent_target, simple_wire_target])
     task = self.create_task(context)
-    self.assertEquals([
+    self.assertEqual([
       '--java_out={}'.format(self.TARGET_WORKDIR),
       '--proto_path={}/src/wire'.format(self.build_root),
       'foo.proto'],

--- a/tests/python/pants_test/backend/codegen/wire/java/test_wire_integration.py
+++ b/tests/python/pants_test/backend/codegen/wire/java/test_wire_integration.py
@@ -47,7 +47,7 @@ class WireIntegrationTest(PantsRunIntegrationTest):
       java_run = subprocess.Popen(args, stdout=subprocess.PIPE, cwd=out_path)
       java_retcode = java_run.wait()
       java_out = java_run.stdout.read()
-      self.assertEquals(java_retcode, 0)
+      self.assertEqual(java_retcode, 0)
       self.assertIn('19 degrees celsius', java_out)
 
   def test_bundle_wire_dependent_targets(self):
@@ -64,7 +64,7 @@ class WireIntegrationTest(PantsRunIntegrationTest):
                                   cwd=out_path)
       java_retcode = java_run.wait()
       java_out = java_run.stdout.read()
-      self.assertEquals(java_retcode, 0)
+      self.assertEqual(java_retcode, 0)
       self.assertIn('Element{symbol=Hg, name=Mercury, atomic_number=80, '
                     'melting_point=Temperature{unit=celsius, number=-39}, '
                     'boiling_point=Temperature{unit=celsius, number=357}}', java_out)

--- a/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
+++ b/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
@@ -85,14 +85,14 @@ This is the second readme file! Isn't it exciting?
     self.assertTrue(isinstance(p, Page), "%s isn't an instance of Page" % p)
     self.assertTrue(isinstance(p.provides[0], WikiArtifact), "%s isn't an instance of WikiArtifact" % p)
     self.assertTrue(isinstance(p.provides[0].wiki, Wiki), "%s isn't an instance of Wiki" % p)
-    self.assertEquals("~areitz", p.provides[0].config['space'])
-    self.assertEquals("test_page", p.provides[0].config['title'])
+    self.assertEqual("~areitz", p.provides[0].config['space'])
+    self.assertEqual("test_page", p.provides[0].config['title'])
     self.assertFalse('parent' in p.provides[0].config)
 
     # Check to make sure the 'readme2' target has been loaded into the build graph (via parsing of
     # the 'README.md' page)
     address = Address.parse('src/docs:readme2', relative_to=get_buildroot())
-    self.assertEquals(p._build_graph.get_target(address), self.target('src/docs:readme2'))
+    self.assertEqual(p._build_graph.get_target(address), self.target('src/docs:readme2'))
 
   def test_wiki_page_fingerprinting(self):
     def create_page_target(space):

--- a/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
+++ b/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
@@ -25,76 +25,76 @@ charlie"""
 
 class ChooseLinesTest(unittest.TestCase):
   def test_include_no_params(self):
-    self.assertEquals(
+    self.assertEqual(
         markdown_to_html_utils.choose_include_text(ABC, '', 'fake.md'),
         '\n'.join(['able', 'baker', 'charlie']))
 
   def test_include_start_at(self):
-    self.assertEquals(
+    self.assertEqual(
         markdown_to_html_utils.choose_include_text(ABC, 'start-at=abl', 'fake.md'),
         '\n'.join(['able', 'baker', 'charlie']))
 
-    self.assertEquals(
+    self.assertEqual(
         markdown_to_html_utils.choose_include_text(ABC, 'start-at=bak', 'fake.md'),
         '\n'.join(['baker', 'charlie']))
 
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'start-at=xxx', 'fake.md'),
       '')
 
   def test_include_start_after(self):
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'start-after=bak', 'fake.md'),
       'charlie')
 
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'start-after=cha', 'fake.md'),
       '')
 
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'start-after=xxx', 'fake.md'),
       '')
 
   def test_include_end_at(self):
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'end-at=abl', 'fake.md'),
       'able')
 
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'end-at=bak', 'fake.md'),
       '\n'.join(['able', 'baker']))
 
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'end-at=xxx', 'fake.md'),
       '')
 
   def test_include_end_before(self):
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'end-before=abl', 'fake.md'),
       '')
 
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'end-before=xxx', 'fake.md'),
       '')
 
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'end-before=bak', 'fake.md'),
       'able')
 
   def test_include_start_at_end_at(self):
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'start-at=abl&end-at=abl', 'fake.md'),
       'able')
 
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'start-at=cha&end-at=cha', 'fake.md'),
       'charlie')
 
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'start-at=abl&end-at=bak', 'fake.md'),
       '\n'.join(['able', 'baker']))
 
-    self.assertEquals(
+    self.assertEqual(
       markdown_to_html_utils.choose_include_text(ABC, 'start-at=bak&end-at=abl', 'fake.md'),
       '')
 

--- a/tests/python/pants_test/backend/graph_info/tasks/test_cloc.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_cloc.py
@@ -37,10 +37,10 @@ class ClocTest(ConsoleTaskTestBase):
         fields = line.split()
         if len(fields) >= 5:
           if fields[0] == lang:
-            self.assertEquals(files, int(fields[1]))
-            self.assertEquals(blank, int(fields[2]))
-            self.assertEquals(comment, int(fields[3]))
-            self.assertEquals(code, int(fields[4]))
+            self.assertEqual(files, int(fields[1]))
+            self.assertEqual(blank, int(fields[2]))
+            self.assertEqual(comment, int(fields[3]))
+            self.assertEqual(code, int(fields[4]))
             return
       self.fail('Found no output line for {}'.format(lang))
 
@@ -70,6 +70,6 @@ class ClocTest(ConsoleTaskTestBase):
       options={'ignored': True},
       scheduler=self.scheduler,
     )
-    self.assertEquals(['Ignored the following files:',
+    self.assertEqual(['Ignored the following files:',
                        'src/py/foo/empty.py: zero sized file'],
                       list(filter(None, res))[-2:])

--- a/tests/python/pants_test/backend/graph_info/tasks/test_cloc_integration.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_cloc_integration.py
@@ -18,7 +18,7 @@ class ClocIntegrationTest(PantsRunIntegrationTest):
     self.assert_success(pants_run)
     # Strip out the header which is non-deterministic because it has speed information in it.
     stdout = str('\n'.join(pants_run.stdout_data.split('\n')[1:]))
-    self.assertEquals(stdout, str("""-------------------------------------------------------------------------------
+    self.assertEqual(stdout, str("""-------------------------------------------------------------------------------
 Language                     files          blank        comment           code
 -------------------------------------------------------------------------------
 Python                           1              3              3              4

--- a/tests/python/pants_test/backend/graph_info/tasks/test_listtargets.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_listtargets.py
@@ -172,7 +172,7 @@ class ListTargetsTest(BaseListTargetsTest):
     targets = []
     targets.extend(self.targets('a/b/d/::'))
     targets.extend(self.target('f:alias').dependencies)
-    self.assertEquals(3, len(targets), "Expected a duplicate of a/b/d:d")
+    self.assertEqual(3, len(targets), "Expected a duplicate of a/b/d:d")
     self.assert_console_output(
       'a/b/c:c3',
       'a/b/d:d',

--- a/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management.py
@@ -48,37 +48,37 @@ class JarDependencyManagementTest(TestBase):
 
   def test_conflict_strategy_use_direct(self):
     manager = self._jar_dependency_management(conflict_strategy='USE_DIRECT')
-    self.assertEquals(self._coord_one, manager.resolve_version_conflict(
+    self.assertEqual(self._coord_one, manager.resolve_version_conflict(
       direct_coord=self._coord_one,
       managed_coord=self._coord_two,
     ))
     manager = self._jar_dependency_management(conflict_strategy='USE_DIRECT',
                                               suppress_conflict_messages=True)
-    self.assertEquals(self._coord_one, manager.resolve_version_conflict(
+    self.assertEqual(self._coord_one, manager.resolve_version_conflict(
       direct_coord=self._coord_one,
       managed_coord=self._coord_two,
     ))
 
   def test_conflict_strategy_use_managed(self):
     manager = self._jar_dependency_management(conflict_strategy='USE_MANAGED')
-    self.assertEquals(self._coord_two, manager.resolve_version_conflict(
+    self.assertEqual(self._coord_two, manager.resolve_version_conflict(
       direct_coord=self._coord_one,
       managed_coord=self._coord_two,
     ))
     manager = self._jar_dependency_management(conflict_strategy='USE_MANAGED',
                                               suppress_conflict_messages=True)
-    self.assertEquals(self._coord_two, manager.resolve_version_conflict(
+    self.assertEqual(self._coord_two, manager.resolve_version_conflict(
       direct_coord=self._coord_one,
       managed_coord=self._coord_two,
     ))
 
   def test_conflict_strategy_use_forced(self):
     manager = self._jar_dependency_management(conflict_strategy='USE_DIRECT_IF_FORCED')
-    self.assertEquals(self._coord_two, manager.resolve_version_conflict(
+    self.assertEqual(self._coord_two, manager.resolve_version_conflict(
       direct_coord=self._coord_one,
       managed_coord=self._coord_two,
     ))
-    self.assertEquals(self._coord_one, manager.resolve_version_conflict(
+    self.assertEqual(self._coord_one, manager.resolve_version_conflict(
       direct_coord=self._coord_one,
       managed_coord=self._coord_two,
       force=True,
@@ -86,11 +86,11 @@ class JarDependencyManagementTest(TestBase):
 
   def test_conflict_strategy_use_newer(self):
     manager = self._jar_dependency_management(conflict_strategy='USE_NEWER')
-    self.assertEquals(self._coord_two, manager.resolve_version_conflict(
+    self.assertEqual(self._coord_two, manager.resolve_version_conflict(
       direct_coord=self._coord_one,
       managed_coord=self._coord_two,
     ))
-    self.assertEquals(self._coord_two, manager.resolve_version_conflict(
+    self.assertEqual(self._coord_two, manager.resolve_version_conflict(
       direct_coord=self._coord_two,
       managed_coord=self._coord_one,
     ))
@@ -116,18 +116,18 @@ class PinnedJarArtifactSetTest(unittest.TestCase):
       M2Coordinate('org', 'foo', '1.2'),
       M2Coordinate('org', 'bar', '7.8'),
     ])
-    self.assertEquals(set1, set2)
-    self.assertEquals(hash(set1), hash(set2))
+    self.assertEqual(set1, set2)
+    self.assertEqual(hash(set1), hash(set2))
 
   def test_iter(self):
     set1 = PinnedJarArtifactSet(pinned_coordinates=[
       M2Coordinate('org', 'foo', '1.2'),
       M2Coordinate('org', 'bar', '7.8'),
     ])
-    self.assertEquals(2, len(set1))
+    self.assertEqual(2, len(set1))
     set2 = PinnedJarArtifactSet(set1)
-    self.assertEquals(2, len(set2))
-    self.assertEquals(set1, set2)
+    self.assertEqual(2, len(set2))
+    self.assertEqual(set1, set2)
 
   def test_replace(self):
     set1 = PinnedJarArtifactSet(pinned_coordinates=[
@@ -135,10 +135,10 @@ class PinnedJarArtifactSetTest(unittest.TestCase):
       M2Coordinate('org', 'bar', '7.8'),
     ])
     set1.put(M2Coordinate('org', 'hello', '9'))
-    self.assertEquals(3, len(set1))
+    self.assertEqual(3, len(set1))
     set1.put(M2Coordinate('org', 'foo', '1.3'))
-    self.assertEquals(3, len(set1))
-    self.assertEquals(M2Coordinate('org', 'foo', '1.3'), set1[M2Coordinate('org', 'foo')])
+    self.assertEqual(3, len(set1))
+    self.assertEqual(M2Coordinate('org', 'foo', '1.3'), set1[M2Coordinate('org', 'foo')])
 
   def test_put_failure(self):
     set1 = PinnedJarArtifactSet()
@@ -151,16 +151,16 @@ class PinnedJarArtifactSetTest(unittest.TestCase):
       M2Coordinate('org', 'bar', '7.8'),
       M2Coordinate('org', 'foo', '1.8', ext='tar')
     ])
-    self.assertEquals('1.2', set1[M2Coordinate('org', 'foo')].rev)
-    self.assertEquals('7.8', set1[M2Coordinate('org', 'bar')].rev)
-    self.assertEquals('1.8', set1[M2Coordinate('org', 'foo', ext='tar')].rev)
-    self.assertEquals(set(coord.rev for coord in set1), {'1.2', '7.8', '1.8'})
+    self.assertEqual('1.2', set1[M2Coordinate('org', 'foo')].rev)
+    self.assertEqual('7.8', set1[M2Coordinate('org', 'bar')].rev)
+    self.assertEqual('1.8', set1[M2Coordinate('org', 'foo', ext='tar')].rev)
+    self.assertEqual(set(coord.rev for coord in set1), {'1.2', '7.8', '1.8'})
     self.assertIn(M2Coordinate('org', 'foo'), set1)
     self.assertIn(M2Coordinate('org', 'foo', '27'), set1)
     self.assertNotIn(M2Coordinate('hello', 'there'), set1)
 
   def test_lookup_noop(self):
-    self.assertEquals(M2Coordinate('org', 'foo', '1.2'),
+    self.assertEqual(M2Coordinate('org', 'foo', '1.2'),
                       PinnedJarArtifactSet()[M2Coordinate('org', 'foo', '1.2')])
 
   def test_id(self):

--- a/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management_integration.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management_integration.py
@@ -47,7 +47,7 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
     classpath = self._classpath_result(spec_name, **kwargs)
     for jar_set, value in expected_sets.items():
       for jar in jar_set:
-        self.assertEquals(value, jar in classpath)
+        self.assertEqual(value, jar in classpath)
 
   def test_unmanaged_no_default(self):
     self._assert_run_classpath({

--- a/tests/python/pants_test/backend/jvm/subsystems/test_shader_integration.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_shader_integration.py
@@ -48,9 +48,9 @@ class ShaderIntegrationTest(PantsRunIntegrationTest):
     path = os.path.join('dist', 'shading.jar')
     init_subsystem(DistributionLocator)
     execute_java = DistributionLocator.cached(minimum_version='1.6').execute_java
-    self.assertEquals(0, execute_java(classpath=[path],
+    self.assertEqual(0, execute_java(classpath=[path],
                                       main='org.pantsbuild.testproject.shading.Main'))
-    self.assertEquals(0, execute_java(classpath=[path],
+    self.assertEqual(0, execute_java(classpath=[path],
                                       main='org.pantsbuild.testproject.foo.bar.MyNameIsDifferentNow'))
 
     received_classes = set()
@@ -67,7 +67,7 @@ class ShaderIntegrationTest(PantsRunIntegrationTest):
 
     All jars including the main jar as well as libraries will run through shader.
     """
-    self.assertEquals({
+    self.assertEqual({
           'Gson': 'moc.elgoog.nosg.Gson',
           'Third': 'org.pantsbuild.testproject.shading.Third',
           'Second': 'hello.org.pantsbuild.testproject.shading.Second',
@@ -85,7 +85,7 @@ class ShaderIntegrationTest(PantsRunIntegrationTest):
           'third.jar']).strip()))
 
   def test_deployjar_run(self):
-    self.assertEquals({
+    self.assertEqual({
           'Gson': 'moc.elgoog.nosg.Gson',
           'Third': 'org.pantsbuild.testproject.shading.Third',
           'Second': 'hello.org.pantsbuild.testproject.shading.Second',
@@ -143,4 +143,4 @@ class ShaderIntegrationTest(PantsRunIntegrationTest):
       self.run_pants(['clean-all'])
       os.remove(jar_path)
       self.assert_success(self.run_pants(['binary', tmpdir]))
-      self.assertEquals(permissions, os.stat(jar_path).st_mode)
+      self.assertEqual(permissions, os.stat(jar_path).st_mode)

--- a/tests/python/pants_test/backend/jvm/targets/test_credentials.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_credentials.py
@@ -15,5 +15,5 @@ class CredentialsTest(TestBase):
     password = 'seriously, don`t.'
     t = self.make_target(':creds', LiteralCredentials, username=username, password=password)
 
-    self.assertEquals(t.username('anything'), username)
-    self.assertEquals(t.password('anything'), password)
+    self.assertEqual(t.username('anything'), username)
+    self.assertEqual(t.password('anything'), password)

--- a/tests/python/pants_test/backend/jvm/targets/test_jar_dependency.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jar_dependency.py
@@ -32,12 +32,12 @@ class JarDependencyTest(unittest.TestCase):
     base_path = 'a/b'
 
     jar_with_rel_url = self._mkjardep(url=rel_url, base_path=base_path)
-    self.assertEquals(abs_url, jar_with_rel_url.get_url())
-    self.assertEquals(rel_url, jar_with_rel_url.get_url(relative=True))
+    self.assertEqual(abs_url, jar_with_rel_url.get_url())
+    self.assertEqual(rel_url, jar_with_rel_url.get_url(relative=True))
 
     jar_with_abs_url = self._mkjardep(url=abs_url, base_path=base_path)
-    self.assertEquals(abs_url, jar_with_abs_url.get_url())
-    self.assertEquals(rel_url, jar_with_abs_url.get_url(relative=True))
+    self.assertEqual(abs_url, jar_with_abs_url.get_url())
+    self.assertEqual(rel_url, jar_with_abs_url.get_url(relative=True))
 
   def _test_copy(self, original):
     # A no-op clone results in an equal object.

--- a/tests/python/pants_test/backend/jvm/targets/test_jar_library.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jar_library.py
@@ -37,7 +37,7 @@ class JarLibraryTest(TestBase):
     lib = JarLibrary(name='foo', address=Address.parse('//:foo'),
                      build_graph=self.build_graph,
                      jars=[jar1, jar2])
-    self.assertEquals((jar1, jar2), lib.jar_dependencies)
+    self.assertEqual((jar1, jar2), lib.jar_dependencies)
 
   def test_empty_jar_dependencies(self):
     def example():
@@ -48,14 +48,14 @@ class JarLibraryTest(TestBase):
     # TODO(Eric Ayers) There doesn't seem to be any way to set this field at the moment.
     lib = JarLibrary(name='foo', address=Address.parse('//:foo'),
                      build_graph=self.build_graph, jars=[jar1])
-    self.assertEquals([], lib.excludes)
+    self.assertEqual([], lib.excludes)
 
   def test_to_jar_dependencies(self):
     def assert_dep(dep, org, name, rev):
       self.assertTrue(isinstance(dep, JarDependency))
-      self.assertEquals(org, dep.org)
-      self.assertEquals(name, dep.name)
-      self.assertEquals(rev, dep.rev)
+      self.assertEqual(org, dep.org)
+      self.assertEqual(name, dep.name)
+      self.assertEqual(rev, dep.rev)
 
     self.add_to_build_file('BUILD', dedent('''
     jar_library(name='lib1',
@@ -72,19 +72,19 @@ class JarLibraryTest(TestBase):
     '''))
     lib1 = self.target('//:lib1')
     self.assertIsInstance(lib1, JarLibrary)
-    self.assertEquals(1, len(lib1.jar_dependencies))
+    self.assertEqual(1, len(lib1.jar_dependencies))
     assert_dep(lib1.jar_dependencies[0], 'testOrg1', 'testName1', '123')
 
     lib2 = self.target('//:lib2')
     self.assertIsInstance(lib2, JarLibrary)
-    self.assertEquals(2, len(lib2.jar_dependencies))
+    self.assertEqual(2, len(lib2.jar_dependencies))
     assert_dep(lib2.jar_dependencies[0], 'testOrg2', 'testName2', '456')
     assert_dep(lib2.jar_dependencies[1], 'testOrg3', 'testName3', '789')
 
     deps = JarLibrary.to_jar_dependencies(lib1.address,
                                           [':lib1', ':lib2'],
                                           self.build_graph)
-    self.assertEquals(3, len(deps))
+    self.assertEqual(3, len(deps))
     assert_dep(lib1.jar_dependencies[0], 'testOrg1', 'testName1', '123')
     assert_dep(lib2.jar_dependencies[0], 'testOrg2', 'testName2', '456')
     assert_dep(lib2.jar_dependencies[1], 'testOrg3', 'testName3', '789')

--- a/tests/python/pants_test/backend/jvm/targets/test_junit_tests.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_junit_tests.py
@@ -29,48 +29,48 @@ class JUnitTestsTest(TestBase):
     # cwd parameter
     testcwd = self.make_target('//:testcwd1', JUnitTests, sources=['Test.java'],
                                concurrency='SERIAL', cwd='/foo/bar')
-    self.assertEquals('/foo/bar', testcwd.cwd)
+    self.assertEqual('/foo/bar', testcwd.cwd)
 
     # concurrency parameter
     tc1 = self.make_target('//:testconcurrency1', JUnitTests, sources=['Test.java'],
                            concurrency='SERIAL')
-    self.assertEquals(JUnitTests.CONCURRENCY_SERIAL, tc1.concurrency)
+    self.assertEqual(JUnitTests.CONCURRENCY_SERIAL, tc1.concurrency)
     tc2 = self.make_target('//:testconcurrency2', JUnitTests, sources=['Test.java'],
                            concurrency='PARALLEL_CLASSES')
-    self.assertEquals(JUnitTests.CONCURRENCY_PARALLEL_CLASSES, tc2.concurrency)
+    self.assertEqual(JUnitTests.CONCURRENCY_PARALLEL_CLASSES, tc2.concurrency)
     tc3 = self.make_target('//:testconcurrency3', JUnitTests, sources=['Test.java'],
                            concurrency='PARALLEL_METHODS')
-    self.assertEquals(JUnitTests.CONCURRENCY_PARALLEL_METHODS, tc3.concurrency)
+    self.assertEqual(JUnitTests.CONCURRENCY_PARALLEL_METHODS, tc3.concurrency)
     tc4 = self.make_target('//:testconcurrency4', JUnitTests, sources=['Test.java'],
                            concurrency='PARALLEL_CLASSES_AND_METHODS')
-    self.assertEquals(JUnitTests.CONCURRENCY_PARALLEL_CLASSES_AND_METHODS, tc4.concurrency)
+    self.assertEqual(JUnitTests.CONCURRENCY_PARALLEL_CLASSES_AND_METHODS, tc4.concurrency)
     with self.assertRaisesRegexp(TargetDefinitionException, r'concurrency'):
       self.make_target('//:testconcurrency5', JUnitTests, sources=['Test.java'],
                        concurrency='nonsense')
 
     # threads parameter
     tt1 = self.make_target('//:testthreads1', JUnitTests, sources=['Test.java'], threads=99)
-    self.assertEquals(99, tt1.threads)
+    self.assertEqual(99, tt1.threads)
     tt2 = self.make_target('//:testthreads2', JUnitTests, sources=['Test.java'], threads="123")
-    self.assertEquals(123, tt2.threads)
+    self.assertEqual(123, tt2.threads)
     with self.assertRaisesRegexp(TargetDefinitionException, r'threads'):
       self.make_target('//:testthreads3', JUnitTests, sources=['Test.java'], threads="abc")
 
     # timeout parameter
     timeout = self.make_target('//:testtimeout1', JUnitTests, sources=['Test.java'], timeout=999)
-    self.assertEquals(999, timeout.timeout)
+    self.assertEqual(999, timeout.timeout)
 
   def test_implicit_junit_dep(self):
     init_subsystem(JUnit)
     # Check that the implicit dep is added, and doesn't replace other deps.
     target = self.make_target('//:target', Target)
     test1 = self.make_target('//:test1', JUnitTests, sources=[], dependencies=[target])
-    self.assertEquals(['JarLibrary(//:junit_library)', 'Target(//:target)'],
+    self.assertEqual(['JarLibrary(//:junit_library)', 'Target(//:target)'],
                       sorted(str(x) for x in test1.dependencies))
 
     # Check that having an explicit dep doesn't cause problems.
     junit_target = self.build_graph.get_target_from_spec('//:junit_library')
     test2 = self.make_target('//:test2', JUnitTests, sources=[],
                              dependencies=[junit_target, target])
-    self.assertEquals(['JarLibrary(//:junit_library)', 'Target(//:target)'],
+    self.assertEqual(['JarLibrary(//:junit_library)', 'Target(//:target)'],
                       sorted(str(x) for x in test2.dependencies))

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
@@ -33,10 +33,10 @@ class JvmAppTest(TestBase):
     binary_target = self.make_target(':foo-binary', JvmBinary, main='com.example.Foo')
     app_target = self.make_target(':foo', JvmApp, basename='foo-app', binary=':foo-binary')
 
-    self.assertEquals('foo-app', app_target.payload.basename)
-    self.assertEquals('foo-app', app_target.basename)
-    self.assertEquals(binary_target, app_target.binary)
-    self.assertEquals([':foo-binary'], list(app_target.compute_dependency_specs(payload=app_target.payload)))
+    self.assertEqual('foo-app', app_target.payload.basename)
+    self.assertEqual('foo-app', app_target.basename)
+    self.assertEqual(binary_target, app_target.binary)
+    self.assertEqual([':foo-binary'], list(app_target.compute_dependency_specs(payload=app_target.payload)))
 
   def test_jvmapp_bundle_payload_fields(self):
     app_target = self.make_target(':foo_payload',
@@ -44,9 +44,9 @@ class JvmAppTest(TestBase):
                                   basename='foo-payload-app',
                                   archive='zip')
 
-    self.assertEquals('foo-payload-app', app_target.payload.basename)
+    self.assertEqual('foo-payload-app', app_target.payload.basename)
     self.assertIsNone(app_target.payload.deployjar)
-    self.assertEquals('zip', app_target.payload.archive)
+    self.assertEqual('zip', app_target.payload.archive)
 
   def test_bad_basename(self):
     with self.assertRaisesRegexp(TargetDefinitionException,
@@ -63,17 +63,17 @@ class JvmAppTest(TestBase):
   def test_binary_via_binary(self):
     bin = self.make_target('src/java/org/archimedes/buoyancy:bin', JvmBinary)
     app = self.create_app('src/java/org/archimedes/buoyancy', binary=':bin')
-    self.assertEquals(app.binary, bin)
+    self.assertEqual(app.binary, bin)
 
   def test_binary_via_dependencies(self):
     bin = self.make_target('src/java/org/archimedes/buoyancy:bin', JvmBinary)
     app = self.create_app('src/java/org/archimedes/buoyancy', dependencies=[bin])
-    self.assertEquals(app.binary, bin)
+    self.assertEqual(app.binary, bin)
 
   def test_degenerate_binaries(self):
     bin = self.make_target('src/java/org/archimedes/buoyancy:bin', JvmBinary)
     app = self.create_app('src/java/org/archimedes/buoyancy', binary=':bin', dependencies=[bin])
-    self.assertEquals(app.binary, bin)
+    self.assertEqual(app.binary, bin)
 
   def test_no_binary(self):
     app = self.create_app('src/java/org/archimedes/buoyancy')
@@ -240,7 +240,7 @@ class BundleTest(TestBase):
                              _bundle(spec_path)(fileset=['a/b'])
                            ])
 
-    self.assertEquals(['y/a/b', 'y/z/*'], sorted(app.globs_relative_to_buildroot()['globs']))
+    self.assertEqual(['y/a/b', 'y/z/*'], sorted(app.globs_relative_to_buildroot()['globs']))
 
   def test_list_of_globs_fails(self):
     # It's not allowed according to the docs, and will behave badly.
@@ -314,7 +314,7 @@ class BundleTest(TestBase):
     self.create_file(os.path.join('y', 'z', 'somefile'))
     bundle = _bundle('y')(rel_path="y/z", fileset=_globs('y/z')('*'))
 
-    self.assertEquals({'globs': [u'y/z/*']}, bundle.fileset.filespec)
+    self.assertEqual({'globs': [u'y/z/*']}, bundle.fileset.filespec)
 
   def test_rel_path_overrides_context_rel_path_for_explicit_path(self):
     spec_path = 'y'
@@ -327,4 +327,4 @@ class BundleTest(TestBase):
                              _bundle(spec_path)(rel_path="config", fileset=['a/b'])
                            ])
     self.assertEqual({os.path.join(self.build_root, 'config/a/b'): 'a/b'}, app.bundles[0].filemap)
-    self.assertEquals(['config/a/b'], sorted(app.globs_relative_to_buildroot()['globs']))
+    self.assertEqual(['config/a/b'], sorted(app.globs_relative_to_buildroot()['globs']))

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
@@ -20,10 +20,10 @@ class JarRulesTest(unittest.TestCase):
 
   def test_jar_rule(self):
     dup_rule = Duplicate('foo', Duplicate.REPLACE)
-    self.assertEquals('Duplicate(apply_pattern=foo, action=REPLACE)',
+    self.assertEqual('Duplicate(apply_pattern=foo, action=REPLACE)',
                       repr(dup_rule))
     skip_rule = Skip('foo')
-    self.assertEquals('Skip(apply_pattern=foo)', repr(skip_rule))
+    self.assertEqual('Skip(apply_pattern=foo)', repr(skip_rule))
 
   def test_invalid_apply_pattern(self):
     with self.assertRaisesRegexp(ValueError, r'The supplied apply_pattern is not a string'):
@@ -72,20 +72,20 @@ class JvmBinaryTest(TestBase):
       'jvm_binary(name = "foo", main = "com.example.Foo", basename = "foo-base")',
     )
     target = self.target(':foo')
-    self.assertEquals('com.example.Foo', target.main)
-    self.assertEquals('com.example.Foo', target.payload.main)
-    self.assertEquals('foo-base', target.basename)
-    self.assertEquals('foo-base', target.payload.basename)
-    self.assertEquals([], target.deploy_excludes)
-    self.assertEquals([], target.payload.deploy_excludes)
-    self.assertEquals(JarRules.default(), target.deploy_jar_rules)
-    self.assertEquals(JarRules.default(), target.payload.deploy_jar_rules)
-    self.assertEquals({}, target.payload.manifest_entries.entries)
+    self.assertEqual('com.example.Foo', target.main)
+    self.assertEqual('com.example.Foo', target.payload.main)
+    self.assertEqual('foo-base', target.basename)
+    self.assertEqual('foo-base', target.payload.basename)
+    self.assertEqual([], target.deploy_excludes)
+    self.assertEqual([], target.payload.deploy_excludes)
+    self.assertEqual(JarRules.default(), target.deploy_jar_rules)
+    self.assertEqual(JarRules.default(), target.payload.deploy_jar_rules)
+    self.assertEqual({}, target.payload.manifest_entries.entries)
 
   def test_default_base(self):
     self.add_to_build_file('', 'jvm_binary(name = "foo", main = "com.example.Foo")')
     target = self.target(':foo')
-    self.assertEquals('foo', target.basename)
+    self.assertEqual('foo', target.basename)
 
   def test_deploy_jar_excludes(self):
     self.add_to_build_file(
@@ -96,7 +96,7 @@ class JvmBinaryTest(TestBase):
   deploy_excludes=[exclude(org = "example.com", name = "foo-lib")],
 )''')
     target = self.target(':foo')
-    self.assertEquals([Exclude(org='example.com', name='foo-lib')],
+    self.assertEqual([Exclude(org='example.com', name='foo-lib')],
                       target.deploy_excludes)
 
   def test_deploy_jar_rules(self):
@@ -112,11 +112,11 @@ class JvmBinaryTest(TestBase):
 )''')
     target = self.target(':foo')
     jar_rules = target.deploy_jar_rules
-    self.assertEquals(1, len(jar_rules.rules))
-    self.assertEquals('foo', jar_rules.rules[0].apply_pattern.pattern)
-    self.assertEquals(repr(Duplicate.SKIP),
+    self.assertEqual(1, len(jar_rules.rules))
+    self.assertEqual('foo', jar_rules.rules[0].apply_pattern.pattern)
+    self.assertEqual(repr(Duplicate.SKIP),
                       repr(jar_rules.rules[0].action))  # <object object at 0x...>
-    self.assertEquals(Duplicate.FAIL, jar_rules.default_dup_action)
+    self.assertEqual(Duplicate.FAIL, jar_rules.default_dup_action)
 
   def test_bad_source_declaration(self):
     self.create_file('foo/foo.py')
@@ -163,7 +163,7 @@ class JvmBinaryTest(TestBase):
       for other_field in fields:
         if field == other_field:
           continue
-        self.assertNotEquals(field.fingerprint(), other_field.fingerprint())
+        self.assertNotEqual(field.fingerprint(), other_field.fingerprint())
 
   def test_jar_rules_field(self):
     field1 = FingerprintedField(JarRules(rules=[Duplicate('foo', Duplicate.SKIP)]))
@@ -181,9 +181,9 @@ class JvmBinaryTest(TestBase):
     field8 = FingerprintedField(JarRules(rules=[Skip('bar')]))
     field8_same = FingerprintedField(JarRules(rules=[Skip('bar')]))
 
-    self.assertEquals(field1.fingerprint(), field1_same.fingerprint())
-    self.assertEquals(field6.fingerprint(), field6_same.fingerprint())
-    self.assertEquals(field8.fingerprint(), field8_same.fingerprint())
+    self.assertEqual(field1.fingerprint(), field1_same.fingerprint())
+    self.assertEqual(field6.fingerprint(), field6_same.fingerprint())
+    self.assertEqual(field8.fingerprint(), field8_same.fingerprint())
     self._assert_fingerprints_not_equal([field1, field2, field3, field4, field5, field6, field7])
 
   def test_manifest_entries(self):
@@ -197,7 +197,7 @@ class JvmBinaryTest(TestBase):
     target = self.target(":foo")
     self.assertTrue(isinstance(target.payload.manifest_entries, ManifestEntries))
     entries = target.payload.manifest_entries.entries
-    self.assertEquals({'Foo-Field': 'foo'}, entries)
+    self.assertEqual({'Foo-Field': 'foo'}, entries)
 
   def test_manifest_not_dict(self):
     self.add_to_build_file(
@@ -230,5 +230,5 @@ class JvmBinaryTest(TestBase):
     field2 = ManifestEntries({'Foo-Field': 'foo'})
     field2_same = ManifestEntries({'Foo-Field': 'foo'})
     field3 = ManifestEntries({'Foo-Field': 'foo', 'Bar-Field': 'bar'})
-    self.assertEquals(field2.fingerprint(), field2_same.fingerprint())
+    self.assertEqual(field2.fingerprint(), field2_same.fingerprint())
     self._assert_fingerprints_not_equal([field1, field2, field3])

--- a/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
@@ -24,7 +24,7 @@ class UnpackedJarsTest(TestBase):
     self.assertIsInstance(target, UnpackedJars)
     dependency_specs = [spec for spec in target.compute_dependency_specs(payload=target.payload)]
     self.assertSequenceEqual([':import_jars'], dependency_specs)
-    self.assertEquals(1, len(target.imported_jars))
+    self.assertEqual(1, len(target.imported_jars))
     import_jar_dep = target.imported_jars[0]
     self.assertIsInstance(import_jar_dep, JarDependency)
 

--- a/tests/python/pants_test/backend/jvm/tasks/coverage/test_cobertura.py
+++ b/tests/python/pants_test/backend/jvm/tasks/coverage/test_cobertura.py
@@ -94,8 +94,8 @@ class TestCobertura(TestBase):
 
   def _assert_calls(self, call_collection, frm, to):
     calls_for_target = call_collection[os.path.join(self.pants_workdir, frm)]
-    self.assertEquals(len(calls_for_target), 1, "Should be 1 call for the_target's path.")
-    self.assertEquals(calls_for_target[0], os.path.join(self.pants_workdir, to))
+    self.assertEqual(len(calls_for_target), 1, "Should be 1 call for the_target's path.")
+    self.assertEqual(calls_for_target[0], os.path.join(self.pants_workdir, to))
 
   def _assert_target_copy(self, coverage, frm, to):
     self._assert_calls(coverage.copy2_calls, frm, to)
@@ -123,12 +123,12 @@ class TestCobertura(TestBase):
                                                self.java_target],
                                               classpath_products)
 
-    self.assertEquals(len(syscalls.copy2_calls), 1,
+    self.assertEqual(len(syscalls.copy2_calls), 1,
                       'Should only be 1 call for the single java_library target.')
     self._assert_target_copy(syscalls,
                              frm='java/target/classpath.jar',
                              to='coverage/classes/foo.foo-java/0')
-    self.assertEquals(len(syscalls.copytree_calls), 0,
+    self.assertEqual(len(syscalls.copytree_calls), 0,
                       'Should be no copytree calls when targets are not coverage targets.')
 
   def test_target_with_multiple_path_entries(self):
@@ -147,7 +147,7 @@ class TestCobertura(TestBase):
                                               [self.java_target],
                                               classpath_products)
 
-    self.assertEquals(len(syscalls.copy2_calls), 3,
+    self.assertEqual(len(syscalls.copy2_calls), 3,
                       'Should be 3 call for the single java_library target.')
     self._assert_target_copy(syscalls,
                              frm='java/target/first.jar',
@@ -159,7 +159,7 @@ class TestCobertura(TestBase):
                              frm='java/target/third.jar',
                              to='coverage/classes/foo.foo-java/2')
 
-    self.assertEquals(len(syscalls.copytree_calls), 0,
+    self.assertEqual(len(syscalls.copytree_calls), 0,
                       'Should be no copytree calls when targets are not coverage targets.')
 
   def test_target_annotation_processor(self):
@@ -176,7 +176,7 @@ class TestCobertura(TestBase):
                                               [self.annotation_target],
                                               classpath_products)
 
-    self.assertEquals(len(syscalls.copy2_calls), 0,
+    self.assertEqual(len(syscalls.copy2_calls), 0,
                       'Should be 0 call for the single annotation target.')
     self._assert_target_copytree(syscalls,
                                  frm='anno/target/dir',

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
@@ -161,7 +161,7 @@ class CacheCompileIntegrationTest(BaseCompileIT):
         return sorted(os.listdir(cd))
 
       # One workdir should contain NotMain, and the other should contain Main.
-      self.assertEquals(sorted(classfiles(w) for w in target_workdirs if w != 'current'),
+      self.assertEqual(sorted(classfiles(w) for w in target_workdirs if w != 'current'),
                         sorted([['A.class', 'Main.class'], ['A.class', 'NotMain.class']]))
 
   def test_analysis_portability(self):
@@ -273,7 +273,7 @@ class CacheCompileIntegrationTest(BaseCompileIT):
           artifact_dir,
           '{}.cachetest'.format(os.path.basename(src_dir)),
         )
-        self.assertEquals(c.artifact_count, len(os.listdir(cache_test_subdir)))
+        self.assertEqual(c.artifact_count, len(os.listdir(cache_test_subdir)))
 
 
 class CacheCompileIntegrationWithZjarsTest(CacheCompileIntegrationTest):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -127,13 +127,13 @@ class JavaCompileIntegrationTest(BaseCompileIT):
         # Locate the report file on the classpath.
         report_file_name = 'deprecation_report.txt'
         reports = [f for f in all_files if f.endswith(report_file_name)]
-        self.assertEquals(1, len(reports),
+        self.assertEqual(1, len(reports),
                           'Expected exactly one {} file; got: {}'.format(report_file_name,
                                                                          all_files))
 
         with open(reports[0]) as fp:
           annotated_classes = [line.rstrip() for line in fp.read().splitlines()]
-          self.assertEquals(
+          self.assertEqual(
             {'org.pantsbuild.testproject.annotation.main.Main',
              'org.pantsbuild.testproject.annotation.main.Main$TestInnerClass'},
             set(annotated_classes))

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
@@ -174,19 +174,19 @@ class JavaCompileSettingsPartitioningTest(TaskTestBase):
       ])
     ))
 
-    self.assertEquals('-C1.7', source)
-    self.assertEquals('-C1.7', target)
-    self.assertEquals('foo', foo)
-    self.assertEquals('bar', bar)
+    self.assertEqual('-C1.7', source)
+    self.assertEqual('-C1.7', target)
+    self.assertEqual('foo', foo)
+    self.assertEqual('bar', bar)
     self.assertNotEqual('$JAVA_HOME', single)
     self.assertNotIn('$JAVA_HOME', composite)
-    self.assertEquals('foo:{0}/bar:{0}/foobar'.format(single), composite)
+    self.assertEqual('foo:{0}/bar:{0}/foobar'.format(single), composite)
 
   def test_java_home_extraction_empty(self):
     result = tuple(ZincCompile._get_zinc_arguments(
       JvmPlatformSettings('1.7', '1.7', [])
     ))
-    self.assertEquals(4, len(result),
+    self.assertEqual(4, len(result),
                       msg='_get_zinc_arguments did not correctly handle empty args.')
 
   def test_java_home_extraction_missing_distributions(self):
@@ -246,8 +246,8 @@ class JavaCompileSettingsPartitioningTest(TaskTestBase):
         target_level=far_future_version,
         args=['$JAVA_HOME/foo', '$JAVA_HOME'],
       ))
-      self.assertEquals(paths[0], results[-1])
-      self.assertEquals('{}/foo'.format(paths[0]), results[-2])
+      self.assertEqual(paths[0], results[-1])
+      self.assertEqual('{}/foo'.format(paths[0]), results[-2])
 
     # Make sure we pick up the strictest possible distribution.
     with fake_distribution_locator(farer_future_version, far_future_version) as paths:
@@ -257,8 +257,8 @@ class JavaCompileSettingsPartitioningTest(TaskTestBase):
         target_level=far_future_version,
         args=['$JAVA_HOME/foo', '$JAVA_HOME'],
       ))
-      self.assertEquals(far_path, results[-1])
-      self.assertEquals('{}/foo'.format(far_path), results[-2])
+      self.assertEqual(far_path, results[-1])
+      self.assertEqual('{}/foo'.format(far_path), results[-2])
 
     # Make sure we pick the higher distribution when the lower one doesn't work.
     with fake_distribution_locator(farer_future_version, far_future_version) as paths:
@@ -268,5 +268,5 @@ class JavaCompileSettingsPartitioningTest(TaskTestBase):
         target_level=farer_future_version,
         args=['$JAVA_HOME/foo', '$JAVA_HOME'],
       ))
-      self.assertEquals(farer_path, results[-1])
-      self.assertEquals('{}/foo'.format(farer_path), results[-2])
+      self.assertEqual(farer_path, results[-1])
+      self.assertEqual('{}/foo'.format(farer_path), results[-2])

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -208,7 +208,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
             extra_args=['--java-javac=testprojects/3rdparty/javactool:custom_javactool_for_testing'],
             clean_all=True
         )
-        self.assertNotEquals(0, pants_run.returncode)  # Our custom javactool always fails.
+        self.assertNotEqual(0, pants_run.returncode)  # Our custom javactool always fails.
         self.assertIn('Pants caused Zinc to load a custom JavacTool', pants_run.stdout_data)
 
   def test_no_zinc_file_manager(self):
@@ -216,4 +216,4 @@ class ZincCompileIntegrationTest(BaseCompileIT):
     with self.temporary_workdir() as workdir:
       with self.temporary_cachedir() as cachedir:
         pants_run = self.run_test_compile(workdir, cachedir, target_spec, clean_all=True)
-        self.assertEquals(0, pants_run.returncode)
+        self.assertEqual(0, pants_run.returncode)

--- a/tests/python/pants_test/backend/jvm/tasks/reports/test_junit_html_report.py
+++ b/tests/python/pants_test/backend/jvm/tasks/reports/test_junit_html_report.py
@@ -85,8 +85,8 @@ class TestJUnitHtmlReport(TestBase):
     self.assertEqual(1, len(testsuites))
     self.assertEqual(2, testsuites[0].tests)
     self.assertEqual(2, len(testsuites[0].testcases))
-    self.assertEquals(u'org.pantsbuild.PåssingTest', testsuites[0].name)
-    self.assertEquals(u'testTwö', testsuites[0].testcases[1].name)
+    self.assertEqual(u'org.pantsbuild.PåssingTest', testsuites[0].name)
+    self.assertEqual(u'testTwö', testsuites[0].testcases[1].name)
     self.assertIn(u'org.pantsbuild.PåssingTest.testTwö', testsuites[0].testcases[1].error)
 
   def test_open_report(self):

--- a/tests/python/pants_test/backend/jvm/tasks/test_binary_create.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_binary_create.py
@@ -38,7 +38,7 @@ class TestBinaryCreate(JvmBinaryTaskTestBase):
     self.assertIsNotNone(jvm_binary_products)
     product_data = jvm_binary_products.get(binary_target)
     dist_root = os.path.join(self.build_root, 'dist')
-    self.assertEquals({dist_root: ['bar-binary.jar']}, product_data)
+    self.assertEqual({dist_root: ['bar-binary.jar']}, product_data)
 
     with open_zip(os.path.join(dist_root, 'bar-binary.jar')) as jar:
       self.assertEqual(sorted(['META-INF/',
@@ -90,7 +90,7 @@ class TestBinaryCreate(JvmBinaryTaskTestBase):
     self.assertIsNotNone(jvm_binary_products)
     product_data = jvm_binary_products.get(binary_target)
     dist_root = os.path.join(self.build_root, 'dist')
-    self.assertEquals({dist_root: ['bar-binary.jar']}, product_data)
+    self.assertEqual({dist_root: ['bar-binary.jar']}, product_data)
 
     with open_zip(os.path.join(dist_root, 'bar-binary.jar')) as jar:
       self.assertEqual(sorted(['META-INF/',

--- a/tests/python/pants_test/backend/jvm/tasks/test_binary_create_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_binary_create_integration.py
@@ -91,7 +91,7 @@ class BinaryCreateIntegrationTest(PantsRunIntegrationTest):
       self.assert_success(pants_run)
       # The resulting binary should not contain any guava classes
       with open_zip(jar_filename) as jar_file:
-        self.assertEquals({'META-INF/',
+        self.assertEqual({'META-INF/',
                            'META-INF/MANIFEST.MF',
                            'org/',
                            'org/pantsbuild/',
@@ -131,7 +131,7 @@ class BinaryCreateIntegrationTest(PantsRunIntegrationTest):
                                cwd=cwd)
     stdout, stderr = process.communicate()
 
-    self.assertEquals(expected_returncode, process.returncode,
+    self.assertEqual(expected_returncode, process.returncode,
                       ('Expected exit code {} from command `{}` but got {}:\n'
                        'stdout:\n{}\n'
                        'stderr:\n{}'

--- a/tests/python/pants_test/backend/jvm/tasks/test_bundle_create.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_bundle_create.py
@@ -180,7 +180,7 @@ class TestBundleCreate(JvmBinaryTaskTestBase):
     product_data = products.get(self.app_target)
     product_basedir = list(product_data.keys())[0]
     self.assertIn(self.pants_workdir, product_basedir)
-    self.assertEquals(product_data[product_basedir], [product_fullname])
+    self.assertEqual(product_data[product_basedir], [product_fullname])
     product_path = os.path.join(product_basedir, product_fullname)
     return product_path
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
@@ -540,7 +540,7 @@ class ClasspathProductsTest(TestBase):
       classpath_products, targets, libs_dir, save_classpath_file=True,
       internal_classpath_only=False, excludes=excludes)
     # check canonical path returned
-    self.assertEquals(expected_canonical_classpath,
+    self.assertEqual(expected_canonical_classpath,
                       relativize_paths(canonical_classpath, libs_dir))
 
     # check canonical path created contain the exact set of files, no more, no less

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_util.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_util.py
@@ -99,7 +99,7 @@ class ClasspathUtilTest(TestBase):
 
     # (a, path2) filtered because of conf
     # (b, path3) filtered because of excludes
-    self.assertEquals(OrderedDict([(a, [ClasspathEntry(path1)]),
+    self.assertEqual(OrderedDict([(a, [ClasspathEntry(path1)]),
                                    (b, [ClasspathEntry(path2)])]),
                       ClasspathUtil.classpath_by_targets(a.closure(bfs=True),
                                                          classpath_products))

--- a/tests/python/pants_test/backend/jvm/tasks/test_consolidate_classpath.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_consolidate_classpath.py
@@ -88,7 +88,7 @@ class TestConsolidateClasspath(JvmBinaryTaskTestBase):
       'pants_backend_jvm_tasks_consolidate_classpath_ConsolidateClasspath'
     )
     found_files = [os.path.basename(f) for f in self.iter_files(task_dir)]
-    self.assertEquals(
+    self.assertEqual(
       sorted(['output-0.jar', 'Foo.class', 'foo.txt', 'file']),
       sorted(found_files)
     )
@@ -113,7 +113,7 @@ class TestConsolidateClasspath(JvmBinaryTaskTestBase):
       'pants_backend_jvm_tasks_consolidate_classpath_ConsolidateClasspath'
     )
     found_files = [os.path.basename(f) for f in self.iter_files(task_dir)]
-    self.assertEquals(
+    self.assertEqual(
       sorted(['output-0.jar', 'Foo.class', 'foo.txt', 'file']),
       sorted(found_files)
     )

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -59,8 +59,8 @@ class CoursierResolveTest(JvmToolTaskTestBase):
     scala_lib = self.make_target('//:b', JavaLibrary, sources=[])
     # Confirm that the deps were added to the appropriate targets.
     compile_classpath = self.resolve([jar_lib, scala_lib])
-    self.assertEquals(1, len(compile_classpath.get_for_target(jar_lib)))
-    self.assertEquals(0, len(compile_classpath.get_for_target(scala_lib)))
+    self.assertEqual(1, len(compile_classpath.get_for_target(jar_lib)))
+    self.assertEqual(0, len(compile_classpath.get_for_target(scala_lib)))
     
   def test_resolve_with_remote_url(self):
     dep_with_url = JarDependency('a', 'b', 'c',
@@ -97,9 +97,9 @@ class CoursierResolveTest(JvmToolTaskTestBase):
       task.resolve([jar_lib, scala_lib], compile_classpath, sources=True, javadoc=True)
 
       # Both javadoc and sources jars are added to the classpath product
-      self.assertEquals(['default', 'src_doc', 'src_doc'],
+      self.assertEqual(['default', 'src_doc', 'src_doc'],
        sorted([c[0] for c in compile_classpath.get_for_target(jar_lib)]))
-      self.assertEquals(0, len(compile_classpath.get_for_target(scala_lib)))
+      self.assertEqual(0, len(compile_classpath.get_for_target(scala_lib)))
 
   def test_resolve_conflicted(self):
     losing_dep = JarDependency('com.google.guava', 'guava', '16.0')
@@ -112,7 +112,7 @@ class CoursierResolveTest(JvmToolTaskTestBase):
     losing_cp = compile_classpath.get_for_target(losing_lib)
     winning_cp = compile_classpath.get_for_target(winning_lib)
 
-    self.assertEquals(losing_cp, winning_cp)
+    self.assertEqual(losing_cp, winning_cp)
 
     self.assertEqual(1, len(winning_cp))
     conf, path = winning_cp[0]
@@ -177,8 +177,8 @@ class CoursierResolveTest(JvmToolTaskTestBase):
     junit_jar_cp = compile_classpath.get_for_target(junit_jar_lib)
     excluding_cp = compile_classpath.get_for_target(excluding_target)
 
-    self.assertEquals(2, len(junit_jar_cp))
-    self.assertEquals(0, len(excluding_cp))
+    self.assertEqual(2, len(junit_jar_cp))
+    self.assertEqual(0, len(excluding_cp))
 
     def get_coord_in_classpath(cp, targets):
       """
@@ -231,7 +231,7 @@ class CoursierResolveTest(JvmToolTaskTestBase):
 
         # └─ junit:junit:4.12
         #    └─ org.hamcrest:hamcrest-core:1.3
-        self.assertEquals(2, len(jar_cp))
+        self.assertEqual(2, len(jar_cp))
 
 
         # Take a sample jar path, remove it, then call the task again, it should invoke coursier again

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
@@ -64,8 +64,8 @@ class IvyResolveTest(JvmToolTaskTestBase):
     scala_lib = self.make_target('//:b', JavaLibrary, sources=[])
     # Confirm that the deps were added to the appropriate targets.
     compile_classpath = self.resolve([jar_lib, scala_lib])
-    self.assertEquals(1, len(compile_classpath.get_for_target(jar_lib)))
-    self.assertEquals(0, len(compile_classpath.get_for_target(scala_lib)))
+    self.assertEqual(1, len(compile_classpath.get_for_target(jar_lib)))
+    self.assertEqual(0, len(compile_classpath.get_for_target(scala_lib)))
 
   @ensure_cached(IvyResolve, expected_num_artifacts=0)
   def test_resolve_conflicted(self):
@@ -136,8 +136,8 @@ class IvyResolveTest(JvmToolTaskTestBase):
     compile_classpath = context.products.get_data('compile_classpath', None)
     losing_cp = compile_classpath.get_for_target(losing_lib)
     winning_cp = compile_classpath.get_for_target(winning_lib)
-    self.assertEquals(losing_cp, winning_cp)
-    self.assertEquals(OrderedSet([(u'default', artifact_path(u'bogus0')),
+    self.assertEqual(losing_cp, winning_cp)
+    self.assertEqual(OrderedSet([(u'default', artifact_path(u'bogus0')),
                                   (u'default', artifact_path(u'bogus1'))]),
                       winning_cp)
 
@@ -183,8 +183,8 @@ class IvyResolveTest(JvmToolTaskTestBase):
     junit_jar_cp = compile_classpath.get_for_target(junit_jar_lib)
     excluding_cp = compile_classpath.get_for_target(excluding_target)
 
-    self.assertEquals(0, len(junit_jar_cp))
-    self.assertEquals(0, len(excluding_cp))
+    self.assertEqual(0, len(junit_jar_cp))
+    self.assertEqual(0, len(excluding_cp))
 
   @ensure_cached(IvyResolve, expected_num_artifacts=0)
   def test_resolve_no_deps(self):
@@ -211,7 +211,7 @@ class IvyResolveTest(JvmToolTaskTestBase):
         jar_lib = self.make_target('//:a', JarLibrary, jars=[dep])
         # Confirm that the deps were added to the appropriate targets.
         compile_classpath = self.resolve([jar_lib])
-        self.assertEquals(1, len(compile_classpath.get_for_target(jar_lib)))
+        self.assertEqual(1, len(compile_classpath.get_for_target(jar_lib)))
 
   @ensure_cached(IvyResolve, expected_num_artifacts=1)
   def test_ivy_classpath(self):
@@ -222,7 +222,7 @@ class IvyResolveTest(JvmToolTaskTestBase):
     task = self.prepare_execute(self.context())
     classpath = task.ivy_classpath([junit_jar_lib])
 
-    self.assertEquals(2, len(classpath))
+    self.assertEqual(2, len(classpath))
 
   def test_second_resolve_reuses_existing_resolution_files(self):
     junit_jar_lib = self._make_junit_target()

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
@@ -139,11 +139,11 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
 
     jars.sort(key=lambda jar: jar.classifier)
 
-    self.assertEquals(['fleem', 'morx'], [jar.classifier for jar in jars])
+    self.assertEqual(['fleem', 'morx'], [jar.classifier for jar in jars])
 
   def test_module_ref_str_minus_classifier(self):
     module_ref = IvyModuleRef(org='org', name='name', rev='rev')
-    self.assertEquals("IvyModuleRef(org:name:rev::jar)", str(module_ref))
+    self.assertEqual("IvyModuleRef(org:name:rev::jar)", str(module_ref))
 
   def test_force_override(self):
     jars = list(self.a.payload.jars)
@@ -350,14 +350,14 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
                                                                                  input_path,
                                                                                  output_path)
           hardlink_foo_path = os.path.join(hardlink_dir, 'foo.jar')
-          self.assertEquals([hardlink_foo_path], result_classpath)
-          self.assertEquals(
+          self.assertEqual([hardlink_foo_path], result_classpath)
+          self.assertEqual(
             {
               os.path.realpath(foo_path): hardlink_foo_path
             },
             result_map)
           with open(output_path, 'r') as outpath:
-            self.assertEquals(hardlink_foo_path, outpath.readline())
+            self.assertEqual(hardlink_foo_path, outpath.readline())
           self.assertFalse(os.path.islink(hardlink_foo_path))
           self.assertTrue(os.path.exists(hardlink_foo_path))
 
@@ -372,16 +372,16 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
                                                                                  input_path,
                                                                                  output_path)
           hardlink_bar_path = os.path.join(hardlink_dir, 'bar.jar')
-          self.assertEquals(
+          self.assertEqual(
             {
               os.path.realpath(foo_path): hardlink_foo_path,
               os.path.realpath(bar_path): hardlink_bar_path,
             },
             result_map)
-          self.assertEquals([hardlink_foo_path, hardlink_bar_path], result_classpath)
+          self.assertEqual([hardlink_foo_path, hardlink_bar_path], result_classpath)
 
           with open(output_path, 'r') as outpath:
-            self.assertEquals(hardlink_foo_path + os.pathsep + hardlink_bar_path, outpath.readline())
+            self.assertEqual(hardlink_foo_path + os.pathsep + hardlink_bar_path, outpath.readline())
           self.assertFalse(os.path.islink(hardlink_foo_path))
           self.assertTrue(os.path.exists(hardlink_foo_path))
           self.assertFalse(os.path.islink(hardlink_bar_path))
@@ -395,7 +395,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
                                                   input_path,
                                                   output_path)
           with open(output_path, 'r') as outpath:
-            self.assertEquals(hardlink_bar_path + os.pathsep + hardlink_foo_path, outpath.readline())
+            self.assertEqual(hardlink_bar_path + os.pathsep + hardlink_foo_path, outpath.readline())
 
   def test_missing_ivy_report(self):
     self.set_options_for_scope(IvySubsystem.options_scope,
@@ -414,7 +414,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
     return ivy_info
 
   def test_ivy_module_ref_cmp(self):
-    self.assertEquals(
+    self.assertEqual(
       IvyModuleRef('foo', 'bar', '1.2.3'), IvyModuleRef('foo', 'bar', '1.2.3'))
     self.assertTrue(
       IvyModuleRef('foo1', 'bar', '1.2.3') < IvyModuleRef('foo2', 'bar', '1.2.3'))
@@ -481,7 +481,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
         return OrderedSet([dep])
 
       result = [ref for ref in info.traverse_dependency_graph(ref1, collector)]
-      self.assertEquals([ref1, ref2, ref3, ref5, ref6, ref4],
+      self.assertEqual([ref1, ref2, ref3, ref5, ref6, ref4],
                         result)
     # Make sure the order remains unchanged no matter what order we insert the into the structure
     assert_order([module1, module2, module3, module4, module5, module6])
@@ -659,15 +659,15 @@ class IvyFrozenResolutionTest(TestBase):
     jar2 = JarDependency('org', 'name', url=rel_url, base_path='.')
     jar3 = JarDependency('org', 'name', url=abs_url, base_path='a/b')
 
-    self.assertEquals(jar1.get_url(relative=False), jar2.get_url(relative=False))
-    self.assertEquals(jar1.get_url(relative=False), jar3.get_url(relative=False))
-    self.assertEquals(jar1.get_url(relative=True), jar2.get_url(relative=True))
+    self.assertEqual(jar1.get_url(relative=False), jar2.get_url(relative=False))
+    self.assertEqual(jar1.get_url(relative=False), jar3.get_url(relative=False))
+    self.assertEqual(jar1.get_url(relative=True), jar2.get_url(relative=True))
 
     def verify_url_attributes(spec, jar, expected_attributes):
       target = self.make_target(spec, JarLibrary, jars=[jar])
       frozen_resolution = FrozenResolution()
       frozen_resolution.add_resolved_jars(target, [])
-      self.assertEquals(list(frozen_resolution.coordinate_to_attributes.values()), expected_attributes)
+      self.assertEqual(list(frozen_resolution.coordinate_to_attributes.values()), expected_attributes)
 
     verify_url_attributes('t1', jar1, [{'url': 'file:a/b/c', 'base_path': '.'}])
     verify_url_attributes('t2', jar2, [{'url': 'file:a/b/c', 'base_path': '.'}])

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_dependency_management_setup.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_dependency_management_setup.py
@@ -55,7 +55,7 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
     task.execute()
     artifact_set = manager.for_target(jar_library)
     self.assertFalse(artifact_set is None)
-    self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+    self.assertEqual('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
 
   def test_bad_default(self):
     jar_library = self.make_target(spec='//foo:library',
@@ -106,7 +106,7 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
     task.execute()
     artifact_set = manager.for_target(jar_library)
     self.assertFalse(artifact_set is None)
-    self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+    self.assertEqual('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
 
   def test_explicit_and_default_target(self):
     default_target = self.make_target(spec='//foo:foobar',
@@ -131,7 +131,7 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
     task.execute()
     artifact_set = manager.for_target(jar_library)
     self.assertFalse(artifact_set is None)
-    self.assertEquals('3', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+    self.assertEqual('3', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
 
   def test_using_jar_library_address(self):
     pin_jar_library = self.make_target(
@@ -158,7 +158,7 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
     task.execute()
     artifact_set = manager.for_target(jar_library)
     self.assertFalse(artifact_set is None)
-    self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+    self.assertEqual('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
 
   def test_duplicate_coord_error(self):
     management_target = self.make_target(spec='//foo:management',
@@ -250,7 +250,7 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
     artifact_set = self._single_artifact_set(manager, [jar_library1, jar_library2,
                                                        unpacked_target])
     self.assertFalse(artifact_set is None)
-    self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+    self.assertEqual('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
 
   def test_indirection(self):
     management_target = self.make_target(
@@ -280,7 +280,7 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
     task.execute()
     artifact_set = self._single_artifact_set(manager, [jar_library1])
     self.assertFalse(artifact_set is None)
-    self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+    self.assertEqual('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
 
   def test_invalid_managed_jar_libraries(self):
     target_aliases = {
@@ -337,10 +337,10 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
       task.execute()
       artifact_set = self._single_artifact_set(manager, [jar_library1])
       self.assertFalse(artifact_set is None)
-      self.assertEquals('3', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
-      self.assertEquals('1', artifact_set[M2Coordinate('barfoo', 'barfoo')].rev)
-      self.assertEquals('4', artifact_set[M2Coordinate('fruit', 'apple')].rev)
-      self.assertEquals('7', artifact_set[M2Coordinate('foobar', 'foobar', ext='tar')].rev)
+      self.assertEqual('3', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+      self.assertEqual('1', artifact_set[M2Coordinate('barfoo', 'barfoo')].rev)
+      self.assertEqual('4', artifact_set[M2Coordinate('fruit', 'apple')].rev)
+      self.assertEqual('7', artifact_set[M2Coordinate('foobar', 'foobar', ext='tar')].rev)
 
     manager = self._init_manager(default_target='//foo:management')
     with self.assertRaises(JarDependencyManagementSetup.IllegalVersionOverride):
@@ -397,10 +397,10 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
       task.execute()
       artifact_set = self._single_artifact_set(manager, [jar_library1])
       self.assertFalse(artifact_set is None)
-      self.assertEquals('3', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
-      self.assertEquals('1', artifact_set[M2Coordinate('barfoo', 'barfoo')].rev)
-      self.assertEquals('4', artifact_set[M2Coordinate('fruit', 'apple')].rev)
-      self.assertEquals('7', artifact_set[M2Coordinate('foobar', 'foobar', ext='tar')].rev)
+      self.assertEqual('3', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+      self.assertEqual('1', artifact_set[M2Coordinate('barfoo', 'barfoo')].rev)
+      self.assertEqual('4', artifact_set[M2Coordinate('fruit', 'apple')].rev)
+      self.assertEqual('7', artifact_set[M2Coordinate('foobar', 'foobar', ext='tar')].rev)
 
     manager = self._init_manager(default_target='//foo:management')
     with self.assertRaises(JarDependencyManagementSetup.IllegalVersionOverride):
@@ -444,7 +444,7 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
     task.execute()
     artifact_set = self._single_artifact_set(manager, [jar_library_unversioned])
     self.assertFalse(artifact_set is None)
-    self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+    self.assertEqual('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
 
   def test_invalid_artifacts_indirection(self):
     class DummyTarget(Target):

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
@@ -139,12 +139,12 @@ class JarPublishTest(TaskTestBase):
       files = []
       for _, _, filenames in safe_walk(self.push_db_basedir):
         files.extend(filenames)
-      self.assertEquals(0, len(files),
+      self.assertEqual(0, len(files),
                         'Nothing should be written to the pushdb during a dryrun publish')
 
-      self.assertEquals(0, task.confirm_push.call_count,
+      self.assertEqual(0, task.confirm_push.call_count,
                         'Expected confirm_push not to be called')
-      self.assertEquals(0, task.publish.call_count,
+      self.assertEqual(0, task.publish.call_count,
                         'Expected publish not to be called')
 
   def test_publish_local(self):
@@ -162,13 +162,13 @@ class JarPublishTest(TaskTestBase):
         files = []
         for _, _, filenames in safe_walk(self.push_db_basedir):
           files.extend(filenames)
-        self.assertEquals(0, len(files),
+        self.assertEqual(0, len(files),
                           'Nothing should be written to the pushdb during a local publish')
 
         publishable_count = len(targets) - (1 if with_alias else 0)
-        self.assertEquals(publishable_count, task.confirm_push.call_count,
+        self.assertEqual(publishable_count, task.confirm_push.call_count,
                           'Expected one call to confirm_push per artifact')
-        self.assertEquals(publishable_count, task.publish.call_count,
+        self.assertEqual(publishable_count, task.publish.call_count,
                           'Expected one call to publish per artifact')
 
   def test_publish_remote(self):
@@ -183,33 +183,33 @@ class JarPublishTest(TaskTestBase):
     for _, _, filenames in safe_walk(self.push_db_basedir):
       files.extend(filenames)
 
-    self.assertEquals(len(targets), len(files),
+    self.assertEqual(len(targets), len(files),
                       'During a remote publish, one pushdb should be written per target')
-    self.assertEquals(len(targets), task.confirm_push.call_count,
+    self.assertEqual(len(targets), task.confirm_push.call_count,
                       'Expected one call to confirm_push per artifact')
-    self.assertEquals(len(targets), task.publish.call_count,
+    self.assertEqual(len(targets), task.publish.call_count,
                       'Expected one call to publish per artifact')
 
-    self.assertEquals(len(targets), task.scm.commit.call_count,
+    self.assertEqual(len(targets), task.scm.commit.call_count,
                       'Expected one call to scm.commit per artifact')
     args, kwargs = task.scm.commit.call_args
     message = args[0]
     message_lines = message.splitlines()
     self.assertTrue(len(message_lines) > 1,
                     'Expected at least one commit message line in addition to the post script.')
-    self.assertEquals('PS', message_lines[-1])
+    self.assertEqual('PS', message_lines[-1])
 
-    self.assertEquals(len(targets), task.scm.add.call_count,
+    self.assertEqual(len(targets), task.scm.add.call_count,
                       'Expected one call to scm.add per artifact')
 
-    self.assertEquals(len(targets), task.scm.tag.call_count,
+    self.assertEqual(len(targets), task.scm.tag.call_count,
                       'Expected one call to scm.tag per artifact')
     args, kwargs = task.scm.tag.call_args
     tag_name, tag_message = args
     tag_message_splitlines = tag_message.splitlines()
     self.assertTrue(len(tag_message_splitlines) > 1,
                     'Expected at least one tag message line in addition to the post script.')
-    self.assertEquals('PS', tag_message_splitlines[-1])
+    self.assertEqual('PS', tag_message_splitlines[-1])
 
   def test_publish_retry_works(self):
     targets = self._prepare_for_publishing()
@@ -221,7 +221,7 @@ class JarPublishTest(TaskTestBase):
     task.scm.push.side_effect = FailNTimes(2, Scm.RemoteException)
     task.execute()
     # Two failures, one success
-    self.assertEquals(2 + 1, task.scm.push.call_count)
+    self.assertEqual(2 + 1, task.scm.push.call_count)
 
   def test_publish_retry_eventually_fails(self):
     targets = self._prepare_for_publishing()
@@ -248,7 +248,7 @@ class JarPublishTest(TaskTestBase):
 
     with self.assertRaises(Scm.LocalException):
       task.execute()
-    self.assertEquals(1, task.scm.push.call_count)
+    self.assertEqual(1, task.scm.push.call_count)
 
   def test_publish_local_only(self):
     with self.assertRaises(TaskError):

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_publish_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_publish_integration.py
@@ -244,7 +244,7 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
                              'org/pantsbuild/testproject/publish/hello-greet/X/hello-greet-X.jar')
           with open_zip(jar, mode='r') as j:
             with j.open(resource_relative_to_sourceroot) as jar_entry:
-              self.assertEquals(resource_content, jar_entry.read())
+              self.assertEqual(resource_content, jar_entry.read())
 
       # Publish the same target twice with different resource content.
       publish('one')

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
@@ -51,7 +51,7 @@ class BaseJarTaskTest(JarTaskTestBase):
       yield fd.name
 
   def assert_listing(self, jar, *expected_items):
-    self.assertEquals({'META-INF/', 'META-INF/MANIFEST.MF'} | set(expected_items),
+    self.assertEqual({'META-INF/', 'META-INF/MANIFEST.MF'} | set(expected_items),
                       set(jar.namelist()))
 
 
@@ -86,7 +86,7 @@ class JarTaskTest(BaseJarTaskTest):
 
         with open_zip(existing_jarfile) as jar:
           self.assert_listing(jar, 'f/', 'f/g/', 'f/g/h')
-          self.assertEquals('e', jar.read('f/g/h'))
+          self.assertEqual('e', jar.read('f/g/h'))
 
   def test_update_writestr(self):
     def assert_writestr(path, contents, *entries):
@@ -96,7 +96,7 @@ class JarTaskTest(BaseJarTaskTest):
 
         with open_zip(existing_jarfile) as jar:
           self.assert_listing(jar, *entries)
-          self.assertEquals(contents, jar.read(path))
+          self.assertEqual(contents, jar.read(path))
 
     assert_writestr('a.txt', b'b', 'a.txt')
     assert_writestr('a/b/c.txt', b'd', 'a/', 'a/b/', 'a/b/c.txt')
@@ -115,7 +115,7 @@ class JarTaskTest(BaseJarTaskTest):
 
         with open_zip(existing_jarfile) as jar:
           self.assert_listing(jar, 'f/', 'f/g/', 'f/g/h')
-          self.assertEquals('e', jar.read('f/g/h'))
+          self.assertEqual('e', jar.read('f/g/h'))
 
   def test_overwrite_writestr(self):
     with self.jarfile() as existing_jarfile:
@@ -124,7 +124,7 @@ class JarTaskTest(BaseJarTaskTest):
 
       with open_zip(existing_jarfile) as jar:
         self.assert_listing(jar, 'README')
-        self.assertEquals('42', jar.read('README'))
+        self.assertEqual('42', jar.read('README'))
 
   @contextmanager
   def _test_custom_manifest(self):
@@ -136,7 +136,7 @@ class JarTaskTest(BaseJarTaskTest):
 
       with open_zip(existing_jarfile) as jar:
         self.assert_listing(jar, 'README')
-        self.assertEquals('42', jar.read('README'))
+        self.assertEqual('42', jar.read('README'))
         self.assertNotEqual(manifest_contents, jar.read('META-INF/MANIFEST.MF'))
 
       with self.jar_task.open_jar(existing_jarfile, overwrite=False) as jar:
@@ -144,8 +144,8 @@ class JarTaskTest(BaseJarTaskTest):
 
       with open_zip(existing_jarfile) as jar:
         self.assert_listing(jar, 'README')
-        self.assertEquals('42', jar.read('README'))
-        self.assertEquals(manifest_contents, jar.read('META-INF/MANIFEST.MF'))
+        self.assertEqual('42', jar.read('README'))
+        self.assertEqual(manifest_contents, jar.read('META-INF/MANIFEST.MF'))
 
   def test_custom_manifest_str(self):
     with self._test_custom_manifest() as (jar, manifest_contents):
@@ -280,7 +280,7 @@ class JarBuilderTest(BaseJarTaskTest):
             'Can-Retransform-Classes': 'true',
             'Can-Set-Native-Method-Prefix': 'true',
         }
-        self.assertEquals(set(expected_entries.items()),
+        self.assertEqual(set(expected_entries.items()),
                           set(expected_entries.items()).intersection(set(all_entries.items())))
 
   def test_manifest_items(self):
@@ -312,5 +312,5 @@ class JarBuilderTest(BaseJarTaskTest):
           'Foo': 'foo-value',
           'Implementation-Version': '1.2.3',
           }
-        self.assertEquals(set(expected_entries.items()),
+        self.assertEqual(set(expected_entries.items()),
                           set(expected_entries.items()).intersection(set(all_entries.items())))

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_bundle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_bundle_integration.py
@@ -31,4 +31,4 @@ class BundleIntegrationTest(PantsRunIntegrationTest):
       stdout = self.bundle_and_run(target, bundle_name, bundle_jar_name=bundle_name, bundle_options=[
           '--bundle-jvm-use-basename-prefix',
         ])
-      self.assertEquals(stdout, 'Hello world!: resource from example {name}\n'.format(name=name))
+      self.assertEqual(stdout, 'Hello world!: resource from example {name}\n'.format(name=name))

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
@@ -124,9 +124,9 @@ class TestJvmDependencyUsage(TaskTestBase):
     graph = self.create_graph(dep_usage, [a, b, c, alias_a_b, alias_b, nested_alias_b])
     # both `:a` and `:b` are resolved from target aliases, one is used the other is not.
     self.assertTrue(graph._nodes[c].dep_edges[a].is_declared)
-    self.assertEquals({'a.class'}, graph._nodes[c].dep_edges[a].products_used)
+    self.assertEqual({'a.class'}, graph._nodes[c].dep_edges[a].products_used)
     self.assertTrue(graph._nodes[c].dep_edges[b].is_declared)
-    self.assertEquals(set(), graph._nodes[c].dep_edges[b].products_used)
+    self.assertEqual(set(), graph._nodes[c].dep_edges[b].products_used)
 
     # With alias to its resolved targets mapping we can determine which aliases are unused.
     # In this example `nested_alias_b` has none of its resolved dependencies being used.

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_prep_command_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_prep_command_integration.py
@@ -20,7 +20,7 @@ class JvmPrepCommandIntegration(PantsRunIntegrationTest):
 
   def assert_prep_compile(self):
     with open_zip('/tmp/running-in-goal-compile.jar') as jar:
-      self.assertEquals(sorted(['BUILD',
+      self.assertEqual(sorted(['BUILD',
                                 'ExampleJvmPrepCommand.java',
                                 'META-INF/', 'META-INF/MANIFEST.MF']),
                         sorted(jar.namelist()))
@@ -53,7 +53,7 @@ class JvmPrepCommandIntegration(PantsRunIntegrationTest):
 args are: "/tmp/running-in-goal-test","foo",
 org.pantsbuild properties: "org.pantsbuild.jvm_prep_command=WORKS-IN-TEST"
 """
-    self.assertEquals(expected, prep_output)
+    self.assertEqual(expected, prep_output)
     self.assert_prep_compile()
 
   def test_jvm_prep_command_in_binary(self):
@@ -72,5 +72,5 @@ org.pantsbuild properties: "org.pantsbuild.jvm_prep_command=WORKS-IN-TEST"
 args are: "/tmp/running-in-goal-binary","bar",
 org.pantsbuild properties: "org.pantsbuild.jvm_prep_command=WORKS-IN-BINARY"
 """
-    self.assertEquals(expected, prep_output)
+    self.assertEqual(expected, prep_output)
     self.assert_prep_compile()

--- a/tests/python/pants_test/backend/jvm/tasks/test_properties.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_properties.py
@@ -70,7 +70,7 @@ a=prop
         self.assertLoaded(props_in, {'it\'s a': 'file'})
 
   def assertLoaded(self, contents, expected):
-    self.assertEquals(expected, Properties.load(contents))
+    self.assertEqual(expected, Properties.load(contents))
 
   def test_dump(self):
     props = OrderedDict()
@@ -80,4 +80,4 @@ a=prop
     props['c'] =' 3 : ='
     out = StringIO()
     Properties.dump(props, out)
-    self.assertEquals('a=1\nb=2\\\n\nc=\\ 3\\ \\:\\ \\=\n', out.getvalue())
+    self.assertEqual('a=1\nb=2\\\n\nc=\\ 3\\ \\:\\ \\=\n', out.getvalue())

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
@@ -139,7 +139,7 @@ class ScalastyleTest(NailgunTaskTestBase):
                                                                  synthetic_scala_target])
 
     # Only the scala target should remain
-    self.assertEquals(1, len(result_targets))
+    self.assertEqual(1, len(result_targets))
     self.assertEqual(scala_target, result_targets[0])
 
   def test_get_non_excluded_scala_sources(self):
@@ -175,7 +175,7 @@ class ScalastyleTest(NailgunTaskTestBase):
       task.get_non_synthetic_scala_targets(context.targets()))
 
     # Only the scala source from target 1 should remain
-    self.assertEquals(1, len(result_sources))
+    self.assertEqual(1, len(result_sources))
     self.assertEqual('a/scala_1/Source1.scala', result_sources[0])
 
   @ensure_cached(Scalastyle, expected_num_artifacts=1)

--- a/tests/python/pants_test/backend/jvm/tasks/test_scope_runtime_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scope_runtime_integration.py
@@ -61,7 +61,7 @@ class ScopeRuntimeIntegrationTest(PantsRunIntegrationTest):
         self.assertIn('com/google/gson/stream/JsonReader.class', f.namelist())
       p = Popen(['java', '-jar', binary], stdout=PIPE, stderr=PIPE)
       p.communicate()
-      self.assertEquals(0, p.returncode)
+      self.assertEqual(0, p.returncode)
 
   def test_compile_binary_has_correct_contents_and_runs(self):
     with temporary_dir() as distdir:
@@ -78,7 +78,7 @@ class ScopeRuntimeIntegrationTest(PantsRunIntegrationTest):
         self.assertNotIn('com/google/gson/stream/JsonReader.class', f.namelist())
       p = Popen(['java', '-jar', binary], stdout=PIPE, stderr=PIPE)
       p.communicate()
-      self.assertNotEquals(0, p.returncode)
+      self.assertNotEqual(0, p.returncode)
 
   def test_runtime_bundle_contents(self):
     spec = self._spec('runtime-pass')

--- a/tests/python/pants_test/backend/jvm/tasks/test_unpack_jars.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_unpack_jars.py
@@ -137,7 +137,7 @@ class UnpackJarsTest(TaskTestBase):
         actual = {k: [set(v[0]), v[1]]
                   for k, v in context.products.get_data('unpacked_archives', dict).items()}
 
-        self.assertEquals(
+        self.assertEqual(
           {unpacked_jar_tgt:
              [expected_files,
               '.pants.d/pants_backend_jvm_tasks_unpack_jars_UnpackJars/unpack.foo']},

--- a/tests/python/pants_test/backend/jvm/test_jar_dependency_utils.py
+++ b/tests/python/pants_test/backend/jvm/test_jar_dependency_utils.py
@@ -14,31 +14,31 @@ class JarDependencyUtilsTest(unittest.TestCase):
   def test_m2_string_representation(self):
     org_name_ref = M2Coordinate(org='org.example', name='lib', rev='the-rev')
 
-    self.assertEquals('org.example:lib:the-rev', str(org_name_ref))
-    self.assertEquals(org_name_ref, M2Coordinate.from_string(str(org_name_ref)))
+    self.assertEqual('org.example:lib:the-rev', str(org_name_ref))
+    self.assertEqual(org_name_ref, M2Coordinate.from_string(str(org_name_ref)))
 
     org_name_ref_classifier = M2Coordinate(org='org.example', name='lib',
                                            rev='the-rev', classifier='classify')
 
-    self.assertEquals('org.example:lib:jar:classify:the-rev', str(org_name_ref_classifier))
-    self.assertEquals(org_name_ref_classifier, M2Coordinate.from_string(str(org_name_ref_classifier)))
+    self.assertEqual('org.example:lib:jar:classify:the-rev', str(org_name_ref_classifier))
+    self.assertEqual(org_name_ref_classifier, M2Coordinate.from_string(str(org_name_ref_classifier)))
 
     org_name_classifier = M2Coordinate(org='org.example', name='lib', classifier='classify')
 
-    self.assertEquals('org.example:lib:jar:classify:', str(org_name_classifier))
-    self.assertEquals(org_name_classifier, M2Coordinate.from_string(str(org_name_classifier)))
+    self.assertEqual('org.example:lib:jar:classify:', str(org_name_classifier))
+    self.assertEqual(org_name_classifier, M2Coordinate.from_string(str(org_name_classifier)))
 
     org_name_type_classifier = M2Coordinate(org='org.example', name='lib',
                                             classifier='classify', ext='zip')
 
-    self.assertEquals('org.example:lib:zip:classify:', str(org_name_type_classifier))
-    self.assertEquals(org_name_type_classifier, M2Coordinate.from_string(str(org_name_type_classifier)))
+    self.assertEqual('org.example:lib:zip:classify:', str(org_name_type_classifier))
+    self.assertEqual(org_name_type_classifier, M2Coordinate.from_string(str(org_name_type_classifier)))
 
     org_name_type_jar_classifier = M2Coordinate(org='org.example', name='lib',
                                                 classifier='classify', ext='jar')
 
-    self.assertEquals('org.example:lib:jar:classify:', str(org_name_type_jar_classifier))
-    self.assertEquals(org_name_type_jar_classifier, M2Coordinate.from_string(str(org_name_type_jar_classifier)))
+    self.assertEqual('org.example:lib:jar:classify:', str(org_name_type_jar_classifier))
+    self.assertEqual(org_name_type_jar_classifier, M2Coordinate.from_string(str(org_name_type_jar_classifier)))
 
   def test_m2_coordinates_with_same_properties(self):
     coordinate1 = M2Coordinate('org.example', 'lib')
@@ -120,7 +120,7 @@ class JarDependencyUtilsTest(unittest.TestCase):
     coord = CoordinateLike()
     m2 = M2Coordinate.create(coord)
     self.assertNotEqual(m2, coord)
-    self.assertEquals(tuple(getattr(coord, a) for a in attrs),
+    self.assertEqual(tuple(getattr(coord, a) for a in attrs),
                       tuple(getattr(m2, a) for a in attrs))
 
   def test_m2_coordinate_unversioned_noop(self):
@@ -131,5 +131,5 @@ class JarDependencyUtilsTest(unittest.TestCase):
   def test_m2_coordinate_unversioned(self):
     m2 = M2Coordinate(org='a', name='b', rev='c', classifier='d', ext='e')
     m2_un = M2Coordinate.unversioned(m2)
-    self.assertNotEquals(m2, m2_un)
+    self.assertNotEqual(m2, m2_un)
     self.assertTrue(m2_un.rev is None)

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -428,10 +428,10 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
   def test_has_python_requirements(self):
     result = self.execute_export_json('src/python/has_reqs')
     interpreters = result['python_setup']['interpreters']
-    self.assertEquals(1, len(interpreters))
+    self.assertEqual(1, len(interpreters))
     chroot = list(interpreters.values())[0]['chroot']
     deps = os.listdir(os.path.join(chroot, '.deps'))
-    self.assertEquals(1, len(deps))
+    self.assertEqual(1, len(deps))
     six_whl = deps[0]
     self.assertTrue(six_whl.startswith('six-1.9.0'))
     self.assertTrue(six_whl.endswith('.whl'))

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
@@ -192,8 +192,8 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
       self.assertFalse('python_setup' in json_data)
       target_name = 'examples/src/java/org/pantsbuild/example/hello/simple:simple'
       targets = json_data.get('targets')
-      self.assertEquals('java7', targets[target_name]['platform'])
-      self.assertEquals(
+      self.assertEqual('java7', targets[target_name]['platform'])
+      self.assertEqual(
         {
           'default_platform' : 'java7',
           'platforms': {
@@ -214,8 +214,8 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
     with self.temporary_workdir() as workdir:
       test_target = 'testprojects/tests/java/org/pantsbuild/testproject/testjvms:eight-test-platform'
       json_data = self.run_export(test_target, workdir)
-      self.assertEquals('java7', json_data['targets'][test_target]['platform'])
-      self.assertEquals('java8', json_data['targets'][test_target]['test_platform'])
+      self.assertEqual('java7', json_data['targets'][test_target]['platform'])
+      self.assertEqual('java8', json_data['targets'][test_target]['test_platform'])
 
   @ensure_resolver
   def test_intellij_integration(self):
@@ -241,7 +241,7 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
 
       python_target = json_data['targets']['src/python/pants/backend/python/targets:targets']
       self.assertIsNotNone(python_target)
-      self.assertEquals(default_interpreter, python_target['python_interpreter'])
+      self.assertEqual(default_interpreter, python_target['python_interpreter'])
 
   @ensure_resolver
   def test_intransitive_and_scope(self):
@@ -251,8 +251,8 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
       json_data = self.run_export(test_target, workdir)
       h = hash_target('{}:shadow'.format(test_path), 'provided')
       synthetic_target = '{}:shadow-unstable-provided-{}'.format(test_path, h)
-      self.assertEquals(False, json_data['targets'][synthetic_target]['transitive'])
-      self.assertEquals('compile test', json_data['targets'][synthetic_target]['scope'])
+      self.assertEqual(False, json_data['targets'][synthetic_target]['transitive'])
+      self.assertEqual('compile test', json_data['targets'][synthetic_target]['scope'])
 
   @ensure_resolver
   def test_export_is_target_roots(self):

--- a/tests/python/pants_test/backend/project_info/tasks/test_idea_plugin_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_idea_plugin_integration.py
@@ -57,9 +57,9 @@ class IdeaPluginIntegrationTest(PantsRunIntegrationTest):
                                 for p in actual_properties
                                 if p.getAttribute('name') == 'incremental_import']
     if incremental_import is None:
-      self.assertEquals(incremental_import_props, [])
+      self.assertEqual(incremental_import_props, [])
     else:
-      self.assertEquals([str(incremental_import)], [p.getAttribute('value')
+      self.assertEqual([str(incremental_import)], [p.getAttribute('value')
                                                     for p in incremental_import_props])
 
   def _get_project_dir(self, output_file):

--- a/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
+++ b/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
@@ -82,7 +82,7 @@ class TestBuildLocalDistsNativeSources(BuildLocalPythonDistributionsTestBase):
     universal_dist = self.target_dict['universal']
     context, synthetic_target, snapshot_version = self._create_distribution_synthetic_target(
       universal_dist)
-    self.assertEquals(['universal_dist==0.0.0+{}'.format(snapshot_version)],
+    self.assertEqual(['universal_dist==0.0.0+{}'.format(snapshot_version)],
                       [str(x.requirement) for x in synthetic_target.requirements.value])
 
     local_wheel_products = context.products.get('local_wheels')
@@ -94,7 +94,7 @@ class TestBuildLocalDistsNativeSources(BuildLocalPythonDistributionsTestBase):
     platform_specific_dist = self.target_dict['platform_specific']
     context, synthetic_target, snapshot_version = self._create_distribution_synthetic_target(
       platform_specific_dist)
-    self.assertEquals(['platform_specific_dist==0.0.0+{}'.format(snapshot_version)],
+    self.assertEqual(['platform_specific_dist==0.0.0+{}'.format(snapshot_version)],
                       [str(x.requirement) for x in synthetic_target.requirements.value])
 
     local_wheel_products = context.products.get('local_wheels')

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes.py
@@ -97,7 +97,7 @@ class TestBuildLocalDistsWithCtypesNativeSources(BuildLocalPythonDistributionsTe
     platform_specific_dist = self.target_dict['platform_specific_ctypes_c_dist']
     context, synthetic_target, snapshot_version = self._create_distribution_synthetic_target(
       platform_specific_dist, extra_targets=[self.target_dict['ctypes_c_library']])
-    self.assertEquals(['platform_specific_ctypes_c_dist==0.0.0+{}'.format(snapshot_version)],
+    self.assertEqual(['platform_specific_ctypes_c_dist==0.0.0+{}'.format(snapshot_version)],
                       [str(x.requirement) for x in synthetic_target.requirements.value])
     local_wheel_products = context.products.get('local_wheels')
     local_wheel = self._retrieve_single_product_at_target_base(
@@ -108,7 +108,7 @@ class TestBuildLocalDistsWithCtypesNativeSources(BuildLocalPythonDistributionsTe
     platform_specific_dist = self.target_dict['platform_specific_ctypes_cpp_dist']
     context, synthetic_target, snapshot_version = self._create_distribution_synthetic_target(
       platform_specific_dist, extra_targets=[self.target_dict['ctypes_cpp_library']])
-    self.assertEquals(['platform_specific_ctypes_cpp_dist==0.0.0+{}'.format(snapshot_version)],
+    self.assertEqual(['platform_specific_ctypes_cpp_dist==0.0.0+{}'.format(snapshot_version)],
                       [str(x.requirement) for x in synthetic_target.requirements.value])
 
     local_wheel_products = context.products.get('local_wheels')

--- a/tests/python/pants_test/backend/python/tasks/test_gather_sources.py
+++ b/tests/python/pants_test/backend/python/tasks/test_gather_sources.py
@@ -77,7 +77,7 @@ class GatherSourcesTest(TaskTestBase):
       expected_content = self.filemap[to_filemap_key(path)]
       with open(os.path.join(pex_path, path)) as infile:
         content = infile.read()
-      self.assertEquals(expected_content, content)
+      self.assertEqual(expected_content, content)
 
   def _assert_content_not_in_pex(self, pex, target):
     _, files = self._extract_files(target)

--- a/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
@@ -49,7 +49,7 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
     self.assertIsNotNone(products)
     product_data = products.get(binary)
     product_basedir = list(product_data.keys())[0]
-    self.assertEquals(product_data[product_basedir], [pex_name])
+    self.assertEqual(product_data[product_basedir], [pex_name])
 
     # Check pex copy.
     pex_copy = os.path.join(self.build_root, 'dist', pex_name)

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -146,7 +146,7 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       try:
         output = subprocess.check_output(pex2)
       except subprocess.CalledProcessError as e:
-        self.assertNotEquals(0, e.returncode)
+        self.assertNotEqual(0, e.returncode)
 
   def test_pants_resolves_local_dists_for_current_platform_only(self):
     # Test that pants will override pants.ini platforms config when building

--- a/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
@@ -63,7 +63,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
                var_key]
     pants_run = self.run_pants(command=command, extra_env={var_key: var_val})
     self.assert_success(pants_run)
-    self.assertEquals(var_val, pants_run.stdout_data.strip())
+    self.assertEqual(var_val, pants_run.stdout_data.strip())
 
   def test_pants_run_interpreter_selection_with_pexrc(self):
     py27 = '2.7'
@@ -169,7 +169,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
     v = echo.split('.')  # E.g., 2.7.13.
     self.assertTrue(len(v) > 2, 'Not a valid version string: {}'.format(v))
     expected_components = version.split('.')
-    self.assertEquals(expected_components, v[:len(expected_components,)])
+    self.assertEqual(expected_components, v[:len(expected_components,)])
 
   def _run_echo_version(self, version):
     binary_name = 'echo_interpreter_version_{}'.format(version)

--- a/tests/python/pants_test/backend/python/tasks/test_resolve_requirements.py
+++ b/tests/python/pants_test/backend/python/tasks/test_resolve_requirements.py
@@ -39,7 +39,7 @@ class ResolveRequirementsTest(TaskTestBase):
     # Check that the module is available if specified as a requirement.
     stdout_data, stderr_data = self._exercise_module(self._resolve_requirements([ansicolors_tgt]),
                                                      'colors')
-    self.assertEquals('', stderr_data.strip())
+    self.assertEqual('', stderr_data.strip())
 
     path = stdout_data.strip()
     # Check that the requirement resolved to what we expect.
@@ -59,7 +59,7 @@ class ResolveRequirementsTest(TaskTestBase):
       }
     })
     stdout_data, stderr_data = self._exercise_module(pex, 'cffi')
-    self.assertEquals('', stderr_data.strip())
+    self.assertEqual('', stderr_data.strip())
 
     path = stdout_data.strip()
     wheel_dir = os.path.join(path[0:path.find('{sep}.deps{sep}'.format(sep=os.sep))], '.deps')

--- a/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
+++ b/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
@@ -105,16 +105,16 @@ class SelectInterpreterTest(TaskTestBase):
 
   def test_interpreter_selection(self):
     self.assertIsNone(self._select_interpreter([]))
-    self.assertEquals('IronPython-2.77.777', self._select_interpreter_and_get_version([self.reqtgt]))
-    self.assertEquals('IronPython-2.77.777', self._select_interpreter_and_get_version([self.tgt1]))
-    self.assertEquals('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt2]))
-    self.assertEquals('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt3]))
-    self.assertEquals('IronPython-2.77.777', self._select_interpreter_and_get_version([self.tgt4]))
-    self.assertEquals('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt20]))
-    self.assertEquals('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt30]))
-    self.assertEquals('IronPython-2.77.777', self._select_interpreter_and_get_version([self.tgt40]))
-    self.assertEquals('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt2, self.tgt3]))
-    self.assertEquals('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt2, self.tgt4]))
+    self.assertEqual('IronPython-2.77.777', self._select_interpreter_and_get_version([self.reqtgt]))
+    self.assertEqual('IronPython-2.77.777', self._select_interpreter_and_get_version([self.tgt1]))
+    self.assertEqual('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt2]))
+    self.assertEqual('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt3]))
+    self.assertEqual('IronPython-2.77.777', self._select_interpreter_and_get_version([self.tgt4]))
+    self.assertEqual('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt20]))
+    self.assertEqual('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt30]))
+    self.assertEqual('IronPython-2.77.777', self._select_interpreter_and_get_version([self.tgt40]))
+    self.assertEqual('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt2, self.tgt3]))
+    self.assertEqual('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt2, self.tgt4]))
 
     with self.assertRaises(TaskError) as cm:
       self._select_interpreter_and_get_version([self.tgt3, self.tgt4])
@@ -124,19 +124,19 @@ class SelectInterpreterTest(TaskTestBase):
   def test_interpreter_selection_invalidation(self):
     tgta = self._fake_target('tgta', compatibility=['IronPython>2.77.777'],
                              dependencies=[self.tgt3])
-    self.assertEquals('IronPython-2.99.999',
+    self.assertEqual('IronPython-2.99.999',
                       self._select_interpreter_and_get_version([tgta], should_invalidate=True))
 
     # A new target with different sources, but identical compatibility, shouldn't invalidate.
     self.create_file('tgtb/foo/bar/baz.py', 'fake content')
     tgtb = self._fake_target('tgtb', compatibility=['IronPython>2.77.777'],
                              dependencies=[self.tgt3], sources=['foo/bar/baz.py'])
-    self.assertEquals('IronPython-2.99.999',
+    self.assertEqual('IronPython-2.99.999',
                       self._select_interpreter_and_get_version([tgtb], should_invalidate=False))
 
   def test_compatibility_AND(self):
     tgt = self._fake_target('tgt5', compatibility=['IronPython>2.77.777,<2.99.999'])
-    self.assertEquals('IronPython-2.88.888', self._select_interpreter_and_get_version([tgt]))
+    self.assertEqual('IronPython-2.88.888', self._select_interpreter_and_get_version([tgt]))
 
   def test_compatibility_AND_impossible(self):
     tgt = self._fake_target('tgt5', compatibility=['IronPython>2.77.777,<2.88.888'])
@@ -146,7 +146,7 @@ class SelectInterpreterTest(TaskTestBase):
 
   def test_compatibility_OR(self):
     tgt = self._fake_target('tgt6', compatibility=['IronPython>2.88.888', 'IronPython<2.7'])
-    self.assertEquals('IronPython-2.99.999', self._select_interpreter_and_get_version([tgt]))
+    self.assertEqual('IronPython-2.99.999', self._select_interpreter_and_get_version([tgt]))
 
   def test_compatibility_OR_impossible(self):
     tgt = self._fake_target('tgt6', compatibility=['IronPython>2.99.999', 'IronPython<2.77.777'])

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py_integration.py
@@ -45,7 +45,7 @@ class SetupPyIntegrationTest(PantsRequirementIntegrationTestBase):
     with tarfile.open(sdist_path, 'r') as sdist:
       infos = sdist.getmembers()
       entries = [(info.name.rstrip('/') + '/' if info.isdir() else info.name) for info in infos]
-      self.assertEquals(sorted(expected_entries), sorted(entries),
+      self.assertEqual(sorted(expected_entries), sorted(entries),
                         '\nExpected entries:\n{}\n\nActual entries:\n{}'.format(
                           '\n'.join(sorted(expected_entries)),
                           '\n'.join(sorted(entries))))

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -97,7 +97,7 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBas
     context = self._scheduling_context(
       target_roots=([python_dist_target] + extra_targets),
       for_task_types=([self.task_type()] + self._extra_relevant_task_types))
-    self.assertEquals(set(self._all_specified_targets()), set(context.build_graph.targets()))
+    self.assertEqual(set(self._all_specified_targets()), set(context.build_graph.targets()))
 
     python_create_distributions_task = self.create_task(context)
     extra_tasks = [
@@ -110,7 +110,7 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBas
     python_create_distributions_task.execute()
 
     synthetic_tgts = set(context.build_graph.targets()) - set(self._all_specified_targets())
-    self.assertEquals(1, len(synthetic_tgts))
+    self.assertEqual(1, len(synthetic_tgts))
     synthetic_target = next(iter(synthetic_tgts))
 
     snapshot_version = self._get_dist_snapshot_version(

--- a/tests/python/pants_test/base/pants_ignore_test_base.py
+++ b/tests/python/pants_test/base/pants_ignore_test_base.py
@@ -66,19 +66,19 @@ class PantsIgnoreTestBase(ProjectTreeTestBase):
     self._project_tree = self.mk_project_tree(self.root_dir, [''])
     files_list = self._walk_tree()
 
-    self.assertEquals(self._all_files, set(files_list))
+    self.assertEqual(self._all_files, set(files_list))
 
   def test_ignore_pattern_comment(self):
     self._project_tree = self.mk_project_tree(self.root_dir, ['#fruit', '#apple', '#banana'])
     files_list = self._walk_tree()
 
-    self.assertEquals(self._all_files, set(files_list))
+    self.assertEqual(self._all_files, set(files_list))
 
   def test_ignore_pattern_negate(self):
     self._project_tree = self.mk_project_tree(self.root_dir, ['*an*', '!*na*'])
     files_list = self._walk_tree()
 
-    self.assertEquals(
+    self.assertEqual(
       self._all_files - {'orange', 'fruit/orange', 'fruit/fruit/orange'},
       set(files_list)
     )
@@ -87,7 +87,7 @@ class PantsIgnoreTestBase(ProjectTreeTestBase):
     self._project_tree = self.mk_project_tree(self.root_dir, ['fruit/'])
     files_list = self._walk_tree()
 
-    self.assertEquals(
+    self.assertEqual(
       self._all_files - {'fruit/apple', 'fruit/banana', 'fruit/orange',
                          'fruit/fruit/apple', 'fruit/fruit/banana', 'fruit/fruit/orange'},
       set(files_list)
@@ -97,7 +97,7 @@ class PantsIgnoreTestBase(ProjectTreeTestBase):
     self._project_tree = self.mk_project_tree(self.root_dir, ['fruit'])
     files_list = self._walk_tree()
 
-    self.assertEquals(
+    self.assertEqual(
       self._all_files - {'fruit/apple', 'fruit/banana', 'fruit/orange',
                          'fruit/fruit/apple', 'fruit/fruit/banana', 'fruit/fruit/orange',
                          'grocery/fruit'},
@@ -108,13 +108,13 @@ class PantsIgnoreTestBase(ProjectTreeTestBase):
     self._project_tree = self.mk_project_tree(self.root_dir, ['fruit/apple'])
     files_list = self._walk_tree()
 
-    self.assertEquals(self._all_files - {'fruit/apple'}, set(files_list))
+    self.assertEqual(self._all_files - {'fruit/apple'}, set(files_list))
 
     files_list = self._project_tree.glob1('fruit', '*')
-    self.assertEquals({'banana', 'orange', 'fruit'}, set(files_list))
+    self.assertEqual({'banana', 'orange', 'fruit'}, set(files_list))
 
     files_list = [s.path for s in self._project_tree.scandir('fruit')]
-    self.assertEquals({'fruit/banana', 'fruit/orange', 'fruit/fruit'}, set(files_list))
+    self.assertEqual({'fruit/banana', 'fruit/orange', 'fruit/fruit'}, set(files_list))
 
     with self.assertRaises(self._project_tree.AccessIgnoredPathError):
       self._project_tree.content('fruit/apple')
@@ -123,14 +123,14 @@ class PantsIgnoreTestBase(ProjectTreeTestBase):
     self._project_tree = self.mk_project_tree(self.root_dir, ['/apple'])
     files_list = self._walk_tree()
 
-    self.assertEquals(self._all_files - {'apple'}, set(files_list))
+    self.assertEqual(self._all_files - {'apple'}, set(files_list))
 
   def test_ignore_pattern_leading_and_trailing_slashes(self):
     self._project_tree = self.mk_project_tree(self.root_dir, ['/apple/'])
     files_list = self._walk_tree()
     # Pattern '/apple/' should only exclude directory `/apple`.
     # File `/apple` is not excluded.
-    self.assertEquals(self._all_files, set(files_list))
+    self.assertEqual(self._all_files, set(files_list))
 
   def test_ignore_pattern_leading_slash_should_exclude_subdirs(self):
     self._project_tree = self.mk_project_tree(self.root_dir, ['/fruit'])
@@ -138,7 +138,7 @@ class PantsIgnoreTestBase(ProjectTreeTestBase):
 
     # root level `/fruit` and its subdirs are excluded.
     # non root level `/grocery/fruit` is included.
-    self.assertEquals(
+    self.assertEqual(
       self._all_files - {'fruit/apple',
                          'fruit/banana',
                          'fruit/orange',
@@ -152,27 +152,27 @@ class PantsIgnoreTestBase(ProjectTreeTestBase):
     self._project_tree = self.mk_project_tree(self.root_dir, ['/*e'])
     files_list = self._walk_tree()
 
-    self.assertEquals(self._all_files - {'apple', 'orange'}, set(files_list))
+    self.assertEqual(self._all_files - {'apple', 'orange'}, set(files_list))
 
     files_list = self._project_tree.glob1('', '*e')
-    self.assertEquals(set(), set(files_list))
+    self.assertEqual(set(), set(files_list))
 
     files_list = [s.path for s in self._project_tree.scandir('')]
-    self.assertEquals({'banana', 'fruit', 'grocery'}, set(files_list))
+    self.assertEqual({'banana', 'fruit', 'grocery'}, set(files_list))
 
   def test_ignore_pattern_two_asterisks(self):
     self._project_tree = self.mk_project_tree(self.root_dir, ['/**/apple'])
     files_list = self._walk_tree()
 
-    self.assertEquals(self._all_files - {'apple', 'fruit/apple', 'fruit/fruit/apple'}, set(files_list))
+    self.assertEqual(self._all_files - {'apple', 'fruit/apple', 'fruit/fruit/apple'}, set(files_list))
 
   def test_ignore_dir_path_ignore_1(self):
     self._project_tree = self.mk_project_tree(self.root_dir, ['fruit/fruit/'])
 
     self.assertFalse(self._project_tree.isdir('fruit/fruit'))
     self.assertFalse(self._project_tree.exists('fruit/fruit'))
-    self.assertEquals({'apple', 'banana', 'orange'}, set(self._project_tree.glob1('fruit', '*')))
-    self.assertEquals({'fruit/apple', 'fruit/banana', 'fruit/orange'},
+    self.assertEqual({'apple', 'banana', 'orange'}, set(self._project_tree.glob1('fruit', '*')))
+    self.assertEqual({'fruit/apple', 'fruit/banana', 'fruit/orange'},
                       set(s.path for s in self._project_tree.scandir('fruit')))
 
   def test_ignore_dir_path_ignore_2(self):
@@ -180,6 +180,6 @@ class PantsIgnoreTestBase(ProjectTreeTestBase):
 
     self.assertFalse(self._project_tree.isdir('fruit'))
     self.assertFalse(self._project_tree.exists('fruit'))
-    self.assertEquals({'apple', 'banana', 'orange', 'grocery'}, set(self._project_tree.glob1('', '*')))
-    self.assertEquals({'apple', 'banana', 'orange', 'grocery'},
+    self.assertEqual({'apple', 'banana', 'orange', 'grocery'}, set(self._project_tree.glob1('', '*')))
+    self.assertEqual({'apple', 'banana', 'orange', 'grocery'},
                       set(s.path for s in self._project_tree.scandir('')))

--- a/tests/python/pants_test/base/test_build_environment.py
+++ b/tests/python/pants_test/base/test_build_environment.py
@@ -17,23 +17,23 @@ class TestBuildEnvironment(unittest.TestCase):
 
   def test_get_configdir(self):
     with environment_as(XDG_CONFIG_HOME=''):
-      self.assertEquals(os.path.expanduser('~/.config/pants'), get_pants_configdir())
+      self.assertEqual(os.path.expanduser('~/.config/pants'), get_pants_configdir())
 
   def test_get_cachedir(self):
     with environment_as(XDG_CACHE_HOME=''):
-      self.assertEquals(os.path.expanduser('~/.cache/pants'), get_pants_cachedir())
+      self.assertEqual(os.path.expanduser('~/.cache/pants'), get_pants_cachedir())
 
   def test_set_configdir(self):
     with temporary_file() as temp:
       with environment_as(XDG_CONFIG_HOME=temp.name):
-        self.assertEquals(os.path.join(temp.name, 'pants'),  get_pants_configdir())
+        self.assertEqual(os.path.join(temp.name, 'pants'),  get_pants_configdir())
 
   def test_set_cachedir(self):
     with temporary_file() as temp:
       with environment_as(XDG_CACHE_HOME=temp.name):
-        self.assertEquals(os.path.join(temp.name, 'pants'), get_pants_cachedir())
+        self.assertEqual(os.path.join(temp.name, 'pants'), get_pants_cachedir())
 
   def test_expand_home_configdir(self):
     with environment_as(XDG_CONFIG_HOME='~/somewhere/in/home'):
-      self.assertEquals(os.path.expanduser(os.path.join('~/somewhere/in/home', 'pants')),
+      self.assertEqual(os.path.expanduser(os.path.join('~/somewhere/in/home', 'pants')),
                         get_pants_configdir())

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -74,7 +74,7 @@ class CmdLineSpecParserTest(TestBase):
     # By adding a double slash, we are insisting that this absolute path is actually
     # relative to the buildroot. Thus, it should parse correctly.
     double_absolute = '/' + os.path.join(self.build_root, 'a')
-    self.assertEquals('//', double_absolute[:2],
+    self.assertEqual('//', double_absolute[:2],
                       'A sanity check we have a leading-// absolute spec')
     self.assert_parsed(double_absolute, single(double_absolute[2:]))
 

--- a/tests/python/pants_test/base/test_exclude_target_regexp_integration.py
+++ b/tests/python/pants_test/base/test_exclude_target_regexp_integration.py
@@ -86,7 +86,7 @@ class ExcludeTargetRegexpIntegrationTest(PantsRunIntegrationTest):
                                       cwd=path)
           java_retcode = java_run.wait()
           java_out = java_run.stdout.read().decode('utf-8')
-          self.assertEquals(java_retcode, 0)
+          self.assertEqual(java_retcode, 0)
           self.assertTrue(expected in java_out, "Expected '{output}' from {jar}, not '{stdout}'."
                                                 .format(output=expected, jar=jar, stdout=java_out))
 

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -23,30 +23,30 @@ class FilesystemBuildFileTest(BuildFileTestBase):
 
   def test_build_files_family_lookup_1(self):
     buildfile = self.create_buildfile('grandparent/parent/BUILD.twitter')
-    self.assertEquals({buildfile, self.buildfile},
+    self.assertEqual({buildfile, self.buildfile},
                       set(self.get_build_files_family('grandparent/parent')))
-    self.assertEquals({buildfile, self.buildfile},
+    self.assertEqual({buildfile, self.buildfile},
                       set(self.get_build_files_family('grandparent/parent/')))
 
-    self.assertEquals({self.create_buildfile('grandparent/parent/child2/child3/BUILD')},
+    self.assertEqual({self.create_buildfile('grandparent/parent/child2/child3/BUILD')},
                       set(self.get_build_files_family('grandparent/parent/child2/child3')))
 
   def test_build_files_family_lookup_2(self):
-    self.assertEquals(OrderedSet([
+    self.assertEqual(OrderedSet([
         self.create_buildfile('grandparent/parent/BUILD'),
         self.create_buildfile('grandparent/parent/BUILD.twitter'),
     ]), self.get_build_files_family('grandparent/parent'))
 
     buildfile = self.create_buildfile('grandparent/parent/child2/child3/BUILD')
-    self.assertEquals(OrderedSet([buildfile]), self.get_build_files_family('grandparent/parent/child2/child3'))
+    self.assertEqual(OrderedSet([buildfile]), self.get_build_files_family('grandparent/parent/child2/child3'))
 
   def test_build_files_family_lookup_with_ignore(self):
-    self.assertEquals(OrderedSet([
+    self.assertEqual(OrderedSet([
         self.create_buildfile('grandparent/parent/BUILD'),
     ]), self.get_build_files_family('grandparent/parent', build_ignore_patterns=['*.twitter']))
 
   def test_build_files_scan(self):
-    self.assertEquals(OrderedSet([
+    self.assertEqual(OrderedSet([
         self.create_buildfile('grandparent/parent/BUILD'),
         self.create_buildfile('grandparent/parent/BUILD.twitter'),
         self.create_buildfile('grandparent/parent/child1/BUILD'),
@@ -59,7 +59,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
     buildfiles = self.scan_buildfiles('', build_ignore_patterns=[
         'grandparent/parent/child1',
         'grandparent/parent/child2'])
-    self.assertEquals(OrderedSet([
+    self.assertEqual(OrderedSet([
         self.create_buildfile('BUILD'),
         self.create_buildfile('BUILD.twitter'),
         self.create_buildfile('grandparent/parent/BUILD'),
@@ -69,7 +69,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
     ]), buildfiles)
 
     buildfiles = self.scan_buildfiles('grandparent/parent', build_ignore_patterns=['grandparent/parent/child1'])
-    self.assertEquals(OrderedSet([
+    self.assertEqual(OrderedSet([
         self.create_buildfile('grandparent/parent/BUILD'),
         self.create_buildfile('grandparent/parent/BUILD.twitter'),
         self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
@@ -78,7 +78,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
 
   def test_build_files_scan_with_abspath_ignore(self):
     self.touch('parent/BUILD')
-    self.assertEquals(OrderedSet([
+    self.assertEqual(OrderedSet([
       self.create_buildfile('BUILD'),
       self.create_buildfile('BUILD.twitter'),
       self.create_buildfile('grandparent/parent/BUILD'),
@@ -91,7 +91,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
     ]), self.scan_buildfiles('', build_ignore_patterns=['/parent']))
 
   def test_build_files_scan_with_wildcard_ignore(self):
-    self.assertEquals(OrderedSet([
+    self.assertEqual(OrderedSet([
       self.create_buildfile('BUILD'),
       self.create_buildfile('BUILD.twitter'),
       self.create_buildfile('grandparent/parent/BUILD'),
@@ -100,7 +100,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
     ]), self.scan_buildfiles('', build_ignore_patterns=['**/child*']))
 
   def test_build_files_scan_with_ignore_patterns(self):
-    self.assertEquals(OrderedSet([
+    self.assertEqual(OrderedSet([
       self.create_buildfile('BUILD'),
       self.create_buildfile('grandparent/parent/BUILD'),
       self.create_buildfile('grandparent/parent/child1/BUILD'),
@@ -112,7 +112,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
   def test_subdir_ignore(self):
     self.touch('grandparent/child1/BUILD')
 
-    self.assertEquals(OrderedSet([
+    self.assertEqual(OrderedSet([
       self.create_buildfile('BUILD'),
       self.create_buildfile('BUILD.twitter'),
       self.create_buildfile('grandparent/child1/BUILD'),
@@ -124,7 +124,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
     ]), self.scan_buildfiles('', build_ignore_patterns=['**/parent/child1']))
 
   def test_subdir_file_pattern_ignore(self):
-    self.assertEquals(OrderedSet([
+    self.assertEqual(OrderedSet([
       self.create_buildfile('BUILD'),
       self.create_buildfile('grandparent/parent/BUILD'),
       self.create_buildfile('grandparent/parent/child1/BUILD'),
@@ -133,7 +133,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
     ]), self.scan_buildfiles('', build_ignore_patterns=['BUILD.*']))
 
   def test_build_files_scan_with_non_default_relpath_ignore(self):
-    self.assertEquals(OrderedSet([
+    self.assertEqual(OrderedSet([
       self.create_buildfile('grandparent/parent/BUILD'),
       self.create_buildfile('grandparent/parent/BUILD.twitter'),
       self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
@@ -155,19 +155,19 @@ class FilesystemBuildFileTest(BuildFileTestBase):
     self.makedirs('suffix-test/child')
     self.touch('suffix-test/child/BUILD.suffix3')
     buildfile = self.create_buildfile('suffix-test/BUILD.suffix')
-    self.assertEquals(OrderedSet([buildfile, self.create_buildfile('suffix-test/BUILD.suffix2')]),
+    self.assertEqual(OrderedSet([buildfile, self.create_buildfile('suffix-test/BUILD.suffix2')]),
         OrderedSet(self.get_build_files_family('suffix-test')))
-    self.assertEquals(OrderedSet([self.create_buildfile('suffix-test/BUILD.suffix'),
+    self.assertEqual(OrderedSet([self.create_buildfile('suffix-test/BUILD.suffix'),
         self.create_buildfile('suffix-test/BUILD.suffix2')]),
         self.get_build_files_family('suffix-test'))
-    self.assertEquals(OrderedSet([self.create_buildfile('suffix-test/child/BUILD.suffix3')]),
+    self.assertEqual(OrderedSet([self.create_buildfile('suffix-test/child/BUILD.suffix3')]),
         self.scan_buildfiles('suffix-test/child'))
 
   def test_directory_called_build_skipped(self):
     # Ensure the buildfiles found do not include grandparent/BUILD since it is a dir.
     buildfiles = self.scan_buildfiles('grandparent')
 
-    self.assertEquals(OrderedSet([
+    self.assertEqual(OrderedSet([
       self.create_buildfile('grandparent/parent/BUILD'),
       self.create_buildfile('grandparent/parent/BUILD.twitter'),
       self.create_buildfile('grandparent/parent/child1/BUILD'),

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -58,8 +58,8 @@ class TestHashUtils(unittest.TestCase):
   def test_sharder(self):
     def check(spec, expected_shard, expected_nshards):
       sharder = Sharder(spec)
-      self.assertEquals(expected_shard, sharder.shard)
-      self.assertEquals(expected_nshards, sharder.nshards)
+      self.assertEqual(expected_shard, sharder.shard)
+      self.assertEqual(expected_nshards, sharder.nshards)
 
     def check_bad_spec(spec):
       self.assertRaises(Sharder.InvalidShardSpec, lambda: Sharder(spec))

--- a/tests/python/pants_test/base/test_payload.py
+++ b/tests/python/pants_test/base/test_payload.py
@@ -91,17 +91,17 @@ class PayloadTest(TestBase):
     payload = Payload()
     payload.add_field('foo', PrimitiveField('test-value'))
     payload.add_field('bar', PrimitiveField(None))
-    self.assertEquals('test-value', payload.foo);
-    self.assertEquals('test-value', payload.get_field('foo').value)
-    self.assertEquals('test-value', payload.get_field_value('foo'))
-    self.assertEquals(None, payload.bar);
-    self.assertEquals(None, payload.get_field('bar').value)
-    self.assertEquals(None, payload.get_field_value('bar'))
-    self.assertEquals(None, payload.get_field('bar', default='nothing').value)
-    self.assertEquals(None, payload.get_field_value('bar', default='nothing'))
+    self.assertEqual('test-value', payload.foo);
+    self.assertEqual('test-value', payload.get_field('foo').value)
+    self.assertEqual('test-value', payload.get_field_value('foo'))
+    self.assertEqual(None, payload.bar);
+    self.assertEqual(None, payload.get_field('bar').value)
+    self.assertEqual(None, payload.get_field_value('bar'))
+    self.assertEqual(None, payload.get_field('bar', default='nothing').value)
+    self.assertEqual(None, payload.get_field_value('bar', default='nothing'))
     with self.assertRaises(KeyError):
-      self.assertEquals(None, payload.field_doesnt_exist)
-    self.assertEquals(None, payload.get_field('field_doesnt_exist'))
-    self.assertEquals(None, payload.get_field_value('field_doesnt_exist'))
-    self.assertEquals('nothing', payload.get_field('field_doesnt_exist', default='nothing'))
-    self.assertEquals('nothing', payload.get_field_value('field_doesnt_exist', default='nothing'))
+      self.assertEqual(None, payload.field_doesnt_exist)
+    self.assertEqual(None, payload.get_field('field_doesnt_exist'))
+    self.assertEqual(None, payload.get_field_value('field_doesnt_exist'))
+    self.assertEqual('nothing', payload.get_field('field_doesnt_exist', default='nothing'))
+    self.assertEqual('nothing', payload.get_field_value('field_doesnt_exist', default='nothing'))

--- a/tests/python/pants_test/base/test_payload_field.py
+++ b/tests/python/pants_test/base/test_payload_field.py
@@ -113,14 +113,14 @@ class PayloadTest(TestBase):
     field1 = TestValue('field1')
     field1_same = TestValue('field1')
     field2 = TestValue('field2')
-    self.assertEquals(field1.fingerprint(), field1_same.fingerprint())
-    self.assertNotEquals(field1.fingerprint(), field2.fingerprint())
+    self.assertEqual(field1.fingerprint(), field1_same.fingerprint())
+    self.assertNotEqual(field1.fingerprint(), field2.fingerprint())
 
     fingerprinted_field1 = FingerprintedField(field1)
     fingerprinted_field1_same = FingerprintedField(field1_same)
     fingerprinted_field2 = FingerprintedField(field2)
-    self.assertEquals(fingerprinted_field1.fingerprint(), fingerprinted_field1_same.fingerprint())
-    self.assertNotEquals(fingerprinted_field1.fingerprint(), fingerprinted_field2.fingerprint())
+    self.assertEqual(fingerprinted_field1.fingerprint(), fingerprinted_field1_same.fingerprint())
+    self.assertNotEqual(fingerprinted_field1.fingerprint(), fingerprinted_field2.fingerprint())
 
   def test_set_of_primitives_field(self):
     # Should preserve `None` values.

--- a/tests/python/pants_test/base/test_run_info.py
+++ b/tests/python/pants_test/base/test_run_info.py
@@ -16,24 +16,24 @@ class RunInfoTest(unittest.TestCase):
       with open(tmppath, 'w') as tmpfile:
         tmpfile.write('foo:bar\n baz :qux quux')
       ri = RunInfo(tmppath)
-      self.assertEquals(ri.path(), tmppath)
+      self.assertEqual(ri.path(), tmppath)
 
       # Test get_info access.
-      self.assertEquals(ri.get_info('foo'), 'bar')
-      self.assertEquals(ri.get_info('baz'), 'qux quux')
+      self.assertEqual(ri.get_info('foo'), 'bar')
+      self.assertEqual(ri.get_info('baz'), 'qux quux')
       self.assertIsNone(ri.get_info('nonexistent'))
 
       # Test dict-like access.
-      self.assertEquals(ri['foo'], 'bar')
-      self.assertEquals(ri['baz'], 'qux quux')
+      self.assertEqual(ri['foo'], 'bar')
+      self.assertEqual(ri['baz'], 'qux quux')
 
   def test_write_run_info(self):
     with temporary_file_path() as tmppath:
       ri = RunInfo(tmppath)
       ri.add_info('key1', 'val1')
       ri.add_infos(('key2', ' val2'), (' key3 ', 'val3 '))
-      self.assertEquals({'key1': 'val1', 'key2': 'val2', 'key3': 'val3'}, ri.get_as_dict())
+      self.assertEqual({'key1': 'val1', 'key2': 'val2', 'key3': 'val3'}, ri.get_as_dict())
 
       with open(tmppath, 'r') as tmpfile:
         contents = tmpfile.read()
-      self.assertEquals('key1: val1\nkey2: val2\nkey3: val3\n', contents)
+      self.assertEqual('key1: val1\nkey2: val2\nkey3: val3\n', contents)

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -201,7 +201,7 @@ class BinaryUtilTest(TestBase):
 
     binary_request = binary_util._make_deprecated_binary_request("supportdir", "version", "name")
 
-    self.assertEquals("supportdir/linux/x86_64/version/name",
+    self.assertEqual("supportdir/linux/x86_64/version/name",
                       binary_util._get_download_path(binary_request))
 
   def test_select_binary_base_path_darwin(self):
@@ -212,7 +212,7 @@ class BinaryUtilTest(TestBase):
 
     binary_request = binary_util._make_deprecated_binary_request("supportdir", "version", "name")
 
-    self.assertEquals("supportdir/mac/10.10/version/name",
+    self.assertEqual("supportdir/mac/10.10/version/name",
                       binary_util._get_download_path(binary_request))
 
   def test_select_binary_base_path_missing_os(self):
@@ -280,7 +280,7 @@ class BinaryUtilTest(TestBase):
 
     binary_request = binary_util._make_deprecated_binary_request("supportdir", "version", "name")
 
-    self.assertEquals("supportdir/skynet/42/version/name",
+    self.assertEqual("supportdir/skynet/42/version/name",
                       binary_util._get_download_path(binary_request))
 
   def test_external_url_generator(self):

--- a/tests/python/pants_test/build_graph/test_address.py
+++ b/tests/python/pants_test/build_graph/test_address.py
@@ -115,15 +115,15 @@ class ParseSpecTest(unittest.TestCase):
 
     # Ensure that a spec in subprojectA is determined correctly.
     subprojectA_spec = parse('src/python/alib', 'subprojectA/src/python')
-    self.assertEquals(subprojectA_spec, 'subprojectA/src/python/alib')
+    self.assertEqual(subprojectA_spec, 'subprojectA/src/python/alib')
 
     # Ensure that a spec in subprojectB, which is more complex, is correct.
     subprojectB_spec = parse('src/python/blib', 'path/to/subprojectB/src/python')
-    self.assertEquals(subprojectB_spec, 'path/to/subprojectB/src/python/blib')
+    self.assertEqual(subprojectB_spec, 'path/to/subprojectB/src/python/blib')
 
     # Ensure that a spec in the parent project is not mapped.
     parent_spec = parse('src/python/parent', 'src/python')
-    self.assertEquals(parent_spec, 'src/python/parent')
+    self.assertEqual(parent_spec, 'src/python/parent')
 
 
 class BaseAddressTest(unittest.TestCase):

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -45,7 +45,7 @@ class BuildFileAddressMapperTest(BaseTest):
     subdir_suffix_build_file = self.add_to_build_file('subdir/BUILD.suffix', 'target(name="baz")')
     with open(os.path.join(self.build_root, 'BUILD.invalid.suffix'), 'w') as invalid_build_file:
       invalid_build_file.write('target(name="foobar")')
-    self.assertEquals({BuildFileAddress(build_file=root_build_file, target_name='foo'),
+    self.assertEqual({BuildFileAddress(build_file=root_build_file, target_name='foo'),
                        BuildFileAddress(build_file=subdir_build_file, target_name='bar'),
                        BuildFileAddress(build_file=subdir_suffix_build_file, target_name='baz')},
                       self.address_mapper.scan_addresses())
@@ -55,7 +55,7 @@ class BuildFileAddressMapperTest(BaseTest):
     subdir_build_file = self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
     subdir_suffix_build_file = self.add_to_build_file('subdir/BUILD.suffix', 'target(name="baz")')
     subdir = os.path.join(self.build_root, 'subdir')
-    self.assertEquals({BuildFileAddress(build_file=subdir_build_file, target_name='bar'),
+    self.assertEqual({BuildFileAddress(build_file=subdir_build_file, target_name='bar'),
                        BuildFileAddress(build_file=subdir_suffix_build_file, target_name='baz')},
                       self.address_mapper.scan_addresses(root=subdir))
 
@@ -129,7 +129,7 @@ class BuildFileAddressMapperWithIgnoreTest(BaseTest):
   def test_scan_from_address_mapper(self):
     root_build_file = self.add_to_build_file('BUILD', 'target(name="foo")')
     self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
-    self.assertEquals(
+    self.assertEqual(
       {BuildFileAddress(build_file=root_build_file, target_name='foo')},
       self.address_mapper.scan_addresses())
 
@@ -137,7 +137,7 @@ class BuildFileAddressMapperWithIgnoreTest(BaseTest):
     self.add_to_build_file('BUILD', 'target(name="foo")')
     self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
     graph = self.context().scan()
-    self.assertEquals([target.address.spec for target in graph.targets()], ['//:foo'])
+    self.assertEqual([target.address.spec for target in graph.targets()], ['//:foo'])
 
 
 class BuildFileAddressMapperScanTest(BaseTest):

--- a/tests/python/pants_test/build_graph/test_build_graph.py
+++ b/tests/python/pants_test/build_graph/test_build_graph.py
@@ -83,10 +83,10 @@ class BuildGraphTest(TestBase):
   def test_get_target_from_spec(self):
     a = self.make_target('foo:a')
     result = self.build_graph.get_target_from_spec('foo:a')
-    self.assertEquals(a, result)
+    self.assertEqual(a, result)
     b = self.make_target('foo:b')
     result = self.build_graph.get_target_from_spec(':b', relative_to='foo')
-    self.assertEquals(b, result)
+    self.assertEqual(b, result)
 
   def test_walk_graph(self):
     # Make sure that BuildGraph.walk_transitive_dependency_graph() and
@@ -96,14 +96,14 @@ class BuildGraphTest(TestBase):
       self.build_graph.walk_transitive_dependency_graph([target.address],
                                                          lambda x: targets.append(x),
                                                         postorder=postorder)
-      self.assertEquals(results, targets)
+      self.assertEqual(results, targets)
 
     def assertDependeeWalk(target, results, postorder=False):
       targets = []
       self.build_graph.walk_transitive_dependee_graph([target.address],
                                                         lambda x: targets.append(x),
                                                         postorder=postorder)
-      self.assertEquals(results, targets)
+      self.assertEqual(results, targets)
 
     a = self.make_target('a')
     b = self.make_target('b', dependencies=[a])
@@ -147,33 +147,33 @@ class BuildGraphTest(TestBase):
 
   def test_target_closure(self):
     a = self.make_target('a')
-    self.assertEquals([a], a.closure())
+    self.assertEqual([a], a.closure())
     b = self.make_target('b', dependencies=[a])
-    self.assertEquals([b, a], b.closure())
+    self.assertEqual([b, a], b.closure())
     c = self.make_target('c', dependencies=[b])
-    self.assertEquals([c, b, a], c.closure())
+    self.assertEqual([c, b, a], c.closure())
     d = self.make_target('d', dependencies=[a, c])
-    self.assertEquals([d, a, c, b], d.closure())
+    self.assertEqual([d, a, c, b], d.closure())
 
   def test_closure(self):
-    self.assertEquals([], BuildGraph.closure([]))
+    self.assertEqual([], BuildGraph.closure([]))
     a = self.make_target('a')
-    self.assertEquals([a], BuildGraph.closure([a]))
+    self.assertEqual([a], BuildGraph.closure([a]))
     b = self.make_target('b', dependencies=[a])
-    self.assertEquals([b, a], BuildGraph.closure([b]))
+    self.assertEqual([b, a], BuildGraph.closure([b]))
     c = self.make_target('c', dependencies=[b])
-    self.assertEquals([c, b, a], BuildGraph.closure([c]))
+    self.assertEqual([c, b, a], BuildGraph.closure([c]))
     d = self.make_target('d', dependencies=[a, c])
-    self.assertEquals([d, a, c, b], BuildGraph.closure([d]))
+    self.assertEqual([d, a, c, b], BuildGraph.closure([d]))
 
     def d_gen():
       yield d
-    self.assertEquals([d, a, c, b], BuildGraph.closure(d_gen()))
+    self.assertEqual([d, a, c, b], BuildGraph.closure(d_gen()))
 
     def empty_gen():
       return
       yield
-    self.assertEquals([], BuildGraph.closure(empty_gen()))
+    self.assertEqual([], BuildGraph.closure(empty_gen()))
 
   def test_closure_bfs(self):
     root = self.inject_graph('a', {
@@ -188,7 +188,7 @@ class BuildGraphTest(TestBase):
     })
 
     bfs_closure = BuildGraph.closure([self.build_graph.get_target(root)], bfs=True)
-    self.assertEquals(
+    self.assertEqual(
         [t.address.target_name for t in bfs_closure],
         [chr(x) for x in range(ord('a'), ord('o') + 1)],
     )
@@ -205,7 +205,7 @@ class BuildGraphTest(TestBase):
       'h': [], 'i': [], 'j': [], 'k': [], 'l': [], 'm': [], 'n': [], 'o': [],
     })
 
-    self.assertEquals(
+    self.assertEqual(
         [t.address.target_name for t in self.build_graph.transitive_subgraph_of_addresses_bfs([root])],
         [chr(x) for x in range(ord('a'), ord('o') + 1)],
     )
@@ -220,13 +220,13 @@ class BuildGraphTest(TestBase):
     predicate = lambda t: t.address.target_name != 'b'
     filtered = self.build_graph.transitive_subgraph_of_addresses_bfs([root], predicate=predicate)
 
-    self.assertEquals([target.address.target_name for target in filtered], ['a', 'c'])
+    self.assertEqual([target.address.target_name for target in filtered], ['a', 'c'])
 
   def test_target_walk(self):
     def assertWalk(expected, target):
       results = []
       target.walk(lambda x: results.append(x))
-      self.assertEquals(expected, results)
+      self.assertEqual(expected, results)
 
     a = self.make_target('a')
     assertWalk([a], a)
@@ -344,7 +344,7 @@ class BuildGraphTest(TestBase):
           return True
 
         result = func([t.address for t in roots], predicate=predicate_sees, **kwargs)
-        self.assertEquals(set(expected), set(result))
+        self.assertEqual(set(expected), set(result))
         if any(ct > 1 for ct in seen_targets.values()):
           self.fail('func {} visited {} more than once.'.format(
             func,

--- a/tests/python/pants_test/build_graph/test_scopes.py
+++ b/tests/python/pants_test/build_graph/test_scopes.py
@@ -14,8 +14,8 @@ from pants_test.test_base import TestBase
 class ScopesTest(TestBase):
 
   def test_mixed_case(self):
-    self.assertEquals(Scope('RUNTIME'), Scope('runtime'))
-    self.assertNotEquals(Scope('RUNTIME'), Scope('COMPILE'))
+    self.assertEqual(Scope('RUNTIME'), Scope('runtime'))
+    self.assertNotEqual(Scope('RUNTIME'), Scope('COMPILE'))
 
   def test_default_parsing(self):
     equivalent_defaults = [
@@ -25,7 +25,7 @@ class ScopesTest(TestBase):
     expected = Scope(Scopes.DEFAULT)
     for i, scope in enumerate(equivalent_defaults):
       received = Scope(scope)
-      self.assertEquals(expected, received, 'Expected scope {i}. {received} == {expected}'.format(
+      self.assertEqual(expected, received, 'Expected scope {i}. {received} == {expected}'.format(
         i=i,
         received=received,
         expected=expected,
@@ -50,7 +50,7 @@ class ScopesTest(TestBase):
                                              exclude_scopes=Scopes.RUNTIME))
 
   def test_scope_equality(self):
-    self.assertEquals(Scope('a b'), Scope('b') + Scope('a'))
+    self.assertEqual(Scope('a b'), Scope('b') + Scope('a'))
 
   def test_invalid_in_scope_params(self):
     bad_values = ['', (), [], {}, set(), OrderedSet(), 'default', 'runtime', ('compile',)]
@@ -82,7 +82,7 @@ class ScopedClosureTest(TestBase):
       respect_intransitive=respect_intransitive,
       bfs=True
     ))
-    self.assertEquals(set_type(expected_targets), bfs_result)
+    self.assertEqual(set_type(expected_targets), bfs_result)
 
   def assert_closure_dfs(self, expected_targets, roots, include_scopes=None, exclude_scopes=None,
                      respect_intransitive=True, ordered=False, postorder=None):
@@ -94,7 +94,7 @@ class ScopedClosureTest(TestBase):
       respect_intransitive=respect_intransitive,
       postorder=postorder
     ))
-    self.assertEquals(set_type(expected_targets), result)
+    self.assertEqual(set_type(expected_targets), result)
 
   def test_find_normal_dependencies(self):
     a = self.make_target('a')

--- a/tests/python/pants_test/build_graph/test_source_mapper.py
+++ b/tests/python/pants_test/build_graph/test_source_mapper.py
@@ -53,7 +53,7 @@ class SourceMapperTest(object):
     )
     '''))
 
-    self.assertEquals(['path:target', 'path:buildholder'],
+    self.assertEqual(['path:target', 'path:buildholder'],
                       list(a.spec for a in self.get_mapper().target_addresses_for_source('path/BUILD')))
 
   def test_joint_ownership(self):

--- a/tests/python/pants_test/build_graph/test_target.py
+++ b/tests/python/pants_test/build_graph/test_target.py
@@ -56,9 +56,9 @@ class TargetTest(TestBase):
     syn_two = self.make_target('y:syn_two', Target, derived_from=syn_one)
 
     # validate
-    self.assertEquals(list(syn_two.derived_from_chain), [syn_one, concrete])
-    self.assertEquals(list(syn_one.derived_from_chain), [concrete])
-    self.assertEquals(list(concrete.derived_from_chain), [])
+    self.assertEqual(list(syn_two.derived_from_chain), [syn_one, concrete])
+    self.assertEqual(list(syn_one.derived_from_chain), [concrete])
+    self.assertEqual(list(concrete.derived_from_chain), [])
 
   def test_is_synthetic(self):
     # add concrete target

--- a/tests/python/pants_test/cache/test_artifact.py
+++ b/tests/python/pants_test/cache/test_artifact.py
@@ -24,7 +24,7 @@ class TarballArtifactTest(unittest.TestCase):
       artifact = TarballArtifact(artifact_root, os.path.join(cache_root, 'some.tar'))
       artifact.collect([file_path])
 
-      self.assertEquals([file_path], list(artifact.get_paths()))
+      self.assertEqual([file_path], list(artifact.get_paths()))
 
   def test_does_not_exist_when_no_tar_file(self):
     with temporary_dir() as tmpdir:

--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -99,7 +99,7 @@ class TestArtifactCache(unittest.TestCase):
       # Check that it was recovered correctly.
       with open(path, 'r') as infile:
         content = infile.read()
-      self.assertEquals(content, TEST_CONTENT1)
+      self.assertEqual(content, TEST_CONTENT1)
 
       # Delete it.
       artifact_cache.delete(key)

--- a/tests/python/pants_test/cache/test_cache_setup.py
+++ b/tests/python/pants_test/cache/test_cache_setup.py
@@ -98,16 +98,16 @@ class TestCacheSetup(TestBase):
   def test_sanitize_cache_spec(self):
     cache_factory = self.cache_factory()
 
-    self.assertEquals(self.CACHE_SPEC_LOCAL_ONLY,
+    self.assertEqual(self.CACHE_SPEC_LOCAL_ONLY,
                       cache_factory._sanitize_cache_spec([self.LOCAL_URI]))
 
-    self.assertEquals(self.CACHE_SPEC_REMOTE_ONLY,
+    self.assertEqual(self.CACHE_SPEC_REMOTE_ONLY,
                       cache_factory._sanitize_cache_spec([self.REMOTE_URI_1]))
 
     # (local, remote) and (remote, local) are equivalent as long as they are valid
-    self.assertEquals(self.CACHE_SPEC_LOCAL_REMOTE,
+    self.assertEqual(self.CACHE_SPEC_LOCAL_REMOTE,
                       cache_factory._sanitize_cache_spec([self.LOCAL_URI, self.REMOTE_URI_1]))
-    self.assertEquals(self.CACHE_SPEC_LOCAL_REMOTE,
+    self.assertEqual(self.CACHE_SPEC_LOCAL_REMOTE,
                       cache_factory._sanitize_cache_spec([self.REMOTE_URI_1, self.LOCAL_URI]))
 
     with self.assertRaises(InvalidCacheSpecError):
@@ -135,17 +135,17 @@ class TestCacheSetup(TestBase):
   def test_resolve(self):
     cache_factory = self.cache_factory()
 
-    self.assertEquals(CacheSpec(local=None,
+    self.assertEqual(CacheSpec(local=None,
                                 remote='{}|{}'.format(self.REMOTE_URI_1, self.REMOTE_URI_2)),
                       cache_factory._resolve(self.CACHE_SPEC_RESOLVE_ONLY))
 
-    self.assertEquals(CacheSpec(local=self.LOCAL_URI,
+    self.assertEqual(CacheSpec(local=self.LOCAL_URI,
                                 remote='{}|{}'.format(self.REMOTE_URI_1, self.REMOTE_URI_2)),
                       cache_factory._resolve(self.CACHE_SPEC_LOCAL_RESOLVE))
 
     self.resolver.resolve.side_effect = Resolver.ResolverError()
     # still have local cache if resolver fails
-    self.assertEquals(CacheSpec(local=self.LOCAL_URI, remote=None),
+    self.assertEqual(CacheSpec(local=self.LOCAL_URI, remote=None),
                       cache_factory._resolve(self.CACHE_SPEC_LOCAL_RESOLVE))
     # no cache created if resolver fails and no local cache
     self.assertFalse(cache_factory._resolve(self.CACHE_SPEC_RESOLVE_ONLY))
@@ -154,11 +154,11 @@ class TestCacheSetup(TestBase):
     self.resolver.resolve = Mock(return_value=[])
     cache_factory = self.cache_factory()
 
-    self.assertEquals(self.CACHE_SPEC_LOCAL_ONLY,
+    self.assertEqual(self.CACHE_SPEC_LOCAL_ONLY,
                       cache_factory._resolve(self.CACHE_SPEC_LOCAL_ONLY))
-    self.assertEquals(self.CACHE_SPEC_RESOLVE_ONLY,
+    self.assertEqual(self.CACHE_SPEC_RESOLVE_ONLY,
                       cache_factory._resolve(self.CACHE_SPEC_RESOLVE_ONLY))
-    self.assertEquals(self.CACHE_SPEC_LOCAL_RESOLVE,
+    self.assertEqual(self.CACHE_SPEC_LOCAL_RESOLVE,
                       cache_factory._resolve(self.CACHE_SPEC_LOCAL_RESOLVE))
 
   def test_cache_spec_parsing(self):
@@ -176,7 +176,7 @@ class TestCacheSetup(TestBase):
     def check(expected_type, spec, resolver=None):
       cache = mk_cache(spec, resolver=resolver)
       self.assertIsInstance(cache, expected_type)
-      self.assertEquals(cache.artifact_root, self.pants_workdir)
+      self.assertEqual(cache.artifact_root, self.pants_workdir)
 
     with temporary_dir() as tmpdir:
       cachedir = os.path.join(tmpdir, 'cachedir')  # Must be a real path, so we can safe_mkdir it.

--- a/tests/python/pants_test/cache/test_pinger.py
+++ b/tests/python/pants_test/cache/test_pinger.py
@@ -87,7 +87,7 @@ class TestBestUrlSelector(TestBase):
   def call_url(self, expected_url, with_error=False):
     try:
       with self.best_url_selector.select_best_url() as url:
-        self.assertEquals(urlparse(expected_url), url)
+        self.assertEqual(urlparse(expected_url), url)
 
         if with_error:
           raise RequestException('error connecting to {}'.format(url))

--- a/tests/python/pants_test/cache/test_resolver.py
+++ b/tests/python/pants_test/cache/test_resolver.py
@@ -19,9 +19,9 @@ class TestResponseParser(unittest.TestCase):
 
   def testParse(self):
     response_parser = ResponseParser()
-    self.assertEquals(['url1', 'url2'], response_parser.parse('{"hostlist": ["url1", "url2"]}'))
+    self.assertEqual(['url1', 'url2'], response_parser.parse('{"hostlist": ["url1", "url2"]}'))
 
-    self.assertEquals([], response_parser.parse('{"hostlist": []}'))
+    self.assertEqual([], response_parser.parse('{"hostlist": []}'))
 
     with self.assertRaises(ResponseParser.ResponseParserError):
       response_parser.parse('{"hostlist": "not a list"}')
@@ -63,7 +63,7 @@ class TestRESTfulResolver(unittest.TestCase):
   def testResolveSuccess(self):
     with patch.object(requests.Session, 'get', **PATCH_OPTS) as mock_get:
       mock_get.return_value = self.mock_response(requests.codes.ok, urls=self.URLS)
-      self.assertEquals(self.URLS, self.resolver.resolve(self.TEST_RESOLVED_FROM))
+      self.assertEqual(self.URLS, self.resolver.resolve(self.TEST_RESOLVED_FROM))
 
   def testResolveErrorEmptyReturn(self):
     with patch.object(requests.Session, 'get', **PATCH_OPTS) as mock_get:

--- a/tests/python/pants_test/core_tasks/test_run_prep_command.py
+++ b/tests/python/pants_test/core_tasks/test_run_prep_command.py
@@ -73,7 +73,7 @@ class RunPrepCommandTest(TaskTestBase):
       context = self.context(target_roots=[a])
       task = self.create_task(context=context, workdir=workdir)
       task.execute()
-      self.assertEquals('fleem', os.environ['test_prep_env_var'])
+      self.assertEqual('fleem', os.environ['test_prep_env_var'])
 
   def test_prep_no_command(self):
     with self.assertRaises(TaskError):
@@ -96,16 +96,16 @@ class RunPrepCommandTest(TaskTestBase):
 
   def test_valid_target_default_goals(self):
     prep_command = self.make_target('foo', PrepCommand, prep_executable='foo.sh')
-    self.assertEquals(frozenset(['test']), prep_command.goals)
+    self.assertEqual(frozenset(['test']), prep_command.goals)
 
   def test_valid_target_single_goal(self):
     prep_command = self.make_target('foo', PrepCommand, prep_executable='foo.sh', goals=['binary'])
-    self.assertEquals(frozenset(['binary']), prep_command.goals)
+    self.assertEqual(frozenset(['binary']), prep_command.goals)
 
   def test_valid_target_multiple_goals(self):
     prep_command = self.make_target('foo', PrepCommand, prep_executable='foo.sh',
                                     goals=['binary', 'test'])
-    self.assertEquals(frozenset(['binary', 'test']), prep_command.goals)
+    self.assertEqual(frozenset(['binary', 'test']), prep_command.goals)
 
   def test_invalid_target_no_executable(self):
     with self.assertRaisesRegexp(TargetDefinitionException,

--- a/tests/python/pants_test/engine/legacy/test_bundle_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_bundle_integration.py
@@ -65,4 +65,4 @@ class BundleIntegrationTest(PantsRunIntegrationTest):
        'testprojects/src/java/org/pantsbuild/testproject/bundle:bundle-resource-ordering']
     )
     self.assert_success(pants_run)
-    self.assertEquals(pants_run.stdout_data.strip(), 'Hello world from Foo')
+    self.assertEqual(pants_run.stdout_data.strip(), 'Hello world from Foo')

--- a/tests/python/pants_test/engine/legacy/test_filemap_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_filemap_integration.py
@@ -30,7 +30,7 @@ class FilemapIntegrationTest(PantsRunIntegrationTest):
     for root, dirs, files in project_tree.walk(''):
       scan_set.update({os.path.join(root, f) for f in files if not should_ignore(f)})
 
-    self.assertEquals(scan_set, self.TEST_EXCLUDE_FILES)
+    self.assertEqual(scan_set, self.TEST_EXCLUDE_FILES)
 
   def _mk_target(self, test_name):
     return '{}:{}'.format(self.PATH_PREFIX, test_name)
@@ -66,44 +66,44 @@ class FilemapIntegrationTest(PantsRunIntegrationTest):
 
   def test_exclude_list_of_strings(self):
     test_out = self._extract_exclude_output('exclude_list_of_strings')
-    self.assertEquals(self.TEST_EXCLUDE_FILES - {'aaa.py', 'dir1/aaa.py'},
+    self.assertEqual(self.TEST_EXCLUDE_FILES - {'aaa.py', 'dir1/aaa.py'},
                       test_out)
 
   def test_exclude_globs(self):
     test_out = self._extract_exclude_output('exclude_globs')
-    self.assertEquals(self.TEST_EXCLUDE_FILES - {'aabb.py', 'dir1/dirdir1/aa.py'},
+    self.assertEqual(self.TEST_EXCLUDE_FILES - {'aabb.py', 'dir1/dirdir1/aa.py'},
                       test_out)
 
   def test_exclude_strings(self):
     test_out = self._extract_exclude_output('exclude_strings')
-    self.assertEquals(self.TEST_EXCLUDE_FILES - {'aa.py', 'ab.py'},
+    self.assertEqual(self.TEST_EXCLUDE_FILES - {'aa.py', 'ab.py'},
                       test_out)
 
   def test_exclude_set(self):
     test_out = self._extract_exclude_output('exclude_set')
-    self.assertEquals(self.TEST_EXCLUDE_FILES - {'aaa.py', 'a.py'},
+    self.assertEqual(self.TEST_EXCLUDE_FILES - {'aaa.py', 'a.py'},
                       test_out)
 
   def test_exclude_rglobs(self):
     test_out = self._extract_exclude_output('exclude_rglobs')
-    self.assertEquals(self.TEST_EXCLUDE_FILES - {'ab.py', 'aabb.py', 'dir1/ab.py', 'dir1/aabb.py', 'dir1/dirdir1/ab.py'},
+    self.assertEqual(self.TEST_EXCLUDE_FILES - {'ab.py', 'aabb.py', 'dir1/ab.py', 'dir1/aabb.py', 'dir1/dirdir1/ab.py'},
                       test_out)
 
   def test_exclude_zglobs(self):
     test_out = self._extract_exclude_output('exclude_zglobs')
-    self.assertEquals(self.TEST_EXCLUDE_FILES - {'ab.py', 'aabb.py', 'dir1/ab.py', 'dir1/aabb.py', 'dir1/dirdir1/ab.py'},
+    self.assertEqual(self.TEST_EXCLUDE_FILES - {'ab.py', 'aabb.py', 'dir1/ab.py', 'dir1/aabb.py', 'dir1/dirdir1/ab.py'},
                       test_out)
 
   def test_exclude_composite(self):
     test_out = self._extract_exclude_output('exclude_composite')
-    self.assertEquals(self.TEST_EXCLUDE_FILES -
+    self.assertEqual(self.TEST_EXCLUDE_FILES -
                       {'a.py', 'aaa.py', 'dir1/a.py', 'dir1/dirdir1/a.py'},
                       test_out)
 
   def test_implicit_sources(self):
     test_out = self._extract_exclude_output('implicit_sources')
-    self.assertEquals({'a.py', 'aa.py', 'aaa.py', 'aabb.py', 'ab.py'},
+    self.assertEqual({'a.py', 'aa.py', 'aaa.py', 'aabb.py', 'ab.py'},
                       test_out)
 
     test_out = self._extract_exclude_output('test_with_implicit_sources')
-    self.assertEquals({'test_a.py'}, test_out)
+    self.assertEqual({'test_a.py'}, test_out)

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -162,7 +162,7 @@ class GraphInvalidationTest(GraphTestBase):
     with self.open_scheduler([spec]) as (graph, _, _):
       target = graph.get_target(Address.parse(spec))
       sources = [os.path.basename(s) for s in target.sources_relative_to_buildroot()]
-      self.assertEquals(expected_sources, sources)
+      self.assertEqual(expected_sources, sources)
 
   def test_sources_ordering_literal(self):
     self._ordering_test('testprojects/src/resources/org/pantsbuild/testproject/ordering:literal')

--- a/tests/python/pants_test/engine/legacy/test_list_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_list_integration.py
@@ -31,7 +31,7 @@ class ListIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.do_command('list',
                                 'testprojects/tests/python/pants/build_parsing::',
                                 success=True)
-    self.assertEquals(
+    self.assertEqual(
       pants_run.stdout_data.strip(),
       'testprojects/tests/python/pants/build_parsing:test-nested-variable-access-in-function-call'
     )

--- a/tests/python/pants_test/engine/legacy/test_options_parsing.py
+++ b/tests/python/pants_test/engine/legacy/test_options_parsing.py
@@ -33,9 +33,9 @@ class TestEngineOptionsParsing(unittest.TestCase):
 
     self.assertIn('binary', options.goals)
     global_options = options.for_global_scope()
-    self.assertEquals(global_options.level, 'debug')
-    self.assertEquals(global_options.enable_pantsd, True)
-    self.assertEquals(global_options.binaries_baseurls, ['https://bins.com'])
+    self.assertEqual(global_options.level, 'debug')
+    self.assertEqual(global_options.enable_pantsd, True)
+    self.assertEqual(global_options.binaries_baseurls, ['https://bins.com'])
 
     python_setup_options = options.for_scope('python-setup')
-    self.assertEquals(python_setup_options.wheel_version, '3.13.37')
+    self.assertEqual(python_setup_options.wheel_version, '3.13.37')

--- a/tests/python/pants_test/engine/legacy/test_owners_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_owners_integration.py
@@ -13,7 +13,7 @@ class ListOwnersIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.do_command('--owner-of=testprojects/tests/python/pants/dummies/test_pass.py',
                                 'list',
                                 success=True)
-    self.assertEquals(
+    self.assertEqual(
       pants_run.stdout_data.strip(),
       'testprojects/tests/python/pants/dummies:passing_target'
     )

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -37,7 +37,7 @@ class ParseAddressFamilyTest(unittest.TestCase):
         (Snapshot, PathGlobs): lambda _: Snapshot(DirectoryDigest(text_type("abc"), 10), (File('/dev/null/BUILD'),)),
         (FilesContent, DirectoryDigest): lambda _: FilesContent([FileContent('/dev/null/BUILD', '')]),
       })
-    self.assertEquals(len(af.objects_by_name), 0)
+    self.assertEqual(len(af.objects_by_name), 0)
 
 
 class AddressesFromAddressFamiliesTest(unittest.TestCase):
@@ -53,8 +53,8 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
         (AddressFamily, Dir): lambda _: address_family,
       })
 
-    self.assertEquals(len(bfas.dependencies), 1)
-    self.assertEquals(bfas.dependencies[0].spec, 'a:a')
+    self.assertEqual(len(bfas.dependencies), 1)
+    self.assertEqual(bfas.dependencies[0].spec, 'a:a')
 
   def test_tag_filter(self):
     """Test that targets are filtered based on `tags`."""
@@ -74,8 +74,8 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
       (AddressFamily, Dir): lambda _: address_family,
     })
 
-    self.assertEquals(len(targets.dependencies), 1)
-    self.assertEquals(targets.dependencies[0].spec, 'root:b')
+    self.assertEqual(len(targets.dependencies), 1)
+    self.assertEqual(targets.dependencies[0].spec, 'root:b')
 
   def test_exclude_pattern(self):
     """Test that targets are filtered based on exclude patterns."""
@@ -92,8 +92,8 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
       (Snapshot, PathGlobs): lambda _: snapshot,
       (AddressFamily, Dir): lambda _: address_family,
     })
-    self.assertEquals(len(targets.dependencies), 1)
-    self.assertEquals(targets.dependencies[0].spec, 'root:not_me')
+    self.assertEqual(len(targets.dependencies), 1)
+    self.assertEqual(targets.dependencies[0].spec, 'root:not_me')
 
 
 class ApacheThriftConfiguration(StructWithDeps):
@@ -164,17 +164,17 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
     """Perform an ExecutionRequest to parse the given Address into a Struct."""
     request = scheduler.execution_request([TestTable().constraint()], [address])
     root_entries = scheduler.execute(request).root_products
-    self.assertEquals(1, len(root_entries))
+    self.assertEqual(1, len(root_entries))
     return request, root_entries[0][1]
 
   def resolve_failure(self, scheduler, address):
     _, state = self._populate(scheduler, address)
-    self.assertEquals(type(state), Throw, '{} is not a Throw.'.format(state))
+    self.assertEqual(type(state), Throw, '{} is not a Throw.'.format(state))
     return state.exc
 
   def resolve(self, scheduler, address):
     _, state = self._populate(scheduler, address)
-    self.assertEquals(type(state), Return, '{} is not a Return.'.format(state))
+    self.assertEqual(type(state), Return, '{} is not a Return.'.format(state))
     return state.value
 
 
@@ -238,14 +238,14 @@ class InlinedGraphTest(GraphTestBase):
 
     nonstrict_address = Address.parse('graph_test:nonstrict')
     nonstrict = self.resolve(scheduler, nonstrict_address)
-    self.assertEquals(nonstrict, self.resolve(scheduler, nonstrict_address))
+    self.assertEqual(nonstrict, self.resolve(scheduler, nonstrict_address))
 
     # The already resolved `nonstrict` interior node should be re-used by `java1`.
     java1_address = Address.parse('graph_test:java1')
     java1 = self.resolve(scheduler, java1_address)
-    self.assertEquals(nonstrict, java1.configurations[1])
+    self.assertEqual(nonstrict, java1.configurations[1])
 
-    self.assertEquals(java1, self.resolve(scheduler, java1_address))
+    self.assertEqual(java1, self.resolve(scheduler, java1_address))
 
   def do_test_trace_message(self, scheduler, parsed_address, expected_string=None):
     # Confirm that the root failed, and that a cycle occurred deeper in the graph.
@@ -310,6 +310,6 @@ class InlinedGraphTest(GraphTestBase):
   def assert_resolve_failure_type(self, expected_type, mismatch, scheduler):
 
     failure = self.resolve_failure(scheduler, mismatch)
-    self.assertEquals(type(failure),
+    self.assertEqual(type(failure),
                       expected_type,
                       'type was not {}. Instead was {}, {!r}'.format(expected_type.__name__, type(failure).__name__, failure))

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -59,7 +59,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
     with self.mk_project_tree(ignore_patterns=ignore_patterns) as project_tree:
       scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree)
       result = self.execute(scheduler, Snapshot, self.specs(filespecs_or_globs))[0]
-      self.assertEquals(sorted([p.path for p in getattr(result, field)]), sorted(paths))
+      self.assertEqual(sorted([p.path for p in getattr(result, field)]), sorted(paths))
 
   def assert_content(self, filespecs_or_globs, expected_content):
     with self.mk_project_tree() as project_tree:
@@ -67,14 +67,14 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       snapshot = self.execute_expecting_one_result(scheduler, Snapshot, self.specs(filespecs_or_globs)).value
       result = self.execute_expecting_one_result(scheduler, FilesContent, snapshot.directory_digest).value
       actual_content = {f.path: f.content for f in result.dependencies}
-      self.assertEquals(expected_content, actual_content)
+      self.assertEqual(expected_content, actual_content)
 
   def assert_digest(self, filespecs_or_globs, expected_files):
     with self.mk_project_tree() as project_tree:
       scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree)
       result = self.execute(scheduler, Snapshot, self.specs(filespecs_or_globs))[0]
       # Confirm all expected files were digested.
-      self.assertEquals(set(expected_files), set(f.path for f in result.files))
+      self.assertEqual(set(expected_files), set(f.path for f in result.files))
       self.assertTrue(result.directory_digest.fingerprint is not None)
 
   def assert_fsnodes(self, filespecs_or_globs, subject_product_pairs):
@@ -86,7 +86,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       # request.
       fs_nodes = [n for n, _ in scheduler.product_graph.walk(roots=request.roots)
                   if type(n) is "TODO: need a new way to filter for FS intrinsics"]
-      self.assertEquals(set((n.subject, n.product) for n in fs_nodes), set(subject_product_pairs))
+      self.assertEqual(set((n.subject, n.product) for n in fs_nodes), set(subject_product_pairs))
 
   def test_walk_literal(self):
     self.assert_walk_files(['4.txt'], ['4.txt'])
@@ -293,7 +293,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
         PathGlobsAndRoot(PathGlobs(("susannah",), ()), text_type(temp_dir)),
         PathGlobsAndRoot(PathGlobs(("doesnotexist",), ()), text_type(temp_dir)),
       ))
-      self.assertEquals(3, len(snapshots))
+      self.assertEqual(3, len(snapshots))
       self.assert_snapshot_equals(snapshots[0], ["roland"], DirectoryDigest(
         text_type("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16"),
         80
@@ -313,8 +313,8 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       self.assertIn("doesnotexist", str(cm.exception))
 
   def assert_snapshot_equals(self, snapshot, files, directory_digest):
-    self.assertEquals([file.path for file in snapshot.files], files)
-    self.assertEquals(snapshot.directory_digest, directory_digest)
+    self.assertEqual([file.path for file in snapshot.files], files)
+    self.assertEqual(snapshot.directory_digest, directory_digest)
 
   def test_merge_zero_directories(self):
     scheduler = self.mk_scheduler(rules=create_fs_rules())
@@ -338,7 +338,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       )
 
       empty_merged = scheduler.merge_directories((empty_snapshot.directory_digest))
-      self.assertEquals(
+      self.assertEqual(
         empty_snapshot.directory_digest,
         empty_merged,
       )
@@ -347,7 +347,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
         roland_snapshot.directory_digest,
         empty_snapshot.directory_digest,
       ))
-      self.assertEquals(
+      self.assertEqual(
         roland_snapshot.directory_digest,
         roland_merged,
       )
@@ -357,7 +357,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
         susannah_snapshot.directory_digest,
       ))
 
-      self.assertEquals(both_snapshot.directory_digest, both_merged)
+      self.assertEqual(both_snapshot.directory_digest, both_merged)
 
   def test_materialize_directories(self):
     # I tried passing in the digest of a file, but it didn't make it to the
@@ -376,7 +376,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       created_file = os.path.join(dir_path, "roland")
       with open(created_file) as f:
         content = f.read()
-        self.assertEquals(content, "European Burmese")
+        self.assertEqual(content, "European Burmese")
 
   def test_glob_match_error(self):
     with self.assertRaises(ValueError) as cm:

--- a/tests/python/pants_test/engine/test_graph.py
+++ b/tests/python/pants_test/engine/test_graph.py
@@ -47,49 +47,49 @@ class GraphTest(unittest.TestCase):
 
   def test_dependency_edges(self):
     self.pg.add_dependencies('A', ['B', 'C'])
-    self.assertEquals({'B', 'C'}, set(self.pg.dependencies_of('A')))
-    self.assertEquals({'A'}, set(self.pg.dependents_of('B')))
-    self.assertEquals({'A'}, set(self.pg.dependents_of('C')))
+    self.assertEqual({'B', 'C'}, set(self.pg.dependencies_of('A')))
+    self.assertEqual({'A'}, set(self.pg.dependents_of('B')))
+    self.assertEqual({'A'}, set(self.pg.dependents_of('C')))
 
   def test_cycle_simple(self):
     self.pg.add_dependencies('A', ['B'])
     self.pg.add_dependencies('B', ['A'])
     # NB: Order matters: the second insertion is the one tracked as a cycle.
-    self.assertEquals({'B'}, set(self.pg.dependencies_of('A')))
-    self.assertEquals(set(), set(self.pg.dependencies_of('B')))
-    self.assertEquals(set(), set(self.pg.cyclic_dependencies_of('A')))
-    self.assertEquals({'A'}, set(self.pg.cyclic_dependencies_of('B')))
+    self.assertEqual({'B'}, set(self.pg.dependencies_of('A')))
+    self.assertEqual(set(), set(self.pg.dependencies_of('B')))
+    self.assertEqual(set(), set(self.pg.cyclic_dependencies_of('A')))
+    self.assertEqual({'A'}, set(self.pg.cyclic_dependencies_of('B')))
 
   def test_cycle_indirect(self):
     self.pg.add_dependencies('A', ['B'])
     self.pg.add_dependencies('B', ['C'])
     self.pg.add_dependencies('C', ['A'])
 
-    self.assertEquals({'B'}, set(self.pg.dependencies_of('A')))
-    self.assertEquals({'C'}, set(self.pg.dependencies_of('B')))
-    self.assertEquals(set(), set(self.pg.dependencies_of('C')))
-    self.assertEquals(set(), set(self.pg.cyclic_dependencies_of('A')))
-    self.assertEquals(set(), set(self.pg.cyclic_dependencies_of('B')))
-    self.assertEquals({'A'}, set(self.pg.cyclic_dependencies_of('C')))
+    self.assertEqual({'B'}, set(self.pg.dependencies_of('A')))
+    self.assertEqual({'C'}, set(self.pg.dependencies_of('B')))
+    self.assertEqual(set(), set(self.pg.dependencies_of('C')))
+    self.assertEqual(set(), set(self.pg.cyclic_dependencies_of('A')))
+    self.assertEqual(set(), set(self.pg.cyclic_dependencies_of('B')))
+    self.assertEqual({'A'}, set(self.pg.cyclic_dependencies_of('C')))
 
   def test_cycle_long(self):
     # Creating a long chain is allowed.
     nodes = list(range(0, 100))
     self._mk_chain(self.pg, nodes, states=(_WAITING,))
     walked_nodes = [node for node, _ in self.pg.walk([nodes[0]])]
-    self.assertEquals(nodes, walked_nodes)
+    self.assertEqual(nodes, walked_nodes)
 
     # Closing the chain is not.
     begin, end = nodes[0], nodes[-1]
     self.pg.add_dependencies(end, [begin])
-    self.assertEquals(set(), set(self.pg.dependencies_of(end)))
-    self.assertEquals({begin}, set(self.pg.cyclic_dependencies_of(end)))
+    self.assertEqual(set(), set(self.pg.dependencies_of(end)))
+    self.assertEqual({begin}, set(self.pg.cyclic_dependencies_of(end)))
 
   def test_walk(self):
     nodes = list('ABCDEF')
     self._mk_chain(self.pg, nodes)
     walked_nodes = list((node for node, _ in self.pg.walk(nodes[0])))
-    self.assertEquals(nodes, walked_nodes)
+    self.assertEqual(nodes, walked_nodes)
 
   def test_invalidate_all(self):
     chain_list = list('ABCDEFGHIJKLMNOPQRSTUVWXYZ')
@@ -128,12 +128,12 @@ class GraphTest(unittest.TestCase):
     # Ensure the final structure of the primary graph matches the comparison graph.
     pg_structure = {n: e.structure() for n, e in self.pg._nodes.items()}
     comparison_structure = {n: e.structure() for n, e in comparison_pg._nodes.items()}
-    self.assertEquals(pg_structure, comparison_structure)
+    self.assertEqual(pg_structure, comparison_structure)
 
   def test_invalidate_count(self):
     self._mk_chain(self.pg, list('ABCDEFGHIJKLMNOPQRSTUVWXYZ'))
     invalidated_count = self.pg.invalidate(lambda node, _: node == 'I')
-    self.assertEquals(invalidated_count, 9)
+    self.assertEqual(invalidated_count, 9)
 
   def test_invalidate_partial_identity_check(self):
     # Create a graph with a chain from A..Z.

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -262,7 +262,7 @@ class ExecuteProcessRequestTest(unittest.TestCase):
       description="Some process",
       env={'VAR': 'VAL'},
     )
-    self.assertEquals(req.env, ('VAR', 'VAL'))
+    self.assertEqual(req.env, ('VAR', 'VAL'))
 
 
 class IsolatedProcessTest(TestBase, unittest.TestCase):
@@ -305,7 +305,7 @@ class IsolatedProcessTest(TestBase, unittest.TestCase):
       [request],
     )[0]
 
-    self.assertEquals(
+    self.assertEqual(
       execute_process_result.output_directory_digest,
       DirectoryDigest(
         fingerprint=text_type("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16"),
@@ -318,7 +318,7 @@ class IsolatedProcessTest(TestBase, unittest.TestCase):
       [execute_process_result.output_directory_digest],
     )[0]
 
-    self.assertEquals(
+    self.assertEqual(
       files_content_result.dependencies,
       (FileContent("roland", "European Burmese"),)
     )
@@ -352,7 +352,7 @@ class Simple {
     result = self.scheduler.product_request(JavacCompileResult, [request])[0]
     files_content = self.scheduler.product_request(FilesContent, [result.directory_digest])[0].dependencies
 
-    self.assertEquals(
+    self.assertEqual(
       tuple(sorted((
         "simple/Simple.java",
         "simple/Simple.class",
@@ -390,7 +390,7 @@ class Broken {
 
     result = self.scheduler.product_request(FallibleExecuteProcessResult, [request])[0]
 
-    self.assertEquals(result.exit_code, 1)
+    self.assertEqual(result.exit_code, 1)
 
   def test_non_fallible_failing_command_raises(self):
     request = ExecuteProcessRequest.create_with_empty_snapshot(

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -119,7 +119,7 @@ class AddressFamilyTest(unittest.TestCase):
   def test_create_empty(self):
     # Case where directory exists but is empty.
     address_family = AddressFamily.create('name/space', [])
-    self.assertEquals(dict(), address_family.addressables)
+    self.assertEqual(dict(), address_family.addressables)
 
   def test_mismatching_paths(self):
     with self.assertRaises(DifferingFamiliesError):

--- a/tests/python/pants_test/engine/test_round_engine.py
+++ b/tests/python/pants_test/engine/test_round_engine.py
@@ -228,15 +228,15 @@ class RoundEngineTest(EngineTestBase, TestBase):
     task1_pre, = install()
     Goal.clear()
     task1_post, = install()
-    self.assertEquals(task1_pre, task1_post)
+    self.assertEqual(task1_pre, task1_post)
 
   def test_replace_target_roots(self):
     task1 = self.install_task('task1', goal='goal1')
     task2 = self.install_task('task2', goal='goal2', alternate_target_roots=[42])
     self.create_context(for_task_types=task1+task2)
-    self.assertEquals([], self._context.target_roots)
+    self.assertEqual([], self._context.target_roots)
     self.engine.attempt(self._context, self.as_goals('goal1', 'goal2'))
-    self.assertEquals([42], self._context.target_roots)
+    self.assertEqual([42], self._context.target_roots)
 
   def test_replace_target_roots_conflict(self):
     task1 = self.install_task('task1', goal='goal1', alternate_target_roots=[42])
@@ -253,4 +253,4 @@ class RoundEngineTest(EngineTestBase, TestBase):
 
     self.engine.attempt(self._context, self.as_goals('goal1', 'goal2'))
 
-    self.assertEquals([], self._context.target_roots)
+    self.assertEqual([], self._context.target_roots)

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -67,7 +67,7 @@ class RuleIndexTest(unittest.TestCase):
   def test_creation_fails_with_bad_declaration_type(self):
     with self.assertRaises(TypeError) as cm:
       RuleIndex.create([A()])
-    self.assertEquals("Unexpected rule type: <class 'pants_test.engine.test_rules.A'>."
+    self.assertEqual("Unexpected rule type: <class 'pants_test.engine.test_rules.A'>."
                       " Rules either extend Rule, or are static functions decorated with @rule.",
       str(cm.exception))
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -74,13 +74,13 @@ class SchedulerTest(unittest.TestCase):
 
   def assert_root(self, root, subject, return_value):
     """Asserts that the given root has the given result."""
-    self.assertEquals(subject, root[0][0])
-    self.assertEquals(Return(return_value), root[1])
+    self.assertEqual(subject, root[0][0])
+    self.assertEqual(Return(return_value), root[1])
 
   def assert_root_failed(self, root, subject, msg_str):
     """Asserts that the root was a Throw result containing the given msg string."""
-    self.assertEquals(subject, root[0][0])
-    self.assertEquals(Throw, type(root[1]))
+    self.assertEqual(subject, root[0][0])
+    self.assertEqual(Throw, type(root[1]))
     self.assertIn(msg_str, str(root[1].exc))
 
   def test_compile_only_3rdparty(self):
@@ -167,7 +167,7 @@ class SchedulerTest(unittest.TestCase):
                                     variants={'resolve': 'latest-hadoop'})
 
     # Confirm that the produced jars had the appropriate versions.
-    self.assertEquals({Jar('org.apache.hadoop', 'hadoop-common', '2.7.0'),
+    self.assertEqual({Jar('org.apache.hadoop', 'hadoop-common', '2.7.0'),
                        Jar('com.google.guava', 'guava', '18.0')},
                       {ret.value for node, ret in walk
                        if node.product == Jar})

--- a/tests/python/pants_test/fs/test_archive.py
+++ b/tests/python/pants_test/fs/test_archive.py
@@ -73,7 +73,7 @@ class ArchiveTest(unittest.TestCase):
         archive = create_archiver('zip').create(fromdir, archivedir, 'archive')
         with temporary_dir() as todir:
           create_archiver('zip').extract(archive, todir, filter_func=do_filter)
-          self.assertEquals(set(['allowed.txt']), self._listtree(todir, empty_dirs=False))
+          self.assertEqual(set(['allowed.txt']), self._listtree(todir, empty_dirs=False))
 
   def test_tar_dereference(self):
 

--- a/tests/python/pants_test/fs/test_expand_path.py
+++ b/tests/python/pants_test/fs/test_expand_path.py
@@ -15,23 +15,23 @@ from pants.util.contextutil import environment_as, pushd, temporary_dir
 class ExpandPathTest(unittest.TestCase):
   def test_pure_relative(self):
     with self.root() as root:
-      self.assertEquals(os.path.join(root, 'a'), expand_path('a'))
+      self.assertEqual(os.path.join(root, 'a'), expand_path('a'))
 
   def test_dot_relative(self):
     with self.root() as root:
-      self.assertEquals(os.path.join(root, 'a'), expand_path('./a'))
+      self.assertEqual(os.path.join(root, 'a'), expand_path('./a'))
 
   def test_absolute(self):
-    self.assertEquals('/tmp/jake/bob', expand_path('/tmp/jake/bob'))
+    self.assertEqual('/tmp/jake/bob', expand_path('/tmp/jake/bob'))
 
   def test_user_expansion(self):
     with environment_as(HOME='/tmp/jake'):
-      self.assertEquals('/tmp/jake/bob', expand_path('~/bob'))
+      self.assertEqual('/tmp/jake/bob', expand_path('~/bob'))
 
   def test_env_var_expansion(self):
     with self.root() as root:
       with environment_as(A='B', C='D'):
-        self.assertEquals(os.path.join(root, 'B/D/E'), expand_path('$A/${C}/E'))
+        self.assertEqual(os.path.join(root, 'B/D/E'), expand_path('$A/${C}/E'))
 
   @contextmanager
   def root(self):

--- a/tests/python/pants_test/goal/test_artifact_cache_stats.py
+++ b/tests/python/pants_test/goal/test_artifact_cache_stats.py
@@ -79,10 +79,10 @@ class ArtifactCacheStatsTest(TestBase):
     with temporary_dir() as tmp_dir:
       artifact_cache_stats = ArtifactCacheStats(tmp_dir)
       yield artifact_cache_stats
-      self.assertEquals(expected_stats, artifact_cache_stats.get_all())
+      self.assertEqual(expected_stats, artifact_cache_stats.get_all())
 
-      self.assertEquals(sorted(list(expected_hit_or_miss_files.keys())),
+      self.assertEqual(sorted(list(expected_hit_or_miss_files.keys())),
                         sorted(os.listdir(tmp_dir)))
       for hit_or_miss_file in expected_hit_or_miss_files.keys():
         with open(os.path.join(tmp_dir, hit_or_miss_file)) as hit_or_miss_saved:
-          self.assertEquals(expected_hit_or_miss_files[hit_or_miss_file], hit_or_miss_saved.read())
+          self.assertEqual(expected_hit_or_miss_files[hit_or_miss_file], hit_or_miss_saved.read())

--- a/tests/python/pants_test/goal/test_context.py
+++ b/tests/python/pants_test/goal/test_context.py
@@ -13,7 +13,7 @@ class ContextTest(TestBase):
   def test_dependents_empty(self):
     context = self.context()
     dependees = context.dependents()
-    self.assertEquals(0, len(dependees))
+    self.assertEqual(0, len(dependees))
 
   def test_dependents_direct(self):
     a = self.make_target('a')
@@ -23,8 +23,8 @@ class ContextTest(TestBase):
     e = self.make_target('e', dependencies=[d])
     context = self.context(target_roots=[a, b, c, d, e])
     dependees = context.dependents(lambda t: t in {e, c})
-    self.assertEquals({c}, dependees.pop(d))
-    self.assertEquals(0, len(dependees))
+    self.assertEqual({c}, dependees.pop(d))
+    self.assertEqual(0, len(dependees))
 
   def test_targets_order(self):
     a = self.make_target('a')
@@ -32,16 +32,16 @@ class ContextTest(TestBase):
     c = self.make_target('c', dependencies=[b])
     d = self.make_target('d', dependencies=[c, a])
     context = self.context(target_roots=[d])
-    self.assertEquals([d, c, b, a], context.targets())
+    self.assertEqual([d, c, b, a], context.targets())
     e = self.make_target('e', dependencies=[d])
     context = self.context(target_roots=[e])
-    self.assertEquals([e, d, c, b, a], context.targets())
+    self.assertEqual([e, d, c, b, a], context.targets())
     f = self.make_target('f', dependencies=[a])
     context = self.context(target_roots=[f])
-    self.assertEquals([f, a], context.targets())
+    self.assertEqual([f, a], context.targets())
     g = self.make_target('g', dependencies=[a, c, d])
     context = self.context(target_roots=[g])
-    self.assertEquals([g, a, c, b, d], context.targets())
+    self.assertEqual([g, a, c, b, d], context.targets())
 
   def test_targets_replace_targets(self):
     a = self.make_target('a')
@@ -49,11 +49,11 @@ class ContextTest(TestBase):
     c = self.make_target('c', dependencies=[b])
 
     context = self.context(target_roots=[b])
-    self.assertEquals([b, a], context.targets())
+    self.assertEqual([b, a], context.targets())
     context._replace_targets([a])
-    self.assertEquals([a], context.targets())
+    self.assertEqual([a], context.targets())
     context._replace_targets([c])
-    self.assertEquals([c, b, a], context.targets())
+    self.assertEqual([c, b, a], context.targets())
 
   def test_targets_synthetic(self):
     a = self.make_target('a')
@@ -61,47 +61,47 @@ class ContextTest(TestBase):
     c = self.make_target('c', dependencies=[b])
     d = self.make_target('d', dependencies=[c, a])
     context = self.context(target_roots=[c])
-    self.assertEquals([c, b, a], context.targets())
+    self.assertEqual([c, b, a], context.targets())
 
     syn_b = context.add_new_target(Address.parse('syn_b'), Target, derived_from=b)
     context.add_new_target(Address.parse('syn_d'), Target, derived_from=d)
     # We expect syn_b to be included now since it has been synthesized during this run from an
     # in-play target.
-    self.assertEquals([c, b, a, syn_b], context.targets())
+    self.assertEqual([c, b, a, syn_b], context.targets())
 
     # And verify the predicate operates over both normal and synthetic targets.
-    self.assertEquals([syn_b], context.targets(lambda t: t.derived_from != t))
-    self.assertEquals([c, b, a], context.targets(lambda t: t.derived_from == t))
+    self.assertEqual([syn_b], context.targets(lambda t: t.derived_from != t))
+    self.assertEqual([c, b, a], context.targets(lambda t: t.derived_from == t))
 
   def test_targets_includes_synthetic_dependencies(self):
     a = self.make_target('a')
     b = self.make_target('b')
     context = self.context(target_roots=[b])
-    self.assertEquals([b], context.targets())
+    self.assertEqual([b], context.targets())
 
     syn_with_deps = context.add_new_target(Address.parse('syn_with_deps'),
                                            Target,
                                            derived_from=b,
                                            dependencies=[a])
 
-    self.assertEquals([b, syn_with_deps, a], context.targets())
+    self.assertEqual([b, syn_with_deps, a], context.targets())
 
   def test_targets_ignore_synthetics_with_no_derived_from_not_injected_into_graph(self):
     a = self.make_target('a')
     b = self.make_target('b')
     context = self.context(target_roots=[b])
-    self.assertEquals([b], context.targets())
+    self.assertEqual([b], context.targets())
 
     context.add_new_target(Address.parse('syn_with_deps'), Target, dependencies=[a])
-    self.assertEquals([b], context.targets())
+    self.assertEqual([b], context.targets())
 
   def test_targets_include_synthetics_with_no_derived_from_injected_into_graph(self):
     a = self.make_target('a')
     b = self.make_target('b')
     context = self.context(target_roots=[b])
-    self.assertEquals([b], context.targets())
+    self.assertEqual([b], context.targets())
 
     syn_with_deps = context.add_new_target(Address.parse('syn_with_deps'), Target, dependencies=[a])
     b.inject_dependency(syn_with_deps.address)
 
-    self.assertEquals([b, syn_with_deps, a], context.targets())
+    self.assertEqual([b, syn_with_deps, a], context.targets())

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -22,12 +22,12 @@ class RunTrackerTest(TestBase):
     class Handler(http.server.BaseHTTPRequestHandler):
       def do_POST(handler):
         try:
-          self.assertEquals('/upload', handler.path)
-          self.assertEquals('application/x-www-form-urlencoded', handler.headers['Content-type'])
+          self.assertEqual('/upload', handler.path)
+          self.assertEqual('application/x-www-form-urlencoded', handler.headers['Content-type'])
           length = int(handler.headers['Content-Length'])
           post_data = parse_qs(handler.rfile.read(length).decode('utf-8'))
           decoded_post_data = {k: json.loads(v[0]) for k, v in post_data.items()}
-          self.assertEquals(stats, decoded_post_data)
+          self.assertEqual(stats, decoded_post_data)
           handler.send_response(200)
         except Exception:
           handler.send_response(400)  # Ensure the main thread knows the test failed.
@@ -56,7 +56,7 @@ class RunTrackerTest(TestBase):
       self.assertTrue(RunTracker.write_stats_to_json(file_name, stats))
       with open(file_name) as f:
         result = json.load(f)
-        self.assertEquals(stats, result)
+        self.assertEqual(stats, result)
 
   def test_create_dict_with_nested_keys_and_val(self):
     keys = []
@@ -65,25 +65,25 @@ class RunTrackerTest(TestBase):
       RunTracker._create_dict_with_nested_keys_and_val(keys, 'something')
 
     keys += ['one']
-    self.assertEquals(
+    self.assertEqual(
       RunTracker._create_dict_with_nested_keys_and_val(keys, 'something'),
       {'one': 'something'}
     )
 
     keys += ['two']
-    self.assertEquals(
+    self.assertEqual(
       RunTracker._create_dict_with_nested_keys_and_val(keys, 'something'),
       {'one': {'two': 'something'}}
     )
 
     keys += ['three']
-    self.assertEquals(
+    self.assertEqual(
       RunTracker._create_dict_with_nested_keys_and_val(keys, 'something'),
       {'one': {'two': {'three': 'something'}}}
     )
 
     keys += ['four']
-    self.assertEquals(
+    self.assertEqual(
       RunTracker._create_dict_with_nested_keys_and_val(keys, 'something'),
       {'one': {'two': {'three': {'four': 'something'}}}}
     )
@@ -104,61 +104,61 @@ class RunTrackerTest(TestBase):
 
     keys = ['a']
     RunTracker._merge_list_of_keys_into_dict(data, keys, 'O-N-E')
-    self.assertEquals(data, {'a': 'O-N-E'})
+    self.assertEqual(data, {'a': 'O-N-E'})
 
     keys = ['one', 'two', 'three']
     RunTracker._merge_list_of_keys_into_dict(data, keys, 'T-H-R-E-E')
-    self.assertEquals(data, {'one': {'two': {'three': 'T-H-R-E-E'}}, 'a': 'O-N-E'})
+    self.assertEqual(data, {'one': {'two': {'three': 'T-H-R-E-E'}}, 'a': 'O-N-E'})
 
     keys = ['one', 'two', 'a']
     RunTracker._merge_list_of_keys_into_dict(data, keys, 'L-A')
-    self.assertEquals(data, {'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E'}}, 'a': 'O-N-E'})
+    self.assertEqual(data, {'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E'}}, 'a': 'O-N-E'})
 
     keys = ['c', 'd', 'e', 'f']
     RunTracker._merge_list_of_keys_into_dict(data, keys, 'F-O-U-R')
-    self.assertEquals(data, {
+    self.assertEqual(data, {
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E'}}, 'a': 'O-N-E',
       'c': {'d': {'e': {'f': 'F-O-U-R'}}}
     })
 
     keys = ['one', 'two', 'x', 'y']
     RunTracker._merge_list_of_keys_into_dict(data, keys, 'W-H-Y')
-    self.assertEquals(data, {
+    self.assertEqual(data, {
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y'}}}, 'a': 'O-N-E',
       'c': {'d': {'e': {'f': 'F-O-U-R'}}}
     })
 
     keys = ['c', 'd', 'e', 'g', 'h']
     RunTracker._merge_list_of_keys_into_dict(data, keys, 'H-E-L-L-O')
-    self.assertEquals(data, {
+    self.assertEqual(data, {
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y'}}}, 'a': 'O-N-E',
       'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O'}}}}
     })
 
     keys = ['one', 'two', 'x', 'z']
     RunTracker._merge_list_of_keys_into_dict(data, keys, 'Z-E-D')
-    self.assertEquals(data, {
+    self.assertEqual(data, {
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
       'a': 'O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O'}}}}
     })
 
     keys = ['c', 'd', 'e', 'g', 'i']
     RunTracker._merge_list_of_keys_into_dict(data, keys, 'E-Y-E')
-    self.assertEquals(data, {
+    self.assertEqual(data, {
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
       'a': 'O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O', 'i': 'E-Y-E'}}}}
     })
 
     keys = ['a']
     RunTracker._merge_list_of_keys_into_dict(data, keys, 'new O-N-E')
-    self.assertEquals(data, {
+    self.assertEqual(data, {
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
       'a': 'new O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O', 'i': 'E-Y-E'}}}}
     })
 
     keys = ['one', 'two', 'a']
     RunTracker._merge_list_of_keys_into_dict(data, keys, 'L-A-L-A')
-    self.assertEquals(data, {
+    self.assertEqual(data, {
       'one': {'two': {'a': 'L-A-L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
       'a': 'new O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O', 'i': 'E-Y-E'}}}}
     })

--- a/tests/python/pants_test/goal/test_union_products.py
+++ b/tests/python/pants_test/goal/test_union_products.py
@@ -23,12 +23,12 @@ class UnionProductsTest(TestBase):
     self.products.add_for_target(b, [2])
     self.products.add_for_target(c, [3])
 
-    self.assertEquals(self.products.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 2, 3]))
-    self.assertEquals(self.products.get_for_targets(b.closure(bfs=True)), OrderedSet([2, 3]))
-    self.assertEquals(self.products.get_for_targets(c.closure(bfs=True)), OrderedSet([3]))
-    self.assertEquals(self.products.get_for_target(a), OrderedSet([1]))
-    self.assertEquals(self.products.get_for_target(b), OrderedSet([2]))
-    self.assertEquals(self.products.get_for_target(c), OrderedSet([3]))
+    self.assertEqual(self.products.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 2, 3]))
+    self.assertEqual(self.products.get_for_targets(b.closure(bfs=True)), OrderedSet([2, 3]))
+    self.assertEqual(self.products.get_for_targets(c.closure(bfs=True)), OrderedSet([3]))
+    self.assertEqual(self.products.get_for_target(a), OrderedSet([1]))
+    self.assertEqual(self.products.get_for_target(b), OrderedSet([2]))
+    self.assertEqual(self.products.get_for_target(c), OrderedSet([3]))
 
   def test_get_product_target_mappings_for_targets(self):
     b = self.make_target('b')
@@ -36,10 +36,10 @@ class UnionProductsTest(TestBase):
     self.products.add_for_target(a, [1, 3])
     self.products.add_for_target(b, [2, 3])
 
-    self.assertEquals(self.products.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 3, 2]))
-    self.assertEquals(self.products.get_for_targets(b.closure(bfs=True)), OrderedSet([2, 3]))
+    self.assertEqual(self.products.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 3, 2]))
+    self.assertEqual(self.products.get_for_targets(b.closure(bfs=True)), OrderedSet([2, 3]))
 
-    self.assertEquals(self.products.get_product_target_mappings_for_targets(a.closure(bfs=True)),
+    self.assertEqual(self.products.get_product_target_mappings_for_targets(a.closure(bfs=True)),
                       [(1, a), (3, a), (2, b), (3, b)])
 
   def test_copy(self):
@@ -51,19 +51,19 @@ class UnionProductsTest(TestBase):
 
     copied = self.products.copy()
 
-    self.assertEquals(self.products.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 2]))
-    self.assertEquals(self.products.get_for_targets(b.closure(bfs=True)), OrderedSet([2]))
-    self.assertEquals(copied.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 2]))
-    self.assertEquals(copied.get_for_targets(b.closure(bfs=True)), OrderedSet([2]))
+    self.assertEqual(self.products.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 2]))
+    self.assertEqual(self.products.get_for_targets(b.closure(bfs=True)), OrderedSet([2]))
+    self.assertEqual(copied.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 2]))
+    self.assertEqual(copied.get_for_targets(b.closure(bfs=True)), OrderedSet([2]))
 
     copied.add_for_target(c, [3])
 
-    self.assertEquals(self.products.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 2]))
-    self.assertEquals(self.products.get_for_targets(b.closure(bfs=True)), OrderedSet([2]))
-    self.assertEquals(self.products.get_for_targets(c.closure(bfs=True)), OrderedSet())
-    self.assertEquals(copied.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 2, 3]))
-    self.assertEquals(copied.get_for_targets(b.closure(bfs=True)), OrderedSet([2, 3]))
-    self.assertEquals(copied.get_for_targets(c.closure(bfs=True)), OrderedSet([3]))
+    self.assertEqual(self.products.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 2]))
+    self.assertEqual(self.products.get_for_targets(b.closure(bfs=True)), OrderedSet([2]))
+    self.assertEqual(self.products.get_for_targets(c.closure(bfs=True)), OrderedSet())
+    self.assertEqual(copied.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 2, 3]))
+    self.assertEqual(copied.get_for_targets(b.closure(bfs=True)), OrderedSet([2, 3]))
+    self.assertEqual(copied.get_for_targets(c.closure(bfs=True)), OrderedSet([3]))
 
   def test_remove_for_target(self):
     c = self.make_target('c')
@@ -75,9 +75,9 @@ class UnionProductsTest(TestBase):
 
     self.products.remove_for_target(a, [1])
 
-    self.assertEquals(self.products.get_for_targets(a.closure(bfs=True)), OrderedSet([2, 3]))
-    self.assertEquals(self.products.get_for_targets(b.closure(bfs=True)), OrderedSet([2, 3]))
-    self.assertEquals(self.products.get_for_targets(c.closure(bfs=True)), OrderedSet([3]))
+    self.assertEqual(self.products.get_for_targets(a.closure(bfs=True)), OrderedSet([2, 3]))
+    self.assertEqual(self.products.get_for_targets(b.closure(bfs=True)), OrderedSet([2, 3]))
+    self.assertEqual(self.products.get_for_targets(c.closure(bfs=True)), OrderedSet([3]))
 
   def test_empty_products(self):
     c = self.make_target('c')

--- a/tests/python/pants_test/help/test_build_dictionary_info_extracter.py
+++ b/tests/python/pants_test/help/test_build_dictionary_info_extracter.py
@@ -185,7 +185,7 @@ class BuildDictionaryInfoExtracterTest(unittest.TestCase):
 
     extracter = BuildDictionaryInfoExtracter(bfa)
     args = BuildDictionaryInfoExtracter.basic_target_args
-    self.assertEquals([BuildSymbolInfo('target1', 'Target1 docstring.', [], args),
+    self.assertEqual([BuildSymbolInfo('target1', 'Target1 docstring.', [], args),
                        BuildSymbolInfo('target2', 'Target2 docstring.', [], args),
                        BuildSymbolInfo('target3', 'Target3 docstring.', [], args)],
                       extracter.get_target_type_info())
@@ -207,7 +207,7 @@ class BuildDictionaryInfoExtracterTest(unittest.TestCase):
       context_aware_object_factories={},
     )
     extracter = BuildDictionaryInfoExtracter(bfa)
-    self.assertEquals([BuildSymbolInfo('foo', 'Foo docstring.', [],
+    self.assertEqual([BuildSymbolInfo('foo', 'Foo docstring.', [],
                                        [FunctionArg('bar', 'Bar details.', False, None),
                                         FunctionArg('baz', 'Baz details.', True, 42)])],
                       extracter.get_object_info())
@@ -229,7 +229,7 @@ class BuildDictionaryInfoExtracterTest(unittest.TestCase):
       }
     )
     extracter = BuildDictionaryInfoExtracter(bfa)
-    self.assertEquals([BuildSymbolInfo('foo', 'Foo docstring.', [],
+    self.assertEqual([BuildSymbolInfo('foo', 'Foo docstring.', [],
                                        [FunctionArg('bar', 'Bar details.', False, None),
                                         FunctionArg('baz', 'Baz details.', True, 42)])],
                       extracter.get_object_factory_info())
@@ -252,7 +252,7 @@ class BuildDictionaryInfoExtracterTest(unittest.TestCase):
       context_aware_object_factories={},
     )
     extracter = BuildDictionaryInfoExtracter(bfa)
-    self.assertEquals([BuildSymbolInfo('foo', 'Foo docstring.', [],
+    self.assertEqual([BuildSymbolInfo('foo', 'Foo docstring.', [],
                                        [FunctionArg('bar', 'Bar details.', False, None),
                                         FunctionArg('baz', 'Baz details.', True, 42)])],
                       extracter.get_object_info())

--- a/tests/python/pants_test/help/test_help_formatter.py
+++ b/tests/python/pants_test/help/test_help_formatter.py
@@ -20,29 +20,29 @@ class OptionHelpFormatterTest(unittest.TestCase):
     ohi = ohi._replace(**kwargs)
     lines = HelpFormatter(scope='', show_recursive=False, show_advanced=False,
                           color=False).format_option(ohi)
-    self.assertEquals(len(lines), 2)
+    self.assertEqual(len(lines), 2)
     self.assertIn('help for foo', lines[1])
     return lines[0]
 
   def test_format_help(self):
     line = self.format_help_for_foo(default='MYDEFAULT')
-    self.assertEquals('--foo (default: MYDEFAULT)', line)
+    self.assertEqual('--foo (default: MYDEFAULT)', line)
 
   def test_format_help_fromfile(self):
     line = self.format_help_for_foo(fromfile=True)
-    self.assertEquals('--foo (@fromfile value supported) (default: None)', line)
+    self.assertEqual('--foo (@fromfile value supported) (default: None)', line)
 
   def test_suppress_advanced(self):
     args = ['--foo']
     kwargs = {'advanced': True}
     lines = HelpFormatter(scope='', show_recursive=False, show_advanced=False,
                           color=False).format_options('', '', [(args, kwargs)])
-    self.assertEquals(0, len(lines))
+    self.assertEqual(0, len(lines))
     lines = HelpFormatter(scope='', show_recursive=True, show_advanced=True,
                           color=False).format_options('', '', [(args, kwargs)])
     print(lines)
-    self.assertEquals(5, len(lines))
+    self.assertEqual(5, len(lines))
 
   def test_format_help_choices(self):
     line = self.format_help_for_foo(typ=str, default='kiwi', choices='apple, banana, kiwi')
-    self.assertEquals('--foo (one of: [apple, banana, kiwi] default: kiwi)', line)
+    self.assertEqual('--foo (one of: [apple, banana, kiwi] default: kiwi)', line)

--- a/tests/python/pants_test/help/test_help_info_extracter.py
+++ b/tests/python/pants_test/help/test_help_info_extracter.py
@@ -78,7 +78,7 @@ class HelpInfoExtracterTest(unittest.TestCase):
                       parent_parser=None, option_tracker=OptionTracker())
       parser.register(*args, **kwargs)
       oshi = HelpInfoExtracter.get_option_scope_help_info_from_parser(parser).basic
-      self.assertEquals(1, len(oshi))
+      self.assertEqual(1, len(oshi))
       ohi = oshi[0]
       self.assertEqual(expected_default, ohi.default)
 
@@ -95,8 +95,8 @@ class HelpInfoExtracterTest(unittest.TestCase):
   def test_deprecated(self):
     kwargs = {'removal_version': '999.99.9', 'removal_hint': 'do not use this'}
     ohi = HelpInfoExtracter('').get_option_help_info([], kwargs)
-    self.assertEquals('999.99.9', ohi.removal_version)
-    self.assertEquals('do not use this', ohi.removal_hint)
+    self.assertEqual('999.99.9', ohi.removal_version)
+    self.assertEqual('do not use this', ohi.removal_hint)
     self.assertIsNotNone(ohi.deprecated_message)
 
   def test_fromfile(self):
@@ -117,9 +117,9 @@ class HelpInfoExtracterTest(unittest.TestCase):
         return int(exp)  # True -> 1, False -> 0.
 
       oshi = HelpInfoExtracter('').get_option_scope_help_info([([], kwargs)])
-      self.assertEquals(exp_to_len(expected_basic), len(oshi.basic))
-      self.assertEquals(exp_to_len(expected_recursive), len(oshi.recursive))
-      self.assertEquals(exp_to_len(expected_advanced), len(oshi.advanced))
+      self.assertEqual(exp_to_len(expected_basic), len(oshi.basic))
+      self.assertEqual(exp_to_len(expected_recursive), len(oshi.recursive))
+      self.assertEqual(exp_to_len(expected_advanced), len(oshi.advanced))
 
     do_test({}, expected_basic=True)
     do_test({'advanced': False}, expected_basic=True)

--- a/tests/python/pants_test/help/test_scope_info_iterator.py
+++ b/tests/python/pants_test/help/test_scope_info_iterator.py
@@ -68,4 +68,4 @@ class ScopeInfoIteratorTest(unittest.TestCase):
 
     expected_scope_infos = [scope_to_infos[x] for x in expected_scopes]
 
-    self.assertEquals(expected_scope_infos, actual)
+    self.assertEqual(expected_scope_infos, actual)

--- a/tests/python/pants_test/invalidation/test_cache_manager.py
+++ b/tests/python/pants_test/invalidation/test_cache_manager.py
@@ -67,15 +67,15 @@ class InvalidationCacheManagerTest(TestBase):
     symlink = os.path.join(parent, 'current')
 
     self.assertTrue(os.path.islink(symlink))
-    self.assertEquals(unstable_dir_name, os.readlink(symlink))
-    self.assertEquals(symlink, vt.results_dir)
+    self.assertEqual(unstable_dir_name, os.readlink(symlink))
+    self.assertEqual(symlink, vt.results_dir)
     # Repoint the symlink, but keep the vt valid (simulates the case where the underlying target's
     # version has changed, so the symlink is pointed to that version, but now the version has
     # reverted, so we must point it back).
     os.unlink(symlink)
     os.symlink(unstable_dir_name + '.other', symlink)
     vt.create_results_dir()
-    self.assertEquals(unstable_dir_name, os.readlink(symlink))
+    self.assertEqual(unstable_dir_name, os.readlink(symlink))
 
   def test_creates_stable_results_dir_prefix_symlink(self):
     parent, unstable_dir_name = os.path.split(self.cache_manager._results_dir_prefix)
@@ -98,10 +98,10 @@ class InvalidationCacheManagerTest(TestBase):
     all_vts = ic.all_vts
     invalid_vts = ic.invalid_vts
 
-    self.assertEquals(5, len(invalid_vts))
-    self.assertEquals(5, len(all_vts))
+    self.assertEqual(5, len(invalid_vts))
+    self.assertEqual(5, len(all_vts))
     vts_targets = [vt.targets[0] for vt in all_vts]
-    self.assertEquals(set(targets), set(vts_targets))
+    self.assertEqual(set(targets), set(vts_targets))
 
   def test_force_invalidate(self):
     vt = self.make_vt()

--- a/tests/python/pants_test/ivy/test_ivy_subsystem.py
+++ b/tests/python/pants_test/ivy/test_ivy_subsystem.py
@@ -15,12 +15,12 @@ class IvySubsystemTest(unittest.TestCase):
 
   def test_parse_proxy_string(self):
     ivy_subsystem = global_subsystem_instance(IvySubsystem)
-    self.assertEquals(('example.com', 1234),
+    self.assertEqual(('example.com', 1234),
                       ivy_subsystem._parse_proxy_string('http://example.com:1234'))
-    self.assertEquals(('secure-example.com', 999),
+    self.assertEqual(('secure-example.com', 999),
                       ivy_subsystem._parse_proxy_string('http://secure-example.com:999'))
     # trailing slash is ok
-    self.assertEquals(('example.com', 1234),
+    self.assertEqual(('example.com', 1234),
                       ivy_subsystem._parse_proxy_string('http://example.com:1234/'))
 
   def test_proxy_from_env(self):
@@ -30,10 +30,10 @@ class IvySubsystemTest(unittest.TestCase):
 
     with environment_as(HTTP_PROXY='http://proxy.example.com:456',
                         HTTPS_PROXY='https://secure-proxy.example.com:789'):
-      self.assertEquals('http://proxy.example.com:456', ivy_subsystem.http_proxy())
-      self.assertEquals('https://secure-proxy.example.com:789', ivy_subsystem.https_proxy())
+      self.assertEqual('http://proxy.example.com:456', ivy_subsystem.http_proxy())
+      self.assertEqual('https://secure-proxy.example.com:789', ivy_subsystem.https_proxy())
 
-      self.assertEquals([
+      self.assertEqual([
         '-Dhttp.proxyHost=proxy.example.com',
         '-Dhttp.proxyPort=456',
         '-Dhttps.proxyHost=secure-proxy.example.com',

--- a/tests/python/pants_test/java/jar/test_manifest.py
+++ b/tests/python/pants_test/java/jar/test_manifest.py
@@ -20,7 +20,7 @@ class TestManifest(unittest.TestCase):
   def test_addentry(self):
     manifest = Manifest()
     manifest.addentry('Header', 'value')
-    self.assertEquals(
+    self.assertEqual(
       'Header: value\n', manifest.contents())
 
   def test_too_long_entry(self):

--- a/tests/python/pants_test/java/test_nailgun_client.py
+++ b/tests/python/pants_test/java/test_nailgun_client.py
@@ -83,12 +83,12 @@ class TestNailgunClientSession(unittest.TestCase):
     NailgunProtocol.write_chunk(self.server_sock, ChunkType.STDOUT, self.TEST_PAYLOAD)
     NailgunProtocol.write_chunk(self.server_sock, ChunkType.STDERR, self.TEST_PAYLOAD)
     NailgunProtocol.write_chunk(self.server_sock, ChunkType.EXIT, b'1729')
-    self.assertEquals(self.nailgun_client_session._process_session(), 1729)
-    self.assertEquals(self.fake_stdout.content, self.TEST_PAYLOAD * 2)
-    self.assertEquals(self.fake_stderr.content, self.TEST_PAYLOAD * 3)
+    self.assertEqual(self.nailgun_client_session._process_session(), 1729)
+    self.assertEqual(self.fake_stdout.content, self.TEST_PAYLOAD * 2)
+    self.assertEqual(self.fake_stderr.content, self.TEST_PAYLOAD * 3)
     self.mock_stdin_reader.start.assert_called_once_with()
     self.mock_stdin_reader.stop.assert_called_once_with()
-    self.assertEquals(self.nailgun_client_session.remote_pid, 31337)
+    self.assertEqual(self.nailgun_client_session.remote_pid, 31337)
 
   def test_process_session_bad_chunk(self):
     NailgunProtocol.write_chunk(self.server_sock, ChunkType.PID, b'31337')
@@ -110,7 +110,7 @@ class TestNailgunClientSession(unittest.TestCase):
       *self.TEST_ARGUMENTS,
       **self.TEST_ENVIRON
     )
-    self.assertEquals(out, self.TEST_PAYLOAD)
+    self.assertEqual(out, self.TEST_PAYLOAD)
     mock_process_session.assert_called_once_with(self.nailgun_client_session)
 
 
@@ -123,9 +123,9 @@ class TestNailgunClient(unittest.TestCase):
     mock_socket = mock.Mock()
     mock_socket_cls.return_value = mock_socket
 
-    self.assertEquals(self.nailgun_client.try_connect(), mock_socket)
+    self.assertEqual(self.nailgun_client.try_connect(), mock_socket)
 
-    self.assertEquals(mock_socket_cls.call_count, 1)
+    self.assertEqual(mock_socket_cls.call_count, 1)
     mock_socket.connect.assert_called_once_with(
       (NailgunClient.DEFAULT_NG_HOST, NailgunClient.DEFAULT_NG_PORT)
     )
@@ -143,8 +143,8 @@ class TestNailgunClient(unittest.TestCase):
   @mock.patch('pants.java.nailgun_client.NailgunClientSession', **PATCH_OPTS)
   def test_execute(self, mock_session, mock_try_connect):
     self.nailgun_client.execute('test')
-    self.assertEquals(mock_try_connect.call_count, 1)
-    self.assertEquals(mock_session.call_count, 1)
+    self.assertEqual(mock_try_connect.call_count, 1)
+    self.assertEqual(mock_session.call_count, 1)
 
   @mock.patch.object(NailgunClient, 'try_connect', **PATCH_OPTS)
   @mock.patch('pants.java.nailgun_client.NailgunClientSession', **PATCH_OPTS)

--- a/tests/python/pants_test/java/test_nailgun_io.py
+++ b/tests/python/pants_test/java/test_nailgun_io.py
@@ -43,7 +43,7 @@ class TestNailgunStreamWriter(unittest.TestCase):
     mock_select.return_value = ([], [], [self.in_fd])
     self.writer.run()
     self.assertFalse(self.writer.is_alive())
-    self.assertEquals(mock_select.call_count, 1)
+    self.assertEqual(mock_select.call_count, 1)
 
   @mock.patch('os.read')
   @mock.patch('select.select')
@@ -70,7 +70,7 @@ class TestNailgunStreamWriter(unittest.TestCase):
     self.assertFalse(self.writer.is_alive())
 
     mock_read.assert_called_with(-1, io.DEFAULT_BUFFER_SIZE)
-    self.assertEquals(mock_read.call_count, 2)
+    self.assertEqual(mock_read.call_count, 2)
 
     mock_writer.assert_has_calls([
       mock.call(mock.ANY, ChunkType.STDIN, b'A' * 300),

--- a/tests/python/pants_test/java/test_nailgun_protocol.py
+++ b/tests/python/pants_test/java/test_nailgun_protocol.py
@@ -184,10 +184,10 @@ class TestNailgunProtocol(unittest.TestCase):
     )
 
   def test_isatty_from_empty_env(self):
-    self.assertEquals(NailgunProtocol.isatty_from_env({}), (False, False, False))
+    self.assertEqual(NailgunProtocol.isatty_from_env({}), (False, False, False))
 
   def test_isatty_from_env(self):
-    self.assertEquals(
+    self.assertEqual(
       NailgunProtocol.isatty_from_env({
         'NAILGUN_TTY_0': '1',
         'NAILGUN_TTY_1': '0',
@@ -197,7 +197,7 @@ class TestNailgunProtocol(unittest.TestCase):
     )
 
   def test_isatty_from_env_mixed(self):
-    self.assertEquals(
+    self.assertEqual(
       NailgunProtocol.isatty_from_env({
         'NAILGUN_TTY_0': '0',
         'NAILGUN_TTY_1': '1'
@@ -220,7 +220,7 @@ class TestNailgunProtocol(unittest.TestCase):
     mock_stdout = self._make_mock_stream(True, 1)
     mock_stderr = self._make_mock_stream(True, 2)
 
-    self.assertEquals(
+    self.assertEqual(
       NailgunProtocol.isatty_to_env(mock_stdin, mock_stdout, mock_stderr),
       {
         'NAILGUN_TTY_0': b'1',
@@ -236,7 +236,7 @@ class TestNailgunProtocol(unittest.TestCase):
     mock_stdout = self._make_mock_stream(False, 1)
     mock_stderr = self._make_mock_stream(False, 2)
 
-    self.assertEquals(
+    self.assertEqual(
       NailgunProtocol.isatty_to_env(mock_stdin, mock_stdout, mock_stderr),
       {
         'NAILGUN_TTY_0': b'0',

--- a/tests/python/pants_test/java/test_runjava_synthetic_classpath.py
+++ b/tests/python/pants_test/java/test_runjava_synthetic_classpath.py
@@ -47,7 +47,7 @@ class SyntheticClasspathTest(JvmToolTaskTestBase):
       executor = task.create_java_executor()
 
       # Executing the jar as is should work.
-      self.assertEquals(0, util.execute_java(
+      self.assertEqual(0, util.execute_java(
         executor=executor,
         classpath=[temp_path.name],
         main='coursier.echo.Echo',
@@ -59,7 +59,7 @@ class SyntheticClasspathTest(JvmToolTaskTestBase):
       safe_concurrent_rename(temp_path.name, new_path)
 
       # Executing the new path should work.
-      self.assertEquals(0, util.execute_java(
+      self.assertEqual(0, util.execute_java(
         executor=executor,
         classpath=[new_path],
         main='coursier.echo.Echo',

--- a/tests/python/pants_test/java/test_util.py
+++ b/tests/python/pants_test/java/test_util.py
@@ -60,7 +60,7 @@ class ExecuteJavaTest(unittest.TestCase):
     :API: public
     """
     with self.mock_safe_classpath_helper():
-      self.assertEquals(0, execute_java(self.TEST_CLASSPATH, self.TEST_MAIN,
+      self.assertEqual(0, execute_java(self.TEST_CLASSPATH, self.TEST_MAIN,
                                         executor=self.executor,
                                         synthetic_jar_dir=self.SYNTHETIC_JAR_DIR))
 
@@ -80,7 +80,7 @@ class ExecuteJavaTest(unittest.TestCase):
     :API: public
     """
     with self.mock_safe_classpath_helper(create_synthetic_jar=False):
-      self.assertEquals(0, execute_java(self.TEST_CLASSPATH, self.TEST_MAIN,
+      self.assertEqual(0, execute_java(self.TEST_CLASSPATH, self.TEST_MAIN,
                                         executor=self.executor,
                                         create_synthetic_jar=False))
 
@@ -120,14 +120,14 @@ class SafeClasspathTest(unittest.TestCase):
     classpath = [jar_file, resource_dir]
 
     safe_cp = safe_classpath(classpath, synthetic_jar_dir)
-    self.assertEquals(1, len(safe_cp))
+    self.assertEqual(1, len(safe_cp))
     safe_jar = safe_cp[0]
     self.assertTrue(os.path.exists(safe_jar))
-    self.assertEquals(synthetic_jar_dir, os.path.dirname(safe_jar))
+    self.assertEqual(synthetic_jar_dir, os.path.dirname(safe_jar))
 
     with open_zip(safe_jar) as synthetic_jar:
       self.assertListEqual([Manifest.PATH], synthetic_jar.namelist())
       # manifest should contain the relative path of both jar and resource directory
-      self.assertEquals('{}: ../{}/{} ../{}/{}/\n'.format(Manifest.CLASS_PATH, LIB_DIR, JAR_FILE,
+      self.assertEqual('{}: ../{}/{} ../{}/{}/\n'.format(Manifest.CLASS_PATH, LIB_DIR, JAR_FILE,
                                                           LIB_DIR, RESOURCES),
                         synthetic_jar.read(Manifest.PATH).replace('\n ', ''))

--- a/tests/python/pants_test/option/test_arg_splitter.py
+++ b/tests/python/pants_test/option/test_arg_splitter.py
@@ -36,16 +36,16 @@ class ArgSplitterTest(unittest.TestCase):
     splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
     args = shlex.split(args_str)
     goals, scope_to_flags, target_specs, passthru, passthru_owner = splitter.split_args(args)
-    self.assertEquals(expected_goals, goals)
-    self.assertEquals(expected_scope_to_flags, scope_to_flags)
-    self.assertEquals(expected_target_specs, target_specs)
-    self.assertEquals(expected_passthru, passthru)
-    self.assertEquals(expected_passthru_owner, passthru_owner)
-    self.assertEquals(expected_is_help, splitter.help_request is not None)
-    self.assertEquals(expected_help_advanced,
+    self.assertEqual(expected_goals, goals)
+    self.assertEqual(expected_scope_to_flags, scope_to_flags)
+    self.assertEqual(expected_target_specs, target_specs)
+    self.assertEqual(expected_passthru, passthru)
+    self.assertEqual(expected_passthru_owner, passthru_owner)
+    self.assertEqual(expected_is_help, splitter.help_request is not None)
+    self.assertEqual(expected_help_advanced,
                       (isinstance(splitter.help_request, OptionsHelp) and
                        splitter.help_request.advanced))
-    self.assertEquals(expected_help_all,
+    self.assertEqual(expected_help_all,
                       (isinstance(splitter.help_request, OptionsHelp) and
                        splitter.help_request.all_scopes))
 

--- a/tests/python/pants_test/option/test_config.py
+++ b/tests/python/pants_test/option/test_config.py
@@ -64,11 +64,11 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual([ini1.name, ini2.name], self.config.sources())
 
   def test_getstring(self):
-    self.assertEquals('/a/b/42', self.config.get('a', 'path'))
-    self.assertEquals('/a/b/42::foo', self.config.get('a', 'embed'))
-    self.assertEquals('[1, 2, 3, 42]', self.config.get('a', 'list'))
-    self.assertEquals('+[7, 8, 9]', self.config.get('a', 'listappend'))
-    self.assertEquals(
+    self.assertEqual('/a/b/42', self.config.get('a', 'path'))
+    self.assertEqual('/a/b/42::foo', self.config.get('a', 'embed'))
+    self.assertEqual('[1, 2, 3, 42]', self.config.get('a', 'list'))
+    self.assertEqual('+[7, 8, 9]', self.config.get('a', 'listappend'))
+    self.assertEqual(
       """
 Let it be known
 that.""",
@@ -78,17 +78,17 @@ that.""",
     self._check_defaults(self.config.get, '42')
 
   def test_default_section(self):
-    self.assertEquals('foo', self.config.get(Config.DEFAULT_SECTION, 'name'))
-    self.assertEquals('foo', self.config.get(Config.DEFAULT_SECTION, 'name'))
+    self.assertEqual('foo', self.config.get(Config.DEFAULT_SECTION, 'name'))
+    self.assertEqual('foo', self.config.get(Config.DEFAULT_SECTION, 'name'))
 
   def test_sections(self):
-    self.assertEquals(['a', 'b', 'defined_section'], self.config.sections())
+    self.assertEqual(['a', 'b', 'defined_section'], self.config.sections())
 
   def test_empty(self):
     config = Config.load([])
-    self.assertEquals([], config.sections())
+    self.assertEqual([], config.sections())
 
   def _check_defaults(self, accessor, default):
-    self.assertEquals(None, accessor('c', 'fast'))
-    self.assertEquals(None, accessor('c', 'preempt', None))
-    self.assertEquals(default, accessor('c', 'jake', default=default))
+    self.assertEqual(None, accessor('c', 'fast'))
+    self.assertEqual(None, accessor('c', 'preempt', None))
+    self.assertEqual(default, accessor('c', 'jake', default=default))

--- a/tests/python/pants_test/option/test_custom_types.py
+++ b/tests/python/pants_test/option/test_custom_types.py
@@ -22,7 +22,7 @@ class CustomTypesTest(unittest.TestCase):
     else:
       raise Exception('Expected value {0} is of unsupported type: {1}'.format(expected_val,
                                                                               type(expected_val)))
-    self.assertEquals(expected_val, val)
+    self.assertEqual(expected_val, val)
 
   def _do_test_dict_error(self, s):
     with self.assertRaises(ParseError):

--- a/tests/python/pants_test/option/test_optionable.py
+++ b/tests/python/pants_test/option/test_optionable.py
@@ -28,14 +28,14 @@ class OptionableTest(unittest.TestCase):
 
     class StringScope(Optionable):
       options_scope = 'good'
-    self.assertEquals('good', StringScope.options_scope)
+    self.assertEqual('good', StringScope.options_scope)
 
     class Intermediate(Optionable):
       pass
 
     class Indirect(Intermediate):
       options_scope = 'good'
-    self.assertEquals('good', Indirect.options_scope)
+    self.assertEqual('good', Indirect.options_scope)
 
   def test_is_valid_scope_name_component(self):
     def check_true(s):

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -812,7 +812,7 @@ class OptionsTest(unittest.TestCase):
       yield w
 
   def assertWarning(self, w, option_string):
-    self.assertEquals(1, len(w))
+    self.assertEqual(1, len(w))
     self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
     warning_message = str(w[-1].message)
     self.assertIn("will be removed in version",
@@ -822,7 +822,7 @@ class OptionsTest(unittest.TestCase):
   def test_deprecated_options_flag(self):
     with self.warnings_catcher() as w:
       options = self._parse('./pants --global-crufty=crufty1')
-      self.assertEquals('crufty1', options.for_global_scope().global_crufty)
+      self.assertEqual('crufty1', options.for_global_scope().global_crufty)
       self.assertWarning(w, 'global_crufty')
 
     with self.warnings_catcher() as w:
@@ -837,7 +837,7 @@ class OptionsTest(unittest.TestCase):
 
     with self.warnings_catcher() as w:
       options = self._parse('./pants stale --crufty=stale_and_crufty')
-      self.assertEquals('stale_and_crufty', options.for_scope('stale').crufty)
+      self.assertEqual('stale_and_crufty', options.for_scope('stale').crufty)
       self.assertWarning(w, 'crufty')
 
     with self.warnings_catcher() as w:
@@ -863,28 +863,28 @@ class OptionsTest(unittest.TestCase):
     # Make sure the warnings don't come out for regular options.
     with self.warnings_catcher() as w:
       self._parse('./pants stale --pants-foo stale --still-good')
-      self.assertEquals(0, len(w))
+      self.assertEqual(0, len(w))
 
   def test_deprecated_options_env(self):
     with self.warnings_catcher() as w:
       options = self._parse('./pants', env={'PANTS_GLOBAL_CRUFTY':'crufty1'})
-      self.assertEquals('crufty1', options.for_global_scope().global_crufty)
+      self.assertEqual('crufty1', options.for_global_scope().global_crufty)
       self.assertWarning(w, 'global_crufty')
 
     with self.warnings_catcher() as w:
       options = self._parse('./pants', env={'PANTS_STALE_CRUFTY':'stale_and_crufty'})
-      self.assertEquals('stale_and_crufty', options.for_scope('stale').crufty)
+      self.assertEqual('stale_and_crufty', options.for_scope('stale').crufty)
       self.assertWarning(w, 'crufty')
 
   def test_deprecated_options_config(self):
     with self.warnings_catcher() as w:
       options = self._parse('./pants', config={'GLOBAL':{'global_crufty':'crufty1'}})
-      self.assertEquals('crufty1', options.for_global_scope().global_crufty)
+      self.assertEqual('crufty1', options.for_global_scope().global_crufty)
       self.assertWarning(w, 'global_crufty')
 
     with self.warnings_catcher() as w:
       options = self._parse('./pants', config={'stale':{'crufty':'stale_and_crufty'}})
-      self.assertEquals('stale_and_crufty', options.for_scope('stale').crufty)
+      self.assertEqual('stale_and_crufty', options.for_scope('stale').crufty)
       self.assertWarning(w, 'crufty')
 
   def test_mutually_exclusive_options_flags(self):
@@ -971,42 +971,42 @@ class OptionsTest(unittest.TestCase):
 
     # Short circuit using command line.
     options = self._parse('./pants --a=100 compile --a=99')
-    self.assertEquals(100, options.for_global_scope().a)
-    self.assertEquals(99, options.for_scope('compile').a)
-    self.assertEquals(99, options.for_scope('compile.java').a)
+    self.assertEqual(100, options.for_global_scope().a)
+    self.assertEqual(99, options.for_scope('compile').a)
+    self.assertEqual(99, options.for_scope('compile.java').a)
 
     options = self._parse('./pants',
                           config={
                             'DEFAULT': {'a': 100},
                             'compile': {'a': 99},
                           })
-    self.assertEquals(100, options.for_global_scope().a)
-    self.assertEquals(99, options.for_scope('compile').a)
-    self.assertEquals(99, options.for_scope('compile.java').a)
+    self.assertEqual(100, options.for_global_scope().a)
+    self.assertEqual(99, options.for_scope('compile').a)
+    self.assertEqual(99, options.for_scope('compile.java').a)
 
     options = self._parse('./pants',
                           env={
                             'PANTS_A': 100,
                             'PANTS_COMPILE_A': 99})
-    self.assertEquals(100, options.for_global_scope().a)
-    self.assertEquals(99, options.for_scope('compile').a)
-    self.assertEquals(99, options.for_scope('compile.java').a)
+    self.assertEqual(100, options.for_global_scope().a)
+    self.assertEqual(99, options.for_scope('compile').a)
+    self.assertEqual(99, options.for_scope('compile.java').a)
 
     # Command line has precedence over config.
     options = self._parse('./pants compile --a=99',
                           config={
                             'DEFAULT': {'a': 100},
                           })
-    self.assertEquals(100, options.for_global_scope().a)
-    self.assertEquals(99, options.for_scope('compile').a)
-    self.assertEquals(99, options.for_scope('compile.java').a)
+    self.assertEqual(100, options.for_global_scope().a)
+    self.assertEqual(99, options.for_scope('compile').a)
+    self.assertEqual(99, options.for_scope('compile.java').a)
 
     # Command line has precedence over environment.
     options = self._parse('./pants compile --a=99',
                           env={'PANTS_A': 100}, )
-    self.assertEquals(100, options.for_global_scope().a)
-    self.assertEquals(99, options.for_scope('compile').a)
-    self.assertEquals(99, options.for_scope('compile.java').a)
+    self.assertEqual(100, options.for_global_scope().a)
+    self.assertEqual(99, options.for_scope('compile').a)
+    self.assertEqual(99, options.for_scope('compile.java').a)
 
     # Env has precedence over config.
     options = self._parse('./pants ',
@@ -1014,25 +1014,25 @@ class OptionsTest(unittest.TestCase):
                             'DEFAULT': {'a': 100},
                           },
                           env={'PANTS_COMPILE_A': 99}, )
-    self.assertEquals(100, options.for_global_scope().a)
-    self.assertEquals(99, options.for_scope('compile').a)
-    self.assertEquals(99, options.for_scope('compile.java').a)
+    self.assertEqual(100, options.for_global_scope().a)
+    self.assertEqual(99, options.for_scope('compile').a)
+    self.assertEqual(99, options.for_scope('compile.java').a)
 
     # Command line global overrides the middle scope setting in then env.
     options = self._parse('./pants --a=100',
                           env={'PANTS_COMPILE_A': 99}, )
-    self.assertEquals(100, options.for_global_scope().a)
-    self.assertEquals(100, options.for_scope('compile').a)
-    self.assertEquals(100, options.for_scope('compile.java').a)
+    self.assertEqual(100, options.for_global_scope().a)
+    self.assertEqual(100, options.for_scope('compile').a)
+    self.assertEqual(100, options.for_scope('compile.java').a)
 
     # Command line global overrides the middle scope in config.
     options = self._parse('./pants --a=100 ',
                           config={
                             'compile': {'a': 99},
                           })
-    self.assertEquals(100, options.for_global_scope().a)
-    self.assertEquals(100, options.for_scope('compile').a)
-    self.assertEquals(100, options.for_scope('compile.java').a)
+    self.assertEqual(100, options.for_global_scope().a)
+    self.assertEqual(100, options.for_scope('compile').a)
+    self.assertEqual(100, options.for_scope('compile.java').a)
 
     # Env global overrides the middle scope in config.
     options = self._parse('./pants --a=100 ',
@@ -1040,20 +1040,20 @@ class OptionsTest(unittest.TestCase):
                             'compile': {'a': 99},
                           },
                           env={'PANTS_A': 100}, )
-    self.assertEquals(100, options.for_global_scope().a)
-    self.assertEquals(100, options.for_scope('compile').a)
-    self.assertEquals(100, options.for_scope('compile.java').a)
+    self.assertEqual(100, options.for_global_scope().a)
+    self.assertEqual(100, options.for_scope('compile').a)
+    self.assertEqual(100, options.for_scope('compile.java').a)
 
   def test_complete_scopes(self):
     _global = GlobalOptionsRegistrar.get_scope_info()
-    self.assertEquals({_global, intermediate('foo'), intermediate('foo.bar'), task('foo.bar.baz')},
+    self.assertEqual({_global, intermediate('foo'), intermediate('foo.bar'), task('foo.bar.baz')},
                       Options.complete_scopes({task('foo.bar.baz')}))
-    self.assertEquals({_global, intermediate('foo'), intermediate('foo.bar'), task('foo.bar.baz')},
+    self.assertEqual({_global, intermediate('foo'), intermediate('foo.bar'), task('foo.bar.baz')},
                       Options.complete_scopes({GlobalOptionsRegistrar.get_scope_info(),
                                                task('foo.bar.baz')}))
-    self.assertEquals({_global, intermediate('foo'), intermediate('foo.bar'), task('foo.bar.baz')},
+    self.assertEqual({_global, intermediate('foo'), intermediate('foo.bar'), task('foo.bar.baz')},
                       Options.complete_scopes({intermediate('foo'), task('foo.bar.baz')}))
-    self.assertEquals({_global, intermediate('foo'), intermediate('foo.bar'), task('foo.bar.baz'),
+    self.assertEqual({_global, intermediate('foo'), intermediate('foo.bar'), task('foo.bar.baz'),
                        intermediate('qux'), task('qux.quux')},
                       Options.complete_scopes({task('foo.bar.baz'), task('qux.quux')}))
 
@@ -1063,7 +1063,7 @@ class OptionsTest(unittest.TestCase):
                           '--modifycompile="blah blah blah" --modifylogs="durrrr" -- -d -v')
 
     pairs = options.get_fingerprintable_for_scope('compile.scala')
-    self.assertEquals([(str, 'blah blah blah'),
+    self.assertEqual([(str, 'blah blah blah'),
                        (bool, True),
                        (int, 77)],
                       pairs)
@@ -1073,7 +1073,7 @@ class OptionsTest(unittest.TestCase):
                           '--modifycompile="blah blah blah" --modifylogs="durrrr" -- -d -v')
 
     pairs = options.get_fingerprintable_for_scope('compile.scala', include_passthru=True)
-    self.assertEquals([(str, '-d'),
+    self.assertEqual([(str, '-d'),
                        (str, '-v'),
                        (str, 'blah blah blah'),
                        (bool, True),
@@ -1183,8 +1183,8 @@ class OptionsTest(unittest.TestCase):
   def test_ranked_value_equality(self):
     none = RankedValue(RankedValue.NONE, None)
     some = RankedValue(RankedValue.HARDCODED, 'some')
-    self.assertEquals('(NONE, None)', str(none))
-    self.assertEquals('(HARDCODED, some)', str(some))
+    self.assertEqual('(NONE, None)', str(none))
+    self.assertEqual('(HARDCODED, some)', str(some))
     self.assertNotEqual(some, none)
     self.assertEqual(some, RankedValue(RankedValue.HARDCODED, 'some'))
     self.assertNotEqual(some, RankedValue(RankedValue.HARDCODED, 'few'))
@@ -1290,27 +1290,27 @@ class OptionsTest(unittest.TestCase):
       vals1 = options.for_scope(DummyOptionable1.options_scope)
 
     # Check that we got a warning, but not for the inherited option.
-    self.assertEquals(1, len(w))
+    self.assertEqual(1, len(w))
     self.assertTrue(isinstance(w[0].message, DeprecationWarning))
     self.assertNotIn('inherited', w[0].message)
 
     # Check values.
     # Deprecated scope takes precedence at equal rank.
-    self.assertEquals('yy', vals1.foo)
-    self.assertEquals('zz', vals1.bar)
+    self.assertEqual('yy', vals1.foo)
+    self.assertEqual('zz', vals1.bar)
     # New scope takes precedence at higher rank.
-    self.assertEquals('vv', vals1.baz)
+    self.assertEqual('vv', vals1.baz)
 
     with self.warnings_catcher() as w:
       vals2 = options.for_scope(DummyOptionable2.options_scope)
 
     # Check that we got a warning.
-    self.assertEquals(1, len(w))
+    self.assertEqual(1, len(w))
     self.assertTrue(isinstance(w[0].message, DeprecationWarning))
     self.assertNotIn('inherited', w[0].message)
 
     # Check values.
-    self.assertEquals('uu', vals2.qux)
+    self.assertEqual('uu', vals2.qux)
 
   def test_scope_deprecation_defaults(self):
     # Confirms that a DEFAULT option does not trigger deprecation warnings for a deprecated scope.
@@ -1341,8 +1341,8 @@ class OptionsTest(unittest.TestCase):
       vals1 = options.for_scope(DummyOptionable1.options_scope)
 
     # Check that we got no warnings and that the actual scope took precedence.
-    self.assertEquals(0, len(w))
-    self.assertEquals('xx', vals1.foo)
+    self.assertEqual(0, len(w))
+    self.assertEqual('xx', vals1.foo)
 
 
 class OptionsTestStringPayloads(OptionsTest):

--- a/tests/python/pants_test/option/test_options_bootstrapper.py
+++ b/tests/python/pants_test/option/test_options_bootstrapper.py
@@ -41,7 +41,7 @@ class BootstrapOptionsTest(unittest.TestCase):
       vals = bootstrapper.get_bootstrap_options().for_global_scope()
 
       vals_dict = {k: getattr(vals, k) for k in expected_entries}
-      self.assertEquals(expected_entries, vals_dict)
+      self.assertEqual(expected_entries, vals_dict)
 
   def test_bootstrap_option_values(self):
     # Check all defaults.
@@ -130,8 +130,8 @@ class BootstrapOptionsTest(unittest.TestCase):
 
       opts.register('foo', '--bar')
       opts.register('fruit', '--apple')
-    self.assertEquals('/qux/baz', opts.for_scope('foo').bar)
-    self.assertEquals('/pear/banana', opts.for_scope('fruit').apple)
+    self.assertEqual('/qux/baz', opts.for_scope('foo').bar)
+    self.assertEqual('/pear/banana', opts.for_scope('fruit').apple)
 
   def do_test_create_bootstrapped_multiple_config(self, create_options_bootstrapper):
     # check with multiple config files, the latest values always get taken
@@ -160,8 +160,8 @@ class BootstrapOptionsTest(unittest.TestCase):
       opts_single_config.register('compile.apt', '--worker-count')
       opts_single_config.register('fruit', '--apple')
 
-      self.assertEquals('1', opts_single_config.for_scope('compile.apt').worker_count)
-      self.assertEquals('red', opts_single_config.for_scope('fruit').apple)
+      self.assertEqual('1', opts_single_config.for_scope('compile.apt').worker_count)
+      self.assertEqual('red', opts_single_config.for_scope('fruit').apple)
 
       with temporary_file() as fp2:
         fp2.write(dedent("""
@@ -183,8 +183,8 @@ class BootstrapOptionsTest(unittest.TestCase):
         opts_double_config.register('compile.apt', '--worker-count')
         opts_double_config.register('fruit', '--apple')
 
-        self.assertEquals('2', opts_double_config.for_scope('compile.apt').worker_count)
-        self.assertEquals('red', opts_double_config.for_scope('fruit').apple)
+        self.assertEqual('2', opts_double_config.for_scope('compile.apt').worker_count)
+        self.assertEqual('red', opts_double_config.for_scope('fruit').apple)
 
   def test_create_bootstrapped_multiple_pants_config_files(self):
     def create_options_bootstrapper(*config_paths):

--- a/tests/python/pants_test/option/test_options_fingerprinter.py
+++ b/tests/python/pants_test/option/test_options_fingerprinter.py
@@ -28,15 +28,15 @@ class OptionsFingerprinterTest(TestBase):
     d3 = {'a': 1, 'b': 2}
     fp1, fp2, fp3 = (self.options_fingerprinter.fingerprint(dict_option, d)
                      for d in (d1, d2, d3))
-    self.assertEquals(fp1, fp2)
-    self.assertNotEquals(fp1, fp3)
+    self.assertEqual(fp1, fp2)
+    self.assertNotEqual(fp1, fp3)
 
   def test_fingerprint_list(self):
     l1 = [1, 2, 3]
     l2 = [1, 3, 2]
     fp1, fp2 = (self.options_fingerprinter.fingerprint(list_option, l)
                      for l in (l1, l2))
-    self.assertNotEquals(fp1, fp2)
+    self.assertNotEqual(fp1, fp2)
 
   def test_fingerprint_target_spec(self):
     specs = [':t1', ':t2']
@@ -49,7 +49,7 @@ class OptionsFingerprinterTest(TestBase):
     fp_spec = lambda spec: self.options_fingerprinter.fingerprint(target_option, spec)
     fp1 = fp_spec(s1)
     fp2 = fp_spec(s2)
-    self.assertNotEquals(fp1, fp2)
+    self.assertNotEqual(fp1, fp2)
 
   def test_fingerprint_target_spec_list(self):
     specs = [':t1', ':t2', ':t3']
@@ -63,8 +63,8 @@ class OptionsFingerprinterTest(TestBase):
     fp1 = fp_specs([s1, s2])
     fp2 = fp_specs([s2, s1])
     fp3 = fp_specs([s1, s3])
-    self.assertEquals(fp1, fp2)
-    self.assertNotEquals(fp1, fp3)
+    self.assertEqual(fp1, fp2)
+    self.assertNotEqual(fp1, fp3)
 
   def test_fingerprint_file(self):
     fp1, fp2, fp3 = (self.options_fingerprinter.fingerprint(file_option,
@@ -72,9 +72,9 @@ class OptionsFingerprinterTest(TestBase):
                      for (f, c) in (('foo/bar.config', 'blah blah blah'),
                                     ('foo/bar.config', 'meow meow meow'),
                                     ('spam/egg.config', 'blah blah blah')))
-    self.assertNotEquals(fp1, fp2)
-    self.assertNotEquals(fp1, fp3)
-    self.assertNotEquals(fp2, fp3)
+    self.assertNotEqual(fp1, fp2)
+    self.assertNotEqual(fp1, fp3)
+    self.assertNotEqual(fp2, fp3)
 
   def test_fingerprint_file_outside_buildroot(self):
     with temporary_dir() as tmp:
@@ -90,12 +90,12 @@ class OptionsFingerprinterTest(TestBase):
     fp1 = self.options_fingerprinter.fingerprint(file_option, [f1, f2])
     fp2 = self.options_fingerprinter.fingerprint(file_option, [f2, f1])
     fp3 = self.options_fingerprinter.fingerprint(file_option, [f1, f3])
-    self.assertEquals(fp1, fp2)
-    self.assertNotEquals(fp1, fp3)
+    self.assertEqual(fp1, fp2)
+    self.assertNotEqual(fp1, fp3)
 
   def test_fingerprint_primitive(self):
     fp1, fp2 = (self.options_fingerprinter.fingerprint('', v) for v in ('foo', 5))
-    self.assertNotEquals(fp1, fp2)
+    self.assertNotEqual(fp1, fp2)
 
   def test_fingerprint_unset_bool(self):
     fp1 = self.options_fingerprinter.fingerprint(UnsetBool, UnsetBool)
@@ -118,8 +118,8 @@ class OptionsFingerprinterTest(TestBase):
     dp3 = self.options_fingerprinter.fingerprint(dir_option, [d2, d1])
     dp4 = self.options_fingerprinter.fingerprint(dir_option, [d3])
 
-    self.assertEquals(dp1, dp1)
-    self.assertEquals(dp2, dp2)
-    self.assertNotEquals(dp1, dp3)
-    self.assertNotEquals(dp1, dp4)
-    self.assertNotEquals(dp2, dp3)
+    self.assertEqual(dp1, dp1)
+    self.assertEqual(dp2, dp2)
+    self.assertNotEqual(dp1, dp3)
+    self.assertNotEqual(dp1, dp4)
+    self.assertNotEqual(dp2, dp3)

--- a/tests/python/pants_test/option/test_options_integration.py
+++ b/tests/python/pants_test/option/test_options_integration.py
@@ -41,8 +41,8 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     try:
       output_map = json.loads(pants_run.stdout_data)
       self.assertIn("time", output_map)
-      self.assertEquals(output_map["time"]["source"], "HARDCODED")
-      self.assertEquals(output_map["time"]["value"], False)
+      self.assertEqual(output_map["time"]["source"], "HARDCODED")
+      self.assertEqual(output_map["time"]["value"], False)
     except ValueError:
       self.fail("Invalid JSON output")
 
@@ -52,9 +52,9 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     try:
       output_map = json.loads(pants_run.stdout_data)
       self.assertIn("time", output_map)
-      self.assertEquals(output_map["time"]["source"], "HARDCODED")
-      self.assertEquals(output_map["time"]["value"], False)
-      self.assertEquals(output_map["time"]["history"], [])
+      self.assertEqual(output_map["time"]["source"], "HARDCODED")
+      self.assertEqual(output_map["time"]["value"], False)
+      self.assertEqual(output_map["time"]["history"], [])
       for _, val in output_map.items():
         self.assertIn("history", val)
     except ValueError:

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -387,7 +387,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
 
         stdout, _ = java_run.communicate()
       java_returncode = java_run.returncode
-      self.assertEquals(java_returncode, 0)
+      self.assertEqual(java_returncode, 0)
       return stdout
 
   def assert_success(self, pants_run, msg=None):

--- a/tests/python/pants_test/pantsd/test_pailgun_server.py
+++ b/tests/python/pants_test/pantsd/test_pailgun_server.py
@@ -46,7 +46,7 @@ class TestPailgunServer(unittest.TestCase):
     mock_sock.getsockname.return_value = ('0.0.0.0', 31337)
     self.server.socket = mock_sock
     self.server.server_bind()
-    self.assertEquals(self.server.server_port, 31337)
+    self.assertEqual(self.server.server_port, 31337)
     self.assertIs(mock_tcpserver_bind.called, True)
 
   @mock.patch.object(PailgunServer, 'close_request', **PATCH_OPTS)
@@ -80,8 +80,8 @@ class TestPailgunHandler(unittest.TestCase):
   def test_handle_error(self):
     self.handler.handle_error()
     last_chunk_type, last_payload = list(NailgunProtocol.iter_chunks(self.client_sock))[-1]
-    self.assertEquals(last_chunk_type, ChunkType.EXIT)
-    self.assertEquals(last_payload, '1')
+    self.assertEqual(last_chunk_type, ChunkType.EXIT)
+    self.assertEqual(last_payload, '1')
 
   @mock.patch.object(PailgunHandler, '_run_pants', **PATCH_OPTS)
   def test_handle_request(self, mock_run_pants):

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -166,7 +166,7 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
     print(bold(cyan('\ncompleted in {} seconds'.format(elapsed))))
 
     runs_created = self._run_count(workdir) - run_count
-    self.assertEquals(
+    self.assertEqual(
         runs_created,
         expected_runs,
         'Expected {} RunTracker run to be created per pantsd run: was {}'.format(
@@ -392,7 +392,7 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
         )
         checker.assert_running()
 
-      self.assertEquals(EXPECTED_VALUE, ''.join(result.stdout_data).strip())
+      self.assertEqual(EXPECTED_VALUE, ''.join(result.stdout_data).strip())
 
   def test_pantsd_launch_env_var_is_not_inherited_by_pantsd_runner_children(self):
     with self.pantsd_test_context() as (workdir, pantsd_config, checker):

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -162,7 +162,7 @@ class TestProcessMetadataManager(TestBase):
          mock.patch('pants.pantsd.process_manager.get_buildroot', return_value=tmpdir):
       self.pmm.write_metadata_by_name(self.NAME, self.TEST_KEY, self.TEST_VALUE)
 
-      self.assertEquals(
+      self.assertEqual(
         self.pmm.await_metadata_by_name(self.NAME, self.TEST_KEY, .1),
         self.TEST_VALUE
       )

--- a/tests/python/pants_test/pantsd/test_watchman.py
+++ b/tests/python/pants_test/pantsd/test_watchman.py
@@ -43,7 +43,7 @@ class TestWatchman(TestBase):
 
   def test_client_property_cached(self):
     self.watchman._watchman_client = 1
-    self.assertEquals(self.watchman.client, 1)
+    self.assertEqual(self.watchman.client, 1)
 
   def test_make_client(self):
     self.assertIsInstance(self.watchman._make_client(), pywatchman.client)
@@ -72,7 +72,7 @@ class TestWatchman(TestBase):
                                           'log_file',
                                           'log_level')
 
-    self.assertEquals(output, ['cmd',
+    self.assertEqual(output, ['cmd',
                                'parts',
                                'etc',
                                '--no-save-state',
@@ -86,7 +86,7 @@ class TestWatchman(TestBase):
 
   def test_parse_pid_from_output(self):
     output = json.dumps(dict(pid=3))
-    self.assertEquals(self.watchman._parse_pid_from_output(output), 3)
+    self.assertEqual(self.watchman._parse_pid_from_output(output), 3)
 
   def test_parse_pid_from_output_bad_output(self):
     output = '{bad JSON.,/#!'
@@ -127,13 +127,13 @@ class TestWatchman(TestBase):
     """Test yielding when watchman reads timeout."""
     with self.setup_subscribed([None]):
       out = self.watchman.subscribed(self.BUILD_ROOT, self.HANDLERS)
-      self.assertEquals(list(out), [(None, None)])
+      self.assertEqual(list(out), [(None, None)])
 
   def test_subscribed_response(self):
     """Test yielding on the watchman response to the initial subscribe command."""
     with self.setup_subscribed([dict(subscribe='test')]):
       out = self.watchman.subscribed(self.BUILD_ROOT, self.HANDLERS)
-      self.assertEquals(list(out), [(None, None)])
+      self.assertEqual(list(out), [(None, None)])
 
   def test_subscribed_event(self):
     """Test yielding on a watchman event for a given subscription."""
@@ -141,10 +141,10 @@ class TestWatchman(TestBase):
 
     with self.setup_subscribed([test_event]):
       out = self.watchman.subscribed(self.BUILD_ROOT, self.HANDLERS)
-      self.assertEquals(list(out), [('test3', test_event)])
+      self.assertEqual(list(out), [('test3', test_event)])
 
   def test_subscribed_unknown_event(self):
     """Test yielding on an unknown watchman event."""
     with self.setup_subscribed([dict(unknown=True)]):
       out = self.watchman.subscribed(self.BUILD_ROOT, self.HANDLERS)
-      self.assertEquals(list(out), [])
+      self.assertEqual(list(out), [])

--- a/tests/python/pants_test/pantsd/test_watchman_launcher.py
+++ b/tests/python/pants_test/pantsd/test_watchman_launcher.py
@@ -62,4 +62,4 @@ class TestWatchmanLauncher(TestBase):
     expected_path = '/a/shorter/path'
     options = ['--watchman-socket-path={}'.format(expected_path)]
     wl = self.watchman_launcher(options)
-    self.assertEquals(wl.watchman._sock_file, expected_path)
+    self.assertEqual(wl.watchman._sock_file, expected_path)

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -126,7 +126,7 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
     self.assert_success(pants_run)
 
   def test_self(self):
-    self.assertEquals([t for s in range(0, self._SHARDS)
+    self.assertEqual([t for s in range(0, self._SHARDS)
                        for t in self.targets_for_shard(s)],
                       self.targets)
 

--- a/tests/python/pants_test/python/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/python/test_interpreter_selection_integration.py
@@ -33,7 +33,7 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
       v = echo.split('.')  # E.g., 2.7.13.
       self.assertTrue(len(v) > 2, 'Not a valid version string: {}'.format(v))
       expected_components = version.split('.')
-      self.assertEquals(expected_components, v[:len(expected_components)])
+      self.assertEqual(expected_components, v[:len(expected_components)])
     else:
       print('No python {} found. Skipping.'.format(version))
       self.skipTest('No python {} on system'.format(version))

--- a/tests/python/pants_test/python/test_python_binary_integration.py
+++ b/tests/python/pants_test/python/test_python_binary_integration.py
@@ -32,7 +32,7 @@ class PythonBinaryIntegrationTest(PantsRunIntegrationTest):
   def assert_pex_attribute(self, pex, attr, value):
     self.assertTrue(os.path.exists(pex))
     pex_info = PexInfo.from_pex(pex)
-    self.assertEquals(getattr(pex_info, attr), value)
+    self.assertEqual(getattr(pex_info, attr), value)
 
   def test_zipsafe_caching(self):
     test_project = 'testprojects/src/python/cache_fields'

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -55,7 +55,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
 
       # The 'latest' link has been removed by clean-all but that's not fatal.
       report_dirs = os.listdir(os.path.join(workdir, 'reports'))
-      self.assertEquals(1, len(report_dirs))
+      self.assertEqual(1, len(report_dirs))
 
       output = os.path.join(workdir, 'reports', report_dirs[0], 'invalidation-report.csv')
       self.assertTrue(os.path.exists(output), msg='Missing report file {}'.format(output))

--- a/tests/python/pants_test/scm/test_git.py
+++ b/tests/python/pants_test/scm/test_git.py
@@ -105,7 +105,7 @@ class GitTest(unittest.TestCase):
 
     for dirname in '.', './.':
       results = reader.listdir(dirname)
-      self.assertEquals([b'README',
+      self.assertEqual([b'README',
                          b'dir',
                          b'link-to-dir',
                          b'loop1',
@@ -115,7 +115,7 @@ class GitTest(unittest.TestCase):
 
     for dirname in 'dir', './dir':
       results = reader.listdir(dirname)
-      self.assertEquals([b'f',
+      self.assertEqual([b'f',
                          'not-absolute\u2764'.encode('utf-8'),
                          b'relative-dotdot',
                          b'relative-nonexistent',
@@ -123,7 +123,7 @@ class GitTest(unittest.TestCase):
                         sorted(results))
 
     results = reader.listdir('link-to-dir')
-    self.assertEquals([b'f',
+    self.assertEqual([b'f',
                        'not-absolute\u2764'.encode('utf-8'),
                        b'relative-dotdot',
                        b'relative-nonexistent',
@@ -138,34 +138,34 @@ class GitTest(unittest.TestCase):
     reader = self.git.repo_reader(self.initial_rev)
     def lstat(*components):
       return type(reader.lstat(os.path.join(*components)))
-    self.assertEquals(reader.Symlink, lstat('dir', 'relative-symlink'))
-    self.assertEquals(reader.Symlink, lstat('not-a-dir'))
-    self.assertEquals(reader.File, lstat('README'))
-    self.assertEquals(reader.Dir, lstat('dir'))
-    self.assertEquals(type(None), lstat('nope-not-here'))
+    self.assertEqual(reader.Symlink, lstat('dir', 'relative-symlink'))
+    self.assertEqual(reader.Symlink, lstat('not-a-dir'))
+    self.assertEqual(reader.File, lstat('README'))
+    self.assertEqual(reader.Dir, lstat('dir'))
+    self.assertEqual(type(None), lstat('nope-not-here'))
 
   def test_readlink(self):
     reader = self.git.repo_reader(self.initial_rev)
     def readlink(*components):
       return reader.readlink(os.path.join(*components))
-    self.assertEquals('dir/f', readlink('dir', 'relative-symlink'))
-    self.assertEquals(None, readlink('not-a-dir'))
-    self.assertEquals(None, readlink('README'))
-    self.assertEquals(None, readlink('dir'))
-    self.assertEquals(None, readlink('nope-not-here'))
+    self.assertEqual('dir/f', readlink('dir', 'relative-symlink'))
+    self.assertEqual(None, readlink('not-a-dir'))
+    self.assertEqual(None, readlink('README'))
+    self.assertEqual(None, readlink('dir'))
+    self.assertEqual(None, readlink('nope-not-here'))
 
   def test_open(self):
     reader = self.git.repo_reader(self.initial_rev)
 
     with reader.open('README') as f:
-      self.assertEquals(b'', f.read())
+      self.assertEqual(b'', f.read())
 
     with reader.open('dir/f') as f:
-      self.assertEquals(b'file in subdir', f.read())
+      self.assertEqual(b'file in subdir', f.read())
 
     with self.assertRaises(reader.MissingFileException):
       with reader.open('no-such-file') as f:
-        self.assertEquals(b'', f.read())
+        self.assertEqual(b'', f.read())
 
     with self.assertRaises(reader.MissingFileException):
       with reader.open('dir/no-such-file') as f:
@@ -173,18 +173,18 @@ class GitTest(unittest.TestCase):
 
     with self.assertRaises(reader.IsDirException):
       with reader.open('dir') as f:
-        self.assertEquals(b'', f.read())
+        self.assertEqual(b'', f.read())
 
     current_reader = self.git.repo_reader(self.current_rev)
 
     with current_reader.open('README') as f:
-      self.assertEquals('Hello World.\u2764'.encode('utf-8'), f.read())
+      self.assertEqual('Hello World.\u2764'.encode('utf-8'), f.read())
 
     with current_reader.open('link-to-dir/f') as f:
-      self.assertEquals(b'file in subdir', f.read())
+      self.assertEqual(b'file in subdir', f.read())
 
     with current_reader.open('dir/relative-symlink') as f:
-      self.assertEquals(b'file in subdir', f.read())
+      self.assertEqual(b'file in subdir', f.read())
 
     with self.assertRaises(current_reader.SymlinkLoopException):
       with current_reader.open('loop1') as f:
@@ -207,7 +207,7 @@ class GitTest(unittest.TestCase):
         pass
 
     with current_reader.open('dir/relative-dotdot') as f:
-      self.assertEquals('Hello World.\u2764'.encode('utf-8'), f.read())
+      self.assertEqual('Hello World.\u2764'.encode('utf-8'), f.read())
 
   def test_integration(self):
     self.assertEqual(set(), self.git.changed_files())
@@ -465,11 +465,11 @@ class GitTest(unittest.TestCase):
 
       subprocess.check_call(['git', 'commit', '-am', 'Conflict'])
 
-      self.assertEquals(set(), self.git.changed_files(include_untracked=True, from_commit='HEAD'))
+      self.assertEqual(set(), self.git.changed_files(include_untracked=True, from_commit='HEAD'))
       with self.assertRaises(Scm.LocalException):
         self.git.refresh(leave_clean=False)
       # The repo is dirty
-      self.assertEquals({'README'},
+      self.assertEqual({'README'},
                         self.git.changed_files(include_untracked=True, from_commit='HEAD'))
 
       with environment_as(GIT_DIR=self.gitdir, GIT_WORK_TREE=self.worktree):
@@ -479,7 +479,7 @@ class GitTest(unittest.TestCase):
       with self.assertRaises(Scm.LocalException):
         self.git.refresh(leave_clean=True)
       # The repo is clean
-      self.assertEquals(set(), self.git.changed_files(include_untracked=True, from_commit='HEAD'))
+      self.assertEqual(set(), self.git.changed_files(include_untracked=True, from_commit='HEAD'))
 
   def test_commit_with_new_untracked_file_adds_file(self):
     new_file = os.path.join(self.worktree, 'untracked_file')

--- a/tests/python/pants_test/source/test_source_root.py
+++ b/tests/python/pants_test/source/test_source_root.py
@@ -29,83 +29,83 @@ class SourceRootTest(TestBase):
 
     # Wildcard at the end.
     trie.add_pattern('src/*')
-    self.assertEquals(root('src/java', ('java',)),
+    self.assertEqual(root('src/java', ('java',)),
                       trie.find('src/java/org/pantsbuild/foo/Foo.java'))
-    self.assertEquals(root('my/project/src/java', ('java',)),
+    self.assertEqual(root('my/project/src/java', ('java',)),
                       trie.find('my/project/src/java/org/pantsbuild/foo/Foo.java'))
-    self.assertEquals(root('src/python', ('python',)),
+    self.assertEqual(root('src/python', ('python',)),
                       trie.find('src/python/pantsbuild/foo/foo.py'))
-    self.assertEquals(root('my/project/src/python', ('python',)),
+    self.assertEqual(root('my/project/src/python', ('python',)),
                       trie.find('my/project/src/python/org/pantsbuild/foo/foo.py'))
 
     # Overlapping pattern.
     trie.add_pattern('src/main/*')
-    self.assertEquals(root('src/main/java', ('java',)),
+    self.assertEqual(root('src/main/java', ('java',)),
                       trie.find('src/main/java/org/pantsbuild/foo/Foo.java'))
-    self.assertEquals(root('my/project/src/main/java', ('java',)),
+    self.assertEqual(root('my/project/src/main/java', ('java',)),
                       trie.find('my/project/src/main/java/org/pantsbuild/foo/Foo.java'))
-    self.assertEquals(root('src/main/python', ('python',)),
+    self.assertEqual(root('src/main/python', ('python',)),
                       trie.find('src/main/python/pantsbuild/foo/foo.py'))
-    self.assertEquals(root('my/project/src/main/python', ('python',)),
+    self.assertEqual(root('my/project/src/main/python', ('python',)),
                       trie.find('my/project/src/main/python/org/pantsbuild/foo/foo.py'))
 
     # Wildcard in the middle.
     trie.add_pattern('src/*/code')
-    self.assertEquals(root('src/java/code', ('java',)),
+    self.assertEqual(root('src/java/code', ('java',)),
                       trie.find('src/java/code/org/pantsbuild/foo/Foo.java'))
-    self.assertEquals(root('my/project/src/java/code', ('java',)),
+    self.assertEqual(root('my/project/src/java/code', ('java',)),
                       trie.find('my/project/src/java/code/org/pantsbuild/foo/Foo.java'))
-    self.assertEquals(root('src/python/code', ('python',)),
+    self.assertEqual(root('src/python/code', ('python',)),
                       trie.find('src/python/code/pantsbuild/foo/foo.py'))
-    self.assertEquals(root('my/project/src/python/code', ('python',)),
+    self.assertEqual(root('my/project/src/python/code', ('python',)),
                       trie.find('my/project/src/python/code/org/pantsbuild/foo/foo.py'))
 
     # Verify that the now even-more-overlapping pattern still works.
-    self.assertEquals(root('src/main/java', ('java',)),
+    self.assertEqual(root('src/main/java', ('java',)),
                       trie.find('src/main/java/org/pantsbuild/foo/Foo.java'))
-    self.assertEquals(root('my/project/src/main/java', ('java',)),
+    self.assertEqual(root('my/project/src/main/java', ('java',)),
                       trie.find('my/project/src/main/java/org/pantsbuild/foo/Foo.java'))
-    self.assertEquals(root('src/main/python', ('python',)),
+    self.assertEqual(root('src/main/python', ('python',)),
                       trie.find('src/main/python/pantsbuild/foo/foo.py'))
-    self.assertEquals(root('my/project/src/main/python', ('python',)),
+    self.assertEqual(root('my/project/src/main/python', ('python',)),
                       trie.find('my/project/src/main/python/org/pantsbuild/foo/foo.py'))
 
     # Verify that we take the first matching prefix.
-    self.assertEquals(root('src/java', ('java',)),
+    self.assertEqual(root('src/java', ('java',)),
                       trie.find('src/java/src/python/Foo.java'))
 
     # Test canonicalization.
-    self.assertEquals(root('src/jvm', ('java', 'scala')),
+    self.assertEqual(root('src/jvm', ('java', 'scala')),
                       trie.find('src/jvm/org/pantsbuild/foo/Foo.java'))
-    self.assertEquals(root('src/jvm', ('java', 'scala')),
+    self.assertEqual(root('src/jvm', ('java', 'scala')),
                       trie.find('src/jvm/org/pantsbuild/foo/Foo.scala'))
-    self.assertEquals(root('src/py', ('python',)),
+    self.assertEqual(root('src/py', ('python',)),
                       trie.find('src/py/pantsbuild/foo/foo.py'))
 
     # Test fixed roots.
     trie.add_fixed('mysrc/scalastuff', ('scala',))
-    self.assertEquals(('mysrc/scalastuff', ('scala',), UNKNOWN),
+    self.assertEqual(('mysrc/scalastuff', ('scala',), UNKNOWN),
                       trie.find('mysrc/scalastuff/org/pantsbuild/foo/Foo.scala'))
     self.assertIsNone(trie.find('my/project/mysrc/scalastuff/org/pantsbuild/foo/Foo.scala'))
 
     # Verify that a fixed root wins over a pattern that is a prefix of it
     # (e.g., that src/go/src wins over src/go).
     trie.add_fixed('src/go/src', ('go',))
-    self.assertEquals(root('src/go/src', ('go',)),
+    self.assertEqual(root('src/go/src', ('go',)),
                       trie.find('src/go/src/foo/bar/baz.go'))
 
   def test_fixed_source_root_at_buildroot(self):
     trie = SourceRootTrie(SourceRootFactory({}))
     trie.add_fixed('', ('proto',))
 
-    self.assertEquals(('', ('proto',), UNKNOWN),
+    self.assertEqual(('', ('proto',), UNKNOWN),
                       trie.find('foo/proto/bar/baz.proto'))
 
   def test_source_root_pattern_at_buildroot(self):
     trie = SourceRootTrie(SourceRootFactory({}))
     trie.add_pattern('*')
 
-    self.assertEquals(('java', ('java',), UNKNOWN),
+    self.assertEqual(('java', ('java',), UNKNOWN),
                       trie.find('java/bar/baz.proto'))
 
   def test_invalid_patterns(self):
@@ -129,17 +129,17 @@ class SourceRootTest(TestBase):
     trie.add_fixed('fixed2/bar2', ['lang2'], TEST)
 
     # Test raw traversal.
-    self.assertEquals([('baz1', (), UNKNOWN),
+    self.assertEqual([('baz1', (), UNKNOWN),
                        ('baz2/qux', (), UNKNOWN)],
                       list(trie._root.children['foo1'].children['bar1'].subpatterns()))
 
-    self.assertEquals([('bar1/baz1', (), UNKNOWN),
+    self.assertEqual([('bar1/baz1', (), UNKNOWN),
                        ('bar1/baz2/qux', (), UNKNOWN),
                        ('bar2/baz1', (), UNKNOWN),
                        ('bar2/baz2', (), UNKNOWN)],
                       list(trie._root.children['foo1'].subpatterns()))
 
-    self.assertEquals([('foo1/bar1/baz1', (), UNKNOWN),
+    self.assertEqual([('foo1/bar1/baz1', (), UNKNOWN),
                        ('foo1/bar1/baz2/qux', (), UNKNOWN),
                        ('foo1/bar2/baz1', (), UNKNOWN),
                        ('foo1/bar2/baz2', (), UNKNOWN),
@@ -149,7 +149,7 @@ class SourceRootTest(TestBase):
                       list(trie._root.subpatterns()))
 
     # Test the fixed() method.
-    self.assertEquals([('fixed1/bar1', ('lang1',), SOURCE),
+    self.assertEqual([('fixed1/bar1', ('lang1',), SOURCE),
                        ('fixed2/bar2', ('lang2',), TEST)],
                       trie.fixed())
 
@@ -185,7 +185,7 @@ class SourceRootTest(TestBase):
     source_roots.add_source_root('fixed/root/jvm', ('java', 'scala'), TEST)
     source_roots.all_roots()
 
-    self.assertEquals({SourceRoot('contrib/go/examples/3rdparty/go', ('go',), THIRDPARTY),
+    self.assertEqual({SourceRoot('contrib/go/examples/3rdparty/go', ('go',), THIRDPARTY),
                        SourceRoot('contrib/go/examples/src/go/src', ('go',), SOURCE),
                        SourceRoot('src/java', ('java',), SOURCE),
                        SourceRoot('src/python', ('python',), SOURCE),

--- a/tests/python/pants_test/source/test_wrapped_globs.py
+++ b/tests/python/pants_test/source/test_wrapped_globs.py
@@ -60,7 +60,7 @@ class FilesetRelPathWrapperTest(TestBase):
     self.add_to_build_file('y/BUILD', 'dummy_target(name="y", sources={})'.format(spec))
     graph = self.context().scan()
     globs = graph.get_target_from_spec('y').globs_relative_to_buildroot()
-    self.assertEquals(expected, globs)
+    self.assertEqual(expected, globs)
 
   def test_glob_to_spec(self):
     self._spec_test('globs("*.java")',
@@ -220,7 +220,7 @@ class FilesetRelPathWrapperTest(TestBase):
     self.add_to_build_file('z/w/BUILD', 'dummy_target(name="w", sources=rglobs("*.java"))')
     graph = self.context().scan()
     relative_sources = set(graph.get_target_from_spec('z/w').sources_relative_to_source_root())
-    self.assertEquals({'y/fleem.java', 'y/morx.java', 'foo.java'}, relative_sources)
+    self.assertEqual({'y/fleem.java', 'y/morx.java', 'foo.java'}, relative_sources)
 
 
 class FilesetWithSpecTest(TestBase):
@@ -252,11 +252,11 @@ class FilesetWithSpecTest(TestBase):
   def test_iter_relative_paths(self):
     self.create_files('test_root', ['a', 'b', 'c'])
     efws = self.sources_for(['a', 'b', 'c'], 'test_root')
-    self.assertEquals(
+    self.assertEqual(
       efws.files_hash,
       'cb11a7f0b5a1e22b93c36783608ba531ea831c2f68a5c9f9498417b211bcfea4',
     )
-    self.assertEquals(
+    self.assertEqual(
       list(efws.paths_from_buildroot_iter()),
       ['test_root/a', 'test_root/b', 'test_root/c'],
     )

--- a/tests/python/pants_test/targets/test_jvm_app_integration.py
+++ b/tests/python/pants_test/targets/test_jvm_app_integration.py
@@ -15,7 +15,7 @@ class TestJvmAppIntegrationTest(PantsRunIntegrationTest):
     Verify synthetic jar contains only a manifest file and the rest bundle contains
     other library jars.
     """
-    self.assertEquals(
+    self.assertEqual(
       'Hello world from Foo\n',
       self.bundle_and_run(
         'testprojects/src/java/org/pantsbuild/testproject/bundle',
@@ -38,7 +38,7 @@ class TestJvmAppIntegrationTest(PantsRunIntegrationTest):
 
     Verify monolithic jar is created with manifest file and the library class.
     """
-    self.assertEquals(
+    self.assertEqual(
       'Hello world from Foo\n',
       self.bundle_and_run(
         'testprojects/src/java/org/pantsbuild/testproject/bundle',

--- a/tests/python/pants_test/targets/test_python_target.py
+++ b/tests/python/pants_test/targets/test_python_target.py
@@ -35,14 +35,14 @@ class PythonTargetTest(TestBase):
     pt_with_artifact = self.make_target(spec=spec,
                                         target_type=PythonTarget,
                                         provides=pa)
-    self.assertEquals(pt_with_artifact.address.spec, spec)
+    self.assertEqual(pt_with_artifact.address.spec, spec)
 
     spec = "//:test-with-none"
     # This test verifies that having no provides is okay.
     pt_no_artifact = self.make_target(spec=spec,
                                       target_type=PythonTarget,
                                       provides=None)
-    self.assertEquals(pt_no_artifact.address.spec, spec)
+    self.assertEqual(pt_no_artifact.address.spec, spec)
 
   def assert_single_resource_dep(self, target, expected_resource_path, expected_resource_contents):
     self.assertEqual(1, len(target.dependencies))

--- a/tests/python/pants_test/targets/test_sort_targets.py
+++ b/tests/python/pants_test/targets/test_sort_targets.py
@@ -48,6 +48,6 @@ class SortTargetsTest(TestBase):
     d = self.make_target(':d', dependencies=[c, a])
     e = self.make_target(':e', dependencies=[d])
 
-    self.assertEquals(sort_targets([a, b, c, d, e]), [e, d, c, b, a])
-    self.assertEquals(sort_targets([b, d, a, e, c]), [e, d, c, b, a])
-    self.assertEquals(sort_targets([e, d, c, b, a]), [e, d, c, b, a])
+    self.assertEqual(sort_targets([a, b, c, d, e]), [e, d, c, b, a])
+    self.assertEqual(sort_targets([b, d, a, e, c]), [e, d, c, b, a])
+    self.assertEqual(sort_targets([e, d, c, b, a]), [e, d, c, b, a])

--- a/tests/python/pants_test/task/test_task.py
+++ b/tests/python/pants_test/task/test_task.py
@@ -137,7 +137,7 @@ class TaskTest(TaskTestBase):
 
   def assertContent(self, vt, content):
     with open(os.path.join(vt.current_results_dir, self._filename), 'r') as f:
-      self.assertEquals(f.read(), content)
+      self.assertEqual(f.read(), content)
 
   def _toggle_cache(self, enable_artifact_cache):
     cache_dir = self.create_dir(self._cachedir)

--- a/tests/python/pants_test/task/test_testrunner_task_mixin.py
+++ b/tests/python/pants_test/task/test_testrunner_task_mixin.py
@@ -122,14 +122,14 @@ class TestRunnerTaskMixinTest(TaskTestBase):
     self.set_options(timeouts=True, timeout_default=2)
     task = self.create_task(self.context())
 
-    self.assertEquals(task._timeout_for_targets([targetA, targetB]), 3)
+    self.assertEqual(task._timeout_for_targets([targetA, targetB]), 3)
 
   def test_get_timeouts_with_maximum(self):
     """If a timeout exceeds the maximum, set it to that."""
 
     self.set_options(timeouts=True, timeout_maximum=1)
     task = self.create_task(self.context())
-    self.assertEquals(task._timeout_for_targets([targetC]), 1)
+    self.assertEqual(task._timeout_for_targets([targetC]), 1)
 
   def test_default_maximum_conflict(self):
     """If the default exceeds the maximum, throw an error."""

--- a/tests/python/pants_test/tasks/test_execution_graph.py
+++ b/tests/python/pants_test/tasks/test_execution_graph.py
@@ -300,8 +300,8 @@ class ExecutionGraphTest(unittest.TestCase):
     with self.assertRaises(ExecutionFailure):
       graph.execute(ImmediatelyExecutingPool(), capturing_logger)
     error_logs = capturing_logger.log_entries['error']
-    self.assertEquals(2, len(error_logs), msg='Wanted one error log, got: {}'.format(error_logs))
-    self.assertEquals("A failed: I'm an error", error_logs[0])
+    self.assertEqual(2, len(error_logs), msg='Wanted one error log, got: {}'.format(error_logs))
+    self.assertEqual("A failed: I'm an error", error_logs[0])
     regex = re.compile(
       "Traceback:.*in raising_wrapper.*raise Exception\\(\"I'm an error\"\\)",
       re.DOTALL,

--- a/tests/python/pants_test/util/test_argutil.py
+++ b/tests/python/pants_test/util/test_argutil.py
@@ -12,25 +12,25 @@ from pants.util.argutil import ensure_arg, remove_arg
 class ArgutilTest(unittest.TestCase):
 
   def test_ensure_arg(self):
-    self.assertEquals(['foo'], ensure_arg([], 'foo'))
-    self.assertEquals(['foo'], ensure_arg(['foo'], 'foo'))
-    self.assertEquals(['bar', 'foo'], ensure_arg(['bar'], 'foo'))
-    self.assertEquals(['bar', 'foo'], ensure_arg(['bar', 'foo'], 'foo'))
+    self.assertEqual(['foo'], ensure_arg([], 'foo'))
+    self.assertEqual(['foo'], ensure_arg(['foo'], 'foo'))
+    self.assertEqual(['bar', 'foo'], ensure_arg(['bar'], 'foo'))
+    self.assertEqual(['bar', 'foo'], ensure_arg(['bar', 'foo'], 'foo'))
 
-    self.assertEquals(['foo', 'baz'], ensure_arg([], 'foo', param='baz'))
-    self.assertEquals(['qux', 'foo', 'baz'], ensure_arg(['qux', 'foo', 'bar'], 'foo', param='baz'))
-    self.assertEquals(['foo', 'baz'], ensure_arg(['foo', 'bar'], 'foo', param='baz'))
-    self.assertEquals(['qux', 'foo', 'baz', 'foobar'], ensure_arg(['qux', 'foo', 'bar', 'foobar'], 'foo', param='baz'))
+    self.assertEqual(['foo', 'baz'], ensure_arg([], 'foo', param='baz'))
+    self.assertEqual(['qux', 'foo', 'baz'], ensure_arg(['qux', 'foo', 'bar'], 'foo', param='baz'))
+    self.assertEqual(['foo', 'baz'], ensure_arg(['foo', 'bar'], 'foo', param='baz'))
+    self.assertEqual(['qux', 'foo', 'baz', 'foobar'], ensure_arg(['qux', 'foo', 'bar', 'foobar'], 'foo', param='baz'))
 
   def test_remove_arg(self):
-    self.assertEquals([], remove_arg([], 'foo'))
-    self.assertEquals([], remove_arg(['foo'], 'foo'))
-    self.assertEquals(['bar'], remove_arg(['foo', 'bar'], 'foo'))
-    self.assertEquals(['bar'], remove_arg(['bar', 'foo'], 'foo'))
-    self.assertEquals(['bar', 'baz'], remove_arg(['bar', 'foo', 'baz'], 'foo'))
+    self.assertEqual([], remove_arg([], 'foo'))
+    self.assertEqual([], remove_arg(['foo'], 'foo'))
+    self.assertEqual(['bar'], remove_arg(['foo', 'bar'], 'foo'))
+    self.assertEqual(['bar'], remove_arg(['bar', 'foo'], 'foo'))
+    self.assertEqual(['bar', 'baz'], remove_arg(['bar', 'foo', 'baz'], 'foo'))
 
-    self.assertEquals([], remove_arg([], 'foo', has_param=True))
-    self.assertEquals([], remove_arg(['foo', 'bar'], 'foo', has_param=True))
-    self.assertEquals(['baz'], remove_arg(['baz', 'foo', 'bar'], 'foo', has_param=True))
-    self.assertEquals(['baz'], remove_arg(['foo', 'bar', 'baz'], 'foo', has_param=True))
-    self.assertEquals(['qux', 'foobar'], remove_arg(['qux', 'foo', 'bar', 'foobar'], 'foo', has_param='baz'))
+    self.assertEqual([], remove_arg([], 'foo', has_param=True))
+    self.assertEqual([], remove_arg(['foo', 'bar'], 'foo', has_param=True))
+    self.assertEqual(['baz'], remove_arg(['baz', 'foo', 'bar'], 'foo', has_param=True))
+    self.assertEqual(['baz'], remove_arg(['foo', 'bar', 'baz'], 'foo', has_param=True))
+    self.assertEqual(['qux', 'foobar'], remove_arg(['qux', 'foo', 'bar', 'foobar'], 'foo', has_param='baz'))

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -41,14 +41,14 @@ class ContextutilTest(unittest.TestCase):
         subprocess.Popen([sys.executable, '-c', 'import os; print(os.environ["HORK"])'],
                          stdout=output).wait()
         output.seek(0)
-        self.assertEquals('BORK\n', output.read())
+        self.assertEqual('BORK\n', output.read())
 
       # test that the variable is cleared
       with temporary_file(binary_mode=False) as new_output:
         subprocess.Popen([sys.executable, '-c', 'import os; print("HORK" in os.environ)'],
                          stdout=new_output).wait()
         new_output.seek(0)
-        self.assertEquals('False\n', new_output.read())
+        self.assertEqual('False\n', new_output.read())
 
   def test_environment_negation(self):
     with temporary_file(binary_mode=False) as output:
@@ -58,7 +58,7 @@ class ContextutilTest(unittest.TestCase):
           subprocess.Popen([sys.executable, '-c', 'import os; print("HORK" in os.environ)'],
                            stdout=output).wait()
           output.seek(0)
-          self.assertEquals('False\n', output.read())
+          self.assertEqual('False\n', output.read())
 
   def test_hermetic_environment(self):
     self.assertIn('USER', os.environ)
@@ -71,7 +71,7 @@ class ContextutilTest(unittest.TestCase):
       output = subprocess.check_output('env', shell=True).decode('utf-8')
       self.assertNotIn('USER=', output)
       self.assertIn('AAA', os.environ)
-      self.assertEquals(os.environ['AAA'], '333')
+      self.assertEqual(os.environ['AAA'], '333')
     self.assertIn('USER', os.environ)
     self.assertNotIn('AAA', os.environ)
 
@@ -80,33 +80,33 @@ class ContextutilTest(unittest.TestCase):
     ENCODED_CHAR = UNICODE_CHAR.encode('utf-8')
     expected_output = UNICODE_CHAR if PY3 else ENCODED_CHAR
     with environment_as(**dict(XXX=UNICODE_CHAR)):
-      self.assertEquals(os.environ['XXX'], expected_output)
+      self.assertEqual(os.environ['XXX'], expected_output)
       with hermetic_environment_as(**dict(AAA=UNICODE_CHAR)):
         self.assertIn('AAA', os.environ)
-        self.assertEquals(os.environ['AAA'], expected_output)
-      self.assertEquals(os.environ['XXX'], expected_output)
+        self.assertEqual(os.environ['AAA'], expected_output)
+      self.assertEqual(os.environ['XXX'], expected_output)
 
   def test_simple_pushd(self):
     pre_cwd = os.getcwd()
     with temporary_dir() as tempdir:
       with pushd(tempdir) as path:
-        self.assertEquals(tempdir, path)
-        self.assertEquals(os.path.realpath(tempdir), os.getcwd())
-      self.assertEquals(pre_cwd, os.getcwd())
-    self.assertEquals(pre_cwd, os.getcwd())
+        self.assertEqual(tempdir, path)
+        self.assertEqual(os.path.realpath(tempdir), os.getcwd())
+      self.assertEqual(pre_cwd, os.getcwd())
+    self.assertEqual(pre_cwd, os.getcwd())
 
   def test_nested_pushd(self):
     pre_cwd = os.getcwd()
     with temporary_dir() as tempdir1:
       with pushd(tempdir1):
-        self.assertEquals(os.path.realpath(tempdir1), os.getcwd())
+        self.assertEqual(os.path.realpath(tempdir1), os.getcwd())
         with temporary_dir(root_dir=tempdir1) as tempdir2:
           with pushd(tempdir2):
-            self.assertEquals(os.path.realpath(tempdir2), os.getcwd())
-          self.assertEquals(os.path.realpath(tempdir1), os.getcwd())
-        self.assertEquals(os.path.realpath(tempdir1), os.getcwd())
-      self.assertEquals(pre_cwd, os.getcwd())
-    self.assertEquals(pre_cwd, os.getcwd())
+            self.assertEqual(os.path.realpath(tempdir2), os.getcwd())
+          self.assertEqual(os.path.realpath(tempdir1), os.getcwd())
+        self.assertEqual(os.path.realpath(tempdir1), os.getcwd())
+      self.assertEqual(pre_cwd, os.getcwd())
+    self.assertEqual(pre_cwd, os.getcwd())
 
   def test_temporary_file_no_args(self):
     with temporary_file() as fp:
@@ -204,7 +204,7 @@ class ContextutilTest(unittest.TestCase):
       with temporary_dir() as tempdir:
         file_symlink = os.path.join(tempdir, 'foo')
         os.symlink(not_zip.name, file_symlink)
-        self.assertEquals(os.path.realpath(file_symlink), os.path.realpath(not_zip.name))
+        self.assertEqual(os.path.realpath(file_symlink), os.path.realpath(not_zip.name))
         with self.assertRaisesRegexp(zipfile.BadZipfile, r'{}'.format(not_zip.name)):
           next(open_zip(file_symlink).gen)
 
@@ -234,19 +234,19 @@ class ContextutilTest(unittest.TestCase):
       with stdio_as(stdout_fd=tmp_stdout.fileno(),
                     stderr_fd=tmp_stderr.fileno(),
                     stdin_fd=tmp_stdin.fileno()):
-        self.assertEquals(sys.stdin.fileno(), 0)
-        self.assertEquals(sys.stdout.fileno(), 1)
-        self.assertEquals(sys.stderr.fileno(), 2)
+        self.assertEqual(sys.stdin.fileno(), 0)
+        self.assertEqual(sys.stdout.fileno(), 1)
+        self.assertEqual(sys.stderr.fileno(), 2)
 
-        self.assertEquals(stdin_data, sys.stdin.read().strip())
+        self.assertEqual(stdin_data, sys.stdin.read().strip())
         print(stdout_data, file=sys.stdout)
         yield
         print(stderr_data, file=sys.stderr)
 
       tmp_stdout.seek(0)
       tmp_stderr.seek(0)
-      self.assertEquals(stdout_data, tmp_stdout.read().strip())
-      self.assertEquals(stderr_data, tmp_stderr.read().strip())
+      self.assertEqual(stdout_data, tmp_stdout.read().strip())
+      self.assertEqual(stderr_data, tmp_stderr.read().strip())
 
   def test_stdio_as(self):
     self.assertTrue(sys.stderr.fileno() > 2,
@@ -262,13 +262,13 @@ class ContextutilTest(unittest.TestCase):
 
       # Validate that after the second level completes, the first level still sees valid
       # fds on `sys.std*`.
-      self.assertEquals(sys.stdin.fileno(), 0)
-      self.assertEquals(sys.stdout.fileno(), 1)
-      self.assertEquals(sys.stderr.fileno(), 2)
+      self.assertEqual(sys.stdin.fileno(), 0)
+      self.assertEqual(sys.stdout.fileno(), 1)
+      self.assertEqual(sys.stderr.fileno(), 2)
 
-    self.assertEquals(sys.stdout, old_stdout)
-    self.assertEquals(sys.stderr, old_stderr)
-    self.assertEquals(sys.stdin, old_stdin)
+    self.assertEqual(sys.stdout, old_stdout)
+    self.assertEqual(sys.stderr, old_stderr)
+    self.assertEqual(sys.stdin, old_stdin)
 
   def test_stdio_as_dev_null(self):
     # Capture output to tempfiles.
@@ -276,7 +276,7 @@ class ContextutilTest(unittest.TestCase):
       # Read/write from/to `/dev/null`, which will be validated by the harness as not
       # affecting the tempfiles.
       with stdio_as(stdout_fd=-1, stderr_fd=-1, stdin_fd=-1):
-        self.assertEquals('', sys.stdin.read())
+        self.assertEqual('', sys.stdin.read())
         print('garbage', file=sys.stdout)
         print('garbage', file=sys.stderr)
 
@@ -290,7 +290,7 @@ class ContextutilTest(unittest.TestCase):
           raise NotImplementedError('blah')
       except NotImplementedError:
         pass
-    self.assertEquals(mock_signal.call_count, 2)
+    self.assertEqual(mock_signal.call_count, 2)
     mock_signal.assert_has_calls([
       mock.call(signal.SIGUSR2, mock_new_handler),
       mock.call(signal.SIGUSR2, mock_initial_handler)
@@ -298,10 +298,10 @@ class ContextutilTest(unittest.TestCase):
 
   def test_permissions(self):
     with temporary_file(permissions=0o700) as f:
-      self.assertEquals(0o700, os.stat(f.name)[0] & 0o777)
+      self.assertEqual(0o700, os.stat(f.name)[0] & 0o777)
 
     with temporary_dir(permissions=0o644) as path:
-      self.assertEquals(0o644, os.stat(path)[0] & 0o777)
+      self.assertEqual(0o644, os.stat(path)[0] & 0o777)
 
   def test_exception_logging(self):
     fake_logger = mock.Mock()

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -37,27 +37,27 @@ class DirutilTest(unittest.TestCase):
   def test_longest_dir_prefix(self):
     # Find the longest prefix (standard case).
     prefixes = ['hello', 'hello_world', 'hello/world', 'helloworld']
-    self.assertEquals(longest_dir_prefix('hello/world/pants', prefixes),
+    self.assertEqual(longest_dir_prefix('hello/world/pants', prefixes),
                       'hello/world')
-    self.assertEquals(longest_dir_prefix('hello/', prefixes),
+    self.assertEqual(longest_dir_prefix('hello/', prefixes),
                       'hello')
-    self.assertEquals(longest_dir_prefix('hello', prefixes),
+    self.assertEqual(longest_dir_prefix('hello', prefixes),
                       'hello')
-    self.assertEquals(longest_dir_prefix('scoobydoobydoo', prefixes),
+    self.assertEqual(longest_dir_prefix('scoobydoobydoo', prefixes),
                       None)
 
   def test_longest_dir_prefix_special(self):
     # Ensure that something that is a longest prefix, but not a longest dir
     # prefix, is not tagged.
     prefixes = ['helloworldhowareyou', 'helloworld']
-    self.assertEquals(longest_dir_prefix('helloworldhowareyoufine/', prefixes),
+    self.assertEqual(longest_dir_prefix('helloworldhowareyoufine/', prefixes),
                       None)
-    self.assertEquals(longest_dir_prefix('helloworldhowareyoufine', prefixes),
+    self.assertEqual(longest_dir_prefix('helloworldhowareyoufine', prefixes),
                       None)
 
   def test_fast_relpath(self):
     def assertRelpath(expected, path, start):
-      self.assertEquals(expected, fast_relpath(path, start))
+      self.assertEqual(expected, fast_relpath(path, start))
     assertRelpath('c', '/a/b/c', '/a/b')
     assertRelpath('c', '/a/b/c', '/a/b/')
     assertRelpath('c', 'b/c', 'b')
@@ -97,13 +97,13 @@ class DirutilTest(unittest.TestCase):
     tempfile_mkdtemp.side_effect = (DIR1, DIR2)
     os_getpid.return_value = 'unicorn'
     try:
-      self.assertEquals(DIR1, dirutil.safe_mkdtemp(dir='1', cleaner=faux_cleaner))
-      self.assertEquals(DIR2, dirutil.safe_mkdtemp(dir='2', cleaner=faux_cleaner))
+      self.assertEqual(DIR1, dirutil.safe_mkdtemp(dir='1', cleaner=faux_cleaner))
+      self.assertEqual(DIR2, dirutil.safe_mkdtemp(dir='2', cleaner=faux_cleaner))
       self.assertIn('unicorn', dirutil._MKDTEMP_DIRS)
-      self.assertEquals({DIR1, DIR2}, dirutil._MKDTEMP_DIRS['unicorn'])
+      self.assertEqual({DIR1, DIR2}, dirutil._MKDTEMP_DIRS['unicorn'])
       dirutil._mkdtemp_atexit_cleaner()
       self.assertNotIn('unicorn', dirutil._MKDTEMP_DIRS)
-      self.assertEquals({'yoyo'}, dirutil._MKDTEMP_DIRS['fluffypants'])
+      self.assertEqual({'yoyo'}, dirutil._MKDTEMP_DIRS['fluffypants'])
     finally:
       dirutil._MKDTEMP_DIRS.pop('unicorn', None)
       dirutil._MKDTEMP_DIRS.pop('fluffypants', None)
@@ -285,7 +285,7 @@ class DirutilTest(unittest.TestCase):
     classpath = [os.path.join(build_root, 'foo.jar'), jar_outside_build_root]
     relativized_classpath = relativize_paths(classpath, build_root)
     jar_relpath = os.path.relpath(jar_outside_build_root, build_root)
-    self.assertEquals(['foo.jar', jar_relpath], relativized_classpath)
+    self.assertEqual(['foo.jar', jar_relpath], relativized_classpath)
 
   def test_relative_symlink(self):
     with temporary_dir() as tmpdir_1:  # source and link in same dir
@@ -294,7 +294,7 @@ class DirutilTest(unittest.TestCase):
       rel_path = os.path.relpath(source, os.path.dirname(link))
       relative_symlink(source, link)
       self.assertTrue(os.path.islink(link))
-      self.assertEquals(rel_path, os.readlink(link))
+      self.assertEqual(rel_path, os.readlink(link))
 
   def test_relative_symlink_source_parent(self):
     with temporary_dir() as tmpdir_1:  # source in parent dir of link
@@ -305,7 +305,7 @@ class DirutilTest(unittest.TestCase):
       relative_symlink(source, link)
       rel_path = os.path.relpath(source, os.path.dirname(link))
       self.assertTrue(os.path.islink(link))
-      self.assertEquals(rel_path, os.readlink(link))
+      self.assertEqual(rel_path, os.readlink(link))
 
   def test_relative_symlink_link_parent(self):
     with temporary_dir() as tmpdir_1:  # link in parent dir of source
@@ -315,7 +315,7 @@ class DirutilTest(unittest.TestCase):
       relative_symlink(source, link)
       rel_path = os.path.relpath(source, os.path.dirname(link))
       self.assertTrue(os.path.islink(link))
-      self.assertEquals(rel_path, os.readlink(link))
+      self.assertEqual(rel_path, os.readlink(link))
 
   def test_relative_symlink_same_paths(self):
     with temporary_dir() as tmpdir_1:  # source is link
@@ -356,9 +356,9 @@ class DirutilTest(unittest.TestCase):
         relative_symlink(source, link_path)
 
   def test_get_basedir(self):
-    self.assertEquals(get_basedir('foo/bar/baz'), 'foo')
-    self.assertEquals(get_basedir('/foo/bar/baz'), '')
-    self.assertEquals(get_basedir('foo'), 'foo')
+    self.assertEqual(get_basedir('foo/bar/baz'), 'foo')
+    self.assertEqual(get_basedir('/foo/bar/baz'), '')
+    self.assertEqual(get_basedir('foo'), 'foo')
 
   def test_rm_rf_file(self, file_name='./foo'):
     with temporary_dir() as td, pushd(td):
@@ -501,7 +501,7 @@ class AbsoluteSymlinkTest(unittest.TestCase):
   def _create_and_check_link(self, source, link):
     absolute_symlink(source, link)
     self.assertTrue(os.path.islink(link))
-    self.assertEquals(source, os.readlink(link))
+    self.assertEqual(source, os.readlink(link))
 
   def test_link(self):
     # Check if parent dirs will be created for the link

--- a/tests/python/pants_test/util/test_fileutil.py
+++ b/tests/python/pants_test/util/test_fileutil.py
@@ -25,7 +25,7 @@ class FileutilTest(unittest.TestCase):
         atomic_copy(src.name, dst.name)
         dst.close()
         with open(dst.name) as new_dst:
-          self.assertEquals(src.name, new_dst.read())
+          self.assertEqual(src.name, new_dst.read())
         self.assertEqual(os.stat(src.name).st_mode, os.stat(dst.name).st_mode)
 
   def test_line_count_estimator(self):

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -79,16 +79,16 @@ class ExactlyTest(TypeConstraintTestBase):
 
   def test_str_and_repr(self):
     exactly_b_types = Exactly(self.B, description='B types')
-    self.assertEquals("=(B types)", str(exactly_b_types))
-    self.assertEquals("Exactly(B types)", repr(exactly_b_types))
+    self.assertEqual("=(B types)", str(exactly_b_types))
+    self.assertEqual("Exactly(B types)", repr(exactly_b_types))
 
     exactly_b = Exactly(self.B)
-    self.assertEquals("=B", str(exactly_b))
-    self.assertEquals("Exactly(B)", repr(exactly_b))
+    self.assertEqual("=B", str(exactly_b))
+    self.assertEqual("Exactly(B)", repr(exactly_b))
 
     exactly_multiple = Exactly(self.A, self.B)
-    self.assertEquals("=(A, B)", str(exactly_multiple))
-    self.assertEquals("Exactly(A, B)", repr(exactly_multiple))
+    self.assertEqual("=(A, B)", str(exactly_multiple))
+    self.assertEqual("Exactly(A, B)", repr(exactly_multiple))
 
   def test_checking_via_bare_type(self):
     self.assertTrue(Exactly(self.B).satisfied_by_type(self.B))

--- a/tests/python/pants_test/util/test_process_handler.py
+++ b/tests/python/pants_test/util/test_process_handler.py
@@ -13,12 +13,12 @@ class TestSubprocessProcessHandler(unittest.TestCase):
   def test_exit_1(self):
     process = subprocess.Popen(["/bin/sh", "-c", "exit 1"])
     process_handler = SubprocessProcessHandler(process)
-    self.assertEquals(process_handler.wait(), 1)
+    self.assertEqual(process_handler.wait(), 1)
 
   def test_exit_0(self):
     process = subprocess.Popen(["/bin/sh", "-c", "exit 0"])
     process_handler = SubprocessProcessHandler(process)
-    self.assertEquals(process_handler.wait(), 0)
+    self.assertEqual(process_handler.wait(), 0)
 
   def test_communicate_teeing_retrieves_stdout_and_stderr(self):
     process = subprocess.Popen(["/bin/bash", "-c",
@@ -36,7 +36,7 @@ class TestSubprocessProcessHandler(unittest.TestCase):
 exit 1
 """], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     process_handler = SubprocessProcessHandler(process)
-    self.assertEquals(process_handler.communicate_teeing_stdout_and_stderr(), (
+    self.assertEqual(process_handler.communicate_teeing_stdout_and_stderr(), (
 b"""1out
 2out
 3out

--- a/tests/python/pants_test/util/test_retry.py
+++ b/tests/python/pants_test/util/test_retry.py
@@ -20,14 +20,14 @@ class RetryTest(unittest.TestCase):
     with self.assertRaises(OSError):
       retry_on_exception(broken_func, 3, (OSError,))
 
-    self.assertEquals(broken_func.call_count, 3)
+    self.assertEqual(broken_func.call_count, 3)
 
   def test_retry_on_exception_immediate_success(self):
     working_func = mock.Mock()
     working_func.return_value = 'works'
 
-    self.assertEquals(retry_on_exception(working_func, 3, (OSError,)), 'works')
-    self.assertEquals(working_func.call_count, 1)
+    self.assertEqual(retry_on_exception(working_func, 3, (OSError,)), 'works')
+    self.assertEqual(working_func.call_count, 1)
 
   @mock.patch('time.sleep', autospec=True, spec_set=True)
   def test_retry_on_exception_eventual_success(self, mock_sleep):
@@ -36,7 +36,7 @@ class RetryTest(unittest.TestCase):
 
     retry_on_exception(broken_func, 3, (OSError,))
 
-    self.assertEquals(broken_func.call_count, 3)
+    self.assertEqual(broken_func.call_count, 3)
 
   @mock.patch('time.sleep', autospec=True, spec_set=True)
   def test_retry_on_exception_not_caught(self, mock_sleep):
@@ -46,7 +46,7 @@ class RetryTest(unittest.TestCase):
     with self.assertRaises(OSError):
       retry_on_exception(broken_func, 3, (TypeError,))
 
-    self.assertEquals(broken_func.call_count, 1)
+    self.assertEqual(broken_func.call_count, 1)
 
   @mock.patch('time.sleep', autospec=True, spec_set=True)
   def test_retry_default_backoff(self, mock_sleep):

--- a/tests/python/pants_test/util/test_socket.py
+++ b/tests/python/pants_test/util/test_socket.py
@@ -35,26 +35,26 @@ class TestRecvBufferedSocket(unittest.TestCase):
 
   def test_recv(self):
     self.server_sock.sendall(b'A' * 300)
-    self.assertEquals(self.buf_sock.recv(1), b'A')
-    self.assertEquals(self.buf_sock.recv(200), b'A' * 200)
-    self.assertEquals(self.buf_sock.recv(99), b'A' * 99)
+    self.assertEqual(self.buf_sock.recv(1), b'A')
+    self.assertEqual(self.buf_sock.recv(200), b'A' * 200)
+    self.assertEqual(self.buf_sock.recv(99), b'A' * 99)
 
   def test_recv_max_larger_than_buf(self):
     double_chunk = self.chunk_size * 2
     self.server_sock.sendall(b'A' * double_chunk)
-    self.assertEquals(self.buf_sock.recv(double_chunk), b'A' * double_chunk)
+    self.assertEqual(self.buf_sock.recv(double_chunk), b'A' * double_chunk)
 
   @mock.patch('pants.util.socket.select.select', **PATCH_OPTS)
   def test_recv_check_calls(self, mock_select):
     mock_select.return_value = ([1], [], [])
     self.mock_socket.recv.side_effect = [b'A' * self.chunk_size, b'B' * self.chunk_size]
 
-    self.assertEquals(self.mocked_buf_sock.recv(128), b'A' * 128)
+    self.assertEqual(self.mocked_buf_sock.recv(128), b'A' * 128)
     self.mock_socket.recv.assert_called_once_with(self.chunk_size)
-    self.assertEquals(self.mocked_buf_sock.recv(128), b'A' * 128)
-    self.assertEquals(self.mocked_buf_sock.recv(128), b'A' * 128)
-    self.assertEquals(self.mocked_buf_sock.recv(128), b'A' * 128)
-    self.assertEquals(self.mock_socket.recv.call_count, 1)
+    self.assertEqual(self.mocked_buf_sock.recv(128), b'A' * 128)
+    self.assertEqual(self.mocked_buf_sock.recv(128), b'A' * 128)
+    self.assertEqual(self.mocked_buf_sock.recv(128), b'A' * 128)
+    self.assertEqual(self.mock_socket.recv.call_count, 1)
 
-    self.assertEquals(self.mocked_buf_sock.recv(self.chunk_size), b'B' * self.chunk_size)
-    self.assertEquals(self.mock_socket.recv.call_count, 2)
+    self.assertEqual(self.mocked_buf_sock.recv(self.chunk_size), b'B' * self.chunk_size)
+    self.assertEqual(self.mock_socket.recv.call_count, 2)

--- a/tests/python/pants_test/util/test_strutil.py
+++ b/tests/python/pants_test/util/test_strutil.py
@@ -15,46 +15,46 @@ class StrutilTest(unittest.TestCase):
 
   def test_camelcase(self):
 
-    self.assertEquals('Foo', camelcase('foo'))
-    self.assertEquals('Foo', camelcase('_foo'))
-    self.assertEquals('Foo', camelcase('foo_'))
-    self.assertEquals('FooBar', camelcase('foo_bar'))
-    self.assertEquals('FooBar', camelcase('foo_bar_'))
-    self.assertEquals('FooBar', camelcase('_foo_bar'))
-    self.assertEquals('FooBar', camelcase('foo__bar'))
-    self.assertEquals('Foo', camelcase('-foo'))
-    self.assertEquals('Foo', camelcase('foo-'))
-    self.assertEquals('FooBar', camelcase('foo-bar'))
-    self.assertEquals('FooBar', camelcase('foo-bar-'))
-    self.assertEquals('FooBar', camelcase('-foo-bar'))
-    self.assertEquals('FooBar', camelcase('foo--bar'))
-    self.assertEquals('FooBar', camelcase('foo-_bar'))
+    self.assertEqual('Foo', camelcase('foo'))
+    self.assertEqual('Foo', camelcase('_foo'))
+    self.assertEqual('Foo', camelcase('foo_'))
+    self.assertEqual('FooBar', camelcase('foo_bar'))
+    self.assertEqual('FooBar', camelcase('foo_bar_'))
+    self.assertEqual('FooBar', camelcase('_foo_bar'))
+    self.assertEqual('FooBar', camelcase('foo__bar'))
+    self.assertEqual('Foo', camelcase('-foo'))
+    self.assertEqual('Foo', camelcase('foo-'))
+    self.assertEqual('FooBar', camelcase('foo-bar'))
+    self.assertEqual('FooBar', camelcase('foo-bar-'))
+    self.assertEqual('FooBar', camelcase('-foo-bar'))
+    self.assertEqual('FooBar', camelcase('foo--bar'))
+    self.assertEqual('FooBar', camelcase('foo-_bar'))
 
   def test_pluralize(self):
-    self.assertEquals('1 bat', pluralize(1, 'bat'))
-    self.assertEquals('1 boss', pluralize(1, 'boss'))
-    self.assertEquals('2 bats', pluralize(2, 'bat'))
-    self.assertEquals('2 bosses', pluralize(2, 'boss'))
-    self.assertEquals('0 bats', pluralize(0, 'bat'))
-    self.assertEquals('0 bosses', pluralize(0, 'boss'))
+    self.assertEqual('1 bat', pluralize(1, 'bat'))
+    self.assertEqual('1 boss', pluralize(1, 'boss'))
+    self.assertEqual('2 bats', pluralize(2, 'bat'))
+    self.assertEqual('2 bosses', pluralize(2, 'boss'))
+    self.assertEqual('0 bats', pluralize(0, 'bat'))
+    self.assertEqual('0 bosses', pluralize(0, 'boss'))
 
   def test_ensure_text(self):
     bytes_val = bytes(bytearray([0xe5, 0xbf, 0xab]))
-    self.assertEquals(u'快', ensure_text(bytes_val))
+    self.assertEqual(u'快', ensure_text(bytes_val))
     with self.assertRaises(TypeError):
       ensure_text(45)
 
   def test_ensure_bytes(self):
     unicode_val = u'快'
-    self.assertEquals(bytearray([0xe5, 0xbf, 0xab]), ensure_binary(unicode_val))
+    self.assertEqual(bytearray([0xe5, 0xbf, 0xab]), ensure_binary(unicode_val))
     with self.assertRaises(TypeError):
       ensure_binary(45)
 
   def test_strip_prefix(self):
-    self.assertEquals('testString', strip_prefix('testString', '//'))
-    self.assertEquals('/testString', strip_prefix('/testString', '//'))
-    self.assertEquals('testString', strip_prefix('//testString', '//'))
-    self.assertEquals('/testString', strip_prefix('///testString', '//'))
-    self.assertEquals('//testString', strip_prefix('////testString', '//'))
-    self.assertEquals('test//String', strip_prefix('test//String', '//'))
-    self.assertEquals('testString//', strip_prefix('testString//', '//'))
+    self.assertEqual('testString', strip_prefix('testString', '//'))
+    self.assertEqual('/testString', strip_prefix('/testString', '//'))
+    self.assertEqual('testString', strip_prefix('//testString', '//'))
+    self.assertEqual('/testString', strip_prefix('///testString', '//'))
+    self.assertEqual('//testString', strip_prefix('////testString', '//'))
+    self.assertEqual('test//String', strip_prefix('test//String', '//'))
+    self.assertEqual('testString//', strip_prefix('testString//', '//'))


### PR DESCRIPTION
`assertEquals` and `assertNotEquals` have been deprecated in favor of their aliases `assertEqual` and `assertNotEqual` since Python 2.7. https://docs.python.org/2/library/unittest.html#deprecated-aliases

While they still aren't removed in Python 3.7, they cause one of the unit tests to fail in Python 3, and should be removed as they're deprecated. 

This is a safe change - they are aliases of each other, and I checked to fix any unintentional renaming of Java's `assertEquals`, including Java code embedded into Python files.