### PR TITLE
Python 3 fixes - add open() backport stage 1

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -17,6 +17,7 @@ python_library(
   name = 'project_tree',
   sources = ['file_system_project_tree.py', 'project_tree.py', 'project_tree_factory.py'],
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python:pathspec',
     '3rdparty/python:scandir',
     '3rdparty/python:six',

--- a/src/python/pants/base/file_system_project_tree.py
+++ b/src/python/pants/base/file_system_project_tree.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 from glob import glob1
 
 from pants.base.project_tree import Dir, File, Link, ProjectTree

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import hashlib
 import json
-from builtins import object
+from builtins import object, open
 
 from pants.util.strutil import ensure_binary
 

--- a/src/python/pants/base/run_info.py
+++ b/src/python/pants/base/run_info.py
@@ -9,7 +9,7 @@ import os
 import re
 import socket
 import time
-from builtins import object, str
+from builtins import object, open, str
 
 from pants import version
 from pants.base.build_environment import get_buildroot, get_scm

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -10,7 +10,7 @@ import signal
 import sys
 import termios
 import time
-from builtins import str, zip
+from builtins import open, str, zip
 from contextlib import contextmanager
 
 from future.utils import raise_with_traceback
@@ -161,7 +161,7 @@ class DaemonPantsRunner(ProcessManager):
       'please file a bug at http://github.com/pantsbuild/pants'
       .format([stdin_ttyname, stdout_ttyname, stderr_ttyname])
     )
-    with open(stdin_ttyname, 'rb+wb', 0) as tty:
+    with open(stdin_ttyname, 'rb+', 0) as tty:
       tty_fileno = tty.fileno()
       with stdio_as(stdin_fd=tty_fileno, stdout_fd=tty_fileno, stderr_fd=tty_fileno):
         def finalizer():

--- a/src/python/pants/build_graph/app_base.py
+++ b/src/python/pants/build_graph/app_base.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from builtins import map, object
+from builtins import map, object, open
 from collections import OrderedDict, namedtuple
 from hashlib import sha1
 
@@ -176,12 +176,12 @@ class BundleField(tuple, PayloadField):
     hasher = sha1()
     hasher.update(bundle.rel_path)
     for abs_path in sorted(bundle.filemap.keys()):
-      buildroot_relative_path = os.path.relpath(abs_path, get_buildroot())
+      buildroot_relative_path = os.path.relpath(abs_path, get_buildroot()).encode('utf-8')
       hasher.update(buildroot_relative_path)
-      hasher.update(bundle.filemap[abs_path])
+      hasher.update(bundle.filemap[abs_path].encode('utf-8'))
       if os.path.isfile(abs_path):
         # Update with any additional string to differentiate empty file with non-existing file.
-        hasher.update('e')
+        hasher.update(b'e')
         with open(abs_path, 'rb') as f:
           hasher.update(f.read())
     return hasher.hexdigest()

--- a/src/python/pants/cache/restful_artifact_cache.py
+++ b/src/python/pants/cache/restful_artifact_cache.py
@@ -8,7 +8,7 @@ import logging
 import multiprocessing
 import queue
 import threading
-from builtins import object
+from builtins import object, open
 
 import requests
 from requests import RequestException

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -10,7 +10,7 @@ import os
 import sys
 import sysconfig
 import traceback
-from builtins import bytes, object, str
+from builtins import bytes, object, open, str
 from contextlib import closing
 
 import cffi
@@ -645,8 +645,8 @@ class Native(object):
     with closing(pkg_resources.resource_stream(__name__, lib_name)) as input_fp:
       # NB: The header stripping code here must be coordinated with header insertion code in
       #     build-support/bin/native/bootstrap_code.sh
-      engine_version = input_fp.readline().strip()
-      repo_version = input_fp.readline().strip()
+      engine_version = input_fp.readline().decode('utf-8').strip()
+      repo_version = input_fp.readline().decode('utf-8').strip()
       logger.debug('using {} built at {}'.format(engine_version, repo_version))
       with open(lib_path, 'wb') as output_fp:
         output_fp.write(input_fp.read())

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import os
 import time
-from builtins import bytes, object, str, zip
+from builtins import object, open, str, zip
 from collections import defaultdict
 from types import GeneratorType
 
@@ -159,8 +159,8 @@ class Scheduler(object):
 
   def graph_trace(self, execution_request):
     with temporary_file_path() as path:
-      self._native.lib.graph_trace(self._scheduler, execution_request, bytes(path, 'utf-8'))
-      with open(path) as fd:
+      self._native.lib.graph_trace(self._scheduler, execution_request, path.encode('utf-8'))
+      with open(path, 'r') as fd:
         for line in fd.readlines():
           yield line.rstrip()
 
@@ -250,14 +250,14 @@ class Scheduler(object):
     self._native.lib.tasks_task_end(self._tasks)
 
   def visualize_graph_to_file(self, session, filename):
-    res = self._native.lib.graph_visualize(self._scheduler, session, bytes(filename, 'utf-8'))
+    res = self._native.lib.graph_visualize(self._scheduler, session, filename.encode('utf-8'))
     self._raise_or_return(res)
 
   def visualize_rule_graph_to_file(self, filename):
     self._native.lib.rule_graph_visualize(
       self._scheduler,
       self._root_type_ids(),
-      bytes(filename, 'utf-8'))
+      filename.encode('utf-8'))
 
   def rule_graph_visualization(self):
     with temporary_file_path() as path:
@@ -275,8 +275,8 @@ class Scheduler(object):
         self._scheduler,
         root_type_id,
         product_type_id,
-        bytes(path, 'utf-8'))
-      with open(path) as fd:
+        path.encode('utf-8'))
+      with open(path, 'r') as fd:
         for line in fd.readlines():
           yield line.rstrip()
 
@@ -286,7 +286,7 @@ class Scheduler(object):
     filenames = set(direct_filenames)
     filenames.update(os.path.dirname(f) for f in direct_filenames)
     filenames_buf = self._native.context.utf8_buf_buf(filenames)
-    invalidated =  self._native.lib.graph_invalidate(self._scheduler, filenames_buf)
+    invalidated = self._native.lib.graph_invalidate(self._scheduler, filenames_buf)
     logger.info('invalidated %d nodes for: %s', invalidated, filenames)
     return invalidated
 

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -89,6 +89,7 @@ python_library(
   name = 'run_tracker',
   sources = ['run_tracker.py'],
   dependencies = [
+    '3rdparty/python:future',
     ':aggregated_timings',
     ':artifact_cache_stats',
     ':pantsd_stats',

--- a/src/python/pants/goal/aggregated_timings.py
+++ b/src/python/pants/goal/aggregated_timings.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from builtins import object
+from builtins import object, open
 from collections import defaultdict
 
 from pants.util.dirutil import safe_mkdir_for

--- a/src/python/pants/goal/artifact_cache_stats.py
+++ b/src/python/pants/goal/artifact_cache_stats.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from builtins import object, str, zip
+from builtins import object, open, str, zip
 from collections import defaultdict, namedtuple
 
 from pants.cache.artifact_cache import UnreadableArtifact

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -12,6 +12,7 @@ import sys
 import threading
 import time
 import uuid
+from builtins import open
 from contextlib import contextmanager
 
 import requests

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -16,6 +16,7 @@ from builtins import open
 from contextlib import contextmanager
 
 import requests
+from future.utils import PY2
 
 from pants.base.build_environment import get_pants_cachedir
 from pants.base.run_info import RunInfo
@@ -331,6 +332,8 @@ class RunTracker(Subsystem):
     :return: True if successfully written, False otherwise.
     """
     params = json.dumps(stats)
+    if PY2:
+      params = params.decode('utf-8')
     try:
       with open(file_name, 'w') as f:
         f.write(params)

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -8,7 +8,7 @@ import hashlib
 import logging
 import os
 import site
-from builtins import object
+from builtins import object, open
 
 from pex import resolver
 from pex.base import requirement_is_exact
@@ -101,7 +101,7 @@ class PluginResolver(object):
           fp.write(plugin.location)
           fp.write('\n')
       os.rename(tmp_plugins_list, resolved_plugins_list)
-    with open(resolved_plugins_list) as fp:
+    with open(resolved_plugins_list, 'r') as fp:
       for plugin_location in fp:
         yield plugin_location.strip()
 

--- a/src/python/pants/invalidation/build_invalidator.py
+++ b/src/python/pants/invalidation/build_invalidator.py
@@ -214,7 +214,7 @@ class BuildInvalidator(object):
     return os.path.join(self._root, safe_filename(id, extension='.hash'))
 
   def _write_sha(self, cache_key):
-    with open(self._sha_file(cache_key), 'w') as fd:
+    with open(self._sha_file(cache_key), 'wb') as fd:
       fd.write(cache_key.hash)
 
   def _read_sha(self, cache_key):
@@ -222,7 +222,7 @@ class BuildInvalidator(object):
 
   def _read_sha_by_id(self, id):
     try:
-      with open(self._sha_file_by_id(id), 'r') as fd:
+      with open(self._sha_file_by_id(id), 'rb') as fd:
         return fd.read().strip()
     except IOError as e:
       if e.errno != errno.ENOENT:

--- a/src/python/pants/invalidation/build_invalidator.py
+++ b/src/python/pants/invalidation/build_invalidator.py
@@ -8,7 +8,7 @@ import errno
 import hashlib
 import os
 from abc import abstractmethod
-from builtins import object
+from builtins import object, open
 from collections import namedtuple
 
 from pants.base.hash_utils import hash_all

--- a/src/python/pants/ivy/bootstrapper.py
+++ b/src/python/pants/ivy/bootstrapper.py
@@ -8,7 +8,7 @@ import hashlib
 import logging
 import os
 import shutil
-from builtins import map, object
+from builtins import map, object, open
 
 from pants.base.build_environment import get_buildroot
 from pants.ivy.ivy import Ivy
@@ -127,7 +127,7 @@ class Bootstrapper(object):
         safe_delete(classpath)
         raise self.Error('Failed to bootstrap an ivy classpath! {}'.format(e))
 
-    with open(classpath) as fp:
+    with open(classpath, 'r') as fp:
       cp = fp.read().strip().split(os.pathsep)
       if not all(map(os.path.exists, cp)):
         safe_delete(classpath)

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -9,6 +9,7 @@ import getpass
 import io
 import itertools
 import os
+from builtins import open
 from contextlib import contextmanager
 
 import six

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import copy
 import sys
-from builtins import object, str
+from builtins import object, open, str
 
 from pants.base.deprecated import warn_or_error
 from pants.option.arg_splitter import GLOBAL_SCOPE, ArgSplitter
@@ -122,7 +122,7 @@ class Options(object):
       target_spec_files = bootstrap_option_values.target_spec_files
       if target_spec_files:
         for spec in target_spec_files:
-          with open(spec) as f:
+          with open(spec, 'r') as f:
             target_specs.extend([line for line in [line.strip() for line in f] if line])
 
     help_request = splitter.help_request

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -8,7 +8,7 @@ import itertools
 import logging
 import os
 import sys
-from builtins import filter, next, object
+from builtins import filter, next, object, open
 
 from pants.base.build_environment import get_default_pants_config_file
 from pants.engine.fs import FileContent
@@ -147,7 +147,7 @@ class OptionsBootstrapper(object):
   def construct_and_set_bootstrap_options(self):
     """Populates the internal bootstrap_options cache."""
     def filecontent_for(path):
-      with open(path, 'rb') as fh:
+      with open(path, 'r') as fh:
         return FileContent(path, fh.read())
 
     # N.B. This adaptor is meant to simulate how we would co-operatively invoke options bootstrap

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import functools
 import json
 import os
-from builtins import object, str
+from builtins import object, open, str
 from hashlib import sha1
 
 import six

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -8,7 +8,7 @@ import copy
 import os
 import re
 import traceback
-from builtins import next, object
+from builtins import next, object, open
 from collections import defaultdict
 
 import six
@@ -452,7 +452,7 @@ class Parser(object):
         else:
           fromfile = val_str[1:]
           try:
-            with open(fromfile) as fp:
+            with open(fromfile, 'r') as fp:
               return fp.read().strip()
           except IOError as e:
             raise self.FromfileError('Failed to read {} in {} from file {}: {}'.format(

--- a/src/python/pants/process/lock.py
+++ b/src/python/pants/process/lock.py
@@ -8,6 +8,7 @@ import errno
 import logging
 import os
 import sys
+from builtins import open
 
 import psutil
 from fasteners import InterProcessLock

--- a/src/python/pants/releases/reversion.py
+++ b/src/python/pants/releases/reversion.py
@@ -12,7 +12,7 @@ import hashlib
 import json
 import os
 import zipfile
-from builtins import str
+from builtins import open, str
 
 from pants.util.contextutil import open_zip, temporary_dir
 from pants.util.dirutil import read_file, safe_file_dump

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -179,6 +179,7 @@ python_tests(
   name = 'run_info',
   sources = ['test_run_info.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/base:run_info',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:test_base',
@@ -207,6 +208,7 @@ python_tests(
   name = 'exiter',
   sources = ['test_exiter.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/bin',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/option:testing',

--- a/tests/python/pants_test/base/test_exiter.py
+++ b/tests/python/pants_test/base/test_exiter.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import unittest
+from builtins import open
 
 from pants.base.exiter import Exiter
 from pants.util.contextutil import temporary_dir

--- a/tests/python/pants_test/base/test_run_info.py
+++ b/tests/python/pants_test/base/test_run_info.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import unittest
+from builtins import open
 
 from pants.base.run_info import RunInfo
 from pants.util.contextutil import temporary_file_path

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import os
-from builtins import object, str
+from builtins import object, open, str
 
 import mock
 from future.utils import PY2, PY3
@@ -255,8 +255,6 @@ class BinaryUtilTest(TestBase):
       "resolve binaries for the current host. Update --binaries-path-by-id to find binaries for "
       "the current host platform ({unicode_literal}\'darwin\', {unicode_literal}\'999\').\\n--binaries-path-by-id was:"
     ).format(unicode_literal='u' if PY2 else '')
-    # expected_msg_postfix = ".\\n--binaries-path-by-id was:"
-    # expected_msg = (expected_msg_prefix + () + expected_msg_postfix)
     self.assertIn(expected_msg, the_raised_exception_message)
 
   def test_select_script_missing_version(self):

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -30,6 +30,7 @@ python_tests(
   name = 'build_file_address_mapper',
   sources = ['test_build_file_address_mapper.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/base:specs',
     'src/python/pants/build_graph',

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import re
+from builtins import open
 from textwrap import dedent
 
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -57,6 +57,7 @@ python_tests(
   name = 'caching_dereference_symlinks',
   sources = ['test_caching_tarball_deference.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/task:task',
     'src/python/pants/cache:cache',
     'src/python/pants/util:dirutil',

--- a/tests/python/pants_test/cache/cache_server.py
+++ b/tests/python/pants_test/cache/cache_server.py
@@ -8,7 +8,7 @@ import http.server
 import os
 import re
 import socketserver
-from builtins import object
+from builtins import object, open
 from contextlib import contextmanager
 from multiprocessing import Process, Queue
 
@@ -95,7 +95,7 @@ class TestCacheServer(object):
       # Truncate the file.
       abspath = os.path.join(self._cache_root, f)
       artifact_size = os.path.getsize(abspath)
-      with open(abspath, 'r+w') as outfile:
+      with open(abspath, 'r+') as outfile:
         outfile.truncate(artifact_size // 2)
 
       count += 1

--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import unittest
-from builtins import str
+from builtins import open, str
 from contextlib import contextmanager
 
 from pants.cache.artifact_cache import (NonfatalArtifactCacheError, call_insert,
@@ -90,14 +90,14 @@ class TestArtifactCache(unittest.TestCase):
       self.assertTrue(artifact_cache.has(key))
 
       # Stomp it.
-      with open(path, 'w') as outfile:
+      with open(path, 'wb') as outfile:
         outfile.write(TEST_CONTENT2)
 
       # Recover it from the cache.
       self.assertTrue(bool(artifact_cache.use_cached_files(key)))
 
       # Check that it was recovered correctly.
-      with open(path, 'r') as infile:
+      with open(path, 'rb') as infile:
         content = infile.read()
       self.assertEqual(content, TEST_CONTENT1)
 
@@ -247,7 +247,7 @@ class TestArtifactCache(unittest.TestCase):
         self.assertTrue(artifact_cache.use_cached_files(key))
         self.assertTrue(os.path.exists(tarfile))
 
-        with open(tarfile, 'w') as outfile:
+        with open(tarfile, 'wb') as outfile:
           outfile.write(b'not a valid tgz any more')
 
         self.assertFalse(artifact_cache.use_cached_files(key))

--- a/tests/python/pants_test/cache/test_caching_tarball_deference.py
+++ b/tests/python/pants_test/cache/test_caching_tarball_deference.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 
 from pants.base.payload import Payload
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -18,7 +19,7 @@ from pants_test.task_test_base import TaskTestBase
 
 SYMLINK_NAME = 'link'
 DUMMY_FILE_NAME = 'dummy'
-DUMMY_FILE_CONTENT = 'dummy_content'
+DUMMY_FILE_CONTENT = b'dummy_content'
 
 
 class DummyCacheLibrary(Target):
@@ -136,7 +137,7 @@ class LocalCachingTarballDereferenceTest(TaskTestBase):
           os.path.islink(file_path)
           , "{} in artifact {} should not be a symlink but it is.".format(SYMLINK_NAME, artifact_address)
         )
-        with open(file_path, 'r') as f:
+        with open(file_path, 'rb') as f:
           self.assertEqual(DUMMY_FILE_CONTENT, f.read())
 
   # Cache creation should fail because the symlink destination is non-existent.
@@ -165,7 +166,7 @@ class LocalCachingTarballDereferenceTest(TaskTestBase):
         )
         # The destination of the symlink should be non-existent, hence IOError.
         with self.assertRaises(IOError):
-          with open(file_path, 'r') as f:
+          with open(file_path, 'rb') as f:
             f.read()
 
   # Symlink in cache should stay as a symlink, and so does the dst file.
@@ -186,7 +187,7 @@ class LocalCachingTarballDereferenceTest(TaskTestBase):
           os.path.islink(file_path),
           "{} in artifact {} should be a symlink but it is not.".format(SYMLINK_NAME, artifact_address)
         )
-        with open(file_path, 'r') as f:
+        with open(file_path, 'rb') as f:
           self.assertEqual(DUMMY_FILE_CONTENT, f.read())
 
   def test_cache_dereference_file_inside_results_dir(self):

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -8,7 +8,7 @@ import logging
 import os
 import tarfile
 import unittest
-from builtins import object, str
+from builtins import object, open, str
 from contextlib import contextmanager
 
 from future.utils import text_type
@@ -374,7 +374,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       scheduler.materialize_directories((DirectoryToMaterialize(text_type(dir_path), digest),))
 
       created_file = os.path.join(dir_path, "roland")
-      with open(created_file) as f:
+      with open(created_file, 'r') as f:
         content = f.read()
         self.assertEqual(content, "European Burmese")
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import unittest
-from builtins import object, str
+from builtins import object, open, str
 from textwrap import dedent
 
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
@@ -233,7 +233,7 @@ class SchedulerTest(unittest.TestCase):
     with temporary_dir() as td:
       output_path = os.path.join(td, 'output.dot')
       self.scheduler.visualize_graph_to_file(output_path)
-      with open(output_path, 'rb') as fh:
+      with open(output_path, 'r') as fh:
         graphviz_output = fh.read().strip()
 
     self.assertIn('digraph', graphviz_output)

--- a/tests/python/pants_test/goal/BUILD
+++ b/tests/python/pants_test/goal/BUILD
@@ -39,6 +39,7 @@ python_tests(
     'test_run_tracker_integration.py'
   ],
   dependencies=[
+    '3rdparty/python:future',
     'src/python/pants/goal:run_tracker',
     'tests/python/pants_test:int-test',
   ],

--- a/tests/python/pants_test/goal/test_artifact_cache_stats.py
+++ b/tests/python/pants_test/goal/test_artifact_cache_stats.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from builtins import str
+from builtins import open, str
 from contextlib import contextmanager
 
 import requests
@@ -84,5 +84,5 @@ class ArtifactCacheStatsTest(TestBase):
       self.assertEqual(sorted(list(expected_hit_or_miss_files.keys())),
                         sorted(os.listdir(tmp_dir)))
       for hit_or_miss_file in expected_hit_or_miss_files.keys():
-        with open(os.path.join(tmp_dir, hit_or_miss_file)) as hit_or_miss_saved:
+        with open(os.path.join(tmp_dir, hit_or_miss_file), 'r') as hit_or_miss_saved:
           self.assertEqual(expected_hit_or_miss_files[hit_or_miss_file], hit_or_miss_saved.read())

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import http.server
 import json
 import threading
+from builtins import open
 
 from future.moves.urllib.parse import parse_qs
 
@@ -54,7 +55,7 @@ class RunTrackerTest(TestBase):
     # Execute & verify
     with temporary_file_path() as file_name:
       self.assertTrue(RunTracker.write_stats_to_json(file_name, stats))
-      with open(file_name) as f:
+      with open(file_name, 'r') as f:
         result = json.load(f)
         self.assertEqual(stats, result)
 

--- a/tests/python/pants_test/goal/test_run_tracker_integration.py
+++ b/tests/python/pants_test/goal/test_run_tracker_integration.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 import os
+from builtins import open
 
 from pants.util.contextutil import temporary_file_path
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest

--- a/tests/python/pants_test/init/repro_mixin.py
+++ b/tests/python/pants_test/init/repro_mixin.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from builtins import object
+from builtins import object, open
 
 from pants.util.dirutil import safe_mkdir_for
 

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -7,10 +7,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import unittest
 import uuid
-from builtins import str
+from builtins import open, str
 from contextlib import closing, contextmanager
-
-import six
+from io import StringIO
 
 from pants.init.logging import setup_logging
 from pants.util.contextutil import temporary_dir
@@ -28,7 +27,7 @@ class SetupTest(unittest.TestCase):
   @contextmanager
   def logger(self, level, file_logging=False):
     logger = logging.getLogger(str(uuid.uuid4()))
-    with closing(six.StringIO()) as stream:
+    with closing(StringIO()) as stream:
       with self.log_dir(file_logging) as log_dir:
         log_file = setup_logging(level, console_stream=stream, log_dir=log_dir, scope=logger.name)
         yield logger, stream, log_file.log_filename
@@ -63,7 +62,7 @@ class SetupTest(unittest.TestCase):
       stream.seek(0)
       self.assertWarnInfoOutput(stream.read().splitlines())
 
-      with open(log_file) as fp:
+      with open(log_file, 'r') as fp:
         loglines = fp.read().splitlines()
         self.assertEqual(2, len(loglines))
         glog_format = r'\d{4} \d{2}:\d{2}:\d{2}.\d{6} \d+ \w+\.py:\d+] '

--- a/tests/python/pants_test/invalidation/BUILD
+++ b/tests/python/pants_test/invalidation/BUILD
@@ -27,6 +27,7 @@ python_tests(
   name = 'strict_deps_invalidation_integration',
   sources = ['test_strict_deps_invalidation_integration.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/base:build_environment',
     'tests/python/pants_test:int-test',
   ],

--- a/tests/python/pants_test/invalidation/test_strict_deps_invalidation_integration.py
+++ b/tests/python/pants_test/invalidation/test_strict_deps_invalidation_integration.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import shutil
+from builtins import open
 
 from pants.base.build_environment import get_buildroot
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest

--- a/tests/python/pants_test/option/BUILD
+++ b/tests/python/pants_test/option/BUILD
@@ -21,6 +21,7 @@ python_tests(
     'test_options_integration.py',
   ],
   dependencies=[
+    '3rdparty/python:future',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -9,7 +9,7 @@ import os
 import shlex
 import unittest
 import warnings
-from builtins import str
+from builtins import open, str
 from contextlib import contextmanager
 from textwrap import dedent
 

--- a/tests/python/pants_test/option/test_options_bootstrapper.py
+++ b/tests/python/pants_test/option/test_options_bootstrapper.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import unittest
+from builtins import open
 from textwrap import dedent
 
 from pants.base.build_environment import get_buildroot

--- a/tests/python/pants_test/option/test_options_integration.py
+++ b/tests/python/pants_test/option/test_options_integration.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 import os
+from builtins import open
 from textwrap import dedent
 
 from pants.util.contextutil import temporary_dir

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -10,7 +10,7 @@ import os
 import signal
 import threading
 import time
-from builtins import range, zip
+from builtins import open, range, zip
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 
@@ -59,7 +59,7 @@ def banner(s):
 
 def read_pantsd_log(workdir):
   # Surface the pantsd log for easy viewing via pytest's `-s` (don't capture stdio) option.
-  with open('{}/pantsd/pantsd.log'.format(workdir)) as f:
+  with open('{}/pantsd/pantsd.log'.format(workdir), 'r') as f:
     for line in f:
       yield line.strip()
 
@@ -297,11 +297,11 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
       ]
       for config_file in config_files:
         print('writing {}'.format(config_file))
-        with open(config_file, 'wb') as fh:
+        with open(config_file, 'w') as fh:
           fh.write('[GLOBAL]\npants_distdir: {}\n'.format(os.path.join(dist_dir_root, 'v1')))
 
       invalidating_config = os.path.join(config_dir, 'pants.ini.invalidates')
-      with open(invalidating_config, 'wb') as fh:
+      with open(invalidating_config, 'w') as fh:
         fh.write('[GLOBAL]\npants_distdir: {}\n'.format(os.path.join(dist_dir_root, 'v2')))
 
       with self.pantsd_successful_run_context() as (pantsd_run, checker, _, _):

--- a/tests/python/pants_test/process/test_lock.py
+++ b/tests/python/pants_test/process/test_lock.py
@@ -8,7 +8,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from builtins import str
+from builtins import open, str
 from multiprocessing import Manager, Process
 from threading import Thread
 

--- a/tests/python/pants_test/releases/BUILD
+++ b/tests/python/pants_test/releases/BUILD
@@ -4,6 +4,7 @@
 python_tests(
   sources = ['test_reversion.py'],
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python:pex',
     '3rdparty/python:requests',
     'tests/python/pants_test:int-test'

--- a/tests/python/pants_test/releases/test_reversion.py
+++ b/tests/python/pants_test/releases/test_reversion.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import shutil
+from builtins import open
 
 import requests
 from pex.bin import pex as pex_main


### PR DESCRIPTION
Ensures these folders use Python 3 semantics for opening files:

- src/base/
- src/bin/
- src/binaries/
- src/build_graph/
- src/cache/
- src/console/
- src/core_tasks/
- src/engine/
- src/fs/
- src/goal/
- src/help/
- src/init/
- src/invalidation/
- src/ivy/
- src/java/
- src/net/
- src/option/
- src/pantsd/
- src/process/
- src/releases/