### PR TITLE
Python 3 fixes - add open() backport stage 2

### DIFF
--- a/src/python/pants/backend/codegen/antlr/java/BUILD
+++ b/src/python/pants/backend/codegen/antlr/java/BUILD
@@ -3,6 +3,7 @@
 
 python_library(
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:nailgun_task',

--- a/src/python/pants/backend/codegen/antlr/java/antlr_java_gen.py
+++ b/src/python/pants/backend/codegen/antlr/java/antlr_java_gen.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import os
 import re
+from builtins import open
 
 from pants.backend.codegen.antlr.java.java_antlr_library import JavaAntlrLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
@@ -159,7 +160,7 @@ class AntlrJavaGen(SimpleCodegenTask, NailgunTask):
       for filename in filenames:
         source = os.path.join(root, filename)
 
-        with open(source) as f:
+        with open(source, 'r') as f:
           lines = f.readlines()
         if len(lines) < 1:
           return

--- a/src/python/pants/backend/codegen/protobuf/java/BUILD
+++ b/src/python/pants/backend/codegen/protobuf/java/BUILD
@@ -3,6 +3,7 @@
 
 python_library(
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/codegen/protobuf/subsystems',
     'src/python/pants/backend/jvm/targets:java',

--- a/src/python/pants/backend/codegen/protobuf/java/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/protobuf/java/protobuf_gen.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 from collections import OrderedDict
 from hashlib import sha1
 
@@ -177,7 +178,8 @@ class ProtobufGen(SimpleCodegenTask):
   def _extract_jar(self, coordinate, jar_path):
     """Extracts the jar to a subfolder of workdir/extracted and returns the path to it."""
     with open(jar_path, 'rb') as f:
-      outdir = os.path.join(self.workdir, 'extracted', sha1(f.read()).hexdigest())
+      sha = sha1(f.read()).hexdigest()
+      outdir = os.path.join(self.workdir, 'extracted', sha)
     if not os.path.exists(outdir):
       ZIP.extract(jar_path, outdir)
       self.context.log.debug('Extracting jar {jar} at {jar_path}.'

--- a/src/python/pants/backend/codegen/ragel/java/BUILD
+++ b/src/python/pants/backend/codegen/ragel/java/BUILD
@@ -3,6 +3,7 @@
 
 python_library(
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/codegen/ragel/subsystems',
     'src/python/pants/base:build_environment',

--- a/src/python/pants/backend/codegen/ragel/java/ragel_gen.py
+++ b/src/python/pants/backend/codegen/ragel/java/ragel_gen.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import re
+from builtins import open
 
 from pants.backend.codegen.ragel.java.java_ragel_library import JavaRagelLibrary
 from pants.backend.codegen.ragel.subsystems.ragel import Ragel

--- a/src/python/pants/backend/codegen/thrift/lib/BUILD
+++ b/src/python/pants/backend/codegen/thrift/lib/BUILD
@@ -3,6 +3,7 @@
 
 python_library(
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',

--- a/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
+++ b/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import re
 import shutil
+from builtins import open
 
 from twitter.common.collections import OrderedSet
 
@@ -108,7 +109,7 @@ class ApacheThriftGenBase(SimpleCodegenTask):
   SERVICE_PARSER = re.compile(r'^\s*service\s+(?:[^\s{]+)')
 
   def _declares_service(self, source):
-    with open(source) as thrift:
+    with open(source, 'r') as thrift:
       return any(line for line in thrift if self.SERVICE_PARSER.search(line))
 
   @memoized_property

--- a/src/python/pants/backend/codegen/thrift/python/BUILD
+++ b/src/python/pants/backend/codegen/thrift/python/BUILD
@@ -3,6 +3,7 @@
 
 python_library(
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/backend/codegen/thrift/lib',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/goal:task_registrar',

--- a/src/python/pants/backend/codegen/thrift/python/apache_thrift_py_gen.py
+++ b/src/python/pants/backend/codegen/thrift/python/apache_thrift_py_gen.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 
 from pants.backend.codegen.thrift.lib.apache_thrift_gen_base import ApacheThriftGenBase
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary

--- a/src/python/pants/backend/docgen/tasks/markdown_to_html_utils.py
+++ b/src/python/pants/backend/docgen/tasks/markdown_to_html_utils.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import sys
-from builtins import range
+from builtins import open, range
 
 import markdown
 from docutils.core import publish_parts
@@ -133,7 +133,7 @@ class IncludeExcerptPattern(markdown.inlinepatterns.Pattern):
     source_dir = os.path.dirname(self.source_path)
     include_path = os.path.join(source_dir, rel_include_path)
     try:
-      with open(include_path) as include_file:
+      with open(include_path, 'r') as include_file:
         file_text = include_file.read()
     except IOError as e:
       raise IOError('Markdown file {0} tried to include file {1}, got '

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -11,11 +11,12 @@ import pkgutil
 import threading
 import xml.etree.ElementTree as ET
 from abc import abstractmethod
-from builtins import object, str
+from builtins import object, open, str
 from collections import OrderedDict, defaultdict, namedtuple
 from functools import total_ordering
 
 import six
+from future.utils import PY3
 from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
@@ -333,7 +334,7 @@ class FrozenResolution(object):
     if not os.path.exists(filename):
       return None
 
-    with open(filename) as f:
+    with open(filename, 'r') as f:
       # Using OrderedDict here to maintain insertion order of dict entries.
       from_file = json.load(f, object_pairs_hook=OrderedDict)
     result = {}
@@ -369,7 +370,8 @@ class FrozenResolution(object):
       ])
 
     with safe_concurrent_creation(filename) as tmp_filename:
-      with open(tmp_filename, 'wb') as f:
+      mode = 'w' if PY3 else 'wb'
+      with open(tmp_filename, mode) as f:
         json.dump(res, f)
 
 

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -53,6 +53,7 @@ python_library(
   name = 'analysis_extraction',
   sources = ['analysis_extraction.py'],
   dependencies = [
+    '3rdparty/python:future',
     ':nailgun_task',
     'src/python/pants/backend/jvm/subsystems:dependency_context',
     'src/python/pants/backend/jvm/subsystems:zinc',
@@ -220,6 +221,7 @@ python_library(
   name = 'ivy_resolve',
   sources = ['ivy_resolve.py'],
   dependencies = [
+    '3rdparty/python:future',
     ':classpath_products',
     ':ivy_task_mixin',
     ':nailgun_task',
@@ -364,6 +366,7 @@ python_library(
   name = 'javadoc_gen',
   sources = ['javadoc_gen.py'],
   dependencies = [
+    '3rdparty/python:future',
     ':jvmdoc_gen',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/java/distribution',

--- a/src/python/pants/backend/jvm/tasks/analysis_extraction.py
+++ b/src/python/pants/backend/jvm/tasks/analysis_extraction.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 import os
+from builtins import open
 from collections import defaultdict
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext
@@ -148,5 +149,5 @@ class AnalysisExtraction(NailgunTask):
       product_deps_by_src[target] = summary_json['dependencies']
 
   def _parse_summary_json(self, summary_json_file):
-    with open(summary_json_file) as f:
+    with open(summary_json_file, 'r') as f:
       return json.load(f, encoding='utf-8')

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -8,10 +8,11 @@ import hashlib
 import itertools
 import json
 import os
-from builtins import str, zip
+from builtins import open, str, zip
 from collections import defaultdict
 
 from future.moves.urllib import parse
+from future.utils import PY3
 
 from pants.backend.jvm.ivy_utils import IvyUtils
 from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
@@ -353,7 +354,7 @@ class CoursierMixin(NailgunTask):
     if return_code:
       raise TaskError('The coursier process exited non-zero: {0}'.format(return_code))
 
-    with open(output_fn) as f:
+    with open(output_fn, 'r') as f:
       return json.loads(f.read())
 
   @staticmethod
@@ -406,7 +407,7 @@ class CoursierMixin(NailgunTask):
       with temporary_file(coursier_workdir, cleanup=False) as f:
         exclude_file = f.name
         with open(exclude_file, 'w') as ex_f:
-          ex_f.write('\n'.join(local_exclude_args).encode('utf8'))
+          ex_f.write('\n'.join(local_exclude_args))
 
         cmd_args.append('--local-exclude-file')
         cmd_args.append(exclude_file)
@@ -480,7 +481,8 @@ class CoursierMixin(NailgunTask):
               compile_classpath.add_jars_for_targets([t], conf, transitive_resolved_jars)
 
   def _populate_results_dir(self, vts_results_dir, results):
-    with open(os.path.join(vts_results_dir, self.RESULT_FILENAME), 'w') as f:
+    mode = 'w' if PY3 else 'wb'
+    with open(os.path.join(vts_results_dir, self.RESULT_FILENAME), mode) as f:
       json.dump(results, f)
 
   def _load_from_results_dir(self, compile_classpath, vts_results_dir,

--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import shutil
 import time
+from builtins import open
 from textwrap import dedent
 
 from pants.backend.jvm.ivy_utils import IvyUtils

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -11,7 +11,7 @@ import os
 import pkgutil
 import shutil
 import sys
-from builtins import input, next, object, str
+from builtins import input, next, object, open, str
 from collections import OrderedDict, defaultdict, namedtuple
 from copy import copy
 

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -8,7 +8,7 @@ import os
 import shutil
 import tempfile
 from abc import abstractmethod
-from builtins import object
+from builtins import object, open
 from contextlib import contextmanager
 
 import six

--- a/src/python/pants/backend/jvm/tasks/javadoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/javadoc_gen.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import functools
 import os
-from builtins import object, str
+from builtins import object, open, str
 from multiprocessing import cpu_count
 
 from twitter.common.collections import OrderedSet
@@ -455,7 +455,7 @@ class JvmCompile(NailgunTaskBase):
       path = os.path.join(outdir, 'compile_classpath', '{}.txt'.format(target.id))
       safe_mkdir(os.path.dirname(path), clean=False)
       with open(path, 'w') as f:
-        f.write(text.encode('utf-8'))
+        f.write(text)
 
   def _compile_vts(self, vts, ctx, upstream_analysis, classpath, progress_message, settings, 
                    compiler_option_sets, zinc_file_manager, counter):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -354,10 +354,10 @@ class BaseZincCompile(JvmCompile):
     zinc_args.extend(ctx.sources)
 
     self.log_zinc_file(ctx.analysis_file)
-    with open(ctx.zinc_args_file, 'w') as fp:
+    with open(ctx.zinc_args_file, 'wb') as fp:
       for arg in zinc_args:
         fp.write(arg)
-        fp.write('\n')
+        fp.write(b'\n')
 
     if self.runjava(classpath=[self._zinc.zinc],
                     main=Zinc.ZINC_COMPILE_MAIN,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import textwrap
+from builtins import open
 from collections import defaultdict
 from contextlib import closing
 from hashlib import sha1
@@ -356,7 +357,7 @@ class BaseZincCompile(JvmCompile):
     with open(ctx.zinc_args_file, 'w') as fp:
       for arg in zinc_args:
         fp.write(arg)
-        fp.write(b'\n')
+        fp.write('\n')
 
     if self.runjava(classpath=[self._zinc.zinc],
                     main=Zinc.ZINC_COMPILE_MAIN,
@@ -486,7 +487,7 @@ class BaseZincCompile(JvmCompile):
 
     if os.path.isdir(classpath_element):
       try:
-        with open(os.path.join(classpath_element, _SCALAC_PLUGIN_INFO_FILE)) as plugin_info_file:
+        with open(os.path.join(classpath_element, _SCALAC_PLUGIN_INFO_FILE), 'r') as plugin_info_file:
           return process_info_file(classpath_element, plugin_info_file)
       except IOError as e:
         if e.errno != errno.ENOENT:

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -172,7 +172,7 @@ class JvmDependencyUsage(Task):
                                         targets_by_file,
                                         transitive_deps)
       vt = target_to_vts[target]
-      mode = 'wb' if PY3 else 'w'
+      mode = 'w' if PY3 else 'wb'
       with open(self.nodes_json(vt.results_dir), mode=mode) as fp:
         json.dump(node.to_cacheable_dict(), fp, indent=2, sort_keys=True)
       vt.update()

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -7,8 +7,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 import os
 import sys
-from builtins import next, object
+from builtins import next, object, open
 from collections import defaultdict, namedtuple
+
+from future.utils import PY3
 
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.tasks.jvm_dependency_analyzer import JvmDependencyAnalyzer
@@ -91,7 +93,7 @@ class JvmDependencyUsage(Task):
       with open(output_file, 'w') as fh:
         self._render(graph, fh)
     else:
-      sys.stdout.write(b'\n')
+      sys.stdout.write('\n')
       self._render(graph, sys.stdout)
 
   @classmethod
@@ -170,7 +172,8 @@ class JvmDependencyUsage(Task):
                                         targets_by_file,
                                         transitive_deps)
       vt = target_to_vts[target]
-      with open(self.nodes_json(vt.results_dir), mode='w') as fp:
+      mode = 'wb' if PY3 else 'w'
+      with open(self.nodes_json(vt.results_dir), mode=mode) as fp:
         json.dump(node.to_cacheable_dict(), fp, indent=2, sort_keys=True)
       vt.update()
       return node
@@ -184,7 +187,7 @@ class JvmDependencyUsage(Task):
       vt = target_to_vts[target]
       if vt.valid and os.path.exists(self.nodes_json(vt.results_dir)):
         try:
-          with open(self.nodes_json(vt.results_dir)) as fp:
+          with open(self.nodes_json(vt.results_dir), 'r') as fp:
             return Node.from_cacheable_dict(json.load(fp),
                                             lambda spec: next(self.context.resolve(spec).__iter__()))
         except Exception:

--- a/src/python/pants/backend/jvm/tasks/properties.py
+++ b/src/python/pants/backend/jvm/tasks/properties.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
-from builtins import next, object, str
+from builtins import next, object, open, str
 from collections import OrderedDict
 
 import six
@@ -112,7 +112,7 @@ class Properties(object):
     if hasattr(output, 'write') and callable(output.write):
       write(output)
     elif isinstance(output, six.string_types):
-      with open(output, 'w+a') as out:
+      with open(output, 'w+') as out:
         write(out)
     else:
       raise TypeError('Can only dump data to a path or a writable object, given: %s' % output)

--- a/src/python/pants/backend/jvm/tasks/reports/junit_html_report.py
+++ b/src/python/pants/backend/jvm/tasks/reports/junit_html_report.py
@@ -11,7 +11,7 @@ import logging
 import os
 import xml.etree.ElementTree as ET
 from abc import abstractmethod
-from builtins import map, next, object
+from builtins import map, next, object, open
 from functools import total_ordering
 
 from pants.base.mustache import MustacheRenderer
@@ -19,7 +19,6 @@ from pants.util.dirutil import safe_mkdir_for, safe_walk
 from pants.util.memo import memoized_property
 from pants.util.meta import AbstractClass
 from pants.util.objects import datatype
-from pants.util.strutil import ensure_binary
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -214,8 +213,8 @@ class JUnitHtmlReport(JUnitHtmlReportInterface):
     testsuites = self._parse_xml_files()
     report_file_path = os.path.join(output_dir, 'reports', 'junit-report.html')
     safe_mkdir_for(report_file_path)
-    with open(report_file_path, 'wb') as fp:
-      fp.write(ensure_binary(self._generate_html(testsuites)))
+    with open(report_file_path, 'w') as fp:
+      fp.write(self._generate_html(testsuites))
     self._logger.debug('JUnit HTML report generated to {}'.format(report_file_path))
     if self._open_report:
       return report_file_path

--- a/src/python/pants/backend/jvm/tasks/scalastyle.py
+++ b/src/python/pants/backend/jvm/tasks/scalastyle.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import re
-from builtins import object, str
+from builtins import object, open, str
 
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
@@ -25,7 +25,7 @@ class FileExcluder(object):
     if excludes_path:
       if not os.path.exists(excludes_path):
         raise TaskError('Excludes file does not exist: {0}'.format(excludes_path))
-      with open(excludes_path) as fh:
+      with open(excludes_path, 'r') as fh:
         for line in fh.readlines():
           pattern = line.strip()
           if pattern and not pattern.startswith('#'):

--- a/src/python/pants/backend/project_info/tasks/BUILD
+++ b/src/python/pants/backend/project_info/tasks/BUILD
@@ -79,6 +79,7 @@ python_library(
   name = 'idea_plugin_gen',
   sources = ['idea_plugin_gen.py'],
   dependencies = [
+    '3rdparty/python:future',
     ':idea_resources',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/python/targets:python',

--- a/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
+++ b/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
@@ -10,6 +10,7 @@ import os
 import pkgutil
 import re
 import shutil
+from builtins import open
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.python.targets.python_target import PythonTarget
@@ -176,7 +177,7 @@ class IdeaPluginGen(ConsoleTask):
     if ide_file and self.get_options().open:
       open_with = self.get_options().open_with
       if open_with:
-        null = open(os.devnull, 'w')
+        null = open(os.devnull, 'wb')
         subprocess.Popen([open_with, ide_file], stdout=null, stderr=null)
       else:
         try:

--- a/src/python/pants/backend/python/python_requirements.py
+++ b/src/python/pants/backend/python/python_requirements.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from builtins import object
+from builtins import object, open
 
 
 class PythonRequirements(object):
@@ -41,7 +41,7 @@ class PythonRequirements(object):
     repository = None
 
     requirements_path = os.path.join(self._parse_context.rel_path, requirements_relpath)
-    with open(requirements_path) as fp:
+    with open(requirements_path, 'r') as fp:
       for line in fp:
         line = line.strip()
         if line and not line.startswith('#'):

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -12,7 +12,7 @@ import shutil
 import time
 import traceback
 import uuid
-from builtins import str
+from builtins import open, str
 from collections import OrderedDict
 from contextlib import contextmanager
 from io import StringIO
@@ -450,7 +450,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
     """.format(sources_map=dict(sources_map), rootdir_comm_path=rootdir_comm_path))
     # Add in the sharding conftest, if any.
     shard_conftest_content = self._get_shard_conftest_content()
-    return (console_output_conftest_content + shard_conftest_content).encode('utf8')
+    return console_output_conftest_content + shard_conftest_content
 
   @contextmanager
   def _conftest(self, sources_map):

--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import hashlib
 import os
+from builtins import open
 
 from pex.interpreter import PythonInterpreter
 
@@ -88,10 +89,10 @@ class SelectInterpreter(Task):
     interpreter = interpreter_cache.select_interpreter_for_targets(targets)
     safe_mkdir_for(interpreter_path_file)
     with open(interpreter_path_file, 'w') as outfile:
-      outfile.write(b'{}\n'.format(interpreter.binary))
+      outfile.write('{}\n'.format(interpreter.binary))
       for dist, location in interpreter.extras.items():
         dist_name, dist_version = dist
-        outfile.write(b'{}\t{}\t{}\n'.format(dist_name, dist_version, location))
+        outfile.write('{}\t{}\t{}\n'.format(dist_name, dist_version, location))
 
   def _interpreter_path_file(self, target_set_id):
     return os.path.join(self.workdir, target_set_id, 'interpreter.info')

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -10,7 +10,7 @@ import os
 import pkgutil
 import plistlib
 from abc import abstractproperty
-from builtins import object, str
+from builtins import object, open, str
 from collections import namedtuple
 from contextlib import contextmanager
 

--- a/src/python/pants/net/http/fetcher.py
+++ b/src/python/pants/net/http/fetcher.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 import time
 from abc import abstractmethod, abstractproperty
-from builtins import object, str
+from builtins import object, open, str
 from contextlib import closing, contextmanager
 
 import requests

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -8,6 +8,7 @@ import logging
 import os
 import queue
 import threading
+from builtins import open
 
 from twitter.common.dirutil import Fileset
 

--- a/src/python/pants/reporting/html_reporter.py
+++ b/src/python/pants/reporting/html_reporter.py
@@ -9,7 +9,7 @@ import os
 import re
 import time
 import uuid
-from builtins import range, str
+from builtins import open, range, str
 from collections import defaultdict, namedtuple
 from textwrap import dedent
 
@@ -317,7 +317,7 @@ class HtmlReporter(Reporter):
         output_files[path] = f
       else:
         f = output_files[path]
-      f.write(self._htmlify_text(s).encode('utf-8'))
+      f.write(self._htmlify_text(s))
       # We must flush in the same thread as the write.
       f.flush()
 

--- a/src/python/pants/reporting/html_reporter.py
+++ b/src/python/pants/reporting/html_reporter.py
@@ -454,7 +454,7 @@ class HtmlReporter(Reporter):
 
   def _htmlify_text(self, s):
     """Make text HTML-friendly."""
-    colored = self._handle_ansi_color_codes(cgi.escape(s.decode('utf-8', 'replace')))
+    colored = self._handle_ansi_color_codes(cgi.escape(s))
     return linkify(self._buildroot, colored, self._linkify_memo).replace('\n', '</br>')
 
   _ANSI_COLOR_CODE_RE = re.compile(r'\033\[((?:\d|;)*)m')

--- a/src/python/pants/reporting/plaintext_reporter.py
+++ b/src/python/pants/reporting/plaintext_reporter.py
@@ -133,11 +133,11 @@ class PlainTextReporter(PlainTextReporterBase):
       # Start output on a new line.
       tool_output_format = self._get_tool_output_format(workunit)
       if tool_output_format == ToolOutputFormat.INDENT:
-        self.emit(self._prefix(workunit, b'\n'))
+        self.emit(self._prefix(workunit, '\n'))
       elif tool_output_format == ToolOutputFormat.UNINDENTED:
-        self.emit(b'\n')
+        self.emit('\n')
     elif label_format == LabelFormat.DOT:
-      self.emit(b'.')
+      self.emit('.')
 
     self.flush()
 
@@ -151,7 +151,7 @@ class PlainTextReporter(PlainTextReporterBase):
       if self._get_label_format(workunit) != LabelFormat.FULL:
         self._emit_indented_workunit_label(workunit)
       for name, outbuf in workunit.outputs().items():
-        self.emit(self._prefix(workunit, b'\n==== {} ====\n'.format(name)))
+        self.emit(self._prefix(workunit, '\n==== {} ====\n'.format(name)))
         self.emit(self._prefix(workunit, outbuf.read_from(0)))
         self.flush()
 
@@ -163,7 +163,7 @@ class PlainTextReporter(PlainTextReporterBase):
     # If the element is a (msg, detail) pair, we ignore the detail. There's no
     # useful way to display it on the console.
     elements = [e if isinstance(e, six.string_types) else e[0] for e in msg_elements]
-    msg = b'\n' + b''.join(elements)
+    msg = '\n' + ''.join(elements)
     if self.use_color_for_workunit(workunit, self.settings.color):
       msg = self._COLOR_BY_LEVEL.get(level, lambda x: x)(msg)
 
@@ -216,7 +216,7 @@ class PlainTextReporter(PlainTextReporterBase):
     return ToolOutputFormat.SUPPRESS
 
   def _emit_indented_workunit_label(self, workunit):
-    self.emit(b'\n{} {} {}[{}]'.format(
+    self.emit('\n{} {} {}[{}]'.format(
       workunit.start_time_string,
       workunit.start_delta_string,
       self._indent(workunit),
@@ -229,23 +229,23 @@ class PlainTextReporter(PlainTextReporterBase):
     return not tool_output_format == ToolOutputFormat.SUPPRESS
 
   def _format_aggregated_timings(self, aggregated_timings):
-    return b'\n'.join([b'{timing:.3f} {label}'.format(**x) for x in aggregated_timings.get_all()])
+    return '\n'.join(['{timing:.3f} {label}'.format(**x) for x in aggregated_timings.get_all()])
 
   def _format_artifact_cache_stats(self, artifact_cache_stats):
     stats = artifact_cache_stats.get_all()
-    return b'No artifact cache reads.' if not stats else \
-    b'\n'.join([b'{cache_name} - Hits: {num_hits} Misses: {num_misses}'.format(**x)
+    return 'No artifact cache reads.' if not stats else \
+    '\n'.join(['{cache_name} - Hits: {num_hits} Misses: {num_misses}'.format(**x)
                 for x in stats])
 
   def _indent(self, workunit):
-    return b'  ' * (len(workunit.ancestors()) - 1)
+    return '  ' * (len(workunit.ancestors()) - 1)
 
-  _time_string_filler = b' ' * len('HH:MM:SS mm:ss ')
+  _time_string_filler = ' ' * len('HH:MM:SS mm:ss ')
 
   def _prefix(self, workunit, s):
     if self.settings.indent:
       def replace(x, c):
         return x.replace(c, c + PlainTextReporter._time_string_filler + self._indent(workunit))
-      return replace(replace(s, b'\r'), b'\n')
+      return replace(replace(s, '\r'), '\n')
     else:
       return PlainTextReporter._time_string_filler + s

--- a/src/python/pants/reporting/plaintext_reporter.py
+++ b/src/python/pants/reporting/plaintext_reporter.py
@@ -185,9 +185,11 @@ class PlainTextReporter(PlainTextReporterBase):
   def emit(self, s, dest=ReporterDestination.OUT):
     # In Py2, sys.stdout tries to coerce into ASCII, and will fail in coercing Unicode. So,
     # we encode prematurely to handle unicode.
-    # In Py3, sys.stdout takes unicode by default, so will work normally.
-    # io.StringIO works with unicode always, so we only modify the std streams.
-    if PY2 and isinstance(self.settings.outfile, file):
+    # In Py3, sys.stdout takes unicode, so will work normally.
+    #
+    # `self.settings.outfile` can also be `io.StringIO` instead of an std stream, in which case it only
+    # accepts unicode, so `s` does not need to be modified.
+    if PY2 and 'std' in str(self.settings.outfile):
       s = s.encode('utf-8')
     if dest == ReporterDestination.OUT:
       self.settings.outfile.write(s)

--- a/src/python/pants/reporting/plaintext_reporter_base.py
+++ b/src/python/pants/reporting/plaintext_reporter_base.py
@@ -11,27 +11,27 @@ class PlainTextReporterBase(Reporter):
   """Base class for plain-text reporting to stdout."""
 
   def generate_epilog(self, settings):
-    ret = b''
+    ret = ''
     if settings.timing:
-      ret += b'\nCumulative Timings\n==================\n{}\n'.format(
+      ret += '\nCumulative Timings\n==================\n{}\n'.format(
         self._format_aggregated_timings(self.run_tracker.cumulative_timings)
       )
-      ret += b'\nSelf Timings\n============\n{}\n'.format(
+      ret += '\nSelf Timings\n============\n{}\n'.format(
         self._format_aggregated_timings(self.run_tracker.self_timings))
 
-      ret += b'\nCritical Path Timings\n=====================\n{}\n'.format(
+      ret += '\nCritical Path Timings\n=====================\n{}\n'.format(
         self._format_aggregated_timings(self.run_tracker.get_critical_path_timings())
       )
     if settings.cache_stats:
-      ret += b'\nCache Stats\n===========\n{}\n'.format(
+      ret += '\nCache Stats\n===========\n{}\n'.format(
         self._format_artifact_cache_stats(self.run_tracker.artifact_cache_stats))
-    ret += b'\n'
+    ret += '\n'
     return ret
 
   def _format_aggregated_timings(self, aggregated_timings):
-    return b'\n'.join([b'{timing:.3f} {label}'.format(**x) for x in aggregated_timings.get_all()])
+    return '\n'.join(['{timing:.3f} {label}'.format(**x) for x in aggregated_timings.get_all()])
 
   def _format_artifact_cache_stats(self, artifact_cache_stats):
     stats = artifact_cache_stats.get_all()
-    return b'No artifact cache reads.' if not stats else b'\n'.join(
-      [b'{cache_name} - Hits: {num_hits} Misses: {num_misses}'.format(**x) for x in stats])
+    return 'No artifact cache reads.' if not stats else '\n'.join(
+      ['{cache_name} - Hits: {num_hits} Misses: {num_misses}'.format(**x) for x in stats])

--- a/src/python/pants/reporting/report.py
+++ b/src/python/pants/reporting/report.py
@@ -128,7 +128,7 @@ class Report(object):
     # Assumes self._lock is held by the caller.
     for workunit in self._workunits.values():
       for label, output in workunit.outputs().items():
-        s = output.read()
+        s = output.read().decode('utf-8')
         if len(s) > 0:
           for reporter in self._reporters.values():
             reporter.handle_output(workunit, label, s)

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import sys
-
-from six import StringIO
+from builtins import open
+from io import StringIO
 
 from pants.base.workunit import WorkUnitLabel
 from pants.reporting.html_reporter import HtmlReporter

--- a/src/python/pants/reporting/reporting_server.py
+++ b/src/python/pants/reporting/reporting_server.py
@@ -12,7 +12,7 @@ import mimetypes
 import os
 import pkgutil
 import re
-from builtins import object, range, str, zip
+from builtins import object, open, range, str, zip
 from collections import namedtuple
 from datetime import date, datetime
 from textwrap import dedent
@@ -76,7 +76,7 @@ class PantsHandler(http.server.BaseHTTPRequestHandler):
         self._handle_runs('', {})
         return
 
-      self._send_content('Invalid GET request {}'.format(self.path), 'text/html', code=400)
+      self._send_content('Invalid GET request {}'.format(self.path).encode('utf-8'), 'text/html', code=400)
     except (IOError, ValueError):
       pass  # Printing these errors gets annoying, and there's nothing to do about them anyway.
       #sys.stderr.write('Invalid GET request {}'.format(self.path))
@@ -166,10 +166,10 @@ class PantsHandler(http.server.BaseHTTPRequestHandler):
     """Render file content for pretty display."""
     abspath = os.path.normpath(os.path.join(self._root, relpath))
     if os.path.isfile(abspath):
-      with open(abspath, 'r') as infile:
+      with open(abspath, 'rb') as infile:
         content = infile.read()
     else:
-      content = 'No file found at {}'.format(abspath)
+      content = 'No file found at {}'.format(abspath).encode('utf-8')
     content_type = mimetypes.guess_type(abspath)[0] or 'text/plain'
     if not content_type.startswith('text/') and not content_type == 'application/xml':
       # Binary file. Display it as hex, split into lines.
@@ -195,7 +195,7 @@ class PantsHandler(http.server.BaseHTTPRequestHandler):
     """Statically serve assets: js, css etc."""
     if self._settings.assets_dir:
       abspath = os.path.normpath(os.path.join(self._settings.assets_dir, relpath))
-      with open(abspath, 'r') as infile:
+      with open(abspath, 'rb') as infile:
         content = infile.read()
     else:
       content = pkgutil.get_data(__name__, os.path.join('assets', relpath))
@@ -217,7 +217,7 @@ class PantsHandler(http.server.BaseHTTPRequestHandler):
       if path:
         abspath = os.path.normpath(os.path.join(self._root, path))
         if os.path.isfile(abspath):
-          with open(abspath, 'r') as infile:
+          with open(abspath, 'rb') as infile:
             if pos:
               infile.seek(pos)
             content = infile.read()
@@ -231,7 +231,7 @@ class PantsHandler(http.server.BaseHTTPRequestHandler):
     """
     latest_runinfo = self._get_run_info_dict('latest')
     if latest_runinfo is None:
-      self._send_content('none', 'text/plain')
+      self._send_content(b'none', 'text/plain')
     else:
       self._send_content(latest_runinfo['id'], 'text/plain')
 
@@ -327,7 +327,7 @@ class PantsHandler(http.server.BaseHTTPRequestHandler):
     client_ip = self._client_address[0]
     if not client_ip in self._settings.allowed_clients and \
        not 'ALL' in self._settings.allowed_clients:
-      self._send_content('Access from host {} forbidden.'.format(client_ip), 'text/html')
+      self._send_content('Access from host {} forbidden.'.format(client_ip).encode('utf-8'), 'text/html')
       return False
     return True
 

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -9,7 +9,7 @@ import io
 import logging
 import os
 import traceback
-from builtins import bytes, object
+from builtins import bytes, object, open
 from contextlib import contextmanager
 
 from pants.scm.scm import Scm

--- a/src/python/pants/source/wrapped_globs.py
+++ b/src/python/pants/source/wrapped_globs.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 from abc import abstractmethod, abstractproperty
+from builtins import open
 from hashlib import sha1
 
 from six import string_types

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -28,6 +28,9 @@ python_library(
 python_library(
   name = 'debug',
   sources = ['debug.py'],
+  dependencies = [
+    '3rdparty/python:future',
+  ],
 )
 
 python_library(
@@ -59,6 +62,7 @@ python_library(
   name = 'fileutil',
   sources = ['fileutil.py'],
   dependencies = [
+    '3rdparty/python:future',
     ':contextutil',
   ],
 )

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -13,7 +13,7 @@ import tempfile
 import time
 import uuid
 import zipfile
-from builtins import object
+from builtins import object, open
 from contextlib import closing, contextmanager
 
 from colors import green

--- a/src/python/pants/util/debug.py
+++ b/src/python/pants/util/debug.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import threading
+from builtins import open
 from collections import namedtuple
 
 
@@ -14,7 +15,7 @@ DEFAULT_LOG_PATH = '/tmp/pants_debug.log'
 
 def dlog(msg, log_path=DEFAULT_LOG_PATH):
   """A handy log utility for debugging multi-process, multi-threaded activities."""
-  with open(log_path, 'ab') as f:
+  with open(log_path, 'a') as f:
     f.write('\n{}@{}: {}'.format(os.getpid(), threading.current_thread().name, msg))
 
 

--- a/src/python/pants/util/fileutil.py
+++ b/src/python/pants/util/fileutil.py
@@ -8,6 +8,7 @@ import errno
 import os
 import random
 import shutil
+from builtins import open
 from uuid import uuid4
 
 from pants.util.contextutil import temporary_file

--- a/src/python/pants/util/rwbuf.py
+++ b/src/python/pants/util/rwbuf.py
@@ -6,8 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import threading
 from builtins import bytes, object, open
-
-from six import StringIO
+from io import BytesIO
 
 
 class _RWBuf(object):
@@ -58,7 +57,7 @@ class InMemoryRWBuf(_RWBuf):
   situations that require a real file (e.g., redirecting stdout/stderr of subprocess.Popen())."""
 
   def __init__(self):
-    super(InMemoryRWBuf, self).__init__(StringIO())
+    super(InMemoryRWBuf, self).__init__(BytesIO())
     self._writepos = 0
 
   def do_write(self, s):

--- a/src/python/pants/util/rwbuf.py
+++ b/src/python/pants/util/rwbuf.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import threading
-from builtins import bytes, object
+from builtins import bytes, object, open
 
 from six import StringIO
 
@@ -75,7 +75,7 @@ class FileBackedRWBuf(_RWBuf):
   when you want to poll the output of long-running subprocesses in a separate thread."""
 
   def __init__(self, backing_file):
-    _RWBuf.__init__(self, open(backing_file, 'a+'))
+    _RWBuf.__init__(self, open(backing_file, 'a+b'))
     self.fileno = self._io.fileno
 
   def do_write(self, s):

--- a/src/python/pants/util/s3_log_aggregator.py
+++ b/src/python/pants/util/s3_log_aggregator.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import sys
-from builtins import object
+from builtins import object, open
 from collections import defaultdict
 
 from s3logparse.s3logparse import parse_log_lines
@@ -47,7 +47,7 @@ class S3LogAccumulator(object):
 
   def accumulate(self, logdir):
     for filename in os.listdir(logdir):
-      with open(os.path.join(logdir, filename)) as fp:
+      with open(os.path.join(logdir, filename), 'r') as fp:
         for log_entry in parse_log_lines(fp.readlines()):
           m = Measure(1, log_entry.bytes_sent)
           self._path_to_measure[log_entry.s3_key] += m

--- a/tests/python/pants_test/backend/codegen/antlr/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/antlr/java/BUILD
@@ -5,6 +5,7 @@
 python_tests(
   sources = globs('*.py', exclude=[globs('*_integration.py')]),
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     'src/python/pants/backend/codegen/antlr/java',
     'src/python/pants/base:exceptions',

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import re
 import time
+from builtins import open
 from textwrap import dedent
 
 from twitter.common.dirutil.fileset import Fileset
@@ -86,7 +87,7 @@ class AntlrJavaGenTest(NailgunTaskTestBase):
     # Check that the synthetic target has a valid source root and the generated sources have the
     # expected java package
     def get_package(path):
-      with open(path) as fp:
+      with open(path, 'r') as fp:
         for line in fp:
           match = self.PACKAGE_RE.match(line)
           if match:

--- a/tests/python/pants_test/backend/codegen/jaxb/BUILD
+++ b/tests/python/pants_test/backend/codegen/jaxb/BUILD
@@ -4,6 +4,7 @@
 
 python_tests(
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/backend/codegen/jaxb',
     'src/python/pants/build_graph',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/backend/codegen/jaxb/test_jaxb_gen.py
+++ b/tests/python/pants_test/backend/codegen/jaxb/test_jaxb_gen.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 
 from pants.backend.codegen.jaxb.jaxb_gen import JaxbGen
 from pants.backend.codegen.jaxb.jaxb_library import JaxbLibrary
@@ -92,6 +93,6 @@ class JaxbGenJavaTest(NailgunTaskTestBase):
 
     # Make sure there is no header with a timestamp in the generated file
     for f in files:
-      with open(f) as jaxb_file:
+      with open(f, 'r') as jaxb_file:
         contents = jaxb_file.read()
         self.assertNotIn('// Generated on:', contents)

--- a/tests/python/pants_test/backend/codegen/thrift/python/BUILD
+++ b/tests/python/pants_test/backend/codegen/thrift/python/BUILD
@@ -3,6 +3,7 @@
 
 python_tests(
   dependencies=[
+    '3rdparty/python:future',
     '3rdparty/python:pex',
     '3rdparty/python:six',
     'src/python/pants/backend/codegen/thrift/lib',

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_apache_thrift_py_gen.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_apache_thrift_py_gen.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 from textwrap import dedent
 
 import six
@@ -50,8 +51,8 @@ class ApacheThriftPyGenTest(TaskTestBase):
     return os.path.join(self.build_root, target.target_base, package_rel_dir, '__init__.py')
 
   def assert_ns_package(self, target, package_rel_dir):
-    with open(self.init_py_path(target, package_rel_dir)) as fp:
-      self.assertEqual(b"__import__('pkg_resources').declare_namespace(__name__)",
+    with open(self.init_py_path(target, package_rel_dir), 'r') as fp:
+      self.assertEqual("__import__('pkg_resources').declare_namespace(__name__)",
                        fp.read().strip())
 
   def assert_leaf_package(self, target, package_rel_dir, *services):

--- a/tests/python/pants_test/backend/docgen/tasks/BUILD
+++ b/tests/python/pants_test/backend/docgen/tasks/BUILD
@@ -6,6 +6,7 @@ python_tests(
   name = 'markdown_to_html',
   sources = ['test_markdown_to_html.py'],
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python:beautifulsoup4',
     '3rdparty/python:mock',
     'src/python/pants/backend/docgen/targets',

--- a/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
+++ b/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import unittest
+from builtins import open
 from textwrap import dedent
 
 import bs4
@@ -159,7 +160,7 @@ class MarkdownToHtmlTest(TaskTestBase):
     self.assertIn('bad.rst', args[0])
 
     # But we still should have gotten (badly) rendered content.
-    with open(self.get_rendered_page(context, bad_rst, 'bad.html')) as fp:
+    with open(self.get_rendered_page(context, bad_rst, 'bad.html'), 'r') as fp:
       html = fp.read()
       self.assertIn('A bad link:', html)
 
@@ -175,7 +176,7 @@ class MarkdownToHtmlTest(TaskTestBase):
     task = self.create_task(context)
     task.execute()
 
-    with open(self.get_rendered_page(context, good_rst, 'good.html')) as fp:
+    with open(self.get_rendered_page(context, good_rst, 'good.html'), 'r') as fp:
       html = fp.read()
 
       soup = bs4.BeautifulSoup(markup=html)

--- a/tests/python/pants_test/backend/jvm/subsystems/BUILD
+++ b/tests/python/pants_test/backend/jvm/subsystems/BUILD
@@ -5,6 +5,7 @@ python_tests(
   name='shader',
   sources=['test_shader.py'],
   dependencies=[
+    '3rdparty/python:future',
     'src/python/pants/backend/jvm/subsystems:shader',
     'src/python/pants/java/distribution',
     'src/python/pants/java:executor',
@@ -45,6 +46,7 @@ python_tests(
   name='shader_integration',
   sources=['test_shader_integration.py'],
   dependencies=[
+    '3rdparty/python:future',
     'src/python/pants/fs',
     'src/python/pants/java/distribution',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/backend/jvm/subsystems/test_shader.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_shader.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import tempfile
 import unittest
+from builtins import open
 
 from pants.backend.jvm.subsystems.shader import RelocateRule, Shader, Shading
 from pants.java.distribution.distribution import DistributionLocator
@@ -96,7 +97,7 @@ class ShaderTest(unittest.TestCase):
 
       rules_file = command.pop(0)
       self.assertTrue(os.path.exists(rules_file))
-      with open(rules_file) as fp:
+      with open(rules_file, 'r') as fp:
         lines = fp.read().splitlines()
         self.assertEqual('rule log4j.** log4j.@1', lines[0])  # The custom rule.
         self.assertEqual('rule * @1', lines[1])  # Exclude main's package.

--- a/tests/python/pants_test/backend/jvm/subsystems/test_shader_integration.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_shader_integration.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 import os
+from builtins import open
 from textwrap import dedent
 
 from pants.base.build_environment import get_buildroot

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -132,6 +132,7 @@ python_tests(
   name = 'checkstyle_integration',
   sources = ['test_checkstyle_integration.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
@@ -247,6 +248,7 @@ python_tests(
   name = 'ivy_outdated_integration',
   sources = ['test_ivy_outdated_integration.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
@@ -257,6 +259,7 @@ python_tests(
   name = 'ivy_resolve',
   sources = ['test_ivy_resolve.py'],
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/jvm:ivy_utils',
     'src/python/pants/java/jar',
@@ -312,6 +315,7 @@ python_tests(
   name = 'ivy_resolve_integration',
   sources = ['test_ivy_resolve_integration.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
@@ -380,6 +384,7 @@ python_tests(
   name = 'jar_publish_integration',
   sources = ['test_jar_publish_integration.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
@@ -504,6 +509,7 @@ python_tests(
   name = 'jvm_dependency_usage_integration',
   sources = ['test_jvm_dependency_usage_integration.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
@@ -551,6 +557,7 @@ python_tests(
   name = 'jvm_prep_command_integration',
   sources = ['test_jvm_prep_command_integration.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:int-test',
@@ -573,6 +580,7 @@ python_tests(
   name = 'jvm_run',
   sources = ['test_jvm_run.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/backend/jvm/subsystems:jvm',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jvm_run',
@@ -627,6 +635,7 @@ python_tests(
   name = 'prepare_resources',
   sources = ['test_prepare_resources.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:prepare_resources',
@@ -640,6 +649,7 @@ python_tests(
   name = 'prepare_services',
   sources = ['test_prepare_services.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/java/jar',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
@@ -653,6 +663,7 @@ python_tests(
   name = 'properties',
   sources = ['test_properties.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/backend/jvm/tasks:properties',
   ]
 )
@@ -661,6 +672,7 @@ python_tests(
   name = 'scalafmt',
   sources = ['test_scalafmt.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/backend/jvm/subsystems:scala_platform',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/targets:scala',
@@ -677,6 +689,7 @@ python_tests(
   name = 'scalafix',
   sources = ['test_scalafix.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/backend/jvm/tasks:scalafix',
     'tests/python/pants_test:int-test',
   ],
@@ -725,6 +738,7 @@ python_tests(
   name = 'scope_runtime_integration',
   sources = ['test_scope_runtime_integration.py'],
   dependencies = [
+    '3rdparty/python:future',
     'tests/python/pants_test:int-test',
   ],
   timeout=300,

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -48,6 +48,7 @@ python_tests(
   name='dep_exports_integration',
   sources=['test_dep_exports_integration.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/base:build_environment',
     'tests/python/pants_test:int-test',
   ],

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -20,6 +20,7 @@ python_tests(
   name='zinc_compile_integration',
   sources=['test_zinc_compile_integration.py'],
   dependencies=[
+    '3rdparty/python:future',
     'src/python/pants/build_graph',
     'tests/python/pants_test/backend/jvm/tasks:missing_jvm_check',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
@@ -32,6 +33,7 @@ python_tests(
   name='java_compile_integration',
   sources=['test_java_compile_integration.py'],
   dependencies=[
+    '3rdparty/python:future',
     'src/python/pants/backend/jvm/tasks/jvm_compile/zinc',
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/jvm_platform_integration_mixin.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/jvm_platform_integration_mixin.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import re
-from builtins import object, str
+from builtins import object, open, str
 from subprocess import PIPE, Popen
 from textwrap import dedent
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 
 from pants.fs.archive import archiver_for_path
 from pants.util.contextutil import temporary_dir
@@ -131,7 +132,7 @@ class JavaCompileIntegrationTest(BaseCompileIT):
                           'Expected exactly one {} file; got: {}'.format(report_file_name,
                                                                          all_files))
 
-        with open(reports[0]) as fp:
+        with open(reports[0], 'r') as fp:
           annotated_classes = [line.rstrip() for line in fp.read().splitlines()]
           self.assertEqual(
             {'org.pantsbuild.testproject.annotation.main.Main',

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 from unittest import skipIf
 
 from pants.build_graph.address import Address
@@ -73,7 +74,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
       processor_service_file = list(processor_service_files)[0]
       self.assertTrue(processor_service_file.endswith(
           'META-INF/services/javax.annotation.processing.Processor'))
-      with open(processor_service_file) as fp:
+      with open(processor_service_file, 'r') as fp:
         self.assertEqual('org.pantsbuild.testproject.annotation.processor.ResourceMappingProcessor',
                           fp.read().strip())
 
@@ -89,7 +90,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
       # This is the proof that the ResourceMappingProcessor annotation processor was compiled in a
       # round and then the Main was compiled in a later round with the annotation processor and its
       # service info file from on its compile classpath.
-      with open(self.get_only(found, 'deprecation_report.txt')) as fp:
+      with open(self.get_only(found, 'deprecation_report.txt'), 'r') as fp:
         self.assertIn('org.pantsbuild.testproject.annotation.main.Main', fp.read().splitlines())
 
   def test_stale_apt_with_deps(self):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import shutil
+from builtins import open
 
 from pants.base.build_environment import get_buildroot
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
@@ -41,8 +42,8 @@ class DepExportsIntegrationTest(PantsRunIntegrationTest):
         pants_run = self.run_pants_with_workdir(command=cmd, workdir=workdir)
         self.assert_success(pants_run)
 
-        with open(os.path.join(src_dir, modify_file), 'ab') as fh:
-          fh.write(b'\n')
+        with open(os.path.join(src_dir, modify_file), 'a') as fh:
+          fh.write('\n')
 
         pants_run = self.run_pants_with_workdir(command=cmd, workdir=workdir)
         self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/BUILD
@@ -15,6 +15,7 @@ python_tests(
   name='zinc_compile_integration_with_zjars',
   sources=['test_zinc_compile_integration_with_zjars.py'],
   dependencies=[
+    '3rdparty/python:future',
     ':zinc_compile_integration_base',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
   ],

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration_with_zjars.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration_with_zjars.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import open
+
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
 from pants_test.backend.jvm.tasks.jvm_compile.zinc.zinc_compile_integration_base import \
   BaseZincCompileIntegrationTest

--- a/tests/python/pants_test/backend/jvm/tasks/reports/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/reports/BUILD
@@ -9,6 +9,7 @@ files(
 python_tests(
   sources = ['test_junit_html_report.py'],
   dependencies = [
+    '3rdparty/python:future',
     ':junit_xml',
     'src/python/pants/backend/jvm/tasks/reports',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/backend/jvm/tasks/reports/test_junit_html_report.py
+++ b/tests/python/pants_test/backend/jvm/tasks/reports/test_junit_html_report.py
@@ -5,12 +5,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 from contextlib import contextmanager
 
 from pants.backend.jvm.tasks.reports.junit_html_report import (JUnitHtmlReport, ReportTestCase,
                                                                ReportTestSuite)
 from pants.util.contextutil import temporary_dir
-from pants.util.strutil import ensure_text
 from pants_test.test_base import TestBase
 
 
@@ -109,16 +109,16 @@ class TestJUnitHtmlReport(TestBase):
 
     with temporary_dir() as output_dir:
       junit_html_report = JUnitHtmlReport.create(xml_dir=self._JUNIT_XML_DIR, open_report=True)
-      with open(junit_html_report.report(output_dir)) as html_file:
-        html_data = ensure_text(html_file.read())
-        self.assertIn(u'</span>&nbsp;org.pantsbuild.PåssingTest', html_data)
-        self.assertIn(u'</span>&nbsp;testTwö</td>', html_data)
-        self.assertIn(u'at org.pantsbuild.PåssingTest.testTwö(ErrorTest.java:29)', html_data)
+      with open(junit_html_report.report(output_dir), 'r') as html_file:
+        html_data = html_file.read()
+        self.assertIn('</span>&nbsp;org.pantsbuild.PåssingTest', html_data)
+        self.assertIn('</span>&nbsp;testTwö</td>', html_data)
+        self.assertIn('at org.pantsbuild.PåssingTest.testTwö(ErrorTest.java:29)', html_data)
 
   def test_merged_no_conflict(self):
     with temporary_dir() as xml_dir:
       def write_xml(name, xml, path=''):
-        with open(os.path.join(xml_dir, path, 'TEST-{}.xml'.format(name)), 'wb') as fp:
+        with open(os.path.join(xml_dir, path, 'TEST-{}.xml'.format(name)), 'w') as fp:
           fp.write(xml)
 
       write_xml('a-1', """
@@ -166,7 +166,7 @@ class TestJUnitHtmlReport(TestBase):
   def merge_conflict(self):
     with temporary_dir() as xml_dir:
       def write_xml(name, xml, path=''):
-        with open(os.path.join(xml_dir, path, 'TEST-{}.xml'.format(name)), 'wb') as fp:
+        with open(os.path.join(xml_dir, path, 'TEST-{}.xml'.format(name)), 'w') as fp:
           fp.write(xml)
 
       write_xml('a-1', """

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 import os
 import shutil
+from builtins import open
 from contextlib import contextmanager
 from textwrap import dedent
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_outdated_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_outdated_integration.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 from textwrap import dedent
 
 from pants.base.build_environment import get_buildroot

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
@@ -8,6 +8,7 @@ import os
 from builtins import open
 from contextlib import contextmanager
 
+from future.utils import PY3
 from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.ivy_utils import IvyInfo, IvyModule, IvyModuleRef, IvyResolveResult
@@ -254,7 +255,7 @@ class IvyResolveTest(JvmToolTaskTestBase):
       ivy_resolve_workdir = self._find_resolve_workdir(workdir)
       raw_classpath_path = os.path.join(ivy_resolve_workdir, 'classpath.raw')
       with open(raw_classpath_path, 'a') as raw_f:
-        raw_f.write(os.pathsep)
+        raw_f.write(os.pathsep if PY3 else os.pathsep.decode('utf-8'))
         raw_f.write(os.path.join('non-existent-file'))
 
       self.resolve([jar_lib])
@@ -401,7 +402,7 @@ class IvyResolveTest(JvmToolTaskTestBase):
         ivy_resolve_workdir = self._find_resolve_workdir(workdir)
         raw_classpath_path = os.path.join(ivy_resolve_workdir, 'classpath.raw')
         with open(raw_classpath_path, 'a') as raw_f:
-          raw_f.write(os.pathsep)
+          raw_f.write(os.pathsep if PY3 else os.pathsep.decode('utf-8'))
           raw_f.write(os.path.join('non-existent-file'))
 
         self.resolve([jar_lib])

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 from contextlib import contextmanager
 
 from twitter.common.collections import OrderedSet
@@ -259,7 +260,7 @@ class IvyResolveTest(JvmToolTaskTestBase):
       self.resolve([jar_lib])
 
       # The raw_classpath should be re-created because the previous resolve became invalid.
-      with open(raw_classpath_path) as f:
+      with open(raw_classpath_path, 'r') as f:
         self.assertNotIn('non-existent-file', f.read())
 
   def test_fetch_has_same_resolved_jars_as_resolve(self):
@@ -361,8 +362,8 @@ class IvyResolveTest(JvmToolTaskTestBase):
         self._assertIsFile(report_path)
 
         _unused_conf, lib_symlink = fetch_classpath.get_for_target(jar_lib)[0]
-        with open(jarfile) as jarfile_f:
-          with open(lib_symlink) as symlink_f:
+        with open(jarfile, 'r') as jarfile_f:
+          with open(lib_symlink, 'r') as symlink_f:
             self.assertTrue(jarfile_f.read() == symlink_f.read(),
                             'Expected linked jar and original to match.')
 
@@ -406,7 +407,7 @@ class IvyResolveTest(JvmToolTaskTestBase):
         self.resolve([jar_lib])
 
         # The raw_classpath should be re-created because the previous resolve became invalid.
-        with open(raw_classpath_path) as f:
+        with open(raw_classpath_path, 'r') as f:
           self.assertNotIn('non-existent-file', f.read())
 
   def _make_junit_target(self):

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve_integration.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import re
+from builtins import open
 
 from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
@@ -65,7 +66,7 @@ class IvyResolveIntegrationTest(PantsRunIntegrationTest):
       self.assertIsNotNone(html_report_file,
                       msg="Couldn't find ivy report in {report_dir} containing files {listdir}"
                       .format(report_dir=ivy_report_dir, listdir=listdir))
-      with open(os.path.join(ivy_report_dir, html_report_file)) as file:
+      with open(os.path.join(ivy_report_dir, html_report_file), 'r') as file:
         self.assertIn('info.cukes', file.read())
 
   def test_ivy_args(self):
@@ -160,7 +161,7 @@ class IvyResolveIntegrationTest(PantsRunIntegrationTest):
                         msg="Couldn't find ivy report in {report_dir} containing files {listdir}"
                         .format(report_dir=ivy_report_dir, listdir=listdir))
 
-        with open(os.path.join(ivy_report_dir, html_report_file)) as file:
+        with open(os.path.join(ivy_report_dir, html_report_file), 'r') as file:
           self.assertIn('junit', file.read())
 
       run_pants(['clean-all'])
@@ -176,7 +177,7 @@ class IvyResolveIntegrationTest(PantsRunIntegrationTest):
                         msg="Couldn't find ivy report in {report_dir} containing files {listdir}"
                         .format(report_dir=ivy_report_dir, listdir=listdir))
 
-        with open(os.path.join(ivy_report_dir, html_report_file)) as file:
+        with open(os.path.join(ivy_report_dir, html_report_file), 'r') as file:
           self.assertIn('junit', file.read())
 
   def _find_html_report(self, ivy_report_dir):

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 import os
 import xml.etree.ElementTree as ET
-from builtins import str
+from builtins import open, str
 from collections import namedtuple
 from textwrap import dedent
 
@@ -538,7 +538,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
                                   ('default',),
                                   'some-name')
 
-      with open(ivyxml) as f:
+      with open(ivyxml, 'r') as f:
         self.assertIn('an-url', f.read())
 
   def test_fetch_requests_classifiers(self):
@@ -549,7 +549,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
                                   ('default',),
                                   'some-name')
 
-      with open(ivyxml) as f:
+      with open(ivyxml, 'r') as f:
         self.assertIn('a-classifier', f.read())
 
   def test_fetch_applies_mutable(self):
@@ -560,7 +560,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
                                   ('default',),
                                   'some-name')
 
-      with open(ivyxml) as f:
+      with open(ivyxml, 'r') as f:
         self.assertIn('changing="true"', f.read())
 
   def test_resolve_ivy_xml_requests_classifiers(self):
@@ -576,7 +576,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
         resolve_hash_name='some-name',
         jar_dep_manager=namedtuple('stub_jar_dep_manager', ['resolve_version_conflict'])(lambda x: x))
 
-      with open(ivyxml) as f:
+      with open(ivyxml, 'r') as f:
         self.assertIn('classifier="a-classifier', f.read())
 
   def test_ivy_resolve_report_copying_fails_when_report_is_missing(self):

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_publish_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_publish_integration.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import re
+from builtins import open
 
 from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import open_zip, temporary_dir

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import re
-from builtins import range
+from builtins import open, range
 from contextlib import contextmanager
 from textwrap import dedent
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from builtins import range
+from builtins import open, range
 from contextlib import contextmanager
 from textwrap import dedent
 
@@ -129,7 +129,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
                       '-dependency', 'junit', 'junit-dep', '4.10'],
                 executor=SubprocessExecutor(distribution=distribution))
 
-    with open(classpath_file_abs_path) as fp:
+    with open(classpath_file_abs_path, 'r') as fp:
       classpath = fp.read()
 
     # Now directly invoke javac to compile the test java code into classfiles that we can later

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage_integration.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 import os
+from builtins import open
 
 from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
@@ -33,7 +34,7 @@ class TestJvmDependencyUsageIntegration(PantsRunIntegrationTest):
 
       # Run, and then parse the report from json.
       self.assert_success(self.run_pants_with_workdir(args, workdir, config))
-      with open(outfile) as f:
+      with open(outfile, 'r') as f:
         return json.load(f)
 
   def _assert_non_zero_usage(self, dep_usage_json):

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis_integration.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from builtins import map, object
+from builtins import map, object, open
 from contextlib import contextmanager
 from textwrap import dedent
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_prep_command_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_prep_command_integration.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import safe_delete
@@ -46,7 +47,7 @@ class JvmPrepCommandIntegration(PantsRunIntegrationTest):
     self.assertTrue(os.path.exists('/tmp/running-in-goal-compile.jar'))
     self.assertFalse(os.path.exists('/tmp/running-in-goal-binary'))
 
-    with open('/tmp/running-in-goal-test') as f:
+    with open('/tmp/running-in-goal-test', 'r') as f:
       prep_output = f.read()
 
     expected = """Running: org.pantsbuild.testproject.jvmprepcommand.ExampleJvmPrepCommand
@@ -65,7 +66,7 @@ org.pantsbuild properties: "org.pantsbuild.jvm_prep_command=WORKS-IN-TEST"
     self.assertTrue(os.path.exists('/tmp/running-in-goal-compile.jar'))
     self.assertFalse(os.path.exists('/tmp/running-in-goal-test'))
 
-    with open('/tmp/running-in-goal-binary') as f:
+    with open('/tmp/running-in-goal-binary', 'r') as f:
       prep_output = f.read()
 
     expected = """Running: org.pantsbuild.testproject.jvmprepcommand.ExampleJvmPrepCommand

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import re
+from builtins import open
 from contextlib import contextmanager
 
 from pants.backend.jvm.subsystems.jvm import JVM
@@ -39,7 +40,7 @@ class JvmRunTest(JvmTaskTestBase):
         self.assertFalse(os.path.exists(cmdline_file))
         jvm_run.execute()
         self.assertTrue(os.path.exists(cmdline_file))
-        with open(cmdline_file) as fp:
+        with open(cmdline_file, 'r') as fp:
           contents = fp.read()
           yield contents
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_prepare_resources.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_prepare_resources.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
@@ -94,7 +95,7 @@ class PrepareResourcesTest(TaskTestBase):
         for f in files:
           abs_path = os.path.join(root, f)
           rel_path = os.path.relpath(abs_path, chroot)
-          with open(abs_path) as fp:
+          with open(abs_path, 'r') as fp:
             self.assertEqual(rel_path, fp.read())
           resource_files.append(rel_path)
       self.assertEqual(sorted(['a/b.txt', 'c.txt']), sorted(resource_files))

--- a/tests/python/pants_test/backend/jvm/tasks/test_prepare_services.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_prepare_services.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
@@ -113,7 +114,7 @@ class PrepareServicesTest(TaskTestBase):
 
       def assert_contents(path, services):
         read_services = []
-        with open(os.path.join(chroot, path)) as fp:
+        with open(os.path.join(chroot, path), 'r') as fp:
           for line in fp.readlines():
             line = line.strip()
             if not line.startswith('#'):

--- a/tests/python/pants_test/backend/jvm/tasks/test_properties.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_properties.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import unittest
+from builtins import open
 from collections import OrderedDict
 from io import StringIO
 from tempfile import NamedTemporaryFile

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import open
+
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 from textwrap import dedent
 
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
@@ -53,7 +54,7 @@ class ScalaFmtTestBase(NailgunTaskTestBase):
     )
 
     self.test_file_contents = dedent(
-      b"""
+      """
       package org.pantsbuild.badscalastyle
 
       /**
@@ -75,7 +76,8 @@ class ScalaFmtTestBase(NailgunTaskTestBase):
     )
     self.test_file = self.create_file(
       relpath='src/scala/org/pantsbuild/badscalastyle/BadScalaStyle.scala',
-      contents=self.test_file_contents
+      contents=self.test_file_contents,
+      mode='w'
     )
     self.library = self.make_target(spec='src/scala/org/pantsbuild/badscalastyle',
                                     sources=['BadScalaStyle.scala'],
@@ -138,7 +140,7 @@ class ScalaFmtFormatTest(ScalaFmtTestBase):
     context = self.context(for_task_types=[check_fmt_task_type], target_roots=self.library)
     self.execute(context)
 
-    with open(self.test_file, 'rb') as fp:
+    with open(self.test_file, 'r') as fp:
       self.assertNotEqual(self.test_file_contents, fp.read())
 
     # verify that the lint check passes.
@@ -161,9 +163,9 @@ class ScalaFmtFormatTest(ScalaFmtTestBase):
       )
       self.execute(context)
 
-      with open(self.test_file, 'rb') as fp:
+      with open(self.test_file, 'r') as fp:
         self.assertEqual(self.test_file_contents, fp.read())
 
       relative_test_file = fast_relpath(self.test_file, self.build_root)
-      with open(os.path.join(output_dir, relative_test_file), 'rb') as fp:
+      with open(os.path.join(output_dir, relative_test_file), 'r') as fp:
         self.assertNotEqual(self.test_file_contents, fp.read())

--- a/tests/python/pants_test/backend/jvm/tasks/test_scope_runtime_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scope_runtime_integration.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import re
+from builtins import open
 from subprocess import PIPE, Popen
 from textwrap import dedent
 from zipfile import ZipFile

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -70,6 +70,7 @@ python_tests(
   name = 'export_integration',
   sources = ['test_export_integration.py'],
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':resolve_jars_test_mixin',
     'src/python/pants/base:build_environment',

--- a/tests/python/pants_test/backend/project_info/tasks/resolve_jars_test_mixin.py
+++ b/tests/python/pants_test/backend/project_info/tasks/resolve_jars_test_mixin.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from builtins import object
+from builtins import object, open
 from textwrap import dedent
 
 from pants.util.contextutil import temporary_dir

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 import os
 import re
+from builtins import open
 
 from twitter.common.collections import maybe_list
 
@@ -46,7 +47,7 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
     self.assertTrue(os.path.exists(export_out_file),
                     msg='Could not find export output file in {out_file}'
                         .format(out_file=export_out_file))
-    with open(export_out_file) as json_file:
+    with open(export_out_file, 'r') as json_file:
       json_data = json.load(json_file)
       if not load_libs:
         self.assertIsNone(json_data.get('libraries'))
@@ -226,7 +227,7 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
       p.communicate()
       self.assertEqual(p.returncode, 0)
 
-      with open(exported_file) as data_file:
+      with open(exported_file, 'r') as data_file:
         json_data = json.load(data_file)
 
       python_setup = json_data['python_setup']

--- a/tests/python/pants_test/backend/project_info/tasks/test_idea_plugin_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_idea_plugin_integration.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 import os
-from builtins import str
+from builtins import open, str
 from xml.dom import minidom
 
 from pants.backend.project_info.tasks.idea_plugin_gen import IDEA_PLUGIN_VERSION, IdeaPluginGen

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -56,6 +56,7 @@ python_library(
   name='pants_requirement_integration_test_base',
   sources=['pants_requirement_integration_test_base.py'],
   dependencies=[
+    '3rdparty/python:future',
     'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',

--- a/tests/python/pants_test/backend/python/pants_requirement_integration_test_base.py
+++ b/tests/python/pants_test/backend/python/pants_requirement_integration_test_base.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import shutil
 import uuid
+from builtins import open
 from contextlib import contextmanager
 
 from pants.base.build_environment import get_buildroot, pants_version
@@ -19,11 +20,11 @@ class PantsRequirementIntegrationTestBase(PantsRunIntegrationTest):
   @contextmanager
   def _unstable_pants_version(self):
     stable_version = pants_version()
-    unstable_version = b'{}+{}'.format(stable_version, uuid.uuid4().hex)
+    unstable_version = '{}+{}'.format(stable_version, uuid.uuid4().hex)
     version_dir = os.path.join(get_buildroot(), 'src/python/pants')
 
     with self.file_renamed(version_dir, 'VERSION', 'VERSION.orig'):
-      with open(os.path.join(version_dir, 'VERSION'), 'wb') as fp:
+      with open(os.path.join(version_dir, 'VERSION'), 'w') as fp:
         fp.write(unstable_version)
 
       pants_run = self.run_pants(['--version'])

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -115,6 +115,7 @@ python_tests(
   name='isort_run',
   sources=['test_isort_run.py'],
   dependencies=[
+    '3rdparty/python:future',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/backend/python/tasks:python_task_test_base',
     'src/python/pants/util:process_handler',

--- a/tests/python/pants_test/backend/python/tasks/test_gather_sources.py
+++ b/tests/python/pants_test/backend/python/tasks/test_gather_sources.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from builtins import str
+from builtins import open, str
 
 from pex.interpreter import PythonInterpreter
 
@@ -75,7 +75,7 @@ class GatherSourcesTest(TaskTestBase):
     pex_path = pex.path()
     for path in files:
       expected_content = self.filemap[to_filemap_key(path)]
-      with open(os.path.join(pex_path, path)) as infile:
+      with open(os.path.join(pex_path, path), 'r') as infile:
         content = infile.read()
       self.assertEqual(expected_content, content)
 

--- a/tests/python/pants_test/backend/python/tasks/test_isort_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_isort_run.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 from textwrap import dedent
 
 from pytest import fail
@@ -113,7 +114,7 @@ class PythonIsortTest(PythonTaskTestBase):
   def test_isort_check_only(self):
     isort_task = self._create_task(target_roots=[self.a_library], passthru_args=['--check-only'])
     with temporary_dir() as output_dir:
-      with open(os.path.join(output_dir, 'stdout'), 'w+b') as stdout:
+      with open(os.path.join(output_dir, 'stdout'), 'w+') as stdout:
         with stdio_as(stdout_fd=stdout.fileno(), stderr_fd=stdout.fileno(), stdin_fd=-1):
           try:
             isort_task.execute()
@@ -127,16 +128,16 @@ class PythonIsortTest(PythonTaskTestBase):
             fail("--check-only test for {} is supposed to fail, but passed.".format(self.a_library))
 
   def assertSortedWithConfigA(self, path):
-    with open(path) as f:
+    with open(path, 'r') as f:
       self.assertEqual(self.RESULT_A, f.read(),
                        '{} should be sorted with CONFIG_A, but is not.'.format(path))
 
   def assertSortedWithConfigB(self, path):
-    with open(path) as f:
+    with open(path, 'r') as f:
       self.assertEqual(self.RESULT_B, f.read(),
                        '{} should be sorted with CONFIG_B, but is not.'.format(path))
 
   def assertNotSorted(self, path):
-    with open(path) as f:
+    with open(path, 'r') as f:
       self.assertEqual(self.BAD_IMPORT_ORDER, f.read(),
                        '{} should not be sorted, but is.'.format(path))

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import functools
 import os
+from builtins import open
 from contextlib import contextmanager
 from textwrap import dedent
 
@@ -133,8 +134,8 @@ class PytestTestFailedPexRun(PytestTestBase):
 
   def test_failed_pex_run_does_not_see_prior_failures(self):
     # Setup a prior failure.
-    with open(self.AlwaysFailingPexRunPytestRun.junitxml_path, mode='wb') as fp:
-      fp.write(b"""
+    with open(self.AlwaysFailingPexRunPytestRun.junitxml_path, mode='w') as fp:
+      fp.write("""
           <testsuite errors="0" failures="1" name="pytest" skips="0" tests="1" time="0.001">
             <testcase classname="tests.test_green.GreenTest"
                       file=".pants.d/gs/8...6-DefaultFingerprintStrategy_e88d80fa140b/test_green.py"

--- a/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
@@ -57,13 +57,13 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
     self.assertTrue(os.path.isfile(pex_copy))
 
     # Check that the pex runs.
-    output = subprocess.check_output(pex_copy)
+    output = subprocess.check_output(pex_copy).decode('utf-8')
     if expected_output:
       self.assertEqual(expected_output, output)
 
     # Check that the pex has the expected shebang.
     if expected_shebang:
-      with open(pex_copy, 'r') as pex:
+      with open(pex_copy, 'rb') as pex:
         line = pex.readline()
         self.assertEqual(expected_shebang, line)
 
@@ -110,4 +110,4 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
                                        shebang='/usr/bin/env python2',
                                        dependencies=['src/python/lib'])
 
-    self._assert_pex(binary, expected_output='Hello World!\n', expected_shebang='#!/usr/bin/env python2\n')
+    self._assert_pex(binary, expected_output='Hello World!\n', expected_shebang=b'#!/usr/bin/env python2\n')

--- a/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 from textwrap import dedent
 
 from pants.backend.python.tasks.gather_sources import GatherSources
@@ -83,6 +84,7 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
     self.create_library('src/things', 'files', 'things', sources=['loose_file'])
     self.create_file('src/things/loose_file', 'data!')
     self.create_python_library('src/python/lib', 'lib', {'lib.py': dedent("""
+    import io
     import os
     import sys
 
@@ -90,7 +92,7 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
     def main():
       here = os.path.dirname(__file__)
       loose_file = os.path.join(here, '../src/things/loose_file')
-      with open(os.path.realpath(loose_file)) as fp:
+      with io.open(os.path.realpath(loose_file), 'r') as fp:
         sys.stdout.write(fp.read())
     """)})
 

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import glob
 import os
 import re
+from builtins import open
 
 from pants.backend.native.config.environment import Platform
 from pants.base.build_environment import get_buildroot

--- a/tests/python/pants_test/backend/python/tasks/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_repl.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 from contextlib import contextmanager
 from textwrap import dedent
 
@@ -75,7 +76,7 @@ class PythonReplTest(PythonTaskTestBase):
       stderr = os.path.join(iodir, 'stderr')
       with open(stdin, 'w') as fp:
         fp.write(stdin_data)
-      with open(stdin, 'rb') as inp, open(stdout, 'wb') as out, open(stderr, 'wb') as err:
+      with open(stdin, 'r') as inp, open(stdout, 'w') as out, open(stderr, 'w') as err:
         with stdio_as(stdin_fd=inp.fileno(), stdout_fd=out.fileno(), stderr_fd=err.fileno()):
           yield (stdin, stdout, stderr)
 
@@ -113,7 +114,7 @@ class PythonReplTest(PythonTaskTestBase):
 
     with self.new_io('\n'.join(code)) as (inp, out, err):
       python_repl.execute()
-      with open(out) as fp:
+      with open(out, 'r') as fp:
         lines = fp.read()
         if not expected:
           self.assertEqual('', lines)
@@ -172,7 +173,7 @@ class PythonReplTest(PythonTaskTestBase):
   def test_ipython(self):
     # IPython supports shelling out with a leading !, so indirectly test its presence by reading
     # the head of this very file.
-    with open(__file__) as fp:
+    with open(__file__, 'r') as fp:
       me = fp.readline()
       self.do_test_repl(code=['!head -1 {}'.format(__file__)],
                         expected=[me],

--- a/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
+++ b/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from builtins import str
+from builtins import open, str
 from textwrap import dedent
 
 import mock

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 from collections import OrderedDict
 from contextlib import contextmanager
 from textwrap import dedent
@@ -118,7 +119,7 @@ class TestSetupPyInterpreter(SetupPyTestBase):
     sdist_srcdir = os.path.join(self.distdir, 'foo-0.0.0', 'src')
     with environment_as(PYTHONPATH=sdist_srcdir):
       with self.run_execute(foo):
-        with open(os.path.join(sdist_srcdir, 'foo', 'commands', 'sys_path.txt')) as fp:
+        with open(os.path.join(sdist_srcdir, 'foo', 'commands', 'sys_path.txt'), 'r') as fp:
           def assert_extra(name, expected_version):
             package = Package.from_href(fp.readline().strip())
             self.assertEqual(name, package.name)
@@ -490,7 +491,7 @@ class TestSetupPy(SetupPyTestBase):
                           path('src/monster/j-function.res')},
                          py_files)
 
-        with open(path('src/monster/j-function.res')) as fp:
+        with open(path('src/monster/j-function.res'), 'r') as fp:
           self.assertEqual('196884', fp.read())
 
   def test_symlinks_issues_2815(self):
@@ -544,7 +545,7 @@ class TestSetupPy(SetupPyTestBase):
                           res_link_path},
                          py_files)
 
-        with open(res_link_path) as fp:
+        with open(res_link_path, 'r') as fp:
           self.assertEqual('196884', fp.read())
 
   def test_prep_command_case(self):

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -8,7 +8,7 @@ import itertools
 import logging
 import os
 import unittest
-from builtins import object
+from builtins import object, open
 from collections import defaultdict
 from contextlib import contextmanager
 from tempfile import mkdtemp
@@ -454,7 +454,7 @@ class BaseTest(unittest.TestCase):
     :API: public
     """
 
-    with open(file_path) as f:
+    with open(file_path, 'r') as f:
       content = f.read()
       self.assertIn(string, content, '"{}" is not in the file {}:\n{}'.format(string, f.name, content))
 

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -22,6 +22,7 @@ python_tests(
   name = 'build_ignore_integration',
   sources = [ 'test_build_ignore_integration.py' ],
   dependencies = [
+    '3rdparty/python:future',
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},

--- a/tests/python/pants_test/engine/legacy/test_build_ignore_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_build_ignore_integration.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import tempfile
+from builtins import open
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 

--- a/tests/python/pants_test/engine/legacy/test_changed_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_changed_integration.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import shutil
-from builtins import str
+from builtins import open, str
 from contextlib import contextmanager
 from textwrap import dedent
 
@@ -39,7 +39,7 @@ def mutated_working_copy(files_to_mutate, to_append='\n '):
   assert to_append, 'to_append may not be empty'
 
   for f in files_to_mutate:
-    with open(f, 'ab') as fh:
+    with open(f, 'a') as fh:
       fh.write(to_append)
   try:
     yield

--- a/tests/python/pants_test/java/junit/test_junit_xml_parser.py
+++ b/tests/python/pants_test/java/junit/test_junit_xml_parser.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import unittest
-from builtins import object
+from builtins import object, open
 
 # NB: The Test -> JUnitTest import re-name above is needed to work around conflicts with pytest test
 # collection and a conflicting Test type in scope during that process.

--- a/tests/python/pants_test/net/http/test_fetcher.py
+++ b/tests/python/pants_test/net/http/test_fetcher.py
@@ -9,7 +9,7 @@ import http.server
 import os
 import socketserver
 import unittest
-from builtins import str
+from builtins import open, str
 from contextlib import closing, contextmanager
 from functools import reduce
 from io import BytesIO

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -9,6 +9,7 @@ import glob
 import os
 import shutil
 import unittest
+from builtins import open
 from collections import namedtuple
 from contextlib import contextmanager
 from operator import eq, ne
@@ -473,7 +474,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
       def write_file(file_path, contents):
         full_file_path = os.path.join(tmp_dir, *file_path.split(os.pathsep))
         safe_mkdir_for(full_file_path)
-        with open(full_file_path, 'wb') as fh:
+        with open(full_file_path, 'w') as fh:
           fh.write(contents)
 
       @contextmanager

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -4,6 +4,7 @@
 python_tests(
   sources = ['test_linkify.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/reporting',
   ],
   timeout = 10,
@@ -13,6 +14,7 @@ python_tests(
   name = 'reporting_integration',
   sources = ['test_reporting_integration.py'],
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python:parameterized',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test'

--- a/tests/python/pants_test/reporting/test_linkify.py
+++ b/tests/python/pants_test/reporting/test_linkify.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from builtins import open
 
 from pants.reporting.linkify import linkify
 

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os.path
 import re
 import unittest
+from builtins import open
 
 from parameterized import parameterized
 
@@ -33,7 +34,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
       self.assert_success(pants_run)
       output = os.path.join(workdir, _REPORT_LOCATION)
       self.assertTrue(os.path.exists(output))
-      with open(output) as f:
+      with open(output, 'r') as f:
         self.assertEqual(_HEADER, f.readline())
         for line in f.readlines():
           self.assertTrue(_ENTRY.match(line))

--- a/tests/python/pants_test/scm/BUILD
+++ b/tests/python/pants_test/scm/BUILD
@@ -5,6 +5,7 @@ python_tests(
   name = 'test_git',
   sources = ['test_git.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/scm',
     'src/python/pants/scm:git',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/scm/test_git.py
+++ b/tests/python/pants_test/scm/test_git.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import unittest
+from builtins import open
 from contextlib import contextmanager
 from textwrap import dedent
 from unittest import skipIf
@@ -272,7 +273,7 @@ class GitTest(unittest.TestCase):
         self.init_repo('origin', self.origin)
         subprocess.check_call(['git', 'pull', '--tags', 'origin', 'master:master'])
 
-        with open(os.path.realpath('README')) as readme:
+        with open(os.path.realpath('README'), 'r') as readme:
           self.assertEqual('--More data.', readme.read())
 
         git = Git()

--- a/tests/python/pants_test/task/BUILD
+++ b/tests/python/pants_test/task/BUILD
@@ -15,6 +15,7 @@ python_tests(
   name = 'goal_options_mixin_integration',
   sources = ['test_goal_options_mixin_integration.py'],
   dependencies = [
+    '3rdparty/python:future',
     'tests/python/pants_test:int-test',
     'tests/python/pants_test/task/echo_plugin:plugin',
   ],

--- a/tests/python/pants_test/task/echo_plugin/BUILD
+++ b/tests/python/pants_test/task/echo_plugin/BUILD
@@ -6,6 +6,7 @@ python_library(
   name = 'plugin',
   sources = ['register.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/goal',
     'src/python/pants/goal:task_registrar',
     'src/python/pants/task',

--- a/tests/python/pants_test/task/echo_plugin/register.py
+++ b/tests/python/pants_test/task/echo_plugin/register.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 
 from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar as task
@@ -19,7 +20,7 @@ class EchoTaskBase(HasSkipAndTransitiveGoalOptionsMixin, Task):
 
   def execute(self):
     with open(os.path.join(self.workdir, 'output'), 'w') as fp:
-      fp.write(b'\n'.join(t.address.spec for t in self.get_targets()))
+      fp.write('\n'.join(t.address.spec for t in self.get_targets()))
 
 
 class EchoOne(EchoTaskBase):

--- a/tests/python/pants_test/task/test_goal_options_mixin_integration.py
+++ b/tests/python/pants_test/task/test_goal_options_mixin_integration.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import textwrap
+from builtins import open
 
 from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import temporary_dir
@@ -41,7 +42,7 @@ class TestGoalOptionsMixinIntegration(PantsRunIntegrationTest):
           if not os.path.exists(path):
             return None
           else:
-            with open(path) as fp:
+            with open(path, 'r') as fp:
               return [os.path.basename(x.strip()) for x in fp.readlines()]
         self.assertEqual(expected_one, get_echo('one'))
         self.assertEqual(expected_two, get_echo('two'))

--- a/tests/python/pants_test/task/test_simple_codegen_task.py
+++ b/tests/python/pants_test/task/test_simple_codegen_task.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from builtins import str
+from builtins import open, str
 from textwrap import dedent
 
 from pants.base.payload import Payload

--- a/tests/python/pants_test/task/test_task.py
+++ b/tests/python/pants_test/task/test_task.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from builtins import str
+from builtins import open, str
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError

--- a/tests/python/pants_test/task/test_testrunner_task_mixin.py
+++ b/tests/python/pants_test/task/test_testrunner_task_mixin.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import collections
 import os
-from builtins import next, object
+from builtins import next, object, open
 from contextlib import contextmanager
 from unittest import TestCase
 from xml.etree.ElementTree import ParseError

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -8,7 +8,7 @@ import itertools
 import logging
 import os
 import unittest
-from builtins import object
+from builtins import object, open
 from collections import defaultdict
 from contextlib import contextmanager
 from tempfile import mkdtemp
@@ -586,7 +586,7 @@ class TestBase(unittest.TestCase):
     :API: public
     """
 
-    with open(file_path) as f:
+    with open(file_path, 'r') as f:
       content = f.read()
       self.assertIn(string, content, '"{}" is not in the file {}:\n{}'.format(string, f.name, content))
 

--- a/tests/python/pants_test/testutils/BUILD
+++ b/tests/python/pants_test/testutils/BUILD
@@ -15,6 +15,9 @@ python_library(
   sources = [
     'file_test_util.py',
   ],
+  dependencies = [
+    '3rdparty/python:future',
+  ],
 )
 
 python_library(
@@ -46,6 +49,7 @@ python_library(
     'pexrc_util.py',
   ],
   dependencies = [
+    '3rdparty/python:future',
     ':git_util'
   ,]
 )

--- a/tests/python/pants_test/testutils/file_test_util.py
+++ b/tests/python/pants_test/testutils/file_test_util.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 
 
 def exact_files(directory, ignore_links=False):
@@ -47,7 +48,7 @@ def check_file_content(path, expected_content):
   :param str path: Path to file.
   :param str expected_content: Expected file content.
   """
-  with open(path) as input:
+  with open(path, 'r') as input:
     return expected_content == input.read()
 
 

--- a/tests/python/pants_test/testutils/pexrc_util.py
+++ b/tests/python/pants_test/testutils/pexrc_util.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+from builtins import open
 from contextlib import contextmanager
 
 

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -58,6 +58,7 @@ python_tests(
   name = 'fileutil',
   sources = ['test_fileutil.py'],
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python:mock',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:fileutil',
@@ -163,6 +164,7 @@ python_tests(
   name = 'tarutil',
   sources = ['test_tarutil.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:tarutil',
   ]

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -8,7 +8,7 @@ import errno
 import os
 import time
 import unittest
-from builtins import str
+from builtins import open, str
 from contextlib import contextmanager
 
 import mock
@@ -153,7 +153,7 @@ class DirutilTest(unittest.TestCase):
 
     @classmethod
     def read(cls, root, relpath):
-      with open(os.path.join(root, relpath)) as fp:
+      with open(os.path.join(root, relpath), 'r') as fp:
         return cls(relpath, fp.read())
 
   class Symlink(datatype(['path'])):
@@ -522,7 +522,7 @@ class AbsoluteSymlinkTest(unittest.TestCase):
     self._create_and_check_link(self.source, self.link)
 
     # The link should have been deleted (over-written), not the file it pointed to.
-    with open(self.source) as fp:
+    with open(self.source, 'r') as fp:
       self.assertEqual('evidence', fp.read())
 
   def test_overwrite_link_dir(self):

--- a/tests/python/pants_test/util/test_fileutil.py
+++ b/tests/python/pants_test/util/test_fileutil.py
@@ -9,6 +9,7 @@ import os
 import random
 import stat
 import unittest
+from builtins import open
 
 from mock import mock
 
@@ -24,7 +25,7 @@ class FileutilTest(unittest.TestCase):
       with temporary_file() as dst:
         atomic_copy(src.name, dst.name)
         dst.close()
-        with open(dst.name) as new_dst:
+        with open(dst.name, 'r') as new_dst:
           self.assertEqual(src.name, new_dst.read())
         self.assertEqual(os.stat(src.name).st_mode, os.stat(dst.name).st_mode)
 

--- a/tests/python/pants_test/util/test_tarutil.py
+++ b/tests/python/pants_test/util/test_tarutil.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import tarfile
 import unittest
+from builtins import open
 
 from pants.util.dirutil import safe_delete, safe_mkdtemp, safe_rmtree, touch
 from pants.util.tarutil import TarFile


### PR DESCRIPTION
Ensures these folders use Python 3 semantics for opening files.

- src/backend/codegen
- src/backend/docgen
- src/backend/graph_info
- src/backend/jvm
- src/backend/native
- src/backend/project_info
- src/backend/python
- src/reporting/
- src/rules
- src/scm/
- src/source/
- src/stats/
- src/subsystem/
- src/task/
- src/util/
- test/ (root)
- test/tasks
- test/testutils

These also were mostly ported in stage 1, but I realized the subfolders weren't ported:
- src/pantsd/
- src/java/
- src/net/
- src/engine/

### Ignores safe_open()
`util/dirutil.py` was not ported because it's `safe_open()` function is used throughout the codebase. That will be a separate PR.

--

See https://github.com/pantsbuild/pants/pull/6290 for stage 1.