### PR TITLE
Ensure that all arguments are parsed as Py 2/3 compatible str

### DIFF
--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import sys
-from builtins import object
+from builtins import object, str
 from collections import namedtuple
 
 from twitter.common.collections import OrderedSet
@@ -149,7 +149,7 @@ class ArgSplitter(object):
     passthru = []
     passthru_owner = None
 
-    self._unconsumed_args = list(reversed(sys.argv if args is None else args))
+    self._unconsumed_args = list(str(a) for a in reversed(sys.argv if args is None else args))
     # In regular use the first token is the binary name, so skip it. However tests may
     # pass just a list of flags, so don't skip it in that case.
     if not self._at_flag() and self._unconsumed_args:

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -8,10 +8,10 @@ import copy
 import os
 import re
 import traceback
-from builtins import next, object, open
+from builtins import next, object, open, str
 from collections import defaultdict
 
-import six
+from future.utils import string_types
 
 from pants.base.deprecated import validate_removal_semver, warn_or_error
 from pants.option.arg_splitter import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION
@@ -54,7 +54,7 @@ class Parser(object):
 
   @staticmethod
   def _ensure_bool(s):
-    if isinstance(s, six.string_types):
+    if isinstance(s, string_types):
       if s.lower() == 'true':
         return True
       elif s.lower() == 'false':
@@ -420,6 +420,8 @@ class Parser(object):
       return list_option
     elif t == dict:
       return dict_option
+    elif t in string_types:
+      return str
     else:
       return t
 

--- a/src/python/pants/task/console_task.py
+++ b/src/python/pants/task/console_task.py
@@ -8,6 +8,8 @@ import errno
 import os
 from contextlib import contextmanager
 
+from future.utils import PY2
+
 from pants.base.exceptions import TaskError
 from pants.task.task import QuietTaskMixin, Task
 from pants.util.dirutil import safe_open
@@ -29,7 +31,8 @@ class ConsoleTask(QuietTaskMixin, Task):
 
   def __init__(self, *args, **kwargs):
     super(ConsoleTask, self).__init__(*args, **kwargs)
-    self._console_separator = self.get_options().sep.decode('unicode_escape')
+    encoding = 'string-escape' if PY2 else 'unicode-escape'
+    self._console_separator = self.get_options().sep.encode('utf-8').decode(encoding)
     if self.get_options().output_file:
       try:
         self._outstream = safe_open(os.path.abspath(self.get_options().output_file), 'wb')

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -602,6 +602,14 @@ class OptionsTest(unittest.TestCase):
     options = self._parse('./pants --implicit-valuey=explicit')
     self.assertEqual('explicit', options.for_global_scope().implicit_valuey)
 
+  def test_string_lift(self):
+    options = self._parse('./pants')
+    self.assertEqual(str, type(options.for_global_scope().implicit_valuey))
+    options = self._parse('./pants --implicit-valuey')
+    self.assertEqual(str, type(options.for_global_scope().implicit_valuey))
+    options = self._parse('./pants --implicit-valuey=explicit')
+    self.assertEqual(str, type(options.for_global_scope().implicit_valuey))
+
   def test_shadowing(self):
     options = Options.create(env={},
                              config=self._create_config({}),


### PR DESCRIPTION
### Problem

See #6293.

### Solution

Convert all string_types options to `future`'s `str` type. Fix one location where we were then attempting to double-decode bytes to unicode.

### Result

Fixes #6293.