### PR TITLE
drop self from __init__ and __new__

### DIFF
--- a/src/python/pants/build_graph/BUILD
+++ b/src/python/pants/build_graph/BUILD
@@ -20,6 +20,7 @@ python_library(
     'src/python/pants/base:specs',
     'src/python/pants/base:target_roots',
     'src/python/pants/base:validation',
+    'src/python/pants/fs',
     'src/python/pants/option',
     'src/python/pants/source',
     'src/python/pants/source:payload_fields',

--- a/src/python/pants/help/build_dictionary_info_extracter.py
+++ b/src/python/pants/help/build_dictionary_info_extracter.py
@@ -167,7 +167,10 @@ class BuildDictionaryInfoExtracter(object):
     arg_descriptions = cls.get_arg_descriptions_from_docstring(func)
     argspec = inspect.getargspec(func)
     arg_names = argspec.args
-    if inspect.ismethod(func) or func.__name__ == '__new__':
+    # Python2 treats __init__ as a method. Python3 doesn't.
+    # Neither treat __new__ as a method.
+    # Always treat __init__ and __new__ as methods, to drop self from their args.
+    if inspect.ismethod(func) or func.__name__ == '__new__' or func.__name__ == '__init__':
       arg_names = arg_names[1:]
     num_defaulted_args = len(argspec.defaults) if argspec.defaults is not None else 0
     first_defaulted_arg = len(arg_names) - num_defaulted_args


### PR DESCRIPTION
An alternative would be to just always drop the first arg if its name is
`self` (or maybe `cls`). But this is the minimally invasive change for
py3 compat.