### PR TITLE
Python 3 fixes - add open() backport to safe_open()

### DIFF
--- a/contrib/avro/tests/python/pants_test/contrib/avro/tasks/test_avro_gen.py
+++ b/contrib/avro/tests/python/pants_test/contrib/avro/tasks/test_avro_gen.py
@@ -58,7 +58,7 @@ class AvroJavaGenTest(NailgunTaskTestBase):
       )
     '''))
 
-    self.create_file(relpath='avro-build/src/avro/schema.avsc', mode='w', contents=dedent('''
+    self.create_file(relpath='avro-build/src/avro/schema.avsc', contents=dedent('''
       {
         "namespace": "",
         "type": "record",
@@ -70,7 +70,7 @@ class AvroJavaGenTest(NailgunTaskTestBase):
       }
     '''))
 
-    self.create_file(relpath='avro-build/src/avro/record.avdl', mode='w', contents=dedent('''
+    self.create_file(relpath='avro-build/src/avro/record.avdl', contents=dedent('''
       protocol Test {
         void test();
       }

--- a/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
+++ b/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
@@ -77,7 +77,7 @@ class ConfluencePublish(Task):
       basedir, htmls = list(html_info.items())[0]
       if len(htmls) != 1:
         raise TaskError('Unexpected resources for {}: {}'.format(page, htmls))
-      with safe_open(os.path.join(basedir, htmls[0])) as contents:
+      with safe_open(os.path.join(basedir, htmls[0]), 'r') as contents:
         url = self.publish_page(
           page.address,
           wiki_artifact.config['space'],

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_buildgen.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_buildgen.py
@@ -93,7 +93,7 @@ class GoBuildgenTest(TaskTestBase):
       task.execute()
 
   def test_existing_targets_wrong_type(self):
-    self.create_file(relpath='src/go/src/fred/foo.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/fred/foo.go', contents=dedent("""
       package main
 
       import "fmt"
@@ -109,7 +109,7 @@ class GoBuildgenTest(TaskTestBase):
     self.assertEqual(GoTargetGenerator.WrongLocalSourceTargetTypeError, type(exc.exception.cause))
 
   def test_noop_applicable_targets_simple(self):
-    self.create_file(relpath='src/go/src/fred/foo.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/fred/foo.go', contents=dedent("""
       package main
 
       import "fmt"
@@ -125,13 +125,13 @@ class GoBuildgenTest(TaskTestBase):
     self.assertEqual(expected, context.targets())
 
   def test_noop_applicable_targets_complete_graph(self):
-    self.create_file(relpath='src/go/src/jane/bar.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/jane/bar.go', contents=dedent("""
       package jane
 
       var PublicConstant = 42
     """))
     jane = self.make_target('src/go/src/jane', GoLibrary)
-    self.create_file(relpath='src/go/src/fred/foo.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/fred/foo.go', contents=dedent("""
       package main
 
       import (
@@ -157,12 +157,12 @@ class GoBuildgenTest(TaskTestBase):
       # We need physical directories on disk for `--materialize` since it does scans.
       self.create_dir('src/go/src')
 
-    self.create_file(relpath='src/go/src/jane/bar.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/jane/bar.go', contents=dedent("""
         package jane
 
         var PublicConstant = 42
       """))
-    self.create_file(relpath='src/go/src/fred/foo.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/fred/foo.go', contents=dedent("""
         package main
 
         import (
@@ -218,14 +218,14 @@ class GoBuildgenTest(TaskTestBase):
       self.create_dir('3rdparty/go')
       self.create_dir('src/go/src')
 
-    self.create_file(relpath='src/go/src/jane/bar.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/jane/bar.go', contents=dedent("""
         package jane
 
         import "pantsbuild.org/fake/prod"
 
         var PublicConstant = prod.DoesNotExistButWeShouldNotCareWhenCheckingDepsAndNotInstalling
       """))
-    self.create_file(relpath='src/go/src/fred/foo.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/fred/foo.go', contents=dedent("""
         package main
 
         import (
@@ -318,7 +318,7 @@ class GoBuildgenTest(TaskTestBase):
     self.add_to_build_file(relpath='3rdparty/go/pantsbuild.org/fake',
                            target='go_remote_library(rev="v4.5.6")')
 
-    self.create_file(relpath='src/go/src/jane/bar.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/jane/bar.go', contents=dedent("""
         package jane
 
         import "pantsbuild.org/fake"
@@ -339,12 +339,12 @@ class GoBuildgenTest(TaskTestBase):
   def test_issues_2616(self):
     self.set_options(remote=False)
 
-    self.create_file(relpath='src/go/src/jane/bar.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/jane/bar.go', contents=dedent("""
         package jane
 
         var PublicConstant = 42
       """))
-    self.create_file(relpath='src/go/src/fred/foo.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/fred/foo.go', contents=dedent("""
         package main
 
         /*
@@ -379,19 +379,19 @@ class GoBuildgenTest(TaskTestBase):
 
     self.set_options(remote=False, materialize=False)
 
-    self.create_file(relpath='src/go/src/helper/helper.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/helper/helper.go', contents=dedent("""
         package helper
 
         const PublicConstant = 42
       """))
 
-    self.create_file(relpath='src/go/src/lib/lib.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/lib/lib.go', contents=dedent("""
         package lib
 
         const privateConstant = 42
       """))
 
-    self.create_file(relpath='src/go/src/lib/lib_test.go', mode='w', contents=dedent("""
+    self.create_file(relpath='src/go/src/lib/lib_test.go', contents=dedent("""
         package lib_test
 
         import (

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
@@ -27,7 +27,7 @@ class GoFetchTest(TaskTestBase):
 
   def test_get_remote_import_paths(self):
     go_fetch = self.create_task(self.context())
-    self.create_file('src/github.com/u/a/a.go', mode='w', contents="""
+    self.create_file('src/github.com/u/a/a.go', contents="""
       package a
 
       import (
@@ -77,7 +77,7 @@ class GoFetchTest(TaskTestBase):
     """Creates a Go package inside dirpath named 'name' importing deps."""
     imports = ['import "localzip/{}"'.format(d) for d in deps]
     f = os.path.join(dirpath, '{name}/{name}.go'.format(name=name))
-    self.create_file(f, mode='w', contents=
+    self.create_file(f, contents=
       """package {name}
         {imports}
       """.format(name=name, imports='\n'.join(imports)))
@@ -192,7 +192,7 @@ class GoFetchTest(TaskTestBase):
 
   def test_issues_2616(self):
     go_fetch = self.create_task(self.context())
-    self.create_file('src/github.com/u/a/a.go', mode='w', contents="""
+    self.create_file('src/github.com/u/a/a.go', contents="""
       package a
 
       import (
@@ -203,7 +203,7 @@ class GoFetchTest(TaskTestBase):
         "bitbucket.org/u/b"
       )
     """)
-    self.create_file('src/github.com/u/a/b.go', mode='w', contents="""
+    self.create_file('src/github.com/u/a/b.go', contents="""
       package a
 
       /*

--- a/contrib/googlejavaformat/tests/python/pants_test/contrib/googlejavaformat/test_googlejavaformat.py
+++ b/contrib/googlejavaformat/tests/python/pants_test/contrib/googlejavaformat/test_googlejavaformat.py
@@ -53,7 +53,6 @@ class GoogleJavaFormatTests(TestBase):
   def test_googlejavaformat(self):
     javafile = self.create_file(
       relpath='src/java/org/pantsbuild/contrib/googlejavaformat/MyClass.java',
-      mode='w',
       contents=self._BADFORMAT)
     target = self.make_target(
       spec='src/java/org/pantsbuild/contrib/googlejavaformat',
@@ -76,7 +75,6 @@ class GoogleJavaFormatCheckFormatTests(TestBase):
   def test_lint_badformat(self):
     self.create_file(
       relpath='src/java/org/pantsbuild/contrib/googlejavaformat/MyClass.java',
-      mode='w',
       contents=self._BADFORMAT)
     target = self.make_target(
       spec='src/java/org/pantsbuild/contrib/googlejavaformat',
@@ -94,7 +92,6 @@ class GoogleJavaFormatCheckFormatTests(TestBase):
   def test_lint_goodformat(self):
     self.create_file(
       relpath='src/java/org/pantsbuild/contrib/googlejavaformat/MyClass.java',
-      mode='w',
       contents=self._GOODFORMAT)
     target = self.make_target(
       spec='src/java/org/pantsbuild/contrib/googlejavaformat',

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_build.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_build.py
@@ -102,7 +102,6 @@ class TestNodeBuild(TaskTestBase):
   def test_run_build_script(self):
     package_json_file = self.create_file(
       'src/node/build_test/package.json',
-      mode='w',
       contents=dedent("""
         {
           "scripts": {
@@ -132,7 +131,7 @@ class TestNodeBuild(TaskTestBase):
 
   def test_run_non_existing_script(self):
     package_json_file = self.create_file(
-      'src/node/build_test/package.json', mode='w', contents='{}')
+      'src/node/build_test/package.json', contents='{}')
     build_script = 'my_non_existing_build_scirpt'
     target = self.make_target(
       spec='src/node/build_test',
@@ -145,7 +144,6 @@ class TestNodeBuild(TaskTestBase):
   def test_run_no_output_dir(self):
     package_json_file = self.create_file(
       'src/node/build_test/package.json',
-      mode='w',
       contents=dedent("""
         {
           "scripts": {

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve.py
@@ -181,7 +181,7 @@ class NodeResolveTest(TaskTestBase):
     self.assertIn('type of bool is: boolean', lines)
 
   def test_resolve_preserves_package_json(self):
-    self.create_file('src/node/util/package.json', mode='w', contents=dedent("""
+    self.create_file('src/node/util/package.json', contents=dedent("""
       {
         "name": "util",
         "version": "0.0.1"
@@ -192,7 +192,7 @@ class NodeResolveTest(TaskTestBase):
                             sources=['package.json'],
                             dependencies=[])
 
-    self.create_file('src/node/scripts_project/package.json', mode='w', contents=dedent("""
+    self.create_file('src/node/scripts_project/package.json', contents=dedent("""
       {
         "name": "scripts_project",
         "version": "1.2.3",
@@ -239,13 +239,13 @@ class NodeResolveTest(TaskTestBase):
 
   def _test_resolve_optional_install_helper(
       self, install_optional, package_manager, expected_params):
-    self.create_file('src/node/util/package.json', mode='w', contents=dedent("""
+    self.create_file('src/node/util/package.json', contents=dedent("""
       {
         "name": "util",
         "version": "0.0.1"
       }
     """))
-    self.create_file('src/node/util/util.js', mode='w', contents=dedent("""
+    self.create_file('src/node/util/util.js', contents=dedent("""
       var typ = require('typ');
       console.log("type of boolean is: " + typ.BOOLEAN);
     """))

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checker.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checker.py
@@ -35,7 +35,7 @@ class PythonCheckStyleTaskTest(PythonTaskTestBase):
     self.assertEqual(None, task.execute())
 
   def test_pass(self):
-    self.create_file('a/python/pass.py', mode='w', contents=dedent("""
+    self.create_file('a/python/pass.py', contents=dedent("""
                        print('Print is a function')
                      """))
     target = self.make_target('a/python:pass', PythonLibrary, sources=['pass.py'])
@@ -44,7 +44,7 @@ class PythonCheckStyleTaskTest(PythonTaskTestBase):
     self.assertEqual(0, task.execute())
 
   def test_failure(self):
-    self.create_file('a/python/fail.py', mode='w', contents=dedent("""
+    self.create_file('a/python/fail.py', contents=dedent("""
                          print 'Print should not be used as a statement'
                        """))
     target = self.make_target('a/python:fail', PythonLibrary, sources=['fail.py'])
@@ -55,10 +55,10 @@ class PythonCheckStyleTaskTest(PythonTaskTestBase):
     self.assertIn('1 Python Style issues found', str(task_error.exception))
 
   def test_suppressed_file_passes(self):
-    self.create_file('a/python/fail.py', mode='w', contents=dedent("""
+    self.create_file('a/python/fail.py', contents=dedent("""
                          print 'Print should not be used as a statement'
                        """))
-    suppression_file = self.create_file('suppress.txt', mode='w', contents=dedent("""
+    suppression_file = self.create_file('suppress.txt', contents=dedent("""
     a/python/fail\.py::print-statements"""))
     target = self.make_target('a/python:fail', PythonLibrary, sources=['fail.py'])
     self.set_options(suppress=suppression_file)
@@ -68,7 +68,7 @@ class PythonCheckStyleTaskTest(PythonTaskTestBase):
     self.assertEqual(0, task.execute())
 
   def test_failure_fail_false(self):
-    self.create_file('a/python/fail.py', mode='w', contents=dedent("""
+    self.create_file('a/python/fail.py', contents=dedent("""
                        print 'Print should not be used as a statement'
                      """))
     target = self.make_target('a/python:fail', PythonLibrary, sources=['fail.py'])
@@ -78,7 +78,7 @@ class PythonCheckStyleTaskTest(PythonTaskTestBase):
     self.assertEqual(1, task.execute())
 
   def test_syntax_error(self):
-    self.create_file('a/python/error.py', mode='w', contents=dedent("""
+    self.create_file('a/python/error.py', contents=dedent("""
                          invalid python
                        """))
     target = self.make_target('a/python:error', PythonLibrary, sources=['error.py'])
@@ -89,7 +89,7 @@ class PythonCheckStyleTaskTest(PythonTaskTestBase):
     self.assertEqual(1, task.execute())
 
   def test_failure_print_nit(self):
-    self.create_file('a/python/fail.py', mode='w', contents=dedent("""
+    self.create_file('a/python/fail.py', contents=dedent("""
                          print 'Print should not be used as a statement'
                        """))
     target = self.make_target('a/python:fail', PythonLibrary, sources=['fail.py'])
@@ -105,7 +105,7 @@ class PythonCheckStyleTaskTest(PythonTaskTestBase):
       str(nits[0]))
 
   def test_syntax_error_nit(self):
-    self.create_file('a/python/error.py', mode='w', contents=dedent("""
+    self.create_file('a/python/error.py', contents=dedent("""
                          invalid python
                        """))
     target = self.make_target('a/python:error', PythonLibrary, sources=['error.py'])
@@ -123,7 +123,7 @@ class PythonCheckStyleTaskTest(PythonTaskTestBase):
                      str(nits[0]))
 
   def test_multiline_nit_printed_only_once(self):
-    self.create_file('a/python/fail.py', mode='w', contents=dedent("""
+    self.create_file('a/python/fail.py', contents=dedent("""
                          print ('Multi'
                                 'line') + 'expression'
                        """))

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_file_excluder.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_file_excluder.py
@@ -33,7 +33,6 @@ class TestExcluder(TestBase):
   def _create_scalastyle_excludes_file(self, exclude_patterns=None):
     return self.create_file(
       relpath='scalastyle_excludes.txt',
-      mode='w',
       contents='\n'.join(exclude_patterns) if exclude_patterns else '')
 
   def test_excludes_cpp_any(self):

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -110,7 +110,7 @@ class ScroogeGenTest(NailgunTaskTestBase):
       }
     ''')
 
-    self.create_file(relpath='test_smoke/a.thrift', mode='w', contents=contents)
+    self.create_file(relpath='test_smoke/a.thrift', contents=contents)
     build_string = self._test_create_build_str(language, compiler_args)
     self.add_to_build_file('test_smoke', build_string)
 
@@ -171,6 +171,6 @@ class ScroogeGenTest(NailgunTaskTestBase):
 
   def _test_dependencies_help(self, contents, declares_service, declares_exception):
     source = 'test_smoke/a.thrift'
-    self.create_file(relpath=source, mode='w', contents=contents)
+    self.create_file(relpath=source, contents=contents)
     self.assertEqual(ScroogeGen._declares_service(source), declares_service)
     self.assertEqual(ScroogeGen._declares_exception(source), declares_exception)

--- a/src/python/pants/backend/docgen/tasks/generate_pants_reference.py
+++ b/src/python/pants/backend/docgen/tasks/generate_pants_reference.py
@@ -107,5 +107,5 @@ class GeneratePantsReference(Task):
     self.context.log.info('Generating {}'.format(output_path))
     html = renderer.render_name(filename, args)
     with safe_open(output_path, 'w') as outfile:
-      outfile.write(html.encode('utf8'))
+      outfile.write(html)
     return output_path

--- a/src/python/pants/backend/jvm/tasks/classpath_products.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_products.py
@@ -273,8 +273,8 @@ class ClasspathProducts(object):
 
         if save_classpath_file:
           classpath = [entry.path for entry in classpath_entries_for_target]
-          with safe_open('{}classpath.txt'.format(classpath_prefix_for_target), 'wb') as classpath_file:
-            classpath_file.write(os.pathsep.join(classpath).encode('utf-8'))
+          with safe_open('{}classpath.txt'.format(classpath_prefix_for_target), 'w') as classpath_file:
+            classpath_file.write(os.pathsep.join(classpath))
             classpath_file.write('\n')
 
     return canonical_classpath

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -626,8 +626,8 @@ class JarPublish(TransitiveOptionRegistrar, HasTransitiveOptionMixin, ScmPublish
 
         if self.publish_changelog:
           changelog_path = self.artifact_path(jar, version, suffix='-CHANGELOG', extension='txt')
-          with safe_open(changelog_path, 'wb') as changelog_file:
-            changelog_file.write(changelog.encode('utf-8'))
+          with safe_open(changelog_path, 'w') as changelog_file:
+            changelog_file.write(changelog)
           publications.add(self.Publication(name=jar.name, classifier='CHANGELOG', ext='txt'))
 
       # Process any extra jars that might have been previously generated for this target, or a

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -15,6 +15,8 @@ from contextlib import closing
 from hashlib import sha1
 from xml.etree import ElementTree
 
+from future.utils import PY3
+
 from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
@@ -68,7 +70,8 @@ class BaseZincCompile(JvmCompile):
   def _write_javac_plugin_info(resources_dir, javac_plugin_target):
     javac_plugin_info_file = os.path.join(resources_dir, _JAVAC_PLUGIN_INFO_FILE)
     with safe_open(javac_plugin_info_file, 'w') as f:
-      f.write(javac_plugin_target.classname)
+      classname = javac_plugin_target.classname if PY3 else javac_plugin_target.classname.decode('utf-8')
+      f.write(classname)
 
   @staticmethod
   def validate_arguments(log, whitelisted_args, args):

--- a/src/python/pants/backend/jvm/tasks/prepare_services.py
+++ b/src/python/pants/backend/jvm/tasks/prepare_services.py
@@ -47,9 +47,9 @@ class PrepareServices(ResourcesTask):
         service_provider_configuration_file = os.path.join(chroot, self.service_info_path(service))
         # NB: provider configuration files must be UTF-8 encoded, see the mini-spec:
         # https://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html
-        with safe_open(service_provider_configuration_file, 'wb') as fp:
+        with safe_open(service_provider_configuration_file, 'w') as fp:
           def write_line(line):
-            fp.write((line + '\n').encode('utf-8'))
+            fp.write((line + '\n'))
           write_line('# Generated from pants target {}'.format(target.address.spec))
           for impl in impls:
             write_line(impl)

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -125,10 +125,7 @@ class RemotePantsRunner(object):
         # Ensure a newline.
         logger.fatal('')
         logger.fatal('lost active connection to pantsd!')
-        raise_with_traceback(
-          self.Terminated,
-          'abruptly lost active connection to pantsd runner: {!r}'.format(e)
-        )
+        raise_with_traceback(self.Terminated('abruptly lost active connection to pantsd runner: {!r}'.format(e)))
 
   def _connect_and_execute(self, port):
     # Merge the nailgun TTY capability environment variables with the passed environment dict.

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -16,7 +16,7 @@ from builtins import open
 from contextlib import contextmanager
 
 import requests
-from future.utils import PY2
+from future.utils import PY2, PY3
 
 from pants.base.build_environment import get_pants_cachedir
 from pants.base.run_info import RunInfo
@@ -363,7 +363,8 @@ class RunTracker(Subsystem):
     # TODO(benjy): Do we really need these, once the statsdb is mature?
     stats_file = os.path.join(get_pants_cachedir(), 'stats',
                               '{}.json'.format(self.run_info.get_info('id')))
-    safe_file_dump(stats_file, json.dumps(stats), binary_mode=False)
+    binary_mode = False if PY3 else True
+    safe_file_dump(stats_file, json.dumps(stats), binary_mode=binary_mode)
 
     # Add to local stats db.
     StatsDBFactory.global_instance().get_db().insert_stats(stats)

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -10,6 +10,7 @@ import os
 import site
 from builtins import object, open
 
+from future.utils import PY3
 from pex import resolver
 from pex.base import requirement_is_exact
 from pkg_resources import Requirement
@@ -98,7 +99,7 @@ class PluginResolver(object):
       tmp_plugins_list = resolved_plugins_list + '~'
       with safe_open(tmp_plugins_list, 'w') as fp:
         for plugin in self._resolve_plugins():
-          fp.write(plugin.location)
+          fp.write(plugin.location if PY3 else plugin.location.decode('utf-8'))
           fp.write('\n')
       os.rename(tmp_plugins_list, resolved_plugins_list)
     with open(resolved_plugins_list, 'r') as fp:

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -332,7 +332,7 @@ class PantsDaemon(FingerprintedProcessManager):
 
     # Once all services are started, write our pid.
     self.write_pid()
-    self.write_metadata_by_name('pantsd', self.FINGERPRINT_KEY, self.options_fingerprint)
+    self.write_metadata_by_name('pantsd', self.FINGERPRINT_KEY, self.options_fingerprint.decode('utf-8'))
 
     # Monitor services.
     while not self.is_killed:

--- a/src/python/pants/pantsd/watchman.py
+++ b/src/python/pants/pantsd/watchman.py
@@ -82,7 +82,7 @@ class Watchman(ProcessManager):
   def _maybe_init_metadata(self):
     safe_mkdir(self._watchman_work_dir)
     # Initialize watchman with an empty, but valid statefile so it doesn't complain on startup.
-    safe_file_dump(self._state_file, '{}')
+    safe_file_dump(self._state_file, b'{}')
 
   def _construct_cmd(self, cmd_parts, state_file, sock_file, pid_file, log_file, log_level):
     return [part for part in cmd_parts] + ['--no-save-state',

--- a/src/python/pants/releases/reversion.py
+++ b/src/python/pants/releases/reversion.py
@@ -86,7 +86,7 @@ def rewrite_record_file(workspace, src_record_file, mutated_file_tuples):
       output_line = line
     output_records.append(output_line)
 
-  safe_file_dump(os.path.join(workspace, dst_record_file), '\r\n'.join(output_records) + '\r\n')
+  safe_file_dump(os.path.join(workspace, dst_record_file), '\r\n'.join(output_records) + '\r\n', binary_mode=False)
 
 
 def reversion(args):

--- a/src/python/pants/reporting/plaintext_reporter.py
+++ b/src/python/pants/reporting/plaintext_reporter.py
@@ -189,6 +189,8 @@ class PlainTextReporter(PlainTextReporterBase):
     #
     # `self.settings.outfile` can also be `io.StringIO` instead of an std stream, in which case it only
     # accepts unicode, so `s` does not need to be modified.
+    # TODO(python3port): Figure out if there's a better way to do this, like opening `sys.stderr` in different mode.
+    # Part of https://github.com/pantsbuild/pants/issues/6071.
     if PY2 and 'std' in str(self.settings.outfile):
       s = s.encode('utf-8')
     if dest == ReporterDestination.OUT:

--- a/src/python/pants/task/console_task.py
+++ b/src/python/pants/task/console_task.py
@@ -55,7 +55,7 @@ class ConsoleTask(QuietTaskMixin, Task):
         targets = self.context.targets()
         for value in self.console_output(targets) or tuple():
           self._outstream.write(value.encode('utf-8'))
-          self._outstream.write(self._console_separator)
+          self._outstream.write(self._console_separator.encode('utf-8'))
       finally:
         self._outstream.flush()
         if self.get_options().output_file:

--- a/src/python/pants/task/console_task.py
+++ b/src/python/pants/task/console_task.py
@@ -29,10 +29,10 @@ class ConsoleTask(QuietTaskMixin, Task):
 
   def __init__(self, *args, **kwargs):
     super(ConsoleTask, self).__init__(*args, **kwargs)
-    self._console_separator = self.get_options().sep.decode('string-escape')
+    self._console_separator = self.get_options().sep.decode('unicode_escape')
     if self.get_options().output_file:
       try:
-        self._outstream = safe_open(os.path.abspath(self.get_options().output_file), 'w')
+        self._outstream = safe_open(os.path.abspath(self.get_options().output_file), 'wb')
       except IOError as e:
         raise TaskError('Error opening stream {out_file} due to'
                         ' {error_str}'.format(out_file=self.get_options().output_file, error_str=e))

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -47,6 +47,7 @@ python_library(
   sources = ['dirutil.py'],
   dependencies = [
     ':strutil',
+    '3rdparty/python:future',
   ],
 )
 

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -12,6 +12,7 @@ import stat
 import tempfile
 import threading
 import uuid
+from builtins import open
 from collections import defaultdict
 from contextlib import contextmanager
 

--- a/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
+++ b/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
@@ -59,7 +59,7 @@ class WikiPageTest(TestBase):
         )
     """))
 
-    self.create_file('src/docs/README.md', mode='w', contents=dedent("""
+    self.create_file('src/docs/README.md', contents=dedent("""
 some text
 
 * [[Link to the other readme file|pants('src/docs:readme2')]]
@@ -70,7 +70,7 @@ some text
 
     """))
 
-    self.create_file('src/docs/README2.md', mode='w', contents=dedent("""
+    self.create_file('src/docs/README2.md', contents=dedent("""
 This is the second readme file! Isn't it exciting?
 
 [[link to the first readme file|pants('src/docs:readme')]]

--- a/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
+++ b/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
@@ -117,7 +117,7 @@ class MarkdownToHtmlTest(TaskTestBase):
     task.execute()
 
   def test_rst_render_failure_fail(self):
-    self.create_file('bad.rst', mode='w', contents=dedent("""
+    self.create_file('bad.rst', contents=dedent("""
     A bad link:
 
     * `RB #2363 https://rbcommons.com/s/twitter/r/2363/>`_
@@ -139,7 +139,7 @@ class MarkdownToHtmlTest(TaskTestBase):
     return pages_by_name.get(rendered_basename)
 
   def test_rst_render_failure_warn(self):
-    self.create_file('bad.rst', mode='w', contents=dedent("""
+    self.create_file('bad.rst', contents=dedent("""
     A bad link:
 
     * `RB #2363 https://rbcommons.com/s/twitter/r/2363/>`_
@@ -165,7 +165,7 @@ class MarkdownToHtmlTest(TaskTestBase):
       self.assertIn('A bad link:', html)
 
   def test_rst_render_success(self):
-    self.create_file('good.rst', mode='w', contents=dedent("""
+    self.create_file('good.rst', contents=dedent("""
     A good link:
 
     * `RB #2363 <https://rbcommons.com/s/twitter/r/2363/>`_

--- a/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html_integration.py
+++ b/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html_integration.py
@@ -19,7 +19,7 @@ class MarkdownIntegrationTest(PantsRunIntegrationTest):
     out_path = os.path.join(get_buildroot(), 'dist', 'markdown/html',
                             'testprojects/src/java/org/pantsbuild/testproject/page',
                             'README.html')
-    with safe_open(out_path) as outfile:
+    with safe_open(out_path, 'r') as outfile:
       page_html = outfile.read()
       self.assertIn('../../../../../../../examples/src/java/org/pantsbuild/'
                     'example/hello/main/README.html',
@@ -33,7 +33,7 @@ class MarkdownIntegrationTest(PantsRunIntegrationTest):
     out_path = os.path.join(get_buildroot(), 'dist', 'markdown/html',
                             'testprojects/src/java/org/pantsbuild/testproject/page',
                             'sense.html')
-    with safe_open(out_path) as outfile:
+    with safe_open(out_path, 'r') as outfile:
       page_html = outfile.read()
       # should get Sense and Sensibility in title (or TITLE, sheesh):
       self.assertRegexpMatches(page_html,

--- a/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
@@ -37,7 +37,7 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
   def tmp_scalastyle_config(self):
     with temporary_dir(root_dir=get_buildroot()) as scalastyle_dir:
       path = os.path.join(scalastyle_dir, 'config.xml')
-      safe_file_dump(path, '''<scalastyle/>''')
+      safe_file_dump(path, '''<scalastyle/>''', binary_mode=False)
       yield '--lint-scalastyle-config={}'.format(path)
 
   def pants_run(self, options=None):

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
@@ -153,21 +153,21 @@ class JarTaskTest(BaseJarTaskTest):
 
   def test_custom_manifest_file(self):
     with self._test_custom_manifest() as (jar, manifest_contents):
-      with safe_open(os.path.join(safe_mkdtemp(), 'any_source_file'), 'w') as fp:
+      with safe_open(os.path.join(safe_mkdtemp(), 'any_source_file'), 'wb') as fp:
         fp.write(manifest_contents)
       jar.write(fp.name, dest='META-INF/MANIFEST.MF')
 
   def test_custom_manifest_dir(self):
     with self._test_custom_manifest() as (jar, manifest_contents):
       basedir = safe_mkdtemp()
-      with safe_open(os.path.join(basedir, 'META-INF/MANIFEST.MF'), 'w') as fp:
+      with safe_open(os.path.join(basedir, 'META-INF/MANIFEST.MF'), 'wb') as fp:
         fp.write(manifest_contents)
       jar.write(basedir)
 
   def test_custom_manifest_dir_custom_dest(self):
     with self._test_custom_manifest() as (jar, manifest_contents):
       basedir = safe_mkdtemp()
-      with safe_open(os.path.join(basedir, 'MANIFEST.MF'), 'w') as fp:
+      with safe_open(os.path.join(basedir, 'MANIFEST.MF'), 'wb') as fp:
         fp.write(manifest_contents)
       jar.write(basedir, dest='META-INF')
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -218,7 +218,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
 
     # Existing files (with and without the method name) should trigger.
     srcfile = os.path.join(self.test_workdir, 'this.is.a.source.file.scala')
-    safe_file_dump(srcfile, 'content!')
+    safe_file_dump(srcfile, 'content!', binary_mode=False)
     self.assertTrue(JUnitRun.request_classes_by_source([srcfile]))
     self.assertTrue(JUnitRun.request_classes_by_source(['{}#method'.format(srcfile)]))
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -77,7 +77,6 @@ class ScalaFmtTestBase(NailgunTaskTestBase):
     self.test_file = self.create_file(
       relpath='src/scala/org/pantsbuild/badscalastyle/BadScalaStyle.scala',
       contents=self.test_file_contents,
-      mode='w'
     )
     self.library = self.make_target(spec='src/scala/org/pantsbuild/badscalastyle',
                                     sources=['BadScalaStyle.scala'],

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -109,7 +109,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
       scheduler = self._sched(work_dir=tmpdir)
 
       source_file_path = os.path.join(tmpdir, file_name)
-      with safe_open(source_file_path, mode='wb') as fp:
+      with safe_open(source_file_path, mode='w') as fp:
         fp.write(contents)
 
       toolchain = self.execute_expecting_one_result(scheduler, toolchain_type, self.toolchain).value

--- a/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
@@ -74,7 +74,7 @@ class PythonTaskTestBase(InterpreterCacheTestMixin, TaskTestBase):
     if source_contents_map:
       self.create_file(relpath=os.path.join(relpath, '__init__.py'))
       for source, contents in source_contents_map.items():
-        self.create_file(relpath=os.path.join(relpath, source), mode='w', contents=contents)
+        self.create_file(relpath=os.path.join(relpath, source), contents=contents)
     return self.target(Address(relpath, name).spec)
 
   def create_python_binary(self, relpath, name, entry_point, dependencies=(), provides=None, shebang=None):

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -114,7 +114,7 @@ class BaseTest(unittest.TestCase):
     safe_mkdir(path)
     return path
 
-  def create_file(self, relpath, contents='', mode='wb'):
+  def create_file(self, relpath, contents='', mode='w'):
     """Writes to a file under the buildroot.
 
     :API: public
@@ -128,7 +128,7 @@ class BaseTest(unittest.TestCase):
       fp.write(contents)
     return path
 
-  def create_workdir_file(self, relpath, contents='', mode='wb'):
+  def create_workdir_file(self, relpath, contents='', mode='w'):
     """Writes to a file under the work directory.
 
     :API: public

--- a/tests/python/pants_test/build_graph/test_build_file_parser.py
+++ b/tests/python/pants_test/build_graph/test_build_file_parser.py
@@ -325,7 +325,7 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTestWithParser):
                  make_lib("com.foo.test", "does_not_exists", "1.0")
                  path_util("baz")
                """)
-    self.create_file('3rdparty/BUILD', contents, mode='w')
+    self.create_file('3rdparty/BUILD', contents)
 
     build_file = BuildFile(FileSystemProjectTree(self.build_root), '3rdparty/BUILD')
     address_map = self.build_file_parser.parse_build_file(build_file)

--- a/tests/python/pants_test/build_graph/test_build_file_parser.py
+++ b/tests/python/pants_test/build_graph/test_build_file_parser.py
@@ -18,7 +18,6 @@ from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.build_file_parser import BuildFileParser
 from pants.build_graph.target import Target
-from pants.util.strutil import ensure_binary
 from pants_test.base_test import BaseTest
 
 
@@ -99,29 +98,27 @@ class BuildFileParserBasicsTest(BaseTestWithParser):
 
   def test_invalid_unicode_in_build_file(self):
     """Demonstrate that unicode characters causing parse errors raise real parse errors."""
-    # TODO(python3port): remove ensure_binary once safe_open() uses backport. This test fails on Py3.
-    self.add_to_build_file('BUILD', ensure_binary(dedent(
+    self.add_to_build_file('BUILD', dedent(
       """
       jvm_binary(name = ‘hello’,  # Parse error due to smart quotes (non ascii characters)
         source = 'HelloWorld.java'
         main = 'foo.HelloWorld',
       )
       """
-    )))
+    ))
     build_file = self.create_buildfile('BUILD')
     self.assert_parser_error(build_file, 'invalid character' if PY3 else 'invalid syntax')
 
   def test_unicode_string_in_build_file(self):
     """Demonstrates that a string containing unicode should work in a BUILD file."""
-    # TODO(python3port): remove ensure_binary once safe_open() uses backport. This test fails on Py3.
-    self.add_to_build_file('BUILD', ensure_binary(dedent(
+    self.add_to_build_file('BUILD', dedent(
         """
         java_library(
           name='foo',
           sources=['א.java']
         )
         """
-    )))
+    ))
     build_file = self.create_buildfile('BUILD')
     self.build_file_parser.parse_build_file(build_file)
 

--- a/tests/python/pants_test/engine/legacy/test_address_mapper.py
+++ b/tests/python/pants_test/engine/legacy/test_address_mapper.py
@@ -41,15 +41,15 @@ class LegacyAddressMapperTest(TestBase):
     safe_mkdir(dir_b)
     safe_mkdir(dir_a_subdir)
 
-    safe_file_dump(os.path.join(self.build_root, 'BUILD'), 'target(name="a")\ntarget(name="b")')
-    safe_file_dump(os.path.join(self.build_root, 'BUILD.other'), 'target(name="c")')
+    safe_file_dump(os.path.join(self.build_root, 'BUILD'), 'target(name="a")\ntarget(name="b")', binary_mode=False)
+    safe_file_dump(os.path.join(self.build_root, 'BUILD.other'), 'target(name="c")', binary_mode=False)
 
-    safe_file_dump(os.path.join(dir_a, 'BUILD'), 'target(name="a")\ntarget(name="b")')
-    safe_file_dump(os.path.join(dir_a, 'BUILD.other'), 'target(name="c")')
+    safe_file_dump(os.path.join(dir_a, 'BUILD'), 'target(name="a")\ntarget(name="b")', binary_mode=False)
+    safe_file_dump(os.path.join(dir_a, 'BUILD.other'), 'target(name="c")', binary_mode=False)
 
-    safe_file_dump(os.path.join(dir_b, 'BUILD'), 'target(name="a")')
+    safe_file_dump(os.path.join(dir_b, 'BUILD'), 'target(name="a")', binary_mode=False)
 
-    safe_file_dump(os.path.join(dir_a_subdir, 'BUILD'), 'target(name="a")')
+    safe_file_dump(os.path.join(dir_a_subdir, 'BUILD'), 'target(name="a")', binary_mode=False)
 
   def test_is_valid_single_address(self):
     self.create_build_files()

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -490,17 +490,17 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
         pantsd_run(['help'])
         checker.assert_started()
 
-        safe_file_dump(test_build_file, "python_library(sources=globs('some_non_existent_file.py'))")
+        safe_file_dump(test_build_file, "python_library(sources=globs('some_non_existent_file.py'))", binary_mode=False)
         result = pantsd_run(export_cmd)
         checker.assert_running()
         self.assertNotRegexpMatches(result.stdout_data, has_source_root_regex)
 
-        safe_file_dump(test_build_file, "python_library(sources=globs('*.py'))")
+        safe_file_dump(test_build_file, "python_library(sources=globs('*.py'))", binary_mode=False)
         result = pantsd_run(export_cmd)
         checker.assert_running()
         self.assertNotRegexpMatches(result.stdout_data, has_source_root_regex)
 
-        safe_file_dump(test_src_file, 'import this\n')
+        safe_file_dump(test_src_file, 'import this\n', binary_mode=False)
         result = pantsd_run(export_cmd)
         checker.assert_running()
         self.assertRegexpMatches(result.stdout_data, has_source_root_regex)

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -144,7 +144,7 @@ class TestBase(unittest.TestCase):
     relative_symlink(src, dst)
     self._invalidate_for(reldst)
 
-  def create_file(self, relpath, contents=b'', mode='wb'):
+  def create_file(self, relpath, contents='', mode='w'):
     """Writes to a file under the buildroot.
 
     :API: public
@@ -168,9 +168,9 @@ class TestBase(unittest.TestCase):
      files: List of file names.
     """
     for f in files:
-      self.create_file(os.path.join(path, f), contents=f, mode='w')
+      self.create_file(os.path.join(path, f), contents=f)
 
-  def create_workdir_file(self, relpath, contents=b'', mode='wb'):
+  def create_workdir_file(self, relpath, contents='', mode='w'):
     """Writes to a file under the work directory.
 
     :API: public


### PR DESCRIPTION
Final stage of adding Python 3 open semantics. Builds off of https://github.com/pantsbuild/pants/pull/6291, https://github.com/pantsbuild/pants/pull/6295, and https://github.com/pantsbuild/pants/pull/6290.