### PR TITLE
Require the system encoding to be UTF-8

### DIFF
--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -21,4 +21,7 @@ USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 # Ensure Pants runs under the 2.7.13 interpreter.
 ENV PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==2.7.13']"
 
+# Our newly created user is unlikely to have a sane environment: set a locale at least.
+ENV LC_ALL="en_US.UTF-8"
+
 WORKDIR /travis/workdir

--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -18,12 +18,6 @@ class PantsLoader(object):
   DEFAULT_ENTRYPOINT = 'pants.bin.pants_exe:main'
 
   ENCODING_IGNORE_ENV_VAR = 'PANTS_IGNORE_UNRECOGNIZED_ENCODING'
-  BLACKLISTED_ENCODINGS = (
-      # Many sources.
-      'us-ascii',
-      # From an Ubuntu Trusty docker image: see #6295.
-      'ansi_x3.4-1968',
-    )
 
   class InvalidLocaleError(Exception):
     """Raised when a valid locale can't be found."""
@@ -42,9 +36,9 @@ class PantsLoader(object):
     # This check is done early to give good feedback to user on how to fix the problem. Other
     # libraries called by Pants may fail with more obscure errors.
     encoding = locale.getpreferredencoding()
-    if encoding.lower() in cls.BLACKLISTED_ENCODINGS and os.environ.get(cls.ENCODING_IGNORE_ENV_VAR, None) is None:
+    if encoding.lower() != 'utf-8' and os.environ.get(cls.ENCODING_IGNORE_ENV_VAR, None) is None:
       raise cls.InvalidLocaleError(
-        'System preferred encoding is `{}`, which is not likely to be what you want.\n'
+        'System preferred encoding is `{}`, but `UTF-8` is required.\n'
         'Check and set the LC_* and LANG environment settings. Example:\n'
         '  LC_ALL=en_US.UTF-8\n'
         '  LANG=en_US.UTF-8\n'

--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -17,6 +17,14 @@ class PantsLoader(object):
   ENTRYPOINT_ENV_VAR = 'PANTS_ENTRYPOINT'
   DEFAULT_ENTRYPOINT = 'pants.bin.pants_exe:main'
 
+  ENCODING_IGNORE_ENV_VAR = 'PANTS_IGNORE_UNRECOGNIZED_ENCODING'
+  BLACKLISTED_ENCODINGS = (
+      # Many sources.
+      'us-ascii',
+      # From an Ubuntu Trusty docker image: see #6295.
+      'ansi_x3.4-1968',
+    )
+
   class InvalidLocaleError(Exception):
     """Raised when a valid locale can't be found."""
 
@@ -33,15 +41,15 @@ class PantsLoader(object):
     # Sanity check for locale, See https://github.com/pantsbuild/pants/issues/2465.
     # This check is done early to give good feedback to user on how to fix the problem. Other
     # libraries called by Pants may fail with more obscure errors.
-    try:
-      locale.getlocale()[1] or locale.getdefaultlocale()[1]
-    except Exception as e:
+    encoding = locale.getpreferredencoding()
+    if encoding.lower() in cls.BLACKLISTED_ENCODINGS and os.environ.get(cls.ENCODING_IGNORE_ENV_VAR, None) is None:
       raise cls.InvalidLocaleError(
-        '{}: {}\n'
-        '  Could not get a valid locale. Check LC_* and LANG environment settings.\n'
-        '  Example for US English:\n'
-        '    LC_ALL=en_US.UTF-8\n'
-        '    LANG=en_US.UTF-8'.format(type(e).__name__, e)
+        'System preferred encoding is `{}`, which is not likely to be what you want.\n'
+        'Check and set the LC_* and LANG environment settings. Example:\n'
+        '  LC_ALL=en_US.UTF-8\n'
+        '  LANG=en_US.UTF-8\n'
+        'To bypass this error, please file an issue and then set:\n'
+        '  {}=1'.format(encoding, cls.ENCODING_IGNORE_ENV_VAR)
       )
 
   @staticmethod

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -5,6 +5,7 @@ python_tests(
   name='loader_integration',
   sources=['test_loader_integration.py'],
   dependencies=[
+    'src/python/pants/bin',
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},

--- a/tests/python/pants_test/bin/test_loader_integration.py
+++ b/tests/python/pants_test/bin/test_loader_integration.py
@@ -4,15 +4,21 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from pants.bin.pants_loader import PantsLoader
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class LoaderIntegrationTest(PantsRunIntegrationTest):
   def test_invalid_locale(self):
+    bypass_env = PantsLoader.ENCODING_IGNORE_ENV_VAR
     pants_run = self.run_pants(command=['help'], extra_env={'LC_ALL': 'iNvALiD-lOcALe'})
     self.assert_failure(pants_run)
-    self.assertIn('Could not get a valid locale.', pants_run.stderr_data)
-    self.assertIn('iNvALiD-lOcALe', pants_run.stderr_data)
+    self.assertIn('System preferred encoding is', pants_run.stderr_data)
+    self.assertIn(bypass_env, pants_run.stderr_data)
+
+    pants_run = self.run_pants(command=['help'], extra_env={'LC_ALL': 'iNvALiD-lOcALe',
+                                                            bypass_env: '1'})
+    self.assert_success(pants_run)
 
   def test_alternate_entrypoint(self):
     pants_run = self.run_pants(

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -254,6 +254,10 @@ class PantsRunIntegrationTest(unittest.TestCase):
     # Only whitelisted entries will be included in the environment if hermetic=True.
     if self.hermetic():
       env = dict()
+      # With an empty environment, we would generally get the true underlying system default
+      # encoding, which is unlikely to be what we want (it's generally ASCII, still). So we
+      # explicitly set an encoding here.
+      env['LC_ALL'] = 'en_US.UTF-8'
       for h in self.hermetic_env_whitelist():
         value = os.getenv(h)
         if value is not None:


### PR DESCRIPTION
### Problem

As seen in #6295, python 3's `open` call defaults to decoding from `locale.getpreferredencoding()` when opened in non-binary mode, which can cause odd misconfigurations to be detected late in the game.

One solution to that problem would be to explicitly specify encodings on all `open` calls where the encoding is known ahead of time, but that game of whack a mole is hard to win, since libraries might also open files indirectly.

### Solution

Require a preferred encoding of `UTF-8`, and address a few locations where pants' own CI was not providing it.

### Result

If folks are using other encodings for valid reasons, hopefully they will file issues; if not, they will have a workaround.