### PR TITLE
Tighten up local process streaming.

### DIFF
--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -5,14 +5,15 @@ use boxfuture::{BoxFuture, Boxable};
 use fs::{self, GlobMatching, PathGlobs, PathStatGetter, Snapshot, StrictGlobMatching};
 use futures::{future, Future, Stream};
 use std::collections::BTreeSet;
+use std::ffi::OsStr;
 use std::ops::Neg;
 use std::os::unix::process::ExitStatusExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 
 use tokio_codec::{BytesCodec, FramedRead};
-use tokio_process::{Child, CommandExt};
+use tokio_process::CommandExt;
 
 use super::{ExecuteProcessRequest, FallibleExecuteProcessResult};
 
@@ -38,28 +39,6 @@ impl CommandRunner {
       work_dir,
       cleanup_local_dirs,
     }
-  }
-
-  fn outputs_stream_for_child(
-    mut child: Child,
-  ) -> impl Stream<Item = ChildOutput, Error = String> + Send {
-    // TODO: This assumes that the Child was launched with stdout/stderr `Stdio::piped`.
-    let stdout_stream = FramedRead::new(child.stdout().take().unwrap(), BytesCodec::new())
-      .map(|bytes| ChildOutput::Stdout(bytes.into()));
-    let stderr_stream = FramedRead::new(child.stderr().take().unwrap(), BytesCodec::new())
-      .map(|bytes| ChildOutput::Stderr(bytes.into()));
-    let exit_stream = child.into_stream().map(|exit_status| {
-      ChildOutput::Exit(
-        exit_status
-          .code()
-          .or(exit_status.signal().map(Neg::neg))
-          .expect("Child process should exit via returned code or signal."),
-      )
-    });
-    stdout_stream
-      .select(stderr_stream)
-      .select(exit_stream)
-      .map_err(|e| format!("Failed to consume process outputs: {:?}", e))
   }
 
   fn construct_output_snapshot(
@@ -108,6 +87,135 @@ impl CommandRunner {
   }
 }
 
+struct StreamedHermeticCommand {
+  inner: Command,
+}
+
+///
+/// The possible incremental outputs of a spawned child process.
+///
+#[derive(Debug)]
+enum ChildOutput {
+  Stdout(Bytes),
+  Stderr(Bytes),
+  Exit(i32),
+}
+
+///
+/// A streaming command that accepts no input stream and does not consult the `PATH`.
+///
+impl StreamedHermeticCommand {
+  fn new<S: AsRef<OsStr>>(program: S) -> StreamedHermeticCommand {
+    let mut inner = Command::new(program);
+    inner
+        .env_clear()
+        // It would be really nice not to have to manually set PATH but this is sadly the only way
+        // to stop automatic PATH searching.
+        .env("PATH", "")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    StreamedHermeticCommand { inner }
+  }
+
+  fn args<I, S>(&mut self, args: I) -> &mut StreamedHermeticCommand
+  where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+  {
+    self.inner.args(args);
+    self
+  }
+
+  fn envs<I, K, V>(&mut self, vars: I) -> &mut StreamedHermeticCommand
+  where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+  {
+    self.inner.envs(vars);
+    self
+  }
+
+  fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut StreamedHermeticCommand {
+    self.inner.current_dir(dir);
+    self
+  }
+
+  fn stream(&mut self) -> Result<impl Stream<Item = ChildOutput, Error = String> + Send, String> {
+    self
+      .inner
+      .spawn_async()
+      .map_err(|e| format!("Error launching process: {:?}", e))
+      .and_then(|mut child| {
+        let stdout_stream = FramedRead::new(child.stdout().take().unwrap(), BytesCodec::new())
+          .map(|bytes| ChildOutput::Stdout(bytes.into()));
+        let stderr_stream = FramedRead::new(child.stderr().take().unwrap(), BytesCodec::new())
+          .map(|bytes| ChildOutput::Stderr(bytes.into()));
+        let exit_stream = child.into_stream().map(|exit_status| {
+          ChildOutput::Exit(
+            exit_status
+              .code()
+              .or(exit_status.signal().map(Neg::neg))
+              .expect("Child process should exit via returned code or signal."),
+          )
+        });
+
+        Ok(
+          stdout_stream
+            .select(stderr_stream)
+            .select(exit_stream)
+            .map_err(|e| format!("Failed to consume process outputs: {:?}", e)),
+        )
+      })
+  }
+}
+
+///
+/// The fully collected outputs of a completed child process.
+///
+struct ChildResults {
+  stdout: Bytes,
+  stderr: Bytes,
+  exit_code: i32,
+}
+
+impl ChildResults {
+  fn collect_from<S, E>(stream: S) -> impl Future<Item = ChildResults, Error = E>
+  where
+    S: Stream<Item = ChildOutput, Error = E> + Send,
+  {
+    // Consume the stream of ChildOutputs incrementally.
+    // NB: We fully buffer up all this incrementalism into final result below and so could
+    // instead be using Command::output_async above to avoid this code. The idea though is
+    // we eventually want to pass incremental results on down the line for streaming process
+    // results to console logs, etc. as tracked by:
+    //   https://github.com/pantsbuild/pants/issues/6089
+    let init = (
+      BytesMut::with_capacity(8192),
+      BytesMut::with_capacity(8192),
+      0,
+    );
+    stream
+      .fold(
+        init,
+        |(mut stdout, mut stderr, mut exit_code), child_output| {
+          match child_output {
+            ChildOutput::Stdout(bytes) => stdout.extend_from_slice(&bytes),
+            ChildOutput::Stderr(bytes) => stderr.extend_from_slice(&bytes),
+            ChildOutput::Exit(code) => exit_code = code,
+          };
+          Ok((stdout, stderr, exit_code)) as Result<_, E>
+        },
+      )
+      .map(|(stdout, stderr, exit_code)| ChildResults {
+        stdout: stdout.into(),
+        stderr: stderr.into(),
+        exit_code,
+      })
+  }
+}
+
 impl super::CommandRunner for CommandRunner {
   ///
   /// Runs a command on this machine in the passed working directory.
@@ -138,45 +246,14 @@ impl super::CommandRunner for CommandRunner {
       .store
       .materialize_directory(workdir_path.clone(), req.input_files)
       .and_then(move |()| {
-        Command::new(&argv[0])
-                  .args(&argv[1..])
-                  .current_dir(&workdir_path)
-                  .env_clear()
-                  // It would be really nice not to have to manually set PATH but this is sadly the only way
-                  // to stop automatic PATH searching.
-                  .env("PATH", "")
-                  .envs(env)
-                  .stdin(Stdio::null())
-                  .stdout(Stdio::piped())
-                  .stderr(Stdio::piped())
-                  .spawn_async()
-                  .map_err(|e| format!("Error launching process: {:?}", e))
+        StreamedHermeticCommand::new(&argv[0])
+          .args(&argv[1..])
+          .current_dir(&workdir_path)
+          .envs(env)
+          .stream()
       })
-      .and_then(|child| {
-        // Consume the stream of ChildOutputs incrementally.
-        // NB: We fully buffer up all this incrementalism into final result below and so could
-        // instead be using Command::output_async above to avoid this code. The idea though is
-        // we eventually want to pass incremental results on down the line for streaming process
-        // results to console logs, etc. as tracked by:
-        //   https://github.com/pantsbuild/pants/issues/6089
-        let init = (
-          BytesMut::with_capacity(8192),
-          BytesMut::with_capacity(8192),
-          0,
-        );
-        Self::outputs_stream_for_child(child).fold(
-          init,
-          |(mut stdout, mut stderr, mut exit_code), child_output| {
-            match child_output {
-              ChildOutput::Stdout(bytes) => stdout.extend_from_slice(&bytes),
-              ChildOutput::Stderr(bytes) => stderr.extend_from_slice(&bytes),
-              ChildOutput::Exit(code) => exit_code = code,
-            };
-            Ok((stdout, stderr, exit_code)) as Result<_, String>
-          },
-        )
-      })
-      .and_then(move |(stdout, stderr, exit_code)| {
+      .and_then(ChildResults::collect_from)
+      .and_then(move |child_results| {
         let output_snapshot = if output_file_paths.is_empty() && output_dir_paths.is_empty() {
           future::ok(fs::Snapshot::empty()).to_boxed()
         } else {
@@ -202,9 +279,9 @@ impl super::CommandRunner for CommandRunner {
 
         output_snapshot
           .map(move |snapshot| FallibleExecuteProcessResult {
-            stdout: stdout.freeze(),
-            stderr: stderr.freeze(),
-            exit_code,
+            stdout: child_results.stdout,
+            stderr: child_results.stderr,
+            exit_code: child_results.exit_code,
             output_directory: snapshot.digest,
           })
           .to_boxed()
@@ -229,16 +306,6 @@ impl super::CommandRunner for CommandRunner {
     self.store.reset_prefork();
     self.fs_pool.reset();
   }
-}
-
-///
-/// An enum of the possible outputs from a child process.
-///
-#[derive(Debug)]
-enum ChildOutput {
-  Stdout(Bytes),
-  Stderr(Bytes),
-  Exit(i32),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We now guaranty the local process is configured for streaming and have
a bit cleaner line to demarc where future streaming would be inserted.
