### PR TITLE
Add extra_jvm_options to jvm_binary targets

### DIFF
--- a/src/python/pants/backend/jvm/targets/junit_tests.py
+++ b/src/python/pants/backend/jvm/targets/junit_tests.py
@@ -51,8 +51,8 @@ class JUnitTests(JvmTarget):
       unspecified, the platform will default to the same one used for compilation.
     :param int timeout: A timeout (in seconds) which covers the total runtime of all tests in this
       target. Only applied if `--test-junit-timeouts` is set to True.
-    :param list extra_jvm_options: A list of key value pairs of jvm options to use when running the
-      tests. Example: ['-Dexample.property=1'] If unspecified, no extra jvm options will be added.
+    :param list extra_jvm_options: A list of options to be passed to the jvm when running the
+      tests. Example: ['-Dexample.property=1', '-DMyFlag', '-Xmx4g'] If unspecified, no extra jvm options will be added.
     :param dict extra_env_vars: A map of environment variables to set when running the tests, e.g.
       { 'FOOBAR': 12 }. Using `None` as the value will cause the variable to be unset.
     :param string concurrency: One of 'SERIAL', 'PARALLEL_CLASSES', 'PARALLEL_METHODS',

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -306,6 +306,7 @@ class JvmBinary(JvmTarget):
                deploy_jar_rules=None,
                manifest_entries=None,
                shading_rules=None,
+               extra_jvm_options=None,
                **kwargs):
     """
     :API: public
@@ -335,6 +336,8 @@ class JvmBinary(JvmTarget):
       (aka monolithic aka fat) binary jar. The order of the rules matters: the first rule which
       matches a fully-qualified class name is used to shade it. See shading_relocate(),
       shading_exclude(), shading_relocate_package(), and shading_exclude_package().
+    :param list extra_jvm_options: A list of key value pairs of jvm options to use when running the
+      binary. Example: ['-Dexample.property=1'] If unspecified, no extra jvm options will be added.
     """
     self.address = address  # Set in case a TargetDefinitionException is thrown early
     if main and not isinstance(main, string_types):
@@ -357,6 +360,7 @@ class JvmBinary(JvmTarget):
       'manifest_entries': FingerprintedField(ManifestEntries(manifest_entries)),
       'main': PrimitiveField(main),
       'shading_rules': PrimitiveField(shading_rules or ()),
+      'extra_jvm_options': PrimitiveField(list(extra_jvm_options or ())),
     })
 
     super(JvmBinary, self).__init__(name=name,

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -336,8 +336,8 @@ class JvmBinary(JvmTarget):
       (aka monolithic aka fat) binary jar. The order of the rules matters: the first rule which
       matches a fully-qualified class name is used to shade it. See shading_relocate(),
       shading_exclude(), shading_relocate_package(), and shading_exclude_package().
-    :param list extra_jvm_options: A list of key value pairs of jvm options to use when running the
-      binary. Example: ['-Dexample.property=1'] If unspecified, no extra jvm options will be added.
+    :param list extra_jvm_options: A list of options to be passed to the jvm when running the
+      binary. Example: ['-Dexample.property=1', '-DMyFlag', '-Xmx4G'] If unspecified, no extra jvm options will be added.
     """
     self.address = address  # Set in case a TargetDefinitionException is thrown early
     if main and not isinstance(main, string_types):

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -80,6 +80,8 @@ class JvmRun(JvmTask):
     else:
       binary = target
 
+    extra_jvm_options = target.payload.extra_jvm_options
+
     # We can't throw if binary isn't a JvmBinary, because perhaps we were called on a
     # python_binary, in which case we have to no-op and let python_run do its thing.
     # TODO(benjy): Some more elegant way to coordinate how tasks claim targets.
@@ -92,7 +94,7 @@ class JvmRun(JvmTask):
           classpath=self.classpath([target]),
           main=self.get_options().main or binary.main,
           executor=executor,
-          jvm_options=self.jvm_options,
+          jvm_options=self.jvm_options + extra_jvm_options,
           args=self.args,
           cwd=working_dir,
           synthetic_jar_dir=self.workdir,

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -80,7 +80,9 @@ class JvmRun(JvmTask):
     else:
       binary = target
 
-    extra_jvm_options = target.payload.extra_jvm_options
+    # Some targets will not have extra_jvm_options in their payload,
+    # so we can't access it with target.payload.extra_jvm_options
+    extra_jvm_options = target.payload.get_field_value("extra_jvm_options")
 
     # We can't throw if binary isn't a JvmBinary, because perhaps we were called on a
     # python_binary, in which case we have to no-op and let python_run do its thing.

--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
@@ -6,7 +6,7 @@ jvm_binary(
 )
 
 jvm_binary(
-    name = 'no-opts',
+    name = 'noopts',
     main = 'opts.Main',
     sources = ['Main.java']
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
@@ -1,5 +1,5 @@
 jvm_binary(
-    extra_jvm_options = ['-Dproperty.color=orange', '-Dproperty.size=2'],
+    extra_jvm_options = ['-Dproperty.color=orange', '-Dproperty.size=2', '-DMyFlag', '-Xmx1m'],
     name = 'opts',
     main = 'opts.Main',
     sources = ['Main.java']

--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
@@ -4,3 +4,9 @@ jvm_binary(
     main = 'opts.Main',
     sources = ['Main.java']
 )
+
+jvm_binary(
+    name = 'no-opts',
+    main = 'opts.Main',
+    sources = ['Main.java']
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
@@ -1,0 +1,6 @@
+jvm_binary(
+    extra_jvm_options = ['-Dproperty.color=orange', '-Dproperty.size=2'],
+    name = 'opts',
+    main = 'opts.Main',
+    sources = ['Main.java']
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/Main.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/Main.java
@@ -1,0 +1,13 @@
+package opts;
+
+public class Main {
+    private static void printProperty(String name) {
+        String value = System.getProperty(name);
+        System.out.println("Property " + name + " is " + value);
+    }
+
+    public static void main(String args[]) {
+       printProperty("property.color");
+       printProperty("property.size");
+    }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/Main.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/Main.java
@@ -1,13 +1,34 @@
 package opts;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.List;
+
 public class Main {
     private static void printProperty(String name) {
         String value = System.getProperty(name);
         System.out.println("Property " + name + " is " + value);
     }
 
+    private static void printFlag(String name) {
+        RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+        List<String> arguments = runtimeMxBean.getInputArguments();
+        
+        if (arguments.contains(name)) {
+          System.out.println("Flag " + name + " is set");
+        } else {
+          System.out.println("Flag " + name + " is NOT set");
+        }
+    }
+
+    private static void printMaxHeapSize() {
+      System.out.println("Max Heap Size: " + Runtime.getRuntime().maxMemory());
+    }
+
     public static void main(String args[]) {
        printProperty("property.color");
        printProperty("property.size");
+       printFlag("-DMyFlag");
+       printMaxHeapSize();
     }
 }

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
@@ -23,13 +23,13 @@ class JvmRunTest(JvmTaskTestBase):
     return JvmRun
 
   @contextmanager
-  def setup_cmdline_run(self, **options):
+  def setup_cmdline_run(self, extra_jvm_options=None, **options):
     """Run the JvmRun task in command line only mode  with the specified extra options.
     :returns: the command line string
     """
     self.set_options(only_write_cmd_line='a', **options)
     jvm_binary = self.make_target('src/java/org/pantsbuild:binary', JvmBinary,
-                                  main='org.pantsbuild.Binary')
+      main='org.pantsbuild.Binary', extra_jvm_options=extra_jvm_options)
     context = self.context(target_roots=[jvm_binary])
     jvm_run = self.create_task(context)
     self._cmdline_classpath = [os.path.join(self.pants_workdir, c) for c in ['bob', 'fred']]
@@ -53,6 +53,13 @@ class JvmRunTest(JvmTaskTestBase):
     main_entry = 'org.pantsbuild.OptMain'
     with self.setup_cmdline_run(main=main_entry) as cmdline:
       self.assertTrue(self._match_cmdline_regex(cmdline, main_entry))
+
+  def test_extra_jvm_option(self):
+    options = ['-Dexample.property1=1', '-Dexample.property2=1']
+    with self.setup_cmdline_run(extra_jvm_options=options) as cmdline:
+      for option in options:
+        self.assertTrue(option in cmdline)
+
 
   def _match_cmdline_regex(self, cmdline, main):
     # Original classpath is embedded in the manifest file of a synthetic jar, just verify

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
@@ -58,8 +58,7 @@ class JvmRunTest(JvmTaskTestBase):
     options = ['-Dexample.property1=1', '-Dexample.property2=1']
     with self.setup_cmdline_run(extra_jvm_options=options) as cmdline:
       for option in options:
-        self.assertTrue(option in cmdline)
-
+        self.assertIn(option, cmdline)
 
   def _match_cmdline_regex(self, cmdline, main):
     # Original classpath is embedded in the manifest file of a synthetic jar, just verify

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -99,6 +99,8 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/3rdparty/org/pantsbuild/testprojects:testprojects',
       # Already tested in 'PantsRequirementIntegrationTest' and 'SetupPyIntegrationTest'.
       'testprojects/pants-plugins/*',
+      'testprojects/src/python/python_distribution/ctypes:ctypes_test',
+      'testprojects/src/python/python_distribution/ctypes_with_third_party:ctypes_test',
     ]
 
     targets_to_exclude = (known_failing_targets + negative_test_targets + need_java_8 +


### PR DESCRIPTION
### Problem

Targets could not include custom jvm options to be passed to the `jvm_run` task.
This creates the need of wrapper scripts around calls to `./pants run ...`
Closes issue: #5868 

### Solution

The `jvm_binary.py` target now accepts `extra_jvm_options` as a parameter.
The `jvm_run.py` task now injects those options into the run command.

### Result

Users can now specify `extra_jvm_options` for `jvm_binary` targets.