### PR TITLE
pantsrc file paths are always unicode

### DIFF
--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -10,6 +10,8 @@ import os
 import sys
 from builtins import filter, next, object, open
 
+from future.utils import binary_type
+
 from pants.base.build_environment import get_default_pants_config_file
 from pants.engine.fs import FileContent
 from pants.option.arg_splitter import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION
@@ -148,6 +150,8 @@ class OptionsBootstrapper(object):
     """Populates the internal bootstrap_options cache."""
     def filecontent_for(path):
       with open(path, 'rb') as fh:
+        if isinstance(path, binary_type):
+          path = path.decode('utf-8')
         return FileContent(path, fh.read())
 
     # N.B. This adaptor is meant to simulate how we would co-operatively invoke options bootstrap


### PR DESCRIPTION
This is a whack-a-mole until all options are always unicode, because
right now I can't run pants without this change :)