### PR TITLE
Use dependency ClasspathEntries, not merged strings

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -117,7 +117,7 @@ class JavacCompile(JvmCompile):
     if JvmPlatform.global_instance().get_options().compiler == 'javac':
       return super(JavacCompile, self).execute()
 
-  def compile(self, ctx, args, classpath, upstream_analysis,
+  def compile(self, ctx, args, dependency_classpath, upstream_analysis,
               settings, fatal_warnings, zinc_file_manager,
               javac_plugin_map, scalac_plugin_map):
     try:
@@ -128,7 +128,7 @@ class JavacCompile(JvmCompile):
     javac_cmd = ['{}/bin/javac'.format(distribution.real_home)]
 
     javac_cmd.extend([
-      '-classpath', ':'.join(classpath),
+      '-classpath', ':'.join((ctx.classes_dir,) + tuple(ce.path for ce in dependency_classpath)),
     ])
 
     if settings.args:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -120,6 +120,11 @@ class JavacCompile(JvmCompile):
   def compile(self, ctx, args, dependency_classpath, upstream_analysis,
               settings, fatal_warnings, zinc_file_manager,
               javac_plugin_map, scalac_plugin_map):
+    classpath = (ctx.classes_dir,) + tuple(ce.path for ce in dependency_classpath)
+
+    if self.get_options().capture_classpath:
+      self._record_compile_classpath(classpath, ctx.target, ctx.classes_dir)
+
     try:
       distribution = JvmPlatform.preferred_jvm_distribution([settings], strict=True)
     except DistributionLocator.Error:
@@ -128,7 +133,7 @@ class JavacCompile(JvmCompile):
     javac_cmd = ['{}/bin/javac'.format(distribution.real_home)]
 
     javac_cmd.extend([
-      '-classpath', ':'.join((ctx.classes_dir,) + tuple(ce.path for ce in dependency_classpath)),
+      '-classpath', ':'.join(classpath),
     ])
 
     if settings.args:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -457,14 +457,13 @@ class JvmCompile(NailgunTaskBase):
     except ExecutionFailure as e:
       raise TaskError("Compilation failure: {}".format(e))
 
-  def _record_compile_classpath(self, classpath, targets, outdir):
-    relative_classpaths = [fast_relpath(entry.path, self.get_options().pants_workdir) for entry in classpath]
+  def _record_compile_classpath(self, classpath, target, outdir):
+    relative_classpaths = [fast_relpath(path, self.get_options().pants_workdir) for path in classpath]
     text = '\n'.join(relative_classpaths)
-    for target in targets:
-      path = os.path.join(outdir, 'compile_classpath', '{}.txt'.format(target.id))
-      safe_mkdir(os.path.dirname(path), clean=False)
-      with open(path, 'w') as f:
-        f.write(text)
+    path = os.path.join(outdir, 'compile_classpath', '{}.txt'.format(target.id))
+    safe_mkdir(os.path.dirname(path), clean=False)
+    with open(path, 'w') as f:
+      f.write(text)
 
   def _compile_vts(self, vts, ctx, upstream_analysis, dependency_classpath, progress_message, settings,
                    compiler_option_sets, zinc_file_manager, counter):
@@ -496,9 +495,6 @@ class JvmCompile(NailgunTaskBase):
         progress_message,
         ').')
       with self.context.new_workunit('compile', labels=[WorkUnitLabel.COMPILER]) as compile_workunit:
-        if self.get_options().capture_classpath:
-          self._record_compile_classpath(dependency_classpath, vts.targets, ctx.classes_dir)
-
         try:
           self.compile(
             ctx,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -281,6 +281,9 @@ class BaseZincCompile(JvmCompile):
               javac_plugin_map, scalac_plugin_map):
     classpath = (ctx.classes_dir,) + tuple(ce.path for ce in dependency_classpath)
 
+    if self.get_options().capture_classpath:
+      self._record_compile_classpath(classpath, ctx.target, ctx.classes_dir)
+
     self._verify_zinc_classpath(classpath)
     self._verify_zinc_classpath(list(upstream_analysis.keys()))
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -276,9 +276,11 @@ class BaseZincCompile(JvmCompile):
     key = hasher.hexdigest()[:12]
     return os.path.join(self.get_options().pants_bootstrapdir, 'zinc', key)
 
-  def compile(self, ctx, args, classpath, upstream_analysis,
+  def compile(self, ctx, args, dependency_classpath, upstream_analysis,
               settings, compiler_option_sets, zinc_file_manager,
               javac_plugin_map, scalac_plugin_map):
+    classpath = (ctx.classes_dir,) + tuple(ce.path for ce in dependency_classpath)
+
     self._verify_zinc_classpath(classpath)
     self._verify_zinc_classpath(list(upstream_analysis.keys()))
 


### PR DESCRIPTION
This will allow the optional DirectoryDigest to be used in hermetic
execution.

The reason for changing this to be just dependencies, and have the
compile function add the target's classpath itself, is that otherwise we
need to make an artificial ClasspathEntry for the current target, which
seems convoluted.