### PR TITLE
[WIP] Fix python_dist() compilation by only modifying PATH

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -225,7 +225,7 @@ class SetupPyExecutionEnvironment(datatype([
         c_linker.path_entries +
         cpp_compiler.path_entries +
         cpp_linker.path_entries)
-      ret['PATH'] = create_path_env_var(all_path_entries)
+      ret['PATH'] = create_path_env_var(all_path_entries, env=os.environ.copy(), prepend=True)
 
       # GCC will output smart quotes in a variety of situations (leading to decoding errors
       # downstream) unless we set this environment variable.

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -227,37 +227,4 @@ class SetupPyExecutionEnvironment(datatype([
         cpp_linker.path_entries)
       ret['PATH'] = create_path_env_var(all_path_entries)
 
-      all_library_dirs = (
-        c_compiler.library_dirs +
-        c_linker.library_dirs +
-        cpp_compiler.library_dirs +
-        cpp_linker.library_dirs)
-      joined_library_dirs = create_path_env_var(all_library_dirs)
-      dynamic_lib_env_var = plat.resolve_platform_specific({
-        'darwin': lambda: 'DYLD_LIBRARY_PATH',
-        'linux': lambda: 'LD_LIBRARY_PATH',
-      })
-      ret[dynamic_lib_env_var] = joined_library_dirs
-
-      all_linking_library_dirs = (c_linker.linking_library_dirs + cpp_linker.linking_library_dirs)
-      ret['LIBRARY_PATH'] = create_path_env_var(all_linking_library_dirs)
-
-      all_include_dirs = cpp_compiler.include_dirs + c_compiler.include_dirs
-      ret['CPATH'] = create_path_env_var(all_include_dirs)
-
-      shared_compile_flags = safe_shlex_join(plat.resolve_platform_specific({
-        'darwin': lambda: [MIN_OSX_VERSION_ARG],
-        'linux': lambda: [],
-      }))
-      ret['CFLAGS'] = shared_compile_flags
-      ret['CXXFLAGS'] = shared_compile_flags
-
-      ret['CC'] = c_compiler.exe_filename
-      ret['CXX'] = cpp_compiler.exe_filename
-      ret['LDSHARED'] = cpp_linker.exe_filename
-
-      all_new_ldflags = cpp_linker.extra_args + plat.resolve_platform_specific(
-        self._SHARED_CMDLINE_ARGS)
-      ret['LDFLAGS'] = safe_shlex_join(all_new_ldflags)
-
     return ret

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -227,4 +227,8 @@ class SetupPyExecutionEnvironment(datatype([
         cpp_linker.path_entries)
       ret['PATH'] = create_path_env_var(all_path_entries)
 
+      # GCC will output smart quotes in a variety of situations (leading to decoding errors
+      # downstream) unless we set this environment variable.
+      ret['LC_ALL'] = 'C'
+
     return ret

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -225,6 +225,9 @@ class SetupPyExecutionEnvironment(datatype([
         c_linker.path_entries +
         cpp_compiler.path_entries +
         cpp_linker.path_entries)
+      # NB: We need to be able to access the python interpreter, so we need the rest of the PATH
+      # entries (after the ones from our native toolchain). This alone is not sufficient to force
+      # setup.py to use only our tools.
       ret['PATH'] = create_path_env_var(all_path_entries, env=os.environ.copy(), prepend=True)
 
       # GCC will output smart quotes in a variety of situations (leading to decoding errors

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -229,11 +229,17 @@ class BuildLocalPythonDistributions(Task):
                              'Installing setup requirements: {}\n\n'
                              .format([req.key for req in setup_reqs_to_resolve]))
 
-    setup_requires_site_dir = ensure_setup_requires_site_dir(
-      setup_reqs_to_resolve, interpreter, setup_requires_dir, platforms=['current'])
-    if setup_requires_site_dir:
-      self.context.log.debug('Setting PYTHONPATH with setup_requires site directory: {}'
-                             .format(setup_requires_site_dir))
+    setup_reqs_pex_path = os.path.join(
+      setup_requires_dir,
+      'setup-requires-{}.pex'.format(versioned_target_fingerprint))
+    setup_requires_pex = self._build_setup_requires_pex_settings.bootstrap(
+      interpreter, setup_reqs_pex_path,
+      # FIXME: remove this obvious hack!
+      extra_reqs=(list(setup_reqs_to_resolve or []) + [
+        PythonRequirement('setuptools==33.1.1'),
+      ]))
+    self.context.log.debug('Using pex file as setup.py interpreter: {}'
+                           .format(setup_requires_pex))
 
     setup_py_execution_environment = SetupPyExecutionEnvironment(
       setup_requires_site_dir=setup_requires_site_dir,

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -12,7 +12,8 @@ import shutil
 from pex import pep425tags
 from pex.interpreter import PythonInterpreter
 
-from pants.backend.native.config.environment import LLVMCppToolchain, LLVMCToolchain, Platform
+from pants.backend.native.config.environment import (GCCCppToolchain, GCCCToolchain,
+                                                     LLVMCppToolchain, LLVMCToolchain, Platform)
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.link_shared_libraries import SharedLibrary
 from pants.backend.python.python_requirement import PythonRequirement
@@ -60,6 +61,24 @@ class BuildLocalPythonDistributions(Task):
     round_manager.require_data(PythonInterpreter)
     round_manager.require(SharedLibrary)
 
+  default_platform_toolchains = {
+    'darwin': 'llvm',
+    'linux': 'gcc',
+  }
+
+  @classmethod
+  def register_options(cls, register):
+    super(BuildLocalPythonDistributions, cls).register_options(register)
+
+    register('--platform-toolchains', type=dict, default=cls.default_platform_toolchains,
+             advanced=True,
+             help='TODO:???/Which toolchain to use for different host platforms pants runs on.')
+
+  @memoized_property
+  def _toolchain_type(self):
+    all_toolchains = self.get_options().platform_toolchains
+    return all_toolchains[self._platform.normalized_os_name]
+
   @classmethod
   def implementation_version(cls):
     return super(BuildLocalPythonDistributions, cls).implementation_version() + [('BuildLocalPythonDistributions', 3)]
@@ -88,15 +107,17 @@ class BuildLocalPythonDistributions(Task):
 
   @memoized_property
   def _c_toolchain(self):
-    llvm_c_toolchain = self._request_single(
-      LLVMCToolchain, self._python_native_code_settings.native_toolchain)
-    return llvm_c_toolchain.c_toolchain
+    c_toolchain_type = LLVMCToolchain if self._toolchain_type == 'llvm' else GCCCToolchain
+    c_toolchain_wrapper = self._request_single(
+      c_toolchain_type, self._python_native_code_settings.native_toolchain)
+    return c_toolchain_wrapper.c_toolchain
 
   @memoized_property
   def _cpp_toolchain(self):
-    llvm_cpp_toolchain = self._request_single(
-      LLVMCppToolchain, self._python_native_code_settings.native_toolchain)
-    return llvm_cpp_toolchain.cpp_toolchain
+    cpp_toolchain_type = LLVMCppToolchain if self._toolchain_type == 'llvm' else GCCCppToolchain
+    cpp_toolchain_wrapper = self._request_single(
+      cpp_toolchain_type, self._python_native_code_settings.native_toolchain)
+    return cpp_toolchain_wrapper.cpp_toolchain
 
   # TODO: This should probably be made into an @classproperty (see PR #5901).
   @property

--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -41,6 +41,8 @@ class PythonInterpreterFingerprintStrategy(DefaultFingerprintHashingMixin, Finge
 class SelectInterpreter(Task):
   """Select an Python interpreter that matches the constraints of all targets in the working set."""
 
+  options_scope = 'select-python-interpreter'
+
   @classmethod
   def implementation_version(cls):
     # TODO(John Sirois): Fixup this task to use VTS results_dirs. Right now version bumps aren't

--- a/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
+++ b/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
@@ -18,8 +18,6 @@ from pants_test.backend.python.tasks.util.build_local_dists_test_base import \
 
 class TestBuildLocalDistsNativeSources(BuildLocalPythonDistributionsTestBase):
 
-  _extra_relevant_task_types = []
-
   _dist_specs = OrderedDict([
 
     ('src/python/dist:universal_dist', {

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes.py
@@ -15,6 +15,7 @@ from pants.backend.native.tasks.c_compile import CCompile
 from pants.backend.native.tasks.cpp_compile import CppCompile
 from pants.backend.native.tasks.link_shared_libraries import LinkSharedLibraries
 from pants.backend.python.targets.python_distribution import PythonDistribution
+from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants_test.backend.python.tasks.python_task_test_base import check_wheel_platform_matches_host
 from pants_test.backend.python.tasks.util.build_local_dists_test_base import \
   BuildLocalPythonDistributionsTestBase
@@ -22,7 +23,12 @@ from pants_test.backend.python.tasks.util.build_local_dists_test_base import \
 
 class TestBuildLocalDistsWithCtypesNativeSources(BuildLocalPythonDistributionsTestBase):
 
-  _extra_relevant_task_types = [CCompile, CppCompile, LinkSharedLibraries]
+  _extra_relevant_task_types = (
+    [
+      CCompile,
+      CppCompile,
+      LinkSharedLibraries,
+    ] + BuildLocalPythonDistributionsTestBase._extra_relevant_task_types)
 
   _dist_specs = OrderedDict([
 

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -8,8 +8,10 @@ import re
 from builtins import next
 
 from pants.backend.native.register import rules as native_backend_rules
+from pants.backend.python.subsystems.python_repos import PythonRepos
 from pants.backend.python.tasks.build_local_python_distributions import \
   BuildLocalPythonDistributions
+from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants.util.collections import assert_single_element
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
@@ -30,7 +32,7 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBas
   # By default, we just use a `BuildLocalPythonDistributions` task. When testing with C/C++ targets,
   # we want to compile and link them as well to get the resulting dist to build, so we add those
   # task types here and execute them beforehand.
-  _extra_relevant_task_types = None
+  _extra_relevant_task_types = [SelectInterpreter]
 
   def setUp(self):
     super(BuildLocalPythonDistributionsTestBase, self).setUp()
@@ -96,7 +98,8 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBas
   def _create_distribution_synthetic_target(self, python_dist_target, extra_targets=[]):
     context = self._scheduling_context(
       target_roots=([python_dist_target] + extra_targets),
-      for_task_types=([self.task_type()] + self._extra_relevant_task_types))
+      for_task_types=([self.task_type()] + self._extra_relevant_task_types),
+      for_subsystems=[PythonRepos])
     self.assertEqual(set(self._all_specified_targets()), set(context.build_graph.targets()))
 
     python_create_distributions_task = self.create_task(context)


### PR DESCRIPTION
*WIP because this resolves a set of problems with compiling a `python_dist()` target's native code, but we need steps to reproduce those errors, and testing. Also, we add a `setuptools` requirement here in a really hacky way that needs to be fixed.*

### Problem

See #6273. `distutils` does all sorts of things with our environment variables (e.g. adding `CFLAGS` to `LDFLAGS`), so until #6273 is merged, trying to modify anything but the `PATH` in the environment in which we invoke `setup.py` in for `python_dist()` targets causes lots of failures in many scenarios.

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

- Only modify the `PATH` in the environment dict produced from `SetupPyExecutionEnvironment`, no other env vars relevant to compilation.
  - Also, prepend our toolchain to the current PATH (commented inline).
- Add `LC_ALL=C` to the environment as well so compilation error output doesn't have decode errors on smart quotes.

(_describe the modifications you've made._)

### Result

- A `python_dist()` target now reliably compiles in an internal centos6 environment, where it didn't before. *This PR needs a repro case, or at least something to test this result.*

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)