### PR TITLE
Strings are correctly returned from rust code

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -479,7 +479,7 @@ def _initialize_externs(ffi):
   def extern_store_utf8(context_handle, utf8_ptr, utf8_len):
     """Given a context and UTF8 bytes, return a new Handle to represent the content."""
     c = ffi.from_handle(context_handle)
-    return c.to_value(text_type(ffi.buffer(utf8_ptr, utf8_len)))
+    return c.to_value(ffi.string(utf8_ptr, utf8_len).decode('utf-8'))
 
   @ffi.def_extern()
   def extern_store_i64(context_handle, i64):

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -209,7 +209,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
     self.assert_walk_dirs(['*', '**'], ['a', 'c.ln', 'd.ln', 'a/b', 'd.ln/b'])
 
   def test_files_content_literal(self):
-    self.assert_content(['4.txt', 'a/4.txt.ln'], {'4.txt': 'four\n', 'a/4.txt.ln': 'four\n'})
+    self.assert_content(['4.txt', 'a/4.txt.ln'], {'4.txt': b'four\n', 'a/4.txt.ln': b'four\n'})
 
   def test_files_content_directory(self):
     with self.assertRaises(Exception):
@@ -218,7 +218,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       self.assert_content(['a/b'], {'a/b': 'nope\n'})
 
   def test_files_content_symlink(self):
-    self.assert_content(['c.ln/../3.txt'], {'c.ln/../3.txt': 'three\n'})
+    self.assert_content(['c.ln/../3.txt'], {'c.ln/../3.txt': b'three\n'})
 
   def test_files_digest_literal(self):
     self.assert_digest(['a/3.txt', '4.txt'], ['a/3.txt', '4.txt'])


### PR DESCRIPTION
Currently we're stringifying a buffer, which on py2 is fine, and on py3 is horribly wrong.