### PR TITLE
[WIP] allow selection of the compile/link toolchain for python_dist()

### DIFF
--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -12,7 +12,8 @@ import shutil
 from pex import pep425tags
 from pex.interpreter import PythonInterpreter
 
-from pants.backend.native.config.environment import LLVMCppToolchain, LLVMCToolchain, Platform
+from pants.backend.native.config.environment import (GCCCppToolchain, GCCCToolchain,
+                                                     LLVMCppToolchain, LLVMCToolchain, Platform)
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.link_shared_libraries import SharedLibrary
 from pants.backend.python.python_requirement import PythonRequirement
@@ -60,6 +61,24 @@ class BuildLocalPythonDistributions(Task):
     round_manager.require_data(PythonInterpreter)
     round_manager.require(SharedLibrary)
 
+  default_platform_toolchains = {
+    'darwin': 'llvm',
+    'linux': 'gcc',
+  }
+
+  @classmethod
+  def register_options(cls, register):
+    super(BuildLocalPythonDistributions, cls).register_options(register)
+
+    register('--platform-toolchains', type=dict, default=cls.default_platform_toolchains,
+             advanced=True,
+             help='TODO:???/Which toolchain to use for different host platforms pants runs on.')
+
+  @memoized_property
+  def _toolchain_type(self):
+    all_toolchains = self.get_options().platform_toolchains
+    return all_toolchains[self._platform.normalized_os_name]
+
   @classmethod
   def implementation_version(cls):
     return super(BuildLocalPythonDistributions, cls).implementation_version() + [('BuildLocalPythonDistributions', 3)]
@@ -88,15 +107,17 @@ class BuildLocalPythonDistributions(Task):
 
   @memoized_property
   def _c_toolchain(self):
-    llvm_c_toolchain = self._request_single(
-      LLVMCToolchain, self._python_native_code_settings.native_toolchain)
-    return llvm_c_toolchain.c_toolchain
+    c_toolchain_type = LLVMCToolchain if self._toolchain_type == 'llvm' else GCCCToolchain
+    c_toolchain_wrapper = self._request_single(
+      c_toolchain_type, self._python_native_code_settings.native_toolchain)
+    return c_toolchain_wrapper.c_toolchain
 
   @memoized_property
   def _cpp_toolchain(self):
-    llvm_cpp_toolchain = self._request_single(
-      LLVMCppToolchain, self._python_native_code_settings.native_toolchain)
-    return llvm_cpp_toolchain.cpp_toolchain
+    cpp_toolchain_type = LLVMCppToolchain if self._toolchain_type == 'llvm' else GCCCppToolchain
+    cpp_toolchain_wrapper = self._request_single(
+      cpp_toolchain_type, self._python_native_code_settings.native_toolchain)
+    return cpp_toolchain_wrapper.cpp_toolchain
 
   # TODO: This should probably be made into an @classproperty (see PR #5901).
   @property
@@ -214,8 +235,7 @@ class BuildLocalPythonDistributions(Task):
       # TODO: test this branch somehow!
       native_tools = SetupPyNativeTools(
         c_toolchain=self._c_toolchain,
-        cpp_toolchain=self._cpp_toolchain,
-        platform=self._platform)
+        cpp_toolchain=self._cpp_toolchain)
       # Native code in this python_dist() target requires marking the dist as platform-specific.
       is_platform_specific = True
     elif len(all_native_artifacts) > 0:


### PR DESCRIPTION
*WIP because there is absolutely no testing yet*

### Problem

There is currently no way for a user to affect which compiler or linker is run at any point in which our native toolchain is invoked. This adds that option for python_dist() targets.

Also, all the random stuff we add to the environment is just confusing distutils and making it produce compile errors in lots of internal usages of `python_dist()` -- until #6273 is merged, leaving the `setup.py` invocation environment mostly untouched allows these to succeed. 

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

(_describe the modifications you've made._)

### Result

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)