### PR TITLE
remove env modifications from the setup.py invocation environment

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -227,37 +227,6 @@ class SetupPyExecutionEnvironment(datatype([
         cpp_linker.path_entries)
       ret['PATH'] = create_path_env_var(all_path_entries)
 
-      all_library_dirs = (
-        c_compiler.library_dirs +
-        c_linker.library_dirs +
-        cpp_compiler.library_dirs +
-        cpp_linker.library_dirs)
-      joined_library_dirs = create_path_env_var(all_library_dirs)
-      dynamic_lib_env_var = plat.resolve_platform_specific({
-        'darwin': lambda: 'DYLD_LIBRARY_PATH',
-        'linux': lambda: 'LD_LIBRARY_PATH',
-      })
-      ret[dynamic_lib_env_var] = joined_library_dirs
-
-      all_linking_library_dirs = (c_linker.linking_library_dirs + cpp_linker.linking_library_dirs)
-      ret['LIBRARY_PATH'] = create_path_env_var(all_linking_library_dirs)
-
-      all_include_dirs = cpp_compiler.include_dirs + c_compiler.include_dirs
-      ret['CPATH'] = create_path_env_var(all_include_dirs)
-
-      shared_compile_flags = safe_shlex_join(plat.resolve_platform_specific({
-        'darwin': lambda: [MIN_OSX_VERSION_ARG],
-        'linux': lambda: [],
-      }))
-      ret['CFLAGS'] = shared_compile_flags
-      ret['CXXFLAGS'] = shared_compile_flags
-
-      ret['CC'] = c_compiler.exe_filename
-      ret['CXX'] = cpp_compiler.exe_filename
-      ret['LDSHARED'] = cpp_linker.exe_filename
-
-      all_new_ldflags = cpp_linker.extra_args + plat.resolve_platform_specific(
-        self._SHARED_CMDLINE_ARGS)
-      ret['LDFLAGS'] = safe_shlex_join(all_new_ldflags)
+      ret['LC_ALL'] = 'C'
 
     return ret

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -22,7 +22,7 @@ from pants.base.exceptions import IncompatiblePlatformsError
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
 from pants.util.objects import SubclassesOf, datatype
-from pants.util.strutil import create_path_env_var, safe_shlex_join
+from pants.util.strutil import create_path_env_var
 
 
 class PythonNativeCode(Subsystem):
@@ -211,7 +211,6 @@ class SetupPyExecutionEnvironment(datatype([
       # An as_tuple() method for datatypes could make this destructuring cleaner!  Alternatively,
       # constructing this environment could be done more compositionally instead of requiring all of
       # these disparate fields together at once.
-      plat = native_tools.platform
       c_toolchain = native_tools.c_toolchain
       c_compiler = c_toolchain.c_compiler
       c_linker = c_toolchain.c_linker

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -22,7 +22,7 @@ from pants.base.exceptions import IncompatiblePlatformsError
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
 from pants.util.objects import SubclassesOf, datatype
-from pants.util.strutil import create_path_env_var
+from pants.util.strutil import create_path_env_var, safe_shlex_join
 
 
 class PythonNativeCode(Subsystem):
@@ -211,6 +211,7 @@ class SetupPyExecutionEnvironment(datatype([
       # An as_tuple() method for datatypes could make this destructuring cleaner!  Alternatively,
       # constructing this environment could be done more compositionally instead of requiring all of
       # these disparate fields together at once.
+      plat = native_tools.platform
       c_toolchain = native_tools.c_toolchain
       c_compiler = c_toolchain.c_compiler
       c_linker = c_toolchain.c_linker
@@ -225,6 +226,11 @@ class SetupPyExecutionEnvironment(datatype([
         cpp_compiler.path_entries +
         cpp_linker.path_entries)
       ret['PATH'] = create_path_env_var(all_path_entries)
+
+      ret['CC'] = c_compiler.exe_filename
+      ret['CXX'] = cpp_compiler.exe_filename
+      ret['LDSHARED'] = cpp_linker.exe_filename
+      ret['LDFLAGS'] = safe_shlex_join(plat.resolve_platform_specific(self._SHARED_CMDLINE_ARGS))
 
       ret['LC_ALL'] = 'C'
 

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -227,6 +227,19 @@ class SetupPyExecutionEnvironment(datatype([
         cpp_linker.path_entries)
       ret['PATH'] = create_path_env_var(all_path_entries)
 
+      all_library_dirs = (
+        c_compiler.library_dirs +
+        c_linker.library_dirs +
+        cpp_compiler.library_dirs +
+        cpp_linker.library_dirs)
+      joined_library_dirs = create_path_env_var(all_library_dirs)
+      dynamic_lib_env_var = plat.resolve_platform_specific({
+        'darwin': lambda: 'DYLD_LIBRARY_PATH',
+        'linux': lambda: 'LD_LIBRARY_PATH',
+      })
+      # Clang needs GCC's libstdc++.so.6 to run on Linux
+      ret[dynamic_lib_env_var] = joined_library_dirs
+
       ret['CC'] = c_compiler.exe_filename
       ret['CXX'] = cpp_compiler.exe_filename
       ret['LDSHARED'] = cpp_linker.exe_filename


### PR DESCRIPTION
This is a partial revert of changes made to `setup_py.py` in #5943 because internal testing at Twitter has shown this is buggy. There are currently no consumers or tests for this behavior -- we will add tests when we have a fix.