### PR TITLE
Log test targets that failed to run.

### DIFF
--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -461,8 +461,12 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
       for partition in sorted(results):
         rv = results[partition]
         failed_targets = set(rv.failed_targets)
+        pre_execution_error = not failed_targets and not rv.success
         for target in partition:
-          if target in failed_targets:
+          if pre_execution_error:
+            log = self.context.log.warn
+            result = 'NOT RUN'
+          elif target in failed_targets:
             log = self.context.log.error
             result = rv
           else:


### PR DESCRIPTION
Previously these would log as successes, now we warn that they did not
run prior to failing the pants run as a whole.

Fixes #6334