### PR TITLE
Download Directory recursively from remote CAS 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ GRTAGS
 GSYMS
 GTAGS
 .mypy_cache/
+
+/target
+**/*.rs.bk

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,3 @@ GRTAGS
 GSYMS
 GTAGS
 .mypy_cache/
-
-/target
-**/*.rs.bk

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -2261,15 +2261,37 @@ mod tests {
     let roland = TestData::roland();
     let catnip = TestData::catnip();
     let testdir = TestDirectory::containing_roland();
+    let testdir_digest = testdir.digest();
+    let testdir_directory = testdir.directory();
     let recursive_testdir = TestDirectory::recursive();
+    let recursive_testdir_directory = recursive_testdir.directory();
+    let recursive_testdir_digest = recursive_testdir.digest();
 
-    let cas = StubCAS::with_content(1024, vec![roland, catnip], vec![testdir, recursive_testdir]);
+    let cas = StubCAS::with_content(
+        1024,
+        vec![roland.clone(), catnip.clone()], vec![testdir, recursive_testdir]
+    );
     new_store(dir.path(), cas.address())
-      .ensure_local_has_recursive_directory(recursive_testdir.digest())
+      .ensure_local_has_recursive_directory(recursive_testdir_digest)
       .wait()
-      .expect("Successfully downloaded recursive dir");
+      .expect("Downloading recursive directory should have succeeded.");
 
-    // TODO(ity): Add check for individual directory/file bytes
+    assert_eq!(
+      load_file_bytes(&new_local_store(dir.path()), roland.digest()),
+      Ok(Some(roland.bytes()))
+    );
+    assert_eq!(
+      load_file_bytes(&new_local_store(dir.path()), catnip.digest()),
+      Ok(Some(catnip.bytes()))
+    );
+    assert_eq!(
+      new_local_store(dir.path()).load_directory(testdir_digest).wait(),
+      Ok(Some(testdir_directory))
+    );
+    assert_eq!(
+      new_local_store(dir.path()).load_directory(recursive_testdir_digest).wait(),
+      Ok(Some(recursive_testdir_directory))
+    );
   }
 
 

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -198,9 +198,9 @@ impl Store {
   }
 
   ///
-  /// Loads bytes from remote cas. Takes two functions f_local and f_remote. These functions are
-  /// any validation or transformations you want to perform on the bytes received from the
-  /// local and remote cas.
+  /// Loads bytes from remote cas if required and possible (i.e. if remote is configured). Takes
+  /// two functions f_local and f_remote. These functions are any validation or transformations you
+  /// want to perform on the bytes received from the local and remote cas (if remote is configured).
   ///
   fn load_bytes_with<
     T: Send + 'static,

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -109,9 +109,9 @@ impl Store {
   }
 
   ///
-  /// Loads the bytes of the file with the passed fingerprint from the local store
-  /// and back-fill from remote when necessary, and returns the result of applying f
-  /// to that value.
+  /// Loads the bytes of the file with the passed fingerprint from the local store and back-fill
+  /// from remote when necessary and possible (i.e. when remote is configured), and returns the
+  /// result of applying f to that value.
   ///
   pub fn load_file_bytes_with<T: Send + 'static, F: Fn(Bytes) -> T + Send + Sync + 'static>(
     &self,

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -5,6 +5,7 @@ use hashing;
 use protobuf::Message;
 use sha2::{self, Digest};
 
+#[derive(Clone)]
 pub struct TestData {
   string: String,
 }


### PR DESCRIPTION
### Problem

see #5708 - we dont currently have the ability to download a `Directory`, and its contents, recursively.

### Solution

Add `ensure_local_has_recursive_directory()` to be able to download  a `Directory`, and its contents, recursively.

### Testing
Added a small test, will be updating with a granular test.

