### PR TITLE
Update default Node.js and Yarnpkg to currently used versions

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -34,7 +34,7 @@ class NodeDistribution(NativeTool):
 
   options_scope = 'node-distribution'
   name = 'node'
-  default_version = 'v6.9.1'
+  default_version = 'v8.11.3'
   archive_type = 'tgz'
 
   @classmethod

--- a/contrib/node/src/python/pants/contrib/node/subsystems/yarnpkg_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/yarnpkg_distribution.py
@@ -17,5 +17,5 @@ class YarnpkgDistribution(NativeTool):
 
   options_scope = 'yarnpkg-distribution'
   name = 'yarnpkg'
-  default_version = 'v0.19.1'
+  default_version = 'v1.6.0'
   archive_type = 'tgz'


### PR DESCRIPTION
### Problem

The default Node.js and Yarnpkg versions in Pants haven't been updated in some time.

### Solution

This bump brings OSS Pants up to date with the Node.js and Yarnpkg versions currently used at Twitter.

In the future, we plan to bump OSS Pants as updates are rolled out to Twitter.