### PR TITLE
ci.sh uses positive rather than negative flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,73 +154,73 @@ matrix:
       env:
         - SHARD="Self checks, lint, and JVM tests"
       script:
-        - ./build-support/bin/ci.sh -x -celpn "${SHARD}"
+        - ./build-support/bin/ci.sh -fkmrjt "${SHARD}"
 
     - <<: *default_test_config
       env:
         - SHARD="Py2 - Unit tests for pants and pants-plugins"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjcnt "${SHARD}"
+        - ./build-support/bin/ci.sh -lp "${SHARD}"
 
     - <<: *default_test_config
       env:
         - SHARD="Py3 - Unit tests for pants and pants-plugins"
       script:
-        - ./build-support/bin/ci.sh -x -3efkmrjcnt "${SHARD}"
+        - ./build-support/bin/ci.sh -3lp "${SHARD}"
 
     - <<: *default_test_config
       env:
         - SHARD="Python contrib tests - shard 1"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrcjlpt -y 0/2 "${SHARD}"
+        - ./build-support/bin/ci.sh -n -y 0/2 "${SHARD}"
 
     - <<: *default_test_config
       env:
         - SHARD="Python contrib tests - shard 2"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrcjlpt -y 1/2 "${SHARD}"
+        - ./build-support/bin/ci.sh -n -y 1/2 "${SHARD}"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 1"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 0/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -c -i 0/7 "${SHARD}"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 2"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 1/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -c -i 1/7 "${SHARD}"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 3"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 2/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -c -i 2/7 "${SHARD}"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 4"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 3/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -c -i 3/7 "${SHARD}"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 5"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 4/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -c -i 4/7 "${SHARD}"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 6"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 5/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -c -i 5/7 "${SHARD}"
 
     - <<: *default_test_config
       env:
         - SHARD="Python integration tests for pants - shard 7"
       script:
-        - ./build-support/bin/ci.sh -x -efkmrjlpnt -i 6/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -c -i 6/7 "${SHARD}"
 
     # Rust on linux
     - os: linux
@@ -244,8 +244,7 @@ matrix:
         - ulimit -c unlimited
         - ulimit -n 8192
       script:
-        - ./build-support/bin/ci.sh -bcfjklmnprtx
-
+        - ./build-support/bin/ci.sh -be
     # Rust on macOS
     - os: osx
       # Fuse actually works on this image. It hangs on many others.
@@ -266,8 +265,7 @@ matrix:
         - ulimit -n 8192
       script:
         # Platform-specific tests currently need a pants pex, so we bootstrap here (no -b) and set -z to run the platform-specific tests.
-        - ./build-support/bin/ci.sh -cfjklmnprtxz
-
+        - ./build-support/bin/ci.sh -ez
 deploy:
   # See: https://docs.travis-ci.com/user/deployment/s3/
   provider: s3

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -70,7 +70,7 @@ while getopts "h3fxbkmrjlpeu:ny:ci:tz" opt; do
     3) python_three="true" ;;
     f) run_pre_commit_checks="true" ;;
     x) run_bootstrap_clean="true" ;;
-    b) run_bootstrap="true" ;;
+    b) run_bootstrap="false" ;;
     k) bootstrap_compile_args=() ;;
     m) run_sanity_checks="true" ;;
     r) run_docs="true" ;;
@@ -110,7 +110,7 @@ if [[ "${run_pre_commit_checks:-false}" == "true" ]]; then
   end_travis_section
 fi
 
-if [[ "${run_bootstrap:-false}" == "true" ]]; then
+if [[ "${run_bootstrap:-true}" == "true" ]]; then
   start_travis_section "Bootstrap" "Bootstrapping pants"
   (
     if [[ "${run_bootstrap_clean:-false}" == "true" ]]; then

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -13,37 +13,37 @@ function usage() {
   cat <<EOF
 Runs commons tests for local or hosted CI.
 
-Usage: $0 (-h|-3fxbkmsrjlpuyncia)
+Usage: $0 (-h|-3fxbkmrjlpuneycitz)
  -h           print out this help message
  -3           After pants is bootstrapped, set --python-setup-interpreter-constraints such that any
               python tests run with Python 3.
- -f           skip python code formatting checks
- -x           skip bootstrap clean-all (assume bootstrapping from a
+ -f           run python code formatting checks
+ -x           run bootstrap clean-all (assume bootstrapping from a
               fresh clone)
  -b           skip bootstrapping pants from local sources
- -k           skip bootstrapped pants self compile check
- -m           skip sanity checks of bootstrapped pants and repo BUILD
+ -k           run bootstrapped pants self compile check
+ -m           run sanity checks of bootstrapped pants and repo BUILD
               files
- -r           skip doc generation tests
- -j           skip core jvm tests
- -l           skip internal backends python tests
- -p           skip core python tests
+ -r           run doc generation tests
+ -j           run core jvm tests
+ -l           run internal backends python tests
+ -p           run core python tests
  -u SHARD_NUMBER/TOTAL_SHARDS
               if running core python tests, divide them into
               TOTAL_SHARDS shards and just run those in SHARD_NUMBER
               to run only even tests: '-u 0/2', odd: '-u 1/2'
- -n           skip contrib python tests
- -e           skip rust tests
+ -n           run contrib python tests
+ -e           run rust tests
  -y SHARD_NUMBER/TOTAL_SHARDS
               if running contrib python tests, divide them into
               TOTAL_SHARDS shards and just run those in SHARD_NUMBER
               to run only even tests: '-u 0/2', odd: '-u 1/2'
- -c           skip pants integration tests (includes examples and testprojects)
+ -c           run pants integration tests (includes examples and testprojects)
  -i SHARD_NUMBER/TOTAL_SHARDS
               if running integration tests, divide them into
               TOTAL_SHARDS shards and just run those in SHARD_NUMBER
               to run only even tests: '-i 0/2', odd: '-i 1/2'
- -t           skip lint
+ -t           run lint
  -z           test platform-specific behavior
 EOF
   if (( $# > 0 )); then
@@ -68,22 +68,22 @@ while getopts "h3fxbkmrjlpeu:ny:ci:tz" opt; do
   case ${opt} in
     h) usage ;;
     3) python_three="true" ;;
-    f) skip_pre_commit_checks="true" ;;
-    x) skip_bootstrap_clean="true" ;;
-    b) skip_bootstrap="true" ;;
+    f) run_pre_commit_checks="true" ;;
+    x) run_bootstrap_clean="true" ;;
+    b) run_bootstrap="true" ;;
     k) bootstrap_compile_args=() ;;
-    m) skip_sanity_checks="true" ;;
-    r) skip_docs="true" ;;
-    j) skip_jvm="true" ;;
-    l) skip_internal_backends="true" ;;
-    p) skip_python="true" ;;
+    m) run_sanity_checks="true" ;;
+    r) run_docs="true" ;;
+    j) run_jvm="true" ;;
+    l) run_internal_backends="true" ;;
+    p) run_python="true" ;;
     u) python_unit_shard=${OPTARG} ;;
-    e) skip_rust_tests="true" ;;
-    n) skip_contrib="true" ;;
+    e) run_rust_tests="true" ;;
+    n) run_contrib="true" ;;
     y) python_contrib_shard=${OPTARG} ;;
-    c) skip_integration="true" ;;
+    c) run_integration="true" ;;
     i) python_intg_shard=${OPTARG} ;;
-    t) skip_lint="true" ;;
+    t) run_lint="true" ;;
     z) test_platform_specific_behavior="true" ;;
     *) usage "Invalid option: -${OPTARG}" ;;
   esac
@@ -104,16 +104,16 @@ case "${OSTYPE}" in
            ;;
 esac
 
-if [[ "${skip_pre_commit_checks:-false}" == "false" ]]; then
+if [[ "${run_pre_commit_checks:-false}" == "true" ]]; then
   start_travis_section "PreCommit" "Running pre-commit checks"
   FULL_CHECK=1 ./build-support/bin/pre-commit.sh || exit 1
   end_travis_section
 fi
 
-if [[ "${skip_bootstrap:-false}" == "false" ]]; then
+if [[ "${run_bootstrap:-false}" == "true" ]]; then
   start_travis_section "Bootstrap" "Bootstrapping pants"
   (
-    if [[ "${skip_bootstrap_clean:-false}" == "false" ]]; then
+    if [[ "${run_bootstrap_clean:-false}" == "true" ]]; then
       ./build-support/python/clean.sh || die "Failed to clean before bootstrapping pants."
     fi
     ./pants ${bootstrap_compile_args[@]} binary \
@@ -134,7 +134,7 @@ if [[ "${python_three:-false}" == "true" ]]; then
   ./pants.pex clean-all
 fi
 
-if [[ "${skip_sanity_checks:-false}" == "false" ]]; then
+if [[ "${run_sanity_checks:-false}" == "true" ]]; then
   start_travis_section "SanityCheck" "Sanity checking bootstrapped pants and repo BUILD files"
   sanity_tests=(
     "bash-completion"
@@ -153,7 +153,7 @@ if [[ "${skip_sanity_checks:-false}" == "false" ]]; then
   end_travis_section
 fi
 
-if [[ "${skip_lint:-false}" == "false" ]]; then
+if [[ "${run_lint:-false}" == "true" ]]; then
   start_travis_section "Lint" "Running lint checks"
   (
     ./pants.pex --tag=-nolint lint contrib:: examples:: src:: tests:: zinc::
@@ -161,13 +161,13 @@ if [[ "${skip_lint:-false}" == "false" ]]; then
   end_travis_section
 fi
 
-if [[ "${skip_docs:-false}" == "false" ]]; then
+if [[ "${run_docs:-false}" == "true" ]]; then
   start_travis_section "DocGen" "Running site doc generation test"
   ./build-support/bin/publish_docs.sh || die "Failed to generate site docs."
   end_travis_section
 fi
 
-if [[ "${skip_jvm:-false}" == "false" ]]; then
+if [[ "${run_jvm:-false}" == "true" ]]; then
   start_travis_section "CoreJVM" "Running core jvm tests"
   (
     ./pants.pex doc test {src,tests}/{java,scala}:: zinc::
@@ -175,7 +175,7 @@ if [[ "${skip_jvm:-false}" == "false" ]]; then
   end_travis_section
 fi
 
-if [[ "${skip_internal_backends:-false}" == "false" ]]; then
+if [[ "${run_internal_backends:-false}" == "true" ]]; then
   start_travis_section "BackendTests" "Running internal backend python tests"
   (
     ./pants.pex test.pytest \
@@ -184,7 +184,7 @@ if [[ "${skip_internal_backends:-false}" == "false" ]]; then
   end_travis_section
 fi
 
-if [[ "${skip_python:-false}" == "false" ]]; then
+if [[ "${run_python:-false}" == "true" ]]; then
   if [[ "0/1" != "${python_unit_shard}" ]]; then
     shard_desc=" [shard ${python_unit_shard}]"
   fi
@@ -202,7 +202,7 @@ if [[ "${skip_python:-false}" == "false" ]]; then
   end_travis_section
 fi
 
-if [[ "${skip_contrib:-false}" == "false" ]]; then
+if [[ "${run_contrib:-false}" == "true" ]]; then
   if [[ "0/1" != "${python_contrib_shard}" ]]; then
     shard_desc=" [shard ${python_contrib_shard}]"
   fi
@@ -215,7 +215,7 @@ if [[ "${skip_contrib:-false}" == "false" ]]; then
   end_travis_section
 fi
 
-if [[ "${skip_rust_tests:-false}" == "false" ]]; then
+if [[ "${run_rust_tests:-false}" == "true" ]]; then
   start_travis_section "RustTests" "Running Pants rust tests"
   (
     test_threads_flag=""
@@ -244,7 +244,7 @@ if [[ "${test_platform_specific_behavior:-false}" == 'true' ]]; then
 fi
 
 
-if [[ "${skip_integration:-false}" == "false" ]]; then
+if [[ "${run_integration:-false}" == "true" ]]; then
   if [[ "0/1" != "${python_intg_shard}" ]]; then
     shard_desc=" [shard ${python_intg_shard}]"
   fi

--- a/src/docs/howto_develop.md
+++ b/src/docs/howto_develop.md
@@ -147,12 +147,14 @@ feature, you might explore `tests/python/pants_tests/.../BUILD`.
 
 Before [[contributing a change to Pants|pants('src/docs:howto_contribute')]],
 make sure it passes **all** of our continuous integration (CI) tests: everything builds,
-all tests pass. To try all the CI tests in a few configurations, you can run the same script
-that our Travis CI does. This can take a while, but it's a good idea to run it before you
-contribute a change or merge it to master:
+all tests pass. Our tests are hard and slow to run all of locally, so we recommend that you create
+a pull request, and allow travis to run them. You can reproduce failures by running
 
     :::bash
     $ ./build-support/bin/ci.sh
+
+with whatever relevant flags reproduce the failure (`./build-support/bin/ci.sh -h` will list the
+available flags).
 
 To run just Pants' *unit* tests (skipping the can-be-slow integration tests), filter out
 the python tests tagged with 'integration':


### PR DESCRIPTION
This makes it much easier to reason about what's happening, and keeps
.travis.yml more concise.