### PR TITLE
Use forked version of grpcio

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
  "build_utils 0.0.1",
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.3.0 (git+https://github.com/illicitonion/grpc-rs.git?rev=d106c615bc0c289ba6d1ce6871786266d109c31c)",
  "grpcio-compiler 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -329,7 +329,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.3.0 (git+https://github.com/illicitonion/grpc-rs.git?rev=d106c615bc0c289ba6d1ce6871786266d109c31c)",
  "hashing 0.0.1",
  "ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -453,12 +453,12 @@ dependencies = [
 [[package]]
 name = "grpcio"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/illicitonion/grpc-rs.git?rev=d106c615bc0c289ba6d1ce6871786266d109c31c#d106c615bc0c289ba6d1ce6871786266d109c31c"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-sys 0.2.3 (git+https://github.com/illicitonion/grpc-rs.git?rev=d106c615bc0c289ba6d1ce6871786266d109c31c)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -474,7 +474,7 @@ dependencies = [
 [[package]]
 name = "grpcio-sys"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/illicitonion/grpc-rs.git?rev=d106c615bc0c289ba6d1ce6871786266d109c31c#d106c615bc0c289ba6d1ce6871786266d109c31c"
 dependencies = [
  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -694,7 +694,7 @@ dependencies = [
  "bazel_protos 0.0.1",
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.3.0 (git+https://github.com/illicitonion/grpc-rs.git?rev=d106c615bc0c289ba6d1ce6871786266d109c31c)",
  "hashing 0.0.1",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
@@ -767,7 +767,7 @@ dependencies = [
  "fs 0.0.1",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.3.0 (git+https://github.com/illicitonion/grpc-rs.git?rev=d106c615bc0c289ba6d1ce6871786266d109c31c)",
  "hashing 0.0.1",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
@@ -1406,9 +1406,9 @@ dependencies = [
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum globset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "464627f948c3190ae3d04b1bc6d7dca2f785bda0ac01278e6db129ad383dbeb6"
-"checksum grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6420fb7aca82b4bf1cf98aa2c70a55cb0cbaa4c5152ba51a47c37d758ac27b2d"
+"checksum grpcio 0.3.0 (git+https://github.com/illicitonion/grpc-rs.git?rev=d106c615bc0c289ba6d1ce6871786266d109c31c)" = "<none>"
 "checksum grpcio-compiler 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a63ccc27b0099347d2bea2c3d0f1c79c018a13cfd08b814a1992e341b645d5e1"
-"checksum grpcio-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5d45a6906ba6faa1be0f04bb61c0a49aef5f279f090b0d24d81912c1c08b995e"
+"checksum grpcio-sys 0.2.3 (git+https://github.com/illicitonion/grpc-rs.git?rev=d106c615bc0c289ba6d1ce6871786266d109c31c)" = "<none>"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bb2f0238094bd1b41800fb6eb9b16fdd5e9832ed6053ed91409f0cd5bf28dcfd"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -13,7 +13,7 @@ digest = "0.6.2"
 futures = "^0.1.16"
 futures-cpupool = "0.1"
 glob = "0.2.11"
-grpcio = { version = "0.3", features = ["secure"] }
+grpcio = { git = "https://github.com/illicitonion/grpc-rs.git", rev = "d106c615bc0c289ba6d1ce6871786266d109c31c", features = ["secure"] }
 hashing = { path = "../hashing" }
 ignore = "0.3.1"
 indexmap = "1"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -13,6 +13,7 @@ digest = "0.6.2"
 futures = "^0.1.16"
 futures-cpupool = "0.1"
 glob = "0.2.11"
+# Pull in https://github.com/pingcap/grpc-rs/pull/211
 grpcio = { git = "https://github.com/illicitonion/grpc-rs.git", rev = "d106c615bc0c289ba6d1ce6871786266d109c31c", features = ["secure"] }
 hashing = { path = "../hashing" }
 ignore = "0.3.1"

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -12,7 +12,7 @@ bytes = "0.4.5"
 digest = "0.6.2"
 fs = { path = "../fs" }
 futures = "^0.1.16"
-grpcio = { version = "0.3", features = ["secure"] }
+grpcio = { git = "https://github.com/illicitonion/grpc-rs.git", rev = "d106c615bc0c289ba6d1ce6871786266d109c31c", features = ["secure"] }
 hashing = { path = "../hashing" }
 log = "0.4"
 protobuf = { version = "2.0.4", features = ["with-bytes"] }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -12,6 +12,7 @@ bytes = "0.4.5"
 digest = "0.6.2"
 fs = { path = "../fs" }
 futures = "^0.1.16"
+# Pull in https://github.com/pingcap/grpc-rs/pull/211
 grpcio = { git = "https://github.com/illicitonion/grpc-rs.git", rev = "d106c615bc0c289ba6d1ce6871786266d109c31c", features = ["secure"] }
 hashing = { path = "../hashing" }
 log = "0.4"

--- a/src/rust/engine/process_execution/bazel_protos/Cargo.toml
+++ b/src/rust/engine/process_execution/bazel_protos/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 bytes = "0.4.5"
 futures = "^0.1.16"
-grpcio = { version = "0.3", features = ["secure"] }
+grpcio = { git = "https://github.com/illicitonion/grpc-rs.git", rev = "d106c615bc0c289ba6d1ce6871786266d109c31c", features = ["secure"] }
 hashing = { path = "../../hashing" }
 protobuf = { version = "2.0.4", features = ["with-bytes"] }
 

--- a/src/rust/engine/process_execution/bazel_protos/Cargo.toml
+++ b/src/rust/engine/process_execution/bazel_protos/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 bytes = "0.4.5"
 futures = "^0.1.16"
+# Pull in https://github.com/pingcap/grpc-rs/pull/211
 grpcio = { git = "https://github.com/illicitonion/grpc-rs.git", rev = "d106c615bc0c289ba6d1ce6871786266d109c31c", features = ["secure"] }
 hashing = { path = "../../hashing" }
 protobuf = { version = "2.0.4", features = ["with-bytes"] }

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 bazel_protos = { path = "../../process_execution/bazel_protos" }
 bytes = "0.4.5"
 futures = "^0.1.16"
+# Pull in https://github.com/pingcap/grpc-rs/pull/211
 grpcio = { git = "https://github.com/illicitonion/grpc-rs.git", rev = "d106c615bc0c289ba6d1ce6871786266d109c31c", features = ["secure"] }
 hashing = { path = "../../hashing" }
 protobuf = { version = "2.0.4", features = ["with-bytes"] }

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 bazel_protos = { path = "../../process_execution/bazel_protos" }
 bytes = "0.4.5"
 futures = "^0.1.16"
-grpcio = { version = "0.3", features = ["secure"] }
+grpcio = { git = "https://github.com/illicitonion/grpc-rs.git", rev = "d106c615bc0c289ba6d1ce6871786266d109c31c", features = ["secure"] }
 hashing = { path = "../../hashing" }
 protobuf = { version = "2.0.4", features = ["with-bytes"] }
 testutil = { path = ".." }


### PR DESCRIPTION
This includes https://github.com/pingcap/grpc-rs/pull/211 which stops us
seeing RpcFinished errors when the server responds very quickly to
requests.

Unfortunately, this will slow down building pants, as you'll need to
checkout the git repository, but that should be a once-per-machine cost.