### PR TITLE
Process execution: Create symlink to JDK on demand

### DIFF
--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -6,12 +6,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 
-import six
+from future.utils import text_type
 
 from pants.engine.fs import DirectoryDigest
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Select
-from pants.util.objects import Exactly, SubclassesOf, TypeCheckError, datatype
+from pants.util.objects import Exactly, TypeCheckError, datatype
 
 
 logger = logging.getLogger(__name__)
@@ -22,12 +22,13 @@ _default_timeout_seconds = 15 * 60
 class ExecuteProcessRequest(datatype([
   ('argv', tuple),
   ('input_files', DirectoryDigest),
-  ('description', SubclassesOf(*six.string_types)),
+  ('description', text_type),
   ('env', tuple),
   ('output_files', tuple),
   ('output_directories', tuple),
   # NB: timeout_seconds covers the whole remote operation including queuing and setup.
   ('timeout_seconds', Exactly(float, int)),
+  ('jdk_home', Exactly(text_type, type(None))),
 ])):
   """Request for execution with args and snapshots to extract."""
 
@@ -40,6 +41,7 @@ class ExecuteProcessRequest(datatype([
     output_files=(),
     output_directories=(),
     timeout_seconds=_default_timeout_seconds,
+    jdk_home=None,
   ):
     if env is None:
       env = ()
@@ -63,6 +65,7 @@ class ExecuteProcessRequest(datatype([
       output_files=output_files,
       output_directories=output_directories,
       timeout_seconds=timeout_seconds,
+      jdk_home=jdk_home,
     )
 
 

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -448,7 +448,10 @@ def _initialize_externs(ffi):
   def extern_val_to_str(context_handle, val):
     """Given a Handle for `obj`, write str(obj) and return it."""
     c = ffi.from_handle(context_handle)
-    return c.utf8_buf(text_type(c.from_value(val[0])))
+    v = c.from_value(val[0])
+    # Consistently use the empty string to indicate None.
+    v_str = '' if v is None else text_type(v)
+    return c.utf8_buf(v_str)
 
   @ffi.def_extern()
   def extern_satisfied_by(context_handle, constraint_val, val):

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -65,6 +65,12 @@ pub struct ExecuteProcessRequest {
   pub timeout: std::time::Duration,
 
   pub description: String,
+
+  ///
+  /// If present, a symlink will be created at .jdk which points to this directory for local
+  /// execution.
+  ///
+  pub jdk_home: Option<PathBuf>,
 }
 
 ///

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -92,6 +92,8 @@ impl super::CommandRunner for CommandRunner {
   /// Loops until the server gives a response, either successful or error. Does not have any
   /// timeout: polls in a tight loop.
   ///
+  /// TODO: Request jdk_home be created if set.
+  ///
   fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<FallibleExecuteProcessResult, String> {
     let operations_client = self.operations_client.clone();
 
@@ -710,6 +712,7 @@ mod tests {
         .collect(),
       timeout: Duration::from_millis(1000),
       description: "some description".to_owned(),
+      jdk_home: None,
     };
     let result = super::make_execute_request(&req);
 
@@ -774,6 +777,7 @@ mod tests {
           output_directories: BTreeSet::new(),
           timeout: Duration::from_millis(1000),
           description: "wrong command".to_string(),
+          jdk_home: None,
         }).unwrap()
           .2,
         vec![],
@@ -986,6 +990,7 @@ mod tests {
       output_directories: BTreeSet::new(),
       timeout: request_timeout,
       description: "echo-a-foo".to_string(),
+      jdk_home: None,
     };
 
     let mock_server = {
@@ -1662,6 +1667,7 @@ mod tests {
       output_directories: BTreeSet::new(),
       timeout: Duration::from_millis(5000),
       description: "echo a foo".to_string(),
+      jdk_home: None,
     }
   }
 
@@ -1839,6 +1845,7 @@ mod tests {
       output_directories: BTreeSet::new(),
       timeout: Duration::from_millis(1000),
       description: "cat a roland".to_string(),
+      jdk_home: None,
     }
   }
 
@@ -1851,6 +1858,7 @@ mod tests {
       output_directories: BTreeSet::new(),
       timeout: Duration::from_millis(1000),
       description: "unleash a roaring meow".to_string(),
+      jdk_home: None,
     }
   }
 }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -154,6 +154,7 @@ fn main() {
     output_directories: BTreeSet::new(),
     timeout: Duration::new(15 * 60, 0),
     description: "process_executor".to_string(),
+    jdk_home: None,
   };
 
   let runner: Box<process_execution::CommandRunner> = match server_arg {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -509,6 +509,15 @@ impl ExecuteProcess {
 
     let description = externs::project_str(&value, "description");
 
+    let jdk_home = {
+      let val = externs::project_str(&value, "jdk_home");
+      if val.is_empty() {
+        None
+      } else {
+        Some(PathBuf::from(val))
+      }
+    };
+
     Ok(ExecuteProcess(process_execution::ExecuteProcessRequest {
       argv: externs::project_multi_strs(&value, "argv"),
       env: env,
@@ -517,6 +526,7 @@ impl ExecuteProcess {
       output_directories: output_directories,
       timeout: Duration::from_millis((timeout_in_seconds * 1000.0) as u64),
       description: description,
+      jdk_home: jdk_home,
     }))
   }
 }


### PR DESCRIPTION
This creates a symlink `.jdk` pointing at the passed JDK, if one was
passed.

This is a hack to allow for a remote execution platform to provide a
pointer at its pre-installed JDK without needing to pollute absolute
paths into the action definition.

Long-term, we want the JDK to be part of the input directory for the
action, but that's a lot of work, and we want to experiment with
pre-installed JDKs in the mean time.