### PR TITLE
Run clippy with nightly rust on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,7 @@ matrix:
       env:
         - SHARD="Self checks, lint, and JVM tests"
       script:
-        - ./build-support/bin/ci.sh -fkmrjt "${SHARD}"
+        - ./build-support/bin/ci.sh -fkmrjst "${SHARD}"
 
     - <<: *default_test_config
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -153,6 +153,11 @@ matrix:
     - <<: *default_test_config
       env:
         - SHARD="Self checks, lint, and JVM tests"
+      before_install:
+        - sudo apt-get install -y pkg-config fuse libfuse-dev
+        - sudo modprobe fuse
+        - sudo chmod 666 /dev/fuse
+        - sudo chown root:$USER /etc/fuse.conf
       script:
         - ./build-support/bin/ci.sh -fkmrjst "${SHARD}"
 

--- a/build-support/bin/native/bootstrap_rust.sh
+++ b/build-support/bin/native/bootstrap_rust.sh
@@ -7,12 +7,6 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd -P)"
 # + fingerprint_data: Fingerprints the data on stdin.
 source "${REPO_ROOT}/build-support/common.sh"
 
-RUST_TOOLCHAIN="$(cat ${REPO_ROOT}/rust-toolchain)"
-readonly RUST_COMPONENTS=(
-  "rustfmt-preview"
-  "rust-src"
-)
-
 readonly rust_toolchain_root="${CACHE_ROOT}/rust"
 export CARGO_HOME="${rust_toolchain_root}/cargo"
 export RUSTUP_HOME="${rust_toolchain_root}/rustup"
@@ -24,6 +18,17 @@ function cargo_bin() {
 }
 
 function bootstrap_rust() {
+  RUST_TOOLCHAIN="$(cat ${REPO_ROOT}/rust-toolchain)"
+  RUST_COMPONENTS=(
+    "rustfmt-preview"
+    "rust-src"
+  )
+
+  if [[ "$#" -eq 1 && "$1" == "+nightly" ]]; then
+    RUST_TOOLCHAIN="nightly"
+    RUST_COMPONENTS=("${RUST_COMPONENTS[@]}" "clippy-preview")
+  fi
+
   # Control a pants-specific rust toolchain.
   if [[ ! -x "${RUSTUP}" ]]
   then
@@ -39,7 +44,7 @@ function bootstrap_rust() {
   local -r cargo="${CARGO_HOME}/bin/cargo"
   local -r cargo_components_fp=$(echo "${RUST_COMPONENTS[@]}" | fingerprint_data)
   local -r cargo_versioned="cargo-${RUST_TOOLCHAIN}-${cargo_components_fp}"
-  if [[ ! -x "${rust_toolchain_root}/${cargo_versioned}" ]]
+  if [[ ! -x "${rust_toolchain_root}/${cargo_versioned}" || "${RUST_TOOLCHAIN}" == "nightly" ]]
   then
     # If rustup was already bootstrapped against a different toolchain in the past, freshen it and
     # ensure the toolchain and components we need are installed.
@@ -47,7 +52,7 @@ function bootstrap_rust() {
     "${RUSTUP}" toolchain install ${RUST_TOOLCHAIN}
     "${RUSTUP}" component add --toolchain ${RUST_TOOLCHAIN} ${RUST_COMPONENTS[@]} >&2
 
-    ln -fs "$(cargo_bin)" "${rust_toolchain_root}/${cargo_versioned}"
+    ln -fs "$(RUSTUP_TOOLCHAIN="${RUST_TOOLCHAIN}" cargo_bin)" "${rust_toolchain_root}/${cargo_versioned}"
   fi
 
   local -r symlink_farm_root="${REPO_ROOT}/build-support/bin/native"

--- a/build-support/bin/native/cargo.sh
+++ b/build-support/bin/native/cargo.sh
@@ -9,7 +9,13 @@ REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd ../../.. && pwd -P)
 # Exposes:
 # + bootstrap_rust: Bootstraps a Pants-controlled rust toolchain and associated extras.
 source "${REPO_ROOT}/build-support/bin/native/bootstrap_rust.sh"
-bootstrap_rust >&2
+
+nightly=""
+if [[ "$@" =~ '+nightly' ]]; then
+  nightly="+nightly"
+fi
+
+bootstrap_rust "${nightly}" >&2
 
 download_binary="${REPO_ROOT}/build-support/bin/download_binary.sh"
 

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "bazel_protos 0.0.1",
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
@@ -228,6 +229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "either"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +249,7 @@ dependencies = [
  "boxfuture 0.0.1",
  "build_utils 0.0.1",
  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
@@ -1387,6 +1398,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9b4e2817eb773f770dcb294127c011e22771899c21d18fce7dd739c0b9832e81"
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
+"checksum dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "37a76dd8b997af7107d0bb69d43903cf37153a18266f8b3fdb9911f28efb5444"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
 "checksum env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0e6e40ebb0e66918a37b38c7acab4e10d299e0463fe2af5d29b9cc86710cfd2a"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -69,6 +69,7 @@ default-members = [
 
 [dependencies]
 boxfuture = { path = "boxfuture" }
+dirs = "1"
 enum_primitive = "0.1.1"
 fnv = "1.0.5"
 fs = { path = "fs" }

--- a/src/rust/engine/async_semaphore/src/lib.rs
+++ b/src/rust/engine/async_semaphore/src/lib.rs
@@ -1,3 +1,20 @@
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 extern crate futures;
 
 use std::collections::VecDeque;

--- a/src/rust/engine/boxfuture/src/lib.rs
+++ b/src/rust/engine/boxfuture/src/lib.rs
@@ -2,6 +2,23 @@
 // https://github.com/alexcrichton/futures-rs/issues/228 has background for its removal.
 // This avoids needing to call Box::new() around every future that we produce.
 
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 extern crate futures;
 
 use futures::future::Future;

--- a/src/rust/engine/build_utils/src/lib.rs
+++ b/src/rust/engine/build_utils/src/lib.rs
@@ -1,3 +1,20 @@
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 use std::env;
 use std::io;
 use std::ops::Deref;

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 bazel_protos = { path = "../../process_execution/bazel_protos" }
 clap = "2"
+dirs = "1"
 env_logger = "0.5.4"
 errno = "0.2.3"
 fs = { path = ".." }

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -1,5 +1,6 @@
 extern crate bazel_protos;
 extern crate clap;
+extern crate dirs;
 extern crate env_logger;
 extern crate errno;
 extern crate fs;
@@ -585,7 +586,7 @@ pub fn mount<'a, P: AsRef<Path>>(
 }
 
 fn main() {
-  let default_store_path = std::env::home_dir()
+  let default_store_path = dirs::home_dir()
     .expect("Couldn't find homedir")
     .join(".cache")
     .join("pants")

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -343,16 +343,14 @@ impl BuildResultFS {
 
               Ok(entries)
             }
-            Ok(None) => {
-              return Err(libc::ENOENT);
-            }
+            Ok(None) => Err(libc::ENOENT),
             Err(err) => {
               error!("Error loading directory {:?}: {}", digest, err);
-              return Err(libc::EINVAL);
+              Err(libc::EINVAL)
             }
           }
         }
-        _ => return Err(libc::ENOENT),
+        _ => Err(libc::ENOENT),
       },
     }
   }

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -640,7 +640,9 @@ fn main() {
   }.expect("Error making store");
 
   let _fs = mount(mount_path, store).expect("Error mounting");
-  loop {}
+  loop {
+    std::thread::sleep(std::time::Duration::from_secs(1));
+  }
 }
 
 #[cfg(target_os = "macos")]

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -647,12 +647,18 @@ fn main() {
 
 #[cfg(target_os = "macos")]
 fn unmount(mount_path: &str) -> i32 {
-  unsafe { libc::unmount(CString::new(mount_path).unwrap().as_ptr(), 0) }
+  unsafe {
+    let path = CString::new(mount_path).unwrap();
+    libc::unmount(path.as_ptr(), 0)
+  }
 }
 
 #[cfg(target_os = "linux")]
 fn unmount(mount_path: &str) -> i32 {
-  unsafe { libc::umount(CString::new(mount_path).unwrap().as_ptr()) }
+  unsafe {
+    let path = CString::new(mount_path).unwrap();
+    libc::umount(path.as_ptr())
+  }
 }
 
 #[cfg(test)]

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -395,11 +395,11 @@ impl fuse::Filesystem for BuildResultFS {
         let maybe_cache_entry = self
           .inode_digest_cache
           .get(&parent)
-          .map(|entry| entry.clone())
+          .cloned()
           .ok_or(libc::ENOENT);
         maybe_cache_entry
           .and_then(|cache_entry| {
-            let parent_digest = cache_entry.digest.clone();
+            let parent_digest = cache_entry.digest;
             self
               .store
               .load_directory(parent_digest)

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -1,3 +1,20 @@
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 extern crate bazel_protos;
 extern crate clap;
 extern crate dirs;

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -498,9 +498,8 @@ impl fuse::Filesystem for BuildResultFS {
             let mut reply = reply.lock().unwrap();
             reply.take().unwrap().data(&bytes.slice(begin, end));
           })
-          .map(|v| match v {
-            Some(_) => {}
-            None => {
+          .map(|v| {
+            if v.is_none() {
               let maybe_reply = reply2.lock().unwrap().take();
               if let Some(reply) = maybe_reply {
                 reply.error(libc::ENOENT);

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -54,7 +54,7 @@ fn attr_for(inode: Inode, size: u64, kind: fuse::FileType, perm: u16) -> fuse::F
 }
 
 pub fn digest_from_filepath(str: &str) -> Result<Digest, String> {
-  let mut parts = str.split("-");
+  let mut parts = str.split('-');
   let fingerprint_str = parts
     .next()
     .ok_or_else(|| format!("Invalid digest: {} wasn't of form fingerprint-size", str))?;

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -294,7 +294,7 @@ fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
           .and_then(move |paths| {
             Snapshot::from_path_stats(
               store_copy.clone(),
-              fs::OneOffStoreFileByDigest::new(store_copy, posix_fs),
+              &fs::OneOffStoreFileByDigest::new(store_copy, posix_fs),
               paths,
             )
           })

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -1,3 +1,20 @@
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 #[macro_use]
 extern crate boxfuture;
 extern crate bytes;

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -525,7 +525,7 @@ impl PosixFS {
     })
   }
 
-  fn scandir_sync(root: PathBuf, dir_relative_to_root: &Dir) -> Result<Vec<Stat>, io::Error> {
+  fn scandir_sync(root: &Path, dir_relative_to_root: &Dir) -> Result<Vec<Stat>, io::Error> {
     let dir_abs = root.join(&dir_relative_to_root.0);
     let mut stats: Vec<Stat> = dir_abs
       .read_dir()?
@@ -659,7 +659,7 @@ impl PosixFS {
     let root = self.root.0.clone();
     self
       .pool
-      .spawn_fn(move || PosixFS::scandir_sync(root, &dir))
+      .spawn_fn(move || PosixFS::scandir_sync(&root, &dir))
       .map(DirectoryListing)
       .to_boxed()
   }

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -1,6 +1,23 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 mod glob_matching;
 pub use glob_matching::GlobMatching;
 mod snapshot;

--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -241,7 +241,7 @@ impl Snapshot {
             .get_files()
             .iter()
             .group_by(|f| f.get_name().to_owned());
-          for (file_name, group) in groups.into_iter() {
+          for (file_name, group) in &groups {
             if group.count() > 1 {
               return future::err(format!(
                 "Can only merge Directories with no duplicates, but found duplicate files: {}",

--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -40,12 +40,12 @@ impl Snapshot {
     Error: fmt::Debug + 'static + Send,
   >(
     store: Store,
-    file_digester: S,
+    file_digester: &S,
     path_stats: Vec<PathStat>,
   ) -> BoxFuture<Snapshot, String> {
     let mut sorted_path_stats = path_stats.clone();
     sorted_path_stats.sort_by(|a, b| a.path().cmp(b.path()));
-    Snapshot::ingest_directory_from_sorted_path_stats(store, &file_digester, &sorted_path_stats)
+    Snapshot::ingest_directory_from_sorted_path_stats(store, file_digester, &sorted_path_stats)
       .map(|digest| Snapshot { digest, path_stats })
       .to_boxed()
   }
@@ -55,12 +55,12 @@ impl Snapshot {
     Error: fmt::Debug + 'static + Send,
   >(
     store: Store,
-    file_digester: S,
+    file_digester: &S,
     path_stats: &[PathStat],
   ) -> BoxFuture<Digest, String> {
     let mut sorted_path_stats = path_stats.to_owned();
     sorted_path_stats.sort_by(|a, b| a.path().cmp(b.path()));
-    Snapshot::ingest_directory_from_sorted_path_stats(store, &file_digester, &sorted_path_stats)
+    Snapshot::ingest_directory_from_sorted_path_stats(store, file_digester, &sorted_path_stats)
   }
 
   fn ingest_directory_from_sorted_path_stats<
@@ -415,7 +415,7 @@ mod tests {
 
     let path_stats = expand_all_sorted(posix_fs);
     assert_eq!(
-      Snapshot::from_path_stats(store, digester, path_stats.clone())
+      Snapshot::from_path_stats(store, &digester, path_stats.clone())
         .wait()
         .unwrap(),
       Snapshot {
@@ -441,7 +441,7 @@ mod tests {
 
     let path_stats = expand_all_sorted(posix_fs);
     assert_eq!(
-      Snapshot::from_path_stats(store, digester, path_stats.clone())
+      Snapshot::from_path_stats(store, &digester, path_stats.clone())
         .wait()
         .unwrap(),
       Snapshot {
@@ -473,7 +473,7 @@ mod tests {
     let mut unsorted_path_stats = sorted_path_stats.clone();
     unsorted_path_stats.reverse();
     assert_eq!(
-      Snapshot::from_path_stats(store, digester, unsorted_path_stats.clone())
+      Snapshot::from_path_stats(store, &digester, unsorted_path_stats.clone())
         .wait()
         .unwrap(),
       Snapshot {
@@ -596,14 +596,12 @@ mod tests {
     );
 
     let merged = {
-      let snapshot1 = Snapshot::from_path_stats(
-        store.clone(),
-        digester.clone(),
-        vec![dir.clone(), file1.clone()],
-      ).wait()
-        .unwrap();
+      let snapshot1 =
+        Snapshot::from_path_stats(store.clone(), &digester, vec![dir.clone(), file1.clone()])
+          .wait()
+          .unwrap();
       let snapshot2 =
-        Snapshot::from_path_stats(store.clone(), digester, vec![dir.clone(), file2.clone()])
+        Snapshot::from_path_stats(store.clone(), &digester, vec![dir.clone(), file2.clone()])
           .wait()
           .unwrap();
       Snapshot::merge(store.clone(), &[snapshot1, snapshot2])
@@ -648,11 +646,10 @@ mod tests {
     );
 
     let merged_res = {
-      let snapshot1 =
-        Snapshot::from_path_stats(store.clone(), digester.clone(), vec![file.clone()])
-          .wait()
-          .unwrap();
-      let snapshot2 = Snapshot::from_path_stats(store.clone(), digester.clone(), vec![file])
+      let snapshot1 = Snapshot::from_path_stats(store.clone(), &digester, vec![file.clone()])
+        .wait()
+        .unwrap();
+      let snapshot2 = Snapshot::from_path_stats(store.clone(), &digester, vec![file])
         .wait()
         .unwrap();
       Snapshot::merge(store.clone(), &[snapshot1, snapshot2]).wait()

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -707,7 +707,7 @@ mod local {
         let (env, _, lease_database) = self.inner.file_dbs.get()?.get(&digest.0);
         env
           .begin_rw_txn()
-          .and_then(|mut txn| self.lease(&lease_database, &digest.0, until, &mut txn))
+          .and_then(|mut txn| self.lease(lease_database, &digest.0, until, &mut txn))
           .map_err(|err| format!("Error leasing digest {:?}: {}", digest, err))?;
       }
       Ok(())
@@ -722,14 +722,14 @@ mod local {
 
     fn lease(
       &self,
-      database: &Database,
+      database: Database,
       fingerprint: &Fingerprint,
       until_secs_since_epoch: u64,
       txn: &mut RwTransaction,
     ) -> Result<(), lmdb::Error> {
       let mut buf = [0; 8];
       LittleEndian::write_u64(&mut buf, until_secs_since_epoch);
-      txn.put(*database, &fingerprint.as_ref(), &buf, WriteFlags::empty())
+      txn.put(database, &fingerprint.as_ref(), &buf, WriteFlags::empty())
     }
 
     ///
@@ -870,7 +870,7 @@ mod local {
             txn.put(content_database, &fingerprint, &bytes, NO_OVERWRITE)?;
             if initial_lease {
               bytestore.lease(
-                &lease_database,
+                lease_database,
                 &fingerprint,
                 Self::default_lease_until_secs_since_epoch(),
                 &mut txn,

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -1689,15 +1689,15 @@ mod remote {
               })
             })
             .and_then(move |received| {
-              if received.get_committed_size() != len as i64 {
+              if received.get_committed_size() == len as i64 {
+                Ok(Digest(fingerprint, len))
+              } else {
                 Err(format!(
                   "Uploading file with fingerprint {}: want commited size {} but got {}",
                   fingerprint,
                   len,
                   received.get_committed_size()
                 ))
-              } else {
-                Ok(Digest(fingerprint, len))
               }
             })
             .to_boxed()

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -809,7 +809,7 @@ mod local {
           .open_ro_cursor(*database)
           .map_err(|err| format!("Failed to open lmdb read cursor: {}", err))?;
         for (key, bytes) in cursor.iter() {
-          *used_bytes = *used_bytes + bytes.len();
+          *used_bytes += bytes.len();
 
           // Random access into the lease_database is slower than iterating, but hopefully garbage
           // collection is rare enough that we can get away with this, rather than do two passes

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -311,9 +311,7 @@ impl Store {
               let entry_type = digest_entry_types[&digest];
               let remote = remote2.clone();
               local
-                .load_bytes_with(entry_type.clone(), digest.0, move |bytes| {
-                  remote.store_bytes(bytes)
-                })
+                .load_bytes_with(entry_type, digest.0, move |bytes| remote.store_bytes(bytes))
                 .and_then(move |maybe_future| match maybe_future {
                   Some(future) => Ok(future),
                   None => Err(format!("Failed to upload digest {:?}: Not found", digest)),

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -50,6 +50,7 @@ impl Generation {
   }
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
 pub(crate) enum EntryState<N: Node> {
   // A node that has either been explicitly cleared, or has not yet started Running. In this state
   // there is no need for a dirty bit because the RunToken is either in its initial state, or has

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -23,7 +23,7 @@ impl RunToken {
     RunToken(0)
   }
 
-  fn next(&self) -> RunToken {
+  fn next(self) -> RunToken {
     RunToken(self.0 + 1)
   }
 }
@@ -45,7 +45,7 @@ impl Generation {
     Generation(0)
   }
 
-  fn next(&self) -> Generation {
+  fn next(self) -> Generation {
     Generation(self.0 + 1)
   }
 }

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -297,7 +297,7 @@ impl<N: Node> InnerGraph<N> {
       let minimum_path_id = root_ids
         .iter()
         .min_by_key(|root_id| path_weights[root_id.index()] as usize)
-        .ok_or_else(|| format!("Encountered a Node that was not reachable from any roots."))?;
+        .ok_or_else(|| "Encountered a Node that was not reachable from any roots.".to_owned())?;
 
       // Collect the path by walking through the `paths` Vec, which contains the indexes of
       // predecessor Nodes along a path to the bottom Node.

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -163,7 +163,9 @@ impl<N: Node> InnerGraph<N> {
 
     // Clear roots and remove their outbound edges.
     for id in &root_ids {
-      self.pg.node_weight_mut(*id).map(|entry| entry.clear());
+      if let Some(entry) = self.pg.node_weight_mut(*id) {
+        entry.clear();
+      }
     }
     self.pg.retain_edges(|pg, edge| {
       if let Some((src, _)) = pg.edge_endpoints(edge) {

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -1,6 +1,23 @@
 // Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 extern crate boxfuture;
 extern crate fnv;
 extern crate futures;

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -335,7 +335,7 @@ impl<N: Node> InnerGraph<N> {
     let file = try!(OpenOptions::new().append(true).open(file_path));
     let mut f = BufWriter::new(file);
 
-    let _format = |eid: EntryId, depth: usize, is_last: bool| -> String {
+    let format = |eid: EntryId, depth: usize, is_last: bool| -> String {
       let entry = self.unsafe_entry_for_id(eid);
       let indent = "  ".repeat(depth);
       let output = format!("{}Computing {}", indent, entry.node().format());
@@ -356,7 +356,7 @@ impl<N: Node> InnerGraph<N> {
       try!(writeln!(
         &mut f,
         "{}",
-        _format(*id, depth, path_iter.peek().is_none())
+        format(*id, depth, path_iter.peek().is_none())
       ));
     }
 

--- a/src/rust/engine/hashing/src/lib.rs
+++ b/src/rust/engine/hashing/src/lib.rs
@@ -1,6 +1,23 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 extern crate digest;
 extern crate hex;
 extern crate sha2;

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -1,3 +1,20 @@
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 extern crate async_semaphore;
 extern crate bazel_protos;
 #[macro_use]

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -156,7 +156,7 @@ impl StreamedHermeticCommand {
           ChildOutput::Exit(
             exit_status
               .code()
-              .or(exit_status.signal().map(Neg::neg))
+              .or_else(|| exit_status.signal().map(Neg::neg))
               .expect("Child process should exit via returned code or signal."),
           )
         });

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -79,7 +79,7 @@ impl CommandRunner {
 
         fs::Snapshot::from_path_stats(
           store.clone(),
-          fs::OneOffStoreFileByDigest::new(store, posix_fs),
+          &fs::OneOffStoreFileByDigest::new(store, posix_fs),
           paths.into_iter().filter_map(|v| v).collect(),
         )
       })

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -48,7 +48,7 @@ impl CommandRunner {
   // behavior.
   fn oneshot_execute(
     &self,
-    execute_request: Arc<bazel_protos::remote_execution::ExecuteRequest>,
+    execute_request: &Arc<bazel_protos::remote_execution::ExecuteRequest>,
   ) -> BoxFuture<bazel_protos::operations::Operation, String> {
     let stream = try_future!(
       self
@@ -120,7 +120,7 @@ impl super::CommandRunner for CommandRunner {
               "Executing remotely request: {:?} (command: {:?})",
               execute_request, command
             );
-            command_runner.oneshot_execute(execute_request)
+            command_runner.oneshot_execute(&execute_request)
           })
           .and_then(move |operation| {
             let start_time = Instant::now();
@@ -146,7 +146,7 @@ impl super::CommandRunner for CommandRunner {
                       let execute_request = execute_request2.clone();
                       store.ensure_remote_has_recursive(missing_digests)
                               .and_then(move |()| {
-                                command_runner2.oneshot_execute(execute_request)
+                                command_runner2.oneshot_execute(&execute_request)
                               })
                               // Reset `iter_num` on `MissingDigests`
                               .map(|operation| future::Loop::Continue((operation, 0)))
@@ -553,7 +553,7 @@ impl CommandRunner {
     let store = self.store.clone();
     fs::Snapshot::digest_from_path_stats(
       self.store.clone(),
-      StoreOneOffRemoteDigest::new(path_map),
+      &StoreOneOffRemoteDigest::new(path_map),
       &path_stats,
     ).map_err(move |error| {
       ExecutionError::Fatal(format!(

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -541,7 +541,7 @@ impl CommandRunner {
     impl fs::StoreFileByDigest<String> for StoreOneOffRemoteDigest {
       fn store_by_digest(&self, file: File) -> BoxFuture<Digest, String> {
         match self.map_of_paths_to_digests.get(&file.path) {
-          Some(digest) => future::ok(digest.clone()),
+          Some(digest) => future::ok(*digest),
           None => future::err(format!(
             "Didn't know digest for path in remote execution response: {:?}",
             file.path

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -1,3 +1,18 @@
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 #[macro_use]
 extern crate clap;
 extern crate env_logger;

--- a/src/rust/engine/resettable/src/lib.rs
+++ b/src/rust/engine/resettable/src/lib.rs
@@ -1,3 +1,20 @@
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 use std::sync::{Arc, RwLock};
 
 ///

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -43,6 +43,7 @@ pub struct Core {
 }
 
 impl Core {
+  #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
   pub fn new(
     root_subject_types: Vec<TypeId>,
     tasks: Tasks,

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -48,7 +48,7 @@ impl Core {
     tasks: Tasks,
     types: Types,
     build_root: &Path,
-    ignore_patterns: Vec<String>,
+    ignore_patterns: &[String],
     work_dir: PathBuf,
     remote_store_server: Option<String>,
     remote_execution_server: Option<String>,

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -1,7 +1,6 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -12,6 +11,7 @@ use futures::Future;
 
 use boxfuture::{BoxFuture, Boxable};
 use core::{Failure, TypeId};
+use dirs;
 use fs::{safe_create_dir_all_ioerror, PosixFS, ResettablePool, Store};
 use graph::{EntryId, Graph, NodeContext};
 use handles::maybe_drop_handles;
@@ -63,7 +63,7 @@ impl Core {
       Arc::new(Runtime::new().unwrap_or_else(|e| panic!("Could not initialize Runtime: {:?}", e)))
     });
 
-    let store_path = match std::env::home_dir() {
+    let store_path = match dirs::home_dir() {
       Some(home_dir) => home_dir.join(".cache").join("pants").join("lmdb_store"),
       None => panic!("Could not find home dir"),
     };

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -48,14 +48,13 @@ impl Interns {
     let type_id = ident.type_id;
     let mut inserted = false;
     let id_generator = self.id_generator;
-    let key = self
+    let key = *self
       .forward
       .entry(InternKey(ident.hash, v.clone()))
       .or_insert_with(|| {
         inserted = true;
         Key::new(id_generator, type_id)
-      })
-      .clone();
+      });
     if inserted {
       self.reverse.insert(key, v);
       self.id_generator += 1;

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -16,6 +16,7 @@ mod types;
 
 #[macro_use]
 extern crate boxfuture;
+extern crate dirs;
 #[macro_use]
 extern crate enum_primitive;
 extern crate fnv;

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -274,7 +274,7 @@ pub extern "C" fn scheduler_create(
     tasks,
     types,
     build_root_buf.to_os_string().as_ref(),
-    ignore_patterns,
+    &ignore_patterns,
     PathBuf::from(work_dir_buf.to_os_string()),
     if remote_store_server_string.is_empty() {
       None

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -1,6 +1,27 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+// We only use unsafe pointer derefrences in our no_mangle exposed API, but it is nicer to list
+// just the one minor call as unsafe, than to mark the whole function as unsafe which may hide
+// other unsafeness.
+#![cfg_attr(feature = "cargo-clippy", allow(not_unsafe_ptr_arg_deref))]
+
 pub mod cffi_externs;
 mod context;
 mod core;

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -91,8 +91,8 @@ impl RawNode {
     };
 
     RawNode {
-      subject: subject.clone(),
-      product: product.clone(),
+      subject: *subject,
+      product: *product,
       state_tag: state_tag,
       state_handle: state_value.into(),
     }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -507,6 +507,10 @@ impl ExecuteProcess {
       .parse::<f64>()
       .map_err(|err| format!("Timeout was not a float: {:?}", err))?;
 
+    if timeout_in_seconds < 0.0 {
+      return Err(format!("Timeout was negative: {:?}", timeout_in_seconds));
+    }
+
     let description = externs::project_str(&value, "description");
 
     let jdk_home = {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -790,7 +790,7 @@ pub struct Task {
 impl Task {
   fn gen_get(
     context: &Context,
-    entry: Arc<rule_graph::Entry>,
+    entry: &Arc<rule_graph::Entry>,
     gets: Vec<externs::Get>,
   ) -> NodeFuture<Vec<Value>> {
     let get_futures = gets
@@ -800,7 +800,7 @@ impl Task {
         let entries = context
           .core
           .rule_graph
-          .edges_for_inner(&entry)
+          .edges_for_inner(entry)
           .expect("edges for task exist.")
           .entries_for(&rule_graph::SelectKey::JustGet(selectors::Get {
             product: product,
@@ -828,10 +828,10 @@ impl Task {
       let entry = entry.clone();
       future::result(externs::generator_send(&generator, &input)).and_then(move |response| {
         match response {
-          externs::GeneratorResponse::Get(get) => Self::gen_get(&context, entry, vec![get])
+          externs::GeneratorResponse::Get(get) => Self::gen_get(&context, &entry, vec![get])
             .map(|vs| future::Loop::Continue(vs.into_iter().next().unwrap()))
             .to_boxed(),
-          externs::GeneratorResponse::GetMulti(gets) => Self::gen_get(&context, entry, gets)
+          externs::GeneratorResponse::GetMulti(gets) => Self::gen_get(&context, &entry, gets)
             .map(|vs| future::Loop::Continue(externs::store_tuple(&vs)))
             .to_boxed(),
           externs::GeneratorResponse::Break(val) => future::ok(future::Loop::Break(val)).to_boxed(),

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -664,7 +664,7 @@ impl Snapshot {
       .expand(path_globs)
       .map_err(|e| format!("PathGlobs expansion failed: {:?}", e))
       .and_then(move |path_stats| {
-        fs::Snapshot::from_path_stats(context.core.store.clone(), context.clone(), path_stats)
+        fs::Snapshot::from_path_stats(context.core.store.clone(), &context, path_stats)
           .map_err(move |e| format!("Snapshot failed: {}", e))
       })
       .map_err(|e| throw(&e))

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -269,7 +269,7 @@ impl Select {
     // Compute PathGlobs for the subject.
     let context = context.clone();
     Select::new(
-      context.core.types.path_globs.clone(),
+      context.core.types.path_globs,
       self.subject,
       self.variants.clone(),
       &edges,
@@ -320,7 +320,7 @@ impl Select {
         |entry| match context.core.rule_graph.rule_for_inner(entry) {
           &rule_graph::Rule::Task(ref task) => context.get(Task {
             subject: self.subject,
-            product: self.product().clone(),
+            product: *self.product(),
             variants: self.variants.clone(),
             task: task.clone(),
             entry: Arc::new(entry.clone()),
@@ -804,7 +804,7 @@ impl Task {
           .expect("edges for task exist.")
           .entries_for(&rule_graph::SelectKey::JustGet(selectors::Get {
             product: product,
-            subject: subject.type_id().clone(),
+            subject: *subject.type_id(),
           }));
         Select::new_with_entries(product, subject, Variants::default(), entries)
           .run(context.clone())

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -71,14 +71,12 @@ impl EntryWithDeps {
       }) => clause
         .iter()
         .map(|s| SelectKey::JustSelect(s.clone()))
-        .chain(gets.iter().map(|g| SelectKey::JustGet(g.clone())))
+        .chain(gets.iter().map(|g| SelectKey::JustGet(*g)))
         .collect(),
       &EntryWithDeps::Inner(InnerEntry {
         rule: Rule::Intrinsic(Intrinsic { ref input, .. }),
         ..
-      }) => vec![SelectKey::JustSelect(Select::without_variant(
-        input.clone(),
-      ))],
+      }) => vec![SelectKey::JustSelect(Select::without_variant(*input))],
     }
   }
 }
@@ -361,7 +359,7 @@ impl<'t> GraphMaker<'t> {
       Some(RootEntry {
         subject_type: subject_type,
         clause: vec![Select {
-          product: product_type.clone(),
+          product: *product_type,
           variant_key: None,
         }],
         gets: vec![],
@@ -729,13 +727,13 @@ fn rhs(tasks: &Tasks, subject_type: TypeId, product_type: &TypeConstraint) -> En
     // NB a matching subject is always picked first
     vec![Entry::new_subject_is_product(subject_type)]
   } else if let Some(&(ref key, _)) = tasks.gen_singleton(product_type) {
-    vec![Entry::new_singleton(key.clone(), product_type.clone())]
+    vec![Entry::new_singleton(*key, *product_type)]
   } else {
     let mut entries = Vec::new();
     if let Some(matching_intrinsic) = tasks.gen_intrinsic(product_type) {
       entries.push(Entry::WithDeps(EntryWithDeps::Inner(InnerEntry {
         subject_type: subject_type,
-        rule: Rule::Intrinsic(matching_intrinsic.clone()),
+        rule: Rule::Intrinsic(*matching_intrinsic),
       })));
     }
     if let Some(matching_tasks) = tasks.gen_tasks(product_type) {

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -497,10 +497,10 @@ fn task_display(task: &Task) -> String {
     .map(|g| get_str(g))
     .collect::<Vec<_>>()
     .join(", ");
-  get_portion = if !task.gets.is_empty() {
-    format!("[{}], ", get_portion)
-  } else {
+  get_portion = if task.gets.is_empty() {
     "".to_string()
+  } else {
+    format!("[{}], ", get_portion)
   };
   let function_name = function_str(&&task.func);
   format!(

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -286,7 +286,7 @@ impl Scheduler {
       .and_then(|path_stats| {
         fs::Snapshot::from_path_stats(
           store.clone(),
-          fs::OneOffStoreFileByDigest::new(store, posix_fs),
+          &fs::OneOffStoreFileByDigest::new(store, posix_fs),
           path_stats,
         )
       })

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -193,7 +193,7 @@ impl bazel_protos::bytestream_grpc::ByteStream for StubCASResponder {
   ) {
     {
       let mut request_count = self.read_request_count.lock().unwrap();
-      *request_count = *request_count + 1;
+      *request_count += 1;
     }
     match self.read_internal(&req) {
       Ok(response) => self.send(

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -104,7 +104,7 @@ impl StubCAS {
   }
 
   pub fn read_request_count(&self) -> usize {
-    self.read_request_count.lock().unwrap().clone()
+    *self.read_request_count.lock().unwrap()
   }
 }
 

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -210,7 +210,7 @@ impl MockResponder {
 
   fn send_next_operation_stream(
     &self,
-    ctx: grpcio::RpcContext,
+    ctx: &grpcio::RpcContext,
     sink: grpcio::ServerStreamingSink<super::bazel_protos::operations::Operation>,
   ) {
     match self
@@ -273,7 +273,7 @@ impl bazel_protos::remote_execution_grpc::Execution for MockResponder {
       return;
     }
 
-    self.send_next_operation_stream(ctx, sink);
+    self.send_next_operation_stream(&ctx, sink);
   }
 
   fn wait_execution(

--- a/src/rust/engine/testutil/mock/src/lib.rs
+++ b/src/rust/engine/testutil/mock/src/lib.rs
@@ -1,3 +1,22 @@
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+// We use a bunch of complex compound tuples for storing call arguments.
+#![cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
+
 extern crate bazel_protos;
 extern crate bytes;
 extern crate futures;

--- a/src/rust/engine/testutil/src/lib.rs
+++ b/src/rust/engine/testutil/src/lib.rs
@@ -1,3 +1,20 @@
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 extern crate bazel_protos;
 extern crate bytes;
 extern crate digest;

--- a/src/rust/engine/ui/src/display.rs
+++ b/src/rust/engine/ui/src/display.rs
@@ -46,13 +46,13 @@ impl EngineDisplay {
       divider: "▵".to_string(),
       poll_interval_ms: Duration::from_millis(55),
       padding: " ".repeat(indent_level.into()),
-      terminal: if !is_tty {
-        Console::Pipe(write_handle)
-      } else {
+      terminal: if is_tty {
         match write_handle.into_raw_mode() {
           Ok(t) => Console::Terminal(t),
           Err(_) => Console::Pipe(stdout()),
         }
+      } else {
+        Console::Pipe(write_handle)
       },
       action_map: BTreeMap::new(),
       // This is arbitrary based on a guesstimated peak terminal row size for modern displays.

--- a/src/rust/engine/ui/src/display.rs
+++ b/src/rust/engine/ui/src/display.rs
@@ -1,3 +1,20 @@
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 extern crate rand;
 extern crate termion;
 extern crate unicode_segmentation;

--- a/src/rust/engine/ui/src/display.rs
+++ b/src/rust/engine/ui/src/display.rs
@@ -235,9 +235,10 @@ impl EngineDisplay {
   // Paints one screen of rendering.
   pub fn render(&mut self) {
     // TODO: Split this fork out into sub-types of EngineDisplay.
-    match self.is_tty {
-      true => self.render_for_tty(),
-      false => self.render_for_pipe(),
+    if self.is_tty {
+      self.render_for_tty()
+    } else {
+      self.render_for_pipe()
     }
   }
 

--- a/src/rust/engine/ui/src/main.rs
+++ b/src/rust/engine/ui/src/main.rs
@@ -62,7 +62,7 @@ fn main() {
 
     gen_display_work(
       &mut display,
-      &counter,
+      counter,
       &random_products,
       &worker_ids,
       &random_verbs,

--- a/src/rust/engine/ui/src/main.rs
+++ b/src/rust/engine/ui/src/main.rs
@@ -48,8 +48,8 @@ fn main() {
   let mut done = false;
   let mut counter: u64 = 0;
 
-  for worker_id in worker_ids.clone().into_iter() {
-    display.add_worker(String::from(worker_id));
+  for worker_id in worker_ids.clone() {
+    display.add_worker(worker_id);
     display.render();
     thread::sleep(Duration::from_millis(63));
   }

--- a/src/rust/engine/ui/src/main.rs
+++ b/src/rust/engine/ui/src/main.rs
@@ -45,41 +45,6 @@ fn main() {
     "Link".to_string()
   );
 
-  fn gen_display_work(
-    display: &mut EngineDisplay,
-    counter: &u64,
-    type_selection: &Vec<String>,
-    worker_ids: &Vec<String>,
-    verb_selection: &Vec<String>,
-    log_level_selection: &Vec<String>,
-  ) {
-    let mut rng = rand::thread_rng();
-
-    for worker_id in worker_ids.clone().into_iter() {
-      let random_product = rng.choose(&type_selection).unwrap();
-      let random_subject = rng.choose(&type_selection).unwrap();
-
-      display.update(
-        worker_id,
-        String::from(format!(
-          "computing {} for {}(...)",
-          random_product, random_subject
-        )),
-      );
-    }
-
-    if counter > &50 && counter % 2 == 0 {
-      let random_log_level = rng.choose(&log_level_selection).unwrap();
-      let random_verb = rng.choose(&verb_selection).unwrap();
-      let random_product_2 = rng.choose(&type_selection).unwrap();
-
-      display.log(format!(
-        "{}] {} {}",
-        random_log_level, random_verb, random_product_2
-      ));
-    }
-  }
-
   let mut done = false;
   let mut counter: u64 = 0;
 
@@ -112,4 +77,36 @@ fn main() {
   }
 
   display.finish();
+}
+
+fn gen_display_work(
+  display: &mut EngineDisplay,
+  counter: u64,
+  type_selection: &[String],
+  worker_ids: &[String],
+  verb_selection: &[String],
+  log_level_selection: &[String],
+) {
+  let mut rng = rand::thread_rng();
+
+  for worker_id in worker_ids {
+    let random_product = rng.choose(&type_selection).unwrap();
+    let random_subject = rng.choose(&type_selection).unwrap();
+
+    display.update(
+      worker_id.to_string(),
+      format!("computing {} for {}(...)", random_product, random_subject),
+    );
+  }
+
+  if counter > 50 && counter % 2 == 0 {
+    let random_log_level = rng.choose(&log_level_selection).unwrap();
+    let random_verb = rng.choose(&verb_selection).unwrap();
+    let random_product_2 = rng.choose(&type_selection).unwrap();
+
+    display.log(format!(
+      "{}] {} {}",
+      random_log_level, random_verb, random_product_2
+    ));
+  }
 }

--- a/src/rust/engine/ui/src/main.rs
+++ b/src/rust/engine/ui/src/main.rs
@@ -1,3 +1,20 @@
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![cfg_attr(
+  feature = "cargo-clippy",
+  deny(
+    clippy, default_trait_access, expl_impl_clone_on_copy, if_not_else, needless_continue,
+    single_match_else, unseparated_literal_suffix, used_underscore_binding
+  )
+)]
+// It is often more clear to show that nothing is being moved.
+#![cfg_attr(feature = "cargo-clippy", allow(match_ref_pats))]
+// Subjective style.
+#![cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty, redundant_field_names))]
+// Default isn't as big a deal as people seem to think it is.
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default, new_without_default_derive))]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+
 extern crate engine_display;
 extern crate rand;
 


### PR DESCRIPTION
This enables all default lints, and a selection of pedantic ones.

It also fixes all code to be clean with respect to those lints.

Each commit is independently reviewable.

It's a shame that the lint selecting can't be shared across creates in some way.