### PR TITLE
Use --entry-point not -c when building pex

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -609,7 +609,7 @@ function build_pex() {
 
     ./${PEX_PEX} \
       -o "${dest}" \
-      -c pants \
+      --entry-point="pants.bin.pants_loader:main" \
       --no-build \
       --no-pypi \
       --disable-cache \


### PR DESCRIPTION
I deterministically get this error:

RuntimeError: Ambiguous script specification pants matches multiple entry points:pants = pants.bin.pants_loader:main pants = pants.bin.pants_loader:main

when building with -c.

https://github.com/pantsbuild/pants/pull/6267 changed this behaviour,
but seems broken - this commit allows me to successfully build pexes.