### PR TITLE
Zinc compiles can execute hermetically

### DIFF
--- a/src/python/pants/backend/jvm/tasks/classpath_products.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_products.py
@@ -329,7 +329,7 @@ class ClasspathProducts(object):
       self._excludes.add_for_target(target, target.excludes)
 
   def _wrap_path_elements(self, classpath_elements):
-    return [(element[0], ClasspathEntry(element[1])) for element in classpath_elements]
+    return [(element[0], ClasspathEntry(*element[1:])) for element in classpath_elements]
 
   def _add_elements_for_target(self, target, elements):
     self._validate_classpath_tuples(elements, target)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -387,6 +387,7 @@ class JvmCompile(NailgunTaskBase):
         classpath_product,
       )
 
+      # TODO: Pass around DirectoryDigests in these ClasspathEntries
       if not self.get_options().use_classpath_jars:
         # Once compilation has completed, replace the classpath entry for each target with
         # its jar'd representation.
@@ -418,6 +419,8 @@ class JvmCompile(NailgunTaskBase):
     valid_targets = [vt.target for vt in invalidation_check.all_vts if vt.valid]
 
     # Register classpaths and products for valid targets.
+    # TODO: Store the DirectoryDigest for successful compiles in the target workdir as text,
+    # and hydrate them into the ClasspathEntries here when we get cache hits.
     for valid_target in valid_targets:
       cc = self.select_runtime_context(compile_contexts[valid_target])
       classpath_product.add_for_target(
@@ -496,7 +499,7 @@ class JvmCompile(NailgunTaskBase):
         ').')
       with self.context.new_workunit('compile', labels=[WorkUnitLabel.COMPILER]) as compile_workunit:
         try:
-          self.compile(
+          directory_digest = self.compile(
             ctx,
             self._args,
             dependency_classpath,
@@ -508,6 +511,7 @@ class JvmCompile(NailgunTaskBase):
             self._get_plugin_map('scalac', ScalaPlatform.global_instance(), ctx.target),
           )
           self._capture_logs(compile_workunit, ctx.log_dir)
+          return directory_digest
         except TaskError:
           if self.get_options().suggest_missing_deps:
             logs = [path
@@ -698,7 +702,7 @@ class JvmCompile(NailgunTaskBase):
         compiler_option_sets = dep_context.defaulted_property(tgt, lambda x: x.compiler_option_sets)
         zinc_file_manager = dep_context.defaulted_property(tgt, lambda x: x.zinc_file_manager)
         with Timer() as timer:
-          self._compile_vts(vts,
+          directory_digest = self._compile_vts(vts,
                             ctx,
                             upstream_analysis,
                             dependency_cp_entries,
@@ -723,7 +727,7 @@ class JvmCompile(NailgunTaskBase):
       # Update the products with the latest classes.
       classpath_product.add_for_target(
         ctx.target,
-        [(conf, self._classpath_for_context(ctx)) for conf in self._confs],
+        [(conf, self._classpath_for_context(ctx), directory_digest) for conf in self._confs],
       )
       self.register_extra_products_from_contexts([ctx.target], all_compile_contexts)
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -388,6 +388,7 @@ class JvmCompile(NailgunTaskBase):
       )
 
       # TODO: Pass around DirectoryDigests in these ClasspathEntries
+      # See https://github.com/pantsbuild/pants/issues/6429
       if not self.get_options().use_classpath_jars:
         # Once compilation has completed, replace the classpath entry for each target with
         # its jar'd representation.
@@ -421,6 +422,7 @@ class JvmCompile(NailgunTaskBase):
     # Register classpaths and products for valid targets.
     # TODO: Store the DirectoryDigest for successful compiles in the target workdir as text,
     # and hydrate them into the ClasspathEntries here when we get cache hits.
+    # See https://github.com/pantsbuild/pants/issues/6429
     for valid_target in valid_targets:
       cc = self.select_runtime_context(compile_contexts[valid_target])
       classpath_product.add_for_target(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -230,7 +230,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
         }
       }
 
-      with self.temporary_workdir(cleanup=False) as workdir:
+      with self.temporary_workdir() as workdir:
         pants_run = self.run_pants_with_workdir(
           [
             '-q',


### PR DESCRIPTION
There are a LOT of TODOs here, but it fundamentally works.

Notable things which are missing:
 * Cached vts won't provide files on the classpath - https://github.com/pantsbuild/pants/issues/6429
 * Rebase map is not set up properly - https://github.com/pantsbuild/pants/issues/6434
 * use-classpath-jars doesn't work
 * workdir must be a child of buildroot
 * classpath entries in the java dist don't work 
 * Upstream analysis may or may not work properly in all cases
 * -zinc-cache-dir is in a homedir, so won't be written if that homedir
   doesn't exist - https://github.com/pantsbuild/pants/issues/6155
 * Many things (e.g. jar_library) don't populate ClasspathEntry
   DirectoryDigests - https://github.com/pantsbuild/pants/issues/6432
 * A big pile of inefficiencies