### PR TITLE
Add an environment marker to `pants_requirement`.

### DIFF
--- a/build-support/known_py3_failures.txt
+++ b/build-support/known_py3_failures.txt
@@ -50,6 +50,7 @@ tests/python/pants_test/backend/project_info/tasks:filedeps
 tests/python/pants_test/backend/python/tasks:isort_run
 tests/python/pants_test/backend/python/tasks:tasks
 tests/python/pants_test/backend/python:interpreter_cache
+tests/python/pants_test/backend/python:pants_requirement
 tests/python/pants_test/binaries:binaries
 tests/python/pants_test/build_graph:build_file_parser
 tests/python/pants_test/build_graph:build_graph

--- a/src/python/pants/backend/python/pants_requirement.py
+++ b/src/python/pants/backend/python/pants_requirement.py
@@ -32,7 +32,14 @@ class PantsRequirement(object):
     :param string name: The name to use for the target, defaults to the parent dir name.
     """
     name = name or os.path.basename(self._parse_context.rel_path)
-    requirement = PythonRequirement(requirement='pantsbuild.pants=={}'.format(pants_version()))
+
+    # TODO(John Sirois): Modify to constraint to >=3.5,<4 as part of
+    # https://github.com/pantsbuild/pants/issues/6062
+    env_marker = "python_version>='2.7' and python_version<'3'"
+
+    requirement = PythonRequirement(requirement="pantsbuild.pants=={version} ; {env_marker}"
+                                    .format(version=pants_version(), env_marker=env_marker))
+
     self._parse_context.create_object('python_requirement_library',
                                       name=name,
                                       requirements=[requirement])

--- a/tests/python/pants_test/backend/python/test_pants_requirement.py
+++ b/tests/python/pants_test/backend/python/test_pants_requirement.py
@@ -19,9 +19,23 @@ class PantsRequirementTest(TestBase):
 
   def assert_pants_requirement(self, python_requirement_library):
     self.assertIsInstance(python_requirement_library, PythonRequirementLibrary)
-    pants_requirement = PythonRequirement('pantsbuild.pants=={}'.format(pants_version()))
-    self.assertEqual([pants_requirement.requirement],
-                     list(pr.requirement for pr in python_requirement_library.payload.requirements))
+    expected = PythonRequirement('pantsbuild.pants=={}'.format(pants_version()))
+
+    def key(python_requirement):
+      return (python_requirement.requirement.key,
+              python_requirement.requirement.specs,
+              python_requirement.requirement.extras)
+
+    self.assertEqual([key(expected)],
+                     [key(pr) for pr in python_requirement_library.payload.requirements])
+
+    req = list(python_requirement_library.payload.requirements)[0]
+    self.assertIsNotNone(req.requirement.marker)
+    self.assertTrue(req.requirement.marker.evaluate(),
+                    'pants_requirement() should always work in the current test environment')
+    self.assertFalse(req.requirement.marker.evaluate({'python_version': '3.5'}))
+    self.assertFalse(req.requirement.marker.evaluate({'python_version': '2.6'}))
+    self.assertTrue(req.requirement.marker.evaluate({'python_version': '2.7'}))
 
   def test_default_name(self):
     self.add_to_build_file('3rdparty/python/pants', 'pants_requirement()')


### PR DESCRIPTION
This properly restricts the dependency to environments pants can
actually run in.

Fixes #6358
