### PR TITLE
Pin interpreter <3.7 in ci.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -130,7 +130,9 @@ fi
 if [[ "${python_three:-false}" == "true" ]]; then
   # The 3.4 end of this constraint is necessary to jive with the travis ubuntu trusty image.
   banner "Setting interpreter constraints for 3!"
-  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS='["CPython>=3.4,<4"]'
+  # TODO(John Sirois): Allow `<4` when the issues with `3.7` are fixed. See:
+  #   https://github.com/pantsbuild/pants/issues/6363
+  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS='["CPython>=3.4,<3.7"]'
   # FIXME: Clear interpreters, otherwise this constraint does not end up applying due to a cache
   # bug between the `./pants binary` and further runs.
   ./pants.pex clean-all

--- a/testprojects/src/python/interpreter_selection/BUILD
+++ b/testprojects/src/python/interpreter_selection/BUILD
@@ -9,7 +9,9 @@ python_library(
   sources = ['echo_interpreter_version.py'],
   dependencies = [],
   # Play with this to test interpreter selection in the pex machinery.
-  compatibility = ['CPython>=2.7,<4']
+  # TODO(John Sirois): Allow `<4` when the issues with `3.7` are fixed. See:
+  #   https://github.com/pantsbuild/pants/issues/6363
+  compatibility = ['CPython>=2.7,<3.7']
 )
 
 python_binary(


### PR DESCRIPTION
Pants does not currently work in 3.7 and this helps repro issues in CI
on a developer workstation that has 3.7 and 3.lower.

Part of work on #6363.