### PR TITLE
Fix Single Address Exclude

### DIFF
--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import unittest
 
-from future.utils import text_type
-
 from pants.base.project_tree import Dir, File
 from pants.base.specs import SiblingAddresses, SingleAddress, Specs
 from pants.build_graph.address import Address
@@ -34,8 +32,8 @@ class ParseAddressFamilyTest(unittest.TestCase):
     """Test that parsing an empty BUILD file results in an empty AddressFamily."""
     address_mapper = AddressMapper(JsonParser(TestTable()))
     af = run_rule(parse_address_family, address_mapper, Dir('/dev/null'), {
-        (Snapshot, PathGlobs): lambda _: Snapshot(DirectoryDigest(text_type("abc"), 10), (File('/dev/null/BUILD'),)),
-        (FilesContent, DirectoryDigest): lambda _: FilesContent([FileContent('/dev/null/BUILD', '')]),
+        (Snapshot, PathGlobs): lambda _: Snapshot(DirectoryDigest('abc', 10), (File('/dev/null/BUILD'),)),
+        (FilesContent, DirectoryDigest): lambda _: FilesContent([FileContent('/dev/null/BUILD', b'')]),
       })
     self.assertEqual(len(af.objects_by_name), 0)
 
@@ -45,7 +43,8 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     """Test that matching the same Spec twice succeeds."""
     address = SingleAddress('a', 'a')
     address_mapper = AddressMapper(JsonParser(TestTable()))
-    snapshot = Snapshot(DirectoryDigest(text_type('xx'), 2), (Path('a/BUILD', File('a/BUILD')),))
+    snapshot = Snapshot(DirectoryDigest('xx', 2),
+                        (Path('a/BUILD', File('a/BUILD')),))
     address_family = AddressFamily('a', {'a': ('a/BUILD', 'this is an object!')})
 
     bfas = run_rule(addresses_from_address_families, address_mapper, Specs([address, address]), {
@@ -60,7 +59,8 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     """Test that targets are filtered based on `tags`."""
     spec = SiblingAddresses('root')
     address_mapper = AddressMapper(JsonParser(TestTable()))
-    snapshot = Snapshot(DirectoryDigest(text_type('xx'), 2), (Path('root/BUILD', File('root/BUILD')),))
+    snapshot = Snapshot(DirectoryDigest('xx', 2),
+                        (Path('root/BUILD', File('root/BUILD')),))
     address_family = AddressFamily('root',
       {'a': ('root/BUILD', TargetAdaptor()),
        'b': ('root/BUILD', TargetAdaptor(tags={'integration'})),
@@ -81,7 +81,8 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     """Test that targets are filtered based on exclude patterns."""
     spec = SiblingAddresses('root')
     address_mapper = AddressMapper(JsonParser(TestTable()))
-    snapshot = Snapshot(DirectoryDigest(text_type('xx'), 2), (Path('root/BUILD', File('root/BUILD')),))
+    snapshot = Snapshot(DirectoryDigest('xx', 2),
+                        (Path('root/BUILD', File('root/BUILD')),))
     address_family = AddressFamily('root',
       {'exclude_me': ('root/BUILD', TargetAdaptor()),
        'not_me': ('root/BUILD', TargetAdaptor()),
@@ -96,10 +97,11 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     self.assertEqual(targets.dependencies[0].spec, 'root:not_me')
 
   def test_exclude_pattern_with_single_address(self):
-    """Test that targets are filtered based on exclude patterns."""
+    """Test that single address targets are filtered based on exclude patterns."""
     spec = SingleAddress('root', 'not_me')
     address_mapper = AddressMapper(JsonParser(TestTable()))
-    snapshot = Snapshot(DirectoryDigest(text_type('xx'), 2), (Path('root/BUILD', File('root/BUILD')),))
+    snapshot = Snapshot(DirectoryDigest('xx', 2),
+                        (Path('root/BUILD', File('root/BUILD')),))
     address_family = AddressFamily('root',
       {
        'not_me': ('root/BUILD', TargetAdaptor()),


### PR DESCRIPTION
### Problem

The git commit hook (and CI lint) will lint targets that own changed files. Transforming specs to single addresses is currently broken and causes a "did you mean error" to be thrown on specs that actually exist in an affected build file:

```
ResolveError: "main_py2" was not found in namespace "testprojects/src/python/interpreter_selection/python_3_selection_testing". Did you mean one of:
          :lib_py2
          :lib_py23
          :lib_py3
          :main_py2
          :main_py23
          :main_py3
          :test_py2
          :test_py23
```
This manifested after trying to make changes to a `testprojects` BUILD file, which is excluded in the CI/commit hook lint step:
`./pants -q --exclude-target-regexp='testprojects/.*' --changed-parent=master lint`

### Solution

Edit build_files.py to aggregate excluded addresses in addition to included ones and check that excluded addresses align with exclude logic so that the "did you mean" error only occurs when the spec actually doesn't exist.

### Result

Changes to files in testprojects will not throw any "did you mean" errors in CI/commit hook lint invoked by the following command:
`./pants -q --exclude-target-regexp='testprojects/.*' --changed-parent=master lint`