### PR TITLE
datatype()s can declare default values

### DIFF
--- a/src/python/pants/base/project_tree.py
+++ b/src/python/pants/base/project_tree.py
@@ -212,19 +212,10 @@ class Stat(AbstractClass):
 class File(datatype(['path']), Stat):
   """A file."""
 
-  def __new__(cls, path):
-    return super(File, cls).__new__(cls, path)
-
 
 class Dir(datatype(['path']), Stat):
   """A directory."""
 
-  def __new__(cls, path):
-    return super(Dir, cls).__new__(cls, path)
-
 
 class Link(datatype(['path']), Stat):
   """A symbolic link."""
-
-  def __new__(cls, path):
-    return super(Link, cls).__new__(cls, path)

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -8,6 +8,7 @@ import re
 from abc import abstractmethod
 
 from pants.util.meta import AbstractClass
+from pants.util.objects import DatatypeFieldDecl as F
 from pants.util.objects import datatype
 
 
@@ -60,11 +61,11 @@ class AscendantAddresses(datatype(['directory']), Spec):
     return '{}^'.format(self.directory)
 
 
-class Specs(datatype(['dependencies', 'tags', ('exclude_patterns', tuple)])):
+class Specs(datatype([
+    'dependencies',
+    F('tags', tuple, default_value=()),
+    F('exclude_patterns', tuple, default_value=())])):
   """A collection of Specs representing Spec subclasses, tags and regex filters."""
-
-  def __new__(cls, dependencies, tags=tuple(), exclude_patterns=tuple()):
-    return super(Specs, cls).__new__(cls, dependencies, tags, exclude_patterns)
 
   def exclude_patterns_memo(self):
     return [re.compile(pattern) for pattern in set(self.exclude_patterns or [])]

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -11,7 +11,8 @@ from builtins import str
 import six
 
 from pants.util.meta import AbstractClass
-from pants.util.objects import Exactly, datatype
+from pants.util.objects import DatatypeFieldDecl as F
+from pants.util.objects import Exactly, SubclassesOf, datatype
 
 
 def type_or_constraint_repr(constraint):
@@ -96,15 +97,14 @@ class Selector(AbstractClass):
     """The product that this selector produces."""
 
 
-class Select(datatype(['product', 'optional']), Selector):
+class Select(datatype([
+    'product',
+    F('optional', bool, default_value=False),
+]), Selector):
   """Selects the given Product for the Subject provided to the constructor.
 
   If optional=True and no matching product can be produced, will return None.
   """
-
-  def __new__(cls, product, optional=False):
-    obj = super(Select, cls).__new__(cls, product, optional)
-    return obj
 
   def __repr__(self):
     return '{}({}{})'.format(type(self).__name__,
@@ -112,7 +112,10 @@ class Select(datatype(['product', 'optional']), Selector):
                              ', optional=True' if self.optional else '')
 
 
-class SelectVariant(datatype(['product', 'variant_key']), Selector):
+class SelectVariant(datatype([
+    'product',
+    ('variant_key', SubclassesOf(*six.string_types)),
+]), Selector):
   """Selects the matching Product and variant name for the Subject provided to the constructor.
 
   For example: a SelectVariant with a variant_key of "thrift" and a product of type ApacheThrift
@@ -120,11 +123,6 @@ class SelectVariant(datatype(['product', 'variant_key']), Selector):
   ApacheThrift value.
   """
   optional = False
-
-  def __new__(cls, product, variant_key):
-    if not isinstance(variant_key, six.string_types):
-      raise ValueError('Expected variant_key to be a string, but was {!r}'.format(variant_key))
-    return super(SelectVariant, cls).__new__(cls, product, variant_key)
 
   def __repr__(self):
     return '{}({}, {})'.format(type(self).__name__,

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -4,15 +4,15 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from collections import namedtuple
+from pants.util.objects import DatatypeFieldDecl as F
+from pants.util.objects import datatype
 
 
 GLOBAL_SCOPE = ''
 GLOBAL_SCOPE_CONFIG_SECTION = 'GLOBAL'
 
 
-# FIXME: convert this to a datatype?
-class ScopeInfo(namedtuple('_ScopeInfo', ['scope', 'category', 'optionable_cls'])):
+class ScopeInfo(datatype(['scope', 'category', F('optionable_cls', default_value=None)])):
   """Information about a scope."""
 
   # Symbolic constants for different categories of scope.
@@ -36,7 +36,3 @@ class ScopeInfo(namedtuple('_ScopeInfo', ['scope', 'category', 'optionable_cls']
 
   def _optionable_cls_attr(self, name, default=None):
     return getattr(self.optionable_cls, name) if self.optionable_cls else default
-
-
-# Allow the optionable_cls to default to None.
-ScopeInfo.__new__.__defaults__ = (None, )

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+import re
 import unittest
 from builtins import str
 
@@ -217,13 +218,11 @@ class ExecuteProcessRequestTest(unittest.TestCase):
     with self.assertRaises(TypeCheckError):
       self._default_args_execute_process_request(argv=('1',), env=['foo', 'bar'])
 
-    # TODO(cosmicexplorer): we should probably check that the digest info in
-    # ExecuteProcessRequest is valid, beyond just checking if it's a string.
     with self.assertRaisesRegexp(TypeCheckError, "env"):
       ExecuteProcessRequest(
         argv=('1',),
-        env=(),
-        input_files='',
+        env=[],
+        input_files=EMPTY_DIRECTORY_DIGEST,
         output_files=(),
         output_directories=(),
         timeout_seconds=0.1,

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-import re
 import unittest
 from builtins import str
 

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -110,7 +110,7 @@ python_tests(
   dependencies = [
     '3rdparty/python:future',
     'src/python/pants/util:objects',
-    'tests/python/pants_test:base_test',
+    'tests/python/pants_test:test_base',
   ]
 )
 

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -614,7 +614,8 @@ field 'some_value' was invalid: value 3 (with type 'int') must satisfy this type
 
     expected_rx_str = re.escape(
       """error: in constructor of type AnotherTypedDatatype: type check error:
-__new__() got an unexpected keyword argument 'nonexistent_field'""")
+Replacing fields {'nonexistent_field': 3} of object AnotherTypedDatatype(string=u'some string', elements=[1, 2, 3]) failed:
+Field 'nonexistent_field' was not recognized.""")
     with self.assertRaisesRegexp(TypeCheckError, expected_rx_str):
       obj.copy(nonexistent_field=3)
 
@@ -628,7 +629,8 @@ __new__() got an unexpected keyword argument 'nonexistent_field'""")
 
     expected_rx_str = re.escape(
       """error: in constructor of type AnotherTypedDatatype: type check error:
-field 'elements' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(list).""")
+Replacing fields {'elements': 3} of object AnotherTypedDatatype(string=u'some string', elements=[1, 2, 3]) failed:
+Type error for field 'elements': value 3 (with type 'int') must satisfy this type constraint: Exactly(list).""")
     with self.assertRaisesRegexp(TypeCheckError, expected_rx_str):
       obj.copy(elements=3)
 


### PR DESCRIPTION
### Problem

It's true that we can define default values and other logic for the arguments of a datatype by overriding the `__new__` method, but it's `False` that it's the most ergonomic, declarative, or composable way to do that. What if we could reach for the stars?

### Solution

```python
# This is the recommended style of importing this class.
from pants.util.objects import DatatypeFieldDecl as F
from pants.util.objects import datatype

class MyType(datatype([F('an_int', int, default_value=3)])): pass

assert(MyType().an_int == 3)
assert(MyType(4).an_int == 4)
MyType('asdf') # raises TypeError

# The above is the same as:

from pants.util.objects import Exactly

class MyType(datatype([F(
  field_name='an_int', 
  type_constraint=Exactly(int), 
  default_value=3, 
  has_default_value=True,
)])): pass

# You can still use the tuple syntax:

# This is the same syntax allowed by Python 3.7's typing.NamedTuple!
class MyOtherType(datatype([('x', int)])): pass

MyOtherType('asdf') # raises TypeError
```

### Result

There are a few elements that I have since removed and split off into separate changes to make this mergeable, but which would help to showcase how neat and compositional this feature is. For example, I have implemented (again, not in this PR) an `optional()` method producing a type constraint which will accept `None`, or an object matching the given type constraint (if given), as well as `convert()`, which will check if an object matches a type constraint, or if not, coerce it in a structured way. This allows succinctly expressing a large variety of the usages of `datatype()` in this repo which were previously overriding `__new__`. With those changes, I was able to wipe away a lot of / almost all `__new__` methods entirely, which seemed like a huge win in (de)clar(at)i(vi)ty.

Also, I added a TODO to use python 3 [dataclasses](https://github.com/ericvsmith/dataclasses) when we can restrict the python version on our python 3 test shard to `CPython>=3.6`.

Please let me know your thoughts on the syntax and implementation!