### PR TITLE
Decode python_eval template resource as utf-8.

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -203,7 +203,7 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
     return modules
 
   def _get_executable_file_content(self, exec_pex_parent, modules):
-    generator = Generator(pkgutil.get_data(__name__, self._EVAL_TEMPLATE_PATH),
+    generator = Generator(pkgutil.get_data(__name__, self._EVAL_TEMPLATE_PATH).decode('utf-8'),
                           chroot_parent=exec_pex_parent, modules=modules)
     return generator.render()
 

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/test_python_eval.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/test_python_eval.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from textwrap import dedent
 
-import pytest
-from future.utils import PY3
 from pants.backend.python.subsystems.python_repos import PythonRepos
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
@@ -15,8 +13,6 @@ from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTest
 from pants.contrib.python.checks.tasks.python_eval import PythonEval
 
 
-# TODO(python3port): https://github.com/pantsbuild/pants/issues/6354. Fix before switching fully to Py3.
-@pytest.mark.skipif(PY3, reason='PEX issue when using Python 3. https://github.com/pantsbuild/pants/issues/6354')
 class PythonEvalTest(PythonTaskTestBase):
 
   @classmethod

--- a/src/python/pants/invalidation/build_invalidator.py
+++ b/src/python/pants/invalidation/build_invalidator.py
@@ -223,7 +223,7 @@ class BuildInvalidator(object):
   def _read_sha_by_id(self, id):
     try:
       with open(self._sha_file_by_id(id), 'rb') as fd:
-        return fd.read().strip()
+        return fd.read().strip().decode('utf-8')
     except IOError as e:
       if e.errno != errno.ENOENT:
         raise


### PR DESCRIPTION
Without this, the template was rendered with literal `\n`'s under
python3. I did not linger to figure out how the rendered string could
possibly load in a python interpreter with no errors!

Fixes #6354
Fixes #6384