### PR TITLE
Add json upload summary to `fs_util` (#6318)

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -630,21 +630,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "local_cas"
+version = "0.0.1"
+dependencies = [
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mock 0.0.1",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "local_cas"
-version = "0.0.1"
-dependencies = [
- "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "mock 0.0.1",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -639,6 +639,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "local_cas"
+version = "0.0.1"
+dependencies = [
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mock 0.0.1",
+]
+
+[[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -319,7 +319,7 @@ name = "failure_derive"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -363,6 +363,8 @@ dependencies = [
  "mock 0.0.1",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "resettable 0.0.1",
+ "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
@@ -380,6 +382,9 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -403,7 +408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -501,7 +506,7 @@ dependencies = [
  "cc 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -510,6 +515,9 @@ version = "0.0.1"
 dependencies = [
  "digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_test 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -565,6 +573,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,7 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -789,16 +802,16 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -814,12 +827,12 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -909,7 +922,7 @@ name = "quote"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1025,6 +1038,11 @@ version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ryu"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "same-file"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1054,39 @@ dependencies = [
 name = "scopeguard"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "sha2"
@@ -1087,7 +1138,7 @@ name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1097,7 +1148,7 @@ name = "synstructure"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1548,6 +1599,7 @@ dependencies = [
 "checksum indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08173ba1e906efb6538785a8844dd496f5d34f0a2d88038e95195172fc667220"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f58856976b776fedd95533137617a02fb25719f40e7d9b01c7043cd65474f450"
+"checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
@@ -1574,10 +1626,10 @@ dependencies = [
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69376b761943787ebd5cc85a5bc95958651a22609c5c1c2b65de21786baec72b"
-"checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
+"checksum parking_lot_core 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "d9f012c3bcd5a1a8ae638ac2b328dceb0a3ca24116cef93f5f8b564f81481b97"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
-"checksum pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "104630aa1c83213cbc76db0703630fcb0421dac3585063be4ce9a8a2feeaa745"
-"checksum proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ee5697238f0d893c7f0ecc59c0999f18d2af85e424de441178bcacc9f9e6cf67"
+"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
+"checksum proc-macro2 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)" = "295af93acfb1d5be29c16ca5b3f82d863836efd9cb0c14fd83811eb9a110e452"
 "checksum protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "128a4f37a2df739a567a8685b17f54aa19b9c3c4a6a5b8731e97a419b3db451c"
 "checksum protobuf-codegen 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3624c0feac7f512de21dbf8b574ae65c6573b1872d3878be951c0912eee4daca"
 "checksum protoc 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8736a41d7c7e321913dd81067fbedf74d037f69999386eba07cc4dd1de7369f0"
@@ -1597,8 +1649,13 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
 "checksum same-file 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10f7794e2fda7f594866840e95f5c5962e886e228e68b6505885811a94dd728c"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)" = "22d340507cea0b7e6632900a176101fea959c7065d93ba555072da90aaaafc87"
+"checksum serde_derive 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)" = "234fc8b737737b148ccd625175fc6390f5e4dacfdaa543cb93a3430d984a9119"
+"checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
+"checksum serde_test 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)" = "daa106a4bb77355f0a714334e3a238d1e6f4f34354da91b9b81e2c4ad40d3295"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -39,6 +39,7 @@ members = [
   "resettable",
   "testutil",
   "testutil/mock",
+  "testutil/local_cas",
   "ui"
 ]
 

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -65,6 +65,7 @@ default-members = [
   "resettable",
   "testutil",
   "testutil/mock",
+  "testutil/local_cas",
   "ui"
 ]
 

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -24,6 +24,8 @@ log = "0.4"
 protobuf = { version = "2.0.4", features = ["with-bytes"] }
 resettable = { path = "../resettable" }
 sha2 = "0.7"
+serde = "1.0"
+serde_derive = "1.0"
 
 [dev-dependencies]
 mock = { path = "../testutil/mock" }

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -13,3 +13,6 @@ fs = { path = ".." }
 futures = "^0.1.16"
 hashing = { path = "../../hashing" }
 protobuf = { version = "2.0.4", features = ["with-bytes"] }
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -88,8 +88,8 @@ fn main() {
 Outputs a fingerprint of its contents and its size in bytes, separated by a space.",
               )
               .arg(Arg::with_name("path").required(true).takes_value(true))
-              .arg(Arg::with_name("output-mode").long("output-mode").multiple(false).takes_value(true).help(
-                "Set --output-mode=(json|simple) manipulate the way a report is displayed. Default is simple."
+              .arg(Arg::with_name("output-mode").long("output-mode").possible_values(&["json", "simple"]).default_value("simple").multiple(false).takes_value(true).help(
+                "Set to manipulate the way a report is displayed."
               )),
           ),
       )
@@ -132,8 +132,8 @@ directory, relative to the root.",
                   "Root under which the globs live. The Directory proto produced will be relative \
 to this directory.",
             ))
-                .arg(Arg::with_name("output-mode").long("output-mode").multiple(false).takes_value(true).help(
-                  "Set --output-mode=(json|simple) manipulate the way a report is displayed. Default is simple."
+                .arg(Arg::with_name("output-mode").long("output-mode").possible_values(&["json", "simple"]).default_value("simple").multiple(false).takes_value(true).help(
+                  "Set to manipulate the way a report is displayed."
                 )),
           )
           .subcommand(
@@ -500,6 +500,7 @@ fn print_upload_summary(mode: Option<&str>, report: &SummaryWithDigest) {
   match mode {
     Some("json") => println!("{}", serde_json::to_string_pretty(&report).unwrap()),
     Some("simple") => println!("{} {}", report.digest.0, report.digest.1),
-    _ => println!("{} {}", report.digest.0, report.digest.1),
+    // This should never be reached, as clap should error with unknown formats.
+    _ => eprintln!("Unknown summary format."),
   };
 }

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -280,11 +280,11 @@ fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
                 }
               };
 
-              match args.value_of("json") {
-                Some("true") => println!("{}", serde_json::to_string_pretty(&report).unwrap()),
-                _ => println!("{} {}", digest.0, digest.1),
+              if let Some("true") = args.value_of("json") {
+                println!("{}", serde_json::to_string_pretty(&report).unwrap());
+              } else {
+                println!("{} {}", report.digest.0, report.digest.1);
               };
-
               Ok(())
             }
             o => Err(
@@ -358,9 +358,10 @@ fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
           }
         };
 
-        match args.value_of("json") {
-          Some("true") => println!("{}", serde_json::to_string_pretty(&report).unwrap()),
-          _ => println!("{} {}", digest.0, digest.1),
+        if let Some("true") = args.value_of("json") {
+          println!("{}", serde_json::to_string_pretty(&report).unwrap());
+        } else {
+          println!("{} {}", report.digest.0, report.digest.1);
         };
 
         Ok(())

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -128,6 +128,9 @@ directory, relative to the root.",
                 .arg(Arg::with_name("root").long("root").required(true).takes_value(true).help(
                   "Root under which the globs live. The Directory proto produced will be relative \
 to this directory.",
+            ))
+                .arg(Arg::with_name("json").long("json").multiple(false).takes_value(true).help(
+                  "Set --json=true to display a JSON report of the ingested and uploaded files."
                 )),
           )
           .subcommand(
@@ -276,7 +279,12 @@ fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
                   summary: None,
                 }
               };
-              println!("{}", serde_json::to_string_pretty(&report).unwrap());
+
+              match args.value_of("json") {
+                Some("true") => println!("{}", serde_json::to_string_pretty(&report).unwrap()),
+                _ => println!("{} {}", digest.0, digest.1),
+              };
+
               Ok(())
             }
             o => Err(
@@ -349,7 +357,11 @@ fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
             summary: None,
           }
         };
-        println!("{}", serde_json::to_string_pretty(&report).unwrap());
+
+        match args.value_of("json") {
+          Some("true") => println!("{}", serde_json::to_string_pretty(&report).unwrap()),
+          _ => println!("{} {}", digest.0, digest.1),
+        };
 
         Ok(())
       }

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -25,7 +25,7 @@ pub use snapshot::{
   OneOffStoreFileByDigest, Snapshot, StoreFileByDigest, EMPTY_DIGEST, EMPTY_FINGERPRINT,
 };
 mod store;
-pub use store::Store;
+pub use store::{Store, UploadSummary};
 mod pool;
 pub use pool::ResettablePool;
 
@@ -52,11 +52,14 @@ extern crate log;
 extern crate mock;
 extern crate protobuf;
 extern crate resettable;
+extern crate serde;
 extern crate sha2;
 #[cfg(test)]
 extern crate tempfile;
 #[cfg(test)]
 extern crate testutil;
+#[macro_use]
+extern crate serde_derive;
 
 use std::cmp::min;
 use std::io::{self, Read};

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -28,7 +28,7 @@ const LOCAL_STORE_GC_TARGET_BYTES: usize = 4 * 1024 * 1024 * 1024;
 // Summary of the files and directories uploaded with an operation
 // ingested_file_{count, bytes}: Number and combined size of processed files
 // uploaded_file_{count, bytes}: Number and combined size of files uploaded to the remote
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize)]
 pub struct UploadSummary {
   ingested_file_count: usize,
   ingested_file_bytes: usize,

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -348,9 +348,9 @@ impl Store {
         let uploaded_file_sizes = uploaded_digests.iter().map(|digest| digest.1);
 
         UploadSummary {
-          ingested_file_count: ingested_file_sizes.clone().count(),
+          ingested_file_count: ingested_file_sizes.len(),
           ingested_file_bytes: ingested_file_sizes.sum(),
-          uploaded_file_count: uploaded_file_sizes.clone().count(),
+          uploaded_file_count: uploaded_file_sizes.len(),
           uploaded_file_bytes: uploaded_file_sizes.sum(),
         }
       })
@@ -1793,7 +1793,7 @@ mod remote {
 
     ///
     /// Given a collection of Digests (digests),
-    /// returns the set of digests from that collection not currently present in the CAS
+    /// returns the set of digests from that collection not present in the CAS.
     ///
     pub fn list_missing_digests<'a, Digests: Iterator<Item = &'a Digest>>(
       &self,
@@ -2187,7 +2187,7 @@ mod tests {
   }
 
   ///
-  /// Create a StubCas with a file and a directory inside
+  /// Create a StubCas with a file and a directory inside.
   ///
   pub fn new_cas(chunk_size_bytes: usize) -> StubCAS {
     StubCAS::with_content(
@@ -2198,7 +2198,7 @@ mod tests {
   }
 
   ///
-  /// Create a new local store with whatever was already serialized in dir
+  /// Create a new local store with whatever was already serialized in dir.
   ///
   fn new_local_store<P: AsRef<Path>>(dir: P) -> Store {
     Store::local_only(dir, Arc::new(ResettablePool::new("test-pool-".to_string())))
@@ -2206,7 +2206,7 @@ mod tests {
   }
 
   ///
-  /// Create a new store with a remote CAS
+  /// Create a new store with a remote CAS.
   ///
   fn new_store<P: AsRef<Path>>(dir: P, cas_address: String) -> Store {
     Store::with_remote(

--- a/src/rust/engine/hashing/Cargo.toml
+++ b/src/rust/engine/hashing/Cargo.toml
@@ -8,3 +8,6 @@ publish = false
 digest = "0.7"
 hex = "0.3.1"
 sha2 = "0.7"
+serde = "1.0"
+serde_derive = "1.0"
+serde_test = "1.0"

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -145,7 +145,7 @@ impl super::CommandRunner for CommandRunner {
                       );
                       let execute_request = execute_request2.clone();
                       store.ensure_remote_has_recursive(missing_digests)
-                              .and_then(move |()| {
+                              .and_then(move |_| {
                                 command_runner2.oneshot_execute(&execute_request)
                               })
                               // Reset `iter_num` on `MissingDigests`

--- a/src/rust/engine/testutil/local_cas/Cargo.toml
+++ b/src/rust/engine/testutil/local_cas/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "local_cas"
+version = "0.0.1"
+authors = [ "Pants Build <pantsbuild@gmail.com>" ]
+publish = false
+
+[dependencies]
+mock = { path = "../mock" }
+clap = "2"
+env_logger = "0.5.4"
+

--- a/src/rust/engine/testutil/local_cas/src/main.rs
+++ b/src/rust/engine/testutil/local_cas/src/main.rs
@@ -1,0 +1,38 @@
+#[macro_use(value_t)]
+extern crate clap;
+extern crate env_logger;
+extern crate mock;
+
+use clap::{App, Arg};
+use mock::StubCAS;
+use std::process::exit;
+
+/// TODO:
+///   - Implement custom ports as flags
+///   - Remove the while(true)
+///   - Better logging
+///   - Proper error handling
+
+fn main() {
+  env_logger::init();
+
+  match execute(
+    &App::new("local_cas")
+      .about("")
+      .arg(Arg::with_name("port").required(false).takes_value(true))
+      .get_matches(),
+  ) {
+    Ok(_) => {}
+    Err(err) => {
+      eprintln!("{}", err);
+      exit(1)
+    }
+  };
+}
+
+fn execute(top_match: &clap::ArgMatches) -> Result<(), String> {
+  let cas = StubCAS::empty();
+  println!("Started CAS at address: {}", cas.address());
+  while true {}
+  Ok(())
+}

--- a/src/rust/engine/testutil/local_cas/src/main.rs
+++ b/src/rust/engine/testutil/local_cas/src/main.rs
@@ -1,4 +1,3 @@
-#[macro_use(value_t)]
 extern crate clap;
 extern crate env_logger;
 extern crate mock;
@@ -6,8 +5,7 @@ extern crate mock;
 use clap::{App, Arg};
 use mock::StubCAS;
 use std::io;
-use std::io::prelude::*;
-use std::process::exit;
+use std::io::Read;
 
 fn main() -> Result<(), String> {
   env_logger::init();
@@ -34,7 +32,7 @@ fn main() -> Result<(), String> {
       .expect("port must be a non-negative number"),
   );
   println!("Started CAS at address: {}", cas.address());
-  println!("Press submit to exit.");
+  println!("Press enter to exit.");
   let _ = stdin.read(&mut [0u8]).unwrap();
   Ok(())
 }


### PR DESCRIPTION
### Problem

fs_util only displayed a minimal output from the operation done, in the form of <fingerprint> <size> pairs.
Closes #6318 

### Solution

Implement richer output, which can then be consumed by other tools.

### Result

An optional flag that generates a json report of the files ingested and uploaded, as well as their sizes:

This execution:
```bash
$ fs_util --server-address localhost:40351 --local-store-path="${HOME}/.cache/pants/lmdb_store" directory save --root=. --json=true  -- '**'
```

Produces (the files were already in the remote, that is why it reports 0 upload):

```json
{
  "digest": [
    "f9e7b01bdf87e9d8e5d50f5e451bd173e792f980f331a5073b8bd9de126f45ea",
    162
  ],
  "summary": {
    "ingested_file_count": 4,
    "ingested_file_bytes": 17520,
    "uploaded_file_count": 0,
    "uploaded_file_bytes": 0
  }
}
```
In addition to that, this PR includes a stub implementation of a binary that can serve as a local server, taking advantage of the test utility `mock::StubCAS`. It is by no means finished, but it serves as an easy testing ground for this new functionality:

```bash
$ cd src/rust/engine/testutil/local_cas
$ ../../../../../build-support/bin/native/cargo.sh run
Started CAS at address: localhost:<random port>
```
