### PR TITLE
Update scalafmt to 1.5.1

### DIFF
--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -32,7 +32,7 @@ class ScalaFmt(RewriteBase):
                           classpath=[
                           JarDependency(org='com.geirsson',
                                         name='scalafmt-cli_2.11',
-                                        rev='1.0.0-RC4')
+                                        rev='1.5.1')
                           ])
 
   @classmethod


### PR DESCRIPTION
### Problem

The scalafmt plugin is out of date and no longer matches the latest plugins for IntelliJ

### Solution

Update the version to 1.5.1
