### PR TITLE
Link requirements targets to their source.

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -25,9 +25,3 @@ python_requirement_library(
     python_requirement('s3-log-parse==0.1.1')
   ]
 )
-
-# NB: Needed only for tests: tests/python/pants_test/engine/legacy:graph.
-files(
-  name='requirements_files',
-  sources=rglobs('**/requirements.txt'),
-)

--- a/src/python/pants/backend/python/python_requirements.py
+++ b/src/python/pants/backend/python/python_requirements.py
@@ -58,9 +58,16 @@ class PythonRequirements(object):
                   raise ValueError('Only 1 --find-links url is supported per requirements file')
                 repository = value
 
+    requirements_file_target_name = requirements_relpath
+    self._parse_context.create_object('files',
+                                      name=requirements_file_target_name,
+                                      sources=[requirements_relpath])
+    requirements_dep = ':{}'.format(requirements_file_target_name)
+
     for requirement in requirements:
       req = self._parse_context.create_object('python_requirement', requirement,
                                               repository=repository)
       self._parse_context.create_object('python_requirement_library',
                                         name=req.project_name,
-                                        requirements=[req])
+                                        requirements=[req],
+                                        dependencies=[requirements_dep])

--- a/src/python/pants/backend/python/tasks/BUILD
+++ b/src/python/pants/backend/python/tasks/BUILD
@@ -15,7 +15,6 @@ python_library(
     'src/python/pants/backend/python:interpreter_cache',
     'src/python/pants/backend/python:pex_util',
     'src/python/pants/backend/python:python_requirement',
-    'src/python/pants/backend/python:python_requirements',
     'src/python/pants/backend/python/subsystems',
     'src/python/pants/backend/python/targets',
     'src/python/pants/backend/python/tasks/coverage:plugin',

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -122,7 +122,6 @@ python_tests(
   dependencies = [
     '3rdparty/python:future',
     '3rdparty/python:mock',
-    '3rdparty/python:requirements_files',
     'src/python/pants/bin',
     'src/python/pants/build_graph',
     'src/python/pants/engine/legacy:graph',


### PR DESCRIPTION
Previsouly the `python_requirements` macro would not link the
`PythonRequirementLibrary` targets it generated from a requirements
file to the requirement file itself, leading to invalidation bugs. We
now do this by adding a dependency on the requirements file to each
`PythonRequirementLibrary` generated.

Fixes #6404