### PR TITLE
Change zinc logging so it doesn't error out

### DIFF
--- a/src/scala/org/pantsbuild/zinc/compiler/Main.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Main.scala
@@ -57,7 +57,8 @@ object Main {
       Util.setProperty("log4j2.disable.jmx", "true")
     }
 
-    // As per #6160, this is a workaround so we can run zinc without $PATH (as needed in remoting).
+    // As per https://github.com/pantsbuild/pants/issues/6160, this is a workaround
+    // so we can run zinc without $PATH (as needed in remoting).
     System.setProperty("sbt.log.format", "true")
 
     val cl =


### PR DESCRIPTION
Fixes #6160.

Before fix with [this line](https://github.com/pantsbuild/pants/pull/6351/files#diff-20c24f86dff2bcf753c09453bcde7821R448) commented out:
```
[tw-mbp-dordogh pants (dotordogh/issue-6160-repro)]$ ./pants clean-all && ./pants run --jvm-platform-compiler=zinc --compile-zinc-use-classpath-jars=False --compile-zinc-execution-strategy=hermetic examples/src/scala/org/pantsbuild/example/hello/exe

12:00:18 00:00 [main]
               (To run a reporting server: ./pants server)
12:00:19 00:01   [setup]
12:00:19 00:01     [parse]
               Executing tasks in goals: clean-all
12:00:19 00:01   [clean-all]
12:00:19 00:01     [ng-killall]
12:00:19 00:01     [kill-pantsd]
12:00:19 00:01     [clean-all]INFO] For async removal, run `./pants clean-all --async`

12:00:20 00:02   [complete]
               SUCCESS

12:00:22 00:00 [main]
               (To run a reporting server: ./pants server)
12:00:22 00:00   [setup]
12:00:22 00:00     [parse]
               Executing tasks in goals: jvm-platform-validate -> native-compile -> link -> bootstrap -> imports -> unpack-jars -> deferred-sources -> gen -> resolve -> resources -> compile -> pyprep -> binary -> run
12:00:23 00:01   [jvm-platform-validate]
12:00:23 00:01     [jvm-platform-validate]
                   Invalidated 3 targets.
12:00:23 00:01   [native-compile]
12:00:23 00:01     [native-third-party-fetch]
12:00:23 00:01     [c-for-ctypes]
12:00:23 00:01     [cpp-for-ctypes]
12:00:23 00:01   [link]
12:00:23 00:01     [shared-libraries]
12:00:23 00:01   [bootstrap]
12:00:23 00:01     [substitute-aliased-targets]
12:00:23 00:01     [jar-dependency-management]
12:00:23 00:01     [bootstrap-jvm-tools]
12:00:23 00:01     [provide-tools-jar]
12:00:23 00:01   [imports]
12:00:23 00:01     [ivy-imports]
12:00:23 00:01   [unpack-jars]
12:00:23 00:01     [unpack-jars]
12:00:23 00:01   [deferred-sources]
12:00:23 00:01     [deferred-sources]
12:00:23 00:01   [gen]
12:00:23 00:01     [antlr-java]
12:00:23 00:01     [antlr-py]
12:00:23 00:01     [jaxb]
12:00:23 00:01     [protoc]
12:00:23 00:01     [ragel]
12:00:23 00:01     [thrift-java]
12:00:23 00:01     [thrift-py]
12:00:23 00:01     [wire]
12:00:23 00:01     [avro-java]
12:00:23 00:01     [go-thrift]
12:00:23 00:01     [go-protobuf]
12:00:23 00:01     [jax-ws]
12:00:23 00:01     [scrooge]
12:00:23 00:01     [thrifty]
12:00:23 00:01   [resolve]
12:00:23 00:01     [ivy]
12:00:23 00:01       [cache].
12:00:23 00:01       [bootstrap-nailgun-server]
                   Invalidated 1 target.
12:00:26 00:04       [ivy-resolve]
12:00:26 00:04     [coursier]
12:00:26 00:04     [go]
12:00:26 00:04     [scala-js-compile]
12:00:26 00:04     [scala-js-link]
12:00:26 00:04     [node]
12:00:26 00:04   [resources]
12:00:26 00:04     [prepare]
                   Invalidated 1 target.
12:00:26 00:04     [services]
12:00:26 00:04   [compile]
12:00:26 00:04     [node]
12:00:26 00:04     [compile-jvm-prep-command]
12:00:26 00:04       [jvm_prep_command]
12:00:26 00:04     [compile-prep-command]
12:00:26 00:04     [compile]
12:00:26 00:04     [zinc]
                   Invalidated 3 targets.
12:00:27 00:05       [isolation-zinc-pool-bootstrap]
                   [1/3] Compiling 1 zinc source in 1 target (examples/src/java/org/pantsbuild/example/hello/greet:greet).
12:00:27 00:05       [compile]

12:00:27 00:05         [cache].
12:00:27 00:05         [bootstrap-scalac_2_11]
12:00:27 00:05         [cache].
                     Using cached artifacts for 1 target.
12:00:27 00:05         [cache].
12:00:27 00:05         [bootstrap-compiler-bridge]
12:00:28 00:06         [cache].
                     Using cached artifacts for 1 target.
12:00:29 00:07         [zinc]
                       [ERROR] Failed to construct terminal; falling back to unsupported
                       java.io.IOException: Cannot run program "sh": error=2, No such file or directory
                       	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.exec(TerminalLineSettings.java:308)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.stty(TerminalLineSettings.java:282)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.get(TerminalLineSettings.java:143)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.<init>(TerminalLineSettings.java:108)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.getSettings(TerminalLineSettings.java:123)
                       	at __shaded_by_pants__.jline.UnixTerminal.<init>(UnixTerminal.java:60)
                       	at __shaded_by_pants__.jline.UnixTerminal.<init>(UnixTerminal.java:50)
                       	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
                       	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
                       	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
                       	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
                       	at java.lang.Class.newInstance(Class.java:442)
                       	at __shaded_by_pants__.jline.TerminalFactory.getFlavor(TerminalFactory.java:211)
                       	at __shaded_by_pants__.jline.TerminalFactory.create(TerminalFactory.java:102)
                       	at __shaded_by_pants__.jline.TerminalFactory.get(TerminalFactory.java:186)
                       	at __shaded_by_pants__.jline.TerminalFactory.get(TerminalFactory.java:192)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleAppender$.ansiSupported(ConsoleAppender.scala:245)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleAppender$.<init>(ConsoleAppender.scala:107)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleAppender$.<clinit>(ConsoleAppender.scala)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleLogger$.<init>(ConsoleAppender.scala:25)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleLogger$.<clinit>(ConsoleAppender.scala)
                       	at org.pantsbuild.zinc.compiler.Main$.mkLogger(Main.scala:60)
                       	at org.pantsbuild.zinc.compiler.Main$.main(Main.scala:76)
                       	at org.pantsbuild.zinc.compiler.Main.main(Main.scala)
                       Caused by: java.io.IOException: error=2, No such file or directory
                       	at java.lang.UNIXProcess.forkAndExec(Native Method)
                       	at java.lang.UNIXProcess.<init>(UNIXProcess.java:247)
                       	at java.lang.ProcessImpl.start(ProcessImpl.java:134)
                       	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
                       	... 24 more

                       [info] Compiling 1 Java source to /Users/dordogh/workspace/pants/.pants.d/process-executionLC9j6w/.pants.d/compile/zinc/a53b6931478d/examples.src.java.org.pantsbuild.example.hello.greet.greet/current/classes ...
                       [info] Done compiling.
                       [info] Compile success at Aug 29, 2018 12:00:33 PM [2.944s]

                   [2/3] Compiling 1 zinc source in 1 target (examples/src/scala/org/pantsbuild/example/hello/welcome:welcome).
12:00:33 00:11       [compile]
                     WARN] ClasspathEntry ClasspathEntry(path=u'/Users/dordogh/workspace/pants/.pants.d/resources/prepare/0409c64cc4e0/examples.src.resources.org.pantsbuild.example.hello.hello/current', directory_digest=None) didn't have a DirectoryDigest, so won't be present for hermetic execution
WARN] ClasspathEntry ArtifactClasspathEntry(path=u'/Users/dordogh/workspace/pants/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.11.12.jar', coordinate=M2Coordinate(org='org.scala-lang', name='scala-library', rev='2.11.12', classifier=None, ext='jar'), cache_path='/Users/dordogh/.ivy2/pants/org.scala-lang/scala-library/jars/scala-library-2.11.12.jar', directory_digest=None) didn't have a DirectoryDigest, so won't be present for hermetic execution

12:00:33 00:11         [zinc]
                       [ERROR] Failed to construct terminal; falling back to unsupported
                       java.io.IOException: Cannot run program "sh": error=2, No such file or directory
                       	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.exec(TerminalLineSettings.java:308)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.stty(TerminalLineSettings.java:282)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.get(TerminalLineSettings.java:143)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.<init>(TerminalLineSettings.java:108)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.getSettings(TerminalLineSettings.java:123)
                       	at __shaded_by_pants__.jline.UnixTerminal.<init>(UnixTerminal.java:60)
                       	at __shaded_by_pants__.jline.UnixTerminal.<init>(UnixTerminal.java:50)
                       	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
                       	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
                       	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
                       	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
                       	at java.lang.Class.newInstance(Class.java:442)
                       	at __shaded_by_pants__.jline.TerminalFactory.getFlavor(TerminalFactory.java:211)
                       	at __shaded_by_pants__.jline.TerminalFactory.create(TerminalFactory.java:102)
                       	at __shaded_by_pants__.jline.TerminalFactory.get(TerminalFactory.java:186)
                       	at __shaded_by_pants__.jline.TerminalFactory.get(TerminalFactory.java:192)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleAppender$.ansiSupported(ConsoleAppender.scala:245)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleAppender$.<init>(ConsoleAppender.scala:107)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleAppender$.<clinit>(ConsoleAppender.scala)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleLogger$.<init>(ConsoleAppender.scala:25)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleLogger$.<clinit>(ConsoleAppender.scala)
                       	at org.pantsbuild.zinc.compiler.Main$.mkLogger(Main.scala:60)
                       	at org.pantsbuild.zinc.compiler.Main$.main(Main.scala:76)
                       	at org.pantsbuild.zinc.compiler.Main.main(Main.scala)
                       Caused by: java.io.IOException: error=2, No such file or directory
                       	at java.lang.UNIXProcess.forkAndExec(Native Method)
                       	at java.lang.UNIXProcess.<init>(UNIXProcess.java:247)
                       	at java.lang.ProcessImpl.start(ProcessImpl.java:134)
                       	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
                       	... 24 more

                       [info] Compiling 1 Scala source to /Users/dordogh/workspace/pants/.pants.d/process-executioneWDo8V/.pants.d/compile/zinc/a53b6931478d/examples.src.scala.org.pantsbuild.example.hello.welcome.welcome/current/classes ...
                       [info] Done compiling.
                       [info] Compile success at Aug 29, 2018 12:00:38 PM [4.563s]

                   [3/3] Compiling 1 zinc source in 1 target (examples/src/scala/org/pantsbuild/example/hello/exe:exe).
12:00:38 00:16       [compile]
                     WARN] ClasspathEntry ClasspathEntry(path=u'/Users/dordogh/workspace/pants/.pants.d/resources/prepare/0409c64cc4e0/examples.src.resources.org.pantsbuild.example.hello.hello/current', directory_digest=None) didn't have a DirectoryDigest, so won't be present for hermetic execution
WARN] ClasspathEntry ArtifactClasspathEntry(path=u'/Users/dordogh/workspace/pants/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.11.12.jar', coordinate=M2Coordinate(org='org.scala-lang', name='scala-library', rev='2.11.12', classifier=None, ext='jar'), cache_path='/Users/dordogh/.ivy2/pants/org.scala-lang/scala-library/jars/scala-library-2.11.12.jar', directory_digest=None) didn't have a DirectoryDigest, so won't be present for hermetic execution

12:00:38 00:16         [zinc]
                       [ERROR] Failed to construct terminal; falling back to unsupported
                       java.io.IOException: Cannot run program "sh": error=2, No such file or directory
                       	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.exec(TerminalLineSettings.java:308)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.stty(TerminalLineSettings.java:282)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.get(TerminalLineSettings.java:143)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.<init>(TerminalLineSettings.java:108)
                       	at __shaded_by_pants__.jline.internal.TerminalLineSettings.getSettings(TerminalLineSettings.java:123)
                       	at __shaded_by_pants__.jline.UnixTerminal.<init>(UnixTerminal.java:60)
                       	at __shaded_by_pants__.jline.UnixTerminal.<init>(UnixTerminal.java:50)
                       	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
                       	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
                       	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
                       	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
                       	at java.lang.Class.newInstance(Class.java:442)
                       	at __shaded_by_pants__.jline.TerminalFactory.getFlavor(TerminalFactory.java:211)
                       	at __shaded_by_pants__.jline.TerminalFactory.create(TerminalFactory.java:102)
                       	at __shaded_by_pants__.jline.TerminalFactory.get(TerminalFactory.java:186)
                       	at __shaded_by_pants__.jline.TerminalFactory.get(TerminalFactory.java:192)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleAppender$.ansiSupported(ConsoleAppender.scala:245)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleAppender$.<init>(ConsoleAppender.scala:107)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleAppender$.<clinit>(ConsoleAppender.scala)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleLogger$.<init>(ConsoleAppender.scala:25)
                       	at __shaded_by_pants__.sbt.internal.util.ConsoleLogger$.<clinit>(ConsoleAppender.scala)
                       	at org.pantsbuild.zinc.compiler.Main$.mkLogger(Main.scala:60)
                       	at org.pantsbuild.zinc.compiler.Main$.main(Main.scala:76)
                       	at org.pantsbuild.zinc.compiler.Main.main(Main.scala)
                       Caused by: java.io.IOException: error=2, No such file or directory
                       	at java.lang.UNIXProcess.forkAndExec(Native Method)
                       	at java.lang.UNIXProcess.<init>(UNIXProcess.java:247)
                       	at java.lang.ProcessImpl.start(ProcessImpl.java:134)
                       	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
                       	... 24 more

                       [info] Compiling 1 Scala source to /Users/dordogh/workspace/pants/.pants.d/process-executionDO93DC/.pants.d/compile/zinc/a53b6931478d/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes ...
                       [info] Done compiling.
                       [info] Compile success at Aug 29, 2018 12:00:43 PM [4.946s]

12:00:43 00:21     [javac]
12:00:43 00:21     [cpp]
12:00:43 00:21     [errorprone]
12:00:43 00:21     [findbugs]
12:00:43 00:21     [go]
12:00:43 00:21   [pyprep]
12:00:43 00:21     [interpreter]
12:00:43 00:21     [build-local-dists]
12:00:43 00:21     [requirements]
12:00:43 00:21     [sources]
12:00:43 00:21   [binary]
12:00:43 00:21     [binary-jvm-prep-command]
12:00:43 00:21       [jvm_prep_command]
12:00:43 00:21     [binary-prep-command]
12:00:43 00:21     [py]
12:00:43 00:21     [py-wheels]
12:00:43 00:21     [jvm]
                   creating dist/exe.jar
12:00:43 00:21       [create-monolithic-jar]
12:00:43 00:21         [add-internal-classes]
12:00:43 00:21         [add-dependency-jars]
12:00:43 00:21         [cache].
12:00:43 00:21         [bootstrap-jar-tool]
12:00:45 00:23     [dup]
12:00:45 00:23     [cpplib]
12:00:45 00:23       [cpp-library]
12:00:45 00:23     [cpp]
12:00:45 00:23       [cpp-binary]
12:00:45 00:23     [go]
12:00:45 00:23   [run]
12:00:45 00:23     [py]
12:00:45 00:23     [jvm]
12:00:45 00:23       [run]
Num args passed: 0. Stand by for welcome...
Hello, Resource World!

12:00:45 00:23     [cpp]
12:00:45 00:23     [go]
12:00:45 00:23     [node]
               Waiting for background workers to finish.
12:00:45 00:23   [complete]
               SUCCESS
```
After fix:
```
[tw-mbp-dordogh pants (dotordogh/issue-6160-repro-with-fix)]$ ./pants clean-all && ./pants run --jvm-platform-compiler=zinc --compile-zinc-use-classpath-jars=False --compile-zinc-execution-strategy=hermetic examples/src/scala/org/pantsbuild/example/hello/exe

12:03:37 00:00 [main]
               (To run a reporting server: ./pants server)
12:03:38 00:01   [setup]
12:03:38 00:01     [parse]
               Executing tasks in goals: clean-all
12:03:38 00:01   [clean-all]
12:03:38 00:01     [ng-killall]INFO] killing nailgun server pid=87154
INFO] killing nailgun server pid=87165

12:03:38 00:01     [kill-pantsd]
12:03:38 00:01     [clean-all]INFO] For async removal, run `./pants clean-all --async`

12:03:39 00:02   [complete]
               SUCCESS

12:03:40 00:00 [main]
               (To run a reporting server: ./pants server)
12:03:41 00:01   [setup]
12:03:41 00:01     [parse]
               Executing tasks in goals: jvm-platform-validate -> native-compile -> link -> bootstrap -> imports -> unpack-jars -> deferred-sources -> gen -> resolve -> resources -> compile -> pyprep -> binary -> run
12:03:41 00:01   [jvm-platform-validate]
12:03:41 00:01     [jvm-platform-validate]
                   Invalidated 3 targets.
12:03:41 00:01   [native-compile]
12:03:41 00:01     [native-third-party-fetch]
12:03:41 00:01     [c-for-ctypes]
12:03:41 00:01     [cpp-for-ctypes]
12:03:42 00:02   [link]
12:03:42 00:02     [shared-libraries]
12:03:42 00:02   [bootstrap]
12:03:42 00:02     [substitute-aliased-targets]
12:03:42 00:02     [jar-dependency-management]
12:03:42 00:02     [bootstrap-jvm-tools]
12:03:42 00:02     [provide-tools-jar]
12:03:42 00:02   [imports]
12:03:42 00:02     [ivy-imports]
12:03:42 00:02   [unpack-jars]
12:03:42 00:02     [unpack-jars]
12:03:42 00:02   [deferred-sources]
12:03:42 00:02     [deferred-sources]
12:03:42 00:02   [gen]
12:03:42 00:02     [antlr-java]
12:03:42 00:02     [antlr-py]
12:03:42 00:02     [jaxb]
12:03:42 00:02     [protoc]
12:03:42 00:02     [ragel]
12:03:42 00:02     [thrift-java]
12:03:42 00:02     [thrift-py]
12:03:42 00:02     [wire]
12:03:42 00:02     [avro-java]
12:03:42 00:02     [go-thrift]
12:03:42 00:02     [go-protobuf]
12:03:42 00:02     [jax-ws]
12:03:42 00:02     [scrooge]
12:03:42 00:02     [thrifty]
12:03:42 00:02   [resolve]
12:03:42 00:02     [ivy]
12:03:42 00:02       [cache].
12:03:42 00:02       [bootstrap-nailgun-server]
                   Invalidated 1 target.
12:03:43 00:03       [ivy-resolve]
12:03:44 00:04     [coursier]
12:03:44 00:04     [go]
12:03:44 00:04     [scala-js-compile]
12:03:44 00:04     [scala-js-link]
12:03:44 00:04     [node]
12:03:44 00:04   [resources]
12:03:44 00:04     [prepare]
                   Invalidated 1 target.
12:03:44 00:04     [services]
12:03:44 00:04   [compile]
12:03:44 00:04     [node]
12:03:44 00:04     [compile-jvm-prep-command]
12:03:44 00:04       [jvm_prep_command]
12:03:44 00:04     [compile-prep-command]
12:03:44 00:04     [compile]
12:03:44 00:04     [zinc]
                   Invalidated 3 targets.
12:03:44 00:04       [isolation-zinc-pool-bootstrap]
                   [1/3] Compiling 1 zinc source in 1 target (examples/src/java/org/pantsbuild/example/hello/greet:greet).
12:03:44 00:04       [compile]

12:03:44 00:04         [cache].
12:03:44 00:04         [bootstrap-scalac_2_11]
12:03:45 00:05         [cache].
                     Using cached artifacts for 1 target.
12:03:45 00:05         [cache].
12:03:45 00:05         [bootstrap-compiler-bridge]
12:03:45 00:05         [cache].
                     Using cached artifacts for 1 target.
12:03:47 00:07         [zinc]
                       [info] Compiling 1 Java source to /Users/dordogh/workspace/pants/.pants.d/process-executionUaQp6G/.pants.d/compile/zinc/a53b6931478d/examples.src.java.org.pantsbuild.example.hello.greet.greet/current/classes ...
                       [info] Done compiling.
                       [info] Compile success at Aug 29, 2018 12:03:50 PM [2.742s]

                   [2/3] Compiling 1 zinc source in 1 target (examples/src/scala/org/pantsbuild/example/hello/welcome:welcome).
12:03:50 00:10       [compile]
                     WARN] ClasspathEntry ClasspathEntry(path=u'/Users/dordogh/workspace/pants/.pants.d/resources/prepare/0409c64cc4e0/examples.src.resources.org.pantsbuild.example.hello.hello/current', directory_digest=None) didn't have a DirectoryDigest, so won't be present for hermetic execution
WARN] ClasspathEntry ArtifactClasspathEntry(path=u'/Users/dordogh/workspace/pants/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.11.12.jar', coordinate=M2Coordinate(org='org.scala-lang', name='scala-library', rev='2.11.12', classifier=None, ext='jar'), cache_path='/Users/dordogh/.ivy2/pants/org.scala-lang/scala-library/jars/scala-library-2.11.12.jar', directory_digest=None) didn't have a DirectoryDigest, so won't be present for hermetic execution

12:03:50 00:10         [zinc]
                       [info] Compiling 1 Scala source to /Users/dordogh/workspace/pants/.pants.d/process-execution9YSR6t/.pants.d/compile/zinc/a53b6931478d/examples.src.scala.org.pantsbuild.example.hello.welcome.welcome/current/classes ...
                       [info] Done compiling.
                       [info] Compile success at Aug 29, 2018 12:03:55 PM [4.949s]

                   [3/3] Compiling 1 zinc source in 1 target (examples/src/scala/org/pantsbuild/example/hello/exe:exe).
12:03:55 00:15       [compile]
                     WARN] ClasspathEntry ClasspathEntry(path=u'/Users/dordogh/workspace/pants/.pants.d/resources/prepare/0409c64cc4e0/examples.src.resources.org.pantsbuild.example.hello.hello/current', directory_digest=None) didn't have a DirectoryDigest, so won't be present for hermetic execution
WARN] ClasspathEntry ArtifactClasspathEntry(path=u'/Users/dordogh/workspace/pants/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.11.12.jar', coordinate=M2Coordinate(org='org.scala-lang', name='scala-library', rev='2.11.12', classifier=None, ext='jar'), cache_path='/Users/dordogh/.ivy2/pants/org.scala-lang/scala-library/jars/scala-library-2.11.12.jar', directory_digest=None) didn't have a DirectoryDigest, so won't be present for hermetic execution

12:03:55 00:15         [zinc]
                       [info] Compiling 1 Scala source to /Users/dordogh/workspace/pants/.pants.d/process-executionk6djEF/.pants.d/compile/zinc/a53b6931478d/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes ...
                       [info] Done compiling.
                       [info] Compile success at Aug 29, 2018 12:04:00 PM [4.483s]

12:04:00 00:20     [javac]
12:04:00 00:20     [cpp]
12:04:00 00:20     [errorprone]
12:04:00 00:20     [findbugs]
12:04:00 00:20     [go]
12:04:00 00:20   [pyprep]
12:04:00 00:20     [interpreter]
12:04:00 00:20     [build-local-dists]
12:04:00 00:20     [requirements]
12:04:00 00:20     [sources]
12:04:00 00:20   [binary]
12:04:00 00:20     [binary-jvm-prep-command]
12:04:00 00:20       [jvm_prep_command]
12:04:00 00:20     [binary-prep-command]
12:04:00 00:20     [py]
12:04:00 00:20     [py-wheels]
12:04:00 00:20     [jvm]
                   creating dist/exe.jar
12:04:00 00:20       [create-monolithic-jar]
12:04:00 00:20         [add-internal-classes]
12:04:00 00:20         [add-dependency-jars]
12:04:00 00:20         [cache].
12:04:00 00:20         [bootstrap-jar-tool]
12:04:02 00:22     [dup]
12:04:02 00:22     [cpplib]
12:04:02 00:22       [cpp-library]
12:04:02 00:22     [cpp]
12:04:02 00:22       [cpp-binary]
12:04:02 00:22     [go]
12:04:02 00:22   [run]
12:04:02 00:22     [py]
12:04:02 00:22     [jvm]
12:04:02 00:22       [run]
Num args passed: 0. Stand by for welcome...
Hello, Resource World!

12:04:02 00:22     [cpp]
12:04:02 00:22     [go]
12:04:02 00:22     [node]
               Waiting for background workers to finish.
12:04:02 00:22   [complete]
               SUCCESS
```