### PR TITLE
Support HEAD redirects in RESTfulArtifactCache.

### DIFF
--- a/src/python/pants/cache/restful_artifact_cache.py
+++ b/src/python/pants/cache/restful_artifact_cache.py
@@ -108,13 +108,23 @@ class RESTfulArtifactCache(ArtifactCache):
       logger.debug('Sending {0} request to {1}'.format(method, url))
       try:
         if 'PUT' == method:
-          response = session.put(url, data=body, timeout=self._write_timeout_secs)
+          response = session.put(url,
+                                 data=body,
+                                 timeout=self._write_timeout_secs,
+                                 allow_redirects=True)
         elif 'GET' == method:
-          response = session.get(url, timeout=self._read_timeout_secs, stream=True)
+          response = session.get(url,
+                                 timeout=self._read_timeout_secs,
+                                 stream=True,
+                                 allow_redirects=True)
         elif 'HEAD' == method:
-          response = session.head(url, timeout=self._read_timeout_secs)
+          response = session.head(url,
+                                  timeout=self._read_timeout_secs,
+                                  allow_redirects=True)
         elif 'DELETE' == method:
-          response = session.delete(url, timeout=self._write_timeout_secs)
+          response = session.delete(url,
+                                    timeout=self._write_timeout_secs,
+                                    allow_redirects=True)
         else:
           raise ValueError('Unknown request method {0}'.format(method))
       except RequestException as e:


### PR DESCRIPTION
Tests are modifed such that if any of the four API methods do not
follow redirects, we get a test failure.

Fixes #6411
