### PR TITLE
Fix --binaries-path-by-id fingerprinting error

### DIFF
--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -18,23 +18,18 @@ from pants.option.custom_types import (UnsetBool, dict_with_files_option, dir_op
                                        target_option)
 
 
-# TODO: this class's methods could be wrapped in @memoized_method -- we would have to manage the
-# cache size somehow if this is done or it might blow up.
 class Encoder(json.JSONEncoder):
-  def _encode_dict_wrapping_keys(self, d):
-    return {self.encode(k):v for k, v in d.items()}
-
   def default(self, o):
     if o is UnsetBool:
       return '_UNSET_BOOL_ENCODING'
-    elif isinstance(o, collections.Iterable):
-      if isinstance(o, collections.Mapping):
-        return self._encode_dict_wrapping_keys(o)
-      else:
-        return list(o)
+    elif isinstance(o, collections.Iterable) and not isinstance(o, collections.Mapping):
+      # For things like sets which JSONEncoder doesn't handle, and raises a TypeError on.
+      return list(o)
     return super(Encoder, self).default(o)
 
 
+# TODO: this function could be wrapped in @memoized -- we would have to manage the cache size
+# somehow if this is done or it might blow up.
 stable_json_sha1 = functools.partial(stable_json_hash, encoder=Encoder)
 
 
@@ -83,6 +78,11 @@ class OptionsFingerprinter(object):
     """
     if option_val is None:
       return None
+
+    # The python documentation (https://docs.python.org/2/library/json.html#json.dumps) states that
+    # dict keys are coerced to strings in json.dumps, but this appears to be incorrect.
+    if isinstance(option_val, dict):
+      option_val = {str(k):v for k, v in option_val.items()}
 
     # For simplicity, we always fingerprint a list.  For non-list-valued options,
     # this will be a singleton list.

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -81,8 +81,8 @@ class OptionsFingerprinter(object):
 
     # The python documentation (https://docs.python.org/2/library/json.html#json.dumps) states that
     # dict keys are coerced to strings in json.dumps, but this appears to be incorrect.
-    if isinstance(option_val, dict):
-      option_val = {str(k):v for k, v in option_val.items()}
+    if isinstance(option_val, collections.Mapping):
+      option_val = {stable_json_sha1(k):v for k, v in option_val.items()}
 
     # For simplicity, we always fingerprint a list.  For non-list-valued options,
     # this will be a singleton list.
@@ -175,6 +175,10 @@ class OptionsFingerprinter(object):
     contents rather than by its path.
 
     This assumes the files are small enough to be read into memory.
+
+    NB: The keys of the dict are assumed to be strings -- if they are not, the dict should be
+    converted to encode its keys with `stable_json_sha1()`, as is done in the `fingerprint()`
+    method.
     """
     # Dicts are wrapped in singleton lists. See the "For simplicity..." comment in `fingerprint()`.
     option_val = option_val[0]

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -23,12 +23,12 @@ class Encoder(json.JSONEncoder):
     return {self.encode(k):v for k, v in d.items()}
 
   def encode(self, o):
-    if isinstance(o, tuple):
+    if isinstance(o, (tuple, set)):
       o = list(o)
     elif isinstance(o, dict):
       o = self._encode_dict_wrapping_keys(o)
     elif len(o) == 1:
-      only_element = o[0]
+      only_element = next(iter(o))
       if isinstance(only_element, dict):
         o = [self._encode_dict_wrapping_keys(only_element)]
 

--- a/tests/python/pants_test/option/test_options_fingerprinter.py
+++ b/tests/python/pants_test/option/test_options_fingerprinter.py
@@ -30,8 +30,8 @@ class JsonEncodingTest(unittest.TestCase):
     self.assertEqual(stable_json_sha1(set([])), '97d170e1550eee4afc0af065b78cda302a97674c')
     self.assertEqual(stable_json_sha1([{}]), '4e9950a1f2305f56d358cad23f28203fb3aacbef')
     self.assertEqual(stable_json_sha1([('a', 3)]), 'd6abed2e53c1595fb3075ecbe020365a47af1f6f')
-    self.assertEqual(stable_json_sha1({'a': 3}), 'ee3442062f5b26c8555c60ff36f7e75eb1a236c5')
-    self.assertEqual(stable_json_sha1([{'a': 3}]), '4d33c5e3a9de12e87aa05e2adfd12e9598d016ac')
+    self.assertEqual(stable_json_sha1({'a': 3}), '9e0e6d8a99c72daf40337183358cbef91bba7311')
+    self.assertEqual(stable_json_sha1([{'a': 3}]), '8f4e36849a0b8fbe9c4a822c80fbee047c65458a')
     self.assertEqual(stable_json_sha1(set([1])), 'f629ae44b7b3dcfed444d363e626edf411ec69a8')
 
 

--- a/tests/python/pants_test/option/test_options_fingerprinter.py
+++ b/tests/python/pants_test/option/test_options_fingerprinter.py
@@ -8,6 +8,8 @@ import os
 import unittest
 from builtins import range, zip
 
+from future.utils import PY2
+
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 from pants.option.custom_types import (UnsetBool, dict_option, dir_option, file_option, list_option,
@@ -35,7 +37,8 @@ class JsonEncodingTest(unittest.TestCase):
     self.assertEqual(stable_json_sha1(set([1])), 'f629ae44b7b3dcfed444d363e626edf411ec69a8')
 
   def test_non_string_dict_key(self):
-    with self.assertRaisesRegexp(TypeError, r'key \(\) is not a string'):
+    error_regex_str = r'key \(\) is not a string' if PY2 else r'keys must be a string'
+    with self.assertRaisesRegexp(TypeError, error_regex_str):
       stable_json_sha1({():()})
 
 
@@ -57,7 +60,7 @@ class OptionsFingerprinterTest(TestBase):
   def test_fingerprint_dict_with_non_string_keys(self):
     d = {('a', 2): (3, 4)}
     fp = self.options_fingerprinter.fingerprint(dict_option, d)
-    self.assertEqual(fp, '9d99b841440f599bf957dcc91a18d235df800b08')
+    self.assertEqual(fp, 'ba3b9319e9477f14dcea56ae1836ae5e73a73a2c')
 
   def test_fingerprint_list(self):
     l1 = [1, 2, 3]

--- a/tests/python/pants_test/option/test_options_fingerprinter.py
+++ b/tests/python/pants_test/option/test_options_fingerprinter.py
@@ -27,10 +27,12 @@ class JsonEncodingTest(unittest.TestCase):
     self.assertEqual(stable_json_sha1({}), 'bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f')
     self.assertEqual(stable_json_sha1(()), '97d170e1550eee4afc0af065b78cda302a97674c')
     self.assertEqual(stable_json_sha1([]), '97d170e1550eee4afc0af065b78cda302a97674c')
+    self.assertEqual(stable_json_sha1(set([])), '97d170e1550eee4afc0af065b78cda302a97674c')
     self.assertEqual(stable_json_sha1([{}]), '4e9950a1f2305f56d358cad23f28203fb3aacbef')
     self.assertEqual(stable_json_sha1([('a', 3)]), 'd6abed2e53c1595fb3075ecbe020365a47af1f6f')
     self.assertEqual(stable_json_sha1({'a': 3}), 'ee3442062f5b26c8555c60ff36f7e75eb1a236c5')
     self.assertEqual(stable_json_sha1([{'a': 3}]), '4d33c5e3a9de12e87aa05e2adfd12e9598d016ac')
+    self.assertEqual(stable_json_sha1(set([1])), 'f629ae44b7b3dcfed444d363e626edf411ec69a8')
 
 
 class OptionsFingerprinterTest(TestBase):

--- a/tests/python/pants_test/option/test_options_fingerprinter.py
+++ b/tests/python/pants_test/option/test_options_fingerprinter.py
@@ -34,6 +34,10 @@ class JsonEncodingTest(unittest.TestCase):
     self.assertEqual(stable_json_sha1([{'a': 3}]), '8f4e36849a0b8fbe9c4a822c80fbee047c65458a')
     self.assertEqual(stable_json_sha1(set([1])), 'f629ae44b7b3dcfed444d363e626edf411ec69a8')
 
+  def test_non_string_dict_key(self):
+    with self.assertRaisesRegexp(TypeError, r'key \(\) is not a string'):
+      stable_json_sha1({():()})
+
 
 class OptionsFingerprinterTest(TestBase):
 
@@ -49,6 +53,11 @@ class OptionsFingerprinterTest(TestBase):
                      for d in (d1, d2, d3))
     self.assertEqual(fp1, fp2)
     self.assertNotEqual(fp1, fp3)
+
+  def test_fingerprint_dict_with_non_string_keys(self):
+    d = {('a', 2): (3, 4)}
+    fp = self.options_fingerprinter.fingerprint(dict_option, d)
+    self.assertEqual(fp, '9d99b841440f599bf957dcc91a18d235df800b08')
 
   def test_fingerprint_list(self):
     l1 = [1, 2, 3]

--- a/tests/python/pants_test/option/test_options_fingerprinter.py
+++ b/tests/python/pants_test/option/test_options_fingerprinter.py
@@ -5,15 +5,32 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+import unittest
 from builtins import range, zip
 
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 from pants.option.custom_types import (UnsetBool, dict_option, dir_option, file_option, list_option,
                                        target_option)
-from pants.option.options_fingerprinter import OptionsFingerprinter
+from pants.option.options_fingerprinter import OptionsFingerprinter, stable_json_sha1
 from pants.util.contextutil import temporary_dir
 from pants_test.test_base import TestBase
+
+
+class JsonEncodingTest(unittest.TestCase):
+  def test_known_checksums(self):
+    """Check a laundry list of supported inputs to stable_json_sha1().
+
+    This checks both that the method can successfully handle the type of input object, but also that
+    the hash of specific objects remains stable.
+    """
+    self.assertEqual(stable_json_sha1({}), 'bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f')
+    self.assertEqual(stable_json_sha1(()), '97d170e1550eee4afc0af065b78cda302a97674c')
+    self.assertEqual(stable_json_sha1([]), '97d170e1550eee4afc0af065b78cda302a97674c')
+    self.assertEqual(stable_json_sha1([{}]), '4e9950a1f2305f56d358cad23f28203fb3aacbef')
+    self.assertEqual(stable_json_sha1([('a', 3)]), 'd6abed2e53c1595fb3075ecbe020365a47af1f6f')
+    self.assertEqual(stable_json_sha1({'a': 3}), 'ee3442062f5b26c8555c60ff36f7e75eb1a236c5')
+    self.assertEqual(stable_json_sha1([{'a': 3}]), '4d33c5e3a9de12e87aa05e2adfd12e9598d016ac')
 
 
 class OptionsFingerprinterTest(TestBase):


### PR DESCRIPTION
### Problem

Fixes #6394. Any attempt to override the global bootstrap option `--binaries-path-by-id` currently fails with a `TypeError`, as described in that ticket.

### Solution

- Override the `default` method on our JSONEncoder subclass to handle non-list iterables.
- Encode each key of the `fingerprint()` method's `option_val` argument with `stable_json_sha1()`, if `option_val` is a dict (this produces string keys).

### Result

The `--binaries-path-by-id` option can now be overridden or extended from the environment or `pants.ini`. Passing this argument on the command line still fails because the option is parsed as "the `--path-by-id` option in the `binaries` scope".