### PR TITLE
Clarify release docs for stable branches.

### DIFF
--- a/src/docs/release.md
+++ b/src/docs/release.md
@@ -140,9 +140,9 @@ whether a release is needed from a stable branch.
 ---------------------
 
 A dry run is not strictly required since CI includes one, but you might
-like to try one anyway; if so, releases should only be published from
-master, so get on master and ensure your version number commit is present.
-After confirming this, run.
+like to try one anyway. To do so, switch to your release branch (which will either be `master` for
+a unstable weekly release, or a release branch like `1.9.x` for a stable release), and ensure that
+your version number commit is present. After confirming this, run:
 
     :::bash
     $ ./build-support/bin/release.sh -n
@@ -159,15 +159,17 @@ is not required.
 ------------------
 
 Once the first two travis shards (the "binary builder" shards) have completed for your release
-commit, you can publish to PyPi. First, ensure you are on the master branch at the release commit.
-If new commits have landed after your release commit, you can reset to your commit
-(`git reset --hard <sha>`). Then, publish the release:
+commit, you can publish to PyPi. First, ensure that you are on your release branch at your version
+bump commit. Then, publish the release:
 
     :::bash
     $ ./build-support/bin/release.sh
 
 This also performs a dry run and then proceeds to upload the smoke
 tested wheels to PyPi. It may take a few minutes for the packages to be downloadable.
+
+Note: If you are releasing from `master` and new commits have landed after your release commit, you
+can reset to your commit (`git reset --hard <sha>`) before publishing.
 
 4. Announce
 -----------

--- a/src/docs/release.md
+++ b/src/docs/release.md
@@ -141,7 +141,7 @@ whether a release is needed from a stable branch.
 
 A dry run is not strictly required since CI includes one, but you might
 like to try one anyway. To do so, switch to your release branch (which will either be `master` for
-a unstable weekly release, or a release branch like `1.9.x` for a stable release), and ensure that
+an unstable weekly release, or a release branch like `1.9.x` for a stable release), and ensure that
 your version number commit is present. After confirming this, run:
 
     :::bash


### PR DESCRIPTION
### Problem

The release docs currently indicate that you need to be on the master branch in order to execute a release, which is not the case for stable releases.

### Solution

Clarify that you should be on the relevant release branch when releasing.