### PR TITLE
Stop setting CAS upload deadline

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -210,7 +210,6 @@ Scheduler* scheduler_create(Tasks*,
                             uint64_t,
                             uint64_t,
                             uint64_t,
-                            uint64_t,
                             _Bool);
 PyResult scheduler_fork_context(Scheduler*, Function);
 Handle scheduler_metrics(Scheduler*, Session*);
@@ -862,7 +861,6 @@ class Native(object):
         self.context.utf8_buf(execution_options.remote_execution_server or ""),
         execution_options.remote_store_thread_count,
         execution_options.remote_store_chunk_bytes,
-        execution_options.remote_store_chunk_upload_timeout_seconds,
         execution_options.process_execution_parallelism,
         execution_options.process_execution_cleanup_local_dirs
       )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -272,8 +272,6 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--remote-store-chunk-bytes', type=int, advanced=True,
              default=DEFAULT_EXECUTION_OPTIONS.remote_store_chunk_bytes,
              help='Size in bytes of chunks transferred to/from the remote file store.')
-    register('--remote-store-chunk-upload-timeout-seconds', type=int, advanced=True,
-             default=0, help='Deprecated and ignored.')
 
     # This should eventually deprecate the RunTracker worker count, which is used for legacy cache
     # lookups via CacheSetup in TaskBase.

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -34,7 +34,6 @@ class ExecutionOptions(datatype([
   'remote_store_thread_count',
   'remote_execution_server',
   'remote_store_chunk_bytes',
-  'remote_store_chunk_upload_timeout_seconds',
   'process_execution_parallelism',
   'process_execution_cleanup_local_dirs',
 ])):
@@ -51,7 +50,6 @@ class ExecutionOptions(datatype([
       remote_execution_server=bootstrap_options.remote_execution_server,
       remote_store_thread_count=bootstrap_options.remote_store_thread_count,
       remote_store_chunk_bytes=bootstrap_options.remote_store_chunk_bytes,
-      remote_store_chunk_upload_timeout_seconds=bootstrap_options.remote_store_chunk_upload_timeout_seconds,
       process_execution_parallelism=bootstrap_options.process_execution_parallelism,
       process_execution_cleanup_local_dirs=bootstrap_options.process_execution_cleanup_local_dirs,
     )
@@ -62,7 +60,6 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_store_thread_count=1,
     remote_execution_server=None,
     remote_store_chunk_bytes=1024*1024,
-    remote_store_chunk_upload_timeout_seconds=60,
     process_execution_parallelism=multiprocessing.cpu_count()*2,
     process_execution_cleanup_local_dirs=True,
   )
@@ -276,8 +273,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              default=DEFAULT_EXECUTION_OPTIONS.remote_store_chunk_bytes,
              help='Size in bytes of chunks transferred to/from the remote file store.')
     register('--remote-store-chunk-upload-timeout-seconds', type=int, advanced=True,
-             default=DEFAULT_EXECUTION_OPTIONS.remote_store_chunk_upload_timeout_seconds,
-             help='Timeout (in seconds) for uploads of individual chunks to the remote file store.')
+             default=0, help='Deprecated and ignored.')
 
     # This should eventually deprecate the RunTracker worker count, which is used for legacy cache
     # lookups via CacheSetup in TaskBase.

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -644,14 +644,9 @@ fn main() {
 
   let pool = Arc::new(fs::ResettablePool::new("brfs-".to_owned()));
   let store = match args.value_of("server-address") {
-    Some(address) => fs::Store::with_remote(
-      &store_path,
-      pool,
-      address.to_owned(),
-      1,
-      4 * 1024 * 1024,
-      std::time::Duration::from_secs(5 * 60),
-    ),
+    Some(address) => {
+      fs::Store::with_remote(&store_path, pool, address.to_owned(), 1, 4 * 1024 * 1024)
+    }
     None => fs::Store::local_only(&store_path, pool),
   }.expect("Error making store");
 

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -41,7 +41,6 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 #[derive(Debug)]
 enum ExitCode {
@@ -216,7 +215,6 @@ fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
             cas_address.to_owned(),
             1,
             chunk_size,
-            Duration::from_secs(30),
           ),
           true,
         )

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1001,7 +1001,6 @@ mod tests {
       cas.address(),
       1,
       10 * 1024 * 1024,
-      Duration::from_secs(1),
     ).expect("Failed to make store");
 
     let cmd_runner = CommandRunner::new(mock_server.address(), 1, store);
@@ -1330,7 +1329,6 @@ mod tests {
       cas.address(),
       1,
       10 * 1024 * 1024,
-      Duration::from_secs(1),
     ).expect("Failed to make store");
     store
       .store_file_bytes(roland.bytes(), false)
@@ -1384,7 +1382,6 @@ mod tests {
       cas.address(),
       1,
       10 * 1024 * 1024,
-      Duration::from_secs(1),
     ).expect("Failed to make store");
 
     let error = CommandRunner::new(mock_server.address(), 1, store)
@@ -1921,7 +1918,6 @@ mod tests {
       cas.address(),
       1,
       10 * 1024 * 1024,
-      Duration::from_secs(1),
     ).expect("Failed to make store");
 
     CommandRunner::new(address, 1, store)

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -152,7 +152,6 @@ fn main() {
         cas_server.to_owned(),
         1,
         chunk_size,
-        Duration::from_secs(30),
       )
     }
     (None, None) => fs::Store::local_only(local_store_path, pool.clone()),

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -3,7 +3,6 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
 
 use tokio::runtime::Runtime;
 
@@ -54,7 +53,6 @@ impl Core {
     remote_execution_server: Option<String>,
     remote_store_thread_count: usize,
     remote_store_chunk_bytes: usize,
-    remote_store_chunk_upload_timeout: Duration,
     process_execution_parallelism: usize,
     process_execution_cleanup_local_dirs: bool,
   ) -> Core {
@@ -74,7 +72,6 @@ impl Core {
           address,
           remote_store_thread_count,
           remote_store_chunk_bytes,
-          remote_store_chunk_upload_timeout,
         ),
         None => Store::local_only(store_path, fs_pool.clone()),
       })

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -59,7 +59,6 @@ use std::mem;
 use std::os::raw;
 use std::panic;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 use context::Core;
 use core::{Failure, Function, Key, TypeConstraint, TypeId, Value};
@@ -246,7 +245,6 @@ pub extern "C" fn scheduler_create(
   remote_execution_server: Buffer,
   remote_store_thread_count: u64,
   remote_store_chunk_bytes: u64,
-  remote_store_chunk_upload_timeout_seconds: u64,
   process_execution_parallelism: u64,
   process_execution_cleanup_local_dirs: bool,
 ) -> *const Scheduler {
@@ -308,7 +306,6 @@ pub extern "C" fn scheduler_create(
     },
     remote_store_thread_count as usize,
     remote_store_chunk_bytes as usize,
-    Duration::from_secs(remote_store_chunk_upload_timeout_seconds),
     process_execution_parallelism as usize,
     process_execution_cleanup_local_dirs as bool,
   ))))


### PR DESCRIPTION
It turns out this deadline applies to the whole stream, not per chunk,
so is completely useless.

We can re-add something more clever if we find a need.