### PR TITLE
Tighten travis matrix and python activation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ default_test_config: &default_test_config
         - libssl-dev
   stage: Test Pants
   language: python
-  python: "2.7.13"
+  python: &python_version "2.7"
   before_install:
     # Remove bad openjdk6 from trusty image, so
     # Pants will pick up oraclejdk6 from `packages` above.
@@ -88,7 +88,8 @@ matrix:
   include:
 
     # Build macOS engine
-    - os: osx
+    - name: "OSX Native Engine Binary Builder"
+      os: osx
       # We request the oldest image we can (corresponding to OSX 10.11) for maximum compatibility.
       # We use 10.11 as a minimum to avoid https://github.com/rust-lang/regex/issues/489.
       # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
@@ -96,19 +97,18 @@ matrix:
       stage: Test Pants
       language: generic
       env:
-        - SHARD="OSX Native Engine Binary Builder"
         - PREPARE_DEPLOY=1
       script:
         - ./pants --version && ./build-support/bin/release.sh -n
 
     # Build Linux engine
-    - os: linux
+    - name: "Linux Native Engine Binary Builder"
+      os: linux
       stage: Test Pants
       language: generic
       services:
         - docker
       env:
-        - SHARD="Linux Native Engine Binary Builder"
         - PREPARE_DEPLOY=1
       before_script:
         - ulimit -c unlimited
@@ -129,7 +129,8 @@ matrix:
         - build-support/bin/ci-failure.sh
 
     # Deploy Pex
-    - os: linux
+    - name: "Deploy Pants PEX"
+      os: linux
       language: python
       stage: Deploy Pants Pex
       env:
@@ -151,109 +152,96 @@ matrix:
           repo: pantsbuild/pants
 
     - <<: *default_test_config
-      env:
-        - SHARD="Self checks, lint, and JVM tests"
+      name: "Self checks, lint, and JVM tests"
       before_install:
         - sudo apt-get install -y pkg-config fuse libfuse-dev
         - sudo modprobe fuse
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf
       script:
-        - ./build-support/bin/ci.sh -fkmrjt "${SHARD}"
+        - ./build-support/bin/travis-ci.sh -fkmrjt
 
     - <<: *default_test_config
-      env:
-        - SHARD="Py2 - Unit tests for pants and pants-plugins"
+      name: "Py2 - Unit tests for pants and pants-plugins"
       script:
-        - ./build-support/bin/ci.sh -lp "${SHARD}"
+        - ./build-support/bin/travis-ci.sh -lp
 
     - <<: *default_test_config
-      env:
-        - SHARD="Py3 - Unit tests for pants and pants-plugins"
+      name: "Py3 - Unit tests for pants and pants-plugins"
       script:
-        - ./build-support/bin/ci.sh -3lp "${SHARD}"
+        - ./build-support/bin/travis-ci.sh -3lp
 
     - <<: *default_test_config
-      env:
-        - SHARD="Py2 - Python contrib tests"
+      name: "Py2 - Python contrib tests"
       script:
-        - ./build-support/bin/ci.sh -n "${SHARD}"
+        - ./build-support/bin/travis-ci.sh -n
 
     - <<: *default_test_config
-      env:
-        - SHARD="Py3 - Python contrib tests"
+      name: "Py3 - Python contrib tests"
       script:
-        - ./build-support/bin/ci.sh -3n "${SHARD}"
+        - ./build-support/bin/travis-ci.sh -3n
 
     - <<: *default_test_config
-      env:
-        - SHARD="Python integration tests for pants - shard 1"
+      name: "Python integration tests for pants - shard 1"
       script:
-        - ./build-support/bin/ci.sh -c -i 0/7 "${SHARD}"
+        - ./build-support/bin/travis-ci.sh -c -i 0/7
 
     - <<: *default_test_config
-      env:
-        - SHARD="Python integration tests for pants - shard 2"
+      name: "Python integration tests for pants - shard 2"
       script:
-        - ./build-support/bin/ci.sh -c -i 1/7 "${SHARD}"
+        - ./build-support/bin/travis-ci.sh -c -i 1/7
 
     - <<: *default_test_config
-      env:
-        - SHARD="Python integration tests for pants - shard 3"
+      name: "Python integration tests for pants - shard 3"
       script:
-        - ./build-support/bin/ci.sh -c -i 2/7 "${SHARD}"
+        - ./build-support/bin/travis-ci.sh -c -i 2/7
 
     - <<: *default_test_config
-      env:
-        - SHARD="Python integration tests for pants - shard 4"
+      name: "Python integration tests for pants - shard 4"
       script:
-        - ./build-support/bin/ci.sh -c -i 3/7 "${SHARD}"
+        - ./build-support/bin/travis-ci.sh -c -i 3/7
 
     - <<: *default_test_config
-      env:
-        - SHARD="Python integration tests for pants - shard 5"
+      name: "Python integration tests for pants - shard 5"
       script:
-        - ./build-support/bin/ci.sh -c -i 4/7 "${SHARD}"
+        - ./build-support/bin/travis-ci.sh -c -i 4/7
 
     - <<: *default_test_config
-      env:
-        - SHARD="Python integration tests for pants - shard 6"
+      name: "Python integration tests for pants - shard 6"
       script:
-        - ./build-support/bin/ci.sh -c -i 5/7 "${SHARD}"
+        - ./build-support/bin/travis-ci.sh -c -i 5/7
 
     - <<: *default_test_config
-      env:
-        - SHARD="Python integration tests for pants - shard 7"
+      name: "Python integration tests for pants - shard 7"
       script:
-        - ./build-support/bin/ci.sh -c -i 6/7 "${SHARD}"
+        - ./build-support/bin/travis-ci.sh -c -i 6/7
 
     # Rust on linux
-    - os: linux
+    - name: "Rust Tests Linux"
+      os: linux
       dist: trusty
       sudo: required
       stage: Test Pants
       language: python
-      python: "2.7.13"
+      python: *python_version
       before_install:
         - sudo apt-get install -y pkg-config fuse libfuse-dev
         - sudo modprobe fuse
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf
-      env:
-        - SHARD="Rust Tests Linux"
       before_script:
         - ulimit -c unlimited
         - ulimit -n 8192
       script:
-        - ./build-support/bin/ci.sh -be
+        - ./build-support/bin/travis-ci.sh -be
     # Rust on macOS
-    - os: osx
+    - name: "Rust + Platform-specific Tests OSX"
+      os: osx
       # Fuse actually works on this image. It hangs on many others.
       osx_image: xcode8.3
       stage: Test Pants
       language: generic
       env:
-        - SHARD="Rust + Platform-specific Tests OSX"
         # Specifically avoid the OSX provided 2.7.10 under xcode8.3 since it returns a platform
         # of `macosx-*-intel` where the `intel` suffix is bogus but pex has not yet been taught to
         # deal with this. Can be removed when this issue is resolved:
@@ -265,39 +253,38 @@ matrix:
         - ulimit -c unlimited
         - ulimit -n 8192
       script:
-        # Platform-specific tests currently need a pants pex, so we bootstrap here (no -b) and set -z to run the platform-specific tests.
-        - ./build-support/bin/ci.sh -ez
+        # Platform-specific tests currently need a pants pex, so we bootstrap here (no -b) and
+        # set -z to run the platform-specific tests.
+        - ./build-support/bin/travis-ci.sh -ez
 
     # Rust Clippy on Linux with nightly Rust
-    - name: rust-clippy
+    - name: &clippy_shard "[ALLOWED TO BE RED] Rust Clippy on Linux with nightly Rust"
       os: linux
       dist: trusty
       sudo: required
       stage: Test Pants
       language: python
-      python: "2.7.13"
+      python: *python_version
       before_install:
         - sudo apt-get install -y pkg-config fuse libfuse-dev
         - sudo modprobe fuse
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf
-      env:
-        - SHARD="Rust Clippy on Linux with nightly Rust"
       before_script:
         - ulimit -c unlimited
         - ulimit -n 8192
       script:
-        - ./build-support/bin/ci.sh -bs
+        - ./build-support/bin/travis-ci.sh -bs
 
   allow_failures:
-    - name: rust-clippy
+    - name: *clippy_shard
 
 deploy:
   # See: https://docs.travis-ci.com/user/deployment/s3/
   provider: s3
   access_key_id: AKIAIWOKBXVU3JLY6EGQ
   secret_access_key:
-    secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
+    secure: "UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM="
   bucket: binaries.pantsbuild.org
   local_dir: dist/deploy
   # Otherwise travis will stash dist/deploy and the deploy will fail.
@@ -309,8 +296,3 @@ deploy:
     # release branches; eg `1.3.x`
     all_branches: true
     repo: pantsbuild/pants
-
-# We accept the default travis-ci email author+committer notification
-# for now which is enabled even with no `notifications` config.
-# notifications:
-#   email: ...

--- a/build-support/bin/travis-ci.sh
+++ b/build-support/bin/travis-ci.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+function pyenv_path {
+  local -r pyenv_root="$(cd "$(dirname "$(which pyenv)")/.." && pwd -P)"
+  pyenv versions --bare | while read v; do
+    echo "${pyenv_root}/versions/${v}/bin"
+  done
+}
+
+if which pyenv &>/dev/null; then
+  PYENV_PYTHONS="$(pyenv_path)"
+  PYENV_PATH="$(echo ${PYENV_PYTHONS} | tr ' ' ':')"
+
+  echo "Executing ./build-support/bin/ci.sh "$@" with ${PYENV_PATH} preprended to the PATH"
+
+  export PATH="${PYENV_PATH}:${PATH}"
+fi
+exec ./build-support/bin/ci.sh "$@"

--- a/build-support/bin/travis-ci.sh
+++ b/build-support/bin/travis-ci.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# TravisCI-specific environment fixups can live in this script which forwards to the generic ci
+# script post fixups.
 
 set -euo pipefail
 
@@ -11,6 +16,10 @@ function pyenv_path {
   done
 }
 
+# TravisCI uses pyenv to provide some interpreters pre-installed for images. Unfortunately it places
+# `~/.pyenv/shims` on the PATH and these shims are broken (see:
+# https://github.com/travis-ci/travis-ci/issues/8363). We work around this by placing
+# `~/.pyenv/versions/<version>/bin` dirs on the PATH ahead of the broken shims.
 if which pyenv &>/dev/null; then
   PYENV_PYTHONS="$(pyenv_path)"
   PYENV_PATH="$(echo ${PYENV_PYTHONS} | tr ' ' ':')"
@@ -19,4 +28,5 @@ if which pyenv &>/dev/null; then
 
   export PATH="${PYENV_PATH}:${PATH}"
 fi
+
 exec ./build-support/bin/ci.sh "$@"


### PR DESCRIPTION
A few improvements and fixes to the travis setup:
+ Specify `python: "2.7"` which floats us to the most modern python 2.7
  (2.7.14 currently)
+ Use `name` uniformly to name shards and kill the `SHARD` env var which
  was only used to achieve the same end.
+ Ensure travis `pyenv` pythons are on `PATH`. This works around
  https://github.com/travis-ci/travis-ci/issues/8315 and nets us both
  python 2.7 and python 3.6 on all `language: python` shards.

This last is needed to support #6428 which fixes #6415.
