### PR TITLE
Get clippy from the beta channel.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -238,7 +238,7 @@ fi
 if [[ "${run_rust_clippy:-false}" == "true" ]]; then
   start_travis_section "RustClippy" "Running Clippy on rust code"
   (
-    "${REPO_ROOT}/build-support/bin/native/cargo" +nightly clippy --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" --all
+    "${REPO_ROOT}/build-support/bin/native/cargo" +beta clippy --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" --all
   ) || die "Pants clippy failure"
 fi
 

--- a/build-support/bin/native/bootstrap_rust.sh
+++ b/build-support/bin/native/bootstrap_rust.sh
@@ -24,8 +24,8 @@ function bootstrap_rust() {
     "rust-src"
   )
 
-  if [[ "$#" -eq 1 && "$1" == "+nightly" ]]; then
-    RUST_TOOLCHAIN="nightly"
+  if [[ "$#" -eq 1 && "$1" == "+beta" ]]; then
+    RUST_TOOLCHAIN="beta"
     RUST_COMPONENTS=("${RUST_COMPONENTS[@]}" "clippy-preview")
   fi
 

--- a/build-support/bin/native/cargo.sh
+++ b/build-support/bin/native/cargo.sh
@@ -10,12 +10,12 @@ REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd ../../.. && pwd -P)
 # + bootstrap_rust: Bootstraps a Pants-controlled rust toolchain and associated extras.
 source "${REPO_ROOT}/build-support/bin/native/bootstrap_rust.sh"
 
-nightly=""
-if [[ "$@" =~ '+nightly' ]]; then
-  nightly="+nightly"
+beta=""
+if [[ "$@" =~ '+beta' ]]; then
+  beta="+beta"
 fi
 
-bootstrap_rust "${nightly}" >&2
+bootstrap_rust "${beta}" >&2
 
 download_binary="${REPO_ROOT}/build-support/bin/download_binary.sh"
 


### PR DESCRIPTION
It is no longer available on nightly and our CI errors out as a result.
