### PR TITLE
Make sure directory digest is defined for cache hits

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -682,6 +682,9 @@ class JvmCompile(NailgunTaskBase):
       # Double check the cache before beginning compilation
       hit_cache = self.check_cache(vts, counter)
 
+      # TODO: Load from store when https://github.com/pantsbuild/pants/issues/6429 is complete.
+      directory_digest = None
+
       if not hit_cache:
         # Compute the compile classpath for this target.
         dependency_cp_entries = self._zinc.compile_classpath_entries(


### PR DESCRIPTION
Not useful, but defined. Which is better than python raising because it isn't defined.