### PR TITLE
Work around production `coverage` float.

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -28,6 +28,21 @@ from pants_test.subsystem.subsystem_util import init_subsystem
 from pants_test.task_test_base import ensure_cached
 
 
+# NB: Our production code depends on `pytest-cov` which indirectly depends on `coverage`, but in
+# this test we have a direct dependency on `coverage` in order to load data files and test that
+# coverage is collected by `pytest-cov` and has expected values. Unfortunately, `pytest-cov` has a
+# floating dependency on `coverage` and `coverage` has changed its data file format in the past (eg:
+# https://pypi.org/project/coverage/5.0a2/). If the default data format differs between `coverage`
+# float and `coverage` pinned, we'll fail to read coverage data here in this test. We work around
+# this by adding a pinned `coverage` requirement that matches our test dependency to the
+# `PytestPrep` production requirements here.
+class PytestPrepCoverageVersionPinned(PytestPrep):
+  def extra_requirements(self):
+    extra_reqs = list(super(PytestPrepCoverageVersionPinned, self).extra_requirements())
+    extra_reqs.append('coverage=={}'.format(coverage.__version__))
+    return extra_reqs
+
+
 class PytestTestBase(PythonTaskTestBase):
   @classmethod
   def task_type(cls):
@@ -68,7 +83,7 @@ class PytestTestBase(PythonTaskTestBase):
     si_task_type = self.synthesize_task_subtype(SelectInterpreter, 'si_scope')
     rr_task_type = self.synthesize_task_subtype(ResolveRequirements, 'rr_scope')
     gs_task_type = self.synthesize_task_subtype(GatherSources, 'gs_scope')
-    pp_task_type = self.synthesize_task_subtype(PytestPrep, 'pp_scope')
+    pp_task_type = self.synthesize_task_subtype(PytestPrepCoverageVersionPinned, 'pp_scope')
     context = self.context(for_task_types=[si_task_type, rr_task_type, gs_task_type, pp_task_type],
                            target_roots=targets,
                            passthru_args=list(passthru_args))


### PR DESCRIPTION
Ensure the hard dependency on `coverage` in tests matches the otherwise
floating indirect dependency on `coverage` via `pytest-cov` in
production code.
