### PR TITLE
Ensure unstable pants dists can never conflict.

### DIFF
--- a/tests/python/pants_test/backend/python/pants_requirement_integration_test_base.py
+++ b/tests/python/pants_test/backend/python/pants_requirement_integration_test_base.py
@@ -10,8 +10,8 @@ import uuid
 from builtins import open
 from contextlib import contextmanager
 
-from pants.base.build_environment import get_buildroot, pants_version
-from pants.util.contextutil import temporary_dir
+from pants.base.build_environment import get_buildroot
+from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import safe_walk
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -19,8 +19,10 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 class PantsRequirementIntegrationTestBase(PantsRunIntegrationTest):
   @contextmanager
   def _unstable_pants_version(self):
-    stable_version = pants_version()
-    unstable_version = '{}+{}'.format(stable_version, uuid.uuid4().hex)
+    # The earliest pantsbuild.pants release on pypi is 0.0.17 so we grab a lower version and tack
+    # on a globally unique local version identifier to ensure we can never collide with past,
+    # present or future stable or unstable releases.
+    unstable_version = '0.0.0+{}'.format(uuid.uuid4().hex)
     version_dir = os.path.join(get_buildroot(), 'src/python/pants')
 
     with self.file_renamed(version_dir, 'VERSION', 'VERSION.orig'):
@@ -31,7 +33,11 @@ class PantsRequirementIntegrationTestBase(PantsRunIntegrationTest):
       self.assert_success(pants_run)
       self.assertEqual(unstable_version, pants_run.stdout_data.strip())
 
-      yield
+      # Notes must be configured for all pants versions so we fake that out ephemerally here.
+      # In pants-plugins/src/python/internal_backend/utilities/register.py see
+      # PantsReleases.notes_for_version.
+      with environment_as(PANTS_PANTS_RELEASES_BRANCH_NOTES="{'0.0.x': 'pants.ini'}"):
+        yield
 
   def _iter_wheels(self, path):
     for root, _, files in safe_walk(path):


### PR DESCRIPTION
This pushes the version of unstable pants dists we generate for tests
to one older than any released pants avoiding contamination of caches
with otherwise valid-looking prereleases.

Fixes #6459.
