### PR TITLE
Cancel running work when entering the fork context

### DIFF
--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -402,7 +402,16 @@ impl<N: Node> Entry<N> {
         dirty,
         ..
       } => {
-        if dirty {
+        if result == Some(Err(N::Error::invalidated())) {
+          // Because it is always ephemeral, invalidation is the only type of Err that we do not
+          // persist in the Graph. Instead, swap the Node to NotStarted to drop all waiters,
+          // causing them to also experience invalidation (transitively).
+          EntryState::NotStarted {
+            run_token: run_token.next(),
+            generation,
+            previous_result,
+          }
+        } else if dirty {
           // The node was dirtied while it was running. The dep_generations and new result cannot
           // be trusted and were never published. We continue to use the previous result.
           Self::run(

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -3,6 +3,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::thread;
 use std::time::Duration;
 
 use tokio::runtime::Runtime;
@@ -121,9 +122,22 @@ impl Core {
   where
     F: Fn() -> T,
   {
-    self.fs_pool.with_shutdown(|| {
-      self.runtime.with_reset(|| {
-        self.graph.with_exclusive(|| {
+    // Only one fork may occur at a time, but draining the Runtime and Graph requires that the
+    // Graph lock is not actually held during draining (as that would not allow the Runtime's
+    // threads to observe the draining value). So we attempt to mark the Graph draining (similar
+    // to a CAS loop), and treat a successful attempt as indication that our thread has permission
+    // to execute the fork.
+    //
+    // An alternative would be to have two locks in the Graph: one outer lock for the draining
+    // bool, and one inner lock for Graph mutations. But forks should be rare enough that busy
+    // waiting is not too contentious.
+    while let Err(()) = self.graph.mark_draining(true) {
+      debug!("Waiting to enter fork_context...");
+      thread::sleep(Duration::from_millis(10));
+    }
+    let t = self.runtime.with_reset(|| {
+      self.graph.with_exclusive(|| {
+        self.fs_pool.with_shutdown(|| {
           // TODO: In order for `CommandRunner` to be "object safe" (which it must be in order to
           // be `Box`ed for use in the `Core` struct without generic parameters), it cannot have
           // a generic return type. Rather than giving it a return type like `void*`, we set a
@@ -135,7 +149,12 @@ impl Core {
           res.expect("with_shutdown method did not call its argument function.")
         })
       })
-    })
+    });
+    self
+      .graph
+      .mark_draining(false)
+      .expect("Multiple callers should not be in the fork context at once.");
+    t
   }
 }
 


### PR DESCRIPTION
### Problem

As described in #6426: when an error occurs prefork with `pantsd` and a request fails fast, work that is still running in the engine can race the shutdown of all resources that happens in order to safely fork, and as a result, can trigger a deadlock if new requests are made to the Runtime.

### Solution

Add the ability to `drain` the engine's `Graph`, causing all work to fail fast with `Invalidated` the next time it attempts to interact with the `Graph`. Additionally, ensure that the `Invalidated` state is not actually stored, since it always represents an ephemeral failure.

(NB: We continue to push toward reducing usage of fork-without-exec by investing in the `--v2` UX, but removing it entirely might be a ways off.)

### Result

Entering the `fork_context` will cause all in-flight work to fail fast in a recoverable way, allowing for safe forking even in the presence of concurrent in-flight `pantsd` runs. According to ~30 minutes of runs that used to repro, this fixes #6426.