### PR TITLE
Remove broken pyenv shims from the PATH.

### DIFF
--- a/build-support/bin/travis-ci.sh
+++ b/build-support/bin/travis-ci.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 PYENV="$(pyenv which pyenv 2>/dev/null || true)"
-PYENV_ROOT="$(cd "$(pyenv root 2>/dev/null || true)" && pwd -P)"
+PYENV_ROOT="$(pyenv root 2>/dev/null || true)"
 
 function pyenv_path {
   "${PYENV}" versions --bare --skip-aliases | while read v; do

--- a/build-support/bin/travis-ci.sh
+++ b/build-support/bin/travis-ci.sh
@@ -9,24 +9,48 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+PYENV="$(pyenv which pyenv 2>/dev/null || true)"
+PYENV_ROOT="$(cd "$(pyenv root 2>/dev/null || true)" && pwd -P)"
+
 function pyenv_path {
-  local -r pyenv_root="$(cd "$(dirname "$(which pyenv)")/.." && pwd -P)"
-  pyenv versions --bare | while read v; do
-    echo "${pyenv_root}/versions/${v}/bin"
+  "${PYENV}" versions --bare --skip-aliases | while read v; do
+    echo "${PYENV_ROOT}/versions/${v}/bin"
+  done
+}
+
+function list_pythons {
+  which -a python{,2,3} | sort -u | while read python_bin; do
+    ${python_bin} <<EOF
+import os
+import sys
+
+print('{} -> {}'.format(os.path.realpath(sys.executable),
+                        '.'.join(map(str, sys.version_info[:3]))))
+EOF
   done
 }
 
 # TravisCI uses pyenv to provide some interpreters pre-installed for images. Unfortunately it places
 # `~/.pyenv/shims` on the PATH and these shims are broken (see:
 # https://github.com/travis-ci/travis-ci/issues/8363). We work around this by placing
-# `~/.pyenv/versions/<version>/bin` dirs on the PATH ahead of the broken shims.
-if which pyenv &>/dev/null; then
+# removing shims from the PATH and adding `~/.pyenv/versions/<version>/bin`.
+if [ -n "${PYENV}" ]; then
   PYENV_PYTHONS="$(pyenv_path)"
   PYENV_PATH="$(echo ${PYENV_PYTHONS} | tr ' ' ':')"
 
-  echo "Executing ./build-support/bin/ci.sh "$@" with ${PYENV_PATH} preprended to the PATH"
+  SHIMLESS_PATH="$(echo "${PATH}" | tr : '\n' | grep -v "${PYENV_ROOT}/shims")"
+  PATH="$(echo ${SHIMLESS_PATH} | tr ' ' ':')"
 
   export PATH="${PYENV_PATH}:${PATH}"
+
+cat <<EOF
+Executing ./build-support/bin/ci.sh "$@" with "${PYENV_PATH}" preprended to the PATH
+and "${PYENV_ROOT}/shims" removed from the PATH.
+
+Visible pythons are now:
+$(list_pythons | sort -u)
+
+EOF
 fi
 
 exec ./build-support/bin/ci.sh "$@"


### PR DESCRIPTION
It turns out these would still get found in various contexts since the
interpreter cache tries to setup everything it finds on the PATH. Add
improved context in the wrapper script to show exactly which pythons
Pants will have access to.
