### PR TITLE
remove clean-all from pants invocations in python_dist() integration testing + some other refactoring

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -78,14 +78,10 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       self.assertEqual('x=3, f(x)=17\n', binary_run_output)
 
   def test_ctypes_third_party_integration(self):
-    pants_binary = self.run_pants(
-      command=['clean-all', 'binary', self._binary_target_with_third_party]
-    )
+    pants_binary = self.run_pants(['binary', self._binary_target_with_third_party])
     self.assert_success(pants_binary)
 
-    pants_run = self.run_pants(
-      command=['clean-all', 'run', self._binary_target_with_third_party]
-    )
+    pants_run = self.run_pants(['run', self._binary_target_with_third_party])
     self.assert_success(pants_run)
     self.assertIn('Test worked!', pants_run.stdout_data)
 
@@ -105,7 +101,6 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     """
     # Clean all to rebuild requirements pex.
     command = [
-      'clean-all',
       'run',
       'testprojects/src/python/python_distribution/ctypes:bin'
     ]

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -176,11 +176,7 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       output = subprocess.check_output(pex).decode('utf-8')
       self._assert_native_greeting(output)
 
-  def test_pants_tests_local_dists_for_simulated_current_platform_only(self):
-    """
-    The "simulated" current platform here is the platform that 'current' will resolve to on this
-    host -- we do support using those platform strings directly as well.
-    """
+  def test_pants_tests_local_dists_for_current_platform_only(self):
     with temporary_dir() as tmp_dir:
       command=[
         '--pants-distdir={}'.format(tmp_dir),

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -10,6 +10,7 @@ import re
 from builtins import open
 
 from pants.backend.native.config.environment import Platform
+from pants.util.collections import assert_single_element
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import is_executable
 from pants.util.process_handler import subprocess
@@ -33,9 +34,6 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
   def test_pants_binary(self):
     with temporary_dir() as tmp_dir:
       pex = os.path.join(tmp_dir, 'main.pex')
-      # The + is because we append the target's fingerprint to the version. We test this version
-      # string in test_build_local_python_distributions.py.
-      wheel_glob = os.path.join(tmp_dir, 'fasthello-1.0.0+*.whl')
       command=[
         '--pants-distdir={}'.format(tmp_dir), 'binary', '{}:main'.format(self.fasthello_project)]
       pants_run = self.run_pants(command=command)
@@ -46,7 +44,8 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       output = subprocess.check_output(pex).decode('utf-8')
       self._assert_native_greeting(output)
       # Check that we have exact one wheel output
-      self.assertEqual(len(glob.glob(wheel_glob)), 1)
+      single_wheel_output = assert_single_element(glob.glob(os.path.join(tmp_dir, '*.whl')))
+      self.assertTrue(os.path.basename(single_wheel_output).startswith('fasthello-1.0.0+'))
 
   def test_pants_run(self):
     with temporary_dir() as tmp_dir:
@@ -66,7 +65,7 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
     with self.mock_buildroot(
         dirs_to_copy=[self.fasthello_install_requires_dir]) as buildroot, buildroot.pushd():
       run_target = lambda: self.run_pants_with_workdir(
-        command=['-ldebug', 'run', fasthello_run],
+        command=['run', fasthello_run],
         workdir=os.path.join(buildroot.new_buildroot, '.pants.d'),
         build_root=buildroot.new_buildroot,
         extra_env={'PEX_VERBOSE': '9'},
@@ -90,7 +89,6 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
 
   def test_pants_test(self):
     with temporary_dir() as tmp_dir:
-      wheel_glob = os.path.join(tmp_dir, '*.whl')
       command=[
         '--pants-distdir={}'.format(tmp_dir),
         'test',
@@ -98,7 +96,7 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       pants_run = self.run_pants(command=command)
       self.assert_success(pants_run)
       # Make sure that there is no wheel output when 'binary' goal is not invoked.
-      self.assertEqual(len(glob.glob(wheel_glob)), 0)
+      self.assertEqual(len(glob.glob(os.path.join(tmp_dir, '*.whl'))), 0)
 
   def test_with_install_requires(self):
     with temporary_dir() as tmp_dir:
@@ -128,7 +126,7 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
     self.assertIn('pycountry', pants_run.stderr_data)
     self.assertIn('fasthello', pants_run.stderr_data)
 
-  def test_pants_binary_dep_isolation_with_multiple_targets(self):
+  def test_binary_dep_isolation_with_multiple_targets(self):
     with temporary_dir() as tmp_dir:
       pex1 = os.path.join(tmp_dir, 'main_with_no_conflict.pex')
       pex2 = os.path.join(tmp_dir, 'main_with_no_pycountry.pex')
@@ -158,6 +156,7 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       pex = os.path.join(tmp_dir, 'main.pex')
       pants_ini_config = {
         'python-setup': {
+          # TODO: explain why we need 'this-platform-does_not-exist' here.
           'platforms': ['current', 'this-platform-does_not-exist'],
         },
       }
@@ -179,25 +178,26 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
 
   def _get_current_platform_string(self):
     return Platform.create().resolve_platform_specific({
+      # TODO: this will fail on everyone's laptop if they're not at 10.12.
       'darwin': lambda: 'macosx-10.12-x86_64',
       'linux': lambda: 'linux-x86_64',
     })
 
-  def test_pants_tests_local_dists_for_current_platform_only(self):
-    platform_string = self._get_current_platform_string()
-    # Use a platform-specific string for testing because the test goal
-    # requires the coverage package and the pex resolver raises an Untranslatable error when
-    # attempting to translate the coverage sdist for incompatible platforms.
-    pants_ini_config = {'python-setup': {'platforms': [platform_string]}}
-    # Clean all to rebuild requirements pex.
-    # TODO: why do we need to clean-all here?
+  def test_pants_tests_local_dists_for_simulated_current_platform_only(self):
+    """
+    The "simulated" current platform here is the platform that 'current' will resolve to on this
+    host -- we do support using those platform strings directly as well.
+    """
     with temporary_dir() as tmp_dir:
       command=[
         '--pants-distdir={}'.format(tmp_dir),
-        'clean-all',
         'test',
         '{}:fasthello'.format(self.fasthello_tests)]
-      pants_run = self.run_pants(command=command, config=pants_ini_config)
+      pants_run = self.run_pants(command=command, config={
+        'python-setup': {
+          'platforms': [self._get_current_platform_string()],
+        },
+      })
       self.assert_success(pants_run)
 
   def test_python_distribution_with_setup_requires(self):
@@ -207,20 +207,13 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       command=['run', '{}:main'.format(self.hello_setup_requires)]
       pants_run = self.run_pants(command=command)
 
-    # Valdiate the run task. Use clean-all to invalidate cached python_dist wheels from
-    # previous test run. Use -ldebug to get debug info on setup_requires functionality.
-    command=['-ldebug', 'clean-all', 'run', '{}:main'.format(self.hello_setup_requires)]
+    command=['run', '{}:main'.format(self.hello_setup_requires)]
     pants_run = self.run_pants(command=command)
 
-    # Validate that the binary can build and run properly. Use clean-all to invalidate cached
-    # python_dist wheels from previous test run. Use -ldebug to get debug info on setup_requires
-    # functionality.
     with temporary_dir() as tmp_dir:
       pex = os.path.join(tmp_dir, 'main.pex')
       command=[
         '--pants-distdir={}'.format(tmp_dir),
-        '-ldebug',
-        'clean-all',
         'binary',
         '{}:main'.format(self.hello_setup_requires),
       ]

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -155,7 +155,8 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       pex = os.path.join(tmp_dir, 'main.pex')
       pants_ini_config = {
         'python-setup': {
-          # TODO: explain why we need 'this-platform-does_not-exist' here.
+          # If no targets exist declaring the nonexistent platform, this should be reduced to just
+          # ['current'] in PythonNativeCode#check_build_for_current_platform_only().
           'platforms': ['current', 'this-platform-does_not-exist'],
         },
       }

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -122,8 +122,7 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
   def run_shard(self, shard):
     targets = self.targets_for_shard(shard)
     pants_run = self.pants_test(targets + ['--jvm-platform-default-platform=java7',
-                                           '--gen-protoc-import-from-root'],
-                                extra_env={'PEX_VERBOSE': '9'})
+                                           '--gen-protoc-import-from-root'])
     self.assert_success(pants_run)
 
   def test_self(self):


### PR DESCRIPTION
### Problem

Resolves #6455.

### Solution

- Remove uses of `clean-all` between `python_dist()` runs to ensure we're not breaking incremental builds.
- Rename a few tests so using pytest's `-k` is easier.
- Add some TODOs.