### PR TITLE
move dict key encoding into hash_utils.py and deprecate stable_json_hash()

### DIFF
--- a/src/python/pants/backend/docgen/targets/doc.py
+++ b/src/python/pants/backend/docgen/targets/doc.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.base.hash_utils import stable_json_hash
+from pants.base.hash_utils import stable_json_sha1
 from pants.base.payload import Payload
 from pants.base.payload_field import PayloadField, PrimitiveField, combine_hashes
 from pants.build_graph.target import Target
@@ -31,7 +31,7 @@ class WikiArtifact(object):
     self.config = kwargs
 
   def fingerprint(self):
-    return combine_hashes([self.wiki.fingerprint(), stable_json_hash(self.config)])
+    return combine_hashes([self.wiki.fingerprint(), stable_json_sha1(self.config)])
 
   def __str__(self):
     return self.wiki.name
@@ -49,7 +49,7 @@ class Wiki(object):
 
   def fingerprint(self):
     # TODO: url_builder is not a part of fingerprint.
-    return stable_json_hash(self.name)
+    return stable_json_sha1(self.name)
 
 
 class Page(Target):

--- a/src/python/pants/backend/jvm/artifact.py
+++ b/src/python/pants/backend/jvm/artifact.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from six import string_types
 
 from pants.backend.jvm.repository import Repository
-from pants.base.hash_utils import stable_json_hash
+from pants.base.hash_utils import stable_json_sha1
 from pants.base.payload_field import PayloadField
 
 
@@ -75,7 +75,7 @@ class Artifact(PayloadField):
       fingerprint = self.publication_metadata.fingerprint()
       if fingerprint:
         data += (fingerprint,)
-    return stable_json_hash(data)
+    return stable_json_sha1(data)
 
   def __ne__(self, other):
     return not self.__eq__(other)

--- a/src/python/pants/backend/jvm/tasks/prepare_services.py
+++ b/src/python/pants/backend/jvm/tasks/prepare_services.py
@@ -9,7 +9,7 @@ import os
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.resources_task import ResourcesTask
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
-from pants.base.hash_utils import stable_json_hash
+from pants.base.hash_utils import stable_json_sha1
 from pants.util.dirutil import safe_open
 
 
@@ -17,7 +17,7 @@ class JvmServiceFingerprintStrategy(DefaultFingerprintStrategy):
   """Fingerprints a JvmTarget for its service provider configuration."""
 
   def compute_fingerprint(self, target):
-    return stable_json_hash(target.services)
+    return stable_json_sha1(target.services)
 
 
 class PrepareServices(ResourcesTask):

--- a/src/python/pants/backend/python/python_artifact.py
+++ b/src/python/pants/backend/python/python_artifact.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.base.hash_utils import stable_json_hash
+from pants.base.hash_utils import stable_json_sha1
 from pants.base.payload_field import PayloadField
 
 
@@ -67,7 +67,7 @@ class PythonArtifact(PayloadField):
     return self.name
 
   def _compute_fingerprint(self):
-    return stable_json_hash((self._kw, self._binaries))
+    return stable_json_sha1((self._kw, self._binaries))
 
   def with_binaries(self, *args, **kw):
     """Add binaries tagged to this artifact.

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -111,6 +111,7 @@ python_library(
   sources = ['hash_utils.py'],
   dependencies = [
     '3rdparty/python:future',
+    ':deprecated',
   ]
 )
 

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -112,6 +112,7 @@ python_library(
   dependencies = [
     '3rdparty/python:future',
     ':deprecated',
+    'src/python/pants/util:collections_abc_backport',
   ]
 )
 

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -9,6 +9,7 @@ import json
 from builtins import bytes, object, open, str
 
 from future.utils import PY3
+from twitter.common.collections import OrderedSet
 
 from pants.base.deprecated import deprecated
 from pants.util.collections_abc_backport import Iterable, Mapping, OrderedDict, Set
@@ -81,6 +82,11 @@ class CoercingEncoder(json.JSONEncoder):
         (self._maybe_encode_dict_key(k), self.default(v))
         for k, v in ordered_kv_pairs)
     elif isinstance(o, Set):
+      # We disallow OrderedSet (although it is not a stdlib collection) for the same reasons as
+      # OrderedDict above.
+      if isinstance(o, OrderedSet):
+        raise TypeError('{cls} does not support OrderedSet inputs: {val!r}.'
+                        .format(cls=type(self).__name__, val=o))
       # Set order is arbitrary in python 3.6 and 3.7, so we need to keep this sorted() call.
       return sorted(self.default(i) for i in o)
     elif isinstance(o, Iterable) and not isinstance(o, (bytes, list, str)):

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -68,7 +68,9 @@ class CoercingEncoder(json.JSONEncoder):
       # 3 (2.7 and 3.6-3.7 are known to have sorted keys, but with different definitions of sorted
       # orders across versions, including insertion order). We want unordered dicts to collide if
       # they have the same keys, in the same way we special-case sets below. Calling sorted() should
-      # be very fast if the keys happen to be pre-sorted.
+      # be very fast if the keys happen to be pre-sorted. Pants options don't support OrderedDict
+      # inputs, and allowing them creates an ambiguity we don't need to deal with right now. See
+      # discussion in #6475.
       if isinstance(o, OrderedDict):
         raise TypeError('{cls} does not support OrderedDict inputs: {val!r}.'
                         .format(cls=type(self).__name__, val=o))

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -74,12 +74,14 @@ class CoercingEncoder(json.JSONEncoder):
       if isinstance(o, OrderedDict):
         raise TypeError('{cls} does not support OrderedDict inputs: {val!r}.'
                         .format(cls=type(self).__name__, val=o))
-      else:
-        ordered_kv_pairs = sorted(o.items(), key=lambda x: x[0])
+      # TODO(#7082): we can remove the sorted() and OrderedDict when we drop python 2.7 and simply
+      # ensure we encode the keys/values as we do right here.
+      ordered_kv_pairs = sorted(o.items(), key=lambda x: x[0])
       return OrderedDict(
         (self._maybe_encode_dict_key(k), self.default(v))
         for k, v in ordered_kv_pairs)
     elif isinstance(o, Set):
+      # Set order is arbitrary in python 3.6 and 3.7, so we need to keep this sorted() call.
       return sorted(self.default(i) for i in o)
     elif isinstance(o, Iterable) and not isinstance(o, (bytes, list, str)):
       return list(self.default(i) for i in o)

--- a/src/python/pants/base/payload_field.py
+++ b/src/python/pants/base/payload_field.py
@@ -11,7 +11,8 @@ from hashlib import sha1
 from future.utils import PY3
 from twitter.common.collections import OrderedSet
 
-from pants.base.hash_utils import stable_json_hash
+from pants.base.deprecated import deprecated
+from pants.base.hash_utils import stable_json_sha1
 from pants.util.meta import AbstractClass
 from pants.util.strutil import ensure_binary
 
@@ -119,7 +120,7 @@ class PythonRequirementsField(frozenset, PayloadField):
           req._use_2to3,
           req.compatibility,
         )
-        yield stable_json_hash(hash_items)
+        yield stable_json_sha1(hash_items)
     return combine_hashes(fingerprint_iter())
 
 
@@ -132,7 +133,7 @@ class ExcludesField(OrderedSet, PayloadField):
   """
 
   def _compute_fingerprint(self):
-    return stable_json_hash(tuple(repr(exclude) for exclude in self))
+    return stable_json_sha1(tuple(repr(exclude) for exclude in self))
 
 
 class JarsField(tuple, PayloadField):
@@ -144,7 +145,7 @@ class JarsField(tuple, PayloadField):
   """
 
   def _compute_fingerprint(self):
-    return stable_json_hash(tuple(jar.cache_key() for jar in self))
+    return stable_json_sha1(tuple(jar.cache_key() for jar in self))
 
 
 class PrimitiveField(PayloadField):
@@ -163,7 +164,7 @@ class PrimitiveField(PayloadField):
     return self._underlying
 
   def _compute_fingerprint(self):
-    return stable_json_hash(self._underlying)
+    return stable_json_sha1(self._underlying)
 
 
 class PrimitivesSetField(PayloadField):
@@ -184,4 +185,4 @@ class PrimitivesSetField(PayloadField):
     return self._underlying
 
   def _compute_fingerprint(self):
-    return stable_json_hash(self._underlying)
+    return stable_json_sha1(self._underlying)

--- a/src/python/pants/base/payload_field.py
+++ b/src/python/pants/base/payload_field.py
@@ -11,7 +11,6 @@ from hashlib import sha1
 from future.utils import PY3
 from twitter.common.collections import OrderedSet
 
-from pants.base.deprecated import deprecated
 from pants.base.hash_utils import stable_json_sha1
 from pants.util.meta import AbstractClass
 from pants.util.strutil import ensure_binary

--- a/src/python/pants/java/jar/jar_dependency.py
+++ b/src/python/pants/java/jar/jar_dependency.py
@@ -10,7 +10,7 @@ from builtins import object
 from future.moves.urllib import parse
 
 from pants.base.build_environment import get_buildroot
-from pants.base.hash_utils import stable_json_hash
+from pants.base.hash_utils import stable_json_sha1
 from pants.base.validation import assert_list
 from pants.java.jar.exclude import Exclude
 from pants.java.jar.jar_dependency_utils import M2Coordinate
@@ -158,7 +158,7 @@ class JarDependency(datatype([
 
   def cache_key(self):
     excludes = [(e.org, e.name) for e in self.excludes]
-    return stable_json_hash(dict(org=self.org,
+    return stable_json_sha1(dict(org=self.org,
                                  name=self.name,
                                  rev=self.rev,
                                  force=self.force,

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -12,7 +12,6 @@ from pants.base.build_environment import get_buildroot
 from pants.base.hash_utils import CoercingEncoder, json_hash
 from pants.option.custom_types import (UnsetBool, dict_with_files_option, dir_option, file_option,
                                        target_option)
-from pants.util.collections_abc_backport import Iterable, Mapping
 
 
 class CoercingOptionEncoder(CoercingEncoder):

--- a/tests/python/pants_test/backend/jvm/tasks/test_resources_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_resources_task.py
@@ -10,7 +10,7 @@ from builtins import range, str
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.resources_task import ResourcesTask
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
-from pants.base.hash_utils import stable_json_hash
+from pants.base.hash_utils import stable_json_sha1
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 from pants.build_graph.target import Target
@@ -158,7 +158,7 @@ class MinimalImplResourcesTaskTest(ResourcesTaskTestBase):
 class CustomInvalidationStrategtResourcesTaskTest(ResourcesTaskTestBase):
   class TagsInvalidationStrategy(DefaultFingerprintStrategy):
     def compute_fingerprint(self, target):
-      return stable_json_hash(sorted(target.tags))
+      return stable_json_sha1(sorted(target.tags))
 
   class CustomInvalidationStrategyResourcesTask(ResourcesTaskTestBase.MinimalImplResourcesTask):
     def create_invalidation_strategy(self):

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -105,6 +105,7 @@ python_tests(
   sources = ['test_hash_utils.py'],
   dependencies = [
     '3rdparty/python:future',
+    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:hash_utils',
     'src/python/pants/util:contextutil',
   ]

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -11,6 +11,8 @@ import unittest
 from builtins import range, str
 from collections import OrderedDict
 
+from future.utils import PY3
+
 from pants.base.hash_utils import CoercingEncoder, Sharder, hash_all, hash_file, stable_json_sha1
 from pants.util.contextutil import temporary_file
 
@@ -121,7 +123,8 @@ class CoercingJsonEncodingTest(unittest.TestCase):
     self.assertEqual(self._coercing_json_encode(set([2, 1, 3])), '[1, 2, 3]')
     self.assertEqual(self._coercing_json_encode({'b': 4, 'a': 3}), '{"a": 3, "b": 4}')
     self.assertEqual(self._coercing_json_encode([('b', 4), ('a', 3)]), '[["b", 4], ["a", 3]]')
-    self.assertEqual(self._coercing_json_encode([{'b': 4, 'a': 3}]), '[{"a": 3, "b": 4}]')
+    self.assertEqual(self._coercing_json_encode([{'b': 4, 'a': 3}]),
+                     '[{"b": 4, "a": 3}]' if PY3 else '[{"a": 3, "b": 4}]')
 
 
 class JsonHashingTest(unittest.TestCase):

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -109,7 +109,7 @@ class CoercingJsonEncodingTest(unittest.TestCase):
 
   def test_non_string_dict_key_coercion(self):
     self.assertEqual(self._coercing_json_encode({('a', 'b'): 'asdf'}),
-                     '{"[\\"a\\", \\"b\\"]": "asdf"}')
+                     r'{"[\"a\", \"b\"]": "asdf"}')
 
   def test_string_like_dict_key_coercion(self):
     self.assertEqual(self._coercing_json_encode({'a': 3}), '{"a": 3}')

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -138,7 +138,7 @@ class JsonHashingTest(unittest.TestCase):
     self.assertEqual(stable_json_sha1({}), 'bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f')
     self.assertEqual(stable_json_sha1(()), '97d170e1550eee4afc0af065b78cda302a97674c')
     self.assertEqual(stable_json_sha1([]), '97d170e1550eee4afc0af065b78cda302a97674c')
-    self.assertEqual(stable_json_sha1(set([])), '97d170e1550eee4afc0af065b78cda302a97674c')
+    self.assertEqual(stable_json_sha1(set()), '97d170e1550eee4afc0af065b78cda302a97674c')
     self.assertEqual(stable_json_sha1([{}]), '4e9950a1f2305f56d358cad23f28203fb3aacbef')
     self.assertEqual(stable_json_sha1([('a', 3)]), 'd6abed2e53c1595fb3075ecbe020365a47af1f6f')
     self.assertEqual(stable_json_sha1({'a': 3}), '9e0e6d8a99c72daf40337183358cbef91bba7311')

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -5,11 +5,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import hashlib
+import json
 import math
 import unittest
 from builtins import range, str
+from collections import OrderedDict
 
-from pants.base.hash_utils import Sharder, hash_all, hash_file
+from pants.base.hash_utils import CoercingEncoder, Sharder, hash_all, hash_file, stable_json_sha1
 from pants.util.contextutil import temporary_file
 
 
@@ -82,3 +84,82 @@ class TestHashUtils(unittest.TestCase):
     check_bad_spec('/')
     check_bad_spec('foo/1')
     check_bad_spec('1/foo')
+
+
+class CoercingJsonEncodingTest(unittest.TestCase):
+  def _coercing_json_encode(self, o, digest=None):
+    return json.dumps(o, cls=CoercingEncoder)
+
+  def test_normal_object_encoding(self):
+    self.assertEqual(self._coercing_json_encode({}), '{}')
+    self.assertEqual(self._coercing_json_encode(()), '[]')
+    self.assertEqual(self._coercing_json_encode([]), '[]')
+    self.assertEqual(self._coercing_json_encode(set([])), '[]')
+    self.assertEqual(self._coercing_json_encode([{}]), '[{}]')
+    self.assertEqual(self._coercing_json_encode([('a', 3)]), '[["a", 3]]')
+    self.assertEqual(self._coercing_json_encode({'a': 3}), '{"a": 3}')
+    self.assertEqual(self._coercing_json_encode([{'a': 3}]), '[{"a": 3}]')
+    self.assertEqual(self._coercing_json_encode(set([1])), '[1]')
+
+  def test_rejects_ordered_dict(self):
+    with self.assertRaisesRegexp(TypeError, r'CoercingEncoder does not support OrderedDict inputs'):
+      self._coercing_json_encode(OrderedDict([('a', 3)]))
+
+  def test_non_string_dict_key_coercion(self):
+    self.assertEqual(self._coercing_json_encode({('a', 'b'): 'asdf'}),
+                     '{"[\\"a\\", \\"b\\"]": "asdf"}')
+
+  def test_string_like_dict_key_coercion(self):
+    self.assertEqual(self._coercing_json_encode({'a': 3}), '{"a": 3}')
+    self.assertEqual(self._coercing_json_encode({b'a': 3}), '{"a": 3}')
+
+  def test_nested_dict_key_coercion(self):
+    self.assertEqual(self._coercing_json_encode({(1,): {(2,): 3}}),
+                     '{"[1]": {"[2]": 3}}')
+
+  def test_collection_ordering(self):
+    self.assertEqual(self._coercing_json_encode(set([2, 1, 3])), '[1, 2, 3]')
+    self.assertEqual(self._coercing_json_encode({'b': 4, 'a': 3}), '{"a": 3, "b": 4}')
+    self.assertEqual(self._coercing_json_encode([('b', 4), ('a', 3)]), '[["b", 4], ["a", 3]]')
+    self.assertEqual(self._coercing_json_encode([{'b': 4, 'a': 3}]), '[{"a": 3, "b": 4}]')
+
+
+class JsonHashingTest(unittest.TestCase):
+
+  def test_known_checksums(self):
+    """Check a laundry list of supported inputs to stable_json_sha1().
+
+    This checks both that the method can successfully handle the type of input object, but also that
+    the hash of specific objects remains stable.
+    """
+    self.assertEqual(stable_json_sha1({}), 'bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f')
+    self.assertEqual(stable_json_sha1(()), '97d170e1550eee4afc0af065b78cda302a97674c')
+    self.assertEqual(stable_json_sha1([]), '97d170e1550eee4afc0af065b78cda302a97674c')
+    self.assertEqual(stable_json_sha1(set([])), '97d170e1550eee4afc0af065b78cda302a97674c')
+    self.assertEqual(stable_json_sha1([{}]), '4e9950a1f2305f56d358cad23f28203fb3aacbef')
+    self.assertEqual(stable_json_sha1([('a', 3)]), 'd6abed2e53c1595fb3075ecbe020365a47af1f6f')
+    self.assertEqual(stable_json_sha1({'a': 3}), '9e0e6d8a99c72daf40337183358cbef91bba7311')
+    self.assertEqual(stable_json_sha1([{'a': 3}]), '8f4e36849a0b8fbe9c4a822c80fbee047c65458a')
+    self.assertEqual(stable_json_sha1(set([1])), 'f629ae44b7b3dcfed444d363e626edf411ec69a8')
+
+  def test_rejects_ordered_dict(self):
+    with self.assertRaisesRegexp(TypeError, r'CoercingEncoder does not support OrderedDict inputs'):
+      stable_json_sha1(OrderedDict([('a', 3)]))
+
+  def test_non_string_dict_key_checksum(self):
+    self.assertEqual(stable_json_sha1({('a', 'b'): 'asdf'}),
+                     '45deafcfa78a92522166c77b24f5faaf9f3f5c5a')
+
+  def test_string_like_dict_key_checksum(self):
+    self.assertEqual(stable_json_sha1({'a': 3}), '9e0e6d8a99c72daf40337183358cbef91bba7311')
+    self.assertEqual(stable_json_sha1({b'a': 3}), '9e0e6d8a99c72daf40337183358cbef91bba7311')
+
+  def test_nested_dict_checksum(self):
+    self.assertEqual(stable_json_sha1({(1,): {(2,): 3}}),
+                     '63124afed13c4a92eb908fe95c1792528abe3621')
+
+  def test_checksum_ordering(self):
+    self.assertEqual(stable_json_sha1(set([2, 1, 3])), 'a01eda32e4e0b1393274e91d1b3e9ecfc5eaba85')
+    self.assertEqual(stable_json_sha1({'b': 4, 'a': 3}), '6348df9579e7a72f6ec3fb37751db73b2c97a135')
+    self.assertEqual(stable_json_sha1([('b', 4), ('a', 3)]), '8e72bb976e71ea81887eb94730655fe49c454d0c')
+    self.assertEqual(stable_json_sha1([{'b': 4, 'a': 3}]), '4735d702f51fb8a98edb9f6f3eb3df1d6d38a77f')

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -143,7 +143,7 @@ class JsonHashingTest(unittest.TestCase):
     self.assertEqual(stable_json_sha1([('a', 3)]), 'd6abed2e53c1595fb3075ecbe020365a47af1f6f')
     self.assertEqual(stable_json_sha1({'a': 3}), '9e0e6d8a99c72daf40337183358cbef91bba7311')
     self.assertEqual(stable_json_sha1([{'a': 3}]), '8f4e36849a0b8fbe9c4a822c80fbee047c65458a')
-    self.assertEqual(stable_json_sha1(set([1])), 'f629ae44b7b3dcfed444d363e626edf411ec69a8')
+    self.assertEqual(stable_json_sha1({1}), 'f629ae44b7b3dcfed444d363e626edf411ec69a8')
 
   def test_rejects_ordered_dict(self):
     with self.assertRaisesRegexp(TypeError, r'CoercingEncoder does not support OrderedDict inputs'):

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -7,11 +7,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import hashlib
 import json
 import math
+import re
 import unittest
 from builtins import range, str
 from collections import OrderedDict
 
 from future.utils import PY3
+from twitter.common.collections import OrderedSet
 
 from pants.base.hash_utils import CoercingEncoder, Sharder, hash_all, hash_file, stable_json_sha1
 from pants.util.contextutil import temporary_file
@@ -145,9 +147,13 @@ class JsonHashingTest(unittest.TestCase):
     self.assertEqual(stable_json_sha1([{'a': 3}]), '8f4e36849a0b8fbe9c4a822c80fbee047c65458a')
     self.assertEqual(stable_json_sha1({1}), 'f629ae44b7b3dcfed444d363e626edf411ec69a8')
 
-  def test_rejects_ordered_dict(self):
-    with self.assertRaisesRegexp(TypeError, r'CoercingEncoder does not support OrderedDict inputs'):
+  def test_rejects_ordered_collections(self):
+    with self.assertRaisesRegexp(TypeError,
+                                 re.escape('CoercingEncoder does not support OrderedDict inputs')):
       stable_json_sha1(OrderedDict([('a', 3)]))
+    with self.assertRaisesRegexp(TypeError,
+                                 re.escape('CoercingEncoder does not support OrderedSet inputs')):
+      stable_json_sha1(OrderedSet([3]))
 
   def test_non_string_dict_key_checksum(self):
     self.assertEqual(stable_json_sha1({('a', 'b'): 'asdf'}),

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -120,7 +120,7 @@ class CoercingJsonEncodingTest(unittest.TestCase):
                      '{"[1]": {"[2]": 3}}')
 
   def test_collection_ordering(self):
-    self.assertEqual(self._coercing_json_encode(set([2, 1, 3])), '[1, 2, 3]')
+    self.assertEqual(self._coercing_json_encode({2, 1, 3}), '[1, 2, 3]')
     self.assertEqual(self._coercing_json_encode({'b': 4, 'a': 3}), '{"a": 3, "b": 4}')
     self.assertEqual(self._coercing_json_encode([('b', 4), ('a', 3)]), '[["b", 4], ["a", 3]]')
     self.assertEqual(self._coercing_json_encode([{'b': 4, 'a': 3}]),

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -96,7 +96,7 @@ class CoercingJsonEncodingTest(unittest.TestCase):
     self.assertEqual(self._coercing_json_encode({}), '{}')
     self.assertEqual(self._coercing_json_encode(()), '[]')
     self.assertEqual(self._coercing_json_encode([]), '[]')
-    self.assertEqual(self._coercing_json_encode(set([])), '[]')
+    self.assertEqual(self._coercing_json_encode(set()), '[]')
     self.assertEqual(self._coercing_json_encode([{}]), '[{}]')
     self.assertEqual(self._coercing_json_encode([('a', 3)]), '[["a", 3]]')
     self.assertEqual(self._coercing_json_encode({'a': 3}), '{"a": 3}')

--- a/tests/python/pants_test/option/test_options_fingerprinter.py
+++ b/tests/python/pants_test/option/test_options_fingerprinter.py
@@ -5,41 +5,15 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-import unittest
 from builtins import range, zip
-
-from future.utils import PY2
 
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 from pants.option.custom_types import (UnsetBool, dict_option, dir_option, file_option, list_option,
                                        target_option)
-from pants.option.options_fingerprinter import OptionsFingerprinter, stable_json_sha1
+from pants.option.options_fingerprinter import OptionsFingerprinter
 from pants.util.contextutil import temporary_dir
 from pants_test.test_base import TestBase
-
-
-class JsonEncodingTest(unittest.TestCase):
-  def test_known_checksums(self):
-    """Check a laundry list of supported inputs to stable_json_sha1().
-
-    This checks both that the method can successfully handle the type of input object, but also that
-    the hash of specific objects remains stable.
-    """
-    self.assertEqual(stable_json_sha1({}), 'bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f')
-    self.assertEqual(stable_json_sha1(()), '97d170e1550eee4afc0af065b78cda302a97674c')
-    self.assertEqual(stable_json_sha1([]), '97d170e1550eee4afc0af065b78cda302a97674c')
-    self.assertEqual(stable_json_sha1(set([])), '97d170e1550eee4afc0af065b78cda302a97674c')
-    self.assertEqual(stable_json_sha1([{}]), '4e9950a1f2305f56d358cad23f28203fb3aacbef')
-    self.assertEqual(stable_json_sha1([('a', 3)]), 'd6abed2e53c1595fb3075ecbe020365a47af1f6f')
-    self.assertEqual(stable_json_sha1({'a': 3}), '9e0e6d8a99c72daf40337183358cbef91bba7311')
-    self.assertEqual(stable_json_sha1([{'a': 3}]), '8f4e36849a0b8fbe9c4a822c80fbee047c65458a')
-    self.assertEqual(stable_json_sha1(set([1])), 'f629ae44b7b3dcfed444d363e626edf411ec69a8')
-
-  def test_non_string_dict_key(self):
-    error_regex_str = r'key \(\) is not a string' if PY2 else r'keys must be a string'
-    with self.assertRaisesRegexp(TypeError, error_regex_str):
-      stable_json_sha1({():()})
 
 
 class OptionsFingerprinterTest(TestBase):
@@ -60,7 +34,7 @@ class OptionsFingerprinterTest(TestBase):
   def test_fingerprint_dict_with_non_string_keys(self):
     d = {('a', 2): (3, 4)}
     fp = self.options_fingerprinter.fingerprint(dict_option, d)
-    self.assertEqual(fp, 'ba3b9319e9477f14dcea56ae1836ae5e73a73a2c')
+    self.assertEqual(fp, '3852a094612ce1c22c08ee2ddcdc03d09e87ad97')
 
   def test_fingerprint_list(self):
     l1 = [1, 2, 3]


### PR DESCRIPTION
### Problem

Resolves #6421, and also resolves #6422.

### Solution

- Create `CoercingEncoder` in `hash_utils.py` to encode dict keys, because the base `JSONEncoder` class can't for some reason.
- Create `CoercingOptionEncoder` subclassing `CoercingEncoder` in `options_fingerprinter.py`, providing an override for `UnsetBool` inputs in the `default` method.
- Deprecate `stable_json_hash()` because it cannot purport to be stable if the user can pass in an arbitrary encoder unless we memoize its return values (and still, that's only stable in the currently running process, which is much weaker than what `stable_json_sha1()` provides). The new method `json_hash()` does what `stable_json_hash()` did (allowing a choice of encoder, which we use with both `CoercingEncoder` and `CoercingOptionEncoder` above), without claiming stability.
- Add testing for JSON encoding of specific inputs, not just the checksum of that encoding.

### Result

The `CoercingEncoder` can only handle dicts with non-(`str`/`float`/`int`/some others) keys if that dict is the top-level object passed to `json.dumps` -- it will fail on nested dicts with non-string keys. This is fine for now / ever but it seems like there should be a way to handle this without reimplementing the `json` module.