### PR TITLE
increase number of retries used to fetch meta tags for go compile

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py
@@ -23,7 +23,7 @@ class GoImportMetaTagReader(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(GoImportMetaTagReader, cls).register_options(register)
-    register('--retries', type=int, default=1, advanced=True,
+    register('--retries', type=int, default=5, advanced=True,
              help='How many times to retry when fetching meta tags.')
 
   _META_IMPORT_REGEX = re.compile(r"""

--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py
@@ -23,6 +23,8 @@ class GoImportMetaTagReader(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(GoImportMetaTagReader, cls).register_options(register)
+    # GoCompileIntegrationTest will flake out pretty often in Travis, and increasing the retries may
+    # make it less flaky -- see #6476.
     register('--retries', type=int, default=5, advanced=True,
              help='How many times to retry when fetching meta tags.')
 

--- a/pants.travis-ci.ini
+++ b/pants.travis-ci.ini
@@ -17,7 +17,3 @@ fast: false
 [libc]
 # Currently, we only need to search for a libc installation to test the native toolchain.
 enable_libc_search: True
-
-[go-import-metatag-reader]
-# GoCompileIntegrationTest will flake out pretty often in Travis if we stick to the default of 1.
-retries: 5

--- a/pants.travis-ci.ini
+++ b/pants.travis-ci.ini
@@ -17,3 +17,7 @@ fast: false
 [libc]
 # Currently, we only need to search for a libc installation to test the native toolchain.
 enable_libc_search: True
+
+[go-import-metatag-reader]
+# GoCompileIntegrationTest will flake out pretty often in Travis if we stick to the default of 1.
+retries: 5


### PR DESCRIPTION
### Problem

GoCompileIntegrationTest will fail intermittently -- example [here](https://travis-ci.org/pantsbuild/pants/jobs/426252430). I haven't been able to detect any pattern for when this occurs, and restarting the shard has always fixed it, but it happens relatively often.

### Solution

- Increase the default value for `--retries` in the `go-import-metatag-reader` subsystem to 5 (over the default 1).

### Result

Questions for the reader:

- Is this an accurate diagnosis of the issue?
- Is this the right fix for the issue?
- How can I test that this actually fixes anything without restarting this PR's travis build 10 times (and the p value is probably still pretty poor with that)?