### PR TITLE
Add missing call to super.

### DIFF
--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -43,6 +43,7 @@ class ResolveRequirementsTaskBase(Task):
 
   @classmethod
   def prepare(cls, options, round_manager):
+    super(ResolveRequirementsTaskBase, cls).prepare(options, round_manager)
     round_manager.require_data(PythonInterpreter)
     round_manager.optional_product(PythonRequirementLibrary)  # For local dists.
     # Codegen may inject extra resolvable deps, so make sure we have a product dependency


### PR DESCRIPTION
Without this, and with codegen backends uninstalled, the `Export` task
would not have `BootstrapJvmTools` scheduled, leading to synthetic tool
classpath targets not being present in the graph, leading to native
engine failure trying to resolve these targets.
