### PR TITLE
refactor command line target spec resolution and check that all target roots exist

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -144,6 +144,8 @@ python_library(
   name = 'specs',
   sources = ['specs.py'],
   dependencies = [
+    'src/python/pants/util:collections',
+    'src/python/pants/util:dirutil',
     'src/python/pants/util:meta',
     'src/python/pants/util:objects',
   ],

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -53,14 +53,13 @@ class Spec(AbstractClass):
 
     :raises: :class:`SingleAddress.SingleAddressResolutionError` for resolution errors with a
              :class:`SingleAddress` instance.
-    :raises: :class:`Spec.AddressResolutionError` if no targets could be found otherwise.
+    :raises: :class:`Spec.AddressResolutionError` if no targets could be found otherwise, if the
+             spec type requires a non-empty set of targets.
     :return: list of (Address, Target) pairs.
     """
     addr_tgt_pairs = []
     for af in address_families:
       addr_tgt_pairs.extend(af.addressables.items())
-    if len(addr_tgt_pairs) == 0:
-      raise self.AddressResolutionError('Spec {} does not match any targets.'.format(self))
     return addr_tgt_pairs
 
 
@@ -125,6 +124,12 @@ class DescendantAddresses(datatype(['directory']), Spec):
       af for ns, af in address_families_dict.items()
       if fast_relpath_optional(ns, self.directory) is not None
     ]
+
+  def all_address_target_pairs(self, address_families):
+    addr_tgt_pairs = super(DescendantAddresses, self).all_address_target_pairs(address_families)
+    if len(addr_tgt_pairs) == 0:
+      raise self.AddressResolutionError('Spec {} does not match any targets.'.format(self))
+    return addr_tgt_pairs
 
 
 class AscendantAddresses(datatype(['directory']), Spec):

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -33,6 +33,7 @@ class Spec(AbstractClass):
     """Given a dict of (namespace path) -> AddressFamily, return the values matching this spec.
 
     :raises: :class:`Spec.AddressFamilyResolutionError` if no address families matched this spec.
+    :return: list of AddressFamily.
     """
 
   @classmethod
@@ -50,9 +51,10 @@ class Spec(AbstractClass):
   def all_address_target_pairs(self, address_families):
     """Given a list of AddressFamily, return (address, target) pairs matching this spec.
 
-    :raises: :class:`SingleAddress.SingleAddressResolutionError` if no targets could be found for a
+    :raises: :class:`SingleAddress.SingleAddressResolutionError` for resolution errors with a
              :class:`SingleAddress` instance.
     :raises: :class:`Spec.AddressResolutionError` if no targets could be found otherwise.
+    :return: list of (Address, Target) pairs.
     """
     addr_tgt_pairs = []
     for af in address_families:
@@ -84,9 +86,11 @@ class SingleAddress(datatype(['directory', 'name']), Spec):
       self.name = name
 
   def all_address_target_pairs(self, address_families):
-    """Return the single target matching the single AddressFamily, or error.
+    """Return the pair for the single target matching the single AddressFamily, or error.
 
-    :raises: :class:`SingleAddress.SingleAddressResolutionError`
+    :raises: :class:`SingleAddress.SingleAddressResolutionError` if no targets could be found for a
+             :class:`SingleAddress` instance.
+    :return: list of (Address, Target) pairs with exactly one element.
     """
     single_af = assert_single_element(address_families)
     addr_tgt_pairs = [

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -53,7 +53,7 @@ class Spec(AbstractClass):
   def address_target_pairs_from_address_families(self, address_families):
     """Given a list of AddressFamily, return (address, target) pairs matching this spec.
 
-    :raises: :class:`SingleAddress.SingleAddressResolutionError` for resolution errors with a
+    :raises: :class:`SingleAddress._SingleAddressResolutionError` for resolution errors with a
              :class:`SingleAddress` instance.
     :raises: :class:`Spec.AddressResolutionError` if no targets could be found otherwise, if the
              spec type requires a non-empty set of targets.
@@ -93,16 +93,16 @@ class SingleAddress(datatype(['directory', 'name']), Spec):
   def matching_address_families(self, address_families_dict):
     return self.address_families_for_dir(address_families_dict, self.directory)
 
-  class SingleAddressResolutionError(Exception):
+  class _SingleAddressResolutionError(Exception):
     def __init__(self, single_address_family, name):
-      super(SingleAddress.SingleAddressResolutionError, self).__init__()
+      super(SingleAddress._SingleAddressResolutionError, self).__init__()
       self.single_address_family = single_address_family
       self.name = name
 
   def address_target_pairs_from_address_families(self, address_families):
     """Return the pair for the single target matching the single AddressFamily, or error.
 
-    :raises: :class:`SingleAddress.SingleAddressResolutionError` if no targets could be found for a
+    :raises: :class:`SingleAddress._SingleAddressResolutionError` if no targets could be found for a
              :class:`SingleAddress` instance.
     :return: list of (Address, Target) pairs with exactly one element.
     """
@@ -112,7 +112,7 @@ class SingleAddress(datatype(['directory', 'name']), Spec):
       if addr.target_name == self.name
     ]
     if len(addr_tgt_pairs) == 0:
-      raise self.SingleAddressResolutionError(single_af, self.name)
+      raise self._SingleAddressResolutionError(single_af, self.name)
     # There will be at most one target with a given name in a single AddressFamily.
     assert(len(addr_tgt_pairs) == 1)
     return addr_tgt_pairs

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -4,9 +4,10 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import re
 from abc import abstractmethod
 
+from pants.util.collections import assert_single_element
+from pants.util.dirutil import fast_relpath_optional
 from pants.util.meta import AbstractClass
 from pants.util.objects import datatype
 
@@ -25,6 +26,30 @@ class Spec(AbstractClass):
   def to_spec_string(self):
     """Returns the normalized string representation of this spec."""
 
+  @abstractmethod
+  def matching_address_families(self, address_families_dict):
+    """???"""
+
+  class AddressResolutionError(Exception): pass
+
+  def all_address_target_pairs(self, address_families):
+    addr_tgt_pairs = []
+    for af in address_families:
+      addr_tgt_pairs.extend(af.addressables.items())
+    if len(addr_tgt_pairs) == 0:
+      raise self.AddressResolutionError('Spec {} does not match any targets.'.format(self))
+    return addr_tgt_pairs
+
+  class AddressFamilyResolutionError(Exception): pass
+
+  def address_families_for_dir(self, address_families_dict, spec_dir_path):
+    maybe_af = address_families_dict.get(spec_dir_path, None)
+    if maybe_af is None:
+      raise self.AddressFamilyResolutionError(
+        'Path "{}" does not contain any BUILD files.'
+        .format(spec_dir_path))
+    return [maybe_af]
+
 
 class SingleAddress(datatype(['directory', 'name']), Spec):
   """A Spec for a single address."""
@@ -38,12 +63,36 @@ class SingleAddress(datatype(['directory', 'name']), Spec):
   def to_spec_string(self):
     return '{}:{}'.format(self.directory, self.name)
 
+  def matching_address_families(self, address_families_dict):
+    return self.address_families_for_dir(address_families_dict, self.directory)
+
+  class SingleAddressResolutionError(Exception):
+    def __init__(self, single_address_family, name):
+      super(SingleAddress.SingleAddressResolutionError, self).__init__()
+      self.single_address_family = single_address_family
+      self.name = name
+
+  def all_address_target_pairs(self, address_families):
+    single_af = assert_single_element(address_families)
+    addr_tgt_pairs = [
+      (addr, tgt) for addr, tgt in single_af.addressables.items()
+      if addr.target_name == self.name
+    ]
+    if len(addr_tgt_pairs) == 0:
+      raise self.SingleAddressResolutionError(single_af, self.name)
+    # There will be at most one target with a given name in a single AddressFamily.
+    assert(len(addr_tgt_pairs) == 1)
+    return addr_tgt_pairs
+
 
 class SiblingAddresses(datatype(['directory']), Spec):
   """A Spec representing all addresses located directly within the given directory."""
 
   def to_spec_string(self):
     return '{}:'.format(self.directory)
+
+  def matching_address_families(self, address_families_dict):
+    return self.address_families_for_dir(address_families_dict, self.directory)
 
 
 class DescendantAddresses(datatype(['directory']), Spec):
@@ -52,6 +101,12 @@ class DescendantAddresses(datatype(['directory']), Spec):
   def to_spec_string(self):
     return '{}::'.format(self.directory)
 
+  def matching_address_families(self, address_families_dict):
+    return [
+      af for ns, af in address_families_dict.items()
+      if fast_relpath_optional(ns, self.directory) is not None
+    ]
+
 
 class AscendantAddresses(datatype(['directory']), Spec):
   """A Spec representing all addresses located recursively _above_ the given directory."""
@@ -59,12 +114,19 @@ class AscendantAddresses(datatype(['directory']), Spec):
   def to_spec_string(self):
     return '{}^'.format(self.directory)
 
+  def matching_address_families(self, address_families_dict):
+    return [
+      af for ns, af in address_families_dict.items()
+      if fast_relpath_optional(self.directory, ns) is not None
+    ]
 
-class Specs(datatype(['dependencies', 'tags', ('exclude_patterns', tuple)])):
+
+class Specs(datatype([('dependencies', tuple), ('tags', tuple), ('exclude_patterns', tuple)])):
   """A collection of Specs representing Spec subclasses, tags and regex filters."""
 
-  def __new__(cls, dependencies, tags=tuple(), exclude_patterns=tuple()):
-    return super(Specs, cls).__new__(cls, dependencies, tags, exclude_patterns)
-
-  def exclude_patterns_memo(self):
-    return [re.compile(pattern) for pattern in set(self.exclude_patterns or [])]
+  def __new__(cls, dependencies, tags=None, exclude_patterns=tuple()):
+    return super(Specs, cls).__new__(
+      cls,
+      dependencies=tuple(dependencies),
+      tags=tuple(tags or []),
+      exclude_patterns=tuple(exclude_patterns))

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -74,6 +74,7 @@ python_library(
     ':struct',
     'src/python/pants/base:project_tree',
     'src/python/pants/build_graph',
+    'src/python/pants/util:collections',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:filtering',
     'src/python/pants/util:objects',

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -280,7 +280,7 @@ def map_specs(address_mapper, specs):
 
 
 @rule(BuildFileAddresses, [Select(MappedSpecs)])
-def addresses_from_mapped_specs(mapped_specs):
+def addresses_from_address_families(mapped_specs):
   """Given an AddressMapper and list of Specs, return matching BuildFileAddresses.
 
   :raises: :class:`ResolveError` if:
@@ -339,7 +339,7 @@ def create_graph_rules(address_mapper, symbol_table):
     # Spec handling: locate directories that contain build files, and request
     # AddressFamilies for each of them.
     map_specs,
-    addresses_from_mapped_specs,
+    addresses_from_address_families,
     # Root rules representing parameters that might be provided via root subjects.
     RootRule(Address),
     RootRule(BuildFileAddress),

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -201,14 +201,14 @@ def _hydrate(item_type, spec_path, **kwargs):
   return item
 
 
-class MappedSpecs(datatype([
+class _MappedSpecs(datatype([
     ('address_families', tuple),
     ('specs', Specs),
 ])):
   """Wraps up logic to resolve specs into individual target addresses, or error out."""
 
   def __new__(cls, address_families, specs):
-    return super(MappedSpecs, cls).__new__(cls, tuple(address_families), specs)
+    return super(_MappedSpecs, cls).__new__(cls, tuple(address_families), specs)
 
   @memoized_property
   def _exclude_compiled_regexps(self):
@@ -283,7 +283,7 @@ def addresses_from_address_families(address_mapper, specs):
 
   # all_matching_addresses() could be a free function as well -- it just seemed to make it easier to
   # follow to package it up into a datatype here.
-  mapped_specs = MappedSpecs(address_families, specs)
+  mapped_specs = _MappedSpecs(address_families, specs)
   deduplicated_addresses = frozenset(mapped_specs.all_matching_addresses())
 
   yield BuildFileAddresses(tuple(deduplicated_addresses))

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -282,8 +282,12 @@ def addresses_from_address_families(address_mapper, specs):
   snapshot = yield Get(Snapshot, PathGlobs, _spec_to_globs(address_mapper, specs))
   dirnames = {dirname(f.stat.path) for f in snapshot.files}
   address_families = yield [Get(AddressFamily, Dir(d)) for d in dirnames]
+
+  # all_matching_addresses() could be a free function as well -- it just seemed to make it easier to
+  # follow to package it up into a datatype here.
   mapped_specs = MappedSpecs(address_families, specs)
   deduplicated_addresses = frozenset(mapped_specs.all_matching_addresses())
+
   yield BuildFileAddresses(tuple(deduplicated_addresses))
 
 

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -280,7 +280,7 @@ def map_specs(address_mapper, specs):
 
 
 @rule(BuildFileAddresses, [Select(MappedSpecs)])
-def addresses_from_address_families(mapped_specs):
+def addresses_from_mapped_specs(mapped_specs):
   """Given an AddressMapper and list of Specs, return matching BuildFileAddresses.
 
   :raises: :class:`ResolveError` if:
@@ -339,7 +339,7 @@ def create_graph_rules(address_mapper, symbol_table):
     # Spec handling: locate directories that contain build files, and request
     # AddressFamilies for each of them.
     map_specs,
-    addresses_from_address_families,
+    addresses_from_mapped_specs,
     # Root rules representing parameters that might be provided via root subjects.
     RootRule(Address),
     RootRule(BuildFileAddress),

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -259,10 +259,10 @@ class MappedSpecs(datatype([
   def all_matching_addresses(self):
     """Return all addresses the given specs resolve to, within the given address families.
 
-    :raises: :class:`ResolveError` for errors matching address families, and for failure to match a
-             SingleAddress spec in an existing AddressFamily.
-    :raises: :class:`AddressLookupError` for failure to match any targets for non-SingleAddress
-             specs.
+    :raises: :class:`ResolveError` if:
+     - there were no matching AddressFamilies, or
+     - the Spec matches no addresses for SingleAddresses.
+    :raises: :class:`AddressLookupError` if no targets are matched for non-SingleAddress specs.
     """
     matched_addresses = []
     for spec in self.specs.dependencies:
@@ -284,9 +284,10 @@ def map_specs(address_mapper, specs):
 def addresses_from_address_families(mapped_specs):
   """Given an AddressMapper and list of Specs, return matching BuildFileAddresses.
 
-  Raises a AddressLookupError if:
+  :raises: :class:`ResolveError` if:
      - there were no matching AddressFamilies, or
      - the Spec matches no addresses for SingleAddresses.
+  :raises: :class:`AddressLookupError` if no targets are matched for non-SingleAddress specs.
   """
   deduplicated_addresses = frozenset(mapped_specs.all_matching_addresses())
   return BuildFileAddresses(tuple(deduplicated_addresses))

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -236,8 +236,6 @@ class MappedSpecs(datatype([
     # NB: if a spec is provided which expands to some number of targets, but those targets match
     # --exclude-target-regexp, we do NOT fail! This is why we wait to apply the tag and exclude
     # patterns until we gather all the targets the spec would have matched without them.
-    # TODO: ensure we fail later (at some point) if we expand to zero targets after applying tags and
-    # --exclude-target-regexp!
     try:
       addr_families_for_spec = spec.matching_address_families(self._address_family_by_directory)
     except Spec.AddressFamilyResolutionError as e:
@@ -254,6 +252,7 @@ class MappedSpecs(datatype([
       addr for (addr, tgt) in all_addr_tgt_pairs
       if self._matches_target_address_pair(addr, tgt)
     ]
+    # NB: This may be empty, as the result of filtering by tag and exclude patterns!
     return all_matching_addresses
 
   def all_matching_addresses(self):

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -251,7 +251,7 @@ class _MappedSpecs(datatype([
       all_addr_tgt_pairs = spec.address_target_pairs_from_address_families(addr_families_for_spec)
     except Spec.AddressResolutionError as e:
       raise raise_from(AddressLookupError(e), e)
-    except SingleAddress.SingleAddressResolutionError as e:
+    except SingleAddress._SingleAddressResolutionError as e:
       _raise_did_you_mean(e.single_address_family, e.name, source=e)
 
     all_matching_addresses = [

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -203,7 +203,7 @@ def _hydrate(item_type, spec_path, **kwargs):
 
 
 class _MappedSpecs(datatype([
-    ('address_families', tuple),
+    ('address_families', tuple), # List[AddressFamily]
     ('specs', Specs),
 ])):
   """Wraps up logic to resolve specs into individual target addresses, or error out."""

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -242,7 +242,7 @@ class MappedSpecs(datatype([
       raise ResolveError(e)
 
     try:
-      all_addr_tgt_pairs = spec.all_address_target_pairs(addr_families_for_spec)
+      all_addr_tgt_pairs = spec.address_target_pairs_from_address_families(addr_families_for_spec)
     except Spec.AddressResolutionError as e:
       raise AddressLookupError(e)
     except SingleAddress.SingleAddressResolutionError as e:

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -12,6 +12,7 @@ from builtins import next, str
 from os.path import dirname, join
 
 import six
+from twitter.common.collections import OrderedSet
 
 from pants.base.project_tree import Dir
 from pants.base.specs import SingleAddress, Spec, Specs
@@ -284,7 +285,7 @@ def addresses_from_address_families(address_mapper, specs):
   # all_matching_addresses() could be a free function as well -- it just seemed to make it easier to
   # follow to package it up into a datatype here.
   mapped_specs = _MappedSpecs(address_families, specs)
-  deduplicated_addresses = frozenset(mapped_specs.all_matching_addresses())
+  deduplicated_addresses = OrderedSet(mapped_specs.all_matching_addresses())
 
   yield BuildFileAddresses(tuple(deduplicated_addresses))
 

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -207,6 +207,7 @@ class MappedSpecs(datatype([
     ('address_families', tuple),
     ('specs', Specs),
 ])):
+  """Wraps up logic to resolve specs into individual target addresses, or error out."""
 
   def __new__(cls, address_families, specs):
     return super(MappedSpecs, cls).__new__(cls, tuple(address_families), specs)
@@ -256,6 +257,13 @@ class MappedSpecs(datatype([
     return all_matching_addresses
 
   def all_matching_addresses(self):
+    """Return all addresses the given specs resolve to, within the given address families.
+
+    :raises: :class:`ResolveError` for errors matching address families, and for failure to match a
+             SingleAddress spec in an existing AddressFamily.
+    :raises: :class:`AddressLookupError` for failure to match any targets for non-SingleAddress
+             specs.
+    """
     matched_addresses = []
     for spec in self.specs.dependencies:
       matched_addresses.extend(self._matching_addresses_for_spec(spec))

--- a/tests/python/pants_test/backend/graph_info/tasks/test_paths_integration.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_paths_integration.py
@@ -8,7 +8,7 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 # TODO: These tests duplicate the unit tests in `test_paths.py`, and should be removed in
-# their favor once #4401 lands and allows unit tests to cover the v2 engine.
+# their favor. However, they also surface some errors which the unit tests don't -- see #6480.
 class PathsIntegrationTest(PantsRunIntegrationTest):
   def test_paths_single(self):
     pants_run = self.run_pants(['paths',

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -13,7 +13,7 @@ from pants.base.specs import SiblingAddresses, SingleAddress, Specs
 from pants.build_graph.address import Address
 from pants.engine.addressable import addressable, addressable_dict
 from pants.engine.build_files import (MappedSpecs, ResolvedTypeMismatchError,
-                                      addresses_from_mapped_specs, create_graph_rules,
+                                      addresses_from_address_families, create_graph_rules,
                                       parse_address_family)
 from pants.engine.fs import (DirectoryDigest, FileContent, FilesContent, PathGlobs, Snapshot,
                              create_fs_rules)
@@ -47,7 +47,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     address_family = AddressFamily('a', {'a': ('a/BUILD', 'this is an object!')})
     mapped_specs = MappedSpecs([address_family], Specs([address, address]))
 
-    bfas = run_rule(addresses_from_mapped_specs, mapped_specs)
+    bfas = run_rule(addresses_from_address_families, mapped_specs)
 
     self.assertEqual(len(bfas.dependencies), 1)
     self.assertEqual(bfas.dependencies[0].spec, 'a:a')
@@ -63,7 +63,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     )
     mapped_specs = MappedSpecs([address_family], Specs([spec], tags=['+integration']))
 
-    targets = run_rule(addresses_from_mapped_specs, mapped_specs)
+    targets = run_rule(addresses_from_address_families, mapped_specs)
 
     self.assertEqual(len(targets.dependencies), 1)
     self.assertEqual(targets.dependencies[0].spec, 'root:b')
@@ -78,13 +78,13 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
       """"b" was not found in namespace "root". Did you mean one of:
   :a""")
     with self.assertRaisesRegexp(ResolveError, expected_rx_str):
-      run_rule(addresses_from_mapped_specs, mapped_specs)
+      run_rule(addresses_from_address_families, mapped_specs)
 
     # Ensure that we still catch nonexistent targets later on in the list of command-line specs.
     specs = Specs([SingleAddress('root', 'a'), SingleAddress('root', 'b')])
     mapped_specs = MappedSpecs([address_family], specs)
     with self.assertRaisesRegexp(ResolveError, expected_rx_str):
-      run_rule(addresses_from_mapped_specs, mapped_specs)
+      run_rule(addresses_from_address_families, mapped_specs)
 
   def test_exclude_pattern(self):
     """Test that targets are filtered based on exclude patterns."""
@@ -95,7 +95,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
       }
     )
     mapped_specs = MappedSpecs([address_family], Specs([spec], exclude_patterns=tuple(['.exclude*'])))
-    targets = run_rule(addresses_from_mapped_specs, mapped_specs)
+    targets = run_rule(addresses_from_address_families, mapped_specs)
     self.assertEqual(len(targets.dependencies), 1)
     self.assertEqual(targets.dependencies[0].spec, 'root:not_me')
 
@@ -108,7 +108,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
       }
     )
     mapped_specs = MappedSpecs([address_family], Specs([spec], exclude_patterns=tuple(['root.*'])))
-    targets = run_rule(addresses_from_mapped_specs, mapped_specs)
+    targets = run_rule(addresses_from_address_families, mapped_specs)
     self.assertEqual(len(targets.dependencies), 0)
 
 

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -41,10 +41,10 @@ class ParseAddressFamilyTest(unittest.TestCase):
 
 class AddressesFromAddressFamiliesTest(unittest.TestCase):
 
-  def _address_mapper():
+  def _address_mapper(self):
     return AddressMapper(JsonParser(TestTable()))
 
-  def _snapshot():
+  def _snapshot(self):
     return Snapshot(
       DirectoryDigest('xx', 2),
       (Path('root/BUILD', File('root/BUILD')),))

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -80,7 +80,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     with self.assertRaisesRegexp(ResolveError, expected_rx_str):
       run_rule(addresses_from_address_families, mapped_specs)
 
-    # ???
+    # Ensure that we still catch nonexistent targets later on in the list of command-line specs.
     specs = Specs([SingleAddress('root', 'a'), SingleAddress('root', 'b')])
     mapped_specs = MappedSpecs([address_family], specs)
     with self.assertRaisesRegexp(ResolveError, expected_rx_str):

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -13,7 +13,7 @@ from pants.base.specs import SiblingAddresses, SingleAddress, Specs
 from pants.build_graph.address import Address
 from pants.engine.addressable import addressable, addressable_dict
 from pants.engine.build_files import (MappedSpecs, ResolvedTypeMismatchError,
-                                      addresses_from_address_families, create_graph_rules,
+                                      addresses_from_mapped_specs, create_graph_rules,
                                       parse_address_family)
 from pants.engine.fs import (DirectoryDigest, FileContent, FilesContent, PathGlobs, Snapshot,
                              create_fs_rules)
@@ -47,7 +47,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     address_family = AddressFamily('a', {'a': ('a/BUILD', 'this is an object!')})
     mapped_specs = MappedSpecs([address_family], Specs([address, address]))
 
-    bfas = run_rule(addresses_from_address_families, mapped_specs)
+    bfas = run_rule(addresses_from_mapped_specs, mapped_specs)
 
     self.assertEqual(len(bfas.dependencies), 1)
     self.assertEqual(bfas.dependencies[0].spec, 'a:a')
@@ -63,7 +63,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     )
     mapped_specs = MappedSpecs([address_family], Specs([spec], tags=['+integration']))
 
-    targets = run_rule(addresses_from_address_families, mapped_specs)
+    targets = run_rule(addresses_from_mapped_specs, mapped_specs)
 
     self.assertEqual(len(targets.dependencies), 1)
     self.assertEqual(targets.dependencies[0].spec, 'root:b')
@@ -78,13 +78,13 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
       """"b" was not found in namespace "root". Did you mean one of:
   :a""")
     with self.assertRaisesRegexp(ResolveError, expected_rx_str):
-      run_rule(addresses_from_address_families, mapped_specs)
+      run_rule(addresses_from_mapped_specs, mapped_specs)
 
     # Ensure that we still catch nonexistent targets later on in the list of command-line specs.
     specs = Specs([SingleAddress('root', 'a'), SingleAddress('root', 'b')])
     mapped_specs = MappedSpecs([address_family], specs)
     with self.assertRaisesRegexp(ResolveError, expected_rx_str):
-      run_rule(addresses_from_address_families, mapped_specs)
+      run_rule(addresses_from_mapped_specs, mapped_specs)
 
   def test_exclude_pattern(self):
     """Test that targets are filtered based on exclude patterns."""
@@ -95,7 +95,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
       }
     )
     mapped_specs = MappedSpecs([address_family], Specs([spec], exclude_patterns=tuple(['.exclude*'])))
-    targets = run_rule(addresses_from_address_families, mapped_specs)
+    targets = run_rule(addresses_from_mapped_specs, mapped_specs)
     self.assertEqual(len(targets.dependencies), 1)
     self.assertEqual(targets.dependencies[0].spec, 'root:not_me')
 
@@ -108,7 +108,7 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
       }
     )
     mapped_specs = MappedSpecs([address_family], Specs([spec], exclude_patterns=tuple(['root.*'])))
-    targets = run_rule(addresses_from_address_families, mapped_specs)
+    targets = run_rule(addresses_from_mapped_specs, mapped_specs)
     self.assertEqual(len(targets.dependencies), 0)
 
 

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -12,9 +12,10 @@ from pants.base.project_tree import Dir, File
 from pants.base.specs import SiblingAddresses, SingleAddress, Specs
 from pants.build_graph.address import Address
 from pants.engine.addressable import addressable, addressable_dict
-from pants.engine.build_files import (ResolvedTypeMismatchError, addresses_from_address_families,
-                                      create_graph_rules, parse_address_family)
-from pants.engine.fs import (DirectoryDigest, FileContent, FilesContent, Path, PathGlobs, Snapshot,
+from pants.engine.build_files import (MappedSpecs, ResolvedTypeMismatchError,
+                                      addresses_from_address_families, create_graph_rules,
+                                      parse_address_family)
+from pants.engine.fs import (DirectoryDigest, FileContent, FilesContent, PathGlobs, Snapshot,
                              create_fs_rules)
 from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.mapper import AddressFamily, AddressMapper, ResolveError
@@ -43,15 +44,10 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
   def test_duplicated(self):
     """Test that matching the same Spec twice succeeds."""
     address = SingleAddress('a', 'a')
-    address_mapper = AddressMapper(JsonParser(TestTable()))
-    snapshot = Snapshot(DirectoryDigest('xx', 2),
-                        (Path('a/BUILD', File('a/BUILD')),))
     address_family = AddressFamily('a', {'a': ('a/BUILD', 'this is an object!')})
+    mapped_specs = MappedSpecs([address_family], Specs([address, address]))
 
-    bfas = run_rule(addresses_from_address_families, address_mapper, Specs([address, address]), {
-        (Snapshot, PathGlobs): lambda _: snapshot,
-        (AddressFamily, Dir): lambda _: address_family,
-      })
+    bfas = run_rule(addresses_from_address_families, mapped_specs)
 
     self.assertEqual(len(bfas.dependencies), 1)
     self.assertEqual(bfas.dependencies[0].spec, 'a:a')
@@ -59,87 +55,60 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
   def test_tag_filter(self):
     """Test that targets are filtered based on `tags`."""
     spec = SiblingAddresses('root')
-    address_mapper = AddressMapper(JsonParser(TestTable()))
-    snapshot = Snapshot(DirectoryDigest('xx', 2),
-                        (Path('root/BUILD', File('root/BUILD')),))
     address_family = AddressFamily('root',
       {'a': ('root/BUILD', TargetAdaptor()),
        'b': ('root/BUILD', TargetAdaptor(tags={'integration'})),
        'c': ('root/BUILD', TargetAdaptor(tags={'not_integration'}))
       }
     )
+    mapped_specs = MappedSpecs([address_family], Specs([spec], tags=['+integration']))
 
-    targets = run_rule(
-      addresses_from_address_families, address_mapper, Specs([spec], tags=['+integration']), {
-      (Snapshot, PathGlobs): lambda _: snapshot,
-      (AddressFamily, Dir): lambda _: address_family,
-    })
+    targets = run_rule(addresses_from_address_families, mapped_specs)
 
     self.assertEqual(len(targets.dependencies), 1)
     self.assertEqual(targets.dependencies[0].spec, 'root:b')
 
   def test_fails_on_nonexistent_specs(self):
     """Test that specs referring to nonexistent targets raise a ResolveError."""
-    address_mapper = AddressMapper(JsonParser(TestTable()))
-    snapshot = Snapshot(DirectoryDigest('xx', 2),
-                        (Path('root/BUILD', File('root/BUILD')),))
     address_family = AddressFamily('root', {'a': ('root/BUILD', TargetAdaptor())})
-
     specs = Specs([SingleAddress('root', 'b'), SingleAddress('root', 'a')])
+    mapped_specs = MappedSpecs([address_family], specs)
+
     expected_rx_str = re.escape(
       """"b" was not found in namespace "root". Did you mean one of:
   :a""")
     with self.assertRaisesRegexp(ResolveError, expected_rx_str):
-      run_rule(
-        addresses_from_address_families, address_mapper, specs, {
-          (Snapshot, PathGlobs): lambda _: snapshot,
-          (AddressFamily, Dir): lambda _: address_family,
-        })
+      run_rule(addresses_from_address_families, mapped_specs)
 
     # ???
     specs = Specs([SingleAddress('root', 'a'), SingleAddress('root', 'b')])
+    mapped_specs = MappedSpecs([address_family], specs)
     with self.assertRaisesRegexp(ResolveError, expected_rx_str):
-      run_rule(
-        addresses_from_address_families, address_mapper, specs, {
-          (Snapshot, PathGlobs): lambda _: snapshot,
-          (AddressFamily, Dir): lambda _: address_family,
-        })
+      run_rule(addresses_from_address_families, mapped_specs)
 
   def test_exclude_pattern(self):
     """Test that targets are filtered based on exclude patterns."""
     spec = SiblingAddresses('root')
-    address_mapper = AddressMapper(JsonParser(TestTable()))
-    snapshot = Snapshot(DirectoryDigest('xx', 2),
-                        (Path('root/BUILD', File('root/BUILD')),))
     address_family = AddressFamily('root',
       {'exclude_me': ('root/BUILD', TargetAdaptor()),
        'not_me': ('root/BUILD', TargetAdaptor()),
       }
     )
-    targets = run_rule(
-      addresses_from_address_families, address_mapper, Specs([spec], exclude_patterns=tuple(['.exclude*'])),{
-      (Snapshot, PathGlobs): lambda _: snapshot,
-      (AddressFamily, Dir): lambda _: address_family,
-    })
+    mapped_specs = MappedSpecs([address_family], Specs([spec], exclude_patterns=tuple(['.exclude*'])))
+    targets = run_rule(addresses_from_address_families, mapped_specs)
     self.assertEqual(len(targets.dependencies), 1)
     self.assertEqual(targets.dependencies[0].spec, 'root:not_me')
 
   def test_exclude_pattern_with_single_address(self):
     """Test that single address targets are filtered based on exclude patterns."""
     spec = SingleAddress('root', 'not_me')
-    address_mapper = AddressMapper(JsonParser(TestTable()))
-    snapshot = Snapshot(DirectoryDigest('xx', 2),
-                        (Path('root/BUILD', File('root/BUILD')),))
     address_family = AddressFamily('root',
       {
        'not_me': ('root/BUILD', TargetAdaptor()),
       }
     )
-    targets = run_rule(
-      addresses_from_address_families, address_mapper, Specs([spec], exclude_patterns=tuple(['root.*'])),{
-      (Snapshot, PathGlobs): lambda _: snapshot,
-      (AddressFamily, Dir): lambda _: address_family,
-    })
+    mapped_specs = MappedSpecs([address_family], Specs([spec], exclude_patterns=tuple(['root.*'])))
+    targets = run_rule(addresses_from_address_families, mapped_specs)
     self.assertEqual(len(targets.dependencies), 0)
 
 


### PR DESCRIPTION
### Problem

This should fail regardless of the order of the command-line target specs (the target named `a` does not exist):
```
> ./pants test tests/python/pants_test/option:a
# ...
ResolveError: "a" was not found in namespace "tests/python/pants_test/option". Did you mean one of:
          :options_integration
          :testing
> ./pants test tests/python/pants_test/option:{testing,a}
# ...
 ===== 158 passed, 1 xfailed in 2.77 seconds ======
                     
                   tests/python/pants_test/option:testing                                          .....   SUCCESS
23:25:48 00:12     [junit]
23:25:48 00:12     [go]
23:25:48 00:12     [node]
               Waiting for background workers to finish.
23:25:49 00:13   [complete]
               SUCCESS
```

### Solution

- Move `AddressFamily` and `Address` resolution logic into the `Spec` class and its subclasses instead of doing a massive `if` chain.
- Introduce the `_MappedSpecs` datatype holding the target `Specs`, and the `AddressFamily`s covering the directories indicated by the `Specs`.
- Move all of the address resolution logic into `_MappedSpecs` for clarity, and replace all `if type(obj) is SingleAddress` chains with abstract methods implemented in `Spec` subclasses.
- Add `test_fails_on_nonexistent_specs()` to test the issue described in the Problem section.