### PR TITLE
Fix formatting in notes

### DIFF
--- a/src/python/pants/notes/1.10.x.rst
+++ b/src/python/pants/notes/1.10.x.rst
@@ -1,15 +1,15 @@
 1.10.x Stable Releases
-=====================
+======================
 
 This document describes releases leading up to the ``1.10.x`` ``stable`` series.
 
 1.10.0 (09/10/2018)
-------------------
+-------------------
 
 The first stable release of the 1.10.x series.
 
 1.10.0rc0 (09/10/2018)
----------------------
+----------------------
 
 New features
 ~~~~~~~~~~~~


### PR DESCRIPTION
While doing the release, doc publishing errored out on formatting. 