### PR TITLE
we can now depend on non-header-only libraries from conan by building them ourselves

### DIFF
--- a/src/python/pants/backend/native/subsystems/binaries/cmake.py
+++ b/src/python/pants/backend/native/subsystems/binaries/cmake.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+from pants.binaries.binary_tool import NativeTool
+from pants.util.memo import memoized_property
+
+
+class CMake(NativeTool):
+  options_scope = 'cmake'
+  default_version = '3.9.5'
+  archive_type = 'tgz'
+
+  @memoized_property
+  def bin_dir(self):
+    return os.path.join(self.select(), 'bin')

--- a/src/python/pants/backend/native/subsystems/binaries/make.py
+++ b/src/python/pants/backend/native/subsystems/binaries/make.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+from pants.binaries.binary_tool import NativeTool
+from pants.util.memo import memoized_property
+
+
+class Make(NativeTool):
+  options_scope = 'make'
+  default_version = '4.2.1'
+  archive_type = 'tgz'
+
+  @memoized_property
+  def bin_dir(self):
+    return os.path.join(self.select(), 'bin')

--- a/src/python/pants/backend/native/subsystems/native_build_step_settings_base.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step_settings_base.py
@@ -10,6 +10,12 @@ from pants.subsystem.subsystem import Subsystem
 
 
 class NativeBuildStepSettingsBase(Subsystem, MirroredTargetOptionMixin):
+  """Holds options which are understood by all parts of the compile and link pipeline.
+
+  NB: This is separate from NativeBuildSettings, which is used to store options controlling pants
+  behavior. Rather, this subsystem stores options which are typically interpreted into command-line
+  arguments or environment variables for a compiler or linker invocation.
+  """
 
   mirrored_option_to_kwarg_map = {
     'fatal_warnings': 'fatal_warnings',

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -192,7 +192,6 @@ class LinkSharedLibraries(NativeTask):
            # TODO: static archives should be resolvable with -L/-l too, but that's not working for
            # some reason with the IrrXML package in testprojects/.
            list(link_request.external_static_archive_paths) +
-           ['-Wl,-rpath,{}'.format(d) for d in link_request.external_lib_dirs] +
            ['-L{}'.format(d) for d in link_request.external_lib_dirs] +
            ['-l{}'.format(l) for l in link_request.external_lib_names] +
            self.platform.resolve_platform_specific(self._SHARED_CMDLINE_ARGS) +

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -192,6 +192,7 @@ class LinkSharedLibraries(NativeTask):
            # TODO: static archives should be resolvable with -L/-l too, but that's not working for
            # some reason with the IrrXML package in testprojects/.
            list(link_request.external_static_archive_paths) +
+           ['-Wl,-rpath,{}'.format(d) for d in link_request.external_lib_dirs] +
            ['-L{}'.format(d) for d in link_request.external_lib_dirs] +
            ['-l{}'.format(l) for l in link_request.external_lib_names] +
            self.platform.resolve_platform_specific(self._SHARED_CMDLINE_ARGS) +

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -153,11 +153,13 @@ class LinkSharedLibraries(NativeTask):
 
     external_lib_dirs = []
     external_lib_names = []
+    external_static_archive_paths = []
     if external_libs_product is not None:
       for nelf in external_libs_product.get_for_targets(deps):
         if nelf.lib_dir:
           external_lib_dirs.append(nelf.lib_dir)
         external_lib_names.extend(nelf.lib_names)
+        external_static_archive_paths.extend(nelf.static_archive_paths)
 
     return LinkSharedLibraryRequest(
       linker=self.linker,
@@ -165,7 +167,8 @@ class LinkSharedLibraries(NativeTask):
       native_artifact=vt.target.ctypes_native_library,
       output_dir=vt.results_dir,
       external_lib_dirs=tuple(external_lib_dirs),
-      external_lib_names=tuple(external_lib_names))
+      external_lib_names=tuple(external_lib_names),
+      external_static_archive_paths=tuple(external_static_archive_paths))
 
   _SHARED_CMDLINE_ARGS = {
     'darwin': lambda: ['-Wl,-dylib'],

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -189,7 +189,8 @@ class LinkSharedLibraries(NativeTask):
     cmd = ([linker.exe_filename] +
            linker.extra_args +
            [os.path.abspath(obj) for obj in object_files] +
-           # TODO: consider -rpath=dir whenever we support depending on dynamic libs?
+           # TODO: static archives should be resolvable with -L/-l too, but that's not working for
+           # some reason with the IrrXML package in testprojects/.
            list(link_request.external_static_archive_paths) +
            ['-L{}'.format(d) for d in link_request.external_lib_dirs] +
            ['-l{}'.format(l) for l in link_request.external_lib_names] +

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -9,8 +9,6 @@ from abc import abstractmethod
 from collections import defaultdict
 
 from pants.backend.native.config.environment import Executable
-from pants.backend.native.targets.external_native_library import ExternalNativeLibrary
-from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.native_external_library_fetch import NativeExternalLibraryFiles
 from pants.backend.native.tasks.native_task import NativeTask
 from pants.base.build_environment import get_buildroot
@@ -40,12 +38,6 @@ class ObjectFiles(datatype(['root_dir', 'filenames'])):
 
 
 class NativeCompile(NativeTask, AbstractClass):
-  # `NativeCompile` will use the `source_target_constraint` to determine what targets have "sources"
-  # to compile, and the `dependent_target_constraint` to determine which dependent targets to
-  # operate on for `strict_deps` calculation.
-  # NB: `source_target_constraint` must be overridden.
-  source_target_constraint = None
-  dependent_target_constraint = SubclassesOf(ExternalNativeLibrary, NativeLibrary)
 
   # `NativeCompile` will use `workunit_label` as the name of the workunit when executing the
   # compiler process. `workunit_label` must be set to a string.

--- a/src/python/pants/backend/native/tasks/native_external_library_fetch.py
+++ b/src/python/pants/backend/native/tasks/native_external_library_fetch.py
@@ -180,6 +180,7 @@ class NativeExternalLibraryFetch(NativeTask):
       include_dir = os.path.join(vt.results_dir, 'include')
 
       lib_names = []
+      static_archive_paths = []
       if os.path.isdir(lib_dir):
         for filename in os.listdir(lib_dir):
           if filename.endswith('.a'):

--- a/src/python/pants/backend/native/tasks/native_external_library_fetch.py
+++ b/src/python/pants/backend/native/tasks/native_external_library_fetch.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import re
+from builtins import str
 from distutils.dir_util import copy_tree
 
 from pex.interpreter import PythonInterpreter
@@ -61,7 +62,7 @@ class ConanRequirement(datatype(['pkg_spec'])):
   def fetch_cmdline_args(self):
     platform = Platform.create()
     conan_os_name = platform.resolve_platform_specific(self.CONAN_OS_NAME)
-    # TODO: document these!
+    # TODO: --build missing should be an option!
     args = [
       'install', self.pkg_spec,
       '-s', 'os={}'.format(conan_os_name),

--- a/src/python/pants/backend/native/tasks/native_task.py
+++ b/src/python/pants/backend/native/tasks/native_task.py
@@ -8,6 +8,7 @@ from builtins import filter
 
 from pants.backend.native.subsystems.native_build_settings import NativeBuildSettings
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
+from pants.backend.native.targets.external_native_library import ExternalNativeLibrary
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.build_graph.dependency_context import DependencyContext
 from pants.task.task import Task
@@ -39,7 +40,7 @@ class NativeTask(Task):
 
     :return: :class:`pants.util.objects.TypeConstraint`
     """
-    return SubclassesOf(NativeLibrary)
+    return SubclassesOf(ExternalNativeLibrary, NativeLibrary)
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -10,9 +10,8 @@ from collections import defaultdict
 
 from pex.pex import PEX
 
-from pants.backend.native.config.environment import CppToolchain, CToolchain, Platform
+from pants.backend.native.config.environment import CppToolchain, CToolchain
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
-from pants.backend.native.subsystems.xcode_cli_tools import MIN_OSX_VERSION_ARG
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.subsystems.python_setup import PythonSetup
@@ -159,7 +158,6 @@ class BuildSetupRequiresPex(ExecutablePexTool):
 class SetupPyNativeTools(datatype([
     ('c_toolchain', CToolchain),
     ('cpp_toolchain', CppToolchain),
-    ('platform', Platform),
 ])):
   """The native tools needed for a setup.py invocation.
 
@@ -174,16 +172,6 @@ class SetupPyExecutionEnvironment(datatype([
     # If None, don't execute in the toolchain environment.
     'setup_py_native_tools',
 ])):
-
-  _SHARED_CMDLINE_ARGS = {
-    'darwin': lambda: [
-      MIN_OSX_VERSION_ARG,
-      '-Wl,-dylib',
-      '-undefined',
-      'dynamic_lookup',
-    ],
-    'linux': lambda: ['-shared'],
-  }
 
   def as_environment(self):
     ret = {}

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -222,8 +222,7 @@ class BuildLocalPythonDistributions(Task):
       # TODO: test this branch somehow!
       native_tools = SetupPyNativeTools(
         c_toolchain=self._c_toolchain,
-        cpp_toolchain=self._cpp_toolchain,
-        platform=self._platform)
+        cpp_toolchain=self._cpp_toolchain)
       # Native code in this python_dist() target requires marking the dist as platform-specific.
       is_platform_specific = True
     elif len(all_native_artifacts) > 0:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import multiprocessing
 import os
 import sys
+from builtins import str
 
 from pants.base.build_environment import (get_buildroot, get_default_pants_config_file,
                                           get_pants_cachedir, get_pants_configdir, pants_version)

--- a/testprojects/src/python/python_distribution/ctypes_with_third_party/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes_with_third_party/BUILD
@@ -7,13 +7,18 @@ ctypes_compatible_cpp_library(
   name='cpp_library_with_third_party',
   sources=['some_more_math.hpp', 'some_more_math_with_third_party.cpp'],
   ctypes_native_library=native_artifact(lib_name='asdf-cpp-tp'),
-  dependencies=[':rang', ':cereal'],
-  fatal_warnings=False
+  dependencies=[
+    ':rang',
+    ':cereal',
+    ':IrrXML',
+  ],
+  fatal_warnings=False,
 )
 
 python_dist(
   name='python_dist_with_third_party_cpp',
   sources=[
+    'test.xml',
     'setup.py',
     'ctypes_python_pkg/__init__.py',
     'ctypes_python_pkg/ctypes_wrapper.py',
@@ -31,6 +36,14 @@ python_binary(
   ],
 )
 
+python_binary(
+  name='get-xml-node-names',
+  source='xml-main.py',
+  dependencies=[
+    ':python_dist_with_third_party_cpp',
+  ],
+)
+
 external_native_library(
   name='rang',
   packages=[
@@ -42,5 +55,12 @@ external_native_library(
   name='cereal',
   packages=[
      'cereal/1.2.2@conan/stable',
+  ],
+)
+
+external_native_library(
+  name='IrrXML',
+  packages=[
+    'IrrXML/1.2@conan/stable',
   ],
 )

--- a/testprojects/src/python/python_distribution/ctypes_with_third_party/ctypes_python_pkg/ctypes_wrapper.py
+++ b/testprojects/src/python/python_distribution/ctypes_with_third_party/ctypes_python_pkg/ctypes_wrapper.py
@@ -20,7 +20,18 @@ def get_generated_shared_lib(lib_name):
 asdf_cpp_lib_path = get_generated_shared_lib('asdf-cpp-tp')
 asdf_cpp_lib = ctypes.CDLL(asdf_cpp_lib_path)
 
+libc = ctypes.CDLL(ctypes.util.find_library('c'))
+libc.free.argtypes = (ctypes.c_void_p,)
+
 def f(x):
   added = x + 3
   multiplied = asdf_cpp_lib.multiply_by_three(added)
   return multiplied
+
+asdf_cpp_lib.get_node_name_xml.argtypes = (ctypes.c_char_p,)
+asdf_cpp_lib.get_node_name_xml.restype = ctypes.c_char_p
+
+test_xml_path = os.path.join(os.path.dirname(__file__), '..', 'test.xml')
+
+def get_node_name():
+  return asdf_cpp_lib.get_node_name_xml(test_xml_path)

--- a/testprojects/src/python/python_distribution/ctypes_with_third_party/some_more_math.hpp
+++ b/testprojects/src/python/python_distribution/ctypes_with_third_party/some_more_math.hpp
@@ -5,4 +5,6 @@ int mangled_function(int);
 
 extern "C" int multiply_by_three(int);
 
+extern "C" const char *get_node_name_xml(const char *);
+
 #endif

--- a/testprojects/src/python/python_distribution/ctypes_with_third_party/some_more_math_with_third_party.cpp
+++ b/testprojects/src/python/python_distribution/ctypes_with_third_party/some_more_math_with_third_party.cpp
@@ -4,62 +4,65 @@
 #include "rang.hpp"
 
 /**
-A C++11 library for integration testing that contains a library archive (.dylib/.so)
-in addition to headers.
+A C++11 library for integration testing that contains a library archive
+(.dylib/.so) in addition to headers.
 
 This snippet is taken from the README at https://github.com/USCiLab/cereal.
  */
-#include <cereal/types/unordered_map.hpp>
-#include <cereal/types/memory.hpp>
 #include <cereal/archives/binary.hpp>
-#include <fstream>
+#include <cereal/types/memory.hpp>
+#include <cereal/types/unordered_map.hpp>
 
-struct MyRecord
-{
+#include <irrXML.h>
+
+#include <cstring>
+#include <fstream>
+#include <string>
+
+struct MyRecord {
   uint8_t x = 1;
   uint8_t y = 2;
   float z;
 
-  template <class Archive>
-  void serialize( Archive & ar )
-  {
-    ar( x, y, z );
-  }
+  template <class Archive> void serialize(Archive &ar) { ar(x, y, z); }
 };
 
-struct SomeData
-{
+struct SomeData {
   int32_t id;
   int data = 3;
 
-  template <class Archive>
-  void save( Archive & ar ) const
-  {
-    ar( data );
-  }
+  template <class Archive> void save(Archive &ar) const { ar(data); }
 
-  template <class Archive>
-  void load( Archive & ar )
-  {
+  template <class Archive> void load(Archive &ar) {
     static int32_t idGen = 0;
     id = idGen++;
-    ar( data );
+    ar(data);
   }
 };
 
-
 int mangled_function(int x) {
 
-	// cereal testing
-	MyRecord myRecord;
-	SomeData myData;
+  // cereal testing
+  MyRecord myRecord;
+  SomeData myData;
 
   // rang testing
-  std::cout << "Testing 3rdparty C++..."
-    << rang::style::bold << "Test worked!"
-    << rang::style::reset << std::endl;
+  std::cout << "Testing 3rdparty C++..." << rang::style::bold << "Test worked!"
+            << rang::style::reset << std::endl;
 
-	return x ^ 3;
+  return x ^ 3;
 }
 
 extern "C" int multiply_by_three(int x) { return mangled_function(x * 3); }
+
+extern "C" const char *get_node_name_xml(const char *filename) {
+  auto reader = irr::io::createIrrXMLReader(filename);
+  std::string s;
+  while (reader->read()) {
+    s += ",";
+    s += reader->getNodeName();
+  }
+  delete reader;
+  /* TODO: This almost definitely leaks the string -- how to avoid this in ctypes? */
+  return strdup(s.c_str());
+}

--- a/testprojects/src/python/python_distribution/ctypes_with_third_party/test.xml
+++ b/testprojects/src/python/python_distribution/ctypes_with_third_party/test.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config>
+  <!-- This is a config file for the mesh viewer -->
+  <model file="dwarf.dea"/>
+  <messageText caption="Irrlicht Engine Mesh Viewer">
+    Welcome to the Mesh Viewer of the "Irrlicht Engine".
+  </messageText>
+</config>

--- a/testprojects/src/python/python_distribution/ctypes_with_third_party/xml-main.py
+++ b/testprojects/src/python/python_distribution/ctypes_with_third_party/xml-main.py
@@ -5,13 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from setuptools import setup, find_packages
+from ctypes_python_pkg.ctypes_wrapper import get_node_name
 
 
-setup(
-  name='ctypes_third_party_test',
-  version='0.0.1',
-  packages=find_packages(),
-  # Declare one shared lib at the top-level directory (denoted by '').
-  data_files=[('', ['libasdf-cpp-tp.so', 'test.xml'])],
-)
+if __name__ == '__main__':
+  print('node_name={}'.format(get_node_name()))

--- a/tests/python/pants_test/backend/python/tasks/test_native_external_library_fetch.py
+++ b/tests/python/pants_test/backend/python/tasks/test_native_external_library_fetch.py
@@ -70,7 +70,14 @@ class TestConanRequirement(unittest.TestCase):
     cr = ConanRequirement(pkg_spec=pkg_spec)
     platform = Platform.create()
     conan_os_name = platform.resolve_platform_specific(self.CONAN_OS_NAME)
-    expected = ['install', 'test/1.0.0@conan/stable', '-s', 'os={}'.format(conan_os_name)]
+    expected = [
+      'install',
+      'test/1.0.0@conan/stable',
+      '-s',
+      'os={}'.format(conan_os_name),
+      '--build',
+      'missing',
+    ]
     self.assertEqual(cr.fetch_cmdline_args, expected)
 
 


### PR DESCRIPTION
### Problem

As @stuhood was valiantly making headway on #6178, we realized that we didn't have any examples of 3rdparty native libraries from Conan that weren't header-only (so we weren't testing the native linking at all for 3rdparty libs). Also, we weren't passing static archives to the linker correctly at all -- we need to refer to them with the full `.a` file path, and after the object files that depend on them.

### Solution

- Separate static archives from shared libraries when creating `NativeExternalLibraryFiles` so we can correctly use them in the link phase.
- Add `--build missing` to the Conan command line, and wrap its invocation environment in our native toolchain. This allows us to depend on native libraries which do not have precompiled binaries (most of them).
- Add a `python_binary` which uses the `IrrXML` library from conan-central (provided as a static archive) in an existing `python_dist` to parse an xml file and print the node names.
- Add an integration test for the above.

### Result

Now we can depend on native libraries like `IrrXML` in our `ctypes_compatible_c{,pp}_library` targets, which is pretty neat.