### PR TITLE
skip integration test with pants_requirement()

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import glob
 import os
 import re
+import unittest
 from builtins import open
 
 from pants.util.collections import assert_single_element
@@ -214,6 +215,7 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       output = subprocess.check_output(pex).decode('utf-8')
       self.assertEqual('Hello, world!\n', output)
 
+  @unittest.skip('Integration tests with pants_requirement() are broken, see #6490.')
   def test_pants_requirement_setup_requires_version(self):
     """Ensure that a pants_requirement() can be successfully used in setup_requires."""
     pants_run = self.run_pants(['-q', 'run', '{}:bin'.format(self.pants_setup_requires)])


### PR DESCRIPTION
### Problem

See #6490. Currently, `test_pants_requirement_setup_requires_version` requires the version of pants specified in `src/python/pants/VERSION` to have been released to pypi. This makes it somewhat difficult for release candidates to pass CI.

### Solution

- Skip `test_pants_requirement_setup_requires_version` to unbreak release CI. This is the only references to the `pants_setup_requires` target I can find in the repo.

### Result

I don't necessarily think that depending on a `pants_requirement()` in a `python_dist()`'s `setup_requires` needs to be tested in CI, and I haven't figured out whether it's appropriate to delete this test entirely. Either way, that will be figured out in a followup diff.