### PR TITLE
Add support for HTTP basic auth.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -25,7 +25,6 @@ pytest-cov>=2.5,<2.6
 pytest>=3.4,<4.0
 pywatchman==1.4.1
 requests[security]>=2.5.0,<2.19
-requests_oauthlib
 scandir==1.2
 setproctitle==1.1.10
 setuptools==33.1.1

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -25,6 +25,7 @@ pytest-cov>=2.5,<2.6
 pytest>=3.4,<4.0
 pywatchman==1.4.1
 requests[security]>=2.5.0,<2.19
+requests_oauthlib
 scandir==1.2
 setproctitle==1.1.10
 setuptools==33.1.1

--- a/src/docs/common_tasks/BUILD
+++ b/src/docs/common_tasks/BUILD
@@ -74,6 +74,11 @@ page(
 )
 
 page(
+  name='login',
+  source='login.md'
+)
+
+page(
   name='pex',
   source='pex.md',
 )

--- a/src/docs/common_tasks/index.md
+++ b/src/docs/common_tasks/index.md
@@ -20,6 +20,7 @@ This section of the Pants documentation describes the most common day-to-day Pan
 * [[Use globs and rglobs to Group Files|pants('src/docs/common_tasks:globs')]]
 * [[Access a REPL for a Target|pants('src/docs/common_tasks:repl')]]
 * [[Generate Code from Thrift Definitions|pants('src/docs/common_tasks:thrift_gen')]]
+* [[Authenticate to a Server|pants('src/docs/common_tasks:login')]]
 
 ### Scala and Java
 

--- a/src/docs/common_tasks/login.md
+++ b/src/docs/common_tasks/login.md
@@ -1,0 +1,46 @@
+# Authenticate to a Server
+
+## Problem
+
+Some Pants operations talk to remote servers. Examples include uploading build stats, querying remote caches 
+and resolving external dependencies.  But in some cases these servers may only allow access to authenticated users. 
+
+## Solution
+
+Currently Pants only supports HTTP basic auth.  How you use this depends on what the server expects:
+
+If the endpoints you're accessing (e.g., the build stats upload endpoint or the remote cache query endpoint)
+accept HTTP basic auth credentials directly, you only need add those creds to a `.netrc` entry for 
+that server.
+  
+However, in many cases the server expects you to provide credentials to an authentication endpoint, 
+in exchange for a session id, and then provide that session id in subsequent requests to the other endpoints.
+
+In the latter case, you can perform that authentication using the `login` goal, and specifying the 
+provider you're authenticating against, either with the `--to` option or with a passthru arg:
+
+```bash
+$ ./pants login --to=myauthprovider
+$ ./pants login -- myauthprovider
+```
+
+This submits credentials from `.netrc` to the provider's authentication endpoint using HTTP basic auth, 
+and stores all returned cookies (which, presumably, include the session id), for future use with the other 
+endpoints.
+
+In the future the `login` goal will optionally prompt for a username and password, allowing you to
+bypass `.netrc` altogether.
+
+
+## Required Configuration
+
+The named provider must be configured. E.g., in `pants.ini` you'd have:
+
+```ini
+[basic_auth]
+providers = {
+    'myauthprovider': {
+      'url': 'https://myauthprovider.com/path/to/authentication/endpoint'
+    }
+  }
+```

--- a/src/python/pants/auth/BUILD
+++ b/src/python/pants/auth/BUILD
@@ -1,0 +1,12 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+python_library(
+  dependencies = [
+    '3rdparty/python:requests',
+    '3rdparty/python:six',
+    'src/python/pants/subsystem',
+    'src/python/pants/util:dirutil',
+  ],
+)

--- a/src/python/pants/auth/BUILD
+++ b/src/python/pants/auth/BUILD
@@ -5,7 +5,6 @@
 python_library(
   dependencies = [
     '3rdparty/python:requests',
-    '3rdparty/python:six',
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
   ],

--- a/src/python/pants/auth/BUILD
+++ b/src/python/pants/auth/BUILD
@@ -6,6 +6,8 @@ python_library(
   dependencies = [
     '3rdparty/python:requests',
     'src/python/pants/subsystem',
+    'src/python/pants/process',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
   ],
 )

--- a/src/python/pants/auth/__init__.py
+++ b/src/python/pants/auth/__init__.py
@@ -1,6 +1,0 @@
-# coding=utf-8
-# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
-# Licensed under the Apache License, Version 2.0 (see LICENSE).
-
-from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
-                        unicode_literals, with_statement)

--- a/src/python/pants/auth/__init__.py
+++ b/src/python/pants/auth/__init__.py
@@ -1,0 +1,6 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)

--- a/src/python/pants/auth/basic_auth.py
+++ b/src/python/pants/auth/basic_auth.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from collections import namedtuple
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+from pants.auth.cookies import Cookies
+from pants.subsystem.subsystem import Subsystem
+
+
+class BasicAuthException(Exception):
+  pass
+
+
+BasicAuthCreds = namedtuple('BasicAuthCreds', ['username', 'password'])
+
+
+class BasicAuth(Subsystem):
+  options_scope = 'basic_auth'
+
+  @classmethod
+  def register_options(cls, register):
+    super(BasicAuth, cls).register_options(register)
+    register('--providers', advanced=True, type=dict,
+             help='Map from provider name to config dict. This dict contains the following items: '
+                  '{url: <url of endpoint that accepts basic auth and sets a session cookie>}')
+
+  def authenticate(self, provider, creds=None, cookies=None):
+    """Authenticate against the specified provider.
+
+    :param str provider: Authorize against this provider.
+    :param pants.auth.basic_auth.BasicAuthCreds creds: The creds to use.
+      If unspecified, assumes that creds are set in the netrc file.
+    :param pants.auth.cookies.Cookies cookies: Store the auth cookies in this instance.
+      If unspecified, uses the global instance.
+
+    """
+    cookies = cookies or Cookies.global_instance()
+
+    if not provider:
+      raise BasicAuthException('No basic auth provider specified.')
+
+    provider_config = self.get_options().providers.get(provider)
+    if not provider_config:
+      raise BasicAuthException('No config found for provider {}.'.format(provider))
+
+    url = provider_config.get('url')
+    if not url:
+      raise BasicAuthException('No url found in config for provider {}.'.format(provider_config))
+
+    if creds:
+      auth = requests.auth.HTTPBasicAuth(creds.username, creds.password)
+    else:
+      auth = None  # requests will use the netrc creds.
+    response = requests.get(url, auth=auth)
+    if response.status_code != requests.codes.ok:
+      raise BasicAuthException('Failed to auth against {}. Status code {}.'.format(
+        response, response.status_code))
+    cookies.update(response.cookies)

--- a/src/python/pants/auth/basic_auth.py
+++ b/src/python/pants/auth/basic_auth.py
@@ -52,6 +52,7 @@ class BasicAuth(Subsystem):
     url = provider_config.get('url')
     if not url:
       raise BasicAuthException('No url found in config for provider {}.'.format(provider_config))
+    # TODO: Require url to be https, except when testing.
 
     if creds:
       auth = requests.auth.HTTPBasicAuth(creds.username, creds.password)

--- a/src/python/pants/auth/basic_auth.py
+++ b/src/python/pants/auth/basic_auth.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import namedtuple
 
 import requests
-from requests.auth import HTTPBasicAuth
 
 from pants.auth.cookies import Cookies
 from pants.subsystem.subsystem import Subsystem

--- a/src/python/pants/auth/basic_auth.py
+++ b/src/python/pants/auth/basic_auth.py
@@ -52,7 +52,8 @@ class BasicAuth(Subsystem):
     url = provider_config.get('url')
     if not url:
       raise BasicAuthException('No url found in config for provider {}.'.format(provider_config))
-    # TODO: Require url to be https, except when testing.
+    # TODO: Require url to be https, except when testing. See
+    # https://github.com/pantsbuild/pants/issues/6496.
 
     if creds:
       auth = requests.auth.HTTPBasicAuth(creds.username, creds.password)

--- a/src/python/pants/auth/basic_auth.py
+++ b/src/python/pants/auth/basic_auth.py
@@ -30,6 +30,10 @@ class BasicAuth(Subsystem):
              help='Map from provider name to config dict. This dict contains the following items: '
                   '{url: <url of endpoint that accepts basic auth and sets a session cookie>}')
 
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(BasicAuth, cls).subsystem_dependencies() + (Cookies,)
+
   def authenticate(self, provider, creds=None, cookies=None):
     """Authenticate against the specified provider.
 
@@ -38,7 +42,8 @@ class BasicAuth(Subsystem):
       If unspecified, assumes that creds are set in the netrc file.
     :param pants.auth.cookies.Cookies cookies: Store the auth cookies in this instance.
       If unspecified, uses the global instance.
-
+    :raises pants.auth.basic_auth.BasicAuthException: If auth fails due to misconfiguration or
+      rejection by the server.
     """
     cookies = cookies or Cookies.global_instance()
 

--- a/src/python/pants/auth/cookies.py
+++ b/src/python/pants/auth/cookies.py
@@ -20,8 +20,9 @@ class Cookies(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(Cookies, cls).register_options(register)
-    register('--path', advanced=True, fingerprint=True, default='~/.pants.cookies',
-             help='Path to file that stores persistent cookies.')
+    register('--path', advanced=True, fingerprint=True, default=None,
+             help='Path to file that stores persistent cookies. '
+                  'Defaults to <pants bootstrap dir>/auth/cookies.')
 
   def update(self, cookies):
     """Add specified cookies to our cookie jar, and persists it.
@@ -49,7 +50,12 @@ class Cookies(Subsystem):
     return cookie_jar
 
   def _get_cookie_file(self):
-    return os.path.realpath(os.path.expanduser(self.get_options().path))
+    path = self.get_options().path
+    if path is None:
+      path = os.path.join(self.get_options().pants_bootstrapdir, 'auth', 'cookies')
+    else:
+      path = os.path.realpath(os.path.expanduser(path))
+    return path
 
   @memoized_property
   def _lock(self):

--- a/src/python/pants/auth/cookies.py
+++ b/src/python/pants/auth/cookies.py
@@ -1,0 +1,52 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+from six.moves.http_cookiejar import LWPCookieJar
+
+from pants.subsystem.subsystem import Subsystem
+from pants.util.dirutil import safe_mkdir_for
+
+
+class BasicAuthException(Exception):
+  pass
+
+
+class Cookies(Subsystem):
+  options_scope = 'cookies'
+
+  @classmethod
+  def register_options(cls, register):
+    super(Cookies, cls).register_options(register)
+    register('--path', advanced=True, default='~/.pants.cookies',
+             help='Path to file that stores persistent cookies.')
+
+  def update(self, cookies):
+    """Add specified cookies to our cookie jar, and persists it.
+
+    :param cookies: Any iterable that yields http.cookiejar.Cookie instances, such as a CookieJar.
+    """
+    cookie_jar = self.get_cookie_jar()
+    for cookie in cookies:
+      cookie_jar.set_cookie(cookie)
+    cookie_jar.save()
+
+  def get_cookie_jar(self):
+    """Returns our cookie jar."""
+    cookie_file = self._get_cookie_file()
+    cookie_jar = LWPCookieJar(cookie_file)
+    if os.path.exists(cookie_file):
+      cookie_jar.load()
+    else:
+      safe_mkdir_for(cookie_file)
+      # Save an empty cookie jar so we can change the file perms on it before writing data to it.
+      cookie_jar.save()
+      os.chmod(cookie_file, 0o600)
+    return cookie_jar
+
+  def _get_cookie_file(self):
+    return os.path.realpath(os.path.expanduser(self.get_options().path))

--- a/src/python/pants/auth/cookies.py
+++ b/src/python/pants/auth/cookies.py
@@ -6,14 +6,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 
-from six.moves.http_cookiejar import LWPCookieJar
+from future.moves.http.cookiejar import LWPCookieJar
 
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import safe_mkdir_for
-
-
-class BasicAuthException(Exception):
-  pass
 
 
 class Cookies(Subsystem):
@@ -22,7 +18,7 @@ class Cookies(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(Cookies, cls).register_options(register)
-    register('--path', advanced=True, default='~/.pants.cookies',
+    register('--path', advanced=True, fingerprint=True, default='~/.pants.cookies',
              help='Path to file that stores persistent cookies.')
 
   def update(self, cookies):

--- a/src/python/pants/auth/cookies.py
+++ b/src/python/pants/auth/cookies.py
@@ -20,7 +20,8 @@ class Cookies(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(Cookies, cls).register_options(register)
-    register('--path', advanced=True, fingerprint=True, default=None,
+    register('--path', advanced=True, fingerprint=True,
+             default=os.path.join(register.bootstrap.pants_bootstrapdir, 'auth', 'cookies'),
              help='Path to file that stores persistent cookies. '
                   'Defaults to <pants bootstrap dir>/auth/cookies.')
 
@@ -50,12 +51,8 @@ class Cookies(Subsystem):
     return cookie_jar
 
   def _get_cookie_file(self):
-    path = self.get_options().path
-    if path is None:
-      path = os.path.join(self.get_options().pants_bootstrapdir, 'auth', 'cookies')
-    else:
-      path = os.path.realpath(os.path.expanduser(path))
-    return path
+    # We expanduser to make it easy for the user to config the cookies into their homedir.
+    return os.path.realpath(os.path.expanduser(self.get_options().path))
 
   @memoized_property
   def _lock(self):

--- a/src/python/pants/core_tasks/BUILD
+++ b/src/python/pants/core_tasks/BUILD
@@ -8,6 +8,7 @@ python_library(
     '3rdparty/python:packaging',
     '3rdparty/python:setuptools',
     ':templates',
+    'src/python/pants/auth',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',

--- a/src/python/pants/core_tasks/login.py
+++ b/src/python/pants/core_tasks/login.py
@@ -29,7 +29,6 @@ class Login(Task):
     register('--to', fingerprint=True,
              help='Log in to this provider.  Can also be specified as a passthru arg.')
 
-
   def execute(self):
     # TODO: When we have other auth methods (e.g., OAuth2), select one by provider name.
     requested_providers = list(filter(None, [self.get_options().to] + self.get_passthru_args()))

--- a/src/python/pants/core_tasks/login.py
+++ b/src/python/pants/core_tasks/login.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from pants.auth.basic_auth import BasicAuth
+from pants.base.exceptions import TaskError
+from pants.task.task import Task
+
+
+class Login(Task):
+  """Task to auth against some identity provider.
+
+  :API: public
+  """
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(Login, cls).subsystem_dependencies() + (BasicAuth,)
+
+  @classmethod
+  def supports_passthru_args(cls):
+    return True
+
+  @classmethod
+  def register_options(cls, register):
+    super(Login, cls).register_options(register)
+    register('--to', fingerprint=True,
+             help='Log in to this provider.  Can also be specified as a passthru arg.')
+
+
+  def execute(self):
+    # TODO: When we have other auth methods (e.g., OAuth2), select one by provider name.
+    requested_providers = list(filter(None, [self.get_options().to] + self.get_passthru_args()))
+    if len(requested_providers) != 1:
+      raise TaskError('Must specify exactly one provider.')
+    BasicAuth.global_instance().authenticate(requested_providers[0])

--- a/src/python/pants/core_tasks/login.py
+++ b/src/python/pants/core_tasks/login.py
@@ -35,4 +35,5 @@ class Login(Task):
     requested_providers = list(filter(None, [self.get_options().to] + self.get_passthru_args()))
     if len(requested_providers) != 1:
       raise TaskError('Must specify exactly one provider.')
+    # TODO: An interactive mode where we prompt for creds. Currently we assume they are in netrc.
     BasicAuth.global_instance().authenticate(requested_providers[0])

--- a/src/python/pants/core_tasks/register.py
+++ b/src/python/pants/core_tasks/register.py
@@ -9,6 +9,7 @@ from pants.core_tasks.clean import Clean
 from pants.core_tasks.deferred_sources_mapper import DeferredSourcesMapper
 from pants.core_tasks.explain_options_task import ExplainOptionsTask
 from pants.core_tasks.list_goals import ListGoals
+from pants.core_tasks.login import Login
 from pants.core_tasks.noop import NoopCompile, NoopTest
 from pants.core_tasks.pantsd_kill import PantsDaemonKill
 from pants.core_tasks.reporting_server_kill import ReportingServerKill
@@ -66,6 +67,9 @@ def register_goals():
   # TODO: The reporting server should be subsumed into pantsd, and not run via a task.
   task(name='server', action=ReportingServerRun, serialize=False).install()
   task(name='killserver', action=ReportingServerKill, serialize=False).install()
+
+  # Auth.
+  task(name='login', action=Login).install()
 
   # Getting help.
   task(name='goals', action=ListGoals).install()

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -95,6 +95,7 @@ python_library(
     ':pantsd_stats',
     '3rdparty/python:requests',
     '3rdparty/python:pyopenssl',
+    'src/python/pants/auth',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:run_info',
     'src/python/pants/base:worker_pool',

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -62,7 +62,7 @@ class RunTracker(Subsystem):
 
   @classmethod
   def subsystem_dependencies(cls):
-    return (StatsDBFactory, Cookies)
+    return super(RunTracker, cls).subsystem_dependencies() + (StatsDBFactory, Cookies)
 
   @classmethod
   def register_options(cls, register):

--- a/tests/python/pants_test/auth/BUILD
+++ b/tests/python/pants_test/auth/BUILD
@@ -1,0 +1,10 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_tests(
+  dependencies=[
+    'src/python/pants/auth',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:test_base',
+  ]
+)

--- a/tests/python/pants_test/auth/__init__.py
+++ b/tests/python/pants_test/auth/__init__.py
@@ -1,6 +1,0 @@
-# coding=utf-8
-# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
-# Licensed under the Apache License, Version 2.0 (see LICENSE).
-
-from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
-                        unicode_literals, with_statement)

--- a/tests/python/pants_test/auth/__init__.py
+++ b/tests/python/pants_test/auth/__init__.py
@@ -1,0 +1,6 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)

--- a/tests/python/pants_test/auth/test_basic_auth.py
+++ b/tests/python/pants_test/auth/test_basic_auth.py
@@ -8,7 +8,7 @@ import base64
 import os
 import threading
 
-from future.moves.http.server import BaseHTTPServer
+from future.moves.http.server import BaseHTTPRequestHandler, HTTPServer
 
 from pants.auth.basic_auth import BasicAuth, BasicAuthCreds
 from pants.auth.cookies import Cookies
@@ -16,7 +16,7 @@ from pants.util.contextutil import environment_as, temporary_dir
 from pants_test.test_base import TestBase
 
 
-class RequestHandlerForTest(BaseHTTPServer.BaseHTTPRequestHandler):
+class RequestHandlerForTest(BaseHTTPRequestHandler):
   def do_GET(self):
     auth_header = self.headers.get('Authorization')
     assert auth_header is not None
@@ -31,7 +31,7 @@ class RequestHandlerForTest(BaseHTTPServer.BaseHTTPRequestHandler):
 
 
 def _run_test_server():
-  httpd = BaseHTTPServer.HTTPServer(('localhost', 0), RequestHandlerForTest)
+  httpd = HTTPServer(('localhost', 0), RequestHandlerForTest)
   thread = threading.Thread(target=httpd.serve_forever)
   thread.daemon = True
   thread.start()

--- a/tests/python/pants_test/auth/test_basic_auth.py
+++ b/tests/python/pants_test/auth/test_basic_auth.py
@@ -75,8 +75,7 @@ class TestBasicAuth(TestBase):
 
   def test_basic_auth_from_netrc(self):
     with temporary_dir(cleanup=False) as tmphomedir:
-      with open(os.path.join(tmphomedir, '.netrc'), 'w') as fp:
-        fp.write('machine localhost\nlogin {}\npassword {}'.format(
-          'test_user', 'test_password').encode('ascii'))
+      with open(os.path.join(tmphomedir, '.netrc'), 'wb') as fp:
+        fp.write('machine localhost\nlogin test_user\npassword test_password'.encode('ascii'))
       with environment_as(HOME=tmphomedir):
         self._do_test_basic_auth(creds=None)

--- a/tests/python/pants_test/auth/test_basic_auth.py
+++ b/tests/python/pants_test/auth/test_basic_auth.py
@@ -1,0 +1,80 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import base64
+import os
+import threading
+
+from six.moves import BaseHTTPServer
+
+from pants.auth.basic_auth import BasicAuth, BasicAuthCreds
+from pants.auth.cookies import Cookies
+from pants.util.contextutil import environment_as, temporary_dir
+from pants_test.test_base import TestBase
+
+
+class RequestHandlerForTest(BaseHTTPServer.BaseHTTPRequestHandler):
+  def do_GET(self):
+    auth_header = self.headers.get('Authorization')
+    assert auth_header is not None
+    token_type, _, credentials = auth_header.partition(' ')
+    assert token_type == 'Basic'
+    username, password = base64.b64decode(credentials).decode('utf8').split(':')
+    assert username == 'test_user'
+    assert password == 'test_password'
+    self.send_response(200)
+    self.send_header('Set-Cookie', 'test_auth_key=test_auth_value; Max-Age=3600')
+    self.end_headers()
+
+def _run_test_server():
+  httpd = BaseHTTPServer.HTTPServer(('localhost', 0), RequestHandlerForTest)
+  thread = threading.Thread(target=httpd.serve_forever)
+  thread.daemon = True
+  thread.start()
+  return httpd.server_port
+
+
+class TestBasicAuth(TestBase):
+  def setUp(self):
+    super(TestBasicAuth, self).setUp()
+    self.port = _run_test_server()
+
+  def _do_test_basic_auth(self, creds):
+    with temporary_dir() as tmpcookiedir:
+      cookie_file = os.path.join(tmpcookiedir, 'pants.test.cookies')
+
+      self.context(for_subsystems=[BasicAuth, Cookies], options={
+        BasicAuth.options_scope: {
+          'providers': {
+            'foobar': { 'url': 'http://localhost:{}'.format(self.port) }
+          }
+        },
+        Cookies.options_scope: {
+          'path': cookie_file
+        }
+      })
+
+      basic_auth = BasicAuth.global_instance()
+      cookies = Cookies.global_instance()
+
+      self.assertListEqual([], list(cookies.get_cookie_jar()))
+      basic_auth.authenticate(provider='foobar', creds=creds, cookies=cookies)
+      cookies_list = list(cookies.get_cookie_jar())
+      self.assertEqual(1, len(cookies_list))
+      auth_cookie = cookies_list[0]
+      self.assertEqual('test_auth_key', auth_cookie.name)
+      self.assertEqual('test_auth_value', auth_cookie.value)
+
+  def test_basic_auth_with_explicit_creds(self):
+    self._do_test_basic_auth(creds=BasicAuthCreds('test_user', 'test_password'))
+
+  def test_basic_auth_from_netrc(self):
+    with temporary_dir(cleanup=False) as tmphomedir:
+      with open(os.path.join(tmphomedir, '.netrc'), 'w') as fp:
+        fp.write('machine localhost\nlogin {}\npassword {}'.format(
+          'test_user', 'test_password').encode('ascii'))
+      with environment_as(HOME=tmphomedir):
+        self._do_test_basic_auth(creds=None)

--- a/tests/python/pants_test/auth/test_cookies.py
+++ b/tests/python/pants_test/auth/test_cookies.py
@@ -27,5 +27,5 @@ class TestCookies(TestBase):
       self.assertFalse(os.path.exists(cookie_file))
       cookies.update([])
       self.assertTrue(os.path.exists(cookie_file))
-      file_permissions = oct(os.stat(cookie_file).st_mode)
-      self.assertEqual('0100600', file_permissions)
+      file_permissions = os.stat(cookie_file).st_mode
+      self.assertEqual(int('0100600', 8), file_permissions)

--- a/tests/python/pants_test/auth/test_cookies.py
+++ b/tests/python/pants_test/auth/test_cookies.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+from pants.auth.cookies import Cookies
+from pants.util.contextutil import temporary_dir
+from pants_test.test_base import TestBase
+
+
+class TestCookies(TestBase):
+
+  def test_cookie_file_permissions(self):
+    with temporary_dir() as tmpcookiedir:
+      cookie_file = os.path.join(tmpcookiedir, 'pants.test.cookies')
+
+      self.context(for_subsystems=[Cookies], options={
+        Cookies.options_scope: {
+          'path': cookie_file
+        }
+      })
+
+      cookies = Cookies.global_instance()
+      self.assertFalse(os.path.exists(cookie_file))
+      cookies.update([])
+      self.assertTrue(os.path.exists(cookie_file))
+      file_permissions = oct(os.stat(cookie_file).st_mode)
+      self.assertEqual('0100600', file_permissions)

--- a/tests/python/pants_test/goal/BUILD
+++ b/tests/python/pants_test/goal/BUILD
@@ -24,6 +24,7 @@ python_tests(
   dependencies=[
     '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/auth',
     'src/python/pants/build_graph',
     'src/python/pants/goal:products',
     'src/python/pants/goal:run_tracker',

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -11,6 +11,7 @@ from builtins import open
 
 from future.moves.urllib.parse import parse_qs
 
+from pants.auth.cookies import Cookies
 from pants.goal.run_tracker import RunTracker
 from pants.util.contextutil import temporary_file_path
 from pants_test.test_base import TestBase
@@ -42,6 +43,7 @@ class RunTrackerTest(TestBase):
     server_thread.daemon = True
     server_thread.start()
 
+    self.context(for_subsystems=[Cookies])
     self.assertTrue(RunTracker.post_stats('http://{}:{}/upload'.format(host, port), stats))
 
     server.shutdown()


### PR DESCRIPTION
Currently pants has no concept of authentication against a remote service (e.g., a remote artifact cache or a stats upload endpoint).  This change introduces HTTP basic auth functionality.

This includes:

1. A subsystem that configures basic auth providers, mapping a name to a url that accepts basic auth creds.
2. Code that sends basic auth creds to the url, and captures the persistent cookies it returns. Said creds may be provided explicitly, or via netrc.
3. A `login` task that triggers 2. It currently accepts no creds, so it can only be used with netrc.
4. Application of those cookies to stats upload requests (but not, yet, cache requests).
