### PR TITLE
make fatal_warnings_enabled_args a tuple in javac  compile instead of just parens

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -60,7 +60,7 @@ class JavacCompile(JvmCompile):
 
   @classmethod
   def get_fatal_warnings_enabled_args_default(cls):
-    return ('-Werror')
+    return ('-Werror',)
 
   @classmethod
   def get_fatal_warnings_disabled_args_default(cls):


### PR DESCRIPTION
### Problem

```
> ./pants options | grep compile.javac.fatal_warnings_enabled_args
compile.javac.fatal_warnings_enabled_args =  [u'-', u'W', u'e', u'r', u'r', u'o', u'r'] (from HARDCODED)
```

### Solution

- Add a comma to make a tuple instead of a string in the javac compile task.

### Result

The default value is a list of strings, not a string split into single characters and wrapped into a list.