### PR TITLE
Apply  workaround similer to #6409 to bootstrapper

### DIFF
--- a/src/scala/org/pantsbuild/zinc/bootstrapper/Main.scala
+++ b/src/scala/org/pantsbuild/zinc/bootstrapper/Main.scala
@@ -17,6 +17,10 @@ object Main {
                          Seq(cliArgs.scalaReflect),
                          cliArgs.scalaLibrary)
 
+        // As per https://github.com/pantsbuild/pants/issues/6160, this is a workaround
+        // so we can run zinc without $PATH (as needed in remoting).
+        System.setProperty("sbt.log.format", "true")
+
         val cl = ConsoleLogger.apply()
 
         BootstrapperUtils


### PR DESCRIPTION
## Problem & Solution (It's a small PR)

The new zinc-bootstrapper jar had the same issue as the compiler, described in #6160.
This PR applies a similar workaround to #6409, as a step towards passing regex-based CI tests in #6463.

This needs a pants committer to publish zinc-bootstrapper.