### PR TITLE
pass through `compatibility` to synthetic python thrift targets

### DIFF
--- a/src/python/pants/backend/codegen/thrift/python/apache_thrift_py_gen.py
+++ b/src/python/pants/backend/codegen/thrift/python/apache_thrift_py_gen.py
@@ -51,6 +51,10 @@ class ApacheThriftPyGen(ApacheThriftGenBase):
         # leave as-is.
         pass
 
+  @property
+  def _copy_target_attributes(self):
+    return super(ApacheThriftPyGen, self)._copy_target_attributes + ['compatibility']
+
   def ignore_dup(self, tgt1, tgt2, rel_src):
     # Thrift generates all the intermediate __init__.py files, and they shouldn't
     # count as dups.


### PR DESCRIPTION
### Problem

Resolves #6484.

### Solution

- Add `compatibility` to the override of `_copy_target_attributes()` for `ApacheThriftPyGen`.
- Add a test to ensure the generated targets resolve an interpreter matching the one indicated by `compatibility`.