### PR TITLE
[WIP] let merge_snapshots() allow duplicate PathStats if they originate from the same base directory

### DIFF
--- a/src/python/pants/source/payload_fields.py
+++ b/src/python/pants/source/payload_fields.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
 from hashlib import sha1
 
 from future.utils import PY3
@@ -14,6 +15,9 @@ from pants.source.filespec import matches_filespec
 from pants.source.source_root import SourceRootConfig
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetWithSpec
 from pants.util.memo import memoized_property
+
+
+logger = logging.getLogger(__name__)
 
 
 class SourcesField(PayloadField):
@@ -66,7 +70,7 @@ class SourcesField(PayloadField):
     """Returns the address this sources field refers to (used by some derived classes)"""
     return self._ref_address
 
-  def snapshot(self, scheduler=None):
+  def snapshot(self, scheduler=None, throw=False):
     """
     Returns a Snapshot containing the sources, relative to the build root.
 
@@ -77,6 +81,9 @@ class SourcesField(PayloadField):
       if snapshot is not None:
         return snapshot
     input_pathglobs = PathGlobs(tuple(self.relative_to_buildroot()))
+    if throw:
+      raise Exception('input_pathglobs: {}'.format(input_pathglobs))
+    logger.debug('input_pathglobs: {}'.format(input_pathglobs))
     return scheduler.product_request(Snapshot, [input_pathglobs])[0]
 
   def relative_to_buildroot(self):


### PR DESCRIPTION
*WIP because it doesn't even compile, will get to this this week*

### Problem

If two targets in the same directory share any source files, merging their snapshots blows up (for e.g. thrift targets generating code for more than one language, this happens 100% of the time).

You can repro this with `./pants cloc tests/python/pants_test/backend/python/tasks:`. *(This also exposes another thing to fix, which is that those test targets definitely shouldn't share sources.)*

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

- I'm currently looking into allowing duplicate `PathStat`s if they both were linked back to the same base directory, which involved adding a `base_dir: Option<PathStat>` field to `Snapshot`. The idea is that if `base_dir` is provided, and it matches the `base_dir` of another `Snapshot`, we know they are unambiguously referring to a single file path. Look at the changes to the `merge_snapshots()` method in the `fs` crate.
- This works fine, but fixing things like the `cloc` command above requires editing duplicate path checks across multiple functions (for example, `merge_snapshots()` and `merge_directories()` both do file deduplication).
- I think this path deduplication logic can be centralized somehow, and that it can be made to respect `base_dir`.

(_describe the modifications you've made._)

### Result

v2 rules don't blow up if they use targets that happen to share source files.

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)