### PR TITLE
gRPC support for golang protobufs.

### DIFF
--- a/contrib/go/README.md
+++ b/contrib/go/README.md
@@ -304,6 +304,38 @@ In Go, we can import and use the protobuf generated code as it were regular Go c
 
 !inc[start-at=main](examples/src/go/distance/main.go)
 
+To select the version of the go protobuf runtime your generated code depends on, set option `import_target`
+in scope `gen.go-protobuf` to point to an appropriate target address. E.g.,
+
+```ini
+[gen.go-protobuf]
+import_target: 3rdparty/go/github.com/golang/protobuf/proto
+```
+
+(Where 3rdparty/go/github.com/golang/protobuf/proto was presumably created by the buildgen process
+described above.)
+
+## gRPC
+
+Pants supports the proto compiler's gRPC plugin. You can activate it for a single `go_protobuf_library`
+by adding  the `protoc_plugins=['grpc']` argument. See, e.g.,
+[`contrib/go/examples/src/protobuf/org/pantsbuild/example/grpc/BUILD`](https://github.com/pantsbuild/pants/blob/master/contrib/go/examples/src/protobuf/org/pantsbuild/example/grpc/BUILD)
+
+You can also activate it for all `go_protobuf_library` targets in your repo, using the `protoc_plugins`
+option in scope `gen.go-protobuf`. E.g., add this to your `pants.ini`:
+
+```ini
+[gen.go-protobuf]
+protoc_plugins=["grpc"]
+import_target: src/protobuf:grpc-deps
+```
+
+Note that we also modify `import_target`, as your code must now depend on the gRPC runtime.
+See, e.g.,
+[`contrib/go/examples/src/protobuf/org/pantsbuild/example/BUILD`](https://github.com/pantsbuild/pants/blob/master/contrib/go/examples/src/protobuf/org/pantsbuild/example/BUILD)
+
+Note that you can activate other plugins, should any become available, in a similar fashion.
+
 ## Working with other Go ecosystem tools
 
 Go and the Go ecosystem provide rich tool support. From native Go tools like `go list` and `go vet`

--- a/contrib/go/examples/3rdparty/go/golang.org/x/net/BUILD
+++ b/contrib/go/examples/3rdparty/go/golang.org/x/net/BUILD
@@ -2,7 +2,7 @@
 # To re-generate run: `pants buildgen.go --materialize --remote`
 
 go_remote_libraries(
-  rev='release-branch.go1.6',
+  rev='release-branch.go1.8',
   packages=[
     'http2',
   ]

--- a/contrib/go/examples/3rdparty/go/google.golang.org/genproto/BUILD
+++ b/contrib/go/examples/3rdparty/go/google.golang.org/genproto/BUILD
@@ -2,8 +2,8 @@
 # To re-generate run: `pants buildgen.go --materialize --remote`
 
 go_remote_libraries(
-  rev='a47340a8e42c4ceb44c00c2a05199e24b24fcaef',
+  rev='4b56f30a1fd96a133a036b62cdd2a249883dd89b',
   packages=[
-    'proto',
+    'googleapis/rpc/status',
   ]
 )

--- a/contrib/go/examples/3rdparty/go/google.golang.org/grpc/BUILD
+++ b/contrib/go/examples/3rdparty/go/google.golang.org/grpc/BUILD
@@ -2,5 +2,5 @@
 # To re-generate run: `pants buildgen.go --materialize --remote`
 
 go_remote_library(
-  rev='785723ef9ce0a96b463848ac3ca912ce1db7250f',
+  rev='bfa5dd27dc338e49287e5b350d6d817bad8992bf',
 )

--- a/contrib/go/examples/src/protobuf/org/pantsbuild/example/BUILD
+++ b/contrib/go/examples/src/protobuf/org/pantsbuild/example/BUILD
@@ -1,0 +1,11 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+target(
+  name = 'protobuf-deps',
+  dependencies = [
+    'contrib/go/examples/3rdparty/go/github.com/golang/protobuf:proto',
+    'contrib/go/examples/3rdparty/go/google.golang.org/grpc',
+    'contrib/go/examples/3rdparty/go/golang.org/x/net:http2',
+  ]
+)

--- a/contrib/go/examples/src/protobuf/org/pantsbuild/example/grpc/BUILD
+++ b/contrib/go/examples/src/protobuf/org/pantsbuild/example/grpc/BUILD
@@ -1,0 +1,9 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+go_protobuf_library(name='grpc-go',
+                    # dependencies=[
+                    #   'contrib/go/examples/3rdparty/go/google.golang.org/grpc',
+                    # ],
+                    protoc_plugins=['grpc'])
+

--- a/contrib/go/examples/src/protobuf/org/pantsbuild/example/grpc/BUILD
+++ b/contrib/go/examples/src/protobuf/org/pantsbuild/example/grpc/BUILD
@@ -2,8 +2,4 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 go_protobuf_library(name='grpc-go',
-                    # dependencies=[
-                    #   'contrib/go/examples/3rdparty/go/google.golang.org/grpc',
-                    # ],
                     protoc_plugins=['grpc'])
-

--- a/contrib/go/examples/src/protobuf/org/pantsbuild/example/grpc/service.proto
+++ b/contrib/go/examples/src/protobuf/org/pantsbuild/example/grpc/service.proto
@@ -1,0 +1,21 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+syntax = "proto3";
+
+package org.pantsbuild.example.grpc;
+
+option go_package = "pantsbuild/example/grpc";
+
+
+message SnowReportRequest {
+  string zipcode = 1;
+}
+
+message SnowReportReply {
+  bool has_snow = 1;
+}
+
+service SnowReport {
+  rpc Report (SnowReportRequest) returns (SnowReportReply) {}
+}

--- a/contrib/go/src/python/pants/contrib/go/targets/go_protobuf_library.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_protobuf_library.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants.base.payload import Payload
+from pants.base.payload_field import PrimitivesSetField
 from pants.build_graph.target import Target
 
 from pants.contrib.go.targets.go_local_source import GoLocalSource
@@ -20,6 +21,7 @@ class GoProtobufLibrary(Target):
                address=None,
                payload=None,
                sources=None,
+               protoc_plugins=None,
                **kwargs):
     """
     :param sources: protobuf source files
@@ -29,15 +31,26 @@ class GoProtobufLibrary(Target):
     payload = payload or Payload()
     payload.add_field('sources',
                       self.create_sources_field(sources, address.spec_path, key_arg='sources'))
+    payload.add_field('protoc_plugins',
+                      PrimitivesSetField(protoc_plugins or []))
 
     super(GoProtobufLibrary, self).__init__(payload=payload, address=address, **kwargs)
 
   @classmethod
   def alias(cls):
-    return "go_protobuf_library"
+    return 'go_protobuf_library'
+
+  @property
+  def protoc_plugins(self):
+    """The names of protoc plugins to use when generating code from this target.
+
+    :rtype: list of strings.
+    """
+    return self.payload.protoc_plugins
 
 
 class GoProtobufGenLibrary(GoTarget):
+  """A target encapsulating the generated .go sources."""
 
   def __init__(self, sources=None, address=None, payload=None, **kwargs):
     payload = payload or Payload()

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_protobuf_gen.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_protobuf_gen.py
@@ -36,6 +36,8 @@ class GoProtobufGen(SimpleCodegenTask):
 
     register('--import-target', type=target_option, fingerprint=True,
              help='Target that will be added as a dependency of protoc-generated Go code.')
+    register('--protoc-plugins', type=list, fingerprint=True,
+             help='List of protoc plugins to activate.  E.g., grpc.')
 
   @classmethod
   def subsystem_dependencies(cls):
@@ -75,7 +77,12 @@ class GoProtobufGen(SimpleCodegenTask):
 
     outdir = os.path.join(target_workdir, 'src', 'go')
     safe_mkdir(outdir)
-    target_cmd.append('--go_out={}'.format(outdir))
+    protoc_plugins = self.get_options().protoc_plugins + list(target.protoc_plugins)
+    if protoc_plugins:
+      go_out = 'plugins={}:{}'.format('+'.join(protoc_plugins), outdir)
+    else:
+      go_out = outdir
+    target_cmd.append('--go_out={}'.format(go_out))
 
     all_sources = list(target.sources_relative_to_buildroot())
     for source in all_sources:

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_protoc_gen_go_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_protoc_gen_go_integration.py
@@ -13,3 +13,8 @@ class ProtocGenGoTest(PantsRunIntegrationTest):
     args = ['compile', 'contrib/go/examples/src/go/distance']
     pants_run = self.run_pants(args)
     self.assert_success(pants_run)
+
+  def test_go_compile_grpc(self):
+    args = ['compile', 'contrib/go/examples/src/protobuf/org/pantsbuild/example/grpc:grpc-go']
+    pants_run = self.run_pants(args)
+    self.assert_success(pants_run)

--- a/pants.ini
+++ b/pants.ini
@@ -162,7 +162,7 @@ antlr3_deps: ["3rdparty/python:antlr-3.1.3"]
 
 
 [gen.go-protobuf]
-import_target: contrib/go/3rdparty/go/github.com/golang/protobuf/proto
+import_target: contrib/go/examples/src/protobuf/org/pantsbuild/example:protobuf-deps
 
 
 [compile.errorprone]

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -50,4 +50,4 @@ OptionNameDash = mk_registration_error('Option name must begin with a dash.')
 OptionNameDoubleDash = mk_registration_error('Long option name must begin with a double-dash.')
 RecursiveSubsystemOption = mk_registration_error("Subsystem option cannot specify 'recursive'. "
                                                  "Subsystem options are always recursive.")
-Shadowing = mk_registration_error('Option shadows an option in scope {outer_scope}')
+Shadowing = mk_registration_error('Option shadows an option in {outer_scope}')


### PR DESCRIPTION
Required updating a host of revs of remote libs in our examples
to support proto3 and relatively recent gRPC.

