### PR TITLE
Refactor pantsd integration test framework

### DIFF
--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -47,17 +47,23 @@ class PantsDaemonMonitor(ProcessManager):
   def assert_started(self, timeout=.1):
     self._process = None
     self._pid = self.await_pid(timeout)
-    self.assert_running()
+    self._check_pantsd_is_alive()
+    return self._pid
+
+  def _check_pantsd_is_alive(self):
+    self._log()
+    assert self._pid is not None and self.is_alive(), 'cannot assert that pantsd is running. Try calling assert_started before calling this method.'
     return self._pid
 
   def assert_running(self):
-    self._log()
-    assert self._pid is not None and self.is_alive(), 'pantsd should be running!'
-    return self._pid
+    if not self._pid:
+      return self.assert_started()
+    else:
+      return self._check_pantsd_is_alive()
 
   def assert_stopped(self):
     self._log()
-    assert self._pid is not None, 'cant assert stoppage on an unknown pid!'
+    assert self._pid is not None, 'cannot assert pantsd stoppage. Try calling assert_started before calling this method.'
     assert self.is_dead(), 'pantsd should be stopped!'
     return self._pid
 


### PR DESCRIPTION
### Problem

When running a pantsd in integration tests, the dependency between `assert_started` and `assert_running` is not clear to the developer.

### Solution

Since we effectively use `_pid` as a flag to control whether or not we called `assert_running`, a solution is to call `assert_started` behind the scenes when we call `assert_running` before we should.

Since the new call to `assert_started` is dependent on a `_pid` being unset, it multiple calls to `assert_running` will be idempotent.

### Result

A new helper function that does what `assert_running` did (to remove the call from `assert_started` to `assert_running`), and a modification to `assert_running` to call `assert_started` if the pid isn't there.