### PR TITLE
Revert "Update notes for 1.10.0rc1"

### DIFF
--- a/src/python/pants/notes/1.10.x.rst
+++ b/src/python/pants/notes/1.10.x.rst
@@ -3,22 +3,10 @@
 
 This document describes releases leading up to the ``1.10.x`` ``stable`` series.
 
+1.10.0 (09/10/2018)
+-------------------
 
-1.10.0rc1 (09/17/2018)
-----------------------
-
-Bugfixes
-~~~~~~~~
-
-* Fix encoding of workunits under pantsd (#6505)
-  `PR #6505 <https://github.com/pantsbuild/pants/pull/6505>`_
-
-Documentation
-~~~~~~~~~~~~~
-
-* Fix formatting in notes (#6482)
-  `PR #6482 <https://github.com/pantsbuild/pants/pull/6482>`_
-
+The first stable release of the 1.10.x series.
 
 1.10.0rc0 (09/10/2018)
 ----------------------
@@ -74,7 +62,6 @@ Bugfixes
 * Remove broken pyenv shims from the PATH. (#6469)
   `PR #6469 <https://github.com/pantsbuild/pants/pull/6469>`_
 
-
 Refactoring, Improvements, and Tooling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -112,7 +99,6 @@ Documentation
 
 * Minor tweak on blogpost (#6438)
   `PR #6438 <https://github.com/pantsbuild/pants/pull/6438>`_
-
 
 1.10.0.dev5 (08/31/2018)
 ------------------------


### PR DESCRIPTION
Reverts pantsbuild/pants#6509
Merged into `1.10.x` branch instead of `master`