### PR TITLE
Upgrade Node.js to 8.11.3 and Yarn to 1.6.0

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -34,7 +34,7 @@ class NodeDistribution(NativeTool):
 
   options_scope = 'node-distribution'
   name = 'node'
-  default_version = 'v6.9.1'
+  default_version = 'v8.11.3'
   archive_type = 'tgz'
 
   @classmethod

--- a/contrib/node/src/python/pants/contrib/node/subsystems/yarnpkg_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/yarnpkg_distribution.py
@@ -17,5 +17,5 @@ class YarnpkgDistribution(NativeTool):
 
   options_scope = 'yarnpkg-distribution'
   name = 'yarnpkg'
-  default_version = 'v0.19.1'
+  default_version = 'v1.6.0'
   archive_type = 'tgz'

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -132,7 +132,7 @@ class JavascriptStyleBase(NodeTask):
     if ignore_patterns:
       # Wrap ignore-patterns in quotes to avoid conflict with shell glob pattern
       args.extend([arg for ignore_args in ignore_patterns
-                   for arg in ['--ignore-pattern', '"{}"'.format(ignore_args)]])
+                   for arg in ['--ignore-pattern', '{}'.format(ignore_args)]])
     if other_args:
       args.extend(other_args)
     args.extend(files)


### PR DESCRIPTION
### Problem
The version of Node.js and Yarnpkg in Pants is outdated by a year. This is duplicating #6341, but has fixes to the Travis CI test failures.

### Solution
Upgrade Node.js to v8.11.3 and Yarnpkg to v1.6.0

### Result
Node.js is by default v8.11.3 and Yarnpkg to v1.6.0