### PR TITLE
Prepare the 1.9.0 release.

### DIFF
--- a/src/python/pants/notes/1.9.x.rst
+++ b/src/python/pants/notes/1.9.x.rst
@@ -3,6 +3,11 @@
 
 This document describes releases leading up to the ``1.9.x`` ``stable`` series.
 
+1.9.0 (09/17/2018)
+------------------
+
+The first stable release of the 1.9.x series, with no changes since `rc3`.
+
 1.9.0rc3 (09/10/2018)
 ---------------------
 


### PR DESCRIPTION
The [1.8.x release notes](https://www.pantsbuild.org/notes-1.8.x.html) have a little blurb:

> Includes helpful new features like the `--owner-of` option for selecting targets by owned filename, and warnings/errors for unmatched globs. Additionally, updates Pants' usage of the zinc incremental Scala compiler to a 1.0.x release.

Please comment if there are any changes in 1.9.0 that we should highlight like this (I think it could be a good idea to have a couple!).