### PR TITLE
Revert "[Hermetic zinc compile] Memoize scalac classpath snapshots (#6491)

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -9,15 +9,10 @@ from collections import namedtuple
 from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.backend.jvm.subsystems.zinc_language_mixin import ZincLanguageMixin
 from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.backend.jvm.tasks.classpath_entry import ClasspathEntry
-from pants.base.build_environment import get_buildroot
 from pants.build_graph.address import Address
 from pants.build_graph.injectables_mixin import InjectablesMixin
-from pants.engine.fs import PathGlobs, PathGlobsAndRoot
 from pants.java.jar.jar_dependency import JarDependency
 from pants.subsystem.subsystem import Subsystem
-from pants.util.dirutil import fast_relpath
-from pants.util.memo import memoized_method
 
 
 # full_version - the full scala version to use.
@@ -137,28 +132,17 @@ class ScalaPlatform(JvmToolMixin, ZincLanguageMixin, InjectablesMixin, Subsystem
     register_custom_tool('scala-repl')
     register_custom_tool('scalastyle')
 
-  def _tool_classpath(self, tool, products, scheduler):
+  def _tool_classpath(self, tool, products):
     """Return the proper classpath based on products and scala version."""
-    classpath = self.tool_classpath_from_products(products,
-                                                  self.versioned_tool_name(tool, self.version),
-                                                  scope=self.options_scope)
-    classpath = tuple(fast_relpath(c, get_buildroot()) for c in classpath)
+    return self.tool_classpath_from_products(products,
+                                             self.versioned_tool_name(tool, self.version),
+                                             scope=self.options_scope)
 
-    return self._memoized_scalac_classpath(classpath, scheduler)
+  def compiler_classpath(self, products):
+    return self._tool_classpath('scalac', products)
 
-  @memoized_method
-  def _memoized_scalac_classpath(self, scala_path, scheduler):
-    snapshots = scheduler.capture_snapshots(tuple(PathGlobsAndRoot(PathGlobs([path]), get_buildroot()) for path in scala_path))
-    return [ClasspathEntry(path, snapshot) for path, snapshot in list(zip(scala_path, snapshots))]
-
-  def compiler_classpath_entries(self, products, scheduler):
-    """Returns classpath entries for the scalac tool."""
-    return self._tool_classpath('scalac', products, scheduler)
-
-  def style_classpath(self, products, scheduler):
-    """Returns classpath as paths for scalastyle."""
-    classpath_entries = self._tool_classpath('scalastyle', products, scheduler)
-    return [classpath_entry.path for classpath_entry in classpath_entries]
+  def style_classpath(self, products):
+    return self._tool_classpath('scalastyle', products)
 
   @property
   def version(self):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -30,7 +30,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.hash_utils import hash_file
 from pants.base.workunit import WorkUnitLabel
-from pants.engine.fs import DirectoryToMaterialize
+from pants.engine.fs import DirectoryToMaterialize, PathGlobs, PathGlobsAndRoot
 from pants.engine.isolated_process import ExecuteProcessRequest
 from pants.java.distribution.distribution import DistributionLocator
 from pants.util.contextutil import open_zip
@@ -261,10 +261,8 @@ class BaseZincCompile(JvmCompile):
     # the JDK it was invoked with.
     return Java.global_javac_classpath(self.context.products)
 
-  def scalac_classpath_entries(self):
-    """Returns classpath entries for the scalac classpath."""
-    return ScalaPlatform.global_instance().compiler_classpath_entries(
-      self.context.products, self.context._scheduler)
+  def scalac_classpath(self):
+    return ScalaPlatform.global_instance().compiler_classpath(self.context.products)
 
   def write_extra_resources(self, compile_context):
     """Override write_extra_resources to produce plugin and annotation processor files."""
@@ -301,17 +299,15 @@ class BaseZincCompile(JvmCompile):
       # TODO: Support workdirs not nested under buildroot by path-rewriting.
       return fast_relpath(path, get_buildroot())
 
+    scala_path = self.scalac_classpath()
     classes_dir = ctx.classes_dir
     analysis_cache = ctx.analysis_file
 
+    scala_path = tuple(relative_to_exec_root(c) for c in scala_path)
     analysis_cache = relative_to_exec_root(analysis_cache)
     classes_dir = relative_to_exec_root(classes_dir)
     # TODO: Have these produced correctly, rather than having to relativize them here
     relative_classpath = tuple(relative_to_exec_root(c) for c in absolute_classpath)
-
-    # list of classpath entries
-    scalac_classpath_entries = self.scalac_classpath_entries()
-    scala_path = [classpath_entry.path for classpath_entry in scalac_classpath_entries]
 
     zinc_args = []
     zinc_args.extend([
@@ -415,9 +411,15 @@ class BaseZincCompile(JvmCompile):
               "execution".format(dep)
             )
 
-      snapshots.extend(
-        classpath_entry.directory_digest for classpath_entry in scalac_classpath_entries
-      )
+      if scala_path:
+        # TODO: ScalaPlatform._tool_classpath should capture this and memoize it.
+        # See https://github.com/pantsbuild/pants/issues/6435
+        snapshots.append(
+          self.context._scheduler.capture_snapshots((PathGlobsAndRoot(
+            PathGlobs(scala_path),
+            get_buildroot(),
+          ),))[0]
+        )
 
       merged_input_digest = self.context._scheduler.merge_directories(
         tuple(s.directory_digest for s in (snapshots)) + directory_digests

--- a/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
@@ -48,8 +48,7 @@ class ScaladocGen(JvmdocGen):
       return None
 
     scala_platform = ScalaPlatform.global_instance()
-    tool_classpath = [cp_entry.path for cp_entry in scala_platform.compiler_classpath_entries(
-      self.context.products, self.context._scheduler)]
+    tool_classpath = scala_platform.compiler_classpath(self.context.products)
 
     args = ['-usejavacp',
             '-classpath', ':'.join(classpath),

--- a/src/python/pants/backend/jvm/tasks/scalastyle.py
+++ b/src/python/pants/backend/jvm/tasks/scalastyle.py
@@ -145,7 +145,7 @@ class Scalastyle(LintTaskMixin, NailgunTask):
           def to_java_boolean(x):
             return str(x).lower()
 
-          cp = ScalaPlatform.global_instance().style_classpath(self.context.products, self.context._scheduler)
+          cp = ScalaPlatform.global_instance().style_classpath(self.context.products)
           scalastyle_args = [
             '-c', scalastyle_config,
             '-v', to_java_boolean(scalastyle_verbose),


### PR DESCRIPTION
This reverts commit 906e4e5f4077cd1627eb5b5400f9cd7d5bbb8fab.

It appears that #6491 caused a failure on master that is deterministic.


```
 ==================== FAILURES ====================
                      IncompleteCustomScalaIntegrationTest.test_working_custom_212 
                     
                     self = <pants_test.backend.jvm.subsystems.test_incomplete_custom_scala.IncompleteCustomScalaIntegrationTest testMethod=test_working_custom_212>
                     
                         def test_working_custom_212(self):
                           with self.tmp_custom_scala('custom_212_scalatools.build') as scalastyle_config_option:
                             pants_run = self.pants_run(
                               options=[
                                 '--scala-version=custom',
                                 '--scala-suffix-version=2.12',
                                 scalastyle_config_option,
                               ]
                             )
                     >       self.assert_success(pants_run)
                     
                     .pants.d/pyprep/sources/32b34c52912fb8c3b2e92ce59cdfba97cc3d91fd/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py:124: 
                     _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
                     .pants.d/pyprep/sources/32b34c52912fb8c3b2e92ce59cdfba97cc3d91fd/pants_test/pants_run_integration_test.py:395: in assert_success
                         self.assert_result(pants_run, self.PANTS_SUCCESS_CODE, expected=True, msg=msg)
                     .pants.d/pyprep/sources/32b34c52912fb8c3b2e92ce59cdfba97cc3d91fd/pants_test/pants_run_integration_test.py:416: in assert_result
                         assertion(value, pants_run.returncode, error_msg)
                     E   AssertionError: /home/travis/build/pantsbuild/pants/pants --no-pantsrc --pants-workdir=/home/travis/build/pantsbuild/pants/.pants.d/tmp/tmpbny7IO.pants.d --kill-nailguns --print-exception-stacktrace=True --pants-config-files=[] --no-cache-read --no-cache-write --cache-bootstrap-read --cache-bootstrap-write --scala-version=custom --scala-suffix-version=2.12 --lint-scalastyle-config=/home/travis/build/pantsbuild/pants/tmpfJLtZi/config.xml clean-all compile lint testprojects/src/scala/org/pantsbuild/testproject/custom_scala_platform
                     E   returncode: 1
                     E   stdout:
                     E   	
                     E   	17:34:41 00:00 [main]
                     E   	               (To run a reporting server: ./pants server)
                     E   	17:34:42 00:01   [setup]
                     E   	17:34:42 00:01     [parse]
                     E   	               Executing tasks in goals: clean-all -> bootstrap -> imports -> unpack-jars -> jvm-platform-validate -> deferred-sources -> gen -> resolve -> compile -> lint
                     E   	17:34:42 00:01   [clean-all]
                     E   	17:34:42 00:01     [ng-killall]
                     E   	17:34:42 00:01     [kill-pantsd]
                     E   	17:34:42 00:01     [clean-all]
                     E   	17:34:42 00:01   [bootstrap]
                     E   	17:34:42 00:01     [substitute-aliased-targets]
                     E   	17:34:42 00:01     [jar-dependency-management]
                     E   	17:34:42 00:01     [bootstrap-jvm-tools]
                     E   	17:34:42 00:01     [provide-tools-jar]
                     E   	17:34:42 00:01   [imports]
                     E   	17:34:42 00:01     [ivy-imports]
                     E   	17:34:42 00:01   [unpack-jars]
                     E   	17:34:42 00:01     [unpack-jars]
                     E   	17:34:42 00:01   [jvm-platform-validate]
                     E   	17:34:42 00:01     [jvm-platform-validate]
                     E   	                   Invalidated 1 target.
                     E   	17:34:42 00:01   [deferred-sources]
                     E   	17:34:42 00:01     [deferred-sources]
                     E   	17:34:42 00:01   [gen]
                     E   	17:34:42 00:01     [antlr-java]
                     E   	17:34:42 00:01     [antlr-py]
                     E   	17:34:42 00:01     [jaxb]
                     E   	17:34:42 00:01     [protoc]
                     E   	17:34:42 00:01     [ragel]
                     E   	17:34:42 00:01     [thrift-java]
                     E   	17:34:42 00:01     [thrift-py]
                     E   	17:34:42 00:01     [wire]
                     E   	17:34:42 00:01   [resolve]
                     E   	17:34:42 00:01     [ivy]
                     E   	17:34:42 00:01       [cache]
                     E   	17:34:42 00:01       [bootstrap-nailgun-server]
                     E   	                   Invalidated 1 target.
                     E   	17:34:43 00:02       [ivy-resolve]
                     E   	17:34:45 00:04     [coursier]
                     E   	17:34:45 00:04   [compile]
                     E   	17:34:45 00:04     [compile-jvm-prep-command]
                     E   	17:34:45 00:04       [jvm_prep_command]
                     E   	17:34:45 00:04     [compile-prep-command]
                     E   	17:34:45 00:04     [compile]
                     E   	17:34:45 00:04     [zinc]
                     E   	                   Invalidated 1 target.
                     E   	17:34:45 00:04       [isolation-zinc-pool-bootstrap]
                     E   	                   [1/1] Compiling 1 zinc source in 1 target (testprojects/src/scala/org/pantsbuild/testproject/custom_scala_platform:custom_scala_platform).
                     E   	17:34:45 00:04       [compile]
                     E   	                     
                     E   	17:34:45 00:04         [cache]
                     E   	17:34:45 00:04         [bootstrap-scalac]
                     E   	17:34:48 00:07         [cache]
                     E   	                     No cached artifacts for 1 target.
                     E   	                     Invalidated 1 target.
                     E   	17:34:48 00:07         [cache]
                     E   	17:34:48 00:07         [bootstrap-zinc]
                     E   	17:34:50 00:09         [cache]
                     E   	17:34:50 00:09         [bootstrap-jar-tool]
                     E   	17:34:52 00:11         [cache]
                     E   	17:34:52 00:11         [bootstrap-jarjar]
                     E   	17:34:54 00:13         [shade-zinc]
                     E   	17:35:22 00:41         [cache]
                     E   	                     No cached artifacts for 1 target.
                     E   	                     Invalidated 1 target.
                     E   	17:35:22 00:41         [cache]
                     E   	17:35:22 00:41         [bootstrap-compiler-interface]
                     E   	17:35:23 00:42         [shade-compiler-interface]
                     E   	17:35:24 00:43         [cache]
                     E   	17:35:24 00:43         [bootstrap-compiler-bridge]
                     E   	17:35:25 00:44         [zinc]
                     E   	                       [info] Compiling 1 Scala source to /home/travis/build/pantsbuild/pants/.pants.d/tmp/tmpbny7IO.pants.d/compile/zinc/a53b6931478d/testprojects.src.scala.org.pantsbuild.testproject.custom_scala_platform.custom_scala_platform/current/classes ...
                     E   	                       java.lang.IncompatibleClassChangeError: Class scala.reflect.internal.Names$TermName_R does not implement the requested interface java.lang.CharSequence
                     E   	                       	at java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:488)
                     E   	                       	at java.lang.StringBuilder.append(StringBuilder.java:166)
                     E   	                       	at xsbt.ClassName.$anonfun$classNameAsSeenIn$1(ClassName.scala:83)
                     E   	                       	at scala.reflect.internal.SymbolTable.enteringPhase(SymbolTable.scala:235)
                     E   	                       	at xsbt.ClassName.classNameAsSeenIn(ClassName.scala:78)
                     E   	                       	at xsbt.ClassName.classNameAsSeenIn$(ClassName.scala:76)
                     E   	                       	at xsbt.ExtractAPI.classNameAsSeenIn(ExtractAPI.scala:49)
                     E   	                       	at xsbt.ExtractAPI.mkClassLike(ExtractAPI.scala:628)
                     E   	                       	at xsbt.ExtractAPI.$anonfun$classLike$1(ExtractAPI.scala:611)
                     E   	                       	at scala.collection.mutable.HashMap.getOrElseUpdate(HashMap.scala:82)
                     E   	                       	at xsbt.ExtractAPI.classLike(ExtractAPI.scala:611)
                     E   	                       	at xsbt.ExtractAPI.extractAllClassesOf(ExtractAPI.scala:596)
                     E   	                       	at xsbt.API$TopLevelHandler.class(API.scala:65)
                     E   	                       	at xsbt.API$TopLevelTraverser.traverse(API.scala:73)
                     E   	                       	at xsbt.API$TopLevelTraverser.traverse(API.scala:69)
                     E   	                       	at scala.reflect.api.Trees$Traverser.$anonfun$traverseStats$2(Trees.scala:2498)
                     E   	                       	at scala.reflect.api.Trees$Traverser.atOwner(Trees.scala:2507)
                     E   	                       	at scala.reflect.api.Trees$Traverser.$anonfun$traverseStats$1(Trees.scala:2498)
                     E   	                       	at scala.reflect.api.Trees$Traverser.traverseStats(Trees.scala:2497)
                     E   	                       	at scala.reflect.internal.Trees.itraverse(Trees.scala:1330)
                     E   	                       	at scala.reflect.internal.Trees.itraverse$(Trees.scala:1204)
                     E   	                       	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
                     E   	                       	at scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
                     E   	                       	at scala.reflect.api.Trees$Traverser.traverse(Trees.scala:2475)
                     E   	                       	at xsbt.API$TopLevelTraverser.traverse(API.scala:75)
                     E   	                       	at xsbt.API$TopLevelTraverser.traverse(API.scala:69)
                     E   	                       	at scala.reflect.api.Trees$Traverser.apply(Trees.scala:2513)
                     E   	                       	at xsbt.API$ApiPhase.processScalaUnit(API.scala:43)
                     E   	                       	at xsbt.API$ApiPhase.processUnit(API.scala:35)
                     E   	                       	at xsbt.API$ApiPhase.apply(API.scala:33)
                     E   	                       	at scala.tools.nsc.Global$GlobalPhase.$anonfun$applyPhase$1(Global.scala:423)
                     E   	                       	at scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:416)
                     E   	                       	at scala.tools.nsc.Global$GlobalPhase.$anonfun$run$1(Global.scala:387)
                     E   	                       	at scala.tools.nsc.Global$GlobalPhase.$anonfun$run$1$adapted(Global.scala:387)
                     E   	                       	at scala.collection.Iterator.foreach(Iterator.scala:929)
                     E   	                       	at scala.collection.Iterator.foreach$(Iterator.scala:929)
                     E   	                       	at scala.collection.AbstractIterator.foreach(Iterator.scala:1417)
                     E   	                       	at scala.tools.nsc.Global$GlobalPhase.run(Global.scala:387)
                     E   	                       	at xsbt.API$ApiPhase.run(API.scala:27)
                     E   	                       	at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1427)
                     E   	                       	at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1412)
                     E   	                       	at scala.tools.nsc.Global$Run.compileSources(Global.scala:1407)
                     E   	                       	at scala.tools.nsc.Global$Run.compile(Global.scala:1501)
                     E   	                       	at xsbt.CachedCompiler0.run(CompilerInterface.scala:131)
                     E   	                       	at xsbt.CachedCompiler0.run(CompilerInterface.scala:106)
                     E   	                       	at xsbt.CompilerInterface.run(CompilerInterface.scala:32)
                     E   	                       	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
                     E   	                       	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
                     E   	                       	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
                     E   	                       	at java.lang.reflect.Method.invoke(Method.java:498)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.AnalyzingCompiler.call(AnalyzingCompiler.scala:237)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:111)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:90)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.MixedAnalyzingCompiler$$anonfun$compileScala$1$1.apply$mcV$sp(MixedAnalyzingCompiler.scala:74)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.MixedAnalyzingCompiler$$anonfun$compileScala$1$1.apply(MixedAnalyzingCompiler.scala:74)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.MixedAnalyzingCompiler$$anonfun$compileScala$1$1.apply(MixedAnalyzingCompiler.scala:74)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:134)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:73)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:117)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl$$anonfun$4.apply(IncrementalCompilerImpl.scala:305)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl$$anonfun$4.apply(IncrementalCompilerImpl.scala:305)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.Incremental$.doCompile(Incremental.scala:101)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.Incremental$$anonfun$1$$anonfun$apply$1.apply(Incremental.scala:82)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.Incremental$$anonfun$1$$anonfun$apply$1.apply(Incremental.scala:82)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.IncrementalCommon.recompileClasses(IncrementalCommon.scala:110)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:51)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.Incremental$$anonfun$1.apply(Incremental.scala:76)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.Incremental$$anonfun$1.apply(Incremental.scala:75)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.Incremental$.manageClassfiles(Incremental.scala:129)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.Incremental$.compile(Incremental.scala:75)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.IncrementalCompile$.apply(Compile.scala:61)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:302)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl$$anonfun$compileIncrementally$1.apply(IncrementalCompilerImpl.scala:263)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl$$anonfun$compileIncrementally$1.apply(IncrementalCompilerImpl.scala:237)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:158)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:237)
                     E   	                       	at __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:68)
                     E   	                       	at org.pantsbuild.zinc.compiler.Main$.main(Main.scala:118)
                     E   	                       	at org.pantsbuild.zinc.compiler.Main.main(Main.scala)
                     E   	                       	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
                     E   	                       	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
                     E   	                       	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
                     E   	                       	at java.lang.reflect.Method.invoke(Method.java:498)
                     E   	                       	at com.martiansoftware.nailgun.NGSession.run(NGSession.java:280)
                     E   	                       [error] ## Exception when compiling 1 sources to /home/travis/build/pantsbuild/pants/.pants.d/tmp/tmpbny7IO.pants.d/compile/zinc/a53b6931478d/testprojects.src.scala.org.pantsbuild.testproject.custom_scala_platform.custom_scala_platform/current/classes
                     E   	                       [error] Class scala.reflect.internal.Names$TermName_R does not implement the requested interface java.lang.CharSequence
                     E   	                       [error] java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:488)
                     E   	                       [error] java.lang.StringBuilder.append(StringBuilder.java:166)
                     E   	                       [error] xsbt.ClassName.$anonfun$classNameAsSeenIn$1(ClassName.scala:83)
                     E   	                       [error] scala.reflect.internal.SymbolTable.enteringPhase(SymbolTable.scala:235)
                     E   	                       [error] xsbt.ClassName.classNameAsSeenIn(ClassName.scala:78)
                     E   	                       [error] xsbt.ClassName.classNameAsSeenIn$(ClassName.scala:76)
                     E   	                       [error] xsbt.ExtractAPI.classNameAsSeenIn(ExtractAPI.scala:49)
                     E   	                       [error] xsbt.ExtractAPI.mkClassLike(ExtractAPI.scala:628)
                     E   	                       [error] xsbt.ExtractAPI.$anonfun$classLike$1(ExtractAPI.scala:611)
                     E   	                       [error] scala.collection.mutable.HashMap.getOrElseUpdate(HashMap.scala:82)
                     E   	                       [error] xsbt.ExtractAPI.classLike(ExtractAPI.scala:611)
                     E   	                       [error] xsbt.ExtractAPI.extractAllClassesOf(ExtractAPI.scala:596)
                     E   	                       [error] xsbt.API$TopLevelHandler.class(API.scala:65)
                     E   	                       [error] xsbt.API$TopLevelTraverser.traverse(API.scala:73)
                     E   	                       [error] xsbt.API$TopLevelTraverser.traverse(API.scala:69)
                     E   	                       [error] scala.reflect.api.Trees$Traverser.$anonfun$traverseStats$2(Trees.scala:2498)
                     E   	                       [error] scala.reflect.api.Trees$Traverser.atOwner(Trees.scala:2507)
                     E   	                       [error] scala.reflect.api.Trees$Traverser.$anonfun$traverseStats$1(Trees.scala:2498)
                     E   	                       [error] scala.reflect.api.Trees$Traverser.traverseStats(Trees.scala:2497)
                     E   	                       [error] scala.reflect.internal.Trees.itraverse(Trees.scala:1330)
                     E   	                       [error] scala.reflect.internal.Trees.itraverse$(Trees.scala:1204)
                     E   	                       [error] scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
                     E   	                       [error] scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:16)
                     E   	                       [error] scala.reflect.api.Trees$Traverser.traverse(Trees.scala:2475)
                     E   	                       [error] xsbt.API$TopLevelTraverser.traverse(API.scala:75)
                     E   	                       [error] xsbt.API$TopLevelTraverser.traverse(API.scala:69)
                     E   	                       [error] scala.reflect.api.Trees$Traverser.apply(Trees.scala:2513)
                     E   	                       [error] xsbt.API$ApiPhase.processScalaUnit(API.scala:43)
                     E   	                       [error] xsbt.API$ApiPhase.processUnit(API.scala:35)
                     E   	                       [error] xsbt.API$ApiPhase.apply(API.scala:33)
                     E   	                       [error] scala.tools.nsc.Global$GlobalPhase.$anonfun$applyPhase$1(Global.scala:423)
                     E   	                       [error] scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:416)
                     E   	                       [error] scala.tools.nsc.Global$GlobalPhase.$anonfun$run$1(Global.scala:387)
                     E   	                       [error] scala.tools.nsc.Global$GlobalPhase.$anonfun$run$1$adapted(Global.scala:387)
                     E   	                       [error] scala.collection.Iterator.foreach(Iterator.scala:929)
                     E   	                       [error] scala.collection.Iterator.foreach$(Iterator.scala:929)
                     E   	                       [error] scala.collection.AbstractIterator.foreach(Iterator.scala:1417)
                     E   	                       [error] scala.tools.nsc.Global$GlobalPhase.run(Global.scala:387)
                     E   	                       [error] xsbt.API$ApiPhase.run(API.scala:27)
                     E   	                       [error] scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1427)
                     E   	                       [error] scala.tools.nsc.Global$Run.compileUnits(Global.scala:1412)
                     E   	                       [error] scala.tools.nsc.Global$Run.compileSources(Global.scala:1407)
                     E   	                       [error] scala.tools.nsc.Global$Run.compile(Global.scala:1501)
                     E   	                       [error] xsbt.CachedCompiler0.run(CompilerInterface.scala:131)
                     E   	                       [error] xsbt.CachedCompiler0.run(CompilerInterface.scala:106)
                     E   	                       [error] xsbt.CompilerInterface.run(CompilerInterface.scala:32)
                     E   	                       [error] sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
                     E   	                       [error] sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
                     E   	                       [error] sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
                     E   	                       [error] java.lang.reflect.Method.invoke(Method.java:498)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.AnalyzingCompiler.call(AnalyzingCompiler.scala:237)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:111)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:90)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.MixedAnalyzingCompiler$$anonfun$compileScala$1$1.apply$mcV$sp(MixedAnalyzingCompiler.scala:74)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.MixedAnalyzingCompiler$$anonfun$compileScala$1$1.apply(MixedAnalyzingCompiler.scala:74)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.MixedAnalyzingCompiler$$anonfun$compileScala$1$1.apply(MixedAnalyzingCompiler.scala:74)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:134)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:73)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:117)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl$$anonfun$4.apply(IncrementalCompilerImpl.scala:305)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl$$anonfun$4.apply(IncrementalCompilerImpl.scala:305)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.Incremental$.doCompile(Incremental.scala:101)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.Incremental$$anonfun$1$$anonfun$apply$1.apply(Incremental.scala:82)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.Incremental$$anonfun$1$$anonfun$apply$1.apply(Incremental.scala:82)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.IncrementalCommon.recompileClasses(IncrementalCommon.scala:110)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:51)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.Incremental$$anonfun$1.apply(Incremental.scala:76)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.Incremental$$anonfun$1.apply(Incremental.scala:75)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.Incremental$.manageClassfiles(Incremental.scala:129)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.Incremental$.compile(Incremental.scala:75)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.IncrementalCompile$.apply(Compile.scala:61)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:302)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl$$anonfun$compileIncrementally$1.apply(IncrementalCompilerImpl.scala:263)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl$$anonfun$compileIncrementally$1.apply(IncrementalCompilerImpl.scala:237)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:158)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:237)
                     E   	                       [error] __shaded_by_pants__.sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:68)
                     E   	                       [error] org.pantsbuild.zinc.compiler.Main$.main(Main.scala:118)
                     E   	                       [error] org.pantsbuild.zinc.compiler.Main.main(Main.scala)
                     E   	                       [error] sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
                     E   	                       [error] sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
                     E   	                       [error] sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
                     E   	                       [error] java.lang.reflect.Method.invoke(Method.java:498)
                     E   	                       [error] com.martiansoftware.nailgun.NGSession.run(NGSession.java:280)
                     E   	                       [error]            
                     E   	                       
                     E   	                   compile(testprojects/src/scala/org/pantsbuild/testproject/custom_scala_platform:custom_scala_platform) failed: Zinc compile failed.
                     E   	                   Traceback:
                     E   	                     File "/home/travis/build/pantsbuild/pants/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py", line 267, in worker
                     E   	                       work()
                     E   	                   
                     E   	                     File "/home/travis/build/pantsbuild/pants/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py", line 44, in __call__
                     E   	                       self.fn()
                     E   	                   
                     E   	                     File "/home/travis/build/pantsbuild/pants/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py", line 718, in work_for_vts
                     E   	                       counter)
                     E   	                   
                     E   	                     File "/home/travis/build/pantsbuild/pants/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py", line 513, in _compile_vts
                     E   	                       self._get_plugin_map('scalac', ScalaPlatform.global_instance(), ctx.target),
                     E   	                   
                     E   	                     File "/home/travis/build/pantsbuild/pants/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py", line 454, in compile
                     E   	                       raise TaskError('Zinc compile failed.')
                     E   	                   
                     E   	FAILURE: Compilation failure: Failed jobs: compile(testprojects/src/scala/org/pantsbuild/testproject/custom_scala_platform:custom_scala_platform)
                     E   	
                     E   	
                     E   	               Waiting for background workers to finish.
                     E   	17:35:31 00:50   [complete]
                     E   	               FAILURE
                     E   stderr:
                     E   	INFO] For async removal, run `./pants clean-all --async`
                     E   	WARN] No default jvm platform is defined.
                     E   	.        INFO] killing nailgun server pid=9855
                     E   	INFO] killing nailgun server pid=9923
                     E   	INFO] killing nailgun server pid=10004
                      generated xml file: /home/travis/build/pantsbuild/pants/.pants.d/test/pytest/tests.python.pants_test.backend.jvm.subsystems.incomplete_custom_scala/junitxml/TEST-tests.python.pants_test.backend.jvm.subsystems.incomplete_custom_scala.xml 
                     ============ slowest 3 test durations ============
                     50.45s call     ../tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py::IncompleteCustomScalaIntegrationTest::test_working_custom_212
                     6.08s call     ../tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py::IncompleteCustomScalaIntegrationTest::test_missing_compiler
                     0.00s teardown ../tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py::IncompleteCustomScalaIntegrationTest::test_working_custom_212
                     ====== 1 failed, 1 passed in 56.65 seconds =======
```