### PR TITLE
custom scalac version test - bump fixture to 2.12.4

### DIFF
--- a/testprojects/src/scala/org/pantsbuild/testproject/custom_scala_platform/custom_212_scalatools.build
+++ b/testprojects/src/scala/org/pantsbuild/testproject/custom_scala_platform/custom_212_scalatools.build
@@ -2,18 +2,18 @@
 
 jar_library(name = 'scalac',
             jars = [
-              jar(org = 'org.scala-lang', name = 'scala-compiler', rev = '2.12.2'),
+              jar(org = 'org.scala-lang', name = 'scala-compiler', rev = '2.12.4'),
             ])
 
 jar_library(name = 'scala-library',
             jars = [
-              jar(org = 'org.scala-lang', name = 'scala-library', rev = '2.12.2'),
+              jar(org = 'org.scala-lang', name = 'scala-library', rev = '2.12.4'),
             ])
 
 jar_library(name = 'scala-repl',
             jars = [
-              jar(org = 'org.scala-lang', name = 'scala-compiler', rev = '2.12.2'),
-              jar(org = 'org.scala-lang', name = 'scala-library', rev = '2.12.2'),
+              jar(org = 'org.scala-lang', name = 'scala-compiler', rev = '2.12.4'),
+              jar(org = 'org.scala-lang', name = 'scala-library', rev = '2.12.4'),
             ])
 
 jar_library(name = 'scalastyle',


### PR DESCRIPTION
### Problem

The custom scala version integration tests had issues because somehow 2.12.4 and 2.12.2 jars were both on the compile classpath (see note on #6531.

### Solution

Update the test fixtures to 2.12.4

### Result

The scala versions should be compatible.