### PR TITLE
create singleton ExceptionSink object to centralize logging of fatal errors

### DIFF
--- a/src/python/pants/bin/exception_sink.py
+++ b/src/python/pants/bin/exception_sink.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import datetime
+from builtins import object
+
+from pants.util.dirutil import is_writable_dir
+
+
+class ExceptionSink(object):
+  """A mutable object representing where exceptions should be logged to."""
+
+  def __init__(self):
+    self._cached_destination = None
+
+  class ExceptionSinkError(Exception): pass
+
+  def _get_timestamp(self):
+    return datetime.datetime.now().isoformat()
+
+  def set_destination(self, dir_path):
+    if not is_writable_dir(dir_path):
+      raise self.ExceptionSinkError(
+        "(at {}) The provided exception sink path at '{}' is not a writable directory."
+        .format(self._get_timestamp(), dir_path))
+    self._cached_destination = dir_path
+
+  def get_destination(self):
+    # TODO: check if the path is writable here too? Doing a syscall might be ok here, depending on
+    # the usage pattern.
+    if self._cached_destination is None:
+      raise self.ExceptionSinkError(
+        "(at {}) The exception sink path was not yet initialized with set_destination()."
+        .format(self._get_timestamp()))
+    return self._cached_destination

--- a/src/python/pants/bin/exception_sink.py
+++ b/src/python/pants/bin/exception_sink.py
@@ -8,10 +8,15 @@ import datetime
 from builtins import object
 
 from pants.util.dirutil import is_writable_dir
+from pants.util.memo import memoized_classproperty
 
 
 class ExceptionSink(object):
-  """A mutable object representing where exceptions should be logged to."""
+  """A mutable singleton object representing where exceptions should be logged to."""
+
+  @memoized_classproperty
+  def instance(cls):
+    return cls()
 
   def __init__(self):
     self._cached_destination = None

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -535,5 +535,13 @@ def check_no_overlapping_paths(paths):
 
 
 def is_readable_dir(path):
-  """Returns whether a path names an existing directory that we can read."""
-  return os.path.isdir(path) and os.access(path, os.R_OK)
+  """Returns whether a path names an existing directory we can list and read files from."""
+  return os.path.isdir(path) and os.access(path, os.R_OK) and os.access(path, os.X_OK)
+
+
+def is_writable_dir(path):
+  """Returns whether a path names an existing directory that we can create and modify files in.
+
+  We call is_readable_dir(), so this definition of "writable" is a superset of that.
+  """
+  return is_readable_dir(path) and os.access(path, os.W_OK)

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -2,6 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
+  name='exception_sink',
+  sources=['test_exception_sink.py'],
+  dependencies=[
+    'src/python/pants/bin',
+  ],
+)
+
+python_tests(
   name='loader_integration',
   sources=['test_loader_integration.py'],
   dependencies=[

--- a/tests/python/pants_test/bin/test_exception_sink.py
+++ b/tests/python/pants_test/bin/test_exception_sink.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+import re
+import unittest
+
+from pants.bin.exception_sink import ExceptionSink
+
+
+class TestExceptionSink(unittest.TestCase):
+
+  def _timestamp_log_rx(self, err_rx):
+    # NB: This is a very light method of testing that the timestamp is a valid timestamp instead of
+    # nonsense -- this can be expanded later if we need to verify correctness of the timestamps
+    # logged in the future.
+    return r'\(at [0-9].*?[0-9]\) {}'.format(err_rx)
+
+  def test_unset_destination(self):
+    sink = ExceptionSink()
+    err_rx = re.escape(
+      'The exception sink path was not yet initialized with set_destination().')
+    with self.assertRaisesRegexp(ExceptionSink.ExceptionSinkError, self._timestamp_log_rx(err_rx)):
+      sink.get_destination()
+
+  def test_set_invalid_destination(self):
+    sink = ExceptionSink()
+    err_rx = re.escape(
+      "The provided exception sink path at '/does/not/exist' is not a writable directory.")
+    with self.assertRaisesRegexp(ExceptionSink.ExceptionSinkError, self._timestamp_log_rx(err_rx)):
+      sink.set_destination('/does/not/exist')
+    err_rx = re.escape(
+      "The provided exception sink path at '/' is not a writable directory.")
+    with self.assertRaisesRegexp(ExceptionSink.ExceptionSinkError, self._timestamp_log_rx(err_rx)):
+      sink.set_destination('/')
+
+  def test_retrieve_destination(self):
+    sink = ExceptionSink()
+    pwd = os.getcwd()
+    sink.set_destination(pwd)
+    self.assertEqual(pwd, sink.get_destination())


### PR DESCRIPTION
### Problem

See #6530. We want to make it simpler to understand where logging of fatal errors occurs and to consume those logs in a structured way.

### Solution

- First step in implementing #6530, a (process-)global singleton to manage where logs are kept (no logging is done yet).
- Add some very basic validation of input and very basic tests.

### Result

We now have an object that can be used to centralize the logging of fatal errors and enables the creation of a single point of failure (by which I mean, a single area of code which describes where this process's exceptions are logged and how to access and append to them), to be implemented in followup PRs.