### PR TITLE
Explicitly use backports.configparser

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import configparser
 import itertools
 import json
 import os
@@ -17,6 +16,8 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from io import StringIO
 from textwrap import dedent
+
+from backports import configparser
 
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.gather_sources import GatherSources

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import configparser
 import getpass
 import io
 import itertools
@@ -13,6 +12,7 @@ from builtins import open
 from contextlib import contextmanager
 
 import six
+from backports import configparser
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot, get_pants_cachedir, get_pants_configdir

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from textwrap import dedent
 
 import coverage
-from six.moves import configparser
+from backports import configparser
 
 from pants.backend.python.tasks.gather_sources import GatherSources
 from pants.backend.python.tasks.pytest_prep import PytestPrep

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import configparser
 import glob
 import os
 import shutil
@@ -14,6 +13,7 @@ from contextlib import contextmanager
 from operator import eq, ne
 from threading import Lock
 
+from backports import configparser
 from colors import strip_color
 
 from pants.base.build_environment import get_buildroot


### PR DESCRIPTION
### Problem

Currently `PYTHONCASEOK=1` would cause `import configparser` to load the system configparser instead of the backported one, causing

```
$ PYTHONCASEOK=1  ./pants -V
Exception caught: (<type 'exceptions.AttributeError'>)
  File "/Users/me/workspace/pants/src/python/pants/bin/pants_loader.py", line 75, in <module>
    main()
  File "/Users/me/workspace/pants/src/python/pants/bin/pants_loader.py", line 71, in main
    PantsLoader.run()
  File "/Users/me/workspace/pants/src/python/pants/bin/pants_loader.py", line 67, in run
    cls.load_and_execute(entrypoint)
  File "/Users/me/workspace/pants/src/python/pants/bin/pants_loader.py", line 60, in load_and_execute
    entrypoint_main()
  File "/Users/me/workspace/pants/src/python/pants/bin/pants_exe.py", line 38, in main
    PantsRunner(exiter, start_time=start_time).run()
  File "/Users/me/workspace/pants/src/python/pants/bin/pants_runner.py", line 35, in run
    bootstrap_options = options_bootstrapper.get_bootstrap_options()
  File "/Users/me/workspace/pants/src/python/pants/option/options_bootstrapper.py", line 171, in get_bootstrap_options
    self.construct_and_set_bootstrap_options()
  File "/Users/me/workspace/pants/src/python/pants/option/options_bootstrapper.py", line 162, in construct_and_set_bootstrap_options
    next_item = producer.send([filecontent_for(f) for f in files])
  File "/Users/me/workspace/pants/src/python/pants/option/options_bootstrapper.py", line 109, in produce_and_set_bootstrap_options
    pre_bootstrap_config = Config.load_file_contents(config_files_products)
  File "/Users/me/workspace/pants/src/python/pants/option/config.py", line 57, in load_file_contents
    return cls._meta_load(opener, file_contents, seed_values)
  File "/Users/me/workspace/pants/src/python/pants/option/config.py", line 89, in _meta_load
    parser.read_file(ini)

Exception message: ConfigParser instance has no attribute 'read_file'
```

### Solution

Use explicit `from backports import configparser`

### Result
```
$ PYTHONCASEOK=1  ./pants -V
1.10.0rc0
```