### PR TITLE
Make the sizes of the members of `enum Node` more uniform

### DIFF
--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -838,6 +838,9 @@ impl NodeTracer<NodeKey> for Tracer {
   }
 }
 
+///
+/// There is large variance in the sizes of the members of this enum, so a few of them are boxed.
+///
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum NodeKey {
   DigestFile(DigestFile),

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -319,7 +319,7 @@ impl WrappedNode for Select {
 
 impl From<Select> for NodeKey {
   fn from(n: Select) -> Self {
-    NodeKey::Select(n)
+    NodeKey::Select(Box::new(n))
   }
 }
 
@@ -424,7 +424,7 @@ impl WrappedNode for ExecuteProcess {
 
 impl From<ExecuteProcess> for NodeKey {
   fn from(n: ExecuteProcess) -> Self {
-    NodeKey::ExecuteProcess(n)
+    NodeKey::ExecuteProcess(Box::new(n))
   }
 }
 
@@ -771,7 +771,7 @@ impl WrappedNode for Task {
 
 impl From<Task> for NodeKey {
   fn from(n: Task) -> Self {
-    NodeKey::Task(n)
+    NodeKey::Task(Box::new(n))
   }
 }
 
@@ -841,12 +841,12 @@ impl NodeTracer<NodeKey> for Tracer {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum NodeKey {
   DigestFile(DigestFile),
-  ExecuteProcess(ExecuteProcess),
+  ExecuteProcess(Box<ExecuteProcess>),
   ReadLink(ReadLink),
   Scandir(Scandir),
-  Select(Select),
+  Select(Box<Select>),
   Snapshot(Snapshot),
-  Task(Task),
+  Task(Box<Task>),
 }
 
 impl NodeKey {

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -211,7 +211,10 @@ impl Scheduler {
                   // Otherwise (if it is a success, some other type of Failure, or if we've run
                   // out of retries) recover to complete the join, which will cause the results to
                   // propagate to the user.
-                  debug!("Root {} completed.", NodeKey::Select(root).format());
+                  debug!(
+                    "Root {} completed.",
+                    NodeKey::Select(Box::new(root)).format()
+                  );
                   Ok(other.map(|res| {
                     res
                       .try_into()


### PR DESCRIPTION
### Problem

The clippy shard is currently failing with a notice that there is a large variance between the sizes of the members of the `Node` enum. It refers to https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#large_enum_variant

According to `mem::size_of`, the sizes are currently:
```
  DigestFile(DigestFile),              // 32
  ExecuteProcess(ExecuteProcess),      // 200
  ReadLink(ReadLink),                  // 24
  Scandir(Scandir),                    // 24
  Select(Select),                      // 232
  Snapshot(Snapshot),                  // 16
  Task(Task),                          // 192
```

### Solution

Box the three largest members to appease clippy.

### Result

No appreciable difference in performance; happy clippy.