### PR TITLE
Ensure consistent performance for instance memos.

### DIFF
--- a/src/python/pants/util/memo.py
+++ b/src/python/pants/util/memo.py
@@ -25,7 +25,7 @@ def equal_args(*args, **kwargs):
 
 
 class InstanceKey(object):
-  """An equality wrapper for an arbirary object instance.
+  """An equality wrapper for an arbitrary object instance.
 
   This wrapper leverages `id` and `is` for fast `__hash__` and `__eq__` but both of these rely on
   the object in question not being gc'd since both `id` and `is` rely on the instance address which


### PR DESCRIPTION
Previously part of a memoization instance key included the `__hash__` /
`__eq__` of the instance. This was un-necessary and allowed poorly
performing instance `__hash__` / `__eq__` to drag memo lookup
performance down. Change the technique used to be guaranteed constant
time for both operations.

Fixes #6550
