### PR TITLE
[zinc-compile][hermetic] raise failure on compile failures

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -438,6 +438,9 @@ class BaseZincCompile(JvmCompile):
         jdk_home=text_type(self._zinc.underlying_dist.home),
       )
       res = self.context.execute_process_synchronously_without_raising(req, self.name(), [WorkUnitLabel.COMPILER])
+      if res.exit_code != 0:
+        raise TaskError('Zinc compile failed.')
+
       # TODO: Materialize as a batch in do_compile or somewhere
       self.context._scheduler.materialize_directories((
         DirectoryToMaterialize(get_buildroot(), res.output_directory_digest),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -437,9 +437,7 @@ class BaseZincCompile(JvmCompile):
         # Since this is always hermetic, we need to use `underlying_dist`
         jdk_home=text_type(self._zinc.underlying_dist.home),
       )
-      res = self.context.execute_process_synchronously_without_raising(req, self.name(), [WorkUnitLabel.COMPILER])
-      if res.exit_code != 0:
-        raise TaskError('Zinc compile failed.')
+      res = self.context.execute_process_synchronously_or_raise(req, self.name(), [WorkUnitLabel.COMPILER])
 
       # TODO: Materialize as a batch in do_compile or somewhere
       self.context._scheduler.materialize_directories((

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -236,6 +236,33 @@ class ZincCompileIntegrationTest(BaseCompileIT):
         )
         self.assert_failure(pants_run)
 
+  def test_failed_compile_with_hermetic(self):
+    with temporary_dir() as cache_dir:
+      config = {
+        'cache.compile.zinc': {'write_to': [cache_dir]},
+        'compile.zinc': {
+          'execution_strategy': 'hermetic',
+          'use_classpath_jars': False,
+          'incremental': False,
+        }
+      }
+
+      with self.temporary_workdir() as workdir:
+        pants_run = self.run_pants_with_workdir(
+          [
+            '-q',
+            'compile',
+            'testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target',
+          ],
+          workdir,
+          config,
+        )
+        self.assert_failure(pants_run)
+        self.assertIn(
+          'Failed jobs: compile(testprojects/src/java/org/pantsbuild/testproject/dummies:'
+          'compilation_failure_target)',
+          pants_run.stdout_data)
+
   def test_hermetic_binary_with_dependencies(self):
     with temporary_dir() as cache_dir:
       config = {


### PR DESCRIPTION
### Problem

Zinc compiler failures do not cause the rest of the compile to fail because they are not propagated.

### Solution

Raise an exception on failure.

### Result

Instead of caching failed zinc compiles, pants will run them again on a subsequent invoke.
