### PR TITLE
[zinc wrapper] Change default for -rebase-map: part 1

### DIFF
--- a/src/scala/org/pantsbuild/zinc/analysis/AnalysisOptions.scala
+++ b/src/scala/org/pantsbuild/zinc/analysis/AnalysisOptions.scala
@@ -13,7 +13,7 @@ import java.io.File
 case class AnalysisOptions(
   _cache: Option[File]         = None,
   cacheMap: Map[File, File]    = Map.empty,
-  rebaseMap: Map[File, File]   = Map.empty,
+  rebaseMap: Map[File, File]   = Map(new File(System.getProperty("user.dir")) -> new File("/proc/self/cwd")),
   clearInvalid: Boolean        = true
 ) {
   lazy val cache: File =

--- a/tests/scala/org/pantsbuild/zinc/analysis/AnalysisMapSpec.scala
+++ b/tests/scala/org/pantsbuild/zinc/analysis/AnalysisMapSpec.scala
@@ -3,6 +3,8 @@
 
 package org.pantsbuild.zinc.analysis
 
+import java.io.File
+
 import sbt.io.IO
 
 import org.junit.runner.RunWith
@@ -22,5 +24,11 @@ class AnalysisMapSpec extends WordSpec with MustMatchers {
     }
     // TODO: needs more testing with spoofed analysis:
     //   see https://github.com/pantsbuild/pants/issues/4756
+  }
+
+  "AnalysisOptions" should {
+    "create a new set of options with a default rebaseMap" in {
+      AnalysisOptions().rebaseMap must be(Map(new File(System.getProperty("user.dir")) -> new File("/proc/self/cwd")))
+    }
   }
 }


### PR DESCRIPTION
Paired with @baroquebobcat on this 😄 

Scala part of the solution for #6434 

Now that the `jdk.home` is underneath the buildroot, we can change the rebase map to make it more general and to default to replacing the current working directory in the absolute path to this special `/proc/self/cwd`.

This allows analysis that is generated in a hermetic sandbox to be rebased correctly. Once the zinc wrapper is published, the python changes will come.