### PR TITLE
Pin jupyter transitive deps in integration tests

### DIFF
--- a/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/BUILD
+++ b/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/BUILD
@@ -7,15 +7,14 @@ python_binary(
   ]
 )
 
-# Without blacklisting, pex resolver will error out
-# on a transitive requirement of jupyter (functools32)
-# when resolving for Python 3.
+# This library requires pex blacklisting under python 3, because the pex resolver will error out
+# on a transitive requirement of jupyter (functools32).
+#
+# This test also runs under python 2 though, and so in order to avoid dep floats of jupyter's
+# transitive deps (which can float upward to versions that do not support python 2), we pin them.
 python_requirement_library(
   name='reqlib',
   requirements=[
-    # NB: jupyter 1.0.0 does not properly pin its dep graph and both ipykernel and ipython support
-    # python 3 only post 5 and 6 respectively; so we add those deps explictly only to constrain them
-    # low such that they support python 2.7 for this test.
     python_requirement('jupyter==1.0.0'),
     python_requirement('ipykernel<5'),
     python_requirement('ipython<6'),

--- a/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/BUILD
+++ b/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/BUILD
@@ -13,7 +13,12 @@ python_binary(
 python_requirement_library(
   name='reqlib',
   requirements=[
-    python_requirement('jupyter'),
+    # NB: jupyter 1.0.0 does not properly pin its dep graph and both ipykernel and ipython support
+    # python 3 only post 5 and 6 respectively; so we add those deps explictly only to constrain them
+    # low such that they support python 2.7 for this test.
+    python_requirement('jupyter==1.0.0'),
+    python_requirement('ipykernel<5'),
+    python_requirement('ipython<6'),
   ]
 )
 


### PR DESCRIPTION
### Problem

As described in https://github.com/pantsbuild/pex/issues/561, jupyter's transitive deps float. Today that caused breakage.

### Solution

Pin the relevant deps (ht John in https://github.com/pantsbuild/pex/pull/562).