### PR TITLE
Fix extra_jvm_options for `jvm_app` targets

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -82,7 +82,7 @@ class JvmRun(JvmTask):
 
     # Some targets will not have extra_jvm_options in their payload,
     # so we can't access it with target.payload.extra_jvm_options
-    extra_jvm_options = target.payload.get_field_value("extra_jvm_options")
+    extra_jvm_options = binary.payload.extra_jvm_options
 
     # We can't throw if binary isn't a JvmBinary, because perhaps we were called on a
     # python_binary, in which case we have to no-op and let python_run do its thing.

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -80,9 +80,11 @@ class JvmRun(JvmTask):
     else:
       binary = target
 
-    # Some targets will not have extra_jvm_options in their payload,
-    # so we can't access it with target.payload.extra_jvm_options
-    extra_jvm_options = binary.payload.get_field_value("extra_jvm_options")
+    # This task is installed in the "run" goal.
+    # This means that, when invoked with ./pants run, it will run regardless of whether
+    # the target is a jvm target.
+    # As a result, not all targets passed here will have good defaults for extra_jvm_options
+    extra_jvm_options = binary.payload.get_field_value("extra_jvm_options", [])
 
     # We can't throw if binary isn't a JvmBinary, because perhaps we were called on a
     # python_binary, in which case we have to no-op and let python_run do its thing.

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -82,7 +82,7 @@ class JvmRun(JvmTask):
 
     # Some targets will not have extra_jvm_options in their payload,
     # so we can't access it with target.payload.extra_jvm_options
-    extra_jvm_options = binary.payload.extra_jvm_options
+    extra_jvm_options = binary.payload.get_field_value("extra_jvm_options")
 
     # We can't throw if binary isn't a JvmBinary, because perhaps we were called on a
     # python_binary, in which case we have to no-op and let python_run do its thing.

--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
@@ -17,8 +17,7 @@ jvm_app(
     dependencies=[':noopts'],
 )
 
-from os.path import join
 python_binary(
-    name=join('python_app'),
+    name='python_app',
     source='main.py',
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
@@ -16,3 +16,9 @@ jvm_app(
     binary=':noopts',
     dependencies=[':noopts'],
 )
+
+from os.path import join
+python_binary(
+    name=join('python_app'),
+    source='main.py',
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/BUILD
@@ -1,12 +1,18 @@
 jvm_binary(
-    extra_jvm_options = ['-Dproperty.color=orange', '-Dproperty.size=2', '-DMyFlag', '-Xmx1m'],
-    name = 'opts',
-    main = 'opts.Main',
-    sources = ['Main.java']
+    extra_jvm_options=['-Dproperty.color=orange', '-Dproperty.size=2', '-DMyFlag', '-Xmx1m'],
+    name='opts',
+    main='opts.Main',
+    sources=['Main.java']
 )
 
 jvm_binary(
-    name = 'noopts',
-    main = 'opts.Main',
-    sources = ['Main.java']
+    name='noopts',
+    main='opts.Main',
+    sources=['Main.java']
+)
+
+jvm_app(
+    name='app_noopts',
+    binary=':noopts',
+    dependencies=[':noopts'],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/main.py
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/main.py
@@ -1,0 +1,2 @@
+if __name__ == '__main__':
+  print("Hello!")

--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/main.py
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/main.py
@@ -1,2 +1,2 @@
 if __name__ == '__main__':
-  print("Hello!")
+  print("Python app runs correctly")

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
@@ -72,3 +72,33 @@ class JvmRunIntegrationTest(PantsRunIntegrationTest):
        '--no-jvm-synthetic-classpath',
        'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:run']).stdout_data
     self.assertIn('Synthetic jar run is not detected', output)
+
+  def test_enable_extra_jvm_options(self):
+    output = self.run_pants(
+      ['run',
+        'testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options:python_app']).stdout_data
+    self.assertIn('Python app runs correctly', output)
+
+    output = self.run_pants(
+      ['run',
+        'testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options:noopts']).stdout_data
+    self.assertIn("""Property property.color is null
+Property property.size is null
+Flag -DMyFlag is NOT set
+Max Heap Size: 954728448""", output)
+
+    output = self.run_pants(
+      ['run',
+        'testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options:app_noopts']).stdout_data
+    self.assertIn("""Property property.color is null
+Property property.size is null
+Flag -DMyFlag is NOT set
+Max Heap Size: 954728448""", output)
+
+    output = self.run_pants(
+      ['run',
+        'testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options:opts']).stdout_data
+    self.assertIn("""Property property.color is orange
+Property property.size is 2
+Flag -DMyFlag is set
+Max Heap Size: 1572864""", output)


### PR DESCRIPTION
### Problem

`extra_jvm_options` is a payload field passed to `jvm_binary` targets. `jvm_app` targets wrap `jvm_binary` targets. When calling `jvm_run` on `jvm_app`s, we tried to get `extra_jvm_options` from the app target, as opposed to the inner `jvm_binary` target. This led to a missing field error.

### Solution

Take the `extra_jvm_options` from the binary target in all cases.

### Result

Fixes #6560 