### PR TITLE
Handle signals gracefully

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -84,6 +84,9 @@ python_library(
 python_library(
   name = 'exceptions',
   sources = ['exceptions.py'],
+  dependencies = [
+    ':exiter',
+  ],
 )
 
 python_library(

--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import os
-import sys
-from builtins import str
 
 from pants.base.build_root import BuildRoot
 from pants.scm.scm import Scm
@@ -33,11 +31,7 @@ def get_buildroot():
 
   :API: public
   """
-  try:
-    return BuildRoot().path
-  except BuildRoot.NotFoundError as e:
-    print(str(e), file=sys.stderr)
-    sys.exit(1)
+  return BuildRoot().path
 
 
 def get_pants_cachedir():

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -274,7 +274,7 @@ class ExceptionSink(object):
       signal.signal(signum, handler)
       # Retry any system calls interrupted by any of the signals we just installed handlers for
       # (instead of having them raise EINTR). siginterrupt(3) says this is the default behavior on
-      # Linux.
+      # Linux and OSX.
       signal.siginterrupt(signum, False)
 
     previous_signal_handler = cls._signal_handler

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -336,7 +336,7 @@ timestamp: {timestamp}
   def _exit_with_failure(cls, terminal_msg):
     formatted_terminal_msg = cls._EXIT_FAILURE_TERMINAL_MESSAGE_FORMAT.format(
       timestamp=cls._iso_timestamp_for_now(),
-      terminal_msg=terminal_msg or '')
+      terminal_msg=terminal_msg or '<no exit reason provided>')
     # Exit with failure, printing a message to the terminal (or whatever the interactive stream is).
     cls._exiter.exit_and_fail(msg=formatted_terminal_msg, out=cls._interactive_output_stream)
 

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -416,10 +416,13 @@ Signal {signum} ({signame}) was raised. Exiting with failure.{formatted_tracebac
 
 # Setup global state such as signal handlers and sys.excepthook with probably-safe values at module
 # import time.
-# TODO: Read this value from some environment variable! This will be overridden by bootstrap options
-# in PantsRunner, so this setting is only for errors occurring during import time (which is
-# nontrivial). Most users won't want a full stacktrace upon pressing control-c!
-ExceptionSink.reset_should_print_backtrace_to_terminal(should_print_backtrace=True)
+# Set whether to print stacktraces on exceptions or signals during import time.
+# NB: This will be overridden by bootstrap options in PantsRunner, so we avoid printing out a full
+# stacktrace when a user presses control-c during import time unless the environment variable is set
+# to explicitly request it. The exception log will have any stacktraces regardless so this should
+# not hamper debugging.
+ExceptionSink.reset_should_print_backtrace_to_terminal(
+  should_print_backtrace=os.environ.get('PANTS_PRINT_EXCEPTION_STACKTRACE') == 'True')
 # Sets fatal signal handlers with reasonable defaults to catch errors early in startup.
 ExceptionSink.reset_log_location(os.path.join(get_buildroot(), '.pants.d'))
 # Sets except hook.

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -74,7 +74,7 @@ class ExceptionSink(object):
   _should_print_backtrace_to_terminal = True
   # An instance of `SignalHandler` which is invoked to handle a static set of specific
   # nonfatal signals (these signal handlers are allowed to make pants exit, but unlike SIGSEGV they
-  # don't need to immediately).
+  # don't need to exit immediately).
   _signal_handler = None
 
   # These persistent open file descriptors are kept so the signal handler can do almost no work
@@ -162,8 +162,6 @@ class ExceptionSink(object):
     This method registers a SIGUSR2 handler, which permits a non-fatal `kill -31 <pants pid>` for
     stacktrace retrieval. This is also where the the error message on fatal exit will be printed to.
     """
-    logger.debug('registering a SIGUSR2 handler')
-
     try:
       # NB: mutate process-global state!
       # This permits a non-fatal `kill -31 <pants pid>` for stacktrace retrieval.
@@ -390,9 +388,6 @@ Signal {signum} ({signame}) was raised. Exiting with failure.{formatted_tracebac
     """Signal handler for non-fatal signals which raises or logs an error and exits with failure.
 
     The `_frame` argument is currently unused.
-
-    NB: Ensure this method remains registered for all the signals supported by SignalHandler
-    in reset_signal_handler()!
     """
     # Extract the stack, and format an entry to be written to the exception log.
     traceback_lines = traceback.format_stack()

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -50,7 +50,7 @@ class SignalHandler(object):
     }
 
   def handle_sigint(self, signum, frame):
-    ExceptionSink._handle_signal_gracefully(signum, 'SIGINT', frame)
+    raise KeyboardInterrupt('User interrupted execution with control-c!')
 
   def handle_sigquit(self, signum, frame):
     ExceptionSink._handle_signal_gracefully(signum, 'SIGQUIT', frame)
@@ -421,6 +421,10 @@ Signal {signum} ({signame}) was raised. Exiting with failure.{formatted_tracebac
 
 # Setup global state such as signal handlers and sys.excepthook with probably-safe values at module
 # import time.
+# TODO: Read this value from some environment variable! This will be overridden by bootstrap options
+# in PantsRunner, so this setting is only for errors occurring during import time (which is
+# nontrivial). Most users won't want a full stacktrace upon pressing control-c!
+ExceptionSink.reset_should_print_backtrace_to_terminal(should_print_backtrace=True)
 # Sets fatal signal handlers with reasonable defaults to catch errors early in startup.
 ExceptionSink.reset_log_location(os.path.join(get_buildroot(), '.pants.d'))
 # Sets except hook.

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -280,6 +280,7 @@ class ExceptionSink(object):
     cls._signal_handler = signal_handler
     return previous_signal_handler
 
+  @classmethod
   @contextmanager
   def trapped_signals(cls, new_signal_handler):
     """A contextmanager which temporarily overrides signal handling."""

--- a/src/python/pants/base/exceptions.py
+++ b/src/python/pants/base/exceptions.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from pants.base.exiter import PANTS_FAILED_EXIT_CODE
+
 
 class TaskError(Exception):
   """Indicates a task has failed.
@@ -13,10 +15,10 @@ class TaskError(Exception):
 
   def __init__(self, *args, **kwargs):
     """
-    :param int exit_code: an optional exit code (default=1)
+    :param int exit_code: an optional exit code (defaults to nonzero)
     :param list failed_targets: an optional list of failed targets (default=[])
     """
-    self._exit_code = kwargs.pop('exit_code', 1)
+    self._exit_code = kwargs.pop('exit_code', PANTS_FAILED_EXIT_CODE)
     self._failed_targets = kwargs.pop('failed_targets', [])
     super(TaskError, self).__init__(*args, **kwargs)
 

--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -16,6 +16,11 @@ from pants.util.strutil import ensure_binary
 logger = logging.getLogger(__name__)
 
 
+# ???/so we're all on the same page
+PANTS_SUCCESS_EXIT_CODE = 0
+PANTS_FAILED_EXIT_CODE = 1
+
+
 class Exiter(object):
   """A class that provides standard runtime exit behavior.
 
@@ -38,7 +43,8 @@ class Exiter(object):
     """Map class calls to self.exit() to support sys.exit() fungibility."""
     return self.exit(*args, **kwargs)
 
-  def exit(self, result=0, msg=None, out=None):
+  # TODO: add PANTS_SUCCESS_EXIT_CODE and PANTS_FAILED_EXIT_CODE to the docstring!
+  def exit(self, result=PANTS_SUCCESS_EXIT_CODE, msg=None, out=None):
     """Exits the runtime.
 
     :param result: The exit status. Typically a 0 indicating success or a 1 indicating failure, but
@@ -67,10 +73,10 @@ class Exiter(object):
     self._exit(result)
 
   def exit_and_fail(self, msg=None, out=None):
-    """Exits the runtime with an exit code of 1, indicating failure.
+    """Exits the runtime with a nonzero exit code, indicating failure.
 
     :param msg: A string message to print to stderr or another custom file desciptor before exiting.
                 (Optional)
     :param out: The file descriptor to emit `msg` to. (Optional)
     """
-    self.exit(result=1, msg=msg, out=out)
+    self.exit(result=PANTS_FAILED_EXIT_CODE, msg=msg, out=out)

--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -17,15 +17,10 @@ logger = logging.getLogger(__name__)
 
 
 class Exiter(object):
-  """A class that provides standard runtime exit and global exception handling behavior.
+  """A class that provides standard runtime exit behavior.
 
-  The expected method call order of this class is as follows:
-
-   1) Call Exiter.set_except_hook() to set sys.excepthook to the internal exception hook. This
-      should happen as early as possible to ensure any/all exceptions are handled by the hook.
-   2) Call Exiter.apply_options() to set traceback printing behavior via an Options object.
-   3) Perform other operations as normal.
-   4) Call Exiter.exit(), Exiter.exit_and_fail() or exiter_inst() when you wish to exit the runtime.
+  `pants.base.exception_sink.ExceptionSink` handles exceptions and fatal signals, delegating to an
+  Exiter instance. Call Exiter.exit() or Exiter.exit_and_fail() when you wish to exit the runtime.
   """
 
   def __init__(self, exiter=sys.exit):
@@ -71,9 +66,11 @@ class Exiter(object):
         logger.exception(e)
     self._exit(result)
 
-  def exit_and_fail(self, msg=None):
+  def exit_and_fail(self, msg=None, out=None):
     """Exits the runtime with an exit code of 1, indicating failure.
 
-    :param str msg: A string message to print to stderr before exiting. (Optional)
+    :param msg: A string message to print to stderr or another custom file desciptor before exiting.
+                (Optional)
+    :param out: The file descriptor to emit `msg` to. (Optional)
     """
-    self.exit(result=1, msg=msg)
+    self.exit(result=1, msg=msg, out=out)

--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 # Centralize integer return codes for the pants process. We just use a single bit for now.
+# TODO: make these into an enum!
 PANTS_SUCCEEDED_EXIT_CODE = 0
 PANTS_FAILED_EXIT_CODE = 1
 

--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -16,8 +16,8 @@ from pants.util.strutil import ensure_binary
 logger = logging.getLogger(__name__)
 
 
-# ???/so we're all on the same page
-PANTS_SUCCESS_EXIT_CODE = 0
+# Centralize integer return codes for the pants process. We just use a single bit for now.
+PANTS_SUCCEEDED_EXIT_CODE = 0
 PANTS_FAILED_EXIT_CODE = 1
 
 
@@ -25,7 +25,8 @@ class Exiter(object):
   """A class that provides standard runtime exit behavior.
 
   `pants.base.exception_sink.ExceptionSink` handles exceptions and fatal signals, delegating to an
-  Exiter instance. Call Exiter.exit() or Exiter.exit_and_fail() when you wish to exit the runtime.
+  Exiter instance which can be set process-globally with ExceptionSink.reset_exiter(). Call
+  .exit() or .exit_and_fail() on an Exiter instance when you wish to exit the runtime.
   """
 
   def __init__(self, exiter=sys.exit):
@@ -43,12 +44,11 @@ class Exiter(object):
     """Map class calls to self.exit() to support sys.exit() fungibility."""
     return self.exit(*args, **kwargs)
 
-  # TODO: add PANTS_SUCCESS_EXIT_CODE and PANTS_FAILED_EXIT_CODE to the docstring!
-  def exit(self, result=PANTS_SUCCESS_EXIT_CODE, msg=None, out=None):
+  def exit(self, result=PANTS_SUCCEEDED_EXIT_CODE, msg=None, out=None):
     """Exits the runtime.
 
-    :param result: The exit status. Typically a 0 indicating success or a 1 indicating failure, but
-                   can be a string as well. (Optional)
+    :param result: The exit status. Typically either PANTS_SUCCEEDED_EXIT_CODE or
+                   PANTS_FAILED_EXIT_CODE, but can be a string as well. (Optional)
     :param msg: A string message to print to stderr or another custom file desciptor before exiting.
                 (Optional)
     :param out: The file descriptor to emit `msg` to. (Optional)

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -16,7 +16,7 @@ from future.utils import PY3, raise_with_traceback
 from setproctitle import setproctitle as set_process_title
 
 from pants.base.build_environment import get_buildroot
-from pants.base.exception_sink import ExceptionSink, GracefulSignalHandler
+from pants.base.exception_sink import ExceptionSink, SignalHandler
 from pants.base.exiter import PANTS_SUCCESS_EXIT_CODE, Exiter
 from pants.bin.local_pants_runner import LocalPantsRunner
 from pants.init.util import clean_global_runtime_state
@@ -28,7 +28,7 @@ from pants.util.contextutil import hermetic_environment_as, stdio_as
 from pants.util.socket import teardown_socket
 
 
-class DaemonSignalHandler(GracefulSignalHandler):
+class DaemonSignalHandler(SignalHandler):
 
   def handle_sigint(self, signum, frame):
     raise KeyboardInterrupt('remote client sent control-c!')
@@ -289,7 +289,7 @@ class DaemonPantsRunner(ProcessManager):
     ExceptionSink.reset_exiter(self._exiter)
 
     ExceptionSink.reset_interactive_output_stream(sys.stderr.buffer if PY3 else sys.stderr)
-    ExceptionSink.reset_graceful_signal_handler(DaemonSignalHandler())
+    ExceptionSink.reset_signal_handler(DaemonSignalHandler())
 
     # Ensure anything referencing sys.argv inherits the Pailgun'd args.
     sys.argv = self._args

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -17,7 +17,7 @@ from setproctitle import setproctitle as set_process_title
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exception_sink import ExceptionSink, SignalHandler
-from pants.base.exiter import PANTS_SUCCESS_EXIT_CODE, Exiter
+from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE, Exiter
 from pants.bin.local_pants_runner import LocalPantsRunner
 from pants.init.util import clean_global_runtime_state
 from pants.java.nailgun_io import NailgunStreamStdinReader, NailgunStreamWriter
@@ -339,4 +339,4 @@ class DaemonPantsRunner(ProcessManager):
       except Exception:
         ExceptionSink._log_unhandled_exception_and_exit()
       else:
-        self._exiter.exit(PANTS_SUCCESS_EXIT_CODE)
+        self._exiter.exit(PANTS_SUCCEEDED_EXIT_CODE)

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -30,7 +30,7 @@ from pants.util.socket import teardown_socket
 
 class DaemonSignalHandler(SignalHandler):
 
-  def handle_sigint(self, signum, frame):
+  def handle_sigint(self, signum, _frame):
     raise KeyboardInterrupt('remote client sent control-c!')
 
 

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -16,7 +16,7 @@ from future.utils import PY3, raise_with_traceback
 from setproctitle import setproctitle as set_process_title
 
 from pants.base.build_environment import get_buildroot
-from pants.base.exception_sink import ExceptionSink
+from pants.base.exception_sink import ExceptionSink, GracefulSignalHandler
 from pants.base.exiter import Exiter
 from pants.bin.local_pants_runner import LocalPantsRunner
 from pants.init.util import clean_global_runtime_state
@@ -26,6 +26,12 @@ from pants.pantsd.process_manager import ProcessManager
 from pants.rules.core.exceptions import GracefulTerminationException
 from pants.util.contextutil import hermetic_environment_as, stdio_as
 from pants.util.socket import teardown_socket
+
+
+class DaemonSignalHandler(GracefulSignalHandler):
+
+  def handle_sigint(self, signum, frame):
+    raise KeyboardInterrupt('remote client sent control-c!')
 
 
 class DaemonExiter(Exiter):
@@ -283,6 +289,7 @@ class DaemonPantsRunner(ProcessManager):
     ExceptionSink.reset_exiter(self._exiter)
 
     ExceptionSink.reset_interactive_output_stream(sys.stderr.buffer if PY3 else sys.stderr)
+    ExceptionSink.reset_graceful_signal_handler(DaemonSignalHandler())
 
     # Ensure anything referencing sys.argv inherits the Pailgun'd args.
     sys.argv = self._args

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -17,7 +17,7 @@ from setproctitle import setproctitle as set_process_title
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exception_sink import ExceptionSink, GracefulSignalHandler
-from pants.base.exiter import Exiter
+from pants.base.exiter import PANTS_SUCCESS_EXIT_CODE, Exiter
 from pants.bin.local_pants_runner import LocalPantsRunner
 from pants.init.util import clean_global_runtime_state
 from pants.java.nailgun_io import NailgunStreamStdinReader, NailgunStreamWriter
@@ -339,4 +339,4 @@ class DaemonPantsRunner(ProcessManager):
       except Exception:
         ExceptionSink._log_unhandled_exception_and_exit()
       else:
-        self._exiter.exit(0)
+        self._exiter.exit(PANTS_SUCCESS_EXIT_CODE)

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -217,7 +217,7 @@ class LocalPantsRunner(object):
     # Launch RunTracker as early as possible (before .run() is called).
     run_tracker = RunTracker.global_instance()
     reporting = Reporting.global_instance()
-    reporting.initialize(run_tracker, self._run_start_time)
+    reporting.initialize(run_tracker, self._options, start_time=self._run_start_time)
 
     # Capture a repro of the 'before' state for this build, if needed.
     repro = Reproducer.global_instance().create_repro()

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -38,10 +38,8 @@ class LocalExiter(Exiter):
   def exit(self, result=0, *args, **kwargs):
     try:
       if not self._run_tracker.has_ended():
-        if result == 0:
-          self._run_tracker.set_root_outcome(WorkUnit.SUCCESS)
-        else:
-          self._run_tracker.set_root_outcome(WorkUnit.FAILURE)
+        outcome = WorkUnit.SUCCESS if result == 0 else WorkUnit.FAILURE
+        self._run_tracker.set_root_outcome(outcome)
         run_tracker_result = self._run_tracker.end()
         assert(result == run_tracker_result)
     except ValueError as e:

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -9,7 +9,7 @@ from builtins import object, str
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exception_sink import ExceptionSink
-from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCESS_EXIT_CODE, Exiter
+from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE, Exiter
 from pants.base.workunit import WorkUnit
 from pants.bin.goal_runner import GoalRunner
 from pants.engine.native import Native
@@ -35,12 +35,12 @@ class LocalExiter(Exiter):
     self._repro = repro
     super(LocalExiter, self).__init__(*args, **kwargs)
 
-  def exit(self, result=PANTS_SUCCESS_EXIT_CODE, msg=None, *args, **kwargs):
+  def exit(self, result=PANTS_SUCCEEDED_EXIT_CODE, msg=None, *args, **kwargs):
     # This variable is prepended to the existing exit message when calling the superclass .exit().
     additional_message = None
     try:
       if not self._run_tracker.has_ended():
-        if result == PANTS_SUCCESS_EXIT_CODE:
+        if result == PANTS_SUCCEEDED_EXIT_CODE:
           outcome = WorkUnit.SUCCESS
         elif result == PANTS_FAILED_EXIT_CODE:
           outcome = WorkUnit.FAILURE
@@ -240,7 +240,7 @@ class LocalPantsRunner(object):
 
   def _maybe_run_v1(self):
     if not self._global_options.v1:
-      return PANTS_SUCCESS_EXIT_CODE
+      return PANTS_SUCCEEDED_EXIT_CODE
 
     # Setup and run GoalRunner.
     goal_runner_factory = GoalRunner.Factory(
@@ -259,7 +259,7 @@ class LocalPantsRunner(object):
     # N.B. For daemon runs, @console_rules are invoked pre-fork -
     # so this path only serves the non-daemon run mode.
     if self._is_daemon or not self._global_options.v2:
-      return PANTS_SUCCESS_EXIT_CODE
+      return PANTS_SUCCEEDED_EXIT_CODE
 
     # If we're a pure --v2 run, validate goals - otherwise some goals specified
     # may be provided by the --v1 task paths.
@@ -280,7 +280,7 @@ class LocalPantsRunner(object):
                   .format(e))
       return PANTS_FAILED_EXIT_CODE
     else:
-      return PANTS_SUCCESS_EXIT_CODE
+      return PANTS_SUCCEEDED_EXIT_CODE
 
   @staticmethod
   def _compute_final_exit_code(*codes):
@@ -301,7 +301,7 @@ class LocalPantsRunner(object):
       except ValueError as e:
         # Calling .end() sometimes writes to a closed file, so we return a dummy result here.
         logger.exception(e)
-        run_tracker_result = PANTS_SUCCESS_EXIT_CODE
+        run_tracker_result = PANTS_SUCCEEDED_EXIT_CODE
 
     final_exit_code = self._compute_final_exit_code(
       engine_result,

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -38,4 +38,4 @@ def main():
     try:
       PantsRunner(exiter, start_time=start_time).run()
     except KeyboardInterrupt as e:
-      exiter.exit_and_fail('Interrupted by user:\n{}'.format(e.message))
+      exiter.exit_and_fail('Interrupted by user:\n{}'.format(e))

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import time
+from builtins import str
 
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import Exiter
@@ -37,5 +38,5 @@ def main():
   with maybe_profiled(os.environ.get('PANTSC_PROFILE')):
     try:
       PantsRunner(exiter, start_time=start_time).run()
-    except KeyboardInterrupt:
-      exiter.exit_and_fail('Interrupted by user.')
+    except KeyboardInterrupt as e:
+      exiter.exit_and_fail('Interrupted by user. {}'.format(str(e)))

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import time
-from builtins import str
 
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import Exiter
@@ -39,4 +38,4 @@ def main():
     try:
       PantsRunner(exiter, start_time=start_time).run()
     except KeyboardInterrupt as e:
-      exiter.exit_and_fail('Interrupted by user. {}'.format(str(e)))
+      exiter.exit_and_fail('Interrupted by user:\n{}'.format(e.message))

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -9,12 +9,21 @@ import os
 import sys
 from builtins import object
 
-from pants.base.exception_sink import ExceptionSink
+from pants.base.exception_sink import ExceptionSink, GracefulSignalHandler
 from pants.bin.remote_pants_runner import RemotePantsRunner
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
 
 logger = logging.getLogger(__name__)
+
+
+class PantsRunnerSignalHandler(GracefulSignalHandler):
+
+  def handle_sigint(self, signum, frame):
+    raise KeyboardInterrupt('User interrupted execution with control-c!')
+
+  def handle_sigquit(self, signum, frame):
+    raise KeyboardInterrupt('A SIGQUIT was received.')
 
 
 class PantsRunner(object):
@@ -42,6 +51,7 @@ class PantsRunner(object):
 
     ExceptionSink.reset_should_print_backtrace_to_terminal(global_bootstrap_options.print_exception_stacktrace)
     ExceptionSink.reset_log_location(global_bootstrap_options.pants_workdir)
+    ExceptionSink.reset_graceful_signal_handler(PantsRunnerSignalHandler())
 
     if global_bootstrap_options.enable_pantsd:
       try:

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -9,7 +9,7 @@ import os
 import sys
 from builtins import object
 
-from pants.base.exception_sink import ExceptionSink, GracefulSignalHandler
+from pants.base.exception_sink import ExceptionSink, SignalHandler
 from pants.bin.remote_pants_runner import RemotePantsRunner
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
@@ -17,7 +17,7 @@ from pants.option.options_bootstrapper import OptionsBootstrapper
 logger = logging.getLogger(__name__)
 
 
-class PantsRunnerSignalHandler(GracefulSignalHandler):
+class PantsRunnerSignalHandler(SignalHandler):
 
   def handle_sigint(self, signum, frame):
     raise KeyboardInterrupt('User interrupted execution with control-c!')
@@ -51,7 +51,7 @@ class PantsRunner(object):
 
     ExceptionSink.reset_should_print_backtrace_to_terminal(global_bootstrap_options.print_exception_stacktrace)
     ExceptionSink.reset_log_location(global_bootstrap_options.pants_workdir)
-    ExceptionSink.reset_graceful_signal_handler(PantsRunnerSignalHandler())
+    ExceptionSink.reset_signal_handler(PantsRunnerSignalHandler())
 
     if global_bootstrap_options.enable_pantsd:
       try:

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -9,21 +9,12 @@ import os
 import sys
 from builtins import object
 
-from pants.base.exception_sink import ExceptionSink, SignalHandler
+from pants.base.exception_sink import ExceptionSink
 from pants.bin.remote_pants_runner import RemotePantsRunner
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
 
 logger = logging.getLogger(__name__)
-
-
-class PantsRunnerSignalHandler(SignalHandler):
-
-  def handle_sigint(self, signum, frame):
-    raise KeyboardInterrupt('User interrupted execution with control-c!')
-
-  def handle_sigquit(self, signum, frame):
-    raise KeyboardInterrupt('A SIGQUIT was received.')
 
 
 class PantsRunner(object):
@@ -51,7 +42,6 @@ class PantsRunner(object):
 
     ExceptionSink.reset_should_print_backtrace_to_terminal(global_bootstrap_options.print_exception_stacktrace)
     ExceptionSink.reset_log_location(global_bootstrap_options.pants_workdir)
-    ExceptionSink.reset_signal_handler(PantsRunnerSignalHandler())
 
     if global_bootstrap_options.enable_pantsd:
       try:

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 def _make_interrupted_by_user_error():
-  """???/used in the signal handler and raised upon a socket timeout error!"""
+  """Create an exception which is set by the signal handler and/or a socket timeout!"""
   return KeyboardInterrupt('Interrupted by user over pailgun client!')
 
 

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -38,20 +38,20 @@ class PailgunClientSignalHandler(SignalHandler):
     self._timeout = timeout
     super(PailgunClientSignalHandler, self).__init__(*args, **kwargs)
 
-  def _ferry_signal_with_timeout(self, signum):
+  def _forward_signal_with_timeout(self, signum):
     self._pailgun_client.set_exit_timeout(
       timeout=self._timeout,
       reason=_make_interrupted_by_user_error())
     self._pailgun_client.maybe_send_signal(signum)
 
-  def handle_sigint(self, signum, frame):
-    self._ferry_signal_with_timeout(signum)
+  def handle_sigint(self, signum, _frame):
+    self._forward_signal_with_timeout(signum)
 
-  def handle_sigquit(self, signum, frame):
-    self._ferry_signal_with_timeout(signum)
+  def handle_sigquit(self, signum, _frame):
+    self._forward_signal_with_timeout(signum)
 
-  def handle_sigterm(self, signum, frame):
-    self._ferry_signal_with_timeout(signum)
+  def handle_sigterm(self, signum, _frame):
+    self._forward_signal_with_timeout(signum)
 
 
 class RemotePantsRunner(object):

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -97,19 +97,10 @@ class RemotePantsRunner(object):
 
   @contextmanager
   def _trapped_signals(self, client):
-    """A contextmanager that overrides the SIGINT (control-c) and SIGQUIT (control-\\) handlers
-    and handles them remotely."""
-
+    """A contextmanager that handles SIGINT (control-c) and SIGQUIT (control-\\) remotely."""
     graceful_signal_handler = PailgunClientSignalHandler(client)
-    previous_signals = ExceptionSink.reset_graceful_signal_handler(graceful_signal_handler)
-
-    try:
+    with ExceptionSink.trapped_signals(graceful_signal_handler):
       yield
-    finally:
-      for signum, handler in previous_signals.items():
-        signal.signal(signum, handler)
-        # siginterrupt(3) says this is the default behavior on Linux.
-        signal.siginterrupt(signum, False)
 
   def _setup_logging(self):
     """Sets up basic stdio logging for the thin client."""

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 
 from future.utils import PY3, raise_with_traceback
 
-from pants.base.exception_sink import ExceptionSink, GracefulSignalHandler
+from pants.base.exception_sink import ExceptionSink, SignalHandler
 from pants.console.stty_utils import STTYSettings
 from pants.java.nailgun_client import NailgunClient
 from pants.java.nailgun_protocol import NailgunProtocol
@@ -25,7 +25,7 @@ from pants.util.dirutil import maybe_read_file
 logger = logging.getLogger(__name__)
 
 
-class PailgunClientSignalHandler(GracefulSignalHandler):
+class PailgunClientSignalHandler(SignalHandler):
 
   def __init__(self, pailgun_client, *args, **kwargs):
     assert(isinstance(pailgun_client, NailgunClient))
@@ -98,8 +98,8 @@ class RemotePantsRunner(object):
   @contextmanager
   def _trapped_signals(self, client):
     """A contextmanager that handles SIGINT (control-c) and SIGQUIT (control-\\) remotely."""
-    graceful_signal_handler = PailgunClientSignalHandler(client)
-    with ExceptionSink.trapped_signals(graceful_signal_handler):
+    signal_handler = PailgunClientSignalHandler(client)
+    with ExceptionSink.trapped_signals(signal_handler):
       yield
 
   def _setup_logging(self):

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -25,8 +25,8 @@ from pants.util.dirutil import maybe_read_file
 logger = logging.getLogger(__name__)
 
 
-# TODO: we should be seeing this in .pants.d/logs/exceptions.log!! we are not!! where is it going???
 def _make_interrupted_by_user_error():
+  """???/used in the signal handler and raised upon a socket timeout error!"""
   return KeyboardInterrupt('Interrupted by user over pailgun client!')
 
 
@@ -45,7 +45,6 @@ class PailgunClientSignalHandler(SignalHandler):
     self._pailgun_client.maybe_send_signal(signum)
 
   def handle_sigint(self, signum, frame):
-    raise KeyboardInterrupt('???')
     self._ferry_signal_with_timeout(signum)
 
   def handle_sigquit(self, signum, frame):

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -164,10 +164,7 @@ class RemotePantsRunner(object):
 
     with self._trapped_signals(client), STTYSettings.preserved():
       # Execute the command on the pailgun.
-      try:
-        result = client.execute(self.PANTS_COMMAND, *self._args, **modified_env)
-      except Exception as e:
-        raise e
+      result = client.execute(self.PANTS_COMMAND, *self._args, **modified_env)
 
     # Exit.
     self._exiter.exit(result)

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -21,6 +21,7 @@ from future.utils import PY2, PY3
 
 from pants.auth.cookies import Cookies
 from pants.base.build_environment import get_pants_cachedir
+from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCESS_EXIT_CODE
 from pants.base.run_info import RunInfo
 from pants.base.worker_pool import SubprocPool, WorkerPool
 from pants.base.workunit import WorkUnit, WorkUnitLabel
@@ -453,6 +454,8 @@ class RunTracker(Subsystem):
   def has_ended(self):
     return self._end_memoized_result is not None
 
+  # TODO: memoize this with a decorator!
+  # TODO: add PANTS_SUCCESS_EXIT_CODE and PANTS_FAILED_EXIT_CODE to the docstring!
   def end(self):
     """This pants run is over, so stop tracking it.
 
@@ -496,7 +499,8 @@ class RunTracker(Subsystem):
     self.report.close()
     self.store_stats()
 
-    result = 1 if outcome in [WorkUnit.FAILURE, WorkUnit.ABORTED] else 0
+    run_failed = outcome in [WorkUnit.FAILURE, WorkUnit.ABORTED]
+    result = PANTS_FAILED_EXIT_CODE if run_failed else PANTS_SUCCESS_EXIT_CODE
     self._end_memoized_result = result
     return self._end_memoized_result
 

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -21,7 +21,7 @@ from future.utils import PY2, PY3
 
 from pants.auth.cookies import Cookies
 from pants.base.build_environment import get_pants_cachedir
-from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCESS_EXIT_CODE
+from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.run_info import RunInfo
 from pants.base.worker_pool import SubprocPool, WorkerPool
 from pants.base.workunit import WorkUnit, WorkUnitLabel
@@ -455,13 +455,12 @@ class RunTracker(Subsystem):
     return self._end_memoized_result is not None
 
   # TODO: memoize this with a decorator!
-  # TODO: add PANTS_SUCCESS_EXIT_CODE and PANTS_FAILED_EXIT_CODE to the docstring!
   def end(self):
     """This pants run is over, so stop tracking it.
 
     Note: If end() has been called once, subsequent calls are no-ops.
 
-    :return: 0 for success, 1 for failure.
+    :return: PANTS_SUCCEEDED_EXIT_CODE or PANTS_FAILED_EXIT_CODE
     """
     if self._end_memoized_result is not None:
       return self._end_memoized_result
@@ -500,7 +499,7 @@ class RunTracker(Subsystem):
     self.store_stats()
 
     run_failed = outcome in [WorkUnit.FAILURE, WorkUnit.ABORTED]
-    result = PANTS_FAILED_EXIT_CODE if run_failed else PANTS_SUCCESS_EXIT_CODE
+    result = PANTS_FAILED_EXIT_CODE if run_failed else PANTS_SUCCEEDED_EXIT_CODE
     self._end_memoized_result = result
     return self._end_memoized_result
 

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -454,7 +454,6 @@ class RunTracker(Subsystem):
   def has_ended(self):
     return self._end_memoized_result is not None
 
-  # TODO: memoize this with a decorator!
   def end(self):
     """This pants run is over, so stop tracking it.
 

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -21,8 +21,10 @@ python_library(
   sources = ['nailgun_client.py'],
   dependencies = [
     '3rdparty/python:future',
+    '3rdparty/python:psutil',
     ':nailgun_io',
     ':nailgun_protocol',
+    'src/python/pants/util:dirutil',
     'src/python/pants/util:socket'
   ]
 )
@@ -43,6 +45,9 @@ python_library(
   dependencies = [
     '3rdparty/python:future',
     '3rdparty/python:six',
+    'src/python/pants/util:meta',
+    'src/python/pants/util:objects',
+    'src/python/pants/util:osutil',
   ]
 )
 

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -141,7 +141,6 @@ class NailgunClientSession(NailgunProtocol, NailgunProtocol.TimeoutObject):
       self._maybe_stop_input_writer()
       # If an asynchronous error was set at any point (such as in a signal handler), we want to make
       # sure we clean up the remote process before exiting with error.
-      # TODO: test this!
       if self._exit_reason:
         if self.remote_pgrp:
           safe_kill(self.remote_pgrp, signal.SIGKILL)
@@ -219,9 +218,12 @@ class NailgunClient(object):
     :param file out: a stream to write command standard output to (defaults to stdout)
     :param file err: a stream to write command standard error to (defaults to stderr)
     :param string workdir: the default working directory for all nailgun commands (defaults to CWD)
-    :param bool exit_on_broken_pipe: whether or not to exit when `Broken Pipe` errors are encountered
-    # TODO: fix docstring!
-    :param bool expects_pid: Whether or not to expect a PID from the server (only true for pantsd)
+    :param bool exit_on_broken_pipe: whether or not to exit when `Broken Pipe` errors are
+                                     encountered
+    :param string metadata_base_dir: If a PID and PGRP are received from the server (only for
+                                     pailgun connections), a file with the remote pid will be
+                                     written under this directory. For non-pailgun connections this
+                                     may be None.
     """
     self._host = host
     self._port = port
@@ -238,7 +240,6 @@ class NailgunClient(object):
     self._current_remote_pid = None
     self._current_remote_pgrp = None
 
-  # TODO: inject the '.pids' dir into the NailgunClient constructor!
   def _get_remote_pid_file_path(self, pid):
     return os.path.join(
       self._metadata_base_dir,
@@ -291,8 +292,8 @@ class NailgunClient(object):
     """Expose the inner session object's exit timeout setter."""
     self._session._set_exit_timeout(timeout, reason)
 
-  # TODO: make all invocations of this method instead require that the process is alive via the
-  # result of .remote_client_status() before sending a signal! safe_kill() should probably be
+  # TODO(#6579): make all invocations of this method instead require that the process is alive via
+  # the result of .remote_client_status() before sending a signal! safe_kill() should probably be
   # removed as well.
   def maybe_send_signal(self, signum, include_pgrp=True):
     """Send the signal `signum` send if the PID and/or PGRP chunks have been received.

--- a/src/python/pants/java/nailgun_protocol.py
+++ b/src/python/pants/java/nailgun_protocol.py
@@ -254,14 +254,10 @@ class NailgunProtocol(object):
   def iter_chunks(cls, sock, return_bytes=False, timeout_object=None):
     """Generates chunks from a connected socket until an Exit chunk is sent or a timeout occurs.
 
-    After this method returns non-None once, the .iter_chunks() method will then check the time on
-    every iteration, raising `cls.ProcessStreamTimeout` if the time runs out before the iteration is
-    complete.
-
     :param sock: the socket to read from.
     :param bool return_bytes: If False, decode the payload into a utf-8 string.
     :param cls.TimeoutProvider timeout_object: If provided, will be checked every iteration for a
-                                             possible timeout.
+                                               possible timeout.
     :raises: :class:`cls.ProcessStreamTimeout`
     """
     assert(timeout_object is None or isinstance(timeout_object, cls.TimeoutProvider))

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -276,6 +276,9 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help='The host to bind the pants nailgun server to.')
     register('--pantsd-pailgun-port', advanced=True, type=int, default=0,
              help='The port to bind the pants nailgun server to. Defaults to a random port.')
+    register('--pantsd-pailgun-quit-timeout', advanced=True, type=float, default=1.0,
+             help='The length of time (in seconds) to wait for further output after sending a '
+                  'signal to the remote pantsd-runner process before killing it.')
     register('--pantsd-log-dir', advanced=True, default=None,
              help='The directory to log pantsd output to.')
     register('--pantsd-invalidation-globs', advanced=True, type=list, fromfile=True, default=[],

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -11,6 +11,7 @@ import threading
 from builtins import object
 from contextlib import contextmanager
 
+from future.utils import PY3
 from setproctitle import setproctitle as set_process_title
 
 from pants.base.build_environment import get_buildroot
@@ -62,6 +63,11 @@ class _LoggerStream(object):
   def write(self, msg):
     msg = ensure_text(msg)
     for line in msg.rstrip().splitlines():
+      # The log only accepts text, and will raise a decoding error if the default encoding is ascii
+      # if provided a bytes input for unicode text.
+      if PY3:
+        if isinstance(line, bytes):
+          line = line.decode('utf-8')
       self._logger.log(self._log_level, line.rstrip())
 
   def flush(self):

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -11,7 +11,6 @@ import threading
 from builtins import object
 from contextlib import contextmanager
 
-from future.utils import PY3
 from setproctitle import setproctitle as set_process_title
 
 from pants.base.build_environment import get_buildroot
@@ -65,9 +64,7 @@ class _LoggerStream(object):
     for line in msg.rstrip().splitlines():
       # The log only accepts text, and will raise a decoding error if the default encoding is ascii
       # if provided a bytes input for unicode text.
-      if PY3:
-        if isinstance(line, bytes):
-          line = line.decode('utf-8')
+      line = ensure_text(line)
       self._logger.log(self._log_level, line.rstrip())
 
   def flush(self):

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -121,7 +121,7 @@ class PantsDaemon(FingerprintedProcessManager):
           return PantsDaemon.Handle(
               stub_pantsd.await_pid(10),
               stub_pantsd.read_named_socket('pailgun', int),
-              stub_pantsd._metadata_base_dir,
+              text_type(stub_pantsd._metadata_base_dir),
           )
 
     @classmethod
@@ -437,7 +437,7 @@ class PantsDaemon(FingerprintedProcessManager):
     listening_port = self.read_named_socket('pailgun', int)
     self._logger.debug('pantsd is running at pid {}, pailgun port is {}'
                        .format(self.pid, listening_port))
-    return self.Handle(pantsd_pid, listening_port, self._metadata_base_dir)
+    return self.Handle(pantsd_pid, listening_port, text_type(self._metadata_base_dir))
 
   def terminate(self, include_watchman=True):
     """Terminates pantsd and watchman.

--- a/src/python/pants/rules/core/exceptions.py
+++ b/src/python/pants/rules/core/exceptions.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCESS_EXIT_CODE
+
 
 class GracefulTerminationException(Exception):
   """Indicates that a console_rule should eagerly terminate the run.
@@ -14,14 +16,16 @@ class GracefulTerminationException(Exception):
   Nothing except a console_rule should ever raise this.
   """
 
-  def __init__(self, message='', exit_code=1):
+  def __init__(self, message='', exit_code=PANTS_FAILED_EXIT_CODE):
     """
-    :param int exit_code: an optional exit code (default=1)
+    :param int exit_code: an optional exit code (defaults to nonzero)
     """
     super(GracefulTerminationException, self).__init__(message)
 
-    if exit_code == 0:
-      raise ValueError("Cannot create GracefulTerminationException with exit code of 0")
+    if exit_code == PANTS_SUCCESS_EXIT_CODE:
+      raise ValueError(
+        "Cannot create GracefulTerminationException with a successful exit code of {}"
+        .format(PANTS_SUCCESS_EXIT_CODE))
 
     self._exit_code = exit_code
 

--- a/src/python/pants/rules/core/exceptions.py
+++ b/src/python/pants/rules/core/exceptions.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCESS_EXIT_CODE
+from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 
 
 class GracefulTerminationException(Exception):
@@ -18,14 +18,14 @@ class GracefulTerminationException(Exception):
 
   def __init__(self, message='', exit_code=PANTS_FAILED_EXIT_CODE):
     """
-    :param int exit_code: an optional exit code (defaults to nonzero)
+    :param int exit_code: an optional exit code (defaults to PANTS_FAILED_EXIT_CODE)
     """
     super(GracefulTerminationException, self).__init__(message)
 
-    if exit_code == PANTS_SUCCESS_EXIT_CODE:
+    if exit_code == PANTS_SUCCEEDED_EXIT_CODE:
       raise ValueError(
         "Cannot create GracefulTerminationException with a successful exit code of {}"
-        .format(PANTS_SUCCESS_EXIT_CODE))
+        .format(PANTS_SUCCEEDED_EXIT_CODE))
 
     self._exit_code = exit_code
 

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants.backend.python.rules.python_test_runner import PyTestResult
+from pants.base.exiter import PANTS_FAILED_EXIT_CODE
 from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.console import Console
@@ -36,7 +37,7 @@ def fast_test(console, addresses):
     console.print_stdout('{0:80}.....{1:>10}'.format(address.reference(), test_result.status))
 
   if did_any_fail:
-    raise GracefulTerminationException("Tests failed", exit_code=1)
+    raise GracefulTerminationException("Tests failed", exit_code=PANTS_FAILED_EXIT_CODE)
 
 
 @rule(TestResult, [Select(HydratedTarget)])

--- a/tests/python/pants_test/backend/codegen/protobuf/java/test_protobuf_integration.py
+++ b/tests/python/pants_test/backend/codegen/protobuf/java/test_protobuf_integration.py
@@ -9,6 +9,7 @@ import re
 from builtins import range
 
 from pants.base.build_environment import get_buildroot
+from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.util.process_handler import subprocess
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -63,7 +64,7 @@ class ProtobufIntegrationTest(PantsRunIntegrationTest):
                          '--deployjar',
                          'examples/src/java/org/pantsbuild/example/protobuf/unpacked_jars']
                         ) as pants_run:
-      self.assertEqual(pants_run.returncode, self.PANTS_SUCCESS_CODE,
+      self.assertEqual(pants_run.returncode, PANTS_SUCCEEDED_EXIT_CODE,
                         "goal bundle run expected success, got {0}\n"
                         "got stderr:\n{1}\n"
                         "got stdout:\n{2}\n".format(pants_run.returncode,

--- a/tests/python/pants_test/base/test_exception_sink.py
+++ b/tests/python/pants_test/base/test_exception_sink.py
@@ -11,7 +11,6 @@ from builtins import open, str
 
 import mock
 
-from pants.base.build_environment import get_buildroot
 from pants.base.exception_sink import ExceptionSink
 from pants.util.contextutil import temporary_dir
 from pants.util.osutil import get_normalized_os_name
@@ -21,17 +20,19 @@ from pants_test.testutils.py2_compat import assertRegex
 
 class TestExceptionSink(TestBase):
 
-  _default_log_dir = os.path.join(get_buildroot(), '.pants.d')
-
   def _gen_sink_subclass(self):
     # Avoid modifying global state by generating a subclass.
     class AnonymousSink(ExceptionSink): pass
     return AnonymousSink
 
   def test_default_log_location(self):
-    # NB: get_buildroot() returns the temporary buildroot used for running this test, so we cheat
-    # and assume we are being run from the buildroot.
-    self.assertEqual(ExceptionSink._log_dir, self._default_log_dir)
+    """Test that the global singleton ExceptionSink's log dir is relative to the original buildroot.
+
+    Assert that the global singleton ExceptionSink had its log dir set relative to the workdir upon
+    pants initialization, and when pants runs this test, it won't have been reset to the fake
+    buildroot we use for tests.
+    """
+    self.assertEqual(ExceptionSink._log_dir, os.path.join(os.getcwd(), '.pants.d'))
 
   def test_reset_log_location(self):
     sink = self._gen_sink_subclass()

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import signal
 import time
-import unittest
 from contextlib import contextmanager
 
 from pants.base.build_environment import get_buildroot
@@ -108,7 +107,6 @@ Signal {signum} ({signame}) was raised\\. Exiting with failure\\. \\(backtrace o
       # Return the (failed) pants execution result.
       yield (workdir, waiter_run)
 
-  @unittest.skip('Flaky: https://github.com/pantsbuild/pants/issues/6708')
   def test_dumps_logs_on_terminate(self):
     # Send a SIGTERM to the local pants process.
     with self._send_signal_to_waiter_handle(signal.SIGTERM) as (workdir, waiter_run):
@@ -123,7 +121,6 @@ Signal {signum} (SIGTERM) was raised. Exiting with failure. \\(backtrace omitted
       self._assert_graceful_signal_log_matches(
           waiter_run.pid, signal.SIGTERM, read_file(shared_log_file, binary_mode=False))
 
-  @unittest.skip('Hangs a lot: https://github.com/pantsbuild/pants/issues/7199')
   def test_dumps_traceback_on_sigabrt(self):
     # SIGABRT sends a traceback to the log file for the current process thanks to
     # faulthandler.enable().

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -151,10 +151,14 @@ Current thread [^\n]+ \\(most recent call first\\):
 """)
 
   def test_keyboardinterrupt_signals(self):
-    for interrupt_signal in [signal.SIGINT, signal.SIGQUIT]:
+    signal_messages = {
+      signal.SIGINT: 'User interrupted execution with control-c!',
+      signal.SIGQUIT: 'A SIGQUIT was received.',
+    }
+    for interrupt_signal, signal_msg in signal_messages.items():
       with self._send_signal_to_waiter_handle(interrupt_signal) as (workdir, waiter_run):
-        # TODO: update this to include the actual message from the KeyboardInterrupt raised!
-        self.assertIn('Interrupted by user:\n???', waiter_run.stderr_data)
+        self.assertIn('Interrupted by user:\n{}'.format(signal_msg),
+                      waiter_run.stderr_data)
 
   def _lifecycle_stub_cmdline(self):
     # Load the testprojects pants-plugins to get some testing tasks and subsystems.

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -153,7 +153,8 @@ Current thread [^\n]+ \\(most recent call first\\):
   def test_keyboardinterrupt_signals(self):
     for interrupt_signal in [signal.SIGINT, signal.SIGQUIT]:
       with self._send_signal_to_waiter_handle(interrupt_signal) as (workdir, waiter_run):
-        self.assertIn('Interrupted by user.', waiter_run.stderr_data)
+        # TODO: update this to include the actual message from the KeyboardInterrupt raised!
+        self.assertIn('Interrupted by user:\n???', waiter_run.stderr_data)
 
   def _lifecycle_stub_cmdline(self):
     # Load the testprojects pants-plugins to get some testing tasks and subsystems.

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -31,6 +31,10 @@ Exception caught: \\(pants\\.build_graph\\.address_lookup_error\\.AddressLookupE
 Exception message: Build graph construction failed: ExecutionError 1 Exception encountered:
   ResolveError: "this-target-does-not-exist" was not found in namespace ""\\. Did you mean one of:
 """.format(pid=pid))
+    # Ensure we write all output such as stderr and reporting files before closing any streams.
+    self.assertNotIn(
+      'Exception message: I/O operation on closed file.',
+      file_contents)
 
   def _get_log_file_paths(self, workdir, pants_run):
     pid_specific_log_file = ExceptionSink.exceptions_log_path(for_pid=pants_run.pid, in_dir=workdir)
@@ -71,6 +75,7 @@ sys\\.argv: ([^\n]+)
 pid: {pid}
 Signal {signum} \\({signame}\\) was raised\\. Exiting with failure\\.
 """.format(pid=pid, signum=signum, signame=signame))
+    # Ensure we write all output such as stderr and reporting files before closing any streams.
     self.assertNotIn(
       'Exception message: I/O operation on closed file.',
       contents)

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -70,8 +70,8 @@ timestamp: ([^\n]+)
 process title: ([^\n]+)
 sys\\.argv: ([^\n]+)
 pid: {pid}
-Signal {signum} was raised\\. Exiting with failure\\. \\(backtrace omitted\\)
-""".format(pid=pid, signum=signum))
+Signal {signum} ({signame}) was raised\\. Exiting with failure\\. \\(backtrace omitted\\)
+""".format(pid=pid, signum=signum, signame=ExceptionSink._SIGNAL_NAMES[signum]))
 
   @contextmanager
   def _make_waiter_handle(self):
@@ -114,7 +114,7 @@ Signal {signum} was raised\\. Exiting with failure\\. \\(backtrace omitted\\)
     with self._send_signal_to_waiter_handle(signal.SIGTERM) as (workdir, waiter_run):
       assertRegex(self, waiter_run.stderr_data, """\
 timestamp: ([^\n]+)
-Signal {signum} was raised. Exiting with failure. \\(backtrace omitted\\)
+Signal {signum} (SIGTERM) was raised. Exiting with failure. \\(backtrace omitted\\)
 """.format(signum=signal.SIGTERM))
       # Check that the logs show a graceful exit by SIGTERM.
       pid_specific_log_file, shared_log_file = self._get_log_file_paths(workdir, waiter_run)
@@ -153,7 +153,7 @@ Current thread [^\n]+ \\(most recent call first\\):
   def test_keyboardinterrupt_signals(self):
     for interrupt_signal in [signal.SIGINT, signal.SIGQUIT]:
       with self._send_signal_to_waiter_handle(interrupt_signal) as (workdir, waiter_run):
-        self.assertIn('Interrupted by user.\n', waiter_run.stderr_data)
+        self.assertIn('Interrupted by user.', waiter_run.stderr_data)
 
   def _lifecycle_stub_cmdline(self):
     # Load the testprojects pants-plugins to get some testing tasks and subsystems.

--- a/tests/python/pants_test/java/test_nailgun_client.py
+++ b/tests/python/pants_test/java/test_nailgun_client.py
@@ -74,7 +74,9 @@ class TestNailgunClientSession(unittest.TestCase):
     self.nailgun_client_session._maybe_start_input_writer()
     self.nailgun_client_session._maybe_stop_input_writer()
 
-  def test_process_session(self):
+  @mock.patch('psutil.Process', **PATCH_OPTS)
+  def test_process_session(self, mock_psutil_process):
+    mock_psutil_process.cmdline.return_value = ['mock', 'process']
     NailgunProtocol.write_chunk(self.server_sock, ChunkType.PID, b'31337')
     NailgunProtocol.write_chunk(self.server_sock, ChunkType.START_READING_INPUT)
     NailgunProtocol.write_chunk(self.server_sock, ChunkType.STDOUT, self.TEST_PAYLOAD)
@@ -90,7 +92,9 @@ class TestNailgunClientSession(unittest.TestCase):
     self.mock_stdin_reader.stop.assert_called_once_with()
     self.assertEqual(self.nailgun_client_session.remote_pid, 31337)
 
-  def test_process_session_bad_chunk(self):
+  @mock.patch('psutil.Process', **PATCH_OPTS)
+  def test_process_session_bad_chunk(self, mock_psutil_process):
+    mock_psutil_process.cmdline.return_value = ['mock', 'process']
     NailgunProtocol.write_chunk(self.server_sock, ChunkType.PID, b'31337')
     NailgunProtocol.write_chunk(self.server_sock, ChunkType.START_READING_INPUT)
     NailgunProtocol.write_chunk(self.server_sock, self.BAD_CHUNK_TYPE, '')

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -17,6 +17,7 @@ from colors import strip_color
 
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
+from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.fs.archive import ZIP
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import environment_as, pushd, temporary_dir
@@ -51,7 +52,7 @@ class PantsJoinHandle(datatype(['command', 'process', 'workdir'])):
       stdin_data = ensure_binary(stdin_data)
     (stdout_data, stderr_data) = communicate_fn(stdin_data)
 
-    if self.process.returncode != PantsRunIntegrationTest.PANTS_SUCCESS_CODE:
+    if self.process.returncode != PANTS_SUCCEEDED_EXIT_CODE:
       render_logs(self.workdir)
 
     return PantsResult(
@@ -160,7 +161,6 @@ def _read_log(filename):
 class PantsRunIntegrationTest(unittest.TestCase):
   """A base class useful for integration tests for targets in the same repo."""
 
-  PANTS_SUCCESS_CODE = 0
   PANTS_SCRIPT_NAME = 'pants'
 
   @classmethod
@@ -453,10 +453,10 @@ class PantsRunIntegrationTest(unittest.TestCase):
       return stdout.decode('utf-8')
 
   def assert_success(self, pants_run, msg=None):
-    self.assert_result(pants_run, self.PANTS_SUCCESS_CODE, expected=True, msg=msg)
+    self.assert_result(pants_run, PANTS_SUCCEEDED_EXIT_CODE, expected=True, msg=msg)
 
   def assert_failure(self, pants_run, msg=None):
-    self.assert_result(pants_run, self.PANTS_SUCCESS_CODE, expected=False, msg=msg)
+    self.assert_result(pants_run, PANTS_SUCCEEDED_EXIT_CODE, expected=False, msg=msg)
 
   def assert_result(self, pants_run, value, expected=True, msg=None):
     check, assertion = (eq, self.assertEqual) if expected else (ne, self.assertNotEqual)

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -46,6 +46,14 @@ class PantsDaemonMonitor(ProcessManager):
     self._check_pantsd_is_alive()
     return self._pid
 
+  def assert_pantsd_runner_started(self, client_pid, timeout=4):
+    return self.await_metadata_by_name(
+      name='nailgun-client',
+      metadata_key=str(client_pid),
+      timeout=timeout,
+      caster=int,
+    )
+
   def _check_pantsd_is_alive(self):
     self._log()
     assert self._pid is not None and self.is_alive(), 'cannot assert that pantsd is running. Try calling assert_started before calling this method.'

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -83,9 +83,6 @@ class PantsDaemonIntegrationTestBase(PantsRunIntegrationTest):
           recursively_update(pantsd_config, extra_config)
         print('>>> config: \n{}\n'.format(pantsd_config))
         checker = PantsDaemonMonitor(runner_process_context, pid_dir)
-        # TODO(#6574): this should be 1, but when we kill pantsd with a signal it doesn't make sure
-        # to close the run tracker -- we can easily address this by moving that cleanup into the
-        # Exiter.
         self.assert_runner(workdir, pantsd_config, ['kill-pantsd'], expected_runs=1)
         try:
           yield workdir, pantsd_config, checker
@@ -98,7 +95,6 @@ class PantsDaemonIntegrationTestBase(PantsRunIntegrationTest):
             workdir,
             pantsd_config,
             ['kill-pantsd'],
-            # TODO(#6574): this should be 1, see above.
             expected_runs=1,
           )
           checker.assert_stopped()

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -37,7 +37,10 @@ class PantsDaemonMonitor(ProcessManager):
       'PantsDaemonMonitor: pid is {} is_alive={}'.format(self._pid, self.is_alive()))
     )
 
-  def assert_started(self, timeout=12):
+  # TODO(#7330): Determine why pantsd takes so long to start! Waiting for
+  # 'testprojects/src/python/coordinated_runs:waiter' specifically seems to require this 16-second
+  # timeout.
+  def assert_started(self, timeout=16):
     self._process = None
     self._pid = self.await_pid(timeout)
     self._check_pantsd_is_alive()

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -37,7 +37,7 @@ class PantsDaemonMonitor(ProcessManager):
       'PantsDaemonMonitor: pid is {} is_alive={}'.format(self._pid, self.is_alive()))
     )
 
-  def assert_started(self, timeout=6):
+  def assert_started(self, timeout=12):
     self._process = None
     self._pid = self.await_pid(timeout)
     self._check_pantsd_is_alive()

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -37,7 +37,7 @@ class PantsDaemonMonitor(ProcessManager):
       'PantsDaemonMonitor: pid is {} is_alive={}'.format(self._pid, self.is_alive()))
     )
 
-  def assert_started(self, timeout=.1):
+  def assert_started(self, timeout=6):
     self._process = None
     self._pid = self.await_pid(timeout)
     self._check_pantsd_is_alive()
@@ -63,7 +63,7 @@ class PantsDaemonMonitor(ProcessManager):
 
 class PantsDaemonIntegrationTestBase(PantsRunIntegrationTest):
   @contextmanager
-  def pantsd_test_context(self, log_level='info', extra_config=None, expected_runs=1):
+  def pantsd_test_context(self, log_level='info', extra_config=None):
     with no_lingering_process_by_command('pantsd-runner') as runner_process_context:
       with self.temporary_workdir() as workdir_base:
         pid_dir = os.path.join(workdir_base, '.pids')
@@ -151,7 +151,7 @@ class PantsDaemonIntegrationTestBase(PantsRunIntegrationTest):
     self.assertEqual(
         runs_created,
         expected_runs,
-        'Expected {} RunTracker run to be created per pantsd run: was {}'.format(
+        'Expected {} RunTracker run(s) to be created per pantsd run: was {}'.format(
           expected_runs,
           runs_created,
         )

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -464,16 +464,15 @@ Signal {signum} (SIGTERM) was raised\\. Exiting with failure\\. \\(backtrace omi
         config,
       )
 
+      checker.assert_started(timeout=12)
+
       # TODO: There is a race condition here, where if the waiter run is killed before it starts the
       # remote client, it will display the PantsRunnerSignalHandler message, but if it is signalled
       # after switching control to the remote client, it will display a message about being
-      # interrupted via the pailgun client (which is what we check here). This means we aren't
-      # necessarily testing that the remote client is handling signals correctly, but it does mean
-      # the test won't flake until we can figure out a better method than relying on timeouts. This
-      # 16-second sleep is longer than the timeout we wait for the process to start, and is
-      # *hopefully* long enough to have pants transition to the remote client phase.
-      time.sleep(16)
-      checker.assert_started(timeout=12)
+      # interrupted via the pailgun client (which is what we check here). We shouldn't be using
+      # timeouts here, and this may cause flakiness. This 4-second sleep is *hopefully* long enough
+      # to have pants transition to the remote client phase.
+      time.sleep(4)
 
       # Get all the pantsd-runner processes while they're still around.
       pantsd_runner_processes = checker.runner_process_context.current_processes()

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -396,6 +396,11 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
     finally:
       rm_rf(test_path)
 
+  # TODO(#7330): Determine why pantsd takes so long to start!
+  def _wait_for_waiter_run(self, checker):
+    """Letting pantsd start for the waiter testproject python_binary() takes a while."""
+    checker.assert_started(16)
+
   def test_pantsd_multiple_parallel_runs(self):
     with self.pantsd_test_context() as (workdir, config, checker):
       file_to_make = os.path.join(workdir, 'some_magic_file')
@@ -405,10 +410,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         config,
       )
 
-      # Wait for the python run to be running
-      time.sleep(15)
-
-      checker.assert_started()
+      self._wait_for_waiter_run(checker)
 
       creator_handle = self.run_pants_with_workdir_without_waiting(
         ['run', 'testprojects/src/python/coordinated_runs:creator', '--', file_to_make],
@@ -464,7 +466,7 @@ Signal {signum} (SIGTERM) was raised\\. Exiting with failure\\. \\(backtrace omi
         config,
       )
 
-      checker.assert_started(timeout=12)
+      self._wait_for_waiter_run(checker)
 
       # TODO: There is a race condition here, where if the waiter run is killed before it starts the
       # remote client, it will display the PantsRunnerSignalHandler message, but if it is signalled

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -405,6 +405,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
       )
 
       checker.assert_started()
+      checker.assert_pantsd_runner_started(waiter_handle.process.pid)
 
       creator_handle = self.run_pants_with_workdir_without_waiting(
         ['run', 'testprojects/src/python/coordinated_runs:creator', '--', file_to_make],

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -396,11 +396,6 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
     finally:
       rm_rf(test_path)
 
-  # TODO(#7330): Determine why pantsd takes so long to start!
-  def _wait_for_waiter_run(self, checker):
-    """Letting pantsd start for the waiter testproject python_binary() takes a while."""
-    checker.assert_started(16)
-
   def test_pantsd_multiple_parallel_runs(self):
     with self.pantsd_test_context() as (workdir, config, checker):
       file_to_make = os.path.join(workdir, 'some_magic_file')
@@ -410,7 +405,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         config,
       )
 
-      self._wait_for_waiter_run(checker)
+      checker.assert_started()
 
       creator_handle = self.run_pants_with_workdir_without_waiting(
         ['run', 'testprojects/src/python/coordinated_runs:creator', '--', file_to_make],
@@ -466,7 +461,7 @@ Signal {signum} (SIGTERM) was raised\\. Exiting with failure\\. \\(backtrace omi
         config,
       )
 
-      self._wait_for_waiter_run(checker)
+      checker.assert_started()
 
       # TODO: There is a race condition here, where if the waiter run is killed before it starts the
       # remote client, it will display the PantsRunnerSignalHandler message, but if it is signalled

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -444,7 +444,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
       # Ensure that we saw the pantsd-runner process's failure in the client's stderr.
       self.assert_failure(waiter_run)
       assertRegex(self, waiter_run.stderr_data, """\
-Signal {signum} was raised\\. Exiting with failure\\. \\(backtrace omitted\\)
+Signal {signum} (SIGTERM) was raised\\. Exiting with failure\\. \\(backtrace omitted\\)
 """.format(signum=signal.SIGTERM))
       # NB: testing stderr is an "end-to-end" test, as it requires pants knowing the correct remote
       # pid and reading those files to print their content to stderr, so we don't necessarily need
@@ -485,11 +485,9 @@ Signal {signum} was raised\\. Exiting with failure\\. \\(backtrace omitted\\)
         # The pantsd-runner processes should be dead, and they should have exited with 1.
         self.assertFalse(proc.is_running())
 
-  @unittest.skip('TODO: this should be unskipped as part of the work for #6574!')
   def test_pantsd_control_c(self):
     self._assert_pantsd_keyboardinterrupt_signal(signal.SIGINT)
 
-  @unittest.skip('TODO: this should be unskipped as part of the work for #6574!')
   def test_pantsd_sigquit(self):
     # We convert a local SIGQUIT in the thin client process -> SIGINT on the remote end in
     # RemotePantsRunner.

--- a/tests/python/pants_test/testutils/py2_compat.py
+++ b/tests/python/pants_test/testutils/py2_compat.py
@@ -7,24 +7,24 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from future.utils import PY3
 
 
-def assertRegex(self, text, expected_regex):
+def assertRegex(self, text, expected_regex, msg=None):
   """Call unit test assertion to ensure regex matches.
 
   While Py3 still has assertRegexpMatches, it's deprecated. This function also exists for consistency with
   our helper function assertNotRegex, which *is* required for Py2-3 compatibility.
   """
   if PY3:
-    self.assertRegex(text, expected_regex)
+    self.assertRegex(text, expected_regex, msg)
   else:
-    self.assertRegexpMatches(text, expected_regex)
+    self.assertRegexpMatches(text, expected_regex, msg)
 
 
-def assertNotRegex(self, text, unexpected_regex):
+def assertNotRegex(self, text, unexpected_regex, msg=None):
   """Call unit test assertion to ensure regex does not match.
 
   Required for compatibility because Py3.4 does not have assertNotRegexpMatches.
   """
   if PY3:
-    self.assertNotRegex(text, unexpected_regex)
+    self.assertNotRegex(text, unexpected_regex, msg)
   else:
-    self.assertNotRegexpMatches(text, unexpected_regex)
+    self.assertNotRegexpMatches(text, unexpected_regex, msg)


### PR DESCRIPTION
### Problem

#6552 has some changes around signal handling. This was an attempt to move those out, and to gain greater visibility into and control over when pants errors out due to a signal (helping to address difficulties in flaky tests around exiting, such as #6708).

Resolves #7014, resolves #6708, resolves #6847, resolves #7199.

### Solution

- Create a very simple `SignalHandler` class which can be subclassed to set pants's behavior upon receiving different signals in different execution contexts.
- Add a `_signal_handler` field to `ExceptionSink`.
- Apply `SignalHandler` everywhere that tries to modify pants's exception handling.
- Add the `--pantsd-pailgun-quit-timeout` bootstrap option and implement a timeout strategy to continue to forward output from the remote `pantsd-runner` process for a brief period of time upon receiving a signal, then killing the remote process if it's still alive at the end.
- Unskip some flaky tests that we hopefully won't have to reskip.

### Result

It's much more clear when and where signal handlers are set, and the flow of control is made more clear. It is easier to extend signal handlers in a hygienic way, allowing for the resolution of multiple flaky tests.