### PR TITLE
add some more context to errors locating the native engine binary

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -703,7 +703,7 @@ class Native(object):
           output_fp.write(input_fp.read())
     except (IOError, OSError) as e:
       raise self.BinaryLocationError(
-        "Error loading the native engine binary from path {}: {}".format(lib_path, e),
+        "Error unpacking the native engine binary to path {}: {}".format(lib_path, e),
         e)
     return lib_path
 

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -685,19 +685,26 @@ class Native(object):
   def visualize_to_dir(self):
     return self._visualize_to_dir
 
+  class BinaryLocationError(Exception): pass
+
   @memoized_property
   def binary(self):
     """Load and return the path to the native engine binary."""
     lib_name = '{}.so'.format(NATIVE_ENGINE_MODULE)
     lib_path = os.path.join(safe_mkdtemp(), lib_name)
-    with closing(pkg_resources.resource_stream(__name__, lib_name)) as input_fp:
-      # NB: The header stripping code here must be coordinated with header insertion code in
-      #     build-support/bin/native/bootstrap_code.sh
-      engine_version = input_fp.readline().decode('utf-8').strip()
-      repo_version = input_fp.readline().decode('utf-8').strip()
-      logger.debug('using {} built at {}'.format(engine_version, repo_version))
-      with open(lib_path, 'wb') as output_fp:
-        output_fp.write(input_fp.read())
+    try:
+      with closing(pkg_resources.resource_stream(__name__, lib_name)) as input_fp:
+        # NB: The header stripping code here must be coordinated with header insertion code in
+        #     build-support/bin/native/bootstrap_code.sh
+        engine_version = input_fp.readline().decode('utf-8').strip()
+        repo_version = input_fp.readline().decode('utf-8').strip()
+        logger.debug('using {} built at {}'.format(engine_version, repo_version))
+        with open(lib_path, 'wb') as output_fp:
+          output_fp.write(input_fp.read())
+    except (IOError, OSError) as e:
+      raise self.BinaryLocationError(
+        "Error loading the native engine binary from path {}: {}".format(lib_path, e),
+        e)
     return lib_path
 
   @memoized_property


### PR DESCRIPTION
### Problem

You can get "no space left on device" errors from writing too many things to `/tmp` -- if that happens to occur as you write the native engine binary to disk from a `pkg_resources.resource_stream()`, all you see is "no space left on device". This is happening on my arch linux laptop for whatever reason but has happened on OSX as well. 

### Solution

Catch `IOError` and `OSError` in `Native#binary` and wrap them in an error message with the attempted path being written to.