### PR TITLE
Improve Noop resolution performance

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -443,6 +443,8 @@ class CoursierMixin(NailgunTask, ResolveBase):
     for coord in coord_to_resolved_jars.keys():
       org_name_to_org_name_rev['{}:{}'.format(coord.org, coord.name)] = coord
 
+    jars_per_target = []
+
     for vt in invalidation_check.all_vts:
       t = vt.target
       jars_to_digest = []
@@ -460,7 +462,6 @@ class CoursierMixin(NailgunTask, ResolveBase):
 
           return transitive_jar_path_for_coord
 
-        jars_per_target = []
         for jar in t.jar_dependencies:
           # if there are override classifiers, then force use of those.
           coord_candidates = []
@@ -486,8 +487,8 @@ class CoursierMixin(NailgunTask, ResolveBase):
 
         jars_per_target.append((t, jars_to_digest))
 
-      for target, jars_to_add in self.add_directory_digests_for_jars(jars_per_target):
-        compile_classpath.add_jars_for_targets([target], conf, jars_to_add)
+    for target, jars_to_add in self.add_directory_digests_for_jars(jars_per_target):
+      compile_classpath.add_jars_for_targets([target], conf, jars_to_add)
 
   def _populate_results_dir(self, vts_results_dir, results):
     mode = 'w' if PY3 else 'wb'

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -22,8 +22,8 @@ from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.coursier.coursier_subsystem import CoursierSubsystem
-from pants.backend.jvm.tasks.nailgun_task import NailgunTask, NailgunTaskBase
-from pants.backend.jvm.tasks.resolve_shared import ResolveBase
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
+from pants.backend.jvm.tasks.resolve_shared import JvmResolverBase
 from pants.base.exceptions import TaskError
 from pants.base.fingerprint_strategy import FingerprintStrategy
 from pants.base.workunit import WorkUnitLabel
@@ -38,7 +38,7 @@ class CoursierResultNotFound(Exception):
   pass
 
 
-class CoursierMixin(NailgunTask, ResolveBase):
+class CoursierMixin(NailgunTask, JvmResolverBase):
   """
   Experimental 3rdparty resolver using coursier.
 
@@ -487,11 +487,7 @@ class CoursierMixin(NailgunTask, ResolveBase):
 
         jars_per_target.append((t, jars_to_digest))
 
-    # If we are not doing hermetic execution, don't capture the digests
-    if self.get_options().execution_strategy == NailgunTaskBase.HERMETIC:
-      jars_per_target = self.add_directory_digests_for_jars(jars_per_target)
-
-    for target, jars_to_add in jars_per_target:
+    for target, jars_to_add in self.add_directory_digests_for_jars(jars_per_target):
       compile_classpath.add_jars_for_targets([target], conf, jars_to_add)
 
   def _populate_results_dir(self, vts_results_dir, results):

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -22,7 +22,7 @@ from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.coursier.coursier_subsystem import CoursierSubsystem
-from pants.backend.jvm.tasks.nailgun_task import NailgunTask
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask, NailgunTaskBase
 from pants.backend.jvm.tasks.resolve_shared import ResolveBase
 from pants.base.exceptions import TaskError
 from pants.base.fingerprint_strategy import FingerprintStrategy
@@ -487,7 +487,11 @@ class CoursierMixin(NailgunTask, ResolveBase):
 
         jars_per_target.append((t, jars_to_digest))
 
-    for target, jars_to_add in self.add_directory_digests_for_jars(jars_per_target):
+    # If we are not doing hermetic execution, don't capture the digests
+    if self.get_options().execution_strategy == NailgunTaskBase.HERMETIC:
+      jars_per_target = self.add_directory_digests_for_jars(jars_per_target)
+
+    for target, jars_to_add in jars_per_target:
       compile_classpath.add_jars_for_targets([target], conf, jars_to_add)
 
   def _populate_results_dir(self, vts_results_dir, results):

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -178,9 +178,9 @@ class IvyTaskMixin(TaskBase, ResolveBase):
     # appropriately.
     classpath_products.add_excludes_for_targets(targets)
     for conf in confs:
-      for target, resolved_jars in result.resolved_jars_for_each_target(conf, targets):
-        jars_to_add = self.add_directory_digests_for_jars(resolved_jars)
-        classpath_products.add_jars_for_targets([target], conf, jars_to_add)
+      resolved_jars_per_target = result.resolved_jars_for_each_target(conf, targets)
+      for target, resolved_jars in self.add_directory_digests_for_jars(resolved_jars_per_target):
+        classpath_products.add_jars_for_targets([target], conf, resolved_jars)
 
     return result
 

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -15,12 +15,11 @@ from pants.backend.jvm.ivy_utils import NO_RESOLVE_RUN_RESULT, IvyFetchStep, Ivy
 from pants.backend.jvm.subsystems.jar_dependency_management import JarDependencyManagement
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
-from pants.backend.jvm.tasks.resolve_shared import ResolveBase
+from pants.backend.jvm.tasks.resolve_shared import JvmResolverBase
 from pants.base.exceptions import TaskError
 from pants.base.fingerprint_strategy import FingerprintStrategy
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.ivy.ivy_subsystem import IvySubsystem
-from pants.task.task import TaskBase
 from pants.util.memo import memoized_property
 
 
@@ -70,7 +69,7 @@ class IvyResolveFingerprintStrategy(FingerprintStrategy):
     return type(self) == type(other) and self._confs == other._confs
 
 
-class IvyTaskMixin(TaskBase, ResolveBase):
+class IvyTaskMixin(JvmResolverBase):
   """A mixin for Tasks that execute resolves via Ivy.
 
   Must be mixed in to a task that registers a --jvm-options option (typically by

--- a/src/python/pants/backend/jvm/tasks/resolve_shared.py
+++ b/src/python/pants/backend/jvm/tasks/resolve_shared.py
@@ -13,18 +13,57 @@ from pants.util.dirutil import fast_relpath
 class ResolveBase(object):
   """Common methods for both Ivy and Coursier resolves."""
 
-  def add_directory_digests_for_jars(self, jars):
-    """Get DirectoryDigests for jars and return them zipped with the jars.
+  def add_directory_digests_for_jars(self, targets_and_jars):
+    """For each target, get DirectoryDigests for its jars and return them zipped with the jars.
 
-    :param jars: List of pants.java.jar.jar_dependency_utils.ResolveJar
-    :return: List of ResolveJars.
+    :param targets_and_jars: List of tuples of the form (Target, [pants.java.jar.jar_dependency_utils.ResolveJar])
+    :return: list[tuple[(Target, list[pants.java.jar.jar_dependency_utils.ResolveJar])]
     """
+
+    # Unzip into a tuple[list[ResolveJar]] (jars_to_snapshot)
+    targets_and_jars=list(targets_and_jars)
+    print("TARGETS AND JARS: ", targets_and_jars)
+
+    if not targets_and_jars:
+      print("asdfasdfasdfasdfasdfasdflkasdjfkjashdfklasdhf")
+      return targets_and_jars
+
+    # [(target, [jars]), (target, [jars])] -> ([target, target], [[jars], [jars]])
+    print("TARGETS AND JARS - 2: ", targets_and_jars)
+    jar_paths = [] # list[list[jar]]
+    for target, jars_to_snapshot in targets_and_jars:
+      for jar in jars_to_snapshot:
+        jar_paths.append(fast_relpath(jar.pants_path, get_buildroot()))
+
+    print("JAR PATHS: ", jar_paths)
+    #
+    # def create_pathglobs(jars):
+    #   return PathGlobs([fast_relpath(jar.pants_path, get_buildroot()) for jar in jars])
+    #
+    # globs = tuple([PathGlobsAndRoot(create_pathglobs(jars), get_buildroot()) for jars in jars_to_snapshot])
+    # print("GLOBS ", globs)
     snapshots = self.context._scheduler.capture_snapshots(
-      tuple(PathGlobsAndRoot(
-        PathGlobs([fast_relpath(jar.pants_path, get_buildroot())]), get_buildroot()) for jar in jars)
-    )
-    return [ResolvedJar(coordinate=jar.coordinate,
-                        cache_path=jar.cache_path,
-                        pants_path=jar.pants_path,
-                        directory_digest=directory_digest) for jar, directory_digest in
-            list(zip(jars, [snapshot.directory_digest for snapshot in snapshots]))]
+      tuple(
+        PathGlobsAndRoot(PathGlobs([jar]), get_buildroot()) for jar in jar_paths
+      ))
+    print("SNAPSHOTS ", snapshots)
+
+    # We want to map back the list[Snapshot] to targets_and_jars
+    # We assume that (1) jars_to_snapshot has the same number of ResolveJars as snapshots does Snapshots,
+    # and that (2) capture_snapshots preserves ordering.
+    digests = [snapshot.directory_digest for snapshot in snapshots]
+    print("DIGESTS ", digests)
+    digest_iterator = iter(digests)
+
+    snapshotted_targets_and_jars = []
+    print("Targets nad jars: ", targets_and_jars)
+    for target, jars_to_snapshot in targets_and_jars:
+      snapshotted_jars = [ResolvedJar(coordinate=jar.coordinate,
+                                      cache_path=jar.cache_path,
+                                      pants_path=jar.pants_path,
+                                      directory_digest=digest_iterator.next()) for jar in jars_to_snapshot]
+      print("SNAPSHOTTED JARS: ", snapshotted_jars)
+      snapshotted_targets_and_jars.append((target, snapshotted_jars))
+
+    print("AFTER SNAPSHOT: ", snapshotted_targets_and_jars)
+    return snapshotted_targets_and_jars

--- a/src/python/pants/backend/jvm/tasks/resolve_shared.py
+++ b/src/python/pants/backend/jvm/tasks/resolve_shared.py
@@ -27,7 +27,8 @@ class ResolveBase(object):
 
     jar_paths = []
     for target, jars_to_snapshot in targets_and_jars:
-      [jar_paths.append(fast_relpath(jar.pants_path, get_buildroot())) for jar in jars_to_snapshot]
+      for jar in jars_to_snapshot:
+        jar_paths.append(fast_relpath(jar.pants_path, get_buildroot()))
 
     snapshots = self.context._scheduler.capture_snapshots(
       tuple(

--- a/src/python/pants/backend/jvm/tasks/resolve_shared.py
+++ b/src/python/pants/backend/jvm/tasks/resolve_shared.py
@@ -20,50 +20,32 @@ class ResolveBase(object):
     :return: list[tuple[(Target, list[pants.java.jar.jar_dependency_utils.ResolveJar])]
     """
 
-    # Unzip into a tuple[list[ResolveJar]] (jars_to_snapshot)
     targets_and_jars=list(targets_and_jars)
-    print("TARGETS AND JARS: ", targets_and_jars)
 
     if not targets_and_jars:
-      print("asdfasdfasdfasdfasdfasdflkasdjfkjashdfklasdhf")
       return targets_and_jars
 
-    # [(target, [jars]), (target, [jars])] -> ([target, target], [[jars], [jars]])
-    print("TARGETS AND JARS - 2: ", targets_and_jars)
-    jar_paths = [] # list[list[jar]]
+    jar_paths = []
     for target, jars_to_snapshot in targets_and_jars:
-      for jar in jars_to_snapshot:
-        jar_paths.append(fast_relpath(jar.pants_path, get_buildroot()))
+      jar_paths = [fast_relpath(jar.pants_path, get_buildroot()) for jar in jars_to_snapshot]
 
-    print("JAR PATHS: ", jar_paths)
-    #
-    # def create_pathglobs(jars):
-    #   return PathGlobs([fast_relpath(jar.pants_path, get_buildroot()) for jar in jars])
-    #
-    # globs = tuple([PathGlobsAndRoot(create_pathglobs(jars), get_buildroot()) for jars in jars_to_snapshot])
-    # print("GLOBS ", globs)
     snapshots = self.context._scheduler.capture_snapshots(
       tuple(
         PathGlobsAndRoot(PathGlobs([jar]), get_buildroot()) for jar in jar_paths
       ))
-    print("SNAPSHOTS ", snapshots)
 
     # We want to map back the list[Snapshot] to targets_and_jars
     # We assume that (1) jars_to_snapshot has the same number of ResolveJars as snapshots does Snapshots,
     # and that (2) capture_snapshots preserves ordering.
     digests = [snapshot.directory_digest for snapshot in snapshots]
-    print("DIGESTS ", digests)
     digest_iterator = iter(digests)
 
     snapshotted_targets_and_jars = []
-    print("Targets nad jars: ", targets_and_jars)
     for target, jars_to_snapshot in targets_and_jars:
       snapshotted_jars = [ResolvedJar(coordinate=jar.coordinate,
                                       cache_path=jar.cache_path,
                                       pants_path=jar.pants_path,
                                       directory_digest=digest_iterator.next()) for jar in jars_to_snapshot]
-      print("SNAPSHOTTED JARS: ", snapshotted_jars)
       snapshotted_targets_and_jars.append((target, snapshotted_jars))
 
-    print("AFTER SNAPSHOT: ", snapshotted_targets_and_jars)
     return snapshotted_targets_and_jars

--- a/src/python/pants/backend/jvm/tasks/resolve_shared.py
+++ b/src/python/pants/backend/jvm/tasks/resolve_shared.py
@@ -22,7 +22,7 @@ class JvmResolverBase(TaskBase):
     super(JvmResolverBase, cls).register_options(register)
     # TODO This flag should be defaulted to True when we are doing hermetic execution,
     # and should probably go away as we move forward into that direction.
-    register('--jvm-resolver-capture-snapshots', type=bool, default=False,
+    register('--capture-snapshots', type=bool, default=False,
       help='Enable capturing snapshots to add directory digests to dependency jars.'
            'Note that this is necessary when hermetic execution is enabled.')
 
@@ -35,7 +35,7 @@ class JvmResolverBase(TaskBase):
 
     targets_and_jars=list(targets_and_jars)
 
-    if not targets_and_jars or not self.get_options().jvm_resolver_capture_snapshots:
+    if not targets_and_jars or not self.get_options().capture_snapshots:
       return targets_and_jars
 
     jar_paths = []

--- a/src/python/pants/backend/jvm/tasks/resolve_shared.py
+++ b/src/python/pants/backend/jvm/tasks/resolve_shared.py
@@ -27,7 +27,7 @@ class ResolveBase(object):
 
     jar_paths = []
     for target, jars_to_snapshot in targets_and_jars:
-      jar_paths = [fast_relpath(jar.pants_path, get_buildroot()) for jar in jars_to_snapshot]
+      [jar_paths.append(fast_relpath(jar.pants_path, get_buildroot())) for jar in jars_to_snapshot]
 
     snapshots = self.context._scheduler.capture_snapshots(
       tuple(

--- a/testprojects/src/java/org/pantsbuild/testproject/cwdexample/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/cwdexample/BUILD
@@ -7,5 +7,6 @@ jvm_binary(
   main='org.pantsbuild.testproject.cwdexample.ExampleCwd',
   dependencies=[
     "3rdparty:guava",
+    "testprojects/3rdparty/checkstyle"
   ]
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -373,12 +373,40 @@ class ZincCompileIntegrationTest(BaseCompileIT):
             path = os.path.join(compile_dir, path_suffix)
             self.assertTrue(os.path.exists(path), "Want path {} to exist".format(path))
 
-  def test_hermetic_binary_with_3rdparty_dependencies(self):
+  def test_hermetic_binary_with_3rdparty_dependencies_ivy(self):
     config = {
       'compile.zinc': {
         'execution_strategy': 'hermetic',
         'use_classpath_jars': False,
         'incremental': False,
+      }
+    }
+
+    with self.temporary_workdir() as workdir:
+      with self.temporary_file_content("readme.txt", "yo"):
+        pants_run = self.run_pants_with_workdir(
+          [
+            'run',
+            'testprojects/src/java/org/pantsbuild/testproject/cwdexample',
+          ],
+          workdir,
+          config,
+        )
+        self.assert_success(pants_run)
+        self.assertIn(
+          'Found readme.txt',
+          pants_run.stdout_data,
+        )
+
+  def test_hermetic_binary_with_3rdparty_dependencies_coursier(self):
+    config = {
+      'compile.zinc': {
+        'execution_strategy': 'hermetic',
+        'use_classpath_jars': False,
+        'incremental': False,
+      },
+      'resolver': {
+        'resolver': 'coursier',
       }
     }
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -379,6 +379,9 @@ class ZincCompileIntegrationTest(BaseCompileIT):
         'execution_strategy': 'hermetic',
         'use_classpath_jars': False,
         'incremental': False,
+      },
+      'resolver': {
+        'resolver': 'ivy',
       }
     }
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -373,8 +373,30 @@ class ZincCompileIntegrationTest(BaseCompileIT):
             path = os.path.join(compile_dir, path_suffix)
             self.assertTrue(os.path.exists(path), "Want path {} to exist".format(path))
 
+  def test_hermetic_binary_with_capturing_off(self):
+    config = {
+      'DEFAULT': {'jvm_resolver_capture_snapshots': False},
+      'compile.zinc': {
+        'execution_strategy': 'hermetic',
+        'use_classpath_jars': False,
+        'incremental': False,
+      },
+    }
+    with self.temporary_workdir() as workdir:
+      with self.temporary_file_content("readme.txt", "yo"):
+        pants_run = self.run_pants_with_workdir(
+          [
+            'run',
+            'testprojects/src/java/org/pantsbuild/testproject/cwdexample',
+          ],
+          workdir,
+          config,
+        )
+        self.assert_failure(pants_run)
+
   def test_hermetic_binary_with_3rdparty_dependencies_ivy(self):
     config = {
+      'DEFAULT': {'jvm_resolver_capture_snapshots': True},
       'compile.zinc': {
         'execution_strategy': 'hermetic',
         'use_classpath_jars': False,
@@ -403,6 +425,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
   def test_hermetic_binary_with_3rdparty_dependencies_coursier(self):
     config = {
+      'DEFAULT': {'jvm_resolver_capture_snapshots': True},
       'compile.zinc': {
         'execution_strategy': 'hermetic',
         'use_classpath_jars': False,

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -374,8 +374,10 @@ class ZincCompileIntegrationTest(BaseCompileIT):
             self.assertTrue(os.path.exists(path), "Want path {} to exist".format(path))
 
   def test_hermetic_binary_with_capturing_off(self):
+    capture_snapshots = False
     config = {
-      'DEFAULT': {'jvm_resolver_capture_snapshots': False},
+      'resolve.ivy': {'capture_snapshots': capture_snapshots},
+      'resolve.coursier': {'capture_snapshots': capture_snapshots},
       'compile.zinc': {
         'execution_strategy': 'hermetic',
         'use_classpath_jars': False,
@@ -396,7 +398,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
   def test_hermetic_binary_with_3rdparty_dependencies_ivy(self):
     config = {
-      'DEFAULT': {'jvm_resolver_capture_snapshots': True},
+      'resolve.ivy': {'capture_snapshots': True},
       'compile.zinc': {
         'execution_strategy': 'hermetic',
         'use_classpath_jars': False,
@@ -425,7 +427,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
   def test_hermetic_binary_with_3rdparty_dependencies_coursier(self):
     config = {
-      'DEFAULT': {'jvm_resolver_capture_snapshots': True},
+      'resolve.coursier': {'capture_snapshots': True},
       'compile.zinc': {
         'execution_strategy': 'hermetic',
         'use_classpath_jars': False,


### PR DESCRIPTION
### Problem

In preparation for remote execution, #6544 introduced many calls to `capture_snapshots`, which added a significant overhead to coursier fetching.

### Solution

A partial solution is to unify all the snapshot capturing into a single call to `capture_snapshots`.

### Result

- Both coursier and ivy resolvers now make a single call to `capture_snapshots`, which reduced the overhead somewhat, though not completely. The synchronous call to `capture_snapshots` adds a 4-5 seconds of overhead to fetching from coursier on a relatively big project. A solution is discussed in a separate comment, below.

**EDIT** This is not true anymore, it was a faulty measurement on my part:
> 
> These are the noop measured times in my laptop. They all clean all and reset the daemon after every run:
> ```
> Measured execution time: 73s for commit 46e9dd901bb768a3256966762f7f1b82063a09d9 (this pr)
> Measured execution time: 96s for commit 6268a77962ff8227360e25d2c50831f0ac773d94 (master with the regression)
> Measured execution time: 38s for commit f60c40a929a70bfd9e8aa3f9b4b954c4bd06883e (master straight before the regression) 
> ```


- Separate test cases to cover ivy and coursier resolution (coursier wasn't covered before).
- The test cases now include 2 3rdparty dependencies, to cover for a logic bug introduced while developing this.



### Acknowledgements
Credit to @dotordogh for pairing on the issue and coming up with the final fix.