### PR TITLE
[WIP] split NailgunProtocol into PailgunProtocol versions of everything, add PGRP chunk

### DIFF
--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -15,12 +15,12 @@ from future.utils import PY3, binary_type, raise_with_traceback
 
 from pants.base.exception_sink import ExceptionSink
 from pants.console.stty_utils import STTYSettings
-from pants.java.nailgun_client import NailgunClient, NailgunClientSession, PailgunClient
+from pants.java.nailgun_client import (NailgunClient, NailgunClientRequest, NailgunClientSession,
+                                       PailgunClient)
 from pants.java.nailgun_protocol import PailgunProtocol
 from pants.pantsd.pants_daemon import PantsDaemon
 from pants.util.collections import combined_dict
 from pants.util.dirutil import maybe_read_file
-from pants.util.osutil import safe_kill
 
 
 logger = logging.getLogger(__name__)
@@ -65,13 +65,8 @@ class RemotePantsRunner(object):
   def _trapped_signals(self, client_handle):
     """A contextmanager that overrides the SIGINT (control-c) and SIGQUIT (control-\\) handlers
     and handles them remotely."""
-    remote_info = client_handle.remote_process_info
-    pid = remote_info.pid
-    pgrp = remote_info.pgrp
-
     def handle_control_c(signum, frame):
-      safe_kill(pgrp, signum)
-      safe_kill(pid, signum)
+      client_handle.send_signal(signum)
 
     existing_sigint_handler = signal.signal(signal.SIGINT, handle_control_c)
     # N.B. SIGQUIT will abruptly kill the pantsd-runner, which will shut down the other end
@@ -149,13 +144,13 @@ class RemotePantsRunner(object):
     assert isinstance(port, int), 'port {} is not an integer!'.format(port)
 
     # Instantiate a PailgunClient.
-    req = NailgunClient.NailgunClientRequest(
+    req = NailgunClientRequest(
       port=port,
       ins=self._stdin,
       out=self._stdout,
       err=self._stderr,
       exit_on_broken_pipe=True)
-    client = PailgunClient(NailgunClient(req))
+    client = PailgunClient(req)
 
     exe_request = NailgunClientSession.NailgunClientSessionExecutionRequest(
       main_class=binary_type(self.PANTS_COMMAND),
@@ -163,14 +158,14 @@ class RemotePantsRunner(object):
       arguments=tuple(self._args),
       environment=dict(**modified_env))
 
+    # Execute the command on the pailgun.
     with client.remote_pants_session(exe_request) as handle,\
          self._trapped_signals(handle),\
          STTYSettings.preserved():
       try:
-        # Execute the command on the pailgun.
-        result = client.execute(self.PANTS_COMMAND, *self._args, **modified_env)
+        result = handle.session.process_session()
       finally:
-        client.send_terminate()
+        handle.send_signal(signal.SIGTERM)
 
     # Exit.
     self._exiter.exit(result)

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -23,7 +23,8 @@ python_library(
     '3rdparty/python:future',
     ':nailgun_io',
     ':nailgun_protocol',
-    'src/python/pants/util:socket'
+    'src/python/pants/util:objects',
+    'src/python/pants/util:socket',
   ]
 )
 
@@ -43,6 +44,7 @@ python_library(
   dependencies = [
     '3rdparty/python:future',
     '3rdparty/python:six',
+    'src/python/pants/util:osutil',
   ]
 )
 

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -9,13 +9,19 @@ import logging
 import os
 import socket
 import sys
+import traceback
 from builtins import object, str
+from contextlib import contextmanager
+
+from future.utils import binary_type
 
 from future.utils import PY3
 
 from pants.java.nailgun_io import NailgunStreamWriter
-from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
-from pants.util.osutil import safe_kill
+from pants.java.nailgun_protocol import (ChunkType, NailgunProtocol, PailgunChunkType,
+                                         PailgunProtocol)
+from pants.util.memo import memoized_property
+from pants.util.objects import Exactly, datatype  # TODO: cache the datatype __hash__!
 from pants.util.socket import RecvBufferedSocket
 
 
@@ -25,29 +31,80 @@ logger = logging.getLogger(__name__)
 class NailgunClientSession(NailgunProtocol):
   """Handles a single nailgun client session."""
 
-  def __init__(self, sock, in_file, out_file, err_file, exit_on_broken_pipe=False,
-               remote_pid_callback=None, remote_pgrp_callback=None):
-    """
-    :param bool exit_on_broken_pipe: whether or not to exit when `Broken Pipe` errors are
-                encountered
-    :param remote_pid_callback: Callback to run when a pid chunk is received from a remote client.
-    :param remote_pgrp_callback: Callback to run when a pgrp (process group) chunk is received from
-                                 a remote client.
-    """
-    self._sock = sock
-    self._input_writer = None if not in_file else NailgunStreamWriter(
-      (in_file.fileno(),),
-      self._sock,
-      (ChunkType.STDIN,),
-      ChunkType.STDIN_EOF
-    )
-    self._stdout = out_file
-    self._stderr = err_file
-    self._exit_on_broken_pipe = exit_on_broken_pipe
-    self.remote_pid = None
-    self.remote_pgrp = None
-    self._remote_pid_callback = remote_pid_callback
-    self._remote_pgrp_callback = remote_pgrp_callback
+  def __init__(self, request):
+    assert(isinstance(request, self.NailgunClientSessionInitiationRequest))
+    self._request = request
+
+  @property
+  def sock(self):
+    return self._request.sock
+
+  class NailgunClientSessionInitiationRequest(datatype([
+      'sock',
+      'input_writer',
+      'stdout',
+      'stderr',
+      ('exit_on_broken_pipe', bool),
+  ])):
+
+    @classmethod
+    def create(cls, sock, in_file, out_file, err_file, exit_on_broken_pipe=False):
+
+      if in_file:
+        input_writer = NailgunStreamWriter(
+          (in_file.fileno(),),
+          sock,
+          (ChunkType.STDIN,),
+          ChunkType.STDIN_EOF)
+      else:
+        input_writer = None
+
+      return cls(sock=sock, input_writer=input_writer, stdout=out_file, stderr=err_file,
+                 exit_on_broken_pipe=exit_on_broken_pipe)
+
+  class NailgunClientSessionExecutionRequest(datatype([
+      # The fully qualified class name of the main entrypoint.
+      ('main_class', binary_type),
+      # Set the working directory for this command
+      ('cwd', Exactly(binary_type, type(None))),
+      # any arguments to pass to the main entrypoint
+      ('arguments', tuple),
+      # an env mapping made available to native nails via the nail context
+      ('environment', dict),
+  ])): pass
+
+  class NailgunClientSessionExecutionResult(datatype([
+      # If the EXIT chunk wasn't sent, this field's value is None.
+      ('maybe_exit_code', Exactly(int, type(None))),
+  ])): pass
+
+  class NailgunClientSessionProtocolError(NailgunProtocol.ProtocolError): pass
+
+  @contextmanager
+  def execution_sub_session_for(self, exe_request):
+    assert(isinstance(exe_request, self.NailgunClientSessionExecutionRequest))
+    try:
+      # Send the nailgun request synchronously -- there is no "response" to this in the base
+      # NailgunProtocol, or a way to know if the remote end is doing anything (yet), so we just
+      # yield a session which can have process_session() called at most once.
+      self.send_request(sock=self._request.sock,
+                        workdir_dir=exe_request.cwd,
+                        command=exe_request.main_class,
+                        *exe_request.arguments,
+                        **exe_request.environment)
+      yield
+    except NailgunProtocol.ProtocolError as e:
+      raise self.NailgunClientSessionProtocolError(
+        'Error in execution sub session initialization: {}'.format(str(e)),
+        e)
+    finally:
+      # Bad chunk types received from the server can throw PailgunProtocol.ProtocolError in
+      # PailgunProtocol.iter_chunks(). This ensures the NailgunStreamWriter is always stopped.
+      self._maybe_stop_input_writer()
+
+  @property
+  def _input_writer(self):
+    return self._request.input_writer
 
   def _maybe_start_input_writer(self):
     if self._input_writer and not self._input_writer.is_alive():
@@ -66,87 +123,163 @@ class NailgunClientSession(NailgunProtocol):
       fd.flush()
     except (IOError, OSError) as e:
       # If a `Broken Pipe` is encountered during a stdio fd write, we're headless - bail.
-      if e.errno == errno.EPIPE and self._exit_on_broken_pipe:
+      if e.errno == errno.EPIPE and self._request.exit_on_broken_pipe:
         sys.exit()
       # Otherwise, re-raise.
       raise
 
-  def _process_session(self):
+  def process_session(self, **iter_chunks_kwargs):
     """Process the outputs of the nailgun session."""
-    try:
-      for chunk_type, payload in self.iter_chunks(self._sock, return_bytes=True):
-        # TODO(#6579): assert that we have at this point received all the chunk types in
-        # ChunkType.REQUEST_TYPES, then require PID and PGRP (exactly once?), and then allow any of
-        # ChunkType.EXECUTION_TYPES.
-        if chunk_type == ChunkType.STDOUT:
-          self._write_flush(self._stdout, payload)
-        elif chunk_type == ChunkType.STDERR:
-          self._write_flush(self._stderr, payload)
-        elif chunk_type == ChunkType.EXIT:
-          self._write_flush(self._stdout)
-          self._write_flush(self._stderr)
-          return int(payload)
-        elif chunk_type == ChunkType.PID:
-          self.remote_pid = int(payload)
-          if self._remote_pid_callback:
-            self._remote_pid_callback(self.remote_pid)
-        elif chunk_type == ChunkType.PGRP:
-          self.remote_pgrp = int(payload)
-          if self._remote_pgrp_callback:
-            self._remote_pgrp_callback(self.remote_pgrp)
-        elif chunk_type == ChunkType.START_READING_INPUT:
-          self._maybe_start_input_writer()
-        else:
-          raise self.ProtocolError('received unexpected chunk {} -> {}'.format(chunk_type, payload))
-    finally:
-      # Bad chunk types received from the server can throw NailgunProtocol.ProtocolError in
-      # NailgunProtocol.iter_chunks(). This ensures the NailgunStreamWriter is always stopped.
-      self._maybe_stop_input_writer()
+    exit_code = None
+    for chunk_type, payload in self.iter_chunks(
+        self.sock, return_bytes=True, break_on_exit_chunk=True, **iter_chunks_kwargs):
+      if chunk_type == PailgunChunkType.STDOUT:
+        self._write_flush(self._stdout, payload)
+      elif chunk_type == PailgunChunkType.STDERR:
+        self._write_flush(self._stderr, payload)
+      elif chunk_type == PailgunChunkType.EXIT:
+        self._write_flush(self._stdout)
+        self._write_flush(self._stderr)
+        exit_code = int(payload)
+      elif chunk_type == PailgunChunkType.START_READING_INPUT:
+        self._maybe_start_input_writer()
+      else:
+        raise self.InvalidChunkType('unrecognized chunk type {}'.format(chunk_type))
+    return exit_code
 
-  def execute(self, working_dir, main_class, *arguments, **environment):
-    # Send the nailgun request.
-    self.send_request(self._sock, working_dir, main_class, *arguments, **environment)
+  # def execute(self, exe_request, **iter_chunks_kwargs):
+  #   assert(isinstance(exe_request, self.NailgunClientSessionExecutionRequest))
+  #   with self.execution_sub_session_for(exe_request):
+  #     exit_code = self.process_session(**iter_chunks_kwargs)
+  #     return self.NailgunClientSessionExecutionResult(exit_code)
 
-    # Process the remainder of the nailgun session.
-    return self._process_session()
+class PailgunClientSession(PailgunProtocol):
+
+  def __init__(self, nailgun_session):
+    # Delegate everything to a NailgunClientSession instance to keep the PailgunProtocol
+    # inheritance.
+    # TODO: figure out if this is the least confusing mixture of inheritance and composition for the
+    # case of implementing/extending a binary protocol like Nailgun.
+    assert(isinstance(nailgun_session, NailgunClientSession))
+    self._nailgun_session = nailgun_session
+
+  class PailgunClientSessionProtocolError(NailgunProtocol.ProtocolError): pass
+
+  @contextmanager
+  def execution_sub_session_for(self, exe_request):
+    """???/so the client can be sure to have the pid and pgrp before proceeding"""
+    # The base NailgunClientSession doesn't yield anything, but we are waiting for pailgun chunks.
+    with self._nailgun_session.execution_sub_session_for(exe_request):
+      try:
+        # Block for the Pailgun-specific PID and PGRP chunks to enable signalling and log traversal.
+        remote_process_info = self.parse_remote_process_initialization_sequence(
+          self._nailgun_session.sock)
+      except NailgunProtocol.ProtocolError as e:
+        raise self.PailgunClientSessionProtocolError(
+          'Error when reading remote process info: {}'.format(str(e)),
+          e)
+
+      try:
+        yield remote_process_info
+      except NailgunProtocol.ProtocolError as e:
+        raise self.PailgunClientSessionProtocolError(
+          'Error in execution sub session for remote process {}: {}'
+          .format(remote_process_info, str(e)),
+          e)
+
+  def process_session(self, **iter_chunks_kwargs):
+    # We return the same execution result, and don't otherwise modify anything compared to base
+    # Nailgun from here on.
+    self._nailgun_session.process_session(
+      # Allow a 0-length read at the beginning of a chunk to denote graceful shutdown.
+      none_on_zero_length_chunk=True,
+      valid_chunk_types=PailgunChunkType.EXECUTION_TYPES,
+      **iter_chunks_kwargs)
 
 
 class NailgunClient(object):
-  """A python nailgun client (see http://martiansoftware.com/nailgun for more info)."""
+  """A python nailgun client (see http://martiansoftware.com/nailgun for more info).
+
+  This nailgun client can be used to issue zero or more nailgun commands (TODO: with?).
+  """
+
+  def __init__(self, request):
+    assert(isinstance(request, self.NailgunClientRequest))
+    self._request = request
+
+  class NailgunClientRequest(datatype([
+      ('host', binary_type),
+      ('port', int),
+      'stdin',
+      'stdout',
+      'stderr',
+      ('workdir', binary_type),
+      ('exit_on_broken_pipe', bool),
+  ])):
+
+    # For backwards compatibility with nails expecting the ng c client special env vars.
+    ENV_DEFAULTS = dict(NAILGUN_FILESEPARATOR=os.sep, NAILGUN_PATHSEPARATOR=os.pathsep)
+    DEFAULT_NG_HOST = '127.0.0.1'
+    DEFAULT_NG_PORT = 2113
+
+    def __new__(cls, host=DEFAULT_NG_HOST, port=DEFAULT_NG_PORT, ins=sys.stdin, out=None, err=None,
+                workdir=None, exit_on_broken_pipe=False):
+      """Creates a nailgun client request that can be ???
+
+      :param string host: the nailgun server to contact (defaults to '127.0.0.1')
+      :param int port: the port the nailgun server is listening on (defaults to the default nailgun
+                       port: 2113)
+      :param file ins: a file to read command standard input from (defaults to stdin) - can be None
+                       in which case no input is read
+      :param file out: a stream to write command standard output to (defaults to stdout)
+      :param file err: a stream to write command standard error to (defaults to stderr)
+      :param string workdir: the default working directory for all nailgun commands (defaults to CWD)
+      :param bool exit_on_broken_pipe: whether or not to exit when `Broken Pipe` errors are
+                                       encountered
+      """
+      return super(NailgunClient.NailgunClientRequest, cls).__new__(
+        cls,
+        host=binary_type(host),
+        port=int(port),
+        stdin=ins,
+        stdout=(out or sys.stdout),
+        stderr=(err or sys.stderr),
+        workdir=binary_type(workdir or os.path.abspath(os.path.curdir)),
+        exit_on_broken_pipe=exit_on_broken_pipe)
+
+    @memoized_property
+    def address(self):
+      return (self.host, self.port)
+
+    @memoized_property
+    def address_string(self):
+      return ':'.join(str(i) for i in self.address)
 
   class NailgunError(Exception):
-    """Indicates an error interacting with a nailgun server."""
+    "Indicates an error interacting with a nailgun server."""
 
     DESCRIPTION = 'Problem talking to nailgun server'
 
     _MSG_FMT = """\
-{description} (address: {address}, remote_pid={pid}, remote_pgrp={pgrp}): {wrapped_exc!r}\
+{description} (address: {address}): {wrapped_exc!r}
+{backtrace}
 """
 
-    def __init__(self, address, pid, pgrp, wrapped_exc, traceback):
+    def __init__(self, address, wrapped_exc, traceback=None):
       self.address = address
-      self.pid = pid
-      self.pgrp = pgrp
       self.wrapped_exc = wrapped_exc
-      self.traceback = traceback
+      self.traceback = traceback or sys.exc_info()[2]
 
-      # TODO: these should be ensured to be non-None in NailgunClientSession!
-      if self.pid is not None:
-        pid_msg = str(self.pid)
-      else:
-        pid_msg = '<remote PID chunk not yet received!>'
-      if self.pgrp is not None:
-        pgrp_msg = str(self.pgrp)
-      else:
-        pgrp_msg = '<remote PGRP chunk not yet received!>'
-
-      msg = self._MSG_FMT.format(
+      msg = self.MSG_FMT.format(
         description=self.DESCRIPTION,
         address=self.address,
-        pid=pid_msg,
-        pgrp=pgrp_msg,
-        wrapped_exc=self.wrapped_exc)
+        wrapped_exc=self.wrapped_exc,
+        backtrace=self.traceback(self.traceback))
       super(NailgunClient.NailgunError, self).__init__(msg, self.wrapped_exc)
+
+    @classmethod
+    def _traceback(cls, tb):
+      return ''.join(traceback.format_tb(tb))
 
   class NailgunConnectionError(NailgunError):
     """Indicates an error upon initial connect to the nailgun server."""
@@ -156,140 +289,59 @@ class NailgunClient(object):
     """Indicates an error upon initial command execution on the nailgun server."""
     DESCRIPTION = 'Problem executing command on nailgun server'
 
-  # For backwards compatibility with nails expecting the ng c client special env vars.
-  ENV_DEFAULTS = dict(NAILGUN_FILESEPARATOR=os.sep, NAILGUN_PATHSEPARATOR=os.pathsep)
-  DEFAULT_NG_HOST = '127.0.0.1'
-  DEFAULT_NG_PORT = 2113
+  @contextmanager
+  def connect_socket(self):
+    """Creates a socket, connects it to this client's address and returns the connected socket.
 
-  def __init__(self, host=DEFAULT_NG_HOST, port=DEFAULT_NG_PORT, ins=sys.stdin, out=None, err=None,
-               workdir=None, exit_on_broken_pipe=False, expects_pid=False):
-    """Creates a nailgun client that can be used to issue zero or more nailgun commands.
-
-    :param string host: the nailgun server to contact (defaults to '127.0.0.1')
-    :param int port: the port the nailgun server is listening on (defaults to the default nailgun
-                     port: 2113)
-    :param file ins: a file to read command standard input from (defaults to stdin) - can be None
-                     in which case no input is read
-    :param file out: a stream to write command standard output to (defaults to stdout)
-    :param file err: a stream to write command standard error to (defaults to stderr)
-    :param string workdir: the default working directory for all nailgun commands (defaults to CWD)
-    :param bool exit_on_broken_pipe: whether or not to exit when `Broken Pipe` errors are encountered
-    :param bool expects_pid: Whether or not to expect a PID from the server (only true for pantsd)
-    """
-    self._host = host
-    self._port = port
-    self._address = (host, port)
-    self._address_string = ':'.join(str(i) for i in self._address)
-    self._stdin = ins
-    self._stdout = out or (sys.stdout.buffer if PY3 else sys.stdout)
-    self._stderr = err or (sys.stderr.buffer if PY3 else sys.stderr)
-    self._workdir = workdir or os.path.abspath(os.path.curdir)
-    self._exit_on_broken_pipe = exit_on_broken_pipe
-    self._expects_pid = expects_pid
-    # Mutable session state.
-    self._session = None
-    self._current_remote_pid = None
-    self._current_remote_pgrp = None
-
-  def _receive_remote_pid(self, pid):
-    self._current_remote_pid = pid
-
-  def _receive_remote_pgrp(self, pgrp):
-    self._current_remote_pgrp = pgrp
-
-  def _maybe_last_pid(self):
-    return self._current_remote_pid
-
-  def _maybe_last_pgrp(self):
-    return self._current_remote_pgrp
-
-  def try_connect(self):
-    """Creates a socket, connects it to the nailgun and returns the connected socket.
-
-    :returns: a connected `socket.socket`.
-    :raises: `NailgunClient.NailgunConnectionError` on failure to connect.
+    :yields: a connected `socket.socket`.
+    :raises: `PailgunClient.NailgunConnectionError` on failure to connect.
     """
     sock = RecvBufferedSocket(socket.socket(socket.AF_INET, socket.SOCK_STREAM))
     try:
-      sock.connect(self._address)
+      sock.connect(self._request.address)
+      yield sock
     except (socket.error, socket.gaierror) as e:
-      logger.debug('Encountered socket exception {!r} when attempting connect to nailgun'.format(e))
-      sock.close()
-      raise self.NailgunConnectionError(
-        address=self._address_string,
-        pid=self._maybe_last_pid(),
-        pgrp=self._maybe_last_pgrp(),
-        wrapped_exc=e,
-        traceback=sys.exc_info()[2],
-      )
-    else:
-      return sock
-
-  def maybe_send_signal(self, signum, include_pgrp=True):
-    """Send the signal `signum` send if the PID and/or PGRP chunks have been received.
-
-    No error is raised if the pid or pgrp are None or point to an already-dead process.
-    """
-    remote_pid = self._maybe_last_pid()
-    if remote_pid is not None:
-      safe_kill(remote_pid, signum)
-    if include_pgrp:
-      remote_pgrp = self._maybe_last_pgrp()
-      if remote_pgrp:
-        safe_kill(remote_pgrp, signum)
-
-  def execute(self, main_class, cwd=None, *args, **environment):
-    """Executes the given main_class with any supplied args in the given environment.
-
-    :param string main_class: the fully qualified class name of the main entrypoint
-    :param string cwd: Set the working directory for this command
-    :param list args: any arguments to pass to the main entrypoint
-    :param dict environment: an env mapping made available to native nails via the nail context
-    :returns: the exit code of the main_class.
-    :raises: :class:`NailgunClient.NailgunError` if there was an error during execution.
-    """
-    environment = dict(**environment)
-    environment.update(self.ENV_DEFAULTS)
-    cwd = cwd or self._workdir
-
-    sock = self.try_connect()
-
-    # TODO(#6579): NailgunClientSession currently requires callbacks because it can't depend on
-    # having received these chunks, so we need to avoid clobbering these fields until we initialize
-    # a new session.
-    self._current_remote_pid = None
-    self._current_remote_pgrp = None
-    self._session = NailgunClientSession(
-      sock=sock,
-      in_file=self._stdin,
-      out_file=self._stdout,
-      err_file=self._stderr,
-      exit_on_broken_pipe=self._exit_on_broken_pipe,
-      remote_pid_callback=self._receive_remote_pid,
-      remote_pgrp_callback=self._receive_remote_pgrp)
-    try:
-      return self._session.execute(cwd, main_class, *args, **environment)
-    except socket.error as e:
-      raise self.NailgunError(
-        address=self._address_string,
-        pid=self._maybe_last_pid(),
-        pgrp=self._maybe_last_pgrp(),
-        wrapped_exc=e,
-        traceback=sys.exc_info()[2]
-      )
-    except NailgunProtocol.ProtocolError as e:
-      raise self.NailgunError(
-        address=self._address_string,
-        pid=self._maybe_last_pid(),
-        pgrp=self._maybe_last_pgrp(),
-        wrapped_exc=e,
-        traceback=sys.exc_info()[2]
-      )
+      logger.debug('Encountered socket exception {!r} when attempting to connect to nailgun'
+                   .format(e))
+      raise self.NailgunConnectionError(address=self._request.address_string, wrapped_exc=e)
     finally:
       sock.close()
-      self._session = None
 
-  def __repr__(self):
-    return 'NailgunClient(host={!r}, port={!r}, workdir={!r})'.format(self._host,
-                                                                      self._port,
-                                                                      self._workdir)
+  @contextmanager
+  def initiate_new_client_session(self):
+    with self.connect_socket() as sock:
+      session_init_request = NailgunClientSession.NailgunClientSessionInitiationRequest.create(
+        sock,
+        in_file=self._request.stdin, out_file=self._request.stdout, err_file=self._request.stderr,
+        exit_on_broken_pipe=self._request.exit_on_broken_pipe)
+      session = NailgunClientSession(session_init_request)
+      try:
+        yield session
+      except (socket.error, NailgunProtocol.ProtocolError) as e:
+        raise self.NailgunError(address=self._request.address_string, wrapped_exc=e)
+
+
+class PailgunClient(NailgunClient):
+
+  def __init__(self, nailgun_client):
+    assert(isinstance(nailgun_client, NailgunClient))
+    self._nailgun_client = nailgun_client
+
+  class PailgunError(NailgunClient.NailgunError): pass
+
+  @contextmanager
+  def initiate_new_client_session(self):
+    with self._nailgun_client.initiate_new_client_session() as nailgun_session:
+      yield PailgunClientSession(nailgun_session)
+
+  class RemotePantsSessionHandle(datatype([
+      ('session', PailgunClientSession),
+      ('remote_process_info', PailgunProtocol.ProcessInitialized),
+  ])): pass
+
+  @contextmanager
+  def remote_pants_session(self, exe_request):
+    with self.initiate_new_client_session() as nailgun_session:
+      pailgun_session = PailgunClientSession(nailgun_session)
+      with pailgun_session.execution_sub_session_for(exe_request) as remote_process_info:
+        yield self.RemotePantsSessionHandle(pailgun_session, remote_process_info)

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 
 from contextlib2 import ExitStack
 
-from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
+from pants.java.nailgun_protocol import ChunkType, NailgunProtocol, PailgunProtocol
 
 
 @contextmanager
@@ -86,12 +86,12 @@ class NailgunStreamStdinReader(_StoppableDaemonThread):
       reader = NailgunStreamStdinReader(sock, os.fdopen(write_fd, 'wb'))
       with reader.running():
         # Instruct the thin client to begin reading and sending stdin.
-        NailgunProtocol.send_start_reading_input(sock)
+        PailgunProtocol.send_start_reading_input(sock)
         yield read_fd
 
   def run(self):
     try:
-      for chunk_type, payload in NailgunProtocol.iter_chunks(self._socket, return_bytes=True):
+      for chunk_type, payload in PailgunProtocol.iter_chunks(self._socket, return_bytes=True):
         if self.is_stopped:
           return
 
@@ -191,14 +191,14 @@ class NailgunStreamWriter(_StoppableDaemonThread):
             # We've reached EOF.
             try:
               if self._chunk_eof_type is not None:
-                NailgunProtocol.write_chunk(self._socket, self._chunk_eof_type)
+                PailgunProtocol.write_chunk(self._socket, self._chunk_eof_type)
             finally:
               try:
                 os.close(fileno)
               finally:
                 self._in_fds.remove(fileno)
           else:
-            NailgunProtocol.write_chunk(
+            PailgunProtocol.write_chunk(
               self._socket,
               self._fileno_chunk_type_map[fileno],
               data

--- a/src/python/pants/java/nailgun_protocol.py
+++ b/src/python/pants/java/nailgun_protocol.py
@@ -112,12 +112,12 @@ class NailgunProtocol(object):
         yield item
 
   @classmethod
-  def send_request(cls, sock, working_dir, command, *arguments, **environment):
+  def send_request(cls, sock, working_dir, command, args, env):
     """Send the initial Nailgun request over the specified socket."""
-    for argument in arguments:
+    for argument in args:
       cls.write_chunk(sock, cls.CHUNK_TYPE.ARGUMENT, argument)
 
-    for item_tuple in environment.items():
+    for item_tuple in env.items():
       cls.write_chunk(sock,
                       cls.CHUNK_TYPE.ENVIRONMENT,
                       cls.ENVIRON_SEP.join(cls._decode_unicode_seq(item_tuple)))

--- a/tests/python/pants_test/java/test_nailgun_client.py
+++ b/tests/python/pants_test/java/test_nailgun_client.py
@@ -9,10 +9,12 @@ import signal
 import socket
 import unittest
 from builtins import object
+from contextlib import contextmanager
 
 import mock
+from future.utils import binary_type
 
-from pants.java.nailgun_client import PailgunClient, PailgunClientSession
+from pants.java.nailgun_client import NailgunClientRequest, NailgunClientSession, PailgunClient
 from pants.java.nailgun_io import NailgunStreamWriter
 from pants.java.nailgun_protocol import NailgunProtocol, PailgunProtocol
 
@@ -44,56 +46,81 @@ class TestPailgunClientSession(unittest.TestCase):
   TEST_ENVIRON = dict(TEST_ENV_VAR='xyz')
 
   def setUp(self):
-    self.client_sock, self.server_sock = socket.socketpair()
-
     self.fake_stdout = FakeFile()
     self.fake_stderr = FakeFile()
 
-    self.pailgun_client_session = PailgunClientSession(
-      sock=self.client_sock,
-      in_file=None,
-      out_file=self.fake_stdout,
-      err_file=self.fake_stderr
-    )
-
     self.mock_stdin_reader = mock.create_autospec(NailgunStreamWriter, spec_set=True)
     self.mock_stdin_reader.is_alive.side_effect = [False, True]
-    self.pailgun_client_session._input_writer = self.mock_stdin_reader
 
-  def tearDown(self):
-    self.server_sock.close()
-    self.client_sock.close()
+  def _pailgun_client(self):
+    nailgun_client_request = NailgunClientRequest(
+      ins=None,
+      out=self.fake_stdout,
+      err=self.fake_stderr,
+    )
+    pailgun_client = PailgunClient(nailgun_client_request)
+    return pailgun_client
+
+  @contextmanager
+  def _pailgun_client_session(self):
+    client_sock, server_sock = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    pailgun_client = self._pailgun_client()
+    pailgun_client._get_socket = lambda: client_sock
+    with pailgun_client.initiate_new_client_session() as pg_session:
+      pg_session._request = pg_session._request.copy(input_writer=self.mock_stdin_reader)
+      try:
+        yield (pg_session, client_sock, server_sock)
+      finally:
+        client_sock.close()
+        server_sock.close()
+
+  @contextmanager
+  def _remote_pailgun_handle(self):
+    client_sock, server_sock = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    pailgun_client = self._pailgun_client()
+    pailgun_client._get_socket = lambda: client_sock
+    exe_req = NailgunClientSession.NailgunClientSessionExecutionRequest(
+      main_class=binary_type(self.TEST_MAIN_CLASS),
+      cwd=binary_type(self.TEST_WORKING_DIR),
+      arguments=tuple(self.TEST_ARGUMENTS),
+      environment=self.TEST_ENVIRON,
+    )
+    PailgunProtocol.send_pid(server_sock, 31337)
+    PailgunProtocol.send_pgrp(server_sock, -31336)
+    with pailgun_client.remote_pants_session(exe_req) as remote_handle:
+      pg_session = remote_handle.session
+      pg_session._request = pg_session._request.copy(input_writer=self.mock_stdin_reader)
+      try:
+        self.assertEqual(remote_handle.remote_process_info,
+                         PailgunProtocol.ProcessInitialized(31337, -31336))
+        yield (remote_handle, client_sock, server_sock)
+      finally:
+        client_sock.close()
+        server_sock.close()
 
   def test_input_writer_start_stop(self):
-    self.pailgun_client_session._maybe_start_input_writer()
-    self.mock_stdin_reader.start.assert_called_once_with()
-
-    self.pailgun_client_session._maybe_stop_input_writer()
-    self.mock_stdin_reader.stop.assert_called_once_with()
+    with self._pailgun_client_session() as (pg_session, _, _):
+      pg_session._maybe_start_input_writer()
+      self.mock_stdin_reader.start.assert_called_once_with()
+      pg_session._maybe_stop_input_writer()
+      self.mock_stdin_reader.stop.assert_called_once_with()
 
   def test_input_writer_noop(self):
-    self.pailgun_client_session._input_writer = None
-    self.pailgun_client_session._maybe_start_input_writer()
-    self.pailgun_client_session._maybe_stop_input_writer()
+    with self._pailgun_client_session() as (pg_session, _, _):
+      pg_session._request._input_writer = None
+      pg_session._maybe_start_input_writer()
+      pg_session._maybe_stop_input_writer()
 
   def test_process_session(self):
-    PailgunProtocol.send_pid(self.server_sock, 31337)
-    PailgunProtocol.send_pgrp(self.server_sock, -31336)
-    PailgunProtocol.send_start_reading_input(self.server_sock)
-    PailgunProtocol.send_stdout(self.server_sock, self.TEST_PAYLOAD)
-    PailgunProtocol.send_stderr(self.server_sock, self.TEST_PAYLOAD)
-    PailgunProtocol.send_stderr(self.server_sock, self.TEST_PAYLOAD)
-    PailgunProtocol.send_stdout(self.server_sock, self.TEST_PAYLOAD)
-    PailgunProtocol.send_stderr(self.server_sock, self.TEST_PAYLOAD)
-    PailgunProtocol.send_exit_with_code(self.server_sock, 1729)
-
-    with self.pailgun_client_session.negotiate(
-        self.TEST_WORKING_DIR,
-        self.TEST_MAIN_CLASS,
-        *self.TEST_ARGUMENTS,
-        **self.TEST_ENVIRON) as remote_process_info:
-      self.assertEqual(remote_process_info, PailgunProtocol.ProcessInitialized(31337, -31336))
-      out = self.pailgun_client_session.process_session()
+    with self._remote_pailgun_handle() as (remote_handle, _, server_sock):
+      PailgunProtocol.send_start_reading_input(server_sock)
+      PailgunProtocol.send_stdout(server_sock, self.TEST_PAYLOAD)
+      PailgunProtocol.send_stderr(server_sock, self.TEST_PAYLOAD)
+      PailgunProtocol.send_stderr(server_sock, self.TEST_PAYLOAD)
+      PailgunProtocol.send_stdout(server_sock, self.TEST_PAYLOAD)
+      PailgunProtocol.send_stderr(server_sock, self.TEST_PAYLOAD)
+      PailgunProtocol.send_exit_with_code(server_sock, 1729)
+      out = remote_handle.session.process_session()
 
     self.assertEqual(out, 1729)
     self.assertEqual(self.fake_stdout.content, self.TEST_PAYLOAD * 2)
@@ -102,39 +129,22 @@ class TestPailgunClientSession(unittest.TestCase):
     self.mock_stdin_reader.stop.assert_called_once_with()
 
   def test_process_session_bad_chunk(self):
-    PailgunProtocol.send_pid(self.server_sock, 31337)
-    PailgunProtocol.send_pgrp(self.server_sock, -31336)
-    PailgunProtocol.send_start_reading_input(self.server_sock)
-    PailgunProtocol.write_chunk(self.server_sock, self.BAD_CHUNK_TYPE, '')
-
-    with self.pailgun_client_session.negotiate(
-        self.TEST_WORKING_DIR,
-        self.TEST_MAIN_CLASS,
-        *self.TEST_ARGUMENTS,
-        **self.TEST_ENVIRON) as remote_process_info:
-      self.assertEqual(remote_process_info, PailgunProtocol.ProcessInitialized(31337, -31336))
+    with self._remote_pailgun_handle() as (remote_handle, _, server_sock):
+      PailgunProtocol.send_start_reading_input(server_sock)
+      PailgunProtocol.write_chunk(server_sock, self.BAD_CHUNK_TYPE, '')
 
       err_rx = re.escape('invalid chunk type: {}'.format(self.BAD_CHUNK_TYPE))
-      with self.assertRaisesRegexp(NailgunProtocol.InvalidChunkType, err_rx):
-        self.pailgun_client_session.process_session()
+      with self.assertRaisesRegexp(NailgunProtocol.ProtocolError, err_rx):
+        remote_handle.session.process_session()
 
     self.mock_stdin_reader.start.assert_called_once_with()
     self.mock_stdin_reader.stop.assert_called_once_with()
 
   def test_execute(self):
-    PailgunProtocol.send_pid(self.server_sock, 31337)
-    PailgunProtocol.send_pgrp(self.server_sock, -31336)
-    PailgunProtocol.send_start_reading_input(self.server_sock)
-    PailgunProtocol.send_exit_with_code(self.server_sock, self.TEST_EXIT_CODE)
-
-    with self.pailgun_client_session.negotiate(
-        self.TEST_WORKING_DIR,
-        self.TEST_MAIN_CLASS,
-        *self.TEST_ARGUMENTS,
-        **self.TEST_ENVIRON
-    ) as remote_process_info:
-      self.assertEqual(remote_process_info, PailgunProtocol.ProcessInitialized(31337, -31336))
-      out = self.pailgun_client_session.process_session()
+    with self._remote_pailgun_handle() as (remote_handle, _, server_sock):
+      PailgunProtocol.send_start_reading_input(server_sock)
+      PailgunProtocol.send_exit_with_code(server_sock, self.TEST_EXIT_CODE)
+      out = remote_handle.session.process_session()
 
     self.assertEqual(out, self.TEST_EXIT_CODE)
     self.mock_stdin_reader.start.assert_called_once_with()
@@ -142,36 +152,40 @@ class TestPailgunClientSession(unittest.TestCase):
 
 
 class TestPailgunClient(unittest.TestCase):
-  def setUp(self):
-    self.pailgun_client = PailgunClient()
+  BAD_CHUNK_TYPE = b';'
+  TEST_PAYLOAD = b't e s t'
+  TEST_EXIT_CODE = 13
+  TEST_WORKING_DIR = '/test_working_dir'
+  TEST_MAIN_CLASS = 'test_main_class'
+  TEST_ARGUMENTS = [b't', b'e', b's', b't']
+  TEST_ENVIRON = dict(TEST_ENV_VAR='xyz')
 
-  @mock.patch('pants.java.nailgun_client.RecvBufferedSocket', **PATCH_OPTS)
-  def test_try_connect(self, mock_socket_cls):
-    mock_socket = mock.Mock()
-    mock_socket_cls.return_value = mock_socket
+  def _pailgun_client(self):
+    request = NailgunClientRequest()
+    client = PailgunClient(request)
+    return client
 
-    self.assertEqual(self.pailgun_client.connect_socket(), mock_socket)
-
-    self.assertEqual(mock_socket_cls.call_count, 1)
-    mock_socket.connect.assert_called_once_with(
-      (PailgunClient.DEFAULT_NG_HOST, PailgunClient.DEFAULT_NG_PORT)
+  @contextmanager
+  def _execute_pailgun_client(self, *arguments):
+    pg_client = self._pailgun_client()
+    exe_req = NailgunClientSession.NailgunClientSessionExecutionRequest(
+      main_class=binary_type(self.TEST_MAIN_CLASS),
+      cwd=binary_type(self.TEST_WORKING_DIR),
+      arguments=tuple(arguments),
+      environment=self.TEST_ENVIRON,
     )
+    with pg_client.remote_pants_session(exe_req) as handle:
+      handle.session.process_session()
+      yield handle
 
-  @mock.patch('pants.java.nailgun_client.RecvBufferedSocket', **PATCH_OPTS)
-  def test_try_connect_socket_error(self, mock_socket_cls):
+  def test_try_connect_socket_error(self):
     mock_socket = mock.Mock()
     mock_socket.connect.side_effect = socket.error()
-    mock_socket_cls.return_value = mock_socket
+    pg_client = self._pailgun_client()
+    pg_client._get_socket = lambda: mock_socket.connect()
 
     with self.assertRaises(PailgunClient.NailgunConnectionError):
-      self.pailgun_client.connect_socket()
-
-  @mock.patch.object(PailgunClient, 'connect_socket', **PATCH_OPTS)
-  @mock.patch('pants.java.nailgun_client.PailgunClientSession', **PATCH_OPTS)
-  def test_execute(self, mock_session, mock_try_connect):
-    self.pailgun_client.execute('test')
-    self.assertEqual(mock_try_connect.call_count, 1)
-    self.assertEqual(mock_session.call_count, 1)
+      pg_client.connect_socket()
 
   @mock.patch.object(PailgunClient, 'connect_socket', **PATCH_OPTS)
   @mock.patch('pants.java.nailgun_client.PailgunClientSession', **PATCH_OPTS)

--- a/tests/python/pants_test/java/test_nailgun_protocol.py
+++ b/tests/python/pants_test/java/test_nailgun_protocol.py
@@ -59,8 +59,8 @@ class TestNailgunProtocol(NailgunProtocolTestBase):
       self.client_sock,
       self.TEST_WORKING_DIR,
       self.TEST_COMMAND,
-      *self.TEST_ARGUMENTS,
-      **self.TEST_ENVIRON
+      args=self.TEST_ARGUMENTS,
+      env=self.TEST_ENVIRON,
     )
 
     # Receive the request from the server-side context.

--- a/tests/python/pants_test/pantsd/test_pailgun_server.py
+++ b/tests/python/pants_test/pantsd/test_pailgun_server.py
@@ -85,6 +85,6 @@ class TestPailgunHandler(unittest.TestCase):
 
   @mock.patch.object(PailgunHandler, '_run_pants', **PATCH_OPTS)
   def test_handle_request(self, mock_run_pants):
-    PailgunProtocol.send_request(self.client_sock, '/test', './pants', 'help-advanced')
+    PailgunProtocol.send_request(self.client_sock, '/test', './pants', args=['help-advanced'])
     self.handler.handle_request()
     self.assertIs(mock_run_pants.called, True)

--- a/tests/python/pants_test/pantsd/test_pailgun_server.py
+++ b/tests/python/pants_test/pantsd/test_pailgun_server.py
@@ -12,7 +12,7 @@ from socketserver import TCPServer
 
 import mock
 
-from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
+from pants.java.nailgun_protocol import PailgunChunkType, PailgunProtocol
 from pants.pantsd.pailgun_server import PailgunHandler, PailgunServer
 
 
@@ -79,12 +79,12 @@ class TestPailgunHandler(unittest.TestCase):
 
   def test_handle_error(self):
     self.handler.handle_error()
-    last_chunk_type, last_payload = list(NailgunProtocol.iter_chunks(self.client_sock))[-1]
-    self.assertEqual(last_chunk_type, ChunkType.EXIT)
+    last_chunk_type, last_payload = list(PailgunProtocol.iter_chunks(self.client_sock))[-1]
+    self.assertEqual(last_chunk_type, PailgunChunkType.EXIT)
     self.assertEqual(last_payload, '1')
 
   @mock.patch.object(PailgunHandler, '_run_pants', **PATCH_OPTS)
   def test_handle_request(self, mock_run_pants):
-    NailgunProtocol.send_request(self.client_sock, '/test', './pants', 'help-advanced')
+    PailgunProtocol.send_request(self.client_sock, '/test', './pants', 'help-advanced')
     self.handler.handle_request()
     self.assertIs(mock_run_pants.called, True)


### PR DESCRIPTION
*WIP because I wasn't able to get the `java/` tests all the way passing last night, there's probably hella refactoring I could do*

### Problem

Our implementation of the Nailgun protocol has an extension in the form of a PID chunk, currently, which we will only worry about if we receive a chunk of that type (types are defined in `ChunkType`). The only difference in the way we use pailgun clients is that the nailgun client (e.g. in RemotePantsRunner) will secretly wait for a PID chunk (even if it's for a nailgun invocation that doesn't support that). This actually works pretty well, and I only ran into issues when I wanted to try adding the PGRP chunk or doing anything based on it, because we currently wait for the PID chunk in the execution loop in `NailgunClientSession#process_session()`, and that doesn't really make it clear when or whether we can expect that chunk or whether there should be more than one.

I realized that the step of receiving the PID/PGRP chunk can be separated into a distinct initialization phase, after the execution request is sent from the nailgun client to pantsd, after our pantsd-runner process self-daemonizes. *Not* doing that now means we don't reliably know the remote pid or pgrp, when we can instead require that these are sent before any execution occurs (this was already deterministically true). So I ran with that and here's the justification for the current changes:

- We're currently using the PID chunk to pass the negated pgrp, not the pid anyway. We need the pid in that PID chunk in order to retrieve fatal error logs from a failed pantsd-runner invocation, the work for which was already done in #6539 (that test was previously xfailed for this reason -- we were only getting the pgrp previously in that chunk, so we didn't know where to look for fatal error logs for the remote pantsd-runner). The pgrp is useful to send a signal to the whole family of pantsd-runner subprocesses at once.
- We're currently letting the pantsd-runner process define when the remote session completes (when we catch control-c on the client, the signal is just caught and transmitted to the pantsd-runner process, then dropped), and that leads directly to interactivity issues later on.

There is (or rather, there's not now at all, but should be) some implicit sequencing required in negotiating a pailgun execution given a live (what is now called) `PailgunClient`:
1. the thin client sends the execution request with args and cwd and whatever to pantsd over a nailgun connection
2. pantsd double forks to create a self-daemonizing pantsd-runner process which sends the PID and PGRP chunks, then hooks up stdio to the nailgun socket shared with pantsd (pantsd closes its end of that socket)
2. the thin client in RemotePantsRunner waits for the PID chunk and PGRP chunk to be sent from the pantsd-runner process over the nailgun connection which was transferred
3. the client writes STDOUT and STDERR chunks as they come in, and exits on the first EXIT chunk (stdin is turned on and off over the course of the nailgun execution with other chunk types) (this part is unchanged).

One contribution of this PR is to make that sequencing (which is specific to pailgun) explicit by composing contextmanagers -- this makes ownership of the underlying resources and the IPC needed to obtain them much more clear, imo. The PID/PGRP dissonance at the top is a prime example of how trying to munge them together is hard (and it ends up being not too much work to un-munge them, even if the diff ends up being big).

If you're concerned that this sounds like it's introducing too much state into the session, I was actually able to remove most (all?) mutations by using contextmanagers, which also makes a pailgun execution simply a matter of a `with` statement inside a nailgun execution (which if you were to write it in pseudocode could maybe look like that as well). Please let me know if there are any minor to sweeping changes or misconceptions to fix on nailgun, python, or IPC in general.

#### TODO
- Can/should we merge the PID and PGRP chunks into a tuple (or a `datatype` to be specific)? This sounds like the right thing to do.
  - We should probably state clearly what these are being used for -- I don't know if there are further uses of the negated pgrp that I'm missing above.
- *there are some more TODOs left in the diff (these will all become separate issues or PRs)*

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

- add PGRP chunk but in a new `PailgunChunkType` class
- create `PailgunProtocol`, `PailgunClient`, etc (was trying to avoid this lengthy mirroring to whatever extent possible but not sure if that is a good idea or feasible at this point)
- use the new process information to withdraw the correct logs / kill the correct process as per the xfailed test from #6539

(_describe the modifications you've made._)

### Result

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)

# TODO
- #7301 should be fixed with this PR.
- #5220 should be fixed with this PR.