### PR TITLE
Enhance the login task.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -32,3 +32,4 @@ six>=1.9.0,<2
 subprocess32==3.2.7 ; python_version<'3'
 thrift>=0.9.1
 wheel==0.29.0
+www-authenticate==0.9.2

--- a/src/docs/docsite.json
+++ b/src/docs/docsite.json
@@ -48,6 +48,7 @@
     "jvm_tests": "dist/markdown/html/src/docs/common_tasks/jvm_tests.html",
     "list_goals": "dist/markdown/html/src/docs/common_tasks/list_goals.html",
     "list_targets": "dist/markdown/html/src/docs/common_tasks/list_targets.html",
+    "login": "dist/markdown/html/src/docs/common_tasks/login.html",
     "notes-1.0.x": "dist/markdown/html/src/python/pants/notes/1.0.x.html",
     "notes-1.0.x": "dist/markdown/html/src/python/pants/notes/1.0.x.html",
     "notes-1.1.x": "dist/markdown/html/src/python/pants/notes/1.1.x.html",

--- a/src/python/pants/auth/BUILD
+++ b/src/python/pants/auth/BUILD
@@ -5,6 +5,7 @@
 python_library(
   dependencies = [
     '3rdparty/python:requests',
+    '3rdparty/python:www-authenticate',
     'src/python/pants/subsystem',
     'src/python/pants/process',
     'src/python/pants/util:dirutil',

--- a/src/python/pants/auth/basic_auth.py
+++ b/src/python/pants/auth/basic_auth.py
@@ -83,7 +83,7 @@ class BasicAuth(Subsystem):
 
     if response.status_code != requests.codes.ok:
       if response.status_code == requests.codes.unauthorized:
-        parsed = www_authenticate.parse(response.headers['WWW-Authenticate'])
+        parsed = www_authenticate.parse(response.headers.get('WWW-Authenticate', ''))
         if 'Basic' in parsed:
           raise Challenged(url, response.status_code, response.reason, parsed['Basic']['realm'])
       raise BasicAuthException(url, response.status_code, response.reason)

--- a/src/python/pants/core_tasks/login.py
+++ b/src/python/pants/core_tasks/login.py
@@ -4,12 +4,17 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.auth.basic_auth import BasicAuth
+import getpass
+from builtins import input
+
+from colors import cyan, green, red
+
+from pants.auth.basic_auth import BasicAuth, BasicAuthCreds, Challenged
 from pants.base.exceptions import TaskError
-from pants.task.task import Task
+from pants.task.console_task import ConsoleTask
 
 
-class Login(Task):
+class Login(ConsoleTask):
   """Task to auth against some identity provider.
 
   :API: public
@@ -29,10 +34,30 @@ class Login(Task):
     register('--to', fingerprint=True,
              help='Log in to this provider.  Can also be specified as a passthru arg.')
 
-  def execute(self):
+  def console_output(self, targets):
+    if targets:
+      raise TaskError('The login task does not take any target arguments.')
+
     # TODO: When we have other auth methods (e.g., OAuth2), select one by provider name.
     requested_providers = list(filter(None, [self.get_options().to] + self.get_passthru_args()))
     if len(requested_providers) != 1:
       raise TaskError('Must specify exactly one provider.')
-    # TODO: An interactive mode where we prompt for creds. Currently we assume they are in netrc.
-    BasicAuth.global_instance().authenticate(requested_providers[0])
+    provider = requested_providers[0]
+    try:
+      BasicAuth.global_instance().authenticate(provider)
+      return ['', 'Logged in successfully using .netrc credentials.']
+    except Challenged as e:
+      creds = self._ask_for_creds(provider, e.url, e.realm)
+      BasicAuth.global_instance().authenticate(provider, creds=creds)
+    return ['', 'Logged in successfully.']
+
+  @staticmethod
+  def _ask_for_creds(provider, url, realm):
+    print(green('\nEnter credentials for:\n'))
+    print('{} {}'.format(green('Provider:'), cyan(provider)))
+    print('{} {}'.format(green('Realm:   '), cyan(realm)))
+    print('{} {}'.format(green('URL:     '), cyan(url)))
+    print(red('\nONLY ENTER YOUR CREDENTIALS IF YOU TRUST THIS SITE!\n'))
+    username = input(green('Username: '))
+    password = getpass.getpass(green('Password: '))
+    return BasicAuthCreds(username, password)

--- a/tests/python/pants_test/auth/test_basic_auth.py
+++ b/tests/python/pants_test/auth/test_basic_auth.py
@@ -52,7 +52,8 @@ class TestBasicAuth(TestBase):
         BasicAuth.options_scope: {
           'providers': {
             'foobar': { 'url': 'http://localhost:{}'.format(self.port) }
-          }
+          },
+          'allow_insecure_urls': True
         },
         Cookies.options_scope: {
           'path': cookie_file

--- a/tests/python/pants_test/auth/test_basic_auth.py
+++ b/tests/python/pants_test/auth/test_basic_auth.py
@@ -7,10 +7,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import base64
 import os
 import threading
+from contextlib import contextmanager
 
 from future.moves.http.server import BaseHTTPRequestHandler, HTTPServer
 
-from pants.auth.basic_auth import BasicAuth, BasicAuthCreds
+from pants.auth.basic_auth import BasicAuth, BasicAuthCreds, BasicAuthException
 from pants.auth.cookies import Cookies
 from pants.util.contextutil import environment_as, temporary_dir
 from pants_test.test_base import TestBase
@@ -24,10 +25,13 @@ class RequestHandlerForTest(BaseHTTPRequestHandler):
     assert token_type == 'Basic'
     username, password = base64.b64decode(credentials).decode('utf8').split(':')
     assert username == 'test_user'
-    assert password == 'test_password'
-    self.send_response(200)
-    self.send_header('Set-Cookie', 'test_auth_key=test_auth_value; Max-Age=3600')
-    self.end_headers()
+    if password == 'test_password':
+      self.send_response(200)
+      self.send_header('Set-Cookie', 'test_auth_key=test_auth_value; Max-Age=3600')
+      self.end_headers()
+    else:
+      self.send_response(401)
+      self.end_headers()
 
 
 def _run_test_server():
@@ -44,7 +48,8 @@ class TestBasicAuth(TestBase):
     self.port, shutdown_func = _run_test_server()
     self.addCleanup(shutdown_func)
 
-  def _do_test_basic_auth(self, creds):
+  @contextmanager
+  def _test_options(self):
     with temporary_dir() as tmpcookiedir:
       cookie_file = os.path.join(tmpcookiedir, 'pants.test.cookies')
 
@@ -59,7 +64,10 @@ class TestBasicAuth(TestBase):
           'path': cookie_file
         }
       })
+      yield
 
+  def _do_test_basic_auth(self, creds):
+    with self._test_options():
       basic_auth = BasicAuth.global_instance()
       cookies = Cookies.global_instance()
 
@@ -80,3 +88,11 @@ class TestBasicAuth(TestBase):
         fp.write('machine localhost\nlogin test_user\npassword test_password'.encode('ascii'))
       with environment_as(HOME=tmphomedir):
         self._do_test_basic_auth(creds=None)
+
+  def test_basic_auth_with_bad_creds(self):
+    self._do_test_basic_auth(creds=BasicAuthCreds('test_user', 'test_password'))
+    basic_auth = BasicAuth.global_instance()
+    cookies = Cookies.global_instance()
+    bad_creds = BasicAuthCreds('test_user', 'bad_password')
+    self.assertRaises(BasicAuthException,
+      lambda: basic_auth.authenticate(provider='foobar', creds=bad_creds, cookies=cookies))


### PR DESCRIPTION
- If the attempt to auth with .netrc creds fails with
  a basic auth challenge, respond to that challenge by
  prompting the user for creds.

- Check that basic auth is only attempted over secure urls (addresses https://github.com/pantsbuild/pants/issues/6496)

- Make the login task a ConsoleTask.

- Remove the underscore in the scope name (safe to do as no one is using login yet). Dashes, or nothing, are a better style for scopes, otherwise they look weird in cmd-line flags.

- Some documentation and message fixes.
