### PR TITLE
Handle RPC errors as well as message-inline errors

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
  "build_utils 0.0.1",
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=bfd7333281c0422028502ccc7f78c57c27fdec08)",
+ "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
  "grpcio-compiler 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -357,7 +357,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=bfd7333281c0422028502ccc7f78c57c27fdec08)",
+ "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
  "hashing 0.0.1",
  "ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -489,10 +489,10 @@ dependencies = [
 [[package]]
 name = "grpcio"
 version = "0.3.0"
-source = "git+https://github.com/pantsbuild/grpc-rs.git?rev=bfd7333281c0422028502ccc7f78c57c27fdec08#bfd7333281c0422028502ccc7f78c57c27fdec08"
+source = "git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0#4dfafe9355dc996d7d0702e7386a6fedcd9734c0"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio-sys 0.2.3 (git+https://github.com/pantsbuild/grpc-rs.git?rev=bfd7333281c0422028502ccc7f78c57c27fdec08)",
+ "grpcio-sys 0.2.3 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "grpcio-sys"
 version = "0.2.3"
-source = "git+https://github.com/pantsbuild/grpc-rs.git?rev=bfd7333281c0422028502ccc7f78c57c27fdec08#bfd7333281c0422028502ccc7f78c57c27fdec08"
+source = "git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0#4dfafe9355dc996d7d0702e7386a6fedcd9734c0"
 dependencies = [
  "cc 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -759,7 +759,7 @@ dependencies = [
  "bazel_protos 0.0.1",
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=bfd7333281c0422028502ccc7f78c57c27fdec08)",
+ "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
  "hashing 0.0.1",
  "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -869,7 +869,7 @@ dependencies = [
  "fs 0.0.1",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=bfd7333281c0422028502ccc7f78c57c27fdec08)",
+ "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
  "hashing 0.0.1",
  "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
@@ -1620,9 +1620,9 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum globset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "464627f948c3190ae3d04b1bc6d7dca2f785bda0ac01278e6db129ad383dbeb6"
-"checksum grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=bfd7333281c0422028502ccc7f78c57c27fdec08)" = "<none>"
+"checksum grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)" = "<none>"
 "checksum grpcio-compiler 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a63ccc27b0099347d2bea2c3d0f1c79c018a13cfd08b814a1992e341b645d5e1"
-"checksum grpcio-sys 0.2.3 (git+https://github.com/pantsbuild/grpc-rs.git?rev=bfd7333281c0422028502ccc7f78c57c27fdec08)" = "<none>"
+"checksum grpcio-sys 0.2.3 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)" = "<none>"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bb2f0238094bd1b41800fb6eb9b16fdd5e9832ed6053ed91409f0cd5bf28dcfd"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -14,7 +14,7 @@ dirs = "1"
 futures = "^0.1.16"
 futures-cpupool = "0.1"
 glob = "0.2.11"
-grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "bfd7333281c0422028502ccc7f78c57c27fdec08", features = ["secure"] }
+grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", features = ["secure"] }
 hashing = { path = "../hashing" }
 ignore = "0.3.1"
 indexmap = "1"

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -12,7 +12,7 @@ bytes = "0.4.5"
 digest = "0.7"
 fs = { path = "../fs" }
 futures = "^0.1.16"
-grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "bfd7333281c0422028502ccc7f78c57c27fdec08", features = ["secure"] }
+grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", features = ["secure"] }
 hashing = { path = "../hashing" }
 log = "0.4"
 protobuf = { version = "2.0.4", features = ["with-bytes"] }

--- a/src/rust/engine/process_execution/bazel_protos/Cargo.toml
+++ b/src/rust/engine/process_execution/bazel_protos/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 bytes = "0.4.5"
 futures = "^0.1.16"
-grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "bfd7333281c0422028502ccc7f78c57c27fdec08", features = ["secure"] }
+grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", features = ["secure"] }
 hashing = { path = "../../hashing" }
 protobuf = { version = "2.0.4", features = ["with-bytes"] }
 

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -19,6 +19,12 @@ use sha2::Sha256;
 use super::{ExecuteProcessRequest, FallibleExecuteProcessResult};
 use std::cmp::min;
 
+#[derive(Debug)]
+enum OperationOrStatus {
+  Operation(bazel_protos::operations::Operation),
+  Status(bazel_protos::status::Status),
+}
+
 #[derive(Clone)]
 pub struct CommandRunner {
   instance_name: Option<String>,
@@ -50,7 +56,7 @@ impl CommandRunner {
   fn oneshot_execute(
     &self,
     execute_request: &Arc<bazel_protos::remote_execution::ExecuteRequest>,
-  ) -> BoxFuture<bazel_protos::operations::Operation, String> {
+  ) -> BoxFuture<OperationOrStatus, String> {
     let stream = try_future!(
       self
         .execution_client
@@ -61,15 +67,18 @@ impl CommandRunner {
     stream
         .take(1)
         .into_future()
+        // If there was a response, drop the _stream to disconnect so that the server doesn't keep
+        // the connection alive and continue sending on it.
+        .map(|(maybe_operation, _stream)| maybe_operation)
         // If there was an error, drop the _stream to disconnect so that the server doesn't keep the
         // connection alive and continue sending on it.
-        .map_err(|(error, _stream)| rpcerror_to_string(error))
-        .and_then(|(maybe_operation, _stream)| {
-          // If there was a response, drop the _stream to disconnect so that the server doesn't keep
-          // the connection alive and continue sending on it.
-          maybe_operation.ok_or_else(|| {
-            "Didn't get proper stream response from server during remote execution".to_owned()
-          })
+        .map_err(|(error, _stream)| error)
+        .then(|maybe_operation_result| {
+          match maybe_operation_result {
+            Ok(Some(operation)) => Ok(OperationOrStatus::Operation(operation)),
+            Ok(None) => Err("Didn't get proper stream response from server during remote execution".to_owned()),
+            Err(err) => rpcerror_to_status_or_string(err).map(OperationOrStatus::Status),
+          }
         })
         .to_boxed()
   }
@@ -188,6 +197,7 @@ impl super::CommandRunner for CommandRunner {
                                 .or_else(move |err| {
                                   rpcerror_recover_cancelled(operation_request.take_name(), err)
                                 })
+                                .map(OperationOrStatus::Operation)
                                 .map_err(rpcerror_to_string),
                             ).map(move |operation| {
                               future::Loop::Continue((operation, iter_num + 1))
@@ -285,118 +295,131 @@ impl CommandRunner {
 
   fn extract_execute_response(
     &self,
-    mut operation: bazel_protos::operations::Operation,
+    operation_or_status: OperationOrStatus,
   ) -> BoxFuture<FallibleExecuteProcessResult, ExecutionError> {
     // TODO: Log less verbosely
-    debug!("Got operation response: {:?}", operation);
-    if !operation.get_done() {
-      return future::err(ExecutionError::NotFinished(operation.take_name())).to_boxed();
-    }
-    if operation.has_error() {
-      return future::err(ExecutionError::Fatal(format_error(&operation.get_error()))).to_boxed();
-    }
-    if !operation.has_response() {
-      return future::err(ExecutionError::Fatal(
-        "Operation finished but no response supplied".to_string(),
-      )).to_boxed();
-    }
-    let mut execute_response = bazel_protos::remote_execution::ExecuteResponse::new();
-    try_future!(
-      execute_response
-        .merge_from_bytes(operation.get_response().get_value())
-        .map_err(|e| ExecutionError::Fatal(format!("Invalid ExecuteResponse: {:?}", e)))
-    );
-    // TODO: Log less verbosely
-    debug!("Got (nested) execute response: {:?}", execute_response);
+    debug!("Got operation response: {:?}", operation_or_status);
 
-    self
-      .extract_stdout(&execute_response)
-      .join(self.extract_stderr(&execute_response))
-      .join(self.extract_output_files(&execute_response))
-      .and_then(move |((stdout, stderr), output_directory)| {
-        match grpcio::RpcStatusCode::from(execute_response.get_status().get_code()) {
-          grpcio::RpcStatusCode::Ok => future::ok(FallibleExecuteProcessResult {
-            stdout: stdout,
-            stderr: stderr,
-            exit_code: execute_response.get_result().get_exit_code(),
-            output_directory: output_directory,
-          }).to_boxed(),
-          grpcio::RpcStatusCode::FailedPrecondition => {
-            if execute_response.get_status().get_details().len() != 1 {
-              return future::err(ExecutionError::Fatal(format!(
-              "Received multiple details in FailedPrecondition ExecuteResponse's status field: {:?}",
-              execute_response.get_status().get_details()
-            ))).to_boxed();
-            }
-            let details = execute_response.get_status().get_details().get(0).unwrap();
-            let mut precondition_failure = bazel_protos::error_details::PreconditionFailure::new();
-            if details.get_type_url()
-              != format!(
-                "type.googleapis.com/{}",
-                precondition_failure.descriptor().full_name()
-              ) {
-              return future::err(ExecutionError::Fatal(format!(
-                "Received FailedPrecondition, but didn't know how to resolve it: {},\
-                 protobuf type {}",
-                execute_response.get_status().get_message(),
-                details.get_type_url()
-              ))).to_boxed();
-            }
-            try_future!(
-              precondition_failure
-                .merge_from_bytes(details.get_value())
-                .map_err(|e| {
-                  ExecutionError::Fatal(format!(
-                    "Error deserializing FailedPrecondition proto: {:?}",
-                    e
-                  ))
-                })
-            );
-
-            let mut missing_digests =
-              Vec::with_capacity(precondition_failure.get_violations().len());
-
-            for violation in precondition_failure.get_violations() {
-              if violation.get_field_type() != "MISSING" {
-                return future::err(ExecutionError::Fatal(format!(
-                  "Didn't know how to process PreconditionFailure violation: {:?}",
-                  violation
-                ))).to_boxed();
-              }
-              let parts: Vec<_> = violation.get_subject().split('/').collect();
-              if parts.len() != 3 || parts[0] != "blobs" {
-                return future::err(ExecutionError::Fatal(format!(
-                  "Received FailedPrecondition MISSING but didn't recognize subject {}",
-                  violation.get_subject()
-                ))).to_boxed();
-              }
-              let digest = Digest(
-                try_future!(Fingerprint::from_hex_string(parts[1]).map_err(|e| {
-                  ExecutionError::Fatal(format!("Bad digest in missing blob: {}: {}", parts[1], e))
-                })),
-                try_future!(
-                  parts[2].parse::<usize>().map_err(|e| {
-                    ExecutionError::Fatal(format!("Missing blob had bad size: {}: {}", parts[2], e))
-                  })
-                ),
-              );
-              missing_digests.push(digest);
-            }
-            if missing_digests.is_empty() {
-              return future::err(ExecutionError::Fatal(
-                "Error from remote execution: FailedPrecondition, but no details".to_owned(),
-              )).to_boxed();
-            }
-            future::err(ExecutionError::MissingDigests(missing_digests)).to_boxed()
-          }
-          code => future::err(ExecutionError::Fatal(format!(
-            "Error from remote execution: {:?}: {:?}",
-            code,
-            execute_response.get_status().get_message()
-          ))).to_boxed(),
+    let status = match operation_or_status {
+      OperationOrStatus::Operation(mut operation) => {
+        if !operation.get_done() {
+          return future::err(ExecutionError::NotFinished(operation.take_name())).to_boxed();
         }
-      })
-      .to_boxed()
+        if operation.has_error() {
+          return future::err(ExecutionError::Fatal(format_error(&operation.get_error())))
+            .to_boxed();
+        }
+        if !operation.has_response() {
+          return future::err(ExecutionError::Fatal(
+            "Operation finished but no response supplied".to_string(),
+          )).to_boxed();
+        }
+
+        let mut execute_response = bazel_protos::remote_execution::ExecuteResponse::new();
+        try_future!(
+          execute_response
+            .merge_from_bytes(operation.get_response().get_value())
+            .map_err(|e| ExecutionError::Fatal(format!("Invalid ExecuteResponse: {:?}", e)))
+        );
+        // TODO: Log less verbosely
+        debug!("Got (nested) execute response: {:?}", execute_response);
+
+        let status = execute_response.take_status();
+        if grpcio::RpcStatusCode::from(status.get_code()) == grpcio::RpcStatusCode::Ok {
+          return self
+            .extract_stdout(&execute_response)
+            .join(self.extract_stderr(&execute_response))
+            .join(self.extract_output_files(&execute_response))
+            .and_then(move |((stdout, stderr), output_directory)| {
+              Ok(FallibleExecuteProcessResult {
+                stdout: stdout,
+                stderr: stderr,
+                exit_code: execute_response.get_result().get_exit_code(),
+                output_directory: output_directory,
+              })
+            }).to_boxed();
+        }
+        status
+      }
+      OperationOrStatus::Status(status) => status,
+    };
+
+    match grpcio::RpcStatusCode::from(status.get_code()) {
+      grpcio::RpcStatusCode::Ok => unreachable!(),
+      grpcio::RpcStatusCode::FailedPrecondition => {
+        if status.get_details().len() != 1 {
+          return future::err(ExecutionError::Fatal(format!(
+            "Received multiple details in FailedPrecondition ExecuteResponse's status field: {:?}",
+            status.get_details()
+          ))).to_boxed();
+        }
+        let details = status.get_details().get(0).unwrap();
+        let mut precondition_failure = bazel_protos::error_details::PreconditionFailure::new();
+        if details.get_type_url() != format!(
+          "type.googleapis.com/{}",
+          precondition_failure.descriptor().full_name()
+        ) {
+          return future::err(ExecutionError::Fatal(format!(
+            "Received FailedPrecondition, but didn't know how to resolve it: {},\
+             protobuf type {}",
+            status.get_message(),
+            details.get_type_url()
+          ))).to_boxed();
+        }
+        try_future!(
+          precondition_failure
+            .merge_from_bytes(details.get_value())
+            .map_err(|e| ExecutionError::Fatal(format!(
+              "Error deserializing FailedPrecondition proto: {:?}",
+              e
+            )))
+        );
+
+        let mut missing_digests = Vec::with_capacity(precondition_failure.get_violations().len());
+
+        for violation in precondition_failure.get_violations() {
+          if violation.get_field_type() != "MISSING" {
+            return future::err(ExecutionError::Fatal(format!(
+              "Didn't know how to process PreconditionFailure violation: {:?}",
+              violation
+            ))).to_boxed();
+          }
+          let parts: Vec<_> = violation.get_subject().split('/').collect();
+          if parts.len() != 3 || parts[0] != "blobs" {
+            return future::err(ExecutionError::Fatal(format!(
+              "Received FailedPrecondition MISSING but didn't recognize subject {}",
+              violation.get_subject()
+            ))).to_boxed();
+          }
+          let digest =
+            Digest(
+              try_future!(Fingerprint::from_hex_string(parts[1]).map_err(|e| {
+                ExecutionError::Fatal(format!("Bad digest in missing blob: {}: {}", parts[1], e))
+              })),
+              try_future!(
+                parts[2]
+                  .parse::<usize>()
+                  .map_err(|e| ExecutionError::Fatal(format!(
+                    "Missing blob had bad size: {}: {}",
+                    parts[2], e
+                  )))
+              ),
+            );
+          missing_digests.push(digest);
+        }
+        if missing_digests.is_empty() {
+          return future::err(ExecutionError::Fatal(
+            "Error from remote execution: FailedPrecondition, but no details".to_owned(),
+          )).to_boxed();
+        }
+        future::err(ExecutionError::MissingDigests(missing_digests)).to_boxed()
+      }
+      code => future::err(ExecutionError::Fatal(format!(
+        "Error from remote execution: {:?}: {:?}",
+        code,
+        status.get_message()
+      ))).to_boxed(),
+    }.to_boxed()
   }
 
   fn extract_stdout(
@@ -683,6 +706,29 @@ fn rpcerror_recover_cancelled(
   }
   // Did not represent cancellation.
   Err(err)
+}
+
+fn rpcerror_to_status_or_string(
+  error: grpcio::Error,
+) -> Result<bazel_protos::status::Status, String> {
+  match error {
+    grpcio::Error::RpcFailure(grpcio::RpcStatus {
+      status_proto_bytes: Some(status_proto_bytes),
+      ..
+    }) => {
+      let mut status_proto = bazel_protos::status::Status::new();
+      status_proto.merge_from_bytes(&status_proto_bytes).unwrap();
+      Ok(status_proto)
+    }
+    grpcio::Error::RpcFailure(grpcio::RpcStatus {
+      status, details, ..
+    }) => Err(format!(
+      "{:?}: {:?}",
+      status,
+      details.unwrap_or_else(|| "[no message]".to_string())
+    )),
+    err => Err(format!("{:?}", err)),
+  }
 }
 
 fn rpcerror_to_string(error: grpcio::Error) -> String {
@@ -2060,7 +2106,9 @@ mod tests {
       .directory(&TestDirectory::containing_roland())
       .build();
     let command_runner = create_command_runner("".to_owned(), &cas);
-    command_runner.extract_execute_response(operation).wait()
+    command_runner
+      .extract_execute_response(super::OperationOrStatus::Operation(operation))
+      .wait()
   }
 
   fn extract_output_files_from_response(

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 bazel_protos = { path = "../../process_execution/bazel_protos" }
 bytes = "0.4.5"
 futures = "^0.1.16"
-grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "bfd7333281c0422028502ccc7f78c57c27fdec08", features = ["secure"] }
+grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", features = ["secure"] }
 hashing = { path = "../../hashing" }
 parking_lot = "0.6"
 protobuf = { version = "2.0.4", features = ["with-bytes"] }


### PR DESCRIPTION
This required a minor change to grpcio
(https://github.com/pantsbuild/grpc-rs/commit/4dfafe9355dc996d7d0702e7386a6fedcd9734c0)
to not throw away the information from the grpc stack.