### PR TITLE
Don't immediately fail after a MacOS upgrade.

### DIFF
--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -74,6 +74,6 @@ SUPPORTED_PLATFORM_NORMALIZED_NAMES = {
 def get_closest_mac_host_platform_pair(darwin_version_upper_bound,
                                        platform_name_map=SUPPORTED_PLATFORM_NORMALIZED_NAMES):
   """Return the (host, platform) pair for the highest known darwin version less than the bound."""
-  darwin_versions = [int(x[1]) for x in SUPPORTED_PLATFORM_NORMALIZED_NAMES if x[0] == 'darwin']
+  darwin_versions = [int(x[1]) for x in platform_name_map if x[0] == 'darwin']
   max_darwin_version = str(max(v for v in darwin_versions if v <= int(darwin_version_upper_bound)))
   return platform_name_map[('darwin', max_darwin_version)]

--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -69,3 +69,11 @@ SUPPORTED_PLATFORM_NORMALIZED_NAMES = {
   ('darwin', '16'): ('mac', '10.12'),
   ('darwin', '17'): ('mac', '10.13'),
 }
+
+
+def get_closest_mac_host_platform_pair(darwin_version_upper_bound,
+                                       platform_name_map=SUPPORTED_PLATFORM_NORMALIZED_NAMES):
+  """Return the (host, platform) pair for the highest known darwin version less than the bound."""
+  darwin_versions = [int(x[1]) for x in SUPPORTED_PLATFORM_NORMALIZED_NAMES if x[0] == 'darwin']
+  max_darwin_version = str(max(v for v in darwin_versions if v <= int(darwin_version_upper_bound)))
+  return platform_name_map[('darwin', max_darwin_version)]

--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -75,5 +75,8 @@ def get_closest_mac_host_platform_pair(darwin_version_upper_bound,
                                        platform_name_map=SUPPORTED_PLATFORM_NORMALIZED_NAMES):
   """Return the (host, platform) pair for the highest known darwin version less than the bound."""
   darwin_versions = [int(x[1]) for x in platform_name_map if x[0] == 'darwin']
-  max_darwin_version = str(max(v for v in darwin_versions if v <= int(darwin_version_upper_bound)))
+  bounded_darwin_versions = [v for v in darwin_versions if v <= int(darwin_version_upper_bound)]
+  if not bounded_darwin_versions:
+    return None, None
+  max_darwin_version = str(max(bounded_darwin_versions))
   return platform_name_map[('darwin', max_darwin_version)]

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -154,7 +154,8 @@ class BinaryUtilTest(TestBase):
 
       binary_path_abs = os.path.join(bootstrap_dir, binary_path)
 
-      self.assertEqual(binary_path_abs, binary_util.select(binary_request))
+      self.assertEqual(os.path.realpath(binary_path_abs),
+                       os.path.realpath(binary_util.select(binary_request)))
 
       self.assertEqual(contents, self._read_file(binary_path_abs))
 
@@ -235,9 +236,9 @@ class BinaryUtilTest(TestBase):
       "Recognized platforms are: [darwin, linux].")
     self.assertIn(expected_msg, the_raised_exception_message)
 
-  def test_select_binary_base_path_missing_version(self):
+  def test_select_binary_base_path_missing_arch(self):
     def uname_func():
-      return "darwin", "dontcare1", "999.9", "dontcare2", "x86_64"
+      return "linux", "dontcare1", "don'tcare2", "dontcare3", "quantum_computer"
 
     binary_util = self._gen_binary_util(uname_func=uname_func)
 
@@ -248,15 +249,16 @@ class BinaryUtilTest(TestBase):
     self.assertIn(BinaryUtil.MissingMachineInfo.__name__, the_raised_exception_message)
     expected_msg = (
       "Error resolving binary request BinaryRequest(supportdir=mysupportdir, version=myversion, "
-      "name=myname, platform_dependent=True, external_url_generator=None, archiver=None): Pants could not "
-      "resolve binaries for the current host. Update --binaries-path-by-id to find binaries for "
-      "the current host platform ({unicode_literal}\'darwin\', {unicode_literal}\'999\').\\n--binaries-path-by-id was:"
+      "name=myname, platform_dependent=True, external_url_generator=None, archiver=None): "
+      "Pants could not resolve binaries for the current host. Update --binaries-path-by-id to "
+      "find binaries for the current host platform ({unicode_literal}\'linux\', "
+      "{unicode_literal}\'quantum_computer\').\\n--binaries-path-by-id was:"
     ).format(unicode_literal='u' if PY2 else '')
     self.assertIn(expected_msg, the_raised_exception_message)
 
-  def test_select_script_missing_version(self):
+  def test_select_script_missing_arch(self):
     def uname_func():
-      return "darwin", "dontcare1", "999.9", "dontcare2", "x86_64"
+      return "linux", "dontcare1", "dontcare2", "dontcare3", "quantum_computer"
 
     binary_util = self._gen_binary_util(uname_func=uname_func)
 
@@ -270,8 +272,8 @@ class BinaryUtilTest(TestBase):
       # platform_dependent=False when doing select_script()
       "name=myname, platform_dependent=False, external_url_generator=None, archiver=None): Pants "
       "could not resolve binaries for the current host. Update --binaries-path-by-id to find "
-      "binaries for the current host platform ({unicode_literal}\'darwin\', {unicode_literal}\'999\')."
-      "\\n--binaries-path-by-id was:"
+      "binaries for the current host platform ({unicode_literal}\'linux\', "
+      "{unicode_literal}\'quantum_computer\').\\n--binaries-path-by-id was:"
     ).format(unicode_literal='u' if PY2 else '')
     self.assertIn(expected_msg, the_raised_exception_message)
 

--- a/tests/python/pants_test/util/test_osutil.py
+++ b/tests/python/pants_test/util/test_osutil.py
@@ -51,7 +51,8 @@ class OsutilTest(TestBase):
     def get_macos_version(darwin_version):
       host, version = get_closest_mac_host_platform_pair(
         darwin_version, platform_name_map=platform_name_map)
-      self.assertEqual('mac', host)
+      if host is not None:
+        self.assertEqual('mac', host)
       return version
 
     self.assertEqual('10.13', get_macos_version('19'))
@@ -61,6 +62,7 @@ class OsutilTest(TestBase):
     self.assertEqual('10.10', get_macos_version('15'))
     self.assertEqual('10.10', get_macos_version('14'))
     self.assertEqual('10.9', get_macos_version('13'))
-    self.assertEqual('10.9', get_macos_version('12'))
-    self.assertEqual('10.9', get_macos_version('11'))
+    self.assertEqual('10.6', get_macos_version('12'))
+    self.assertEqual('10.6', get_macos_version('11'))
     self.assertEqual('10.6', get_macos_version('10'))
+    self.assertEqual(None, get_macos_version('9'))

--- a/tests/python/pants_test/util/test_osutil.py
+++ b/tests/python/pants_test/util/test_osutil.py
@@ -6,7 +6,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 
-from pants.util.osutil import OS_ALIASES, known_os_names, normalize_os_name
+from pants.util.osutil import (OS_ALIASES, get_closest_mac_host_platform_pair, known_os_names,
+                               normalize_os_name)
 from pants_test.test_base import TestBase
 
 
@@ -34,3 +35,32 @@ class OsutilTest(TestBase):
       normalize_os_name(name)
       self.assertEqual(1, len(captured.warnings()),
                        'Expected exactly one warning, but got: {}'.format(captured.warnings()))
+
+  def test_get_closest_mac_host_platform_pair(self):
+    # Note the gaps in darwin versions.
+    platform_name_map = {
+      ('linux', 'x86_64'): ('linux', 'x86_64'),
+      ('linux', 'amd64'): ('linux', 'x86_64'),
+      ('darwin', '10'): ('mac', '10.6'),
+      ('darwin', '13'): ('mac', '10.9'),
+      ('darwin', '14'): ('mac', '10.10'),
+      ('darwin', '16'): ('mac', '10.12'),
+      ('darwin', '17'): ('mac', '10.13'),
+    }
+
+    def get_macos_version(darwin_version):
+      host, version = get_closest_mac_host_platform_pair(
+        darwin_version, platform_name_map=platform_name_map)
+      self.assertEqual('mac', host)
+      return version
+
+    self.assertEqual('10.13', get_macos_version('19'))
+    self.assertEqual('10.13', get_macos_version('18'))
+    self.assertEqual('10.13', get_macos_version('17'))
+    self.assertEqual('10.12', get_macos_version('16'))
+    self.assertEqual('10.10', get_macos_version('15'))
+    self.assertEqual('10.10', get_macos_version('14'))
+    self.assertEqual('10.9', get_macos_version('13'))
+    self.assertEqual('10.9', get_macos_version('12'))
+    self.assertEqual('10.9', get_macos_version('11'))
+    self.assertEqual('10.6', get_macos_version('10'))


### PR DESCRIPTION
Currently if you upgrade MacOS to a version that
didn't exist at the time your Pants version was built,
Pants support binary fetching will fail. To fix this
we had to publish every support binary under a new path.

But this is unnecessary, since new versions of MacOS
can always run binaries built for older versions (at
least until Macs change their architecture again).

This change allows unknown MacOS versions to fall back
to the most recent version Pants knows about.
