### PR TITLE
Support uploading stats to multiple endpoints.

### DIFF
--- a/src/docs/setup_repo.md
+++ b/src/docs/setup_repo.md
@@ -126,9 +126,18 @@ To upload these stats to a server for future analysis set the following option i
 
     :::ini
     [run-tracker]
-    stats_upload_url: "http://myorg.org/pantsstats"
+    stats_upload_urls: {
+      'http://myorg.org/pantsstats': 'authprovider'
+    }
 
-Pants will `POST` JSON data to that URL.  The JSON format should be self-explanatory.
+Pants will `POST` JSON data to each key URL.  The `authprovider` is the name of the provider the
+user must auth against in order to post to the corresponding URL.
+See [[here|pants('src/docs/common_tasks:login')]] for details on how to authenticate Pants against
+an auth provider.
+
+If posting to the URL does not require authentication, use the empty string as the auth provider.
+
+The posted JSON format should be self-explanatory.
 
 Using Pants behind a firewall
 -----------------------------

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -199,7 +199,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   'project depends on.')
     register('--owner-of', type=list, default=[], daemon=False, fromfile=True, metavar='<path>',
              help='Select the targets that own these files. '
-                  'This is the third target calculation strategy along with the --changed '
+                  'This is the third target calculation strategy along with the --changed-* '
                   'options and specifying the targets directly. These three types of target '
                   'selection are mutually exclusive.')
 
@@ -297,7 +297,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--process-execution-parallelism', type=int, default=multiprocessing.cpu_count(),
              advanced=True,
              help='Number of concurrent processes that may be executed either locally and remotely.')
-    register('--process-execution-cleanup-local-dirs', type=bool, default=True,
+    register('--process-execution-cleanup-local-dirs', type=bool, default=True, advanced=True,
              help='Whether or not to cleanup directories used for local process execution '
                   '(primarily useful for e.g. debugging).')
 

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -24,13 +24,19 @@ class RunTrackerTest(TestBase):
     class Handler(http.server.BaseHTTPRequestHandler):
       def do_POST(handler):
         try:
-          self.assertEqual('/upload', handler.path)
-          self.assertEqual('application/x-www-form-urlencoded', handler.headers['Content-type'])
-          length = int(handler.headers['Content-Length'])
-          post_data = parse_qs(handler.rfile.read(length).decode('utf-8'))
-          decoded_post_data = {k: json.loads(v[0]) for k, v in post_data.items()}
-          self.assertEqual(stats, decoded_post_data)
-          handler.send_response(200)
+          if handler.path.startswith('/redirect'):
+            code = int(handler.path[-3:])
+            handler.send_response(code)
+            handler.send_header('location', mk_url('/upload'))
+            handler.end_headers()
+          else:
+            self.assertEqual('/upload', handler.path)
+            self.assertEqual('application/x-www-form-urlencoded', handler.headers['Content-type'])
+            length = int(handler.headers['Content-Length'])
+            post_data = parse_qs(handler.rfile.read(length).decode('utf-8'))
+            decoded_post_data = {k: json.loads(v[0]) for k, v in post_data.items()}
+            self.assertEqual(stats, decoded_post_data)
+            handler.send_response(200)
         except Exception:
           handler.send_response(400)  # Ensure the main thread knows the test failed.
           raise
@@ -39,12 +45,17 @@ class RunTrackerTest(TestBase):
     server = http.server.HTTPServer(server_address, Handler)
     host, port = server.server_address
 
+    def mk_url(path):
+      return 'http://{}:{}{}'.format(host, port, path)
+
     server_thread = threading.Thread(target=server.serve_forever)
     server_thread.daemon = True
     server_thread.start()
 
     self.context(for_subsystems=[Cookies])
-    self.assertTrue(RunTracker.post_stats('http://{}:{}/upload'.format(host, port), stats))
+    self.assertTrue(RunTracker.post_stats(mk_url('/upload'), stats))
+    self.assertTrue(RunTracker.post_stats(mk_url('/redirect307'), stats))
+    self.assertFalse(RunTracker.post_stats(mk_url('/redirect302'), stats))
 
     server.shutdown()
     server.server_close()


### PR DESCRIPTION
Also:

- Allow associating a stats upload endpoint with a corresponding
  auth provider, for better error messaging.
- Don't follow redirects to GET when posting. These almost certainly
  indicate an auth failure (redirecting to a login page), and
  should trigger an error message.
- Piggybacked a small change to help display for a couple of
  global options.
