### PR TITLE
Simplify pants.pex creation, leverage -c.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -614,7 +614,7 @@ function build_pex() {
 
     ./${PEX_PEX} \
       -o "${dest}" \
-      --entry-point="pants.bin.pants_loader:main" \
+      --script=pants \
       --no-build \
       --no-pypi \
       --disable-cache \


### PR DESCRIPTION
This lets the full entry-point live in less places. The `pants` console
script will be much more stable and it's easy to remember / ~obviously
right.

I forgot to leverage the work in
https://github.com/pantsbuild/pex/pull/545 when upgrading from
pex 1.4.5 to 1.4.8 as part of #5922.