### PR TITLE
Introduce factory_dict.

### DIFF
--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -81,6 +81,7 @@ python_library(
   dependencies = [
     '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/util:collections',
     'src/python/pants/util:dirutil',
   ],
 )

--- a/src/python/pants/goal/products.py
+++ b/src/python/pants/goal/products.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 import six
 from twitter.common.collections import OrderedSet
 
+from pants.util.collections import factory_dict
 from pants.util.dirutil import fast_relpath
 
 
@@ -198,7 +199,7 @@ class MultipleRootedProducts(object):
     """
     :API: public
     """
-    self._rooted_products_by_root = {}
+    self._rooted_products_by_root = factory_dict(RootedProducts)
 
   def add_rel_paths(self, root, rel_paths):
     """
@@ -227,7 +228,7 @@ class MultipleRootedProducts(object):
       yield root, products.abs_paths()
 
   def _get_products_for_root(self, root):
-    return self._rooted_products_by_root.setdefault(root, RootedProducts(root))
+    return self._rooted_products_by_root[root]
 
   def __bool__(self):
     """Return True if any of the roots contains products"""
@@ -365,7 +366,7 @@ class Products(object):
   def __init__(self):
     # TODO(John Sirois): Kill products and simply have users register ProductMapping subtypes
     # as data products.  Will require a class factory, like `ProductMapping.named(typename)`.
-    self.products = {}  # type -> ProductMapping instance.
+    self.products = factory_dict(Products.ProductMapping)  # type -> ProductMapping instance.
     self.required_products = set()
 
     self.data_products = {}  # type -> arbitrary object.
@@ -392,7 +393,7 @@ class Products(object):
 
     :API: public
     """
-    return self.products.setdefault(typename, Products.ProductMapping(typename))
+    return self.products[typename]
 
   def require_data(self, typename):
     """Registers a requirement that data produced by tasks is required.

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -34,7 +34,9 @@ def factory_dict(value_factory, *args, **kwargs):
       super(FactoryDict, self).__init__(self.__never_called, *args, **kwargs)
 
     def __missing__(self, key):
-      return value_factory(key)
+      value = value_factory(key)
+      self[key] = value
+      return value
 
   return FactoryDict()
 

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -4,12 +4,39 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import collections
 from builtins import next
 
 
 def combined_dict(*dicts):
   """Combine one or more dicts into a new, unified dict (dicts to the right take precedence)."""
   return {k: v for d in dicts for k, v in d.items()}
+
+
+def factory_dict(value_factory, *args, **kwargs):
+  """A dict whose values are computed by `value_factory` when a `__getitem__` key is missing.
+
+  Not that values retrieved by any other method will not be lazily computed; eg: via `get`.
+
+  :param value_factory:
+  :type value_factory: A function from dict key to value.
+  :param *args: Any positional args to pass through to `dict`.
+  :param **kwrags: Any kwargs to pass through to `dict`.
+  :rtype: dict
+  """
+  class FactoryDict(collections.defaultdict):
+    @staticmethod
+    def __never_called():
+      raise AssertionError('The default factory should never be called since we override '
+                           '__missing__.')
+
+    def __init__(self):
+      super(FactoryDict, self).__init__(self.__never_called, *args, **kwargs)
+
+    def __missing__(self, key):
+      return value_factory(key)
+
+  return FactoryDict()
 
 
 def recursively_update(d, d2):

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -16,7 +16,7 @@ def combined_dict(*dicts):
 def factory_dict(value_factory, *args, **kwargs):
   """A dict whose values are computed by `value_factory` when a `__getitem__` key is missing.
 
-  Not that values retrieved by any other method will not be lazily computed; eg: via `get`.
+  Note that values retrieved by any other method will not be lazily computed; eg: via `get`.
 
   :param value_factory:
   :type value_factory: A function from dict key to value.

--- a/tests/python/pants_test/util/test_collections.py
+++ b/tests/python/pants_test/util/test_collections.py
@@ -7,7 +7,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 from builtins import str
 
-from pants.util.collections import assert_single_element, combined_dict, recursively_update
+from pants.util.collections import (assert_single_element, combined_dict, factory_dict,
+                                    recursively_update)
 
 
 class TestCollections(unittest.TestCase):
@@ -20,6 +21,21 @@ class TestCollections(unittest.TestCase):
       ),
       {'a': 1, 'b': 2, 'c': 3}
     )
+
+  def test_factory_dict(self):
+    cubes = factory_dict(lambda x: x ** 3, ((x, x ** 2) for x in range(3)), three=42)
+    self.assertEqual(0, cubes[0])
+    self.assertEqual(1, cubes[1])
+    self.assertEqual(4, cubes[2])
+
+    self.assertEqual(27, cubes[3])
+
+    self.assertIsNone(cubes.get(4))
+    self.assertEqual(64, cubes[4])
+
+    self.assertEqual(42, cubes['three'])
+
+    self.assertEqual('jake', cubes.get(5, 'jake'))
 
   def test_recursively_update(self):
     d = {'a': 1, 'b': {'c': 2, 'o': 'z'}, 'z': {'y': 0}}

--- a/tests/python/pants_test/util/test_collections.py
+++ b/tests/python/pants_test/util/test_collections.py
@@ -23,15 +23,18 @@ class TestCollections(unittest.TestCase):
     )
 
   def test_factory_dict(self):
-    cubes = factory_dict(lambda x: x ** 3, ((x, x ** 2) for x in range(3)), three=42)
+    cubes = factory_dict(lambda x: [x ** 3], ((x, x ** 2) for x in range(3)), three=42)
     self.assertEqual(0, cubes[0])
     self.assertEqual(1, cubes[1])
     self.assertEqual(4, cubes[2])
 
-    self.assertEqual(27, cubes[3])
+    self.assertEqual([27], cubes[3])
 
     self.assertIsNone(cubes.get(4))
-    self.assertEqual(64, cubes[4])
+    self.assertEqual([64], cubes[4])
+
+    cubes.get(4).append(8)
+    self.assertEqual([64, 8], cubes[4])
 
     self.assertEqual(42, cubes['three'])
 


### PR DESCRIPTION
This generates values from keys when no entry is present, a feature
you might guess collections.defaultdict would support by passing keys
through to default_factory functions.

Update products to use this.
PR #6618 will also pull it in or else it will be used in a follow-up.