### PR TITLE
Create exactly one associated subsystem per checkstyle plugin

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/plugin_subsystem_base.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/plugin_subsystem_base.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 
 from pants.subsystem.subsystem import Subsystem
+from pants.util.memo import memoized
 
 
 class PluginSubsystemBase(Subsystem):
@@ -28,6 +29,7 @@ class PluginSubsystemBase(Subsystem):
     return json.dumps(options_dict) if options_dict else None
 
 
+@memoized
 def default_subsystem_for_plugin(plugin_type):
   return type(str('{}Subsystem'.format(plugin_type.__name__)),
               (PluginSubsystemBase,),

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/plugin_subsystem_base.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/plugin_subsystem_base.py
@@ -33,7 +33,7 @@ class PluginSubsystemBase(Subsystem):
 def default_subsystem_for_plugin(plugin_type):
   """Create a singleton PluginSubsystemBase subclass for the given plugin type.
 
-  The singleton enforrcement is useful in cases where dependent Tasks are installed multiple times,
+  The singleton enforcement is useful in cases where dependent Tasks are installed multiple times,
   to avoid creating duplicate types which would have option scope collisions.
 
   :param plugin_type: A CheckstylePlugin subclass.

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/plugin_subsystem_base.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/plugin_subsystem_base.py
@@ -31,6 +31,15 @@ class PluginSubsystemBase(Subsystem):
 
 @memoized
 def default_subsystem_for_plugin(plugin_type):
+  """Create a singleton PluginSubsystemBase subclass for the given plugin type.
+
+  The singleton enforrcement is useful in cases where dependent Tasks are installed multiple times,
+  to avoid creating duplicate types which would have option scope collisions.
+
+  :param plugin_type: A CheckstylePlugin subclass.
+  :type: :class:`pants.contrib.python.checks.checker.common.CheckstylePlugin`
+  :rtype: :class:`pants.contrib.python.checks.tasks.checkstyle.plugin_subsystem_base.PluginSubsystemBase`
+  """
   return type(str('{}Subsystem'.format(plugin_type.__name__)),
               (PluginSubsystemBase,),
               {


### PR DESCRIPTION
### Problem

Each call to the `default_subsystem_for_plugin` method created a new instance of an anonymous class, which caused multiple identically named/scoped subsystem classes, and a namespace scope collision when the Checkstyle task was installed multiple times. Twitter internally install Checkstyle in multiple places with different configuration.

### Solution

Memoize the anonymous class creation, resulting in exactly one Subsystem class type being created per plugin class type. 

### Result

Checkstyle can be installed multiple times again.