### PR TITLE
[dep-usage] when no summary, ensure json output is unicode

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 import os
 import sys
-from builtins import next, object, open
+from builtins import next, object, open, str as text
 from collections import defaultdict, namedtuple
 
 from future.utils import PY3
@@ -440,4 +440,4 @@ class DependencyUsageGraph(object):
         'dependencies': [gen_dep_edge(node, edge, dep_tgt, node.dep_aliases.get(dep_tgt, {}))
                          for dep_tgt, edge in node.dep_edges.items()],
       }
-    yield json.dumps(res_dict, indent=2, sort_keys=True)
+    yield text(json.dumps(res_dict, indent=2, sort_keys=True))

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 import os
 import sys
-from builtins import next, object, open, str as text
+from builtins import next, object, open, str
 from collections import defaultdict, namedtuple
 
 from future.utils import PY3
@@ -440,4 +440,4 @@ class DependencyUsageGraph(object):
         'dependencies': [gen_dep_edge(node, edge, dep_tgt, node.dep_aliases.get(dep_tgt, {}))
                          for dep_tgt, edge in node.dep_edges.items()],
       }
-    yield text(json.dumps(res_dict, indent=2, sort_keys=True))
+    yield str(json.dumps(res_dict, indent=2, sort_keys=True))

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage_integration.py
@@ -74,3 +74,10 @@ class TestJvmDependencyUsageIntegration(PantsRunIntegrationTest):
       # Confirm that usage is non-zero, and that the reports match.
       self._assert_non_zero_usage(run_two)
       self.assertEqual(run_one, run_two)
+
+  def test_no_summary_works(self):
+    target = 'testprojects/src/java/org/pantsbuild/testproject/unicode/main'
+    with self.temporary_cachedir() as cachedir, \
+      self.temporary_workdir() as workdir:
+      self._run_dep_usage(workdir, target, clean_all=True, cachedir=cachedir,
+        extra_args=['--no-dep-usage-jvm-summary'])


### PR DESCRIPTION
### Problem
When no summary is requested for dep usage, generating the json blows up due to a type mismatch.

### Solution
Convert the json into unicode by using the builtin.

### Result
The added test for a no-summary invoke passes.