### PR TITLE
Add bounds checking to Entry::current_running_duration

### DIFF
--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -495,7 +495,7 @@ impl<N: Node> Entry<N> {
   pub(crate) fn current_running_duration(&self, now: Instant) -> Option<Duration> {
     match *self.state.lock() {
       EntryState::Running { start_time, .. } =>
-      // NB: `Instant::duration_since` panics if the start time is before the end time, which can
+      // NB: `Instant::duration_since` panics if the end time is before the start time, which can
       // happen when starting a Node races against a caller creating their Instant.
       {
         Some(if start_time < now {


### PR DESCRIPTION
### Problem

As shown in #6640, once we moved `Entry` locks outside of the `Graph` lock in #6095, it became possible for `heavy_hitters` to race against `Nodes` that are starting outside of the `Graph` lock. 

### Solution

Add a bounds check for `Instant::duration_since` in `current_running_duration`, to handle the case where a Node is started after we begin computing `heavy_hitters`. While switching to `Instant::elapsed` would "mostly" avoid this case, it would incur additional syscalls, without fully avoiding panics.

### Result

Fixes #6640.