### PR TITLE
Fix console_rule generators, and add a test to cover running them under run_rule.

### DIFF
--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -11,6 +11,7 @@ import logging
 from abc import abstractproperty
 from builtins import bytes, str
 from collections import OrderedDict
+from types import GeneratorType
 
 from future.utils import PY2
 from twitter.common.collections import OrderedSet
@@ -59,6 +60,17 @@ class _GoalProduct(object):
     return cls.PRODUCT_MAP[name]
 
 
+def _terminated(generator, terminator):
+  """A generator that "appends" the given terminator value to the given generator."""
+  gen_input = None
+  try:
+    while True:
+      res = generator.send(gen_input)
+      gen_input = yield res
+  except StopIteration:
+    yield terminator
+
+
 def _make_rule(output_type, input_selectors, for_goal=None):
   """A @decorator that declares that a particular static function may be used as a TaskRule.
 
@@ -95,7 +107,10 @@ def _make_rule(output_type, input_selectors, for_goal=None):
     if for_goal:
       def goal_and_return(*args, **kwargs):
         res = func(*args, **kwargs)
-        if res is not None:
+        if isinstance(res, GeneratorType):
+          # Return a generator with an output_type instance appended.
+          return _terminated(res, output_type())
+        elif res is not None:
           raise Exception('A @console_rule should not have a return value.')
         return output_type()
       functools.update_wrapper(goal_and_return, func)

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -184,6 +184,7 @@ python_tests(
     ':util',
     ':scheduler_test_base',
     'src/python/pants/engine:build_files',
+    'src/python/pants/engine:console',
     'src/python/pants/engine:rules',
     'src/python/pants/engine:selectors',
     'src/python/pants/util:objects',


### PR DESCRIPTION
### Problem

`@console_rule`s do not currently support being run as generators.

### Solution

Add support for running as generators, and add a test to cover running them under `run_rule` for unit testing.