### PR TITLE
Collection is iterable

### DIFF
--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -393,7 +393,13 @@ class SubclassesOf(TypeConstraint):
 
 
 class Collection(object):
-  """Constructs classes representing collections of objects of a particular type."""
+  """Constructs classes representing collections of objects of a particular type.
+
+  The produced class will expose its values under a field named dependencies - this is a stable API
+  which may be consumed e.g. over FFI from the engine.
+
+  Python consumers of a Collection should prefer to use its standard iteration API.
+  """
   # TODO: could we check that the input is iterable in the ctor?
 
   @classmethod
@@ -412,3 +418,6 @@ class Collection(object):
     setattr(sys.modules[cls.__module__], type_name, collection_of_type)
 
     return collection_of_type
+
+  def __iter__(self):
+    return iter(self.dependencies)

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -110,7 +110,7 @@ python_tests(
   dependencies = [
     '3rdparty/python:future',
     'src/python/pants/util:objects',
-    'tests/python/pants_test:base_test',
+    'tests/python/pants_test:test_base',
   ]
 )
 

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -12,12 +12,17 @@ from builtins import object, str
 
 from future.utils import PY2, PY3, text_type
 
-from pants.util.objects import (Exactly, SubclassesOf, SuperclassesOf, TypeCheckError,
+from pants.util.objects import (Collection, Exactly, SubclassesOf, SuperclassesOf, TypeCheckError,
                                 TypedDatatypeInstanceConstructionError, datatype, enum)
-from pants_test.base_test import BaseTest
+from pants_test.test_base import TestBase
 
 
-class TypeConstraintTestBase(BaseTest):
+class CollectionTest(TestBase):
+  def test_collection_iteration(self):
+    self.assertEqual([1, 2], [x for x in Collection.of(int)([1, 2])])
+
+
+class TypeConstraintTestBase(TestBase):
   class A(object):
     pass
 
@@ -199,7 +204,7 @@ class ReturnsNotImplemented(object):
 class SomeEnum(enum('x', [1, 2])): pass
 
 
-class DatatypeTest(BaseTest):
+class DatatypeTest(TestBase):
 
   def test_eq_with_not_implemented_super(self):
     class DatatypeSuperNotImpl(datatype(['val']), ReturnsNotImplemented, tuple):
@@ -303,7 +308,7 @@ class DatatypeTest(BaseTest):
       bar(other=1)
 
 
-class TypedDatatypeTest(BaseTest):
+class TypedDatatypeTest(TestBase):
 
   def test_class_construction_errors(self):
     # NB: datatype subclasses declared at top level are the success cases


### PR DESCRIPTION
This is more idiomatic to use from Python than calling .dependencies

Also, update to non-deprecated test base class