### PR TITLE
Allow v2-only goals to be implicitly registered

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -183,11 +183,11 @@ class LocalPantsRunner(object):
     # If we're a pure --v2 run, validate goals - otherwise some goals specified
     # may be provided by the --v1 task paths.
     if not self._global_options.v1:
-      self._graph_session.validate_goals(self._options.goals)
+      self._graph_session.validate_goals(self._options.goals_and_possible_v2_goals)
 
     try:
       self._graph_session.run_console_rules(
-        self._options.goals,
+        self._options.goals_and_possible_v2_goals,
         self._target_roots
       )
     except Exception as e:

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -25,7 +25,7 @@ class ArgSplitterError(Exception):
 
 
 class SplitArgs(namedtuple('SplitArgs',
-                           ['goals', 'scope_to_flags', 'targets', 'passthru', 'passthru_owner'])):
+                           ['goals', 'scope_to_flags', 'targets', 'passthru', 'passthru_owner', 'unknown_scopes'])):
   """The result of splitting args.
 
   goals: A list of explicitly specified goals.
@@ -202,7 +202,7 @@ class ArgSplitter(object):
     if not goals and not self._help_request:
       self._help_request = NoGoalHelp()
 
-    return SplitArgs(goals, scope_to_flags, targets, passthru, passthru_owner if passthru else None)
+    return SplitArgs(goals, scope_to_flags, targets, passthru, passthru_owner if passthru else None, self._unknown_scopes)
 
   def _consume_scope(self):
     """Returns a pair (scope, list of flags encountered in that scope).

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -211,10 +211,10 @@ class SchedulerService(PantsService):
 
     if global_options.v2:
       if not global_options.v1:
-        session.validate_goals(options.goals)
+        session.validate_goals(options.goals_and_possible_v2_goals)
 
       # N.B. @console_rules run pre-fork in order to cache the products they request during execution.
-      session.run_console_rules(options.goals, target_roots)
+      session.run_console_rules(options.goals_and_possible_v2_goals, target_roots)
 
     return target_roots
 

--- a/tests/python/pants_test/option/test_arg_splitter.py
+++ b/tests/python/pants_test/option/test_arg_splitter.py
@@ -31,11 +31,13 @@ class ArgSplitterTest(unittest.TestCase):
 
   def _split(self, args_str, expected_goals, expected_scope_to_flags, expected_target_specs,
              expected_passthru=None, expected_passthru_owner=None,
-             expected_is_help=False, expected_help_advanced=False, expected_help_all=False):
+             expected_is_help=False, expected_help_advanced=False, expected_help_all=False,
+             expected_unknown_scopes=None):
     expected_passthru = expected_passthru or []
+    expected_unknown_scopes = expected_unknown_scopes or []
     splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
     args = shlex.split(args_str)
-    goals, scope_to_flags, target_specs, passthru, passthru_owner = splitter.split_args(args)
+    goals, scope_to_flags, target_specs, passthru, passthru_owner, unknown_scopes = splitter.split_args(args)
     self.assertEqual(expected_goals, goals)
     self.assertEqual(expected_scope_to_flags, scope_to_flags)
     self.assertEqual(expected_target_specs, target_specs)
@@ -48,6 +50,7 @@ class ArgSplitterTest(unittest.TestCase):
     self.assertEqual(expected_help_all,
                       (isinstance(splitter.help_request, OptionsHelp) and
                        splitter.help_request.all_scopes))
+    self.assertEqual(expected_unknown_scopes, unknown_scopes)
 
   def _split_help(self, args_str, expected_goals, expected_scope_to_flags, expected_target_specs,
                   expected_help_advanced=False, expected_help_all=False):
@@ -64,9 +67,10 @@ class ArgSplitterTest(unittest.TestCase):
 
   def _split_unknown_goal(self, args_str, unknown_goals):
     splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
-    splitter.split_args(shlex.split(args_str))
+    result = splitter.split_args(shlex.split(args_str))
     self.assertTrue(isinstance(splitter.help_request, UnknownGoalHelp))
     self.assertSetEqual(set(unknown_goals), set(splitter.help_request.unknown_goals))
+    self.assertEqual(result.unknown_scopes, unknown_goals)
 
   def _split_no_goal(self, args_str):
     splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)


### PR DESCRIPTION
If a @console_task is registered with a goal name, that goal will be
registered, even if no v1 goal exists with that name.

This is pretty hacky, and should be replaced by something better soon.
See https://github.com/pantsbuild/pants/issues/6651.

Fixes https://github.com/pantsbuild/pants/issues/6650