### PR TITLE
Compiler option sets for Native targets

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -23,6 +23,7 @@ from pants.engine.fs import DirectoryToMaterialize
 from pants.engine.isolated_process import ExecuteProcessRequest
 from pants.java.distribution.distribution import DistributionLocator
 from pants.util.dirutil import safe_open
+from pants.util.meta import classproperty
 from pants.util.process_handler import subprocess
 
 
@@ -59,11 +60,11 @@ class JavacCompile(JvmCompile):
   def get_no_warning_args_default(cls):
     return ('-nowarn', '-Xlint:none', )
 
-  @classmethod
+  @classproperty
   def get_fatal_warnings_enabled_args_default(cls):
     return ('-Werror',)
 
-  @classmethod
+  @classproperty
   def get_fatal_warnings_disabled_args_default(cls):
     return ()
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -44,7 +44,7 @@ from pants.util.fileutil import create_size_estimators
 from pants.util.memo import memoized_method, memoized_property
 
 
-class JvmCompile(NailgunTaskBase, CompilerOptionSetsMixin):
+class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
   """A common framework for JVM compilation.
 
   To subclass for a specific JVM language, implement the static values and methods

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -53,11 +53,6 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
 
   size_estimators = create_size_estimators()
 
-  mirrored_option_to_kwarg_map = {
-    'fatal_warnings': 'fatal_warnings',
-    'compiler_option_sets': 'compiler_option_sets',
-  }
-
   @classmethod
   def size_estimator_by_name(cls, estimation_strategy_name):
     return cls.size_estimators[estimation_strategy_name]

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -35,6 +35,7 @@ from pants.base.exceptions import TaskError
 from pants.base.worker_pool import WorkerPool
 from pants.base.workunit import WorkUnitLabel
 from pants.engine.fs import PathGlobs, PathGlobsAndRoot
+from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.util.contextutil import Timer
 from pants.util.dirutil import (fast_relpath, read_file, safe_delete, safe_mkdir, safe_rmtree,
@@ -43,7 +44,7 @@ from pants.util.fileutil import create_size_estimators
 from pants.util.memo import memoized_method, memoized_property
 
 
-class JvmCompile(NailgunTaskBase):
+class JvmCompile(NailgunTaskBase, CompilerOptionSetsMixin):
   """A common framework for JVM compilation.
 
   To subclass for a specific JVM language, implement the static values and methods
@@ -78,22 +79,6 @@ class JvmCompile(NailgunTaskBase):
     register('--no-warning-args', advanced=True, type=list, fingerprint=True,
              default=list(cls.get_no_warning_args_default()),
              help='Extra compiler args to use when warnings are disabled.')
-
-    register('--fatal-warnings-enabled-args', advanced=True, type=list, fingerprint=True,
-             default=list(cls.get_fatal_warnings_enabled_args_default()),
-             help='Extra compiler args to use when fatal warnings are enabled.')
-
-    register('--fatal-warnings-disabled-args', advanced=True, type=list, fingerprint=True,
-             default=list(cls.get_fatal_warnings_disabled_args_default()),
-             help='Extra compiler args to use when fatal warnings are disabled.')
-
-    register('--compiler-option-sets-enabled-args', advanced=True, type=dict, fingerprint=True,
-             default={'fatal_warnings': list(cls.get_fatal_warnings_enabled_args_default())},
-             help='Extra compiler args to use for each enabled option set.')
-
-    register('--compiler-option-sets-disabled-args', advanced=True, type=dict, fingerprint=True,
-             default={'fatal_warnings': list(cls.get_fatal_warnings_disabled_args_default())},
-             help='Extra compiler args to use for each disabled option set.')
 
     register('--debug-symbols', type=bool, fingerprint=True,
              help='Compile with debug symbol enabled.')
@@ -204,16 +189,6 @@ class JvmCompile(NailgunTaskBase):
   @classmethod
   def get_no_warning_args_default(cls):
     """Override to set default for --no-warning-args option."""
-    return ()
-
-  @classmethod
-  def get_fatal_warnings_enabled_args_default(cls):
-    """Override to set default for --fatal-warnings-enabled-args option."""
-    return ()
-
-  @classmethod
-  def get_fatal_warnings_disabled_args_default(cls):
-    """Override to set default for --fatal-warnings-disabled-args option."""
     return ()
 
   @property

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -53,6 +53,11 @@ class JvmCompile(NailgunTaskBase, CompilerOptionSetsMixin):
 
   size_estimators = create_size_estimators()
 
+  mirrored_option_to_kwarg_map = {
+    'fatal_warnings': 'fatal_warnings',
+    'compiler_option_sets': 'compiler_option_sets',
+  }
+
   @classmethod
   def size_estimator_by_name(cls, estimation_strategy_name):
     return cls.size_estimators[estimation_strategy_name]

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -145,8 +145,8 @@ class BaseZincCompile(JvmCompile):
     return ('-S-Xfatal-warnings', '-C-Werror')
 
   @classmethod
-  def get_fatal_warnings_disabled_args_default(cls):
-    return ()
+  def get_compiler_option_sets_enabled_default_value(cls):
+    return {'fatal_warnings': cls.get_fatal_warnings_enabled_args_default}
 
   @classmethod
   def register_options(cls, register):
@@ -357,17 +357,8 @@ class BaseZincCompile(JvmCompile):
     zinc_args.extend(self._get_zinc_arguments(settings))
     zinc_args.append('-transactional')
 
-    for option_set in compiler_option_sets:
-      enabled_args = self.get_options().compiler_option_sets_enabled_args.get(option_set, [])
-      if option_set == 'fatal_warnings':
-        enabled_args = self.get_options().fatal_warnings_enabled_args
-      zinc_args.extend(enabled_args)
-
-    for option_set, disabled_args in self.get_options().compiler_option_sets_disabled_args.items():
-      if option_set not in compiler_option_sets:
-        if option_set == 'fatal_warnings':
-          disabled_args = self.get_options().fatal_warnings_disabled_args
-        zinc_args.extend(disabled_args)
+    compiler_option_sets_args = self.get_merged_args_for_compiler_option_sets(ctx.target)
+    zinc_args.extend(compiler_option_sets_args)
 
     if not self._clear_invalid_analysis:
       zinc_args.append('-no-clear-invalid-analysis')

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -36,6 +36,7 @@ from pants.java.distribution.distribution import DistributionLocator
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import fast_relpath, safe_open
 from pants.util.memo import memoized_method, memoized_property
+from pants.util.meta import classproperty
 
 
 # Well known metadata file required to register scalac plugins with nsc.
@@ -140,13 +141,13 @@ class BaseZincCompile(JvmCompile):
   def get_no_warning_args_default(cls):
     return ('-C-nowarn', '-C-Xlint:none', '-S-nowarn', '-S-Xlint:none', )
 
-  @classmethod
+  @classproperty
   def get_fatal_warnings_enabled_args_default(cls):
     return ('-S-Xfatal-warnings', '-C-Werror')
 
-  @classmethod
+  @classproperty
   def get_compiler_option_sets_enabled_default_value(cls):
-    return {'fatal_warnings': cls.get_fatal_warnings_enabled_args_default()}
+    return {'fatal_warnings': cls.get_fatal_warnings_enabled_args_default}
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -146,7 +146,7 @@ class BaseZincCompile(JvmCompile):
 
   @classmethod
   def get_compiler_option_sets_enabled_default_value(cls):
-    return {'fatal_warnings': cls.get_fatal_warnings_enabled_args_default}
+    return {'fatal_warnings': cls.get_fatal_warnings_enabled_args_default()}
 
   @classmethod
   def register_options(cls, register):
@@ -357,7 +357,7 @@ class BaseZincCompile(JvmCompile):
     zinc_args.extend(self._get_zinc_arguments(settings))
     zinc_args.append('-transactional')
 
-    compiler_option_sets_args = self.get_merged_args_for_compiler_option_sets(ctx.target)
+    compiler_option_sets_args = self.get_merged_args_for_compiler_option_sets(compiler_option_sets)
     zinc_args.extend(compiler_option_sets_args)
 
     if not self._clear_invalid_analysis:

--- a/src/python/pants/backend/native/subsystems/conan.py
+++ b/src/python/pants/backend/native/subsystems/conan.py
@@ -22,23 +22,7 @@ class Conan(ExecutablePexTool):
 
   # TODO: It would be great if these requirements could be drawn from a BUILD file (potentially with
   # a special target specified in BUILD.tools)?
-  default_conan_requirements = (
-    'conan==1.4.4',
-    'PyJWT>=1.4.0, <2.0.0',
-    'requests>=2.7.0, <3.0.0',
-    'colorama>=0.3.3, <0.4.0',
-    'PyYAML>=3.11, <3.13.0',
-    'patch==1.16',
-    'fasteners>=0.14.1',
-    'six>=1.10.0',
-    'node-semver==0.2.0',
-    'distro>=1.0.2, <1.2.0',
-    'pylint>=1.8.1, <1.9.0',
-    'future==0.16.0',
-    'pygments>=2.0, <3.0',
-    'astroid>=1.6, <1.7',
-    'deprecation>=2.0, <2.1'
-  )
+  default_conan_requirements = ('conan==1.8.2',)
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/native/subsystems/conan.py
+++ b/src/python/pants/backend/native/subsystems/conan.py
@@ -22,7 +22,23 @@ class Conan(ExecutablePexTool):
 
   # TODO: It would be great if these requirements could be drawn from a BUILD file (potentially with
   # a special target specified in BUILD.tools)?
-  default_conan_requirements = ('conan==1.8.2',)
+  default_conan_requirements = (
+    'conan==1.4.4',
+    'PyJWT>=1.4.0, <2.0.0',
+    'requests>=2.7.0, <3.0.0',
+    'colorama>=0.3.3, <0.4.0',
+    'PyYAML>=3.11, <3.13.0',
+    'patch==1.16',
+    'fasteners>=0.14.1',
+    'six>=1.10.0',
+    'node-semver==0.2.0',
+    'distro>=1.0.2, <1.2.0',
+    'pylint>=1.8.1, <1.9.0',
+    'future==0.16.0',
+    'pygments>=2.0, <3.0',
+    'astroid>=1.6, <1.7',
+    'deprecation>=2.0, <2.1'
+  )
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/native/subsystems/native_build_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_settings.py
@@ -15,6 +15,7 @@ class NativeBuildSettings(Subsystem, MirroredTargetOptionMixin):
 
   mirrored_option_to_kwarg_map = {
     'strict_deps': 'strict_deps',
+    'compiler_option_sets': 'compiler_option_sets',
   }
 
   @classmethod
@@ -27,6 +28,13 @@ class NativeBuildSettings(Subsystem, MirroredTargetOptionMixin):
                   "for C and C++ targets by default. If this is False, all transitive dependencies "
                   "are used when compiling and linking native code. C and C++ targets may override "
                   "this behavior with the strict_deps keyword argument as well.")
+    register('--compiler-option-sets', advanced=True, default=[], type=list,
+             fingerprint=True,
+             help='The default for the "compiler_option_sets" argument '
+                  'for targets of this language.')
 
   def get_strict_deps_value_for_target(self, target):
     return self.get_target_mirrored_option('strict_deps', target)
+
+  def get_compiler_option_sets_for_target(self, target):
+    return self.get_target_mirrored_option('compiler_option_sets', target)

--- a/src/python/pants/backend/native/subsystems/native_build_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_settings.py
@@ -15,7 +15,6 @@ class NativeBuildSettings(Subsystem, MirroredTargetOptionMixin):
 
   mirrored_option_to_kwarg_map = {
     'strict_deps': 'strict_deps',
-    'compiler_option_sets': 'compiler_option_sets',
   }
 
   @classmethod
@@ -28,10 +27,6 @@ class NativeBuildSettings(Subsystem, MirroredTargetOptionMixin):
                   "for C and C++ targets by default. If this is False, all transitive dependencies "
                   "are used when compiling and linking native code. C and C++ targets may override "
                   "this behavior with the strict_deps keyword argument as well.")
-    register('--compiler-option-sets', advanced=True, default=[], type=list,
-             fingerprint=True,
-             help='The default for the "compiler_option_sets" argument '
-                  'for targets of this language.')
 
   def get_strict_deps_value_for_target(self, target):
     return self.get_target_mirrored_option('strict_deps', target)

--- a/src/python/pants/backend/native/subsystems/native_build_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_settings.py
@@ -35,6 +35,3 @@ class NativeBuildSettings(Subsystem, MirroredTargetOptionMixin):
 
   def get_strict_deps_value_for_target(self, target):
     return self.get_target_mirrored_option('strict_deps', target)
-
-  def get_compiler_option_sets_for_target(self, target):
-    return self.get_target_mirrored_option('compiler_option_sets', target)

--- a/src/python/pants/backend/native/subsystems/native_build_step_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step_settings.py
@@ -4,12 +4,14 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from pants.backend.native.subsystems.utils.mirrored_target_option_mixin import \
+  MirroredTargetOptionMixin
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
 
 
-class NativeBuildStepSettings(CompilerOptionSetsMixin, Subsystem):
+class NativeBuildStepSettings(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsystem):
 
   options_scope = 'native-build-step-settings'
 

--- a/src/python/pants/backend/native/subsystems/native_build_step_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step_settings.py
@@ -4,14 +4,12 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.native.subsystems.native_build_settings import NativeBuildSettings
-from pants.backend.native.subsystems.utils.mirrored_target_option_mixin import \
-  MirroredTargetOptionMixin
+from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
 
 
-class NativeBuildStepSettings(Subsystem, MirroredTargetOptionMixin):
+class NativeBuildStepSettings(CompilerOptionSetsMixin, Subsystem):
 
   options_scope = 'native-build-step-settings'
 
@@ -21,53 +19,16 @@ class NativeBuildStepSettings(Subsystem, MirroredTargetOptionMixin):
   }
 
   @classmethod
-  def subsystem_dependencies(cls):
-    return super(NativeBuildStepSettings, cls).subsystem_dependencies() + (
-      NativeBuildSettings.scoped(cls),
-    )
-
-  @memoized_property
-  def _native_build_settings(self):
-    return NativeBuildSettings.scoped_instance(self)
-
-  @classmethod
   def register_options(cls, register):
     super(NativeBuildStepSettings, cls).register_options(register)
 
-    # TODO: Deprecate `--fatal-warnings` in a follow-up revision.
     register('--fatal-warnings', type=bool, default=True, fingerprint=True, advanced=True,
-             help='The default for the "fatal_warnings" argument for targets of this language.')
-    register('--compiler-option-sets-enabled-args', advanced=True, type=dict, fingerprint=True,
-             default={}, help='Extra compiler args to use for each enabled option set.')
-    register('--compiler-option-sets-disabled-args', advanced=True, type=dict, fingerprint=True,
-             default={}, help='Extra compiler args to use for each disabled option set.')
+             help='The default for the "fatal_warnings" argument for targets of this language.',
+             removal_version='1.14.0.dev2',
+             removal_hint='Use compiler options sets instead.')
 
   def get_fatal_warnings_value_for_target(self, target):
     return self.get_target_mirrored_option('fatal_warnings', target)
-
-  def get_merged_compiler_options_for_target(self, target):
-    """Merge compiler option sets for a native target into a list of compiler flags.
-
-    :param target: a `NativeLibrary` target that may set a compiler_option_sets argument.
-    :returns: compiler_options: a list of compiler flags as individual strings.
-    """
-    compiler_option_sets = self._native_build_settings.get_target_mirrored_option(
-        'compiler_option_sets', target)
-    compiler_options = set()
-
-    # Set values for enabled options.
-    for opt_set_key in compiler_option_sets:
-      val = self.get_options().compiler_option_sets_enabled_args.get(opt_set_key)
-      if val:
-        compiler_options.update(val)
-
-    # Set values for disabled options.
-    for opt_set_key, opt_value in self.get_options().compiler_option_sets_disabled_args.items():
-      if not opt_set_key in compiler_option_sets:
-        compiler_options.update(opt_value)
-
-    compiler_options = list(compiler_options)
-    return compiler_options
 
 
 class CCompileSettings(Subsystem):
@@ -80,7 +41,7 @@ class CCompileSettings(Subsystem):
     )
 
   @memoized_property
-  def _native_build_step_settings(self):
+  def native_build_step_settings(self):
     return NativeBuildStepSettings.scoped_instance(self)
 
 
@@ -94,7 +55,7 @@ class CppCompileSettings(Subsystem):
     )
 
   @memoized_property
-  def _native_build_step_settings(self):
+  def native_build_step_settings(self):
     return NativeBuildStepSettings.scoped_instance(self)
 
 

--- a/src/python/pants/backend/native/subsystems/native_build_step_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step_settings.py
@@ -25,7 +25,7 @@ class NativeBuildStepSettings(CompilerOptionSetsMixin, Subsystem):
     register('--fatal-warnings', type=bool, default=True, fingerprint=True, advanced=True,
              help='The default for the "fatal_warnings" argument for targets of this language.',
              removal_version='1.14.0.dev2',
-             removal_hint='Use compiler options sets instead.')
+             removal_hint='Use compiler option sets instead.')
     register('--compiler-option-sets', advanced=True, default=(), type=list,
              fingerprint=True,
              help='The default for the "compiler_option_sets" argument '

--- a/src/python/pants/backend/native/subsystems/native_build_step_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step_settings.py
@@ -14,7 +14,7 @@ from pants.util.meta import classproperty
 
 class NativeBuildStepSettings(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsystem):
 
-  options_scope = 'native-build-step-settings'
+  options_scope = 'native-build-step'
 
   mirrored_option_to_kwarg_map = {
     'compiler_option_sets': 'compiler_option_sets',

--- a/src/python/pants/backend/native/subsystems/native_build_step_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step_settings.py
@@ -26,9 +26,16 @@ class NativeBuildStepSettings(CompilerOptionSetsMixin, Subsystem):
              help='The default for the "fatal_warnings" argument for targets of this language.',
              removal_version='1.14.0.dev2',
              removal_hint='Use compiler options sets instead.')
+    register('--compiler-option-sets', advanced=True, default=(), type=list,
+             fingerprint=True,
+             help='The default for the "compiler_option_sets" argument '
+                  'for targets of this language.')
 
   def get_fatal_warnings_value_for_target(self, target):
     return self.get_target_mirrored_option('fatal_warnings', target)
+
+  def get_compiler_option_sets_for_target(self, target):
+    return self.get_target_mirrored_option('compiler_option_sets', target)
 
 
 class CCompileSettings(Subsystem):

--- a/src/python/pants/backend/native/subsystems/native_build_step_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step_settings.py
@@ -9,6 +9,7 @@ from pants.backend.native.subsystems.utils.mirrored_target_option_mixin import \
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
+from pants.util.meta import classproperty
 
 
 class NativeBuildStepSettings(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsystem):
@@ -16,7 +17,6 @@ class NativeBuildStepSettings(CompilerOptionSetsMixin, MirroredTargetOptionMixin
   options_scope = 'native-build-step-settings'
 
   mirrored_option_to_kwarg_map = {
-    'fatal_warnings': 'fatal_warnings',
     'compiler_option_sets': 'compiler_option_sets',
   }
 
@@ -24,20 +24,17 @@ class NativeBuildStepSettings(CompilerOptionSetsMixin, MirroredTargetOptionMixin
   def register_options(cls, register):
     super(NativeBuildStepSettings, cls).register_options(register)
 
-    register('--fatal-warnings', type=bool, default=True, fingerprint=True, advanced=True,
-             help='The default for the "fatal_warnings" argument for targets of this language.',
-             removal_version='1.14.0.dev2',
-             removal_hint='Use compiler option sets instead.')
     register('--compiler-option-sets', advanced=True, default=(), type=list,
              fingerprint=True,
              help='The default for the "compiler_option_sets" argument '
                   'for targets of this language.')
 
-  def get_fatal_warnings_value_for_target(self, target):
-    return self.get_target_mirrored_option('fatal_warnings', target)
-
   def get_compiler_option_sets_for_target(self, target):
     return self.get_target_mirrored_option('compiler_option_sets', target)
+
+  @classproperty
+  def get_compiler_option_sets_enabled_default_value(cls):
+    return {"fatal_warnings": ["-Werror"]}
 
 
 class CCompileSettings(Subsystem):

--- a/src/python/pants/backend/native/subsystems/native_build_step_settings_base.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step_settings_base.py
@@ -13,6 +13,8 @@ class NativeBuildStepSettingsBase(Subsystem, MirroredTargetOptionMixin):
 
   mirrored_option_to_kwarg_map = {
     'fatal_warnings': 'fatal_warnings',
+    'ndebug': 'ndebug',
+    'glibcxx_use_cxx11_abi': 'glibcxx_use_cxx11_abi',
   }
 
   @classmethod
@@ -23,9 +25,19 @@ class NativeBuildStepSettingsBase(Subsystem, MirroredTargetOptionMixin):
     # flags!
     register('--fatal-warnings', type=bool, default=True, fingerprint=True, advanced=True,
              help='The default for the "fatal_warnings" argument for targets of this language.')
+    register('--ndebug', type=bool, default=False, fingerprint=True, advanced=True,
+             help='The default for the "ndebug" argument for targets of this language.')
+    register('--glibcxx-use-cxx11-abi', type=bool, default=False, fingerprint=True, advanced=True,
+             help='The default for the "glibcxx_use_cxx11_abi" argument for targets of this language.')
 
   def get_fatal_warnings_value_for_target(self, target):
     return self.get_target_mirrored_option('fatal_warnings', target)
+
+  def get_ndebug_value_for_target(self, target):
+    return self.get_target_mirrored_option('ndebug', target)
+
+  def get_glibcxx_use_cxx11_abi_value_for_target(self, target):
+    return self.get_target_mirrored_option('glibcxx_use_cxx11_abi', target)
 
 
 class CCompileSettings(NativeBuildStepSettingsBase):

--- a/src/python/pants/backend/native/subsystems/native_build_step_settings_base.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step_settings_base.py
@@ -4,12 +4,16 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from pants.backend.native.subsystems.native_build_settings import NativeBuildSettings
 from pants.backend.native.subsystems.utils.mirrored_target_option_mixin import \
   MirroredTargetOptionMixin
 from pants.subsystem.subsystem import Subsystem
+from pants.util.memo import memoized_property
 
 
-class NativeBuildStepSettingsBase(Subsystem, NativeBuildSettings, MirroredTargetOptionMixin):
+class NativeBuildStepSettingsBase(Subsystem, MirroredTargetOptionMixin):
+
+  options_scope = 'native-build-step-settings-base'
 
   mirrored_option_to_kwarg_map = {
     'fatal_warnings': 'fatal_warnings',
@@ -17,55 +21,96 @@ class NativeBuildStepSettingsBase(Subsystem, NativeBuildSettings, MirroredTarget
   }
 
   @classmethod
+  def subsystem_dependencies(cls):
+    return super(NativeBuildStepSettingsBase, cls).subsystem_dependencies() + (
+      NativeBuildSettings.scoped(cls),
+    )
+
+  @memoized_property
+  def _native_build_settings(self):
+    return NativeBuildSettings.scoped_instance(self)
+
+  @classmethod
   def register_options(cls, register):
     super(NativeBuildStepSettingsBase, cls).register_options(register)
 
-    register('--fatal-warnings-enabled-args', advanced=True, type=list, fingerprint=True,
-             default=list(cls.get_fatal_warnings_enabled_args_default()),
-             help='Extra compiler args to use when fatal warnings are enabled.')
-    register('--fatal-warnings-disabled-args', advanced=True, type=list, fingerprint=True,
-             default=list(cls.get_fatal_warnings_disabled_args_default()),
-             help='Extra compiler args to use when fatal warnings are disabled.')
+    # TODO: Deprecate `--fatal-warnings` in a follow-up revision.
+    register('--fatal-warnings', type=bool, default=True, fingerprint=True, advanced=True,
+             help='The default for the "fatal_warnings" argument for targets of this language.')
     register('--compiler-option-sets-enabled-args', advanced=True, type=dict, fingerprint=True,
-             default={
-              'fatal_warnings': list(cls.get_fatal_warnings_enabled_args_default()),
-             },
-             help='Extra compiler args to use for each enabled option set.')
+             default={}, help='Extra compiler args to use for each enabled option set.')
     register('--compiler-option-sets-disabled-args', advanced=True, type=dict, fingerprint=True,
-             default={
-              'fatal_warnings': list(cls.get_fatal_warnings_disabled_args_default()),
-             },
-             help='Extra compiler args to use for each disabled option set.')
+             default={}, help='Extra compiler args to use for each disabled option set.')
 
-  @classmethod
-  def get_fatal_warnings_enabled_args_default(cls):
-    """Override to set default for this option."""
-    return ('-Werror',)
+  def get_fatal_warnings_value_for_target(self, target):
+    return self.get_target_mirrored_option('fatal_warnings', target)
 
-  @classmethod
-  def get_fatal_warnings_disabled_args_default(cls):
-    """Override to set default for this option."""
-    return ()
+  def get_merged_compiler_options_for_target(self, target, opt_set_enabled_dicts, opt_set_disabled_dicts):
+    """Merge compiler option sets for a native target into a list of compiler flags."""
+    compiler_option_sets = self._native_build_settings.get_target_mirrored_option(
+        'compiler_option_sets', target)
+    compiler_options = set()
 
-  def get_merged_compiler_options_for_target(self, target):
-    fatal_warnings = self.get_target_mirrored_option('fatal_warnings', target)
-    compiler_option_sets = self.get_compiler_option_sets_for_target(target)
-    compiler_options = []
+    # Set values for enabled options.
     if compiler_option_sets:
-      for option_set_key in compiler_option_sets:
-        compiler_option_sets.update(
-          self.get_options().compiler_option_sets_enabled_args[option_set_key]
-        )
-        compiler_options = list(compiler_option_sets)
+      for opt_set_key in compiler_option_sets:
+        for osed in (opt_set_enabled_dicts + [self.get_options().compiler_option_sets_enabled_args]):
+          val = osed.get(opt_set_key)
+          if val:
+            compiler_options.update(val)
+
+    # Set values for disabled options.
+    for osdd in (opt_set_disabled_dicts + [self.get_options().compiler_option_sets_disabled_args]):
+      for opt_set_key, opt_value in osdd.items():
+        if not opt_set_key in compiler_option_sets:
+          compiler_options.update(opt_value)
+
+    compiler_options = list(compiler_options)
     return compiler_options
 
 
-class CCompileSettings(NativeBuildStepSettingsBase):
+class CCompileSettings(Subsystem):
   options_scope = 'c-compile-settings'
 
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(CCompileSettings, cls).subsystem_dependencies() + (
+      NativeBuildStepSettingsBase.scoped(cls),
+    )
 
-class CppCompileSettings(NativeBuildStepSettingsBase):
+  @classmethod
+  def register_options(cls, register):
+    super(CCompileSettings, cls).register_options(register)
+    register('--compiler-option-sets-enabled-args', advanced=True, type=dict, fingerprint=True,
+             default={}, help='Extra compiler args to use for each enabled option set.')
+    register('--compiler-option-sets-disabled-args', advanced=True, type=dict, fingerprint=True,
+             default={}, help='Extra compiler args to use for each disabled option set.')
+
+  @memoized_property
+  def _native_build_step_settings(self):
+    return NativeBuildStepSettingsBase.scoped_instance(self)
+
+
+class CppCompileSettings(Subsystem):
   options_scope = 'cpp-compile-settings'
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(CppCompileSettings, cls).subsystem_dependencies() + (
+      NativeBuildStepSettingsBase.scoped(cls),
+    )
+
+  @classmethod
+  def register_options(cls, register):
+    super(CppCompileSettings, cls).register_options(register)
+    register('--compiler-option-sets-enabled-args', advanced=True, type=dict, fingerprint=True,
+             default={}, help='Extra compiler args to use for each enabled option set.')
+    register('--compiler-option-sets-disabled-args', advanced=True, type=dict, fingerprint=True,
+             default={}, help='Extra compiler args to use for each disabled option set.')
+
+  @memoized_property
+  def _native_build_step_settings(self):
+    return NativeBuildStepSettingsBase.scoped_instance(self)
 
 
 # TODO: add a fatal_warnings kwarg to NativeArtifact and make a LinkSharedLibrariesSettings subclass

--- a/src/python/pants/backend/native/subsystems/native_build_step_settings_base.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step_settings_base.py
@@ -52,12 +52,11 @@ class NativeBuildStepSettingsBase(Subsystem, MirroredTargetOptionMixin):
     compiler_options = set()
 
     # Set values for enabled options.
-    if compiler_option_sets:
-      for opt_set_key in compiler_option_sets:
-        for osed in (opt_set_enabled_dicts + [self.get_options().compiler_option_sets_enabled_args]):
-          val = osed.get(opt_set_key)
-          if val:
-            compiler_options.update(val)
+    for opt_set_key in compiler_option_sets:
+      for osed in (opt_set_enabled_dicts + [self.get_options().compiler_option_sets_enabled_args]):
+        val = osed.get(opt_set_key)
+        if val:
+          compiler_options.update(val)
 
     # Set values for disabled options.
     for osdd in (opt_set_disabled_dicts + [self.get_options().compiler_option_sets_disabled_args]):
@@ -87,7 +86,7 @@ class CCompileSettings(Subsystem):
              default={}, help='Extra compiler args to use for each disabled option set.')
 
   @memoized_property
-  def _native_build_step_settings(self):
+  def _native_build_step_settings_base(self):
     return NativeBuildStepSettingsBase.scoped_instance(self)
 
 
@@ -109,7 +108,7 @@ class CppCompileSettings(Subsystem):
              default={}, help='Extra compiler args to use for each disabled option set.')
 
   @memoized_property
-  def _native_build_step_settings(self):
+  def _native_build_step_settings_base(self):
     return NativeBuildStepSettingsBase.scoped_instance(self)
 
 

--- a/src/python/pants/backend/native/targets/native_library.py
+++ b/src/python/pants/backend/native/targets/native_library.py
@@ -20,8 +20,8 @@ class NativeLibrary(Target, AbstractClass):
     return isinstance(target, cls) and bool(target.ctypes_native_library)
 
   def __init__(self, address, payload=None, sources=None, ctypes_native_library=None,
-               strict_deps=None, fatal_warnings=None, ndebug=None,
-               glibcxx_use_cxx11_abi=None, **kwargs):
+               strict_deps=None, fatal_warnings=None, compiler_option_sets=None,
+               **kwargs):
 
     if not payload:
       payload = Payload()
@@ -50,7 +50,7 @@ class NativeLibrary(Target, AbstractClass):
   def fatal_warnings(self):
     return self.payload.fatal_warnings
 
-  @memoized_property
+  @property
   def compiler_option_sets(self):
     """For every element in this list, enable the corresponding flags on compilation
     of targets.

--- a/src/python/pants/backend/native/targets/native_library.py
+++ b/src/python/pants/backend/native/targets/native_library.py
@@ -22,7 +22,8 @@ class NativeLibrary(Target, AbstractClass):
     return isinstance(target, cls) and bool(target.ctypes_native_library)
 
   def __init__(self, address, payload=None, sources=None, ctypes_native_library=None,
-               strict_deps=None, fatal_warnings=None, extra_compiler_options=None, **kwargs):
+               strict_deps=None, fatal_warnings=None, ndebug=None,
+               glibcxx_use_cxx11_abi=None, **kwargs):
 
     if not payload:
       payload = Payload()
@@ -32,7 +33,8 @@ class NativeLibrary(Target, AbstractClass):
       'ctypes_native_library': ctypes_native_library,
       'strict_deps': PrimitiveField(strict_deps),
       'fatal_warnings': PrimitiveField(fatal_warnings),
-      'extra_compiler_options': PrimitiveField(maybe_list(extra_compiler_options or ())),
+      'ndebug': PrimitiveField(ndebug),
+      'glibcxx_use_cxx11_abi': PrimitiveField(glibcxx_use_cxx11_abi),
     })
 
     if ctypes_native_library and not isinstance(ctypes_native_library, NativeArtifact):
@@ -52,8 +54,12 @@ class NativeLibrary(Target, AbstractClass):
     return self.payload.fatal_warnings
 
   @property
-  def extra_compiler_options(self):
-    return self.payload.extra_compiler_options
+  def ndebug(self):
+    return self.payload.ndebug
+
+  @property
+  def glibcxx_use_cxx11_abi(self):
+    return self.payload.glibcxx_use_cxx11_abi
 
   @property
   def ctypes_native_library(self):

--- a/src/python/pants/backend/native/targets/native_library.py
+++ b/src/python/pants/backend/native/targets/native_library.py
@@ -4,12 +4,10 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from twitter.common.collections import maybe_list
-
 from pants.backend.native.targets.native_artifact import NativeArtifact
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
-from pants.base.payload_field import PrimitiveField
+from pants.base.payload_field import PrimitiveField, PrimitivesSetField
 from pants.build_graph.target import Target
 from pants.util.meta import AbstractClass
 
@@ -33,8 +31,7 @@ class NativeLibrary(Target, AbstractClass):
       'ctypes_native_library': ctypes_native_library,
       'strict_deps': PrimitiveField(strict_deps),
       'fatal_warnings': PrimitiveField(fatal_warnings),
-      'ndebug': PrimitiveField(ndebug),
-      'glibcxx_use_cxx11_abi': PrimitiveField(glibcxx_use_cxx11_abi),
+      'compiler_option_sets': PrimitivesSetField(compiler_option_sets),
     })
 
     if ctypes_native_library and not isinstance(ctypes_native_library, NativeArtifact):
@@ -53,13 +50,14 @@ class NativeLibrary(Target, AbstractClass):
   def fatal_warnings(self):
     return self.payload.fatal_warnings
 
-  @property
-  def ndebug(self):
-    return self.payload.ndebug
-
-  @property
-  def glibcxx_use_cxx11_abi(self):
-    return self.payload.glibcxx_use_cxx11_abi
+  @memoized_property
+  def compiler_option_sets(self):
+    """For every element in this list, enable the corresponding flags on compilation
+    of targets.
+    :return: See constructor.
+    :rtype: list
+    """
+    return self.payload.compiler_option_sets
 
   @property
   def ctypes_native_library(self):

--- a/src/python/pants/backend/native/targets/native_library.py
+++ b/src/python/pants/backend/native/targets/native_library.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from twitter.common.collections import maybe_list
+
 from pants.backend.native.targets.native_artifact import NativeArtifact
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
@@ -20,7 +22,7 @@ class NativeLibrary(Target, AbstractClass):
     return isinstance(target, cls) and bool(target.ctypes_native_library)
 
   def __init__(self, address, payload=None, sources=None, ctypes_native_library=None,
-               strict_deps=None, fatal_warnings=None, **kwargs):
+               strict_deps=None, fatal_warnings=None, extra_compiler_options=None, **kwargs):
 
     if not payload:
       payload = Payload()
@@ -30,6 +32,7 @@ class NativeLibrary(Target, AbstractClass):
       'ctypes_native_library': ctypes_native_library,
       'strict_deps': PrimitiveField(strict_deps),
       'fatal_warnings': PrimitiveField(fatal_warnings),
+      'extra_compiler_options': PrimitiveField(maybe_list(extra_compiler_options or ())),
     })
 
     if ctypes_native_library and not isinstance(ctypes_native_library, NativeArtifact):
@@ -47,6 +50,10 @@ class NativeLibrary(Target, AbstractClass):
   @property
   def fatal_warnings(self):
     return self.payload.fatal_warnings
+
+  @property
+  def extra_compiler_options(self):
+    return self.payload.extra_compiler_options
 
   @property
   def ctypes_native_library(self):

--- a/src/python/pants/backend/native/tasks/c_compile.py
+++ b/src/python/pants/backend/native/tasks/c_compile.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants.backend.native.config.environment import LLVMCToolchain
-from pants.backend.native.subsystems.native_build_step_settings_base import CCompileSettings
+from pants.backend.native.subsystems.native_build_step_settings import CCompileSettings
 from pants.backend.native.targets.native_library import CLibrary
 from pants.backend.native.tasks.native_compile import NativeCompile
 from pants.util.objects import SubclassesOf

--- a/src/python/pants/backend/native/tasks/cpp_compile.py
+++ b/src/python/pants/backend/native/tasks/cpp_compile.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants.backend.native.config.environment import LLVMCppToolchain
-from pants.backend.native.subsystems.native_build_step_settings_base import CppCompileSettings
+from pants.backend.native.subsystems.native_build_step_settings import CppCompileSettings
 from pants.backend.native.targets.native_library import CppLibrary
 from pants.backend.native.tasks.native_compile import NativeCompile
 from pants.util.objects import SubclassesOf

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -48,8 +48,6 @@ class NativeCompile(NativeTask, AbstractClass):
   source_target_constraint = None
   dependent_target_constraint = SubclassesOf(ExternalNativeLibrary, NativeLibrary)
 
-  HEADER_EXTENSIONS = ('.h', '.hpp')
-
   # `NativeCompile` will use `workunit_label` as the name of the workunit when executing the
   # compiler process. `workunit_label` must be set to a string.
   @classproperty
@@ -178,11 +176,11 @@ class NativeCompile(NativeTask, AbstractClass):
       include_dirs=include_dirs,
       sources=sources_and_headers,
       fatal_warnings=(self._compile_settings
-                         ._native_build_step_settings
+                         .native_build_step_settings
                          .get_fatal_warnings_value_for_target(target)),
       compiler_options=(self._compile_settings
-                           ._native_build_step_settings
-                           .get_merged_compiler_options_for_target(target)),
+                            .native_build_step_settings
+                            .get_merged_args_for_compiler_option_sets(target)),
       output_dir=versioned_target.results_dir)
 
   def _make_compile_argv(self, compile_request):
@@ -217,7 +215,7 @@ class NativeCompile(NativeTask, AbstractClass):
     """
     sources = compile_request.sources
 
-    if len(sources) == 0 or not any(s for s in sources if not s.endswith(self.HEADER_EXTENSIONS)):
+    if len(sources) == 0:
       # TODO: do we need this log message? Should we still have it for intentionally header-only
       # libraries (that might be a confusing message to see)?
       self.context.log.debug("no sources in request {}, skipping".format(compile_request))

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -178,29 +178,22 @@ class NativeCompile(NativeTask, AbstractClass):
       include_dirs=include_dirs,
       sources=sources_and_headers,
       fatal_warnings=self._compile_settings.get_fatal_warnings_value_for_target(target),
-      ndebug=self._compile_settings.get_ndebug_value_for_target(target),
-      glibcxx_use_cxx11_abi=self._compile_settings.get_glibcxx_use_cxx11_abi_value_for_target(target),
+      compiler_option_sets_options=self._compile_settings.get_merged_compiler_options_for_target(target),
       output_dir=versioned_target.results_dir)
 
   def _make_compile_argv(self, compile_request):
     """Return a list of arguments to use to compile sources. Subclasses can override and append."""
     compiler = compile_request.compiler
-    err_flags = ['-Werror'] if compile_request.fatal_warnings else []
-    ndebug_flag = ['-DNDEBUG'] if compile_request.ndebug else []
-    glibcxx_use_cxx11_abi_flag = []
-    use_cxx_flag_value = '1' if compile_request.glibcxx_use_cxx11_abi else '0'
-    glibcxx_use_cxx11_abi_flag = ['-D_GLIBCXX_USE_CXX11_ABI={}'.format(use_cxx_flag_value)]
+    compiler_option_sets_options = compile_request.compiler_option_sets_options
 
     # We are going to execute in the target output, so get absolute paths for everything.
     buildroot = get_buildroot()
     argv = (
       [compiler.exe_filename] +
       compiler.extra_args +
-      err_flags +
-      ndebug_flag +
-      glibcxx_use_cxx11_abi_flag +
       # TODO: If we need to produce static libs, don't add -fPIC! (could use Variants -- see #5788).
       ['-c', '-fPIC'] +
+      compiler_option_sets_options +
       [
         '-I{}'.format(os.path.join(buildroot, inc_dir))
         for inc_dir in compile_request.include_dirs

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -136,7 +136,7 @@ class NativeCompile(NativeTask, AbstractClass):
 
   @abstractmethod
   def get_compile_settings(self):
-    """Return a subclass of NativeBuildStepSettingsBase.
+    """Return a subclass of NativeBuildStepSettings.
 
     NB: Subclasses will be queried for the compile settings once and the result cached.
     """
@@ -178,13 +178,11 @@ class NativeCompile(NativeTask, AbstractClass):
       include_dirs=include_dirs,
       sources=sources_and_headers,
       fatal_warnings=(self._compile_settings
-                         ._native_build_step_settings_base
+                         ._native_build_step_settings
                          .get_fatal_warnings_value_for_target(target)),
       compiler_options=(self._compile_settings
-                           ._native_build_step_settings_base
-                           .get_merged_compiler_options_for_target(target,
-          [self._compile_settings.get_options().compiler_option_sets_enabled_args],
-          [self._compile_settings.get_options().compiler_option_sets_disabled_args])),
+                           ._native_build_step_settings
+                           .get_merged_compiler_options_for_target(target)),
       output_dir=versioned_target.results_dir)
 
   def _make_compile_argv(self, compile_request):
@@ -192,7 +190,6 @@ class NativeCompile(NativeTask, AbstractClass):
     compiler = compile_request.compiler
     err_flags = ['-Werror'] if compile_request.fatal_warnings else []
     compiler_options = compile_request.compiler_options
-
     # We are going to execute in the target output, so get absolute paths for everything.
     buildroot = get_buildroot()
     argv = (

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -169,8 +169,10 @@ class NativeCompile(NativeTask, AbstractClass):
 
     include_dirs = [self._include_dirs_for_target(dep_tgt) for dep_tgt in dependencies]
     include_dirs.extend(self._get_third_party_include_dirs(external_libs_product, dependencies))
-
     sources_and_headers = self.get_sources_headers_for_target(target)
+    compiler_option_sets = (self._compile_settings.native_build_step_settings
+                                .get_compiler_option_sets_for_target(target))
+
     return NativeCompileRequest(
       compiler=self._compiler,
       include_dirs=include_dirs,
@@ -180,7 +182,7 @@ class NativeCompile(NativeTask, AbstractClass):
                          .get_fatal_warnings_value_for_target(target)),
       compiler_options=(self._compile_settings
                             .native_build_step_settings
-                            .get_merged_args_for_compiler_option_sets(target)),
+                            .get_merged_args_for_compiler_option_sets(compiler_option_sets)),
       output_dir=versioned_target.results_dir)
 
   def _make_compile_argv(self, compile_request):

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -28,8 +28,9 @@ class NativeCompileRequest(datatype([
     'include_dirs',
     'sources',
     ('fatal_warnings', bool),
+    ('ndebug', bool),
+    ('glibcxx_use_cxx11_abi', bool),
     'output_dir',
-    'extra_compiler_options',
 ])): pass
 
 
@@ -164,13 +165,6 @@ class NativeCompile(NativeTask, AbstractClass):
             for nelf in external_libs_product.get_for_targets(dependencies)
             if nelf.include_dir]
 
-  def _merge_extra_compiler_options_for_targets(self, targets):
-    options = set()
-    for tgt in targets:
-      if getattr(tgt, 'extra_compiler_options', None):
-        options.update(tgt.extra_compiler_options)
-    return list(options)
-
   def _make_compile_request(self, versioned_target, dependencies, external_libs_product):
     target = versioned_target.target
 
@@ -178,21 +172,24 @@ class NativeCompile(NativeTask, AbstractClass):
     include_dirs.extend(self._get_third_party_include_dirs(external_libs_product, dependencies))
 
     sources_and_headers = self.get_sources_headers_for_target(target)
-    extra_compiler_options = self._merge_extra_compiler_options_for_targets([target] + dependencies)
 
     return NativeCompileRequest(
       compiler=self._compiler,
       include_dirs=include_dirs,
       sources=sources_and_headers,
       fatal_warnings=self._compile_settings.get_fatal_warnings_value_for_target(target),
-      output_dir=versioned_target.results_dir,
-      extra_compiler_options=extra_compiler_options)
+      ndebug=self._compile_settings.get_ndebug_value_for_target(target),
+      glibcxx_use_cxx11_abi=self._compile_settings.get_glibcxx_use_cxx11_abi_value_for_target(target),
+      output_dir=versioned_target.results_dir)
 
   def _make_compile_argv(self, compile_request):
     """Return a list of arguments to use to compile sources. Subclasses can override and append."""
     compiler = compile_request.compiler
     err_flags = ['-Werror'] if compile_request.fatal_warnings else []
-    extra_compiler_options = compile_request.extra_compiler_options
+    ndebug_flag = ['-DNDEBUG'] if compile_request.ndebug else []
+    glibcxx_use_cxx11_abi_flag = []
+    use_cxx_flag_value = '1' if compile_request.glibcxx_use_cxx11_abi else '0'
+    glibcxx_use_cxx11_abi_flag = ['-D_GLIBCXX_USE_CXX11_ABI={}'.format(use_cxx_flag_value)]
 
     # We are going to execute in the target output, so get absolute paths for everything.
     buildroot = get_buildroot()
@@ -200,9 +197,10 @@ class NativeCompile(NativeTask, AbstractClass):
       [compiler.exe_filename] +
       compiler.extra_args +
       err_flags +
+      ndebug_flag +
+      glibcxx_use_cxx11_abi_flag +
       # TODO: If we need to produce static libs, don't add -fPIC! (could use Variants -- see #5788).
       ['-c', '-fPIC'] +
-      extra_compiler_options +
       [
         '-I{}'.format(os.path.join(buildroot, inc_dir))
         for inc_dir in compile_request.include_dirs

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -134,7 +134,7 @@ class NativeCompile(NativeTask, AbstractClass):
 
   @abstractmethod
   def get_compile_settings(self):
-    """Return a subclass of NativeBuildStepSettings.
+    """Return an instance of NativeBuildStepSettings.
 
     NB: Subclasses will be queried for the compile settings once and the result cached.
     """

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -27,7 +27,6 @@ class NativeCompileRequest(datatype([
     # TODO: add type checking for Collection.of(<type>)!
     'include_dirs',
     'sources',
-    ('fatal_warnings', bool),
     'compiler_options',
     'output_dir',
 ])): pass
@@ -177,9 +176,6 @@ class NativeCompile(NativeTask, AbstractClass):
       compiler=self._compiler,
       include_dirs=include_dirs,
       sources=sources_and_headers,
-      fatal_warnings=(self._compile_settings
-                         .native_build_step_settings
-                         .get_fatal_warnings_value_for_target(target)),
       compiler_options=(self._compile_settings
                             .native_build_step_settings
                             .get_merged_args_for_compiler_option_sets(compiler_option_sets)),
@@ -188,14 +184,12 @@ class NativeCompile(NativeTask, AbstractClass):
   def _make_compile_argv(self, compile_request):
     """Return a list of arguments to use to compile sources. Subclasses can override and append."""
     compiler = compile_request.compiler
-    err_flags = ['-Werror'] if compile_request.fatal_warnings else []
     compiler_options = compile_request.compiler_options
     # We are going to execute in the target output, so get absolute paths for everything.
     buildroot = get_buildroot()
     argv = (
       [compiler.exe_filename] +
       compiler.extra_args +
-      err_flags +
       # TODO: If we need to produce static libs, don't add -fPIC! (could use Variants -- see #5788).
       ['-c', '-fPIC'] +
       compiler_options +

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -48,6 +48,8 @@ class NativeCompile(NativeTask, AbstractClass):
   source_target_constraint = None
   dependent_target_constraint = SubclassesOf(ExternalNativeLibrary, NativeLibrary)
 
+  HEADER_EXTENSIONS = ('.h', '.hpp')
+
   # `NativeCompile` will use `workunit_label` as the name of the workunit when executing the
   # compiler process. `workunit_label` must be set to a string.
   @classproperty
@@ -176,10 +178,10 @@ class NativeCompile(NativeTask, AbstractClass):
       include_dirs=include_dirs,
       sources=sources_and_headers,
       fatal_warnings=(self._compile_settings
-                         ._native_build_step_settings
+                         ._native_build_step_settings_base
                          .get_fatal_warnings_value_for_target(target)),
       compiler_options=(self._compile_settings
-                           ._native_build_step_settings
+                           ._native_build_step_settings_base
                            .get_merged_compiler_options_for_target(target,
           [self._compile_settings.get_options().compiler_option_sets_enabled_args],
           [self._compile_settings.get_options().compiler_option_sets_disabled_args])),
@@ -218,7 +220,7 @@ class NativeCompile(NativeTask, AbstractClass):
     """
     sources = compile_request.sources
 
-    if len(sources) == 0 or not [s for s in sources if not s.endswith(('.h', '.hpp'))]:
+    if len(sources) == 0 or not any(s for s in sources if not s.endswith(self.HEADER_EXTENSIONS)):
       # TODO: do we need this log message? Should we still have it for intentionally header-only
       # libraries (that might be a confusing message to see)?
       self.context.log.debug("no sources in request {}, skipping".format(compile_request))

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -29,6 +29,7 @@ class NativeCompileRequest(datatype([
     'sources',
     ('fatal_warnings', bool),
     'output_dir',
+    'extra_compiler_options',
 ])): pass
 
 
@@ -163,6 +164,13 @@ class NativeCompile(NativeTask, AbstractClass):
             for nelf in external_libs_product.get_for_targets(dependencies)
             if nelf.include_dir]
 
+  def _merge_extra_compiler_options_for_targets(self, targets):
+    options = set()
+    for tgt in targets:
+      if getattr(tgt, 'extra_compiler_options', None):
+        options.update(tgt.extra_compiler_options)
+    return list(options)
+
   def _make_compile_request(self, versioned_target, dependencies, external_libs_product):
     target = versioned_target.target
 
@@ -170,18 +178,21 @@ class NativeCompile(NativeTask, AbstractClass):
     include_dirs.extend(self._get_third_party_include_dirs(external_libs_product, dependencies))
 
     sources_and_headers = self.get_sources_headers_for_target(target)
+    extra_compiler_options = self._merge_extra_compiler_options_for_targets([target] + dependencies)
 
     return NativeCompileRequest(
       compiler=self._compiler,
       include_dirs=include_dirs,
       sources=sources_and_headers,
       fatal_warnings=self._compile_settings.get_fatal_warnings_value_for_target(target),
-      output_dir=versioned_target.results_dir)
+      output_dir=versioned_target.results_dir,
+      extra_compiler_options=extra_compiler_options)
 
   def _make_compile_argv(self, compile_request):
     """Return a list of arguments to use to compile sources. Subclasses can override and append."""
     compiler = compile_request.compiler
     err_flags = ['-Werror'] if compile_request.fatal_warnings else []
+    extra_compiler_options = compile_request.extra_compiler_options
 
     # We are going to execute in the target output, so get absolute paths for everything.
     buildroot = get_buildroot()
@@ -191,6 +202,7 @@ class NativeCompile(NativeTask, AbstractClass):
       err_flags +
       # TODO: If we need to produce static libs, don't add -fPIC! (could use Variants -- see #5788).
       ['-c', '-fPIC'] +
+      extra_compiler_options +
       [
         '-I{}'.format(os.path.join(buildroot, inc_dir))
         for inc_dir in compile_request.include_dirs
@@ -209,7 +221,7 @@ class NativeCompile(NativeTask, AbstractClass):
     """
     sources = compile_request.sources
 
-    if len(sources) == 0:
+    if len(sources) == 0 or not [s for s in sources if not s.endswith(('.h', '.hpp'))]:
       # TODO: do we need this log message? Should we still have it for intentionally header-only
       # libraries (that might be a confusing message to see)?
       self.context.log.debug("no sources in request {}, skipping".format(compile_request))

--- a/src/python/pants/backend/native/tasks/native_task.py
+++ b/src/python/pants/backend/native/tasks/native_task.py
@@ -8,6 +8,7 @@ from builtins import filter
 
 from pants.backend.native.subsystems.native_build_settings import NativeBuildSettings
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
+from pants.backend.native.targets.external_native_library import ExternalNativeLibrary
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.build_graph.dependency_context import DependencyContext
 from pants.task.task import Task
@@ -39,7 +40,7 @@ class NativeTask(Task):
 
     :return: :class:`pants.util.objects.TypeConstraint`
     """
-    return SubclassesOf(NativeLibrary)
+    return SubclassesOf(ExternalNativeLibrary, NativeLibrary)
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/src/python/pants/option/compiler_option_sets_mixin.py
+++ b/src/python/pants/option/compiler_option_sets_mixin.py
@@ -6,11 +6,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from builtins import object
 
-from pants.backend.native.subsystems.utils.mirrored_target_option_mixin import \
-  MirroredTargetOptionMixin
 
-
-class CompilerOptionSetsMixin(MirroredTargetOptionMixin, object):
+class CompilerOptionSetsMixin(object):
   """A mixin for language-scoped that support compiler option sets."""
 
   @classmethod

--- a/src/python/pants/option/compiler_option_sets_mixin.py
+++ b/src/python/pants/option/compiler_option_sets_mixin.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from builtins import object
 
+from pants.util.meta import classproperty
+
 
 class CompilerOptionSetsMixin(object):
   """A mixin for language-scoped that support compiler option sets."""
@@ -15,19 +17,23 @@ class CompilerOptionSetsMixin(object):
     super(CompilerOptionSetsMixin, cls).register_options(register)
 
     register('--fatal-warnings-enabled-args', advanced=True, type=list, fingerprint=True,
-             default=list(cls.get_fatal_warnings_enabled_args_default()),
-             help='Extra compiler args to use when fatal warnings are enabled.')
+             default=cls.get_fatal_warnings_enabled_args_default,
+             help='Extra compiler args to use when fatal warnings are enabled.',
+             removal_version='1.14.0.dev2',
+             removal_hint='Use compiler option sets instead.')
     register('--fatal-warnings-disabled-args', advanced=True, type=list, fingerprint=True,
-             default=list(cls.get_fatal_warnings_disabled_args_default()),
-             help='Extra compiler args to use when fatal warnings are disabled.')
+             default=cls.get_fatal_warnings_disabled_args_default,
+             help='Extra compiler args to use when fatal warnings are disabled.',
+             removal_version='1.14.0.dev2',
+             removal_hint='Use compiler option sets instead.')
     register('--compiler-option-sets-enabled-args', advanced=True, type=dict, fingerprint=True,
-             default=cls.get_compiler_option_sets_enabled_default_value(),
+             default=cls.get_compiler_option_sets_enabled_default_value,
              help='Extra compiler args to use for each enabled option set.')
     register('--compiler-option-sets-disabled-args', advanced=True, type=dict, fingerprint=True,
-             default=cls.get_compiler_option_sets_disabled_default_value(),
+             default=cls.get_compiler_option_sets_disabled_default_value,
              help='Extra compiler args to use for each disabled option set.')
 
-  @property
+  @classproperty
   def compiler_option_sets(self):
     """For every element in this list, enable the corresponding flags on compilation
     of targets.
@@ -35,7 +41,7 @@ class CompilerOptionSetsMixin(object):
     """
     return self.get_options().compiler_option_sets
 
-  @property
+  @classproperty
   def compiler_option_sets_enabled_args(self):
     """For every element in this list, enable the corresponding flags on compilation
     of targets.
@@ -43,7 +49,7 @@ class CompilerOptionSetsMixin(object):
     """
     return self.get_options().compiler_option_sets_enabled_args
 
-  @property
+  @classproperty
   def compiler_option_sets_disabled_args(self):
     """For every element in this list, enable the corresponding flags on compilation
     of targets.
@@ -51,22 +57,22 @@ class CompilerOptionSetsMixin(object):
     """
     return self.get_options().compiler_option_sets_disabled_args
 
-  @classmethod
+  @classproperty
   def get_compiler_option_sets_enabled_default_value(cls):
     """Override to set default for this option."""
     return {}
 
-  @classmethod
+  @classproperty
   def get_compiler_option_sets_disabled_default_value(cls):
     """Override to set default for this option."""
     return {}
 
-  @classmethod
+  @classproperty
   def get_fatal_warnings_enabled_args_default(cls):
     """Override to set default for this option."""
     return ()
 
-  @classmethod
+  @classproperty
   def get_fatal_warnings_disabled_args_default(cls):
     """Override to set default for this option."""
     return ()

--- a/src/python/pants/option/compiler_option_sets_mixin.py
+++ b/src/python/pants/option/compiler_option_sets_mixin.py
@@ -80,19 +80,23 @@ class CompilerOptionSetsMixin(MirroredTargetOptionMixin, object):
     # Set values for enabled options.
     for option_set_key in compiler_option_sets:
       # Fatal warnings option has special treatment for backwards compatibility.
-      if option_set_key == 'fatal_warnings':
-        enabled_fatal_warn_args = self.get_options().fatal_warnings_enabled_args
-        compiler_options.update(enabled_fatal_warn_args)
-      val = self.get_options().compiler_option_sets_enabled_args.get(option_set_key, ())
-      compiler_options.update(val)
+      # This is because previously this has had its own {enabled, disabled}_args
+      # options when these were defined in the jvm compile task.
+      fatal_warnings = self.get_options().fatal_warnings_enabled_args
+      if option_set_key == 'fatal_warnings' and fatal_warnings:
+        compiler_options.update(fatal_warnings)
+      else:
+        val = self.get_options().compiler_option_sets_enabled_args.get(option_set_key, ())
+        compiler_options.update(val)
 
     # Set values for disabled options.
     for option_set, disabled_args in self.get_options().compiler_option_sets_disabled_args.items():
       # Fatal warnings option has special treatment for backwards compatibility.
-      if option_set == 'fatal_warnings':
-        disabled_fatal_warn_args = self.get_options().fatal_warnings_disabled_args
+      disabled_fatal_warn_args = self.get_options().fatal_warnings_disabled_args
+      if option_set == 'fatal_warnings' and disabled_fatal_warn_args:
         compiler_options.update(disabled_fatal_warn_args)
-      if not option_set in compiler_option_sets:
-        compiler_options.update(disabled_args)
+      else:
+        if not option_set in compiler_option_sets:
+          compiler_options.update(disabled_args)
 
     return list(compiler_options)

--- a/src/python/pants/option/compiler_option_sets_mixin.py
+++ b/src/python/pants/option/compiler_option_sets_mixin.py
@@ -17,10 +17,6 @@ class CompilerOptionSetsMixin(MirroredTargetOptionMixin, object):
   def register_options(cls, register):
     super(CompilerOptionSetsMixin, cls).register_options(register)
 
-    register('--compiler-option-sets', advanced=True, default=(), type=list,
-             fingerprint=True,
-             help='The default for the "compiler_option_sets" argument '
-                  'for targets of this language.')
     register('--fatal-warnings-enabled-args', advanced=True, type=list, fingerprint=True,
              default=list(cls.get_fatal_warnings_enabled_args_default()),
              help='Extra compiler args to use when fatal warnings are enabled.')
@@ -78,9 +74,7 @@ class CompilerOptionSetsMixin(MirroredTargetOptionMixin, object):
     """Override to set default for this option."""
     return ()
 
-  def get_merged_args_for_compiler_option_sets(self, target):
-    compiler_option_sets = self.get_target_mirrored_option(
-        'compiler_option_sets', target)
+  def get_merged_args_for_compiler_option_sets(self, compiler_option_sets):
     compiler_options = set()
 
     # Set values for enabled options.

--- a/src/python/pants/option/compiler_option_sets_mixin.py
+++ b/src/python/pants/option/compiler_option_sets_mixin.py
@@ -34,30 +34,6 @@ class CompilerOptionSetsMixin(object):
              help='Extra compiler args to use for each disabled option set.')
 
   @classproperty
-  def compiler_option_sets(self):
-    """For every element in this list, enable the corresponding flags on compilation
-    of targets.
-    :rtype: list
-    """
-    return self.get_options().compiler_option_sets
-
-  @classproperty
-  def compiler_option_sets_enabled_args(self):
-    """For every element in this list, enable the corresponding flags on compilation
-    of targets.
-    :rtype: list
-    """
-    return self.get_options().compiler_option_sets_enabled_args
-
-  @classproperty
-  def compiler_option_sets_disabled_args(self):
-    """For every element in this list, enable the corresponding flags on compilation
-    of targets.
-    :rtype: list
-    """
-    return self.get_options().compiler_option_sets_disabled_args
-
-  @classproperty
   def get_compiler_option_sets_enabled_default_value(cls):
     """Override to set default for this option."""
     return {}

--- a/src/python/pants/option/compiler_option_sets_mixin.py
+++ b/src/python/pants/option/compiler_option_sets_mixin.py
@@ -1,0 +1,104 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from builtins import object
+
+from pants.backend.native.subsystems.utils.mirrored_target_option_mixin import \
+  MirroredTargetOptionMixin
+
+
+class CompilerOptionSetsMixin(MirroredTargetOptionMixin, object):
+  """A mixin for language-scoped that support compiler option sets."""
+
+  @classmethod
+  def register_options(cls, register):
+    super(CompilerOptionSetsMixin, cls).register_options(register)
+
+    register('--compiler-option-sets', advanced=True, default=(), type=list,
+             fingerprint=True,
+             help='The default for the "compiler_option_sets" argument '
+                  'for targets of this language.')
+    register('--fatal-warnings-enabled-args', advanced=True, type=list, fingerprint=True,
+             default=list(cls.get_fatal_warnings_enabled_args_default()),
+             help='Extra compiler args to use when fatal warnings are enabled.')
+    register('--fatal-warnings-disabled-args', advanced=True, type=list, fingerprint=True,
+             default=list(cls.get_fatal_warnings_disabled_args_default()),
+             help='Extra compiler args to use when fatal warnings are disabled.')
+    register('--compiler-option-sets-enabled-args', advanced=True, type=dict, fingerprint=True,
+             default=cls.get_compiler_option_sets_enabled_default_value(),
+             help='Extra compiler args to use for each enabled option set.')
+    register('--compiler-option-sets-disabled-args', advanced=True, type=dict, fingerprint=True,
+             default=cls.get_compiler_option_sets_disabled_default_value(),
+             help='Extra compiler args to use for each disabled option set.')
+
+  @property
+  def compiler_option_sets(self):
+    """For every element in this list, enable the corresponding flags on compilation
+    of targets.
+    :rtype: list
+    """
+    return self.get_options().compiler_option_sets
+
+  @property
+  def compiler_option_sets_enabled_args(self):
+    """For every element in this list, enable the corresponding flags on compilation
+    of targets.
+    :rtype: list
+    """
+    return self.get_options().compiler_option_sets_enabled_args
+
+  @property
+  def compiler_option_sets_disabled_args(self):
+    """For every element in this list, enable the corresponding flags on compilation
+    of targets.
+    :rtype: list
+    """
+    return self.get_options().compiler_option_sets_disabled_args
+
+  @classmethod
+  def get_compiler_option_sets_enabled_default_value(cls):
+    """Override to set default for this option."""
+    return {}
+
+  @classmethod
+  def get_compiler_option_sets_disabled_default_value(cls):
+    """Override to set default for this option."""
+    return {}
+
+  @classmethod
+  def get_fatal_warnings_enabled_args_default(cls):
+    """Override to set default for this option."""
+    return ()
+
+  @classmethod
+  def get_fatal_warnings_disabled_args_default(cls):
+    """Override to set default for this option."""
+    return ()
+
+  def get_merged_args_for_compiler_option_sets(self, target):
+    compiler_option_sets = self.get_target_mirrored_option(
+        'compiler_option_sets', target)
+    compiler_options = set()
+
+    # Set values for enabled options.
+    for option_set_key in compiler_option_sets:
+      # Fatal warnings option has special treatment for backwards compatibility.
+      if option_set_key == 'fatal_warnings':
+        enabled_fatal_warn_args = self.get_options().fatal_warnings_enabled_args
+        compiler_options.update(enabled_fatal_warn_args)
+      val = self.get_options().compiler_option_sets_enabled_args.get(option_set_key, ())
+      compiler_options.update(val)
+
+    # Set values for disabled options.
+    for option_set, disabled_args in self.get_options().compiler_option_sets_disabled_args.items():
+      # Fatal warnings option has special treatment for backwards compatibility.
+      if option_set == 'fatal_warnings':
+        disabled_fatal_warn_args = self.get_options().fatal_warnings_disabled_args
+        compiler_options.update(disabled_fatal_warn_args)
+      if not option_set in compiler_option_sets:
+        compiler_options.update(disabled_args)
+
+    return list(compiler_options)

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/BUILD
@@ -1,0 +1,30 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+ctypes_compatible_cpp_library(
+  name='cpp_library',
+  sources=['some_more_math.hpp', 'some_more_math.cpp'],
+  ctypes_native_library=native_artifact(lib_name='asdf-cpp'),
+  extra_compiler_options=["-DNDEBUG"],
+)
+
+python_dist(
+  name="ctypes",
+  sources=[
+    'setup.py',
+    'ctypes_python_pkg/__init__.py',
+    'ctypes_python_pkg/ctypes_wrapper.py',
+  ],
+  dependencies=[
+    ':cpp_library',
+  ],
+)
+
+python_binary(
+  name='bin',
+  source='main.py',
+  dependencies=[
+    ':ctypes',
+  ],
+  platforms=['current'],
+)

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/BUILD
@@ -5,7 +5,8 @@ ctypes_compatible_cpp_library(
   name='cpp_library',
   sources=['some_more_math.hpp', 'some_more_math.cpp'],
   ctypes_native_library=native_artifact(lib_name='asdf-cpp'),
-  extra_compiler_options=["-DNDEBUG"],
+  ndebug=True,
+  glibcxx_use_cxx11_abi=False,
 )
 
 python_dist(

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/BUILD
@@ -5,8 +5,7 @@ ctypes_compatible_cpp_library(
   name='cpp_library',
   sources=['some_more_math.hpp', 'some_more_math.cpp'],
   ctypes_native_library=native_artifact(lib_name='asdf-cpp'),
-  ndebug=True,
-  glibcxx_use_cxx11_abi=False,
+  compiler_option_sets={'ndebug', 'glibcxx_use_cxx11_abi'},
 )
 
 python_dist(

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/BUILD
@@ -5,7 +5,7 @@ ctypes_compatible_cpp_library(
   name='cpp_library',
   sources=['some_more_math.hpp', 'some_more_math.cpp'],
   ctypes_native_library=native_artifact(lib_name='asdf-cpp'),
-  compiler_option_sets={'ndebug', 'glibcxx_use_cxx11_abi'},
+  compiler_option_sets={'ndebug', 'asdf'},
 )
 
 python_dist(

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/BUILD
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/BUILD
@@ -5,7 +5,7 @@ ctypes_compatible_cpp_library(
   name='cpp_library',
   sources=['some_more_math.hpp', 'some_more_math.cpp'],
   ctypes_native_library=native_artifact(lib_name='asdf-cpp'),
-  compiler_option_sets={'ndebug', 'asdf'},
+  compiler_option_sets={'asdf'},
 )
 
 python_dist(

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/ctypes_python_pkg/ctypes_wrapper.py
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/ctypes_python_pkg/ctypes_wrapper.py
@@ -21,5 +21,5 @@ asdf_cpp_lib_path = get_generated_shared_lib('asdf-cpp')
 asdf_cpp_lib = ctypes.CDLL(asdf_cpp_lib_path)
 
 def f(x):
-  multiplied = asdf_cpp_lib.multiply_by_three(42)
+  multiplied = asdf_cpp_lib.multiply_by_something(42)
   return multiplied

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/ctypes_python_pkg/ctypes_wrapper.py
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/ctypes_python_pkg/ctypes_wrapper.py
@@ -1,0 +1,25 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import ctypes
+import os
+
+
+def get_generated_shared_lib(lib_name):
+  # These are the same filenames as in setup.py.
+  filename = 'lib{}.so'.format(lib_name)
+  # The data files are in the root directory, but we are in ctypes_python_pkg/.
+  rel_path = os.path.join(os.path.dirname(__file__), '..', filename)
+  return os.path.normpath(rel_path)
+
+
+asdf_cpp_lib_path = get_generated_shared_lib('asdf-cpp')
+asdf_cpp_lib = ctypes.CDLL(asdf_cpp_lib_path)
+
+def f(x):
+  multiplied = asdf_cpp_lib.multiply_by_three(42)
+  return multiplied

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/main.py
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/main.py
@@ -1,0 +1,13 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from ctypes_python_pkg.ctypes_wrapper import f
+
+
+if __name__ == '__main__':
+  x = 3
+  print('x={}, f(x)={}'.format(x, f(x)))

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/setup.py
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/setup.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from setuptools import setup, find_packages
+
+
+setup(
+  name='ctypes_test',
+  version='0.0.1',
+  packages=find_packages(),
+  data_files=[('', ['libasdf-cpp.so'])],
+)

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.cpp
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.cpp
@@ -4,7 +4,7 @@
 int mangled_function(int x) {
   double y = -1.0;
   assert(y >= 0.0);
-  return x ^ 3;
+  return x * SOMETHING;
 }
 
-extern "C" int multiply_by_three(int x) { return mangled_function(x * 3); }
+extern "C" int multiply_by_something(int x) { return mangled_function(x * 3); }

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.cpp
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.cpp
@@ -2,8 +2,6 @@
 #include <assert.h>
 
 int mangled_function(int x) {
-  double y = -1.0;
-  assert(y >= 0.0);
   return x * SOMETHING;
 }
 

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.cpp
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.cpp
@@ -1,0 +1,10 @@
+#include "some_more_math.hpp"
+#include <assert.h>
+
+int mangled_function(int x) {
+  double y = -1.0;
+  assert(y >= 0.0);
+  return x ^ 3;
+}
+
+extern "C" int multiply_by_three(int x) { return mangled_function(x * 3); }

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
@@ -7,8 +7,8 @@
 #define assert(condition)
 #endif
 
-#ifdef _GLIBCXX_USE_CXX11_ABI
-#if _GLIBCXX_USE_CXX11_ABI == 0
+#ifdef ASDF
+#if ASDF == 0
 #define SOMETHING 800000
 #else
 #define SOMETHING 1

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
@@ -5,7 +5,7 @@
     #if _ASDF == 0
         #define SOMETHING 800000
     #else
-        #define SOMETHING 1
+        #define SOMETHING 100000
     #endif
 #else
     #define SOMETHING -1

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
@@ -2,17 +2,19 @@
 #define __SOME_MORE_MATH_HPP__
 
 #ifdef NDEBUG
-#define assert(condition) ((void)0)
-#else
-#define assert(condition)
+        #define assert(condition) ((void)0)
+    #else
+        #define assert(condition)
 #endif
 
 #ifdef ASDF
-#if ASDF == 0
-#define SOMETHING 800000
+    #if ASDF == 0
+        #define SOMETHING 800000
+    #else
+        #define SOMETHING 1
+    #endif
 #else
-#define SOMETHING 1
-#endif
+    #define SOMETHING 0
 #endif
 
 int mangled_function(int);

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
@@ -1,0 +1,14 @@
+#ifndef __SOME_MORE_MATH_HPP__
+#define __SOME_MORE_MATH_HPP__
+
+#ifdef NDEBUG
+#define assert(condition) ((void)0)
+#else
+#define assert(condition) /*implementation defined*/
+#endif
+
+int mangled_function(int);
+
+extern "C" int multiply_by_three(int);
+
+#endif

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
@@ -4,7 +4,7 @@
 #ifdef NDEBUG
 #define assert(condition) ((void)0)
 #else
-#define assert(condition) /*implementation defined*/
+#define assert(condition)
 #endif
 
 int mangled_function(int);

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
@@ -1,20 +1,14 @@
 #ifndef __SOME_MORE_MATH_HPP__
 #define __SOME_MORE_MATH_HPP__
 
-#ifdef NDEBUG
-        #define assert(condition) ((void)0)
-    #else
-        #define assert(condition)
-#endif
-
-#ifdef ASDF
-    #if ASDF == 0
+#ifdef _ASDF
+    #if _ASDF == 0
         #define SOMETHING 800000
     #else
         #define SOMETHING 1
     #endif
 #else
-    #define SOMETHING 0
+    #define SOMETHING -1
 #endif
 
 int mangled_function(int);

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/some_more_math.hpp
@@ -7,8 +7,16 @@
 #define assert(condition)
 #endif
 
+#ifdef _GLIBCXX_USE_CXX11_ABI
+#if _GLIBCXX_USE_CXX11_ABI == 0
+#define SOMETHING 800000
+#else
+#define SOMETHING 1
+#endif
+#endif
+
 int mangled_function(int);
 
-extern "C" int multiply_by_three(int);
+extern "C" int multiply_by_something(int);
 
 #endif

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -162,11 +162,10 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(command=command, config={
       'native-build-step.cpp-compile-settings': {
         'compiler_option_sets_enabled_args': {
-          'ndebug': ['-DNDEBUG'],
-          'asdf': ['-DASDF=1'],
+          'asdf': ['-D_ASDF=1'],
         },
         'compiler_option_sets_disabled_args': {
-          'asdf': ['-DASDF=0'],
+          'asdf': ['-D_ASDF=0'],
         }
       },
     })

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -170,4 +170,4 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       },
     })
     self.assert_success(pants_run)
-    self.assertIn('x=3, f(x)=126', pants_run.stdout_data)
+    self.assertIn('x=3, f(x)=12600000', pants_run.stdout_data)

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -147,11 +147,15 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     self.assertIn('x=3, f(x)=17', pants_run.stdout_data)
 
   def test_cpp_library_extra_options_integration(self):
-    """Test that native compilation includes extra compiler flags from target definitions."""
+    """Test that native compilation includes extra compiler flags from target definitions.
+
+    This target has ndebug=True and glibcxx_use_cxx11_abi=False.
+    If either of these are not present or negated, this test will fail.
+    """
     command = [
       'run',
       'testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags:bin'
     ]
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
-    self.assertIn('x=3, f(x)=125', pants_run.stdout_data)
+    self.assertIn('x=3, f(x)=126', pants_run.stdout_data)

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -146,7 +146,8 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     self.assert_success(pants_run)
     self.assertIn('x=3, f(x)=17', pants_run.stdout_data)
 
-  def test_cpp_library_extra_options_integration(self):
+  '''
+  def test_native_compiler_option_sets_integration(self):
     """Test that native compilation includes extra compiler flags from target definitions.
 
     This target has ndebug=True and glibcxx_use_cxx11_abi=False.
@@ -159,3 +160,4 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
     self.assertIn('x=3, f(x)=126', pants_run.stdout_data)
+  '''

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -160,7 +160,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       self._binary_target_with_compiler_option_sets
     ]
     pants_run = self.run_pants(command=command, config={
-      'native-build-step-settings.cpp-compile-settings': {
+      'native-build-step.cpp-compile-settings': {
         'compiler_option_sets_enabled_args': {
           'ndebug': ['-DNDEBUG'],
           'asdf': ['-DASDF=1'],

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -145,3 +145,13 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     })
     self.assert_success(pants_run)
     self.assertIn('x=3, f(x)=17', pants_run.stdout_data)
+
+  def test_cpp_library_extra_options_integration(self):
+    """Test that native compilation includes extra compiler flags from target definitions."""
+    command = [
+      'run',
+      'testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags:bin'
+    ]
+    pants_run = self.run_pants(command=command)
+    self.assert_success(pants_run)
+    self.assertIn('x=3, f(x)=125', pants_run.stdout_data)

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -160,18 +160,13 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       self._binary_target_with_compiler_option_sets
     ]
     pants_run = self.run_pants(command=command, config={
-      'cpp-compile-settings': {
+      'native-build-step-settings.cpp-compile-settings': {
         'compiler_option_sets_enabled_args': {
           'ndebug': ['-DNDEBUG'],
           'glibcxx_use_cxx11_abi': ['-D_GLIBCXX_USE_CXX11_ABI=1'],
         },
         'compiler_option_sets_disabled_args': {
           'glibcxx_use_cxx11_abi': ['-D_GLIBCXX_USE_CXX11_ABI=0'],
-        }
-      },
-      'native-build-step-settings-base': {
-        'compiler_option_sets_enabled_args': {
-          'ndebug': ['-DNDEBUG'],
         }
       },
     })

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -152,7 +152,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
   def test_native_compiler_option_sets_integration(self):
     """Test that native compilation includes extra compiler flags from target definitions.
 
-    This target uses the ndebug and glibcxx_use_cxx11_abi option sets.
+    This target uses the ndebug and asdf option sets.
     If either of these are not present (disabled), this test will fail.
     """
     command = [
@@ -163,10 +163,10 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       'native-build-step-settings.cpp-compile-settings': {
         'compiler_option_sets_enabled_args': {
           'ndebug': ['-DNDEBUG'],
-          'glibcxx_use_cxx11_abi': ['-D_GLIBCXX_USE_CXX11_ABI=1'],
+          'asdf': ['-DASDF=1'],
         },
         'compiler_option_sets_disabled_args': {
-          'glibcxx_use_cxx11_abi': ['-D_GLIBCXX_USE_CXX11_ABI=0'],
+          'asdf': ['-DASDF=0'],
         }
       },
     })

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -32,6 +32,9 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
   _binary_target_with_third_party = (
     'testprojects/src/python/python_distribution/ctypes_with_third_party:bin_with_third_party'
   )
+  _binary_target_with_compiler_option_sets = (
+    'testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags:bin'
+  )
 
   def test_ctypes_run(self):
     pants_run = self.run_pants(command=['-q', 'run', self._binary_target])
@@ -146,18 +149,31 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     self.assert_success(pants_run)
     self.assertIn('x=3, f(x)=17', pants_run.stdout_data)
 
-  '''
   def test_native_compiler_option_sets_integration(self):
     """Test that native compilation includes extra compiler flags from target definitions.
 
-    This target has ndebug=True and glibcxx_use_cxx11_abi=False.
-    If either of these are not present or negated, this test will fail.
+    This target uses the ndebug and glibcxx_use_cxx11_abi option sets.
+    If either of these are not present (disabled), this test will fail.
     """
     command = [
       'run',
-      'testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags:bin'
+      self._binary_target_with_compiler_option_sets
     ]
-    pants_run = self.run_pants(command=command)
+    pants_run = self.run_pants(command=command, config={
+      'cpp-compile-settings': {
+        'compiler_option_sets_enabled_args': {
+          'ndebug': ['-DNDEBUG'],
+          'glibcxx_use_cxx11_abi': ['-D_GLIBCXX_USE_CXX11_ABI=1'],
+        },
+        'compiler_option_sets_disabled_args': {
+          'glibcxx_use_cxx11_abi': ['-D_GLIBCXX_USE_CXX11_ABI=0'],
+        }
+      },
+      'native-build-step-settings-base': {
+        'compiler_option_sets_enabled_args': {
+          'ndebug': ['-DNDEBUG'],
+        }
+      },
+    })
     self.assert_success(pants_run)
     self.assertIn('x=3, f(x)=126', pants_run.stdout_data)
-  '''

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -101,6 +101,7 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/pants-plugins/*',
       'testprojects/src/python/python_distribution/ctypes:ctypes_test',
       'testprojects/src/python/python_distribution/ctypes_with_third_party:ctypes_test',
+      'testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags:bin',
     ]
 
     targets_to_exclude = (known_failing_targets + negative_test_targets + need_java_8 +


### PR DESCRIPTION
### Problem

Native targets do not have support for compiler option sets.

### Solution

Add support for compiler options sets for use in native compile tasks.

### Result

Users can specify option set defaults and their corresponding default enabled values in Pants.ini. Native targets support option sets.