### PR TITLE
Fix bugs in the parent/child relationship in ProcessManager

### DIFF
--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -474,25 +474,26 @@ class ProcessManager(ProcessMetadataManager):
           return False, True
         else:
           if write_pid: self.write_pid(second_pid)
-          return True, False
+          return False, False
       else:
         # This prevents un-reaped, throw-away parent processes from lingering in the process table.
         os.waitpid(pid, 0)
-      return False, False
+        return True, False
 
     fork_func = functools.partial(fork_context, double_fork) if fork_context else double_fork
 
     # Perform the double fork (optionally under the fork_context). Three outcomes are possible after
-    # the double fork: we're either the original process, the double-fork parent, or the double-fork
-    # child. We assert below that a process is not somehow both the parent and the child.
+    # the double fork: we're either the original parent process, the middle double-fork process, or
+    # the child. We assert below that a process is not somehow both the parent and the child.
     self.purge_metadata()
     self.pre_fork(**pre_fork_opts or {})
     is_parent, is_child = fork_func()
-    if not is_parent and not is_child:
-      return
 
     try:
-      if is_parent:
+      if not is_parent and not is_child:
+        # Middle process.
+        os._exit(0)
+      elif is_parent:
         assert not is_child
         self.post_fork_parent(**post_fork_parent_opts or {})
       else:
@@ -501,7 +502,6 @@ class ProcessManager(ProcessMetadataManager):
         self.post_fork_child(**post_fork_child_opts or {})
     except Exception:
       logger.critical(traceback.format_exc())
-    finally:
       os._exit(0)
 
   def daemon_spawn(self, pre_fork_opts=None, post_fork_parent_opts=None, post_fork_child_opts=None):

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -404,7 +404,7 @@ class TestProcessManager(TestBase):
 
   def test_daemonize_child_parent(self):
     with self.mock_daemonize_context(chk_post_parent=True) as mock_fork:
-      mock_fork.side_effect = [0, 1]    # Simulate the childs parent.
+      mock_fork.side_effect = [1, 1]    # Simulate the original parent process.
       self.pm.daemonize(write_pid=False)
 
   def test_daemon_spawn_parent(self):


### PR DESCRIPTION
### Problem

`ProcessManager.daemonize` and `ProcessManager.daemon_spawn` were out of sync with regard to the definition of what the `post_fork_parent` process was. `daemon_spawn` treated the original parent process of the double fork as the "post fork parent", while `daemonize` treated the short-lived "middle" process of the double fork as the "post fork parent".

Additionally, the middle process in a double-fork calls `exit` immediately after having forked its child, so having any sort of callback there was unlikely to be useful.

### Solution

Align `daemon_spawn` and `daemonize` with regard to the definition of the "post fork parent", such that both of those methods run the `post_fork_parent` callback in the original process.

### Result

The `post_fork_parent` method is called in the expected (and more useful) location.