### PR TITLE
Pause all PantsService threads before forking a pantsd-runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,9 @@ default_test_config: &default_test_config
     - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
     - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
     - jdk_switcher use oraclejdk8
+    # Increase the max number of user watches to ensure that watchman is able to watch all
+    # files in the working copy.
+    - sudo sysctl fs.inotify.max_user_watches=524288
 
 matrix:
   include:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -264,8 +264,9 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--watchman-startup-timeout', type=float, advanced=True, default=30.0,
              help='The watchman socket timeout (in seconds) for the initial `watch-project` command. '
                   'This may need to be set higher for larger repos due to watchman startup cost.')
-    register('--watchman-socket-timeout', type=float, advanced=True, default=5.0,
-             help='The watchman client socket timeout in seconds.')
+    register('--watchman-socket-timeout', type=float, advanced=True, default=0.1,
+             help='The watchman client socket timeout in seconds. Setting this to too high a '
+                  'value can negatively impact the latency of runs forked by pantsd.')
     register('--watchman-socket-path', type=str, advanced=True, default=None,
              help='The path to the watchman UNIX socket. This can be overridden if the default '
                   'absolute path length exceeds the maximum allowed by the OS.')

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -152,7 +152,7 @@ class PantsDaemon(FingerprintedProcessManager):
       else:
         build_root = None
         native = None
-        services = PantsServices(tuple(), dict(), threading.RLock())
+        services = PantsServices()
 
       return PantsDaemon(
         native=native,
@@ -207,12 +207,8 @@ class PantsDaemon(FingerprintedProcessManager):
       store_gc_service = StoreGCService(legacy_graph_scheduler.scheduler)
 
       return PantsServices(
-        # Services.
-        (fs_event_service, scheduler_service, pailgun_service, store_gc_service),
-        # Port map.
-        dict(pailgun=pailgun_service.pailgun_port),
-        # The lifecyle lock.
-        threading.RLock(),
+        services=(fs_event_service, scheduler_service, pailgun_service, store_gc_service),
+        port_map=dict(pailgun=pailgun_service.pailgun_port),
       )
 
   def __init__(self, native, build_root, work_dir, log_level, services,

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -27,6 +27,7 @@ from pants.option.options_fingerprinter import OptionsFingerprinter
 from pants.pantsd.process_manager import FingerprintedProcessManager
 from pants.pantsd.service.fs_event_service import FSEventService
 from pants.pantsd.service.pailgun_service import PailgunService
+from pants.pantsd.service.pants_service import PantsServices
 from pants.pantsd.service.scheduler_service import SchedulerService
 from pants.pantsd.service.store_gc_service import StoreGCService
 from pants.pantsd.watchman_launcher import WatchmanLauncher
@@ -94,7 +95,7 @@ class PantsDaemon(FingerprintedProcessManager):
       :rtype: PantsDaemon.Handle
       """
       stub_pantsd = cls.create(bootstrap_options, full_init=False)
-      with stub_pantsd.lifecycle_lock:
+      with stub_pantsd._services.lifecycle_lock:
         if stub_pantsd.needs_restart(stub_pantsd.options_fingerprint):
           # Once we determine we actually need to launch, recreate with full initialization.
           pantsd = cls.create(bootstrap_options)
@@ -115,7 +116,7 @@ class PantsDaemon(FingerprintedProcessManager):
       :rtype: PantsDaemon.Handle
       """
       pantsd = cls.create(bootstrap_options)
-      with pantsd.lifecycle_lock:
+      with pantsd._services.lifecycle_lock:
         # N.B. This will call `pantsd.terminate()` before starting.
         return pantsd.launch()
 
@@ -131,13 +132,8 @@ class PantsDaemon(FingerprintedProcessManager):
       """
       bootstrap_options = bootstrap_options or cls._parse_bootstrap_options()
       bootstrap_options_values = bootstrap_options.for_global_scope()
-
       # TODO: https://github.com/pantsbuild/pants/issues/3479
       watchman = WatchmanLauncher.create(bootstrap_options_values).watchman
-      native = None
-      build_root = None
-      services = None
-      port_map = None
 
       if full_init:
         build_root = get_buildroot()
@@ -147,12 +143,16 @@ class PantsDaemon(FingerprintedProcessManager):
         legacy_graph_scheduler = EngineInitializer.setup_legacy_graph(native,
                                                                       bootstrap_options_values,
                                                                       build_config)
-        services, port_map = cls._setup_services(
+        services = cls._setup_services(
           build_root,
           bootstrap_options_values,
           legacy_graph_scheduler,
           watchman
         )
+      else:
+        build_root = None
+        native = None
+        services = PantsServices(tuple(), dict(), threading.RLock())
 
       return PantsDaemon(
         native=native,
@@ -160,7 +160,6 @@ class PantsDaemon(FingerprintedProcessManager):
         work_dir=bootstrap_options_values.pants_workdir,
         log_level=bootstrap_options_values.level.upper(),
         services=services,
-        socket_map=port_map,
         metadata_base_dir=bootstrap_options_values.pants_subprocessdir,
         bootstrap_options=bootstrap_options
       )
@@ -173,7 +172,7 @@ class PantsDaemon(FingerprintedProcessManager):
     def _setup_services(build_root, bootstrap_options, legacy_graph_scheduler, watchman):
       """Initialize pantsd services.
 
-      :returns: A tuple of (`tuple` service_instances, `dict` port_map).
+      :returns: A PantsServices instance.
       """
       fs_event_service = FSEventService(
         watchman,
@@ -207,20 +206,23 @@ class PantsDaemon(FingerprintedProcessManager):
 
       store_gc_service = StoreGCService(legacy_graph_scheduler.scheduler)
 
-      return (
+      return PantsServices(
         # Services.
         (fs_event_service, scheduler_service, pailgun_service, store_gc_service),
         # Port map.
-        dict(pailgun=pailgun_service.pailgun_port)
+        dict(pailgun=pailgun_service.pailgun_port),
+        # The lifecyle lock.
+        threading.RLock(),
       )
 
-  def __init__(self, native, build_root, work_dir, log_level, services, socket_map,
+  def __init__(self, native, build_root, work_dir, log_level, services,
                metadata_base_dir, bootstrap_options=None):
     """
     :param Native native: A `Native` instance.
     :param string build_root: The pants build root.
     :param string work_dir: The pants work directory.
     :param string log_level: The log level to use for daemon logging.
+    :param PantsServices services: A registry of services to use in this run.
     :param string metadata_base_dir: The ProcessManager metadata base dir.
     :param Options bootstrap_options: The bootstrap options, if available.
     """
@@ -230,14 +232,10 @@ class PantsDaemon(FingerprintedProcessManager):
     self._work_dir = work_dir
     self._log_level = log_level
     self._services = services
-    self._socket_map = socket_map
     self._bootstrap_options = bootstrap_options
 
     self._log_dir = os.path.join(work_dir, self.name)
     self._logger = logging.getLogger(__name__)
-    # A lock to guard the service thread lifecycles. This can be used by individual services
-    # to safeguard daemon-synchronous sections that should be protected from abrupt teardown.
-    self._lifecycle_lock = threading.RLock()
     # N.B. This Event is used as nothing more than a convenient atomic flag - nothing waits on it.
     self._kill_switch = threading.Event()
 
@@ -260,7 +258,7 @@ class PantsDaemon(FingerprintedProcessManager):
 
   def shutdown(self, service_thread_map):
     """Gracefully terminate all services and kill the main PantsDaemon loop."""
-    with self._lifecycle_lock:
+    with self._services.lifecycle_lock:
       for service, service_thread in service_thread_map.items():
         self._logger.info('terminating pantsd service: {}'.format(service))
         service.terminate()
@@ -309,11 +307,10 @@ class PantsDaemon(FingerprintedProcessManager):
       self._logger.debug('logging initialized')
       yield result.log_handler.stream
 
-  def _setup_services(self, services):
-    assert self._lifecycle_lock is not None, 'PantsDaemon lock has not been set!'
-    for service in services:
+  def _setup_services(self, pants_services):
+    for service in pants_services.services:
       self._logger.info('setting up service {}'.format(service))
-      service.setup(self._lifecycle_lock)
+      service.setup(self._services)
 
   @staticmethod
   def _make_thread(target):
@@ -321,13 +318,14 @@ class PantsDaemon(FingerprintedProcessManager):
     t.daemon = True
     return t
 
-  def _run_services(self, services):
+  def _run_services(self, pants_services):
     """Service runner main loop."""
-    if not services:
+    if not pants_services.services:
       self._logger.critical('no services to run, bailing!')
       return
 
-    service_thread_map = {service: self._make_thread(service.run) for service in services}
+    service_thread_map = {service: self._make_thread(service.run)
+                          for service in pants_services.services}
 
     # Start services.
     for service, service_thread in service_thread_map.items():
@@ -383,7 +381,7 @@ class PantsDaemon(FingerprintedProcessManager):
       set_process_title('pantsd [{}]'.format(self._build_root))
 
       # Write service socket information to .pids.
-      self._write_named_sockets(self._socket_map)
+      self._write_named_sockets(self._services.port_map)
 
       # Enter the main service runner loop.
       self._setup_services(self._services)
@@ -402,7 +400,7 @@ class PantsDaemon(FingerprintedProcessManager):
   def needs_launch(self):
     """Determines if pantsd needs to be launched.
 
-    N.B. This should always be called under care of `self.lifecycle_lock`.
+    N.B. This should always be called under care of the `lifecycle_lock`.
 
     :returns: True if the daemon needs launching, False otherwise.
     :rtype: bool
@@ -415,7 +413,7 @@ class PantsDaemon(FingerprintedProcessManager):
   def launch(self):
     """Launches pantsd in a subprocess.
 
-    N.B. This should always be called under care of `self.lifecycle_lock`.
+    N.B. This should always be called under care of the `lifecycle_lock`.
 
     :returns: A Handle for the pantsd instance.
     :rtype: PantsDaemon.Handle
@@ -434,7 +432,7 @@ class PantsDaemon(FingerprintedProcessManager):
   def terminate(self, include_watchman=True):
     """Terminates pantsd and watchman.
 
-    N.B. This should always be called under care of `self.lifecycle_lock`.
+    N.B. This should always be called under care of the `lifecycle_lock`.
     """
     super(PantsDaemon, self).terminate()
     if include_watchman:

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -463,7 +463,6 @@ class ProcessManager(ProcessMetadataManager):
       challenging. If no fork_context is passed, the fork function is called directly.
     """
 
-
     def double_fork():
       logger.debug('forking %s', self)
       pid = os.fork()

--- a/src/python/pants/pantsd/service/fs_event_service.py
+++ b/src/python/pants/pantsd/service/fs_event_service.py
@@ -115,7 +115,7 @@ class FSEventService(PantsService):
 
     # Setup subscriptions and begin the main event firing loop.
     for handler_name, event_data in self._watchman.subscribed(self._build_root, subscriptions):
-      if self.is_killed:
+      if self._state.is_terminating:
         break
 
       if event_data:

--- a/src/python/pants/pantsd/service/fs_event_service.py
+++ b/src/python/pants/pantsd/service/fs_event_service.py
@@ -115,6 +115,7 @@ class FSEventService(PantsService):
 
     # Setup subscriptions and begin the main event firing loop.
     for handler_name, event_data in self._watchman.subscribed(self._build_root, subscriptions):
+      self._state.maybe_pause()
       if self._state.is_terminating:
         break
 

--- a/src/python/pants/pantsd/service/pailgun_service.py
+++ b/src/python/pants/pantsd/service/pailgun_service.py
@@ -67,7 +67,7 @@ class PailgunService(PantsService):
 
     try:
       # Manually call handle_request() in a loop vs serve_forever() for interruptability.
-      while not self.is_killed:
+      while not self._state.is_terminating:
         self.pailgun.handle_request()
     except select.error as e:
       # SocketServer can throw `error: (9, 'Bad file descriptor')` on teardown. Ignore it.

--- a/src/python/pants/pantsd/service/pailgun_service.py
+++ b/src/python/pants/pantsd/service/pailgun_service.py
@@ -52,9 +52,11 @@ class PailgunService(PantsService):
       )
 
     # Plumb the daemon's lifecycle lock to the `PailgunServer` to safeguard teardown.
+    # This indirection exists to allow the server to be created before PantsService.setup
+    # has been called to actually initialize the `services` field.
     @contextmanager
     def lifecycle_lock():
-      with self.lifecycle_lock:
+      with self.services.lifecycle_lock:
         yield
 
     return PailgunServer(self._bind_addr, runner_factory, lifecycle_lock)

--- a/src/python/pants/pantsd/service/pants_service.py
+++ b/src/python/pants/pantsd/service/pants_service.py
@@ -140,7 +140,7 @@ class _ServiceState(object):
     If a timeout is specified, the method may return False to indicate a timeout: with no timeout
     it will always (eventually) return True.
 
-    Raises if the service is not currently in either the Pausing or Running state.
+    Raises if the service is not currently in the Pausing state.
     """
     deadline = time.time() + timeout if timeout else None
     with self._lock:
@@ -151,17 +151,17 @@ class _ServiceState(object):
         timeout = deadline - time.time() if deadline else None
         if timeout and timeout <= 0:
           return False
-        self._condition.wait(timeout)
+        self._condition.wait(timeout=timeout)
       return True
 
   def maybe_pause(self, timeout=None):
     """Called by the service to indicate that it is pausable.
 
     If the service calls this method while the state is `Pausing`, the state will transition
-    to `Paused`, and the service will block here until it is marked `Running` again.
+    to `Paused`, and the service will block here until it is marked `Running` or `Terminating`.
 
     If the state is not currently `Pausing`, and a timeout is not passed, this method returns
-    immediately. If a timeout is passed, this method block up to that number of seconds to wait
+    immediately. If a timeout is passed, this method blocks up to that number of seconds to wait
     to transition to `Pausing`.
     """
     deadline = time.time() + timeout if timeout else None

--- a/src/python/pants/pantsd/service/pants_service.py
+++ b/src/python/pants/pantsd/service/pants_service.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import threading
+import time
 from abc import abstractmethod
 
 from pants.util.meta import AbstractClass
@@ -25,26 +26,34 @@ class PantsServices(datatype([
 ])):
   """A registry of PantsServices instances"""
 
+  def __new__(cls, services=None, port_map=None, lifecycle_lock=None):
+    services = services or tuple()
+    port_map = port_map or dict()
+    lifecycle_lock = lifecycle_lock or threading.RLock()
+    return super(PantsServices, cls).__new__(cls, services, port_map, lifecycle_lock)
+
 
 class PantsService(AbstractClass):
-  """Pants daemon service base class."""
+  """Pants daemon service base class.
+
+  The service lifecycle is made up of states described in the _ServiceState class, and controlled
+  by a calling thread that is holding the Service `lifecycle_lock`. Under that lock, a caller
+  can signal a service to "pause", "run", or "terminate" (see _ServiceState for more details).
+
+  pantsd pauses all Services before forking a pantsd-runner in order to ensure that no "relevant"
+  locks are held (or awaited: see #6565) by threads that might not survive the fork. While paused,
+  a Service must not have any threads running that might interact with any non-private locks.
+
+  After forking, the pantsd-runner (child) process should call `terminate()` to finish shutting down
+  the service, and the parent process should call `resume()` to cause the service to resume running.
+  """
 
   class ServiceError(Exception): pass
 
   def __init__(self):
     super(PantsService, self).__init__()
     self.name = self.__class__.__name__
-    self._kill_switch = threading.Event()
-
-  @property
-  def is_killed(self):
-    """A `threading.Event`-checking property to facilitate graceful shutdown of services.
-
-    Subclasses should check this property for a True value in their core runtime. If True, the
-    service should teardown and gracefully exit. This represents a fatal/one-time event for the
-    service.
-    """
-    return self._kill_switch.is_set()
+    self._state = _ServiceState()
 
   def setup(self, services):
     """Called before `run` to allow for service->service or other side-effecting setup.
@@ -57,6 +66,146 @@ class PantsService(AbstractClass):
   def run(self):
     """The main entry-point for the service called by the service runner."""
 
+  def mark_pausing(self):
+    """Triggers pausing of the service, without waiting for it to have paused.
+
+    See the class and _ServiceState pydocs.
+    """
+    self._state.mark_pausing()
+
+  def await_paused(self):
+    """Once a service has been marked pausing, waits for it to have paused.
+
+    See the class and _ServiceState pydocs.
+    """
+    self._state.await_paused()
+
+  def resume(self):
+    """Triggers the service to resume running, without waiting.
+
+    See the class and _ServiceState pydocs.
+    """
+    self._state.mark_running()
+
   def terminate(self):
-    """Called upon service teardown."""
-    self._kill_switch.set()
+    """Triggers termination of the service, without waiting.
+
+    See the class and _ServiceState pydocs.
+    """
+    self._state.mark_terminating()
+
+
+class _ServiceState(object):
+  """A threadsafe state machine for controlling a service running in another thread.
+
+  The state machine represents two stable states:
+    Running
+    Paused
+  And two transitional states:
+    Pausing
+    Terminating
+
+  The methods of this class allow a caller to ask the Service to transition states, and then wait
+  for those transitions to occur.
+
+  A simplifying assumption is that there is one service thread that interacts with the state, and
+  only one controlling thread. In the case of `pantsd`, the "one calling thread" condition is
+  protected by the service `lifecycle_lock`.
+
+  A complicating assumption is that while a service thread is `Paused`, it must be in a position
+  where it could safely disappear and never come back. This is accounted for by having the service
+  thread wait on a Condition variable while Paused: testing indicates that for multiple Pythons
+  on both OSX and Linux, this does not result in poisoning of the associated Lock.
+  """
+  _RUNNING = 'Running'
+  _PAUSED = 'Paused'
+  _PAUSING = 'Pausing'
+  _TERMINATING = 'Terminating'
+
+  def __init__(self):
+    """Creates a ServiceState in the Running state."""
+    self._state = self._RUNNING
+    self._lock = threading.Lock()
+    self._condition = threading.Condition(self._lock)
+
+  def _set_state(self, state, *valid_states):
+    if valid_states and self._state not in valid_states:
+      raise AssertionError('Cannot move {} to `{}` while it is `{}`.'.format(self, state, self._state))
+    self._state = state
+    self._condition.notify_all()
+
+  def await_paused(self, timeout=None):
+    """Blocks until the service is in the Paused state, then returns True.
+
+    If a timeout is specified, the method may return False to indicate a timeout: with no timeout
+    it will always (eventually) return True.
+
+    Raises if the service is not currently in either the Pausing or Running state.
+    """
+    deadline = time.time() + timeout if timeout else None
+    with self._lock:
+      # Wait until the service transitions out of Pausing.
+      while self._state != self._PAUSED:
+        if self._state != self._PAUSING:
+          raise AssertionError('Cannot wait for {} to reach `{}` while it is in `{}`.'.format(self, self._PAUSED, self._state))
+        timeout = deadline - time.time() if deadline else None
+        if timeout and timeout <= 0:
+          return False
+        self._condition.wait(timeout)
+      return True
+
+  def maybe_pause(self, timeout=None):
+    """Called by the service to indicate that it is pausable.
+
+    If the service calls this method while the state is `Pausing`, the state will transition
+    to `Paused`, and the service will block here until it is marked `Running` again.
+
+    If the state is not currently `Pausing`, and a timeout is not passed, this method returns
+    immediately. If a timeout is passed, this method block up to that number of seconds to wait
+    to transition to `Pausing`.
+    """
+    deadline = time.time() + timeout if timeout else None
+    with self._lock:
+      while self._state != self._PAUSING:
+        # If we've been terminated, or the deadline has passed, return.
+        timeout = deadline - time.time() if deadline else None
+        if self._state == self._TERMINATING or not timeout or timeout <= 0:
+          return
+        # Otherwise, wait for the state to change.
+        self._condition.wait(timeout=timeout)
+
+      # Set Paused, and then wait until we are no longer Paused.
+      self._set_state(self._PAUSED, self._PAUSING)
+      while self._state == self._PAUSED:
+        self._condition.wait()
+
+  def mark_pausing(self):
+    """Requests that the service move to the Paused state, without waiting for it to do so.
+
+    Raises if the service is not currently in the Running state.
+    """
+    with self._lock:
+      self._set_state(self._PAUSING, self._RUNNING)
+
+  def mark_running(self):
+    """Moves the service to the Running state.
+
+    Raises if the service is not currently in the Paused state.
+    """
+    with self._lock:
+      self._set_state(self._RUNNING, self._PAUSED)
+
+  def mark_terminating(self):
+    """Requests that the service move to the Terminating state, without waiting for it to do so."""
+    with self._lock:
+      self._set_state(self._TERMINATING)
+
+  @property
+  def is_terminating(self):
+    """Returns True if the Service should currently be terminating.
+
+    NB: `Terminating` does not have an associated "terminated" state, because the caller uses
+    liveness of the service thread to determine when a service is terminated.
+    """
+    with self._lock:
+      return self._state == self._TERMINATING

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -64,9 +64,9 @@ class SchedulerService(PantsService):
   def _combined_invalidating_fileset_from_globs(glob_strs, root):
     return set.union(*(Fileset.globs(glob_str, root=root)() for glob_str in glob_strs))
 
-  def setup(self, lifecycle_lock):
+  def setup(self, services):
     """Service setup."""
-    super(SchedulerService, self).setup(lifecycle_lock)
+    super(SchedulerService, self).setup(services)
     # Register filesystem event handlers on an FSEventService instance.
     self._fs_event_service.register_all_files_handler(self._enqueue_fs_event)
 

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -128,7 +128,7 @@ class SchedulerService(PantsService):
   def _process_event_queue(self):
     """File event notification queue processor."""
     try:
-      event = self._event_queue.get(timeout=1)
+      event = self._event_queue.get(timeout=0.05)
     except queue.Empty:
       return
 
@@ -222,6 +222,7 @@ class SchedulerService(PantsService):
     """Main service entrypoint."""
     while not self._state.is_terminating:
       self._process_event_queue()
+      self._state.maybe_pause()
 
 
 class LoopCondition(object):

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -184,7 +184,7 @@ class SchedulerService(PantsService):
     # TODO: See https://github.com/pantsbuild/pants/issues/6288 regarding Ctrl+C handling.
     iterations = options.for_global_scope().loop_max
     target_roots = None
-    while iterations and not self.is_killed:
+    while iterations and not self._state.is_terminating:
       try:
         target_roots = self._prefork_body(session, options)
       except session.scheduler_session.execution_error_type as e:
@@ -192,7 +192,7 @@ class SchedulerService(PantsService):
         print(e, file=sys.stderr)
 
       iterations -= 1
-      while iterations and not self.is_killed and not self._loop_condition.wait(timeout=1):
+      while iterations and not self._state.is_terminating and not self._loop_condition.wait(timeout=1):
         continue
     return target_roots
 
@@ -220,7 +220,7 @@ class SchedulerService(PantsService):
 
   def run(self):
     """Main service entrypoint."""
-    while not self.is_killed:
+    while not self._state.is_terminating:
       self._process_event_queue()
 
 

--- a/src/python/pants/pantsd/service/store_gc_service.py
+++ b/src/python/pants/pantsd/service/store_gc_service.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-import threading
 import time
 
 from pants.pantsd.service.pants_service import PantsService
@@ -26,37 +25,38 @@ class StoreGCService(PantsService):
     self._scheduler = scheduler
     self._logger = logging.getLogger(__name__)
 
-  @staticmethod
-  def _launch_thread(f):
-    t = threading.Thread(target=f)
-    t.daemon = True
-    t.start()
-    return t
+    self._set_next_gc()
+    self._set_next_lease_extension()
 
-  def _extend_lease(self):
-    while 1:
-      self._logger.debug('Extending leases')
-      self._scheduler.lease_files_in_graph()
-      self._logger.debug('Done extending leases')
-      time.sleep(self._LEASE_EXTENSION_INTERVAL_SECONDS)
+  def _set_next_gc(self):
+    self._next_gc = time.time() + self._GARBAGE_COLLECTION_INTERVAL_SECONDS
 
-  def _garbage_collect(self):
-    while 1:
-      time.sleep(self._GARBAGE_COLLECTION_INTERVAL_SECONDS)
-      self._logger.debug('Garbage collecting store')
-      self._scheduler.garbage_collect_store()
-      self._logger.debug('Done garbage collecting store')
+  def _set_next_lease_extension(self):
+    self._next_lease_extension = time.time() + self._GARBAGE_COLLECTION_INTERVAL_SECONDS
+
+  def _maybe_extend_lease(self):
+    if time.time() < self._next_lease_extension:
+      return
+    self._logger.debug('Extending leases')
+    self._scheduler.lease_files_in_graph()
+    self._logger.debug('Done extending leases')
+    self._set_next_lease_extension()
+
+  def _maybe_garbage_collect(self):
+    if time.time() < self._next_gc:
+      return
+    self._logger.debug('Garbage collecting store')
+    self._scheduler.garbage_collect_store()
+    self._logger.debug('Done garbage collecting store')
+    self._set_next_gc()
 
   def run(self):
     """Main service entrypoint. Called via Thread.start() via PantsDaemon.run()."""
-    jobs = (self._extend_lease, self._garbage_collect)
-    threads = [self._launch_thread(job) for job in jobs]
-
     while not self._state.is_terminating:
-      for thread in threads:
-        # If any job threads die, we want to exit the `PantsService` thread to cause
-        # a daemon teardown.
-        if not thread.isAlive():
-          self._logger.warn('thread {} died - aborting!'.format(thread))
-          return
-        thread.join(.1)
+      self._maybe_garbage_collect()
+      self._maybe_extend_lease()
+      # Waiting with a timeout in maybe_pause has the effect of waiting until:
+      # 1) we are paused and then resumed
+      # 2) we are terminated (which will break the loop)
+      # 3) the timeout is reached, which will cause us to wake up and check gc/leases
+      self._state.maybe_pause(timeout=10)

--- a/src/python/pants/pantsd/service/store_gc_service.py
+++ b/src/python/pants/pantsd/service/store_gc_service.py
@@ -52,7 +52,7 @@ class StoreGCService(PantsService):
     jobs = (self._extend_lease, self._garbage_collect)
     threads = [self._launch_thread(job) for job in jobs]
 
-    while not self.is_killed:
+    while not self._state.is_terminating:
       for thread in threads:
         # If any job threads die, we want to exit the `PantsService` thread to cause
         # a daemon teardown.

--- a/src/python/pants/pantsd/service/store_gc_service.py
+++ b/src/python/pants/pantsd/service/store_gc_service.py
@@ -32,7 +32,7 @@ class StoreGCService(PantsService):
     self._next_gc = time.time() + self._GARBAGE_COLLECTION_INTERVAL_SECONDS
 
   def _set_next_lease_extension(self):
-    self._next_lease_extension = time.time() + self._GARBAGE_COLLECTION_INTERVAL_SECONDS
+    self._next_lease_extension = time.time() + self._LEASE_EXTENSION_INTERVAL_SECONDS
 
   def _maybe_extend_lease(self):
     if time.time() < self._next_lease_extension:

--- a/src/python/pants/pantsd/watchman.py
+++ b/src/python/pants/pantsd/watchman.py
@@ -24,7 +24,7 @@ class Watchman(ProcessManager):
     """Raised when Watchman crashes."""
 
   STARTUP_TIMEOUT_SECONDS = 30.0
-  SOCKET_TIMEOUT_SECONDS = 5.0
+  SOCKET_TIMEOUT_SECONDS = 0.1
 
   EventHandler = namedtuple('EventHandler', ['name', 'metadata', 'callback'])
 

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -57,6 +57,7 @@ python_tests(
   coverage = ['pants.pantsd.pants_daemon'],
   dependencies = [
     ':test_deps',
+    'src/python/pants/bin',
     'src/python/pants/pantsd:pants_daemon',
     'src/python/pants/pantsd/service:pants_service',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -7,14 +7,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import functools
 import os
 import time
-from builtins import open
 from contextlib import contextmanager
 
 from colors import bold, cyan, magenta
 
 from pants.pantsd.process_manager import ProcessManager
 from pants.util.collections import recursively_update
-from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest, read_pantsd_log
 from pants_test.testutils.process_test_util import no_lingering_process_by_command
 
 
@@ -22,17 +21,6 @@ def banner(s):
   print(cyan('=' * 63))
   print(cyan('- {} {}'.format(s, '-' * (60 - len(s)))))
   print(cyan('=' * 63))
-
-
-def read_pantsd_log(workdir):
-  # Surface the pantsd log for easy viewing via pytest's `-s` (don't capture stdio) option.
-  with open('{}/pantsd/pantsd.log'.format(workdir), 'r') as f:
-    for line in f:
-      yield line.strip()
-
-
-def full_pantsd_log(workdir):
-  return '\n'.join(read_pantsd_log(workdir))
 
 
 class PantsDaemonMonitor(ProcessManager):

--- a/tests/python/pants_test/pantsd/service/test_pants_service.py
+++ b/tests/python/pants_test/pantsd/service/test_pants_service.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import threading
+
 from pants.pantsd.service.pants_service import PantsService
 from pants_test.test_base import TestBase
 
@@ -26,4 +28,28 @@ class TestPantsService(TestBase):
 
   def test_terminate(self):
     self.service.terminate()
-    assert self.service.is_killed
+    assert self.service._state.is_terminating
+
+  def test_maybe_pause(self):
+    # Confirm that maybe_pause with/without a timeout does not deadlock when we are not
+    # marked Pausing/Paused.
+    self.service._state.maybe_pause(timeout=None)
+    self.service._state.maybe_pause(timeout=0.5)
+
+  def test_pause_and_resume(self):
+    self.service.mark_pausing()
+    # Confirm that we don't transition to Paused without a service thread to maybe_pause.
+    self.assertFalse(self.service._state.await_paused(timeout=0.5))
+    # Spawn a thread to call maybe_pause.
+    t = threading.Thread(target=self.service._state.maybe_pause)
+    t.daemon = True
+    t.start()
+    # Confirm that we observe the pause from the main thread, and that the child thread pauses
+    # there without exiting.
+    self.assertTrue(self.service._state.await_paused(timeout=5))
+    t.join(timeout=0.5)
+    self.assertTrue(t.isAlive())
+    # Resume the service, and confirm that the child thread exits.
+    self.service.resume()
+    t.join(timeout=5)
+    self.assertFalse(t.isAlive())

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -14,8 +14,8 @@ from builtins import open, range, zip
 
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, touch
-from pants_test.pantsd.pantsd_integration_test_base import (PantsDaemonIntegrationTestBase,
-                                                            full_pantsd_log, read_pantsd_log)
+from pants_test.pants_run_integration_test import read_pantsd_log
+from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 from pants_test.testutils.process_test_util import no_lingering_process_by_command
 
 
@@ -291,9 +291,12 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
       # Let any fs events quiesce.
       time.sleep(5)
 
+      def full_pantsd_log():
+        return '\n'.join(read_pantsd_log(workdir))
+
       # Check the logs.
       self.assertRegexpMatches(
-        full_pantsd_log(workdir),
+        full_pantsd_log(),
         r'watching invalidating files:.*{}'.format(test_file)
       )
 
@@ -303,7 +306,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
       time.sleep(10)
       checker.assert_stopped()
 
-      self.assertIn('saw file events covered by invalidation globs', full_pantsd_log(workdir))
+      self.assertIn('saw file events covered by invalidation globs', full_pantsd_log())
 
   def test_pantsd_pid_deleted(self):
     with self.pantsd_successful_run_context() as (pantsd_run, checker, workdir, config):

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -21,6 +21,9 @@ from pants_test.testutils.process_test_util import no_lingering_process_by_comma
 
 def launch_file_toucher(f):
   """Launch a loop to touch the given file, and return a function to call to stop and join it."""
+  if not os.path.isfile(f):
+    raise AssertionError('Refusing to touch a non-file.')
+
   halt = threading.Event()
   def file_toucher():
     while not halt.isSet():
@@ -227,10 +230,10 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
       checker.assert_started()
 
       # Launch a separate thread to poke files in 3rdparty.
-      join = launch_file_toucher('3rdparty/BUILD')
+      join = launch_file_toucher('3rdparty/jvm/com/google/auto/value/BUILD')
 
       # Repeatedly re-list 3rdparty while the file is being invalidated.
-      for _ in range(0, 8):
+      for _ in range(0, 16):
         pantsd_run(cmd)
         checker.assert_running()
 


### PR DESCRIPTION
### Problem

As described in #6565, I had a fundamental misunderstanding of what was legal during a fork, which resulted in intermittent hangs when a `PantsService` thread (usually `FSEventService`, but potentially the `StoreGCService` threads as well) were blocked on locks while attempting to acquire resources pre-fork.

As mentioned on the ticket, the `fork_lock` used to act as a honeypot to block any threads that might be attempting to interact with the Engine. This mostly had the right effect, but it was possible to forget to wrap some other lock access in the fork lock (because, in effect, _all_ shared lock access needed to be protected by the `fork_lock`). But also, after the fork the `fork_lock` would be poisoned. This represented a challenging line to walk, where we needed to protect all shared locks, but we also needed to avoid that protection post fork in order to avoid deadlock.

### Solution

Rather than using a lock to approximate all of the other locks, instead ensure that all Service threads that might interact with any non-private locks are "paused" in well-known locations ("safe points"?) while we fork. Since we would like to have more and more-fine-grained locks over time, while keeping the number of un-pooled threads relatively constrained, adding this bookkeeping to service threads seems like the right tradeoff.

While we continue to move toward a world (via `--v2` and `@console_rule`) where forking is not necessary, we'd also like to be able to incrementally gain benefit from the daemon by porting portions of `--v1` pipelines pre-fork.

### Result

Fixes #6565 and fixes #6621.