### PR TITLE
Re-add used-but-removed futures dep

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -9,6 +9,7 @@ fasteners==0.14.1
 faulthandler==2.6 ; python_version<'3'
 fire==0.1.3
 future==0.16.0
+futures==3.0.5 ; python_version<'3'
 Markdown==2.1.1
 mock==2.0.0
 packaging==16.8


### PR DESCRIPTION
Re-add used-but-removed futures dep, which (due to a PR race) had a new usage added in 01c807ef, but its declaration removed in faeaf078.