### PR TITLE
Move ivy/coursier link farms under versioned task directories

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -41,7 +41,7 @@ class IvyResolutionStep(object):
   # It also specifies the abstract methods that define the components of resolution steps.
 
   def __init__(self, confs, hash_name, pinned_artifacts, soft_excludes, ivy_resolution_cache_dir,
-               ivy_repository_cache_dir, global_ivy_workdir):
+               ivy_repository_cache_dir, ivy_workdir):
     """
     :param confs: A tuple of string ivy confs to resolve for.
     :param hash_name: A unique string name for this resolve.
@@ -50,7 +50,7 @@ class IvyResolutionStep(object):
                           fact.
     :param ivy_repository_cache_dir: The cache directory used by Ivy for repository cache data.
     :param ivy_resolution_cache_dir: The cache directory used by Ivy for resolution cache data.
-    :param global_ivy_workdir: The workdir that all ivy outputs live in.
+    :param ivy_workdir: A task-specific workdir that all ivy outputs live in.
     """
 
     self.confs = confs
@@ -60,7 +60,7 @@ class IvyResolutionStep(object):
 
     self.ivy_repository_cache_dir = ivy_repository_cache_dir
     self.ivy_resolution_cache_dir = ivy_resolution_cache_dir
-    self.global_ivy_workdir = global_ivy_workdir
+    self.ivy_workdir = ivy_workdir
 
     self.workdir_reports_by_conf = {c: self.resolve_report_path(c) for c in confs}
 
@@ -83,7 +83,7 @@ class IvyResolutionStep(object):
 
   @property
   def workdir(self):
-    return os.path.join(self.global_ivy_workdir, self.hash_name)
+    return os.path.join(self.ivy_workdir, self.hash_name)
 
   @property
   def hardlink_classpath_filename(self):
@@ -99,7 +99,7 @@ class IvyResolutionStep(object):
 
   @property
   def hardlink_dir(self):
-    return os.path.join(self.global_ivy_workdir, 'jars')
+    return os.path.join(self.ivy_workdir, 'jars')
 
   @abstractmethod
   def ivy_xml_path(self):
@@ -174,7 +174,7 @@ class IvyFetchStep(IvyResolutionStep):
 
     if not result.all_linked_artifacts_exist():
       raise IvyResolveMappingError(
-        'Some artifacts were not linked to {} for {}'.format(self.global_ivy_workdir,
+        'Some artifacts were not linked to {} for {}'.format(self.ivy_workdir,
                                                              result))
     return result
 
@@ -240,7 +240,7 @@ class IvyResolveStep(IvyResolutionStep):
 
     if not result.all_linked_artifacts_exist():
       raise IvyResolveMappingError(
-        'Some artifacts were not linked to {} for {}'.format(self.global_ivy_workdir,
+        'Some artifacts were not linked to {} for {}'.format(self.ivy_workdir,
                                                              result))
 
     frozen_resolutions_by_conf = result.get_frozen_resolutions_by_conf(targets)

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -101,7 +101,7 @@ class IvyTaskMixin(JvmResolverBase):
 
   @classmethod
   def implementation_version(cls):
-    return super(IvyTaskMixin, cls).implementation_version() + [('IvyTaskMixin', 4)]
+    return super(IvyTaskMixin, cls).implementation_version() + [('IvyTaskMixin', 5)]
 
   @memoized_property
   def ivy_repository_cache_dir(self):
@@ -230,8 +230,9 @@ class IvyTaskMixin(JvmResolverBase):
       resolve_vts = VersionedTargetSet.from_versioned_targets(invalidation_check.all_vts)
 
       resolve_hash_name = resolve_vts.cache_key.hash
-      global_ivy_workdir = os.path.join(self.context.options.for_global_scope().pants_workdir,
-                                        'ivy')
+      # NB: This used to be a global directory, but is now specific to each task that includes
+      # this mixin.
+      ivy_workdir = os.path.join(self.versioned_workdir, 'ivy')
       targets = resolve_vts.targets
 
       fetch = IvyFetchStep(confs,
@@ -240,14 +241,14 @@ class IvyTaskMixin(JvmResolverBase):
                            self.get_options().soft_excludes,
                            self.ivy_resolution_cache_dir,
                            self.ivy_repository_cache_dir,
-                           global_ivy_workdir)
+                           ivy_workdir)
       resolve = IvyResolveStep(confs,
                                resolve_hash_name,
                                pinned_artifacts,
                                self.get_options().soft_excludes,
                                self.ivy_resolution_cache_dir,
                                self.ivy_repository_cache_dir,
-                               global_ivy_workdir)
+                               ivy_workdir)
 
       return self._perform_resolution(fetch, resolve, executor, extra_args, invalidation_check,
                                       resolve_vts, targets, workunit_name)

--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -272,14 +272,13 @@ class InvalidationCacheManager(object):
                fingerprint_strategy=None,
                invalidation_report=None,
                task_name=None,
-               task_version=None,
+               task_version_slug=None,
                artifact_write_callback=lambda _: None):
     """
     :API: public
     """
     self._cache_key_generator = cache_key_generator
     self._task_name = task_name or 'UNKNOWN'
-    self._task_version = task_version or 'Unknown_0'
     self._invalidate_dependents = invalidate_dependents
     self._invalidator = build_invalidator
     self._fingerprint_strategy = fingerprint_strategy
@@ -288,9 +287,7 @@ class InvalidationCacheManager(object):
 
     # Create the task-versioned prefix of the results dir, and a stable symlink to it
     # (useful when debugging).
-    task_version_sha = sha1(self._task_version.encode('utf-8')).hexdigest()[:12]
-    self._results_dir_prefix = os.path.join(results_dir_root,
-                                            task_version_sha)
+    self._results_dir_prefix = os.path.join(results_dir_root, task_version_slug)
     safe_mkdir(self._results_dir_prefix)
     stable_prefix = os.path.join(results_dir_root, self._STABLE_DIR_NAME)
     safe_delete(stable_prefix)

--- a/testprojects/src/java/org/pantsbuild/testproject/deployexcludes/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/deployexcludes/BUILD
@@ -1,17 +1,22 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(
-  main='org.pantsbuild.testproject.deployexcludes.DeployExcludesMain',
-  dependencies=[
-    ':lib',
-  ],
-  deploy_excludes=[
-    exclude(org='com.google.guava', name='guava'),
-  ],
-)
+def jvm_excludes_binary(name, excludes=True):
+  deploy_excludes = [exclude(org='com.google.guava', name='guava')] if excludes else []
+  jvm_binary(
+    name=name,
+    main='org.pantsbuild.testproject.deployexcludes.DeployExcludesMain',
+    dependencies=[
+      ':lib',
+    ],
+    deploy_excludes=deploy_excludes,
+  )
 
-java_library(name='lib',
+jvm_excludes_binary('deployexcludes', excludes=True)
+jvm_excludes_binary('nodeployexcludes', excludes=False)
+
+java_library(
+  name='lib',
   sources=['DeployExcludesMain.java'],
   dependencies=[
     '3rdparty:guava',

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -320,6 +320,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
+  timeout = 120,
   tags = {'integration'},
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -80,6 +80,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:int-test',
   ],
+  timeout=180,
   tags = {'integration'},
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
@@ -115,7 +115,7 @@ class RscCompileTest(TaskTestBase):
 
   def test_desandbox_fn(self):
     # TODO remove this after https://github.com/scalameta/scalameta/issues/1791 is released
-    desandbox = _create_desandboxify_fn(['.pants.d/cool/beans', '.pants.d/c/r/c'])
+    desandbox = _create_desandboxify_fn(['.pants.d/cool/beans.*', '.pants.d/c/r/c/.*'])
     self.assertEqual(desandbox('/some/path/.pants.d/cool/beans'), '.pants.d/cool/beans')
     self.assertEqual(desandbox('/some/path/.pants.d/c/r/c/beans'), '.pants.d/c/r/c/beans')
     self.assertEqual(desandbox(

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import glob
 import os
 from builtins import open
 from contextlib import contextmanager
@@ -302,11 +303,7 @@ class IvyResolveTest(JvmToolTaskTestBase):
       self.resolve([junit_jar_lib])
 
       # Find the resolution work dir.
-      ivy_workdir = os.path.join(workdir, 'ivy')
-      ivy_subdirs = os.listdir(ivy_workdir)
-      ivy_subdirs.remove('jars')
-      self.assertEqual(1, len(ivy_subdirs))
-      resolve_workdir = os.path.join(ivy_workdir, ivy_subdirs[0])
+      resolve_workdir = self._find_resolve_workdir(workdir)
 
       # Remove a required file for a simple load to force a fetch.
       resolve_report = os.path.join(resolve_workdir, 'resolve-report-default.xml')
@@ -417,7 +414,8 @@ class IvyResolveTest(JvmToolTaskTestBase):
     return junit_jar_lib
 
   def _find_resolve_workdir(self, workdir):
-    ivy_dir = os.path.join(workdir, 'ivy')
+    # NB: Skip one component for the workdir version suffix.
+    ivy_dir = glob.glob(os.path.join(workdir, '[a-f0-9]*/ivy'))[0]
     ivy_dir_subdirs = os.listdir(ivy_dir)
     ivy_dir_subdirs.remove('jars')  # Ignore the jars directory.
     self.assertEqual(1, len(ivy_dir_subdirs), 'There should only be the resolve directory.')

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve_integration.py
@@ -192,9 +192,7 @@ class IvyResolveIntegrationTest(PantsRunIntegrationTest):
     return html_report_file, listdir
 
   def _find_resolve_workdir(self, workdir):
-    # Finds the first resolve workdir that contains a resolution.json.
-    # Otherwise fails
-    ivy_dir = os.path.join(workdir, 'ivy')
+    ivy_dir = os.path.join(workdir, 'export/export/current/ivy')
     listdir = os.listdir(ivy_dir)
     listdir.remove('jars')
     for dir in listdir:

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
@@ -612,7 +612,7 @@ class IvyUtilsResolveStepsTest(TestBase):
                          None,
                          'ivy_resolution_cache_dir',
                          'ivy_repository_cache_dir',
-                         'global_ivy_workdir')
+                         'ivy_workdir')
 
     # Stub resolving and creating the result, returning one missing artifacts.
     fetch._do_fetch = do_nothing

--- a/tests/python/pants_test/invalidation/test_cache_manager.py
+++ b/tests/python/pants_test/invalidation/test_cache_manager.py
@@ -39,6 +39,7 @@ class InvalidationCacheManagerTest(TestBase):
       cache_key_generator=CacheKeyGenerator(),
       build_invalidator=BuildInvalidator(os.path.join(self._dir, 'build_invalidator')),
       invalidate_dependents=True,
+      task_version_slug='deadbeef',
     )
 
   def tearDown(self):

--- a/tests/python/pants_test/task/test_task.py
+++ b/tests/python/pants_test/task/test_task.py
@@ -346,16 +346,18 @@ files(
     one = '1\n'
     two = '2\n'
 
+    def vt_for_implementation_version(version, content):
+      DummyTask._implementation_version = version
+      DummyTask.implementation_version_slug.clear()
+      self._create_clean_file(content)
+      task = self._task(incremental=True)
+      vt, _ = task.execute()
+      self.assertContent(vt, content)
+      return vt
+
     # Run twice, with a different implementation version the second time.
-    DummyTask._implementation_version = 0
-    self._create_clean_file(one)
-    task = self._task(incremental=True)
-    vtA, _ = task.execute()
-    self.assertContent(vtA, one)
-    DummyTask._implementation_version = 1
-    self._create_clean_file(two)
-    task = self._task(incremental=True)
-    vtB, _ = task.execute()
+    vtA = vt_for_implementation_version(0, one)
+    vtB = vt_for_implementation_version(1, two)
 
     # No incrementalism.
     self.assertFalse(vtA.is_incremental)


### PR DESCRIPTION
### Problem

As described in #6679, the ivy and coursier link farms are not versioned along with the tasks that consume them. This had the effect of breaking backwards compatibility when those links converted from being symlinks to hardlinks in #6246.

### Solution

Move the "task versioned workdir" logic from `CacheManager` to `Task`, to allow it to be used in more places, and then use it for both `IvyTaskMixin` and `CoursierResolve`.

### Result

Rather than having a "global" link farm at `.pants.d/{ivy,coursier}`, the installed instances of tasks extending `IvyTaskMixin` or `CoursierResolve` will each have their own independent, versioned link farms.

Fixes #6679.