### PR TITLE
Narrow the scope of test_v2_list to a well-known static set of targets

### DIFF
--- a/tests/python/pants_test/engine/legacy/test_console_rule_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_console_rule_integration.py
@@ -16,25 +16,19 @@ from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegratio
 
 class TestConsoleRuleIntegration(PantsDaemonIntegrationTestBase):
 
-  maxDiff = None
+  def test_v2_list_is_identical_to_v1(self):
+    def run_list(extra_flags=[]):
+      with self.pantsd_successful_run_context() as (runner, checker, workdir, pantsd_config):
+        print(workdir)
+        command = extra_flags + ['list', '3rdparty/::']
+        res = runner(command)
+        checker.assert_running()
+        return res
 
-  def test_v2_list(self):
-    with self.pantsd_successful_run_context() as (runner, checker, workdir, pantsd_config):
-      v1_command = ['list',
-                    '::']
+    v1_res = run_list()
+    v2_res = run_list(['--v2', '--no-v1'])
 
-      v1_res = runner(v1_command)
-      checker.assert_started()
-
-      v2_command = ['--no-v1',
-        '--v2',
-        'list',
-        '::']
-
-      v2_res = runner(v2_command)
-      checker.assert_started()
-
-      self.assertEqual(sorted(v1_res.stdout_data.splitlines()), sorted(v2_res.stdout_data.splitlines()))
+    self.assertEqual(sorted(v1_res.stdout_data.splitlines()), sorted(v2_res.stdout_data.splitlines()))
 
   def test_v2_list_does_not_cache(self):
     with self.pantsd_successful_run_context() as (runner, checker, workdir, pantsd_config):


### PR DESCRIPTION
### Problem

As described in #6687, `test_v2_list` is now flaky. This is due to the way pants invocations are done, in a temporary workdir whose contents might change from one run to the other.

### Solution

The solution is to narrow down the scope of the tests to a well-known, unlikely to change set of targets (`3rdparty` in this case).

### Result

Hopefully that test should be deterministically successful now. This fixes #6687 