### PR TITLE
Bump to jarjar 1.7.2 to pull in several fixes.

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/shader.py
+++ b/src/python/pants/backend/jvm/subsystems/shader.py
@@ -246,7 +246,7 @@ class Shader(object):
       cls.register_jvm_tool(register,
                             'jarjar',
                             classpath=[
-                              JarDependency(org='org.pantsbuild', name='jarjar', rev='1.6.5')
+                              JarDependency(org='org.pantsbuild', name='jarjar', rev='1.7.2')
                             ])
 
     @classmethod


### PR DESCRIPTION
Support java 10 & 11 classfiles via updates to asm as well as
transformation of lambda deserialization bytecode amongst other
newerJava support improvements.