### PR TITLE
Python3 unit test fixes pt1

### DIFF
--- a/build-support/known_py3_failures.txt
+++ b/build-support/known_py3_failures.txt
@@ -1,7 +1,2 @@
-tests/python/pants_test/backend/codegen/thrift/python:python
 tests/python/pants_test/backend/jvm/tasks:jar_publish
-tests/python/pants_test/backend/jvm/tasks:junit_run
-tests/python/pants_test/backend/python/tasks:tasks
-tests/python/pants_test/build_graph:build_graph
-tests/python/pants_test/goal:other
 tests/python/pants_test/pantsd:process_manager

--- a/src/python/pants/build_graph/build_graph.py
+++ b/src/python/pants/build_graph/build_graph.py
@@ -127,7 +127,7 @@ class BuildGraph(AbstractClass):
     """
     self._target_by_address = OrderedDict()
     self._target_dependencies_by_address = defaultdict(OrderedSet)
-    self._target_dependees_by_address = defaultdict(set)
+    self._target_dependees_by_address = defaultdict(OrderedSet)
     self._derived_from_by_derivative = {}  # Address -> Address.
     self._derivatives_by_derived_from = defaultdict(list)   # Address -> list of Address.
     self.synthetic_addresses = set()

--- a/tests/python/pants_test/backend/python/tasks/test_resolve_requirements.py
+++ b/tests/python/pants_test/backend/python/tasks/test_resolve_requirements.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+import re
 from builtins import str
 
 from future.utils import PY3
@@ -40,7 +41,8 @@ class ResolveRequirementsTest(TaskTestBase):
       self.assertIn("ModuleNotFoundError: No module named 'colors'", stderr_data)
     except AssertionError:
       # < Python 3.6 uses ImportError instead of ModuleNotFoundError.
-      self.assertIn("ImportError: No module named 'colors'", stderr_data)
+      # Python < 3 uses not quotes for module, python >= 3 does.
+      self.assertNotEqual(re.search(r"ImportError: No module named '?colors'?", stderr_data), None)
 
     # Check that the module is available if specified as a requirement.
     stdout_data, stderr_data = self._exercise_module(self._resolve_requirements([ansicolors_tgt]),

--- a/tests/python/pants_test/backend/python/tasks/test_resolve_requirements.py
+++ b/tests/python/pants_test/backend/python/tasks/test_resolve_requirements.py
@@ -88,9 +88,9 @@ class ResolveRequirementsTest(TaskTestBase):
       # This is technically also true for the hard-coded platforms we list below, but we chose
       # those and we happen to know that cffi wheels exist for them.  Whereas we have no such
       # advance knowledge for the current platform, whatever that might be in the future.
-      ('cffi-1.9.1', 'macosx_10_10_x86_64'),
-      ('cffi-1.9.1', 'manylinux1_i686'),
-      ('cffi-1.9.1', 'win_amd64'),
+      'macosx',
+      'manylinux1_i686',
+      'win_amd64',
     }
 
     # pycparser is a dependency of cffi only on CPython.  We might as well check for it,
@@ -107,9 +107,15 @@ class ResolveRequirementsTest(TaskTestBase):
         'could not find pycparser in transitive dependencies!'
       )
 
-    self.assertTrue(expected_name_and_platforms.issubset(names_and_platforms),
-                    '{} is not a subset of {}'.format(expected_name_and_platforms,
-                                                      names_and_platforms))
+    for name, platform in names_and_platforms:
+      if 'macosx' in platform:
+        platform = 'macosx'
+
+      expected_name_and_platforms.discard(platform)
+
+    self.assertEqual(len(expected_name_and_platforms), 0, "Found no wheels for {} in {}".format(
+      expected_name_and_platforms, names_and_platforms
+    ))
 
     # Check that the path is under the test's build root, so we know the pex was created there.
     self.assertTrue(path.startswith(os.path.realpath(get_buildroot())))

--- a/tests/python/pants_test/backend/python/tasks/test_resolve_requirements.py
+++ b/tests/python/pants_test/backend/python/tasks/test_resolve_requirements.py
@@ -40,7 +40,7 @@ class ResolveRequirementsTest(TaskTestBase):
       self.assertIn("ModuleNotFoundError: No module named 'colors'", stderr_data)
     except AssertionError:
       # < Python 3.6 uses ImportError instead of ModuleNotFoundError.
-      self.assertIn('ImportError: No module named colors', stderr_data)
+      self.assertIn("ImportError: No module named 'colors'", stderr_data)
 
     # Check that the module is available if specified as a requirement.
     stdout_data, stderr_data = self._exercise_module(self._resolve_requirements([ansicolors_tgt]),

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -37,6 +37,7 @@ class RunTrackerTest(TestBase):
             decoded_post_data = {k: json.loads(v[0]) for k, v in post_data.items()}
             self.assertEqual(stats, decoded_post_data)
             handler.send_response(200)
+            handler.end_headers()
         except Exception:
           handler.send_response(400)  # Ensure the main thread knows the test failed.
           raise


### PR DESCRIPTION
### Problem
We have a couple unit tests that fail when run against python 3.

### Solution
Fix tests.

### Result
This PR contains fixes for 4 tests: 
```
- test_resolve_multiplatform_requirements
- test_resolve_simple_requirements
- test_walk_graph
- test_upload_stats
```

More tests where fixed by earlier work, but not uncovered because of blacklist.

(this is a cleaned up version of the work @ https://github.com/pantsbuild/pants/pull/6682)