### PR TITLE
Fixup `Checkstyle` for local resolves.

### DIFF
--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
@@ -5,6 +5,7 @@ python_tests(
   dependencies=[
     '3rdparty/python:future',
     '3rdparty/python:parameterized',
+    '3rdparty/python:pex',
     '3rdparty/python:wheel',
     'contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle',
     'src/python/pants/backend/python/subsystems',

--- a/src/python/pants/backend/python/tasks/pex_build_util.py
+++ b/src/python/pants/backend/python/tasks/pex_build_util.py
@@ -290,5 +290,8 @@ class PexBuilderWrapper(object):
   def add_distribution(self, dist):
     self._builder.add_distribution(dist)
 
+  def add_dist_location(self, location):
+    self._builder.add_dist_location(location)
+
   def set_script(self, script):
     self._builder.set_script(script)


### PR DESCRIPTION
Previously the local resolve in tests was pointed to the wrong path.
This was masked on unstable master since there, version changes come
earlier than code changes, meaning the checker dist from the prior
release was being remotely resolved. On a version bump change this
masking was exposed since no remote dist of the just-bumped-version was
deployed.

Upon unmasking, a bug was also revealed in the production code
implementation of local resolves from sys.path.

Both are fixed.

Fixes #6706