### PR TITLE
Fix test get subprocess output interleaved py3k

### DIFF
--- a/build-support/known_py3_failures.txt
+++ b/build-support/known_py3_failures.txt
@@ -1,2 +1,1 @@
 tests/python/pants_test/backend/jvm/tasks:jar_publish
-tests/python/pants_test/pantsd:process_manager

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -215,7 +215,7 @@ class TestProcessManager(TestBase):
     self.assertEqual(self.pm.get_subprocess_output(['echo', '-n', test_str]), test_str)
 
   def test_get_subprocess_output_interleaved(self):
-    cmd_payload = 'import sys; ' + ('sys.stderr.write("9"); sys.stdout.write("3"); ' * 3)
+    cmd_payload = 'import sys; ' + ('sys.stderr.write("9"); sys.stderr.flush(); sys.stdout.write("3"); sys.stdout.flush();' * 3)
     cmd = [sys.executable, '-c', cmd_payload]
 
     self.assertEqual(self.pm.get_subprocess_output(cmd), '333')

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -222,6 +222,14 @@ class TestProcessManager(TestBase):
     self.assertEqual(self.pm.get_subprocess_output(cmd, ignore_stderr=False), '939393')
     self.assertEqual(self.pm.get_subprocess_output(cmd, stderr=subprocess.STDOUT), '939393')
 
+  def test_get_subprocess_output_interleaved_bash(self):
+    cmd_payload = 'printf "9">&2; printf "3";' * 3
+    cmd = ['/bin/bash', '-c', cmd_payload]
+
+    self.assertEqual(self.pm.get_subprocess_output(cmd), '333')
+    self.assertEqual(self.pm.get_subprocess_output(cmd, ignore_stderr=False), '939393')
+    self.assertEqual(self.pm.get_subprocess_output(cmd, stderr=subprocess.STDOUT), '939393')
+
   def test_get_subprocess_output_oserror_exception(self):
     with self.assertRaises(ProcessManager.ExecutionError):
       self.pm.get_subprocess_output(['i_do_not_exist'])


### PR DESCRIPTION
### Problem
While running our unit tests in python 3, `test_get_subprocess_output_interleaved` started consistently failing with:
```
==================== FAILURES ====================
 TestProcessManager.test_get_subprocess_output_interleaved 

self = <pants_test.pantsd.test_process_manager.TestProcessManager testMethod=test_get_subprocess_output_interleaved>

    def test_get_subprocess_output_interleaved(self):
      cmd_payload = 'import sys; ' + ('sys.stderr.write("9"); sys.stdout.write("3"); ' * 3)
      cmd = [sys.executable, '-c', cmd_payload]
    
      self.assertEqual(self.pm.get_subprocess_output(cmd), '333')
>     self.assertEqual(self.pm.get_subprocess_output(cmd, ignore_stderr=False), '939393')
E     AssertionError: '333999' != '939393'
E     - 333999
E     + 939393

pants_test/pantsd/test_process_manager.py:222: AssertionError
-------------- Captured stderr call --------------
999
```
Also see https://github.com/pantsbuild/pants/issues/6385 for more context

### Solution
Fix test.

Inline message for from fixing commit (https://github.com/pantsbuild/pants/pull/6713/commits/48c478e749900256ec0fee193ab79b5eaaed9a08):
```
This one need some explaining.

This arised because Python 3 makes `sys.std{err,out}` a
`TextIOWrapper` and as per the python 3 man page "The text I/O layer
will still be line-buffered.". And that's with `-u` or
`PYTHONUNBUFFERED` set.

BUT, this test is not checking that python is buffering or not. It's
checking that if we run an executable in a subrocess for which we
capture output, we're correctly reading the potentially interleaved
STDIN and STDERR.

Unfortunatly, the "executable" we're using to test the capturing was
broken by the change to python 3. This change fixes the executable.
```

I also added a test to try and make potential future failures easier to understand.

### Result
- Failure is resolved.