### PR TITLE
[feat] Don't blacklist `jar_publish`.

### DIFF
--- a/build-support/known_py3_failures.txt
+++ b/build-support/known_py3_failures.txt
@@ -1,1 +1,0 @@
-tests/python/pants_test/backend/jvm/tasks:jar_publish


### PR DESCRIPTION
WIP

### Problem
We currently have a black list for tests running in python 3. That blacklist is down to one target `jar_publish`. On a separate branch I've had multiple builds without any failures for this target.

### Solution
Unblacklist target


### Result
We know run the same unit test for python 2 and 3