### PR TITLE
Set GOROOT properly

### DIFF
--- a/build-support/bin/native/cargo.sh
+++ b/build-support/bin/native/cargo.sh
@@ -17,7 +17,7 @@ download_binary="${REPO_ROOT}/build-support/bin/download_binary.sh"
 # The following is needed by grpcio-sys and we have no better way to hook its build.rs than this;
 # ie: wrapping cargo.
 cmakeroot="$("${download_binary}" "cmake" "3.9.5" "cmake.tar.gz")"
-goroot="$("${download_binary}" "go" "1.7.3" "go.tar.gz")/go"
+goroot="$("${download_binary}" "go" "1.7.3" "go.tar.gz")"
 
 # Code generation in the bazel_protos crate needs to be able to find protoc on the PATH.
 protoc="$("${download_binary}" "protobuf" "3.4.1" "protoc")"


### PR DESCRIPTION
I get GOROOT not found when building without this

It looks like #6681 changed this to return the container directory from the tar, rather than the directory in which the tar was unpacked.