### PR TITLE
Fix Python 3 renaming assertRegexpMatches to assertRegex

### DIFF
--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
@@ -20,6 +20,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:process_handler',
     'tests/python/pants_test/subsystem:subsystem_utils',
+    'tests/python/pants_test/testutils:py2_compat',
   ]
 )
 

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_go_distribution.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_go_distribution.py
@@ -11,6 +11,7 @@ from builtins import str
 from pants.util.contextutil import environment_as
 from pants.util.process_handler import subprocess
 from pants_test.subsystem.subsystem_util import global_subsystem_instance
+from pants_test.testutils.py2_compat import assertRegex
 
 from pants.contrib.go.subsystems.go_distribution import GoDistribution
 
@@ -57,7 +58,7 @@ class GoDistributionTest(unittest.TestCase):
     self.assertEqual(default_gopath, go_cmd.check_output().decode('utf-8').strip())
 
     regex = GoDistributionTest._generate_go_command_regex(gopath=default_gopath, final_value='GOPATH')
-    self.assertRegexpMatches(str(go_cmd), regex)
+    assertRegex(self, str(go_cmd), regex)
 
   def test_go_command_no_gopath(self):
     self.assert_no_gopath()
@@ -79,4 +80,4 @@ class GoDistributionTest(unittest.TestCase):
     self.assertEqual(['env', 'GOROOT'], go_cmd.cmdline[1:])
 
     regex = GoDistributionTest._generate_go_command_regex(gopath='/tmp/fred', final_value='GOROOT')
-    self.assertRegexpMatches(str(go_cmd), regex)
+    assertRegex(self, str(go_cmd), regex)

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
@@ -30,6 +30,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test/testutils:file_test_util',
+    'tests/python/pants_test/testutils:py2_compat',
     'tests/python/pants_test:int-test',
   ],
   tags={'integration'},

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_run_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_run_integration.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 from pants_test.testutils.py2_compat import assertRegex
 
+
 class GoRunIntegrationTest(PantsRunIntegrationTest):
 
   def test_go_run_simple(self):

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_run_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_run_integration.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
-
+from pants_test.testutils.py2_compat import assertRegex
 
 class GoRunIntegrationTest(PantsRunIntegrationTest):
 
@@ -21,4 +21,4 @@ class GoRunIntegrationTest(PantsRunIntegrationTest):
     args = ['-q', 'run', 'contrib/go/examples/src/go/cgo']
     pants_run = self.run_pants(args)
     self.assert_success(pants_run)
-    self.assertRegexpMatches(pants_run.stdout_data.strip(), r'^Random from C: \d+$')
+    assertRegex(self, pants_run.stdout_data.strip(), r'^Random from C: \d+$')

--- a/tests/python/pants_test/backend/docgen/tasks/BUILD
+++ b/tests/python/pants_test/backend/docgen/tasks/BUILD
@@ -27,6 +27,7 @@ python_tests(
     'src/python/pants/base:build_environment',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:int-test',
+    'tests/python/pants_test/testutils:py2_compat',
   ],
   coverage = [
     'pants.backend.docgen.tasks.markdown_to_html',

--- a/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html_integration.py
+++ b/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html_integration.py
@@ -9,6 +9,7 @@ import os
 from pants.base.build_environment import get_buildroot
 from pants.util.dirutil import safe_open
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.testutils.py2_compat import assertRegex
 
 
 class MarkdownIntegrationTest(PantsRunIntegrationTest):
@@ -36,13 +37,13 @@ class MarkdownIntegrationTest(PantsRunIntegrationTest):
     with safe_open(out_path, 'r') as outfile:
       page_html = outfile.read()
       # should get Sense and Sensibility in title (or TITLE, sheesh):
-      self.assertRegexpMatches(page_html,
+      assertRegex(self, page_html,
                                r'(?i).*<title[^>]*>\s*Sense\s+and\s+Sensibility\s*</title')
       # should get formatted with h1:
-      self.assertRegexpMatches(page_html,
+      assertRegex(self, page_html,
                                r'(?i).*<h1[^>]*>\s*They\s+Heard\s+Her\s+With\s+Surprise\s*</h1>')
       # should get formatted with _something_
-      self.assertRegexpMatches(page_html, r'.*>\s*inhabiting\s*</')
-      self.assertRegexpMatches(page_html, r'.*>\s*civilly\s*</')
+      assertRegex(self, page_html, r'.*>\s*inhabiting\s*</')
+      assertRegex(self, page_html, r'.*>\s*civilly\s*</')
       # there should be a link that has href="http://www.calderdale.gov.uk/"
-      self.assertRegexpMatches(page_html, r'.*<a [^>]*href\s*=\s*[\'"]http://www.calderdale')
+      assertRegex(self, page_html, r'.*<a [^>]*href\s*=\s*[\'"]http://www.calderdale')

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -37,6 +37,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/testutils:git_util',
     'tests/python/pants_test/testutils:pexrc_util',
+    'tests/python/pants_test/testutils:py2_compat',
     'tests/python/pants_test:int-test',
     'tests/python/pants_test:test_base',
   ],

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -98,6 +98,7 @@ python_tests(
     'tests/python/pants_test/backend/python:interpreter_selection_utils',
     'tests/python/pants_test/backend/python:pants_requirement_integration_test_base',
     'tests/python/pants_test:int-test',
+    'tests/python/pants_test/testutils:py2_compat',
   ],
   tags={'integration'},
   timeout=2400

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -14,6 +14,7 @@ from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import is_executable
 from pants.util.process_handler import subprocess
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.testutils.py2_compat import assertRegex
 
 
 class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
@@ -42,7 +43,7 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       self._assert_native_greeting(output)
       # Check that we have exactly one wheel output.
       single_wheel_output = assert_single_element(glob.glob(os.path.join(tmp_dir, '*.whl')))
-      self.assertRegexpMatches(os.path.basename(single_wheel_output),
+      assertRegex(self, os.path.basename(single_wheel_output),
                                r'\A{}'.format(re.escape('fasthello-1.0.0+')))
 
   def test_pants_run(self):

--- a/tests/python/pants_test/backend/python/tasks/test_python_repl_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_repl_integration.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
 from pants_test.testutils.py2_compat import assertRegex
 
+
 class PythonReplIntegrationTest(PantsRunIntegrationTest):
 
   @ensure_daemon

--- a/tests/python/pants_test/backend/python/tasks/test_python_repl_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_repl_integration.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
-
+from pants_test.testutils.py2_compat import assertRegex
 
 class PythonReplIntegrationTest(PantsRunIntegrationTest):
 
@@ -30,7 +30,7 @@ class PythonReplIntegrationTest(PantsRunIntegrationTest):
                '--quiet']
     program = 'from interpreter_selection.echo_interpreter_version import say_hello; say_hello()'
     pants_run = self.run_pants(command=command, stdin_data=program)
-    self.assertRegexpMatches(pants_run.stdout_data, r'2\.\d\.\d')
+    assertRegex(self, pants_run.stdout_data, r'2\.\d\.\d')
 
   @ensure_daemon
   def test_run_repl_with_3(self):
@@ -41,4 +41,4 @@ class PythonReplIntegrationTest(PantsRunIntegrationTest):
                '--quiet']
     program = 'from interpreter_selection.echo_interpreter_version import say_hello; say_hello()'
     pants_run = self.run_pants(command=command, stdin_data=program)
-    self.assertRegexpMatches(pants_run.stdout_data, r'3\.\d\.\d')
+    assertRegex(self, pants_run.stdout_data, r'3\.\d\.\d')

--- a/tests/python/pants_test/backend/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/backend/python/test_interpreter_cache.py
@@ -24,6 +24,7 @@ from pants_test.backend.python.interpreter_selection_utils import (PY_27, PY_36,
 from pants_test.subsystem.subsystem_util import global_subsystem_instance
 from pants_test.test_base import TestBase
 from pants_test.testutils.pexrc_util import setup_pexrc_with_pex_python_path
+from pants_test.testutils.py2_compat import assertRegex
 
 
 class TestInterpreterCache(TestBase):
@@ -91,7 +92,7 @@ class TestInterpreterCache(TestBase):
       self.assertEqual(1, len(resolved_dists))
       dist_location = resolved_dists[0].distribution.location
 
-      self.assertRegexpMatches(dist_location, r'\.egg$')
+      assertRegex(self, dist_location, r'\.egg$')
       os.symlink(dist_location, os.path.join(repo_root, os.path.basename(dist_location)))
 
       return Package.from_href(dist_location).raw_version

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -217,6 +217,7 @@ python_tests(
     'src/python/pants/util:osutil',
     'tests/python/pants_test:test_base',
     'tests/python/pants_test/option/util',
+    'tests/python/pants_test/testutils:py2_compat',
   ],
   tags={'platform_specific_behavior'},
 )
@@ -230,6 +231,7 @@ python_tests(
     'src/python/pants/base:exception_sink',
     'src/python/pants/util:osutil',
     'tests/python/pants_test:int-test',
+    'tests/python/pants_test/testutils:py2_compat',
   ],
   tags = {'platform_specific_behavior', 'integration'},
   timeout = 360,

--- a/tests/python/pants_test/base/test_exception_sink.py
+++ b/tests/python/pants_test/base/test_exception_sink.py
@@ -16,6 +16,7 @@ from pants.base.exception_sink import ExceptionSink
 from pants.util.contextutil import temporary_dir
 from pants.util.osutil import get_normalized_os_name
 from pants_test.test_base import TestBase
+from pants_test.testutils.py2_compat import assertRegex
 
 
 class TestExceptionSink(TestBase):
@@ -99,9 +100,9 @@ pid: {pid}
            pid=pid,
            msg=msg)
       with open(cur_process_error_log_path, 'r') as cur_pid_file:
-        self.assertRegexpMatches(cur_pid_file.read(), err_rx)
+        assertRegex(self, cur_pid_file.read(), err_rx)
       with open(shared_error_log_path, 'r') as shared_log_file:
-        self.assertRegexpMatches(shared_log_file.read(), err_rx)
+        assertRegex(self, shared_log_file.read(), err_rx)
 
   def test_backup_logging_on_fatal_error(self):
     sink = self._gen_sink_subclass()
@@ -122,5 +123,5 @@ pid: {pid}
         "\nfake write failure",
       ])
 
-    self.assertRegexpMatches(str(errors[0]), format_log_rx('pid-specific'))
-    self.assertRegexpMatches(str(errors[1]), format_log_rx('shared'))
+    assertRegex(self, str(errors[0]), format_log_rx('pid-specific'))
+    assertRegex(self, str(errors[1]), format_log_rx('shared'))

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -14,6 +14,7 @@ from pants.base.exception_sink import ExceptionSink
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import read_file, safe_file_dump, safe_mkdir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.testutils.py2_compat import assertRegex
 
 
 class ExceptionSinkIntegrationTest(PantsRunIntegrationTest):

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -19,7 +19,7 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 class ExceptionSinkIntegrationTest(PantsRunIntegrationTest):
 
   def _assert_unhandled_exception_log_matches(self, pid, file_contents):
-    self.assertRegexpMatches(file_contents, """\
+    assertRegex(self, file_contents, """\
 timestamp: ([^\n]+)
 process title: ([^\n]+)
 sys\\.argv: ([^\n]+)
@@ -52,7 +52,7 @@ Exception message: Build graph construction failed: ExecutionError 1 Exception e
         # The backtrace should be omitted when --print-exception-stacktrace=False.
         print_exception_stacktrace=False)
       self.assert_failure(pants_run)
-      self.assertRegexpMatches(pants_run.stderr_data, """\\A\
+      assertRegex(self, pants_run.stderr_data, """\\A\
 timestamp: ([^\n]+)
 Exception caught: \\(pants\\.build_graph\\.address_lookup_error\\.AddressLookupError\\) \\(backtrace omitted\\)
 Exception message: Build graph construction failed: ExecutionError 1 Exception encountered:
@@ -65,7 +65,7 @@ Exception message: Build graph construction failed: ExecutionError 1 Exception e
         pants_run.pid, read_file(shared_log_file, binary_mode=False))
 
   def _assert_graceful_signal_log_matches(self, pid, signum, contents):
-    self.assertRegexpMatches(contents, """\
+    assertRegex(self, contents, """\
 timestamp: ([^\n]+)
 process title: ([^\n]+)
 sys\\.argv: ([^\n]+)
@@ -103,7 +103,7 @@ Signal {signum} was raised\\. Exiting with failure\\. \\(backtrace omitted\\)
   def test_dumps_logs_on_terminate(self):
     # Send a SIGTERM to the local pants process.
     with self._send_signal_to_waiter_handle(signal.SIGTERM) as (workdir, waiter_run):
-      self.assertRegexpMatches(waiter_run.stderr_data, """\
+      assertRegex(self, waiter_run.stderr_data, """\
 timestamp: ([^\n]+)
 Signal {signum} was raised. Exiting with failure. \\(backtrace omitted\\)
 """.format(signum=signal.SIGTERM))
@@ -120,7 +120,7 @@ Signal {signum} was raised. Exiting with failure. \\(backtrace omitted\\)
     with self._send_signal_to_waiter_handle(signal.SIGABRT) as (workdir, waiter_run):
       # Check that the logs show an abort signal and the beginning of a traceback.
       pid_specific_log_file, shared_log_file = self._get_log_file_paths(workdir, waiter_run)
-      self.assertRegexpMatches(read_file(pid_specific_log_file, binary_mode=False), """\
+      assertRegex(self, read_file(pid_specific_log_file, binary_mode=False), """\
 Fatal Python error: Aborted
 
 Thread [^\n]+ \\(most recent call first\\):
@@ -138,7 +138,7 @@ Thread [^\n]+ \\(most recent call first\\):
       os.kill(waiter_handle.process.pid, signal.SIGKILL)
       waiter_run = waiter_handle.join()
       self.assert_failure(waiter_run)
-      self.assertRegexpMatches(waiter_run.stderr_data, """\
+      assertRegex(self, waiter_run.stderr_data, """\
 Current thread [^\n]+ \\(most recent call first\\):
 """)
 

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -170,6 +170,7 @@ python_tests(
   dependencies=[
     '3rdparty/python:future',
     'tests/python/pants_test/engine/examples:parsers',
+    'tests/python/pants_test/testutils:py2_compat',
     'src/python/pants/engine:objects',
   ]
 )

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -99,7 +99,8 @@ python_tests(
   sources = ['test_filemap_integration.py'],
   dependencies = [
     'src/python/pants/base:project_tree',
-    'tests/python/pants_test:int-test'
+    'tests/python/pants_test:int-test',
+    'tests/python/pants_test/testutils:py2_compat',
   ],
   tags = {'integration'},
   timeout = 180,
@@ -148,7 +149,8 @@ python_tests(
   name = 'list_integration',
   sources = ['test_list_integration.py'],
   dependencies = [
-    'tests/python/pants_test:int-test'
+    'tests/python/pants_test:int-test',
+    'tests/python/pants_test/testutils:py2_compat',
   ],
   tags = {'integration'},
   timeout = 180,
@@ -181,7 +183,7 @@ python_tests(
   sources = ['test_pants_engine_integration.py'],
   dependencies = [
     'tests/python/pants_test:int-test',
-    '3rdparty/python:future',
+    'tests/python/pants_test/testutils:py2_compat',
   ],
   tags = {'integration'}
 )

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -180,7 +180,8 @@ python_tests(
   name = 'pants_engine_integration',
   sources = ['test_pants_engine_integration.py'],
   dependencies = [
-    'tests/python/pants_test:int-test'
+    'tests/python/pants_test:int-test',
+    '3rdparty/python:future',
   ],
   tags = {'integration'}
 )

--- a/tests/python/pants_test/engine/legacy/test_filemap_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_filemap_integration.py
@@ -8,6 +8,7 @@ import os
 
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.testutils.py2_compat import assertRegex
 
 
 class FilemapIntegrationTest(PantsRunIntegrationTest):
@@ -61,7 +62,7 @@ class FilemapIntegrationTest(PantsRunIntegrationTest):
       pants_run = self.do_command('filemap',
                                   self._mk_target('exclude_strings_disallowed'),
                                   success=False)
-      self.assertRegexpMatches(pants_run.stderr_data,
+      assertRegex(self, pants_run.stderr_data,
                                r'Excludes of type `.*` are not supported')
 
   def test_exclude_list_of_strings(self):

--- a/tests/python/pants_test/engine/legacy/test_list_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_list_integration.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.testutils.py2_compat import assertRegex
 
 
 class ListIntegrationTest(PantsRunIntegrationTest):
@@ -40,7 +41,7 @@ class ListIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.do_command('list',
                                 'testprojects/tests/java/org/pantsbuild/build_parsing::',
                                 success=True)
-    self.assertRegexpMatches(
+    assertRegex(self,
       pants_run.stdout_data,
       r'testprojects/tests/java/org/pantsbuild/build_parsing:trailing_glob_doublestar'
     )

--- a/tests/python/pants_test/engine/legacy/test_pants_engine_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_pants_engine_integration.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from future.utils import PY3
+
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -14,7 +16,10 @@ class PantsEngineIntegrationTest(PantsRunIntegrationTest):
     self.assertRegexpMatches(pants_run.stderr_data, 'build_graph is: .*LegacyBuildGraph')
     self.assertRegexpMatches(pants_run.stderr_data,
                              'computed \d+ nodes in')
-    self.assertNotRegexpMatches(pants_run.stderr_data, 'pantsd is running at pid \d+')
+    if PY3:
+      self.assertNotRegex(pants_run.stderr_data, 'pantsd is running at pid \d+')
+    else:
+      self.assertNotRegexpMatches(pants_run.stderr_data, 'pantsd is running at pid \d+')
 
   def test_engine_binary(self):
     self.assert_success(

--- a/tests/python/pants_test/engine/legacy/test_pants_engine_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_pants_engine_integration.py
@@ -4,22 +4,18 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from future.utils import PY3
-
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.testutils.py2_compat import assertRegex, assertNotRegex
 
 
 class PantsEngineIntegrationTest(PantsRunIntegrationTest):
   def test_engine_list(self):
     pants_run = self.run_pants(['-ldebug', 'list', '3rdparty::'])
     self.assert_success(pants_run)
-    self.assertRegexpMatches(pants_run.stderr_data, 'build_graph is: .*LegacyBuildGraph')
-    self.assertRegexpMatches(pants_run.stderr_data,
+    assertRegex(self, pants_run.stderr_data, 'build_graph is: .*LegacyBuildGraph')
+    assertRegex(self, pants_run.stderr_data,
                              'computed \d+ nodes in')
-    if PY3:
-      self.assertNotRegex(pants_run.stderr_data, 'pantsd is running at pid \d+')
-    else:
-      self.assertNotRegexpMatches(pants_run.stderr_data, 'pantsd is running at pid \d+')
+    assertNotRegex(self, pants_run.stderr_data, 'pantsd is running at pid \d+')
 
   def test_engine_binary(self):
     self.assert_success(

--- a/tests/python/pants_test/engine/legacy/test_pants_engine_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_pants_engine_integration.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
-from pants_test.testutils.py2_compat import assertRegex, assertNotRegex
+from pants_test.testutils.py2_compat import assertNotRegex, assertRegex
 
 
 class PantsEngineIntegrationTest(PantsRunIntegrationTest):

--- a/tests/python/pants_test/engine/test_parsers.py
+++ b/tests/python/pants_test/engine/test_parsers.py
@@ -12,6 +12,7 @@ from textwrap import dedent
 from pants.engine import parser
 from pants.engine.objects import Resolvable
 from pants_test.engine.examples import parsers
+from pants_test.testutils.py2_compat import assertRegex
 
 
 # A duck-typed Serializable with an `==` suitable for ease of testing.
@@ -230,7 +231,7 @@ class JsonParserTest(unittest.TestCase):
     actual_lines = [line.rstrip() for line in str(exc.exception).splitlines()]
 
     # This message from the json stdlib varies between python releases, so fuzz the match a bit.
-    self.assertRegexpMatches(actual_lines[0],
+    assertRegex(self, actual_lines[0],
                              r'Expecting (?:,|\',\'|",") delimiter: line 3 column 12 \(char 67\)')
 
     self.assertEqual(dedent("""

--- a/tests/python/pants_test/init/BUILD
+++ b/tests/python/pants_test/init/BUILD
@@ -26,6 +26,7 @@ python_tests(
     'src/python/pants/util:objects',
     'tests/python/pants_test:test_base',
     'tests/python/pants_test/subsystem:subsystem_utils'
+    'tests/python/pants_test/testutils:py2_compat'
   ],
   coverage = ['pants.init'],
 )

--- a/tests/python/pants_test/init/BUILD
+++ b/tests/python/pants_test/init/BUILD
@@ -25,8 +25,8 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:objects',
     'tests/python/pants_test:test_base',
-    'tests/python/pants_test/subsystem:subsystem_utils'
-    'tests/python/pants_test/testutils:py2_compat'
+    'tests/python/pants_test/subsystem:subsystem_utils',
+    'tests/python/pants_test/testutils:py2_compat',
   ],
   coverage = ['pants.init'],
 )

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -15,6 +15,7 @@ from pants.init.logging import setup_logging
 from pants.util.contextutil import temporary_dir
 from pants_test.testutils.py2_compat import assertRegex
 
+
 class SetupTest(unittest.TestCase):
   @contextmanager
   def log_dir(self, file_logging):

--- a/tests/python/pants_test/init/test_logging.py
+++ b/tests/python/pants_test/init/test_logging.py
@@ -13,7 +13,7 @@ from io import StringIO
 
 from pants.init.logging import setup_logging
 from pants.util.contextutil import temporary_dir
-
+from pants_test.testutils.py2_compat import assertRegex
 
 class SetupTest(unittest.TestCase):
   @contextmanager
@@ -39,7 +39,7 @@ class SetupTest(unittest.TestCase):
     has been registered as a global log level.  See options_bootstrapper.py.
     """
     self.assertEqual(2, len(lines))
-    self.assertRegexpMatches(lines[0], '^WARN\w*] warn')
+    assertRegex(self, lines[0], '^WARN\w*] warn')
     self.assertEqual('INFO] info', lines[1])
 
   def test_standard_logging(self):
@@ -66,5 +66,5 @@ class SetupTest(unittest.TestCase):
         loglines = fp.read().splitlines()
         self.assertEqual(2, len(loglines))
         glog_format = r'\d{4} \d{2}:\d{2}:\d{2}.\d{6} \d+ \w+\.py:\d+] '
-        self.assertRegexpMatches(loglines[0], r'^W{}warn$'.format(glog_format))
-        self.assertRegexpMatches(loglines[1], r'^I{}info$'.format(glog_format))
+        assertRegex(self, loglines[0], r'^W{}warn$'.format(glog_format))
+        assertRegex(self, loglines[1], r'^I{}info$'.format(glog_format))

--- a/tests/python/pants_test/logging/BUILD
+++ b/tests/python/pants_test/logging/BUILD
@@ -16,7 +16,7 @@ python_tests(
   ],
   dependencies=[
     'tests/python/pants_test:int-test',
-    '3rdparty/python:future',
+    'tests/python/testutils:py2_compat',
   ],
   tags = {'integration'},
 )

--- a/tests/python/pants_test/logging/BUILD
+++ b/tests/python/pants_test/logging/BUILD
@@ -16,7 +16,7 @@ python_tests(
   ],
   dependencies=[
     'tests/python/pants_test:int-test',
-    'tests/python/testutils:py2_compat',
+    'tests/python/pants_test/testutils:py2_compat',
   ],
   tags = {'integration'},
 )

--- a/tests/python/pants_test/logging/BUILD
+++ b/tests/python/pants_test/logging/BUILD
@@ -16,6 +16,7 @@ python_tests(
   ],
   dependencies=[
     'tests/python/pants_test:int-test',
+    '3rdparty/python:future',
   ],
   tags = {'integration'},
 )

--- a/tests/python/pants_test/logging/test_native_engine_logging.py
+++ b/tests/python/pants_test/logging/test_native_engine_logging.py
@@ -5,7 +5,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
-from pants_test.testutils.py2_compat import assertRegex, assertNotRegex
+from pants_test.testutils.py2_compat import assertNotRegex, assertRegex
+
 
 class NativeEngineLoggingTest(PantsRunIntegrationTest):
   def test_native_logging(self):

--- a/tests/python/pants_test/logging/test_native_engine_logging.py
+++ b/tests/python/pants_test/logging/test_native_engine_logging.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from future.utils import PY3
+
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -13,7 +15,10 @@ class NativeEngineLoggingTest(PantsRunIntegrationTest):
     pants_run = self.run_pants([
       "-linfo", "list", "3rdparty::"
     ])
-    self.assertNotRegexpMatches(pants_run.stderr_data, "DEBUG] Launching \\d+ root")
+    if PY3:
+      self.assertNotRegex(pants_run.stderr_data, "DEBUG] Launching \\d+ root")
+    else:
+      self.assertNotRegexpMatches(pants_run.stderr_data, "DEBUG] Launching \\d+ root")
 
     pants_run = self.run_pants([
       "-ldebug", "list", "3rdparty::"

--- a/tests/python/pants_test/logging/test_native_engine_logging.py
+++ b/tests/python/pants_test/logging/test_native_engine_logging.py
@@ -4,10 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from future.utils import PY3
-
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
-
+from pants_test.testutils.py2_compat import assertRegex, assertNotRegex
 
 class NativeEngineLoggingTest(PantsRunIntegrationTest):
   def test_native_logging(self):
@@ -15,12 +13,9 @@ class NativeEngineLoggingTest(PantsRunIntegrationTest):
     pants_run = self.run_pants([
       "-linfo", "list", "3rdparty::"
     ])
-    if PY3:
-      self.assertNotRegex(pants_run.stderr_data, "DEBUG] Launching \\d+ root")
-    else:
-      self.assertNotRegexpMatches(pants_run.stderr_data, "DEBUG] Launching \\d+ root")
+    assertNotRegex(self, pants_run.stderr_data, "DEBUG] Launching \\d+ root")
 
     pants_run = self.run_pants([
       "-ldebug", "list", "3rdparty::"
     ])
-    self.assertRegexpMatches(pants_run.stderr_data, "DEBUG] Launching \\d+ root")
+    assertRegex(self, pants_run.stderr_data, "DEBUG] Launching \\d+ root")

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -80,9 +80,11 @@ python_tests(
   name = 'pantsd_integration',
   sources = ['test_pantsd_integration.py'],
   dependencies = [
+    '3rdparty/python:future',
     ':pantsd_integration_test_base',
     'tests/python/pants_test:int-test',
     'tests/python/pants_test/testutils:process_test_util',
+    'tests/python/pants_test/testutils:py2_compat',
   ],
   tags = {'integration'},
   timeout = 900

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -19,6 +19,7 @@ from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, touch
 from pants_test.pants_run_integration_test import read_pantsd_log
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 from pants_test.testutils.process_test_util import no_lingering_process_by_command
+from pants_test.testutils.py2_compat import assertRegex, assertNotRegex
 
 
 def launch_file_toucher(f):
@@ -82,10 +83,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
           continue
 
         # Check if the line begins with W or E to check if it is a warning or error line.
-        if PY3:
-          self.assertNotRegex(line, r'^[WE].*')
-        else:
-          self.assertNotRegexpMatches(line, r'^[WE].*')
+        assertNotRegex(self, line, r'^[WE].*')
 
   def test_pantsd_broken_pipe(self):
     with self.pantsd_test_context() as (workdir, pantsd_config, checker):
@@ -300,7 +298,8 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         return '\n'.join(read_pantsd_log(workdir))
 
       # Check the logs.
-      self.assertRegexpMatches(
+      assertRegex(
+        self,
         full_pantsd_log(),
         r'watching invalidating files:.*{}'.format(test_file)
       )
@@ -366,23 +365,17 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         safe_file_dump(test_build_file, "python_library(sources=globs('some_non_existent_file.py'))", binary_mode=False)
         result = pantsd_run(export_cmd)
         checker.assert_running()
-        if PY3:
-          self.assertNotRegex(result.stdout_data, has_source_root_regex)
-        else:
-          self.assertNotRegexpMatches(result.stdout_data, has_source_root_regex)
+        assertNotRegex(self, result.stdout_data, has_source_root_regex)
 
         safe_file_dump(test_build_file, "python_library(sources=globs('*.py'))", binary_mode=False)
         result = pantsd_run(export_cmd)
         checker.assert_running()
-        if PY3:
-          self.assertNotRegex(result.stdout_data, has_source_root_regex)
-        else:
-          self.assertNotRegexpMatches(result.stdout_data, has_source_root_regex)
+        assertNotRegex(self, result.stdout_data, has_source_root_regex)
 
         safe_file_dump(test_src_file, 'import this\n', binary_mode=False)
         result = pantsd_run(export_cmd)
         checker.assert_running()
-        self.assertRegexpMatches(result.stdout_data, has_source_root_regex)
+        assertRegex(self, result.stdout_data, has_source_root_regex)
     finally:
       rm_rf(test_path)
 
@@ -453,7 +446,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
 
       # Ensure that we saw the pantsd-runner process's failure in the client's stderr.
       self.assert_failure(waiter_run)
-      self.assertRegexpMatches(waiter_run.stderr_data, """\
+      assertRegex(self, waiter_run.stderr_data, """\
 Signal {signum} was raised\\. Exiting with failure\\. \\(backtrace omitted\\)
 """.format(signum=signal.SIGTERM))
       # NB: testing stderr is an "end-to-end" test, as it requires pants knowing the correct remote

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -12,14 +12,12 @@ import time
 import unittest
 from builtins import open, range, zip
 
-from future.utils import PY3
-
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, touch
 from pants_test.pants_run_integration_test import read_pantsd_log
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 from pants_test.testutils.process_test_util import no_lingering_process_by_command
-from pants_test.testutils.py2_compat import assertRegex, assertNotRegex
+from pants_test.testutils.py2_compat import assertNotRegex, assertRegex
 
 
 def launch_file_toucher(f):

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -12,6 +12,8 @@ import time
 import unittest
 from builtins import open, range, zip
 
+from future.utils import PY3
+
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, touch
 from pants_test.pants_run_integration_test import read_pantsd_log
@@ -80,7 +82,10 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
           continue
 
         # Check if the line begins with W or E to check if it is a warning or error line.
-        self.assertNotRegexpMatches(line, r'^[WE].*')
+        if PY3:
+          self.assertNotRegex(line, r'^[WE].*')
+        else:
+          self.assertNotRegexpMatches(line, r'^[WE].*')
 
   def test_pantsd_broken_pipe(self):
     with self.pantsd_test_context() as (workdir, pantsd_config, checker):
@@ -361,12 +366,18 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         safe_file_dump(test_build_file, "python_library(sources=globs('some_non_existent_file.py'))", binary_mode=False)
         result = pantsd_run(export_cmd)
         checker.assert_running()
-        self.assertNotRegexpMatches(result.stdout_data, has_source_root_regex)
+        if PY3:
+          self.assertNotRegex(result.stdout_data, has_source_root_regex)
+        else:
+          self.assertNotRegexpMatches(result.stdout_data, has_source_root_regex)
 
         safe_file_dump(test_build_file, "python_library(sources=globs('*.py'))", binary_mode=False)
         result = pantsd_run(export_cmd)
         checker.assert_running()
-        self.assertNotRegexpMatches(result.stdout_data, has_source_root_regex)
+        if PY3:
+          self.assertNotRegex(result.stdout_data, has_source_root_regex)
+        else:
+          self.assertNotRegexpMatches(result.stdout_data, has_source_root_regex)
 
         safe_file_dump(test_src_file, 'import this\n', binary_mode=False)
         result = pantsd_run(export_cmd)

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -54,6 +54,7 @@ python_tests(
   sources = ['test_execution_graph.py'],
   dependencies = [
     'src/python/pants/backend/jvm/tasks/jvm_compile:execution_graph',
+    'tests/python/pants_test/testutils:py2_compat',
     ]
 )
 

--- a/tests/python/pants_test/tasks/test_execution_graph.py
+++ b/tests/python/pants_test/tasks/test_execution_graph.py
@@ -14,6 +14,7 @@ from future.utils import PY3
 from pants.backend.jvm.tasks.jvm_compile.execution_graph import (ExecutionFailure, ExecutionGraph,
                                                                  Job, JobExistsError,
                                                                  NoRootJobError, UnknownJobError)
+from pants_test.testutils.py2_compat import assertRegex
 
 
 class ImmediatelyExecutingPool(object):
@@ -306,4 +307,4 @@ class ExecutionGraphTest(unittest.TestCase):
       "Traceback:.*in raising_wrapper.*raise Exception\\(\"I'm an error\"\\)",
       re.DOTALL,
     )
-    self.assertRegexpMatches(error_logs[1], regex)
+    assertRegex(self, error_logs[1], regex)

--- a/tests/python/pants_test/testutils/BUILD
+++ b/tests/python/pants_test/testutils/BUILD
@@ -53,3 +53,13 @@ python_library(
     ':git_util'
   ,]
 )
+
+python_library(
+  name = 'py2_compat',
+  sources = [
+    'py2_compat.py',
+  ],
+  dependencies = [
+    '3rdparty/python:future',
+  ,]
+)

--- a/tests/python/pants_test/testutils/BUILD
+++ b/tests/python/pants_test/testutils/BUILD
@@ -61,5 +61,5 @@ python_library(
   ],
   dependencies = [
     '3rdparty/python:future',
-  ,]
+  ]
 )

--- a/tests/python/pants_test/testutils/py2_compat.py
+++ b/tests/python/pants_test/testutils/py2_compat.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from future.utils import PY3
+
+def assertRegex(self, text, expected_regex):
+  """Call unit test assertion to ensure regex matches.
+
+  While Py3 still has assertRegexpMatches, it's deprecated. This function also exists for consistency with
+  our helper function assertNotRegex, which is required for Py2 - Py3 compatibility.
+  """
+  if PY3:
+    self.assertRegex(text, unexpected_regex)
+  else:
+    self.assertRegexpMatches(text, unexpected_regex)
+
+
+def assertNotRegex(self, text, unexpected_regex):
+  """Call unit test assertion to ensure regex does not match.
+
+  Required for compatibility because Py3 .4 does not have assertNotRegexpMatches.
+  """
+  if PY3:
+    self.assertNotRegex(text, unexpected_regex)
+  else:
+    self.assertNotRegexpMatches(text, unexpected_regex)

--- a/tests/python/pants_test/testutils/py2_compat.py
+++ b/tests/python/pants_test/testutils/py2_compat.py
@@ -2,7 +2,10 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from future.utils import PY3
+
 
 def assertRegex(self, text, expected_regex):
   """Call unit test assertion to ensure regex matches.
@@ -11,9 +14,9 @@ def assertRegex(self, text, expected_regex):
   our helper function assertNotRegex, which *is* required for Py2-3 compatibility.
   """
   if PY3:
-    self.assertRegex(text, unexpected_regex)
+    self.assertRegex(text, expected_regex)
   else:
-    self.assertRegexpMatches(text, unexpected_regex)
+    self.assertRegexpMatches(text, expected_regex)
 
 
 def assertNotRegex(self, text, unexpected_regex):

--- a/tests/python/pants_test/testutils/py2_compat.py
+++ b/tests/python/pants_test/testutils/py2_compat.py
@@ -8,7 +8,7 @@ def assertRegex(self, text, expected_regex):
   """Call unit test assertion to ensure regex matches.
 
   While Py3 still has assertRegexpMatches, it's deprecated. This function also exists for consistency with
-  our helper function assertNotRegex, which is required for Py2 - Py3 compatibility.
+  our helper function assertNotRegex, which *is* required for Py2-3 compatibility.
   """
   if PY3:
     self.assertRegex(text, unexpected_regex)
@@ -19,7 +19,7 @@ def assertRegex(self, text, expected_regex):
 def assertNotRegex(self, text, unexpected_regex):
   """Call unit test assertion to ensure regex does not match.
 
-  Required for compatibility because Py3 .4 does not have assertNotRegexpMatches.
+  Required for compatibility because Py3.4 does not have assertNotRegexpMatches.
   """
   if PY3:
     self.assertNotRegex(text, unexpected_regex)


### PR DESCRIPTION
### Problem

Python 3 renamed `assertRegexpMatches` to `assertRegex`, and `assertNotRegexpMatches` to `assertNotRegex`. They kept the alias `assertRegexpMatches`, and just deprecated it. 

However, they did not add an alias for `assertNotRegexpMatches` until Python 3.5 (see https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertNotRegex). So, our CI, which runs Py3.4, was failing.

### Solution

`Six` and `Future` do not have backports for both `assertRegex` or `assertNotRegex`, so we now implement our own backports.

Note that we technically do not need the backport for `assertRegex`, but are using it for consistency because we do need the backport `assertNotRegex`.