### PR TITLE
De-flake JarPublishTest.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -195,14 +195,9 @@ if [[ "${run_python:-false}" == "true" ]]; then
   fi
   start_travis_section "CoreTests" "Running core python tests${shard_desc}"
   (
-    if [[ "${python_three:-false}" == "true" ]]; then
-      targets="$(comm -23 <(./pants.pex --tag='-integration' list tests/python:: | grep '.' | sort) <(sort "${REPO_ROOT}/build-support/known_py3_failures.txt"))"
-    else
-      targets="tests/python::"
-    fi
     ./pants.pex --tag='-integration' test.pytest --chroot \
       --test-pytest-test-shard=${python_unit_shard} \
-      $targets -- ${PYTEST_PASSTHRU_ARGS}
+      tests/python:: -- ${PYTEST_PASSTHRU_ARGS}
   ) || die "Core python test failure"
   end_travis_section
 fi

--- a/build-support/known_py3_failures.txt
+++ b/build-support/known_py3_failures.txt
@@ -1,1 +1,0 @@
-tests/python/pants_test/backend/jvm/tasks:jar_publish


### PR DESCRIPTION
Previously, a dict was used unnecessarily in target preparation leading
to unexpected results when attempting to access a particular target
instead of all prepared targets as a whole.

Fixes #6382