### PR TITLE
Add test to assert that type validation works for Get

### DIFF
--- a/tests/python/pants_test/engine/test_selectors.py
+++ b/tests/python/pants_test/engine/test_selectors.py
@@ -7,10 +7,18 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 from builtins import object
 
-from pants.engine.selectors import Select
+from pants.engine.selectors import Get, Select
 
 
 class AClass(object):
+  pass
+
+
+class BClass(object):
+  pass
+
+
+class SubBClass(BClass):
   pass
 
 
@@ -21,3 +29,10 @@ class SelectorsTest(unittest.TestCase):
 
   def assert_repr(self, expected, selector):
     self.assertEqual(expected, repr(selector))
+
+
+class GetTest(unittest.TestCase):
+  def test_get(self):
+    sub_b = SubBClass()
+    with self.assertRaises(TypeError):
+      Get(AClass, BClass, sub_b)

--- a/tests/python/pants_test/engine/test_selectors.py
+++ b/tests/python/pants_test/engine/test_selectors.py
@@ -34,5 +34,6 @@ class SelectorsTest(unittest.TestCase):
 class GetTest(unittest.TestCase):
   def test_get(self):
     sub_b = SubBClass()
-    with self.assertRaises(TypeError):
+    with self.assertRaises(TypeError) as cm:
       Get(AClass, BClass, sub_b)
+    self.assertIn("Declared type did not match actual type", str(cm.exception))


### PR DESCRIPTION
### Problem

According to #6656, Get wasn't validating its inputs. However, upon reading the code, its inputs should be validated at runtime. 

### Solution

I added a test to ensure the validation behavior is correct. 