### PR TITLE
Run integration test against Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -204,52 +204,52 @@ matrix:
         - ./build-support/bin/travis-ci.sh -3n
 
     - <<: *default_test_config
-      name: "Python integration tests for pants - shard 1"
+      name: "Py3 integration tests for pants - shard 1"
       script:
         - ./build-support/bin/travis-ci.sh -c3 -i 0/6
 
     - <<: *default_test_config
-      name: "Python integration tests for pants - shard 2"
+      name: "Py3 integration tests for pants - shard 2"
       script:
         - ./build-support/bin/travis-ci.sh -c3 -i 1/6
 
     - <<: *default_test_config
-      name: "Python integration tests for pants - shard 3"
+      name: "Py3 integration tests for pants - shard 3"
       script:
         - ./build-support/bin/travis-ci.sh -c3 -i 2/6
 
     - <<: *default_test_config
-      name: "Python integration tests for pants - shard 4"
+      name: "Py3 integration tests for pants - shard 4"
       script:
         - ./build-support/bin/travis-ci.sh -c3 -i 3/6
 
     - <<: *default_test_config
-      name: "Python integration tests for pants - shard 5"
+      name: "Py3 integration tests for pants - shard 5"
       script:
         - ./build-support/bin/travis-ci.sh -c3 -i 4/6
 
     - <<: *default_test_config
-      name: "Python integration tests for pants - shard 6"
+      name: "Py3 integration tests for pants - shard 6"
       script:
         - ./build-support/bin/travis-ci.sh -c3 -i 5/6
 
     - <<: *default_test_config
-      name: "Python 2 integration tests for pants - shard 1"
+      name: "Py 2 integration tests for pants - shard 1"
       script:
         - ./build-support/bin/travis-ci.sh -cw -i 0/2
 
     - <<: *default_test_config
-      name: "Python 2 integration tests for pants - shard 2"
+      name: "Py 2 integration tests for pants - shard 2"
       script:
         - ./build-support/bin/travis-ci.sh -cw -i 1/2
 
     - <<: *default_cron_test_config
-      name: "Python 2 integration tests for pants - shard 1"
+      name: "Py 2 integration tests for pants (cron) - shard 1"
       script:
         - ./build-support/bin/travis-ci.sh -c -i 0/2
 
     - <<: *default_cron_test_config
-      name: "Python 2 integration tests for pants - shard 2"
+      name: "Py 2 integration tests for pants (cron) - shard 2"
       script:
         - ./build-support/bin/travis-ci.sh -c -i 1/2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -234,24 +234,49 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c3 -i 5/6
 
     - <<: *default_test_config
-      name: "Py 2 integration tests for pants - shard 1"
+      name: "Py2 integration tests for pants - shard 1"
       script:
         - ./build-support/bin/travis-ci.sh -cw -i 0/2
 
     - <<: *default_test_config
-      name: "Py 2 integration tests for pants - shard 2"
+      name: "Py2 integration tests for pants - shard 2"
       script:
         - ./build-support/bin/travis-ci.sh -cw -i 1/2
 
     - <<: *default_cron_test_config
-      name: "Py 2 integration tests for pants (cron) - shard 1"
+      name: "Py2 integration tests for pants (cron) - shard 1"
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 0/2
+        - ./build-support/bin/travis-ci.sh -c -i 0/7
 
     - <<: *default_cron_test_config
-      name: "Py 2 integration tests for pants (cron) - shard 2"
+      name: "Py2 integration tests for pants (cron) - shard 2"
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 1/2
+        - ./build-support/bin/travis-ci.sh -c -i 1/7
+
+    - <<: *default_cron_test_config
+      name: "Py2 integration tests for pants (cron) - shard 3"
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 2/7
+
+    - <<: *default_cron_test_config
+      name: "Py2 integration tests for pants (cron) - shard 4"
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 3/7
+
+    - <<: *default_cron_test_config
+      name: "Py2 integration tests for pants (cron) - shard 5"
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 4/7
+
+    - <<: *default_cron_test_config
+      name: "Py2 integration tests for pants (cron) - shard 6"
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 5/7
+
+    - <<: *default_cron_test_config
+      name: "Py2 integration tests for pants (cron) - shard 7"
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 6/7
 
     # Rust on linux
     - name: "Rust Tests Linux"

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,37 +199,37 @@ matrix:
     - <<: *default_test_config
       name: "Python integration tests for pants - shard 1"
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 0/7
+        - ./build-support/bin/travis-ci.sh -c3 -i 0/7
 
     - <<: *default_test_config
       name: "Python integration tests for pants - shard 2"
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 1/7
+        - ./build-support/bin/travis-ci.sh -c3 -i 1/7
 
     - <<: *default_test_config
       name: "Python integration tests for pants - shard 3"
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 2/7
+        - ./build-support/bin/travis-ci.sh -c3 -i 2/7
 
     - <<: *default_test_config
       name: "Python integration tests for pants - shard 4"
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 3/7
+        - ./build-support/bin/travis-ci.sh -c3 -i 3/7
 
     - <<: *default_test_config
       name: "Python integration tests for pants - shard 5"
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 4/7
+        - ./build-support/bin/travis-ci.sh -c3 -i 4/7
 
     - <<: *default_test_config
       name: "Python integration tests for pants - shard 6"
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 5/7
+        - ./build-support/bin/travis-ci.sh -c3 -i 5/7
 
     - <<: *default_test_config
       name: "Python integration tests for pants - shard 7"
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 6/7
+        - ./build-support/bin/travis-ci.sh -c3 -i 6/7
 
     # Rust on linux
     - name: "Rust Tests Linux"

--- a/.travis.yml
+++ b/.travis.yml
@@ -229,12 +229,12 @@ matrix:
     - <<: *default_test_config
       name: "Python 2 integration tests for pants - shard 1"
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 0/2
+        - ./build-support/bin/travis-ci.sh -cw -i 0/2
 
     - <<: *default_test_config
       name: "Python 2 integration tests for pants - shard 2"
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 1/2
+        - ./build-support/bin/travis-ci.sh -cw -i 1/2
 
     # Rust on linux
     - name: "Rust Tests Linux"

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ stages:
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable
-    if: tag IS NOT present AND type != pull_request
+    if: tag IS NOT present AND type NOT IN (pull_request, cron)
 
 default_test_config: &default_test_config
   os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,42 +199,42 @@ matrix:
     - <<: *default_test_config
       name: "Python integration tests for pants - shard 1"
       script:
-        - ./build-support/bin/travis-ci.sh -c3 -i 0/7
+        - ./build-support/bin/travis-ci.sh -c3 -i 0/6
 
     - <<: *default_test_config
       name: "Python integration tests for pants - shard 2"
       script:
-        - ./build-support/bin/travis-ci.sh -c3 -i 1/7
+        - ./build-support/bin/travis-ci.sh -c3 -i 1/6
 
     - <<: *default_test_config
       name: "Python integration tests for pants - shard 3"
       script:
-        - ./build-support/bin/travis-ci.sh -c3 -i 2/7
+        - ./build-support/bin/travis-ci.sh -c3 -i 2/6
 
     - <<: *default_test_config
       name: "Python integration tests for pants - shard 4"
       script:
-        - ./build-support/bin/travis-ci.sh -c3 -i 3/7
+        - ./build-support/bin/travis-ci.sh -c3 -i 3/6
 
     - <<: *default_test_config
       name: "Python integration tests for pants - shard 5"
       script:
-        - ./build-support/bin/travis-ci.sh -c3 -i 4/7
+        - ./build-support/bin/travis-ci.sh -c3 -i 4/6
 
     - <<: *default_test_config
       name: "Python integration tests for pants - shard 6"
       script:
-        - ./build-support/bin/travis-ci.sh -c3 -i 5/7
+        - ./build-support/bin/travis-ci.sh -c3 -i 5/6
 
     - <<: *default_test_config
-      name: "Python integration tests for pants - shard 7"
+      name: "Python 2 integration tests for pants - shard 1"
       script:
-        - ./build-support/bin/travis-ci.sh -c3 -i 6/7
+        - ./build-support/bin/travis-ci.sh -c -i 0/2
 
     - <<: *default_test_config
-      name: "Python 2 integration tests for pants"
+      name: "Python 2 integration tests for pants - shard 2"
       script:
-        - ./build-support/bin/travis-ci.sh -c
+        - ./build-support/bin/travis-ci.sh -c -i 1/2
 
     # Rust on linux
     - name: "Rust Tests Linux"

--- a/.travis.yml
+++ b/.travis.yml
@@ -231,6 +231,11 @@ matrix:
       script:
         - ./build-support/bin/travis-ci.sh -c3 -i 6/7
 
+    - <<: *default_test_config
+      name: "Python 2 integration tests for pants"
+      script:
+        - ./build-support/bin/travis-ci.sh -c
+
     # Rust on linux
     - name: "Rust Tests Linux"
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,10 @@ cache:
 
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
-  - Test Pants
+  - name: &test Test Pants
+    if: type != cron
+  - name: &cron Cron
+    if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable
@@ -76,7 +79,7 @@ default_test_config: &default_test_config
         - python3
         - openssl
         - libssl-dev
-  stage: Test Pants
+  stage: *test
   language: python
   python: &python_version "2.7"
   before_install:
@@ -89,6 +92,10 @@ default_test_config: &default_test_config
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288
 
+default_cron_test_congig:
+  <<: *default_test_config
+  stage: *cron
+
 matrix:
   include:
 
@@ -99,7 +106,7 @@ matrix:
       # We use 10.11 as a minimum to avoid https://github.com/rust-lang/regex/issues/489.
       # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
       osx_image: xcode8
-      stage: Test Pants
+      stage: *test
       language: generic
       env:
         - PREPARE_DEPLOY=1
@@ -109,7 +116,7 @@ matrix:
     # Build Linux engine
     - name: "Linux Native Engine Binary Builder"
       os: linux
-      stage: Test Pants
+      stage: *test
       language: generic
       services:
         - docker
@@ -236,12 +243,22 @@ matrix:
       script:
         - ./build-support/bin/travis-ci.sh -cw -i 1/2
 
+    - <<: *default_cron_test_config
+      name: "Python 2 integration tests for pants - shard 1"
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 0/2
+
+    - <<: *default_cron_test_config
+      name: "Python 2 integration tests for pants - shard 2"
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 1/2
+
     # Rust on linux
     - name: "Rust Tests Linux"
       os: linux
       dist: trusty
       sudo: required
-      stage: Test Pants
+      stage: *test
       language: python
       python: *python_version
       before_install:
@@ -259,7 +276,7 @@ matrix:
       os: osx
       # Fuse actually works on this image. It hangs on many others.
       osx_image: xcode8.3
-      stage: Test Pants
+      stage: *test
       language: generic
       before_install:
         - brew tap caskroom/cask && brew update && brew cask install osxfuse
@@ -276,7 +293,7 @@ matrix:
       os: linux
       dist: trusty
       sudo: required
-      stage: Test Pants
+      stage: *test
       language: python
       python: *python_version
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ default_test_config: &default_test_config
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288
 
-default_cron_test_congig:
+default_cron_test_config: &default_cron_test_config
   <<: *default_test_config
   stage: *cron
 

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -257,9 +257,14 @@ if [[ "${run_integration:-false}" == "true" ]]; then
   fi
   start_travis_section "IntegrationTests" "Running Pants Integration tests${shard_desc}"
   (
+    if [[ "${python_three:-false}" == "true" ]]; then
+      targets="$(comm -23 <(./pants.pex --tag='+integration' list tests/python:: | grep '.' | sort) <(sort "${REPO_ROOT}/build-support/known_py3_integration_failures.txt"))"
+    else
+      targets="tests/python::"
+    fi
     ./pants.pex --tag='+integration' test.pytest \
       --test-pytest-test-shard=${python_intg_shard} \
-      tests/python:: -- ${PYTEST_PASSTHRU_ARGS}
+      $targets -- ${PYTEST_PASSTHRU_ARGS}
   ) || die "Pants Integration test failure"
   end_travis_section
 fi

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -66,7 +66,7 @@ python_contrib_shard="0/1"
 python_intg_shard="0/1"
 python_three="false"
 
-while getopts "h3fxbkmrjlpesu:ny:ci:tz" opt; do
+while getopts "h3fxbkmrjlpesu:ny:ci:tzw" opt; do
   case ${opt} in
     h) usage ;;
     3) python_three="true" ;;

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -260,7 +260,7 @@ if [[ "${run_integration:-false}" == "true" ]]; then
     if [[ "${python_three:-false}" == "true" ]]; then
       targets="$(comm -23 <(./pants.pex --tag='+integration' list tests/python:: | grep '.' | sort) <(sort "${REPO_ROOT}/build-support/known_py3_integration_failures.txt"))"
     else
-      targets="tests/python::"
+       targets="$(cat ${REPO_ROOT}/build-support/known_py3_integration_failures.txt)"
     fi
     ./pants.pex --tag='+integration' test.pytest \
       --test-pytest-test-shard=${python_intg_shard} \

--- a/build-support/known_py3_integration_failures.txt
+++ b/build-support/known_py3_integration_failures.txt
@@ -1,6 +1,7 @@
 tests/python/pants_test/backend/codegen/antlr/python:integration
 tests/python/pants_test/backend/jvm/tasks:checkstyle_integration
 tests/python/pants_test/backend/python/tasks:integration
+tests/python/pants_test/backend/python/tasks:python_native_code_testing
 tests/python/pants_test/engine/legacy:pants_engine_integration
 tests/python/pants_test/option:options_integration
 tests/python/pants_test/pantsd:pantsd_integration

--- a/build-support/known_py3_integration_failures.txt
+++ b/build-support/known_py3_integration_failures.txt
@@ -1,0 +1,7 @@
+tests/python/pants_test/backend/codegen/antlr/python:integration
+tests/python/pants_test/backend/jvm/tasks:checkstyle_integration
+tests/python/pants_test/backend/python/tasks:integration
+tests/python/pants_test/engine/legacy:pants_engine_integration
+tests/python/pants_test/option:options_integration
+tests/python/pants_test/pantsd:pantsd_integration
+tests/python/pants_test/projects:

--- a/build-support/known_py3_integration_failures.txt
+++ b/build-support/known_py3_integration_failures.txt
@@ -5,4 +5,4 @@ tests/python/pants_test/backend/python/tasks:python_native_code_testing
 tests/python/pants_test/engine/legacy:pants_engine_integration
 tests/python/pants_test/option:options_integration
 tests/python/pants_test/pantsd:pantsd_integration
-tests/python/pants_test/projects:
+tests/python/pants_test/projects:testprojects_integration

--- a/tests/python/pants_test/projects/BUILD
+++ b/tests/python/pants_test/projects/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
+  name="testprojects_integration",
   sources=['test_testprojects_integration.py'],
   dependencies=[
     '3rdparty/python:future',


### PR DESCRIPTION
### Problem
As we push towards python 3 support for pants, we want more than our unit tests to run against python 3. 

### Solution
Run integration tests against python 3

### Notes:
- As the cost of running integration test against both python 2 and 3 is too costly, it was decided we would switch CI to run python 3 only with a daily cron job running same tests against python 2
- We have a blacklist at `build-support/known_py3_integration_failures.txt` for all tests failing in python3. We do run those tests against python2.
- I added 1 shard and reshuffled integration shards. So we now have 8 integration tests shards, 6 for python 3 and 2 for python 2 (blacklisted tests).


