### PR TITLE
Jacoco report target filtering.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coverage/manager.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/manager.py
@@ -85,8 +85,9 @@ class CodeCoverage(Subsystem):
                   '(defaults to False, as otherwise the coverage results would be unreliable).')
 
     # register options for coverage engines
-    # TODO(jtrobec): get rid of this calls when engines are dependent subsystems
+    # TODO(jtrobec): get rid of these calls when engines are dependent subsystems
     Cobertura.register_junit_options(register, register_jvm_tool)
+    Jacoco.register_junit_options(register, register_jvm_tool)
 
   class InvalidCoverageEngine(Exception):
     """Indicates an invalid coverage engine type was selected."""

--- a/testprojects/src/java/org/pantsbuild/testproject/coverage/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/coverage/BUILD
@@ -1,0 +1,6 @@
+java_library(
+    dependencies=[
+        'testprojects/src/java/org/pantsbuild/testproject/coverage/one',
+        'testprojects/src/java/org/pantsbuild/testproject/coverage/two',
+    ]
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/coverage/one/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/coverage/one/BUILD
@@ -1,0 +1,5 @@
+java_library(
+  sources=[
+    'CoverageClassOne.java',
+  ],
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/coverage/one/CoverageClassOne.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/coverage/one/CoverageClassOne.java
@@ -1,0 +1,31 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+package org.pantsbuild.testproject.coverage.one;
+
+/**
+ * This is a trivial class for use in testing pants java code covearge
+ * functionality. It is initialized with a given value, and has methods
+ * to return the value, +/- some other value.
+ */
+public class CoverageClassOne {
+    private final int magnitude;
+
+    public CoverageClassOne(int magnitude) {
+        this.magnitude = magnitude;
+    }
+
+    public int add(int toAdd) {
+        return this.magnitude + toAdd;
+    }
+
+    public int sub(int toSub) {
+        return this.magnitude - toSub;
+    }
+
+    public int addIfTrue(boolean isTrue, int toAdd) {
+        if (isTrue) {
+            return add(toAdd);
+        }
+        return this.magnitude;
+    }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/coverage/two/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/coverage/two/BUILD
@@ -1,0 +1,5 @@
+java_library(
+  sources=[
+    'CoverageClassTwo.java',
+  ],
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/coverage/two/CoverageClassTwo.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/coverage/two/CoverageClassTwo.java
@@ -1,0 +1,31 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+package org.pantsbuild.testproject.coverage.two;
+
+/**
+ * This is a trivial class for use in testing pants java code covearge
+ * functionality. It is initialized with a given value, and has methods
+ * to return the value, mult/div some other value.
+ */
+public class CoverageClassTwo {
+    private final int magnitude;
+
+    public CoverageClassTwo(int magnitude) {
+        this.magnitude = magnitude;
+    }
+
+    public int mult(int toMult) {
+        return this.magnitude * toMult;
+    }
+
+    public int div(int toDiv) {
+        return this.magnitude / toDiv;
+    }
+
+    public int multIfTrue(boolean isTrue, int toMult) {
+        if (isTrue) {
+            return mult(toMult);
+        }
+        return this.magnitude;
+    }
+}

--- a/testprojects/tests/java/org/pantsbuild/testproject/coverage/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/coverage/BUILD
@@ -1,0 +1,10 @@
+junit_tests(name='all',
+  dependencies=[
+    '3rdparty:junit',
+    'testprojects/src/java/org/pantsbuild/testproject/coverage/one',
+    'testprojects/src/java/org/pantsbuild/testproject/coverage/two',
+  ],
+  sources=[
+    'CoverAllTest.java',
+  ],
+)

--- a/testprojects/tests/java/org/pantsbuild/testproject/coverage/CoverAllTest.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/coverage/CoverAllTest.java
@@ -1,0 +1,27 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+package org.pantsbuild.testproject.coverage;
+
+
+import org.pantsbuild.testproject.coverage.one.CoverageClassOne;
+import org.pantsbuild.testproject.coverage.two.CoverageClassTwo;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class CoverAllTest {
+    @Test public void coverAllTest() {
+        final CoverageClassOne one = new CoverageClassOne(1);
+        final CoverageClassTwo two = new CoverageClassTwo(2);
+        
+        assertEquals(2, one.add(1));
+        assertEquals(0, one.sub(1));
+        assertEquals(2, one.addIfTrue(true, 1));
+        assertEquals(1, one.addIfTrue(false, 1));
+
+        assertEquals(4, two.mult(2));
+        assertEquals(1, two.div(2));
+        assertEquals(4, two.multIfTrue(true, 2));
+        assertEquals(2, two.multIfTrue(false, 2));
+    }
+}


### PR DESCRIPTION
Adds an argument for the jacoco jvm coverage processor that filters targets included in reports using a list of regular expressions.

### Problem

The current implementation of jacoco code coverage will produce a report that includes all targets used in the test run. This includes targets not directly under test, but dependencies of the package actually under test. As a result, there's a lot of undesirable noise in the reports.

### Solution

Introduce a parameter to filter the class files supplied to the jacoco cli when the report is produced. The jacoco cli does not provide a native parameter for exclusions, and instead the best we can do is to exclude class files when generating the reports. Classes that aren't passed to the cli during report generation aren't included in the resulting report.

The parameter I've added is a list of regular expressions. When specified, pants will only pass targets that match one of the regexes to the cli during report generation. Any target that doesn't match the pattern will be excluded, and thus not show up in the report.