### PR TITLE
Add optional 'thrift-preprocess' product containing targets for thrift linter task to skip

### DIFF
--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -33,4 +33,4 @@ do
   esac
 done
 
-./pants -q --changed-parent=master fmt.isort -- ${isort_args[@]}
+./pants -q --changed-parent=master --exclude-target-regexp='testprojects/.*' fmt.isort -- ${isort_args[@]}

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
@@ -116,3 +116,19 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(cmd, config=pants_ini_config)
     self.assert_success(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
+
+  def test_thrift_preprocess_targets_skipped(self):
+    broken_thrift_target_spec = 'testprojects/src/thrift/org/pantsbuild/broken_thrift'
+    cmd = ['lint', broken_thrift_target_spec]
+    pants_run = self.run_pants(cmd)
+    self.assert_failure(pants_run)
+    self.assertIn("com.twitter.scrooge.frontend.FileParseException: Exception parsing: testprojects/src/thrift/org/pantsbuild/broken_thrift/broken.thrift",
+                  pants_run.stdout_data)
+    pants_ini_config = {
+      'GLOBAL': {
+        'pythonpath': "+['%(buildroot)s/contrib/scrooge/src/python', '%(buildroot)s/testprojects/pants-plugins/src/python']",
+        'backend_packages': "+['pants.contrib.scrooge', 'test_pants_plugin']",
+      }
+    }
+    pants_run = self.run_pants(cmd, config=pants_ini_config)
+    self.assert_success(pants_run)

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/BUILD
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/BUILD
@@ -3,6 +3,7 @@ python_library(
     'testprojects/pants-plugins/3rdparty/python/pants',
     'testprojects/pants-plugins/src/python/test_pants_plugin/subsystems',
     'testprojects/pants-plugins/src/python/test_pants_plugin/tasks',
+    'contrib/scrooge/src/python/pants/contrib/scrooge/tasks',
   ],
   provides=setup_py(
     name='test_pants_plugin',

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
@@ -8,9 +8,12 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from test_pants_plugin.pants_infra_tests import PantsInfraTests
 from test_pants_plugin.subsystems.pants_test_infra import PantsTestInfra
 from test_pants_plugin.tasks.lifecycle_stub_task import LifecycleStubTask
+from test_pants_plugin.tasks.thrift_preprocess_stub import ThriftPreprocessStub
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task
+
+from pants.contrib.scrooge.tasks.thrift_linter import ThriftLinter
 
 
 def build_file_aliases():
@@ -22,6 +25,8 @@ def build_file_aliases():
 
 def register_goals():
   task(name='lifecycle-stub-task', action=LifecycleStubTask).install('lifecycle-stub-goal')
+  task(name='preprocess-stub-for-thrift', action=ThriftPreprocessStub).install('thrift-stub-goal')
+  task(name='thrift-linter', action=ThriftLinter).install('lint')
 
 
 def global_subsystems():

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/tasks/BUILD
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/tasks/BUILD
@@ -6,5 +6,6 @@ python_library(
   dependencies=[
     'testprojects/pants-plugins/3rdparty/python/pants',
     'testprojects/pants-plugins/src/python/test_pants_plugin/subsystems',
+    'contrib/scrooge/src/python/pants/contrib/scrooge/tasks',
   ],
 )

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/tasks/thrift_preprocess_stub.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/tasks/thrift_preprocess_stub.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import sys
+from builtins import open
+
+from pants.backend.codegen.thrift.java.java_thrift_library import JavaThriftLibrary
+from pants.base.exception_sink import ExceptionSink
+from pants.base.exiter import Exiter
+from pants.task.task import Task
+from pants.util.memo import memoized_property
+
+from pants.contrib.scrooge.tasks.scrooge_gen import ScroogeGen
+
+
+class ThriftPreprocessStub(ScroogeGen):
+
+  @classmethod
+  def product_types(cls):
+    return ['thrift-preprocess']
+
+  def is_gentarget(self, target):
+    return isinstance(target, JavaThriftLibrary)
+
+  def execute_codegen(self, target, target_workdir):
+    preprocessed_thrift_product = self.context.products.get('thrift-preprocess')
+    preprocessed_thrift_product.add(target, target.address.spec_path)

--- a/testprojects/src/thrift/org/pantsbuild/broken_thrift/BUILD
+++ b/testprojects/src/thrift/org/pantsbuild/broken_thrift/BUILD
@@ -1,0 +1,4 @@
+java_thrift_library(
+  sources=globs('*.thrift'),
+  compiler='scrooge',
+)

--- a/testprojects/src/thrift/org/pantsbuild/broken_thrift/broken.thrift
+++ b/testprojects/src/thrift/org/pantsbuild/broken_thrift/broken.thrift
@@ -1,0 +1,3 @@
+# The below is an example of invalid thrift source text, which will cause an error during lint or
+# compile.
+asdkjf;alsdjgfkla;sjdtg;lasjlgk;jal

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py_integration.py
@@ -161,4 +161,5 @@ class SetupPyIntegrationTest(PantsRequirementIntegrationTestBase):
         'test_pants_plugin/tasks/',
         'test_pants_plugin/tasks/__init__.py',
         'test_pants_plugin/tasks/lifecycle_stub_task.py',
+        'test_pants_plugin/tasks/thrift_preprocess_stub.py',
       ])

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -69,6 +69,7 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/tests/java/org/pantsbuild/testproject/parallel.*',
       'testprojects/src/python/python_distribution/fasthello_with_install_requires.*',
       'testprojects/src/python/unicode/compilation_failure',
+      'testprojects/src/thrift/org/pantsbuild/broken_thrift',
     ]
 
     # May not succeed without java8 installed


### PR DESCRIPTION
### Problem

Resolves #6729.

### Solution

- add optional `thrift-preprocess` product dependency to `ThriftLinter`
- don't try to lint the targets which are the keys of the `thrift-preprocess` product mapping
- add an integration test
- make `build-support/bin/isort.sh` exclude `testprojects/*` so that the broken thrift target for the purposes of the integration test could the pre-commit check

### Result

Tasks which generate any scrooge sources can add them to the `thrift-preprocess` product to avoid being linted.