### PR TITLE
Ignore paths more deeply to avoid graph impact when ignored files are added/removed

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -284,14 +284,10 @@ class Scheduler(object):
     filenames = set(direct_filenames)
     filenames.update(os.path.dirname(f) for f in direct_filenames)
     filenames_buf = self._native.context.utf8_buf_buf(filenames)
-    invalidated = self._native.lib.graph_invalidate(self._scheduler, filenames_buf)
-    logger.info('invalidated %d nodes for: %s', invalidated, filenames)
-    return invalidated
+    return self._native.lib.graph_invalidate(self._scheduler, filenames_buf)
 
   def invalidate_all_files(self):
-    invalidated =  self._native.lib.graph_invalidate_all_paths(self._scheduler)
-    logger.info('invalidated all %d nodes', invalidated)
-    return invalidated
+    return self._native.lib.graph_invalidate_all_paths(self._scheduler)
 
   def graph_len(self):
     return self._native.lib.graph_len(self._scheduler)

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -112,11 +112,9 @@ trait GlobMatchingImplementation<E: Send + Sync + 'static>: VFS<E> {
                 .map(|file_name| symbolic_path.join(file_name))
                 .map(|symbolic_stat_path| (symbolic_stat_path, stat))
             }).map(|(stat_symbolic_path, stat)| {
-              // Canonicalize matched PathStats, and filter paths that are ignored by either the
-              // context, or by local excludes. Note that we apply context ignore patterns to both
-              // the symbolic and canonical names of Links, but only apply local excludes to their
-              // symbolic names.
-              if context.is_ignored(&stat) || exclude.is_ignored(&stat) {
+              // Canonicalize matched PathStats, and filter paths that are ignored by local excludes.
+              // Context ("global") ignore patterns are applied during `scandir`.
+              if exclude.is_ignored(&stat) {
                 future::ok(None).to_boxed()
               } else {
                 match stat {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -537,6 +537,7 @@ pub struct GlobWithSource {
 ///
 /// All Stats consumed or return by this type are relative to the root.
 ///
+#[derive(Clone)]
 pub struct PosixFS {
   root: Dir,
   pool: Arc<ResettablePool>,
@@ -578,8 +579,8 @@ impl PosixFS {
     })
   }
 
-  fn scandir_sync(root: &Path, dir_relative_to_root: &Dir) -> Result<Vec<Stat>, io::Error> {
-    let dir_abs = root.join(&dir_relative_to_root.0);
+  fn scandir_sync(&self, dir_relative_to_root: &Dir) -> Result<Vec<Stat>, io::Error> {
+    let dir_abs = self.root.0.join(&dir_relative_to_root.0);
     let mut stats: Vec<Stat> = dir_abs
       .read_dir()?
       .map(|readdir| {
@@ -591,6 +592,14 @@ impl PosixFS {
           &dir_abs,
           get_metadata,
         )
+      }).filter(|s| match s {
+        Ok(ref s) =>
+        // It would be nice to be able to ignore paths before stat'ing them, but in order to apply
+        // git-style ignore patterns, we need to know whether a path represents a directory.
+        {
+          !self.ignore.is_ignored(s)
+        }
+        Err(_) => true,
       }).collect::<Result<Vec<_>, io::Error>>()?;
     stats.sort_by(|s1, s2| s1.path().cmp(s2.path()));
     Ok(stats)
@@ -706,10 +715,10 @@ impl PosixFS {
 
   pub fn scandir(&self, dir: &Dir) -> BoxFuture<DirectoryListing, io::Error> {
     let dir = dir.to_owned();
-    let root = self.root.0.clone();
+    let fs: PosixFS = self.clone();
     self
       .pool
-      .spawn_fn(move || PosixFS::scandir_sync(&root, &dir))
+      .spawn_fn(move || fs.scandir_sync(&dir))
       .map(DirectoryListing)
       .to_boxed()
   }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -11,8 +11,8 @@ use futures::future::{self, Future};
 
 use context::{Context, Core};
 use core::{Failure, Key, Params, TypeConstraint, TypeId, Value};
-use graph::{EntryId, Graph, Node, NodeContext};
-use log::debug;
+use graph::{EntryId, Graph, InvalidationResult, Node, NodeContext};
+use log::{debug, info, warn};
 use nodes::{NodeKey, Select, Tracer, TryInto, Visualizer};
 use parking_lot::Mutex;
 use rule_graph;
@@ -145,27 +145,37 @@ impl Scheduler {
   /// Invalidate the invalidation roots represented by the given Paths.
   ///
   pub fn invalidate(&self, paths: &HashSet<PathBuf>) -> usize {
-    let invalidation_result = self.core.graph.invalidate_from_roots(move |node| {
-      if let Some(fs_subject) = node.fs_subject() {
-        paths.contains(fs_subject)
-      } else {
-        false
-      }
-    });
-    // TODO: Expose.
-    invalidation_result.cleared + invalidation_result.dirtied
+    let InvalidationResult { cleared, dirtied } =
+      self.core.graph.invalidate_from_roots(move |node| {
+        if let Some(fs_subject) = node.fs_subject() {
+          paths.contains(fs_subject)
+        } else {
+          false
+        }
+      });
+    // TODO: The rust log level is not currently set correctly in a pantsd context. To ensure that
+    // we see this even at `info` level, we set it to warn. #6004 should address this by making
+    // rust logging re-configuration an explicit step in `src/python/pants/init/logging.py`.
+    warn!(
+      "invalidation: cleared {} and dirtied {} nodes for: {:?}",
+      cleared, dirtied, paths
+    );
+    cleared + dirtied
   }
 
   ///
   /// Invalidate all filesystem dependencies in the graph.
   ///
   pub fn invalidate_all_paths(&self) -> usize {
-    let invalidation_result = self
+    let InvalidationResult { cleared, dirtied } = self
       .core
       .graph
       .invalidate_from_roots(|node| node.fs_subject().is_some());
-    // TODO: Expose.
-    invalidation_result.cleared + invalidation_result.dirtied
+    info!(
+      "invalidation: cleared {} and dirtied {} nodes for all paths",
+      cleared, dirtied
+    );
+    cleared + dirtied
   }
 
   ///


### PR DESCRIPTION
### Problem

The path ignoring that is controlled by the `--pants-ignore` global option currently ignores paths during glob expansion. But glob expansion consumes cached filesystem operations, meaning that those cached filesystem operations are not pre-filtered for ignored files. The effect is that the cached `DirectoryListing` for a directory still changes when ignored files are added and removed.

### Solution

Push path filtering down to `scandir_sync`, so that it is below the `Scandir`/`DirectoryListing` caching. In a separate commit, log both the number of `cleared` and `dirtied` nodes.

### Result

Node dirtying should be effective in more cases, because creating/removing a file at an ignored path will only clear a single node, while all other nodes can be cleaned without re-running.

Example for creating a file `ignore_this_file` after running `./pants --enable-pantsd --pants-ignore='+["ignore_this_file"]' list ::` :
```
# Before
I1109 12:14:50.272815 86270 scheduler_service.py:88] enqueuing 1 changes for subscription all_files
I1109 12:14:50.306777 86270 scheduler.py:282] invalidated 10433 nodes for: set([u'', u'ignore_this_file'])
I1109 12:14:54.746129 86270 pailgun_server.py:72] handling pailgun request: `./pants --enable-pantsd --pants-ignore=+["ignore_this_file"] list ::`
W1109 12:14:54.918494 86270 native.py:413] Globs did not match. Excludes were: []. Unmatched globs were: ["testprojects/src/java/org/pantsbuild/testproject/bundle/file1.aaaa", "testprojects/src/java/org/pantsbuild/testproject/bundle/file2.aaaa"].
<snip more running globs>
I1109 12:14:56.162152 86270 pailgun_server.py:81] pailgun request completed: `./pants --enable-pantsd --pants-ignore=+["ignore_this_file"] list ::`

# After
I1109 12:11:46.683013 83652 scheduler_service.py:88] enqueuing 1 changes for subscription all_files
W1109 12:11:46.719578 83652 native.py:413] invalidation: cleared 1 and dirtied 10432 nodes for: {"", "ignore_this_file"}
I1109 12:11:51.063949 83652 pailgun_server.py:72] handling pailgun request: `./pants --enable-pantsd --pants-ignore=+["ignore_this_file"] list ::`
I1109 12:11:51.748687 83652 pailgun_server.py:81] pailgun request completed: `./pants --enable-pantsd --pants-ignore=+["ignore_this_file"] list ::`
```