### PR TITLE
Fix Python 3 option integration test issue with unicode

### DIFF
--- a/build-support/known_py3_integration_failures.txt
+++ b/build-support/known_py3_integration_failures.txt
@@ -3,6 +3,5 @@ tests/python/pants_test/backend/jvm/tasks:checkstyle_integration
 tests/python/pants_test/backend/python/tasks:integration
 tests/python/pants_test/backend/python/tasks:python_native_code_testing
 tests/python/pants_test/engine/legacy:pants_engine_integration
-tests/python/pants_test/option:options_integration
 tests/python/pants_test/pantsd:pantsd_integration
 tests/python/pants_test/projects:testprojects_integration

--- a/tests/python/pants_test/option/test_quiet_option_integration.py
+++ b/tests/python/pants_test/option/test_quiet_option_integration.py
@@ -37,7 +37,7 @@ class TestOptionsQuietIntegration(PantsRunIntegrationTest):
       pants_run = self.run_pants(['--no-quiet', 'export', '--output-file={}'.format(f.name)])
       self.assert_success(pants_run)
 
-      json_string = f.read()
+      json_string = f.read().decode('utf8')
       # Make sure the json is valid from the file read.
       json.loads(json_string)
       # Make sure json string does not appear in stdout.


### PR DESCRIPTION
### Problem
Python 3 makes a big deal about string and bytes are totally different.

### Solution
Make sure we convert the bytes to a string.

### Result
Test is fixed.