### PR TITLE
Turn PythonInterpreterCache into a subsystem

### DIFF
--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -8,8 +8,6 @@ import os
 from builtins import filter, open, str
 
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
-from pants.backend.python.subsystems.python_repos import PythonRepos
-from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_target import PythonTarget
@@ -45,6 +43,10 @@ class MypyTask(ResolveRequirementsTaskBase):
   @classmethod
   def supports_passthru_args(cls):
     return True
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(MypyTask, cls).subsystem_dependencies() + (PythonInterpreterCache,)
 
   def find_py3_interpreter(self):
     interpreters = self._interpreter_cache.setup(filters=['>=3'])
@@ -82,9 +84,7 @@ class MypyTask(ResolveRequirementsTaskBase):
 
   @memoized_property
   def _interpreter_cache(self):
-    return PythonInterpreterCache(PythonSetup.global_instance(),
-                                  PythonRepos.global_instance(),
-                                  logger=self.context.log.debug)
+    return PythonInterpreterCache.global_instance()
 
   def _run_mypy(self, py3_interpreter, mypy_args, **kwargs):
     pex_info = PexInfo.default()

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -58,8 +58,8 @@ class Checkstyle(LintTaskMixin, Task):
   @classmethod
   def subsystem_dependencies(cls):
     return super(Task, cls).subsystem_dependencies() + cls.plugin_subsystems + (
-      # Needed implicitly by the pex_build_util functions we use.
-      PythonSetup, PythonRepos)
+      PythonSetup, PythonRepos, PythonInterpreterCache
+    )
 
   @classmethod
   def implementation_version(cls):
@@ -220,9 +220,7 @@ class Checkstyle(LintTaskMixin, Task):
     )
     if not python_tgts:
       return 0
-    interpreter_cache = PythonInterpreterCache(PythonSetup.global_instance(),
-                                               PythonRepos.global_instance(),
-                                               logger=self.context.log.debug)
+    interpreter_cache = PythonInterpreterCache.global_instance()
     with self.invalidated(self.get_targets(self._is_checked)) as invalidation_check:
       failure_count = 0
       tgts_by_compatibility, _ = interpreter_cache.partition_targets_by_compatibility(

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -45,7 +45,9 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
 
   @classmethod
   def subsystem_dependencies(cls):
-    return super(PythonEval, cls).subsystem_dependencies() + (PythonRepos, PythonSetup)
+    return super(PythonEval, cls).subsystem_dependencies() + (
+      PythonRepos, PythonSetup, PythonInterpreterCache
+    )
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -72,9 +74,7 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
 
   @memoized_property
   def _interpreter_cache(self):
-    return PythonInterpreterCache(PythonSetup.global_instance(),
-                                  PythonRepos.global_instance(),
-                                  logger=self.context.log.debug)
+    return PythonInterpreterCache.global_instance()
 
   def _compile_targets(self, invalid_vts):
     with self.context.new_workunit(name='eval-targets', labels=[WorkUnitLabel.MULTITOOL]):

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -23,8 +23,6 @@ from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.coursier_resolve import CoursierMixin
 from pants.backend.jvm.tasks.ivy_task_mixin import IvyTaskMixin
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
-from pants.backend.python.subsystems.python_repos import PythonRepos
-from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.targets.python_tests import PythonTests
@@ -67,7 +65,7 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
   @classmethod
   def subsystem_dependencies(cls):
     return super(ExportTask, cls).subsystem_dependencies() + (
-      DistributionLocator, JvmPlatform, PythonSetup, PythonRepos
+      DistributionLocator, JvmPlatform, PythonInterpreterCache
     )
 
   class SourceRootTypes(object):
@@ -125,9 +123,7 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
 
   @memoized_property
   def _interpreter_cache(self):
-    return PythonInterpreterCache(PythonSetup.global_instance(),
-                                  PythonRepos.global_instance(),
-                                  logger=self.context.log.debug)
+    return PythonInterpreterCache.global_instance()
 
   def check_artifact_cache_for(self, invalidation_check):
     # Export is an output dependent on the entire target set, and is not divisible

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -45,6 +45,7 @@ python_library(
     'src/python/pants/backend/python/targets',
     'src/python/pants/base:exceptions',
     'src/python/pants/process',
+    'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
   ]

--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -12,7 +12,6 @@ from future.utils import PY3
 from pex.interpreter import PythonInterpreter
 
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
-from pants.backend.python.subsystems.python_repos import PythonRepos
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
@@ -49,7 +48,8 @@ class SelectInterpreter(Task):
 
   @classmethod
   def subsystem_dependencies(cls):
-    return super(SelectInterpreter, cls).subsystem_dependencies() + (PythonSetup, PythonRepos)
+    return super(SelectInterpreter, cls).subsystem_dependencies() + (
+      PythonSetup, PythonInterpreterCache)
 
   @classmethod
   def product_types(cls):
@@ -88,9 +88,7 @@ class SelectInterpreter(Task):
     self.context.products.register_data(PythonInterpreter, interpreter)
 
   def _create_interpreter_path_file(self, interpreter_path_file, targets):
-    interpreter_cache = PythonInterpreterCache(PythonSetup.global_instance(),
-                                               PythonRepos.global_instance(),
-                                               logger=self.context.log.debug)
+    interpreter_cache = PythonInterpreterCache.global_instance()
     interpreter = interpreter_cache.select_interpreter_for_targets(targets)
     safe_mkdir_for(interpreter_path_file)
     with open(interpreter_path_file, 'w') as outfile:

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_apache_thrift_py_gen.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_apache_thrift_py_gen.py
@@ -16,7 +16,6 @@ from pants.backend.codegen.thrift.python.apache_thrift_py_gen import ApacheThrif
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
 from pants.backend.python.subsystems.python_repos import PythonRepos
-from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.base.build_environment import get_buildroot
 from pants.util.process_handler import subprocess
@@ -143,10 +142,9 @@ class ApacheThriftPyGenTest(TaskTestBase):
     self.assertNotEqual(synthetic_target_one.target_base, synthetic_target_two.target_base)
 
     targets = (synthetic_target_one, synthetic_target_two)
-
-    python_repos = global_subsystem_instance(PythonRepos)
-    python_setup = global_subsystem_instance(PythonSetup)
-    interpreter_cache = PythonInterpreterCache(python_setup, python_repos)
+    self.context(for_subsystems=[PythonInterpreterCache, PythonRepos])
+    interpreter_cache = PythonInterpreterCache.global_instance()
+    python_repos = PythonRepos.global_instance()
     interpreter = interpreter_cache.select_interpreter_for_targets(targets)
 
     # We need setuptools to import namespace packages (via pkg_resources), so we prime the

--- a/tests/python/pants_test/backend/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/backend/python/test_interpreter_cache.py
@@ -14,14 +14,11 @@ from pex.package import EggPackage, Package, SourcePackage
 from pex.resolver import Unsatisfiable, resolve
 
 from pants.backend.python.interpreter_cache import PythonInterpreter, PythonInterpreterCache
-from pants.backend.python.subsystems.python_repos import PythonRepos
-from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import temporary_dir
 from pants_test.backend.python.interpreter_selection_utils import (PY_27, PY_36,
                                                                    python_interpreter_path,
                                                                    skip_unless_python27_and_python36)
-from pants_test.subsystem.subsystem_util import global_subsystem_instance
 from pants_test.test_base import TestBase
 from pants_test.testutils.pexrc_util import setup_pexrc_with_pex_python_path
 from pants_test.testutils.py2_compat import assertRegex
@@ -43,13 +40,13 @@ class TestInterpreterCache(TestBase):
     super(TestInterpreterCache, self).setUp()
     self._interpreter = PythonInterpreter.get()
 
-  def create_python_subsystems(self, setup_options=None, repos_options=None):
+  def _create_interpreter_cache(self, setup_options=None, repos_options=None):
     Subsystem.reset(reset_options=True)
-    def create_subsystem(subsystem_type, options=None):
-      return global_subsystem_instance(subsystem_type,
-                                       options={subsystem_type.options_scope: options or {}})
-    return (create_subsystem(PythonSetup, setup_options),
-            create_subsystem(PythonRepos, repos_options))
+    self.context(for_subsystems=[PythonInterpreterCache], options={
+      'python-setup': setup_options,
+      'python-repos': repos_options
+    })
+    return PythonInterpreterCache.global_instance()
 
   @contextmanager
   def _setup_cache(self, constraints=None):
@@ -61,8 +58,7 @@ class TestInterpreterCache(TestBase):
     setup_options = {'interpreter_cache_dir': path}
     if constraints:
       setup_options.update(interpreter_constraints=constraints)
-    python_setup, python_repos = self.create_python_subsystems(setup_options=setup_options)
-    return PythonInterpreterCache(python_setup=python_setup, python_repos=python_repos)
+    return self._create_interpreter_cache(setup_options=setup_options, repos_options={})
 
   def test_cache_setup_with_no_filters_uses_repo_default_excluded(self):
     bad_interpreter_requirement = self._make_bad_requirement(self._interpreter.identity.requirement)
@@ -105,23 +101,21 @@ class TestInterpreterCache(TestBase):
 
       interpreter_requirement = self._interpreter.identity.requirement
 
-      python_setup, python_repos = self.create_python_subsystems(
+      cache = self._create_interpreter_cache(
         setup_options={
           'interpreter_cache_dir': None,
           'pants_workdir': os.path.join(root, 'workdir'),
           'constraints': [interpreter_requirement],
           'setuptools_version': setuptools_version,
           'wheel_version': wheel_version,
+          'interpreter_search_paths': [os.path.dirname(self._interpreter.binary)]
         },
         repos_options={
           'indexes': [],
           'repos': [egg_dir],
         }
       )
-      cache = PythonInterpreterCache(python_setup=python_setup, python_repos=python_repos)
-
-      interpereters = cache.setup(paths=[os.path.dirname(self._interpreter.binary)],
-                                  filters=[str(interpreter_requirement)])
+      interpereters = cache.setup(filters=[str(interpreter_requirement)])
       self.assertGreater(len(interpereters), 0)
 
       def assert_egg_extra(interpreter, name, version):


### PR DESCRIPTION
It effectively depended on other subsystems (expecting instances to be passed into it), so it's a natural fit.  

Switches it to use a local `logger` instead of one passed in from task context. The logger was only used for debug output anyway, and we want all such output to go through standard logging in the future anyway. 

Also simplifies the interface of `PythonInterpreterCache.setup()`. Previously you could pass a list of paths to it, overriding its internal logic. However this was only used in tests, which can easily be converted to use the appropriate option instead. 

This is the first step in simplifying the path-selection logic to be entirely option-based, instead of the current chain of `or`s that can't be fully overridden in options. 