### PR TITLE
Remove Params::expect_single compatibility API

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -126,14 +126,7 @@ typedef void Session;
 typedef void ExecutionRequest;
 
 typedef struct {
-  Key             subject;
-  TypeConstraint  product;
-  uint8_t         state_tag;
-  Handle          state_value;
-} RawNode;
-
-typedef struct {
-  RawNode*  nodes_ptr;
+  PyResult*  nodes_ptr;
   uint64_t  nodes_len;
   // NB: there are more fields in this struct, but we can safely (?)
   // ignore them because we never have collections of this type.

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -316,13 +316,10 @@ class Scheduler(object):
     try:
       roots = []
       for raw_root in self._native.unpack(raw_roots.nodes_ptr, raw_roots.nodes_len):
-        if raw_root.state_tag is 1:
-          state = Return(self._from_value(raw_root.state_value))
-        elif raw_root.state_tag in (2, 3):
-          state = Throw(self._from_value(raw_root.state_value))
+        if raw_root.is_throw:
+          state = Throw(self._from_value(raw_root.value))
         else:
-          raise ValueError(
-            'Unrecognized State type `{}` on: {}'.format(raw_root.state_tag, raw_root))
+          state = Return(self._from_value(raw_root.value))
         roots.append(state)
     finally:
       self._native.lib.nodes_destroy(raw_roots)

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -30,21 +30,6 @@ impl Params {
   }
 
   ///
-  /// TODO: This is a compatibility API to assist in the transition from "every Node has exactly
-  /// one Subject" to "every Node has zero or more Params". See:
-  ///   https://github.com/pantsbuild/pants/issues/6478
-  ///
-  pub fn expect_single(&self) -> &Key {
-    if self.0.len() != 1 {
-      panic!(
-        "Expect Params to contain exactly one value... contained: {:?}",
-        self.0
-      );
-    }
-    &self.0[0]
-  }
-
-  ///
   /// Returns the Key for the given TypeId if it is represented in this set of Params.
   ///
   pub fn find(&self, type_id: TypeId) -> Option<&Key> {

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -46,7 +46,7 @@ impl Params {
   pub fn display(mut params: Vec<String>) -> String {
     match params.len() {
       0 => "()".to_string(),
-      1 => params.iter().next().unwrap().to_string(),
+      1 => params.pop().unwrap(),
       _ => {
         params.sort();
         format!("({})", params.join("+"))

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -45,7 +45,7 @@ impl Params {
   }
 
   ///
-  /// Returns the given TypeId if it is represented in this set of Params.
+  /// Returns the Key for the given TypeId if it is represented in this set of Params.
   ///
   pub fn find(&self, type_id: TypeId) -> Option<&Key> {
     self
@@ -87,6 +87,16 @@ pub type Id = u64;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TypeId(pub Id);
+
+impl fmt::Display for TypeId {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    if *self == ANY_TYPE {
+      write!(f, "Any")
+    } else {
+      write!(f, "{}", externs::type_to_str(*self))
+    }
+  }
+}
 
 // On the python side, the 0th type id is used as an anonymous id
 pub const ANY_TYPE: TypeId = TypeId(0);

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -54,6 +54,30 @@ impl Params {
       .ok()
       .map(|idx| &self.0[idx])
   }
+
+  ///
+  /// Given a set of either param type or param value strings: sort, join, and render as one string.
+  ///
+  pub fn display(mut params: Vec<String>) -> String {
+    match params.len() {
+      0 => "()".to_string(),
+      1 => params.iter().next().unwrap().to_string(),
+      _ => {
+        params.sort();
+        format!("({})", params.join("+"))
+      }
+    }
+  }
+}
+
+impl fmt::Display for Params {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(
+      f,
+      "{}",
+      Self::display(self.0.iter().map(|k| format!("{}", k)).collect())
+    )
+  }
 }
 
 pub type Id = u64;
@@ -98,6 +122,12 @@ impl PartialEq for Key {
 impl hash::Hash for Key {
   fn hash<H: hash::Hasher>(&self, state: &mut H) {
     self.id.hash(state);
+  }
+}
+
+impl fmt::Display for Key {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "{}", externs::key_to_str(self))
   }
 }
 

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -30,14 +30,34 @@ impl Params {
   }
 
   ///
+  /// Adds the given param Key to these Params, replacing an existing param with the same type if
+  /// it exists.
+  ///
+  pub fn put(&mut self, param: Key) {
+    match self.binary_search(param.type_id) {
+      Ok(idx) => self.0[idx] = param,
+      Err(idx) => self.0.insert(idx, param),
+    }
+  }
+
+  ///
+  /// Filters this Params object in-place to contain only params matching the given predicate.
+  ///
+  pub fn retain<F: FnMut(&mut Key) -> bool>(&mut self, f: F) {
+    self.0.retain(f)
+  }
+
+  ///
   /// Returns the Key for the given TypeId if it is represented in this set of Params.
   ///
   pub fn find(&self, type_id: TypeId) -> Option<&Key> {
+    self.binary_search(type_id).ok().map(|idx| &self.0[idx])
+  }
+
+  fn binary_search(&self, type_id: TypeId) -> Result<usize, usize> {
     self
       .0
       .binary_search_by(|probe| probe.type_id().cmp(&type_id))
-      .ok()
-      .map(|idx| &self.0[idx])
   }
 
   ///

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -364,6 +364,27 @@ impl PyResult {
   }
 }
 
+impl From<Result<Value, Failure>> for PyResult {
+  fn from(result: Result<Value, Failure>) -> Self {
+    match result {
+      Ok(val) => PyResult {
+        is_throw: false,
+        handle: val.into(),
+      },
+      Err(f) => {
+        let val = match f {
+          Failure::Invalidated => create_exception("Exhausted retries due to changed files."),
+          Failure::Throw(exc, _) => exc,
+        };
+        PyResult {
+          is_throw: true,
+          handle: val.into(),
+        }
+      }
+    }
+  }
+}
+
 impl From<PyResult> for Result<Value, Failure> {
   fn from(result: PyResult) -> Self {
     let value = result.handle.into();

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -115,7 +115,7 @@ impl Select {
     product: TypeConstraint,
     edges: &rule_graph::RuleEdges,
   ) -> Select {
-    let select_key = rule_graph::SelectKey::JustSelect(selectors::Select::new(product.clone()));
+    let select_key = rule_graph::SelectKey::JustSelect(selectors::Select::new(product));
     // TODO: Is it worth propagating an error here?
     let entry = edges
       .entry_for(&select_key)
@@ -158,7 +158,7 @@ impl WrappedNode for Select {
       {
         &rule_graph::Rule::Task(ref task) => context.get(Task {
           params: self.params.clone(),
-          product: self.product.clone(),
+          product: self.product,
           task: task.clone(),
           entry: Arc::new(self.entry.clone()),
         }),

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1106,15 +1106,11 @@ impl Node for NodeKey {
       &NodeKey::ExecuteProcess(ref s) => format!("ExecuteProcess({:?}", s.0),
       &NodeKey::ReadLink(ref s) => format!("ReadLink({:?})", s.0),
       &NodeKey::Scandir(ref s) => format!("Scandir({:?})", s.0),
-      &NodeKey::Select(ref s) => format!(
-        "Select({}, {})",
-        keystr(&s.params.expect_single()),
-        typstr(&s.selector.product)
-      ),
+      &NodeKey::Select(ref s) => format!("Select({}, {})", s.params, typstr(&s.selector.product)),
       &NodeKey::Task(ref s) => format!(
         "Task({}, {}, {}, {})",
         externs::project_str(&externs::val_for(&s.task.func.0), "__name__"),
-        keystr(&s.params.expect_single()),
+        s.params,
         typstr(&s.product),
         s.task.cacheable,
       ),

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -39,7 +39,7 @@ pub enum EntryWithDeps {
 }
 
 impl EntryWithDeps {
-  fn params(&self) -> &ParamTypes {
+  pub fn params(&self) -> &ParamTypes {
     match self {
       &EntryWithDeps::Inner(ref ie) => &ie.params,
       &EntryWithDeps::Root(ref re) => &re.params,

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -6,7 +6,7 @@ use std::io;
 
 use itertools::Itertools;
 
-use core::{Function, Key, Params, TypeConstraint, TypeId, Value, ANY_TYPE};
+use core::{Function, Key, Params, TypeConstraint, TypeId, Value};
 use externs;
 use selectors::{Get, Select};
 use tasks::{Intrinsic, Task, Tasks};
@@ -801,11 +801,7 @@ fn function_str(func: &Function) -> String {
 }
 
 pub fn type_str(type_id: TypeId) -> String {
-  if type_id == ANY_TYPE {
-    "Any".to_string()
-  } else {
-    externs::type_to_str(type_id)
-  }
+  format!("{}", type_id)
 }
 
 pub fn params_str(params: &ParamTypes) -> String {

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -6,7 +6,7 @@ use std::io;
 
 use itertools::Itertools;
 
-use core::{Function, Key, TypeConstraint, TypeId, Value, ANY_TYPE};
+use core::{Function, Key, Params, TypeConstraint, TypeId, Value, ANY_TYPE};
 use externs;
 use selectors::{Get, Select};
 use tasks::{Intrinsic, Task, Tasks};
@@ -809,16 +809,11 @@ pub fn type_str(type_id: TypeId) -> String {
 }
 
 pub fn params_str(params: &ParamTypes) -> String {
-  let mut param_names = params
+  let param_names = params
     .iter()
     .map(|type_id| type_str(*type_id))
     .collect::<Vec<_>>();
-  param_names.sort();
-  match param_names.len() {
-    0 => "()".to_string(),
-    1 => param_names.iter().next().unwrap().to_string(),
-    _ => format!("({})", param_names.join("+")),
-  }
+  Params::display(param_names)
 }
 
 fn val_name(val: &Value) -> String {

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -118,9 +118,11 @@ impl Scheduler {
       subject.type_id().clone(),
       &selectors::Select::new(product),
     )?;
-    request
-      .roots
-      .push(Select::new(product, Params::new_single(subject), &edges));
+    request.roots.push(Select::new_from_edges(
+      Params::new_single(subject),
+      product,
+      &edges,
+    ));
     Ok(())
   }
 

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -263,11 +263,7 @@ impl Scheduler {
   ///
   /// Compute the results for roots in the given request.
   ///
-  pub fn execute<'e>(
-    &self,
-    request: &'e ExecutionRequest,
-    session: &Session,
-  ) -> Vec<(&'e Key, &'e TypeConstraint, RootResult)> {
+  pub fn execute(&self, request: &ExecutionRequest, session: &Session) -> Vec<RootResult> {
     // Bootstrap tasks for the roots, and then wait for all of them.
     debug!("Launching {} roots.", request.roots.len());
 
@@ -307,12 +303,7 @@ impl Scheduler {
       display.finish();
     };
 
-    request
-      .roots
-      .iter()
-      .zip(results.into_iter())
-      .map(|(s, r)| (s.params.expect_single(), &s.selector.product, r))
-      .collect()
+    results
   }
 
   fn display_ongoing_tasks(

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -101,22 +101,16 @@ class JavacVersionExecutionRequest(datatype([('binary_location', BinaryLocation)
     return (self.bin_path, '-version',)
 
 
-@rule(ExecuteProcessRequest, [Select(JavacVersionExecutionRequest)])
-def process_request_from_javac_version(javac_version_exe_req):
-  yield ExecuteProcessRequest(
-    argv=javac_version_exe_req.gen_argv(),
-    description=javac_version_exe_req.description,
-    input_files=EMPTY_DIRECTORY_DIGEST,
-  )
-
-
 class JavacVersionOutput(datatype([('value', text_type)])): pass
 
 
 @rule(JavacVersionOutput, [Select(JavacVersionExecutionRequest)])
 def get_javac_version_output(javac_version_command):
-  javac_version_proc_req = yield Get(
-    ExecuteProcessRequest, JavacVersionExecutionRequest, javac_version_command)
+  javac_version_proc_req = ExecuteProcessRequest(
+    argv=javac_version_command.gen_argv(),
+    description=javac_version_command.description,
+    input_files=EMPTY_DIRECTORY_DIGEST,
+  )
   javac_version_proc_result = yield Get(
     ExecuteProcessResult, ExecuteProcessRequest, javac_version_proc_req)
 
@@ -273,7 +267,6 @@ class IsolatedProcessTest(TestBase, unittest.TestCase):
   def rules(cls):
     return super(IsolatedProcessTest, cls).rules() + [
       RootRule(JavacVersionExecutionRequest),
-      process_request_from_javac_version,
       get_javac_version_output,
     ] + create_cat_stdout_rules() + create_javac_compile_rules()
 


### PR DESCRIPTION
### Problem

`Params::expect_single` was a compatibility API that was meant to simplify the transition from "Node has a single Subject" to "Node has a set of Params", but usage of that API inherently blocks exposing the ability to pass multiple `Params` in a run (and thus blocks #6478).

### Solution

Remove the three distinct usages of `Params::expect_single` by:

1. simplifying the signature of `scheduler_execute`, which was returning a copy of the subject that was unused anyway
2. directly displaying `Params` rather than looking for a single subject value
3. inlining `Select::gen_node` and resolving a TODO to consume `Entry::Param` and `Params::find` to expect parameter values

### Result

Progress toward #6478, and a ~5% speedup due to taking better advantage of the static rule_graph in `Select`.