### PR TITLE
Force consistent stty size on travis

### DIFF
--- a/build-support/bin/travis-ci.sh
+++ b/build-support/bin/travis-ci.sh
@@ -53,4 +53,7 @@ $(list_pythons | sort -u)
 EOF
 fi
 
+stty rows 60
+stty cols 120
+
 exec ./build-support/bin/ci.sh "$@"

--- a/build-support/bin/travis-ci.sh
+++ b/build-support/bin/travis-ci.sh
@@ -53,6 +53,10 @@ $(list_pythons | sort -u)
 EOF
 fi
 
+# We have tests which parse pytest's output, which varies based on stty size.
+# On 2018-11-13 Travis's stty got significantly more narrow than it was, causing
+# tests in tests/python/pants_test/rules:test_integration to fail.
+# Force a consistent stty size to avoid this noise.
 stty rows 60
 stty cols 120
 


### PR DESCRIPTION
It apparently got much narrower yesterday, which causes some tests which
are sensitive to stty width (around parsing pytest output) to fail.