### PR TITLE
Make it easy to get a logger from a RunTracker instance.

### DIFF
--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -21,7 +21,6 @@ from pants.engine.isolated_process import (FallibleExecuteProcessResult,
 from pants.goal.products import Products
 from pants.goal.workspace import ScmWorkspace
 from pants.process.lock import OwnerPrintingInterProcessFileLock
-from pants.reporting.report import Report
 from pants.source.source_root import SourceRootConfig
 
 
@@ -37,27 +36,6 @@ class Context(object):
   :API: public
   """
 
-  class Log(object):
-    """A logger facade that logs into the pants reporting framework."""
-
-    def __init__(self, run_tracker):
-      self._run_tracker = run_tracker
-
-    def debug(self, *msg_elements):
-      self._run_tracker.log(Report.DEBUG, *msg_elements)
-
-    def info(self, *msg_elements):
-      self._run_tracker.log(Report.INFO, *msg_elements)
-
-    def warn(self, *msg_elements):
-      self._run_tracker.log(Report.WARN, *msg_elements)
-
-    def error(self, *msg_elements):
-      self._run_tracker.log(Report.ERROR, *msg_elements)
-
-    def fatal(self, *msg_elements):
-      self._run_tracker.log(Report.FATAL, *msg_elements)
-
   # TODO: Figure out a more structured way to construct and use context than this big flat
   # repository of attributes?
   def __init__(self, options, run_tracker, target_roots,
@@ -69,7 +47,7 @@ class Context(object):
     self.build_file_parser = build_file_parser
     self.address_mapper = address_mapper
     self.run_tracker = run_tracker
-    self._log = self.Log(run_tracker)
+    self._log = run_tracker.logger
     self._target_base = target_base or Target
     self._products = Products()
     self._buildroot = get_buildroot()

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -124,6 +124,9 @@ class RunTracker(Subsystem):
     # Note that multiple threads may share a name (e.g., all the threads in a pool).
     self._threadlocal = threading.local()
 
+    # A logger facade that logs into this RunTracker.
+    self._logger = RunTrackerLogger(self)
+
     # For background work.  Created lazily if needed.
     self._background_worker_pool = None
     self._background_root_workunit = None
@@ -240,6 +243,10 @@ class RunTracker(Subsystem):
   def set_root_outcome(self, outcome):
     """Useful for setup code that doesn't have a reference to a workunit."""
     self._main_root_workunit.set_outcome(outcome)
+
+  @property
+  def logger(self):
+    return self._logger
 
   @contextmanager
   def new_workunit(self, name, labels=None, cmd='', log_config=None):
@@ -607,3 +614,25 @@ class RunTracker(Subsystem):
     new_key_list = [target.address.spec, scope]
     new_key_list += keys
     self._merge_list_of_keys_into_dict(self._target_to_data, new_key_list, val, 0)
+
+
+class RunTrackerLogger(object):
+  """A logger facade that logs into a run tracker."""
+
+  def __init__(self, run_tracker):
+    self._run_tracker = run_tracker
+
+  def debug(self, *msg_elements):
+    self._run_tracker.log(Report.DEBUG, *msg_elements)
+
+  def info(self, *msg_elements):
+    self._run_tracker.log(Report.INFO, *msg_elements)
+
+  def warn(self, *msg_elements):
+    self._run_tracker.log(Report.WARN, *msg_elements)
+
+  def error(self, *msg_elements):
+    self._run_tracker.log(Report.ERROR, *msg_elements)
+
+  def fatal(self, *msg_elements):
+    self._run_tracker.log(Report.FATAL, *msg_elements)

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -64,6 +64,7 @@ python_library(
     'src/python/pants/base:workunit',
     'src/python/pants/build_graph',
     'src/python/pants/goal:context',
+    'src/python/pants/goal:run_tracker',
     'tests/python/pants_test/option/util',
   ]
 )

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -48,6 +48,7 @@ class TestContext(Context):
 
   class DummyRunTracker(object):
     """A runtracker stand-in that does no actual tracking."""
+
     def __init__(self):
       self.logger = RunTrackerLogger(self)
 

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -14,6 +14,7 @@ from twitter.common.collections import maybe_list
 from pants.base.workunit import WorkUnit
 from pants.build_graph.target import Target
 from pants.goal.context import Context
+from pants.goal.run_tracker import RunTrackerLogger
 
 
 class TestContext(Context):
@@ -47,6 +48,9 @@ class TestContext(Context):
 
   class DummyRunTracker(object):
     """A runtracker stand-in that does no actual tracking."""
+    def __init__(self):
+      self.logger = RunTrackerLogger(self)
+
     class DummyArtifactCacheStats(object):
       def add_hits(self, cache_name, targets): pass
 


### PR DESCRIPTION
This allows anything with access to subsystems to get a logger,
with `RunTracker.global_instance().logger`.

Eventually we can leverage this to stop having to plumb loggers
in via the task context all over the place (or not logging
because we can't be bothered to do the plumbing). Logging is a
crosscutting concern, so it makes total sense for a logger to
be available in this manner.
