### PR TITLE
bump pex version to 1.5.3

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -14,7 +14,7 @@ mock==2.0.0
 packaging==16.8
 parameterized==0.6.1
 pathspec==0.5.0
-pex==1.5.2
+pex==1.5.3
 psutil==4.3.0
 pycodestyle==2.4.0
 pyflakes==2.0.0


### PR DESCRIPTION
### Problem

See pantsbuild/pex#623 for the pex release ticket. This release incorporates two changes, one of which (pantsbuild/pex#599) was necessary to fix the issue in pantsbuild/pex#598.

### Solution

Bump the pex version to `1.5.3`.