### PR TITLE
Make cargo as relative symlink not absolute

### DIFF
--- a/build-support/bin/native/bootstrap_rust.sh
+++ b/build-support/bin/native/bootstrap_rust.sh
@@ -48,7 +48,8 @@ function bootstrap_rust() {
     "${RUSTUP}" toolchain install ${RUST_TOOLCHAIN}
     "${RUSTUP}" component add --toolchain ${RUST_TOOLCHAIN} ${RUST_COMPONENTS[@]} >&2
 
-    ln -fs "$(RUSTUP_TOOLCHAIN="${RUST_TOOLCHAIN}" cargo_bin)" "${rust_toolchain_root}/${cargo_versioned}"
+    symlink_target="$(perl -e 'use File::Spec; print File::Spec->abs2rel(@ARGV) . "\n"' "$(RUSTUP_TOOLCHAIN="${RUST_TOOLCHAIN}" cargo_bin)" "${rust_toolchain_root}")"
+    ln -fs "${symlink_target}" "${rust_toolchain_root}/${cargo_versioned}"
   fi
 
   local -r symlink_farm_root="${REPO_ROOT}/build-support/bin/native"

--- a/build-support/bin/native/bootstrap_rust.sh
+++ b/build-support/bin/native/bootstrap_rust.sh
@@ -48,7 +48,7 @@ function bootstrap_rust() {
     "${RUSTUP}" toolchain install ${RUST_TOOLCHAIN}
     "${RUSTUP}" component add --toolchain ${RUST_TOOLCHAIN} ${RUST_COMPONENTS[@]} >&2
 
-    symlink_target="$(perl -e 'use File::Spec; print File::Spec->abs2rel(@ARGV) . "\n"' "$(RUSTUP_TOOLCHAIN="${RUST_TOOLCHAIN}" cargo_bin)" "${rust_toolchain_root}")"
+    symlink_target="$(python -c 'import os, sys; print(os.path.relpath(*sys.argv[1:]))' "$(RUSTUP_TOOLCHAIN="${RUST_TOOLCHAIN}" cargo_bin)" "${rust_toolchain_root}")"
     ln -fs "${symlink_target}" "${rust_toolchain_root}/${cargo_versioned}"
   fi
 


### PR DESCRIPTION
This makes the .cache/pants/rust directory more self-contained and copyable

I have been using this to copy things into / out of docker containers and network-restricted areas for debugging avoiding needing to re-initialise all of the rust stuff every time.