### PR TITLE
add a --toolchain-variant option to select the compiler for C/C++

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -403,6 +403,6 @@ fragment: True
 [sitegen]
 config_path: src/docs/docsite.json
 
-# TODO(#???): this should be removed when we can fully support both toolchains.
+# TODO(#6848): this should be removed when we can fully support both toolchains.
 [native-build-settings]
 toolchain_variant: llvm

--- a/pants.ini
+++ b/pants.ini
@@ -402,3 +402,7 @@ fragment: True
 
 [sitegen]
 config_path: src/docs/docsite.json
+
+# TODO(#???): this should be removed when we can fully support both toolchains.
+[native-build-settings]
+toolchain_variant: llvm

--- a/pants.travis-ci.ini
+++ b/pants.travis-ci.ini
@@ -17,7 +17,3 @@ fast: false
 [libc]
 # Currently, we only need to search for a libc installation to test the native toolchain.
 enable_libc_search: True
-
-# TODO(#???): this should be removed when we can fully support both toolchains.
-[native-build-settings]
-toolchain_variant: llvm

--- a/pants.travis-ci.ini
+++ b/pants.travis-ci.ini
@@ -17,3 +17,7 @@ fast: false
 [libc]
 # Currently, we only need to search for a libc installation to test the native toolchain.
 enable_libc_search: True
+
+# TODO(#???): this should be removed when we can fully support both toolchains.
+[native-build-settings]
+toolchain_variant: llvm

--- a/src/python/pants/backend/native/config/BUILD
+++ b/src/python/pants/backend/native/config/BUILD
@@ -6,6 +6,7 @@ python_library(
   dependencies=[
     '3rdparty/python:future',
     'src/python/pants/engine:rules',
+    'src/python/pants/util:meta',
     'src/python/pants/util:objects',
     'src/python/pants/util:osutil',
   ],

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -42,7 +42,6 @@ class Platform(datatype(['normalized_os_name'])):
     return fun_for_platform()
 
 
-# NB: @abstractproperty requires inheriting from AbstractClass to work!
 class Executable(AbstractClass):
 
   @abstractproperty
@@ -61,7 +60,7 @@ class Executable(AbstractClass):
     :rtype: str
     """
 
-  # TODO(#???): rename this to 'runtime_library_dirs'!
+  # TODO: rename this to 'runtime_library_dirs'!
   @abstractproperty
   def library_dirs(self):
     """Directories containing shared libraries that must be on the runtime library search path.

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -96,7 +96,10 @@ class LinkerMixin(Executable):
 
   @abstractproperty
   def extra_object_files(self):
-    """???"""
+    """A list of object files required to perform a successful link.
+
+    This includes crti.o from libc for gcc on Linux, for example.
+    """
 
   @property
   def as_invocation_environment_dict(self):

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import os
 from abc import abstractproperty
 from builtins import object
 
@@ -93,13 +94,21 @@ class LinkerMixin(Executable):
   def linking_library_dirs(self):
     """Directories to search for libraries needed at link time."""
 
+  @abstractproperty
+  def extra_object_files(self):
+    """???"""
+
   @property
   def as_invocation_environment_dict(self):
     ret = super(LinkerMixin, self).as_invocation_environment_dict.copy()
 
+    full_library_path_dirs = self.linking_library_dirs + [
+      os.path.dirname(f) for f in self.extra_object_files
+    ]
+
     ret.update({
       'LDSHARED': self.exe_filename,
-      'LIBRARY_PATH': create_path_env_var(self.linking_library_dirs),
+      'LIBRARY_PATH': create_path_env_var(full_library_path_dirs),
     })
 
     return ret

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
 from abc import abstractproperty
 from builtins import object
 
@@ -189,10 +188,7 @@ class GCCCppToolchain(datatype([('cpp_toolchain', CppToolchain)])): pass
 
 # TODO: make this an @rule, after we can automatically produce LibcDev and other subsystems in the
 # v2 engine (see #5788).
-class HostLibcDev(datatype(['crti_object', 'fingerprint'])):
-
-  def get_lib_dir(self):
-    return os.path.dirname(self.crti_object)
+class HostLibcDev(datatype(['crti_object', 'fingerprint'])): pass
 
 
 def create_native_environment_rules():

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -164,26 +164,10 @@ class CppCompiler(datatype([
     return ret
 
 
-# NB: These wrapper classes for LLVM and GCC toolchains are performing the work of variants. A
-# CToolchain cannot be requested directly, but native_toolchain.py provides an LLVMCToolchain,
-# which contains a CToolchain representing the clang compiler and a linker paired to work with
-# objects compiled by that compiler.
 class CToolchain(datatype([('c_compiler', CCompiler), ('c_linker', Linker)])): pass
 
 
-class LLVMCToolchain(datatype([('c_toolchain', CToolchain)])): pass
-
-
-class GCCCToolchain(datatype([('c_toolchain', CToolchain)])): pass
-
-
 class CppToolchain(datatype([('cpp_compiler', CppCompiler), ('cpp_linker', Linker)])): pass
-
-
-class LLVMCppToolchain(datatype([('cpp_toolchain', CppToolchain)])): pass
-
-
-class GCCCppToolchain(datatype([('cpp_toolchain', CppToolchain)])): pass
 
 
 # TODO: make this an @rule, after we can automatically produce LibcDev and other subsystems in the

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -111,6 +111,7 @@ class Linker(datatype([
     'library_dirs',
     'linking_library_dirs',
     'extra_args',
+    'extra_object_files',
 ]), LinkerMixin): pass
 
 

--- a/src/python/pants/backend/native/register.py
+++ b/src/python/pants/backend/native/register.py
@@ -8,6 +8,7 @@ from pants.backend.native.config.environment import create_native_environment_ru
 from pants.backend.native.subsystems.binaries.binutils import create_binutils_rules
 from pants.backend.native.subsystems.binaries.gcc import create_gcc_rules
 from pants.backend.native.subsystems.binaries.llvm import create_llvm_rules
+from pants.backend.native.subsystems.native_build_settings import NativeBuildSettings
 from pants.backend.native.subsystems.native_toolchain import create_native_toolchain_rules
 from pants.backend.native.subsystems.xcode_cli_tools import create_xcode_cli_tools_rules
 from pants.backend.native.targets.external_native_library import ExternalNativeLibrary
@@ -32,6 +33,10 @@ def build_file_aliases():
       NativeArtifact.alias(): NativeArtifact,
     }
   )
+
+
+def global_subsystems():
+  return {NativeBuildSettings}
 
 
 def register_goals():

--- a/src/python/pants/backend/native/subsystems/binaries/binutils.py
+++ b/src/python/pants/backend/native/subsystems/binaries/binutils.py
@@ -32,7 +32,9 @@ class Binutils(NativeTool):
       exe_filename='ld',
       library_dirs=[],
       linking_library_dirs=[],
-      extra_args=[])
+      extra_args=[],
+      extra_object_files=[],
+    )
 
 
 @rule(Assembler, [Select(Binutils)])

--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -75,6 +75,8 @@ class GCC(NativeTool):
       ('include/c++', self.version()),
     ])
 
+    # TODO: determine whether there is any manual explaining when any of these file paths are
+    # necessary.
     # This file is needed for C++ compilation.
     cpp_config_header_path = self._file_mapper.assert_single_path_by_glob(
       # NB: There are multiple paths matching this glob unless we provide the full path to

--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -75,7 +75,7 @@ class GCC(NativeTool):
       ('include/c++', self.version()),
     ])
 
-    # TODO: determine whether there is any manual explaining when any of these file paths are
+    # TODO(#6143): determine whether there is any manual explaining when any of these file paths are
     # necessary.
     # This file is needed for C++ compilation.
     cpp_config_header_path = self._file_mapper.assert_single_path_by_glob(

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -92,7 +92,9 @@ class LLVM(NativeTool):
         self._PLATFORM_SPECIFIC_LINKER_NAME),
       library_dirs=[],
       linking_library_dirs=[],
-      extra_args=[])
+      extra_args=[],
+      extra_object_files=[],
+    )
 
   @memoized_property
   def _common_include_dirs(self):

--- a/src/python/pants/backend/native/subsystems/libc_dev.py
+++ b/src/python/pants/backend/native/subsystems/libc_dev.py
@@ -11,7 +11,7 @@ from pants.backend.native.subsystems.utils.parse_search_dirs import ParseSearchD
 from pants.base.hash_utils import hash_file
 from pants.option.custom_types import dir_option
 from pants.subsystem.subsystem import Subsystem
-from pants.util.memo import memoized_property
+from pants.util.memo import memoized_method, memoized_property
 
 
 class LibcDev(Subsystem):
@@ -99,11 +99,8 @@ class LibcDev(Subsystem):
 
     return self._get_host_libc_from_host_compiler()
 
-  def get_libc_dirs(self, platform):
+  @memoized_method
+  def get_libc(self):
     if not self.get_options().enable_libc_search:
-      return []
-
-    return platform.resolve_platform_specific({
-      'darwin': lambda: [],
-      'linux': lambda: [self._host_libc.get_lib_dir()],
-    })
+      return None
+    return self._host_libc

--- a/src/python/pants/backend/native/subsystems/libc_dev.py
+++ b/src/python/pants/backend/native/subsystems/libc_dev.py
@@ -101,6 +101,4 @@ class LibcDev(Subsystem):
 
   @memoized_method
   def get_libc_objects(self):
-    if not self.get_options().enable_libc_search:
-      return []
-    return [self._host_libc.crti_object]
+    return [self._host_libc.crti_object] if self.get_options().enable_libc_search else []

--- a/src/python/pants/backend/native/subsystems/libc_dev.py
+++ b/src/python/pants/backend/native/subsystems/libc_dev.py
@@ -100,7 +100,7 @@ class LibcDev(Subsystem):
     return self._get_host_libc_from_host_compiler()
 
   @memoized_method
-  def get_libc(self):
+  def get_libc_objects(self):
     if not self.get_options().enable_libc_search:
-      return None
-    return self._host_libc
+      return []
+    return [self._host_libc.crti_object]

--- a/src/python/pants/backend/native/subsystems/native_build_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_settings.py
@@ -7,10 +7,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from pants.backend.native.subsystems.utils.mirrored_target_option_mixin import \
   MirroredTargetOptionMixin
 from pants.subsystem.subsystem import Subsystem
+from pants.util.objects import enum
+
+
+class ToolchainVariant(enum('descriptor', ['gnu', 'llvm'])): pass
 
 
 class NativeBuildSettings(Subsystem, MirroredTargetOptionMixin):
-  """Any settings relevant to a compiler and/or linker invocation."""
+  """Settings which affect both the compile and link phases."""
   options_scope = 'native-build-settings'
 
   mirrored_option_to_kwarg_map = {
@@ -27,6 +31,12 @@ class NativeBuildSettings(Subsystem, MirroredTargetOptionMixin):
                   "for C and C++ targets by default. If this is False, all transitive dependencies "
                   "are used when compiling and linking native code. C and C++ targets may override "
                   "this behavior with the strict_deps keyword argument as well.")
+    register('--toolchain-variant', type=str,
+             choices=ToolchainVariant.allowed_values,
+             default=ToolchainVariant.default_value,
+             advanced=True,
+             help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
+                  "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
 
   def get_strict_deps_value_for_target(self, target):
     return self.get_target_mirrored_option('strict_deps', target)

--- a/src/python/pants/backend/native/subsystems/native_build_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_settings.py
@@ -4,19 +4,9 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
-
 from pants.backend.native.subsystems.utils.mirrored_target_option_mixin import \
   MirroredTargetOptionMixin
 from pants.subsystem.subsystem import Subsystem
-from pants.util.memo import memoized_property
-from pants.util.objects import enum
-
-
-logger = logging.getLogger(__name__)
-
-
-class ToolchainVariant(enum('descriptor', ['gnu', 'llvm'])): pass
 
 
 class NativeBuildSettings(Subsystem, MirroredTargetOptionMixin):
@@ -37,18 +27,6 @@ class NativeBuildSettings(Subsystem, MirroredTargetOptionMixin):
                   "for C and C++ targets by default. If this is False, all transitive dependencies "
                   "are used when compiling and linking native code. C and C++ targets may override "
                   "this behavior with the strict_deps keyword argument as well.")
-    register('--toolchain-variant', type=str,
-             choices=ToolchainVariant.allowed_values,
-             default=ToolchainVariant.default_value,
-             advanced=True,
-             help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
-                  "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
 
   def get_strict_deps_value_for_target(self, target):
     return self.get_target_mirrored_option('strict_deps', target)
-
-  @memoized_property
-  def toolchain_variant(self):
-    variant = ToolchainVariant.create(self.get_options().toolchain_variant)
-    logger.debug('{} was selected.'.format(variant))
-    return variant

--- a/src/python/pants/backend/native/subsystems/native_build_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_settings.py
@@ -4,10 +4,16 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
+
 from pants.backend.native.subsystems.utils.mirrored_target_option_mixin import \
   MirroredTargetOptionMixin
 from pants.subsystem.subsystem import Subsystem
+from pants.util.memo import memoized_property
 from pants.util.objects import enum
+
+
+logger = logging.getLogger(__name__)
 
 
 class ToolchainVariant(enum('descriptor', ['gnu', 'llvm'])): pass
@@ -40,3 +46,9 @@ class NativeBuildSettings(Subsystem, MirroredTargetOptionMixin):
 
   def get_strict_deps_value_for_target(self, target):
     return self.get_target_mirrored_option('strict_deps', target)
+
+  @memoized_property
+  def toolchain_variant(self):
+    variant = ToolchainVariant.create(self.get_options().toolchain_variant)
+    logger.debug('{} was selected.'.format(variant))
+    return variant

--- a/src/python/pants/backend/native/subsystems/native_build_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_settings.py
@@ -7,6 +7,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from pants.backend.native.subsystems.utils.mirrored_target_option_mixin import \
   MirroredTargetOptionMixin
 from pants.subsystem.subsystem import Subsystem
+from pants.util.memo import memoized_property
+from pants.util.objects import enum
+
+
+class ToolchainVariant(enum('descriptor', ['gnu', 'llvm'])):
+
+  @property
+  def is_gnu(self):
+    return self.descriptor == 'gnu'
 
 
 class NativeBuildSettings(Subsystem, MirroredTargetOptionMixin):
@@ -28,5 +37,15 @@ class NativeBuildSettings(Subsystem, MirroredTargetOptionMixin):
                   "are used when compiling and linking native code. C and C++ targets may override "
                   "this behavior with the strict_deps keyword argument as well.")
 
+    register('--toolchain-variant', type=str, fingerprint=True, advanced=True,
+             choices=ToolchainVariant.allowed_values,
+             default=ToolchainVariant.default_value,
+             help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
+                  "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
+
   def get_strict_deps_value_for_target(self, target):
     return self.get_target_mirrored_option('strict_deps', target)
+
+  @memoized_property
+  def toolchain_variant(self):
+    return ToolchainVariant.create(self.get_options().toolchain_variant)

--- a/src/python/pants/backend/native/subsystems/native_build_step_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step_settings.py
@@ -13,6 +13,7 @@ from pants.util.meta import classproperty
 
 
 class NativeBuildStepSettings(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsystem):
+  """Settings which are specific to a target and do not need to be the same for compile and link."""
 
   options_scope = 'native-build-step'
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -162,8 +162,6 @@ def select_llvm_c_toolchain(platform, native_toolchain):
   # These arguments are shared across platforms.
   llvm_c_compiler_args = [
     '-x', 'c', '-std=c11',
-    # TODO(#6855): gcc works when we pass this option, but not clang for some reason.
-    # '-nostdinc',
   ]
 
   if platform.normalized_os_name == 'darwin':
@@ -202,11 +200,10 @@ def select_llvm_cpp_toolchain(platform, native_toolchain):
   # These arguments are shared across platforms.
   llvm_cpp_compiler_args = [
     '-x', 'c++', '-std=c++11',
-    # TODO(#6855): gcc works when we pass this option, but not clang for some reason.
-    # '-nostdinc',
-    # This mean we don't use any of the headers from our LLVM distribution's C++ stdlib
-    # implementation, or any from the host system. Instead, we use include dirs from the
+    # This flag is intended to avoid using any of the headers from our LLVM distribution's C++
+    # stdlib implementation, or any from the host system, and instead, use include dirs from the
     # XCodeCLITools or GCC.
+    # TODO(#6855): Determine precisely what this flag does and why it's necessary.
     '-nostdinc++',
   ]
 
@@ -259,7 +256,6 @@ def select_gcc_c_toolchain(platform, native_toolchain):
 
   gcc_c_compiler_args = [
     '-x', 'c', '-std=c11',
-    '-nostdinc',
   ]
 
   if platform.normalized_os_name == 'darwin':
@@ -297,7 +293,10 @@ def select_gcc_cpp_toolchain(platform, native_toolchain):
 
   gcc_cpp_compiler_args = [
     '-x', 'c++', '-std=c++11',
-    '-nostdinc',
+    # This flag is intended to avoid using any of the headers from our LLVM distribution's C++
+    # stdlib implementation, or any from the host system, and instead, use include dirs from the
+    # XCodeCLITools or GCC.
+    # TODO(#6855): Determine precisely what this flag does and why it's necessary.
     '-nostdinc++',
   ]
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -203,7 +203,7 @@ def select_llvm_cpp_toolchain(platform, native_toolchain):
     # This flag is intended to avoid using any of the headers from our LLVM distribution's C++
     # stdlib implementation, or any from the host system, and instead, use include dirs from the
     # XCodeCLITools or GCC.
-    # TODO(#6855): Determine precisely what this flag does and why it's necessary.
+    # TODO(#6143): Determine precisely what this flag does and why it's necessary.
     '-nostdinc++',
   ]
 
@@ -296,7 +296,7 @@ def select_gcc_cpp_toolchain(platform, native_toolchain):
     # This flag is intended to avoid using any of the headers from our LLVM distribution's C++
     # stdlib implementation, or any from the host system, and instead, use include dirs from the
     # XCodeCLITools or GCC.
-    # TODO(#6855): Determine precisely what this flag does and why it's necessary.
+    # TODO(#6143): Determine precisely what this flag does and why it's necessary.
     '-nostdinc++',
   ]
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -182,7 +182,7 @@ def select_llvm_c_toolchain(platform, native_toolchain):
   llvm_linker_wrapper = yield Get(LLVMLinker, NativeToolchain, native_toolchain)
   llvm_linker = llvm_linker_wrapper.linker
 
-  # TODO: create an algebra so these changes are more clear!
+  # TODO(#6855): introduce a more concise way to express these compositions of executables.
   working_linker = llvm_linker.copy(
     path_entries=(llvm_linker.path_entries + working_c_compiler.path_entries),
     exe_filename=working_c_compiler.exe_filename,

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -162,8 +162,8 @@ def select_llvm_c_toolchain(platform, native_toolchain):
   # These arguments are shared across platforms.
   llvm_c_compiler_args = [
     '-x', 'c', '-std=c11',
-    '-nobuiltininc',
-    '-nostdinc',
+    # TODO(#6855): gcc works when we pass this option, but not clang for some reason.
+    # '-nostdinc',
   ]
 
   if platform.normalized_os_name == 'darwin':
@@ -202,11 +202,11 @@ def select_llvm_cpp_toolchain(platform, native_toolchain):
   # These arguments are shared across platforms.
   llvm_cpp_compiler_args = [
     '-x', 'c++', '-std=c++11',
+    # TODO(#6855): gcc works when we pass this option, but not clang for some reason.
+    # '-nostdinc',
     # This mean we don't use any of the headers from our LLVM distribution's C++ stdlib
     # implementation, or any from the host system. Instead, we use include dirs from the
     # XCodeCLITools or GCC.
-    '-nobuiltininc',
-    '-nostdinc',
     '-nostdinc++',
   ]
 

--- a/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
+++ b/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
@@ -156,7 +156,9 @@ class XCodeCLITools(Subsystem):
       exe_filename='ld',
       library_dirs=[],
       linking_library_dirs=[],
-      extra_args=[MIN_OSX_VERSION_ARG])
+      extra_args=[MIN_OSX_VERSION_ARG],
+      extra_object_files=[],
+    )
 
   @memoized_method
   def c_compiler(self):

--- a/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
+++ b/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
@@ -84,7 +84,9 @@ class XCodeCLITools(Subsystem):
   # NB: We use @memoized_method in this file for methods which may raise.
   @memoized_method
   def _get_existing_subdirs(self, subdir_name):
-    # TODO: consume ArchiveFileMapper instead of doing all that logic over again in this file.
+    # TODO(#6143): We should attempt to use ParseSearchDirs here or find some documentation on which
+    # directories we should be adding to the include path, and why. If we do need to manually
+    # specify paths, use ArchiveFileMapper instead of doing all that logic over again in this file.
     maybe_subdirs = [os.path.join(pfx, subdir_name) for pfx in self._all_existing_install_prefixes]
     existing_dirs = [existing_dir for existing_dir in maybe_subdirs if is_readable_dir(existing_dir)]
 
@@ -125,22 +127,7 @@ class XCodeCLITools(Subsystem):
 
   @memoized_method
   def include_dirs(self, include_cpp_inc=False):
-    base_inc_dirs = self._get_existing_subdirs('include')
-
-    all_inc_dirs = base_inc_dirs
-    for d in base_inc_dirs:
-      # TODO: figure out what this directory does and why it's not already found by this compiler.
-      secure_inc_dir = os.path.join(d, 'secure')
-      if is_readable_dir(secure_inc_dir):
-        all_inc_dirs.append(secure_inc_dir)
-
-      # TODO: figure out why we need to specify this directory separately.
-      if include_cpp_inc:
-        cpp_inc_dir = os.path.join(d, 'c++/v1')
-        if is_readable_dir(cpp_inc_dir):
-          all_inc_dirs.append(cpp_inc_dir)
-
-    return all_inc_dirs
+    return self._get_existing_subdirs('include')
 
   @memoized_method
   def assembler(self):

--- a/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
+++ b/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
@@ -84,6 +84,7 @@ class XCodeCLITools(Subsystem):
   # NB: We use @memoized_method in this file for methods which may raise.
   @memoized_method
   def _get_existing_subdirs(self, subdir_name):
+    # TODO: consume ArchiveFileMapper instead of doing all that logic over again in this file.
     maybe_subdirs = [os.path.join(pfx, subdir_name) for pfx in self._all_existing_install_prefixes]
     existing_dirs = [existing_dir for existing_dir in maybe_subdirs if is_readable_dir(existing_dir)]
 
@@ -123,7 +124,7 @@ class XCodeCLITools(Subsystem):
     return self._get_existing_subdirs('lib')
 
   @memoized_method
-  def include_dirs(self):
+  def include_dirs(self, include_cpp_inc=False):
     base_inc_dirs = self._get_existing_subdirs('include')
 
     all_inc_dirs = base_inc_dirs
@@ -132,6 +133,12 @@ class XCodeCLITools(Subsystem):
       secure_inc_dir = os.path.join(d, 'secure')
       if is_readable_dir(secure_inc_dir):
         all_inc_dirs.append(secure_inc_dir)
+
+      # TODO: figure out why we need to specify this directory separately.
+      if include_cpp_inc:
+        cpp_inc_dir = os.path.join(d, 'c++/v1')
+        if is_readable_dir(cpp_inc_dir):
+          all_inc_dirs.append(cpp_inc_dir)
 
     return all_inc_dirs
 
@@ -166,7 +173,7 @@ class XCodeCLITools(Subsystem):
       path_entries=self.path_entries(),
       exe_filename='clang++',
       library_dirs=self.lib_dirs(),
-      include_dirs=self.include_dirs(),
+      include_dirs=self.include_dirs(include_cpp_inc=True),
       extra_args=[MIN_OSX_VERSION_ARG])
 
 

--- a/src/python/pants/backend/native/tasks/c_compile.py
+++ b/src/python/pants/backend/native/tasks/c_compile.py
@@ -31,4 +31,4 @@ class CCompile(NativeCompile):
     return CCompileSettings.scoped_instance(self)
 
   def get_compiler(self):
-    return self.get_c_toolchain_variant().c_toolchain.c_compiler
+    return self.get_c_toolchain_variant().c_compiler

--- a/src/python/pants/backend/native/tasks/c_compile.py
+++ b/src/python/pants/backend/native/tasks/c_compile.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.native.config.environment import LLVMCToolchain
 from pants.backend.native.subsystems.native_build_step_settings import CCompileSettings
 from pants.backend.native.targets.native_library import CLibrary
 from pants.backend.native.tasks.native_compile import NativeCompile
@@ -32,4 +31,4 @@ class CCompile(NativeCompile):
     return CCompileSettings.scoped_instance(self)
 
   def get_compiler(self):
-    return self._request_single(LLVMCToolchain, self._native_toolchain).c_toolchain.c_compiler
+    return self.get_c_toolchain_variant().c_toolchain.c_compiler

--- a/src/python/pants/backend/native/tasks/cpp_compile.py
+++ b/src/python/pants/backend/native/tasks/cpp_compile.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.native.config.environment import LLVMCppToolchain
 from pants.backend.native.subsystems.native_build_step_settings import CppCompileSettings
 from pants.backend.native.targets.native_library import CppLibrary
 from pants.backend.native.tasks.native_compile import NativeCompile
@@ -32,4 +31,4 @@ class CppCompile(NativeCompile):
     return CppCompileSettings.scoped_instance(self)
 
   def get_compiler(self):
-    return self._request_single(LLVMCppToolchain, self._native_toolchain).cpp_toolchain.cpp_compiler
+    return self.get_cpp_toolchain_variant().cpp_toolchain.cpp_compiler

--- a/src/python/pants/backend/native/tasks/cpp_compile.py
+++ b/src/python/pants/backend/native/tasks/cpp_compile.py
@@ -31,4 +31,4 @@ class CppCompile(NativeCompile):
     return CppCompileSettings.scoped_instance(self)
 
   def get_compiler(self):
-    return self.get_cpp_toolchain_variant().cpp_toolchain.cpp_compiler
+    return self.get_cpp_toolchain_variant().cpp_compiler

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -139,13 +139,17 @@ class LinkSharedLibraries(NativeTask):
           external_lib_dirs.append(nelf.lib_dir)
         external_lib_names.extend(nelf.lib_names)
 
-    return LinkSharedLibraryRequest(
+    link_request = LinkSharedLibraryRequest(
       linker=self.linker,
       object_files=tuple(all_compiled_object_files),
       native_artifact=vt.target.ctypes_native_library,
       output_dir=vt.results_dir,
       external_lib_dirs=tuple(external_lib_dirs),
       external_lib_names=tuple(external_lib_names))
+
+    self.context.log.debug(link_request)
+
+    return link_request
 
   _SHARED_CMDLINE_ARGS = {
     'darwin': lambda: ['-Wl,-dylib'],
@@ -173,7 +177,9 @@ class LinkSharedLibraries(NativeTask):
            ['-L{}'.format(lib_dir) for lib_dir in link_request.external_lib_dirs] +
            ['-l{}'.format(lib_name) for lib_name in link_request.external_lib_names] +
            [os.path.abspath(obj) for obj in object_files])
-    self.context.log.debug("linker command: {}".format(cmd))
+
+    self.context.log.info("selected linker exe name: '{}'".format(linker.exe_filename))
+    self.context.log.debug("linker argv: {}".format(cmd))
 
     env = linker.as_invocation_environment_dict
     self.context.log.debug("linker invocation environment: {}".format(env))

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -65,7 +65,7 @@ class LinkSharedLibraries(NativeTask):
   def linker(self):
     # NB: we are using the C++ toolchain here for linking every type of input, including compiled C
     # source files.
-    return self.get_cpp_toolchain_variant().cpp_toolchain.cpp_linker
+    return self.get_cpp_toolchain_variant().cpp_linker
 
   @memoized_property
   def platform(self):

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -189,6 +189,7 @@ class LinkSharedLibraries(NativeTask):
            ['-L{}'.format(lib_dir) for lib_dir in link_request.external_lib_dirs] +
            ['-l{}'.format(lib_name) for lib_name in link_request.external_lib_names] +
            [os.path.abspath(obj) for obj in object_files] +
+           # TODO: this should be moved back to the Linker's extra_args!
            self.libc_objects)
 
     self.context.log.info("selected linker exe name: '{}'".format(linker.exe_filename))

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -168,6 +168,7 @@ class LinkSharedLibraries(NativeTask):
     output_dir = link_request.output_dir
     resulting_shared_lib_path = os.path.join(output_dir,
                                              native_artifact.as_shared_lib(self.platform))
+
     self.context.log.debug("resulting_shared_lib_path: {}".format(resulting_shared_lib_path))
     # We are executing in the results_dir, so get absolute paths for everything.
     cmd = ([linker.exe_filename] +
@@ -176,8 +177,7 @@ class LinkSharedLibraries(NativeTask):
            ['-o', os.path.abspath(resulting_shared_lib_path)] +
            ['-L{}'.format(lib_dir) for lib_dir in link_request.external_lib_dirs] +
            ['-l{}'.format(lib_name) for lib_name in link_request.external_lib_names] +
-           [os.path.abspath(obj) for obj in object_files] +
-           linker.extra_object_files)
+           [os.path.abspath(obj) for obj in object_files])
 
     self.context.log.info("selected linker exe name: '{}'".format(linker.exe_filename))
     self.context.log.debug("linker argv: {}".format(cmd))

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -159,7 +159,7 @@ class LinkSharedLibraries(NativeTask):
       external_lib_dirs=tuple(external_lib_dirs),
       external_lib_names=tuple(external_lib_names))
 
-    self.context.log.debug(link_request)
+    self.context.log.debug(repr(link_request))
 
     return link_request
 

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 
 from pants.backend.native.config.environment import Linker, Platform
-from pants.backend.native.subsystems.libc_dev import LibcDev
 from pants.backend.native.targets.native_artifact import NativeArtifact
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.native_compile import ObjectFiles
@@ -72,17 +71,6 @@ class LinkSharedLibraries(NativeTask):
   def platform(self):
     # TODO: convert this to a v2 engine dependency injection.
     return Platform.create()
-
-  @memoized_property
-  def _libc(self):
-    return self._request_single(LibcDev, self._native_toolchain)
-
-  @memoized_property
-  def libc_objects(self):
-    return self.platform.resolve_platform_specific({
-      'darwin': lambda: [],
-      'linux': lambda: self._libc.get_libc_objects(),
-    })
 
   def execute(self):
     targets_providing_artifacts = self.context.targets(NativeLibrary.produces_ctypes_native_library)
@@ -188,9 +176,7 @@ class LinkSharedLibraries(NativeTask):
            ['-o', os.path.abspath(resulting_shared_lib_path)] +
            ['-L{}'.format(lib_dir) for lib_dir in link_request.external_lib_dirs] +
            ['-l{}'.format(lib_name) for lib_name in link_request.external_lib_names] +
-           [os.path.abspath(obj) for obj in object_files] +
-           # TODO: this should be moved back to the Linker's extra_args!
-           self.libc_objects)
+           [os.path.abspath(obj) for obj in object_files])
 
     self.context.log.info("selected linker exe name: '{}'".format(linker.exe_filename))
     self.context.log.debug("linker argv: {}".format(cmd))

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -176,7 +176,8 @@ class LinkSharedLibraries(NativeTask):
            ['-o', os.path.abspath(resulting_shared_lib_path)] +
            ['-L{}'.format(lib_dir) for lib_dir in link_request.external_lib_dirs] +
            ['-l{}'.format(lib_name) for lib_name in link_request.external_lib_names] +
-           [os.path.abspath(obj) for obj in object_files])
+           [os.path.abspath(obj) for obj in object_files] +
+           linker.extra_object_files)
 
     self.context.log.info("selected linker exe name: '{}'".format(linker.exe_filename))
     self.context.log.debug("linker argv: {}".format(cmd))

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 
-from pants.backend.native.config.environment import Linker, LLVMCppToolchain, Platform
+from pants.backend.native.config.environment import Linker, Platform
 from pants.backend.native.targets.native_artifact import NativeArtifact
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.native_compile import ObjectFiles
@@ -62,12 +62,10 @@ class LinkSharedLibraries(NativeTask):
   class LinkSharedLibrariesError(TaskError): pass
 
   @memoized_property
-  def _cpp_toolchain(self):
-    return self._request_single(LLVMCppToolchain, self._native_toolchain).cpp_toolchain
-
-  @memoized_property
   def linker(self):
-    return self._cpp_toolchain.cpp_linker
+    # NB: we are using the C++ toolchain here for linking every type of input, including compiled C
+    # source files.
+    return self.get_cpp_toolchain_variant().cpp_toolchain.cpp_linker
 
   @memoized_property
   def platform(self):

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -183,16 +183,16 @@ class NativeCompile(NativeTask, AbstractClass):
       output_dir=versioned_target.results_dir,
       header_file_extensions=self._compile_settings.header_file_extensions)
 
+    self.context.log.debug(repr(compile_request))
+
+    return compile_request
+
   def _iter_sources_minus_headers(self, compile_request):
     for s in compile_request.sources:
       if not s.endswith(tuple(compile_request.header_file_extensions)):
         yield s
 
   class _HeaderOnlyLibrary(Exception): pass
-
-    self.context.log.debug(repr(compile_request))
-
-    return compile_request
 
   def _make_compile_argv(self, compile_request):
     """Return a list of arguments to use to compile sources. Subclasses can override and append."""

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -205,10 +205,10 @@ class NativeCompile(NativeTask, AbstractClass):
     compiler_options = compile_request.compiler_options
     # We are going to execute in the target output, so get absolute paths for everything.
     buildroot = get_buildroot()
+    # TODO: add -v to every compiler and linker invocation!
     argv = (
       [compiler.exe_filename] +
       compiler.extra_args +
-      # TODO: add -v to every compiler and linker invocation!
       # TODO: If we need to produce static libs, don't add -fPIC! (could use Variants -- see #5788).
       ['-c', '-fPIC'] +
       compiler_options +

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -173,7 +173,7 @@ class NativeCompile(NativeTask, AbstractClass):
     compiler_option_sets = (self._compile_settings.native_build_step_settings
                                 .get_compiler_option_sets_for_target(target))
 
-    return NativeCompileRequest(
+    compile_request = NativeCompileRequest(
       compiler=self._compiler,
       include_dirs=include_dirs,
       sources=sources_and_headers,
@@ -189,6 +189,10 @@ class NativeCompile(NativeTask, AbstractClass):
         yield s
 
   class _HeaderOnlyLibrary(Exception): pass
+
+    self.context.log.debug(compile_request)
+
+    return compile_request
 
   def _make_compile_argv(self, compile_request):
     """Return a list of arguments to use to compile sources. Subclasses can override and append."""
@@ -213,6 +217,7 @@ class NativeCompile(NativeTask, AbstractClass):
       ] +
       [os.path.join(buildroot, src) for src in sources_minus_headers])
 
+    self.context.log.info("selected compiler exe name: '{}'".format(compiler.exe_filename))
     self.context.log.debug("compile argv: {}".format(argv))
 
     return argv

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -208,6 +208,7 @@ class NativeCompile(NativeTask, AbstractClass):
     argv = (
       [compiler.exe_filename] +
       compiler.extra_args +
+      # TODO: add -v to every compiler and linker invocation!
       # TODO: If we need to produce static libs, don't add -fPIC! (could use Variants -- see #5788).
       ['-c', '-fPIC'] +
       compiler_options +

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -190,7 +190,7 @@ class NativeCompile(NativeTask, AbstractClass):
 
   class _HeaderOnlyLibrary(Exception): pass
 
-    self.context.log.debug(compile_request)
+    self.context.log.debug(repr(compile_request))
 
     return compile_request
 

--- a/src/python/pants/backend/native/tasks/native_task.py
+++ b/src/python/pants/backend/native/tasks/native_task.py
@@ -8,7 +8,8 @@ from builtins import filter
 
 from pants.backend.native.config.environment import CppToolchain, CToolchain
 from pants.backend.native.subsystems.native_build_settings import NativeBuildSettings
-from pants.backend.native.subsystems.native_toolchain import NativeToolchain
+from pants.backend.native.subsystems.native_toolchain import (NativeToolchain,
+                                                              ToolchainVariantRequest)
 from pants.backend.native.targets.external_native_library import ExternalNativeLibrary
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.build_graph.dependency_context import DependencyContext
@@ -65,13 +66,19 @@ class NativeTask(Task):
   def _native_toolchain(self):
     return NativeToolchain.scoped_instance(self)
 
+  @memoized_property
+  def _toolchain_variant_request(self):
+    return ToolchainVariantRequest(
+      toolchain=self._native_toolchain,
+      variant=self._native_build_settings.toolchain_variant)
+
   @memoized_method
   def get_c_toolchain_variant(self):
-    return self._request_single(CToolchain, NativeToolchain, self._native_toolchain)
+    return self._request_single(CToolchain, self._toolchain_variant_request)
 
   @memoized_method
   def get_cpp_toolchain_variant(self):
-    return self._request_single(CppToolchain, NativeToolchain, self._native_toolchain)
+    return self._request_single(CppToolchain, self._toolchain_variant_request)
 
   def native_deps(self, target):
     return self.strict_deps_for_target(

--- a/src/python/pants/backend/native/tasks/native_task.py
+++ b/src/python/pants/backend/native/tasks/native_task.py
@@ -6,8 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from builtins import filter
 
-from pants.backend.native.config.environment import (GCCCppToolchain, GCCCToolchain,
-                                                     LLVMCppToolchain, LLVMCToolchain)
+from pants.backend.native.config.environment import CppToolchain, CToolchain
 from pants.backend.native.subsystems.native_build_settings import NativeBuildSettings
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.external_native_library import ExternalNativeLibrary
@@ -62,47 +61,17 @@ class NativeTask(Task):
   def _native_build_settings(self):
     return NativeBuildSettings.global_instance()
 
-  # TODO: consume this in native_toolchain.py's v2 @rules to provide the CCompiler, Linker, etc to
-  # avoid the boilerplate to select a toolchain within this task.
-  @memoized_property
-  def _toolchain_variant(self):
-    return self._native_build_settings.get_options().toolchain_variant
-
   @memoized_property
   def _native_toolchain(self):
     return NativeToolchain.scoped_instance(self)
 
   @memoized_method
   def get_c_toolchain_variant(self):
-    # TODO: add exhaustiveness checking for `enum()` like we do in
-    # `Platform#resolve_platform_specific()`?
-    if self._toolchain_variant == 'gnu':
-      return self._gcc_c_toolchain
-    else:
-      return self._llvm_c_toolchain
+    return self._request_single(CToolchain, NativeToolchain, self._native_toolchain)
 
   @memoized_method
   def get_cpp_toolchain_variant(self):
-    if self._toolchain_variant == 'gnu':
-      return self._gcc_cpp_toolchain
-    else:
-      return self._llvm_cpp_toolchain
-
-  @memoized_property
-  def _gcc_c_toolchain(self):
-    return self._request_single(GCCCToolchain, self._native_toolchain)
-
-  @memoized_property
-  def _gcc_cpp_toolchain(self):
-    return self._request_single(GCCCppToolchain, self._native_toolchain)
-
-  @memoized_property
-  def _llvm_c_toolchain(self):
-    return self._request_single(LLVMCToolchain, self._native_toolchain)
-
-  @memoized_property
-  def _llvm_cpp_toolchain(self):
-    return self._request_single(LLVMCppToolchain, self._native_toolchain)
+    return self._request_single(CppToolchain, NativeToolchain, self._native_toolchain)
 
   def native_deps(self, target):
     return self.strict_deps_for_target(

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -12,7 +12,7 @@ import shutil
 from pex import pep425tags
 from pex.interpreter import PythonInterpreter
 
-from pants.backend.native.config.environment import LLVMCppToolchain, LLVMCToolchain, Platform
+from pants.backend.native.config.environment import CppToolchain, CToolchain, Platform
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.link_shared_libraries import SharedLibrary
 from pants.backend.python.python_requirement import PythonRequirement
@@ -96,15 +96,11 @@ class BuildLocalPythonDistributions(Task):
 
   @memoized_property
   def _c_toolchain(self):
-    llvm_c_toolchain = self._request_single(
-      LLVMCToolchain, self._python_native_code_settings.native_toolchain)
-    return llvm_c_toolchain.c_toolchain
+    return self._request_single(CToolchain, self._python_native_code_settings.native_toolchain)
 
   @memoized_property
   def _cpp_toolchain(self):
-    llvm_cpp_toolchain = self._request_single(
-      LLVMCppToolchain, self._python_native_code_settings.native_toolchain)
-    return llvm_cpp_toolchain.cpp_toolchain
+    return self._request_single(CppToolchain, self._python_native_code_settings.native_toolchain)
 
   # TODO: This should probably be made into an @classproperty (see PR #5901).
   @property

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -13,6 +13,8 @@ from pex import pep425tags
 from pex.interpreter import PythonInterpreter
 
 from pants.backend.native.config.environment import CppToolchain, CToolchain, Platform
+from pants.backend.native.subsystems.native_build_settings import NativeBuildSettings
+from pants.backend.native.subsystems.native_toolchain import ToolchainVariantRequest
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.link_shared_libraries import SharedLibrary
 from pants.backend.python.python_requirement import PythonRequirement
@@ -71,6 +73,7 @@ class BuildLocalPythonDistributions(Task):
   def subsystem_dependencies(cls):
     return super(BuildLocalPythonDistributions, cls).subsystem_dependencies() + (
       BuildSetupRequiresPex.scoped(cls),
+      NativeBuildSettings,
       PythonNativeCode.scoped(cls),
     )
 
@@ -85,6 +88,20 @@ class BuildLocalPythonDistributions(Task):
     return PythonNativeCode.scoped_instance(self)
 
   @memoized_property
+  def _native_toolchain(self):
+    return self._python_native_code_settings.native_toolchain
+
+  @memoized_property
+  def _toolchain_variant_request(self):
+    return ToolchainVariantRequest(
+      toolchain=self._native_toolchain,
+      variant=self._native_build_settings.toolchain_variant)
+
+  @memoized_property
+  def _native_build_settings(self):
+    return NativeBuildSettings.global_instance()
+
+  @memoized_property
   def _build_setup_requires_pex_settings(self):
     return BuildSetupRequiresPex.scoped_instance(self)
 
@@ -96,11 +113,11 @@ class BuildLocalPythonDistributions(Task):
 
   @memoized_property
   def _c_toolchain(self):
-    return self._request_single(CToolchain, self._python_native_code_settings.native_toolchain)
+    return self._request_single(CToolchain, self._toolchain_variant_request)
 
   @memoized_property
   def _cpp_toolchain(self):
-    return self._request_single(CppToolchain, self._python_native_code_settings.native_toolchain)
+    return self._request_single(CppToolchain, self._toolchain_variant_request)
 
   # TODO: This should probably be made into an @classproperty (see PR #5901).
   @property

--- a/tests/python/pants_test/backend/native/subsystems/test_libc_resolution.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_libc_resolution.py
@@ -25,17 +25,12 @@ class TestLibcDirectorySearchFailure(TestBase):
     self.libc = global_subsystem_instance(LibcDev)
     self.platform = Platform.create()
 
-  @platform_specific('linux')
   def test_libc_search_failure(self):
     with self.assertRaises(LibcDev.HostLibcDevResolutionError) as cm:
-      self.libc.get_libc_dirs(self.platform)
+      self.libc.get_libc_objects()
     expected_msg = (
       "Could not locate crti.o in directory /does/not/exist provided by the --libc-dir option.")
     self.assertEqual(expected_msg, str(cm.exception))
-
-  @platform_specific('darwin')
-  def test_libc_search_noop_osx(self):
-    self.assertEqual([], self.libc.get_libc_dirs(self.platform))
 
 
 class TestLibcSearchDisabled(TestBase):
@@ -51,9 +46,8 @@ class TestLibcSearchDisabled(TestBase):
     self.libc = global_subsystem_instance(LibcDev)
     self.platform = Platform.create()
 
-  @platform_specific('linux')
   def test_libc_disabled_search(self):
-    self.assertEqual([], self.libc.get_libc_dirs(self.platform))
+    self.assertEqual([], self.libc.get_libc_objects())
 
 
 class TestLibcCompilerSearchFailure(TestBase):
@@ -72,7 +66,7 @@ class TestLibcCompilerSearchFailure(TestBase):
   @platform_specific('linux')
   def test_libc_compiler_search_failure(self):
     with self.assertRaises(ParseSearchDirs.ParseSearchDirsError) as cm:
-      self.libc.get_libc_dirs(self.platform)
+      self.libc.get_libc_objects()
     expected_msg = (
       "Process invocation with argv "
       "'this_executable_does_not_exist -print-search-dirs' and environment None failed.")

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -127,7 +127,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     return self._invoke_capturing_output(cmd, env)
 
   def _invoke_linker(self, linker, args):
-    cmd = [linker.exe_filename] + linker.extra_args + args
+    cmd = [linker.exe_filename] + linker.extra_args + args + linker.extra_object_files
     return self._invoke_capturing_output(
       cmd,
       linker.as_invocation_environment_dict)

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -8,13 +8,14 @@ import os
 import re
 from contextlib import contextmanager
 
-from pants.backend.native.config.environment import (GCCCppToolchain, GCCCToolchain,
-                                                     LLVMCppToolchain, LLVMCToolchain, Platform)
+from pants.backend.native.config.environment import Platform
 from pants.backend.native.register import rules as native_backend_rules
 from pants.backend.native.subsystems.binaries.gcc import GCC
 from pants.backend.native.subsystems.binaries.llvm import LLVM
 from pants.backend.native.subsystems.libc_dev import LibcDev
-from pants.backend.native.subsystems.native_toolchain import NativeToolchain
+from pants.backend.native.subsystems.native_toolchain import (GCCCppToolchain, GCCCToolchain,
+                                                              LLVMCppToolchain, LLVMCToolchain,
+                                                              NativeToolchain)
 from pants.util.contextutil import environment_as, pushd, temporary_dir
 from pants.util.dirutil import is_executable, safe_open
 from pants.util.process_handler import subprocess

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -127,7 +127,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     return self._invoke_capturing_output(cmd, env)
 
   def _invoke_linker(self, linker, args):
-    cmd = [linker.exe_filename] + linker.extra_args + args + linker.extra_object_files
+    cmd = [linker.exe_filename] + linker.extra_args + args
     return self._invoke_capturing_output(
       cmd,
       linker.as_invocation_environment_dict)

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -119,9 +119,11 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
 
   def _invoke_compiler(self, compiler, args):
     cmd = [compiler.exe_filename] + compiler.extra_args + args
-    return self._invoke_capturing_output(
-      cmd,
-      compiler.as_invocation_environment_dict)
+    env = compiler.as_invocation_environment_dict
+    # TODO: add an `extra_args`-like field to `Executable`s which allows for overriding env vars
+    # like this, but declaratively!
+    env['LC_ALL'] = 'C'
+    return self._invoke_capturing_output(cmd, env)
 
   def _invoke_linker(self, linker, args):
     cmd = [linker.exe_filename] + linker.extra_args + args

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -37,7 +37,6 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
 
     self.platform = Platform.create()
     self.toolchain = global_subsystem_instance(NativeToolchain)
-    self.libc_dev = global_subsystem_instance(LibcDev)
     self.rules = native_backend_rules()
 
     gcc_subsystem = global_subsystem_instance(GCC)
@@ -159,14 +158,9 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
       ['-c', source_file, '-o', intermediate_obj_file_name])
     self.assertTrue(os.path.isfile(intermediate_obj_file_name))
 
-    libc_objects = self.platform.resolve_platform_specific({
-      'darwin': lambda: [],
-      'linux': lambda: self.libc_dev.get_libc_objects(),
-    })
-
     self._invoke_linker(
       linker,
-      [intermediate_obj_file_name, '-o', outfile] + libc_objects)
+      [intermediate_obj_file_name, '-o', outfile])
     self.assertTrue(is_executable(outfile))
 
     program_out = self._invoke_capturing_output([os.path.abspath(outfile)])

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -37,6 +37,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
 
     self.platform = Platform.create()
     self.toolchain = global_subsystem_instance(NativeToolchain)
+    self.libc_dev = global_subsystem_instance(LibcDev)
     self.rules = native_backend_rules()
 
     gcc_subsystem = global_subsystem_instance(GCC)
@@ -158,9 +159,14 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
       ['-c', source_file, '-o', intermediate_obj_file_name])
     self.assertTrue(os.path.isfile(intermediate_obj_file_name))
 
+    libc_objects = self.platform.resolve_platform_specific({
+      'darwin': lambda: [],
+      'linux': lambda: self.libc_dev.get_libc_objects(),
+    })
+
     self._invoke_linker(
       linker,
-      [intermediate_obj_file_name, '-o', outfile])
+      [intermediate_obj_file_name, '-o', outfile] + libc_objects)
     self.assertTrue(is_executable(outfile))
 
     program_out = self._invoke_capturing_output([os.path.abspath(outfile)])

--- a/tests/python/pants_test/backend/native/tasks/test_link_shared_libraries.py
+++ b/tests/python/pants_test/backend/native/tasks/test_link_shared_libraries.py
@@ -19,11 +19,17 @@ class LinkSharedLibrariesTest(NativeTaskTestBase, NativeCompileTestMixin):
     return LinkSharedLibraries
 
   def test_caching(self):
-    cpp = self. create_simple_cpp_library(ctypes_native_library=NativeArtifact(lib_name='test'),)
+    cpp = self.create_simple_cpp_library(ctypes_native_library=NativeArtifact(lib_name='test'),)
 
     cpp_compile_task_type = self.synthesize_task_subtype(CppCompile, 'cpp_compile_scope')
-    context = self.prepare_context_for_compile(target_roots=[cpp],
-                                               for_task_types=[cpp_compile_task_type])
+    context = self.prepare_context_for_compile(
+      target_roots=[cpp],
+      for_task_types=[cpp_compile_task_type],
+      options={
+        'libc': {
+          'enable_libc_search': True,
+        },
+      })
 
     cpp_compile = cpp_compile_task_type(context, os.path.join(self.pants_workdir, 'cpp_compile'))
     cpp_compile.execute()

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes.py
@@ -71,8 +71,13 @@ class TestBuildLocalDistsWithCtypesNativeSources(BuildLocalPythonDistributionsTe
       'ctypes_native_library': NativeArtifact(lib_name='cpp-math-lib'),
       'sources': ['cpp_math_lib.cpp', 'cpp_math_lib.hpp'],
       'filemap': {
-        'src/python/plat_specific_cpp_dist/cpp_math_lib.cpp': '',
-        'src/python/plat_specific_cpp_dist/cpp_math_lib.hpp': '',
+        'src/python/plat_specific_cpp_dist/cpp_math_lib.cpp': dedent("""\
+#include "cpp_math_lib.h"
+int add_two(int x) { return (x++)++; }
+"""),
+        'src/python/plat_specific_cpp_dist/cpp_math_lib.hpp': dedent("""\
+int add_two(int);
+"""),
       },
     }),
 

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes.py
@@ -72,8 +72,8 @@ class TestBuildLocalDistsWithCtypesNativeSources(BuildLocalPythonDistributionsTe
       'sources': ['cpp_math_lib.cpp', 'cpp_math_lib.hpp'],
       'filemap': {
         'src/python/plat_specific_cpp_dist/cpp_math_lib.cpp': dedent("""\
-#include "cpp_math_lib.h"
-int add_two(int x) { return (x++)++; }
+#include "cpp_math_lib.hpp"
+int add_two(int x) { return (x++) + 1; }
 """),
         'src/python/plat_specific_cpp_dist/cpp_math_lib.hpp': dedent("""\
 int add_two(int);

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes.py
@@ -71,11 +71,11 @@ class TestBuildLocalDistsWithCtypesNativeSources(BuildLocalPythonDistributionsTe
       'ctypes_native_library': NativeArtifact(lib_name='cpp-math-lib'),
       'sources': ['cpp_math_lib.cpp', 'cpp_math_lib.hpp'],
       'filemap': {
-        'src/python/plat_specific_cpp_dist/cpp_math_lib.cpp': dedent("""\
+        'src/python/plat_specific_cpp_dist/cpp_math_lib.cpp': dedent("""
 #include "cpp_math_lib.hpp"
 int add_two(int x) { return (x++) + 1; }
 """),
-        'src/python/plat_specific_cpp_dist/cpp_math_lib.hpp': dedent("""\
+        'src/python/plat_specific_cpp_dist/cpp_math_lib.hpp': dedent("""
 int add_two(int);
 """),
       },

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -198,7 +198,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         build_root=buildroot.new_buildroot)
       self.assert_failure(pants_binary_strict_deps_failure)
       self.assertIn(self._include_not_found_message_for_variant[toolchain_variant],
-                    pants_binary_strict_deps_failure.stdout_dMata)
+                    pants_binary_strict_deps_failure.stdout_data)
 
     # TODO(#???): we need to provide the libstdc++.so.6.dylib which comes with gcc on osx in the
     # DYLD_LIBRARY_PATH during the 'run' goal somehow.

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -63,8 +63,6 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
   }
 
   def _assert_ctypes_binary(self, toolchain_variant):
-    # TODO: figure out a way to check that when we select 'gnu' as the `toolchain_variant`, we use
-    # gcc to compile the C/C++ targets -- the same for 'llvm' and clang.
     with temporary_dir() as tmp_dir:
       pants_run = self.run_pants(command=['binary', self._binary_target], config={
         GLOBAL_SCOPE_CONFIG_SECTION: {
@@ -82,6 +80,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       for compiler_name in self._compiler_names_for_variant[toolchain_variant]:
         self.assertIn("selected compiler exe name: '{}'".format(compiler_name),
                       pants_run.stdout_data)
+
       for linker_name in self._linker_names_for_variant[toolchain_variant]:
         self.assertIn("selected linker exe name: '{}'".format(linker_name),
                       pants_run.stdout_data)

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -188,7 +188,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         command=['binary', self._binary_target_with_interop],
         # Explicitly set to True (although this is the default).
         config={
-          # TODO: don't make it possible to forget to add the toolchain_variant option!
+          # TODO(#6848): don't make it possible to forget to add the toolchain_variant option!
           'native-build-settings': {
             'toolchain_variant': toolchain_variant,
             'strict_deps': True,
@@ -200,7 +200,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       self.assertIn(self._include_not_found_message_for_variant[toolchain_variant],
                     pants_binary_strict_deps_failure.stdout_data)
 
-    # TODO(#???): we need to provide the libstdc++.so.6.dylib which comes with gcc on osx in the
+    # TODO(#6848): we need to provide the libstdc++.so.6.dylib which comes with gcc on osx in the
     # DYLD_LIBRARY_PATH during the 'run' goal somehow.
     attempt_pants_run = Platform.create().resolve_platform_specific({
       'darwin': lambda: toolchain_variant != 'gnu',
@@ -224,7 +224,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     pants_binary = self.run_pants(['binary', self._binary_target_with_third_party])
     self.assert_success(pants_binary)
 
-    # TODO(#???): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
+    # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
     # be available on the runtime library path.
     pants_run = self.run_pants(['-q', 'run', self._binary_target_with_third_party])
     self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -77,6 +77,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
       # Check that we have selected the appropriate compilers for our selected toolchain variant,
       # for both C and C++ compilation.
+      # TODO(#6866): don't parse info logs for testing!
       for compiler_name in self._compiler_names_for_variant[toolchain_variant]:
         self.assertIn("selected compiler exe name: '{}'".format(compiler_name),
                       pants_run.stdout_data)

--- a/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_ctypes_integration.py
@@ -217,6 +217,8 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     pants_binary = self.run_pants(['binary', self._binary_target_with_third_party])
     self.assert_success(pants_binary)
 
+    # TODO(#???): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
+    # be available on the runtime library path.
     pants_run = self.run_pants(['-q', 'run', self._binary_target_with_third_party])
     self.assert_success(pants_run)
     self.assertIn('Test worked!\n', pants_run.stdout_data)

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -117,8 +117,8 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBas
       for_subsystems=[PythonRepos, LibcDev],
       # TODO(#???): we should be testing all of these with both of our toolchains.
       options={
-        'libc-dev': {
-          'enable_libc_search': True,
+        'native-build-settings': {
+          'toolchain_variant': 'llvm',
         },
       })
     self.assertEqual(set(self._all_specified_targets()), set(context.build_graph.targets()))

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -115,7 +115,7 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBas
       target_roots=([python_dist_target] + extra_targets),
       for_task_types=(all_synthesized_task_types),
       for_subsystems=[PythonRepos, LibcDev],
-      # TODO(#???): we should be testing all of these with both of our toolchains.
+      # TODO(#6848): we should be testing all of these with both of our toolchains.
       options={
         'native-build-settings': {
           'toolchain_variant': 'llvm',

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -8,6 +8,7 @@ import re
 from builtins import next
 
 from pants.backend.native.register import rules as native_backend_rules
+from pants.backend.native.subsystems.libc_dev import LibcDev
 from pants.backend.python.subsystems.python_repos import PythonRepos
 from pants.backend.python.tasks.build_local_python_distributions import \
   BuildLocalPythonDistributions
@@ -113,7 +114,13 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, SchedulerTestBas
     context = self._scheduling_context(
       target_roots=([python_dist_target] + extra_targets),
       for_task_types=(all_synthesized_task_types),
-      for_subsystems=[PythonRepos])
+      for_subsystems=[PythonRepos, LibcDev],
+      # TODO(#???): we should be testing all of these with both of our toolchains.
+      options={
+        'libc-dev': {
+          'enable_libc_search': True,
+        },
+      })
     self.assertEqual(set(self._all_specified_targets()), set(context.build_graph.targets()))
 
     all_other_task_instances = [


### PR DESCRIPTION
### Problem

We have not previously made it possible for the user to select the compiler to use for C/C++ code (although we have unit tests for both compilers). It is currently hardcoded to use LLVM.

### Solution

- Add a `--toolchain-variant` enum option to `NativeBuildSettings`.
- Convert the subsystem dependency in `NativeTask` on `NativeBuildSettings` to be a global subsystem dependency instead of a scoped dependency.
- Add some boilerplate in `NativeTask` to select the toolchain based on the option.
- Add an info-level log to the compile and link tasks stating the executable name which is being used.
- Expand an integration test to cover each toolchain variant.

### Result

Users can now elect to use `--native-build-settings-toolchain-variant=llvm` to use clang/clang++ for the compiler. The default compiler has been changed to be gcc/g++ (previously `llvm` was the only option).