### PR TITLE
Header file extensions as options for C/C++ targets

### DIFF
--- a/src/python/pants/backend/native/subsystems/native_build_step_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step_settings.py
@@ -45,7 +45,9 @@ class CompileSettingsBase(Subsystem):
       NativeBuildStepSettings.scoped(cls),
     )
 
-  header_file_extensions_default = None
+  @classproperty
+  def header_file_extensions_default(cls):
+    raise NotImplementedError('header_file_extensions_default() must be overridden!')
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -48,8 +48,6 @@ class NativeCompile(NativeTask, AbstractClass):
   source_target_constraint = None
   dependent_target_constraint = SubclassesOf(ExternalNativeLibrary, NativeLibrary)
 
-  HEADER_EXTENSIONS = ('.h', '.hpp')
-
   # `NativeCompile` will use `workunit_label` as the name of the workunit when executing the
   # compiler process. `workunit_label` must be set to a string.
   @classproperty
@@ -230,6 +228,7 @@ class NativeCompile(NativeTask, AbstractClass):
       compile_request.sources, compile_request.header_file_extensions)
 
     if len(sources) == 0:
+      self.context.log.info('{} is a header-only library'.format(compile_request))
       return
 
     compiler = compile_request.compiler

--- a/tests/python/pants_test/backend/native/tasks/native_task_test_base.py
+++ b/tests/python/pants_test/backend/native/tasks/native_task_test_base.py
@@ -20,6 +20,17 @@ class NativeTaskTestBase(TaskTestBase):
 
 
 class NativeCompileTestMixin(object):
+
+  def _retrieve_single_product_at_target_base(self, product_mapping, target):
+    product = product_mapping.get(target)
+    base_dirs = list(product.keys())
+    self.assertEqual(1, len(base_dirs))
+    single_base_dir = base_dirs[0]
+    all_products = product[single_base_dir]
+    self.assertEqual(1, len(all_products))
+    single_product = all_products[0]
+    return single_product
+
   def create_simple_cpp_library(self, **kwargs):
     self.create_file('src/cpp/test/test.hpp', contents=dedent("""
       #ifndef __TEST_HPP__

--- a/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
+++ b/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
@@ -4,6 +4,10 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
+from textwrap import dedent
+
+from pants.backend.native.targets.native_library import CppLibrary
 from pants.backend.native.tasks.cpp_compile import CppCompile
 from pants_test.backend.native.tasks.native_task_test_base import (NativeCompileTestMixin,
                                                                    NativeTaskTestBase)
@@ -13,6 +17,33 @@ class CppCompileTest(NativeTaskTestBase, NativeCompileTestMixin):
   @classmethod
   def task_type(cls):
     return CppCompile
+
+  def create_simple_header_only_library(self, **kwargs):
+    self.create_file('src/cpp/test/test.hpp', contents=dedent("""
+      #ifndef __TEST_HPP__
+      #define __TEST_HPP__
+
+      template <typename T>
+      T add(T a, T b) {
+        return a + b;
+      }
+
+      #endif
+"""))
+    return self.make_target(spec='src/cpp/test',
+                     target_type=CppLibrary,
+                     sources=['test.hpp'],
+                     **kwargs)
+
+  def test_header_only_target_noop(self):
+    cpp = self.create_simple_header_only_library()
+    context = self.prepare_context_for_compile(target_roots=[cpp])
+    cpp_compile = self.create_task(context)
+
+    with self.captured_logging(level=logging.INFO) as logs:
+      cpp_compile.execute()
+      info = list(logs.infos())[-1]
+      self.assertIn('is a header-only library', info)
 
   def test_caching(self):
     cpp = self.create_simple_cpp_library()

--- a/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
+++ b/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
@@ -4,11 +4,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
 from textwrap import dedent
 
 from pants.backend.native.targets.native_library import CppLibrary
 from pants.backend.native.tasks.cpp_compile import CppCompile
+from pants.backend.native.tasks.native_compile import ObjectFiles
 from pants_test.backend.native.tasks.native_task_test_base import (NativeCompileTestMixin,
                                                                    NativeTaskTestBase)
 
@@ -19,6 +19,9 @@ class CppCompileTest(NativeTaskTestBase, NativeCompileTestMixin):
     return CppCompile
 
   def create_simple_header_only_library(self, **kwargs):
+    # TODO: determine if there are other features that people expect from header-only libraries that
+    # we could be testing here. Currently this file's contents are just C++ which doesn't define any
+    # non-template classes or methods.
     self.create_file('src/cpp/test/test.hpp', contents=dedent("""
       #ifndef __TEST_HPP__
       #define __TEST_HPP__
@@ -38,17 +41,21 @@ class CppCompileTest(NativeTaskTestBase, NativeCompileTestMixin):
   def test_header_only_target_noop(self):
     cpp = self.create_simple_header_only_library()
     context = self.prepare_context_for_compile(target_roots=[cpp])
-    cpp_compile = self.create_task(context)
 
-    with self.captured_logging(level=logging.INFO) as logs:
-      cpp_compile.execute()
-      info = list(logs.infos())[-1]
-      self.assertIn('is a header-only library', info)
+    # Test that the task runs without error if provided a header-only library.
+    cpp_compile = self.create_task(context)
+    cpp_compile.execute()
+
+    object_files_product = context.products.get(ObjectFiles)
+    object_files_for_target = self._retrieve_single_product_at_target_base(object_files_product, cpp)
+    # Test that no object files were produced.
+    self.assertEqual(0, len(object_files_for_target.filenames))
 
   def test_caching(self):
     cpp = self.create_simple_cpp_library()
     context = self.prepare_context_for_compile(target_roots=[cpp])
     cpp_compile = self.create_task(context)
 
+    # TODO: what is this testing?
     cpp_compile.execute()
     cpp_compile.execute()


### PR DESCRIPTION
### Problem

The file extensions we consider "header files" for C/C++ targets are hardcoded as `('.h', '.hpp')`. Additionally, we will error out on header-only `ctypes_compatible_cpp_library()` targets (as for C targets).

### Solution

- Create the `--header-file-extensions` option in the CCompileSettings and CppCompileSettings subsystems.
- Make a debug-level log if the library undergoing compile is a header-only library before early returning.
- Add some tests.