### PR TITLE
Fix documentation example for using scalac_plugins

### DIFF
--- a/examples/src/scala/org/pantsbuild/example/README.md
+++ b/examples/src/scala/org/pantsbuild/example/README.md
@@ -152,6 +152,7 @@ compilation for `fmt` and `lint`:
         '-S-Yrangepos',
       ]
 
+    [scala]
     scalac_plugins: [
         'semanticdb',
       ]


### PR DESCRIPTION
### Problem

The current documentation example for using scalac plugins has the `scalac_plugins` option 
in the wrong section. This fixes it.