### PR TITLE
Fix dissappearing cursor

### DIFF
--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -304,6 +304,7 @@ impl Scheduler {
       }
     };
     if let Some(display) = optional_display.as_mut() {
+      // Ran after printing the result of a console_rule.
       display.finish();
     };
 

--- a/src/rust/engine/ui/src/display.rs
+++ b/src/rust/engine/ui/src/display.rs
@@ -327,5 +327,6 @@ impl EngineDisplay {
         clear_after_cursor = clear::AfterCursor,
         reveal_cursor = termion::cursor::Show
       )).expect("could not write to terminal");
+    self.flush();
   }
 }


### PR DESCRIPTION
### Problem

When running a rule under the V2 UI, the cursor disappeared at the end, leaving the terminal unusable for further commands.

### Solution

Flush the terminal as the last thing it does in `finish()`.


### Result

Even though the output of a `@console_rule` is still broken, the cursor appears after calling pants, which makes it a lot nicer to work on this.

![screenshot 2018-11-26 at 16 14 11](https://user-images.githubusercontent.com/5861182/49026669-56e47000-f196-11e8-9b4d-11d6fc26166e.png)

Part 1 of #6808 