### PR TITLE
Log aggregate statistics for remote executions

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1253,6 +1253,7 @@ dependencies = [
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -3474,7 +3474,7 @@ mod tests {
         ingested_file_count: 1,
         ingested_file_bytes: testroland.digest().1,
         uploaded_file_count: 1,
-        uploaded_file_bytes: testroland.digest().1
+        uploaded_file_bytes: testroland.digest().1,
         upload_wall_time: Duration::default(),
       }
     );
@@ -3495,7 +3495,7 @@ mod tests {
         ingested_file_count: 3,
         ingested_file_bytes: testdir.digest().1 + testroland.digest().1 + testcatnip.digest().1,
         uploaded_file_count: 2,
-        uploaded_file_bytes: testdir.digest().1 + testcatnip.digest().1
+        uploaded_file_bytes: testdir.digest().1 + testcatnip.digest().1,
         upload_wall_time: Duration::default(),
       }
     );

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -14,7 +14,7 @@ use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
 use pool::ResettablePool;
@@ -33,10 +33,12 @@ pub const DEFAULT_LOCAL_STORE_GC_TARGET_BYTES: usize = 4 * 1024 * 1024 * 1024;
 // uploaded_file_{count, bytes}: Number and combined size of files uploaded to the remote
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize)]
 pub struct UploadSummary {
-  ingested_file_count: usize,
-  ingested_file_bytes: usize,
-  uploaded_file_count: usize,
-  uploaded_file_bytes: usize,
+  pub ingested_file_count: usize,
+  pub ingested_file_bytes: usize,
+  pub uploaded_file_count: usize,
+  pub uploaded_file_bytes: usize,
+  #[serde(skip)]
+  pub upload_wall_time: Duration,
 }
 
 ///
@@ -282,6 +284,8 @@ impl Store {
     &self,
     digests: Vec<Digest>,
   ) -> BoxFuture<UploadSummary, String> {
+    let start_time = Instant::now();
+
     let remote = match self.remote {
       Some(ref remote) => remote,
       None => {
@@ -343,7 +347,7 @@ impl Store {
             }).collect::<Vec<_>>(),
         ).and_then(future::join_all)
         .map(|uploaded_digests| (uploaded_digests, ingested_digests))
-      }).map(|(uploaded_digests, ingested_digests)| {
+      }).map(move |(uploaded_digests, ingested_digests)| {
         let ingested_file_sizes = ingested_digests.iter().map(|(digest, _)| digest.1);
         let uploaded_file_sizes = uploaded_digests.iter().map(|digest| digest.1);
 
@@ -352,6 +356,7 @@ impl Store {
           ingested_file_bytes: ingested_file_sizes.sum(),
           uploaded_file_count: uploaded_file_sizes.len(),
           uploaded_file_bytes: uploaded_file_sizes.sum(),
+          upload_wall_time: start_time.elapsed(),
         }
       }).to_boxed()
   }
@@ -3407,7 +3412,7 @@ mod tests {
       .store_file_bytes(testcatnip.bytes(), false)
       .wait()
       .expect("Error storing file locally");
-    let summary = new_store(dir.path(), cas.address())
+    let mut summary = new_store(dir.path(), cas.address())
       .ensure_remote_has_recursive(vec![testdir.digest()])
       .wait()
       .expect("Error uploading file");
@@ -3419,13 +3424,15 @@ mod tests {
       testcatnip.digest().1,
     ];
     let test_bytes = test_data.iter().sum();
+    summary.upload_wall_time = Duration::default();
     assert_eq!(
       summary,
       UploadSummary {
         ingested_file_count: test_data.len(),
         ingested_file_bytes: test_bytes,
         uploaded_file_count: test_data.len(),
-        uploaded_file_bytes: test_bytes
+        uploaded_file_bytes: test_bytes,
+        upload_wall_time: Duration::default(),
       }
     );
   }
@@ -3455,10 +3462,11 @@ mod tests {
       .expect("Error storing file locally");
 
     // Store testroland first, which should return a summary of one file
-    let data_summary = new_store(dir.path(), cas.address())
+    let mut data_summary = new_store(dir.path(), cas.address())
       .ensure_remote_has_recursive(vec![testroland.digest()])
       .wait()
       .expect("Error uploading file");
+    data_summary.upload_wall_time = Duration::default();
 
     assert_eq!(
       data_summary,
@@ -3467,16 +3475,19 @@ mod tests {
         ingested_file_bytes: testroland.digest().1,
         uploaded_file_count: 1,
         uploaded_file_bytes: testroland.digest().1
+        upload_wall_time: Duration::default(),
       }
     );
 
     // Store the directory and catnip.
     // It should see the digest of testroland already in cas,
     // and not report it in uploads.
-    let dir_summary = new_store(dir.path(), cas.address())
+    let mut dir_summary = new_store(dir.path(), cas.address())
       .ensure_remote_has_recursive(vec![testdir.digest()])
       .wait()
       .expect("Error uploading directory");
+
+    dir_summary.upload_wall_time = Duration::default();
 
     assert_eq!(
       dir_summary,
@@ -3485,6 +3496,7 @@ mod tests {
         ingested_file_bytes: testdir.digest().1 + testroland.digest().1 + testcatnip.digest().1,
         uploaded_file_count: 2,
         uploaded_file_bytes: testdir.digest().1 + testcatnip.digest().1
+        upload_wall_time: Duration::default(),
       }
     );
   }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -19,6 +19,7 @@ protobuf = { version = "2.0.4", features = ["with-bytes"] }
 sha2 = "0.8"
 tempfile = "3"
 futures-timer = "0.1"
+time = "0.1.40"
 tokio-codec = "0.1"
 tokio-process = "0.2.1"
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -46,14 +46,17 @@ extern crate sha2;
 extern crate tempfile;
 #[cfg(test)]
 extern crate testutil;
+extern crate time;
 extern crate tokio_codec;
 extern crate tokio_process;
 
 use boxfuture::BoxFuture;
 use bytes::Bytes;
 use std::collections::{BTreeMap, BTreeSet};
+use std::ops::AddAssign;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_semaphore::AsyncSemaphore;
 
@@ -115,6 +118,28 @@ pub struct FallibleExecuteProcessResult {
   // It's unclear whether this should be a Snapshot or a digest of a Directory. A Directory digest
   // is handy, so let's try that out for now.
   pub output_directory: hashing::Digest,
+
+  pub execution_attempts: Vec<ExecutionStats>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ExecutionStats {
+  uploaded_bytes: usize,
+  uploaded_file_count: usize,
+  upload: Duration,
+  remote_queue: Option<Duration>,
+  remote_input_fetch: Option<Duration>,
+  remote_execution: Option<Duration>,
+  remote_output_store: Option<Duration>,
+  was_cache_hit: bool,
+}
+
+impl AddAssign<fs::UploadSummary> for ExecutionStats {
+  fn add_assign(&mut self, summary: fs::UploadSummary) {
+    self.uploaded_file_count += summary.uploaded_file_count;
+    self.uploaded_bytes += summary.uploaded_file_bytes;
+    self.upload += summary.upload_wall_time;
+  }
 }
 
 pub trait CommandRunner: Send + Sync {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -122,6 +122,14 @@ pub struct FallibleExecuteProcessResult {
   pub execution_attempts: Vec<ExecutionStats>,
 }
 
+#[cfg(test)]
+impl FallibleExecuteProcessResult {
+  pub fn without_execution_attempts(mut self) -> Self {
+    self.execution_attempts = vec![];
+    self
+  }
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ExecutionStats {
   uploaded_bytes: usize,

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -338,6 +338,7 @@ mod tests {
         stderr: as_bytes(""),
         exit_code: 0,
         output_directory: fs::EMPTY_DIGEST,
+        execution_attempts: vec![],
       }
     )
   }
@@ -363,6 +364,7 @@ mod tests {
         stderr: as_bytes("bar"),
         exit_code: 1,
         output_directory: fs::EMPTY_DIGEST,
+        execution_attempts: vec![],
       }
     )
   }
@@ -389,6 +391,7 @@ mod tests {
         stderr: as_bytes(""),
         exit_code: -15,
         output_directory: fs::EMPTY_DIGEST,
+        execution_attempts: vec![],
       }
     )
   }
@@ -490,6 +493,7 @@ mod tests {
         stderr: as_bytes(""),
         exit_code: 0,
         output_directory: fs::EMPTY_DIGEST,
+        execution_attempts: vec![],
       }
     )
   }
@@ -518,6 +522,7 @@ mod tests {
         stderr: as_bytes(""),
         exit_code: 0,
         output_directory: TestDirectory::containing_roland().digest(),
+        execution_attempts: vec![],
       }
     )
   }
@@ -551,6 +556,7 @@ mod tests {
         stderr: as_bytes(""),
         exit_code: 0,
         output_directory: TestDirectory::recursive().digest(),
+        execution_attempts: vec![],
       }
     )
   }
@@ -585,6 +591,7 @@ mod tests {
         stderr: as_bytes(""),
         exit_code: 0,
         output_directory: TestDirectory::recursive().digest(),
+        execution_attempts: vec![],
       }
     )
   }
@@ -617,6 +624,7 @@ mod tests {
         stderr: as_bytes(""),
         exit_code: 1,
         output_directory: TestDirectory::containing_roland().digest(),
+        execution_attempts: vec![],
       }
     )
   }
@@ -647,6 +655,7 @@ mod tests {
         stderr: as_bytes(""),
         exit_code: 0,
         output_directory: TestDirectory::containing_roland().digest(),
+        execution_attempts: vec![],
       }
     )
   }
@@ -678,6 +687,7 @@ mod tests {
         stderr: as_bytes(""),
         exit_code: 0,
         output_directory: TestDirectory::nested().digest(),
+        execution_attempts: vec![],
       }
     )
   }
@@ -706,6 +716,7 @@ mod tests {
         stderr: as_bytes(""),
         exit_code: 0,
         output_directory: fs::EMPTY_DIGEST,
+        execution_attempts: vec![],
       })
     )
   }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -279,6 +279,7 @@ impl super::CommandRunner for CommandRunner {
             stderr: child_results.stderr,
             exit_code: child_results.exit_code,
             output_directory: snapshot.digest,
+            execution_attempts: vec![],
           }).to_boxed()
       }).then(move |result| {
         // Force workdir not to get dropped until after we've ingested the outputs

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -407,19 +407,19 @@ impl CommandRunner {
 
           match (worker_start - enqueued).to_std() {
             Ok(duration) => attempts.current_attempt.remote_queue = Some(duration),
-            Err(_) => warn!("Got negative remote queue time"),
+            Err(err) => warn!("Got negative remote queue time: {}", err),
           }
           match (input_fetch_completed - input_fetch_start).to_std() {
             Ok(duration) => attempts.current_attempt.remote_input_fetch = Some(duration),
-            Err(_) => warn!("Got negative remote input fetch time"),
+            Err(err) => warn!("Got negative remote input fetch time: {}", err),
           }
           match (execution_completed - execution_start).to_std() {
             Ok(duration) => attempts.current_attempt.remote_execution = Some(duration),
-            Err(_) => warn!("Got negative remote execution time"),
+            Err(err) => warn!("Got negative remote execution time: {}", err),
           }
           match (output_upload_completed - output_upload_start).to_std() {
             Ok(duration) => attempts.current_attempt.remote_output_store = Some(duration),
-            Err(_) => warn!("Got negative remote output store time"),
+            Err(err) => warn!("Got negative remote output store time: {}", err),
           }
           attempts.current_attempt.was_cache_hit = execute_response.cached_result;
         }
@@ -891,7 +891,10 @@ mod tests {
   use testutil::{as_bytes, owned_string_vec};
 
   use super::super::CommandRunner as CommandRunnerTrait;
-  use super::{CommandRunner, ExecuteProcessRequest, ExecutionError, FallibleExecuteProcessResult};
+  use super::{
+    CommandRunner, ExecuteProcessRequest, ExecutionError, ExecutionHistory,
+    FallibleExecuteProcessResult,
+  };
   use mock::execution_server::MockOperation;
   use std::collections::{BTreeMap, BTreeSet};
   use std::iter::{self, FromIterator};
@@ -1251,6 +1254,7 @@ mod tests {
         stderr: as_bytes(""),
         exit_code: 0,
         output_directory: fs::EMPTY_DIGEST,
+        execution_attempts: vec![],
       }
     );
   }
@@ -1276,6 +1280,7 @@ mod tests {
         stderr: testdata_empty.bytes(),
         exit_code: 0,
         output_directory: fs::EMPTY_DIGEST,
+        execution_attempts: vec![],
       })
     );
   }
@@ -1301,6 +1306,7 @@ mod tests {
         stderr: testdata.bytes(),
         exit_code: 0,
         output_directory: fs::EMPTY_DIGEST,
+        execution_attempts: vec![],
       })
     );
   }
@@ -1352,6 +1358,7 @@ mod tests {
         stderr: test_stderr.bytes(),
         exit_code: 0,
         output_directory: fs::EMPTY_DIGEST,
+        execution_attempts: vec![],
       })
     );
 
@@ -1411,6 +1418,7 @@ mod tests {
         stderr: as_bytes(""),
         exit_code: 0,
         output_directory: fs::EMPTY_DIGEST,
+        execution_attempts: vec![],
       }
     );
   }
@@ -1486,6 +1494,7 @@ mod tests {
         stderr: as_bytes(""),
         exit_code: 0,
         output_directory: fs::EMPTY_DIGEST,
+        execution_attempts: vec![],
       }
     );
   }
@@ -1707,6 +1716,7 @@ mod tests {
         stderr: Bytes::from(""),
         exit_code: 0,
         output_directory: fs::EMPTY_DIGEST,
+        execution_attempts: vec![],
       })
     );
     {
@@ -1786,6 +1796,7 @@ mod tests {
         stderr: Bytes::from(""),
         exit_code: 0,
         output_directory: fs::EMPTY_DIGEST,
+        execution_attempts: vec![],
       })
     );
     {
@@ -1868,6 +1879,7 @@ mod tests {
       stderr: Bytes::from("simba"),
       exit_code: 17,
       output_directory: TestDirectory::nested().digest(),
+      execution_attempts: vec![],
     };
 
     let mut output_file = bazel_protos::remote_execution::OutputFile::new();
@@ -2410,8 +2422,10 @@ mod tests {
       .build();
     let command_runner = create_command_runner("".to_owned(), &cas);
     command_runner
-      .extract_execute_response(super::OperationOrStatus::Operation(operation))
-      .wait()
+      .extract_execute_response(
+        super::OperationOrStatus::Operation(operation),
+        &mut ExecutionHistory::default(),
+      ).wait()
   }
 
   fn extract_output_files_from_response(

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -13,7 +13,7 @@ use futures::{future, Future, Stream};
 use futures_timer::Delay;
 use grpcio;
 use hashing::{Digest, Fingerprint};
-use log::{debug, warn};
+use log::{debug, trace, warn};
 use protobuf::{self, Message, ProtobufEnum};
 use sha2::Sha256;
 use time;
@@ -152,7 +152,7 @@ impl super::CommandRunner for CommandRunner {
           .upload_protos(&command, &action)
           .and_then(move |summary| {
             history.current_attempt += summary;
-            debug!(
+            trace!(
               "Executing remotely request: {:?} (command: {:?})",
               execute_request,
               command
@@ -183,7 +183,7 @@ impl super::CommandRunner for CommandRunner {
                         current_attempt,
                       } = history;
 
-                      debug!(
+                      trace!(
                         "Server reported missing digests ({:?}); trying to upload: {:?}",
                         current_attempt,
                         missing_digests,
@@ -368,8 +368,7 @@ impl CommandRunner {
     operation_or_status: OperationOrStatus,
     attempts: &mut ExecutionHistory,
   ) -> BoxFuture<FallibleExecuteProcessResult, ExecutionError> {
-    // TODO: Log less verbosely
-    debug!("Got operation response: {:?}", operation_or_status);
+    trace!("Got operation response: {:?}", operation_or_status);
 
     let status = match operation_or_status {
       OperationOrStatus::Operation(mut operation) => {
@@ -392,8 +391,7 @@ impl CommandRunner {
             .merge_from_bytes(operation.get_response().get_value())
             .map_err(|e| ExecutionError::Fatal(format!("Invalid ExecuteResponse: {:?}", e)))
         );
-        // TODO: Log less verbosely
-        debug!("Got (nested) execute response: {:?}", execute_response);
+        trace!("Got (nested) execute response: {:?}", execute_response);
 
         if execute_response.get_result().has_execution_metadata() {
           let metadata = execute_response.get_result().get_execution_metadata();


### PR DESCRIPTION
Also, tone down background logging.

This is not super structured, and at some point we should do something more structured, but this is useful for now.