### PR TITLE
Fix a bug when selecting interpreters with no constraints at all.

### DIFF
--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -190,16 +190,16 @@ class PythonInterpreterCache(Subsystem):
       'Initializing Python interpreter cache matching filters `{}` from paths `{}`'.format(
         ':'.join(filters), ':'.join(setup_paths)))
 
-    def unsatisfied_filters(ipreters):
-      return [f for f in filters if len(list(self._matching(ipreters, [f]))) == 0]
-
     interpreters = []
+    def unsatisfied_filters():
+      return [f for f in filters if len(list(self._matching(interpreters, [f]))) == 0]
+
     with OwnerPrintingInterProcessFileLock(path=os.path.join(self._cache_dir, '.file_lock')):
       interpreters.extend(self._setup_cached(filters=filters))
-      if not interpreters or unsatisfied_filters(interpreters):
+      if not interpreters or unsatisfied_filters():
         interpreters.extend(self._setup_paths(setup_paths, filters=filters))
 
-    for filt in unsatisfied_filters(interpreters):
+    for filt in unsatisfied_filters():
       logger.debug('No valid interpreters found for {}!'.format(filt))
 
     matches = list(self._matching(interpreters, filters=filters))

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -185,7 +185,7 @@ class PythonInterpreterCache(Subsystem):
     filters = filters if any(filters) else self._python_setup.interpreter_constraints
     setup_paths = (self.pex_python_paths()
                    or self._python_setup.interpreter_search_paths
-                   or os.getenv(b'PATH').split(os.pathsep))
+                   or os.getenv('PATH').split(os.pathsep))
     logger.debug(
       'Initializing Python interpreter cache matching filters `{}` from paths `{}`'.format(
         ':'.join(filters), ':'.join(setup_paths)))

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -185,18 +185,18 @@ class PythonInterpreterCache(Subsystem):
     filters = filters if any(filters) else self._python_setup.interpreter_constraints
     setup_paths = (self.pex_python_paths()
                    or self._python_setup.interpreter_search_paths
-                   or os.getenv('PATH').split(os.pathsep))
+                   or os.getenv(b'PATH').split(os.pathsep))
     logger.debug(
       'Initializing Python interpreter cache matching filters `{}` from paths `{}`'.format(
         ':'.join(filters), ':'.join(setup_paths)))
 
-    def unsatisfied_filters(interpreters):
-      return [f for f in filters if len(list(self._matching(interpreters, [f]))) == 0]
+    def unsatisfied_filters(ipreters):
+      return [f for f in filters if len(list(self._matching(ipreters, [f]))) == 0]
 
     interpreters = []
     with OwnerPrintingInterProcessFileLock(path=os.path.join(self._cache_dir, '.file_lock')):
       interpreters.extend(self._setup_cached(filters=filters))
-      if unsatisfied_filters(interpreters):
+      if not interpreters or unsatisfied_filters(interpreters):
         interpreters.extend(self._setup_paths(setup_paths, filters=filters))
 
     for filt in unsatisfied_filters(interpreters):

--- a/tests/python/pants_test/backend/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/backend/python/test_interpreter_cache.py
@@ -56,7 +56,7 @@ class TestInterpreterCache(TestBase):
 
   def _setup_cache_at(self, path, constraints=None):
     setup_options = {'interpreter_cache_dir': path}
-    if constraints:
+    if constraints is not None:
       setup_options.update(interpreter_constraints=constraints)
     return self._create_interpreter_cache(setup_options=setup_options, repos_options={})
 
@@ -66,7 +66,7 @@ class TestInterpreterCache(TestBase):
       self.assertEqual([], cache.setup())
 
   def test_cache_setup_with_no_filters_uses_repo_default(self):
-    with self._setup_cache(constraints=['']) as (cache, _):
+    with self._setup_cache(constraints=[]) as (cache, _):
       self.assertIn(self._interpreter, cache.setup())
 
   def test_cache_setup_with_filter_overrides_repo_default(self):


### PR DESCRIPTION
Previously, if there were no interpreter constraints at all, not even default ones (e.g., if the value of `interpreter_constraints` in `[python-setup]` was explicitly set to an empty list in `pants.ini`) we would fail to select an interpreter. This was due to the empty set of interpreters vacuously satisfying the condition of "not leaving any filters unsatisfied" when there are no filters.

This change fixes this, and updates the test that was supposed to exercise this to actually do so. Previously that test set the constraint list to `['']`, but that is a contrived value, and not the same as having no values at all in the list.
