### PR TITLE
Pin a floating conan dep

### DIFF
--- a/src/python/pants/backend/native/subsystems/conan.py
+++ b/src/python/pants/backend/native/subsystems/conan.py
@@ -24,6 +24,8 @@ class Conan(ExecutablePexTool):
   # a special target specified in BUILD.tools)?
   default_conan_requirements = (
     'conan==1.9.2',
+    # NB: Only versions of pylint below `2.0.0` support use in python 2.
+    'pylint==1.9.3',
   )
 
   @classmethod


### PR DESCRIPTION
### Problem

Master is currently failing to translate `typed_ast` on python 2, with:
```
**** Failed to install typed-ast-1.1.0 (caused by: NonZeroExit("received exit code 1 during execution of `['/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/bin/python2.7', '-', 'bdist_wheel', '--dist-dir=/tmp/tmpJy273C']` while trying to execute `['/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/bin/python2.7', '-', 'bdist_wheel', '--dist-dir=/tmp/tmpJy273C']`",)
 ):
 stdout:
 
 stderr:
 Error: typed_ast only runs on Python 3.3 and above.
```

### Solution

Pin a conan dep that was floating to a version that was not compatible with py2.

### Result

Broken tests are fixed.