### PR TITLE
Fix unused error value.

### DIFF
--- a/src/rust/engine/ui/src/display.rs
+++ b/src/rust/engine/ui/src/display.rs
@@ -175,7 +175,7 @@ impl EngineDisplay {
       Console::Terminal(ref mut t) => t.write(msg.as_bytes()),
       Console::Pipe(ref mut p) => p.write(msg.as_bytes()),
     };
-    self.flush();
+    self.flush()?;
     res
   }
 


### PR DESCRIPTION
Previously we'd see:
```
   Compiling ui v0.0.1 (/home/jsirois/dev/pantsbuild/pants/src/rust/engine/ui)
warning: unused `std::result::Result` which must be used
   --> ui/src/display.rs:178:5
    |
178 |     self.flush();
    |     ^^^^^^^^^^^^^
    |
    = note: #[warn(unused_must_use)] on by default
    = note: this `Result` may be an `Err` variant, which should be handled
```
