### PR TITLE
Include uname in rust cache key

### DIFF
--- a/build-support/bin/native/bootstrap_code.sh
+++ b/build-support/bin/native/bootstrap_code.sh
@@ -41,6 +41,7 @@ function calculate_current_hash() {
    cd ${REPO_ROOT}
    (echo "${MODE_FLAG}"
     echo "${RUST_TOOLCHAIN}"
+    uname
     git ls-files -c -o --exclude-standard \
      "${NATIVE_ROOT}" \
      "${REPO_ROOT}/rust-toolchain" \


### PR DESCRIPTION
Otherwise dockering Linux on OSX may fetch the OSX generated binary which won't work