### PR TITLE
Straighten out interpreter search path configuration

### DIFF
--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -13,7 +13,6 @@ from collections import defaultdict
 from pex.interpreter import PythonInterpreter
 from pex.package import EggPackage, Package, SourcePackage
 from pex.resolver import resolve
-from pex.variables import Variables
 
 from pants.backend.python.subsystems.python_repos import PythonRepos
 from pants.backend.python.subsystems.python_setup import PythonSetup
@@ -59,22 +58,6 @@ class PythonInterpreterCache(Subsystem):
     for interpreter in interpreters:
       if cls._matches(interpreter, filters=filters):
         yield interpreter
-
-  @classmethod
-  def pex_python_paths(cls):
-    """A list of paths to Python interpreter binaries as defined by a
-    PEX_PYTHON_PATH defined in either in '/etc/pexrc', '~/.pexrc'.
-    PEX_PYTHON_PATH defines a colon-separated list of paths to interpreters
-    that a pex can be built and ran against.
-
-    :return: paths to interpreters as specified by PEX_PYTHON_PATH
-    :rtype: list
-    """
-    ppp = Variables.from_rc().get('PEX_PYTHON_PATH')
-    if ppp:
-      return ppp.split(os.pathsep)
-    else:
-      return []
 
   @memoized_property
   def _python_setup(self):
@@ -183,9 +166,7 @@ class PythonInterpreterCache(Subsystem):
     # because setting up some python versions (e.g., 3<=python<3.3) crashes, and this gives us
     # an escape hatch.
     filters = filters if any(filters) else self._python_setup.interpreter_constraints
-    setup_paths = (self.pex_python_paths()
-                   or self._python_setup.interpreter_search_paths
-                   or os.getenv('PATH').split(os.pathsep))
+    setup_paths = self._python_setup.interpreter_search_paths
     logger.debug(
       'Initializing Python interpreter cache matching filters `{}` from paths `{}`'.format(
         ':'.join(filters), ':'.join(setup_paths)))

--- a/src/python/pants/backend/python/subsystems/BUILD
+++ b/src/python/pants/backend/python/subsystems/BUILD
@@ -8,5 +8,7 @@ python_library(
     '3rdparty/python:setuptools',
     'src/python/pants/option',
     'src/python/pants/subsystem',
+    'src/python/pants/util:memo',
+    'src/python/pants/util:process_handler',
   ],
 )

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -197,7 +197,10 @@ class PythonSetup(Subsystem):
   @staticmethod
   def get_environment_paths():
     """Returns a list of paths specified by the PATH env var."""
-    return os.getenv('PATH').split(os.pathsep)
+    pathstr = os.getenv('PATH')
+    if pathstr:
+      return pathstr.split(os.pathsep)
+    return []
 
   @staticmethod
   def get_pex_python_paths():

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -60,10 +60,11 @@ class PythonSetup(Subsystem):
              help='The parent directory for the python artifact cache. '
                   'If unspecified, a standard path under the workdir is used.')
     register('--interpreter-search-paths', advanced=True, type=list,
-             default=['<PEXRC_PATH>', '<PATH>'], metavar='<binary-paths>',
+             default=['<PEXRC>', '<PATH>'], metavar='<binary-paths>',
              help='A list of paths to search for python interpreters. The following special '
-                  'strings are supported: "<PATH>" (the contents of the PATH env var), '
-                  '"<PEXRC_PATH>" (paths in the PEX_PYTHON_PATH variable in a pexrc file), '
+                  'strings are supported: '
+                  '"<PATH>" (the contents of the PATH env var), '
+                  '"<PEXRC>" (paths in the PEX_PYTHON_PATH variable in a pexrc file), '
                   '"<PYENV>" (all python versions under $(pyenv root)/versions).')
     register('--resolver-blacklist', advanced=True, type=dict, default={},
              removal_version='1.13.0.dev2',
@@ -172,7 +173,7 @@ class PythonSetup(Subsystem):
   @classmethod
   def expand_interpreter_search_paths(cls, interpreter_search_paths, pyenv_root_func=None):
     special_strings = {
-      '<PEXRC_PATH>': cls.get_pex_python_paths,
+      '<PEXRC>': cls.get_pex_python_paths,
       '<PATH>': cls.get_environment_paths,
       '<PYENV>': lambda: cls.get_pyenv_paths(pyenv_root_func=pyenv_root_func)
     }

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -178,11 +178,20 @@ class PythonSetup(Subsystem):
       '<PYENV>': lambda: cls.get_pyenv_paths(pyenv_root_func=pyenv_root_func)
     }
     expanded = []
+    from_pexrc = None
     for s in interpreter_search_paths:
       if s in special_strings:
-        expanded.extend(special_strings[s]())
+        special_paths = special_strings[s]()
+        if s == '<PEXRC>':
+          from_pexrc = special_paths
+        expanded.extend(special_paths)
       else:
         expanded.append(s)
+    # Some special-case logging to avoid misunderstandings.
+    if from_pexrc and len(expanded) > len(from_pexrc):
+      logger.info('pexrc interpreters requested and found, but other paths were also specified, '
+                  'so interpreters may not be restricted to the pexrc ones. Full search path is: '
+                  '{}'.format(':'.join(expanded)))
     return expanded
 
   @staticmethod

--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -68,11 +68,6 @@ class SelectInterpreter(Task):
     python_tgts = [tgt for tgt in python_tgts_and_reqs if isinstance(tgt, PythonTarget)]
     fs = PythonInterpreterFingerprintStrategy()
     with self.invalidated(python_tgts, fingerprint_strategy=fs) as invalidation_check:
-      if (PythonSetup.global_instance().interpreter_search_paths
-          and PythonInterpreterCache.pex_python_paths()):
-        self.context.log.warn("Detected both PEX_PYTHON_PATH and "
-                              "--python-setup-interpreter-search-paths. Ignoring "
-                              "--python-setup-interpreter-search-paths.")
       # If there are no relevant targets, we still go through the motions of selecting
       # an interpreter, to prevent downstream tasks from having to check for this special case.
       if invalidation_check.all_vts:

--- a/tests/python/pants_test/backend/python/subsystems/BUILD
+++ b/tests/python/pants_test/backend/python/subsystems/BUILD
@@ -1,0 +1,13 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_tests(
+  name='python_setup',
+  sources=['test_python_setup.py'],
+  dependencies=[
+    'src/python/pants/backend/python/subsystems',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:test_base',
+    'tests/python/pants_test/testutils:pexrc_util',
+  ]
+)

--- a/tests/python/pants_test/backend/python/subsystems/test_python_setup.py
+++ b/tests/python/pants_test/backend/python/subsystems/test_python_setup.py
@@ -42,7 +42,7 @@ class TestPythonSetup(TestBase):
     with environment_as(PATH='/env/path1:/env/path2'):
       with setup_pexrc_with_pex_python_path(['/pexrc/path1:/pexrc/path2']):
         with fake_pyenv_root(['2.7.14', '3.5.5']) as (pyenv_root, expected_pyenv_paths):
-          paths = ['/foo', '<PATH>', '/bar', '<PEXRC_PATH>', '/baz', '<PYENV>', '/qux']
+          paths = ['/foo', '<PATH>', '/bar', '<PEXRC>', '/baz', '<PYENV>', '/qux']
           expanded_paths = PythonSetup.expand_interpreter_search_paths(
             paths, pyenv_root_func=lambda: pyenv_root)
 

--- a/tests/python/pants_test/backend/python/subsystems/test_python_setup.py
+++ b/tests/python/pants_test/backend/python/subsystems/test_python_setup.py
@@ -1,0 +1,51 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+from contextlib import contextmanager
+
+from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.util.contextutil import environment_as, temporary_dir
+from pants_test.test_base import TestBase
+from pants_test.testutils.pexrc_util import setup_pexrc_with_pex_python_path
+
+
+@contextmanager
+def fake_pyenv_root(fake_versions):
+  with temporary_dir() as pyenv_root:
+    fake_version_dirs = [os.path.join(pyenv_root, 'versions', v, 'bin') for v in fake_versions]
+    for d in fake_version_dirs:
+      os.makedirs(d)
+    yield pyenv_root, fake_version_dirs
+
+
+class TestPythonSetup(TestBase):
+  def test_get_environment_paths(self):
+    with environment_as(PATH='foo/bar:baz:/qux/quux'):
+      paths = PythonSetup.get_environment_paths()
+    self.assertListEqual(['foo/bar', 'baz', '/qux/quux'], paths)
+
+  def test_get_pex_python_paths(self):
+    with setup_pexrc_with_pex_python_path(['foo/bar', 'baz', '/qux/quux']):
+      paths = PythonSetup.get_pex_python_paths()
+    self.assertListEqual(['foo/bar', 'baz', '/qux/quux'], paths)
+
+  def test_get_pyenv_paths(self):
+    with fake_pyenv_root(['2.7.14', '3.5.5']) as (pyenv_root, expected_paths):
+      paths = PythonSetup.get_pyenv_paths(pyenv_root_func=lambda: pyenv_root)
+    self.assertListEqual(expected_paths, paths)
+
+  def test_expand_interpreter_search_paths(self):
+    with environment_as(PATH='/env/path1:/env/path2'):
+      with setup_pexrc_with_pex_python_path(['/pexrc/path1:/pexrc/path2']):
+        with fake_pyenv_root(['2.7.14', '3.5.5']) as (pyenv_root, expected_pyenv_paths):
+          paths = ['/foo', '<PATH>', '/bar', '<PEXRC_PATH>', '/baz', '<PYENV>', '/qux']
+          expanded_paths = PythonSetup.expand_interpreter_search_paths(
+            paths, pyenv_root_func=lambda: pyenv_root)
+
+    expected = ['/foo', '/env/path1', '/env/path2', '/bar', '/pexrc/path1', '/pexrc/path2',
+                '/baz'] + expected_pyenv_paths + ['/qux']
+    self.assertListEqual(expected, expanded_paths)

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -130,7 +130,12 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     py27_path, py3_path = python_interpreter_path(PY_27), python_interpreter_path(PY_3)
     with setup_pexrc_with_pex_python_path([py27_path, py3_path]):
       with temporary_dir() as interpreters_cache:
-        pants_ini_config = {'python-setup': {'interpreter_cache_dir': interpreters_cache}}
+        pants_ini_config = {
+          'python-setup': {
+            'interpreter_cache_dir': interpreters_cache,
+            'interpreter_search_paths': ['<PEXRC>'],
+          }
+        }
         pants_run_27 = self.run_pants(
           command=['test', '{}:test_py2'.format(os.path.join(self.testproject,
                                                              'python_3_selection_testing'))],

--- a/tests/python/pants_test/backend/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/backend/python/test_interpreter_cache.py
@@ -154,7 +154,7 @@ class TestInterpreterCache(TestBase):
     py27_path, py36_path = python_interpreter_path(PY_27), python_interpreter_path(PY_36)
     with setup_pexrc_with_pex_python_path([py27_path, py36_path]):
       with self._setup_cache(constraints=['CPython>=2.7,<3'],
-                             search_paths=['<PEXRC']) as (cache, _):
+                             search_paths=['<PEXRC>']) as (cache, _):
         self.assertIn(py27_path, {pi.binary for pi in cache.setup()})
       with self._setup_cache(constraints=['CPython>=3.6,<4'],
                              search_paths=['<PEXRC>']) as (cache, _):

--- a/tests/python/pants_test/backend/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/backend/python/test_interpreter_cache.py
@@ -151,16 +151,13 @@ class TestInterpreterCache(TestBase):
   @skip_unless_python27_and_python36
   def test_interpereter_cache_setup_using_pex_python_paths(self):
     """Test cache setup using interpreters from a mocked PEX_PYTHON_PATH."""
-    # self.context(for_subsystems=[PythonInterpreterCache], options={
-    #   'python-setup': {'interpreter_search_paths': ['<PEXRC_PATH>']},
-    # })
     py27_path, py36_path = python_interpreter_path(PY_27), python_interpreter_path(PY_36)
     with setup_pexrc_with_pex_python_path([py27_path, py36_path]):
       with self._setup_cache(constraints=['CPython>=2.7,<3'],
-                             search_paths=['<PEXRC_PATH>']) as (cache, _):
+                             search_paths=['<PEXRC']) as (cache, _):
         self.assertIn(py27_path, {pi.binary for pi in cache.setup()})
       with self._setup_cache(constraints=['CPython>=3.6,<4'],
-                             search_paths=['<PEXRC_PATH>']) as (cache, _):
+                             search_paths=['<PEXRC>']) as (cache, _):
         self.assertIn(py36_path, {pi.binary for pi in cache.setup()})
 
   def test_setup_cached_warm(self):


### PR DESCRIPTION
Previously, a value in a pexrc would completely override the value of the `--interpreter-search-paths` option. This change allows you to have any combination of fixed paths, a pexrc value, the env PATH value, and  - as a new feature - interpreters managed by pyenv.

Note that this slightly changes the previous behavior, in that the default behavior (if no `--interpreter-search-paths` are specified) is now pexrc + PATH, whereas previously it was pexrc or PATH. 