### PR TITLE
try defining algebraic Executables in the native backend to compose more readable toolchains

### DIFF
--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -6,9 +6,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 from abc import abstractmethod, abstractproperty
+from builtins import object
 
 from pants.engine.rules import SingletonRule
 from pants.util.meta import AbstractClass, classproperty
+from pants.util.memo import memoized_classproperty
 from pants.util.objects import datatype, enum
 from pants.util.osutil import all_normalized_os_names, get_normalized_os_name
 from pants.util.strutil import create_path_env_var
@@ -19,21 +21,47 @@ class Platform(enum('normalized_os_name', all_normalized_os_names())):
   default_value = get_normalized_os_name()
 
 
-class ExtensibleAlgebraic(AbstractClass):
+def _list_field(func):
+  """A decorator for methods corresponding to list-valued fields of an `ExtensibleAlgebraic`.
+
+  The result is also wrapped in `abstractproperty`.
+  """
+  wrapped = abstractproperty(func)
+  wrapped._field_type = 'list'
+  return wrapped
+
+
+def _algebraic_data(metaclass):
+  """A class decorator to pull out `_list_fields` from a mixin class for use with a `datatype`.
+  """
+  def wrapper(cls):
+    cls.__bases__ += (metaclass,)
+    cls._list_fields = metaclass._list_fields
+    return cls
+  return wrapper
+
+
+class _ExtensibleAlgebraic(AbstractClass):
   """A mixin to make it more concise to coalesce datatypes with related collection fields."""
 
   # NB: prototypal inheritance seems *deeply* linked with the idea here!
 
-  # TODO: populate these for the `Executable` class with a decorator that checks if the fields are
-  # defined? basically just don't require everything to be repeated here.
-  list_fields = []
+  @memoized_classproperty
+  def _list_fields(cls):
+    all_list_fields = []
+    for field_name in cls.__abstractmethods__:
+      f = getattr(cls, field_name)
+      if getattr(f, '_field_type', None) == 'list':
+        all_list_fields.append(field_name)
+    return frozenset(all_list_fields)
 
   @abstractmethod
   def copy(self, **kwargs):
     """Analogous to a `datatype()`'s `copy()` method."""
-    raise NotImplementedError('copy() must be implemented by subclasses of ExtensibleAlgebraic!')
+    raise NotImplementedError('copy() must be implemented by subclasses of _ExtensibleAlgebraic!')
 
   def _single_list_field_operation(self, field_name, list_value, prepend=True):
+    assert(field_name in self._list_fields)
     cur_value = getattr(self, field_name)
 
     if prepend:
@@ -58,13 +86,13 @@ class ExtensibleAlgebraic(AbstractClass):
     List fields will be concatenated.
 
     The return type of this method is the type of `self`, but the `other` can be any
-    `ExtensibleAlgebraic` instance.
+    `_ExtensibleAlgebraic` instance.
     """
     exclude_list_fields = exclude_list_fields or []
     overwrite_kwargs = {}
 
-    shared_list_fields = (frozenset(self.list_fields)
-                          & frozenset(other.list_fields)
+    shared_list_fields = (self._list_fields
+                          & other._list_fields
                           - frozenset(exclude_list_fields))
     for list_field_name in shared_list_fields:
       lhs_value = getattr(self, list_field_name)
@@ -77,13 +105,9 @@ class ExtensibleAlgebraic(AbstractClass):
     return self.copy(**overwrite_kwargs)
 
 
-class Executable(ExtensibleAlgebraic):
+class _Executable(_ExtensibleAlgebraic):
 
-  @classproperty
-  def list_fields(cls):
-    return ['path_entries', 'library_dirs', 'extra_args']
-
-  @abstractproperty
+  @_list_field
   def path_entries(self):
     """A list of directory paths containing this executable, to be used in a subprocess's PATH.
 
@@ -98,34 +122,34 @@ class Executable(ExtensibleAlgebraic):
 
     :rtype: str
     """
-    raise NotImplementedError('exe_filename is a scalar field of Executable!')
+    raise NotImplementedError('exe_filename is a scalar field of _Executable!')
 
   # TODO: rename this to 'runtime_library_dirs'!
-  @abstractproperty
+  @_list_field
   def library_dirs(self):
     """Directories containing shared libraries that must be on the runtime library search path.
 
-    Note: this is for libraries needed for the current Executable to run -- see LinkerMixin below
+    Note: this is for libraries needed for the current _Executable to run -- see _LinkerMixin below
     for libraries that are needed at link time.
     :rtype: list of str
     """
-    raise NotImplementedError('library_dirs is a list field of Executable!')
+    raise NotImplementedError('library_dirs is a list field of _Executable!')
 
-  @abstractproperty
+  @_list_field
   def extra_args(self):
-    """Additional arguments used when invoking this Executable.
+    """Additional arguments used when invoking this _Executable.
 
     These are typically placed before the invocation-specific command line arguments.
 
     :rtype: list of str
     """
-    raise NotImplementedError('extra_args is a list field of Executable!')
+    raise NotImplementedError('extra_args is a list field of _Executable!')
 
   _platform = Platform.create()
 
   @property
   def as_invocation_environment_dict(self):
-    """A dict to use as this Executable's execution environment.
+    """A dict to use as this _Executable's execution environment.
 
     :rtype: dict of string -> string
     """
@@ -139,30 +163,26 @@ class Executable(ExtensibleAlgebraic):
     }
 
 
+@_algebraic_data(_Executable)
 class Assembler(datatype([
     'path_entries',
     'exe_filename',
     'library_dirs',
     'extra_args',
-]), Executable):
-  pass
+])): pass
 
 
-class LinkerMixin(Executable):
+class _LinkerMixin(_Executable):
 
-  @classproperty
-  def list_fields(cls):
-    return super(LinkerMixin, cls).list_fields + ['linking_library_dirs', 'extra_object_files']
-
-  @abstractproperty
+  @_list_field
   def linking_library_dirs(self):
     """Directories to search for libraries needed at link time.
 
     :rtype: list of str
     """
-    raise NotImplementedError('linking_library_dirs is a list field of LinkerMixin!')
+    raise NotImplementedError('linking_library_dirs is a list field of _LinkerMixin!')
 
-  @abstractproperty
+  @_list_field
   def extra_object_files(self):
     """A list of object files required to perform a successful link.
 
@@ -170,11 +190,11 @@ class LinkerMixin(Executable):
 
     :rtype: list of str
     """
-    raise NotImplementedError('include_dirs is a list field of CompilerMixin!')
+    raise NotImplementedError('extra_object_files is a list field of _LinkerMixin!')
 
   @property
   def as_invocation_environment_dict(self):
-    ret = super(LinkerMixin, self).as_invocation_environment_dict.copy()
+    ret = super(_LinkerMixin, self).as_invocation_environment_dict.copy()
 
     full_library_path_dirs = self.linking_library_dirs + [
       os.path.dirname(f) for f in self.extra_object_files
@@ -188,6 +208,7 @@ class LinkerMixin(Executable):
     return ret
 
 
+@_algebraic_data(_LinkerMixin)
 class Linker(datatype([
     'path_entries',
     'exe_filename',
@@ -195,26 +216,22 @@ class Linker(datatype([
     'linking_library_dirs',
     'extra_args',
     'extra_object_files',
-]), LinkerMixin): pass
+])): pass
 
 
-class CompilerMixin(Executable):
+class _CompilerMixin(_Executable):
 
-  @classproperty
-  def list_fields(cls):
-    return super(CompilerMixin, cls).list_fields + ['include_dirs']
-
-  @abstractproperty
+  @_list_field
   def include_dirs(self):
     """Directories to search for header files to #include during compilation.
 
     :rtype: list of str
     """
-    raise NotImplementedError('extra_object_files is a list field of LinkerMixin!')
+    raise NotImplementedError('include_dirs is a list field of _CompilerMixin!')
 
   @property
   def as_invocation_environment_dict(self):
-    ret = super(CompilerMixin, self).as_invocation_environment_dict.copy()
+    ret = super(_CompilerMixin, self).as_invocation_environment_dict.copy()
 
     if self.include_dirs:
       ret['CPATH'] = create_path_env_var(self.include_dirs)
@@ -222,13 +239,14 @@ class CompilerMixin(Executable):
     return ret
 
 
+@_algebraic_data(_CompilerMixin)
 class CCompiler(datatype([
     'path_entries',
     'exe_filename',
     'library_dirs',
     'include_dirs',
     'extra_args',
-]), CompilerMixin):
+])):
 
   @property
   def as_invocation_environment_dict(self):
@@ -239,13 +257,14 @@ class CCompiler(datatype([
     return ret
 
 
+@_algebraic_data(_CompilerMixin)
 class CppCompiler(datatype([
     'path_entries',
     'exe_filename',
     'library_dirs',
     'include_dirs',
     'extra_args',
-]), CompilerMixin):
+])):
 
   @property
   def as_invocation_environment_dict(self):

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -6,11 +6,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 from abc import abstractmethod, abstractproperty
-from builtins import object
 
 from pants.engine.rules import SingletonRule
-from pants.util.meta import AbstractClass, classproperty
 from pants.util.memo import memoized_classproperty
+from pants.util.meta import AbstractClass
 from pants.util.objects import datatype, enum
 from pants.util.osutil import all_normalized_os_names, get_normalized_os_name
 from pants.util.strutil import create_path_env_var
@@ -32,8 +31,7 @@ def _list_field(func):
 
 
 def _algebraic_data(metaclass):
-  """A class decorator to pull out `_list_fields` from a mixin class for use with a `datatype`.
-  """
+  """A class decorator to pull out `_list_fields` from a mixin class for use with a `datatype`."""
   def wrapper(cls):
     cls.__bases__ += (metaclass,)
     cls._list_fields = metaclass._list_fields
@@ -41,10 +39,9 @@ def _algebraic_data(metaclass):
   return wrapper
 
 
+# NB: prototypal inheritance seems *deeply* linked with the idea here!
 class _ExtensibleAlgebraic(AbstractClass):
   """A mixin to make it more concise to coalesce datatypes with related collection fields."""
-
-  # NB: prototypal inheritance seems *deeply* linked with the idea here!
 
   @memoized_classproperty
   def _list_fields(cls):
@@ -124,16 +121,15 @@ class _Executable(_ExtensibleAlgebraic):
     """
     raise NotImplementedError('exe_filename is a scalar field of _Executable!')
 
-  # TODO: rename this to 'runtime_library_dirs'!
   @_list_field
-  def library_dirs(self):
+  def runtime_library_dirs(self):
     """Directories containing shared libraries that must be on the runtime library search path.
 
     Note: this is for libraries needed for the current _Executable to run -- see _LinkerMixin below
     for libraries that are needed at link time.
     :rtype: list of str
     """
-    raise NotImplementedError('library_dirs is a list field of _Executable!')
+    raise NotImplementedError('runtime_library_dirs is a list field of _Executable!')
 
   @_list_field
   def extra_args(self):
@@ -159,7 +155,7 @@ class _Executable(_ExtensibleAlgebraic):
     })
     return {
       'PATH': create_path_env_var(self.path_entries),
-      lib_env_var: create_path_env_var(self.library_dirs),
+      lib_env_var: create_path_env_var(self.runtime_library_dirs),
     }
 
 
@@ -167,7 +163,7 @@ class _Executable(_ExtensibleAlgebraic):
 class Assembler(datatype([
     'path_entries',
     'exe_filename',
-    'library_dirs',
+    'runtime_library_dirs',
     'extra_args',
 ])): pass
 
@@ -212,7 +208,7 @@ class _LinkerMixin(_Executable):
 class Linker(datatype([
     'path_entries',
     'exe_filename',
-    'library_dirs',
+    'runtime_library_dirs',
     'linking_library_dirs',
     'extra_args',
     'extra_object_files',
@@ -243,7 +239,7 @@ class _CompilerMixin(_Executable):
 class CCompiler(datatype([
     'path_entries',
     'exe_filename',
-    'library_dirs',
+    'runtime_library_dirs',
     'include_dirs',
     'extra_args',
 ])):
@@ -261,7 +257,7 @@ class CCompiler(datatype([
 class CppCompiler(datatype([
     'path_entries',
     'exe_filename',
-    'library_dirs',
+    'runtime_library_dirs',
     'include_dirs',
     'extra_args',
 ])):

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -98,7 +98,7 @@ class Executable(ExtensibleAlgebraic):
 
     :rtype: str
     """
-    raise NotImplementedError('path_entries is a list field of Executable!')
+    raise NotImplementedError('exe_filename is a scalar field of Executable!')
 
   # TODO: rename this to 'runtime_library_dirs'!
   @abstractproperty
@@ -110,11 +110,6 @@ class Executable(ExtensibleAlgebraic):
     :rtype: list of str
     """
     raise NotImplementedError('library_dirs is a list field of Executable!')
-
-  @abstractproperty
-  def exe_filename(self):
-    """The "entry point" -- which file to invoke when PATH is set to `path_entries()`."""
-    raise NotImplementedError('exe_filename is a scalar field of Executable!')
 
   @abstractproperty
   def extra_args(self):

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -31,6 +31,7 @@ class ExtensibleAlgebraic(AbstractClass):
   @abstractmethod
   def copy(self, **kwargs):
     """Analogous to a `datatype()`'s `copy()` method."""
+    raise NotImplementedError('copy() must be implemented by subclasses of ExtensibleAlgebraic!')
 
   def _single_list_field_operation(self, field_name, list_value, prepend=True):
     cur_value = getattr(self, field_name)
@@ -44,17 +45,20 @@ class ExtensibleAlgebraic(AbstractClass):
     return self.copy(**arg_dict)
 
   def prepend_field(self, field_name, list_value):
+    """Return a copy of this object with `list_value` prepended to the field named `field_name`."""
     return self._single_list_field_operation(field_name, list_value, prepend=True)
 
   def append_field(self, field_name, list_value):
+    """Return a copy of this object with `list_value` appended to the field named `field_name`."""
     return self._single_list_field_operation(field_name, list_value, prepend=False)
 
   def sequence(self, other, exclude_list_fields=None):
-    """
-    - the return type is the type of this object (or just whatever .copy() does!)
-      - but the `other` can be any `ExtensibleAlgebraic`
-    - for this particular operation: "add" all of the list_fields together, for the fields common to
-      both types
+    """Return a copy of this object which combines all the fields common to both `self` and `other`.
+
+    List fields will be concatenated.
+
+    The return type of this method is the type of `self`, but the `other` can be any
+    `ExtensibleAlgebraic` instance.
     """
     exclude_list_fields = exclude_list_fields or []
     overwrite_kwargs = {}
@@ -94,6 +98,7 @@ class Executable(ExtensibleAlgebraic):
 
     :rtype: str
     """
+    raise NotImplementedError('path_entries is a list field of Executable!')
 
   # TODO: rename this to 'runtime_library_dirs'!
   @abstractproperty
@@ -104,10 +109,12 @@ class Executable(ExtensibleAlgebraic):
     for libraries that are needed at link time.
     :rtype: list of str
     """
+    raise NotImplementedError('library_dirs is a list field of Executable!')
 
   @abstractproperty
   def exe_filename(self):
     """The "entry point" -- which file to invoke when PATH is set to `path_entries()`."""
+    raise NotImplementedError('exe_filename is a scalar field of Executable!')
 
   @abstractproperty
   def extra_args(self):
@@ -117,6 +124,7 @@ class Executable(ExtensibleAlgebraic):
 
     :rtype: list of str
     """
+    raise NotImplementedError('extra_args is a list field of Executable!')
 
   _platform = Platform.create()
 
@@ -149,7 +157,7 @@ class LinkerMixin(Executable):
 
   @classproperty
   def list_fields(cls):
-    return super(LinkerMixin, cls).list_fields + ['linking_library_dirs']
+    return super(LinkerMixin, cls).list_fields + ['linking_library_dirs', 'extra_object_files']
 
   @abstractproperty
   def linking_library_dirs(self):
@@ -157,6 +165,7 @@ class LinkerMixin(Executable):
 
     :rtype: list of str
     """
+    raise NotImplementedError('linking_library_dirs is a list field of LinkerMixin!')
 
   @abstractproperty
   def extra_object_files(self):
@@ -166,6 +175,7 @@ class LinkerMixin(Executable):
 
     :rtype: list of str
     """
+    raise NotImplementedError('include_dirs is a list field of CompilerMixin!')
 
   @property
   def as_invocation_environment_dict(self):
@@ -205,6 +215,7 @@ class CompilerMixin(Executable):
 
     :rtype: list of str
     """
+    raise NotImplementedError('extra_object_files is a list field of LinkerMixin!')
 
   @property
   def as_invocation_environment_dict(self):

--- a/src/python/pants/backend/native/subsystems/binaries/binutils.py
+++ b/src/python/pants/backend/native/subsystems/binaries/binutils.py
@@ -24,7 +24,8 @@ class Binutils(NativeTool):
     return Assembler(
       path_entries=self.path_entries(),
       exe_filename='as',
-      library_dirs=[])
+      library_dirs=[],
+      extra_args=[])
 
   def linker(self):
     return Linker(

--- a/src/python/pants/backend/native/subsystems/binaries/binutils.py
+++ b/src/python/pants/backend/native/subsystems/binaries/binutils.py
@@ -24,14 +24,14 @@ class Binutils(NativeTool):
     return Assembler(
       path_entries=self.path_entries(),
       exe_filename='as',
-      library_dirs=[],
+      runtime_library_dirs=[],
       extra_args=[])
 
   def linker(self):
     return Linker(
       path_entries=self.path_entries(),
       exe_filename='ld',
-      library_dirs=[],
+      runtime_library_dirs=[],
       linking_library_dirs=[],
       extra_args=[],
       extra_object_files=[],

--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -65,7 +65,7 @@ class GCC(NativeTool):
     return CCompiler(
       path_entries=self.path_entries,
       exe_filename='gcc',
-      library_dirs=self._common_lib_dirs(platform),
+      runtime_library_dirs=self._common_lib_dirs(platform),
       include_dirs=self._common_include_dirs,
       extra_args=[])
 
@@ -91,7 +91,7 @@ class GCC(NativeTool):
     return CppCompiler(
       path_entries=self.path_entries,
       exe_filename='g++',
-      library_dirs=self._common_lib_dirs(platform),
+      runtime_library_dirs=self._common_lib_dirs(platform),
       include_dirs=(self._common_include_dirs + self._cpp_include_dirs),
       extra_args=[])
 

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -105,7 +105,7 @@ class LLVM(NativeTool):
     return CCompiler(
       path_entries=self.path_entries,
       exe_filename='clang',
-      library_dirs=self._common_lib_dirs,
+      runtime_library_dirs=self._common_lib_dirs,
       include_dirs=self._common_include_dirs,
       extra_args=[])
 
@@ -117,7 +117,7 @@ class LLVM(NativeTool):
     return CppCompiler(
       path_entries=self.path_entries,
       exe_filename='clang++',
-      library_dirs=self._common_lib_dirs,
+      runtime_library_dirs=self._common_lib_dirs,
       include_dirs=(self._cpp_include_dirs + self._common_include_dirs),
       extra_args=[])
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -180,7 +180,7 @@ def select_llvm_c_toolchain(platform, native_toolchain):
                          .sequence(provided_gcc)
                          .append_field('extra_args', gcc_install.as_clang_argv)
                          # We need g++'s version of the GLIBCXX library to be able to run.
-                         .prepend_field('library_dirs', provided_gcc.library_dirs))
+                         .prepend_field('runtime_library_dirs', provided_gcc.runtime_library_dirs))
 
   working_c_compiler = joined_c_compiler.prepend_field('extra_args', [
     '-x', 'c', '-std=c11',
@@ -213,8 +213,8 @@ def select_llvm_cpp_toolchain(platform, native_toolchain):
                            .copy(include_dirs=provided_gpp.include_dirs)
                            .append_field('extra_args', gcc_install.as_clang_argv)
                            # We need g++'s version of the GLIBCXX library to be able to run.
-                           .prepend_field('library_dirs', provided_gpp.library_dirs))
-    extra_llvm_linking_library_dirs = provided_gpp.library_dirs + provided_clangpp.library_dirs
+                           .prepend_field('runtime_library_dirs', provided_gpp.runtime_library_dirs))
+    extra_llvm_linking_library_dirs = provided_gpp.runtime_library_dirs + provided_clangpp.runtime_library_dirs
     # Ensure we use libstdc++, provided by g++, during the linking stage.
     linker_extra_args=['-stdlib=libstdc++']
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -74,7 +74,9 @@ class LinkerWrapperMixin(object):
   def for_compiler(self, compiler, platform):
     """Return a Linker object which is intended to be compatible with the given `compiler`."""
     return (self.linker
-            .sequence(compiler, exclude_list_fields=['extra_args'])
+            # TODO(#6143): describe why the compiler needs to be first on the PATH!
+            .sequence(compiler, exclude_list_fields=['extra_args', 'path_entries'])
+            .prepend_field('path_entries', compiler.path_entries)
             .copy(exe_filename=compiler.exe_filename))
 
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -6,9 +6,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from builtins import object
 
-from pants.backend.native.config.environment import (Assembler, CCompiler, CompilerMixin,
-                                                     CppCompiler, CppToolchain, CToolchain, Linker,
-                                                     Platform)
+from pants.backend.native.config.environment import (Assembler, CCompiler, CppCompiler,
+                                                     CppToolchain, CToolchain, Linker, Platform)
 from pants.backend.native.subsystems.binaries.binutils import Binutils
 from pants.backend.native.subsystems.binaries.gcc import GCC
 from pants.backend.native.subsystems.binaries.llvm import LLVM
@@ -74,7 +73,6 @@ class LinkerWrapperMixin(object):
 
   def for_compiler(self, compiler, platform):
     """Return a Linker object which is intended to be compatible with the given `compiler`."""
-    assert(isinstance(compiler, CompilerMixin))
     return (self.linker
             .sequence(compiler, exclude_list_fields=['extra_args'])
             .copy(exe_filename=compiler.exe_filename))

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -280,6 +280,10 @@ def select_gcc_cpp_toolchain(platform, native_toolchain):
   assembler = yield Get(Assembler, NativeToolchain, native_toolchain)
   working_cpp_compiler = joined_cpp_compiler.sequence(assembler).prepend_field('extra_args', [
     '-x', 'c++', '-std=c++11',
+    # This flag is intended to avoid using any of the headers from our LLVM distribution's C++
+    # stdlib implementation, or any from the host system, and instead, use include dirs from the
+    # XCodeCLITools or GCC.
+    # TODO(#6143): Determine precisely what this flag does and why it's necessary.
     '-nostdinc++',
   ])
 

--- a/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
+++ b/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
@@ -134,7 +134,7 @@ class XCodeCLITools(Subsystem):
     return Assembler(
       path_entries=self.path_entries(),
       exe_filename='as',
-      library_dirs=[],
+      runtime_library_dirs=[],
       extra_args=[])
 
   @memoized_method
@@ -142,7 +142,7 @@ class XCodeCLITools(Subsystem):
     return Linker(
       path_entries=self.path_entries(),
       exe_filename='ld',
-      library_dirs=[],
+      runtime_library_dirs=[],
       linking_library_dirs=[],
       extra_args=[MIN_OSX_VERSION_ARG],
       extra_object_files=[],
@@ -153,7 +153,7 @@ class XCodeCLITools(Subsystem):
     return CCompiler(
       path_entries=self.path_entries(),
       exe_filename='clang',
-      library_dirs=self.lib_dirs(),
+      runtime_library_dirs=self.lib_dirs(),
       include_dirs=self.include_dirs(),
       extra_args=[MIN_OSX_VERSION_ARG])
 
@@ -162,7 +162,7 @@ class XCodeCLITools(Subsystem):
     return CppCompiler(
       path_entries=self.path_entries(),
       exe_filename='clang++',
-      library_dirs=self.lib_dirs(),
+      runtime_library_dirs=self.lib_dirs(),
       include_dirs=self.include_dirs(include_cpp_inc=True),
       extra_args=[MIN_OSX_VERSION_ARG])
 

--- a/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
+++ b/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
@@ -134,7 +134,8 @@ class XCodeCLITools(Subsystem):
     return Assembler(
       path_entries=self.path_entries(),
       exe_filename='as',
-      library_dirs=[])
+      library_dirs=[],
+      extra_args=[])
 
   @memoized_method
   def linker(self):

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -171,7 +171,7 @@ class LinkSharedLibraries(NativeTask):
     self.context.log.info("selected linker exe name: '{}'".format(linker.exe_filename))
     self.context.log.debug("linker argv: {}".format(cmd))
 
-    env = linker.as_invocation_environment_dict
+    env = linker.invocation_environment_dict
     self.context.log.debug("linker invocation environment: {}".format(env))
 
     with self.context.new_workunit(name='link-shared-libraries',

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -228,7 +228,7 @@ class NativeCompile(NativeTask, AbstractClass):
 
     compiler = compile_request.compiler
     output_dir = compile_request.output_dir
-    env = compiler.as_invocation_environment_dict
+    env = compiler.invocation_environment_dict
 
     with self.context.new_workunit(
         name=self.workunit_label, labels=[WorkUnitLabel.COMPILER]) as workunit:

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -14,7 +14,7 @@ from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.meta import AbstractClass, classproperty
-from pants.util.objects import SubclassesOf, datatype
+from pants.util.objects import datatype
 from pants.util.process_handler import subprocess
 
 

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -8,7 +8,6 @@ import os
 from abc import abstractmethod
 from collections import defaultdict
 
-from pants.backend.native.config.environment import Executable
 from pants.backend.native.tasks.native_task import NativeTask
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
@@ -20,7 +19,7 @@ from pants.util.process_handler import subprocess
 
 
 class NativeCompileRequest(datatype([
-    ('compiler', SubclassesOf(Executable)),
+    'compiler',
     # TODO: add type checking for Collection.of(<type>)!
     'include_dirs',
     'sources',
@@ -134,11 +133,11 @@ class NativeCompile(NativeTask, AbstractClass):
 
   @abstractmethod
   def get_compiler(self, native_library_target):
-    """An instance of `Executable` which can be invoked to compile files.
+    """An instance of `_CompilerMixin` which can be invoked to compile files.
 
     NB: Subclasses will be queried for the compiler instance once and the result cached.
 
-    :return: :class:`pants.backend.native.config.environment.Executable`
+    :return: :class:`pants.backend.native.config.environment._CompilerMixin`
     """
 
   def _compiler(self, native_library_target):

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -56,7 +56,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     gcc = gcc_c_toolchain.c_toolchain.c_compiler
     gcc_version_out = self._invoke_capturing_output(
       [gcc.exe_filename, '--version'],
-      env=gcc.as_invocation_environment_dict)
+      env=gcc.invocation_environment_dict)
 
     gcc_version_regex = re.compile('^gcc.*{}$'.format(re.escape(self.gcc_version)),
                                    flags=re.MULTILINE)
@@ -70,7 +70,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     gpp = gcc_cpp_toolchain.cpp_toolchain.cpp_compiler
     gpp_version_out = self._invoke_capturing_output(
       [gpp.exe_filename, '--version'],
-      env=gpp.as_invocation_environment_dict)
+      env=gpp.invocation_environment_dict)
 
     gpp_version_regex = re.compile(r'^g\+\+.*{}$'.format(re.escape(self.gcc_version)),
                                    flags=re.MULTILINE)
@@ -84,7 +84,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     clang = llvm_c_toolchain.c_toolchain.c_compiler
     clang_version_out = self._invoke_capturing_output(
       [clang.exe_filename, '--version'],
-      env=clang.as_invocation_environment_dict)
+      env=clang.invocation_environment_dict)
 
     clang_version_regex = re.compile('^clang version {}'.format(re.escape(self.llvm_version)),
                                      flags=re.MULTILINE)
@@ -100,7 +100,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     clangpp = llvm_cpp_toolchain.cpp_toolchain.cpp_compiler
     clanggpp_version_out = self._invoke_capturing_output(
       [clangpp.exe_filename, '--version'],
-      env=clangpp.as_invocation_environment_dict)
+      env=clangpp.invocation_environment_dict)
 
     self.assertIsNotNone(clangpp_version_regex.search(clanggpp_version_out))
 
@@ -120,7 +120,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
 
   def _invoke_compiler(self, compiler, args):
     cmd = [compiler.exe_filename] + compiler.extra_args + args
-    env = compiler.as_invocation_environment_dict
+    env = compiler.invocation_environment_dict
     # TODO: add an `extra_args`-like field to `Executable`s which allows for overriding env vars
     # like this, but declaratively!
     env['LC_ALL'] = 'C'
@@ -130,7 +130,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     cmd = [linker.exe_filename] + linker.extra_args + args
     return self._invoke_capturing_output(
       cmd,
-      linker.as_invocation_environment_dict)
+      linker.invocation_environment_dict)
 
   def _invoke_capturing_output(self, cmd, env=None):
     env = env or {}


### PR DESCRIPTION
### Problem

As can be seen in `native_toolchain.py` in e.g. #6800, it is often difficult to follow changes to the native backend, especially changes which modify the order of resources such as library and include directories for our linkers and compilers. This is because we have been patching together collections of these resources "by hand", without applying any higher-level structure (explicitly constructing each `path_entries` and `library_dirs` field for every executable, every time, for example). This was done to avoid creating abstractions that might break down due to the rapidly evolving code. We can now take the step of more clearly defining the relationships between the toolchains we construct hierarchically.

### Solution

- Add an `ExtensibleAlgebraic` mixin which allows declaring list fields which can be immutably modified one at a time with `prepend_field` and `append_field`, or all at once with `sequence`.
- Add a `for_compiler` method to `BaseLinker` to wrap the specific process required to prep our linker for a specific compiler.
- Apply all of the above in `native_toolchain.py`.

### Result

The compilers and linkers provided by `@rule`s in `native_toolchain.py` are composed with consistent verbs from `ExtensibleAlgebraic`, leading to increased readability.