### PR TITLE
add `scala_jar` to the docsite

### DIFF
--- a/examples/src/java/org/pantsbuild/example/3rdparty_jvm.md
+++ b/examples/src/java/org/pantsbuild/example/3rdparty_jvm.md
@@ -27,6 +27,7 @@ Here, the <a pantsref="bdict_jar_library">`jar_library`</a>'s name
 defines a target address that other build targets can refer to. The
 <a pantsref="bdict_jar">`jar`</a>s refer to jars that Ivy can resolve and fetch.
 
+When [[using Scala with pants|pants('examples/src/scala/org/pantsbuild/example:readme')]], the <a pantsref="bdict_scala_jar">`scala_jar`</a> symbol will add the appropriate Scala version suffix (e.g. `_2.12`) to the `name` field automatically.
 
 Your Code's BUILD File
 ----------------------

--- a/examples/src/scala/org/pantsbuild/example/README.md
+++ b/examples/src/scala/org/pantsbuild/example/README.md
@@ -65,6 +65,10 @@ information about your custom Scala version.  The first two of these default to 
 addresses `//:scala-library` and `//:scala-repl` respectively, so you can simply define those
 targets (in the root `BUILD.tools` file by convention) to point to the relevant JARs.
 
+Scala 3rdparty Jars
+-------------------
+
+You can depend on Scala-specific [[3rdparty jars|pants('examples/src/java/org/pantsbuild/example:readme')]] using the <a pantsref="bdict_scala_jar">`scala_jar`</a> symbol. This will append e.g. `_2.12` to the name field of the <a pantsref="bdict_jar">`jar`</a>. The version string used is whatever the `--scala-version` is set to, or, if it is "custom", then the `--scala-suffix-version`.
 
 Scala REPL
 ----------
@@ -140,6 +144,8 @@ In a `BUILD` file at the root of the repo, define the `semanticdb` compiler plug
       name = 'scalac-plugin-dep',
       jars = [jar(org='org.scalameta', name='semanticdb-scalac_{}'.format(SCALA_REV), rev='2.0.1')],
     )
+
+Note that the explicit full scala version string (`2.11.12`) is required for the semanticdb jar we use here, which is why we can't just use <a pantsref="bdict_jar">`scala_jar`</a> (which would just append e.g. `_2.12` to the name).
 
 Then, reference it from `pants.ini` to load the plugin, and enable semantic rewrites to require
 compilation for `fmt` and `lint`:


### PR DESCRIPTION
*TODO: is it possible to refer to a particular heading within a page?*

### Problem

`scala_jar` was never added to the docsite.

### Solution

- Add `scala_jar` to the Scala support and 3rdparty jvm pages.