### PR TITLE
Fix clippy pre-commit check when used as a commit hook

### DIFF
--- a/build-support/bin/check_clippy.sh
+++ b/build-support/bin/check_clippy.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd ${REPO_ROOT}
+
+./build-support/bin/native/cargo clippy --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" --all

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -236,7 +236,7 @@ fi
 if [[ "${run_rust_clippy:-false}" == "true" ]]; then
   start_travis_section "RustClippy" "Running Clippy on rust code"
   (
-    "${REPO_ROOT}/build-support/bin/native/cargo" clippy --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" --all
+    "${REPO_ROOT}/build-support/bin/check_clippy.sh"
   ) || die "Pants clippy failure"
 fi
 

--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -14,8 +14,8 @@ echo "* Checking headers" && ./build-support/bin/check_header.sh || exit 1
 echo "* Checking for banned imports" && ./build-support/bin/check_banned_imports.sh || exit 1
 
 if git diff master --name-only | grep '\.rs$' > /dev/null; then
-  echo "* Checking formatting of rust files" && "$(pwd)/build-support/bin/check_rust_formatting.sh" || exit 1
-  echo "* Running cargo clippy" && build-support/bin/ci.sh -bs || exit 1
+  echo "* Checking formatting of rust files" && ./build-support/bin/check_rust_formatting.sh || exit 1
+  echo "* Running cargo clippy" && ./build-support/bin/check_clippy.sh || exit 1
 fi
 
 echo "* Checking for bad shell patterns" && ./build-support/bin/check_shell.sh || exit 1


### PR DESCRIPTION
### Problem

The new `clippy` check in `pre-commit.sh` invokes `ci.sh`, which does not appear to work in the context of a commit hook (which is a usage suggested by https://www.pantsbuild.org/howto_contribute.html#getting-pants-source-code).

### Solution

Extract a `clippy` check script to remove the need to invoke all of `ci.sh`.