### PR TITLE
Always set -XX:-MaxFDLimit

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/jvm.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm.py
@@ -19,7 +19,12 @@ class JVM(Subsystem):
 
   # Broken out here instead of being inlined in the registration stanza,
   # because various tests may need to access these.
-  options_default = ['-Xmx256m']
+  options_default = [
+    '-Xmx256m',
+    # Always bump MaxFDLimit - this means that Java will listen to the environmental FD limit,
+    # rather than imposing its own. This should just be what the JVM does by default. Boo.
+    '-XX:-MaxFDLimit',
+  ]
 
   @classmethod
   def register_options(cls, register):


### PR DESCRIPTION
This should just always be the JVM default.