### PR TITLE
Expose an API to pass multiple Params to an engine request

### DIFF
--- a/src/python/pants/engine/legacy/address_mapper.py
+++ b/src/python/pants/engine/legacy/address_mapper.py
@@ -80,11 +80,12 @@ class LegacyAddressMapper(AddressMapper):
           return set()
       else:
         raise self.BuildFileScanError(str(state.exc))
-    elif missing_is_fatal and not state.value.dependencies:
+
+    _, state = returns[0]
+    if missing_is_fatal and not state.value.dependencies:
       raise self.BuildFileScanError(
         'Spec `{}` does not match any targets.'.format(self._specs_string(specs)))
 
-    _, state = returns[0]
     return set(state.value.dependencies)
 
   def scan_addresses(self, root=None):

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -226,7 +226,7 @@ uint64_t graph_invalidate_all_paths(Scheduler*);
 PyResult graph_visualize(Scheduler*, Session*, char*);
 void graph_trace(Scheduler*, ExecutionRequest*, char*);
 
-PyResult  execution_add_root_select(Scheduler*, ExecutionRequest*, Key, TypeConstraint);
+PyResult execution_add_root_select(Scheduler*, ExecutionRequest*, HandleBuffer, TypeConstraint);
 
 PyResult capture_snapshots(Scheduler*, Handle);
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -170,6 +170,9 @@ class Scheduler(object):
   def _assert_ruleset_valid(self):
     self._raise_or_return(self._native.lib.validator_run(self._scheduler))
 
+  def _to_vals_buf(self, objs):
+    return self._native.context.vals_buf(tuple(self._native.context.to_value(obj) for obj in objs))
+
   def _to_value(self, obj):
     return self._native.context.to_value(obj)
 
@@ -295,7 +298,7 @@ class Scheduler(object):
   def add_root_selection(self, execution_request, subject, product):
     res = self._native.lib.execution_add_root_select(self._scheduler,
                                                      execution_request,
-                                                     self._to_key(subject),
+                                                     self._to_vals_buf([subject]),
                                                      self._to_constraint(product))
     self._raise_or_return(res)
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -9,10 +9,8 @@ import multiprocessing
 import os
 import time
 from builtins import object, open, str, zip
-from collections import defaultdict
 from types import GeneratorType
 
-from pants.base.exceptions import TaskError
 from pants.base.project_tree import Dir, File, Link
 from pants.build_graph.address import Address
 from pants.engine.fs import (Digest, DirectoryToMaterialize, FileContent, FilesContent,
@@ -20,7 +18,7 @@ from pants.engine.fs import (Digest, DirectoryToMaterialize, FileContent, FilesC
                              UrlToFetch)
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.engine.native import Function, TypeConstraint, TypeId
-from pants.engine.nodes import Return, State, Throw
+from pants.engine.nodes import Return, Throw
 from pants.engine.rules import RuleIndex, SingletonRule, TaskRule
 from pants.engine.selectors import Select, constraint_for
 from pants.rules.core.exceptions import GracefulTerminationException
@@ -41,34 +39,6 @@ class ExecutionRequest(datatype(['roots', 'native'])):
   :param roots: Roots for this request.
   :type roots: list of tuples of subject and product.
   """
-
-
-class ExecutionResult(datatype(['error', 'root_products'])):
-  """Represents the result of a single execution."""
-
-  @classmethod
-  def finished(cls, root_products):
-    """Create a success or partial success result from a finished run.
-
-    Runs can either finish with no errors, satisfying all promises, or they can partially finish
-    if run in fail-slow mode producing as many products as possible.
-    :param root_products: List of ((subject, product), State) tuples.
-    :rtype: `ExecutionResult`
-    """
-    return cls(error=None, root_products=root_products)
-
-  @classmethod
-  def failure(cls, error):
-    """Create a failure result.
-
-    A failure result represent a run with a fatal error.  It presents the error but no
-    products.
-
-    :param error: The execution error encountered.
-    :type error: :class:`pants.base.exceptions.TaskError`
-    :rtype: `ExecutionResult`
-    """
-    return cls(error=error, root_products=None)
 
 
 class ExecutionError(Exception):
@@ -478,12 +448,10 @@ class SchedulerSession(object):
       self._run_count += 1
       self.visualize_graph_to_file(os.path.join(self._scheduler.visualize_to_dir(), name))
 
-  def schedule(self, execution_request):
-    """Yields batches of Steps until the roots specified by the request have been completed.
+  def execute(self, execution_request):
+    """Invoke the engine for the given ExecutionRequest, returning Return and Throw states.
 
-    This method should be called by exactly one scheduling thread, but the Step objects returned
-    by this method are intended to be executed in multiple threads, and then satisfied by the
-    scheduling thread.
+    :return: A tuple of (root, Return) tuples and (root, Throw) tuples.
     """
     start_time = time.time()
     roots = list(zip(execution_request.roots,
@@ -498,23 +466,9 @@ class SchedulerSession(object):
       self._scheduler.graph_len()
     )
 
-    return roots
-
-  def execute(self, execution_request):
-    """Executes the requested build and returns the resulting root entries.
-
-    TODO: Merge with `schedule`.
-    TODO2: Use of TaskError here is... odd.
-
-    :param execution_request: The description of the goals to achieve.
-    :type execution_request: :class:`ExecutionRequest`
-    :returns: The result of the run.
-    :rtype: :class:`Engine.Result`
-    """
-    try:
-      return ExecutionResult.finished(self.schedule(execution_request))
-    except TaskError as e:
-      return ExecutionResult.failure(e)
+    returns = tuple((root, state) for root, state in roots if type(state) is Return)
+    throws = tuple((root, state) for root, state in roots if type(state) is Throw)
+    return returns, throws
 
   def _trace_on_error(self, unique_exceptions, request):
     exception_noun = pluralize(len(unique_exceptions), 'Exception')
@@ -534,62 +488,19 @@ class SchedulerSession(object):
 
   def run_console_rule(self, product, subject, v2_ui):
     """
-
     :param product: product type for the request.
     :param subject: subject for the request.
     :param v2_ui: whether to render the v2 engine UI
-    :return: A dict from product type to lists of products each with length matching len(subjects).
     """
     request = self.execution_request([product], [subject], v2_ui)
-    result = self.execute(request)
-    if result.error:
-      raise result.error
+    returns, throws = self.execute(request)
 
-    self._state_validation(result)
-    assert len(result.root_products) == 1
-    root, state = result.root_products[0]
-    if type(state) is Throw:
+    if throws:
+      _, state = throws[0]
       exc = state.exc
       if isinstance(exc, GracefulTerminationException):
         raise exc
       self._trace_on_error([exc], request)
-    return {result.root_products[0]: [state.value]}
-
-  def _state_validation(self, result):
-    # State validation.
-    unknown_state_types = tuple(
-      type(state) for _, state in result.root_products if type(state) not in (Throw, Return)
-    )
-    if unknown_state_types:
-      State.raise_unrecognized(unknown_state_types)
-
-  def products_request(self, products, subjects):
-    """Executes a request for multiple products for some subjects, and returns the products.
-
-    :param list products: A list of product type for the request.
-    :param list subjects: A list of subjects for the request.
-    :returns: A dict from product type to lists of products each with length matching len(subjects).
-    """
-    request = self.execution_request(products, subjects)
-    result = self.execute(request)
-    if result.error:
-      raise result.error
-
-    self._state_validation(result)
-
-    # Throw handling.
-    # TODO: See https://github.com/pantsbuild/pants/issues/3912
-    throw_root_states = tuple(state for root, state in result.root_products if type(state) is Throw)
-    if throw_root_states:
-      unique_exceptions = tuple({t.exc for t in throw_root_states})
-      self._trace_on_error(unique_exceptions, request)
-
-    # Everything is a Return: we rely on the fact that roots are ordered to preserve subject
-    # order in output lists.
-    product_results = defaultdict(list)
-    for (_, product), state in result.root_products:
-      product_results[product].append(state.value)
-    return product_results
 
   def product_request(self, product, subjects):
     """Executes a request for a single product for some subjects, and returns the products.
@@ -598,7 +509,17 @@ class SchedulerSession(object):
     :param list subjects: A list of subjects for the request.
     :returns: A list of the requested products, with length match len(subjects).
     """
-    return self.products_request([product], subjects)[product]
+    request = self.execution_request([product], subjects)
+    returns, throws = self.execute(request)
+
+    # Throw handling.
+    if throws:
+      unique_exceptions = tuple({t.exc for _, t in throws})
+      self._trace_on_error(unique_exceptions, request)
+
+    # Everything is a Return: we rely on the fact that roots are ordered to preserve subject
+    # order in output lists.
+    return [ret.value for _, ret in returns]
 
   def capture_snapshots(self, path_globs_and_roots):
     """Synchronously captures Snapshots for each matching PathGlobs rooted at a its root directory.

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -5,10 +5,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import ast
-from abc import abstractproperty
 from builtins import str
 
-from pants.util.meta import AbstractClass
 from pants.util.objects import Exactly, datatype
 
 
@@ -78,23 +76,17 @@ class Get(datatype(['product', 'subject'])):
     return super(Get, cls).__new__(cls, product, subject)
 
 
-class Selector(AbstractClass):
+class Params(datatype([('params', tuple)])):
+  """A set of values with distinct types.
 
-  @property
-  def type_constraint(self):
-    """The type constraint for the product type for this selector."""
-    return constraint_for(self.product)
+  Distinct types are enforced at consumption time by the rust type of the same name.
+  """
 
-  @abstractproperty
-  def optional(self):
-    """Return true if this Selector is optional. It may result in a `None` match."""
-
-  @abstractproperty
-  def product(self):
-    """The product that this selector produces."""
+  def __new__(cls, *args):
+    return super(Params, cls).__new__(cls, tuple(args))
 
 
-class Select(datatype(['product', 'optional']), Selector):
+class Select(datatype(['product', 'optional'])):
   """Selects the given Product for the Subject provided to the constructor.
 
   If optional=True and no matching product can be produced, will return None.
@@ -103,6 +95,11 @@ class Select(datatype(['product', 'optional']), Selector):
   def __new__(cls, product, optional=False):
     obj = super(Select, cls).__new__(cls, product, optional)
     return obj
+
+  @property
+  def type_constraint(self):
+    """The type constraint for the product type for this selector."""
+    return constraint_for(self.product)
 
   def __repr__(self):
     return '{}({}{})'.format(type(self).__name__,

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -180,9 +180,7 @@ class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'goal_ma
     logger.debug('warming target_roots for: %r', target_roots)
     subjects = self._determine_subjects(target_roots)
     request = self.scheduler_session.execution_request([TransitiveHydratedTargets], subjects)
-    result = self.scheduler_session.execute(request)
-    if result.error:
-      raise result.error
+    self.scheduler_session.execute(request)
 
   def validate_goals(self, goals):
     """Checks for @console_rules that satisfy requested goals.

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -910,11 +910,13 @@ impl RuleGraph {
     GraphMaker::new(tasks, root_param_types).full_graph()
   }
 
-  pub fn find_root_edges(&self, param_type: TypeId, select: Select) -> Option<RuleEdges> {
-    // TODO: Support more than one root parameter... needs some API work.
-    //   see https://github.com/pantsbuild/pants/issues/6478
+  pub fn find_root_edges<I: IntoIterator<Item = TypeId>>(
+    &self,
+    param_inputs: I,
+    select: Select,
+  ) -> Option<RuleEdges> {
     let root = RootEntry {
-      params: vec![param_type].into_iter().collect(),
+      params: param_inputs.into_iter().collect(),
       clause: vec![select],
       gets: vec![],
     };

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -945,7 +945,7 @@ impl RuleGraph {
     match subset_matches.len() {
       1 => Ok(subset_matches[0].1.clone()),
       0 => Err(format!(
-        "No installed @rules can satisfy {} for input Params {}.",
+        "No installed @rules can satisfy {} for input Params({}).",
         select_str(&select),
         params_str(&params),
       )),
@@ -955,7 +955,7 @@ impl RuleGraph {
           .map(|(e, _)| entry_with_deps_str(e))
           .collect::<Vec<_>>();
         Err(format!(
-          "More than one set of @rules can satisfy {} for input Params {}:\n  {}",
+          "More than one set of @rules can satisfy {} for input Params({}):\n  {}",
           select_str(&select),
           params_str(&params),
           match_strs.join("\n  "),

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -16,7 +16,6 @@ use indexmap::IndexMap;
 use log::{debug, info, warn};
 use nodes::{NodeKey, Select, Tracer, TryInto, Visualizer};
 use parking_lot::Mutex;
-use rule_graph;
 use selectors;
 use ui::EngineDisplay;
 
@@ -114,18 +113,10 @@ impl Scheduler {
     params: Params,
     product: TypeConstraint,
   ) -> Result<(), String> {
-    let select = selectors::Select::new(product);
     let edges = self
       .core
       .rule_graph
-      .find_root_edges(params.type_ids(), select.clone())
-      .ok_or_else(|| {
-        format!(
-          "No installed @rules can satisfy {} for input Params: {}.",
-          rule_graph::select_str(&select),
-          params,
-        )
-      })?;
+      .find_root_edges(params.type_ids(), &selectors::Select::new(product))?;
     request
       .roots
       .push(Select::new_from_edges(params, product, &edges));

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -205,6 +205,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/engine:scheduler',
     'tests/python/pants_test/engine/examples:scheduler_inputs',
+    'tests/python/pants_test:test_base',
   ]
 )
 

--- a/tests/python/pants_test/engine/legacy/test_address_mapper.py
+++ b/tests/python/pants_test/engine/legacy/test_address_mapper.py
@@ -14,7 +14,6 @@ from pants.build_graph.address import Address, BuildFileAddress
 from pants.build_graph.address_mapper import AddressMapper
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
 from pants.engine.nodes import Throw
-from pants.engine.scheduler import ExecutionResult
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_file_dump, safe_mkdir
 from pants_test.test_base import TestBase
@@ -167,7 +166,7 @@ class LegacyAddressMapperTest(TestBase):
         pass
 
       def execute(self, *args):
-        return ExecutionResult(None, [(('some-thing', None), Throw(Exception('just an exception')))])
+        return [], [(('some-thing', None), Throw(Exception('just an exception')))]
 
     with temporary_dir() as build_root:
       mapper = LegacyAddressMapper(ThrowReturningScheduler(), build_root)

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -200,9 +200,9 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
   def _populate(self, scheduler, address):
     """Perform an ExecutionRequest to parse the given Address into a Struct."""
     request = scheduler.execution_request([TestTable().constraint()], [address])
-    root_entries = scheduler.execute(request).root_products
-    self.assertEqual(1, len(root_entries))
-    return request, root_entries[0][1]
+    returns, _ = scheduler.execute(request)
+    self.assertEqual(1, len(returns))
+    return request, returns[0][1]
 
   def resolve_failure(self, scheduler, address):
     _, state = self._populate(scheduler, address)

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -200,9 +200,12 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
   def _populate(self, scheduler, address):
     """Perform an ExecutionRequest to parse the given Address into a Struct."""
     request = scheduler.execution_request([TestTable().constraint()], [address])
-    returns, _ = scheduler.execute(request)
-    self.assertEqual(1, len(returns))
-    return request, returns[0][1]
+    returns, throws = scheduler.execute(request)
+    if returns:
+      state = returns[0][1]
+    else:
+      state = throws[0][1]
+    return request, state
 
   def resolve_failure(self, scheduler, address):
     _, state = self._populate(scheduler, address)

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -200,7 +200,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     with self.assertRaises(Exception) as cm:
       list(scheduler.product_request(A, subjects=[(B())]))
 
-    self.assert_equal_with_printing('No installed rules can satisfy Select(A) for a root subject of type B.', str(cm.exception))
+    self.assert_equal_with_printing('No installed @rules can satisfy Select(A) for input Params(B).', str(cm.exception))
 
   def test_non_existing_root_fails_differently(self):
     rules = [


### PR DESCRIPTION
### Problem

Although consumption of multiple `Params` is now supported, there is currently no way to actually provide them to a request. See #6478 for more info.

### Solution

Expose and test the ability to pass in a small `Params` datatype as a subject, which is flattened into a corresponding set of rust-side `Params` in `add_root_select`. 

### Result

Fixes #6478.