### PR TITLE
Add the ability to consume scoped Options from @rules

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -30,7 +30,7 @@ class LocalPantsRunner(object):
 
   @staticmethod
   def parse_options(args, env, setup_logging=False, options_bootstrapper=None):
-    options_bootstrapper = options_bootstrapper or OptionsBootstrapper(args=args, env=env)
+    options_bootstrapper = options_bootstrapper or OptionsBootstrapper.create(args=args, env=env)
     bootstrap_options = options_bootstrapper.get_bootstrap_options().for_global_scope()
     if setup_logging:
       # Bootstrap logging and then fully initialize options.

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -40,15 +40,15 @@ class LocalPantsRunner(object):
     return options, build_config, options_bootstrapper
 
   @staticmethod
-  def _maybe_init_graph_session(graph_session, global_options, build_config):
+  def _maybe_init_graph_session(graph_session, options_bootstrapper, build_config):
     if graph_session:
       return graph_session
 
-    native = Native.create(global_options)
+    native = Native.create(options_bootstrapper.bootstrap_options.for_global_scope())
     native.set_panic_handler()
     graph_scheduler_helper = EngineInitializer.setup_legacy_graph(
       native,
-      global_options,
+      options_bootstrapper,
       build_config
     )
     return graph_scheduler_helper.new_session()
@@ -103,7 +103,7 @@ class LocalPantsRunner(object):
     # resident graph helper - otherwise initialize a new one here.
     graph_session = cls._maybe_init_graph_session(
       daemon_graph_session,
-      global_options,
+      options_bootstrapper,
       build_config
     )
 

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -36,7 +36,7 @@ class PantsRunner(object):
     # this point onwards will use that exiter in the case of a fatal error.
     ExceptionSink.reset_exiter(self._exiter)
 
-    options_bootstrapper = OptionsBootstrapper(env=self._env, args=self._args)
+    options_bootstrapper = OptionsBootstrapper.create(env=self._env, args=self._args)
     bootstrap_options = options_bootstrapper.get_bootstrap_options()
     global_bootstrap_options = bootstrap_options.for_global_scope()
 

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -37,7 +37,7 @@ class PantsRunner(object):
     ExceptionSink.reset_exiter(self._exiter)
 
     options_bootstrapper = OptionsBootstrapper.create(env=self._env, args=self._args)
-    bootstrap_options = options_bootstrapper.get_bootstrap_options()
+    bootstrap_options = options_bootstrapper.bootstrap_options
     global_bootstrap_options = bootstrap_options.for_global_scope()
 
     ExceptionSink.reset_should_print_backtrace_to_terminal(global_bootstrap_options.print_exception_stacktrace)
@@ -45,7 +45,7 @@ class PantsRunner(object):
 
     if global_bootstrap_options.enable_pantsd:
       try:
-        return RemotePantsRunner(self._exiter, self._args, self._env, bootstrap_options).run()
+        return RemotePantsRunner(self._exiter, self._args, self._env, options_bootstrapper).run()
       except RemotePantsRunner.Fallback as e:
         logger.warn('caught client exception: {!r}, falling back to non-daemon mode'.format(e))
 

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -40,12 +40,12 @@ class RemotePantsRunner(object):
     NailgunClient.NailgunExecutionError
   )
 
-  def __init__(self, exiter, args, env, bootstrap_options, stdin=None, stdout=None, stderr=None):
+  def __init__(self, exiter, args, env, options_bootstrapper, stdin=None, stdout=None, stderr=None):
     """
     :param Exiter exiter: The Exiter instance to use for this run.
     :param list args: The arguments (e.g. sys.argv) for this run.
     :param dict env: The environment (e.g. os.environ) for this run.
-    :param Options bootstrap_options: The Options bag containing the bootstrap options.
+    :param OptionsBootstrapper options_bootstrapper: The bootstrap options.
     :param file stdin: The stream representing stdin.
     :param file stdout: The stream representing stdout.
     :param file stderr: The stream representing stderr.
@@ -54,7 +54,8 @@ class RemotePantsRunner(object):
     self._exiter = exiter
     self._args = args
     self._env = env
-    self._bootstrap_options = bootstrap_options
+    self._options_bootstrapper = options_bootstrapper
+    self._bootstrap_options = options_bootstrapper.bootstrap_options
     self._stdin = stdin or sys.stdin
     self._stdout = stdout or sys.stdout
     self._stderr = stderr or sys.stderr
@@ -178,10 +179,10 @@ class RemotePantsRunner(object):
       nailgun_error, exception_suffix))
 
   def _restart_pantsd(self):
-    return PantsDaemon.Factory.restart(bootstrap_options=self._bootstrap_options)
+    return PantsDaemon.Factory.restart(options_bootstrapper=self._options_bootstrapper)
 
   def _maybe_launch_pantsd(self):
-    return PantsDaemon.Factory.maybe_launch(bootstrap_options=self._bootstrap_options)
+    return PantsDaemon.Factory.maybe_launch(options_bootstrapper=self._options_bootstrapper)
 
   def run(self, args=None):
     self._setup_logging()

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -491,7 +491,7 @@ def main():
   # Parse positional arguments to the script.
   args = _create_bootstrap_binary_arg_parser().parse_args()
   # Resolve bootstrap options with a fake empty command line.
-  options_bootstrapper = OptionsBootstrapper(args=[sys.argv[0]])
+  options_bootstrapper = OptionsBootstrapper.create(args=[sys.argv[0]])
   subsystems = (GlobalOptionsRegistrar, BinaryUtil.Factory)
   known_scope_infos = reduce(set.union, (ss.known_scope_infos() for ss in subsystems), set())
   options = options_bootstrapper.get_full_options(known_scope_infos)

--- a/src/python/pants/core_tasks/pantsd_kill.py
+++ b/src/python/pants/core_tasks/pantsd_kill.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants.base.exceptions import TaskError
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.pantsd.pants_daemon import PantsDaemon
 from pants.pantsd.process_manager import ProcessManager
 from pants.task.task import Task
@@ -15,7 +16,7 @@ class PantsDaemonKill(Task):
 
   def execute(self):
     try:
-      pantsd = PantsDaemon.Factory.create(self.context.options, full_init=False)
+      pantsd = PantsDaemon.Factory.create(OptionsBootstrapper.create(), full_init=False)
       with pantsd.lifecycle_lock:
         pantsd.terminate()
     except ProcessManager.NonResponsiveProcess as e:

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -311,7 +311,8 @@ class EngineInitializer(object):
     """
 
     build_root = build_root or get_buildroot()
-    build_configuration = build_configuration or BuildConfigInitializer.get(OptionsBootstrapper())
+    options_bootstrapper = OptionsBootstrapper.create()
+    build_configuration = build_configuration or BuildConfigInitializer.get(options_bootstrapper)
     build_file_aliases = build_configuration.registered_aliases()
     rules = build_configuration.rules()
     console = Console()

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -14,6 +14,7 @@ from twitter.common.collections import OrderedSet
 from pants.base.deprecated import warn_or_error
 from pants.option.arg_splitter import GLOBAL_SCOPE, ArgSplitter
 from pants.option.global_options import GlobalOptionsRegistrar
+from pants.option.option_tracker import OptionTracker
 from pants.option.option_util import is_list_option
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.parser_hierarchy import ParserHierarchy, all_enclosing_scopes, enclosing_scope
@@ -77,9 +78,6 @@ class Options(object):
     - None.
   """
 
-  class OptionTrackerRequiredError(Exception):
-    """Options requires an OptionTracker instance."""
-
   class FrozenOptionsError(Exception):
     """Options are frozen and can't be mutated."""
 
@@ -110,8 +108,7 @@ class Options(object):
     return ret
 
   @classmethod
-  def create(cls, env, config, known_scope_infos, args=None, bootstrap_option_values=None,
-             option_tracker=None):
+  def create(cls, env, config, known_scope_infos, args=None, bootstrap_option_values=None):
     """Create an Options instance.
 
     :param env: a dict of environment variables.
@@ -120,8 +117,6 @@ class Options(object):
     :param args: a list of cmd-line args; defaults to `sys.argv` if None is supplied.
     :param bootstrap_option_values: An optional namespace containing the values of bootstrap
            options. We can use these values when registering other options.
-    :param :class:`pants.option.option_tracker.OptionTracker` option_tracker: option tracker
-           instance to record how option values were assigned.
     """
     # We need parsers for all the intermediate scopes, so inherited option values
     # can propagate through them.
@@ -130,8 +125,7 @@ class Options(object):
     args = sys.argv if args is None else args
     goals, scope_to_flags, target_specs, passthru, passthru_owner, unknown_scopes = splitter.split_args(args)
 
-    if not option_tracker:
-      raise cls.OptionTrackerRequiredError()
+    option_tracker = OptionTracker()
 
     if bootstrap_option_values:
       target_spec_files = bootstrap_option_values.target_spec_files

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -16,7 +16,6 @@ from pants.option.arg_splitter import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION
 from pants.option.config import Config
 from pants.option.custom_types import ListValueComponent
 from pants.option.global_options import GlobalOptionsRegistrar
-from pants.option.option_tracker import OptionTracker
 from pants.option.options import Options
 from pants.util.strutil import ensure_text
 
@@ -72,7 +71,6 @@ class OptionsBootstrapper(object):
     self._args = sys.argv if args is None else args
     self._bootstrap_options = None  # We memoize the bootstrap options here.
     self._full_options = {}  # We memoize the full options here.
-    self._option_tracker = OptionTracker()
 
   def produce_and_set_bootstrap_options(self):
     """Cooperatively populates the internal bootstrap_options cache with
@@ -114,7 +112,6 @@ class OptionsBootstrapper(object):
         config=config,
         known_scope_infos=[GlobalOptionsRegistrar.get_scope_info()],
         args=bargs,
-        option_tracker=self._option_tracker
       )
 
       def register_global(*args, **kwargs):
@@ -188,8 +185,7 @@ class OptionsBootstrapper(object):
                                                self._post_bootstrap_config,
                                                known_scope_infos,
                                                args=self._args,
-                                               bootstrap_option_values=bootstrap_option_values,
-                                               option_tracker=self._option_tracker)
+                                               bootstrap_option_values=bootstrap_option_values)
     return self._full_options[key]
 
   def verify_configs_against_options(self, options):

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -4,15 +4,20 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from collections import namedtuple
+from builtins import str
+
+from pants.util.objects import datatype
 
 
 GLOBAL_SCOPE = ''
 GLOBAL_SCOPE_CONFIG_SECTION = 'GLOBAL'
 
 
-# TODO: convert this to a datatype?
-class ScopeInfo(namedtuple('_ScopeInfo', ['scope', 'category', 'optionable_cls'])):
+class Scope(datatype([('scope', str)])):
+  """An options scope."""
+
+
+class ScopeInfo(datatype(['scope', 'category', 'optionable_cls'])):
   """Information about a scope."""
 
   # Symbolic constants for different categories of scope.
@@ -21,6 +26,9 @@ class ScopeInfo(namedtuple('_ScopeInfo', ['scope', 'category', 'optionable_cls']
   TASK = 'TASK'
   SUBSYSTEM = 'SUBSYSTEM'
   INTERMEDIATE = 'INTERMEDIATE'  # Scope added automatically to fill out the scope hierarchy.
+
+  def __new__(cls, scope, category, optionable_cls=None):
+    return super(ScopeInfo, cls).__new__(cls, scope, category, optionable_cls)
 
   @property
   def description(self):
@@ -36,7 +44,3 @@ class ScopeInfo(namedtuple('_ScopeInfo', ['scope', 'category', 'optionable_cls']
 
   def _optionable_cls_attr(self, name, default=None):
     return getattr(self.optionable_cls, name) if self.optionable_cls else default
-
-
-# Allow the optionable_cls to default to None.
-ScopeInfo.__new__.__defaults__ = (None, )

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -130,7 +130,9 @@ class PantsDaemon(FingerprintedProcessManager):
                              initialize the engine). See the impl of `maybe_launch` for an example
                              of the intended usage.
       """
-      bootstrap_options = bootstrap_options or cls._parse_bootstrap_options()
+      # TODO: This method should receive an OptionsBootstrapper instead, to avoid re-parsing.
+      options_bootstrapper = OptionsBootstrapper.create() if full_init or not bootstrap_options else None
+      bootstrap_options = bootstrap_options or options_bootstrapper.bootstrap_options
       bootstrap_options_values = bootstrap_options.for_global_scope()
       # TODO: https://github.com/pantsbuild/pants/issues/3479
       watchman = WatchmanLauncher.create(bootstrap_options_values).watchman
@@ -138,7 +140,6 @@ class PantsDaemon(FingerprintedProcessManager):
       if full_init:
         build_root = get_buildroot()
         native = Native.create(bootstrap_options_values)
-        options_bootstrapper = OptionsBootstrapper()
         build_config = BuildConfigInitializer.get(options_bootstrapper)
         legacy_graph_scheduler = EngineInitializer.setup_legacy_graph(native,
                                                                       bootstrap_options_values,
@@ -163,10 +164,6 @@ class PantsDaemon(FingerprintedProcessManager):
         metadata_base_dir=bootstrap_options_values.pants_subprocessdir,
         bootstrap_options=bootstrap_options
       )
-
-    @staticmethod
-    def _parse_bootstrap_options():
-      return OptionsBootstrapper().get_bootstrap_options()
 
     @staticmethod
     def _setup_services(build_root, bootstrap_options, legacy_graph_scheduler, watchman):

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -142,7 +142,7 @@ class PantsDaemon(FingerprintedProcessManager):
         native = Native.create(bootstrap_options_values)
         build_config = BuildConfigInitializer.get(options_bootstrapper)
         legacy_graph_scheduler = EngineInitializer.setup_legacy_graph(native,
-                                                                      bootstrap_options_values,
+                                                                      options_bootstrapper,
                                                                       build_config)
         services = cls._setup_services(
           build_root,

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -466,7 +466,7 @@ class BaseTest(unittest.TestCase):
     """
     # Can't parse any options without a pants.ini.
     self.create_file('pants.ini')
-    return OptionsBootstrapper(args=cli_options).get_bootstrap_options().for_global_scope()
+    return OptionsBootstrapper.create(args=cli_options).bootstrap_options.for_global_scope()
 
   class LoggingRecorder(object):
     """Simple logging handler to record warnings."""

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -45,7 +45,8 @@ class GraphTestBase(unittest.TestCase):
   def _default_build_config(self, build_file_aliases=None):
     # TODO: Get default BuildFileAliases by extending BaseTest post
     #   https://github.com/pantsbuild/pants/issues/4401
-    build_config = BuildConfigInitializer.get(OptionsBootstrapper())
+    options_bootstrapper = OptionsBootstrapper.create()
+    build_config = BuildConfigInitializer.get(options_bootstrapper)
     if build_file_aliases:
       build_config.register_aliases(build_file_aliases)
     return build_config

--- a/tests/python/pants_test/engine/legacy/test_options_parsing.py
+++ b/tests/python/pants_test/engine/legacy/test_options_parsing.py
@@ -4,38 +4,64 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
+from builtins import str
 
-from pants.engine.legacy.options_parsing import OptionsParseRequest, parse_options
+from pants.engine.legacy.options_parsing import ScopedOptions
+from pants.engine.selectors import Params
 from pants.init.options_initializer import BuildConfigInitializer
 from pants.option.options_bootstrapper import OptionsBootstrapper
-from pants_test.engine.util import run_rule
+from pants.option.scope import GLOBAL_SCOPE, Scope
+from pants_test.test_base import TestBase
 
 
-class TestEngineOptionsParsing(unittest.TestCase):
+class TestEngineOptionsParsing(TestBase):
 
-  def test_options_parsing_request(self):
-    parse_request = OptionsParseRequest.create(
-      ['./pants', '-ldebug', '--python-setup-wheel-version=3.13.37', 'binary', 'src/python::'],
-      dict(PANTS_ENABLE_PANTSD='True', PANTS_BINARIES_BASEURLS='["https://bins.com"]')
+  def _ob(self, args=tuple(), env=tuple()):
+    self.create_file('pants.ini')
+    options_bootstrap = OptionsBootstrapper.create(
+      args=tuple(args),
+      env=dict(env),
     )
+    # NB: BuildConfigInitializer has sideeffects on first-run: in actual usage, these
+    # sideeffects will happen during setup. We force them here.
+    BuildConfigInitializer.get(options_bootstrap)
+    return options_bootstrap
 
-    # TODO: Once we have the ability to get FileContent for arbitrary
-    # paths outside of the buildroot, we can move the construction of
-    # OptionsBootstrapper into an @rule by cooperatively calling
-    # OptionsBootstrapper.produce_and_set_bootstrap_options() which
-    # will yield lists of file paths for use as subject values and permit
-    # us to avoid the direct file I/O that this currently requires.
-    options_bootstrapper = OptionsBootstrapper.from_options_parse_request(parse_request)
-    build_config = BuildConfigInitializer.get(options_bootstrapper)
+  def test_options_parse_scoped(self):
+    options_bootstrapper = self._ob(
+        args=['./pants', '-ldebug', '--python-setup-wheel-version=3.13.37', 'binary', 'src/python::'],
+        env=dict(PANTS_ENABLE_PANTSD='True', PANTS_BINARIES_BASEURLS='["https://bins.com"]'),
+      )
 
-    options = run_rule(parse_options, options_bootstrapper, build_config)[0]
+    global_options_params = Params(Scope(str(GLOBAL_SCOPE)), options_bootstrapper)
+    python_setup_options_params = Params(Scope(str('python-setup')), options_bootstrapper)
+    global_options, python_setup_options = self.scheduler.product_request(
+        ScopedOptions,
+        [global_options_params, python_setup_options_params],
+      )
 
-    self.assertIn('binary', options.goals)
-    global_options = options.for_global_scope()
-    self.assertEqual(global_options.level, 'debug')
-    self.assertEqual(global_options.enable_pantsd, True)
-    self.assertEqual(global_options.binaries_baseurls, ['https://bins.com'])
+    self.assertEqual(global_options.options.level, 'debug')
+    self.assertEqual(global_options.options.enable_pantsd, True)
+    self.assertEqual(global_options.options.binaries_baseurls, ['https://bins.com'])
 
-    python_setup_options = options.for_scope('python-setup')
-    self.assertEqual(python_setup_options.wheel_version, '3.13.37')
+    self.assertEqual(python_setup_options.options.wheel_version, '3.13.37')
+
+  def test_options_parse_memoization(self):
+    # Confirm that re-executing with a new-but-identical Options object results in memoization.
+    def ob():
+      return self._ob(args=['./pants', '-ldebug', 'binary', 'src/python::'])
+    def parse(ob):
+      params = Params(Scope(str(GLOBAL_SCOPE)), ob)
+      return self.scheduler.product_request(ScopedOptions, [params])
+
+    # If two OptionsBootstrapper instances are not equal, memoization will definitely not kick in.
+    one_opts = ob()
+    two_opts = ob()
+    self.assertEquals(one_opts, two_opts)
+    self.assertEquals(hash(one_opts), hash(two_opts))
+
+    # If they are equal, executing parsing on them should result in a memoized object.
+    one, = parse(one_opts)
+    two, = parse(two_opts)
+    self.assertEqual(one, two)
+    self.assertIs(one, two)

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -14,7 +14,7 @@ from pants.option.options_bootstrapper import OptionsBootstrapper
 
 class OptionsInitializerTest(unittest.TestCase):
   def test_invalid_version(self):
-    options_bootstrapper = OptionsBootstrapper(args=['--pants-version=99.99.9999'])
+    options_bootstrapper = OptionsBootstrapper.create(args=['--pants-version=99.99.9999'])
     build_config = BuildConfigInitializer.get(options_bootstrapper)
 
     with self.assertRaises(BuildConfigurationError):
@@ -22,7 +22,7 @@ class OptionsInitializerTest(unittest.TestCase):
 
   def test_global_options_validation(self):
     # Specify an invalid combination of options.
-    ob = OptionsBootstrapper(args=['--loop', '--v1'])
+    ob = OptionsBootstrapper.create(args=['--loop', '--v1'])
     build_config = BuildConfigInitializer.get(ob)
     with self.assertRaises(OptionsError) as exc:
       OptionsInitializer.create(ob, build_config)

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -76,7 +76,7 @@ class PluginResolverTest(unittest.TestCase):
         touch(configpath)
       args = ["--pants-config-files=['{}']".format(configpath)]
 
-      options_bootstrapper = OptionsBootstrapper(env=env, args=args)
+      options_bootstrapper = OptionsBootstrapper.create(env=env, args=args)
       plugin_resolver = PluginResolver(options_bootstrapper)
       cache_dir = plugin_resolver.plugin_cache_dir
       yield plugin_resolver.resolve(WorkingSet(entries=[])), root_dir, repo_dir, cache_dir

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -696,8 +696,8 @@ class OptionsTest(unittest.TestCase):
       cmdline = './pants --target-spec-file={filename} --pants-config-files="[]" ' \
                 'compile morx:tgt fleem:tgt'.format(
         filename=tmp.name)
-      bootstrapper = OptionsBootstrapper(args=shlex.split(cmdline))
-      bootstrap_options = bootstrapper.get_bootstrap_options().for_global_scope()
+      bootstrapper = OptionsBootstrapper.create(args=shlex.split(cmdline))
+      bootstrap_options = bootstrapper.bootstrap_options.for_global_scope()
       options = self._parse(cmdline, bootstrap_option_values=bootstrap_options)
       sorted_specs = sorted(options.target_specs)
       self.assertEqual(['bar', 'fleem:tgt', 'foo', 'morx:tgt'], sorted_specs)

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -26,7 +26,6 @@ from pants.option.errors import (BooleanOptionNameWithNo, FrozenRegistration, Im
                                  OptionNameDoubleDash, ParseError, RecursiveSubsystemOption,
                                  Shadowing)
 from pants.option.global_options import GlobalOptionsRegistrar
-from pants.option.option_tracker import OptionTracker
 from pants.option.optionable import Optionable
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -71,8 +70,7 @@ class OptionsTest(unittest.TestCase):
                                   config=self._create_config(config or {}),
                                   known_scope_infos=OptionsTest._known_scope_infos,
                                   args=args,
-                                  bootstrap_option_values=bootstrap_option_values,
-                                  option_tracker=OptionTracker())
+                                  bootstrap_option_values=bootstrap_option_values)
     self._register(options)
     return options
 
@@ -191,16 +189,14 @@ class OptionsTest(unittest.TestCase):
     options = Options.create(env={'PANTS_FOO_BAR': "['123','456']"},
                              config=self._create_config({}),
                              known_scope_infos=OptionsTest._known_scope_infos,
-                             args=shlex.split('./pants'),
-                             option_tracker=OptionTracker())
+                             args=shlex.split('./pants'))
     options.register(GLOBAL_SCOPE, '--foo-bar', type=list, member_type=int)
     self.assertEqual([123, 456], options.for_global_scope().foo_bar)
 
     options = Options.create(env={'PANTS_FOO_BAR': '123'},
                              config=self._create_config({}),
                              known_scope_infos=OptionsTest._known_scope_infos,
-                             args=shlex.split('./pants'),
-                             option_tracker=OptionTracker())
+                             args=shlex.split('./pants'))
     options.register(GLOBAL_SCOPE, '--foo-bar', type=int)
     self.assertEqual(123, options.for_global_scope().foo_bar)
 
@@ -576,7 +572,7 @@ class OptionsTest(unittest.TestCase):
     def assertError(expected_error, *args, **kwargs):
       with self.assertRaises(expected_error):
         options = Options.create(args=[], env={}, config=self._create_config({}),
-                                 known_scope_infos=[], option_tracker=OptionTracker())
+                                 known_scope_infos=[])
         options.register(GLOBAL_SCOPE, *args, **kwargs)
         options.for_global_scope()
 
@@ -594,7 +590,7 @@ class OptionsTest(unittest.TestCase):
 
   def test_frozen_registration(self):
     options = Options.create(args=[], env={}, config=self._create_config({}),
-                             known_scope_infos=[task('foo')], option_tracker=OptionTracker())
+                             known_scope_infos=[task('foo')])
     options.register('foo', '--arg1')
     with self.assertRaises(FrozenRegistration):
       options.register(GLOBAL_SCOPE, '--arg2')
@@ -611,8 +607,7 @@ class OptionsTest(unittest.TestCase):
     options = Options.create(env={},
                              config=self._create_config({}),
                              known_scope_infos=[task('bar'), intermediate('foo'), task('foo.bar')],
-                             args='./pants',
-                             option_tracker=OptionTracker())
+                             args='./pants')
     options.register('', '--opt1')
     options.register('foo', '-o', '--opt2')
     with self.assertRaises(Shadowing):
@@ -643,8 +638,7 @@ class OptionsTest(unittest.TestCase):
     options = Options.create(env={},
                              config=self._create_config({}),
                              known_scope_infos=[subsystem('foo')],
-                             args='./pants',
-                             option_tracker=OptionTracker())
+                             args='./pants')
     # All subsystem options are implicitly recursive (a subscope of subsystem scope represents
     # a separate instance of the subsystem, so it needs all the options).
     # We disallow explicit specification of recursive (even if set to True), to avoid confusion.
@@ -1209,10 +1203,6 @@ class OptionsTest(unittest.TestCase):
     self.assertNotEqual(some, RankedValue(RankedValue.HARDCODED, 'few'))
     self.assertNotEqual(some, RankedValue(RankedValue.CONFIG, 'some'))
 
-  def test_option_tracker_required(self):
-    with self.assertRaises(Options.OptionTrackerRequiredError):
-      Options.create(None, None, [])
-
   def test_pants_global_designdoc_example(self):
     # The example from the design doc.
     # Get defaults from config and environment.
@@ -1257,8 +1247,7 @@ class OptionsTest(unittest.TestCase):
     options = Options.create(env={},
                              config=self._create_config({}),
                              known_scope_infos=OptionsTest._known_scope_infos,
-                             args=shlex.split('./pants'),
-                             option_tracker=OptionTracker())
+                             args=shlex.split('./pants'))
     options.register(GLOBAL_SCOPE, '--foo-bar')
     self.assertRaises(OptionAlreadyRegistered, lambda: options.register(GLOBAL_SCOPE, '--foo-bar'))
 
@@ -1296,8 +1285,7 @@ class OptionsTest(unittest.TestCase):
                                DummyOptionable1.get_scope_info(),
                                DummyOptionable2.get_scope_info()
                              ],
-                             args=shlex.split('./pants --new-scope1-baz=vv'),
-                             option_tracker=OptionTracker())
+                             args=shlex.split('./pants --new-scope1-baz=vv'))
 
     options.register(GLOBAL_SCOPE, '--inherited')
     options.register(DummyOptionable1.options_scope, '--foo')
@@ -1351,8 +1339,7 @@ class OptionsTest(unittest.TestCase):
                              known_scope_infos=[
                                DummyOptionable1.get_scope_info(),
                              ],
-                             args=shlex.split('./pants'),
-                             option_tracker=OptionTracker())
+                             args=shlex.split('./pants'))
 
     options.register(DummyOptionable1.options_scope, '--foo')
 

--- a/tests/python/pants_test/option/test_options_bootstrapper.py
+++ b/tests/python/pants_test/option/test_options_bootstrapper.py
@@ -38,7 +38,7 @@ class BootstrapOptionsTest(unittest.TestCase):
       fp.close()
 
       args = args + self._config_path(fp.name)
-      bootstrapper = OptionsBootstrapper(env=env, args=args)
+      bootstrapper = OptionsBootstrapper.create(env=env, args=args)
       vals = bootstrapper.get_bootstrap_options().for_global_scope()
 
       vals_dict = {k: getattr(vals, k) for k in expected_entries}
@@ -116,7 +116,7 @@ class BootstrapOptionsTest(unittest.TestCase):
       """))
       fp.close()
       args = ['--pants-workdir=/qux'] + self._config_path(fp.name)
-      bootstrapper = OptionsBootstrapper(env={
+      bootstrapper = OptionsBootstrapper.create(env={
                                            'PANTS_SUPPORTDIR': '/pear'
                                          },
                                          args=args)
@@ -189,14 +189,14 @@ class BootstrapOptionsTest(unittest.TestCase):
 
   def test_create_bootstrapped_multiple_pants_config_files(self):
     def create_options_bootstrapper(*config_paths):
-      return OptionsBootstrapper(args=['--pants-config-files={}'.format(cp) for cp in config_paths])
+      return OptionsBootstrapper.create(args=['--pants-config-files={}'.format(cp) for cp in config_paths])
 
     self.do_test_create_bootstrapped_multiple_config(create_options_bootstrapper)
 
   def test_full_options_caching(self):
     with temporary_file_path() as config:
       args = self._config_path(config)
-      bootstrapper = OptionsBootstrapper(env={}, args=args)
+      bootstrapper = OptionsBootstrapper.create(env={}, args=args)
 
       opts1 = bootstrapper.get_full_options(known_scope_infos=[ScopeInfo('', ScopeInfo.GLOBAL),
                                                                ScopeInfo('foo', ScopeInfo.TASK)])
@@ -219,7 +219,7 @@ class BootstrapOptionsTest(unittest.TestCase):
   def test_bootstrap_short_options(self):
     def parse_options(*args):
       full_args = list(args) + self._config_path(None)
-      return OptionsBootstrapper(args=full_args).get_bootstrap_options().for_global_scope()
+      return OptionsBootstrapper.create(args=full_args).get_bootstrap_options().for_global_scope()
 
     # No short options passed - defaults presented.
     vals = parse_options()
@@ -238,7 +238,7 @@ class BootstrapOptionsTest(unittest.TestCase):
   def test_bootstrap_options_passthrough_dup_ignored(self):
     def parse_options(*args):
       full_args = list(args) + self._config_path(None)
-      return OptionsBootstrapper(args=full_args).get_bootstrap_options().for_global_scope()
+      return OptionsBootstrapper.create(args=full_args).get_bootstrap_options().for_global_scope()
 
     vals = parse_options('main', 'args', '-d/tmp/frogs', '--', '-d/tmp/logs')
     self.assertEqual('/tmp/frogs', vals.logdir)
@@ -285,6 +285,6 @@ class BootstrapOptionsTest(unittest.TestCase):
       with open(config2, 'w') as out2:
         out2.write('[DEFAULT]\nlogdir: logdir2\n')
 
-      ob = OptionsBootstrapper(env={}, args=["--pants-config-files=['{}']".format(config1)])
+      ob = OptionsBootstrapper.create(env={}, args=["--pants-config-files=['{}']".format(config1)])
       logdir = ob.get_bootstrap_options().for_global_scope().logdir
       self.assertEqual('logdir1', logdir)

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -397,6 +397,7 @@ class TestBase(unittest.TestCase):
       local_store_dir=cls._local_store_dir,
       build_file_imports_behavior='allow',
       native=init_native(),
+      options_bootstrapper=OptionsBootstrapper.create(args=['--pants-config-files=[]']),
       build_configuration=cls.build_config(),
       build_ignore_patterns=None,
     ).new_session()
@@ -619,9 +620,8 @@ class TestBase(unittest.TestCase):
 
     :param cli_options: An iterable of CLI flags to pass as arguments to `OptionsBootstrapper`.
     """
-    # Can't parse any options without a pants.ini.
-    self.create_file('pants.ini')
-    return OptionsBootstrapper.create(args=cli_options).bootstrap_options.for_global_scope()
+    args = tuple(['--pants-config-files=[]']) + tuple(cli_options)
+    return OptionsBootstrapper.create(args=args).bootstrap_options.for_global_scope()
 
   class LoggingRecorder(object):
     """Simple logging handler to record warnings."""

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -621,7 +621,7 @@ class TestBase(unittest.TestCase):
     """
     # Can't parse any options without a pants.ini.
     self.create_file('pants.ini')
-    return OptionsBootstrapper(args=cli_options).get_bootstrap_options().for_global_scope()
+    return OptionsBootstrapper.create(args=cli_options).bootstrap_options.for_global_scope()
 
   class LoggingRecorder(object):
     """Simple logging handler to record warnings."""


### PR DESCRIPTION
### Problem

As described in #5869, we need a way to consume `Options` in the new engine in order to provide access to `Subsystems` in `@rules`. 

### Solution

Convert `OptionsBootstrapper` and `Config` into `datatype`s in order to give them useful eq/hash implementations.

Then, modify the `@rules` that were added in #5889 to consume the `Params` API added in #6871 and expose a `ScopedOptions` wrapper around the set of options for a `Scope`.

### Result

`@rules` can consume `ScopedOptions`, although there should probably be built-in rules that can consume `ScopedOptions` to create `Subsystems`. Nonetheless, let's say that this "fixes #5869", and open a followup for actually exposing `Subsystems` to `@rules` in a generic way.