### PR TITLE
Flush the console after all @console_rules have completed

### DIFF
--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -8,7 +8,6 @@ import sys
 
 
 class Console(object):
-
   @property
   def stdout(self):
     return sys.stdout
@@ -28,3 +27,7 @@ class Console(object):
 
   def print_stderr(self, payload):
     print(payload, file=self.stderr)
+
+  def flush(self):
+    self.stdout.flush()
+    self.stderr.flush()

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -206,10 +206,12 @@ class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'console
     # Console rule can only have one subject.
     assert len(subjects) == 1
     for goal in goals:
-      goal_product = self.goal_map[goal]
-      logger.debug('requesting {} to satisfy execution of `{}` goal'.format(goal_product, goal))
-      self.scheduler_session.run_console_rule(goal_product, subjects[0], v2_ui)
-    self.console.flush()
+      try:
+        goal_product = self.goal_map[goal]
+        logger.debug('requesting {} to satisfy execution of `{}` goal'.format(goal_product, goal))
+        self.scheduler_session.run_console_rule(goal_product, subjects[0], v2_ui)
+      finally:
+        self.console.flush()
 
   def create_build_graph(self, target_roots, build_root=None):
     """Construct and return a `BuildGraph` given a set of input specs.

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -140,15 +140,15 @@ def _tuplify(v):
   return (v,)
 
 
-class LegacyGraphScheduler(datatype(['scheduler', 'symbol_table', 'goal_map'])):
+class LegacyGraphScheduler(datatype(['scheduler', 'symbol_table', 'console', 'goal_map'])):
   """A thin wrapper around a Scheduler configured with @rules for a symbol table."""
 
   def new_session(self):
     session = self.scheduler.new_session()
-    return LegacyGraphSession(session, self.symbol_table, self.goal_map)
+    return LegacyGraphSession(session, self.symbol_table, self.console, self.goal_map)
 
 
-class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'goal_map'])):
+class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'console', 'goal_map'])):
   """A thin wrapper around a SchedulerSession configured with @rules for a symbol table."""
 
   class InvalidGoals(Exception):
@@ -209,6 +209,7 @@ class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'goal_ma
       goal_product = self.goal_map[goal]
       logger.debug('requesting {} to satisfy execution of `{}` goal'.format(goal_product, goal))
       self.scheduler_session.run_console_rule(goal_product, subjects[0], v2_ui)
+    self.console.flush()
 
   def create_build_graph(self, target_roots, build_root=None):
     """Construct and return a `BuildGraph` given a set of input specs.
@@ -367,4 +368,4 @@ class EngineInitializer(object):
       include_trace_on_error=include_trace_on_error,
     )
 
-    return LegacyGraphScheduler(scheduler, symbol_table, goal_map)
+    return LegacyGraphScheduler(scheduler, symbol_table, console, goal_map)

--- a/tests/python/pants_test/rules/test_test_integration.py
+++ b/tests/python/pants_test/rules/test_test_integration.py
@@ -4,8 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -92,7 +90,6 @@ testprojects/tests/python/pants/dummies:failing_target                          
 """,
     )
 
-  @unittest.skip('Flaky test: https://github.com/pantsbuild/pants/issues/6782')
   def test_mixed_python_tests(self):
     args = [
       '--no-v1',


### PR DESCRIPTION
### Problem

I noticed some flakiness while using `--no-v1 --v2 list` under `pantsd`, and diffing the output of a successful and unsuccessful run indicated that it was an issue with truncation.

### Solution

Add and use `Console.flush()` after all `@console_rules` have completed.

### Result

I'm fairly sure that this fixes #6782: unmarking it here.