### PR TITLE
Bump Thrift to >=0.10

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -31,6 +31,6 @@ setproctitle==1.1.10
 setuptools==40.4.3
 six>=1.9.0,<2
 subprocess32==3.2.7 ; python_version<'3'
-thrift>=0.9.1
+thrift>=0.10.0
 wheel==0.31.1
 www-authenticate==0.9.2


### PR DESCRIPTION
### Problem
Thrift 0.9 does not properly support Python 3 [(Jira ticket)](https://issues.apache.org/jira/browse/THRIFT-1857).

This led to several Python 3 integration test failures, such as `backend/python/tasks/test_pytest_run_integration.py` resulting in 
```error
E   	                     >   from ttypes import *
E   	                     E   ImportError: No module named 'ttypes'
```

### Solution
Require at least Thrift 0.10, the first major version to support Python 3. For reference, the [changelog](https://github.com/apache/thrift/blob/master/CHANGES#L302)

Note that the most recent version is Thrift 0.11, but this only requires the minimum to get the job done to ease the upgrade path for any Pants consumers, especially those who use it as a library like Foursquare.