### PR TITLE
Travis finally released xenial (16.04).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,8 +83,10 @@ default_test_config: &default_test_config
   language: python
   python: &python_version "2.7"
   before_install:
-    - which java
-    - echo $PATH
+    - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
+    - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+    - java -version
+    - ls /usr/local/lib/ | grep jvm
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,8 @@ default_test_config: &default_test_config
   language: python
   python: &python_version "2.7"
   before_install:
-    - update-java-alternatives -l && 1
+    - which java
+    - echo $PATH
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,10 +82,8 @@ default_test_config: &default_test_config
   language: python
   python: &python_version "2.7"
   before_install:
-    #- PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
-    #- JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-    - export JAVA_HOME=$HOME/oraclejdk8
-    - $TRAVIS_BUILD_DIR/install-jdk.sh --install oraclejdk8 --target $JAVA_HOME
+    - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
+    - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
     - ls /usr/local/lib/jvm
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,15 +79,11 @@ default_test_config: &default_test_config
         - python3
         - openssl
         - libssl-dev
+        - oracle-java8-installer
   stage: *test
   language: python
   python: &python_version "2.7"
   before_install:
-    # Remove bad openjdk6 from trusty image, so
-    # Pants will pick up oraclejdk6 from `packages` above.
-    - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
-    - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
-    - jdk_switcher use oraclejdk8
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,11 +78,13 @@ default_test_config: &default_test_config
         - python-dev
         - openssl
         - libssl-dev
+        - default-jdk
   stage: *test
   language: python
   python: &python_version "2.7"
   jdk: oraclejdk8
   before_install:
+    - update-java-alternatives -l
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,13 +76,12 @@ default_test_config: &default_test_config
         - lib32z1-dev
         - gcc-multilib
         - python-dev
-        - python3
         - openssl
         - libssl-dev
-        - oracle-java8-installer
   stage: *test
   language: python
   python: &python_version "2.7"
+  jdk: oraclejdk8
   before_install:
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,8 @@ default_test_config: &default_test_config
   python: &python_version "2.7"
   before_install:
     - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
+    - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+    - ls /usr/local/lib/jvm
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288
@@ -101,6 +103,7 @@ default_cron_test_config: &default_cron_test_config
 linux_with_fuse: &linux_with_fuse
   before_install:
     - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
+    - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
     - sudo apt-get install -y pkg-config fuse libfuse-dev
     - sudo modprobe fuse
     - sudo chmod 666 /dev/fuse

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,6 @@ default_test_config: &default_test_config
   python: &python_version "2.7"
   before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64k
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288
@@ -102,7 +101,6 @@ default_cron_test_config: &default_cron_test_config
 linux_with_fuse: &linux_with_fuse
   before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
     - sudo apt-get install -y pkg-config fuse libfuse-dev
     - sudo modprobe fuse
     - sudo chmod 666 /dev/fuse

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ default_test_config: &default_test_config
   python: &python_version "2.7"
   before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64k
     - ls /usr/local/lib/jvm
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
@@ -103,7 +103,7 @@ default_cron_test_config: &default_cron_test_config
 linux_with_fuse: &linux_with_fuse
   before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
     - sudo apt-get install -y pkg-config fuse libfuse-dev
     - sudo modprobe fuse
     - sudo chmod 666 /dev/fuse

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,9 +82,8 @@ default_test_config: &default_test_config
   stage: *test
   language: python
   python: &python_version "2.7"
-  jdk: oraclejdk8
   before_install:
-    - update-java-alternatives -l
+    - update-java-alternatives -l && 1
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,8 +83,6 @@ default_test_config: &default_test_config
   python: &python_version "2.7"
   before_install:
     - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
-    - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-    - ls /usr/local/lib/jvm
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288
@@ -103,7 +101,6 @@ default_cron_test_config: &default_cron_test_config
 linux_with_fuse: &linux_with_fuse
   before_install:
     - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
-    - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
     - sudo apt-get install -y pkg-config fuse libfuse-dev
     - sudo modprobe fuse
     - sudo chmod 666 /dev/fuse

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ default_test_config: &default_test_config
   language: python
   python: &python_version "2.7"
   before_install:
-    - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
+    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
     - ls /usr/local/lib/jvm
     # Increase the max number of user watches to ensure that watchman is able to watch all
@@ -102,7 +102,7 @@ default_cron_test_config: &default_cron_test_config
 
 linux_with_fuse: &linux_with_fuse
   before_install:
-    - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
+    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
     - sudo apt-get install -y pkg-config fuse libfuse-dev
     - sudo modprobe fuse

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ default_test_config: &default_test_config
   python: &python_version "2.7"
   before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
+    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288
@@ -101,6 +102,7 @@ default_cron_test_config: &default_cron_test_config
 linux_with_fuse: &linux_with_fuse
   before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
+    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
     - sudo apt-get install -y pkg-config fuse libfuse-dev
     - sudo modprobe fuse
     - sudo chmod 666 /dev/fuse

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,6 @@ default_test_config: &default_test_config
   before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64k
-    - ls /usr/local/lib/jvm
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,10 @@ default_test_config: &default_test_config
   language: python
   python: &python_version "2.7"
   before_install:
-    - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
-    - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+    #- PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
+    #- JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+    - export JAVA_HOME=$HOME/oraclejdk8
+    - $TRAVIS_BUILD_DIR/install-jdk.sh --install oraclejdk8 --target $JAVA_HOME
     - ls /usr/local/lib/jvm
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ stages:
 
 default_test_config: &default_test_config
   os: linux
-  dist: trusty
+  dist: xenial
   sudo: required
   addons:
     apt:
@@ -301,7 +301,7 @@ matrix:
     - <<: *linux_with_fuse
       name: "Rust Tests Linux"
       os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       stage: *test
       language: python
@@ -332,7 +332,7 @@ matrix:
     - <<: *linux_with_fuse
       name: "Rust Clippy on Linux"
       os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       stage: *test
       language: python
@@ -347,7 +347,7 @@ matrix:
     - <<: *linux_with_fuse
       name: "Cargo audit"
       os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       stage: *cron
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,15 +78,13 @@ default_test_config: &default_test_config
         - python-dev
         - openssl
         - libssl-dev
-        - default-jdk
   stage: *test
   language: python
   python: &python_version "2.7"
   before_install:
     - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
     - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-    - java -version
-    - ls /usr/local/lib/ | grep jvm
+    - ls /usr/local/lib/jvm
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288
@@ -104,6 +102,8 @@ default_cron_test_config: &default_cron_test_config
 
 linux_with_fuse: &linux_with_fuse
   before_install:
+    - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
+    - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
     - sudo apt-get install -y pkg-config fuse libfuse-dev
     - sudo modprobe fuse
     - sudo chmod 666 /dev/fuse

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_compile.py
@@ -74,4 +74,7 @@ class BaseZincCompileJDKTest(TaskTestBase):
   def test_hermetic_jdk_being_underlying_dist(self):
     context = self.context(target_roots=[])
     zinc = Zinc.Factory.global_instance().create(context.products, NailgunTaskBase.HERMETIC)
-    self.assertFalse(os.path.islink(zinc.dist.home))
+    self.assertFalse(
+      os.path.islink(zinc.dist.home),
+      "Expected {} to not be a link, it was.".format(zinc.dist.home)
+    )


### PR DESCRIPTION
Travis released Xenial (16.04) (see https://changelog.travis-ci.com/ubuntu-xenial-16-04-build-environment-is-here!-79690) This PR moves us to this new image. 

The two major changes are:
- Switch to Python 3.5 in CI.
This coincides with prior discussions in Slack that we want to target Python 3.5 as the minimum Python 3 version. This is to give us access to native type hints and async/await syntax, along with general improvements such as fixing the `shutil` bug identified in https://github.com/pantsbuild/pants/pull/6882.

- Switch to openjdk over oraclejdk. This is mostly because travis only bakes version 10 and 11 of the oracle jdk and has removed all the tooling to get other versions of that jdk. While image comes with version 8 of the openjdk.

