### PR TITLE
[WIP] use graal native-image to create native images of jvm tools for performance increases in certain workflows

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -446,3 +446,7 @@ enable_libc_search: True
 
 [sourcefile-validation]
 config: @build-support/regexes/config.yaml
+detail_level: nonmatching
+
+[build-native-image]
+compiler_option_sets: ['image-build-debug']

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -6,6 +6,8 @@ from pants.backend.jvm.ossrh_publication_metadata import (Developer, License,
                                                           OSSRHPublicationMetadata, Scm)
 from pants.backend.jvm.repository import Repository as repo
 from pants.backend.jvm.scala_artifact import ScalaArtifact
+from pants.backend.jvm.subsystems.graal import BuildNativeImage
+from pants.backend.jvm.subsystems.graal import rules as graal_rules
 from pants.backend.jvm.subsystems.jar_dependency_management import JarDependencyManagementSetup
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.subsystems.scoverage_platform import ScoveragePlatform
@@ -138,7 +140,7 @@ def build_file_aliases():
 
 
 def global_subsystems():
-  return (ScalaPlatform, ScoveragePlatform, )
+  return (ScalaPlatform, ScoveragePlatform, BuildNativeImage,)
 
 
 # TODO https://github.com/pantsbuild/pants/issues/604 register_goals
@@ -228,3 +230,7 @@ def register_goals():
   task(name='test-jvm-prep-command', action=RunTestJvmPrepCommand).install('test', first=True)
   task(name='binary-jvm-prep-command', action=RunBinaryJvmPrepCommand).install('binary', first=True)
   task(name='compile-jvm-prep-command', action=RunCompileJvmPrepCommand).install('compile', first=True)
+
+
+def rules():
+  return graal_rules()

--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -178,3 +178,20 @@ python_library(
     'src/python/pants/util:dirutil',
   ],
 )
+
+python_library(
+  name='graal',
+  sources=['graal.py'],
+  dependencies=[
+    'src/python/pants/backend/native/config',
+    'src/python/pants/backend/native/subsystems',
+    'src/python/pants/base:build_environment',
+    'src/python/pants/base:hash_utils',
+    'src/python/pants/binaries',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
+    'src/python/pants/util:process_handler',
+    'src/python/pants/util:strutil',
+  ],
+)

--- a/src/python/pants/backend/jvm/subsystems/graal.py
+++ b/src/python/pants/backend/jvm/subsystems/graal.py
@@ -1,0 +1,267 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+import os
+from builtins import str
+
+from future.utils import binary_type
+
+from pants.backend.native.config.environment import Platform
+from pants.backend.native.subsystems.native_toolchain import GCCCToolchain, NativeToolchain
+from pants.binaries.binary_tool import NativeTool
+from pants.binaries.binary_util import BinaryToolUrlGenerator
+from pants.engine.fs import Digest, MergedDirectories, Snapshot, rooted_toplevel_globs_for_paths
+from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.rules import RootRule, rule
+from pants.engine.selectors import Get, Params
+from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
+from pants.subsystem.subsystem import Subsystem
+from pants.util.memo import memoized_method
+from pants.util.meta import classproperty
+from pants.util.objects import datatype, string_list, string_type
+from pants.util.strutil import safe_shlex_join, safe_shlex_split
+
+
+logger = logging.getLogger(__name__)
+
+
+class GraalCEUrlGenerator(BinaryToolUrlGenerator):
+
+  _DIST_URL_FMT = 'https://github.com/oracle/graal/releases/download/vm-{version}/{base}'
+  _ARCHIVE_BASE_FMT = 'graalvm-ce-{version}-{system_id}-amd64.tar.gz'
+  _SYSTEM_ID = {
+    'mac': 'macos',
+    'linux': 'linux',
+  }
+
+  def generate_urls(self, version, host_platform):
+    system_id = self._SYSTEM_ID[host_platform.os_name]
+    archive_basename = self._ARCHIVE_BASE_FMT.format(version=version, system_id=system_id)
+    return [self._DIST_URL_FMT.format(version=version, base=archive_basename)]
+
+
+class GraalCE(NativeTool):
+
+  options_scope = 'graal'
+  default_version = '1.0.0-rc15'
+  archive_type = 'tgz'
+
+  def get_external_url_generator(self):
+    return GraalCEUrlGenerator()
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(GraalCE, cls).subsystem_dependencies() + (
+      NativeToolchain.scoped(cls),
+    )
+
+  @memoized_method
+  def select(self, context=None):
+    unpacked_base_path = super(GraalCE, self).select(context=context)
+    trailing_containing_dirs = Platform.current.resolve_for_enum_variant({
+      'darwin': ['Contents', 'home'],
+      'linux': [],
+    })
+    return os.path.join(
+      unpacked_base_path,
+      'graalvm-ce-{}'.format(self.version()),
+      *trailing_containing_dirs)
+
+  @memoized_method
+  def create_native_image_build_environment(self, context):
+    gcc_c_toolchain, = context._scheduler.product_request(GCCCToolchain, tuple([
+      Params(Platform.current, NativeToolchain.scoped_instance(self)),
+    ]))
+    gcc_c_compiler = gcc_c_toolchain.c_toolchain.c_compiler
+    c_compiler_rooted_globs = rooted_toplevel_globs_for_paths(
+      gcc_c_compiler.path_entries
+      + gcc_c_compiler.runtime_library_dirs
+      + gcc_c_compiler.include_dirs
+    )
+
+    # TODO(#7127): make @memoized_method convert lists to tuples for hashing!
+    merged_snapshot = context._scheduler.capture_merged_snapshot(tuple(c_compiler_rooted_globs + [
+      self._as_rooted_glob(context)
+    ]))
+    native_image_exe_path = os.path.realpath(os.path.join(self.select(), 'bin', 'native-image'))
+    return NativeImageBuildEnvironment(
+      merged_directories=merged_snapshot.directory_digest,
+      # TODO: assert this is found as one of the .files in the merged snapshot?!
+      native_image_tool_relpath=os.path.relpath(native_image_exe_path, self.select()),
+    )
+
+
+class BuildNativeImage(Subsystem, CompilerOptionSetsMixin):
+
+  options_scope = 'build-native-image'
+
+  @classmethod
+  def register_options(cls, register):
+    super(BuildNativeImage, cls).register_options(register)
+    cls.register_compiler_option_sets_options(register)
+
+    register('--max-heap-size', advanced=True,
+             default='4g',
+             help='The -Xmx argument provided to the native-image tool as it builds. '
+                  'This value overrides any -Xmx value provided to in other jvm options.')
+    register('--options', type=list, member_type=str,
+             fingerprint=True, default=cls._default_cmdline_args,
+             help='Arguments that are always passed to the native-image command line.')
+    register('--compiler-option-sets', type=list, member_type=str,
+             fingerprint=True, default=[],
+             help='The "compiler_option_sets" value for building native images of this jvm tool.')
+
+  @classproperty
+  def get_compiler_option_sets_enabled_default_value(cls):
+    return {
+      'image-build-debug': [
+        '--verbose',
+        '--no-server',
+        '-H:+ReportExceptionStackTraces',
+      ],
+      'release': ['-O9'],
+    }
+
+  @classproperty
+  def get_compiler_option_sets_disabled_default_value(cls):
+    return {
+      'release': ['-O0'],
+    }
+
+  @classproperty
+  def _default_cmdline_args(cls):
+    return [
+      '--enable-all-security-services',
+      '--allow-incomplete-classpath',
+      '--report-unsupported-elements-at-runtime',
+    ]
+
+  def generate_native_image_build_argv(self, tool_classpath, main_class, extra_args, exe_relpath,
+                                       output_file_name):
+    shlexed_options = [
+      opt
+      for el in self.get_options().options
+      for opt in safe_shlex_split(el)
+    ]
+
+    merged_option_sets = self.get_merged_args_for_compiler_option_sets(
+      self.get_options().compiler_option_sets)
+
+    return (
+      [
+        exe_relpath,
+        '-classpath', os.pathsep.join(tool_classpath),
+        main_class,
+        '-H:Name={}'.format(output_file_name),
+        '-J-Xmx{}'.format(self.get_options().max_heap_size),
+      ]
+      + shlexed_options
+      + merged_option_sets
+      + list(extra_args))
+
+
+class NativeImageBuildRequest(datatype([
+    ('tool_classpath_snapshot', Snapshot),
+    ('main_class', string_type),
+    ('extra_args', string_list),
+])):
+  """Any configuration that needs to be provided to native-image to successfully build.
+
+  While many jvm tools work out of the box with native-image, some require additional configuration
+  to build correctly. Moreover, some may build correctly, but experience failures at runtime: see
+  https://medium.com/graalvm/understanding-class-initialization-in-graalvm-native-image-generation-d765b7e4d6ed.
+
+  More complex configuration such as substitutions can be embedded in the jar itself as in
+  https://github.com/pantsbuild/pants/pull/7506, but that requires the tool's maintainer to have
+  published jars with this configuration.
+
+  For tools which don't work out of the box and haven't made changes upstream to support
+  native-image, we can still use them in pants by providing an instance of this class to produce the
+  necessary configuration.
+  """
+
+  def __new__(cls, tool_classpath_snapshot, main_class, extra_args=None):
+    return super(NativeImageBuildRequest, cls).__new__(cls, tool_classpath_snapshot, main_class,
+                                                       extra_args=extra_args or [])
+
+
+class NativeImageBuildEnvironment(datatype([
+    ('merged_directories', Digest),
+    ('native_image_tool_relpath', string_type),
+    # TODO: gcc relpath?!
+])): pass
+
+
+class CompiledNativeImage(datatype([
+    ('file_path', string_type),
+    ('built_image', Digest),
+    ('stdout', binary_type),
+    ('stderr', binary_type),
+])): pass
+
+
+@rule(CompiledNativeImage, [
+  Platform,
+  BuildNativeImage,
+  NativeImageBuildEnvironment,
+  NativeImageBuildRequest,
+])
+def build_native_image(platform, build_native_image, native_image_build_env, native_image_config):
+  graal_digest = native_image_build_env.merged_directories
+  native_image_tool_relpath = native_image_build_env.native_image_tool_relpath
+
+  tool_classpath_snapshot = native_image_config.tool_classpath_snapshot
+  main_class = native_image_config.main_class
+  extra_args = native_image_config.extra_args
+
+  image_output_file_name = '{}-pants-native-image'.format(main_class)
+
+  all_digests = yield Get(
+    Digest,
+    MergedDirectories(directories=tuple([
+      graal_digest,
+      tool_classpath_snapshot.directory_digest,
+    ]))
+  )
+
+  argv = build_native_image.generate_native_image_build_argv(
+    tool_classpath_snapshot.files, main_class, extra_args, native_image_tool_relpath,
+    image_output_file_name)
+
+  sub_commands = []
+  if platform == Platform.darwin:
+    # native-image will specifically #include <CoreFoundation/CoreFoundation.h>
+    # and we want to support that convention, so this uses a top-level 'Headers/' dir populated by
+    # XCodeCLITools, and symlinks it to the desired 'CoreFoundation/' include directory.
+    sub_commands.append('/bin/ln -sfv ../Headers include/CoreFoundation')
+  sub_commands.append('PATH=$(pwd)/bin CPATH=$(pwd)/include {}'.format(safe_shlex_join(argv)))
+
+  result = yield Get(ExecuteProcessResult, ExecuteProcessRequest(
+    argv=tuple([
+      '/bin/sh', '-c',
+      ' && '.join(sub_commands),
+    ]),
+    input_files=all_digests,
+    description='build native-image for {}'.format(main_class),
+    output_files=tuple([image_output_file_name]),
+  ))
+
+  yield CompiledNativeImage(
+    file_path=image_output_file_name,
+    built_image=result.output_directory_digest,
+    stdout=result.stdout,
+    stderr=result.stderr,
+  )
+
+
+def rules():
+  return [
+    RootRule(BuildNativeImage),
+    RootRule(NativeImageBuildEnvironment),
+    RootRule(NativeImageBuildRequest),
+    build_native_image
+  ]

--- a/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
@@ -8,7 +8,7 @@ from future.utils import text_type
 
 from pants.base.exceptions import TaskError
 from pants.engine.fs import PathGlobs, PathGlobsAndRoot
-from pants.java.distribution.distribution import DistributionLocator
+from pants.java.distribution.distribution import DistributionLocator, HermeticDistribution
 from pants.option.custom_types import target_option
 from pants.util.memo import memoized_staticmethod
 from pants.util.objects import datatype
@@ -177,6 +177,10 @@ class JvmToolMixin:
       # Use default until told otherwise.
       self.set_distribution()
     return self._dist
+
+  @property
+  def hermetic_dist(self):
+    return HermeticDistribution.create(self.dist)
 
   @classmethod
   def tool_jar_from_products(cls, products, key, scope):

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -540,6 +540,7 @@ python_library(
     'src/python/pants/java/jar',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
+    'src/python/pants/backend/jvm/subsystems:graal',
     'src/python/pants/java/distribution:distribution',
     'src/python/pants/java:executor',
     'src/python/pants/java:nailgun_executor',
@@ -665,12 +666,14 @@ python_library(
   sources = ['scalafmt.py'],
   dependencies = [
     ':rewrite_base',
+    'src/python/pants/backend/jvm/subsystems:graal',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
     'src/python/pants/java/jar',
     'src/python/pants/option',
     'src/python/pants/task',
+    'src/python/pants/util:collections',
   ]
 )
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -47,7 +47,7 @@ _JAVAC_PLUGIN_INFO_FILE = 'META-INF/services/com.sun.source.util.Plugin'
 _PROCESSOR_INFO_FILE = 'META-INF/services/javax.annotation.processing.Processor'
 
 
-class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
+class JvmCompile(NailgunTaskBase, CompilerOptionSetsMixin):
   """A common framework for JVM compilation.
 
   To subclass for a specific JVM language, implement the static values and methods
@@ -68,6 +68,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
+    cls.register_compiler_option_sets_options(register)
 
     register('--args', advanced=True, type=list,
              default=list(cls.get_args_default(register.bootstrap)), fingerprint=True,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -29,7 +29,7 @@ from pants.base.exceptions import TaskError
 from pants.base.worker_pool import WorkerPool
 from pants.base.workunit import WorkUnitLabel
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, PathGlobs, PathGlobsAndRoot
-from pants.java.distribution.distribution import DistributionLocator
+from pants.java.distribution.distribution import DistributionLocator, HermeticDistribution
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.option.ranked_value import RankedValue
 from pants.reporting.reporting_utils import items_to_report_element
@@ -880,41 +880,6 @@ class JvmCompile(NailgunTaskBase, CompilerOptionSetsMixin):
       local_distribution = JvmPlatform.preferred_jvm_distribution(settings_args, strict=False)
     return local_distribution
 
-  class _HermeticDistribution(object):
-    def __init__(self, home_path, distribution):
-      self._underlying = distribution
-      self._home = home_path
-
-    def find_libs(self, names):
-      underlying_libs = self._underlying.find_libs(names)
-      return [self._rehome(l) for l in underlying_libs]
-
-    def find_libs_path_globs(self, names):
-      libs_abs = self._underlying.find_libs(names)
-      libs_unrooted = [self._unroot_lib_path(l) for l in libs_abs]
-      path_globs = PathGlobsAndRoot(
-        PathGlobs(tuple(libs_unrooted)),
-        self._underlying.home)
-      return (libs_unrooted, path_globs)
-
-    @property
-    def java(self):
-      return os.path.join(self._home, 'bin', 'java')
-
-    @property
-    def home(self):
-      return self._home
-
-    @property
-    def underlying_home(self):
-      return self._underlying.home
-
-    def _unroot_lib_path(self, path):
-      return path[len(self._underlying.home)+1:]
-
-    def _rehome(self, l):
-      return os.path.join(self._home, self._unroot_lib_path(l))
-
   def _get_jvm_distribution(self):
     # TODO We may want to use different jvm distributions depending on what
     # java version the target expects to be compiled against.
@@ -924,7 +889,7 @@ class JvmCompile(NailgunTaskBase, CompilerOptionSetsMixin):
     return self.execution_strategy_enum.resolve_for_enum_variant({
       self.SUBPROCESS: lambda: local_distribution,
       self.NAILGUN: lambda: local_distribution,
-      self.HERMETIC: lambda: self._HermeticDistribution('.jdk', local_distribution),
+      self.HERMETIC: lambda: HermeticDistribution.create(local_distribution),
     })()
 
   def _default_double_check_cache_for_vts(self, vts):

--- a/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
@@ -2,7 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
+from pants.base.build_environment import get_buildroot
 from pants.task.task import TaskBase
+from pants.util.dirutil import fast_relpath_collection
+from pants.util.memo import memoized_method
 
 
 class JvmToolTaskMixin(JvmToolMixin, TaskBase):
@@ -66,3 +69,11 @@ class JvmToolTaskMixin(JvmToolMixin, TaskBase):
 
   def _scope(self, scope=None):
     return scope or self.options_scope
+
+  @memoized_method
+  def tool_classpath_snapshot(self, key, scope=None):
+    """???"""
+    cp_abs_paths = self.tool_classpath(key, scope=scope)
+    cp_rel_paths = fast_relpath_collection(cp_abs_paths, get_buildroot())
+    return self.digest_classpath_paths_synchronously(
+      tuple(cp_rel_paths), get_buildroot(), self.context._scheduler)

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -1,10 +1,16 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from abc import abstractmethod
+import os
+from abc import abstractmethod, abstractproperty
+
+from future.utils import text_type
 
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
+from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
+from pants.engine.fs import DirectoryToMaterialize, PathGlobs, PathGlobsAndRoot
+from pants.engine.isolated_process import ExecuteProcessRequest
 from pants.java.jar.jar_dependency import JarDependency
 from pants.option.custom_types import file_option
 from pants.task.fmt_task_mixin import FmtTaskMixin
@@ -22,7 +28,9 @@ class ScalaFmt(RewriteBase):
   def register_options(cls, register):
     super().register_options(register)
     register('--configuration', advanced=True, type=file_option, fingerprint=True,
-              help='Path to scalafmt config file, if not specified default scalafmt config used')
+             help='Path to scalafmt config file, if not specified default scalafmt config used')
+    register('--use-hermetic-execution', advanced=True, type=bool, default=False,
+             help='Execute scalafmt using the v2 engine process execution framework.')
 
     cls.register_jvm_tool(register,
                           'scalafmt',
@@ -43,6 +51,75 @@ class ScalaFmt(RewriteBase):
   @classmethod
   def implementation_version(cls):
     return super().implementation_version() + [('ScalaFmt', 5)]
+
+  def _execute_hermetic(self, targets):
+    classpath_snapshot = self.tool_classpath_snapshot('scalafmt')
+
+    source_snapshots = [
+      tgt.sources_snapshot(scheduler=self.context._scheduler)
+      for tgt in targets
+    ]
+
+    config_file = self.get_options().configuration
+    if config_file is not None:
+      config_rel_path = os.path.relpath(config_file, get_buildroot())
+      merged_snapshot = self.context._scheduler.capture_merged_snapshot(tuple([
+        PathGlobsAndRoot(
+          PathGlobs([config_rel_path]),
+          root=text_type(get_buildroot()),
+        )
+      ]))
+      config_args = ['--config', config_rel_path]
+    else:
+      merged_snapshot = None
+      config_args = []
+
+    merged_inputs = self.context._scheduler.merge_directories(tuple(
+      [classpath_snapshot.directory_digest]
+      + [snap.directory_digest for snap in source_snapshots]
+      + ([merged_snapshot.directory_digest] if merged_snapshot else [])))
+    rel_src_files = [
+      src_file
+      for snap in source_snapshots
+      for src_file in snap.files
+    ]
+
+    hermetic_jvm_dist = self.hermetic_dist
+
+    full_argv = ([
+      hermetic_jvm_dist.java,
+      '-classpath', os.pathsep.join(classpath_snapshot.files + classpath_snapshot.dirs),
+      'org.scalafmt.cli.Cli',
+    ] + config_args
+      + self.additional_args
+      + rel_src_files)
+    request = ExecuteProcessRequest(
+      argv=tuple(full_argv),
+      input_files=merged_inputs,
+      description='execute scalafmt via native-image',
+      output_files=tuple(rel_src_files),
+      # TODO: this argument could potentially be added automatically.
+      jdk_home=hermetic_jvm_dist.underlying_home
+    )
+    result = self.context.execute_process_synchronously_without_raising(
+      request,
+      'execute-scalafmt-hermetically',
+    )
+    if self.sideeffecting:
+      output_dir = self.get_options().output_dir or get_buildroot()
+      self.context._scheduler.materialize_directories(tuple([
+        DirectoryToMaterialize(
+          path=text_type(output_dir),
+          directory_digest=result.output_directory_digest,
+        ),
+        ]))
+    return self.process_result(result.exit_code)
+
+  def _execute_for(self, targets):
+    if self.get_options().use_hermetic_execution:
+      return self._execute_hermetic(targets)
+    else:
+      return super(ScalaFmt, self)._execute_for(targets)
 
   def invoke_tool(self, absolute_root, target_sources):
     # If no config file is specified use default scalafmt config.

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -6,15 +6,19 @@ from abc import abstractmethod, abstractproperty
 
 from future.utils import text_type
 
+from pants.backend.jvm.subsystems.graal import (BuildNativeImage, CompiledNativeImage, GraalCE,
+                                                NativeImageBuildRequest)
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.engine.fs import DirectoryToMaterialize, PathGlobs, PathGlobsAndRoot
 from pants.engine.isolated_process import ExecuteProcessRequest
+from pants.engine.selectors import Params
 from pants.java.jar.jar_dependency import JarDependency
 from pants.option.custom_types import file_option
 from pants.task.fmt_task_mixin import FmtTaskMixin
 from pants.task.lint_task_mixin import LintTaskMixin
+from pants.util.memo import memoized_property
 
 
 class ScalaFmt(RewriteBase):
@@ -31,6 +35,8 @@ class ScalaFmt(RewriteBase):
              help='Path to scalafmt config file, if not specified default scalafmt config used')
     register('--use-hermetic-execution', advanced=True, type=bool, default=False,
              help='Execute scalafmt using the v2 engine process execution framework.')
+    register('--use-hermetic-native-image', advanced=True, type=bool, default=False,
+             help='Use a Graal native-image to execute scalafmt in the v2 engine.')
 
     cls.register_jvm_tool(register,
                           'scalafmt',
@@ -39,6 +45,13 @@ class ScalaFmt(RewriteBase):
                                         name='scalafmt-cli_2.11',
                                         rev='1.5.1')
                           ])
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(ScalaFmt, cls).subsystem_dependencies() + (
+      BuildNativeImage.scoped(cls),
+      GraalCE.scoped(cls),
+    )
 
   @classmethod
   def target_types(cls):
@@ -52,8 +65,63 @@ class ScalaFmt(RewriteBase):
   def implementation_version(cls):
     return super().implementation_version() + [('ScalaFmt', 5)]
 
+  @memoized_property
+  def _native_image_build_request(self):
+    """Delay the initialization of the scalafmt class which makes relative paths absolute.
+
+    By default with native-image, if provided relative paths to source files, scalafmt will read
+    from the 'user.dir' property active at image build time, as native-image executes static
+    initializers by default. This behavior can be delayed to runtime, but also tends to require
+    searching for other classes which depend on a run-time value and marking them for delayed
+    initialization as well: see
+    https://medium.com/graalvm/understanding-class-initialization-in-graalvm-native-image-generation-d765b7e4d6ed.
+
+    Here, we ensure that the System.getProperty("user.dir") access is delayed to runtime, which
+    allows passing in relative file paths to scalafmt. This allows it to be executed hermetically.
+    """
+    return NativeImageBuildRequest(
+      tool_classpath_snapshot=self.tool_classpath_snapshot('scalafmt'),
+      main_class='org.scalafmt.cli.Cli',
+      extra_args=tuple([
+        '--delay-class-initialization-to-runtime=org.scalafmt.util.AbsoluteFile$',
+        '--delay-class-initialization-to-runtime=org.scalafmt.cli.CommonOptions$',
+        '--delay-class-initialization-to-runtime=org.scalafmt.cli.CliOptions$',
+        '--delay-class-initialization-to-runtime=org.scalafmt.cli.Cli$',
+        '--delay-class-initialization-to-runtime=org.scalafmt.util.GitOps$',
+      ]),
+    )
+
+  @memoized_property
+  def _native_image_build_environment(self):
+    return GraalCE.scoped_instance(self).create_native_image_build_environment(self.context)
+
+  @memoized_property
+  def _scalafmt_built_native_image(self):
+    with self.context.new_workunit('build-native-image') as workunit:
+      compiled_native_image, = self.context._scheduler.product_request(CompiledNativeImage, tuple([
+        Params(
+          # TODO: we shouldn't need to do this! the optionable_rule() appears to not be working?!
+          BuildNativeImage.scoped_instance(self),
+          self._native_image_build_environment,
+          self._native_image_build_request),
+      ]))
+      workunit.output('stdout').write(compiled_native_image.stdout)
+      workunit.output('stderr').write(compiled_native_image.stderr)
+      return compiled_native_image
+
   def _execute_hermetic(self, targets):
-    classpath_snapshot = self.tool_classpath_snapshot('scalafmt')
+    if self.get_options().use_hermetic_native_image:
+      native_image = self._scalafmt_built_native_image
+      base_argv = ['./{}'.format(native_image.file_path)]
+      build_env_digest = native_image.built_image
+    else:
+      classpath_snapshot = self.tool_classpath_snapshot('scalafmt')
+      base_argv = [
+        self.hermetic_dist.java,
+        '-classpath', os.pathsep.join(classpath_snapshot.files + classpath_snapshot.dirs),
+        'org.scalafmt.cli.Cli',
+      ]
+      build_env_digest = classpath_snapshot.directory_digest
 
     source_snapshots = [
       tgt.sources_snapshot(scheduler=self.context._scheduler)
@@ -75,7 +143,7 @@ class ScalaFmt(RewriteBase):
       config_args = []
 
     merged_inputs = self.context._scheduler.merge_directories(tuple(
-      [classpath_snapshot.directory_digest]
+      [build_env_digest]
       + [snap.directory_digest for snap in source_snapshots]
       + ([merged_snapshot.directory_digest] if merged_snapshot else [])))
     rel_src_files = [
@@ -84,22 +152,17 @@ class ScalaFmt(RewriteBase):
       for src_file in snap.files
     ]
 
-    hermetic_jvm_dist = self.hermetic_dist
-
-    full_argv = ([
-      hermetic_jvm_dist.java,
-      '-classpath', os.pathsep.join(classpath_snapshot.files + classpath_snapshot.dirs),
-      'org.scalafmt.cli.Cli',
-    ] + config_args
-      + self.additional_args
-      + rel_src_files)
+    full_argv = (base_argv
+                 + config_args
+                 + self.additional_args
+                 + rel_src_files)
     request = ExecuteProcessRequest(
       argv=tuple(full_argv),
       input_files=merged_inputs,
       description='execute scalafmt via native-image',
       output_files=tuple(rel_src_files),
       # TODO: this argument could potentially be added automatically.
-      jdk_home=hermetic_jvm_dist.underlying_home
+      jdk_home=self.hermetic_dist.underlying_home
     )
     result = self.context.execute_process_synchronously_without_raising(
       request,

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -14,7 +14,7 @@ from pants.util.objects import enum
 class ToolchainVariant(enum(['gnu', 'llvm'])): pass
 
 
-class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsystem):
+class NativeBuildStep(Subsystem, CompilerOptionSetsMixin, MirroredTargetOptionMixin):
   """Settings which are specific to a target and do not need to be the same for compile and link."""
 
   options_scope = 'native-build-step'
@@ -27,6 +27,7 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
+    cls.register_compiler_option_sets_options(register)
 
     register('--compiler-option-sets', advanced=True, default=(), type=list,
              fingerprint=True,

--- a/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
+++ b/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
@@ -54,6 +54,7 @@ class XCodeCLITools(Subsystem):
     '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr',
     '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/9.1.0',
     '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr',
+    '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks',
   ]
 
   class XCodeToolsUnavailable(Exception):
@@ -121,7 +122,13 @@ class XCodeCLITools(Subsystem):
 
   @memoized_method
   def include_dirs(self, include_cpp_inc=False):
-    return self._get_existing_subdirs('include')
+    normal_inc_dirs = self._get_existing_subdirs('include')
+    # Some tools (like native-image) will specifically #include <CoreFoundation/CoreFoundation.h>
+    # and we want to support that convention, so this populates a top-level 'Headers/' dir when
+    # used with hermetic execution.
+    core_foundation_header_dirs = self._get_existing_subdirs(
+      'CoreFoundation.framework/Versions/A/Headers')
+    return normal_inc_dirs + core_foundation_header_dirs
 
   @memoized_method
   def assembler(self):

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -9,7 +9,8 @@ from pants.binaries.binary_util import BinaryRequest, BinaryUtil
 from pants.engine.fs import PathGlobs, PathGlobsAndRoot
 from pants.fs.archive import XZCompressedTarArchiver, create_archiver
 from pants.subsystem.subsystem import Subsystem
-from pants.util.memo import memoized_method, memoized_property
+from pants.util.collections import assert_single_element
+from pants.util.memo import memoized_classmethod, memoized_method, memoized_property
 
 
 logger = logging.getLogger(__name__)
@@ -201,6 +202,34 @@ class BinaryToolBase(Subsystem):
     with self._snapshot_lock:
       return self._hackily_snapshot_exclusive(context)
 
+  def _as_rooted_glob(self, context):
+    extracted = self.select(context=context)
+    # TODO: ???/some are dirs and some are files
+    if os.path.isdir(extracted):
+      rooted_glob = PathGlobsAndRoot(
+        path_globs=PathGlobs(include=['**/*']),
+        root=text_type(extracted),
+        # TODO: consider `digest_hint`!
+      )
+    else:
+      assert os.path.isfile(extracted)
+      rooted_glob = PathGlobsAndRoot(
+        path_globs=PathGlobs(include=[os.path.basename(extracted)]),
+        root=text_type(os.path.dirname(extracted)),
+      )
+    return rooted_glob
+
+  @memoized_classmethod
+  def _hackily_snapshot_multiple(self, binary_tool_instances, context):
+    """???
+
+    ???/This needs to exist to efficiently get multiple snapshots from multiple tools at once (???)
+    """
+    # ???/convert all the binary tools into globs with their own roots
+    globs_with_roots = [tool._as_rooted_glob(context) for tool in binary_tool_instances]
+    # Request all the snapshots at once, then return a single merged digest.
+    return context._scheduler.capture_merged_snapshot(tuple(globs_with_roots))
+
 
 class NativeTool(BinaryToolBase):
   """A base class for native-code tools.
@@ -216,6 +245,12 @@ class Script(BinaryToolBase):
   :API: public
   """
   platform_dependent = False
+
+  def hackily_snapshot(self, context):
+    snapshot = self._hackily_snapshot_multiple([self], context=context)
+    assert (not snapshot.dirs)
+    script_relpath = assert_single_element(snapshot.files)
+    return (script_relpath, snapshot)
 
 
 class XZ(NativeTool):

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -385,6 +385,8 @@ class BinaryUtil:
   def _get_urls(self, url_generator, binary_request):
     return url_generator.generate_urls(binary_request.version, self._host_platform())
 
+  # TODO(#7517): make a `host_platform` arg which defaults to self._host_platform() in order to
+  # resolve tools for a separate target platform for cross-compilation via remote execution!
   def select(self, binary_request):
     """Fetches a file, unpacking it if necessary."""
 

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -1,14 +1,21 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import logging
 import os
 
+from future.utils import bytes, str
+
+from pants.base.build_environment import get_buildroot
 from pants.engine.objects import Collection
 from pants.engine.rules import RootRule
 from pants.option.custom_types import GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
-from pants.util.dirutil import maybe_read_file, safe_delete, safe_file_dump
+from pants.util.dirutil import fast_relpath_optional, maybe_read_file, safe_delete, safe_file_dump
 from pants.util.objects import Exactly, datatype
+
+
+logger = logging.getLogger(__name__)
 
 
 class FileContent(datatype([('path', str), ('content', bytes)])):
@@ -173,6 +180,54 @@ EMPTY_SNAPSHOT = Snapshot(
   files=(),
   dirs=()
 )
+
+
+def _pathglob_for(filename, root=None):
+  root = root or get_buildroot()
+  return PathGlobsAndRoot(
+    PathGlobs(tuple([fast_relpath_optional(filename, root)])),
+    str(root))
+
+
+def digest_file_paths(paths, scheduler, root=None):
+  """Generate digests for a set of file paths.
+
+  :rtype: list of (path, digest)
+  """
+  if not paths:
+    return tuple()
+  # list of path ->
+  # list of (path, optional<digest>) ->
+  path_and_digests = [(p, Digest.load(os.path.dirname(p))) for p in paths]
+  # partition: list of path, list of tuples
+  paths_without_digests = [p for (p, d) in path_and_digests if not d]
+  if paths_without_digests:
+    logger.debug('Expected to find digests for {}, capturing them.'
+                           .format(paths_without_digests))
+  paths_with_digests = [(p, d) for (p, d) in path_and_digests if d]
+  # list of path -> list path, captured snapshot -> list of path with digest
+  snapshots = scheduler.capture_snapshots(
+    tuple(_pathglob_for(p, root=root) for p in paths_without_digests))
+  captured_paths_and_digests = [
+    (p, s.directory_digest)
+    for (p, s) in zip(paths_without_digests, snapshots)
+  ]
+  return paths_with_digests + captured_paths_and_digests
+
+
+def rooted_toplevel_globs_for_paths(absolute_paths):
+  """???"""
+  return [
+    PathGlobsAndRoot(
+      PathGlobs(include=[
+        os.path.basename(file_or_dir_path)
+        if os.path.isfile(file_or_dir_path)
+        else '{}/**'.format(os.path.basename(file_or_dir_path))
+      ]),
+      root=str(os.path.dirname(file_or_dir_path)),
+    )
+    for file_or_dir_path in absolute_paths
+  ]
 
 
 def create_fs_rules():

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -10,6 +10,8 @@ import traceback
 from textwrap import dedent
 from types import GeneratorType
 
+from twitter.common.collections import OrderedSet
+
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE
 from pants.base.project_tree import Dir, File, Link
 from pants.build_graph.address import Address
@@ -283,6 +285,68 @@ class Scheduler:
       self._native.lib.nodes_destroy(raw_roots)
     return roots
 
+  def capture_snapshots(self, path_globs_and_roots):
+    """Synchronously captures Snapshots for each matching PathGlobs rooted at a its root directory.
+
+    This is a blocking operation, and should be avoided where possible.
+
+    :param path_globs_and_roots tuple<PathGlobsAndRoot>: The PathGlobs to capture, and the root
+           directory relative to which each should be captured.
+    :returns: A tuple of Snapshots.
+    """
+    result = self._native.lib.capture_snapshots(
+      self._scheduler,
+      self._to_value(_PathGlobsAndRootCollection(path_globs_and_roots)),
+    )
+    return self._raise_or_return(result)
+
+  def merge_directories(self, directory_digests):
+    """Merges any number of directories.
+
+    :param directory_digests: Tuple of DirectoryDigests.
+    :return: A Digest.
+    """
+    result = self._native.lib.merge_directories(
+      self._scheduler,
+      self._to_value(_DirectoryDigests(directory_digests)),
+    )
+    return self._raise_or_return(result)
+
+  def capture_merged_snapshot(self, path_globs_and_roots):
+    """???"""
+    # TODO: ...can we just use lists here?
+    digests = OrderedSet()
+    files = OrderedSet()
+    dirs = OrderedSet()
+    for snapshot in self.capture_snapshots(path_globs_and_roots):
+      digests.add(snapshot.directory_digest)
+      files.update(snapshot.files)
+      dirs.update(snapshot.dirs)
+
+    merged_digest = self.merge_directories(tuple(digests))
+    return Snapshot(
+      directory_digest=merged_digest,
+      files=tuple(files),
+      dirs=tuple(dirs),
+    )
+
+  def materialize_directories(self, directories_paths_and_digests):
+    """Creates the specified directories on the file system.
+
+    :param directories_paths_and_digests tuple<DirectoryToMaterialize>: Tuple of the path and
+           digest of the directories to materialize.
+    :returns: Nothing or an error.
+    """
+    # Ensure there isn't more than one of the same directory paths and paths do not have the same prefix.
+    dir_list = [dpad.path for dpad in directories_paths_and_digests]
+    check_no_overlapping_paths(dir_list)
+
+    result = self._native.lib.materialize_directories(
+      self._scheduler,
+      self._to_value(_DirectoriesToMaterialize(directories_paths_and_digests)),
+    )
+    return self._raise_or_return(result)
+
   def lease_files_in_graph(self):
     self._native.lib.lease_files_in_graph(self._scheduler)
 
@@ -545,6 +609,9 @@ class SchedulerSession:
       self._scheduler._to_value(_DirectoryDigests(directory_digests)),
     )
     return self._scheduler._raise_or_return(result)
+
+  def capture_merged_snapshot(self, path_globs_and_roots):
+    return self._scheduler.capture_merged_snapshot(path_globs_and_roots)
 
   def materialize_directories(self, directories_paths_and_digests):
     """Creates the specified directories on the file system.

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -18,6 +18,7 @@ from pants.goal.products import Products
 from pants.goal.workspace import ScmWorkspace
 from pants.process.lock import OwnerPrintingInterProcessFileLock
 from pants.source.source_root import SourceRootConfig
+from pants.util.strutil import safe_shlex_join
 
 
 class Context:
@@ -391,7 +392,7 @@ class Context:
     with self.new_workunit(
       name=name,
       labels=labels,
-      cmd=' '.join(execute_process_request.argv),
+      cmd=safe_shlex_join(execute_process_request.argv),
     ) as workunit:
       result = self._scheduler.product_request(FallibleExecuteProcessResult, [execute_process_request])[0]
       workunit.output("stdout").write(result.stdout)

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -12,6 +12,7 @@ from collections import namedtuple
 from contextlib import contextmanager
 
 from pants.base.revision import Revision
+from pants.engine.fs import PathGlobs, PathGlobsAndRoot
 from pants.java.util import execute_java, execute_java_async
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import temporary_dir
@@ -631,3 +632,44 @@ class DistributionLocator(Subsystem):
     return _Locator(environment,
                     self.get_options().minimum_version,
                     self.get_options().maximum_version)
+
+
+class HermeticDistribution(object):
+
+  @classmethod
+  def create(cls, local_dist):
+    return cls('.jdk', local_dist)
+
+  def __init__(self, home_path, distribution):
+    self._underlying = distribution
+    self._home = home_path
+
+  def find_libs(self, names):
+    underlying_libs = self._underlying.find_libs(names)
+    return [self._rehome(l) for l in underlying_libs]
+
+  def find_libs_path_globs(self, names):
+    libs_abs = self._underlying.find_libs(names)
+    libs_unrooted = [self._unroot_lib_path(l) for l in libs_abs]
+    path_globs = PathGlobsAndRoot(
+      PathGlobs(tuple(libs_unrooted)),
+      text_type(self._underlying.home))
+    return (libs_unrooted, path_globs)
+
+  @property
+  def java(self):
+    return os.path.join(self._home, 'bin', 'java')
+
+  @property
+  def home(self):
+    return self._home
+
+  @property
+  def underlying_home(self):
+    return self._underlying.home
+
+  def _unroot_lib_path(self, path):
+    return path[len(self._underlying.home)+1:]
+
+  def _rehome(self, l):
+    return os.path.join(self._home, self._unroot_lib_path(l))

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -16,7 +16,7 @@ from pants.java.nailgun_protocol import ChunkType, MaybeShutdownSocket, NailgunP
 from pants.util.dirutil import safe_file_dump
 from pants.util.osutil import safe_kill
 from pants.util.socket import RecvBufferedSocket
-from pants.util.strutil import ensure_binary, safe_shlex_join
+from pants.util.strutil import safe_shlex_join
 
 
 logger = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ class NailgunClientSession(NailgunProtocol, NailgunProtocol.TimeoutProvider):
     """Write a payload to a given fd (if provided) and flush the fd."""
     try:
       if payload:
-        fd.write(ensure_binary(payload))
+        fd.write(payload.decode('utf-8'))
       fd.flush()
     except (IOError, OSError) as e:
       # If a `Broken Pipe` is encountered during a stdio fd write, we're headless - bail.

--- a/src/python/pants/java/util.py
+++ b/src/python/pants/java/util.py
@@ -13,7 +13,7 @@ from pants.java.jar.manifest import Manifest
 from pants.java.nailgun_executor import NailgunExecutor
 from pants.util.contextutil import open_zip, temporary_file
 from pants.util.dirutil import safe_concurrent_rename, safe_mkdir, safe_mkdtemp
-from pants.util.process_handler import ProcessHandler, SubprocessProcessHandler
+from pants.util.process_handler import SubprocessProcessHandler
 
 
 logger = logging.getLogger(__name__)
@@ -201,10 +201,11 @@ def execute_runner_async(runner, workunit_factory=None, workunit_name=None, work
                            stderr=workunit.output('stderr'),
                            cwd=cwd)
 
-    class WorkUnitProcessHandler(ProcessHandler):
-      def wait(_, timeout=None):
+    class WorkUnitProcessHandler(SubprocessProcessHandler):
+
+      def wait(self, timeout=None):
         try:
-          ret = process.wait(timeout=timeout)
+          ret = super(WorkUnitProcessHandler, self).wait(timeout=timeout)
           workunit.set_outcome(WorkUnit.FAILURE if ret else WorkUnit.SUCCESS)
           workunit_generator.__exit__(None, None, None)
           return ret
@@ -212,16 +213,7 @@ def execute_runner_async(runner, workunit_factory=None, workunit_name=None, work
           if not workunit_generator.__exit__(*sys.exc_info()):
             raise
 
-      def kill(_):
-        return process.kill()
-
-      def terminate(_):
-        return process.terminate()
-
-      def poll(_):
-        return process.poll()
-
-    return WorkUnitProcessHandler()
+    return WorkUnitProcessHandler(process)
 
 
 def relativize_classpath(classpath, root_dir, followlinks=True):

--- a/src/python/pants/option/compiler_option_sets_mixin.py
+++ b/src/python/pants/option/compiler_option_sets_mixin.py
@@ -13,8 +13,7 @@ class CompilerOptionSetsMixin:
   """A mixin for language-scoped that support compiler option sets."""
 
   @classmethod
-  def register_options(cls, register):
-    super().register_options(register)
+  def register_compiler_option_sets_options(cls, register):
     register('--compiler-option-sets-enabled-args', advanced=True, type=dict, fingerprint=True,
              default=cls.get_compiler_option_sets_enabled_default_value,
              help='Extra compiler args to use for each enabled option set.')

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -56,6 +56,11 @@ def fast_relpath_optional(path, start):
     return path[pref_end+1:]
 
 
+def fast_relpath_collection(collection, root):
+  """Apply a prefix-based relpath to an iterable of file paths."""
+  return [fast_relpath(c, root) or c for c in collection]
+
+
 def safe_mkdir(directory, clean=False):
   """Ensure a directory is present.
 

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -307,6 +307,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
           })
           .unwrap_or_else(|| vec![])
       })
+      .or_else(|_e| future::ok(vec![]))
       .and_then(move |link_globs| {
         future::result(PathGlobs::from_globs(link_globs))
           .map_err(|e| Self::mk_error(e.as_str()))

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -365,16 +365,12 @@ impl PathGlob {
       // The resulting symbolic path will continue to contain a literal `..`.
       let mut canonical_dir_parent = canonical_dir;
       let mut symbolic_path_parent = symbolic_path;
-      if !canonical_dir_parent.0.pop() {
-        let mut symbolic_path = symbolic_path_parent;
-        symbolic_path.extend(parts.iter().map(Pattern::as_str));
-        return Err(format!(
-          "Globs may not traverse outside of the buildroot: {:?}",
-          symbolic_path,
-        ));
+      if canonical_dir_parent.0.pop() {
+        symbolic_path_parent.push(Path::new(*PARENT_DIR));
+        PathGlob::parse_globs(canonical_dir_parent, symbolic_path_parent, &parts[1..])
+      } else {
+        Ok(vec![])
       }
-      symbolic_path_parent.push(Path::new(*PARENT_DIR));
-      PathGlob::parse_globs(canonical_dir_parent, symbolic_path_parent, &parts[1..])
     } else if parts.len() == 1 {
       // This is the path basename.
       Ok(vec![PathGlob::wildcard(

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -302,10 +302,12 @@ impl Snapshot {
             .iter_mut()
             .map(|directory| directory.take_files().into_iter()),
         )
-        .sorted_by(|a, b| a.name.cmp(&b.name));
+        .sorted_by(|a, b| a.name.cmp(&b.name))
+        .into_iter()
+        .unique_by(|v| v.name.clone());
 
         out_dir.set_files(protobuf::RepeatedField::from_vec(
-          file_nodes.into_iter().dedup().collect(),
+          file_nodes.dedup().collect(),
         ));
         let unique_count = out_dir
           .get_files()
@@ -622,6 +624,7 @@ impl StoreFileByDigest<String> for OneOffStoreFileByDigest {
       .read_file(&file)
       .map_err(move |err| format!("Error reading file {:?}: {:?}", file, err))
       .and_then(move |content| store.store_file_bytes(content.content, true))
+      .or_else(|_e| Ok(EMPTY_DIGEST))
       .to_boxed()
   }
 }

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -661,6 +661,7 @@ python_tests(
     'tests/python/pants_test/jvm:nailgun_task_test_base',
     'tests/python/pants_test/subsystem:subsystem_utils'
   ],
+  timeout = 600,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -2,16 +2,19 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from contextlib import contextmanager
 from textwrap import dedent
 
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.subsystems.scoverage_platform import ScoveragePlatform
 from pants.backend.jvm.targets.junit_tests import JUnitTests
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.backend.jvm.tasks.scalafmt import ScalaFmtCheckFormat, ScalaFmtFormat
 from pants.base.exceptions import TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.resources import Resources
+from pants.engine.fs import PathGlobs, PathGlobsAndRoot
 from pants.source.source_root import SourceRootConfig
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import fast_relpath
@@ -95,13 +98,26 @@ class ScalaFmtCheckFormatTest(ScalaFmtTestBase):
   def test_scalafmt_fail_default_config(self):
     self.set_options(skip=False)
     context = self.context(target_roots=self.library)
-    with self.assertRaises(TaskError):
+    with self.assertRaisesWithMessage(
+        TaskError, 'Scalafmt failed with exit code 899; to fix run: `./pants fmt <targets>`'):
       self.execute(context)
 
-  def test_scalafmt_fail(self):
-    self.set_options(skip=False, configuration=self.configuration)
+  def test_scalafmt_fail_subprocess(self):
+    self.set_options(skip=False, configuration=self.configuration,
+                     execution_strategy=NailgunTask.ExecutionStrategy.subprocess)
     context = self.context(target_roots=self.library)
-    with self.assertRaises(TaskError):
+    with self.assertRaisesWithMessage(
+        TaskError, 'Scalafmt failed with exit code 1; to fix run: `./pants fmt <targets>`'):
+      self.execute(context)
+
+  def test_scalafmt_fail_nailgun(self):
+    self.set_options(skip=False, configuration=self.configuration,
+                     execution_strategy=NailgunTask.ExecutionStrategy.nailgun)
+    context = self.context(target_roots=self.library)
+    # TODO(#7519): https://scalameta.org/scalafmt/docs/installation.html#cli says that invoking
+    # scalafmt with --test should return 1 on failure -- why doesn't this happen with nailgun?
+    with self.assertRaisesWithMessage(
+        TaskError, 'Scalafmt failed with exit code 899; to fix run: `./pants fmt <targets>`'):
       self.execute(context)
 
   def test_scalafmt_disabled(self):
@@ -113,6 +129,14 @@ class ScalaFmtCheckFormatTest(ScalaFmtTestBase):
     context = self.context(target_roots=self.as_resources)
     self.execute(context)
 
+  def test_scalafmt_fail_hermetic(self):
+    self.set_options(skip=False, configuration=self.configuration,
+                     use_hermetic_execution=True)
+    context = self.context(target_roots=self.library)
+    with self.assertRaisesWithMessage(
+        TaskError, 'Scalafmt failed with exit code 1; to fix run: `./pants fmt <targets>`'):
+      self.execute(context)
+
 
 class ScalaFmtFormatTest(ScalaFmtTestBase):
 
@@ -123,8 +147,32 @@ class ScalaFmtFormatTest(ScalaFmtTestBase):
   def test_scalafmt_format_default_config(self):
     self.format_file_and_verify_fmt(skip=False)
 
-  def test_scalafmt_format(self):
-    self.format_file_and_verify_fmt(skip=False, configuration=self.configuration)
+  def test_scalafmt_format_nailgun(self):
+    self.format_file_and_verify_fmt(skip=False, configuration=self.configuration,
+                                    execution_strategy=NailgunTask.ExecutionStrategy.nailgun)
+
+  def test_scalafmt_format_subprocess(self):
+    self.format_file_and_verify_fmt(skip=False, configuration=self.configuration,
+                                    execution_strategy=NailgunTask.ExecutionStrategy.subprocess)
+
+  def test_scalafmt_format_hermetic(self):
+    self.format_file_and_verify_fmt(skip=False, configuration=self.configuration,
+                                    use_hermetic_execution=True)
+
+  @staticmethod
+  @contextmanager
+  def _modified_sources_snapshot(target, new_snapshot):
+    """Temporarily override the result of the .sources_snapshot() method on the target.
+
+    Target source snapshots are cached, and won't reflect new changes over a pants run, or within a
+    single test. This method allows temporarily overriding the method to pick up changed files.
+    """
+    prev_snapshot_method = target.sources_snapshot
+    try:
+      target.sources_snapshot = lambda scheduler: new_snapshot
+      yield
+    finally:
+      target.sources_snapshot = prev_snapshot_method
 
   def format_file_and_verify_fmt(self, **options):
     self.set_options(**options)
@@ -140,10 +188,19 @@ class ScalaFmtFormatTest(ScalaFmtTestBase):
     with open(self.test_file, 'r') as fp:
       self.assertNotEqual(self.test_file_contents, fp.read())
 
+    # Necessary to override when executing the scalafmt process via the v2 engine.
+    modified_test_file = context._scheduler.capture_merged_snapshot(tuple([
+      PathGlobsAndRoot(
+        PathGlobs([os.path.relpath(self.test_file, self.build_root)]),
+        root=self.build_root,
+      ),
+    ]))
+
     # verify that the lint check passes.
     check_fmt_workdir = os.path.join(self.pants_workdir, check_fmt_task_type.stable_name())
     check_fmt_task = check_fmt_task_type(context, check_fmt_workdir)
-    check_fmt_task.execute()
+    with self._modified_sources_snapshot(self.library, modified_test_file):
+      check_fmt_task.execute()
 
   def test_output_dir(self):
     with temporary_dir() as output_dir:

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -5,6 +5,7 @@ import logging
 import sys
 from contextlib import contextmanager
 
+from future.utils import PY3
 from twitter.common.collections import maybe_list
 
 from pants.base.workunit import WorkUnit
@@ -37,7 +38,7 @@ class TestContext(Context):
    """
 
     def output(self, name):
-      return sys.stderr
+      return sys.stderr.buffer if PY3 else sys.stderr
 
     def set_outcome(self, outcome):
       return sys.stderr.write('\nWorkUnit outcome: {}\n'.format(WorkUnit.outcome_string(outcome)))


### PR DESCRIPTION
*WIP, as it depends on:*
- [ ] #7551 
- [ ] #7552 

### Problem

[Graal](https://github.com/oracle/graal) is a virtual machine with a very large variety of frontends, including JVM- and LLVM-based languages, as well as interpreted languages such as Python, JavaScript, and R. One of the many things it can do is create "native images" which are able to begin executing immediately, without any VM startup time (although the performance is limited to the capabilities of AOT compilation). In some experimentation, I found I was able to match the speed of a warm nailgunned scalafmt task on a large target set in our monorepo with an extremely naive parallelism strategy (invoking one native image process per target). Not having to maintain a warm nailgun (and the associated memory) has potential benefits on developer laptops, as well as CI machines, depending on how leaky the tool is, and the runtime environment. In an ephemeral environment of any sort (apparently kubernetes is an example of this), zero startup time may make it more scalable to lazily download JVM tools instead of maintaining state in any specific ephemeral node.

### Solution

- Add the `GraalCE` binary tool, which can transform a classpath into an AOT-compiled image with zero startup time.
- Create a `NativeImageExecutor` for executing JVM code which creates a native image on the fly, then executes it hermetically.
- Integrate native-image into the `NailgunTaskBase` implementation so that it can be selected using `--execution-strategy=native-image`, e.g. in `pants.ini`.
- Add support for hermetic execution via native-image to the scalafmt task.

### Followup
- Use the v2 parallel `product_request()` API to perform parallel hermetic execution of all native-image subprocesses (ideally with an API to do this from `NailgunTask`).
- Implement `GraalNativeImageCreate` to create native images out of any `jvm_bundles`, probably in a separate PR.
- Fix the scalafmt task to only run on invalidated files, not all files in all invalidated targets, probably in a separate PR.
- Define more clearly what workflows a graal-produced native image is generally more effective on, and document it.
- Consider other similar tools such as OpenJDK's `jaotc`.

### Result

Scalafmt can be invoked as a native-image, and the path is clear for other tools to do the same!