### PR TITLE
Fix Task fingerprinting.

### DIFF
--- a/src/python/pants/subsystem/subsystem_client_mixin.py
+++ b/src/python/pants/subsystem/subsystem_client_mixin.py
@@ -66,6 +66,20 @@ class SubsystemClientMixin(object):
       else:
         yield SubsystemDependency(dep, GLOBAL_SCOPE)
 
+  @classmethod
+  def subsystem_closure_iter(cls, seen=None):
+    """Iterate over the transitive closure of subsystem dependencies of this Optionable.
+
+    :rtype: :class:`collections.Iterator` of :class:`SubsystemDependency`
+    """
+    seen = seen or set()
+    for dep in cls.subsystem_dependencies_iter():
+      if dep not in seen:
+        seen.add(dep)
+        yield dep
+        for d in dep.subsystem_cls.subsystem_closure_iter(seen=seen):
+          yield d
+
   class CycleException(Exception):
     """Thrown when a circular subsystem dependency is detected."""
 

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -291,8 +291,7 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     hasher.update(self.stable_name().encode('utf-8'))
     hasher.update(self._options_fingerprint(self.options_scope).encode('utf-8'))
     hasher.update(self.implementation_version_str().encode('utf-8'))
-    # TODO: this is not recursive, but should be: see #2739
-    for dep in self.subsystem_dependencies_iter():
+    for dep in self.subsystem_closure_iter():
       hasher.update(self._options_fingerprint(dep.options_scope()).encode('utf-8'))
     return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
 

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -224,3 +224,31 @@ class SubsystemTest(unittest.TestCase):
 
     dep_scopes = {dep.options_scope() for dep in SubsystemA.subsystem_dependencies_iter()}
     self.assertEqual({'b', 'dummy.a'}, dep_scopes)
+
+  def test_subsystem_closure_iter(self):
+    class SubsystemA(Subsystem):
+      options_scope = 'a'
+
+    class SubsystemB(Subsystem):
+      options_scope = 'b'
+
+      @classmethod
+      def subsystem_dependencies(cls):
+        return (SubsystemA,)
+
+    class SubsystemC(Subsystem):
+      options_scope = 'c'
+
+      @classmethod
+      def subsystem_dependencies(cls):
+        return (SubsystemA, SubsystemB.scoped(cls))
+
+    class SubsystemD(Subsystem):
+      options_scope = 'd'
+
+      @classmethod
+      def subsystem_dependencies(cls):
+        return (SubsystemC, SubsystemB)
+
+    dep_scopes = [dep.options_scope() for dep in SubsystemD.subsystem_closure_iter()]
+    self.assertEqual(['c', 'a', 'b.c', 'b'], dep_scopes)


### PR DESCRIPTION
Previously transitive Subsystem dependencies did not count against the
task fingerprint which was a known, latent and slient bug.

Fixes #2739
