### PR TITLE
Skip EngineTest#test_trace_multi.

### DIFF
--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -145,6 +145,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     res = self.mk_scheduler().with_fork_context(fork_context_body)
     self.assertEquals(res, expected)
 
+  @unittest.skip('Inherently flaky as described in https://github.com/pantsbuild/pants/issues/6829')
   def test_trace_multi(self):
     # Tests that when multiple distinct failures occur, they are each rendered.
     rules = [


### PR DESCRIPTION
The test is known to be inherently flakey as descrbed in #6829.
