### PR TITLE
Ensure pants is running in exception sink tests.

### DIFF
--- a/testprojects/src/python/coordinated_runs/BUILD
+++ b/testprojects/src/python/coordinated_runs/BUILD
@@ -4,6 +4,11 @@ python_binary(
 )
 
 python_binary(
+  name='phaser',
+  source='phaser.py',
+)
+
+python_binary(
   name='waiter',
   source='waiter.py',
 )

--- a/testprojects/src/python/coordinated_runs/creator.py
+++ b/testprojects/src/python/coordinated_runs/creator.py
@@ -1,4 +1,5 @@
 import sys
 
+
 with open(sys.argv[1], 'w') as f:
   pass

--- a/testprojects/src/python/coordinated_runs/phaser.py
+++ b/testprojects/src/python/coordinated_runs/phaser.py
@@ -1,0 +1,14 @@
+import os
+import sys
+import time
+
+
+arrive_file, await_file = sys.argv[1:3]
+
+# Signal we've arrived.
+with open(arrive_file, 'w') as fp:
+  fp.close()
+
+# Await a graceful join.
+while not os.path.isfile(await_file):
+  time.sleep(0.1)


### PR DESCRIPTION
Previously, pants was run asynchronously with no way to guaranty it was
up and initialized the way we expected it to be before testing its
signal handling. Introduce a phaser testproject target that allows the
integration test to ensure the pants run state is as expected.

Fixes #6847
