### PR TITLE
Fix Scrooge linter using wrong version number

### DIFF
--- a/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter/BUILD
+++ b/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter/BUILD
@@ -4,6 +4,7 @@
 java_thrift_library(
   name = 'bad-thrift-default',
   sources = ['bad-default.thrift'],
+  compiler = 'scrooge',
   tags=['nolint'],
   # thrift_linter_strict not defined
 )
@@ -11,6 +12,7 @@ java_thrift_library(
 java_thrift_library(
   name = 'bad-thrift-strict',
   sources = ['bad-strict.thrift'],
+  compiler = 'scrooge',
   thrift_linter_strict=True,
   tags=['nolint'],
 )
@@ -18,6 +20,7 @@ java_thrift_library(
 java_thrift_library(
   name = 'bad-thrift-strict2',
   sources = ['bad-strict2.thrift'],
+  compiler = 'scrooge',
   thrift_linter_strict=True,
   tags=['nolint'],
 )
@@ -25,6 +28,7 @@ java_thrift_library(
 java_thrift_library(
   name = 'bad-thrift-non-strict',
   sources = ['bad-non-strict.thrift'],
+  compiler = 'scrooge',
   thrift_linter_strict=False,
   tags=['nolint'],
 )
@@ -32,6 +36,7 @@ java_thrift_library(
 java_thrift_library(
   name = 'good-thrift',
   sources = ['good.thrift'],
+  compiler = 'scrooge',
   thrift_linter_strict=True,
   tags=['nolint'],
 )


### PR DESCRIPTION
### Problem
`contrib/scrooge/thrift_linter` is using Apache Thrift version 0.9.2, rather than the 0.6.1 version we use for Scrooge. 

```bash
$ ./pants gen dependencies contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter:: | grep '3rdparty:libthrift'
3rdparty:libthrift-0.9.2
```

This is not expected, as Scrooge should always use 0.6.1 due to compatibility issues.

### Solution
Add a constraint to the BUILD file for this test code to specify it should use `scrooge`. Otherwise, we default to using the Apache Thrift linter used by the main `src` code (version 0.9.2).

I considered two other solutions:
1) Stu's recommendation in https://github.com/pantsbuild/pants/pull/6883#issuecomment-445959746 to try moving the folder to `testprojects`, with the hypothesis that the target is getting its classpath mixed with other files in the `contrib` folder so leading to the wrong Thrift version. I don't think this would fix it, because running `thrift_linter` in isolation (so no classpath issues) still produces the wrong version.
2) Modifying the integration test itself to specify Thrift 0.6.1. This is how we do it with the `scrooge_gen` tests. However, it looks like the wrong solution and requires more code than necessary.

### Result
With the new constraint, we are now correctly using Thrift 0.6.1 for Scrooge's thrift linter in the tests.

```bash
$ ./pants gen dependencies contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter:: | grep '3rdparty:libthrift'
3rdparty:libthrift-0.6.1
```
Note that this is _only fixing tests_, it does not actually change source code / does not address the root cause.