### PR TITLE
support source and 3rdparty dependencies in v2 python test running

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -38,10 +38,10 @@ def run_python_test(transitive_hydrated_target):
   # Produce a pex containing pytest and all transitive 3rdparty requirements.
   all_requirements = []
   for maybe_python_req_lib in all_targets:
-    # This is a python_requirement().
+    # This is a python_requirement()-like target.
     if hasattr(maybe_python_req_lib.adaptor, 'requirement'):
       all_requirements.append(str(maybe_python_req_lib.requirement))
-    # This is a python_requirement_library(). TODO: see if this is correct?!
+    # This is a python_requirement_library()-like target.
     if hasattr(maybe_python_req_lib.adaptor, 'requirements'):
       for py_req in maybe_python_req_lib.adaptor.requirements:
         all_requirements.append(str(py_req.requirement))
@@ -55,6 +55,8 @@ def run_python_test(transitive_hydrated_target):
     '--python', python_binary,
     '-e', 'pytest:main',
     '-o', output_pytest_requirements_pex_filename,
+    # TODO: This is non-hermetic because pytest will be resolved on the fly by pex27, where it should be hermetically provided in some way.
+    # We should probably also specify a specific version.
     'pytest',
   ] + all_requirements
   requirements_pex_request = ExecuteProcessRequest(
@@ -69,7 +71,8 @@ def run_python_test(transitive_hydrated_target):
     FallibleExecuteProcessResult, ExecuteProcessRequest, requirements_pex_request)
 
   # Gather sources.
-  # TODO: make TargetAdaptor return a 'sources' field with an empty snapshot instead of raising (?)
+  # TODO: make TargetAdaptor return a 'sources' field with an empty snapshot instead of raising to
+  # simplify the hasattr() checks here!
   all_sources_digests = []
   for maybe_source_target in all_targets:
     if hasattr(maybe_source_target.adaptor, 'sources'):

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -58,7 +58,8 @@ def run_python_test(transitive_hydrated_target):
     # TODO: This is non-hermetic because pytest will be resolved on the fly by pex27, where it should be hermetically provided in some way.
     # We should probably also specify a specific version.
     'pytest',
-  ] + all_requirements
+    # Sort all the requirement strings to increase the chance of cache hits across invocations.
+  ] + sorted(all_requirements)
   requirements_pex_request = ExecuteProcessRequest(
     argv=tuple(requirements_pex_argv),
     input_files=pex_snapshot.directory_digest,

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -382,7 +382,8 @@ class HydratedTarget(datatype(['address', 'adaptor', 'dependencies'])):
     return hash(self.address)
 
 
-# TODO: are there performance concerns to adding type checks here?
+# TODO: add type-checking to datatype fields in this file! Tuple fields such as 'dependencies' need
+# some groundwork to be more ergonomic -- see #6936 for one possible implementation.
 class TransitiveHydratedTarget(datatype([('root', HydratedTarget), 'dependencies'])):
   """A recursive structure wrapping a HydratedTarget root and TransitiveHydratedTarget deps."""
 

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -382,7 +382,8 @@ class HydratedTarget(datatype(['address', 'adaptor', 'dependencies'])):
     return hash(self.address)
 
 
-class TransitiveHydratedTarget(datatype(['root', 'dependencies'])):
+# TODO: are there performance concerns to adding type checks here?
+class TransitiveHydratedTarget(datatype([('root', HydratedTarget), 'dependencies'])):
   """A recursive structure wrapping a HydratedTarget root and TransitiveHydratedTarget deps."""
 
 

--- a/testprojects/tests/python/pants/dummies/BUILD
+++ b/testprojects/tests/python/pants/dummies/BUILD
@@ -20,3 +20,11 @@ python_tests(
     ':example_lib',
   ],
 )
+
+python_tests(
+  name = 'target_with_thirdparty_dep',
+  sources = ['test_with_thirdparty_dep.py'],
+  dependencies = [
+    '3rdparty/python:futures',
+  ],
+)

--- a/testprojects/tests/python/pants/dummies/BUILD
+++ b/testprojects/tests/python/pants/dummies/BUILD
@@ -25,6 +25,6 @@ python_tests(
   name = 'target_with_thirdparty_dep',
   sources = ['test_with_thirdparty_dep.py'],
   dependencies = [
-    '3rdparty/python:futures',
+    '3rdparty/python:future',
   ],
 )

--- a/testprojects/tests/python/pants/dummies/BUILD
+++ b/testprojects/tests/python/pants/dummies/BUILD
@@ -7,3 +7,16 @@ python_tests(
   name = 'failing_target',
   sources = ['test_fail.py'],
 )
+
+python_library(
+  name = 'example_lib',
+  sources = 'example_source.py',
+)
+
+python_tests(
+  name = 'target_with_source_dep',
+  sources = ['test_with_source_dep.py'],
+  dependencies = [
+    ':example_lib',
+  ],
+)

--- a/testprojects/tests/python/pants/dummies/example_source.py
+++ b/testprojects/tests/python/pants/dummies/example_source.py
@@ -1,0 +1,2 @@
+def add_two(x):
+  return x + 2

--- a/testprojects/tests/python/pants/dummies/test_with_source_dep.py
+++ b/testprojects/tests/python/pants/dummies/test_with_source_dep.py
@@ -1,0 +1,5 @@
+from example_source import add_two
+
+
+def test_external_method():
+  assert add_two(2) == 4

--- a/testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py
+++ b/testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py
@@ -4,8 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from future.utils import text_type
+from builtins import str
 
 
 def test_f():
-  assert isinstance(text_type("foo"), text_type)
+  assert isinstance("foo", str)

--- a/testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py
+++ b/testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py
@@ -1,0 +1,13 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from builtins import str
+
+from future.utils import text_type
+
+
+def test_f():
+  assert str == text_type

--- a/testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py
+++ b/testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py
@@ -4,10 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import str
-
 from future.utils import text_type
 
 
 def test_f():
-  assert str == text_type
+  assert isinstance(text_type("foo"), text_type)

--- a/tests/python/pants_test/rules/test_test.py
+++ b/tests/python/pants_test/rules/test_test.py
@@ -65,7 +65,7 @@ some/target                                                                     
 """
     )
 
-  def test_output_training_newline(self):
+  def test_output_trailing_newline(self):
     self.single_target_test(
       TestResult(status=Status.SUCCESS, stdout=str('Here is some output from a test\n')),
       """Here is some output from a test

--- a/tests/python/pants_test/rules/test_test_integration.py
+++ b/tests/python/pants_test/rules/test_test_integration.py
@@ -108,6 +108,7 @@ testprojects/tests/python/pants/dummies:failing_target                          
 """,
     )
 
+  @unittest.skip('Flaky test: https://github.com/pantsbuild/pants/issues/6782')
   def test_source_dep(self):
     pants_run = self.run_passing_pants_test([
       'testprojects/tests/python/pants/dummies:target_with_source_dep',
@@ -125,6 +126,7 @@ testprojects/tests/python/pants/dummies/test_with_source_dep.py .        [100%]
 testprojects/tests/python/pants/dummies:target_with_source_dep                  .....   SUCCESS
 """)
 
+  @unittest.skip('Flaky test: https://github.com/pantsbuild/pants/issues/6782')
   def test_thirdparty_dep(self):
     pants_run = self.run_passing_pants_test([
       'testprojects/tests/python/pants/dummies:target_with_thirdparty_dep',

--- a/tests/python/pants_test/rules/test_test_integration.py
+++ b/tests/python/pants_test/rules/test_test_integration.py
@@ -125,6 +125,23 @@ testprojects/tests/python/pants/dummies/test_with_source_dep.py .        [100%]
 testprojects/tests/python/pants/dummies:target_with_source_dep                  .....   SUCCESS
 """)
 
+  def test_thirdparty_dep(self):
+    pants_run = self.run_passing_pants_test([
+      'testprojects/tests/python/pants/dummies:target_with_thirdparty_dep',
+    ])
+    self.assert_fuzzy_string_match(pants_run.stdout_data, """\
+============================= test session starts ==============================
+platform SOME_TEXT
+rootdir: SOME_TEXT
+collected 1 item
+
+testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py .    [100%]
+
+=========================== 1 passed in SOME_TEXT ===========================
+
+testprojects/tests/python/pants/dummies:target_with_thirdparty_dep              .....   SUCCESS
+""")
+
   @unittest.skip('Flaky test: https://github.com/pantsbuild/pants/issues/6782')
   def test_mixed_python_tests(self):
     pants_run = self.run_failing_pants_test([

--- a/tests/python/pants_test/rules/test_test_integration.py
+++ b/tests/python/pants_test/rules/test_test_integration.py
@@ -11,6 +11,11 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 class TestIntegrationTest(PantsRunIntegrationTest):
 
+  def run_pants(self, args):
+    # Set TERM=dumb to stop pytest from trying to be clever and wrap lines which may interfere with
+    # our golden data.
+    return super(TestIntegrationTest, self).run_pants(args, extra_env={'TERM': 'dumb'})
+
   # TODO: Modify flags (or pytest) so that output is hermetic and deterministic, and doesn't require fuzzy matching
   def assert_fuzzy_string_match(self, got, want):
     want_lines = want.split('\n')
@@ -20,32 +25,50 @@ class TestIntegrationTest(PantsRunIntegrationTest):
     for line_number, (want_line, got_line) in enumerate(zip(want_lines, got_lines)):
       want_parts = want_line.split('SOME_TEXT')
       if len(want_parts) == 1:
-        self.assertEqual(want_line, got_line, "Line {} wrong".format(line_number))
+        self.assertEqual(want_line, got_line,
+                         "Line {} wrong: want '{}', got '{}'"
+                         .format(line_number, want_line, got_line))
       elif len(want_parts) == 2:
         self.assertTrue(got_line.startswith(want_parts[0]), 'Line {} Want "{}" to start with "{}"'.format(line_number, got_line, want_parts[0]))
         self.assertTrue(got_line.endswith(want_parts[1]), 'Line {} Want "{}" to end with "{}"'.format(line_number, got_line, want_parts[1]))
 
-  def run_pants(self, args):
-    # Set TERM=dumb to stop pytest from trying to be clever and wrap lines which may interfere with
-    # our golden data.
-    return super(TestIntegrationTest, self).run_pants(args, extra_env={'TERM': 'dumb'})
-
-  def test_passing_python_test(self):
+  def run_passing_pants_test(self, trailing_args):
     args = [
       '--no-v1',
       '--v2',
       'test',
-      'testprojects/tests/python/pants/dummies:passing_target',
-    ]
-    pants_run = self.run_pants(args)
-    self.assert_success(pants_run)
+    ] + trailing_args
 
+    pants_run = self.run_pants(args)
+
+    self.assert_success(pants_run)
     self.assertEqual("", pants_run.stderr_data)
     self.assertEqual(pants_run.returncode, 0)
 
+    return pants_run
+
+  def run_failing_pants_test(self, trailing_args):
+    args = [
+      '--no-v1',
+      '--v2',
+      'test',
+    ] + trailing_args
+
+    pants_run = self.run_pants(args)
+
+    self.assert_failure(pants_run)
+    self.assertEqual("", pants_run.stderr_data)
+    self.assertEqual(pants_run.returncode, 1)
+
+    return pants_run
+
+  def test_passing_python_test(self):
+    pants_run = self.run_passing_pants_test([
+      'testprojects/tests/python/pants/dummies:passing_target',
+    ])
     self.assert_fuzzy_string_match(
-      pants_run.stdout_data,
-      """============================= test session starts ==============================
+      pants_run.stdout_data, """\
+============================= test session starts ==============================
 platform SOME_TEXT
 rootdir: SOME_TEXT
 collected 1 item
@@ -59,19 +82,12 @@ testprojects/tests/python/pants/dummies:passing_target                          
     )
 
   def test_failing_python_test(self):
-    args = [
-      '--no-v1',
-      '--v2',
-      'test',
+    pants_run = self.run_failing_pants_test([
       'testprojects/tests/python/pants/dummies:failing_target',
-    ]
-    pants_run = self.run_pants(args)
-    self.assert_failure(pants_run)
-    self.assertEqual("", pants_run.stderr_data)
-    self.assertEqual(pants_run.returncode, 1)
+    ])
     self.assert_fuzzy_string_match(
-      pants_run.stdout_data,
-      """============================= test session starts ==============================
+      pants_run.stdout_data, """\
+============================= test session starts ==============================
 platform SOME_TEXT
 rootdir: SOME_TEXT
 collected 1 item
@@ -92,22 +108,32 @@ testprojects/tests/python/pants/dummies:failing_target                          
 """,
     )
 
+  def test_source_dep(self):
+    pants_run = self.run_passing_pants_test([
+      'testprojects/tests/python/pants/dummies:target_with_source_dep',
+    ])
+    self.assert_fuzzy_string_match(pants_run.stdout_data, """\
+============================= test session starts ==============================
+platform SOME_TEXT
+rootdir: SOME_TEXT
+collected 1 item
+
+testprojects/tests/python/pants/dummies/test_with_source_dep.py .        [100%]
+
+=========================== 1 passed in SOME_TEXT ===========================
+
+testprojects/tests/python/pants/dummies:target_with_source_dep                  .....   SUCCESS
+""")
+
   @unittest.skip('Flaky test: https://github.com/pantsbuild/pants/issues/6782')
   def test_mixed_python_tests(self):
-    args = [
-      '--no-v1',
-      '--v2',
-      'test',
+    pants_run = self.run_failing_pants_test([
       'testprojects/tests/python/pants/dummies:failing_target',
       'testprojects/tests/python/pants/dummies:passing_target',
-    ]
-    pants_run = self.run_pants(args)
-    self.assert_failure(pants_run)
-    self.assertEqual("", pants_run.stderr_data)
-    self.assertEqual(pants_run.returncode, 1)
+    ])
     self.assert_fuzzy_string_match(
-      pants_run.stdout_data,
-      """============================= test session starts ==============================
+      pants_run.stdout_data, """\
+============================= test session starts ==============================
 platform SOME_TEXT
 rootdir: SOME_TEXT
 collected 1 item


### PR DESCRIPTION
### Problem

See #6764. We can run pytest on single targets *(kind of -- see #6782)*. We can't yet handle tests which depend on other python targets or 3rdparty libraries.

### Solution

- Make the `run_python_test` rule select a `TransitiveHydratedTarget`.
- Rewrite the `run_python_test` rule to gather snapshots of the sources of any `python_library()` dependents (actually, just anything with a `sources` attribute), using the `TransitiveHydratedTarget` argument.
- Instead of executing pytest with a pex command directly, generate a requirements pex with pytest and all the requirements from dependent 3rdparty libs.
- Add a couple test cases which unfortunately are skipped for now pending resolution of a nondeterministic dep graph cycle error -- see [this comment]https://github.com/pantsbuild/pants/issues/6782#issuecomment-447147972) on #6782.

### Result

We can run real python tests!