### PR TITLE
Add tool classpath for ./pants scalafix

### DIFF
--- a/src/python/pants/backend/jvm/tasks/scalafix.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix.py
@@ -38,6 +38,7 @@ class ScalaFix(RewriteBase):
                           classpath=[
                             JarDependency(org='ch.epfl.scala', name='scalafix-cli_2.11.11', rev='0.5.2'),
                           ])
+    cls.register_jvm_tool(register, 'scalafix-tool-classpath', classpath=[])
 
   @classmethod
   def target_types(cls):
@@ -60,8 +61,9 @@ class ScalaFix(RewriteBase):
 
   def invoke_tool(self, absolute_root, target_sources):
     args = []
-    if self.get_options().tool_classpath:
-      args.append('--tool-classpath={}'.format(self.get_options().tool_classpath))
+    tool_classpath = self.tool_classpath('scalafix-tool-classpath')
+    if tool_classpath:
+      args.append('--tool-classpath={}'.format(':'.join(tool_classpath)))
     if self.get_options().semantic:
       # If semantic checks are enabled, pass the relevant classpath entries for these
       # targets.

--- a/src/python/pants/backend/jvm/tasks/scalafix.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix.py
@@ -31,6 +31,8 @@ class ScalaFix(RewriteBase):
                   'providing the target classpath to scalafix. To enable this option, you '
                   'will need to install the `semanticdb-scalac` compiler plugin. See '
                   'https://www.pantsbuild.org/scalac_plugins.html for more information.')
+    register('--tool-classpath', type=str, default="", fingerprint=True,
+             help="A classpath containing additional rules.")
     cls.register_jvm_tool(register,
                           'scalafix',
                           classpath=[
@@ -58,6 +60,8 @@ class ScalaFix(RewriteBase):
 
   def invoke_tool(self, absolute_root, target_sources):
     args = []
+    if self.get_options().tool_classpath:
+      args.append('--tool-classpath={}'.format(self.get_options().tool_classpath))
     if self.get_options().semantic:
       # If semantic checks are enabled, pass the relevant classpath entries for these
       # targets.

--- a/src/python/pants/backend/jvm/tasks/scalafix.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix.py
@@ -31,8 +31,6 @@ class ScalaFix(RewriteBase):
                   'providing the target classpath to scalafix. To enable this option, you '
                   'will need to install the `semanticdb-scalac` compiler plugin. See '
                   'https://www.pantsbuild.org/scalac_plugins.html for more information.')
-    register('--tool-classpath', type=str, default="", fingerprint=True,
-             help="A classpath containing additional rules.")
     cls.register_jvm_tool(register,
                           'scalafix',
                           classpath=[


### PR DESCRIPTION
### Problem

Same as in pr #6922
In order to run custom scalafix rules that are distributed in .jar form, they must be added to scalafix's '--tool-classpath' command line argument. Currently there is no way to set this argument from pants.

### Solution

Add scalafix-tool-classpath via register_jvm_tool to ./pants scalafix, with default empty classpath so you don't need to add a target if you don't want.

### Result

scalafix_tool_classpath can be set in pants.ini or on the command line, and scalafix will be able to load your precompiled custom rules.