### PR TITLE
Handle ValueError when child wants to reset stderr but it is closed.

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
+import logging
 import os
 import sys
 import termios
@@ -283,7 +284,13 @@ class DaemonPantsRunner(ProcessManager):
     # terminal window.
     # TODO: test the above!
     ExceptionSink.reset_exiter(self._exiter)
-    ExceptionSink.reset_interactive_output_stream(sys.stderr)
+
+    try:
+      ExceptionSink.reset_interactive_output_stream(sys.stderr)
+    except ValueError:
+      # Warn about "ValueError: IO on closed file" when stderr is closed.
+      logger = logging.getLogger(__name__)
+      logger.warn("Cannot reset output stream - sys.stderr is closed")
 
     # Ensure anything referencing sys.argv inherits the Pailgun'd args.
     sys.argv = self._args

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
-import logging
 import os
 import sys
 import termios
@@ -285,12 +284,7 @@ class DaemonPantsRunner(ProcessManager):
     # TODO: test the above!
     ExceptionSink.reset_exiter(self._exiter)
 
-    try:
-      ExceptionSink.reset_interactive_output_stream(sys.stderr)
-    except ValueError:
-      # Warn about "ValueError: IO on closed file" when stderr is closed.
-      logger = logging.getLogger(__name__)
-      logger.warn("Cannot reset output stream - sys.stderr is closed")
+    ExceptionSink.reset_interactive_output_stream(sys.stderr)
 
     # Ensure anything referencing sys.argv inherits the Pailgun'd args.
     sys.argv = self._args


### PR DESCRIPTION
### Problem

After forking, when the child wants to reset `sys.stderr` as part of setting up the `ExceptionSink`, if `sys.stderr` was closed, it would except and crash.

### Solution

Wrap the line in `try:except`, and log it as a warning. However, I have a doubt:
The line in question happens in {{post_fork_child}} after a call to {{daemonize}}, and fails because {{sys.stderr}} is closed. So, given that we are considering that case as "non-fatal" (hence turning the exception into a warning), would it make sense to instead write something like:

```python
if not sys.stderr.closed:
  ExceptionSink.reset_interactive_output_stream(sys.stderr)
else:
  logger = logging.getLogger(__name__)
  logger.warn("Cannot reset output stream - sys.stderr is closed")
```

The difference is small, but if the answer is no it means that I'm missing something.

### Result

One less hard-to-find crash, hopefully.