### PR TITLE
Fix Travis environment variable overriding interpreter_selection test's config

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -135,9 +135,8 @@ fi
 
 # NB: Ordering matters here. We (currently) always bootstrap a Python 2 pex.
 if [[ "${python_three:-false}" == "true" ]]; then
-  # The 3.4 end of this constraint is necessary to jive with the travis ubuntu trusty image.
   banner "Setting interpreter constraints for 3!"
-  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS='["CPython>=3.4,<4"]'
+  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS='["CPython>=3.5,<4"]'
   # TODO: Clear interpreters, otherwise this constraint does not end up applying due to a cache
   # bug between the `./pants binary` and further runs.
   ./pants.pex clean-all

--- a/testprojects/src/python/interpreter_selection/BUILD
+++ b/testprojects/src/python/interpreter_selection/BUILD
@@ -9,9 +9,7 @@ python_library(
   sources = ['echo_interpreter_version.py'],
   dependencies = [],
   # Play with this to test interpreter selection in the pex machinery.
-  # TODO(John Sirois): Allow `<4` when the issues with `3.7` are fixed. See:
-  #   https://github.com/pantsbuild/pants/issues/6363
-  compatibility = ['CPython>=2.7,<3.7']
+  compatibility = ['CPython>=2.7,<4']
 )
 
 python_binary(

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -14,7 +14,16 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
+
   testproject = 'testprojects/src/python/interpreter_selection'
+
+  @classmethod
+  def hermetic(cls):
+    # We must set as true to ignore `PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS`
+    # preconfiguring the interpreter_constraint. For example, in `ci.sh` we set
+    # this environment variable to Python 3, which overrides any config defined
+    # in the below tests.
+    return True
 
   def test_cli_option_wins_compatibility_conflict(self):
     # Tests that targets with compatibility conflicts collide.


### PR DESCRIPTION
### Problem
In `test_conflict_via_config()`, we try to constraint Python to `< 2.7`. However, this fails to do anything when running on Python 3, because it's overriden by `ci.sh`'s environment variable `export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS='["CPython>=3.5,<4"]'`.

This is expected behavior, that the environment variable overrides the command line argument. So, the issue is not with the source code, but this test should also not be failing.

### Solution
Set the integration test to be hermetic.