### PR TITLE
Fix relative import for conftest test on Python 3

### DIFF
--- a/testprojects/tests/python/pants/conf_test/my_test.py
+++ b/testprojects/tests/python/pants/conf_test/my_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-import conftest
+from . import conftest
 
 
 class MyTest(unittest.TestCase):


### PR DESCRIPTION
Python 3 does not allow implicit relative imports. Instead, they must be explicitly marked via `from . import x`.