### PR TITLE
Fix relative import for testprojects dummy test on Python 3

### DIFF
--- a/testprojects/tests/python/pants/dummies/test_with_source_dep.py
+++ b/testprojects/tests/python/pants/dummies/test_with_source_dep.py
@@ -1,4 +1,4 @@
-from example_source import add_two
+from .example_source import add_two
 
 
 def test_external_method():


### PR DESCRIPTION
Similar to https://github.com/pantsbuild/pants/pull/6941, one of the test projects was missing the explicit relative import syntax so failed on Py3.

Note we did not catch this earlier because many testprojects files do not use `from __future__ import absolute_import`. This PR does not make that change since our integration tests should catch any Py2 and Py3 compatibility issues, but adding those `__future__` imports could prevent future issues.