### PR TITLE
don't eagerly set jvm target platform when not specified in order to increase the default jvm platform for testprojects integration to java8

### DIFF
--- a/contrib/errorprone/src/python/pants/contrib/errorprone/tasks/errorprone.py
+++ b/contrib/errorprone/src/python/pants/contrib/errorprone/tasks/errorprone.py
@@ -135,7 +135,11 @@ class ErrorProne(NailgunTask):
 
     # Try to run errorprone with the same java version as the target
     # The minimum JDK for errorprone is JDK 1.8
-    min_jdk_version = max(target.platform.target_level, Revision.lenient('1.8'))
+    errorprone_min_jdk = Revision.lenient('1.8')
+    if target.platform:
+      min_jdk_version = max(target.platform.target_level, errorprone_min_jdk)
+    else:
+      min_jdk_version = errorprone_min_jdk
     if min_jdk_version.components[0] == 1:
       max_jdk_version = Revision(min_jdk_version.components[0], min_jdk_version.components[1], '9999')
     else:
@@ -154,10 +158,10 @@ class ErrorProne(NailgunTask):
     ]
 
     # Errorprone does not recognize source or target 10 yet
-    if target.platform.source_level < Revision.lenient('10'):
+    if (target.platform is not None) and (target.platform.source_level < Revision.lenient('10')):
       args.extend(['-source', str(target.platform.source_level)])
 
-    if target.platform.target_level < Revision.lenient('10'):
+    if (target.platform is not None) and (target.platform.target_level < Revision.lenient('10')):
       args.extend(['-target', str(target.platform.target_level)])
 
     errorprone_classpath_file = os.path.join(self.workdir, '{}.classpath'.format(os.path.basename(output_dir)))

--- a/contrib/findbugs/src/python/pants/contrib/findbugs/tasks/findbugs.py
+++ b/contrib/findbugs/src/python/pants/contrib/findbugs/tasks/findbugs.py
@@ -189,7 +189,11 @@ class FindBugs(NailgunTask):
 
     # Try to run spotbugs with the same java version as the target
     # The minimum JDK for spotbugs is JDK 1.8
-    min_jdk_version = max(target.platform.target_level, Revision.lenient('1.8'))
+    spotbugs_min_jdk = Revision.lenient('1.8')
+    if target.platform:
+      min_jdk_version = max(target.platform.target_level, spotbugs_min_jdk)
+    else:
+      min_jdk_version = spotbugs_min_jdk
     if min_jdk_version.components[0] == 1:
       max_jdk_version = Revision(min_jdk_version.components[0], min_jdk_version.components[1], '9999')
     else:

--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -132,7 +132,7 @@ class JvmPlatform(Subsystem):
     :rtype: JvmPlatformSettings
     """
     if not name:
-      return self.default_platform
+      return None
     if name not in self.platforms_by_name:
       raise self.UndefinedJvmPlatform(for_target, name, self.platforms_by_name)
     return self.platforms_by_name[name]

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -298,9 +298,11 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
                                            **kwargs)
 
   def preferred_jvm_distribution_for_targets(self, targets):
-    return JvmPlatform.preferred_jvm_distribution([target.platform for target in targets
-                                                  if isinstance(target, JvmTarget)],
-                                                  self._strict_jvm_version)
+    all_specified_platforms = [
+      target.platform for target in targets
+      if isinstance(target, JvmTarget) and target.platform is not None
+    ]
+    return JvmPlatform.preferred_jvm_distribution(all_specified_platforms, self._strict_jvm_version)
 
   def _spawn(self, distribution, executor=None, *args, **kwargs):
     """Returns a processhandler to a process executing java.

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -512,7 +512,7 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
   def _iter_batches(self, test_registry):
     tests_by_properties = test_registry.index(
       lambda tgt: tgt.cwd if tgt.cwd is not None else self._working_dir,
-      lambda tgt: tgt.test_platform,
+      lambda tgt: tgt.test_platform or JvmPlatform.global_instance().default_platform,
       lambda tgt: tgt.payload.extra_jvm_options,
       lambda tgt: tgt.payload.extra_env_vars,
       lambda tgt: tgt.concurrency,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -851,13 +851,15 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
       tgt, = vts.targets
       compiler_option_sets = dep_context.defaulted_property(tgt, lambda x: x.compiler_option_sets)
       zinc_file_manager = dep_context.defaulted_property(tgt, lambda x: x.zinc_file_manager)
+      # TODO: consider making jvm platform part of the DependencyContext!
+      jvm_platform = tgt.platform or JvmPlatform.global_instance().default_platform
       with Timer() as timer:
         directory_digest = self._compile_vts(vts,
                           ctx,
                           upstream_analysis,
                           dependency_cp_entries,
                           progress_message,
-                          tgt.platform,
+                          jvm_platform,
                           compiler_option_sets,
                           zinc_file_manager,
                           counter)

--- a/src/python/pants/backend/jvm/tasks/run_jvm_prep_command.py
+++ b/src/python/pants/backend/jvm/tasks/run_jvm_prep_command.py
@@ -72,7 +72,8 @@ class RunJvmPrepCommandBase(Task):
 
     with self.context.new_workunit(name='jvm_prep_command', labels=[WorkUnitLabel.PREP]) as workunit:
       for target in targets:
-        distribution = JvmPlatform.preferred_jvm_distribution([target.platform])
+        jvm_platform = target.platform or JvmPlatform.global_instance().default_platform
+        distribution = JvmPlatform.preferred_jvm_distribution([jvm_platform])
         executor = SubprocessExecutor(distribution)
 
         mainclass = target.payload.get_field_value('mainclass')

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -271,7 +271,10 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
 
       if isinstance(current_target, JvmTarget):
         info['excludes'] = [self._exclude_id(exclude) for exclude in current_target.excludes]
-        info['platform'] = current_target.platform.name
+        # TODO: this is a breaking change! should return the default jvm platform if this breaks
+        # anything
+        if current_target.platform:
+          info['platform'] = current_target.platform.name
         if hasattr(current_target, 'test_platform'):
           info['test_platform'] = current_target.test_platform.name
 

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -275,15 +275,9 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
 
       if isinstance(current_target, JvmTarget):
         info['excludes'] = [self._exclude_id(exclude) for exclude in current_target.excludes]
-        if current_target.platform:
-          info['platform'] = current_target.platform.name
-        else:
-          info['platform'] = self._default_jvm_platform_name
+        info['platform'] = current_target.platform.name if current_target.platform else self._default_jvm_platform_name
         if hasattr(current_target, 'test_platform'):
-          if current_target.test_platform:
-            info['test_platform'] = current_target.test_platform.name
-          else:
-            info['test_platform'] = self._default_jvm_platform_name
+          info['test_platform'] = current_target.test_platform.name if current_target.test_platform else self._default_jvm_platform_name
 
       info['roots'] = [{
         'source_root': source_root_package_prefix[0],

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
@@ -62,7 +62,8 @@ class JavaCompileSettingsPartitioningTest(TaskTestBase):
     self._task_setup(targets, **options)
     partition = defaultdict(set)
     for target in targets:
-      partition[target.platform.target_level].add(target)
+      if target.platform is not None:
+        partition[target.platform.target_level].add(target)
     return partition
 
   def _format_partition(self, partition):
@@ -129,7 +130,7 @@ class JavaCompileSettingsPartitioningTest(TaskTestBase):
                                 platforms=self._platforms('1.6', '1.7'),
                                 default_platform='1.6')
     self.assert_partitions_equal({
-      self._version('1.6'): {java, java6},
+      self._version('1.6'): {java6},
       self._version('1.7'): {java7},
     }, partition)
 

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -124,7 +124,7 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
   @ensure_resolver
   def run_shard(self, shard):
     targets = self.targets_for_shard(shard)
-    pants_run = self.pants_test(targets + ['--jvm-platform-default-platform=java7',
+    pants_run = self.pants_test(targets + ['--jvm-platform-default-platform=java8',
                                            '--gen-protoc-import-from-root'])
     self.assert_success(pants_run)
 


### PR DESCRIPTION
### Problem

In #6945 we realized we needed to increase the default jvm platform to support java code generated by the new version of Scrooge. In doing so, we found that we are eagerly assigning the jvm platform to `JvmTarget`s in the `.platform` property, which is incorrect behavior, or at least very surprising. This surfaced an error in the testprojects integration testing, which can be seen on master:

```
> ./pants jvm-platform-validate testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified:lib testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified:java7

18:12:13 00:00 [main]
               (To run a reporting server: ./pants server)
18:12:14 00:01   [setup]
18:12:14 00:01     [parse]
               Executing tasks in goals: jvm-platform-validate
18:12:14 00:01   [jvm-platform-validate]
18:12:14 00:01     [jvm-platform-validate]
                   Invalidated 2 targets.
FAILURE: Dependencies cannot have a higher java target level than dependees!

  testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified:lib targeting "java8"
  is depended on by: 
    testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified:java7 targeting "java7"

Consider running ./pants jvm-platform-explain with the same targets for more details.
``` 

### Solution

- Return `None` for `JvmTarget#platform` when it's not explicitly specified on the target.
- Update all consumers of the `.platform` property to handle a `None` platform.
- Increase the jvm default platform for the testprojects integration testing to `java8`.
- Properly propagate any explicitly-specified jvm platform to intermediate jvm targets in the `jvm-platform-validate` task, and add a test case for this.
  - This part is necessary to allow the non-eager evaluation of the target jvm platform when unspecified.

### Result

`JvmTarget`s which don't specify a platform can be depended on by targets which do, even if the default jvm platform is greater than the one explicitly specified on a target. When there is a conflict due to transitive constraints, the error message makes it clear where the constraint is coming from.