### PR TITLE
 Add a flag to filedeps v1 to output abs or rel paths

### DIFF
--- a/src/python/pants/build_graph/app_base.py
+++ b/src/python/pants/build_graph/app_base.py
@@ -81,6 +81,21 @@ class BundleProps(namedtuple('_BundleProps', ['rel_path', 'mapper', 'fileset']))
         filemap[abspath] = self.mapper(abspath)
     return filemap
 
+  @memoized_property
+  def relative_filemap(self):
+    filemap = OrderedDict()
+    if self.fileset is not None:
+      paths = self.fileset() if isinstance(self.fileset, Fileset) \
+        else self.fileset if hasattr(self.fileset, '__iter__') \
+        else [self.fileset]
+      for path in paths:
+        if os.path.isabs(path):
+          relpath = fast_relpath(path, get_buildroot())
+        else:
+          relpath = os.path.join(self.rel_path, path)
+        filemap[relpath] = self.mapper(relpath)
+    return filemap
+
   def __hash__(self):
     # Leave out fileset from hash calculation since it may not be hashable.
     return hash((self.rel_path, self.mapper))

--- a/src/python/pants/build_graph/app_base.py
+++ b/src/python/pants/build_graph/app_base.py
@@ -67,34 +67,31 @@ class DirectoryReMapper(object):
 
 
 class BundleProps(namedtuple('_BundleProps', ['rel_path', 'mapper', 'fileset'])):
-  @memoized_property
-  def filemap(self):
+  def _filemap(self, abs_path):
     filemap = OrderedDict()
     if self.fileset is not None:
       paths = self.fileset() if isinstance(self.fileset, Fileset) \
         else self.fileset if hasattr(self.fileset, '__iter__') \
         else [self.fileset]
       for path in paths:
-        abspath = path
-        if not os.path.isabs(abspath):
-          abspath = os.path.join(get_buildroot(), self.rel_path, path)
-        filemap[abspath] = self.mapper(abspath)
+        if abs_path:
+          if not os.path.isabs(path):
+            path = os.path.join(get_buildroot(), self.rel_path, path)
+        else:
+          if os.path.isabs(path):
+            path = fast_relpath(path, get_buildroot())
+          else:
+            path = os.path.join(self.rel_path, path)
+        filemap[path] = self.mapper(path)
     return filemap
 
   @memoized_property
+  def filemap(self):
+    return self._filemap(abs_path=True)
+
+  @memoized_property
   def relative_filemap(self):
-    filemap = OrderedDict()
-    if self.fileset is not None:
-      paths = self.fileset() if isinstance(self.fileset, Fileset) \
-        else self.fileset if hasattr(self.fileset, '__iter__') \
-        else [self.fileset]
-      for path in paths:
-        if os.path.isabs(path):
-          relpath = fast_relpath(path, get_buildroot())
-        else:
-          relpath = os.path.join(self.rel_path, path)
-        filemap[relpath] = self.mapper(relpath)
-    return filemap
+    return self._filemap(abs_path=False)
 
   def __hash__(self):
     # Leave out fileset from hash calculation since it may not be hashable.

--- a/tests/python/pants_test/backend/project_info/tasks/test_filedeps.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_filedeps.py
@@ -15,7 +15,7 @@ from pants.build_graph.register import build_file_aliases as register_core
 from pants_test.task_test_base import ConsoleTaskTestBase
 
 
-class FileDepsTest(ConsoleTaskTestBase):
+class FileDepsTestBase(ConsoleTaskTestBase):
 
   @classmethod
   def alias_groups(cls):
@@ -26,7 +26,7 @@ class FileDepsTest(ConsoleTaskTestBase):
     return FileDeps
 
   def setUp(self):
-    super(FileDepsTest, self).setUp()
+    super(FileDepsTestBase, self).setUp()
     self.context(options={
       'scala': {
         'runtime': ['tools:scala-library']
@@ -233,6 +233,24 @@ class FileDepsTest(ConsoleTaskTestBase):
       targets=[self.target('project:app')]
     )
 
+
+class FileDepsAbsoluteTest(FileDepsTestBase):
+
   def assert_console_output(self, *paths, **kwargs):
+    if 'options' not in kwargs:
+      kwargs['options'] = {}
+    kwargs['options'].update({'abs': True})
+
     abs_paths = [os.path.join(self.build_root, path) for path in paths]
-    super(FileDepsTest, self).assert_console_output(*abs_paths, **kwargs)
+
+    super(FileDepsTestBase, self).assert_console_output(*abs_paths, **kwargs)
+
+
+class FileDepsRelativeTest(FileDepsTestBase):
+
+  def assert_console_output(self, *paths, **kwargs):
+    if 'options' not in kwargs:
+      kwargs['options'] = {}
+    kwargs['options'].update({'abs': False})
+
+    super(FileDepsTestBase, self).assert_console_output(*paths, **kwargs)

--- a/tests/python/pants_test/backend/project_info/tasks/test_filedeps.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_filedeps.py
@@ -16,7 +16,7 @@ from pants_test.task_test_base import ConsoleTaskTestBase
 from pants_test.test_base import TestGenerator
 
 
-class FileDepsTestBase(ConsoleTaskTestBase, TestGenerator):
+class FileDepsTest(ConsoleTaskTestBase, TestGenerator):
 
   @classmethod
   def alias_groups(cls):
@@ -30,10 +30,10 @@ class FileDepsTestBase(ConsoleTaskTestBase, TestGenerator):
     if kwargs['options']['absolute']:
       paths = [os.path.join(self.build_root, path) for path in paths]
 
-    super(FileDepsTestBase, self).assert_console_output(*paths, **kwargs)
+    super(FileDepsTest, self).assert_console_output(*paths, **kwargs)
 
   def setUp(self):
-    super(FileDepsTestBase, self).setUp()
+    super(FileDepsTest, self).setUp()
     self.context(options={
       'scala': {
         'runtime': ['tools:scala-library']
@@ -250,12 +250,12 @@ class FileDepsTestBase(ConsoleTaskTestBase, TestGenerator):
           options=dict(absolute=is_absolute),
         )
 
-      for test in [test_resources, test_globs, test_globs_app, test_scala_java_cycle_scala_end,\
-        test_scala_java_cycle_java_end, test_concrete_only, test_jvm_app]:
-        cls.add_test(
-          '{}_{}'.format(test.__name__, "abs_path" if is_absolute else "rel_path"),
-          test
-        )
+      for test_name, test in sorted(locals().items()):
+        if test_name.startswith('test_'):
+          cls.add_test(
+            '{}_{}'.format(test_name, "abs_path" if is_absolute else "rel_path"),
+            test
+          )
 
 
-FileDepsTestBase.generate_tests()
+FileDepsTest.generate_tests()

--- a/tests/python/pants_test/backend/project_info/tasks/test_filedeps.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_filedeps.py
@@ -239,7 +239,7 @@ class FileDepsAbsoluteTest(FileDepsTestBase):
   def assert_console_output(self, *paths, **kwargs):
     if 'options' not in kwargs:
       kwargs['options'] = {}
-    kwargs['options'].update({'abs': True})
+    kwargs['options'].update({'absolute': True})
 
     abs_paths = [os.path.join(self.build_root, path) for path in paths]
 
@@ -251,6 +251,6 @@ class FileDepsRelativeTest(FileDepsTestBase):
   def assert_console_output(self, *paths, **kwargs):
     if 'options' not in kwargs:
       kwargs['options'] = {}
-    kwargs['options'].update({'abs': False})
+    kwargs['options'].update({'absolute': False})
 
     super(FileDepsTestBase, self).assert_console_output(*paths, **kwargs)


### PR DESCRIPTION
Previously Filedeps v1 listed files with absolute paths. 
This PR adds a flag that allows listing files with relative or absolute path.
Unitest are updated.
