### PR TITLE
Add support for deprecating scoped SubsystemDependencies

### DIFF
--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -49,6 +49,11 @@ class Optionable(AbstractClass):
     return ScopeInfo(cls.options_scope, cls.options_scope_category, cls)
 
   @classmethod
+  def subscope(cls, scope):
+    """Create a subscope under this Optionable's scope."""
+    return '{0}.{1}'.format(cls.options_scope, scope)
+
+  @classmethod
   def known_scope_infos(cls):
     """Yields ScopeInfo for all known scopes for this optionable, in no particular order.
 

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -17,7 +17,17 @@ class Scope(datatype([('scope', str)])):
   """An options scope."""
 
 
-class ScopeInfo(datatype(['scope', 'category', 'optionable_cls'])):
+class ScopeInfo(datatype([
+  'scope',
+  'category',
+  'optionable_cls',
+  # A ScopeInfo may have a deprecated_scope (from its associated optionable_cls), which represents a
+  # previous/deprecated name for a current/non-deprecated ScopeInfo. It may also be directly
+  # deprecated via this `removal_version`, which allows for the deprecation of an entire scope,
+  # including that of a SubsystemDependency (ie, deprecation of a dependency on a scoped Subsystem).
+  'removal_version',
+  'removal_hint',
+])):
   """Information about a scope."""
 
   # Symbolic constants for different categories of scope.
@@ -27,8 +37,8 @@ class ScopeInfo(datatype(['scope', 'category', 'optionable_cls'])):
   SUBSYSTEM = 'SUBSYSTEM'
   INTERMEDIATE = 'INTERMEDIATE'  # Scope added automatically to fill out the scope hierarchy.
 
-  def __new__(cls, scope, category, optionable_cls=None):
-    return super(ScopeInfo, cls).__new__(cls, scope, category, optionable_cls)
+  def __new__(cls, scope, category, optionable_cls=None, removal_version=None, removal_hint=None):
+    return super(ScopeInfo, cls).__new__(cls, scope, category, optionable_cls, removal_version, removal_hint)
 
   @property
   def description(self):

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -50,12 +50,15 @@ class Subsystem(SubsystemClientMixin, Optionable):
     return inspect.isclass(obj) and issubclass(obj, cls)
 
   @classmethod
-  def scoped(cls, optionable):
+  def scoped(cls, optionable, removal_version=None, removal_hint=None):
     """Returns a dependency on this subsystem, scoped to `optionable`.
+
+    :param removal_version: An optional deprecation version for this scoped Subsystem dependency.
+    :param removal_hint: An optional hint to accompany a deprecation removal_version.
 
     Return value is suitable for use in SubsystemClientMixin.subsystem_dependencies().
     """
-    return SubsystemDependency(cls, optionable.options_scope)
+    return SubsystemDependency(cls, optionable.options_scope, removal_version, removal_hint)
 
   @classmethod
   def get_scope_info(cls, subscope=None):
@@ -64,11 +67,6 @@ class Subsystem(SubsystemClientMixin, Optionable):
       return super(Subsystem, cls).get_scope_info()
     else:
       return ScopeInfo(cls.subscope(subscope), ScopeInfo.SUBSYSTEM, cls)
-
-  @classmethod
-  def subscope(cls, scope):
-    """Create a subscope under this Subsystem's scope."""
-    return '{0}.{1}'.format(cls.options_scope, scope)
 
   # The full Options object for this pants run.  Will be set after options are parsed.
   # TODO: A less clunky way to make option values available?

--- a/src/python/pants/subsystem/subsystem_client_mixin.py
+++ b/src/python/pants/subsystem/subsystem_client_mixin.py
@@ -24,6 +24,9 @@ class SubsystemDependency(datatype([
 ])):
   """Indicates intent to use an instance of `subsystem_cls` scoped to `scope`."""
 
+  def __new__(cls, subsystem_cls, scope, removal_version=None, removal_hint=None):
+    return super(SubsystemDependency, cls).__new__(cls, subsystem_cls, scope, removal_version, removal_hint)
+
   def is_global(self):
     return self.scope == GLOBAL_SCOPE
 
@@ -144,12 +147,12 @@ class SubsystemClientMixin(object):
           # NB: We do not apply deprecations to this implicit global copy of the scope, because if
           # the intention was to deprecate the entire scope, that could be accomplished by
           # deprecating all options in the scope.
+          collect_scope_infos(dep.subsystem_cls, GLOBAL_SCOPE)
           if not dep.is_global():
-            collect_scope_infos(dep.subsystem_cls, GLOBAL_SCOPE)
-          collect_scope_infos(dep.subsystem_cls,
-                              scope,
-                              removal_version=dep.removal_version,
-                              removal_hint=dep.removal_hint)
+            collect_scope_infos(dep.subsystem_cls,
+                                scope,
+                                removal_version=dep.removal_version,
+                                removal_hint=dep.removal_hint)
 
       optionables_path.remove(scope_info.optionable_cls)
 


### PR DESCRIPTION
### Problem

In order for a `v2` `Goal` (in #6880) to replace a goal that was previously implemented as a collection of v1 `Task`s, we need the ability to declare a deprecated dependency on a `Subsystem` (concretely: `CacheSetup`, in that case).

As explained in the patch, this is different from `Optionable.deprecated_scope` in one fundamental way: with `deprecated_scope` options live in two locations simultaneously (one of which is deprecated), while with a deprecated dependency they live in one location (which is deprecated). This split plays out in the unit tests, which verify that `Optionable.deprecated_scope` allows for splitting of a deprecated scope between two new destinations.

### Solution

Add a `removal_version` to `SubsystemDependency` and `ScopeInfo`, and consume it in `Options` in order to render a warning for a deprecated `ScopeInfo`.

The ability to deprecate a scoped dependency is exposed via `Subsystem.scoped(cls, removal_version=.., removal_hint=..)`.

### Result

Callers can use `Subsystem.scoped(cls, removal_version=.., removal_hint=..)` to deprecate a scoped `Subsystem` dependency. #6880 will be unblocked to introduce a deprecated dependency on `CacheSetup` for v2 goals.