### PR TITLE
Fix tokenize encoding issue engine parser on Python 3

### DIFF
--- a/src/python/pants/engine/legacy/parser.py
+++ b/src/python/pants/engine/legacy/parser.py
@@ -8,9 +8,10 @@ import logging
 import os
 import tokenize
 from builtins import object
-from io import StringIO
+from io import BytesIO, StringIO
 
 import six
+from future.utils import PY3
 
 from pants.base.build_file_target_factory import BuildFileTargetFactory
 from pants.base.parse_context import ParseContext
@@ -127,7 +128,7 @@ class LegacyPythonCallbacksParser(Parser):
     return symbols, parse_context
 
   def parse(self, filepath, filecontent):
-    python = filecontent.decode('utf-8')
+    python = filecontent.decode('utf-8') if PY3 else filecontent
 
     # Mutate the parse context for the new path, then exec, and copy the resulting objects.
     # We execute with a (shallow) clone of the symbols as a defense against accidental
@@ -143,7 +144,8 @@ class LegacyPythonCallbacksParser(Parser):
     # But it's sufficient to tell most users who aren't being actively malicious that they're doing
     # something wrong, and it has a low performance overhead.
     if self._build_file_imports_behavior != 'allow' and 'import' in python:
-      for token in tokenize.generate_tokens(StringIO(python).readline):
+      io_wrapped_python = StringIO(python) if PY3 else BytesIO(python)
+      for token in tokenize.generate_tokens(io_wrapped_python.readline):
         if token[1] == 'import':
           line_being_tokenized = token[4]
           if self._build_file_imports_behavior == 'warn':

--- a/src/python/pants/engine/legacy/parser.py
+++ b/src/python/pants/engine/legacy/parser.py
@@ -8,7 +8,7 @@ import logging
 import os
 import tokenize
 from builtins import object
-from io import BytesIO
+from io import StringIO
 
 import six
 
@@ -127,7 +127,7 @@ class LegacyPythonCallbacksParser(Parser):
     return symbols, parse_context
 
   def parse(self, filepath, filecontent):
-    python = filecontent
+    python = filecontent.decode('utf-8')
 
     # Mutate the parse context for the new path, then exec, and copy the resulting objects.
     # We execute with a (shallow) clone of the symbols as a defense against accidental
@@ -143,7 +143,7 @@ class LegacyPythonCallbacksParser(Parser):
     # But it's sufficient to tell most users who aren't being actively malicious that they're doing
     # something wrong, and it has a low performance overhead.
     if self._build_file_imports_behavior != 'allow' and 'import' in python:
-      for token in tokenize.generate_tokens(BytesIO(python).readline):
+      for token in tokenize.generate_tokens(StringIO(python).readline):
         if token[1] == 'import':
           line_being_tokenized = token[4]
           if self._build_file_imports_behavior == 'warn':

--- a/tests/python/pants_test/engine/legacy/test_parser.py
+++ b/tests/python/pants_test/engine/legacy/test_parser.py
@@ -17,7 +17,7 @@ class LegacyPythonCallbacksParserTest(unittest.TestCase):
     # A parser with no symbols registered.
     parser = LegacyPythonCallbacksParser(EmptyTable(), BuildFileAliases(), build_file_imports_behavior='allow')
     # Call to import a module should succeed.
-    parser.parse('/dev/null', '''import os; os.path.join('x', 'y')''')
+    parser.parse('/dev/null', b'''import os; os.path.join('x', 'y')''')
     # But the imported module should not be visible as a symbol in further parses.
     with self.assertRaises(NameError):
-      parser.parse('/dev/null', '''os.path.join('x', 'y')''')
+      parser.parse('/dev/null', b'''os.path.join('x', 'y')''')


### PR DESCRIPTION
We were always reading file content as bytes, when in Python 2 the tokenize library does expect bytes but in Python 3 it expects unicode. This led to a MappingError whenever trying to execute any goal that involved reading a BUILD file.

We originally improperly fixed this by having the test code pass unicode, which worked because Python 2 would implicitly coerce the test content into unicode, and Python 3 was using the unicode it needed.

We now properly decode the file to unicode conditional on the interpreter used.