### PR TITLE
Fix scheduler.metrics() using bytes instead of unicode

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -400,8 +400,8 @@ class RunTracker(Subsystem):
     # TODO(benjy): Do we really need these, once the statsdb is mature?
     stats_file = os.path.join(get_pants_cachedir(), 'stats',
                               '{}.json'.format(self.run_info.get_info('id')))
-    binary_mode = False if PY3 else True
-    safe_file_dump(stats_file, json.dumps(stats), binary_mode=binary_mode)
+    mode = 'w' if PY3 else 'wb'
+    safe_file_dump(stats_file, json.dumps(stats), mode=mode)
 
     # Add to local stats db.
     StatsDBFactory.global_instance().get_db().insert_stats(stats)

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -346,7 +346,7 @@ pub extern "C" fn scheduler_metrics(
         .into_iter()
         .map(|(metric, value)| {
           externs::store_tuple(&[
-            externs::store_bytes(metric.as_bytes()),
+            externs::store_utf8(metric),
             externs::store_i64(value),
           ])
         }).collect::<Vec<_>>();


### PR DESCRIPTION
`scheduler.metrics()` was returning a `Dict[bytes, int]`, whereas we want `Dict[str, int]`. 

This was leading to issues when running Pants with Python 3, whereas Python 2 would allow mixing bytes and unicode.