### PR TITLE
Fix python_artifact fingerprint unicode issue for Python 3

### DIFF
--- a/src/python/pants/backend/python/python_artifact.py
+++ b/src/python/pants/backend/python/python_artifact.py
@@ -71,10 +71,11 @@ class PythonArtifact(PayloadField):
     return self.name
 
   def _compute_fingerprint(self):
-    fingerprint = sha1(json.dumps((self._kw, self._binaries),
+    json_representation = json.dumps((self._kw, self._binaries),
                                   ensure_ascii=True,
                                   allow_nan=False,
-                                  sort_keys=True)).hexdigest()
+                                  sort_keys=True)
+    fingerprint = sha1(json_representation.encode('utf-8')).hexdigest()
     return fingerprint if PY3 else fingerprint.decode('utf-8')
 
   def with_binaries(self, *args, **kw):

--- a/src/python/pants/backend/python/python_artifact.py
+++ b/src/python/pants/backend/python/python_artifact.py
@@ -9,6 +9,7 @@ from hashlib import sha1
 
 from future.utils import PY3
 
+from pants.base.hash_utils import stable_json_hash
 from pants.base.payload_field import PayloadField
 
 
@@ -71,12 +72,7 @@ class PythonArtifact(PayloadField):
     return self.name
 
   def _compute_fingerprint(self):
-    json_representation = json.dumps((self._kw, self._binaries),
-                                  ensure_ascii=True,
-                                  allow_nan=False,
-                                  sort_keys=True)
-    fingerprint = sha1(json_representation.encode('utf-8')).hexdigest()
-    return fingerprint if PY3 else fingerprint.decode('utf-8')
+    return stable_json_hash((self._kw, self._binaries))
 
   def with_binaries(self, *args, **kw):
     """Add binaries tagged to this artifact.

--- a/src/python/pants/backend/python/python_artifact.py
+++ b/src/python/pants/backend/python/python_artifact.py
@@ -4,9 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import json
-from hashlib import sha1
-
 from pants.base.hash_utils import stable_json_hash
 from pants.base.payload_field import PayloadField
 

--- a/src/python/pants/backend/python/python_artifact.py
+++ b/src/python/pants/backend/python/python_artifact.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import json
 from hashlib import sha1
 
-from future.utils import PY3
-
 from pants.base.hash_utils import stable_json_hash
 from pants.base.payload_field import PayloadField
 


### PR DESCRIPTION
In Python 3, `json.dumps()` returns unicode. We were not then converting this into bytes before passing it to `sha1()`.

This resulted in issues trying to run commands like `./pants lint ::` when using a Python 3 interpreter.