### PR TITLE
Markdown writer errors are written properly

### DIFF
--- a/src/python/pants/backend/docgen/tasks/markdown_to_html.py
+++ b/src/python/pants/backend/docgen/tasks/markdown_to_html.py
@@ -22,6 +22,7 @@ from pants.build_graph.address import Address
 from pants.task.task import Task
 from pants.util import desktop
 from pants.util.dirutil import safe_mkdir
+from pants.util.rwbuf import StringWriter
 
 
 def util():
@@ -201,7 +202,7 @@ class MarkdownToHtml(Task):
     source_path = os.path.join(get_buildroot(), source)
     with codecs.open(source_path, 'r', 'utf-8') as source_stream:
       rst_html, returncode = util().rst_to_html(source_stream.read(),
-                                                stderr=workunit.output('stderr'))
+                                                stderr=StringWriter(workunit.output('stderr')))
       if returncode != 0:
         message = '{} rendered with errors.'.format(source_path)
         if self.get_options().ignore_failure:

--- a/src/python/pants/util/rwbuf.py
+++ b/src/python/pants/util/rwbuf.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import threading
-from builtins import bytes, object, open
+from builtins import bytes, object, open, str
 from io import BytesIO
 
 
@@ -79,3 +79,29 @@ class FileBackedRWBuf(_RWBuf):
 
   def do_write(self, s):
     self._io.write(s)
+
+
+class StringWriter(object):
+  """A write-only buffer which accepts strings and writes to another buffer which accepts bytes.
+
+  Writes strings as utf-8.
+
+  This is write-only because it's unclear whether seeking should seek by code-point or byte, and
+  implementing the former is non-trivial. If you need to read, read from the underlying buffer's
+  bytes.
+  """
+
+  def __init__(self, underlying):
+    # Called buffer to mirror how sys.stdout and sys.stderr expose this.
+    self.buffer = underlying
+
+  def write(self, s):
+    if not isinstance(s, str):
+      raise ValueError('Expected unicode str, not {}, for argument {}'.format(type(s), s))
+    self.buffer.write(s.encode('utf-8'))
+
+  def flush(self):
+    self.buffer.flush()
+
+  def close(self):
+    self.buffer.close()

--- a/src/python/pants/util/rwbuf.py
+++ b/src/python/pants/util/rwbuf.py
@@ -92,6 +92,9 @@ class StringWriter(object):
   """
 
   def __init__(self, underlying):
+    """
+    :param underlying: Any file-like object which has a write(binary_string) function.
+    """
     # Called buffer to mirror how sys.stdout and sys.stderr expose this.
     self.buffer = underlying
 

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -142,6 +142,15 @@ python_tests(
 )
 
 python_tests(
+  name = 'rwbuf',
+  sources = ['test_rwbuf.py'],
+  dependencies = [
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:rwbuf',
+  ],
+)
+
+python_tests(
   name = 'socket',
   sources = ['test_socket.py'],
   coverage = ['pants.util.socket'],

--- a/tests/python/pants_test/util/test_rwbuf.py
+++ b/tests/python/pants_test/util/test_rwbuf.py
@@ -17,7 +17,7 @@ class StringWriterTest(unittest.TestCase):
       fb = FileBackedRWBuf(p)
       try:
         sw = StringWriter(fb)
-        sw.write(u"\u2764 Curious Zelda")
+        sw.write("\u2764 Curious Zelda")
       finally:
         fb.close()
       with open(p, 'rb') as f:
@@ -39,9 +39,9 @@ class StringWriterTest(unittest.TestCase):
       fb = FileBackedRWBuf(p)
       try:
         sw = StringWriter(fb)
-        sw.write(u"\u2764")
+        sw.write("\u2764")
         sw.buffer.write(b" Curious")
-        sw.write(u" Zelda")
+        sw.write(" Zelda")
       finally:
         fb.close()
       with open(p, 'rb') as f:

--- a/tests/python/pants_test/util/test_rwbuf.py
+++ b/tests/python/pants_test/util/test_rwbuf.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+from pants.util.contextutil import temporary_file_path
+from pants.util.rwbuf import FileBackedRWBuf, StringWriter
+
+
+class StringWriterTest(unittest.TestCase):
+
+  def test_writes_string(self):
+    with temporary_file_path() as p:
+      fb = FileBackedRWBuf(p)
+      try:
+        sw = StringWriter(fb)
+        sw.write(u"\u2764 Curious Zelda")
+      finally:
+        fb.close()
+      with open(p, 'rb') as f:
+        contents = f.read()
+        self.assertEquals(contents, b'\xe2\x9d\xa4 Curious Zelda')
+
+  def test_rejects_binary(self):
+    with temporary_file_path() as p:
+      fb = FileBackedRWBuf(p)
+      sw = StringWriter(fb)
+      try:
+        with self.assertRaises(ValueError):
+          sw.write(b"Curious Zelda")
+      finally:
+        fb.close()
+
+  def test_can_write_binary_to_buffer(self):
+    with temporary_file_path() as p:
+      fb = FileBackedRWBuf(p)
+      try:
+        sw = StringWriter(fb)
+        sw.write(u"\u2764")
+        sw.buffer.write(b" Curious")
+        sw.write(u" Zelda")
+      finally:
+        fb.close()
+      with open(p, 'rb') as f:
+        contents = f.read()
+        self.assertEquals(contents, b'\xe2\x9d\xa4 Curious Zelda')


### PR DESCRIPTION
Before this change, if we encounter errors rendering markdown, docutils
will try to write unicode errors to the RWBuf, which will fail because
the RWBuf expects binary.