### PR TITLE
Convert Native into a singleton

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -44,7 +44,7 @@ class LocalPantsRunner(object):
     if graph_session:
       return graph_session
 
-    native = Native.instance()
+    native = Native()
     native.set_panic_handler()
     graph_scheduler_helper = EngineInitializer.setup_legacy_graph(
       native,

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -44,7 +44,7 @@ class LocalPantsRunner(object):
     if graph_session:
       return graph_session
 
-    native = Native.create(options_bootstrapper.bootstrap_options.for_global_scope())
+    native = Native.instance()
     native.set_panic_handler()
     graph_scheduler_helper = EngineInitializer.setup_legacy_graph(
       native,

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -21,7 +21,7 @@ from future.utils import PY2, binary_type, text_type
 from pants.engine.selectors import Get, constraint_for
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import read_file, safe_mkdir, safe_mkdtemp
-from pants.util.memo import memoized_classproperty, memoized_property
+from pants.util.memo import memoized_classproperty, memoized_method, memoized_property
 from pants.util.objects import datatype
 
 
@@ -531,23 +531,12 @@ class ExternContext(object):
 class Native(object):
   """Encapsulates fetching a platform specific version of the native portion of the engine."""
 
-  @staticmethod
-  def create(bootstrap_options):
-    """:param options: Any object that provides access to bootstrap option values."""
-    return Native(bootstrap_options.native_engine_visualize_to)
-
-  def __init__(self, visualize_to_dir):
-    """
-    :param visualize_to_dir: An existing directory (or None) to visualize executions to.
-    """
-    # TODO: This should likely be a per-session property... ie, not a bootstrap option.
-    self._visualize_to_dir = visualize_to_dir
-
-  @property
-  def visualize_to_dir(self):
-    return self._visualize_to_dir
-
   class BinaryLocationError(Exception): pass
+
+  @classmethod
+  @memoized_method
+  def instance(cls):
+    return Native()
 
   @memoized_property
   def binary(self):

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -21,7 +21,8 @@ from future.utils import PY2, binary_type, text_type
 from pants.engine.selectors import Get, constraint_for
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import read_file, safe_mkdir, safe_mkdtemp
-from pants.util.memo import memoized_classproperty, memoized_method, memoized_property
+from pants.util.memo import memoized_classproperty, memoized_property
+from pants.util.meta import Singleton
 from pants.util.objects import datatype
 
 
@@ -528,15 +529,10 @@ class ExternContext(object):
     return self._lib.val_for(key)
 
 
-class Native(object):
+class Native(Singleton):
   """Encapsulates fetching a platform specific version of the native portion of the engine."""
 
   class BinaryLocationError(Exception): pass
-
-  @classmethod
-  @memoized_method
-  def instance(cls):
-    return Native()
 
   @memoized_property
   def binary(self):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -58,6 +58,7 @@ class Scheduler(object):
     execution_options,
     include_trace_on_error=True,
     validate=True,
+    visualize_to_dir=None,
   ):
     """
     :param native: An instance of engine.native.Native.
@@ -76,6 +77,7 @@ class Scheduler(object):
 
     self._native = native
     self.include_trace_on_error = include_trace_on_error
+    self._visualize_to_dir = visualize_to_dir
     # Validate and register all provided and intrinsic tasks.
     rule_index = RuleIndex.create(list(rules))
     self._root_subject_types = sorted(rule_index.roots, key=repr)
@@ -120,9 +122,9 @@ class Scheduler(object):
 
 
     # If configured, visualize the rule graph before asserting that it is valid.
-    if self.visualize_to_dir() is not None:
+    if self._visualize_to_dir is not None:
       rule_graph_name = 'rule_graph.dot'
-      self.visualize_rule_graph_to_file(os.path.join(self.visualize_to_dir(), rule_graph_name))
+      self.visualize_rule_graph_to_file(os.path.join(self._visualize_to_dir, rule_graph_name))
 
     if validate:
       self._assert_ruleset_valid()
@@ -277,7 +279,7 @@ class Scheduler(object):
     self._raise_or_return(res)
 
   def visualize_to_dir(self):
-    return self._native.visualize_to_dir
+    return self._visualize_to_dir
 
   def _metrics(self, session):
     metrics_val = self._native.lib.scheduler_metrics(self._scheduler, session)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -32,7 +32,6 @@ from pants.engine.legacy.structs import (AppAdaptor, JvmBinaryAdaptor, PageAdapt
                                          PythonTargetAdaptor, PythonTestsAdaptor,
                                          RemoteSourcesAdaptor, TargetAdaptor)
 from pants.engine.mapper import AddressMapper
-from pants.engine.native import Native
 from pants.engine.parser import SymbolTable
 from pants.engine.rules import SingletonRule
 from pants.engine.scheduler import Scheduler
@@ -319,6 +318,8 @@ class EngineInitializer(object):
 
     build_root = build_root or get_buildroot()
     build_configuration = build_configuration or BuildConfigInitializer.get(options_bootstrapper)
+    bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
+
     build_file_aliases = build_configuration.registered_aliases()
     rules = build_configuration.rules()
     console = Console()
@@ -339,9 +340,6 @@ class EngineInitializer(object):
                                    build_ignore_patterns=build_ignore_patterns,
                                    exclude_target_regexps=exclude_target_regexps,
                                    subproject_roots=subproject_roots)
-
-    # Load the native backend.
-    native = native or Native.create()
 
     # Create a Scheduler containing graph and filesystem rules, with no installed goals. The
     # LegacyBuildGraph will explicitly request the products it needs.
@@ -372,6 +370,7 @@ class EngineInitializer(object):
       rules,
       execution_options,
       include_trace_on_error=include_trace_on_error,
+      visualize_to_dir=bootstrap_options.native_engine_visualize_to,
     )
 
     return LegacyGraphScheduler(scheduler, symbol_table, console, goal_map)

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -137,7 +137,7 @@ class PantsDaemon(FingerprintedProcessManager):
 
       if full_init:
         build_root = get_buildroot()
-        native = Native.create(bootstrap_options_values)
+        native = Native.instance()
         build_config = BuildConfigInitializer.get(options_bootstrapper)
         legacy_graph_scheduler = EngineInitializer.setup_legacy_graph(native,
                                                                       options_bootstrapper,

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -137,7 +137,7 @@ class PantsDaemon(FingerprintedProcessManager):
 
       if full_init:
         build_root = get_buildroot()
-        native = Native.instance()
+        native = Native()
         build_config = BuildConfigInitializer.get(options_bootstrapper)
         legacy_graph_scheduler = EngineInitializer.setup_legacy_graph(native,
                                                                       options_bootstrapper,

--- a/tests/python/pants_test/engine/util.py
+++ b/tests/python/pants_test/engine/util.py
@@ -11,7 +11,6 @@ from io import StringIO
 from types import GeneratorType
 
 from pants.base.file_system_project_tree import FileSystemProjectTree
-from pants.binaries.binary_util import BinaryUtil
 from pants.engine.addressable import addressable_list
 from pants.engine.native import Native
 from pants.engine.parser import SymbolTable
@@ -20,10 +19,7 @@ from pants.engine.selectors import Get
 from pants.engine.struct import Struct
 from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS
 from pants.util.dirutil import safe_mkdtemp
-from pants.util.memo import memoized
 from pants.util.objects import SubclassesOf
-from pants_test.option.util.fakes import create_options_for_optionables
-from pants_test.subsystem.subsystem_util import init_subsystem
 
 
 def run_rule(rule, *args):
@@ -86,12 +82,9 @@ def run_rule(rule, *args):
       return res
 
 
-@memoized
 def init_native():
-  """Initialize and return a `Native` instance."""
-  init_subsystem(BinaryUtil.Factory)
-  opts = create_options_for_optionables([])
-  return Native.create(opts.for_global_scope())
+  """Return the `Native` instance."""
+  return Native.instance()
 
 
 def create_scheduler(rules, validate=True, native=None):

--- a/tests/python/pants_test/engine/util.py
+++ b/tests/python/pants_test/engine/util.py
@@ -84,7 +84,7 @@ def run_rule(rule, *args):
 
 def init_native():
   """Return the `Native` instance."""
-  return Native.instance()
+  return Native()
 
 
 def create_scheduler(rules, validate=True, native=None):


### PR DESCRIPTION
### Problem

Previously the binary blob loaded by the `Native` instance was fetched using `BinaryUtils`, which meant that fetching it required bootstrap options, which put constraints on where in the process you could use the native instance.

But a while back that binary blob was moved to being loaded with python resources, so instantiating the `Native` instance no longer required any configuration... although its API continued to suggest that it did.

### Solution

Move the last remaining argument for `Native.create(..)` to `Scheduler.__init__`, and replace `Native.create(..)` with `Native.instance()`. While it should also be possible now to remove the passing of the `native` instance in a bunch of places, this PR does not do that, in order to avoid conflicts with other in flight PRs.

### Result

The true requirements of loading a `Native` instance are more apparent, and the initialization code in #6817 should be simplified.