### PR TITLE
Don't explicitly use TaskRule

### DIFF
--- a/src/python/pants/engine/parser.py
+++ b/src/python/pants/engine/parser.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from abc import abstractmethod
 
 from pants.util.meta import AbstractClass
-from pants.util.objects import Exactly
+from pants.util.objects import Exactly, datatype
 
 
 class ParseError(Exception):
@@ -26,6 +26,14 @@ class SymbolTable(AbstractClass):
     # NB Sort types so that multiple calls get the same tuples.
     symbol_table_types = sorted(set(self.table().values()), key=repr)
     return Exactly(*symbol_table_types, description='symbol table types')
+
+
+class TargetAdaptorContainer(datatype(["value"])):
+  """A wrapper around a concrete TargetAdaptor subclass.
+
+  This exists so that the rule graph can statically provide a TargetAdaptor for a target, and rules can depend on this
+  without needing to depend on having a concrete instance of SymbolTable to register their input selectors.
+  """
 
 
 class EmptyTable(SymbolTable):

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import ast
 import functools
 import inspect
+import itertools
 import logging
 from abc import abstractproperty
 from builtins import bytes, str
@@ -86,7 +87,11 @@ def _make_rule(output_type, input_selectors, for_goal=None, cacheable=True):
       raise ValueError('The @rule decorator must be applied innermost of all decorators.')
 
     caller_frame = inspect.stack()[1][0]
-    module_ast = ast.parse(inspect.getsource(func))
+    source = inspect.getsource(func)
+    if source.startswith(" "):
+      to_trim = sum(1 for _ in itertools.takewhile(lambda c: c in {' ', b' '}, source))
+      source = "\n".join(line[to_trim:] for line in source.split("\n"))
+    module_ast = ast.parse(source)
 
     def resolve_type(name):
       resolved = caller_frame.f_globals.get(name) or caller_frame.f_builtins.get(name)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -348,11 +348,12 @@ class EngineInitializer(object):
         SingletonRule.from_instance(console),
         SingletonRule.from_instance(GlobMatchErrorBehavior.create(glob_match_error_behavior)),
         SingletonRule.from_instance(build_configuration),
+        SingletonRule(SymbolTable, symbol_table),
       ] +
-      create_legacy_graph_tasks(symbol_table) +
+      create_legacy_graph_tasks() +
       create_fs_rules() +
       create_process_rules() +
-      create_graph_rules(address_mapper, symbol_table) +
+      create_graph_rules(address_mapper) +
       create_options_parsing_rules() +
       create_core_rules() +
       # TODO: This should happen automatically, but most tests (e.g. tests/python/pants_test/auth) fail if it's not here:

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -155,7 +155,7 @@ class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
     # We add the `unhydrated_structs` rule because it is otherwise not used in the core engine.
     rules = [
         unhydrated_structs
-      ] + create_fs_rules() + create_graph_rules(address_mapper, symbol_table)
+      ] + create_fs_rules() + create_graph_rules(address_mapper)
 
     project_tree = self.mk_fs_tree(os.path.join(os.path.dirname(__file__), 'examples/mapper_test'))
     self.build_root = project_tree.build_root

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -223,7 +223,7 @@ class RuleGraphMakerTest(unittest.TestCase):
   def test_full_graph_for_planner_example(self):
     symbol_table = TargetTable()
     address_mapper = AddressMapper(JsonParser(symbol_table), '*.BUILD.json')
-    rules = create_graph_rules(address_mapper, symbol_table) + create_fs_rules()
+    rules = create_graph_rules(address_mapper) + create_fs_rules()
 
     fullgraph_str = self.create_full_graph(rules)
 

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -230,7 +230,7 @@ class RulesetValidatorTest(unittest.TestCase):
 
     @rule(D, [Select(A), Select(SubA)])
     def d_from_a_and_suba(a, suba):
-      _ = yield Get(A, C, C())
+      _ = yield Get(A, C, C())  # noqa: F841
 
     @rule(A, [Select(C)])
     def a_from_c(c):
@@ -551,7 +551,7 @@ class RuleGraphMakerTest(unittest.TestCase):
   def test_get_with_matching_singleton(self):
     @rule(Exactly(A), [Select(SubA)])
     def a_from_suba(suba):
-      _ = yield Get(B, C, C())
+      _ = yield Get(B, C, C())  # noqa: F841
 
     rules = [
       a_from_suba,
@@ -645,7 +645,7 @@ class RuleGraphMakerTest(unittest.TestCase):
   def test_get_simple(self):
     @rule(Exactly(A), [])
     def a():
-      _ = yield Get(B, D, D())
+      _ = yield Get(B, D, D())  # noqa: F841
 
     @rule(B, [Select(D)])
     def b_from_d(d):

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -12,8 +12,7 @@ from pants.engine.build_files import create_graph_rules
 from pants.engine.console import Console
 from pants.engine.fs import create_fs_rules
 from pants.engine.mapper import AddressMapper
-from pants.engine.rules import (RootRule, RuleIndex, SingletonRule, TaskRule, _GoalProduct,
-                                console_rule)
+from pants.engine.rules import RootRule, RuleIndex, SingletonRule, _GoalProduct, console_rule, rule
 from pants.engine.selectors import Get, Select
 from pants.util.objects import Exactly
 from pants_test.engine.examples.parsers import JsonParser
@@ -83,85 +82,130 @@ class RuleIndexTest(unittest.TestCase):
 
 class RulesetValidatorTest(unittest.TestCase):
   def test_ruleset_with_missing_product_type(self):
-    rules = _suba_root_rules + [TaskRule(A, [Select(B)], noop)]
+    @rule(A, [Select(B)])
+    def a_from_b_noop(b):
+      pass
+
+    rules = _suba_root_rules + [a_from_b_noop]
 
     with self.assertRaises(Exception) as cm:
       create_scheduler(rules)
 
     self.assert_equal_with_printing(dedent("""
                      Rules with errors: 1
-                       (A, [Select(B)], noop):
+                       (A, [Select(B)], a_from_b_noop):
                          No rule was available to compute B with parameter type SubA
                      """).strip(),
                                     str(cm.exception))
 
   def test_ruleset_with_ambiguity(self):
+    @rule(A, [Select(C), Select(B)])
+    def a_from_c_and_b(c, b):
+      pass
+
+    @rule(A, [Select(B), Select(C)])
+    def a_from_b_and_c(b, c):
+      pass
+
+    @rule(D, [Select(A)])
+    def d_from_a(a):
+      pass
+
+
     rules = [
-        TaskRule(A, [Select(C), Select(B)], noop),
-        TaskRule(A, [Select(B), Select(C)], noop),
+        a_from_c_and_b,
+        a_from_b_and_c,
         RootRule(B),
         RootRule(C),
         # TODO: Without a rule triggering the selection of A, we don't detect ambiguity here.
-        TaskRule(D, [Select(A)], noop),
+        d_from_a,
       ]
     with self.assertRaises(Exception) as cm:
       create_scheduler(rules)
 
     self.assert_equal_with_printing(dedent("""
                      Rules with errors: 1
-                       (D, [Select(A)], noop):
+                       (D, [Select(A)], d_from_a):
                          ambiguous rules for Select(A) with parameter types (B+C):
-                           (A, [Select(B), Select(C)], noop) for (B+C)
-                           (A, [Select(C), Select(B)], noop) for (B+C)
+                           (A, [Select(B), Select(C)], a_from_b_and_c) for (B+C)
+                           (A, [Select(C), Select(B)], a_from_c_and_b) for (B+C)
                      """).strip(),
       str(cm.exception))
 
   def test_ruleset_with_rule_with_two_missing_selects(self):
-    rules = _suba_root_rules + [TaskRule(A, [Select(B), Select(C)], noop)]
+    @rule(A, [Select(B), Select(C)])
+    def a_from_b_and_c(b, c):
+      pass
+
+    rules = _suba_root_rules + [a_from_b_and_c]
     with self.assertRaises(Exception) as cm:
       create_scheduler(rules)
 
     self.assert_equal_with_printing(dedent("""
                      Rules with errors: 1
-                       (A, [Select(B), Select(C)], noop):
+                       (A, [Select(B), Select(C)], a_from_b_and_c):
                          No rule was available to compute B with parameter type SubA
                          No rule was available to compute C with parameter type SubA
                      """).strip(),
       str(cm.exception))
 
   def test_ruleset_with_selector_only_provided_as_root_subject(self):
-    rules = [RootRule(B), TaskRule(A, [Select(B)], noop)]
+    @rule(A, [Select(B)])
+    def a_from_b(b):
+      pass
+
+    rules = [RootRule(B), a_from_b]
     create_scheduler(rules)
 
   def test_ruleset_with_superclass_of_selected_type_produced_fails(self):
+    @rule(A, [Select(B)])
+    def a_from_b(b):
+      pass
+
+    @rule(B, [Select(SubA)])
+    def b_from_suba(suba):
+      pass
+
     rules = [
       RootRule(C),
-      TaskRule(A, [Select(B)], noop),
-      TaskRule(B, [Select(SubA)], noop)
+      a_from_b,
+      b_from_suba,
     ]
 
     with self.assertRaises(Exception) as cm:
       create_scheduler(rules)
     self.assert_equal_with_printing(dedent("""
                                       Rules with errors: 2
-                                        (A, [Select(B)], noop):
+                                        (A, [Select(B)], a_from_b):
                                           No rule was available to compute B with parameter type C
-                                        (B, [Select(SubA)], noop):
+                                        (B, [Select(SubA)], b_from_suba):
                                           No rule was available to compute SubA with parameter type C
                                       """).strip(),
                                     str(cm.exception))
 
   def test_ruleset_with_explicit_type_constraint(self):
+    @rule(Exactly(A), [Select(B)])
+    def a_from_b(b):
+      pass
+
+    @rule(B, [Select(A)])
+    def b_from_a(a):
+      pass
+
     rules = _suba_root_rules + [
-      TaskRule(Exactly(A), [Select(B)], noop),
-      TaskRule(B, [Select(A)], noop)
+      a_from_b,
+      b_from_a,
     ]
     create_scheduler(rules)
 
   def test_ruleset_with_failure_due_to_incompatible_subject_for_singleton(self):
+    @rule(D, [Select(C)])
+    def d_from_c(c):
+      pass
+
     rules = [
       RootRule(A),
-      TaskRule(D, [Select(C)], noop),
+      d_from_c,
       SingletonRule(B, B()),
     ]
 
@@ -171,7 +215,7 @@ class RulesetValidatorTest(unittest.TestCase):
     # This error message could note near matches like the singleton.
     self.assert_equal_with_printing(dedent("""
                                       Rules with errors: 1
-                                        (D, [Select(C)], noop):
+                                        (D, [Select(C)], d_from_c):
                                           No rule was available to compute C with parameter type A
                                       """).strip(),
                                     str(cm.exception))
@@ -179,10 +223,23 @@ class RulesetValidatorTest(unittest.TestCase):
   def test_not_fulfillable_duplicated_dependency(self):
     # If a rule depends on another rule+subject in two ways, and one of them is unfulfillable
     # Only the unfulfillable one should be in the errors.
+
+    @rule(B, [Select(D)])
+    def b_from_d(d):
+      pass
+
+    @rule(D, [Select(A), Select(SubA)])
+    def d_from_a_and_suba(a, suba):
+      _ = yield Get(A, C, C())
+
+    @rule(A, [Select(C)])
+    def a_from_c(c):
+      pass
+
     rules = _suba_root_rules + [
-      TaskRule(B, [Select(D)], noop),
-      TaskRule(D, [Select(A), Select(SubA)], noop, input_gets=[Get(A, C)]),
-      TaskRule(A, [Select(C)], noop)
+      b_from_d,
+      d_from_a_and_suba,
+      a_from_c,
     ]
 
     with self.assertRaises(Exception) as cm:
@@ -190,9 +247,9 @@ class RulesetValidatorTest(unittest.TestCase):
 
     self.assert_equal_with_printing(dedent("""
                       Rules with errors: 2
-                        (B, [Select(D)], noop):
+                        (B, [Select(D)], b_from_d):
                           No rule was available to compute D with parameter type SubA
-                        (D, [Select(A), Select(SubA)], [Get(A, C)], noop):
+                        (D, [Select(A), Select(SubA)], [Get(A, C)], d_from_a_and_suba):
                           No rule was available to compute A with parameter type SubA
                       """).strip(),
         str(cm.exception))
@@ -204,9 +261,13 @@ class RuleGraphMakerTest(unittest.TestCase):
   # TODO HasProducts?
 
   def test_smallest_full_test(self):
+    @rule(Exactly(A), [Select(SubA)])
+    def a_from_suba(suba):
+      pass
+
     rules = _suba_root_rules + [
       RootRule(SubA),
-      TaskRule(Exactly(A), [Select(SubA)], noop)
+      a_from_suba,
     ]
     fullgraph = self.create_full_graph(rules)
 
@@ -215,9 +276,9 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(SubA)], noop) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA)], noop) for SubA" -> {"Param(SubA)"}
+                         "(A, [Select(SubA)], a_from_suba) for SubA" -> {"Param(SubA)"}
                      }""").strip(), fullgraph)
 
   def test_full_graph_for_planner_example(self):
@@ -253,11 +314,19 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assertTrue(12 < len(root_rule_lines)) # 2 lines per entry
 
   def test_smallest_full_test_multiple_root_subject_types(self):
+    @rule(A, [Select(SubA)])
+    def a_from_suba(suba):
+      pass
+
+    @rule(B, [Select(A)])
+    def b_from_a(a):
+      pass
+
     rules = [
       RootRule(SubA),
       RootRule(A),
-      TaskRule(A, [Select(SubA)], noop),
-      TaskRule(B, [Select(A)], noop)
+      a_from_suba,
+      b_from_a,
     ]
     fullgraph = self.create_full_graph(rules)
 
@@ -268,21 +337,25 @@ class RuleGraphMakerTest(unittest.TestCase):
                          "Select(A) for A" [color=blue]
                          "Select(A) for A" -> {"Param(A)"}
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(SubA)], noop) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
                          "Select(B) for A" [color=blue]
-                         "Select(B) for A" -> {"(B, [Select(A)], noop) for A"}
+                         "Select(B) for A" -> {"(B, [Select(A)], b_from_a) for A"}
                          "Select(B) for SubA" [color=blue]
-                         "Select(B) for SubA" -> {"(B, [Select(A)], noop) for SubA"}
+                         "Select(B) for SubA" -> {"(B, [Select(A)], b_from_a) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA)], noop) for SubA" -> {"Param(SubA)"}
-                         "(B, [Select(A)], noop) for A" -> {"Param(A)"}
-                         "(B, [Select(A)], noop) for SubA" -> {"(A, [Select(SubA)], noop) for SubA"}
+                         "(A, [Select(SubA)], a_from_suba) for SubA" -> {"Param(SubA)"}
+                         "(B, [Select(A)], b_from_a) for A" -> {"Param(A)"}
+                         "(B, [Select(A)], b_from_a) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
                      }""").strip(),
                      fullgraph)
 
   def test_single_rule_depending_on_subject_selection(self):
+    @rule(Exactly(A), [Select(SubA)])
+    def a_from_suba(suba):
+      pass
+
     rules = [
-      TaskRule(Exactly(A), [Select(SubA)], noop)
+      a_from_suba,
     ]
 
     subgraph = self.create_subgraph(A, rules, SubA())
@@ -292,16 +365,24 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(SubA)], noop) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA)], noop) for SubA" -> {"Param(SubA)"}
+                         "(A, [Select(SubA)], a_from_suba) for SubA" -> {"Param(SubA)"}
                      }""").strip(),
       subgraph)
 
   def test_multiple_selects(self):
+    @rule(Exactly(A), [Select(SubA), Select(B)])
+    def a_from_suba_and_b(suba, b):
+      pass
+
+    @rule(B, [])
+    def b():
+      pass
+
     rules = [
-      TaskRule(Exactly(A), [Select(SubA), Select(B)], noop),
-      TaskRule(B, [], noop)
+      a_from_suba_and_b,
+      b,
     ]
 
     subgraph = self.create_subgraph(A, rules, SubA())
@@ -311,17 +392,25 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(SubA), Select(B)], noop) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(SubA), Select(B)], a_from_suba_and_b) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA), Select(B)], noop) for SubA" -> {"(B, [], noop) for ()" "Param(SubA)"}
-                         "(B, [], noop) for ()" -> {}
+                         "(A, [Select(SubA), Select(B)], a_from_suba_and_b) for SubA" -> {"(B, [], b) for ()" "Param(SubA)"}
+                         "(B, [], b) for ()" -> {}
                      }""").strip(),
       subgraph)
 
   def test_one_level_of_recursion(self):
+    @rule(Exactly(A), [Select(B)])
+    def a_from_b(b):
+      pass
+
+    @rule(B, [Select(SubA)])
+    def b_from_suba(suba):
+      pass
+
     rules = [
-      TaskRule(Exactly(A), [Select(B)], noop),
-      TaskRule(B, [Select(SubA)], noop)
+      a_from_b,
+      b_from_suba,
     ]
 
     subgraph = self.create_subgraph(A, rules, SubA())
@@ -331,17 +420,25 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(B)], noop) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(B)], a_from_b) for SubA"}
                        // internal entries
-                         "(A, [Select(B)], noop) for SubA" -> {"(B, [Select(SubA)], noop) for SubA"}
-                         "(B, [Select(SubA)], noop) for SubA" -> {"Param(SubA)"}
+                         "(A, [Select(B)], a_from_b) for SubA" -> {"(B, [Select(SubA)], b_from_suba) for SubA"}
+                         "(B, [Select(SubA)], b_from_suba) for SubA" -> {"Param(SubA)"}
                      }""").strip(),
       subgraph)
 
   def test_noop_removal_in_subgraph(self):
+    @rule(Exactly(A), [Select(C)])
+    def a_from_c(c):
+      pass
+
+    @rule(Exactly(A), [])
+    def a():
+      pass
+
     rules = [
-      TaskRule(Exactly(A), [Select(C)], noop),
-      TaskRule(Exactly(A), [], noop),
+      a_from_c,
+      a,
       SingletonRule(B, B()),
     ]
 
@@ -352,16 +449,24 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for ()" [color=blue]
-                         "Select(A) for ()" -> {"(A, [], noop) for ()"}
+                         "Select(A) for ()" -> {"(A, [], a) for ()"}
                        // internal entries
-                         "(A, [], noop) for ()" -> {}
+                         "(A, [], a) for ()" -> {}
                      }""").strip(),
       subgraph)
 
   def test_noop_removal_full_single_subject_type(self):
+    @rule(Exactly(A), [Select(C)])
+    def a_from_c(c):
+      pass
+
+    @rule(Exactly(A), [])
+    def a():
+      pass
+
     rules = _suba_root_rules + [
-      TaskRule(Exactly(A), [Select(C)], noop),
-      TaskRule(Exactly(A), [], noop),
+      a_from_c,
+      a,
     ]
 
     fullgraph = self.create_full_graph(rules, validate=False)
@@ -371,18 +476,26 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for ()" [color=blue]
-                         "Select(A) for ()" -> {"(A, [], noop) for ()"}
+                         "Select(A) for ()" -> {"(A, [], a) for ()"}
                        // internal entries
-                         "(A, [], noop) for ()" -> {}
+                         "(A, [], a) for ()" -> {}
                      }""").strip(),
       fullgraph)
 
   def test_root_tuple_removed_when_no_matches(self):
+    @rule(A, [Select(C)])
+    def a_from_c(c):
+      pass
+
+    @rule(B, [Select(D), Select(A)])
+    def b_from_d_and_a(d, a):
+      pass
+
     rules = [
       RootRule(C),
       RootRule(D),
-      TaskRule(Exactly(A), [Select(C)], noop),
-      TaskRule(Exactly(B), [Select(D), Select(A)], noop),
+      a_from_c,
+      b_from_d_and_a,
     ]
 
     fullgraph = self.create_full_graph(rules, validate=False)
@@ -392,22 +505,35 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: C, D
                        // root entries
                          "Select(A) for C" [color=blue]
-                         "Select(A) for C" -> {"(A, [Select(C)], noop) for C"}
+                         "Select(A) for C" -> {"(A, [Select(C)], a_from_c) for C"}
                          "Select(B) for (C+D)" [color=blue]
-                         "Select(B) for (C+D)" -> {"(B, [Select(D), Select(A)], noop) for (C+D)"}
+                         "Select(B) for (C+D)" -> {"(B, [Select(D), Select(A)], b_from_d_and_a) for (C+D)"}
                        // internal entries
-                         "(A, [Select(C)], noop) for C" -> {"Param(C)"}
-                         "(B, [Select(D), Select(A)], noop) for (C+D)" -> {"(A, [Select(C)], noop) for C" "Param(D)"}
+                         "(A, [Select(C)], a_from_c) for C" -> {"Param(C)"}
+                         "(B, [Select(D), Select(A)], b_from_d_and_a) for (C+D)" -> {"(A, [Select(C)], a_from_c) for C" "Param(D)"}
                      }""").strip(),
       fullgraph)
 
   def test_noop_removal_transitive(self):
     # If a noop-able rule has rules that depend on it,
     # they should be removed from the graph.
+
+    @rule(Exactly(B), [Select(C)])
+    def b_from_c(c):
+      pass
+
+    @rule(Exactly(A), [Select(B)])
+    def a_from_b(b):
+      pass
+
+    @rule(Exactly(A), [])
+    def a():
+      pass
+
     rules = [
-      TaskRule(Exactly(B), [Select(C)], noop),
-      TaskRule(Exactly(A), [Select(B)], noop),
-      TaskRule(Exactly(A), [], noop),
+      b_from_c,
+      a_from_b,
+      a,
     ]
     subgraph = self.create_subgraph(A, rules, SubA(), validate=False)
 
@@ -416,15 +542,19 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for ()" [color=blue]
-                         "Select(A) for ()" -> {"(A, [], noop) for ()"}
+                         "Select(A) for ()" -> {"(A, [], a) for ()"}
                        // internal entries
-                         "(A, [], noop) for ()" -> {}
+                         "(A, [], a) for ()" -> {}
                      }""").strip(),
       subgraph)
 
   def test_get_with_matching_singleton(self):
+    @rule(Exactly(A), [Select(SubA)])
+    def a_from_suba(suba):
+      _ = yield Get(B, C, C())
+
     rules = [
-      TaskRule(Exactly(A), [Select(SubA)], noop, input_gets=[Get(B, C)]),
+      a_from_suba,
       SingletonRule(B, B()),
     ]
 
@@ -435,17 +565,29 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(SubA)], [Get(B, C)], noop) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(SubA)], [Get(B, C)], a_from_suba) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA)], [Get(B, C)], noop) for SubA" -> {"Param(SubA)" "Singleton(B(), B)"}
+                         "(A, [Select(SubA)], [Get(B, C)], a_from_suba) for SubA" -> {"Param(SubA)" "Singleton(B(), B)"}
                      }""").strip(),
       subgraph)
 
   def test_depends_on_multiple_one_noop(self):
+    @rule(B, [Select(A)])
+    def b_from_a(a):
+      pass
+
+    @rule(A, [Select(C)])
+    def a_from_c(c):
+      pass
+
+    @rule(A, [Select(SubA)])
+    def a_from_suba(suba):
+      pass
+
     rules = [
-      TaskRule(B, [Select(A)], noop),
-      TaskRule(A, [Select(C)], noop),
-      TaskRule(A, [Select(SubA)], noop)
+     b_from_a,
+      a_from_c,
+      a_from_suba,
     ]
 
     subgraph = self.create_subgraph(B, rules, SubA(), validate=False)
@@ -455,18 +597,30 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(B) for SubA" [color=blue]
-                         "Select(B) for SubA" -> {"(B, [Select(A)], noop) for SubA"}
+                         "Select(B) for SubA" -> {"(B, [Select(A)], b_from_a) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA)], noop) for SubA" -> {"Param(SubA)"}
-                         "(B, [Select(A)], noop) for SubA" -> {"(A, [Select(SubA)], noop) for SubA"}
+                         "(A, [Select(SubA)], a_from_suba) for SubA" -> {"Param(SubA)"}
+                         "(B, [Select(A)], b_from_a) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
                      }""").strip(),
       subgraph)
 
   def test_multiple_depend_on_same_rule(self):
+    @rule(B, [Select(A)])
+    def b_from_a(a):
+      pass
+
+    @rule(C, [Select(A)])
+    def c_from_a(a):
+      pass
+
+    @rule(A, [Select(SubA)])
+    def a_from_suba(suba):
+      pass
+
     rules = _suba_root_rules + [
-      TaskRule(B, [Select(A)], noop),
-      TaskRule(C, [Select(A)], noop),
-      TaskRule(A, [Select(SubA)], noop)
+      b_from_a,
+      c_from_a,
+      a_from_suba,
     ]
 
     subgraph = self.create_full_graph(rules)
@@ -476,22 +630,30 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(SubA)], noop) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
                          "Select(B) for SubA" [color=blue]
-                         "Select(B) for SubA" -> {"(B, [Select(A)], noop) for SubA"}
+                         "Select(B) for SubA" -> {"(B, [Select(A)], b_from_a) for SubA"}
                          "Select(C) for SubA" [color=blue]
-                         "Select(C) for SubA" -> {"(C, [Select(A)], noop) for SubA"}
+                         "Select(C) for SubA" -> {"(C, [Select(A)], c_from_a) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA)], noop) for SubA" -> {"Param(SubA)"}
-                         "(B, [Select(A)], noop) for SubA" -> {"(A, [Select(SubA)], noop) for SubA"}
-                         "(C, [Select(A)], noop) for SubA" -> {"(A, [Select(SubA)], noop) for SubA"}
+                         "(A, [Select(SubA)], a_from_suba) for SubA" -> {"Param(SubA)"}
+                         "(B, [Select(A)], b_from_a) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
+                         "(C, [Select(A)], c_from_a) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
                      }""").strip(),
       subgraph)
 
   def test_get_simple(self):
+    @rule(Exactly(A), [])
+    def a():
+      _ = yield Get(B, D, D())
+
+    @rule(B, [Select(D)])
+    def b_from_d(d):
+      pass
+
     rules = [
-      TaskRule(Exactly(A), [], noop, [Get(B, D)]),
-      TaskRule(B, [Select(D)], noop),
+      a,
+      b_from_d,
     ]
 
     subgraph = self.create_subgraph(A, rules, SubA())
@@ -501,10 +663,10 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for ()" [color=blue]
-                         "Select(A) for ()" -> {"(A, [], [Get(B, D)], noop) for ()"}
+                         "Select(A) for ()" -> {"(A, [], [Get(B, D)], a) for ()"}
                        // internal entries
-                         "(A, [], [Get(B, D)], noop) for ()" -> {"(B, [Select(D)], noop) for D"}
-                         "(B, [Select(D)], noop) for D" -> {"Param(D)"}
+                         "(A, [], [Get(B, D)], a) for ()" -> {"(B, [Select(D)], b_from_d) for D"}
+                         "(B, [Select(D)], b_from_d) for D" -> {"Param(D)"}
                      }""").strip(),
                                     subgraph)
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -8,7 +8,7 @@ import unittest
 from builtins import object, str
 from textwrap import dedent
 
-from pants.engine.rules import RootRule, TaskRule, rule
+from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Params, Select
 from pants_test.engine.util import (assert_equal_with_printing, create_scheduler,
                                     remove_locations_from_traceback)
@@ -27,6 +27,7 @@ def fn_raises(x):
   raise Exception('An exception for {}'.format(type(x).__name__))
 
 
+@rule(A, [Select(B)])
 def nested_raise(x):
   fn_raises(x)
 
@@ -67,7 +68,7 @@ class SchedulerTraceTest(unittest.TestCase):
   def test_trace_includes_rule_exception_traceback(self):
     rules = [
       RootRule(B),
-      TaskRule(A, [Select(B)], nested_raise)
+      nested_raise,
     ]
 
     scheduler = create_scheduler(rules)


### PR DESCRIPTION
The public API we want people to use is `@rule`. Stop using `TaskRule` in its stead, as exposing multiple ways of registering rules is confusing.

Also, use a `SingletonRule` for `SymbolTable` instead of currying it, and simplify `TaskRule` a little.

Also also, allow `@rule`s to be declared nested inside functions (which we use in tests).