### PR TITLE
Fix test_checkstyle.py interpreter constraint 

### DIFF
--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
@@ -32,7 +32,7 @@ CHECKER_RESOLVE_METHOD = [('sys.path', True), ('resolve', False)]
 class CheckstyleTest(PythonTaskTestBase):
 
   py2_constraint = 'CPython>=2.7,<3'
-  py3_constraint = 'CPython>=3.4,<=3.5'
+  py3_constraint = 'CPython>=3.4,<3.6'
 
   @staticmethod
   def build_checker_wheel(root_dir):

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
@@ -32,7 +32,7 @@ CHECKER_RESOLVE_METHOD = [('sys.path', True), ('resolve', False)]
 class CheckstyleTest(PythonTaskTestBase):
 
   py2_constraint = 'CPython>=2.7,<3'
-  py3_constraint = 'CPython>=3.6,<4'
+  py3_constraint = 'CPython>=3.4,<3.5'
 
   @staticmethod
   def build_checker_wheel(root_dir):
@@ -195,7 +195,7 @@ class CheckstyleTest(PythonTaskTestBase):
     self.assertIn('4 Python Style issues found', str(task_error.exception))
 
   def test_lint_ignores_unwhitelisted_constraints(self):
-    target_py3 = self.create_py3_failing_target() 
+    target_py3 = self.create_py3_failing_target()
     self.assertEqual(0, self.execute_task(target_roots=[target_py3]))
 
   def test_lint_runs_for_single_whitelisted_constraints(self):

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
@@ -32,7 +32,7 @@ CHECKER_RESOLVE_METHOD = [('sys.path', True), ('resolve', False)]
 class CheckstyleTest(PythonTaskTestBase):
 
   py2_constraint = 'CPython>=2.7,<3'
-  py3_constraint = 'CPython>=3.4,<3.5'
+  py3_constraint = 'CPython>=3.4,<=3.5'
 
   @staticmethod
   def build_checker_wheel(root_dir):


### PR DESCRIPTION
### Problem
Right now, `test_checkstyle.py` relies on the assumption that we only allow `CPython>=2.7,3`. 

The tests stop behaving as intended when allowing `CPython>=3.6<4`, as we will be doing in https://github.com/pantsbuild/pants/pull/6959. This is because the tests are testing how we handle a whitelist of `CPython>=3.6`, but when we allow this by default, the whitelist no longer matters because the linter will already be working with that interpreter.

### Solution
Constrain the test targets to `CPython>=3.4,<=3.5`, as we no longer support these Python 3 versions, yet they are still meaningful versions. When the whitelist is turned on, the tests will run the linter using either Python 3.4 or 3.5.

Note that constraining to `CPython>=3.8` does not work, as Python 3.8 is not yet available so the tests white listing that interpreter will fail due to not finding a corresponding interpreter.

#### Other solution attempted
I first tried to constrain `PythonSetup.global_instance().interpreter_constraints` to only allow Python 2.7, as we do now. 

I got the constraint to work, but the tests were still failing. I found that this is due to the function `PythonSetup.compatibility_or_constraints`, which no matter what uses the passed compatibility constraints when given, rather than first trying to read the target's compatibility. So, the Python 3 targets were improperly resolving as Python 2 compatible.