### PR TITLE
Fix invalid escape sequence & regex expression deprecations

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/fetcher_factory.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/fetcher_factory.py
@@ -33,12 +33,12 @@ class FetcherFactory(Subsystem):
     # TODO: Add launchpad.net?
     r'bitbucket\.org/(?P<user>[^/]+)/(?P<repo>[^/]+)':
       ArchiveFetcher.UrlInfo(
-          url_format='https://bitbucket.org/\g<user>/\g<repo>/get/{rev}.tar.gz',
+          url_format=r'https://bitbucket.org/\g<user>/\g<repo>/get/{rev}.tar.gz',
           default_rev='tip',
           strip_level=1),
     r'github\.com/(?P<user>[^/]+)/(?P<repo>[^/]+)':
       ArchiveFetcher.UrlInfo(
-          url_format='https://github.com/\g<user>/\g<repo>/archive/{rev}.tar.gz',
+          url_format=r'https://github.com/\g<user>/\g<repo>/archive/{rev}.tar.gz',
           default_rev='master',
           strip_level=1),
   }

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_task.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_task.py
@@ -98,7 +98,7 @@ class ImportOracle(object):
   # This simple regex mirrors the behavior of the relevant go code in practice (see
   # repoRootForImportDynamic and surrounding code in
   # https://github.com/golang/go/blob/7bc40ffb05d8813bf9b41a331b45d37216f9e747/src/cmd/go/vcs.go).
-  _remote_import_re = re.compile('[^.]+(?:\.[^.]+)+\/')
+  _remote_import_re = re.compile(r'[^.]+(?:\.[^.]+)+\/')
 
   def is_remote_import(self, import_path):
     """Whether the specified import_path denotes a remote import."""

--- a/src/python/pants/backend/codegen/antlr/java/antlr_java_gen.py
+++ b/src/python/pants/backend/codegen/antlr/java/antlr_java_gen.py
@@ -124,7 +124,7 @@ class AntlrJavaGen(SimpleCodegenTask, NailgunTask):
       target.walk(collect_sources)
     return sources
 
-  _COMMENT_WITH_TIMESTAMP_RE = re.compile('^//.*\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d')
+  _COMMENT_WITH_TIMESTAMP_RE = re.compile(r'^//.*\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d')
 
   def _rearrange_output_for_package(self, target_workdir, java_package):
     """Rearrange the output files to match a standard Java structure.

--- a/src/python/pants/backend/jvm/artifact.py
+++ b/src/python/pants/backend/jvm/artifact.py
@@ -18,7 +18,7 @@ class PublicationMetadata(PayloadField):
 class Artifact(PayloadField):
   """Represents a publishable jvm artifact ala maven or ivy.
 
-  Used in the ``provides`` parameter to *jvm*\_library targets.
+  Used in the ``provides`` parameter to *jvm*\\_library targets.
 
   :API: public
   """

--- a/src/python/pants/backend/jvm/targets/jar_library.py
+++ b/src/python/pants/backend/jvm/targets/jar_library.py
@@ -31,7 +31,7 @@ class JarLibrary(Target):
 
   def __init__(self, payload=None, jars=None, managed_dependencies=None, **kwargs):
     """
-    :param jars: List of `jar <#jar>`_\s to depend upon.
+    :param jars: List of `jar <#jar>`_\\s to depend upon.
     :param managed_dependencies: Address of a managed_jar_dependencies() target to use. If omitted, uses
       the default managed_jar_dependencies() target set by --jar-dependency-management-default-target.
     """

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -322,7 +322,7 @@ class JvmBinary(JvmTarget):
     :param dependencies: Targets (probably ``java_library`` and
      ``scala_library`` targets) to "link" in.
     :type dependencies: list of target specs
-    :param deploy_excludes: List of `exclude <#exclude>`_\s to apply
+    :param deploy_excludes: List of `exclude <#exclude>`_\\s to apply
       at deploy time.
       If you, for example, deploy a java servlet that has one version of
       ``servlet.jar`` onto a Tomcat environment that provides another version,

--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -52,7 +52,7 @@ class JvmTarget(Target, Jarable):
     """
     :API: public
 
-    :param excludes: List of `exclude <#exclude>`_\s to filter this target's
+    :param excludes: List of `exclude <#exclude>`_\\s to filter this target's
       transitive dependencies against.
     :param sources: Source code files to build. Paths are relative to the BUILD
       file's directory.

--- a/src/python/pants/backend/jvm/targets/managed_jar_dependencies.py
+++ b/src/python/pants/backend/jvm/targets/managed_jar_dependencies.py
@@ -22,7 +22,7 @@ class ManagedJarDependencies(Target):
 
   def __init__(self, payload=None, artifacts=None, **kwargs):
     """
-    :param artifacts: List of `jar <#jar>`_\s or specs to jar_library targets with pinned versions.
+    :param artifacts: List of `jar <#jar>`_\\s or specs to jar_library targets with pinned versions.
       Versions are pinned per (org, name, classifier, ext) artifact coordinate (excludes, etc are
       ignored for the purposes of pinning).
     """
@@ -127,7 +127,7 @@ class ManagedJarLibraries(object):
   def __call__(self, name=None, artifacts=None, **kwargs):
     """
     :param string name: The optional name of the generated managed_jar_dependencies() target.
-    :param artifacts: List of `jar <#jar>`_\s or specs to jar_library targets with pinned versions.
+    :param artifacts: List of `jar <#jar>`_\\s or specs to jar_library targets with pinned versions.
       Versions are pinned per (org, name, classifier, ext) artifact coordinate (excludes, etc are
       ignored for the purposes of pinning).
     """

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -254,7 +254,7 @@ class JarPublish(TransitiveOptionRegistrar, HasTransitiveOptionMixin, ScmPublish
   `annotation_processor <build_dictionary.html#annotation_processor>`_.
   Targets to publish and their dependencies must be publishable target
   types and specify the ``provides`` argument. One exception is
-  `jar <build_dictionary.html#jar>`_\s - pants will generate a pom file that
+  `jar <build_dictionary.html#jar>`_\\s - pants will generate a pom file that
   depends on the already-published jar.
 
   Example usage: ::

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
@@ -25,7 +25,7 @@ CLASS_NOT_FOUND_ERROR_PATTERNS = [
 
   # scalac errors. More work undergoing to improve scalac error messages.
   (r'\s*\[error\] missing or invalid dependency detected while loading class file '
-   r'\'(?P<dependee_classname>\S+)\.class\'\.\n'
+   r"'(?P<dependee_classname>\S+)\.class'\.\n"
    r'\s*\[error\] Could not access type (?P<classnameonly>\S+) in (value|package) '
    r'(?P<packagename>\S+),'),
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): exception during macro expansion:\s*\n'

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
@@ -8,31 +8,31 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 CLASS_NOT_FOUND_ERROR_PATTERNS = [
   # javac errors.
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot find symbol\n'
-   '\s*\[error\]   symbol:   class (\S+)\n'
-   '\s*\[error\]   location: package (\S+)\n'
-   '\s*\[error\] import (?P<classname>\S+);'),
+   r'\s*\[error\]   symbol:   class (\S+)\n'
+   r'\s*\[error\]   location: package (\S+)\n'
+   r'\s*\[error\] import (?P<classname>\S+);'),
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot access (\S+)\n'
-   '\s*\[error\]   class file for (?P<classname>\S+) not found'),
+   r'\s*\[error\]   class file for (?P<classname>\S+) not found'),
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): package (\S+) does not exist\n'
-   '\s*\[error\] import (?P<classname>\S+);'),
+   r'\s*\[error\] import (?P<classname>\S+);'),
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot find symbol\n'
-   '\s*\[error\]   symbol:   class (?P<classnameonly>\S+)\n'
-   '\s*\[error\]   location: package (?P<packagename>\S+)'),
+   r'\s*\[error\]   symbol:   class (?P<classnameonly>\S+)\n'
+   r'\s*\[error\]   location: package (?P<packagename>\S+)'),
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): '
-   'package (?P<packagename>\S+) does not exist\n'
-   '\s*\[error\] .*\W(?P<classname>(?P=packagename)\.\w+)\W.*'),
+   r'package (?P<packagename>\S+) does not exist\n'
+   r'\s*\[error\] .*\W(?P<classname>(?P=packagename)\.\w+)\W.*'),
   (r'.*java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
 
   # scalac errors. More work undergoing to improve scalac error messages.
   (r'\s*\[error\] missing or invalid dependency detected while loading class file '
-   '\'(?P<dependee_classname>\S+)\.class\'\.\n'
-   '\s*\[error\] Could not access type (?P<classnameonly>\S+) in (value|package) '
-   '(?P<packagename>\S+),'),
+   r'\'(?P<dependee_classname>\S+)\.class\'\.\n'
+   r'\s*\[error\] Could not access type (?P<classnameonly>\S+) in (value|package) '
+   r'(?P<packagename>\S+),'),
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): exception during macro expansion:\s*\n'
-   '\s*\[error\] java.lang.ClassNotFoundException: (?P<classname>\S+)'),
+   r'\s*\[error\] java.lang.ClassNotFoundException: (?P<classname>\S+)'),
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): object (\S+) '
-   'is not a member of package (\S+)\n'
-   '\s*\[error\] import (?P<classname>\S+)'),
+   r'is not a member of package (\S+)\n'
+   r'\s*\[error\] import (?P<classname>\S+)'),
   (r'\s*\[error\] Class (?P<classname>\S+) not found \- continuing with a stub\.'),
   
   # scalac errors with strict_deps enabled. Some errors may still be missing.
@@ -57,7 +57,7 @@ CLASS_NOT_FOUND_ERROR_PATTERNS = [
 
   # zinc errors.
   (r'\s*\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
-   '\s*\[error\] Type (?P<classname>\S+) not present'),
+   r'\s*\[error\] Type (?P<classname>\S+) not present'),
   (r'\s*\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
-   '\s*\[error\] java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
+   r'\s*\[error\] java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
 ]

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -900,8 +900,8 @@ class RscCompile(ZincCompile):
         os.path.join(relative_workdir, 'resolve', 'coursier', '[^/]*', 'cache', '.*'),
         os.path.join(relative_workdir, 'resolve', 'ivy', '[^/]*', 'ivy', 'jars', '.*'),
         os.path.join(relative_workdir, 'compile', 'rsc', '.*'),
-        os.path.join(relative_workdir, '\.jdk', '.*'),
-        os.path.join('\.jdk', '.*'),
+        os.path.join(relative_workdir, r'\.jdk', '.*'),
+        os.path.join(r'\.jdk', '.*'),
       ]
       )
 

--- a/src/python/pants/backend/python/targets/python_requirement_library.py
+++ b/src/python/pants/backend/python/targets/python_requirement_library.py
@@ -19,7 +19,7 @@ class PythonRequirementLibrary(Target):
 
   def __init__(self, payload=None, requirements=None, **kwargs):
     """
-    :param requirements: pip requirements as `python_requirement <#python_requirement>`_\s.
+    :param requirements: pip requirements as `python_requirement <#python_requirement>`_\\s.
     :type requirements: List of python_requirement calls
     """
     payload = payload or Payload()

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -32,7 +32,7 @@ class BuildFile(AbstractClass):
     """Raised when scan_buildfiles is called on a nonexistent directory."""
 
   _BUILD_FILE_PREFIX = 'BUILD'
-  _PATTERN = re.compile('^{prefix}(\.[a-zA-Z0-9_-]+)?$'.format(prefix=_BUILD_FILE_PREFIX))
+  _PATTERN = re.compile(r'^{prefix}(\.[a-zA-Z0-9_-]+)?$'.format(prefix=_BUILD_FILE_PREFIX))
 
   _cache = {}
 

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -62,7 +62,7 @@ class RemotePantsRunner(object):
 
   @contextmanager
   def _trapped_signals(self, client):
-    """A contextmanager that overrides the SIGINT (control-c) and SIGQUIT (control-\) handlers
+    """A contextmanager that overrides the SIGINT (control-c) and SIGQUIT (control-\\) handlers
     and handles them remotely."""
     def handle_control_c(signum, frame):
       client.maybe_send_signal(signum, include_pgrp=True)

--- a/src/python/pants/build_graph/app_base.py
+++ b/src/python/pants/build_graph/app_base.py
@@ -226,7 +226,7 @@ class AppBase(Target):
     """
     :param string binary: Target spec of the ``jvm_binary`` or the ``python_binary``
       that contains the app main.
-    :param bundles: One or more ``bundle``\s
+    :param bundles: One or more ``bundle``\\s
       describing "extra files" that should be included with this app
       (e.g.: config files, startup scripts).
     :param string basename: Name of this application, if different from the

--- a/src/python/pants/build_graph/resources.py
+++ b/src/python/pants/build_graph/resources.py
@@ -10,7 +10,7 @@ from pants.build_graph.files import Files
 class Resources(Files):
   """Resource files.
 
-  Looking for loose files in your JVM application bundle? Those are `bundle <#bundle>`_\s.
+  Looking for loose files in your JVM application bundle? Those are `bundle <#bundle>`_\\s.
 
   Resources are files included in deployable units like Java jars or Python wheels and accessible
   via language-specific APIs.

--- a/src/python/pants/help/build_dictionary_info_extracter.py
+++ b/src/python/pants/help/build_dictionary_info_extracter.py
@@ -97,12 +97,12 @@ class BuildDictionaryInfoExtracter(object):
     (e.g., :param str a:), where there is a single word between the colons (e.g., :returns:),
     and where a newline immediately follows the second colon in the stanza.
     """
-    return re.compile(':(\w+)\s*(\w+\s+)?(\w*):\s*(.*)')
+    return re.compile(r':(\w+)\s*(\w+\s+)?(\w*):\s*(.*)')
 
   @classmethod
   @memoized_method
   def _get_default_value_re(cls):
-    return re.compile(' \([Dd]efault: (.*)\)')
+    return re.compile(r' \([Dd]efault: (.*)\)')
 
   @classmethod
   def get_arg_descriptions_from_docstring(cls, obj):

--- a/src/python/pants/java/jar/jar_dependency.py
+++ b/src/python/pants/java/jar/jar_dependency.py
@@ -57,7 +57,7 @@ class JarDependencyParseContextWrapper(object):
       (specifying this parameter is unusual). Path of file URL can be either absolute or relative
       to the belonging BUILD file.
     :param string apidocs: URL of existing javadocs, which if specified, pants-generated javadocs
-      will properly hyperlink {\ @link}s.
+      will properly hyperlink {\\ @link}s.
     :param string classifier: Classifier specifying the artifact variant to use.
     :param boolean mutable: Inhibit caching of this mutable artifact. A common use is for
       Maven -SNAPSHOT style artifacts in an active development/integration cycle.

--- a/src/python/pants/reporting/linkify.py
+++ b/src/python/pants/reporting/linkify.py
@@ -29,7 +29,7 @@ _IGNORE_LONG_DOT_CHAINS = r'(?!\.{5})'
 # ellipsis after file names (I'm looking at you, zinc). None of our files end in a dot in practice,
 # so this is fine.
 _PATH = _IGNORE_LONG_DOT_CHAINS + _PREFIX + _REL_PATH_COMPONENT + _OPTIONAL_PORT + \
-        _ABS_PATH_COMPONENTS + _OPTIONAL_TARGET_SUFFIX + '\w'
+        _ABS_PATH_COMPONENTS + _OPTIONAL_TARGET_SUFFIX + r'\w'
 _PATH_RE = re.compile(_PATH)
 
 _NO_URL = "no url"  # Sentinel value for non-existent files in linkify's memo


### PR DESCRIPTION
### Problem
Python 3.6 added a deprecation warning for invalid escape sequences like `\s` and invalid regex expressions. 

All along, Python has been implicitly adding an extra `\` into the string representation; for example, `\s` becomes `\\s` when entered into a REPL. However, Python will eventually stop doing this implicit expansion.

In the meantime, these invalid uses result in 37 deprecation warnings anytime someone tries using Pants via Python 3 (see https://travis-ci.org/pantsbuild/pants/jobs/471642650).

### Solution
Where the string is small enough, use a raw string, which is prefixed with `r"my string"`. This keeps the `\` character without interpreting it as an escape sequence.

When the string is too long, namely docstring, simply add an additional `\` to specify the original `\` is meant to be included as a character, not an escape sequence.

This solution attempts to keep identical semantics to before, only make what was before implicit now explicit.