### PR TITLE
Replace deprecated cgi.escape() with html.escape()

### DIFF
--- a/pants-plugins/src/python/internal_backend/sitegen/tasks/sitegen.py
+++ b/pants-plugins/src/python/internal_backend/sitegen/tasks/sitegen.py
@@ -353,9 +353,7 @@ def generate_generated(config, here):
 
 def render_html(dst, config, soups, precomputed, template):
   soup = soups[dst]
-  renderer = Renderer(escape=cgi.escape)  # TODO(python3port): cgi.escape is deprecated in favor html.escape
-                                          # (the default used by Pystache on Python3). html.escape() escapes single
-                                          # quotes, whereas cgi.escape() does not. This will need to be addressed.
+  renderer = Renderer()
   title = precomputed.page[dst].title
   topdots = ('../' * dst.count('/'))
   if soup.body:

--- a/pants-plugins/src/python/internal_backend/sitegen/tasks/sitegen.py
+++ b/pants-plugins/src/python/internal_backend/sitegen/tasks/sitegen.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import cgi
 import collections
 import json
 import os

--- a/pants-plugins/tests/python/internal_backend_test/sitegen/test_sitegen.py
+++ b/pants-plugins/tests/python/internal_backend_test/sitegen/test_sitegen.py
@@ -205,12 +205,13 @@ class AllTheThingsTestCase(unittest.TestCase):
                                    {{/site_toc}}
                                    """)
     self.assertIn("DEPTH=1 LINK=None HEADING=non_collapse", rendered)
+    escaped_single_quote = '&#x27;'
     # Py2 and Py3 order the elements differently and Py3 doesn't render 'u' in unicode literals. Both are valid.
-    rendered_expected = ("DEPTH=1 LINK=[{'link': 'subdir/page2.html', 'text': 'Page 2: Electric Boogaloo', 'here': False}, "
-                         "{'link': 'index.html', 'text': 'Pants Build System', 'here': True}] HEADING=collapse"
+    rendered_expected = ("DEPTH=1 LINK=[{{{q}link{q}: {q}subdir/page2.html{q}, {q}text{q}: {q}Page 2: Electric Boogaloo{q}, {q}here{q}: False}}, "
+                         "{{{q}link{q}: {q}index.html{q}, {q}text{q}: {q}Pants Build System{q}, {q}here{q}: True}}] HEADING=collapse".format(q=escaped_single_quote)
                          if PY3 else
-                         "DEPTH=1 LINK=[{'text': u'Page 2: Electric Boogaloo', 'link': u'subdir/page2.html', 'here': False}, "
-                         "{'text': u'Pants Build System', 'link': u'index.html', 'here': True}] HEADING=collapse")
+                         "DEPTH=1 LINK=[{{{q}text{q}: u{q}Page 2: Electric Boogaloo{q}, {q}link{q}: u{q}subdir/page2.html{q}, {q}here{q}: False}}, "
+                         "{{{q}text{q}: u{q}Pants Build System{q}, {q}link{q}: u{q}index.html{q}, {q}here{q}: True}}] HEADING=collapse".format(q=escaped_single_quote))
     self.assertIn(rendered_expected, rendered)
 
   def test_transform_fixes_up_internal_links(self):

--- a/src/python/pants/reporting/html_reporter.py
+++ b/src/python/pants/reporting/html_reporter.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import cgi
+import html
 import os
 import re
 import time
@@ -454,7 +454,7 @@ class HtmlReporter(Reporter):
 
   def _htmlify_text(self, s):
     """Make text HTML-friendly."""
-    colored = self._handle_ansi_color_codes(cgi.escape(s))
+    colored = self._handle_ansi_color_codes(html.escape(s))
     return linkify(self._buildroot, colored, self._linkify_memo).replace('\n', '</br>')
 
   _ANSI_COLOR_CODE_RE = re.compile(r'\033\[((?:\d|;)*)m')


### PR DESCRIPTION
### Problem
`cgi.escape()` has been deprecated since Python 3.2 and it will be removed in Python 3.8. It results in a DeprecationWarning whenever running Pants with Python 3.

### Solution
Allow Pystache to use its default of `html.escape`, which we're still able to access in Python 2 thanks to the `future` backports.

The only behavior difference between what we had vs. `html.escape` is that single quotes are now escaped, which is good for security. 

Because this module appears to only be consumed internally to generate our documentation site, I do not think we need the typical deprecation policy for this minor change.