### PR TITLE
Add support for consuming Subsystems from @rules

### DIFF
--- a/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
+++ b/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
@@ -4,16 +4,22 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import str
+
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.console import Console
+from pants.engine.legacy.options_parsing import ScopedOptions
 from pants.engine.rules import console_rule
-from pants.engine.selectors import Select
+from pants.engine.selectors import Get, Select
+from pants.option.scope import Scope
 from pants.rules.core.exceptions import GracefulTerminationException
 
 
 @console_rule('list-and-die-for-testing', [Select(Console), Select(BuildFileAddresses)])
 def fast_list_and_die_for_testing(console, addresses):
-  """A fast variant of `./pants list` with a reduced feature set."""
+  """A fast and deadly variant of `./pants list`."""
+  options = yield Get(ScopedOptions, Scope(str('list')))
+  console.print_stderr('>>> Got an interesting option: {}'.format(options.options.documented))
   for address in addresses.dependencies:
     console.print_stdout(address.spec)
   raise GracefulTerminationException(exit_code=42)

--- a/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
+++ b/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
@@ -8,10 +8,9 @@ from builtins import str
 
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.console import Console
-from pants.engine.legacy.options_parsing import ScopedOptions
 from pants.engine.rules import console_rule
 from pants.engine.selectors import Get, Select
-from pants.option.scope import Scope
+from pants.option.scope import Scope, ScopedOptions
 from pants.rules.core.exceptions import GracefulTerminationException
 
 

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -84,9 +84,9 @@ class DaemonPantsRunner(ProcessManager):
       # to the nailgun session. We'll later do this a second time post-fork, because
       # threads.
       with cls.nailgunned_stdio(sock, env, handle_stdin=False):
-        options, build_config, options_bootstrapper = LocalPantsRunner.parse_options(args, env)
+        options, _, options_bootstrapper = LocalPantsRunner.parse_options(args, env)
         subprocess_dir = options.for_global_scope().pants_subprocessdir
-        graph_helper, target_roots = scheduler_service.prefork(options, build_config)
+        graph_helper, target_roots = scheduler_service.prefork(options, options_bootstrapper)
         deferred_exc = None
     except Exception:
       deferred_exc = sys.exc_info()

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -122,6 +122,7 @@ class LocalPantsRunner(object):
       build_root,
       exiter,
       options,
+      options_bootstrapper,
       build_config,
       target_roots,
       graph_session,
@@ -129,12 +130,13 @@ class LocalPantsRunner(object):
       profile_path
     )
 
-  def __init__(self, build_root, exiter, options, build_config, target_roots, graph_session,
-               is_daemon, profile_path):
+  def __init__(self, build_root, exiter, options, options_bootstrapper, build_config, target_roots,
+               graph_session, is_daemon, profile_path):
     """
     :param string build_root: The build root for this run.
     :param Exiter exiter: The Exiter instance to use for this run.
     :param Options options: The parsed options for this run.
+    :param OptionsBootstrapper options_bootstrapper: The OptionsBootstrapper instance to use.
     :param BuildConfiguration build_config: The parsed build configuration for this run.
     :param TargetRoots target_roots: The `TargetRoots` for this run.
     :param LegacyGraphSession graph_session: A LegacyGraphSession instance for graph reuse.
@@ -144,6 +146,7 @@ class LocalPantsRunner(object):
     self._build_root = build_root
     self._exiter = exiter
     self._options = options
+    self._options_bootstrapper = options_bootstrapper
     self._build_config = build_config
     self._target_roots = target_roots
     self._graph_session = graph_session
@@ -190,6 +193,7 @@ class LocalPantsRunner(object):
 
     try:
       self._graph_session.run_console_rules(
+        self._options_bootstrapper,
         self._options.goals_and_possible_v2_goals,
         self._target_roots,
       )

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -495,10 +495,7 @@ def select(argv):
   subsystems = (GlobalOptionsRegistrar, BinaryUtil.Factory)
   known_scope_infos = reduce(set.union, (ss.known_scope_infos() for ss in subsystems), set())
   options = options_bootstrapper.get_full_options(known_scope_infos)
-  # Set the options on all applicable scopes so BinaryUtil.Factory.create() can use the applicable
-  # bootstrap options.
-  for subsystem in subsystems:
-    subsystem.register_options_on_scope(options)
+  # Initialize Subsystems.
   Subsystem.set_options(options)
 
   # If the filename provided ends in a known archive extension (such as ".tar.gz"), then we get the

--- a/src/python/pants/engine/legacy/options_parsing.py
+++ b/src/python/pants/engine/legacy/options_parsing.py
@@ -7,22 +7,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Select
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
-from pants.option.option_value_container import OptionValueContainer
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
-from pants.option.scope import Scope
+from pants.option.scope import Scope, ScopedOptions
 from pants.util.objects import datatype
 
 
 class _Options(datatype([('options', Options)])):
   """A wrapper around bootstrapped options values: not for direct consumption."""
-
-
-class ScopedOptions(datatype([
-  ('scope', Scope),
-  ('options', OptionValueContainer),
-])):
-  """A wrapper around options selected for a particular Scope."""
 
 
 @rule(_Options, [Select(OptionsBootstrapper)])

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -80,7 +80,7 @@ class Scheduler(object):
     self._visualize_to_dir = visualize_to_dir
     # Validate and register all provided and intrinsic tasks.
     rule_index = RuleIndex.create(list(rules))
-    self._root_subject_types = sorted(rule_index.roots, key=repr)
+    self._root_subject_types = [r.output_constraint for r in rule_index.roots]
 
     # Create the native Scheduler and Session.
     # TODO: This `_tasks` reference could be a local variable, since it is not used
@@ -130,7 +130,7 @@ class Scheduler(object):
       self._assert_ruleset_valid()
 
   def _root_type_ids(self):
-    return self._to_ids_buf(sorted(self._root_subject_types, key=repr))
+    return self._to_ids_buf(self._root_subject_types)
 
   def graph_trace(self, execution_request):
     with temporary_file_path() as path:

--- a/src/python/pants/help/scope_info_iterator.py
+++ b/src/python/pants/help/scope_info_iterator.py
@@ -67,7 +67,7 @@ class ScopeInfoIterator(object):
     def subsys_deps(subsystem_client_cls):
       for dep in subsystem_client_cls.subsystem_dependencies_iter():
         if dep.scope != GLOBAL_SCOPE:
-          yield self._scope_to_info[dep.options_scope()]
+          yield self._scope_to_info[dep.options_scope]
           for x in subsys_deps(dep.subsystem_cls):
             yield x
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -39,7 +39,6 @@ from pants.engine.selectors import Params
 from pants.init.options_initializer import BuildConfigInitializer
 from pants.option.global_options import (DEFAULT_EXECUTION_OPTIONS, ExecutionOptions,
                                          GlobMatchErrorBehavior)
-from pants.rules.core.register import create_core_rules
 from pants.util.objects import datatype
 
 
@@ -248,7 +247,7 @@ class EngineInitializer(object):
           'could not map goal `{}` to rule `{}`: already claimed by product `{}`'
           .format(goal, rule, goal_map[goal])
         )
-      goal_map[goal] = rule.output_type
+      goal_map[goal] = rule.output_constraint
     return goal_map
 
   @staticmethod
@@ -356,7 +355,6 @@ class EngineInitializer(object):
       create_process_rules() +
       create_graph_rules(address_mapper) +
       create_options_parsing_rules() +
-      create_core_rules() +
       # TODO: This should happen automatically, but most tests (e.g. tests/python/pants_test/auth) fail if it's not here:
       [run_python_test] +
       rules

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -33,8 +33,9 @@ from pants.engine.legacy.structs import (AppAdaptor, JvmBinaryAdaptor, PageAdapt
                                          RemoteSourcesAdaptor, TargetAdaptor)
 from pants.engine.mapper import AddressMapper
 from pants.engine.parser import SymbolTable
-from pants.engine.rules import SingletonRule
+from pants.engine.rules import RootRule, SingletonRule
 from pants.engine.scheduler import Scheduler
+from pants.engine.selectors import Params
 from pants.init.options_initializer import BuildConfigInitializer
 from pants.option.global_options import (DEFAULT_EXECUTION_OPTIONS, ExecutionOptions,
                                          GlobMatchErrorBehavior)
@@ -138,15 +139,15 @@ def _tuplify(v):
   return (v,)
 
 
-class LegacyGraphScheduler(datatype(['scheduler', 'symbol_table', 'console', 'goal_map'])):
+class LegacyGraphScheduler(datatype(['scheduler', 'symbol_table', 'goal_map'])):
   """A thin wrapper around a Scheduler configured with @rules for a symbol table."""
 
   def new_session(self, v2_ui=False):
     session = self.scheduler.new_session(v2_ui)
-    return LegacyGraphSession(session, self.symbol_table, self.console, self.goal_map)
+    return LegacyGraphSession(session, self.symbol_table, self.goal_map)
 
 
-class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'console', 'goal_map'])):
+class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'goal_map'])):
   """A thin wrapper around a SchedulerSession configured with @rules for a symbol table."""
 
   class InvalidGoals(Exception):
@@ -189,7 +190,7 @@ class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'console
     if invalid_goals:
       raise self.InvalidGoals(invalid_goals)
 
-  def run_console_rules(self, goals, target_roots):
+  def run_console_rules(self, options_bootstrapper, goals, target_roots):
     """Runs @console_rules sequentially and interactively by requesting their implicit Goal products.
 
     For retryable failures, raises scheduler.ExecutionError.
@@ -200,15 +201,17 @@ class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'console
     # Reduce to only applicable goals - with validation happening by way of `validate_goals()`.
     goals = [goal for goal in goals if goal in self.goal_map]
     subjects = self._determine_subjects(target_roots)
+    console = Console()
     # Console rule can only have one subject.
     assert len(subjects) == 1
     for goal in goals:
       try:
         goal_product = self.goal_map[goal]
+        params = Params(subjects[0], options_bootstrapper, console)
         logger.debug('requesting {} to satisfy execution of `{}` goal'.format(goal_product, goal))
-        self.scheduler_session.run_console_rule(goal_product, subjects[0])
+        self.scheduler_session.run_console_rule(goal_product, params)
       finally:
-        self.console.flush()
+        console.flush()
 
   def create_build_graph(self, target_roots, build_root=None):
     """Construct and return a `BuildGraph` given a set of input specs.
@@ -321,7 +324,6 @@ class EngineInitializer(object):
 
     build_file_aliases = build_configuration.registered_aliases()
     rules = build_configuration.rules()
-    console = Console()
 
     symbol_table = LegacySymbolTable(build_file_aliases)
 
@@ -344,7 +346,7 @@ class EngineInitializer(object):
     # LegacyBuildGraph will explicitly request the products it needs.
     rules = (
       [
-        SingletonRule.from_instance(console),
+        RootRule(Console),
         SingletonRule.from_instance(GlobMatchErrorBehavior.create(glob_match_error_behavior)),
         SingletonRule.from_instance(build_configuration),
         SingletonRule(SymbolTable, symbol_table),
@@ -373,4 +375,4 @@ class EngineInitializer(object):
       visualize_to_dir=bootstrap_options.native_engine_visualize_to,
     )
 
-    return LegacyGraphScheduler(scheduler, symbol_table, console, goal_map)
+    return LegacyGraphScheduler(scheduler, symbol_table, goal_map)

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -87,7 +87,7 @@ def load_plugins(build_configuration, plugins, working_set):
 
     if 'global_subsystems' in entries:
       subsystems = entries['global_subsystems'].load()()
-      build_configuration.register_subsystems(subsystems)
+      build_configuration.register_optionables(subsystems)
 
     if 'rules' in entries:
       rules = entries['rules'].load()()
@@ -145,7 +145,7 @@ def load_backend(build_configuration, backend_package):
 
   subsystems = invoke_entrypoint('global_subsystems')
   if subsystems:
-    build_configuration.register_subsystems(subsystems)
+    build_configuration.register_optionables(subsystems)
 
   rules = invoke_entrypoint('rules')
   if rules:

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -91,19 +91,12 @@ class OptionsInitializer(object):
       set(Goal.get_optionables())
     )
 
-    known_scope_infos = sorted({
-      si for optionable in top_level_optionables for si in optionable.known_scope_infos()
-    })
-
-    # Now that we have the known scopes we can get the full options.
-    options = options_bootstrapper.get_full_options(known_scope_infos)
-
-    distinct_optionable_classes = sorted({si.optionable_cls for si in known_scope_infos},
-                                         key=lambda o: o.options_scope)
-    for optionable_cls in distinct_optionable_classes:
-      optionable_cls.register_options_on_scope(options)
-
-    return options
+    # Now that we have the known scopes we can get the full options. `get_full_options` will
+    # sort and de-duplicate these for us.
+    known_scope_infos = [si
+                         for optionable in top_level_optionables
+                         for si in optionable.known_scope_infos()]
+    return options_bootstrapper.get_full_options(known_scope_infos)
 
   @classmethod
   def create(cls, options_bootstrapper, build_configuration, init_subsystems=True):

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -87,7 +87,7 @@ class OptionsInitializer(object):
     top_level_optionables = (
       {GlobalOptionsRegistrar} |
       GlobalSubsystems.get() |
-      build_configuration.subsystems() |
+      build_configuration.optionables() |
       set(Goal.get_optionables())
     )
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -134,6 +134,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                       'pants.backend.python',
                       'pants.backend.jvm',
                       'pants.backend.native',
+                      # TODO: Move into the graph_info backend.
+                      'pants.rules.core',
                       'pants.backend.codegen.antlr.java',
                       'pants.backend.codegen.antlr.python',
                       'pants.backend.codegen.jaxb',

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -4,16 +4,59 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import functools
 import re
+from abc import abstractproperty
+from builtins import str
 
 from six import string_types
 
+from pants.engine.selectors import Get
 from pants.option.errors import OptionsError
-from pants.option.scope import ScopeInfo
-from pants.util.meta import AbstractClass
+from pants.option.scope import Scope, ScopedOptions, ScopeInfo
+from pants.util.meta import AbstractClass, classproperty
 
 
-class Optionable(AbstractClass):
+def _construct_optionable(optionable_factory):
+  scope = optionable_factory.options_scope
+  scoped_options = yield Get(ScopedOptions, Scope(str(scope)))
+  yield optionable_factory.optionable_cls(scope, scoped_options.options)
+
+
+class OptionableFactory(AbstractClass):
+  """A mixin that provides a method that returns an @rule to construct subclasses of Optionable.
+
+  Optionable subclasses constructed in this manner must have a particular constructor shape, which is
+  loosely defined by `_construct_optionable` and `OptionableFactory.signature`.
+  """
+
+  @abstractproperty
+  def optionable_cls(self):
+    """The Optionable class that is constructed by this OptionableFactory."""
+
+  @abstractproperty
+  def options_scope(self):
+    """The scope from which the ScopedOptions for the target Optionable will be parsed."""
+
+  @classmethod
+  def signature(cls):
+    """Returns kwargs to construct a `TaskRule` that will construct the target Optionable.
+
+    TODO: This indirection avoids a cycle between this module and the `rules` module.
+    """
+    snake_scope = cls.options_scope.replace('-', '_')
+    partial_construct_optionable = functools.partial(_construct_optionable, cls)
+    partial_construct_optionable.__name__ = 'construct_scope_{}'.format(snake_scope)
+    return dict(
+        output_type=cls.optionable_cls,
+        input_selectors=tuple(),
+        func=partial_construct_optionable,
+        input_gets=(Get(ScopedOptions, Scope),),
+        dependency_optionables=(cls.optionable_cls,),
+      )
+
+
+class Optionable(OptionableFactory, AbstractClass):
   """A mixin for classes that can register options on some scope."""
 
   # Subclasses must override.
@@ -28,6 +71,11 @@ class Optionable(AbstractClass):
   deprecated_options_scope_removal_version = None
 
   _scope_name_component_re = re.compile(r'^(?:[a-z0-9])+(?:-(?:[a-z0-9])+)*$')
+
+  @classproperty
+  def optionable_cls(cls):
+    # Fills the `OptionableFactory` contract.
+    return cls
 
   @classmethod
   def is_valid_scope_name_component(cls, s):

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -178,11 +178,20 @@ class OptionsBootstrapper(datatype([
   @memoized_method
   def _full_options(self, known_scope_infos):
     bootstrap_option_values = self.get_bootstrap_options().for_global_scope()
-    return Options.create(self.env,
-                          self.config,
-                          known_scope_infos,
-                          args=self.args,
-                          bootstrap_option_values=bootstrap_option_values)
+    options = Options.create(self.env,
+                             self.config,
+                             known_scope_infos,
+                             args=self.args,
+                             bootstrap_option_values=bootstrap_option_values)
+
+    distinct_optionable_classes = set()
+    for ksi in sorted(known_scope_infos, key=lambda si: si.scope):
+      if not ksi.optionable_cls or ksi.optionable_cls in distinct_optionable_classes:
+        continue
+      distinct_optionable_classes.add(ksi.optionable_cls)
+      ksi.optionable_cls.register_options_on_scope(options)
+
+    return options
 
   def get_full_options(self, known_scope_infos):
     """Get the full Options instance bootstrapped by this object for the given known scopes.

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from builtins import str
 
+from pants.option.option_value_container import OptionValueContainer
 from pants.util.objects import datatype
 
 
@@ -54,3 +55,10 @@ class ScopeInfo(datatype([
 
   def _optionable_cls_attr(self, name, default=None):
     return getattr(self.optionable_cls, name) if self.optionable_cls else default
+
+
+class ScopedOptions(datatype([
+  ('scope', Scope),
+  ('options', OptionValueContainer),
+])):
+  """A wrapper around options selected for a particular Scope."""

--- a/src/python/pants/rules/core/fastlist.py
+++ b/src/python/pants/rules/core/fastlist.py
@@ -4,14 +4,91 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from pants.base.specs import Specs
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.console import Console
-from pants.engine.rules import console_rule
-from pants.engine.selectors import Select
+from pants.engine.legacy.graph import HydratedTargets
+from pants.engine.rules import console_rule, optionable_rule
+from pants.engine.selectors import Get, Select
+from pants.subsystem.subsystem import Subsystem
 
 
-@console_rule('list', [Select(Console), Select(BuildFileAddresses)])
-def fast_list(console, addresses):
+class ListOptions(Subsystem):
+  """Lists all targets matching the target specs.
+
+  If no targets are specified, lists all targets in the workspace.
+  """
+
+  # NB: This option scope is temporary: a followup to #6880 will replace the v1 list goal and rename
+  # this scope.
+  options_scope = 'fastlist'
+
+  @classmethod
+  def register_options(cls, register):
+    super(ListOptions, cls).register_options(register)
+    register('--provides', type=bool,
+             help='List only targets that provide an artifact, displaying the columns specified by '
+                  '--provides-columns.')
+    register('--provides-columns', default='address,artifact_id',
+             help='Display these columns when --provides is specified. Available columns are: '
+                  'address, artifact_id, repo_name, repo_url, push_db_basedir')
+    register('--documented', type=bool,
+             help='Print only targets that are documented with a description.')
+
+
+@console_rule('list', [Select(Console), Select(ListOptions), Select(Specs)])
+def fast_list(console, options, specs):
   """A fast variant of `./pants list` with a reduced feature set."""
-  for address in addresses:
-    console.print_stdout(address.spec)
+
+  provides = options.get_options().provides
+  provides_columns = options.get_options().provides_columns
+  documented = options.get_options().documented
+  if provides or documented:
+    # To get provides clauses or documentation, we need hydrated targets.
+    collection = yield Get(HydratedTargets, Specs, specs)
+    if provides:
+      extractors = dict(
+          address=lambda target: target.address.spec,
+          artifact_id=lambda target: str(target.adaptor.provides),
+          repo_name=lambda target: target.adaptor.provides.repo.name,
+          repo_url=lambda target: target.adaptor.provides.repo.url,
+          push_db_basedir=lambda target: target.adaptor.provides.repo.push_db_basedir,
+      )
+
+      def print_provides(column_extractors, target):
+        if getattr(target.adaptor, 'provides', None):
+          return ' '.join(extractor(target) for extractor in column_extractors)
+
+      try:
+        column_extractors = [extractors[col] for col in (provides_columns.split(','))]
+      except KeyError:
+        raise Exception('Invalid columns specified: {0}. Valid columns are: address, artifact_id, '
+                        'repo_name, repo_url, push_db_basedir.'.format(provides_columns))
+
+      print_fn = lambda target: print_provides(column_extractors, target)
+    else:
+      def print_documented(target):
+        description = getattr(target.adaptor, 'description', None)
+        if description:
+          return '{0}\n  {1}'.format(target.address.spec,
+                                     '\n  '.join(description.strip().split('\n')))
+      print_fn = print_documented
+  else:
+    # Otherwise, we can use only addresses.
+    collection = yield Get(BuildFileAddresses, Specs, specs)
+    print_fn = lambda address: address.spec
+
+  if not collection.dependencies:
+    console.print_stderr('WARNING: No targets were matched in goal `{}`.'.format('list'))
+
+  for item in collection:
+    result = print_fn(item)
+    if result:
+      console.print_stdout(result)
+
+
+def rules():
+  return [
+      optionable_rule(ListOptions),
+      fast_list
+    ]

--- a/src/python/pants/rules/core/filedeps.py
+++ b/src/python/pants/rules/core/filedeps.py
@@ -30,3 +30,9 @@ def file_deps(console, transitive_hydrated_targets):
 
   for f_path in uniq_set:
     console.print_stdout(f_path)
+
+
+def rules():
+  return [
+      file_deps,
+    ]

--- a/src/python/pants/rules/core/register.py
+++ b/src/python/pants/rules/core/register.py
@@ -4,15 +4,12 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.rules.core.fastlist import fast_list
-from pants.rules.core.filedeps import file_deps
+from pants.rules.core import fastlist, filedeps
 from pants.rules.core.test import coordinator_of_tests, fast_test
 
 
-def create_core_rules():
-  return [
-    fast_list,
+def rules():
+  return fastlist.rules() + filedeps.rules() + [
     fast_test,
     coordinator_of_tests,
-    file_deps,
   ]

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -148,6 +148,14 @@ class Subsystem(SubsystemClientMixin, Optionable):
   def options_scope(self):
     return self._scope
 
+  @property
+  def options(self):
+    """Returns the option values for this subsystem's scope.
+
+    :API: public
+    """
+    return self._scoped_options
+
   def get_options(self):
     """Returns the option values for this subsystem's scope.
 

--- a/src/python/pants/subsystem/subsystem_client_mixin.py
+++ b/src/python/pants/subsystem/subsystem_client_mixin.py
@@ -9,6 +9,7 @@ from builtins import object
 from twitter.common.collections import OrderedSet
 
 from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.optionable import OptionableFactory
 from pants.option.scope import ScopeInfo
 from pants.util.objects import datatype
 
@@ -21,7 +22,7 @@ class SubsystemDependency(datatype([
   'scope',
   'removal_version',
   'removal_hint',
-])):
+]), OptionableFactory):
   """Indicates intent to use an instance of `subsystem_cls` scoped to `scope`."""
 
   def __new__(cls, subsystem_cls, scope, removal_version=None, removal_hint=None):
@@ -30,6 +31,12 @@ class SubsystemDependency(datatype([
   def is_global(self):
     return self.scope == GLOBAL_SCOPE
 
+  @property
+  def optionable_cls(self):
+    # Fills the OptionableFactory contract.
+    return self.subsystem_cls
+
+  @property
   def options_scope(self):
     """The subscope for options of `subsystem_cls` scoped to `scope`.
 

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -292,7 +292,7 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     hasher.update(self._options_fingerprint(self.options_scope).encode('utf-8'))
     hasher.update(self.implementation_version_str().encode('utf-8'))
     for dep in self.subsystem_closure_iter():
-      hasher.update(self._options_fingerprint(dep.options_scope()).encode('utf-8'))
+      hasher.update(self._options_fingerprint(dep.options_scope).encode('utf-8'))
     return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
 
   def artifact_cache_reads_enabled(self):

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -295,7 +295,7 @@ class BaseTest(unittest.TestCase):
       if subsystem.options_scope is None:
         raise TaskError('You must set a scope on your subsystem type before using it in tests.')
 
-    optionables = {SourceRootConfig} | self._build_configuration.subsystems() | for_subsystems
+    optionables = {SourceRootConfig} | self._build_configuration.optionables() | for_subsystems
 
     for_task_types = for_task_types or ()
     for task_type in for_task_types:

--- a/tests/python/pants_test/engine/legacy/test_options_parsing.py
+++ b/tests/python/pants_test/engine/legacy/test_options_parsing.py
@@ -6,11 +6,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from builtins import str
 
-from pants.engine.legacy.options_parsing import ScopedOptions
 from pants.engine.selectors import Params
 from pants.init.options_initializer import BuildConfigInitializer
 from pants.option.options_bootstrapper import OptionsBootstrapper
-from pants.option.scope import GLOBAL_SCOPE, Scope
+from pants.option.scope import GLOBAL_SCOPE, Scope, ScopedOptions
 from pants_test.test_base import TestBase
 
 

--- a/tests/python/pants_test/engine/util.py
+++ b/tests/python/pants_test/engine/util.py
@@ -44,7 +44,7 @@ def run_rule(rule, *args):
   :returns: The return value of the completed @rule.
   """
 
-  task_rule = getattr(rule, '_rule', None)
+  task_rule = getattr(rule, 'rule', None)
   if task_rule is None:
     raise TypeError('Expected to receive a decorated `@rule`; got: {}'.format(rule))
 

--- a/tests/python/pants_test/init/test_extension_loader.py
+++ b/tests/python/pants_test/init/test_extension_loader.py
@@ -155,7 +155,7 @@ class LoaderTest(unittest.TestCase):
     self.assertEqual(0, len(registered_aliases.target_macro_factories))
     self.assertEqual(0, len(registered_aliases.objects))
     self.assertEqual(0, len(registered_aliases.context_aware_object_factories))
-    self.assertEqual(self.build_configuration.subsystems(), set())
+    self.assertEqual(self.build_configuration.optionables(), set())
     self.assertEqual(0, len(self.build_configuration.rules()))
 
   def test_load_valid_empty(self):
@@ -173,7 +173,7 @@ class LoaderTest(unittest.TestCase):
       self.assertEqual(DummyTarget, registered_aliases.target_types['bob'])
       self.assertEqual(DummyObject1, registered_aliases.objects['obj1'])
       self.assertEqual(DummyObject2, registered_aliases.objects['obj2'])
-      self.assertEqual(self.build_configuration.subsystems(), {DummySubsystem1, DummySubsystem2})
+      self.assertEqual(self.build_configuration.optionables(), {DummySubsystem1, DummySubsystem2})
 
   def test_load_valid_partial_goals(self):
     def register_goals():
@@ -323,14 +323,14 @@ class LoaderTest(unittest.TestCase):
     self.assertEqual(DummyTarget, registered_aliases.target_types['pluginalias'])
     self.assertEqual(DummyObject1, registered_aliases.objects['FROMPLUGIN1'])
     self.assertEqual(DummyObject2, registered_aliases.objects['FROMPLUGIN2'])
-    self.assertEqual(self.build_configuration.subsystems(), {DummySubsystem1, DummySubsystem2})
+    self.assertEqual(self.build_configuration.optionables(), {DummySubsystem1, DummySubsystem2})
 
   def test_subsystems(self):
     def global_subsystems():
       return {DummySubsystem1, DummySubsystem2}
     with self.create_register(global_subsystems=global_subsystems) as backend_package:
       load_backend(self.build_configuration, backend_package)
-      self.assertEqual(self.build_configuration.subsystems(),
+      self.assertEqual(self.build_configuration.optionables(),
                        {DummySubsystem1, DummySubsystem2})
 
   def test_rules(self):

--- a/tests/python/pants_test/init/test_extension_loader.py
+++ b/tests/python/pants_test/init/test_extension_loader.py
@@ -339,7 +339,7 @@ class LoaderTest(unittest.TestCase):
     with self.create_register(rules=backend_rules) as backend_package:
       load_backend(self.build_configuration, backend_package)
       self.assertEqual(self.build_configuration.rules(),
-                       [example_rule, RootRule(RootType)])
+                       [example_rule.rule, RootRule(RootType)])
 
     def plugin_rules():
       return [example_plugin_rule]
@@ -347,7 +347,7 @@ class LoaderTest(unittest.TestCase):
     self.working_set.add(self.get_mock_plugin('this-plugin-rules', '0.0.1', rules=plugin_rules))
     self.load_plugins(['this-plugin-rules'])
     self.assertEqual(self.build_configuration.rules(),
-                     [example_rule, RootRule(RootType), example_plugin_rule])
+                     [example_rule.rule, RootRule(RootType), example_plugin_rule.rule])
 
   def test_backend_plugin_ordering(self):
     def reg_alias():

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -222,7 +222,7 @@ class SubsystemTest(unittest.TestCase):
       def subsystem_dependencies(cls):
         return (DummySubsystem.scoped(cls), SubsystemB)
 
-    dep_scopes = {dep.options_scope() for dep in SubsystemA.subsystem_dependencies_iter()}
+    dep_scopes = {dep.options_scope for dep in SubsystemA.subsystem_dependencies_iter()}
     self.assertEqual({'b', 'dummy.a'}, dep_scopes)
 
   def test_subsystem_closure_iter(self):
@@ -250,7 +250,7 @@ class SubsystemTest(unittest.TestCase):
       def subsystem_dependencies(cls):
         return (SubsystemC, SubsystemB)
 
-    dep_scopes = {dep.options_scope() for dep in SubsystemD.subsystem_closure_iter()}
+    dep_scopes = {dep.options_scope for dep in SubsystemD.subsystem_closure_iter()}
     self.assertEqual({'c', 'a', 'b.c', 'b'}, dep_scopes)
 
   def test_subsystem_closure_iter_cycle(self):

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -454,7 +454,7 @@ class TestBase(unittest.TestCase):
       if subsystem.options_scope is None:
         raise TaskError('You must set a scope on your subsystem type before using it in tests.')
 
-    optionables = {SourceRootConfig} | self._build_configuration.subsystems() | for_subsystems
+    optionables = {SourceRootConfig} | self._build_configuration.optionables() | for_subsystems
 
     for_task_types = for_task_types or ()
     for task_type in for_task_types:


### PR DESCRIPTION
### Problem

#6872 laid groundwork for consuming `(Scoped)Options` from `@rules`, but did not actually expose a facility for a `@(console_)rule` to consume a `Subsystem`.

### Solution

Expose `ScopedOptions` parsing to `@console_rules`, and add a helper method that creates an `@rule` to construct a `Subsystem`. Finally, use this facility to have `v2` `list` consume a `Subsystem` that holds options that define (most) of the behaviour that would allow it to replace the `Task`/`v1` implementation of `./pants list`.

### Result

`@rules` and `@console_rules` can consume `Subsystems`. This is a prerequisite for #6880, which will build atop this facility to fully support `v2`-only goals, and replace `v1` `list` with `v2` `list`.