### PR TITLE
Core has a PathBuf for build root

### DIFF
--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -45,6 +45,7 @@ pub struct Core {
   store_and_command_runner_and_http_client:
     Resettable<(Store, BoundedCommandRunner, reqwest::r#async::Client)>,
   pub vfs: PosixFS,
+  pub build_root: PathBuf,
 }
 
 impl Core {
@@ -53,7 +54,7 @@ impl Core {
     root_subject_types: Vec<TypeId>,
     tasks: Tasks,
     types: Types,
-    build_root: &Path,
+    build_root: PathBuf,
     ignore_patterns: &[String],
     work_dir: PathBuf,
     local_store_dir: PathBuf,
@@ -170,9 +171,10 @@ impl Core {
       store_and_command_runner_and_http_client: store_and_command_runner_and_http_client,
       // TODO: Errors in initialization should definitely be exposed as python
       // exceptions, rather than as panics.
-      vfs: PosixFS::new(build_root, fs_pool, &ignore_patterns).unwrap_or_else(|e| {
+      vfs: PosixFS::new(&build_root, fs_pool, &ignore_patterns).unwrap_or_else(|e| {
         panic!("Could not initialize VFS: {:?}", e);
       }),
+      build_root: build_root,
     }
   }
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -287,7 +287,7 @@ pub extern "C" fn scheduler_create(
     root_type_ids.clone(),
     tasks,
     types,
-    build_root_buf.to_os_string().as_ref(),
+    PathBuf::from(build_root_buf.to_os_string()),
     &ignore_patterns,
     PathBuf::from(work_dir_buf.to_os_string()),
     PathBuf::from(local_store_dir_buf.to_os_string()),


### PR DESCRIPTION
We didn't need to actually store an owned value before; we just needed a reference we could use to construct a `PosixFS` - I'm about to add a new piece of code which will need to refer to the build root from a reference to a `Core` (after `Core` has been constructed), so need to keep the value around.