### PR TITLE
Let pants discover pyenv interpreters directly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 .pants.run
 .pants.workdir.file_lock
 .pants.stats
+.pexrc
 .pids
 .project
 .settings

--- a/build-support/bin/travis-ci.sh
+++ b/build-support/bin/travis-ci.sh
@@ -11,47 +11,29 @@ cd "$(git rev-parse --show-toplevel)"
 
 export RUNNING_VIA_TRAVIS_CI_SCRIPT=1
 
-PYENV="$(which pyenv 2>/dev/null)"
 PYENV_ROOT="$(pyenv root 2>/dev/null || true)"
 
 function pyenv_path {
-  "${PYENV}" versions --bare --skip-aliases | while read v; do
-    echo "${PYENV_ROOT}/versions/${v}/bin"
-  done
-}
-
-function list_pythons {
-  which -a python{,2,3} | sort -u | while read python_bin; do
-    ${python_bin} <<EOF
-import os
-import sys
-
-print('{} -> {}'.format(os.path.realpath(sys.executable),
-                        '.'.join(map(str, sys.version_info[:3]))))
-EOF
+  pyenv versions --bare --skip-aliases | while read v; do
+    echo "${PYENV_ROOT}/versions/${v}/bin/python"
   done
 }
 
 # TravisCI uses pyenv to provide some interpreters pre-installed for images. Unfortunately it places
 # `~/.pyenv/shims` on the PATH and these shims are broken (see:
-# https://github.com/travis-ci/travis-ci/issues/8363). We work around this by placing
-# removing shims from the PATH and adding `~/.pyenv/versions/<version>/bin`.
-if [ -n "${PYENV}" ]; then
+# https://github.com/travis-ci/travis-ci/issues/8363). We work around this by setting
+# PEX_PYTHON_PATH in <buildroot>/.pexrc. This will force pex to use only these paths at runtime,
+# and we similarly force pants to do so at pex build time by setting the interpreter_search_path
+# appropriately in pants.travis-ci.ini.
+if [ -n "${PYENV_ROOT}" ]; then
+  PEXRC_FILE=./.pexrc
   PYENV_PYTHONS="$(pyenv_path)"
   PYENV_PATH="$(echo ${PYENV_PYTHONS} | tr ' ' ':')"
-
-  SHIMLESS_PATH="$(echo "${PATH}" | tr : '\n' | grep -v "${PYENV_ROOT}/shims")"
-  PATH="$(echo ${SHIMLESS_PATH} | tr ' ' ':')"
-
-  export PATH="${PYENV_PATH}:${PATH}"
+  PEX_PYTHON_PATH_STANZA="PEX_PYTHON_PATH=${PYENV_PATH}"
+  echo ${PEX_PYTHON_PATH_STANZA} > ${PEXRC_FILE}
 
 cat <<EOF
-Executing ./build-support/bin/ci.sh "$@" with "${PYENV_PATH}" preprended to the PATH
-and "${PYENV_ROOT}/shims" removed from the PATH.
-
-Visible pythons are now:
-$(list_pythons | sort -u)
-
+Executing ./build-support/bin/ci.sh "$@" with ${PEX_PYTHON_PATH_STANZA} set in ${PEXRC_FILE}
 EOF
 fi
 

--- a/pants.ini
+++ b/pants.ini
@@ -375,6 +375,7 @@ verify_commit: False
 # Note this does not mean client code has to use these specified versions, only that
 # an appropriate interpreter must be discoverable.
 interpreter_constraints: ["CPython>=2.7,<3","CPython>=3.6,<4"]
+interpreter_search_paths: +['<PYENV>']
 interpreter_cache_dir: %(pants_bootstrapdir)s/python_cache/interpreters
 resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
 

--- a/pants.travis-ci.ini
+++ b/pants.travis-ci.ini
@@ -4,6 +4,12 @@
 # Turn off all nailgun use.
 execution_strategy: subprocess
 
+[python-setup]
+# See travis-ci.sh for how and why we set PEX_PYTHON_PATH in .pexrc, to force pex to use only
+# the pyenv interpreters at runtime.  This option similarly forces pants to use only those
+# interpreters at build time.
+interpreter_search_paths: ['<PEXRC>']
+
 [compile.zinc]
 # If we use the default of 1 worker per core, we see too many cores under travis
 # and get oomkilled from launching too many workers with too much total memory

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -228,6 +228,8 @@ class PythonSetup(Subsystem):
     if pyenv_root is None:
       return []
     versions_dir = os.path.join(pyenv_root, 'versions')
+    if not os.path.exists(versions_dir):
+      return []
     paths = []
     for version in sorted(os.listdir(versions_dir)):
       path = os.path.join(versions_dir, version, 'bin')


### PR DESCRIPTION
Since 3275416187 pants has the ability to discover interpreters managed by pyenv directly, without them needing to be on the PATH.  This change forces CI to use this functionality, ignoring the PATH entirely. This allows us to get rid of some unpleasant PATH munging we had to do in CI, because Travis provides interpreters via pyenv, but puts broken shims on the PATH.

This change also enables (but does not require) pyenv use in the pants repo, for general convenience. 