### PR TITLE
 register --skip for TestRunnerTaskMixin with a target restriction mixin

### DIFF
--- a/src/python/pants/core_tasks/register.py
+++ b/src/python/pants/core_tasks/register.py
@@ -23,6 +23,7 @@ from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar as task
 from pants.task.fmt_task_mixin import FmtTaskMixin
 from pants.task.lint_task_mixin import LintTaskMixin
+from pants.task.testrunner_task_mixin import TestRunnerTaskMixin
 
 
 def register_goals():
@@ -37,7 +38,8 @@ def register_goals():
   Goal.register('binary', 'Create a runnable binary.')
   Goal.register('resources', 'Prepare resources.')
   Goal.register('bundle', 'Create a deployable application bundle.')
-  Goal.register('test', 'Run tests.')
+  Goal.register('test', 'Run tests.',
+                TestRunnerTaskMixin.goal_options_registrar_cls)
   Goal.register('bench', 'Run benchmarks.')
   Goal.register('repl', 'Run a REPL.')
   Goal.register('repl-dirty', 'Run a REPL, skipping compilation.')

--- a/src/python/pants/task/target_restriction_mixins.py
+++ b/src/python/pants/task/target_restriction_mixins.py
@@ -67,7 +67,7 @@ class SkipOptionRegistrar(object):
 
 
 class HasSkipGoalOptionMixin(GoalOptionsMixin, HasSkipOptionMixin):
-  """A mixin for tasks that have a --skip option."""
+  """A mixin for tasks that have a --skip option at the goal level."""
   pass
 
 

--- a/src/python/pants/task/target_restriction_mixins.py
+++ b/src/python/pants/task/target_restriction_mixins.py
@@ -66,8 +66,13 @@ class SkipOptionRegistrar(object):
              help='Skip task.')
 
 
-class SkipOptionGoalRegistrar(SkipOptionRegistrar, GoalOptionsRegistrar):
+class HasSkipGoalOptionMixin(GoalOptionsMixin, HasSkipOptionMixin):
   """A mixin for tasks that have a --skip option."""
+  pass
+
+
+class SkipOptionGoalRegistrar(SkipOptionRegistrar, GoalOptionsRegistrar):
+  """Registrar of --skip at the goal level."""
   pass
 
 

--- a/src/python/pants/task/target_restriction_mixins.py
+++ b/src/python/pants/task/target_restriction_mixins.py
@@ -66,6 +66,11 @@ class SkipOptionRegistrar(object):
              help='Skip task.')
 
 
+class SkipOptionGoalRegistrar(SkipOptionRegistrar, GoalOptionsRegistrar):
+  """A mixin for tasks that have a --skip option."""
+  pass
+
+
 class HasSkipAndTransitiveOptionsMixin(HasSkipOptionMixin, HasTransitiveOptionMixin):
   """A mixin for tasks that have a --transitive and a --skip option."""
   pass

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -13,7 +13,7 @@ from builtins import filter, next, object, str
 from pants.base.exceptions import ErrorWhileTesting, TaskError
 from pants.build_graph.files import Files
 from pants.invalidation.cache_manager import VersionedTargetSet
-from pants.task.target_restriction_mixins import HasSkipOptionMixin, SkipOptionGoalRegistrar
+from pants.task.target_restriction_mixins import HasSkipGoalOptionMixin, SkipOptionGoalRegistrar
 from pants.task.task import Task
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.process_handler import subprocess
@@ -88,7 +88,7 @@ class TestResult(object):
     return self
 
 
-class TestRunnerTaskMixin(HasSkipOptionMixin):
+class TestRunnerTaskMixin(HasSkipGoalOptionMixin):
   """A mixin to combine with test runner tasks.
 
   The intent is to migrate logic over time out of JUnitRun and PytestRun, so the functionality

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -13,6 +13,7 @@ from builtins import filter, next, object, str
 from pants.base.exceptions import ErrorWhileTesting, TaskError
 from pants.build_graph.files import Files
 from pants.invalidation.cache_manager import VersionedTargetSet
+from pants.task.target_restriction_mixins import HasSkipOptionMixin, SkipOptionGoalRegistrar
 from pants.task.task import Task
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.process_handler import subprocess
@@ -87,17 +88,17 @@ class TestResult(object):
     return self
 
 
-class TestRunnerTaskMixin(object):
+class TestRunnerTaskMixin(HasSkipOptionMixin):
   """A mixin to combine with test runner tasks.
 
   The intent is to migrate logic over time out of JUnitRun and PytestRun, so the functionality
   expressed can support both languages, and any additional languages that are added to pants.
   """
+  goal_options_registrar_cls = SkipOptionGoalRegistrar
 
   @classmethod
   def register_options(cls, register):
     super(TestRunnerTaskMixin, cls).register_options(register)
-    register('--skip', type=bool, help='Skip running tests.')
     register('--timeouts', type=bool, default=True,
              help='Enable test target timeouts. If timeouts are enabled then tests with a '
                   'timeout= parameter set on their target will time out after the given number of '

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -131,7 +131,7 @@ class TestRunnerTaskMixin(HasSkipGoalOptionMixin):
       self.context.log.error(message)
       raise ErrorWhileTesting(message)
 
-    if not self.get_options().skip:
+    if not self.skip_execution:
       test_targets = self._get_test_targets()
       for target in test_targets:
         self._validate_target(target)


### PR DESCRIPTION
### Problem

If you register a task in the `test` goal containing a `--skip` option (e.g. in an internal repo), it will fail because `TestRunnerTaskMixin` (and e.g. `JUnitRun`) does so as well, and our scoping rules don't currently allow that (not sure why).

### Solution

- Make `TestRunnerTaskMixin` use `HasSkipGoalOptionMixin`.
- Register `--skip` at the `test` goal level, as we do with `lint`.

### Open Questions

- Is it intentional that no two tasks under the same goal can register an option of the same name? I don't see where any ambiguity could come from, as task options still need to be prefaced with the task's name it was registered with.