### PR TITLE
simplify the --interpreter-constraints-whitelist option, and improve performance of python checkstyle

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -79,7 +79,9 @@ class Checkstyle(LintTaskMixin, Task):
     register('--fail', fingerprint=True, default=True, type=bool,
              help='If disabled, prevent pants from exiting with a failure, but still produce '
                   'output for style problems.')
-    register('--enable-py3-lint', fingerprint=True, default=False, type=bool,
+    register('--enable-py3-lint', fingerprint=True, default=True, type=bool,
+             removal_version='1.14.0.dev0',
+             removal_hint='Python 3 linting will eventually be turned on without a flag',
              help='Enable linting on Python 3-compatible targets.')
 
   @memoized_property
@@ -283,7 +285,7 @@ class Checkstyle(LintTaskMixin, Task):
       # TODO: consider changing the language here to "upcoming" instead of "deprecated".
       deprecated_conditional(
         predicate=lambda: py3_was_encountered and not self.get_options().enable_py3_lint,
-        removal_version='1.14.0.dev2',
+        removal_version='1.14.0.dev0',
         entity_description="This warning",
         hint_message=(
           "Python 3 linting is currently experimental. Add --{}-enable-py3-lint to the "

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -239,7 +239,6 @@ class Checkstyle(LintTaskMixin, Task):
       # create and invoke, which reduces the runtime of this task -- unfortunately, this is an
       # instance of general SAT and is a bit too much effort to implement right now, so we greedily
       # take the minimum here.
-      # TODO: test for targets with different compatibility but same interpreter!
       targets_with_min_interpreter = [
         (min(self._interpreter_cache.setup(filters=filters)), targets)
         for filters, targets in targets_by_compatibility.items()

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -105,11 +105,12 @@ class Checkstyle(LintTaskMixin, Task):
 
     if pants_dev_mode:
       checker_id = self.checker_target.transitive_invalidation_hash()
+      pex_base_dir = self.workdir
     else:
       checker_id = hash_all([self._CHECKER_REQ])
+      pex_base_dir = os.path.join(get_pants_cachedir(), 'python-checkstyle-checker')
 
-    pex_path = os.path.join(
-      get_pants_cachedir(), 'python-checkstyle-checker', checker_id, str(interpreter.identity))
+    pex_path = os.path.join(pex_base_dir, checker_id, str(interpreter.identity))
 
     if not os.path.exists(pex_path):
       with self.context.new_workunit(name='build-checker'):

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -80,7 +80,7 @@ class Checkstyle(LintTaskMixin, Task):
              help='If disabled, prevent pants from exiting with a failure, but still produce '
                   'output for style problems.')
     register('--enable-py3-lint', fingerprint=True, default=True, type=bool,
-             removal_version='1.14.0.dev0',
+             removal_version='1.14.0.dev2',
              removal_hint='Python 3 linting will eventually be turned on without a flag',
              help='Enable linting on Python 3-compatible targets.')
 
@@ -267,7 +267,7 @@ class Checkstyle(LintTaskMixin, Task):
       # TODO: consider changing the language here to "upcoming" instead of "deprecated".
       deprecated_conditional(
         predicate=lambda: py3_was_encountered and not self.get_options().enable_py3_lint,
-        removal_version='1.14.0.dev0',
+        removal_version='1.14.0.dev2',
         entity_description="This warning",
         hint_message=(
           "Python 3 linting is currently experimental. Add --{}-enable-py3-lint to the "

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -84,7 +84,7 @@ class Checkstyle(LintTaskMixin, Task):
              removal_hint='Python 3 linting will eventually be turned on without a flag',
              help='Enable linting on Python 3-compatible targets.')
 
-  @memoized_property
+  @property
   def _interpreter_cache(self):
     return PythonInterpreterCache.global_instance()
 
@@ -264,11 +264,10 @@ class Checkstyle(LintTaskMixin, Task):
       targets_by_min_interpreter, py3_was_encountered = self._partition_targets_by_min_interpreter(
         vt.target for vt in invalidation_check.invalid_vts)
 
-      # TODO: consider changing the language here to "upcoming" instead of "deprecated".
       deprecated_conditional(
         predicate=lambda: py3_was_encountered and not self.get_options().enable_py3_lint,
         removal_version='1.14.0.dev2',
-        entity_description="This warning",
+        entity_description="Disabling python 3 linting",
         hint_message=(
           "Python 3 linting is currently experimental. Add --{}-enable-py3-lint to the "
           "front of the pants command line to silence this message."

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -288,6 +288,9 @@ class Checkstyle(LintTaskMixin, Task):
       failure_count = 0
 
       for interpreter, targets in targets_by_min_interpreter.items():
+        if interpreter.identity.version[0] == 3:
+          if not self.get_options().enable_py3_lint:
+            continue
         sources_for_targets = self.calculate_sources(targets)
         if sources_for_targets:
           failure_count += self.checkstyle(interpreter, sources_for_targets)

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
@@ -157,6 +157,21 @@ class CheckstyleTest(PythonTaskTestBase):
                                  re.escape('7 Python Style issues found')):
       self.execute_task(target_roots=[target_py2, target_py3])
 
+  def test_failure_same_interpreter_different_constraints(self):
+    target_py2 = self.create_py2_failing_target()
+    self.create_file('a/python/fail.py', contents=dedent("""
+                        class lower_case(object):
+                          pass
+                       """))
+    target_py2_different = self.make_target(
+      'a/python:fail', PythonLibrary, sources=['fail.py'],
+      # This will also choose a python 2.7 interpreter, but technically has different filters than
+      # self.py2_constraint. Both of these targets should have lint run.
+      compatibility=['CPython>=2.7,<2.8'])
+    with self.assertRaisesRegexp(Checkstyle.CheckstyleRunError,
+                                 re.escape('5 Python Style issues found')):
+      self.execute_task(target_roots=[target_py2, target_py2_different])
+
   @parameterized.expand(CHECKER_RESOLVE_METHOD)
   def test_suppressed_file_passes(self, unused_test_name, resolve_local):
     self.create_file('a/python/fail.py', contents=dedent("""

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
@@ -165,10 +165,8 @@ class CheckstyleTest(PythonTaskTestBase):
   def test_py3_skipped(self):
     target_py3 = self.create_py3_failing_target()
     self.set_options(enable_py3_lint=False)
-    with self.captured_logging(logging.WARNING) as captured:
-      self.execute_task(target_roots=[target_py3])
-      self.assertIn('Python 3 linting is currently experimental.',
-                    str(assert_single_element(captured.warnings())))
+    # The task will succeed (with a deprecation warning), so no exception is raised.
+    self.execute_task(target_roots=[target_py3])
 
   def test_failure_same_interpreter_different_constraints(self):
     target_py2 = self.create_py2_failing_target()

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
@@ -128,7 +128,6 @@ class CheckstyleTest(PythonTaskTestBase):
 
   @parameterized.expand(CHECKER_RESOLVE_METHOD)
   def test_no_sources(self, unused_test_name, resolve_local):
-    self.set_options(enable_py3_lint=True)
     self.execute_task(resolve_local=resolve_local)
 
   @parameterized.expand(CHECKER_RESOLVE_METHOD)
@@ -138,7 +137,6 @@ class CheckstyleTest(PythonTaskTestBase):
                          pass
                      """))
     target = self.make_target('a/python:pass', PythonLibrary, sources=['pass.py'])
-    self.set_options(enable_py3_lint=True)
     self.execute_task(target_roots=[target], resolve_local=resolve_local)
 
   @parameterized.expand(CHECKER_RESOLVE_METHOD)
@@ -149,7 +147,6 @@ class CheckstyleTest(PythonTaskTestBase):
                        """))
     target = self.make_target('a/python:fail', PythonLibrary, sources=['fail.py'])
     # Needed for when pants runs in a python 3 interpreter.
-    self.set_options(enable_py3_lint=True)
     with self.assertRaisesRegexp(Checkstyle.CheckstyleRunError,
                                  re.escape('1 Python Style issues found')):
       self.execute_task(target_roots=[target], resolve_local=resolve_local)
@@ -157,7 +154,6 @@ class CheckstyleTest(PythonTaskTestBase):
   def test_failure_py2_and_py3(self):
     target_py2 = self.create_py2_failing_target()
     target_py3 = self.create_py3_failing_target()
-    self.set_options(enable_py3_lint=True)
     with self.assertRaises(Checkstyle.CheckstyleRunError) as cm:
       self.execute_task(target_roots=[target_py2, target_py3])
     self.assertIn('7 Python Style issues found', str(cm.exception))
@@ -201,7 +197,7 @@ class CheckstyleTest(PythonTaskTestBase):
     suppression_file = self.create_file('suppress.txt', contents=dedent("""
     a/python/fail\.py::variable-names"""))
     target = self.make_target('a/python:fail', PythonLibrary, sources=['fail.py'])
-    self.set_options(suppress=suppression_file, enable_py3_lint=True)
+    self.set_options(suppress=suppression_file)
     self.execute_task(target_roots=[target], resolve_local=resolve_local)
 
   @parameterized.expand(CHECKER_RESOLVE_METHOD)
@@ -211,7 +207,7 @@ class CheckstyleTest(PythonTaskTestBase):
                           pass
                      """))
     target = self.make_target('a/python:fail', PythonLibrary, sources=['fail.py'])
-    self.set_options(fail=False, enable_py3_lint=True)
+    self.set_options(fail=False)
     with self.captured_logging(logging.WARNING) as captured:
       self.execute_task(target_roots=[target], resolve_local=resolve_local)
       self.assertIn('1 Python Style issues found', str(assert_single_element(captured.warnings())))
@@ -222,7 +218,7 @@ class CheckstyleTest(PythonTaskTestBase):
                          invalid python
                        """))
     target = self.make_target('a/python:error', PythonLibrary, sources=['error.py'])
-    self.set_options(fail=False, enable_py3_lint=True)
+    self.set_options(fail=False)
     with self.captured_logging(logging.WARNING) as captured:
       self.execute_task(target_roots=[target], resolve_local=resolve_local)
       self.assertIn('1 Python Style issues found', str(assert_single_element(captured.warnings())))

--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -56,10 +56,6 @@ class SelectInterpreter(Task):
     return [PythonInterpreter]
 
   def execute(self):
-    # NB: Downstream product consumers may need the selected interpreter for use with
-    # any type of importable Python target, including `PythonRequirementLibrary` targets
-    # (for use with the `repl` goal, for instance). For interpreter selection,
-    # we only care about targets with compatibility constraints.
     python_tgts_and_reqs = self.context.targets(
       lambda tgt: isinstance(tgt, (PythonTarget, PythonRequirementLibrary))
     )


### PR DESCRIPTION
### Problem

- In the python checkstyle task, we are creating a pex to perform the checking in the task workdir, which goes away after a clean-all.

This affects the checkstyle task's runtime, and since this runs as part of this repo's pre-commit hook, that's significant.

### Solution

- Create the checker pex in `~/.cache/pants/python-checkstyle-checker/` to improve cacheability in non-development cases.
- Make use of the `self.skip_execution` and `self.act_transitively` properties inherited from the checkstyle base class to respect the `--skip` and `--transitive` options which are already registered at the `lint` goal level.

### Result

Python checkstyle is cached a little more often.