### PR TITLE
set PEX_PYTHON_PATH when invoking the checkstyle pex for pexrc to work

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -198,8 +198,12 @@ class Checkstyle(LintTaskMixin, Task):
                                      labels=[WorkUnitLabel.TOOL, WorkUnitLabel.LINT],
                                      cmd=' '.join(checker.cmdline(args))) as workunit:
         return checker.run(args=args,
-                                    stdout=workunit.output('stdout'),
-                                    stderr=workunit.output('stderr'))
+                           stdout=workunit.output('stdout'),
+                           stderr=workunit.output('stderr'),
+                           # Overriding PEX_PYTHON_PATH is necessary to satisfy the interpreter
+                           # constraint we added when creating the checker pex to guard against a
+                           # pexrc.
+                           env={'PEX_PYTHON_PATH': interpreter.binary})
 
   def _constraints_are_whitelisted(self, constraint_tuple):
     """

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -128,10 +128,6 @@ class Checkstyle(LintTaskMixin, Task):
             builder=PEXBuilder(path=chroot, interpreter=interpreter),
             log=self.context.log)
 
-          # Constraining is required to guard against the case where the user
-          # has a pexrc file set.
-          pex_builder.add_interpreter_constraint(str(interpreter.identity.requirement))
-
           if pants_dev_mode:
             pex_builder.add_sources_from(self.checker_target)
             req_libs = [tgt for tgt in self.checker_target.closure()
@@ -197,13 +193,16 @@ class Checkstyle(LintTaskMixin, Task):
       with self.context.new_workunit(name='pythonstyle',
                                      labels=[WorkUnitLabel.TOOL, WorkUnitLabel.LINT],
                                      cmd=' '.join(checker.cmdline(args))) as workunit:
+
+        # We have determined the exact interpreter we want here, so we override any pexrc settings.
+        pex_invocation_env = {
+          'PEX_PYTHON': interpreter.binary,
+          'PEX_IGNORE_RCFILES': 'True',
+        }
         return checker.run(args=args,
                            stdout=workunit.output('stdout'),
                            stderr=workunit.output('stderr'),
-                           # Overriding PEX_PYTHON_PATH is necessary to satisfy the interpreter
-                           # constraint we added when creating the checker pex to guard against a
-                           # pexrc.
-                           env={'PEX_PYTHON_PATH': interpreter.binary})
+                           env=pex_invocation_env)
 
   def _constraints_are_whitelisted(self, constraint_tuple):
     """


### PR DESCRIPTION
### Problem

In #6606, we added an interpreter constraint to the pex we created to perform python checkstyle in order to work around pantsbuild/pex#604 (see [previous discussion in #6606](https://github.com/pantsbuild/pants/pull/6606/files#r225310941)). This now fails on my machine with an error like this in the pre-commit hook with a pexrc set:

```
10:24:26 00:03     [pythonstyle][32m
                  Invalidated 259 targets.[0mINFO] pexrc interpreters requested and found, but other paths were also specified, so interpreters may not be restricted to the pexrc ones. Full search path is: /opt/ee/python/2.7/bin/python2.7:/opt/ee/python/3.6/bin/python3.6:/Users/dmcclanahan/tools/pants/build-support/pants_dev_deps.venv/bin:... (more omitted)
10:24:26 00:03       [build-checker]
10:24:28 00:05       [pythonstyle]
                    Failed to find compatible interpreter for constraints: [u'CPython==2.7.10']
                    
FAILURE: 1 Python Style issues found. You may try `./pants fmt <targets>`


              Waiting for background workers to finish.
10:24:28 00:05   [complete]
              FAILURE

```

### Solution

- Set `PEX_PYTHON` and `PEX_IGNORE_RCFILES` in the environment when invoking the checker pex so pex can find the interpreter we're asking it to.

### Result

The pre-commit hook no longer fails on my osx machine which has a pexrc file.