### PR TITLE
[WIP] Minimize python checkstyle invocations by interpreter

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -234,6 +234,7 @@ class Checkstyle(LintTaskMixin, Task):
 
       # Accumulate all the sources by the minimum interpreter assigned to their owning target, and
       # check them all at once to minimize the number of serial invocations of a checker pex.
+      # TODO: the v2 engine will allow parallelism in this task for free.
       sources_by_min_interpreter = defaultdict(list)
       for filters, targets in targets_by_compatibility.items():
         if self.get_options().interpreter_constraints_whitelist is None and not self._constraints_are_whitelisted(filters):

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -253,6 +253,10 @@ class Checkstyle(LintTaskMixin, Task):
             if not allowed_interpreters:
               raise TaskError('No valid interpreters found for targets: {}\n(filters: {})'
                               .format(targets, filters))
+            # TODO: Minimizing the number of interpreters used reduces the number of pexes we have
+            # to create and invoke, which reduces the runtime of this task -- unfortunately, this is
+            # an instance of general SAT and is a bit too much effort to implement right now, so we
+            # greedily take the minimum here.
             interpreter = min(allowed_interpreters)
             sources_by_min_interpreter[interpreter].extend(sources_for_target)
 

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_checkstyle.py
@@ -32,7 +32,7 @@ CHECKER_RESOLVE_METHOD = [('sys.path', True), ('resolve', False)]
 class CheckstyleTest(PythonTaskTestBase):
 
   py2_constraint = 'CPython>=2.7,<3'
-  py3_constraint = 'CPython>=3.4,<3.6'
+  py3_constraint = 'CPython>=3.4,<=3.7'
 
   @staticmethod
   def build_checker_wheel(root_dir):


### PR DESCRIPTION
*WIP to determine perf gains. This will have some minor merge conflicts with #7011.*

### Problem

In the python checkstyle task, we're creating a distinct pex with `pycodestyle` and any registered checkers, and invoking it in series for each unique set of interpreter constraints. Since many different interpreter constraints can resolve to the same minimum interpreter, this may be more process invocations than necessary.

The next step is to convert this task to use v2 `@rule`s -- a TODO was left to this effect.

### Solution

- Coalesce all targets by the minimum python interpreter that satisfies their constraints.
- Coalesce all source files from all the targets matching some minimum interpreter.
- Run a single checker pex invocation per minimum interpreter.

### Result

Python checkstyle might be faster.