### PR TITLE
use the asttokens 3rdparty lib to make @rule parsing errors very smooth

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,4 +1,5 @@
 ansicolors==1.0.2
+asttokens==1.1.13
 beautifulsoup4>=4.6.0,<4.7
 cffi==1.11.1
 configparser==3.5.0 ; python_version<'3'

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -13,7 +13,6 @@ python_library(
   name = 'legacy_engine',
   sources = ['legacy_engine.py', 'round_engine.py', 'round_manager.py'],
   dependencies = [
-    'src/python/pants/util:collections_abc_backport',
     '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:exceptions',
@@ -27,7 +26,6 @@ python_library(
   name='addressable',
   sources=['addressable.py'],
   dependencies=[
-    'src/python/pants/util:collections_abc_backport',
     '3rdparty/python:future',
     ':objects',
     'src/python/pants/build_graph',
@@ -40,7 +38,6 @@ python_library(
   name='struct',
   sources=['struct.py'],
   dependencies=[
-    'src/python/pants/util:collections_abc_backport',
     '3rdparty/python:future',
     ':objects',
     'src/python/pants/util:objects',
@@ -67,7 +64,6 @@ python_library(
   name='build_files',
   sources=['build_files.py'],
   dependencies=[
-    'src/python/pants/util:collections_abc_backport',
     '3rdparty/python:future',
     '3rdparty/python:six',
     ':addressable',
@@ -89,7 +85,6 @@ python_library(
   name='mapper',
   sources=['mapper.py'],
   dependencies=[
-    'src/python/pants/util:collections_abc_backport',
     ':objects',
     ':parser',
     'src/python/pants/build_graph',
@@ -146,7 +141,7 @@ python_library(
   name='rules',
   sources=['rules.py'],
   dependencies=[
-    'src/python/pants/util:collections_abc_backport',
+    '3rdparty/python:asttokens',
     '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':selectors',

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -155,8 +155,10 @@ The rule defined by function `{func_name}` begins at:
       if not self._stmt_is_at_end_of_parent_list(expr_for_yield):
         raise self.YieldVisitError(
           self._generate_ast_error_message(node, """\
+yield in @rule without assignment must come at the end of a series of statements.
+
 A yield in an @rule without an assignment is equivalent to a return, and we
-currently require that it comes at the end of a series of statements.
+currently require that no statements follow such a yield at the same level of nesting.
 Use `_ = yield Get(...)` if you wish to yield control to the engine and discard the result.
 """))
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -74,10 +74,10 @@ The invalid statement was:
 {node_text}
 
 The rule defined by function `{func_name}` begins at:
-{filename}:{line_number}:
+{filename}:{line_number}:{orig_indent}
 {context_lines}
 """.format(func_name=self._func.__name__, msg=msg,
-           filename=filename, line_number=line_number,
+           filename=filename, line_number=line_number, orig_indent=self._orig_indent,
            node_line_number=node_file_line,
            node_col=fully_indented_node_col,
            node_text=indented_node_text,

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -714,11 +714,12 @@ test_rules.py:{lineno}:{col}
     # Matches the line number of the @rule decorator.
     self.assertIn('The rule defined by function `g` begins at:', exc_msg)
     self.assertIn("""\
-test_rules.py:{lineno}:
+test_rules.py:{lineno}:{col}
     with self.assertRaises(_RuleVisitor.YieldVisitError) as cm:
       @rule(A, [])
       def g():
-""".format(lineno=sys._getframe().f_lineno - 22),
+""".format(lineno=sys._getframe().f_lineno - 22,
+           col=6),
                   exc_msg)
 
   def create_full_graph(self, rules, validate=True):


### PR DESCRIPTION
### Problem

As @stuhood and @baroquebobcat [pointed](https://github.com/pantsbuild/pants/pull/7019#discussion_r245098273) [out](https://github.com/pantsbuild/pants/pull/7019#discussion_r245171933) in #7019, it seems a little silly to only be able to provide the location of the start of the offending `@rule` for `yield` statements which would lead to ambiguity (see #7019), instead of the actual `yield` statement to blame. In that PR, we punted and used `ast.dump()`, but in the meantime I was able to find a 3rdparty library ([`asttokens`](https://github.com/gristlabs/asttokens)) which performs the appropriate bookkeeping to get the correct source text as well as line and column offsets of individual nodes within an [`ast`](https://docs.python.org/2/library/ast.html) parse tree.

If you are interested in why this isn't trivial, I recommend trying an `ast.dump(node, include_attributes=True)` and trying to hook up the numbers yourself (and if it is obvious, let me know, but I don't think this particular 3rdparty lib is too difficult of a dependency to bring in).

### Solution

- Add `asttokens` 3rdparty requirement.
- Use `asttokens.ASTTokens` and `asttokens.LineNumbers` to get the text and position of the offending `yield` statement in the original file.
- Re-add indentation that we had to remove to parse the `@rule` body in the first place so that our error message is exactly what the source text is.

### Result

An invalid rule like:

```python
@rule(A, [])
def f():
  yield Get(SomeProduct, SomeInput, some_input)
  yield A()
```

Will now raise an error like:

```
In function f: yield in @rule without assignment must come at the end of a series of statements.

A yield in an @rule without an assignment is equivalent to a return, and we
currently require that no statements follow such a yield at the same level of nesting.
Use `_ = yield Get(...)` if you wish to yield control to the engine and discard the result.

The invalid statement was:
test_rules.py:45:2
  yield Get(SomeProduct, SomeInput, some_input)

The rule defined by function `f` begins at:
test_rules.py:43:0
@rule(A, [])
def f():
```

I can now jump to a parse error (an invalid `yield` statement, as above) and hit the return key in emacs's compilation-mode to jump again to the precise source text which caused the error. This makes the prospect of adding more `ast` magic in the future (or not, and continuing to use what was added in #7019) in a highly structured and specific way much more plausible and understandable to users not incredibly well-versed in the semantics of the v2 engine.