### PR TITLE
Nicer rule graph viz

### DIFF
--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -143,7 +143,8 @@ class Target(Struct):
 TARGET_TABLE = SymbolTable({'struct': Struct, 'target': Target})
 
 
-def assert_equal_with_printing(test_case, expected, actual):
+def assert_equal_with_printing(test_case, expected, actual,
+                               uniform_formatter: Optional[Callable[[str], str]] = None):
   """Asserts equality, but also prints the values so they can be compared on failure.
 
   Usage:
@@ -159,6 +160,11 @@ def assert_equal_with_printing(test_case, expected, actual):
   print(expected)
   print('Actual:')
   print(str_actual)
+
+  if uniform_formatter is not None:
+    expected = uniform_formatter(expected)
+    str_actual = uniform_formatter(str_actual)
+
   test_case.assertEqual(expected, str_actual)
 
 
@@ -212,9 +218,7 @@ def fmt_rust_function(func: Callable) -> str:
   return f"{func.__module__}:{func.__code__.co_firstlineno}:{func.__name__}"
 
 
-def fmt_rule(
-  rule: Callable, *, gets: Optional[List[Tuple[str, str]]] = None,
-) -> str:
+def fmt_rule(rule: Callable, *, gets: Optional[List[Tuple[str, str]]] = None) -> str:
   """Generate the str that the engine will use for the rule.
 
   This is useful when comparing strings against engine error messages.

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -31,7 +31,7 @@ mod rules;
 use std::collections::{hash_map, BTreeSet, HashMap, HashSet};
 use std::io;
 
-pub use crate::rules::{DependencyKey, Rule, TypeId};
+pub use crate::rules::{DependencyKey, DisplayForGraph, Rule, TypeId};
 
 // TODO: Consider switching to HashSet and dropping the Ord bound from TypeId.
 type ParamTypes<T> = BTreeSet<T>;
@@ -825,8 +825,10 @@ impl Palette {
       Self::Blue => "0.5,1,0.9".to_string(),
     }
   }
+}
 
-  pub fn color_format_string(&self) -> String {
+impl DisplayForGraph for Palette {
+  fn fmt_for_graph(&self) -> String {
     format!("[color=\"{}\",style=filled]", self.color_string())
   }
 }
@@ -837,20 +839,20 @@ pub fn entry_node_str_with_attrs<R: Rule>(entry: &Entry<R>) -> GraphVizEntryWith
   let (entry_str, attrs_str) = match entry {
     &Entry::WithDeps(ref e) => (
       entry_with_deps_str(e),
-      // Color "singleton" entries (with no params) as a nice olive green!
+      // Color "singleton" entries (with no params)!
       if e.params().is_empty() {
-        Some(Palette::Olive.color_format_string())
+        Some(Palette::Olive.fmt_for_graph())
       } else if let Some(color) = e.rule().and_then(|r| r.color()) {
-        // Color "intrinsic" entries (provided by the rust codebase) with a steely gray!
-        Some(color.color_format_string())
+        // Color "intrinsic" entries (provided by the rust codebase)!
+        Some(color.fmt_for_graph())
       } else {
         None
       },
     ),
     &Entry::Param(type_id) => (
       format!("Param({})", type_id),
-      // Color "Param"s with a laid-back orange!
-      Some(Palette::Orange.color_format_string()),
+      // Color "Param"s!
+      Some(Palette::Orange.fmt_for_graph()),
     ),
   };
   GraphVizEntryWithAttrs {
@@ -1084,7 +1086,7 @@ impl<R: Rule> RuleGraph<R> {
           Some(format!(
             "    \"{}\" {}\n{}    \"{}\" -> {{{}}}",
             root_str,
-            Palette::Blue.color_format_string(),
+            Palette::Blue.fmt_for_graph(),
             deps_with_attrs,
             root_str,
             dep_entries

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -62,6 +62,13 @@ pub enum EntryWithDeps<R: Rule> {
 }
 
 impl<R: Rule> EntryWithDeps<R> {
+  pub fn rule(&self) -> Option<R> {
+    match self {
+      &EntryWithDeps::Inner(InnerEntry { ref rule, .. }) => Some(rule.clone()),
+      &EntryWithDeps::Root(_) => None,
+    }
+  }
+
   pub fn params(&self) -> &ParamTypes<R::TypeId> {
     match self {
       EntryWithDeps::Inner(ref ie) => &ie.params,
@@ -786,31 +793,85 @@ pub fn params_str<T: TypeId>(params: &ParamTypes<T>) -> String {
   T::display(params.iter().cloned())
 }
 
-///
-/// TODO: Move all of these methods to Display impls.
-///
 pub fn entry_str<R: Rule>(entry: &Entry<R>) -> String {
-  match entry {
-    Entry::WithDeps(ref e) => entry_with_deps_str(e),
-    Entry::Param(type_id) => format!("Param({})", type_id),
+  entry_node_str_with_attrs(entry).entry_str
+}
+
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
+pub struct GraphVizEntryWithAttrs {
+  entry_str: String,
+  attrs_str: Option<String>,
+}
+
+pub enum Palette {
+  Olive,
+  Gray,
+  Orange,
+  Blue,
+}
+
+impl Palette {
+  // https://c.eev.ee/kouyou/ is wonderful for selecting lovely color juxtapositions across multiple
+  // different color axes.
+  fn color_string(&self) -> String {
+    // These color values are all in HSV. See https://www.graphviz.org/doc/info/colors.html for
+    // other methods of specifying
+    // colors. https://renenyffenegger.ch/notes/tools/Graphviz/attributes/_color/index may also be
+    // useful.
+    match self {
+      Self::Olive => "0.2214,0.7179,0.8528".to_string(),
+      Self::Gray => "0.576,0,0.6242".to_string(),
+      Self::Orange => "0.08,0.5,0.976".to_string(),
+      Self::Blue => "0.5,1,0.9".to_string(),
+    }
+  }
+
+  pub fn color_format_string(&self) -> String {
+    format!("[color=\"{}\",style=filled]", self.color_string())
+  }
+}
+
+///
+/// Apply coloration to several nodes.
+pub fn entry_node_str_with_attrs<R: Rule>(entry: &Entry<R>) -> GraphVizEntryWithAttrs {
+  let (entry_str, attrs_str) = match entry {
+    &Entry::WithDeps(ref e) => (
+      entry_with_deps_str(e),
+      // Color "singleton" entries (with no params) as a nice olive green!
+      if e.params().is_empty() {
+        Some(Palette::Olive.color_format_string())
+      } else if let Some(color) = e.rule().and_then(|r| r.color()) {
+        // Color "intrinsic" entries (provided by the rust codebase) with a steely gray!
+        Some(color.color_format_string())
+      } else {
+        None
+      },
+    ),
+    &Entry::Param(type_id) => (
+      format!("Param({})", type_id),
+      // Color "Param"s with a laid-back orange!
+      Some(Palette::Orange.color_format_string()),
+    ),
+  };
+  GraphVizEntryWithAttrs {
+    entry_str,
+    attrs_str,
   }
 }
 
 fn entry_with_deps_str<R: Rule>(entry: &EntryWithDeps<R>) -> String {
   match entry {
-    EntryWithDeps::Inner(InnerEntry {
+    &EntryWithDeps::Inner(InnerEntry {
       ref rule,
       ref params,
-    }) => format!("{} for {}", rule, params_str(params)),
-    EntryWithDeps::Root(ref root) => {
+    }) => format!("{}\nfor {}", rule.fmt_for_graph(), params_str(params)),
+    &EntryWithDeps::Root(ref root) => format!(
       // TODO: Consider dropping this (final) public use of the keyword "Select", while ensuring
       // that error messages remain sufficiently grokkable.
-      format!(
-        "Select({}) for {}",
-        root.dependency_key,
-        params_str(&root.params),
-      )
-    }
+      "Select({})\nfor {}",
+      root.dependency_key,
+      params_str(&root.params)
+    ),
   }
 }
 
@@ -1008,13 +1069,28 @@ impl<R: Rule> RuleGraph<R> {
       .filter_map(|(k, deps)| match k {
         EntryWithDeps::Root(_) => {
           let root_str = entry_with_deps_str(k);
+          let mut dep_entries = deps
+            .all_dependencies()
+            .map(|d| entry_node_str_with_attrs(d))
+            .collect::<Vec<_>>();
+          dep_entries.sort();
+          let deps_with_attrs = dep_entries
+            .iter()
+            .cloned()
+            .filter(|d| d.attrs_str.is_some())
+            .map(|d| format!("\"{}\" {}", d.entry_str, d.attrs_str.unwrap()))
+            .collect::<Vec<String>>()
+            .join("\n");
           Some(format!(
-            "    \"{}\" [color=blue]\n    \"{}\" -> {{{}}}",
+            "    \"{}\" {}\n{}    \"{}\" -> {{{}}}",
             root_str,
+            Palette::Blue.color_format_string(),
+            deps_with_attrs,
             root_str,
-            deps
-              .all_dependencies()
-              .map(|d| format!("\"{}\"", entry_str(d)))
+            dep_entries
+              .iter()
+              .cloned()
+              .map(|d| format!("\"{}\"", d.entry_str))
               .collect::<Vec<String>>()
               .join(" ")
           ))
@@ -1030,16 +1106,29 @@ impl<R: Rule> RuleGraph<R> {
       .rule_dependency_edges
       .iter()
       .filter_map(|(k, deps)| match k {
-        EntryWithDeps::Inner(_) => {
-          let mut deps_strs = deps
+        &EntryWithDeps::Inner(_) => {
+          let mut dep_entries = deps
             .all_dependencies()
-            .map(|d| format!("\"{}\"", entry_str(d)))
-            .collect::<Vec<String>>();
-          deps_strs.sort();
+            .map(|d| entry_node_str_with_attrs(d))
+            .collect::<Vec<_>>();
+          dep_entries.sort();
+          let deps_with_attrs = dep_entries
+            .iter()
+            .cloned()
+            .filter(|d| d.attrs_str.is_some())
+            .map(|d| format!("\"{}\" {}", d.entry_str, d.attrs_str.unwrap()))
+            .collect::<Vec<String>>()
+            .join("\n");
           Some(format!(
-            "    \"{}\" -> {{{}}}",
+            "{}    \"{}\" -> {{{}}}",
+            deps_with_attrs,
             entry_with_deps_str(k),
-            deps_strs.join(" ")
+            dep_entries
+              .iter()
+              .cloned()
+              .map(|d| format!("\"{}\"", d.entry_str))
+              .collect::<Vec<String>>()
+              .join(" "),
           ))
         }
         _ => None,

--- a/src/rust/engine/rule_graph/src/rules.rs
+++ b/src/rust/engine/rule_graph/src/rules.rs
@@ -4,6 +4,8 @@
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
+use super::Palette;
+
 pub trait TypeId: Clone + Copy + Debug + Display + Hash + Eq + Ord + Sized + 'static {
   ///
   /// Render a string for a collection of TypeIds.
@@ -46,4 +48,15 @@ pub trait Rule: Clone + Debug + Display + Hash + Eq + Sized + 'static {
   /// True if this rule implementation should be required to be reachable in the RuleGraph.
   ///
   fn require_reachable(&self) -> bool;
+
+  ///
+  /// Return any specific color this rule should be drawn with on the visualized graph. Note that
+  /// this coloration setting may be superseded by other factors.
+  ///
+  fn color(&self) -> Option<Palette>;
+
+  ///
+  /// Return a pretty-printed representation of this Rule's graph node, suitable for graphviz.
+  ///
+  fn fmt_for_graph(&self) -> String;
 }

--- a/src/rust/engine/rule_graph/src/rules.rs
+++ b/src/rust/engine/rule_graph/src/rules.rs
@@ -35,7 +35,14 @@ pub trait DependencyKey: Clone + Copy + Debug + Display + Hash + Eq + Sized + 's
   fn provided_param(&self) -> Option<Self::TypeId>;
 }
 
-pub trait Rule: Clone + Debug + Display + Hash + Eq + Sized + 'static {
+pub trait DisplayForGraph {
+  ///
+  /// Return a pretty-printed representation of this Rule's graph node, suitable for graphviz.
+  ///
+  fn fmt_for_graph(&self) -> String;
+}
+
+pub trait Rule: Clone + Debug + Display + Hash + Eq + Sized + DisplayForGraph + 'static {
   type TypeId: TypeId;
   type DependencyKey: DependencyKey<TypeId = Self::TypeId>;
 
@@ -54,9 +61,4 @@ pub trait Rule: Clone + Debug + Display + Hash + Eq + Sized + 'static {
   /// this coloration setting may be superseded by other factors.
   ///
   fn color(&self) -> Option<Palette>;
-
-  ///
-  /// Return a pretty-printed representation of this Rule's graph node, suitable for graphviz.
-  ///
-  fn fmt_for_graph(&self) -> String;
 }

--- a/src/rust/engine/rule_graph/src/tests.rs
+++ b/src/rust/engine/rule_graph/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::RuleGraph;
+use crate::{Palette, RuleGraph};
 use std::fmt;
 
 #[test]
@@ -50,6 +50,14 @@ impl super::Rule for Rule {
 
   fn require_reachable(&self) -> bool {
     true
+  }
+
+  fn color(&self) -> Option<Palette> {
+    None
+  }
+
+  fn fmt_for_graph(&self) -> String {
+    "???".to_string()
   }
 }
 

--- a/src/rust/engine/rule_graph/src/tests.rs
+++ b/src/rust/engine/rule_graph/src/tests.rs
@@ -55,7 +55,9 @@ impl super::Rule for Rule {
   fn color(&self) -> Option<Palette> {
     None
   }
+}
 
+impl super::DisplayForGraph for Rule {
   fn fmt_for_graph(&self) -> String {
     "???".to_string()
   }

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -128,9 +128,9 @@ impl Rule {
     let select_clause_threshold = visualization_params.map(|p| p.select_clause_threshold);
 
     let clause_portion = match select_clause_threshold {
-      None => select_clauses.join(", ").to_string(),
+      None => select_clauses.join(", "),
       Some(select_clause_threshold) if select_clauses.len() <= select_clause_threshold => {
-        select_clauses.join(", ").to_string()
+        select_clauses.join(", ")
       }
       Some(_) => format!("\n{},\n", select_clauses.join(",\n")),
     };


### PR DESCRIPTION
### Problem

When looking at @benjyw's [comment thread](https://github.com/pantsbuild/pants/pull/6993#discussion_r245115870) with @stuhood on #6993, it seemed like it was difficult to create effective screenshots of the rule graph. This seemed to be for two reasons:

1. The nodes of the drawn graph are exceedingly wide due to the text being written in a single line.
2. The context of each node isn't clear (root nodes are outlined in blue, which is hard to make out compared to black against a white background, especially as the HSV coloration that `dot` outputs or that the OSX Preview app displays seems to be a bit off compared to other HSV selectors).

### Solution

- Insert some newlines in the formatting of nodes in the rule graph to make it skinnier.
- Color many different types of nodes by printing the node name, then its attributes, before printing the node again within a pair of `{ ... }` in the `.dot` file.

### TODO
- [x] Use `Display` impls as [noted by @stuhood below](https://github.com/pantsbuild/pants/pull/7024#discussion_r245383642), and/or make clear the difference between string representations for diagnostics and errors vs strings for graph drawing.
- [x] Color intrinsics the way we now do with Params, Singletons, and root nodes. This would require modifying `entry_node_str_with_attrs()` in much the same way as is done with `entry_str()` and `entry_node_str_with_attrs()` here.
- [x] Remove the stub `__str__()` implementations which currently have `???`s.
- [ ] Consider using more formatting attributes, such as `height`, `width`, `fixed-size` -- see `dot(1)`.
- [x] **(#9016)** Weight *edges* with `Get`s, as described in https://github.com/pantsbuild/pants/pull/7024#issuecomment-578244620.

### Result

![graph-thin](https://user-images.githubusercontent.com/1305167/73127432-270e4380-3fb8-11ea-880e-5104083c20c8.png)
<img width="1425" alt="graph-wider" src="https://user-images.githubusercontent.com/1305167/73127433-270e4380-3fb8-11ea-9ebb-c319f1080abb.png">
<img width="1407" alt="graph-thicc" src="https://user-images.githubusercontent.com/1305167/73127431-270e4380-3fb8-11ea-8bf0-09c28f6c3229.png">
