### PR TITLE
Revert "set PEX_PYTHON_PATH when invoking the checkstyle pex for pexrc to work (#7013)

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checkstyle.py
@@ -128,6 +128,10 @@ class Checkstyle(LintTaskMixin, Task):
             builder=PEXBuilder(path=chroot, interpreter=interpreter),
             log=self.context.log)
 
+          # Constraining is required to guard against the case where the user
+          # has a pexrc file set.
+          pex_builder.add_interpreter_constraint(str(interpreter.identity.requirement))
+
           if pants_dev_mode:
             pex_builder.add_sources_from(self.checker_target)
             req_libs = [tgt for tgt in self.checker_target.closure()
@@ -193,16 +197,9 @@ class Checkstyle(LintTaskMixin, Task):
       with self.context.new_workunit(name='pythonstyle',
                                      labels=[WorkUnitLabel.TOOL, WorkUnitLabel.LINT],
                                      cmd=' '.join(checker.cmdline(args))) as workunit:
-
-        # We have determined the exact interpreter we want here, so we override any pexrc settings.
-        pex_invocation_env = {
-          'PEX_PYTHON': interpreter.binary,
-          'PEX_IGNORE_RCFILES': 'True',
-        }
         return checker.run(args=args,
-                           stdout=workunit.output('stdout'),
-                           stderr=workunit.output('stderr'),
-                           env=pex_invocation_env)
+                                    stdout=workunit.output('stdout'),
+                                    stderr=workunit.output('stderr'))
 
   def _constraints_are_whitelisted(self, constraint_tuple):
     """


### PR DESCRIPTION
### Problem

Python checkstyle is failing in our docker container in #7025 -- see https://travis-ci.org/pantsbuild/pants/jobs/476054023. This goes away with this commit reverted.

### Solution

- Revert #7013.