### PR TITLE
Ensure all rust crates have common prefix

### DIFF
--- a/build-support/bin/check_rust_target_headers.sh
+++ b/build-support/bin/check_rust_target_headers.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+cargo="${REPO_ROOT}/build-support/bin/native/cargo"
+
+"${cargo}" ensure-installed --package cargo-ensure-prefix --version 0.1.3
+
+out="$("${cargo}" ensure-prefix --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" --prefix-path="${REPO_ROOT}/build-support/rust-target-prefix.txt" --all --exclude=bazel_protos)"
+if [[ $? -ne 0 ]]; then
+  echo >&2 "Rust targets didn't have correct prefix:"
+  echo >&2 "${out}"
+  exit 1
+fi

--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -16,6 +16,7 @@ echo "* Checking for banned imports" && ./build-support/bin/check_banned_imports
 if git diff master --name-only | grep '\.rs$' > /dev/null; then
   echo "* Checking formatting of rust files" && ./build-support/bin/check_rust_formatting.sh || exit 1
   echo "* Running cargo clippy" && ./build-support/bin/check_clippy.sh || exit 1
+  echo "* Checking rust target headers" && build-support/bin/check_rust_target_headers.sh || exit 1
 fi
 
 echo "* Checking for bad shell patterns" && ./build-support/bin/check_shell.sh || exit 1

--- a/build-support/rust-target-prefix.txt
+++ b/build-support/rust-target-prefix.txt
@@ -1,4 +1,4 @@
-// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Copyright  Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 #![deny(unused_must_use)]
@@ -29,16 +29,3 @@
 )]
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
-
-#![allow(clippy::all)]
-
-use bazel_protos;
-
-use futures;
-use grpcio;
-
-use protobuf;
-
-mod cas;
-pub use crate::cas::StubCAS;
-pub mod execution_server;

--- a/src/rust/engine/async_semaphore/src/lib.rs
+++ b/src/rust/engine/async_semaphore/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 #![deny(unused_must_use)]
 // Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
 #![deny(

--- a/src/rust/engine/boxfuture/src/lib.rs
+++ b/src/rust/engine/boxfuture/src/lib.rs
@@ -1,6 +1,5 @@
-// This file provides backward-compatibility for the deprecated BoxFuture type from futures.
-// https://github.com/alexcrichton/futures-rs/issues/228 has background for its removal.
-// This avoids needing to call Box::new() around every future that we produce.
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 #![deny(unused_must_use)]
 // Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
@@ -30,6 +29,10 @@
 )]
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
+
+// This file provides backward-compatibility for the deprecated BoxFuture type from futures.
+// https://github.com/alexcrichton/futures-rs/issues/228 has background for its removal.
+// This avoids needing to call Box::new() around every future that we produce.
 
 use futures::future::Future;
 

--- a/src/rust/engine/build_utils/src/lib.rs
+++ b/src/rust/engine/build_utils/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 #![deny(unused_must_use)]
 // Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
 #![deny(

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 #![deny(unused_must_use)]
 // Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
 #![deny(

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 #![deny(unused_must_use)]
 // Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
 #![deny(

--- a/src/rust/engine/process_execution/bazel_protos/build.rs
+++ b/src/rust/engine/process_execution/bazel_protos/build.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 use protoc_grpcio;
 
 use std::path::{Path, PathBuf};

--- a/src/rust/engine/process_execution/bazel_protos/src/lib.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/lib.rs
@@ -1,3 +1,8 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+#![deny(unused_must_use)]
+
 use hashing;
 use protobuf;
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 #![deny(unused_must_use)]
 // Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
 #![deny(

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -2174,7 +2174,12 @@ mod tests {
       let messages = mock_server.mock_responder.received_messages.lock();
       assert!(messages.len() == 2);
       assert!(
-        messages.get(1).unwrap().2.sub(messages.get(0).unwrap().2) >= Duration::from_millis(500)
+        messages
+          .get(1)
+          .unwrap()
+          .received_at
+          .sub(messages.get(0).unwrap().received_at)
+          >= Duration::from_millis(500)
       );
     }
   }
@@ -2209,13 +2214,28 @@ mod tests {
       let messages = mock_server.mock_responder.received_messages.lock();
       assert!(messages.len() == 4);
       assert!(
-        messages.get(1).unwrap().2.sub(messages.get(0).unwrap().2) >= Duration::from_millis(500)
+        messages
+          .get(1)
+          .unwrap()
+          .received_at
+          .sub(messages.get(0).unwrap().received_at)
+          >= Duration::from_millis(500)
       );
       assert!(
-        messages.get(2).unwrap().2.sub(messages.get(1).unwrap().2) >= Duration::from_millis(1000)
+        messages
+          .get(2)
+          .unwrap()
+          .received_at
+          .sub(messages.get(1).unwrap().received_at)
+          >= Duration::from_millis(1000)
       );
       assert!(
-        messages.get(3).unwrap().2.sub(messages.get(2).unwrap().2) >= Duration::from_millis(1500)
+        messages
+          .get(3)
+          .unwrap()
+          .received_at
+          .sub(messages.get(2).unwrap().received_at)
+          >= Duration::from_millis(1500)
       );
     }
   }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 #![deny(unused_must_use)]
 // Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
 #![deny(

--- a/src/rust/engine/resettable/src/lib.rs
+++ b/src/rust/engine/resettable/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 #![deny(unused_must_use)]
 // Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
 #![deny(

--- a/src/rust/engine/src/cffi_build.rs
+++ b/src/rust/engine/src/cffi_build.rs
@@ -1,3 +1,35 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+#![deny(unused_must_use)]
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![deny(
+  clippy::all,
+  clippy::default_trait_access,
+  clippy::expl_impl_clone_on_copy,
+  clippy::if_not_else,
+  clippy::needless_continue,
+  clippy::single_match_else,
+  clippy::unseparated_literal_suffix,
+  clippy::used_underscore_binding
+)]
+// It is often more clear to show that nothing is being moved.
+#![allow(clippy::match_ref_pats)]
+// Subjective style.
+#![allow(
+  clippy::len_without_is_empty,
+  clippy::redundant_field_names,
+  clippy::too_many_arguments
+)]
+// Default isn't as big a deal as people seem to think it is.
+#![allow(
+  clippy::new_without_default,
+  clippy::new_without_default_derive,
+  clippy::new_ret_no_self
+)]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![allow(clippy::mutex_atomic)]
+
 use cbindgen;
 use cc;
 

--- a/src/rust/engine/tar_api/src/tar_api.rs
+++ b/src/rust/engine/tar_api/src/tar_api.rs
@@ -1,3 +1,35 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+#![deny(unused_must_use)]
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![deny(
+  clippy::all,
+  clippy::default_trait_access,
+  clippy::expl_impl_clone_on_copy,
+  clippy::if_not_else,
+  clippy::needless_continue,
+  clippy::single_match_else,
+  clippy::unseparated_literal_suffix,
+  clippy::used_underscore_binding
+)]
+// It is often more clear to show that nothing is being moved.
+#![allow(clippy::match_ref_pats)]
+// Subjective style.
+#![allow(
+  clippy::len_without_is_empty,
+  clippy::redundant_field_names,
+  clippy::too_many_arguments
+)]
+// Default isn't as big a deal as people seem to think it is.
+#![allow(
+  clippy::new_without_default,
+  clippy::new_without_default_derive,
+  clippy::new_ret_no_self
+)]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![allow(clippy::mutex_atomic)]
+
 use flate2::read::GzDecoder;
 use std::fs::File;
 use std::path::Path;

--- a/src/rust/engine/testutil/local_cas/src/main.rs
+++ b/src/rust/engine/testutil/local_cas/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 #![deny(unused_must_use)]
 // Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
 #![deny(

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -141,10 +141,17 @@ impl Drop for TestServer {
   }
 }
 
+#[derive(Debug)]
+pub struct ReceivedMessage {
+  pub message_type: String,
+  pub message: Box<dyn protobuf::Message>,
+  pub received_at: Instant,
+}
+
 #[derive(Clone, Debug)]
 pub struct MockResponder {
   mock_execution: MockExecution,
-  pub received_messages: Arc<Mutex<Vec<(String, Box<dyn protobuf::Message>, Instant)>>>,
+  pub received_messages: Arc<Mutex<Vec<ReceivedMessage>>>,
 }
 
 impl MockResponder {
@@ -156,11 +163,11 @@ impl MockResponder {
   }
 
   fn log<T: protobuf::Message + Sized>(&self, message: T) {
-    self.received_messages.lock().push((
-      message.descriptor().name().to_string(),
-      Box::new(message),
-      Instant::now(),
-    ));
+    self.received_messages.lock().push(ReceivedMessage {
+      message_type: message.descriptor().name().to_string(),
+      message: Box::new(message),
+      received_at: Instant::now(),
+    });
   }
 
   fn display_all<D: Debug>(items: &[D]) -> String {

--- a/src/rust/engine/testutil/mock/src/lib.rs
+++ b/src/rust/engine/testutil/mock/src/lib.rs
@@ -30,8 +30,6 @@
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
-#![allow(clippy::all)]
-
 use bazel_protos;
 
 use futures;

--- a/src/rust/engine/testutil/src/lib.rs
+++ b/src/rust/engine/testutil/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 #![deny(unused_must_use)]
 // Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
 #![deny(

--- a/src/rust/engine/ui/src/display.rs
+++ b/src/rust/engine/ui/src/display.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 #![deny(unused_must_use)]
 // Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
 #![deny(

--- a/src/rust/engine/ui/src/main.rs
+++ b/src/rust/engine/ui/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 #![deny(unused_must_use)]
 // Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
 #![deny(


### PR DESCRIPTION
This covers:
* Copyright notice
* Warnings as errors
* Clippy configuration