### PR TITLE
Fix awscli install to be language agnostic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ default_test_config: &default_test_config
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288
-    - pip install awscli
+    - sudo pip install awscli
     # Multipart operations aren't supported for anonymous users, so we set the
     # threshold high to avoid them being used automatically by the aws cli.
     - aws configure set default.s3.multipart_threshold 1024MB
@@ -127,7 +127,7 @@ linux_with_fuse: &linux_with_fuse
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288
-    - pip install awscli
+    - sudo pip install awscli
     # Multipart operations aren't supported for anonymous users, so we set the
     # threshold high to avoid them being used automatically by the aws cli.
     - aws configure set default.s3.multipart_threshold 1024MB

--- a/build-support/travis/before_install.mustache
+++ b/build-support/travis/before_install.mustache
@@ -3,7 +3,7 @@
     # Increase the max number of user watches to ensure that watchman is able to watch all
     # files in the working copy.
     - sudo sysctl fs.inotify.max_user_watches=524288
-    - pip install awscli
+    - sudo pip install awscli
     # Multipart operations aren't supported for anonymous users, so we set the
     # threshold high to avoid them being used automatically by the aws cli.
     - aws configure set default.s3.multipart_threshold 1024MB


### PR DESCRIPTION
Previously the install only worked if the shard language was python on
linux.

Fixes #7032
