### PR TITLE
Improve readability of integration test logging

### DIFF
--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -154,7 +154,7 @@ def read_pantsd_log(workdir):
 def _read_log(filename):
   with open(filename, 'r') as f:
     for line in f:
-      yield line.strip()
+      yield line.rstrip()
 
 
 class PantsRunIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
### Problem

When an integration test fails, we log all relevant logs. But because we strip all whitespace (rather than just trailing whitespace and newlines), we lose the indentation of those logs.

### Solution

Only strip trailing whitespace.

### Result

Indentation is preserved:
```
logs/exceptions.70779.log >>> pid: 70779
logs/exceptions.70779.log >>> Exception caught: (exceptions.TypeError)
logs/exceptions.70779.log >>>   File "/Users/stuhood/src/pants/src/python/pants/bin/pants_loader.py", line 80, in <module>
logs/exceptions.70779.log >>>     main()
logs/exceptions.70779.log >>>   File "/Users/stuhood/src/pants/src/python/pants/bin/pants_loader.py", line 76, in main
logs/exceptions.70779.log >>>     PantsLoader.run()
<snip>
logs/exceptions.70779.log >>>   File "/Users/stuhood/src/pants/src/python/pants/engine/round_engine.py", line 49, in attempt
logs/exceptions.70779.log >>>     task.execute()
logs/exceptions.70779.log >>>   File "/Users/stuhood/src/pants/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py", line 364, in execute
logs/exceptions.70779.log >>>     for vt in invalidation_check.all_vts}
logs/exceptions.70779.log >>>   File "/Users/stuhood/src/pants/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py", line 364, in <dictcomp>
logs/exceptions.70779.log >>>     for vt in invalidation_check.all_vts}
logs/exceptions.70779.log >>>   File "/Users/stuhood/src/pants/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py", line 334, in create_compile_context
logs/exceptions.70779.log >>>     self._compute_sources_for_target(target))
logs/exceptions.70779.log >>>
logs/exceptions.70779.log >>> Exception message: __init__() takes exactly 7 arguments (8 given)
```