### PR TITLE
[compile.rsc] fix key error; ensure java compiles get necessary zinc scala deps

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -757,11 +757,20 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         return True
       if target in invalid_target_set:
         invalid_dependencies.add(target)
-        return False
+        return self._on_invalid_compile_dependency(target, compile_target)
       return True
 
     compile_target.walk(work, predicate)
     return invalid_dependencies
+
+  def _on_invalid_compile_dependency(self, dep, compile_target):
+    """Decide whether to continue searching for invalid targets to use in the execution graph.
+
+    By default, don't recurse because once we have an invalid dependency, we can rely on its
+    dependencies having been compiled already.
+
+    Override to adjust this behavior."""
+    return False
 
   def _create_context_jar(self, compile_context):
     """Jar up the compile_context to its output jar location.

--- a/testprojects/src/java/org/pantsbuild/testproject/javadepsonscalatransitive/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/javadepsonscalatransitive/BUILD
@@ -1,0 +1,10 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(
+  dependencies = [
+    'testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive:scala'
+  ],
+  sources = rglobs('*.java'),
+  strict_deps = True
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/javadepsonscalatransitive/Java.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/javadepsonscalatransitive/Java.java
@@ -1,0 +1,16 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.javadepsonscalatransitive;
+
+public class Java {
+
+  public String doStuff() {
+      // This should not trigger a missing dependency warning
+      // since we actually depend on the scala library.
+    Scala scala = new Scala();
+    Scala2 scala2 = new Scala2();
+    return scala.toString() + scala2.toString();
+  }
+
+}

--- a/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive/BUILD
@@ -1,0 +1,14 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+scala_library(
+  name = 'scala',
+  sources = ['Scala.scala'],
+  dependencies = [':scala-2'],
+  exports = [':scala-2']
+)
+
+scala_library(
+  name = 'scala-2',
+  sources = ['Scala2.scala']
+)

--- a/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive/README.md
+++ b/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive/README.md
@@ -1,0 +1,2 @@
+If a java_library depends on a scala_library and a scala_library exported by that scala_library, it
+should still be compilable.

--- a/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive/Scala.scala
+++ b/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive/Scala.scala
@@ -1,0 +1,3 @@
+package org.pantsbuild.testproject.javadepsonscalatransitive
+
+class Scala {}

--- a/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive/Scala2.scala
+++ b/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive/Scala2.scala
@@ -1,0 +1,3 @@
+package org.pantsbuild.testproject.javadepsonscalatransitive
+
+class Scala2 {}

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -96,3 +96,21 @@ class RscCompileIntegration(BaseCompileIT):
           workdir, config)
         self.assert_success(pants_run)
         self.assertIn('Hello, Resource World!', pants_run.stdout_data)
+
+  def test_java_with_transitive_exported_scala_dep(self):
+    with temporary_dir() as cache_dir:
+      config = {
+        'cache.compile.rsc': {'write_to': [cache_dir]},
+        'jvm-platform': {'compiler': 'rsc'},
+        'compile.rsc': {
+          'execution_strategy': 'subprocess',
+          'worker_count': 1}
+      }
+      with self.temporary_workdir() as workdir:
+        pants_run = self.run_pants_with_workdir(
+          ['compile',
+            'testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive:scala',
+          ],
+          workdir, config)
+        self.assert_success(pants_run)
+        self.assertIn('Hello, Resource World!', pants_run.stdout_data)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -113,4 +113,3 @@ class RscCompileIntegration(BaseCompileIT):
           ],
           workdir, config)
         self.assert_success(pants_run)
-        self.assertIn('Hello, Resource World!', pants_run.stdout_data)


### PR DESCRIPTION
### Problem
- the dependency list for java compiles used the wrong keys in some cases
- collecting the invalid deps for the graph for java zinc compiles requires traversing transitive scala deps

### Solution
- add a helper for metacp deps
- override collecting invalid deps to ensure the walk recurses when the compile target has java deps and the current is scala

### Description

For a plain zinc compile, all of the work has the same flavor, so we can assume that only depending on a direct dependency will give us the outputs needed. But, the Rsc graph has multiple flavors of nodes, so to ensure the right dependency flavors have already been calculated, we need to traverse more of the invalidated graph.
