### PR TITLE
Expose 1.13.x in the docsite notes dropdown.

### DIFF
--- a/src/docs/docsite.json
+++ b/src/docs/docsite.json
@@ -189,6 +189,7 @@
        },
        {"collapsible_heading": "Release Notes",
         "pages" : [
+                    "notes-1.13.x",
                     "notes-1.12.x",
                     "notes-1.11.x",
                     "notes-1.10.x",


### PR DESCRIPTION
### Problem

There are too many steps involved in cutting a new stable branch, and it is easy to miss one of them.

### Solution

Fix a symptom, rather than the underlying issue (unfortunately!).