### PR TITLE
Use max compatible Python interpreter rather than minimum

### DIFF
--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -336,8 +336,8 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
       # across all the python targets in-play.
       #
       # For now, make our arbitrary historical choice of a default interpreter explicit and use the
-      # lowest version.
-      default_interpreter = min(python_interpreter_targets_mapping.keys())
+      # highest version.
+      default_interpreter = max(python_interpreter_targets_mapping.keys())
 
       interpreters_info = {}
       for interpreter, targets in six.iteritems(python_interpreter_targets_mapping):

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -112,8 +112,8 @@ class PythonInterpreterCache(Subsystem):
         'Unable to detect a suitable interpreter for compatibilities: {} '
         '(Conflicting targets: {})'.format(' && '.join(sorted(unique_compatibilities_strs)),
                                            ', '.join(tgts_by_compatibilities_strs)))
-    # Return the lowest compatible interpreter.
-    return min(allowed_interpreters)
+    # Return the highest compatible interpreter.
+    return max(allowed_interpreters)
 
   def _interpreter_from_path(self, path, filters=()):
     try:

--- a/tests/python/pants_test/backend/python/interpreter_selection_utils.py
+++ b/tests/python/pants_test/backend/python/interpreter_selection_utils.py
@@ -36,7 +36,7 @@ def python_interpreter_path(version):
     command = ['python{}'.format(version), '-c', 'import sys; print(sys.executable)']
     py_path = subprocess.check_output(command).decode('utf-8').strip()
     return os.path.realpath(py_path)
-  except subprocess.CalledProcessError:
+  except (subprocess.CalledProcessError, OSError):
     return None
 
 

--- a/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
+++ b/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
@@ -105,14 +105,14 @@ class SelectInterpreterTest(TaskTestBase):
 
   def test_interpreter_selection(self):
     self.assertIsNone(self._select_interpreter([]))
-    self.assertEqual('IronPython-2.77.777', self._select_interpreter_and_get_version([self.reqtgt]))
-    self.assertEqual('IronPython-2.77.777', self._select_interpreter_and_get_version([self.tgt1]))
-    self.assertEqual('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt2]))
+    self.assertEqual('IronPython-2.99.999', self._select_interpreter_and_get_version([self.reqtgt]))
+    self.assertEqual('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt1]))
+    self.assertEqual('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt2]))
     self.assertEqual('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt3]))
-    self.assertEqual('IronPython-2.77.777', self._select_interpreter_and_get_version([self.tgt4]))
-    self.assertEqual('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt20]))
+    self.assertEqual('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt4]))
+    self.assertEqual('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt20]))
     self.assertEqual('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt30]))
-    self.assertEqual('IronPython-2.77.777', self._select_interpreter_and_get_version([self.tgt40]))
+    self.assertEqual('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt40]))
     self.assertEqual('IronPython-2.99.999', self._select_interpreter_and_get_version([self.tgt2, self.tgt3]))
     self.assertEqual('IronPython-2.88.888', self._select_interpreter_and_get_version([self.tgt2, self.tgt4]))
 


### PR DESCRIPTION
### Problem

When running `./pants3`, we would expect to run subprocesses like Pytest using Python 3 as well. Instead, we resort to using Python 2—as it's the minimum acceptable—unless `--python-setup-interpreter-constraints` is explicitly set to require Python 3.

One workaround to this issue would be setting `PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS` to only allow Python 3, but this would mean that `./pants3` could no longer be used to run targets that require Python 2 like Antlr.

Further, we in general want to write Python 3-first code. Defaulting to the minimum interpreter possible does not coincide with this objective.

### How to get to prior behavior

Users may go back to using the minimum interpreter through several ways:
- temporarily via the `--python-setup-interpreter-constraints` flag
- temporarily via `PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS`
- globally via `pants.ini` and `compatibility`
- at the target level via `BUILD` files and `compatibility`

### Implications

- CI's Python 3 shards will use Python 3.7, not 3.6
- Once we merge https://github.com/pantsbuild/pants/pull/6959, Pants and CI will default to using Python 3 for subprocesses instead of Python 2—even when using Python 2 under-the-hood. This is intentional. We can use the compatibility mechanisms to force Python 2 (e.g. CI will use `PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS` to get our Py2 shards to use Python 2).
- New Python major releases will potentially cause issues for Pants users if their code is not ready. For example, if they run `brew upgrade` when 3.8 comes out, and used our internal compatibility setting of `>=2.7,<3 or >=3.6,<4` and have issues like not using `collections.abc`, then they will get a `SyntaxError`. Keep in mind this only happens one a year, though, when a new version is released. Further, it is easy to constrain their compatibility to no longer allow 3.8.