### PR TITLE
Remote execution uses tower-grpc to start executions

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1281,17 +1281,26 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
+ "h2 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
+ "http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "resettable 0.0.1",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-connect 0.1.0 (git+https://github.com/pantsbuild/tokio-connect?rev=f7ad1ca437973d6e24037ac6f7d5ef1013833c0b)",
  "tokio-process 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-grpc 0.1.0 (git+https://github.com/pantsbuild/tower-grpc.git?rev=ef19f2e1715f415ecb699e8f17f5845ad2b45daf)",
+ "tower-h2 0.1.0 (git+https://github.com/pantsbuild/tower-h2?rev=44b0efb4983b769283efd5b2a3bc3decbf7c33de)",
+ "tower-http 0.1.0 (git+https://github.com/pantsbuild/tower-http?rev=56049ee7f31d4f6c549f5d1d5fbbfd7937df3d00)",
+ "tower-util 0.1.0 (git+https://github.com/pantsbuild/tower?rev=7b61c1fc1992c1df684fd3f179644ef0ca9bfa4c)",
 ]
 
 [[package]]
@@ -1306,6 +1315,7 @@ dependencies = [
  "hashing 0.0.1",
  "process_execution 0.0.1",
  "resettable 0.0.1",
+ "tokio 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -13,18 +13,27 @@ bytes = "0.4.5"
 digest = "0.8"
 fs = { path = "../fs" }
 futures = "^0.1.16"
+# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
+futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", default_features = false, features = ["protobuf-codec"] }
+h2 = "0.1.13"
 hashing = { path = "../hashing" }
+http = "0.1"
 log = "0.4"
+parking_lot = "0.6"
 protobuf = { version = "2.0.4", features = ["with-bytes"] }
 resettable = { path = "../resettable" }
 sha2 = "0.8"
 tempfile = "3"
-# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
-futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 time = "0.1.40"
+tokio = "0.1.14"
 tokio-codec = "0.1"
+tokio-connect = { git = "https://github.com/pantsbuild/tokio-connect.git", rev = "f7ad1ca437973d6e24037ac6f7d5ef1013833c0b" }
 tokio-process = "0.2.1"
+tower-grpc = { git = "https://github.com/pantsbuild/tower-grpc.git", rev = "ef19f2e1715f415ecb699e8f17f5845ad2b45daf" }
+tower-h2 = { git = "https://github.com/pantsbuild/tower-h2.git", rev = "44b0efb4983b769283efd5b2a3bc3decbf7c33de" }
+tower-http = { git = "https://github.com/pantsbuild/tower-http.git", rev = "56049ee7f31d4f6c549f5d1d5fbbfd7937df3d00" }
+tower-util = { git = "https://github.com/pantsbuild/tower.git", rev = "7b61c1fc1992c1df684fd3f179644ef0ca9bfa4c" }
 
 [dev-dependencies]
 mock = { path = "../testutil/mock" }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::mem::drop;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -14,6 +13,7 @@ use futures_timer::Delay;
 use grpcio;
 use hashing::{Digest, Fingerprint};
 use log::{debug, trace, warn};
+use parking_lot::Mutex;
 use protobuf::{self, Message, ProtobufEnum};
 use sha2::Sha256;
 use time;
@@ -21,6 +21,13 @@ use time;
 use super::{ExecuteProcessRequest, ExecutionStats, FallibleExecuteProcessResult};
 use std;
 use std::cmp::min;
+
+use std::net::SocketAddr;
+use std::net::ToSocketAddrs;
+use tokio::net::tcp::{ConnectFuture, TcpStream};
+use tower_grpc::Request;
+use tower_h2::client;
+use tower_util::MakeService;
 
 // Environment variable which is exclusively used for cache key invalidation.
 // This may be not specified in an ExecuteProcessRequest, and may be populated only by the
@@ -34,13 +41,31 @@ enum OperationOrStatus {
 }
 
 #[derive(Clone)]
+#[allow(clippy::type_complexity)]
 pub struct CommandRunner {
   cache_key_gen_version: Option<String>,
   instance_name: Option<String>,
   authorization_header: Option<String>,
   channel: grpcio::Channel,
   env: Arc<grpcio::Environment>,
-  execution_client: Arc<bazel_protos::remote_execution_grpc::ExecutionClient>,
+  execution_client: futures::future::Shared<
+    BoxFuture<
+      Arc<
+        Mutex<
+          bazel_protos::build::bazel::remote::execution::v2::client::Execution<
+            tower_http::add_origin::AddOrigin<
+              tower_h2::client::Connection<
+                tokio::net::tcp::TcpStream,
+                tokio::runtime::TaskExecutor,
+                tower_grpc::BoxBody,
+              >,
+            >,
+          >,
+        >,
+      >,
+      String,
+    >,
+  >,
   operations_client: Arc<bazel_protos::operations_grpc::OperationsClient>,
   store: Store,
   futures_timer_thread: resettable::Resettable<futures_timer::HelperThread>,
@@ -72,35 +97,35 @@ impl CommandRunner {
   // behavior.
   fn oneshot_execute(
     &self,
-    execute_request: &Arc<bazel_protos::remote_execution::ExecuteRequest>,
-  ) -> BoxFuture<OperationOrStatus, String> {
-    let stream = try_future!(self
+    execute_request: bazel_protos::build::bazel::remote::execution::v2::ExecuteRequest,
+  ) -> impl Future<Item = OperationOrStatus, Error = String> {
+    self
       .execution_client
-      .execute_opt(&execute_request, self.call_option())
-      .map_err(rpcerror_to_string));
-    stream
-      .take(1)
-      .into_future()
-      // If there was a response, drop the _stream to disconnect so that the server doesn't keep
-      // the connection alive and continue sending on it.
-      .map(|(maybe_operation, stream)| {
-        drop(stream);
-        maybe_operation
+      .clone()
+      .map_err(|err| format!("Error getting execution_client: {}", err))
+      .and_then(|execution_client| {
+        let mut execution_client = execution_client.lock();
+        execution_client
+          .execute(Request::new(execute_request))
+          .map_err(towergrpcerror_to_string)
+          .and_then(|response_stream| {
+            response_stream
+              .into_inner()
+              .take(1)
+              .into_future()
+              .map_err(|err| {
+                format!(
+                  "Error getting response from remote process execution {:?}",
+                  err
+                )
+              })
+              .and_then(|(resp, stream)| {
+                std::mem::drop(stream);
+                resp.ok_or_else(|| "Didn't get response from remote process execution".to_owned())
+              })
+              .map(|operation| OperationOrStatus::Operation(operation.into()))
+          })
       })
-      // If there was an error, drop the _stream to disconnect so that the server doesn't keep the
-      // connection alive and continue sending on it.
-      .map_err(|(error, stream)| {
-        drop(stream);
-        error
-      })
-      .then(|maybe_operation_result| match maybe_operation_result {
-        Ok(Some(operation)) => Ok(OperationOrStatus::Operation(operation)),
-        Ok(None) => {
-          Err("Didn't get proper stream response from server during remote execution".to_owned())
-        }
-        Err(err) => rpcerror_to_status_or_string(err).map(OperationOrStatus::Status),
-      })
-      .to_boxed()
   }
 }
 
@@ -145,7 +170,6 @@ impl super::CommandRunner for CommandRunner {
         let command_runner = self.clone();
         let command_runner2 = self.clone();
         let command_runner3 = self.clone();
-        let execute_request = Arc::new(execute_request);
         let execute_request2 = execute_request.clone();
         let futures_timer_thread = self.futures_timer_thread.clone();
 
@@ -166,7 +190,7 @@ impl super::CommandRunner for CommandRunner {
               command
             );
             command_runner
-              .oneshot_execute(&execute_request)
+              .oneshot_execute(execute_request)
               .join(future::ok(history))
           })
           .and_then(move |(operation, history)| {
@@ -212,7 +236,7 @@ impl super::CommandRunner for CommandRunner {
                           let mut history = history;
                           history.current_attempt += summary;
                           command_runner2
-                            .oneshot_execute(&execute_request)
+                            .oneshot_execute(execute_request)
                             .join(future::ok(history))
                         })
                         // Reset `iter_num` on `MissingDigests`
@@ -306,7 +330,8 @@ impl CommandRunner {
     thread_count: usize,
     store: Store,
     futures_timer_thread: resettable::Resettable<futures_timer::HelperThread>,
-  ) -> CommandRunner {
+    executor: tokio::runtime::TaskExecutor,
+  ) -> Result<CommandRunner, String> {
     let env = Arc::new(grpcio::Environment::new(thread_count));
     let channel = {
       let builder = grpcio::ChannelBuilder::new(env.clone());
@@ -322,24 +347,62 @@ impl CommandRunner {
         builder.connect(address)
       }
     };
-    let execution_client = Arc::new(bazel_protos::remote_execution_grpc::ExecutionClient::new(
-      channel.clone(),
-    ));
     let operations_client = Arc::new(bazel_protos::operations_grpc::OperationsClient::new(
       channel.clone(),
     ));
 
-    CommandRunner {
+    struct Dst(SocketAddr);
+
+    impl tokio_connect::Connect for Dst {
+      type Connected = TcpStream;
+      type Error = ::std::io::Error;
+      type Future = ConnectFuture;
+
+      fn connect(&self) -> Self::Future {
+        TcpStream::connect(&self.0)
+      }
+    }
+
+    // TODO: Support https
+    let uri: http::Uri = format!("http://{}", address)
+      .parse()
+      .map_err(|err| format!("Failed to parse remote server address URL: {}", err))?;
+    let socket_addr = address
+      .to_socket_addrs()
+      .map_err(|err| format!("Failed to resolve remote socket address URL: {}", err))?
+      .next()
+      .ok_or_else(|| "Remote server address resolved to no addresses".to_owned())?;
+    let execution_client =
+      client::Connect::new(Dst(socket_addr), h2::client::Builder::default(), executor)
+        .make_service(())
+        .map_err(|err| format!("Error connecting to remote execution server: {}", err))
+        .and_then(move |conn| {
+          let conn = tower_http::add_origin::Builder::new()
+            .uri(uri)
+            .build(conn)
+            .map_err(|err| {
+              format!(
+                "Failed to add origin for remote execution server: {:?}",
+                err
+              )
+            })?;
+          Ok(Arc::new(Mutex::new(
+            bazel_protos::build::bazel::remote::execution::v2::client::Execution::new(conn),
+          )))
+        })
+        .to_boxed()
+        .shared();
+    Ok(CommandRunner {
       cache_key_gen_version,
       instance_name,
       authorization_header: oauth_bearer_token.map(|t| format!("Bearer {}", t)),
       channel,
       env,
-      execution_client,
       operations_client,
+      execution_client,
       store,
       futures_timer_thread,
-    }
+    })
   }
 
   fn call_option(&self) -> grpcio::CallOption {
@@ -737,7 +800,7 @@ fn make_execute_request(
   (
     bazel_protos::remote_execution::Action,
     bazel_protos::remote_execution::Command,
-    bazel_protos::remote_execution::ExecuteRequest,
+    bazel_protos::build::bazel::remote::execution::v2::ExecuteRequest,
   ),
   String,
 > {
@@ -806,11 +869,13 @@ fn make_execute_request(
   action.set_command_digest((&digest(&command)?).into());
   action.set_input_root_digest((&req.input_files).into());
 
-  let mut execute_request = bazel_protos::remote_execution::ExecuteRequest::new();
-  if let Some(instance_name) = instance_name {
-    execute_request.set_instance_name(instance_name.clone());
-  }
-  execute_request.set_action_digest((&digest(&action)?).into());
+  let execute_request = bazel_protos::build::bazel::remote::execution::v2::ExecuteRequest {
+    action_digest: Some((&digest(&action)?).into()),
+    skip_cache_lookup: false,
+    instance_name: instance_name.clone().unwrap_or_default(),
+    execution_policy: None,
+    results_cache_policy: None,
+  };
 
   Ok((action, command, execute_request))
 }
@@ -845,29 +910,6 @@ fn rpcerror_recover_cancelled(
   Err(err)
 }
 
-fn rpcerror_to_status_or_string(
-  error: grpcio::Error,
-) -> Result<bazel_protos::status::Status, String> {
-  match error {
-    grpcio::Error::RpcFailure(grpcio::RpcStatus {
-      status_proto_bytes: Some(status_proto_bytes),
-      ..
-    }) => {
-      let mut status_proto = bazel_protos::status::Status::new();
-      status_proto.merge_from_bytes(&status_proto_bytes).unwrap();
-      Ok(status_proto)
-    }
-    grpcio::Error::RpcFailure(grpcio::RpcStatus {
-      status, details, ..
-    }) => Err(format!(
-      "{:?}: {:?}",
-      status,
-      details.unwrap_or_else(|| "[no message]".to_string())
-    )),
-    err => Err(format!("{:?}", err)),
-  }
-}
-
 fn rpcerror_to_string(error: grpcio::Error) -> String {
   match error {
     grpcio::Error::RpcFailure(status) => format!(
@@ -876,6 +918,20 @@ fn rpcerror_to_string(error: grpcio::Error) -> String {
       status.details.unwrap_or_else(|| "[no message]".to_string())
     ),
     err => format!("{:?}", err),
+  }
+}
+
+fn towergrpcerror_to_string<T: std::fmt::Debug>(error: tower_grpc::Error<T>) -> String {
+  match error {
+    tower_grpc::Error::Grpc(status) => {
+      let error_message = if status.error_message() == "" {
+        "[no message]"
+      } else {
+        &status.error_message()
+      };
+      format!("{:?}: {}", status.code(), error_message)
+    }
+    tower_grpc::Error::Inner(v) => format!("{:?}", v),
   }
 }
 
@@ -989,17 +1045,22 @@ mod tests {
     );
     want_action.set_input_root_digest((&input_directory.digest()).into());
 
-    let mut want_execute_request = bazel_protos::remote_execution::ExecuteRequest::new();
-    want_execute_request.set_action_digest(
-      (&Digest(
-        Fingerprint::from_hex_string(
-          "844c929423444f3392e0dcc89ebf1febbfdf3a2e2fcab7567cc474705a5385e4",
-        )
-        .unwrap(),
-        140,
-      ))
-        .into(),
-    );
+    let want_execute_request = bazel_protos::build::bazel::remote::execution::v2::ExecuteRequest {
+      action_digest: Some(
+        (&Digest(
+          Fingerprint::from_hex_string(
+            "844c929423444f3392e0dcc89ebf1febbfdf3a2e2fcab7567cc474705a5385e4",
+          )
+          .unwrap(),
+          140,
+        ))
+          .into(),
+      ),
+      instance_name: String::new(),
+      execution_policy: None,
+      results_cache_policy: None,
+      skip_cache_lookup: false,
+    };
 
     assert_eq!(
       super::make_execute_request(&req, &None, &None),
@@ -1075,6 +1136,23 @@ mod tests {
         .into(),
     );
 
+    let want_execute_request = bazel_protos::build::bazel::remote::execution::v2::ExecuteRequest {
+      action_digest: Some(
+        (&Digest(
+          Fingerprint::from_hex_string(
+            "844c929423444f3392e0dcc89ebf1febbfdf3a2e2fcab7567cc474705a5385e4",
+          )
+          .unwrap(),
+          140,
+        ))
+          .into(),
+      ),
+      instance_name: "dark-tower".to_owned(),
+      execution_policy: None,
+      results_cache_policy: None,
+      skip_cache_lookup: false,
+    };
+
     assert_eq!(
       super::make_execute_request(&req, &Some("dark-tower".to_owned()), &None),
       Ok((want_action, want_command, want_execute_request))
@@ -1142,17 +1220,22 @@ mod tests {
     );
     want_action.set_input_root_digest((&input_directory.digest()).into());
 
-    let mut want_execute_request = bazel_protos::remote_execution::ExecuteRequest::new();
-    want_execute_request.set_action_digest(
-      (&Digest(
-        Fingerprint::from_hex_string(
-          "0ee5d4c8ac12513a87c8d949c6883ac533a264d30215126af71a9028c4ab6edf",
-        )
-        .unwrap(),
-        140,
-      ))
-        .into(),
-    );
+    let want_execute_request = bazel_protos::build::bazel::remote::execution::v2::ExecuteRequest {
+      action_digest: Some(
+        (&Digest(
+          Fingerprint::from_hex_string(
+            "0ee5d4c8ac12513a87c8d949c6883ac533a264d30215126af71a9028c4ab6edf",
+          )
+          .unwrap(),
+          140,
+        ))
+          .into(),
+      ),
+      instance_name: String::new(),
+      execution_policy: None,
+      results_cache_policy: None,
+      skip_cache_lookup: false,
+    };
 
     assert_eq!(
       super::make_execute_request(&req, &None, &Some("meep".to_owned())),
@@ -1197,17 +1280,22 @@ mod tests {
     );
     want_action.set_input_root_digest((&input_directory.digest()).into());
 
-    let mut want_execute_request = bazel_protos::remote_execution::ExecuteRequest::new();
-    want_execute_request.set_action_digest(
-      (&Digest(
-        Fingerprint::from_hex_string(
-          "b1fb7179ce496995a4e3636544ec000dca1b951f1f6216493f6c7608dc4dd910",
-        )
-        .unwrap(),
-        140,
-      ))
-        .into(),
-    );
+    let want_execute_request = bazel_protos::build::bazel::remote::execution::v2::ExecuteRequest {
+      action_digest: Some(
+        (&Digest(
+          Fingerprint::from_hex_string(
+            "b1fb7179ce496995a4e3636544ec000dca1b951f1f6216493f6c7608dc4dd910",
+          )
+          .unwrap(),
+          140,
+        ))
+          .into(),
+      ),
+      instance_name: String::new(),
+      execution_policy: None,
+      results_cache_policy: None,
+      skip_cache_lookup: false,
+    };
 
     assert_eq!(
       super::make_execute_request(&req, &None, &None),
@@ -1245,7 +1333,7 @@ mod tests {
     let error = run_command_remote(mock_server.address(), execute_request).expect_err("Want Err");
     assert_eq!(
       error,
-      "InvalidArgument: \"Did not expect this request\"".to_string()
+      "InvalidArgument: Did not expect this request".to_string()
     );
   }
 
@@ -1388,6 +1476,8 @@ mod tests {
     )
     .expect("Failed to make store");
 
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
     let cmd_runner = CommandRunner::new(
       &mock_server.address(),
       None,
@@ -1397,8 +1487,11 @@ mod tests {
       1,
       store,
       timer_thread,
-    );
-    let result = cmd_runner.run(echo_roland_request()).wait().unwrap();
+      rt.executor(),
+    )
+    .unwrap();
+    let result = rt.block_on(cmd_runner.run(echo_roland_request())).unwrap();
+    rt.shutdown_now().wait().unwrap();
     assert_eq!(
       result.without_execution_attempts(),
       FallibleExecuteProcessResult {
@@ -1764,21 +1857,26 @@ mod tests {
       .wait()
       .expect("Saving directory bytes to store");
 
-    let result = CommandRunner::new(
-      &mock_server.address(),
-      None,
-      None,
-      None,
-      None,
-      1,
-      store,
-      timer_thread,
-    )
-    .run(cat_roland_request())
-    .wait()
-    .unwrap();
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+    let result = rt.block_on(
+      CommandRunner::new(
+        &mock_server.address(),
+        None,
+        None,
+        None,
+        None,
+        1,
+        store,
+        timer_thread,
+        rt.executor(),
+      )
+      .unwrap()
+      .run(cat_roland_request()),
+    );
+    rt.shutdown_now().wait().unwrap();
     assert_eq!(
-      result.without_execution_attempts(),
+      result.unwrap().without_execution_attempts(),
       FallibleExecuteProcessResult {
         stdout: roland.bytes(),
         stderr: Bytes::from(""),
@@ -1860,18 +1958,22 @@ mod tests {
       .wait()
       .expect("Saving file bytes to store");
 
-    let result = CommandRunner::new(
-      &mock_server.address(),
-      None,
-      None,
-      None,
-      None,
-      1,
-      store,
-      timer_thread,
-    )
-    .run(cat_roland_request())
-    .wait();
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let result = rt.block_on(
+      CommandRunner::new(
+        &mock_server.address(),
+        None,
+        None,
+        None,
+        None,
+        1,
+        store,
+        timer_thread,
+        rt.executor(),
+      )
+      .unwrap()
+      .run(cat_roland_request()),
+    );
     assert_eq!(
       result,
       Ok(FallibleExecuteProcessResult {
@@ -1928,19 +2030,24 @@ mod tests {
     )
     .expect("Failed to make store");
 
-    let error = CommandRunner::new(
-      &mock_server.address(),
-      None,
-      None,
-      None,
-      None,
-      1,
-      store,
-      timer_thread,
-    )
-    .run(cat_roland_request())
-    .wait()
-    .expect_err("Want error");
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let result = rt.block_on(
+      CommandRunner::new(
+        &mock_server.address(),
+        None,
+        None,
+        None,
+        None,
+        1,
+        store,
+        timer_thread,
+        rt.executor(),
+      )
+      .unwrap()
+      .run(cat_roland_request()),
+    );
+    rt.shutdown_now().wait().unwrap();
+    let error = result.expect_err("Want error");
     assert_contains(&error, &format!("{}", missing_digest.0));
   }
 
@@ -2512,11 +2619,18 @@ mod tests {
       .file(&TestData::roland())
       .directory(&TestDirectory::containing_roland())
       .build();
-    let command_runner = create_command_runner(address, &cas);
-    command_runner.run(request).wait()
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    let command_runner = create_command_runner(address, &cas, &runtime);
+    let result = runtime.block_on(command_runner.run(request));
+    runtime.shutdown_now().wait().unwrap();
+    result
   }
 
-  fn create_command_runner(address: String, cas: &mock::StubCAS) -> CommandRunner {
+  fn create_command_runner(
+    address: String,
+    cas: &mock::StubCAS,
+    runtime: &tokio::runtime::Runtime,
+  ) -> CommandRunner {
     let store_dir = TempDir::new().unwrap();
     let timer_thread = timer_thread();
     let store = fs::Store::with_remote(
@@ -2535,7 +2649,18 @@ mod tests {
     )
     .expect("Failed to make store");
 
-    CommandRunner::new(&address, None, None, None, None, 1, store, timer_thread)
+    CommandRunner::new(
+      &address,
+      None,
+      None,
+      None,
+      None,
+      1,
+      store,
+      timer_thread,
+      runtime.executor(),
+    )
+    .expect("Failed to make command runner")
   }
 
   fn timer_thread() -> resettable::Resettable<futures_timer::HelperThread> {
@@ -2549,13 +2674,15 @@ mod tests {
       .file(&TestData::roland())
       .directory(&TestDirectory::containing_roland())
       .build();
-    let command_runner = create_command_runner("".to_owned(), &cas);
-    command_runner
-      .extract_execute_response(
-        super::OperationOrStatus::Operation(operation),
-        &mut ExecutionHistory::default(),
-      )
-      .wait()
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    let command_runner = create_command_runner("127.0.0.1:0".to_owned(), &cas, &runtime);
+    let result = runtime.block_on(command_runner.extract_execute_response(
+      super::OperationOrStatus::Operation(operation),
+      &mut ExecutionHistory::default(),
+    ));
+
+    runtime.shutdown_now().wait().unwrap();
+    result
   }
 
   fn extract_output_files_from_response(
@@ -2565,10 +2692,12 @@ mod tests {
       .file(&TestData::roland())
       .directory(&TestDirectory::containing_roland())
       .build();
-    let command_runner = create_command_runner("".to_owned(), &cas);
-    command_runner
-      .extract_output_files(&execute_response)
-      .wait()
+
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    let command_runner = create_command_runner("127.0.0.1:0".to_owned(), &cas, &runtime);
+    let result = runtime.block_on(command_runner.extract_output_files(&execute_response));
+    runtime.shutdown_now().wait().unwrap();
+    result
   }
 
   fn make_any_proto(message: &dyn Message) -> protobuf::well_known_types::Any {

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -15,3 +15,4 @@ hashing = { path = "../hashing" }
 futures = "^0.1.16"
 process_execution = { path = "../process_execution" }
 resettable = { path = "../resettable" }
+tokio = "0.1.14"

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -194,6 +194,9 @@ fn main() {
   let timer_thread = resettable::Resettable::new(|| futures_timer::HelperThread::new().unwrap());
   let server_arg = args.value_of("server");
   let remote_instance_arg = args.value_of("remote-instance-name").map(str::to_owned);
+
+  let mut rt = tokio::runtime::Runtime::new().unwrap();
+
   let store = match (server_arg, args.value_of("cas-server")) {
     (Some(_server), Some(cas_server)) => {
       let chunk_size =
@@ -269,25 +272,31 @@ fn main() {
           None
         };
 
-      Box::new(process_execution::remote::CommandRunner::new(
-        address,
-        args.value_of("cache-key-gen-version").map(str::to_owned),
-        remote_instance_arg,
-        root_ca_certs,
-        oauth_bearer_token,
-        1,
-        store,
-        timer_thread,
-      ))
+      Box::new(
+        process_execution::remote::CommandRunner::new(
+          address,
+          args.value_of("cache-key-gen-version").map(str::to_owned),
+          remote_instance_arg,
+          root_ca_certs,
+          oauth_bearer_token,
+          1,
+          store,
+          timer_thread,
+          rt.executor(),
+        )
+        .expect("Could not initialize remote execution client"),
+      ) as Box<dyn process_execution::CommandRunner>
     }
     None => Box::new(process_execution::local::CommandRunner::new(
       store, pool, work_dir, true,
-    )),
+    )) as Box<dyn process_execution::CommandRunner>,
   };
-
-  let result = runner.run(request).wait().expect("Error executing");
+  let result = rt.block_on(runner.run(request)).unwrap();
 
   print!("{}", String::from_utf8(result.stdout.to_vec()).unwrap());
   eprint!("{}", String::from_utf8(result.stderr.to_vec()).unwrap());
+
+  rt.shutdown_now().wait().unwrap();
+
   exit(result.exit_code);
 }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -195,8 +195,6 @@ fn main() {
   let server_arg = args.value_of("server");
   let remote_instance_arg = args.value_of("remote-instance-name").map(str::to_owned);
 
-  let mut rt = tokio::runtime::Runtime::new().unwrap();
-
   let store = match (server_arg, args.value_of("cas-server")) {
     (Some(_server), Some(cas_server)) => {
       let chunk_size =
@@ -282,7 +280,6 @@ fn main() {
           1,
           store,
           timer_thread,
-          rt.executor(),
         )
         .expect("Could not initialize remote execution client"),
       ) as Box<dyn process_execution::CommandRunner>
@@ -291,6 +288,7 @@ fn main() {
       store, pool, work_dir, true,
     )) as Box<dyn process_execution::CommandRunner>,
   };
+  let mut rt = tokio::runtime::Runtime::new().unwrap();
   let result = rt.block_on(runner.run(request)).unwrap();
 
   print!("{}", String::from_utf8(result.stdout.to_vec()).unwrap());

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -101,6 +101,7 @@ impl Core {
     let fs_pool2 = fs_pool.clone();
     let futures_timer_thread = Resettable::new(|| futures_timer::HelperThread::new().unwrap());
     let futures_timer_thread2 = futures_timer_thread.clone();
+    let runtime2 = runtime.clone();
     let store_and_command_runner_and_http_client = Resettable::new(move || {
       let local_store_dir = local_store_dir.clone();
       let store = safe_create_dir_all_ioerror(&local_store_dir)
@@ -130,23 +131,27 @@ impl Core {
         .unwrap_or_else(|e| panic!("Could not initialize Store: {:?}", e));
 
       let underlying_command_runner: Box<dyn CommandRunner> = match &remote_execution_server {
-        Some(ref address) => Box::new(process_execution::remote::CommandRunner::new(
-          address,
-          remote_execution_process_cache_namespace.clone(),
-          remote_instance_name.clone(),
-          root_ca_certs.clone(),
-          oauth_bearer_token.clone(),
-          // Allow for some overhead for bookkeeping threads (if any).
-          process_execution_parallelism + 2,
-          store.clone(),
-          futures_timer_thread2.clone(),
-        )),
+        Some(ref address) => Box::new(
+          process_execution::remote::CommandRunner::new(
+            address,
+            remote_execution_process_cache_namespace.clone(),
+            remote_instance_name.clone(),
+            root_ca_certs.clone(),
+            oauth_bearer_token.clone(),
+            // Allow for some overhead for bookkeeping threads (if any).
+            process_execution_parallelism + 2,
+            store.clone(),
+            futures_timer_thread2.clone(),
+            runtime2.with(|runtime| runtime.executor()),
+          )
+          .expect("Could not initialize remote execution client"),
+        ) as Box<dyn CommandRunner>,
         None => Box::new(process_execution::local::CommandRunner::new(
           store.clone(),
           fs_pool2.clone(),
           work_dir.clone(),
           process_execution_cleanup_local_dirs,
-        )),
+        )) as Box<dyn CommandRunner>,
       };
 
       let command_runner =

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -101,7 +101,6 @@ impl Core {
     let fs_pool2 = fs_pool.clone();
     let futures_timer_thread = Resettable::new(|| futures_timer::HelperThread::new().unwrap());
     let futures_timer_thread2 = futures_timer_thread.clone();
-    let runtime2 = runtime.clone();
     let store_and_command_runner_and_http_client = Resettable::new(move || {
       let local_store_dir = local_store_dir.clone();
       let store = safe_create_dir_all_ioerror(&local_store_dir)
@@ -142,7 +141,6 @@ impl Core {
             process_execution_parallelism + 2,
             store.clone(),
             futures_timer_thread2.clone(),
-            runtime2.with(|runtime| runtime.executor()),
           )
           .expect("Could not initialize remote execution client"),
         ) as Box<dyn CommandRunner>,

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -53,12 +53,12 @@ impl MockExecution {
   ///
   pub fn new(
     name: String,
-    execute_request: bazel_protos::remote_execution::ExecuteRequest,
+    execute_request: bazel_protos::build::bazel::remote::execution::v2::ExecuteRequest,
     operation_responses: Vec<MockOperation>,
   ) -> MockExecution {
     MockExecution {
       name: name,
-      execute_request: execute_request,
+      execute_request: execute_request.into(),
       operation_responses: Arc::new(Mutex::new(VecDeque::from(operation_responses))),
     }
   }


### PR DESCRIPTION
grpcio is still used both for GetOperation requests, and for all fs
operations. It won't be for long, though... :)