### PR TITLE
Workaround homebrew bug with osx shard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -558,6 +558,11 @@ matrix:
       osx_image: xcode8.3
       stage: *test
       language: generic
+      # TODO: workaround for Homebrew bug triggered by running `brew update`. 
+      # Follow at https://github.com/Homebrew/brew/issues/5513 and remove this workaround once its fixed.
+      env:
+        - HOMEBREW_LOGS=~/homebrew-logs
+        - HOMEBREW_TEMP=~/homebrew-temp
       before_install:
         - brew tap caskroom/cask && brew update && brew cask install osxfuse
       before_script:

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -274,6 +274,11 @@ matrix:
       osx_image: xcode8.3
       stage: *test
       language: generic
+      # TODO: workaround for Homebrew bug triggered by running `brew update`. 
+      # Follow at https://github.com/Homebrew/brew/issues/5513 and remove this workaround once its fixed.
+      env:
+        - HOMEBREW_LOGS=~/homebrew-logs
+        - HOMEBREW_TEMP=~/homebrew-temp
       before_install:
         - brew tap caskroom/cask && brew update && brew cask install osxfuse
       before_script:


### PR DESCRIPTION
### Problem
Homebrew fails to execute when running `brew upgrade`. This leads to the OSX Rust + Platform Specific Tests shard consistently failing.

### Solution
Use workaround described in https://github.com/Homebrew/brew/issues/5513.