### PR TITLE
Upgrade several dependencies to fix Py3 deprecations

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -18,7 +18,7 @@ pex==1.5.3
 psutil==4.3.0
 pycodestyle==2.4.0
 pyflakes==2.0.0
-Pygments==1.4
+Pygments==2.3.1
 pyopenssl==17.3.0
 pystache==0.5.3
 pytest-cov>=2.5,<2.6

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -13,7 +13,7 @@ Markdown==2.1.1
 mock==2.0.0
 packaging==16.8
 parameterized==0.6.1
-pathspec==0.5.0
+pathspec==0.5.9
 pex==1.5.3
 psutil==4.3.0
 pycodestyle==2.4.0

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,7 +1,7 @@
 ansicolors==1.0.2
 beautifulsoup4>=4.6.0,<4.7
 cffi==1.11.1
-configparser==3.5.0
+configparser==3.5.0 ; python_version<'3'
 contextlib2==0.5.5
 coverage>=4.5,<4.6
 docutils>=0.12,<0.13

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -24,7 +24,7 @@ pystache==0.5.3
 pytest-cov>=2.5,<2.6
 pytest>=3.4,<4.0
 pywatchman==1.4.1
-requests[security]>=2.5.0,<2.19
+requests[security]>=2.20.1
 responses==0.10.4
 scandir==1.2
 setproctitle==1.1.10

--- a/src/python/pants/backend/python/tasks/BUILD
+++ b/src/python/pants/backend/python/tasks/BUILD
@@ -3,7 +3,6 @@
 
 python_library(
   dependencies=[
-    '3rdparty/python:configparser',
     '3rdparty/python:future',
     '3rdparty/python:pex',
     '3rdparty/python/twitter/commons:twitter.common.collections',
@@ -34,6 +33,7 @@ python_library(
     'src/python/pants/util:meta',
     'src/python/pants/util:objects',
     'src/python/pants/util:process_handler',
+    'src/python/pants/util:py2_compat',
     'src/python/pants/util:xml_parser',
   ]
 )

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -17,8 +17,6 @@ from contextlib import contextmanager
 from io import StringIO
 from textwrap import dedent
 
-from backports import configparser
-
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.gather_sources import GatherSources
 from pants.backend.python.tasks.pytest_prep import PytestPrep
@@ -35,6 +33,7 @@ from pants.util.dirutil import mergetree, safe_mkdir, safe_mkdir_for
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.objects import datatype
 from pants.util.process_handler import SubprocessProcessHandler
+from pants.util.py2_compat import configparser
 from pants.util.strutil import safe_shlex_split
 from pants.util.xml_parser import XmlParser
 

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -3,7 +3,6 @@
 
 python_library(
   dependencies=[
-    '3rdparty/python:configparser',
     '3rdparty/python:future',
     '3rdparty/python:ansicolors',
     '3rdparty/python:setuptools',
@@ -15,6 +14,7 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
     'src/python/pants/util:objects',
+    'src/python/pants/util:py2_compat',
     'src/python/pants/util:strutil',
   ]
 )

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -13,13 +13,13 @@ from contextlib import contextmanager
 from hashlib import sha1
 
 import six
-from backports import configparser
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot, get_pants_cachedir, get_pants_configdir
 from pants.util.eval import parse_expression
 from pants.util.meta import AbstractClass
 from pants.util.objects import datatype
+from pants.util.py2_compat import configparser
 
 
 class Config(AbstractClass):

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -130,6 +130,15 @@ python_library(
 )
 
 python_library(
+  name = 'py2_compat',
+  sources = ['py2_compat.py'],
+  dependencies= [
+    '3rdparty/python:future',
+    '3rdparty/python:configparser',
+  ]
+)
+
+python_library(
   name = 'retry',
   sources = ['retry.py'],
   dependencies = [

--- a/src/python/pants/util/py2_compat.py
+++ b/src/python/pants/util/py2_compat.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from future.utils import PY3
 
+
 if PY3:
   import configparser  # noqa: F401
 else:

--- a/src/python/pants/util/py2_compat.py
+++ b/src/python/pants/util/py2_compat.py
@@ -1,0 +1,12 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from future.utils import PY3
+
+if PY3:
+  import configparser  # noqa: F401
+else:
+  from backports import configparser  # noqa: F401

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -53,7 +53,6 @@ python_library(
   ],
   dependencies = [
     '3rdparty/python:future',
-    '3rdparty/python:configparser',
     '3rdparty/python:ansicolors',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file',
@@ -62,6 +61,7 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:process_handler',
+    'src/python/pants/util:py2_compat',
     'tests/python/pants_test/testutils:file_test_util',
     'tests/python/pants_test/testutils:pexrc_util',
   ]

--- a/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
+++ b/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
@@ -179,7 +179,7 @@ class MarkdownToHtmlTest(TaskTestBase):
     with open(self.get_rendered_page(context, good_rst, 'good.html'), 'r') as fp:
       html = fp.read()
 
-      soup = bs4.BeautifulSoup(markup=html)
+      soup = bs4.BeautifulSoup(markup=html, features="html.parser")
       self.assertIsNotNone(soup.find(text='A good link:'))
 
       unordered_list = soup.find(name='ul')

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -125,6 +125,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:process_handler',
+    'src/python/pants/util:py2_compat',
     'tests/python/pants_test/backend/python:interpreter_selection_utils',
     'tests/python/pants_test/engine:scheduler_test_base',
     'tests/python/pants_test/subsystem:subsystem_utils',

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -11,7 +11,6 @@ from contextlib import contextmanager
 from textwrap import dedent
 
 import coverage
-from backports import configparser
 
 from pants.backend.python.tasks.gather_sources import GatherSources
 from pants.backend.python.tasks.pytest_prep import PytestPrep
@@ -23,6 +22,7 @@ from pants.build_graph.target import Target
 from pants.source.source_root import SourceRootConfig
 from pants.util.contextutil import pushd, temporary_dir, temporary_file
 from pants.util.dirutil import safe_mkdtemp, safe_rmtree
+from pants.util.py2_compat import configparser
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
 from pants_test.subsystem.subsystem_util import init_subsystem
 from pants_test.task_test_base import ensure_cached

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -13,7 +13,6 @@ from contextlib import contextmanager
 from operator import eq, ne
 from threading import Lock
 
-from backports import configparser
 from colors import strip_color
 
 from pants.base.build_environment import get_buildroot
@@ -25,6 +24,7 @@ from pants.util.dirutil import fast_relpath, safe_mkdir, safe_mkdir_for, safe_op
 from pants.util.objects import Exactly, datatype
 from pants.util.osutil import IntegerForPid
 from pants.util.process_handler import SubprocessProcessHandler, subprocess
+from pants.util.py2_compat import configparser
 from pants.util.strutil import ensure_binary
 from pants_test.testutils.file_test_util import check_symlinks, contains_exact_files
 


### PR DESCRIPTION
* Upgrade Pygments to fix regex warning
* Upgrade pathspec to fix collections deprecation
* Upgrade requests to fix urrlib and requests deprecations
   - Requests includes urllib3, which had deprecation warnings, along with warnings for requests itself.
   - Note that 2.19.0 is the minimum required to fix the deprecation warnings, but a security vulnerability was discovered that was fixed by 2.20.0, so no library should use <2.20.0 if possible.
* Setup our own configparser backport to only use library backport with Py2 
  - The configparser library has a deprecation warning in Python 3. They haven't updated the library in 2 years, so there is little hope this will be addressed. Further, upon reading their documentation, they state you should not use the backport when using Python 3.
  - Instead create our own compat file that will use the backport with Py2 and will use stdlib with Py3.