### PR TITLE
Improve symlink errors

### DIFF
--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -27,7 +27,7 @@ pub trait GlobMatching<E: Display + Send + Sync + 'static>: VFS<E> {
   ///
   /// TODO: Should handle symlink loops (which would exhibit as an infinite loop in expand).
   ///
-  fn canonicalize(&self, symbolic_path: PathBuf, link: &Link) -> BoxFuture<Option<PathStat>, E> {
+  fn canonicalize(&self, symbolic_path: PathBuf, link: Link) -> BoxFuture<Option<PathStat>, E> {
     GlobMatchingImplementation::canonicalize(self, symbolic_path, link)
   }
 
@@ -121,7 +121,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
                 future::ok(None).to_boxed()
               } else {
                 match stat {
-                  Stat::Link(l) => context.canonicalize(stat_symbolic_path, l),
+                  Stat::Link(l) => context.canonicalize(stat_symbolic_path, l.clone()),
                   Stat::Dir(d) => future::ok(Some(PathStat::dir(
                     stat_symbolic_path.to_owned(),
                     d.clone(),
@@ -399,8 +399,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
     }
   }
 
-  fn canonicalize(&self, symbolic_path: PathBuf, link: &Link) -> BoxFuture<Option<PathStat>, E> {
-    let link = link.clone();
+  fn canonicalize(&self, symbolic_path: PathBuf, link: Link) -> BoxFuture<Option<PathStat>, E> {
     // Read the link, which may result in PathGlob(s) that match 0 or 1 Path.
     let context = self.clone();
     self

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -380,9 +380,11 @@ impl PathGlob {
       let mut canonical_dir_parent = canonical_dir;
       let mut symbolic_path_parent = symbolic_path;
       if !canonical_dir_parent.0.pop() {
+        let mut symbolic_path = symbolic_path_parent;
+        symbolic_path.extend(parts.iter().map(|p| p.as_str()));
         return Err(format!(
-          "Globs may not traverse outside the root: {:?}",
-          parts
+          "Globs may not traverse outside of the buildroot: {:?}",
+          symbolic_path,
         ));
       }
       symbolic_path_parent.push(Path::new(*PARENT_DIR));

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -763,7 +763,7 @@ impl PathStatGetter<io::Error> for Arc<PosixFS> {
             .and_then(move |maybe_stat| {
               match maybe_stat {
                 // Note: This will drop PathStats for symlinks which don't point anywhere.
-                Some(Stat::Link(link)) => fs.canonicalize(link.0.clone(), &link),
+                Some(Stat::Link(link)) => fs.canonicalize(link.0.clone(), link),
                 Some(Stat::Dir(dir)) => {
                   future::ok(Some(PathStat::dir(dir.0.clone(), dir))).to_boxed()
                 }

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -240,6 +240,15 @@ pub enum Failure {
   Throw(Value, String),
 }
 
+impl fmt::Display for Failure {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match self {
+      Failure::Invalidated => write!(f, "Exhausted retries due to changed files."),
+      Failure::Throw(exc, _) => write!(f, "{}", externs::val_to_str(exc)),
+    }
+  }
+}
+
 pub fn throw(msg: &str) -> Failure {
   Failure::Throw(
     externs::create_exception(msg),

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -404,7 +404,7 @@ impl From<Result<Value, Failure>> for PyResult {
       },
       Err(f) => {
         let val = match f {
-          Failure::Invalidated => create_exception("Exhausted retries due to changed files."),
+          f @ Failure::Invalidated => create_exception(&format!("{}", f)),
           Failure::Throw(exc, _) => exc,
         };
         PyResult {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -499,7 +499,7 @@ impl Snapshot {
     // and fs::Snapshot::from_path_stats tracking dependencies for file digests.
     context
       .expand(path_globs)
-      .map_err(|e| format!("PathGlobs expansion failed: {:?}", e))
+      .map_err(|e| format!("PathGlobs expansion failed: {}", e))
       .and_then(move |path_stats| {
         fs::Snapshot::from_path_stats(context.core.store(), &context, path_stats)
           .map_err(move |e| format!("Snapshot failed: {}", e))


### PR DESCRIPTION
### Problem

When a glob attempted to match something outside the buildroot, the resulting error did not include a useful form of the erroneous path. And additionally, when a symlink was the source of that glob, we would also not render the symlink. See #7051.

### Solution

Render a user-friendly form of the relevant path in the error when we detect a glob the exits the buildroot. Additionally, implement `Display` for `Failure`, and concatenate information about the symlink we were expanding when we fail to expand a symlink.

### Result

The repro from #7051 renders as:
```
./pants --no-print-exception-stacktrace list testprojects/badsymlink::
timestamp: 2019-01-09T20:56:38.674131
Exception caught: (pants.build_graph.address_lookup_error.AddressLookupError) (backtrace omitted)
Exception message: Build graph construction failed: ExecutionError 1 Exception encountered:
  Exception: PathGlobs expansion failed: While expanding link "testprojects/badsymlink/subdir/bad_symlink": Globs may not traverse outside of the buildroot: "testprojects/badsymlink/subdir/../../../../foo"
```

Fixes #7051.