### PR TITLE
Fix additional invalid escape sequence deprecation warnings

### DIFF
--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -62,7 +62,7 @@ class PythonBinary(PythonTarget):
     :param ignore_errors: should we ignore inability to resolve dependencies?
     :param platforms: extra platforms to target when building this binary. If this is, e.g.,
       ``['current', 'linux-x86_64', 'macosx-10.4-x86_64']``, then when building the pex, then
-      for any platform-dependent modules, Pants will include ``egg``\s for Linux (64-bit Intel),
+      for any platform-dependent modules, Pants will include ``egg``\\s for Linux (64-bit Intel),
       Mac OS X (version 10.4 or newer), and the current platform (whatever is being used when
       making the PEX).
     :param compatibility: either a string or list of strings that represents

--- a/src/python/pants/reporting/reporting_server.py
+++ b/src/python/pants/reporting/reporting_server.py
@@ -30,7 +30,7 @@ from pants.stats.statsdb import StatsDBFactory
 logger = logging.getLogger(__name__)
 
 # Google Prettyprint plugin files.
-PPP_RE = re.compile("""^lang-.*\.js$""")
+PPP_RE = re.compile(r"^lang-.*\.js$")
 
 
 class PantsHandler(http.server.BaseHTTPRequestHandler):


### PR DESCRIPTION
Followup from https://github.com/pantsbuild/pants/pull/6984. These were not caught then, but are still printing DeprecationWarning whenever running `./pants3`.