### PR TITLE
refactor ImportJarsMixin into ImportRemoteSourcesMixin for extensibility (same with tasks)

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/java/java_protobuf_library.py
+++ b/src/python/pants/backend/codegen/protobuf/java/java_protobuf_library.py
@@ -22,7 +22,7 @@ class JavaProtobufLibrary(ImportJarsMixin, JvmTarget):
   imported_target_kwargs_field = 'imports'
   imported_target_payload_field = 'import_specs'
 
-  def __init__(self, payload=None, buildflags=None, imports=None, **kwargs):
+  def __init__(self, address, payload=None, buildflags=None, imports=None, **kwargs):
     """
     :param buildflags: Unused, and will be removed in a future release.
     :param list imports: List of addresses of `jar_library <#jar_library>`_
@@ -34,7 +34,7 @@ class JavaProtobufLibrary(ImportJarsMixin, JvmTarget):
       lambda: imports is not None,
       '1.16.0.dev1',
       "{cls} target definition at {addr} setting attribute 'imports'"
-      .format(cls=type(self).__name__, addr=self.address.spec),
+      .format(cls=type(self).__name__, addr=address.spec),
       hint_message="Use a combination of remote_sources() and unpacked_jars() instead.")
     # TODO(Eric Ayers): The target needs to incorporate the settings of --gen-protoc-version
     # and --gen-protoc-plugins into the fingerprint.  Consider adding a custom FingeprintStrategy
@@ -42,7 +42,7 @@ class JavaProtobufLibrary(ImportJarsMixin, JvmTarget):
     payload.add_fields({
       'import_specs': PrimitiveField(imports or ())
     })
-    super(JavaProtobufLibrary, self).__init__(payload=payload, **kwargs)
+    super(JavaProtobufLibrary, self).__init__(address=address, payload=payload, **kwargs)
 
     deprecated_conditional(
       lambda: buildflags is not None,

--- a/src/python/pants/backend/codegen/protobuf/java/java_protobuf_library.py
+++ b/src/python/pants/backend/codegen/protobuf/java/java_protobuf_library.py
@@ -29,6 +29,7 @@ class JavaProtobufLibrary(ImportJarsMixin, JvmTarget):
       targets which contain .proto definitions.
     """
     payload = payload or Payload()
+    # TODO(#7111): Remove the `imports` field and make this not subclass `ImportJarsMixin`!
     deprecated_conditional(
       lambda: imports is not None,
       '1.16.0.dev1',

--- a/src/python/pants/backend/codegen/protobuf/java/java_protobuf_library.py
+++ b/src/python/pants/backend/codegen/protobuf/java/java_protobuf_library.py
@@ -29,6 +29,12 @@ class JavaProtobufLibrary(ImportJarsMixin, JvmTarget):
       targets which contain .proto definitions.
     """
     payload = payload or Payload()
+    deprecated_conditional(
+      lambda: imports is not None,
+      '1.16.0.dev1',
+      "{cls} target definition at {addr} setting attribute 'imports'"
+      .format(cls=type(self).__name__, addr=self.address.spec),
+      hint_message="Use a combination of remote_sources() and unpacked_jars() instead.")
     # TODO(Eric Ayers): The target needs to incorporate the settings of --gen-protoc-version
     # and --gen-protoc-plugins into the fingerprint.  Consider adding a custom FingeprintStrategy
     # into ProtobufGen to get it.
@@ -40,5 +46,6 @@ class JavaProtobufLibrary(ImportJarsMixin, JvmTarget):
     deprecated_conditional(
       lambda: buildflags is not None,
       '1.16.0.dev1',
-      "Target definition at {addr} setting attribute 'buildflags'".format(addr=self.address.spec),
-      hint_message="is ignored")
+      "{cls} target definition at {addr} setting attribute 'buildflags'"
+      .format(cls=type(self).__name__, addr=self.address.spec),
+      hint_message="Use the options denoted in `./pants help gen.protoc` instead.")

--- a/src/python/pants/backend/codegen/protobuf/java/java_protobuf_library.py
+++ b/src/python/pants/backend/codegen/protobuf/java/java_protobuf_library.py
@@ -8,6 +8,7 @@ import logging
 
 from pants.backend.jvm.targets.import_jars_mixin import ImportJarsMixin
 from pants.backend.jvm.targets.jvm_target import JvmTarget
+from pants.base.deprecated import deprecated_conditional
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 
@@ -17,6 +18,9 @@ logger = logging.getLogger(__name__)
 
 class JavaProtobufLibrary(ImportJarsMixin, JvmTarget):
   """A Java library generated from Protocol Buffer IDL files."""
+
+  imported_target_kwargs_field = 'imports'
+  imported_target_payload_field = 'import_specs'
 
   def __init__(self, payload=None, buildflags=None, imports=None, **kwargs):
     """
@@ -32,15 +36,9 @@ class JavaProtobufLibrary(ImportJarsMixin, JvmTarget):
       'import_specs': PrimitiveField(imports or ())
     })
     super(JavaProtobufLibrary, self).__init__(payload=payload, **kwargs)
-    if buildflags is not None:
-      logger.warn("Target definition at {address} sets attribute 'buildflags' which is "
-                  "ignored and will be removed in a future release"
-                  .format(address=self.address.spec))
 
-  @classmethod
-  def imported_jar_library_spec_fields(cls):
-    """Fields to extract JarLibrary specs from.
-
-    Required to implement the ImportJarsMixin.
-    """
-    yield ('imports', 'import_specs')
+    deprecated_conditional(
+      lambda: buildflags is not None,
+      '1.16.0.dev1',
+      "Target definition at {addr} setting attribute 'buildflags'".format(addr=self.address.spec),
+      hint_message="is ignored")

--- a/src/python/pants/backend/codegen/protobuf/java/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/protobuf/java/protobuf_gen.py
@@ -84,13 +84,13 @@ class ProtobufGen(SimpleCodegenTask):
 
   def synthetic_target_extra_dependencies(self, target, target_workdir):
     deps = OrderedSet()
-    if target.imported_jars:
+    if target.all_imported_jar_deps:
       # We need to add in the proto imports jars.
       jars_address = Address(os.path.relpath(target_workdir, get_buildroot()),
                              target.id + '-rjars')
       jars_target = self.context.add_new_target(jars_address,
                                                 JarLibrary,
-                                                jars=target.imported_jars,
+                                                jars=target.all_imported_jar_deps,
                                                 derived_from=target)
       deps.update([jars_target])
     deps.update(self.javadeps)

--- a/src/python/pants/backend/jvm/targets/import_jars_mixin.py
+++ b/src/python/pants/backend/jvm/targets/import_jars_mixin.py
@@ -18,7 +18,6 @@ class ImportJarsMixin(ImportRemoteSourcesMixin):
 
   @memoized_property
   def all_imported_jar_deps(self):
-    # TODO: figure out if this OrderedSet is necessary.
     jar_deps = OrderedSet()
     for jar_lib in self.imported_targets:
       jar_deps.update(jar_lib.jar_dependencies)

--- a/src/python/pants/backend/jvm/targets/import_jars_mixin.py
+++ b/src/python/pants/backend/jvm/targets/import_jars_mixin.py
@@ -4,100 +4,22 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from future.utils import string_types
+from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.build_graph.address_lookup_error import AddressLookupError
-from pants.build_graph.target import Target
+from pants.build_graph.import_remote_sources_mixin import ImportRemoteSourcesMixin
 from pants.util.memo import memoized_property
+from pants.util.objects import SubclassesOf
 
 
-class ImportJarsMixin(Target):
-  """A Target Mixin to be used when a target declares JarLibraries to be imported."""
+class ImportJarsMixin(ImportRemoteSourcesMixin):
 
-  class UnresolvedImportError(AddressLookupError):
-    """Raised when an imported JarLibrary cannot be resolved."""
-
-  class ExpectedJarLibraryError(AddressLookupError):
-    """Raised when a target is referenced by a jar import that is not a JarLibrary."""
-
-  @classmethod
-  def imported_jar_library_spec_fields(cls):
-    """This method must be implemented by the target that includes ImportJarsMixin.
-
-    :returns: list of tuples representing fields to source JarLibrary specs to be imported from
-              as (pre-init kwargs field, post-init payload field).
-    """
-    raise NotImplementedError(
-      'subclasses of ImportJarsMixin must implement an '
-      '`imported_jar_library_spec_fields` classmethod'
-    )
-
-  @classmethod
-  def imported_jar_library_specs(cls, kwargs=None, payload=None):
-    """
-    :param kwargs: A kwargs dict representing Target.__init__(**kwargs) (Optional).
-    :param payload: A Payload object representing the Target.__init__(payload=...) param.  (Optional).
-    :returns: list of JarLibrary specs to be imported.
-    :rtype: list of JarLibrary
-    """
-    assert kwargs is not None or payload is not None, 'must provide either kwargs or payload'
-    assert not (kwargs is not None and payload is not None), 'may not provide both kwargs and payload'
-
-    field_pos = 0 if kwargs is not None else 1
-    target_representation = kwargs or payload.as_dict()
-
-    def gen_specs():
-      for fields_tuple in cls.imported_jar_library_spec_fields():
-        for item in target_representation.get(fields_tuple[field_pos], ()):
-          # For better error handling, this simply skips over non-strings, but we catch them
-          # with a WrongTargetType in JarLibrary.to_jar_dependencies.
-          if not isinstance(item, string_types):
-            raise JarLibrary.ExpectedAddressError(
-              'expected imports to contain string addresses, got {found_class} instead.'
-              .format(found_class=type(item).__name__)
-            )
-          yield item
-
-    return list(gen_specs())
+  expected_target_constraint = SubclassesOf(JarLibrary)
 
   @memoized_property
-  def imported_jars(self):
-    """:returns: the string specs of JarDependencies referenced by imported_jar_library_specs
-    :rtype: list of JarDependency
-    """
-    return JarLibrary.to_jar_dependencies(self.address,
-                                          self.imported_jar_library_specs(payload=self.payload),
-                                          self._build_graph)
-
-  @memoized_property
-  def imported_jar_libraries(self):
-    """:returns: target instances for specs referenced by imported_jar_library_specs.
-    :rtype: list of JarLibrary
-    """
-    libs = []
-    for spec in self.imported_jar_library_specs(payload=self.payload):
-      resolved_target = self._build_graph.get_target_from_spec(spec,
-                                                               relative_to=self.address.spec_path)
-      if not resolved_target:
-        raise self.UnresolvedImportError(
-          'Could not find JarLibrary target {spec} referenced from {relative_to}'
-          .format(spec=spec, relative_to=self.address.spec))
-      if not isinstance(resolved_target, JarLibrary):
-        raise self.ExpectedJarLibraryError(
-          'Expected JarLibrary got {target_type} for jar imports in {spec} referenced from '
-          '{relative_to}'
-          .format(target_type=type(resolved_target), spec=spec,
-                  relative_to=self.address.spec))
-      libs.append(resolved_target)
-    return libs
-
-  @classmethod
-  def compute_dependency_specs(cls, kwargs=None, payload=None):
-    """Tack imported_jar_library_specs onto the traversable_specs generator for this target."""
-    for spec in super(ImportJarsMixin, cls).compute_dependency_specs(kwargs, payload):
-      yield spec
-
-    imported_jar_library_specs = cls.imported_jar_library_specs(kwargs=kwargs, payload=payload)
-    for spec in imported_jar_library_specs:
-      yield spec
+  def all_imported_jar_deps(self):
+    # TODO: figure out if this OrderedSet is necessary.
+    jar_deps = OrderedSet()
+    for jar_lib in self.imported_targets:
+      jar_deps.update(jar_lib.jar_dependencies)
+    return list(jar_deps)

--- a/src/python/pants/backend/jvm/targets/jar_library.py
+++ b/src/python/pants/backend/jvm/targets/jar_library.py
@@ -4,9 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from future.utils import string_types
-from twitter.common.collections import OrderedSet
-
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import ExcludesField, JarsField, PrimitiveField
@@ -20,14 +17,6 @@ class JarLibrary(Target):
 
   :API: public
   """
-
-  class WrongTargetTypeError(Exception):
-    """Thrown if the wrong type of target is encountered."""
-    pass
-
-  class ExpectedAddressError(Exception):
-    """Thrown if an object that is not an address."""
-    pass
 
   def __init__(self, payload=None, jars=None, managed_dependencies=None, **kwargs):
     """
@@ -79,42 +68,6 @@ class JarLibrary(Target):
     # Is currently aliased to dependencies. For future work see
     # https://github.com/pantsbuild/pants/issues/4398
     return self.dependencies
-
-  @staticmethod
-  def to_jar_dependencies(relative_to, jar_library_specs, build_graph):
-    """Convenience method to resolve a list of specs to JarLibraries and return its jars attributes.
-
-    Expects that the jar_libraries are declared relative to this target.
-
-    :API: public
-
-    :param Address relative_to: address target that references jar_library_specs, for
-      error messages
-    :param list jar_library_specs: string specs to JavaLibrary targets. Note, this list should be returned
-      by the caller's traversable_specs() implementation to make sure that the jar_dependency jars
-      have been added to the build graph.
-    :param BuildGraph build_graph: build graph instance used to search for specs
-    :return: list of JarDependency instances represented by the library_specs
-    """
-    jar_deps = OrderedSet()
-    for spec in jar_library_specs:
-      if not isinstance(spec, string_types):
-        raise JarLibrary.ExpectedAddressError(
-          "{address}: expected imports to contain string addresses, got {found_class}."
-          .format(address=relative_to.spec,
-                  found_class=type(spec).__name__))
-
-      lookup = Address.parse(spec, relative_to=relative_to.spec_path)
-      target = build_graph.get_target(lookup)
-      if not isinstance(target, JarLibrary):
-        raise JarLibrary.WrongTargetTypeError(
-          "{address}: expected {spec} to be jar_library target type, got {found_class}"
-          .format(address=relative_to.spec,
-                  spec=spec,
-                  found_class=type(target).__name__))
-      jar_deps.update(target.jar_dependencies)
-
-    return list(jar_deps)
 
   @property
   def strict_deps(self):

--- a/src/python/pants/backend/jvm/targets/unpacked_jars.py
+++ b/src/python/pants/backend/jvm/targets/unpacked_jars.py
@@ -21,6 +21,9 @@ class UnpackedJars(ImportJarsMixin, Target):
   :API: public
   """
 
+  imported_target_kwargs_field = 'libraries'
+  imported_target_payload_field = 'library_specs'
+
   class ExpectedLibrariesError(Exception):
     """Thrown when the target has no libraries defined."""
     pass
@@ -49,11 +52,3 @@ class UnpackedJars(ImportJarsMixin, Target):
     if not libraries:
       raise self.ExpectedLibrariesError('Expected non-empty libraries attribute for {spec}'
                                         .format(spec=self.address.spec))
-
-  @classmethod
-  def imported_jar_library_spec_fields(cls):
-    """Fields to extract JarLibrary specs from.
-
-    Required to implement the ImportJarsMixin.
-    """
-    yield ('libraries', 'library_specs')

--- a/src/python/pants/backend/jvm/targets/unpacked_jars.py
+++ b/src/python/pants/backend/jvm/targets/unpacked_jars.py
@@ -47,8 +47,6 @@ class UnpackedJars(ImportJarsMixin, Target):
     })
     super(UnpackedJars, self).__init__(payload=payload, **kwargs)
 
-    self._files = None
-
     if not libraries:
       raise self.ExpectedLibrariesError('Expected non-empty libraries attribute for {spec}'
                                         .format(spec=self.address.spec))

--- a/src/python/pants/backend/jvm/tasks/ivy_imports.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_imports.py
@@ -12,7 +12,7 @@ from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 
 
 class IvyImports(IvyTaskMixin, NailgunTask):
-  """Resolves jar files for imported_jar_libraries on `ImportJarsMixin` targets.
+  """Resolves jar files for imported_targets on `ImportJarsMixin` targets.
 
   One use case is for JavaProtobufLibrary, which includes imports for jars containing .proto files.
   """
@@ -25,7 +25,7 @@ class IvyImports(IvyTaskMixin, NailgunTask):
 
   @staticmethod
   def has_imports(target):
-    return isinstance(target, ImportJarsMixin) and target.imported_jar_libraries
+    return isinstance(target, ImportJarsMixin) and target.imported_targets
 
   def execute(self):
     jar_import_products = self.context.products.get_data(JarImportProducts,
@@ -39,7 +39,7 @@ class IvyImports(IvyTaskMixin, NailgunTask):
     # Create a list of all of these targets plus the list of JarDependencies they depend on.
     all_targets = set(targets)
     for target in targets:
-      all_targets.update(target.imported_jar_libraries)
+      all_targets.update(target.imported_targets)
 
     imports_classpath = ClasspathProducts(self.get_options().pants_workdir)
     self.resolve(executor=self.create_java_executor(),

--- a/src/python/pants/backend/jvm/tasks/jar_import_products.py
+++ b/src/python/pants/backend/jvm/tasks/jar_import_products.py
@@ -30,7 +30,7 @@ class JarImportProducts(object):
     """Registers a :class`JarImportProducts.JarImport` for the given target.
 
     :param target: The :class:`pants.backend.jvm.targets.import_jars_mixin.ImportJarsMixin` target
-                   whose `imported_jar_library_specs` were resolved.
+                   whose `all_imported_jar_deps` were resolved.
     :param coordinate: The maven coordinate of the import jar.
     :type coordinate: :class:`pants.java.jar_utls.M2Coordinate`
     :param string jar: The path of the resolved import jar.

--- a/src/python/pants/backend/jvm/tasks/unpack_jars.py
+++ b/src/python/pants/backend/jvm/tasks/unpack_jars.py
@@ -4,24 +4,16 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
-import os
-import re
-import shutil
 from hashlib import sha1
 
 from future.utils import PY3
-from twitter.common.dirutil.fileset import fnmatch_translate_extended
 
 from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
 from pants.backend.jvm.tasks.jar_import_products import JarImportProducts
-from pants.base.build_environment import get_buildroot
 from pants.base.fingerprint_strategy import DefaultFingerprintHashingMixin, FingerprintStrategy
 from pants.fs.archive import ZIP
-from pants.task.task import Task
-
-
-logger = logging.getLogger(__name__)
+from pants.task.unpack_remote_sources_base import UnpackRemoteSourcesBase
+from pants.util.objects import SubclassesOf
 
 
 class UnpackJarsFingerprintStrategy(DefaultFingerprintHashingMixin, FingerprintStrategy):
@@ -32,14 +24,14 @@ class UnpackJarsFingerprintStrategy(DefaultFingerprintHashingMixin, FingerprintS
     """
     if isinstance(target, UnpackedJars):
       hasher = sha1()
-      for cache_key in sorted(jar.cache_key() for jar in target.imported_jars):
+      for cache_key in sorted(jar.cache_key() for jar in target.all_imported_jar_deps):
         hasher.update(cache_key.encode('utf-8'))
       hasher.update(target.payload.fingerprint().encode('utf-8'))
       return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
     return None
 
 
-class UnpackJars(Task):
+class UnpackJars(UnpackRemoteSourcesBase):
   """Unpack artifacts specified by unpacked_jars() targets.
 
   Adds an entry to SourceRoot for the contents.
@@ -47,120 +39,27 @@ class UnpackJars(Task):
   :API: public
   """
 
-  class InvalidPatternError(Exception):
-    """Raised if a pattern can't be compiled for including or excluding args"""
-
-  class MissingUnpackedDirsError(Exception):
-    """Raised if a directory that is expected to be unpacked doesn't exist."""
-
-  @classmethod
-  def product_types(cls):
-    return ['unpacked_archives']
+  source_target_constraint = SubclassesOf(UnpackedJars)
 
   @classmethod
   def prepare(cls, options, round_manager):
     super(UnpackJars, cls).prepare(options, round_manager)
     round_manager.require_data(JarImportProducts)
 
-  def _unpack_dir(self, unpacked_jars):
-    return os.path.normpath(os.path.join(self._workdir, unpacked_jars.id))
-
   @classmethod
-  def _file_filter(cls, filename, include_patterns, exclude_patterns):
-    """:returns: `True` if the file should be allowed through the filter."""
-    for exclude_pattern in exclude_patterns:
-      if exclude_pattern.match(filename):
-        return False
-    if include_patterns:
-      found = False
-      for include_pattern in include_patterns:
-        if include_pattern.match(filename):
-          found = True
-          break
-      if not found:
-        return False
-    return True
+  def implementation_version(cls):
+    return super(UnpackJars, cls).implementation_version() + [('UnpackJars', 0)]
 
-  @classmethod
-  def compile_patterns(cls, patterns, field_name="Unknown", spec="Unknown"):
-    compiled_patterns = []
-    for p in patterns:
-      try:
-        compiled_patterns.append(re.compile(fnmatch_translate_extended(p)))
-      except (TypeError, re.error) as e:
-        raise cls.InvalidPatternError(
-          'In {spec}, "{field_value}" in {field_name} can\'t be compiled: {msg}'
-          .format(field_name=field_name, field_value=p, spec=spec, msg=e))
-    return compiled_patterns
+  def get_fingerprint_strategy(self):
+    return UnpackJarsFingerprintStrategy()
 
-  @classmethod
-  def calculate_unpack_filter(cls, includes=None, excludes=None, spec=None):
-    """Take regex patterns and return a filter function.
-
-    :param list includes: List of include patterns to pass to _file_filter.
-    :param list excludes: List of exclude patterns to pass to _file_filter.
-    """
-    include_patterns = cls.compile_patterns(includes or [],
-                                            field_name='include_patterns',
-                                            spec=spec)
-    exclude_patterns = cls.compile_patterns(excludes or [],
-                                            field_name='exclude_patterns',
-                                            spec=spec)
-    return lambda f: cls._file_filter(f, include_patterns, exclude_patterns)
-
-  # TODO(mateor) move unpack code that isn't jar-specific to fs.archive or an Unpack base class.
-  @classmethod
-  def get_unpack_filter(cls, unpacked_jars):
-    """Calculate a filter function from the include/exclude patterns of a Target.
-
-    :param Target unpacked_jars: A target with include_patterns and exclude_patterns attributes.
-    """
-    return cls.calculate_unpack_filter(includes=unpacked_jars.payload.include_patterns,
-                                       excludes=unpacked_jars.payload.exclude_patterns,
-                                       spec=unpacked_jars.address.spec)
-
-  def _unpack(self, unpacked_jars):
-    """Extracts files from the downloaded jar files and places them in a work directory.
-
-    :param UnpackedJars unpacked_jars: target referencing jar_libraries to unpack.
-    """
-    unpack_dir = self._unpack_dir(unpacked_jars)
-    if os.path.exists(unpack_dir):
-      shutil.rmtree(unpack_dir)
-    if not os.path.exists(unpack_dir):
-      os.makedirs(unpack_dir)
-
-    direct_coords = {jar.coordinate for jar in unpacked_jars.imported_jars}
+  def unpack_target(self, unpacked_jars, unpack_dir):
+    direct_coords = {jar.coordinate for jar in unpacked_jars.all_imported_jar_deps}
     unpack_filter = self.get_unpack_filter(unpacked_jars)
     jar_import_products = self.context.products.get_data(JarImportProducts)
+
     for coordinate, jar_path in jar_import_products.imports(unpacked_jars):
       if not unpacked_jars.payload.intransitive or coordinate in direct_coords:
         self.context.log.info('Unpacking jar {coordinate} from {jar_path} to {unpack_dir}.'.format(
           coordinate=coordinate, jar_path=jar_path, unpack_dir=unpack_dir))
         ZIP.extract(jar_path, unpack_dir, filter_func=unpack_filter)
-
-  def execute(self):
-    addresses = [target.address for target in self.context.targets()]
-    closure = self.context.build_graph.transitive_subgraph_of_addresses(addresses)
-    unpacked_jars_list = [t for t in closure if isinstance(t, UnpackedJars)]
-
-    with self.invalidated(unpacked_jars_list,
-                          fingerprint_strategy=UnpackJarsFingerprintStrategy(),
-                          invalidate_dependents=True) as invalidation_check:
-      for vt in invalidation_check.invalid_vts:
-        self._unpack(vt.target)
-
-    for unpacked_jars_target in unpacked_jars_list:
-      unpack_dir = self._unpack_dir(unpacked_jars_target)
-      if not (os.path.exists(unpack_dir) and os.path.isdir(unpack_dir)):
-        raise self.MissingUnpackedDirsError(
-          "Expected {unpack_dir} to exist containing unpacked files for {target}"
-          .format(unpack_dir=unpack_dir, target=unpacked_jars_target.address.spec))
-      found_files = []
-      for root, dirs, files in os.walk(unpack_dir):
-        for f in files:
-          relpath = os.path.relpath(os.path.join(root, f), unpack_dir)
-          found_files.append(relpath)
-      rel_unpack_dir = os.path.relpath(unpack_dir, get_buildroot())
-      unpacked_sources_product = self.context.products.get_data('unpacked_archives', lambda: {})
-      unpacked_sources_product[unpacked_jars_target] = [found_files, rel_unpack_dir]

--- a/src/python/pants/build_graph/import_remote_sources_mixin.py
+++ b/src/python/pants/build_graph/import_remote_sources_mixin.py
@@ -27,11 +27,18 @@ class ImportRemoteSourcesMixin(Target, AbstractClass):
   class WrongTargetTypeError(AddressLookupError):
     """Thrown if the wrong type of target is encountered."""
 
-  # TODO: make a quick utility in pants.util.meta to register these standard `NotImplementedError`s!
   @classproperty
   def expected_target_constraint(cls):
-    """???"""
-    raise NotImplementedError('???')
+    """
+    :returns: A type constraint which is used to validate the targets containing remote sources,
+              specified `imported_target_kwargs_field` in a BUILD file.
+    :rtype: TypeConstraint
+    """
+    # TODO: make a utility in pants.util.meta to register these standard `NotImplementedError`s!
+    raise NotImplementedError(
+      'subclasses of ImportRemoteSourcesMixin must implement an '
+      '`expected_target_constraint` classproperty'
+    )
 
   @classproperty
   def imported_target_kwargs_field(cls):

--- a/src/python/pants/build_graph/import_remote_sources_mixin.py
+++ b/src/python/pants/build_graph/import_remote_sources_mixin.py
@@ -67,8 +67,8 @@ class ImportRemoteSourcesMixin(Target, AbstractClass):
     """
     :param kwargs: A kwargs dict representing Target.__init__(**kwargs) (Optional).
     :param payload: A Payload object representing the Target.__init__(payload=...) param.  (Optional).
-    :returns: list of JarLibrary specs to be imported.
-    :rtype: list of JarLibrary
+    :returns: list of target specs to be imported.
+    :rtype: list of str
     """
     if kwargs is not None:
       assert payload is None, 'may not provide both kwargs and payload'
@@ -94,7 +94,7 @@ class ImportRemoteSourcesMixin(Target, AbstractClass):
   def imported_targets(self):
     """
     :returns: target instances for specs referenced by imported_target_specs.
-    :rtype: list of JarLibrary
+    :rtype: list of Target
     """
     libs = []
     for spec in self.imported_target_specs(payload=self.payload):

--- a/src/python/pants/build_graph/import_remote_sources_mixin.py
+++ b/src/python/pants/build_graph/import_remote_sources_mixin.py
@@ -1,0 +1,116 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from builtins import str
+
+from future.utils import string_types
+
+from pants.build_graph.address_lookup_error import AddressLookupError
+from pants.build_graph.target import Target
+from pants.util.memo import memoized_property
+from pants.util.meta import AbstractClass, classproperty
+from pants.util.objects import TypeConstraintError
+
+
+class ImportRemoteSourcesMixin(Target, AbstractClass):
+  """A Target Mixin to be used when a target declares another target type to be imported."""
+
+  class ExpectedAddressError(AddressLookupError):
+    """Thrown upon attempting to resolved an object that is not an address."""
+
+  class UnresolvedImportError(AddressLookupError):
+    """Raised when an imported target cannot be resolved."""
+
+  class WrongTargetTypeError(AddressLookupError):
+    """Thrown if the wrong type of target is encountered."""
+
+  # TODO: make a quick utility in pants.util.meta to register these standard `NotImplementedError`s!
+  @classproperty
+  def expected_target_constraint(cls):
+    """???"""
+    raise NotImplementedError('???')
+
+  @classproperty
+  def imported_target_kwargs_field(cls):
+    """
+    :returns: string representing the keyword argument of an uninitialized target representing
+              source target specs to be imported.
+    """
+    raise NotImplementedError(
+      'subclasses of ImportRemoteSourcesMixin must implement an '
+      '`imported_target_kwargs_field` classproperty'
+    )
+
+  @classproperty
+  def imported_target_payload_field(cls):
+    """
+    :returns: string representing the payload field of an already-initialized target containing
+              source target specs to be imported.
+    """
+    raise NotImplementedError(
+      'subclasses of ImportRemoteSourcesMixin must implement an '
+      '`imported_target_payload_field` classproperty'
+    )
+
+  @classmethod
+  def imported_target_specs(cls, kwargs=None, payload=None):
+    """
+    :param kwargs: A kwargs dict representing Target.__init__(**kwargs) (Optional).
+    :param payload: A Payload object representing the Target.__init__(payload=...) param.  (Optional).
+    :returns: list of JarLibrary specs to be imported.
+    :rtype: list of JarLibrary
+    """
+    if kwargs is not None:
+      assert payload is None, 'may not provide both kwargs and payload'
+      field = cls.imported_target_kwargs_field
+      target_representation = kwargs
+    else:
+      assert payload is not None, 'must provide either kwargs or payload'
+      field = cls.imported_target_payload_field
+      target_representation = payload.as_dict()
+
+    specs = []
+    for item in target_representation.get(field, ()):
+      if not isinstance(item, string_types):
+        raise cls.ExpectedAddressError(
+          'expected imports to contain string addresses, got {obj} (type: {found_class}) instead.'
+          .format(obj=item, found_class=type(item).__name__)
+        )
+      specs.append(item)
+
+    return specs
+
+  @memoized_property
+  def imported_targets(self):
+    """:returns: target instances for specs referenced by imported_target_specs.
+    :rtype: list of JarLibrary
+    """
+    libs = []
+    for spec in self.imported_target_specs(payload=self.payload):
+      resolved_target = self._build_graph.get_target_from_spec(spec,
+                                                               relative_to=self.address.spec_path)
+      if not resolved_target:
+        raise self.UnresolvedImportError(
+          'Could not find target {spec} referenced from {relative_to}'
+          .format(spec=spec, relative_to=self.address.spec))
+      try:
+        libs.append(self.expected_target_constraint.validate_satisfied_by(resolved_target))
+      except TypeConstraintError as e:
+        raise self.WrongTargetTypeError(
+          'Wrong target type {spec} referenced from remote sources target {relative_to}: {err}'
+          .format(spec=spec, relative_to=self.address.spec, err=str(e)),
+          e)
+    return libs
+
+  @classmethod
+  def compute_dependency_specs(cls, kwargs=None, payload=None):
+    """Tack imported_target_specs onto the traversable_specs generator for this target."""
+    for spec in super(ImportRemoteSourcesMixin, cls).compute_dependency_specs(kwargs, payload):
+      yield spec
+
+    imported_target_specs = cls.imported_target_specs(kwargs=kwargs, payload=payload)
+    for spec in imported_target_specs:
+      yield spec

--- a/src/python/pants/build_graph/import_remote_sources_mixin.py
+++ b/src/python/pants/build_graph/import_remote_sources_mixin.py
@@ -92,7 +92,8 @@ class ImportRemoteSourcesMixin(Target, AbstractClass):
 
   @memoized_property
   def imported_targets(self):
-    """:returns: target instances for specs referenced by imported_target_specs.
+    """
+    :returns: target instances for specs referenced by imported_target_specs.
     :rtype: list of JarLibrary
     """
     libs = []

--- a/src/python/pants/core_tasks/deferred_sources_mapper.py
+++ b/src/python/pants/core_tasks/deferred_sources_mapper.py
@@ -14,13 +14,14 @@ from pants.build_graph.remote_sources import RemoteSources
 from pants.engine.fs import PathGlobs, PathGlobsAndRoot
 from pants.source.wrapped_globs import EagerFilesetWithSpec
 from pants.task.task import Task
+from pants.task.unpack_remote_sources_base import UnpackedArchives
 
 
 logger = logging.getLogger(__name__)
 
 
 class DeferredSourcesMapper(Task):
-  """Map DeferredSourcesFields to files that produce the product 'unpacked_archives'.
+  """Map DeferredSourcesFields to files that produce the product `UnpackedArchives`.
 
   If you want a task to be able to map sources like this, make it require the 'deferred_sources'
   product.
@@ -47,11 +48,11 @@ class DeferredSourcesMapper(Task):
 
   @classmethod
   def prepare(cls, options, round_manager):
-    round_manager.require_data('unpacked_archives')
+    round_manager.require_data(UnpackedArchives)
 
   def process_remote_sources(self):
     """Create synthetic targets with populated sources from remote_sources targets."""
-    unpacked_sources = self.context.products.get_data('unpacked_archives')
+    unpacked_sources = self.context.products.get_data(UnpackedArchives)
     remote_sources_targets = self.context.targets(predicate=lambda t: isinstance(t, RemoteSources))
     if not remote_sources_targets:
       return
@@ -60,7 +61,11 @@ class DeferredSourcesMapper(Task):
     filespecs = []
     unpack_dirs = []
     for target in remote_sources_targets:
-      sources, rel_unpack_dir = unpacked_sources[target.sources_target]
+      unpacked_archive = unpacked_sources[target.sources_target]
+      sources = unpacked_archive.found_files
+      rel_unpack_dir = unpacked_archive.rel_unpack_dir
+      self.context.log.debug('target: {}, rel_unpack_dir: {}, sources: {}'
+                             .format(target, rel_unpack_dir, sources))
       sources_in_dir = tuple(os.path.join(rel_unpack_dir, source) for source in sources)
       snapshot_specs.append(PathGlobsAndRoot(
         PathGlobs(sources_in_dir),
@@ -80,6 +85,7 @@ class DeferredSourcesMapper(Task):
         derived_from=target,
         **target.destination_target_args
       )
+      self.context.log.debug('synthetic_target: {}'.format(synthetic_target))
       for dependent in self.context.build_graph.dependents_of(target.address):
         self.context.build_graph.inject_dependency(dependent, synthetic_target.address)
 

--- a/src/python/pants/core_tasks/deferred_sources_mapper.py
+++ b/src/python/pants/core_tasks/deferred_sources_mapper.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class DeferredSourcesMapper(Task):
-  """Map DeferredSourcesFields to files that produce the product `UnpackedArchives`.
+  """Map `remote_sources()` to files that produce the product `UnpackedArchives`.
 
   If you want a task to be able to map sources like this, make it require the 'deferred_sources'
   product.

--- a/src/python/pants/task/unpack_remote_sources_base.py
+++ b/src/python/pants/task/unpack_remote_sources_base.py
@@ -9,7 +9,7 @@ import os
 import re
 from abc import abstractmethod
 
-from future.utils import binary_type
+from future.utils import text_type
 from twitter.common.dirutil.fileset import fnmatch_translate_extended
 
 from pants.base.build_environment import get_buildroot
@@ -22,13 +22,13 @@ from pants.util.objects import datatype
 logger = logging.getLogger(__name__)
 
 
-class UnpackedArchives(datatype([('found_files', tuple), ('rel_unpack_dir', binary_type)])):
+class UnpackedArchives(datatype([('found_files', tuple), ('rel_unpack_dir', text_type)])):
 
   def __new__(cls, found_files, rel_unpack_dir):
     return super(UnpackedArchives, cls).__new__(
       cls,
       tuple(found_files),
-      binary_type(rel_unpack_dir))
+      text_type(rel_unpack_dir))
 
 
 class UnpackRemoteSourcesBase(Task, AbstractClass):

--- a/src/python/pants/task/unpack_remote_sources_base.py
+++ b/src/python/pants/task/unpack_remote_sources_base.py
@@ -51,7 +51,7 @@ class UnpackRemoteSourcesBase(Task, AbstractClass):
 
   @abstractmethod
   def unpack_target(unpackable_target, unpack_dir):
-    """???"""
+    """Unpack the remote resources indicated by `unpackable_target` into `unpack_dir`."""
 
   @property
   def _unpacked_sources_product(self):
@@ -90,7 +90,7 @@ class UnpackRemoteSourcesBase(Task, AbstractClass):
     return compiled_patterns
 
   @classmethod
-  def calculate_unpack_filter(cls, includes=None, excludes=None, spec=None):
+  def _calculate_unpack_filter(cls, includes=None, excludes=None, spec=None):
     """Take regex patterns and return a filter function.
 
     :param list includes: List of include patterns to pass to _file_filter.
@@ -116,9 +116,9 @@ class UnpackRemoteSourcesBase(Task, AbstractClass):
                                                        exclude_patterns attributes.
     """
     # TODO: we may be able to make use of glob matching in the engine to avoid doing this filtering.
-    return cls.calculate_unpack_filter(includes=unpackable_target.payload.include_patterns,
-                                       excludes=unpackable_target.payload.exclude_patterns,
-                                       spec=unpackable_target.address.spec)
+    return cls._calculate_unpack_filter(includes=unpackable_target.payload.include_patterns,
+                                        excludes=unpackable_target.payload.exclude_patterns,
+                                        spec=unpackable_target.address.spec)
 
   class DuplicateUnpackedSourcesError(TaskError): pass
 
@@ -131,7 +131,7 @@ class UnpackRemoteSourcesBase(Task, AbstractClass):
     rel_unpack_dir = os.path.relpath(unpack_dir, get_buildroot())
     return found_files, rel_unpack_dir
 
-  def add_unpacked_sources_for_target(self, target, unpack_dir):
+  def _add_unpacked_sources_for_target(self, target, unpack_dir):
     maybe_existing_sources = self._unpacked_sources_product.get(target, None)
     if maybe_existing_sources:
       raise self.DuplicateUnpackedSourcesError(
@@ -156,4 +156,4 @@ class UnpackRemoteSourcesBase(Task, AbstractClass):
         self.unpack_target(vt.target, vt.results_dir)
 
       for vt in invalidation_check.all_vts:
-        self.add_unpacked_sources_for_target(vt.target, vt.results_dir)
+        self._add_unpacked_sources_for_target(vt.target, vt.results_dir)

--- a/src/python/pants/task/unpack_remote_sources_base.py
+++ b/src/python/pants/task/unpack_remote_sources_base.py
@@ -1,0 +1,159 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+import os
+import re
+from abc import abstractmethod
+
+from future.utils import binary_type
+from twitter.common.dirutil.fileset import fnmatch_translate_extended
+
+from pants.base.build_environment import get_buildroot
+from pants.base.exceptions import TaskError
+from pants.task.task import Task
+from pants.util.meta import AbstractClass, classproperty
+from pants.util.objects import datatype
+
+
+logger = logging.getLogger(__name__)
+
+
+class UnpackedArchives(datatype([('found_files', tuple), ('rel_unpack_dir', binary_type)])):
+
+  def __new__(cls, found_files, rel_unpack_dir):
+    return super(UnpackedArchives, cls).__new__(
+      cls,
+      tuple(found_files),
+      binary_type(rel_unpack_dir))
+
+
+class UnpackRemoteSourcesBase(Task, AbstractClass):
+
+  @property
+  def cache_target_dirs(cls):
+    return True
+
+  @classmethod
+  def product_types(cls):
+    return [UnpackedArchives]
+
+  @classproperty
+  def source_target_constraint(cls):
+    """Return a type constraint which is evaluated to determine "source" targets for this task.
+
+    :return: :class:`pants.util.objects.TypeConstraint`
+    """
+    raise NotImplementedError()
+
+  @abstractmethod
+  def unpack_target(unpackable_target, unpack_dir):
+    """???"""
+
+  @property
+  def _unpacked_sources_product(self):
+    return self.context.products.get_data(UnpackedArchives, lambda: {})
+
+  @classmethod
+  def _file_filter(cls, filename, include_patterns, exclude_patterns):
+    """:returns: `True` if the file should be allowed through the filter."""
+    logger.debug('filename: {}'.format(filename))
+    for exclude_pattern in exclude_patterns:
+      if exclude_pattern.match(filename):
+        return False
+    if include_patterns:
+      found = False
+      for include_pattern in include_patterns:
+        if include_pattern.match(filename):
+          found = True
+          break
+      if not found:
+        return False
+    return True
+
+  class InvalidPatternError(Exception):
+    """Raised if a pattern can't be compiled for including or excluding args"""
+
+  @classmethod
+  def compile_patterns(cls, patterns, field_name="Unknown", spec="Unknown"):
+    compiled_patterns = []
+    for p in patterns:
+      try:
+        compiled_patterns.append(re.compile(fnmatch_translate_extended(p)))
+      except (TypeError, re.error) as e:
+        raise cls.InvalidPatternError(
+          'In {spec}, "{field_value}" in {field_name} can\'t be compiled: {msg}'
+          .format(field_name=field_name, field_value=p, spec=spec, msg=e))
+    return compiled_patterns
+
+  @classmethod
+  def calculate_unpack_filter(cls, includes=None, excludes=None, spec=None):
+    """Take regex patterns and return a filter function.
+
+    :param list includes: List of include patterns to pass to _file_filter.
+    :param list excludes: List of exclude patterns to pass to _file_filter.
+    """
+    include_patterns = cls.compile_patterns(includes or [],
+                                            field_name='include_patterns',
+                                            spec=spec)
+    logger.debug('include_patterns: {}'
+                 .format(p.pattern for p in include_patterns))
+    exclude_patterns = cls.compile_patterns(excludes or [],
+                                            field_name='exclude_patterns',
+                                            spec=spec)
+    logger.debug('exclude_patterns: {}'
+                 .format(p.pattern for p in exclude_patterns))
+    return lambda f: cls._file_filter(f, include_patterns, exclude_patterns)
+
+  @classmethod
+  def get_unpack_filter(cls, unpackable_target):
+    """Calculate a filter function from the include/exclude patterns of a Target.
+
+    :param ImportRemoteSourcesMixin unpackable_target: A target with include_patterns and
+                                                       exclude_patterns attributes.
+    """
+    # TODO: we may be able to make use of glob matching in the engine to avoid doing this filtering.
+    return cls.calculate_unpack_filter(includes=unpackable_target.payload.include_patterns,
+                                       excludes=unpackable_target.payload.exclude_patterns,
+                                       spec=unpackable_target.address.spec)
+
+  class DuplicateUnpackedSourcesError(TaskError): pass
+
+  def _traverse_unpacked_dir(self, unpack_dir):
+    found_files = []
+    for root, dirs, files in os.walk(unpack_dir):
+      for f in files:
+        relpath = os.path.relpath(os.path.join(root, f), unpack_dir)
+        found_files.append(relpath)
+    rel_unpack_dir = os.path.relpath(unpack_dir, get_buildroot())
+    return found_files, rel_unpack_dir
+
+  def add_unpacked_sources_for_target(self, target, unpack_dir):
+    maybe_existing_sources = self._unpacked_sources_product.get(target, None)
+    if maybe_existing_sources:
+      raise self.DuplicateUnpackedSourcesError(
+        "Target {} must not have any unpacked sources already registered!\n"
+        "The existing value was: {}\n"
+        "The second unpacked directory registered was: {}"
+        .format(target, maybe_existing_sources, unpack_dir))
+
+    found_files, rel_unpack_dir = self._traverse_unpacked_dir(unpack_dir)
+    self.context.log.debug('target: {}, rel_unpack_dir: {}, found_files: {}'
+                           .format(target, rel_unpack_dir, found_files))
+    self._unpacked_sources_product[target] = UnpackedArchives(found_files, rel_unpack_dir)
+
+  class MissingUnpackedDirsError(Exception):
+    """Raised if a directory that is expected to be unpacked doesn't exist."""
+
+  def execute(self):
+    with self.invalidated(self.get_targets(self.source_target_constraint.satisfied_by),
+                          fingerprint_strategy=self.get_fingerprint_strategy(),
+                          invalidate_dependents=True) as invalidation_check:
+      for vt in invalidation_check.invalid_vts:
+        self.unpack_target(vt.target, vt.results_dir)
+
+      for vt in invalidation_check.all_vts:
+        self.add_unpacked_sources_for_target(vt.target, vt.results_dir)

--- a/tests/python/pants_test/backend/codegen/protobuf/java/test_java_protobuf_library.py
+++ b/tests/python/pants_test/backend/codegen/protobuf/java/test_java_protobuf_library.py
@@ -35,7 +35,7 @@ class JavaProtobufLibraryTest(TestBase):
     )'''))
     target = self.target('//:foo')
     self.assertIsInstance(target, JavaProtobufLibrary)
-    self.assertSequenceEqual([], target.imported_jars)
+    self.assertSequenceEqual([], target.all_imported_jar_deps)
 
   def test_jar_library_imports(self):
     self.add_to_build_file('BUILD', dedent('''
@@ -51,8 +51,8 @@ class JavaProtobufLibraryTest(TestBase):
     '''))
     target = self.target('//:foo')
     self.assertIsInstance(target, JavaProtobufLibrary)
-    self.assertEqual(1, len(target.imported_jars))
-    import_jar_dep = target.imported_jars[0]
+    self.assertEqual(1, len(target.all_imported_jar_deps))
+    import_jar_dep = target.all_imported_jar_deps[0]
     self.assertIsInstance(import_jar_dep, JarDependency)
 
   def test_wrong_import_type1(self):
@@ -68,8 +68,8 @@ class JavaProtobufLibraryTest(TestBase):
       '''))
     target = self.target('//:foo')
     self.assertIsInstance(target, JavaProtobufLibrary)
-    with self.assertRaises(JarLibrary.WrongTargetTypeError):
-      target.imported_jars
+    with self.assertRaises(JavaProtobufLibrary.WrongTargetTypeError):
+      target.all_imported_jar_deps
 
   def test_wrong_import_type2(self):
     self.add_to_build_file('BUILD', dedent('''
@@ -80,7 +80,7 @@ class JavaProtobufLibraryTest(TestBase):
         ],
       )
       '''))
-    with self.assertRaises(JarLibrary.ExpectedAddressError):
+    with self.assertRaises(JavaProtobufLibrary.ExpectedAddressError):
       self.target('//:foo')
 
   def test_compute_dependency_specs(self):

--- a/tests/python/pants_test/backend/jvm/targets/test_jar_library.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jar_library.py
@@ -4,8 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from textwrap import dedent
-
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.base.exceptions import TargetDefinitionException
 from pants.build_graph.address import Address
@@ -49,42 +47,3 @@ class JarLibraryTest(TestBase):
     lib = JarLibrary(name='foo', address=Address.parse('//:foo'),
                      build_graph=self.build_graph, jars=[jar1])
     self.assertEqual([], lib.excludes)
-
-  def test_to_jar_dependencies(self):
-    def assert_dep(dep, org, name, rev):
-      self.assertTrue(isinstance(dep, JarDependency))
-      self.assertEqual(org, dep.org)
-      self.assertEqual(name, dep.name)
-      self.assertEqual(rev, dep.rev)
-
-    self.add_to_build_file('BUILD', dedent('''
-    jar_library(name='lib1',
-      jars=[
-        jar(org='testOrg1', name='testName1', rev='123'),
-      ],
-    )
-    jar_library(name='lib2',
-      jars=[
-        jar(org='testOrg2', name='testName2', rev='456'),
-        jar(org='testOrg3', name='testName3', rev='789'),
-      ],
-    )
-    '''))
-    lib1 = self.target('//:lib1')
-    self.assertIsInstance(lib1, JarLibrary)
-    self.assertEqual(1, len(lib1.jar_dependencies))
-    assert_dep(lib1.jar_dependencies[0], 'testOrg1', 'testName1', '123')
-
-    lib2 = self.target('//:lib2')
-    self.assertIsInstance(lib2, JarLibrary)
-    self.assertEqual(2, len(lib2.jar_dependencies))
-    assert_dep(lib2.jar_dependencies[0], 'testOrg2', 'testName2', '456')
-    assert_dep(lib2.jar_dependencies[1], 'testOrg3', 'testName3', '789')
-
-    deps = JarLibrary.to_jar_dependencies(lib1.address,
-                                          [':lib1', ':lib2'],
-                                          self.build_graph)
-    self.assertEqual(3, len(deps))
-    assert_dep(lib1.jar_dependencies[0], 'testOrg1', 'testName1', '123')
-    assert_dep(lib2.jar_dependencies[0], 'testOrg2', 'testName2', '456')
-    assert_dep(lib2.jar_dependencies[1], 'testOrg3', 'testName3', '789')

--- a/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
@@ -4,14 +4,26 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from textwrap import dedent
+
 from pants.backend.jvm.targets.import_jars_mixin import ImportJarsMixin
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
+from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.java.jar.jar_dependency import JarDependency
 from pants_test.test_base import TestBase
 
 
 class UnpackedJarsTest(TestBase):
+
+  @classmethod
+  def alias_groups(cls):
+    return BuildFileAliases(
+      targets={
+        'jar_library': JarLibrary,
+        'unpacked_jars': UnpackedJars,
+      },
+      objects={'jar': JarDependency})
 
   def test_empty_libraries(self):
     with self.assertRaises(UnpackedJars.ExpectedLibrariesError):
@@ -34,3 +46,45 @@ class UnpackedJarsTest(TestBase):
     target = self.make_target(':foo', UnpackedJars, libraries=[':wrong-type'])
     with self.assertRaises(ImportJarsMixin.WrongTargetTypeError):
       target.imported_targets
+
+  def test_has_all_imported_jar_deps(self):
+    def assert_dep(dep, org, name, rev):
+      self.assertTrue(isinstance(dep, JarDependency))
+      self.assertEqual(org, dep.org)
+      self.assertEqual(name, dep.name)
+      self.assertEqual(rev, dep.rev)
+
+    self.add_to_build_file('BUILD', dedent('''
+    jar_library(name='lib1',
+      jars=[
+        jar(org='testOrg1', name='testName1', rev='123'),
+      ],
+    )
+    jar_library(name='lib2',
+      jars=[
+        jar(org='testOrg2', name='testName2', rev='456'),
+        jar(org='testOrg3', name='testName3', rev='789'),
+      ],
+    )
+    unpacked_jars(name='unpacked-lib',
+      libraries=[':lib1', ':lib2'],
+    )
+    '''))
+    lib1 = self.target('//:lib1')
+    self.assertIsInstance(lib1, JarLibrary)
+    self.assertEqual(1, len(lib1.jar_dependencies))
+    assert_dep(lib1.jar_dependencies[0], 'testOrg1', 'testName1', '123')
+
+    lib2 = self.target('//:lib2')
+    self.assertIsInstance(lib2, JarLibrary)
+    self.assertEqual(2, len(lib2.jar_dependencies))
+    assert_dep(lib2.jar_dependencies[0], 'testOrg2', 'testName2', '456')
+    assert_dep(lib2.jar_dependencies[1], 'testOrg3', 'testName3', '789')
+
+    unpacked_lib = self.target('//:unpacked-lib')
+    unpacked_jar_deps = unpacked_lib.all_imported_jar_deps
+
+    self.assertEqual(3, len(unpacked_jar_deps))
+    assert_dep(lib1.jar_dependencies[0], 'testOrg1', 'testName1', '123')
+    assert_dep(lib2.jar_dependencies[0], 'testOrg2', 'testName2', '456')
+    assert_dep(lib2.jar_dependencies[1], 'testOrg3', 'testName3', '789')

--- a/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
@@ -24,13 +24,13 @@ class UnpackedJarsTest(TestBase):
     self.assertIsInstance(target, UnpackedJars)
     dependency_specs = [spec for spec in target.compute_dependency_specs(payload=target.payload)]
     self.assertSequenceEqual([':import_jars'], dependency_specs)
-    self.assertEqual(1, len(target.imported_jars))
-    import_jar_dep = target.imported_jars[0]
+    self.assertEqual(1, len(target.all_imported_jar_deps))
+    import_jar_dep = target.all_imported_jar_deps[0]
     self.assertIsInstance(import_jar_dep, JarDependency)
 
   def test_bad_libraries_ref(self):
     self.make_target(':right-type', JarLibrary, jars=[JarDependency('foo', 'bar', '123')])
     self.make_target(':wrong-type', UnpackedJars, libraries=[':right-type'])
     target = self.make_target(':foo', UnpackedJars, libraries=[':wrong-type'])
-    with self.assertRaises(ImportJarsMixin.ExpectedJarLibraryError):
-      target.imported_jar_libraries
+    with self.assertRaises(ImportJarsMixin.WrongTargetTypeError):
+      target.imported_targets


### PR DESCRIPTION
*This PR does not depend on #7060!*

### Problem

We want to use `remote_sources()` in #7046 to wrap C/C++ headers and libraries extracted from python wheels in a generalizable way. `remote_sources()` requires a target type to produce with `DeferredSourcesMapper`, specified with the `dest=` kwarg, so we introduced `packaged_native_library()` as an intermediate representation for native resources in #7060. The only targets which can currently be used as the `sources_target` kwarg of a `remote_sources()` target are subclasses of `ImportJarsMixin`. These targets are then consumed by the `UnpackJars` task, which currently has [a comment about splitting out the jar-specific code into its own subclass](https://github.com/pantsbuild/pants/blob/f30c612f7b9c70e0b1f4cf234d8c9155a8b27508/src/python/pants/backend/jvm/tasks/unpack_jars.py#L111) (which I noticed only after I was deep into this PR -- the class names can be changed if `Unpack` is better). As we want to extend this concept to extract resources from python wheels in #7046, we have taken up that challenge and created `ImportRemoteSourcesMixin`, cleaning up some duplicated logic along the way.

### Solution

- Create base classes `ImportJarsMixin -> ImportRemoteSourcesMixin` and `UnpackJars -> UnpackRemoteSourcesBase` so jar-specific code is localized to the subclasses (the result is significantly easier to understand, imo).
- Introduce `UnpackedArchives` datatype for `DeferredSourcesMapper` to consume instead of destructuring raw tuples.

### Result

The `UnpackedArchives` product is easier to understand than writing raw tuples, and a clear set of base classes are defined so that the stage is set for introducing `UnpackedWheels` in #7046.