### PR TITLE
Use Homebrew addon in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -632,16 +632,10 @@ matrix:
         - CACHE_NAME=macosrusttests
       # Fuse actually works on this image. It hangs on many others.
       osx_image: xcode8.3
-      # TODO: workaround for Homebrew bug triggered by running `brew update`. 
-      # Follow at https://github.com/Homebrew/brew/issues/5513 and remove this workaround once its fixed.
-      env:
-        - HOMEBREW_LOGS=~/homebrew-logs
-        - HOMEBREW_TEMP=~/homebrew-temp
-      before_install:
-        - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
-        - chmod 755 /usr/local/bin/jq
-        - ./build-support/bin/install_aws_cli_for_ci.sh
-        - brew tap caskroom/cask && brew update && brew cask install osxfuse
+      addons:
+        homebrew:
+          casks:
+          - osxfuse
       script:
         - ./build-support/bin/travis-ci.sh -bez
 

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -335,14 +335,10 @@ matrix:
         - CACHE_NAME=macosrusttests
       # Fuse actually works on this image. It hangs on many others.
       osx_image: xcode8.3
-      # TODO: workaround for Homebrew bug triggered by running `brew update`. 
-      # Follow at https://github.com/Homebrew/brew/issues/5513 and remove this workaround once its fixed.
-      env:
-        - HOMEBREW_LOGS=~/homebrew-logs
-        - HOMEBREW_TEMP=~/homebrew-temp
-      before_install:
-        {{>before_install_osx}}
-        - brew tap caskroom/cask && brew update && brew cask install osxfuse
+      addons:
+        homebrew:
+          casks:
+          - osxfuse
       script:
         - ./build-support/bin/travis-ci.sh -bez
 


### PR DESCRIPTION
Travis recommends using their [official homebrew addon](https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos), rather than how we have been using brew directly.

Beyond being more idiomatic, this will solve an [issue with Ruby version incompatibility](https://docs.travis-ci.com/user/installing-dependencies/#using-homebrew-without-addon-on-older-macos-images) encountered when using an older OSX version. Further, this speeds up the `OSX Rust` shard by avoiding having to update all of brew.