### PR TITLE
Nicer local docker iteration

### DIFF
--- a/build-support/docker/bootstrap-docker-snapshot-image.sh
+++ b/build-support/docker/bootstrap-docker-snapshot-image.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+CENTOS_SNAPSHOT_TAG='pants_centos6_snapshot'
+docker build -t "$CENTOS_SNAPSHOT_TAG" ./build-support/docker/centos6
+TRAVIS_SNAPSHOT_TAG='travis_ci_snapshot'
+docker build -t "$TRAVIS_SNAPSHOT_TAG" \
+       --build-arg BASE_IMAGE="$CENTOS_SNAPSHOT_TAG" \
+       ./build-support/docker/travis_ci
+
+docker run -i \
+       -v "$(pwd):/pants-repo" -w '/pants-repo'\
+       -t "$TRAVIS_SNAPSHOT_TAG" \
+       /bin/bash --init-file ./build-support/docker/nicer-shell-environment.sh

--- a/build-support/docker/nicer-shell-environment.sh
+++ b/build-support/docker/nicer-shell-environment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+# This script is intended to be sourced, not executed!
 
 if [[ -f ~/.bashrc ]]; then
   source ~/.bashrc

--- a/build-support/docker/nicer-shell-environment.sh
+++ b/build-support/docker/nicer-shell-environment.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [[ -f ~/.bashrc ]]; then
+  source ~/.bashrc
+fi
+
+# long mode, show all, natural sort, type squiggles, friendly sizes
+if hash dircolors 2>/dev/null && [[ ! "$TERM" =~ 'dumb|emacs' ]]; then
+  eval "$(dircolors -b)"
+  # -A, --almost-all           do not list implied . and ..
+  # -F, --classify             append indicator (one of */=>@|) to entries
+  # -l                         use a long listing format
+  # -h, --human-readable       with -l and -s, print sizes like 1K 234M 2G etc.
+  #     --si                   likewise, but use powers of 1000 not 1024
+  # -v                         natural sort of (version) numbers within text
+  LSOPTS='-lAvFh --si --color=always'
+  LLOPTS='-lAvFh --color=always'
+else
+  export CLICOLOR=YES
+  LSOPTS='-lAvFh'
+  LLOPTS=''
+fi
+
+alias ls="ls $LSOPTS"
+alias ll="ls $LLOPTS | less -FX"
+
+export PAGER=less
+# Never wrap long lines by default
+# I'd love to have the effect of -F, but I don't want -X all the time, alas.
+export LESS="-RMi~Kq"
+
+export PS1='\u@\H:\w (bash \V)$ '

--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -2,7 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 # Use our custom Centos6 image for binary compatibility with old linux distros.
-FROM pantsbuild/centos6:latest
+ARG BASE_IMAGE=pantsbuild/centos6:latest
+FROM ${BASE_IMAGE}
 
 # Setup mount points for the travis ci user & workdir.
 VOLUME /travis/home


### PR DESCRIPTION
### Problem

I was looking into #7064 and was always a little annoyed that we couldn't plug in more functionality to our docker image, or modify the centos6 image when iterating on image generation locally.

### Solution

- Add a `BASE_IMAGE` arg to the `travis_ci` Dockerfile to allow modifying both the centos6 image and the travis image.
- Add `bootstrap-docker-snapshot-image.sh` to build the `travis_ci` image, run it, and add some nice shell environment tweaks that are useful when debugging locally.