### PR TITLE
Add specific copyright year check on newly added python files

### DIFF
--- a/build-support/bin/check_header.sh
+++ b/build-support/bin/check_header.sh
@@ -5,4 +5,11 @@ set -e
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
-build-support/bin/check_header_helper.py src tests pants-plugins examples contrib
+# Read added files from stdin, and ensure check_header_helper.py checks for the current copyright
+# year for the intersection of these files with the ones it checks.
+# Check for copies (-C) and moves (-M), so we don't get false positives when people do
+# refactorings. -l50 bounds the time git takes to search for these non-additions.
+# See git-diff(1) and https://stackoverflow.com/a/2299672/2518889 for discussion of these options.
+# Exporting IGNORE_ADDED_FILES will avoid checking the specific copyright year for added files.
+git diff --cached --name-only --diff-filter=A -C -M -l50 \
+  | build-support/bin/check_header_helper.py src tests pants-plugins examples contrib

--- a/build-support/bin/check_header_helper.py
+++ b/build-support/bin/check_header_helper.py
@@ -96,6 +96,8 @@ def main():
     print()
     print(EXPECTED_HEADER)
     print('---')
+    print('Some additional checking is performed on newly added files, such as \n'
+          'validating the copyright year. You can export IGNORE_ADDED_FILES to disable this check.')
     print('The following {} file(s) do not conform:'.format(len(header_parse_failures)))
     print('  {}'.format('\n  '.join(header_parse_failures)))
     sys.exit(1)

--- a/build-support/bin/check_header_helper.py
+++ b/build-support/bin/check_header_helper.py
@@ -14,7 +14,6 @@ import datetime
 import os
 import re
 import sys
-from builtins import str
 from io import open
 
 EXPECTED_HEADER="""# coding=utf-8
@@ -85,11 +84,11 @@ def check_dir(directory, newly_created_files):
 def main():
   dirs = sys.argv
   header_parse_failures = []
-  if os.environ.get('IGNORE_ADDED_FILES', None):
-    newly_created_files = frozenset()
-  else:
-    # Input lines denote file paths relative to the repo root and are assumed to all end in \n.
-    newly_created_files = frozenset(line[0:-1] for line in sys.stdin)
+  # Input lines denote file paths relative to the repo root and are assumed to all end in \n.
+  newly_created_files = frozenset((line[0:-1] for line in sys.stdin)
+                                  if 'IGNORE_ADDED_FILES' not in os.environ
+                                  else [])
+
   for directory in dirs:
     header_parse_failures.extend(check_dir(directory, newly_created_files))
   if header_parse_failures:

--- a/build-support/bin/check_header_helper.py
+++ b/build-support/bin/check_header_helper.py
@@ -49,7 +49,7 @@ def check_header(filename, is_newly_created=False):
         # Check if the copyright year can be parsed as within the current century, or the current
         # year if it is a new file.
         if line.startswith("# Copyright"):
-          year = line[12:-4]
+          year = line[12:16]
           if is_newly_created:
             if not year == _current_year:
               raise HeaderCheckFailure('{}: copyright year must be {} (was {})'
@@ -79,7 +79,7 @@ def check_dir(directory, newly_created_files):
           check_header(filename, filename in newly_created_files)
         except HeaderCheckFailure as e:
           header_parse_failures.append(e.message)
-  return failed_files
+  return header_parse_failures
 
 
 def main():

--- a/build-support/bin/check_header_helper.py
+++ b/build-support/bin/check_header_helper.py
@@ -10,9 +10,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import datetime
 import os
 import re
 import sys
+from builtins import str
 from io import open
 
 EXPECTED_HEADER="""# coding=utf-8
@@ -24,8 +26,18 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 """
 
 
-def check_header(filename):
-  """Returns True if header check passes."""
+_current_year = str(datetime.datetime.now().year)
+
+
+_current_century_regex = re.compile(r'20\d\d')
+
+
+class HeaderCheckFailure(Exception):
+  """This is only used for control flow and to propagate the `.message` field."""
+
+
+def check_header(filename, is_newly_created=False):
+  """Raises `HeaderCheckFailure` if the header doesn't match."""
   try:
     with open(filename, 'r') as pyfile:
       buf = ""
@@ -34,42 +46,59 @@ def check_header(filename):
         # Skip shebang line
         if lineno == 1 and line.startswith('#!'):
           line = pyfile.readline()
-        # Don't care much about the actual year, just that its there
+        # Check if the copyright year can be parsed as within the current century, or the current
+        # year if it is a new file.
         if line.startswith("# Copyright"):
           year = line[12:-4]
-          if not re.match(r'20\d\d', year):
-            return False
+          if is_newly_created:
+            if not year == _current_year:
+              raise HeaderCheckFailure('{}: copyright year must be {} (was {})'
+                                       .format(filename, _current_year, year))
+          else:
+            if not _current_century_regex.match(year):
+              raise HeaderCheckFailure('{}: copyright year must match {} (was {})'
+                                       .format(filename, _current_century_regex.pattern, year))
           line = "# Copyright YYYY" + line[16:]
         buf += line
-      return buf == EXPECTED_HEADER
-  except IOError:
-    return False
+      if buf != EXPECTED_HEADER:
+        raise HeaderCheckFailure('{}: failed to parse header at all'
+                                 .format(filename))
+  except IOError as e:
+    raise HeaderCheckFailure('{}: error while reading input ({})'
+                             .format(filename, str(e)))
 
 
-def check_dir(directory):
+def check_dir(directory, newly_created_files):
   """Returns list of files that fail the check."""
-  failed_files = []
+  header_parse_failures = []
   for root, dirs, files in os.walk(directory):
     for f in files:
       if f.endswith('.py') and os.path.basename(f) != '__init__.py':
         filename = os.path.join(root, f)
-        if not check_header(filename):
-          failed_files.append(filename)
+        try:
+          check_header(filename, filename in newly_created_files)
+        except HeaderCheckFailure as e:
+          header_parse_failures.append(e.message)
   return failed_files
 
 
 def main():
   dirs = sys.argv
-  failed_files = []
+  header_parse_failures = []
+  if os.environ.get('IGNORE_ADDED_FILES', None):
+    newly_created_files = frozenset()
+  else:
+    # Input lines denote file paths relative to the repo root and are assumed to all end in \n.
+    newly_created_files = frozenset(line[0:-1] for line in sys.stdin)
   for directory in dirs:
-    failed_files.extend(check_dir(directory))
-  if failed_files:
+    header_parse_failures.extend(check_dir(directory, newly_created_files))
+  if header_parse_failures:
     print('ERROR: All .py files other than __init__.py should start with the following header:')
     print()
     print(EXPECTED_HEADER)
     print('---')
-    print('The following {} file(s) do not conform:'.format(len(failed_files)))
-    print('  {}'.format('\n  '.join(failed_files)))
+    print('The following {} file(s) do not conform:'.format(len(header_parse_failures)))
+    print('  {}'.format('\n  '.join(header_parse_failures)))
     sys.exit(1)
 
 

--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -9,6 +9,8 @@ then
     export GIT_HOOK=1
 fi
 
+# TODO: Fix all these checks to only act on staged files with `git diff --cached --name-only`! See
+# check_header.sh for an example of this command.
 echo "* Checking packages" && ./build-support/bin/check_packages.sh || exit 1
 echo "* Checking headers" && ./build-support/bin/check_header.sh || exit 1
 echo "* Checking for banned imports" && ./build-support/bin/check_banned_imports.sh || exit 1

--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -9,8 +9,8 @@ then
     export GIT_HOOK=1
 fi
 
-# TODO: Fix all these checks to only act on staged files with `git diff --cached --name-only`! See
-# check_header.sh for an example of this command.
+# TODO(#7068): Fix all these checks to only act on staged files with
+# `git diff --cached --name-only`! See check_header.sh for an example of this command.
 echo "* Checking packages" && ./build-support/bin/check_packages.sh || exit 1
 echo "* Checking headers" && ./build-support/bin/check_header.sh || exit 1
 echo "* Checking for banned imports" && ./build-support/bin/check_banned_imports.sh || exit 1


### PR DESCRIPTION
### Problem

*See [this slack conversation](https://pantsbuild.slack.com/archives/C046T6T9U/p1547163296121700).*

When people add new python files to pants, they (I) can sometimes add files with the wrong copyright year (the current year), by copy and pasting from another file. This is fine, but can be confusing when looking through git history, and while it can be caught in review, this check happens to be automateable.

### Solution

- Use `git diff --cached` to obtain newly created files added to the index and check their copyright year specifically in `check_header_helper.py`.
- Some other edits to `check_header_helper.py` to support this (raising an exception instead of returning a boolean for a failed header check).
- Leave a TODO linking to #7068 to make more of the pre-commit checks act on files in the index instead of the worktree.
- Allow exporting `IGNORE_ADDED_FILES` to avoid this extra checking entirely.

### Result

Something automateable is automated!