### PR TITLE
Fixes to get contrib, lint, JVM tests, and platform-specific tests working with ./pants3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -972,7 +972,7 @@ matrix:
       script:
         - ./build-support/bin/travis-ci.sh -2n
 
-    - <<: *py2_linux_test_config
+    - <<: *py3_linux_test_config
       name: "Python contrib tests (Py3 PEX)"
       env:
         - *py3_linux_test_config_env

--- a/.travis.yml
+++ b/.travis.yml
@@ -607,11 +607,8 @@ matrix:
     - <<: *py2_osx_build_engine
     - <<: *py3_osx_build_engine
 
-    # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
-    # May be completely fixed by https://github.com/pantsbuild/pants/pull/7067..
     - <<: *py2_lint
-      stage: *test
-    # - <<: *py3_lint
+    - <<: *py3_lint
 
     - <<: *linux_rust_clippy
     - <<: *cargo_audit
@@ -975,16 +972,13 @@ matrix:
       script:
         - ./build-support/bin/travis-ci.sh -2n
 
-    # TODO: get this passing with a Python 3 PEX.
     - <<: *py2_linux_test_config
-      name: "Python contrib tests (Py2 PEX w/ Py3 constraints)"
-      stage: *test
+      name: "Python contrib tests (Py3 PEX)"
       env:
-        - *py2_linux_test_config_env
-        - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
+        - *py3_linux_test_config_env
         - CACHE_NAME=linuxcontribtests.py3
       script:
-        - ./build-support/bin/travis-ci.sh -2n
+        - ./build-support/bin/travis-ci.sh -n
 
     - <<: *py2_osx_10_12_sanity_check
     - <<: *py3_osx_10_12_sanity_check
@@ -992,15 +986,11 @@ matrix:
     - <<: *py2_osx_10_13_sanity_check
     - <<: *py3_osx_10_13_sanity_check
 
-    # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
     - <<: *py2_osx_platform_tests
-      stage: *test
-    # - <<: *py3_osx_platform_tests
+    - <<: *py3_osx_platform_tests
 
-    # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
     - <<: *py2_jvm_tests
-      stage: *test
-    # - <<: *py3_jvm_tests
+    - <<: *py3_jvm_tests
 
     - <<: *deploy_stable_multiplatform_pex
     - <<: *deploy_unstable_multiplatform_pex

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -586,11 +586,8 @@ matrix:
     - <<: *py2_osx_build_engine
     - <<: *py3_osx_build_engine
 
-    # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
-    # May be completely fixed by https://github.com/pantsbuild/pants/pull/7067..
     - <<: *py2_lint
-      stage: *test
-    # - <<: *py3_lint
+    - <<: *py3_lint
 
     - <<: *linux_rust_clippy
     - <<: *cargo_audit
@@ -660,16 +657,13 @@ matrix:
       script:
         - ./build-support/bin/travis-ci.sh -2n
 
-    # TODO: get this passing with a Python 3 PEX.
     - <<: *py2_linux_test_config
-      name: "Python contrib tests (Py2 PEX w/ Py3 constraints)"
-      stage: *test
+      name: "Python contrib tests (Py3 PEX)"
       env:
-        - *py2_linux_test_config_env
-        - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
+        - *py3_linux_test_config_env
         - CACHE_NAME=linuxcontribtests.py3
       script:
-        - ./build-support/bin/travis-ci.sh -2n
+        - ./build-support/bin/travis-ci.sh -n
 
     - <<: *py2_osx_10_12_sanity_check
     - <<: *py3_osx_10_12_sanity_check
@@ -677,15 +671,11 @@ matrix:
     - <<: *py2_osx_10_13_sanity_check
     - <<: *py3_osx_10_13_sanity_check
 
-    # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
     - <<: *py2_osx_platform_tests
-      stage: *test
-    # - <<: *py3_osx_platform_tests
+    - <<: *py3_osx_platform_tests
 
-    # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
     - <<: *py2_jvm_tests
-      stage: *test
-    # - <<: *py3_jvm_tests
+    - <<: *py3_jvm_tests
 
     - <<: *deploy_stable_multiplatform_pex
     - <<: *deploy_unstable_multiplatform_pex

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -657,7 +657,7 @@ matrix:
       script:
         - ./build-support/bin/travis-ci.sh -2n
 
-    - <<: *py2_linux_test_config
+    - <<: *py3_linux_test_config
       name: "Python contrib tests (Py3 PEX)"
       env:
         - *py3_linux_test_config_env

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_binary_fingerprint_strategy.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_binary_fingerprint_strategy.py
@@ -32,7 +32,7 @@ class GoBinaryFingerprintStrategy(FingerprintStrategy):
       return fp
 
     hasher = hashlib.sha1()
-    hasher.update(fp)
+    hasher.update(fp.encode('utf-8'))
     hasher.update(str(self._get_build_flags_func(target)).encode('utf-8'))
     return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
 

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
@@ -147,10 +147,10 @@ class GoCompile(GoWorkspaceTask):
     # Note that environment variables don't invalidate the build graph, so changes to GOOS or GOARCH
     # require a clean-all.
 
-    host_goos = self.go_dist.create_go_cmd('env', gopath=gopath, args=["GOHOSTOS"]).check_output().strip()
-    target_goos = self.go_dist.create_go_cmd('env', gopath=gopath, args=["GOOS"]).check_output().strip()
-    host_arch = self.go_dist.create_go_cmd('env', gopath=gopath, args=["GOARCH"]).check_output().strip()
-    target_arch = self.go_dist.create_go_cmd('env', gopath=gopath, args=["GOHOSTARCH"]).check_output().strip()
+    host_goos = self.go_dist.create_go_cmd('env', gopath=gopath, args=["GOHOSTOS"]).check_output().decode('utf-8').strip()
+    target_goos = self.go_dist.create_go_cmd('env', gopath=gopath, args=["GOOS"]).check_output().decode('utf-8').strip()
+    host_arch = self.go_dist.create_go_cmd('env', gopath=gopath, args=["GOARCH"]).check_output().decode('utf-8').strip()
+    target_arch = self.go_dist.create_go_cmd('env', gopath=gopath, args=["GOHOSTARCH"]).check_output().decode('utf-8').strip()
 
     host_pair = "{}_{}".format(host_goos, host_arch)
     target_pair = "{}_{}".format(target_goos, target_arch)

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_task.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_task.py
@@ -73,7 +73,7 @@ class GoTask(Task):
                                     goarch=self._lookup_go_env_var('GOARCH'))
 
   def _lookup_go_env_var(self, var):
-    return self.go_dist.create_go_cmd('env', args=[var]).check_output().strip()
+    return self.go_dist.create_go_cmd('env', args=[var]).check_output().decode('utf-8').strip()
 
 
 class ImportOracle(object):

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/java_thrift_library_fingerprint_strategy.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/java_thrift_library_fingerprint_strategy.py
@@ -39,7 +39,7 @@ class JavaThriftLibraryFingerprintStrategy(FingerprintStrategy):
 
     default_java_namespace = self._thrift_defaults.default_java_namespace(target)
     if default_java_namespace:
-      hasher.update(default_java_namespace)
+      hasher.update(default_java_namespace.encode('utf-8'))
 
     if target.include_paths:
       hasher.update(str(target.include_paths).encode('utf-8'))

--- a/src/python/pants/backend/graph_info/tasks/dependees.py
+++ b/src/python/pants/backend/graph_info/tasks/dependees.py
@@ -55,10 +55,10 @@ class ReverseDepmap(ConsoleTask):
       yield json.dumps(deps, indent=4, separators=(',', ': '), sort_keys=True)
     else:
       if self._closed:
-        for root in roots:
+        for root in sorted(roots):
           yield root.address.spec
 
-      for dependent in self.get_dependents(dependees_by_target, roots):
+      for dependent in sorted(self.get_dependents(dependees_by_target, roots)):
         yield dependent.address.spec
 
   def get_dependents(self, dependees_by_target, roots):

--- a/src/python/pants/backend/graph_info/tasks/dependees.py
+++ b/src/python/pants/backend/graph_info/tasks/dependees.py
@@ -55,9 +55,13 @@ class ReverseDepmap(ConsoleTask):
       yield json.dumps(deps, indent=4, separators=(',', ': '), sort_keys=True)
     else:
       if self._closed:
+        # N.B. Sorting is necessary because `roots` is a set, and in Python 3 sets
+        # are no longer consistently sorted (even though dictionaries are in 3.6+).
+        # Without this sort, the output of `./pants3 dependees` will vary every run.
         for root in sorted(roots):
           yield root.address.spec
 
+      # N.B. Sorting is necessary here for consistent output in Python 3. See above N.B.
       for dependent in sorted(self.get_dependents(dependees_by_target, roots)):
         yield dependent.address.spec
 

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -496,15 +496,14 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
     # We provide this custom key function to avoid such invalid comparisons, while still allowing us
     # to use None to represent non-present properties.
     def _sort_properties(properties_with_tests):
-      properties = properties_with_tests[0]
+      workdir, platform, extra_jvm_options, extra_env_vars, concurrency, threads = properties_with_tests[0]
       return (
-        properties[0] or '',  # cwd
-        properties[1],  # platform
-        properties[2] or [],  # extra_jvm_options
-        properties[3] or {},  # extra_env_vars
-        properties[4] or "",  # concurrency
-        properties[5] or 0  # threads
-      )
+        workdir or '',
+        platform,
+        extra_jvm_options or [],
+        extra_env_vars or {},
+        concurrency or "",
+        threads or 0)
 
     for properties, tests in sorted(tests_by_properties.items(), key=_sort_properties):
       sorted_tests = sorted(tests)

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -490,11 +490,11 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
       lambda tgt: tgt.concurrency,
       lambda tgt: tgt.threads)
 
-    # N.B. Python 3 does not allow comparisons between None and other types like str.
-    # Several of the properties, which act as dictionary keys, may have None values, whereras a
-    # another has a non-None value for the same property, so comparison when sorting would fail.
-    # We provide this custom key function to avoid such invalid comparisons, while still allowing us
-    # to use None to represent non-present properties.
+    # N.B. Python 3 does not allow comparisons between None and other types like str. Several
+    # of the properties, which act as dictionary keys, may have None values, whereras another
+    # may have a non-None value for the same property, so comparison when sorting would fail.
+    # We provide this custom key function to avoid such invalid comparisons, while still
+    # allowing us to use None to represent non-present properties.
     def _sort_properties(properties_with_tests):
       workdir, platform, extra_jvm_options, extra_env_vars, concurrency, threads = properties_with_tests[0]
       return (

--- a/src/python/pants/reporting/report.py
+++ b/src/python/pants/reporting/report.py
@@ -131,7 +131,10 @@ class Report(object):
     # Assumes self._lock is held by the caller.
     for workunit in self._workunits.values():
       # N.B. Wrap .items() call with list() due to issues with workunit.outputs()
-      # changing its size during iteration.
+      # changing its size during iteration, which causes an error in Python 3.
+      # We did not catch this issue in Python 2, because .items() returns a new list
+      # in Python 2. It is not clear why the dictionary size is changing, and this may
+      # be a potential source of issues.
       for label, output in list(workunit.outputs().items()):
         s = output.read().decode('utf-8')
         if len(s) > 0:

--- a/src/python/pants/reporting/report.py
+++ b/src/python/pants/reporting/report.py
@@ -130,7 +130,9 @@ class Report(object):
     # than the current one, if work is happening in parallel.
     # Assumes self._lock is held by the caller.
     for workunit in self._workunits.values():
-      for label, output in workunit.outputs().items():
+      # N.B. Wrap .items() call with list() due to issues with workunit.outputs()
+      # changing its size during iteration.
+      for label, output in list(workunit.outputs().items()):
         s = output.read().decode('utf-8')
         if len(s) > 0:
           for reporter in self._reporters.values():


### PR DESCRIPTION
## Problem
In CI, beyond normal Python unit tests and integration tests, we run several other types of tests and audits, such as a Lint shard, tests from the contrib folder, and JVM tests.

When we first made the change to running Python 3 in CI, we had to run the Lint, Contrib, JVM tests, and OSX Platform Specific tests using a Python 2 PEX, as we originally had always done, due to various Python 3 compatibility issues.

To ensure full Python 3 support, however, these shards need to run with a Python 3 PEX.

## Solution
Whack-a-mole various issues that were causing these 4 shards to fail with Python 3, as follows:

* Fix scrooge hasher encoding issue.
   * Hashers must always use bytes, so encode.
* Fix go hasher encoding issue.
   * Hashers must always use bytes, so encode.
* Sort output of dependees goal.
  * In Py3, sets are non-deterministic, even with 3.6 and 3.7 making dictionaries deterministic. So, `./pants3 dependees src/python/pants/util:strutil` returns different output each time, whereas `./pants` with py2 is deterministic.
  * This was causing a failure `contrib/buildrefactor/test_meta_rename_integration.py`.
  * Note we already sorted output if the format was json. This change adds sorting when not json.
* Fix issue with `report.py` dict changing size during iteration.
   * See https://github.com/pantsbuild/pants/pull/7067/commits/40b3dff56ff25c0c6f336fa78f1bb6f461e79898 for the stacktrace that caused this failure.
   * It's not clear why this the size is changing.
   * We did not encounter this in Python 2 because Python 2 returns a new list when calling `items()`.
* Add key function for safe sorting in `junit_run.py`.
   * We call `sorted()` on a tuple of 6 properties taken from `JUnitTests`.
   * Some of these properties may be `None` if the value is missing, but sometimes they have an actual value. Because `sorted()` calls `__lt__()`, comparisons between these missing and valid properties result in a `TypeError`.
* Properly decode Go Compile env variables
   * Failing to decode them was causing the byte string prefix `b''` to pop up in filenames, which led to test failures. For example, `GOOS="windows" ./pants3 binary contrib/go/examples/src/go/hello` would fail that it could not find the file, because the filename was nonsense with `b''` in it.

With these source code changes, the final changes of this PR are to remove the temporary `.travis.yml` code we had to ignore the Python 3 version of these four shards.

## Result
These four shards now work completely with Python 3 without compromise. This means in daily CI we will run the Python 3 version, and we add to the nightly Cron job running the shards with Python 2 to check for regressions.

(Exception for the Contrib test, which during daily always runs both Python 2 and Python 3, and is not a part of the cron job.)