### PR TITLE
Fix threading issue with report.py when using Py3

### DIFF
--- a/src/python/pants/reporting/report.py
+++ b/src/python/pants/reporting/report.py
@@ -30,7 +30,7 @@ class EmitterThread(threading.Thread):
     self.daemon = True
 
   def run(self):
-    # NB(Eric Ayers) Using self._stop.wait(timeout=0.5) causes spurious exceptions on shutdown
+    # NB(Eric Ayers) Using self._stopper.wait(timeout=0.5) causes spurious exceptions on shutdown
     # on some platforms. See https://github.com/pantsbuild/pants/issues/2750
     while not self._stopper.is_set():
       self._report.flush()


### PR DESCRIPTION
### Problem
The Py3 threading library has an attribute called `_stop()` for` Event`s. Our implementation in `report.py` was thus overriding the default, and resulting in the error `TypeError: 'Event' object is not callable` whenever running a test with `./pants3`.

### Solution
Rename `self._stop` to `self._stopper`.

See https://stackoverflow.com/questions/323972/is-there-any-way-to-kill-a-thread/325528#325528.