### PR TITLE
Split out unrelated CI jobs into their own distinct shards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -554,7 +554,7 @@ osx_rust_tests: &osx_rust_tests
   # not present. So we add `before_install` with a no-op.
   # See https://travis-ci.community/t/homebrew-addon-does-not-work-if-before-install-step-is-skipped/1564
   before_install:
-    - :
+    - echo ''
   addons:
     homebrew:
       casks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -528,6 +528,7 @@ py3_osx_platform_tests: &py3_osx_platform_tests
 # -------------------------------------------------------------------------
 
 base_rust_tests: &base_rust_tests
+  <<: *native_engine_cache_config
   stage: *test
   before_script:
     - ulimit -c unlimited
@@ -536,7 +537,6 @@ base_rust_tests: &base_rust_tests
 linux_rust_tests: &linux_rust_tests
   <<: *base_rust_tests
   <<: *linux_with_fuse
-  <<: *native_engine_cache_config
   name: "Linux Rust tests (No PEX)"
   env:
     - CACHE_NAME=linuxrusttests

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
 stages:
   - &bootstrap Bootstrap Pants
   - name: &test Test Pants
-    if: type == cron
+    if: type != cron
   - name: &cron Cron
     if: type = cron
   - name: &build_stable Deploy Pants Pex
@@ -233,7 +233,7 @@ linux_with_fuse: &linux_with_fuse
 
 base_linux_build_engine: &base_linux_build_engine
   <<: *native_engine_cache_config
-  stage: *test
+  stage: *bootstrap
   services:
     - docker
   env:
@@ -280,7 +280,7 @@ py3_linux_build_engine: &py3_linux_build_engine
 
 base_osx_build_engine: &base_osx_build_engine
   <<: *native_engine_cache_config
-  stage: *test
+  stage: *bootstrap
   # We request the oldest image we can (corresponding to OSX 10.11) for maximum compatibility.
   # We use 10.11 as a minimum to avoid https://github.com/rust-lang/regex/issues/489.
   # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
@@ -550,7 +550,7 @@ osx_rust_tests: &osx_rust_tests
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3
   name: "OSX Rust tests (No PEX)"
-  stage: *bootstrap
+  stage: *test
   addons:
     homebrew:
       casks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -546,18 +546,11 @@ linux_rust_tests: &linux_rust_tests
     - ./build-support/bin/travis-ci.sh -be
 
 osx_rust_tests: &osx_rust_tests
+  os: osx
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3
   name: "OSX Rust tests (No PEX)"
   stage: *bootstrap
-  language: generic
-  # N.B. Travis's brew addon has a bug where it will skip installing if the section `before_install` is 
-  # not present. So we add `before_install` with a no-op.
-  # See https://travis-ci.community/t/homebrew-addon-does-not-work-if-before-install-step-is-skipped/1564
-  before_install:
-    - echo ''
-  before_script:
-    - echo ''
   addons:
     homebrew:
       casks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -550,6 +550,11 @@ osx_rust_tests: &osx_rust_tests
   osx_image: xcode8.3
   name: "OSX Rust tests (No PEX)"
   stage: *test
+  # N.B. Travis's brew addon has a bug where it will skip installing if the section `before_install` is 
+  # not present. So we add `before_install` with a no-op.
+  # See https://travis-ci.community/t/homebrew-addon-does-not-work-if-before-install-step-is-skipped/1564
+  before_install:
+    - :
   addons:
     homebrew:
       casks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -415,26 +415,23 @@ py3_osx_10_13_sanity_check: &py3_osx_10_13_sanity_check
 # Lint
 # -------------------------------------------------------------------------
 
-base_lint: &base_lint
-  <<: *linux_with_fuse
-  script:
-    - ./build-support/bin/travis-ci.sh -fbmrjt
-
 py2_lint: &py2_lint
   <<: *py2_linux_test_config
-  <<: *base_lint
-  name: "Self-checks, lint, and JVM tests (Py2 PEX)"
+  name: "Self-checks and lint (Py2 PEX)"
   env:
     - *py2_linux_test_config_env
     - CACHE_NAME=linuxselfchecks.py2
+  script:
+    - ./build-support/bin/travis-ci.sh -fbmrt2
 
 py3_lint: &py3_lint
   <<: *py3_linux_test_config
-  <<: *base_lint
-  name: "Self-checks, lint, and JVM tests (Py3 PEX)"
+  name: "Self-checks and lint (Py3 PEX)"
   env:
     - *py3_linux_test_config_env
     - CACHE_NAME=linuxselfchecks.py3
+  script:
+    - ./build-support/bin/travis-ci.sh -fbmrt
 
 # -------------------------------------------------------------------------
 # Deploy
@@ -476,6 +473,33 @@ deploy_unstable_multiplatform_pex: &deploy_unstable_multiplatform_pex
     - PREPARE_DEPLOY=1
   script:
     - ./build-support/bin/release.sh -p && mkdir -p dist/deploy/pex/ && mv dist/pants*.pex dist/deploy/pex/
+
+# -------------------------------------------------------------------------
+# JVM tests
+# -------------------------------------------------------------------------
+
+base_jvm_tests: &base_jvm_tests
+  <<: *linux_with_fuse
+
+py2_jvm_tests: &py2_jvm_tests
+  <<: *py2_linux_test_config
+  <<: *base_jvm_tests
+  name: "JVM tests (Py2 PEX)"
+  env:
+    - *py2_linux_test_config_env
+    - CACHE_NAME=linuxjvmtests.py2
+  script:
+    - ./build-support/bin/travis-ci.sh -bj2
+
+py3_jvm_tests: &py3_jvm_tests
+  <<: *py3_linux_test_config
+  <<: *base_jvm_tests
+  name: "JVM tests (Py3 PEX)"
+  env:
+    - *py3_linux_test_config_env
+    - CACHE_NAME=linuxjvmtests.py3
+  script:
+    - ./build-support/bin/travis-ci.sh -bj
 
 # -------------------------------------------------------------------------
 # Platform specific tests
@@ -602,10 +626,7 @@ matrix:
     - <<: *deploy_unstable_multiplatform_pex
 
     - <<: *py2_lint
-      stage: *test
-    # TODO: lint shard fails with Py3 pex (see https://travis-ci.org/pantsbuild/pants/jobs/478884818#L3355)
-    # Temporarily use Py2 pex and fix this in a later PR.
-    # - <<: *py3_lint
+    - <<: *py3_lint
 
     - <<: *py2_linux_test_config
       name: "Unit tests for pants and pants-plugins (Py2 PEX)"
@@ -978,6 +999,11 @@ matrix:
       script:
         - ./build-support/bin/travis-ci.sh -bc2 -i 19/20
 
+
+    # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
+    - <<: *py2_jvm_tests
+      stage: *test
+    # - <<: *py3_jvm_tests
 
     # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
     - <<: *py2_osx_platform_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
 stages:
   - &bootstrap Bootstrap Pants
   - name: &test Test Pants
-    if: type != cron
+    if: type == cron
   - name: &cron Cron
     if: type = cron
   - name: &build_stable Deploy Pants Pex
@@ -233,7 +233,7 @@ linux_with_fuse: &linux_with_fuse
 
 base_linux_build_engine: &base_linux_build_engine
   <<: *native_engine_cache_config
-  stage: *bootstrap
+  stage: *test
   services:
     - docker
   env:
@@ -280,7 +280,7 @@ py3_linux_build_engine: &py3_linux_build_engine
 
 base_osx_build_engine: &base_osx_build_engine
   <<: *native_engine_cache_config
-  stage: *bootstrap
+  stage: *test
   # We request the oldest image we can (corresponding to OSX 10.11) for maximum compatibility.
   # We use 10.11 as a minimum to avoid https://github.com/rust-lang/regex/issues/489.
   # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
@@ -549,7 +549,7 @@ osx_rust_tests: &osx_rust_tests
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3
   name: "OSX Rust tests (No PEX)"
-  stage: *test
+  stage: *bootstrap
   # N.B. Travis's brew addon has a bug where it will skip installing if the section `before_install` is 
   # not present. So we add `before_install` with a no-op.
   # See https://travis-ci.community/t/homebrew-addon-does-not-work-if-before-install-step-is-skipped/1564

--- a/.travis.yml
+++ b/.travis.yml
@@ -625,8 +625,11 @@ matrix:
     - <<: *deploy_stable_multiplatform_pex
     - <<: *deploy_unstable_multiplatform_pex
 
+    # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
+    # May be completely fixed by https://github.com/pantsbuild/pants/pull/7067..
     - <<: *py2_lint
-    - <<: *py3_lint
+      stage: *test
+    # - <<: *py3_lint
 
     - <<: *py2_linux_test_config
       name: "Unit tests for pants and pants-plugins (Py2 PEX)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -478,6 +478,28 @@ deploy_unstable_multiplatform_pex: &deploy_unstable_multiplatform_pex
     - ./build-support/bin/release.sh -p && mkdir -p dist/deploy/pex/ && mv dist/pants*.pex dist/deploy/pex/
 
 # -------------------------------------------------------------------------
+# Platform specific tests
+# -------------------------------------------------------------------------
+
+py2_osx_platform_tests: &py2_osx_platform_tests
+  <<: *py2_osx_test_config
+  name: "OSX platform-specific tests (Py2 PEX)"
+  env:
+    - *py2_osx_test_config_env
+    - CACHE_NAME=macosplatformtests.py2
+  script:
+    - ./build-support/bin/travis-ci.sh -bz2
+
+py3_osx_platform_tests: &py3_osx_platform_tests
+  <<: *py3_osx_test_config
+  name: "OSX platform-specific tests (Py3 PEX)"
+  env:
+    - *py3_osx_test_config_env
+    - CACHE_NAME=macosplatformtests.py3
+  script:
+    - ./build-support/bin/travis-ci.sh -bz
+
+# -------------------------------------------------------------------------
 # Rust tests
 # -------------------------------------------------------------------------
 
@@ -499,37 +521,19 @@ linux_rust_tests: &linux_rust_tests
   script:
     - ./build-support/bin/travis-ci.sh -be
 
-base_osx_rust_tests: &base_osx_rust_tests
+osx_rust_tests: &osx_rust_tests
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3
+  name: "OSX Rust tests (No PEX)"
+  stage: *test
   addons:
     homebrew:
-      casks: &base_osx_rust_tests_brew_casks
+      casks:
       - osxfuse
-
-py2_osx_rust_tests: &py2_osx_rust_tests
-  <<: *base_osx_rust_tests
-  <<: *py2_osx_test_config
-  name: "OSX Rust + platform-specific tests (Py2 PEX)"
   env:
-    - *py2_osx_test_config_env
-    - CACHE_NAME=macosrusttests.py2
+    - CACHE_NAME=macosrusttests
   script:
-    - ./build-support/bin/travis-ci.sh -bez2
-
-py3_osx_rust_tests: &py3_osx_rust_tests
-  <<: *base_osx_rust_tests
-  <<: *py3_osx_test_config
-  name: "OSX Rust + platform-specific tests (Py3 PEX)"
-  env:
-    - *py3_osx_test_config_env
-    - CACHE_NAME=macosrusttests.py3
-  addons:
-    homebrew:
-      packages: *py3_osx_config_brew_packages
-      casks: *base_osx_rust_tests_brew_casks
-  script:
-    - ./build-support/bin/travis-ci.sh -bez
+    - ./build-support/bin/travis-ci.sh -be
 
 # -------------------------------------------------------------------------
 # Rust audits
@@ -975,12 +979,13 @@ matrix:
         - ./build-support/bin/travis-ci.sh -bc2 -i 19/20
 
 
-    - <<: *linux_rust_tests
-
     # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
-    - <<: *py2_osx_rust_tests
+    - <<: *py2_osx_platform_tests
       stage: *test
-    # - <<: *py3_osx_rust_tests
+    # - <<: *py3_osx_platform_tests
+
+    - <<: *linux_rust_tests
+    - <<: *osx_rust_tests
 
     - <<: *linux_rust_clippy
     - <<: *cargo_audit

--- a/.travis.yml
+++ b/.travis.yml
@@ -550,10 +550,13 @@ osx_rust_tests: &osx_rust_tests
   osx_image: xcode8.3
   name: "OSX Rust tests (No PEX)"
   stage: *bootstrap
+  language: generic
   # N.B. Travis's brew addon has a bug where it will skip installing if the section `before_install` is 
   # not present. So we add `before_install` with a no-op.
   # See https://travis-ci.community/t/homebrew-addon-does-not-work-if-before-install-step-is-skipped/1564
   before_install:
+    - echo ''
+  before_script:
     - echo ''
   addons:
     homebrew:

--- a/.travis.yml
+++ b/.travis.yml
@@ -527,7 +527,14 @@ py3_osx_platform_tests: &py3_osx_platform_tests
 # Rust tests
 # -------------------------------------------------------------------------
 
+base_rust_tests: &base_rust_tests
+  stage: *test
+  before_script:
+    - ulimit -c unlimited
+    - ulimit -n 8192
+
 linux_rust_tests: &linux_rust_tests
+  <<: *base_rust_tests
   <<: *linux_with_fuse
   <<: *native_engine_cache_config
   name: "Linux Rust tests (No PEX)"
@@ -538,25 +545,21 @@ linux_rust_tests: &linux_rust_tests
   sudo: required
   language: python
   python: *python3_version
-  stage: *test
-  before_script:
-    - ulimit -c unlimited
-    - ulimit -n 8192
   script:
     - ./build-support/bin/travis-ci.sh -be
 
 osx_rust_tests: &osx_rust_tests
+  <<: *base_rust_tests
+  name: "OSX Rust tests (No PEX)"
+  env:
+    - CACHE_NAME=macosrusttests
   os: osx
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3
-  name: "OSX Rust tests (No PEX)"
-  stage: *test
   addons:
     homebrew:
       casks:
       - osxfuse
-  env:
-    - CACHE_NAME=macosrusttests
   script:
     - ./build-support/bin/travis-ci.sh -be
 

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -529,6 +529,11 @@ osx_rust_tests: &osx_rust_tests
   osx_image: xcode8.3
   name: "OSX Rust tests (No PEX)"
   stage: *test
+  # N.B. Travis's brew addon has a bug where it will skip installing if the section `before_install` is 
+  # not present. So we add `before_install` with a no-op.
+  # See https://travis-ci.community/t/homebrew-addon-does-not-work-if-before-install-step-is-skipped/1564
+  before_install:
+    - :
   addons:
     homebrew:
       casks:

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -507,6 +507,7 @@ py3_osx_platform_tests: &py3_osx_platform_tests
 # -------------------------------------------------------------------------
 
 base_rust_tests: &base_rust_tests
+  <<: *native_engine_cache_config
   stage: *test
   before_script:
     - ulimit -c unlimited
@@ -515,7 +516,6 @@ base_rust_tests: &base_rust_tests
 linux_rust_tests: &linux_rust_tests
   <<: *base_rust_tests
   <<: *linux_with_fuse
-  <<: *native_engine_cache_config
   name: "Linux Rust tests (No PEX)"
   env:
     - CACHE_NAME=linuxrusttests

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -533,7 +533,7 @@ osx_rust_tests: &osx_rust_tests
   # not present. So we add `before_install` with a no-op.
   # See https://travis-ci.community/t/homebrew-addon-does-not-work-if-before-install-step-is-skipped/1564
   before_install:
-    - :
+    - echo ''
   addons:
     homebrew:
       casks:

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -20,7 +20,7 @@ env:
 stages:
   - &bootstrap Bootstrap Pants
   - name: &test Test Pants
-    if: type != cron
+    if: type == cron
   - name: &cron Cron
     if: type = cron
   - name: &build_stable Deploy Pants Pex
@@ -212,7 +212,7 @@ linux_with_fuse: &linux_with_fuse
 
 base_linux_build_engine: &base_linux_build_engine
   <<: *native_engine_cache_config
-  stage: *bootstrap
+  stage: *test
   services:
     - docker
   env:
@@ -259,7 +259,7 @@ py3_linux_build_engine: &py3_linux_build_engine
 
 base_osx_build_engine: &base_osx_build_engine
   <<: *native_engine_cache_config
-  stage: *bootstrap
+  stage: *test
   # We request the oldest image we can (corresponding to OSX 10.11) for maximum compatibility.
   # We use 10.11 as a minimum to avoid https://github.com/rust-lang/regex/issues/489.
   # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
@@ -528,7 +528,7 @@ osx_rust_tests: &osx_rust_tests
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3
   name: "OSX Rust tests (No PEX)"
-  stage: *test
+  stage: *bootstrap
   # N.B. Travis's brew addon has a bug where it will skip installing if the section `before_install` is 
   # not present. So we add `before_install` with a no-op.
   # See https://travis-ci.community/t/homebrew-addon-does-not-work-if-before-install-step-is-skipped/1564

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -506,7 +506,14 @@ py3_osx_platform_tests: &py3_osx_platform_tests
 # Rust tests
 # -------------------------------------------------------------------------
 
+base_rust_tests: &base_rust_tests
+  stage: *test
+  before_script:
+    - ulimit -c unlimited
+    - ulimit -n 8192
+
 linux_rust_tests: &linux_rust_tests
+  <<: *base_rust_tests
   <<: *linux_with_fuse
   <<: *native_engine_cache_config
   name: "Linux Rust tests (No PEX)"
@@ -517,25 +524,21 @@ linux_rust_tests: &linux_rust_tests
   sudo: required
   language: python
   python: *python3_version
-  stage: *test
-  before_script:
-    - ulimit -c unlimited
-    - ulimit -n 8192
   script:
     - ./build-support/bin/travis-ci.sh -be
 
 osx_rust_tests: &osx_rust_tests
+  <<: *base_rust_tests
+  name: "OSX Rust tests (No PEX)"
+  env:
+    - CACHE_NAME=macosrusttests
   os: osx
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3
-  name: "OSX Rust tests (No PEX)"
-  stage: *test
   addons:
     homebrew:
       casks:
       - osxfuse
-  env:
-    - CACHE_NAME=macosrusttests
   script:
     - ./build-support/bin/travis-ci.sh -be
 

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -394,26 +394,23 @@ py3_osx_10_13_sanity_check: &py3_osx_10_13_sanity_check
 # Lint
 # -------------------------------------------------------------------------
 
-base_lint: &base_lint
-  <<: *linux_with_fuse
-  script:
-    - ./build-support/bin/travis-ci.sh -fbmrjt
-
 py2_lint: &py2_lint
   <<: *py2_linux_test_config
-  <<: *base_lint
-  name: "Self-checks, lint, and JVM tests (Py2 PEX)"
+  name: "Self-checks and lint (Py2 PEX)"
   env:
     - *py2_linux_test_config_env
     - CACHE_NAME=linuxselfchecks.py2
+  script:
+    - ./build-support/bin/travis-ci.sh -fbmrt2
 
 py3_lint: &py3_lint
   <<: *py3_linux_test_config
-  <<: *base_lint
-  name: "Self-checks, lint, and JVM tests (Py3 PEX)"
+  name: "Self-checks and lint (Py3 PEX)"
   env:
     - *py3_linux_test_config_env
     - CACHE_NAME=linuxselfchecks.py3
+  script:
+    - ./build-support/bin/travis-ci.sh -fbmrt
 
 # -------------------------------------------------------------------------
 # Deploy
@@ -455,6 +452,33 @@ deploy_unstable_multiplatform_pex: &deploy_unstable_multiplatform_pex
     - PREPARE_DEPLOY=1
   script:
     - ./build-support/bin/release.sh -p && mkdir -p dist/deploy/pex/ && mv dist/pants*.pex dist/deploy/pex/
+
+# -------------------------------------------------------------------------
+# JVM tests
+# -------------------------------------------------------------------------
+
+base_jvm_tests: &base_jvm_tests
+  <<: *linux_with_fuse
+
+py2_jvm_tests: &py2_jvm_tests
+  <<: *py2_linux_test_config
+  <<: *base_jvm_tests
+  name: "JVM tests (Py2 PEX)"
+  env:
+    - *py2_linux_test_config_env
+    - CACHE_NAME=linuxjvmtests.py2
+  script:
+    - ./build-support/bin/travis-ci.sh -bj2
+
+py3_jvm_tests: &py3_jvm_tests
+  <<: *py3_linux_test_config
+  <<: *base_jvm_tests
+  name: "JVM tests (Py3 PEX)"
+  env:
+    - *py3_linux_test_config_env
+    - CACHE_NAME=linuxjvmtests.py3
+  script:
+    - ./build-support/bin/travis-ci.sh -bj
 
 # -------------------------------------------------------------------------
 # Platform specific tests
@@ -581,10 +605,7 @@ matrix:
     - <<: *deploy_unstable_multiplatform_pex
 
     - <<: *py2_lint
-      stage: *test
-    # TODO: lint shard fails with Py3 pex (see https://travis-ci.org/pantsbuild/pants/jobs/478884818#L3355)
-    # Temporarily use Py2 pex and fix this in a later PR.
-    # - <<: *py3_lint
+    - <<: *py3_lint
 
     - <<: *py2_linux_test_config
       name: "Unit tests for pants and pants-plugins (Py2 PEX)"
@@ -655,6 +676,11 @@ matrix:
         - ./build-support/bin/travis-ci.sh -bc2 -i {{.}}/{{cron_integration_shards_length}}
 
 {{/cron_integration_shards}}
+
+    # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
+    - <<: *py2_jvm_tests
+      stage: *test
+    # - <<: *py3_jvm_tests
 
     # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
     - <<: *py2_osx_platform_tests

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -604,8 +604,11 @@ matrix:
     - <<: *deploy_stable_multiplatform_pex
     - <<: *deploy_unstable_multiplatform_pex
 
+    # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
+    # May be completely fixed by https://github.com/pantsbuild/pants/pull/7067..
     - <<: *py2_lint
-    - <<: *py3_lint
+      stage: *test
+    # - <<: *py3_lint
 
     - <<: *py2_linux_test_config
       name: "Unit tests for pants and pants-plugins (Py2 PEX)"

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -457,6 +457,28 @@ deploy_unstable_multiplatform_pex: &deploy_unstable_multiplatform_pex
     - ./build-support/bin/release.sh -p && mkdir -p dist/deploy/pex/ && mv dist/pants*.pex dist/deploy/pex/
 
 # -------------------------------------------------------------------------
+# Platform specific tests
+# -------------------------------------------------------------------------
+
+py2_osx_platform_tests: &py2_osx_platform_tests
+  <<: *py2_osx_test_config
+  name: "OSX platform-specific tests (Py2 PEX)"
+  env:
+    - *py2_osx_test_config_env
+    - CACHE_NAME=macosplatformtests.py2
+  script:
+    - ./build-support/bin/travis-ci.sh -bz2
+
+py3_osx_platform_tests: &py3_osx_platform_tests
+  <<: *py3_osx_test_config
+  name: "OSX platform-specific tests (Py3 PEX)"
+  env:
+    - *py3_osx_test_config_env
+    - CACHE_NAME=macosplatformtests.py3
+  script:
+    - ./build-support/bin/travis-ci.sh -bz
+
+# -------------------------------------------------------------------------
 # Rust tests
 # -------------------------------------------------------------------------
 
@@ -478,37 +500,19 @@ linux_rust_tests: &linux_rust_tests
   script:
     - ./build-support/bin/travis-ci.sh -be
 
-base_osx_rust_tests: &base_osx_rust_tests
+osx_rust_tests: &osx_rust_tests
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3
+  name: "OSX Rust tests (No PEX)"
+  stage: *test
   addons:
     homebrew:
-      casks: &base_osx_rust_tests_brew_casks
+      casks:
       - osxfuse
-
-py2_osx_rust_tests: &py2_osx_rust_tests
-  <<: *base_osx_rust_tests
-  <<: *py2_osx_test_config
-  name: "OSX Rust + platform-specific tests (Py2 PEX)"
   env:
-    - *py2_osx_test_config_env
-    - CACHE_NAME=macosrusttests.py2
+    - CACHE_NAME=macosrusttests
   script:
-    - ./build-support/bin/travis-ci.sh -bez2
-
-py3_osx_rust_tests: &py3_osx_rust_tests
-  <<: *base_osx_rust_tests
-  <<: *py3_osx_test_config
-  name: "OSX Rust + platform-specific tests (Py3 PEX)"
-  env:
-    - *py3_osx_test_config_env
-    - CACHE_NAME=macosrusttests.py3
-  addons:
-    homebrew:
-      packages: *py3_osx_config_brew_packages
-      casks: *base_osx_rust_tests_brew_casks
-  script:
-    - ./build-support/bin/travis-ci.sh -bez
+    - ./build-support/bin/travis-ci.sh -be
 
 # -------------------------------------------------------------------------
 # Rust audits
@@ -652,12 +656,13 @@ matrix:
 
 {{/cron_integration_shards}}
 
-    - <<: *linux_rust_tests
-
     # TODO: get this to pass using Python 3. In the meantime, just use Python 2.
-    - <<: *py2_osx_rust_tests
+    - <<: *py2_osx_platform_tests
       stage: *test
-    # - <<: *py3_osx_rust_tests
+    # - <<: *py3_osx_platform_tests
+
+    - <<: *linux_rust_tests
+    - <<: *osx_rust_tests
 
     - <<: *linux_rust_clippy
     - <<: *cargo_audit

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -525,18 +525,11 @@ linux_rust_tests: &linux_rust_tests
     - ./build-support/bin/travis-ci.sh -be
 
 osx_rust_tests: &osx_rust_tests
+  os: osx
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3
   name: "OSX Rust tests (No PEX)"
   stage: *bootstrap
-  language: generic
-  # N.B. Travis's brew addon has a bug where it will skip installing if the section `before_install` is 
-  # not present. So we add `before_install` with a no-op.
-  # See https://travis-ci.community/t/homebrew-addon-does-not-work-if-before-install-step-is-skipped/1564
-  before_install:
-    - echo ''
-  before_script:
-    - echo ''
   addons:
     homebrew:
       casks:

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -529,10 +529,13 @@ osx_rust_tests: &osx_rust_tests
   osx_image: xcode8.3
   name: "OSX Rust tests (No PEX)"
   stage: *bootstrap
+  language: generic
   # N.B. Travis's brew addon has a bug where it will skip installing if the section `before_install` is 
   # not present. So we add `before_install` with a no-op.
   # See https://travis-ci.community/t/homebrew-addon-does-not-work-if-before-install-step-is-skipped/1564
   before_install:
+    - echo ''
+  before_script:
     - echo ''
   addons:
     homebrew:

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -20,7 +20,7 @@ env:
 stages:
   - &bootstrap Bootstrap Pants
   - name: &test Test Pants
-    if: type == cron
+    if: type != cron
   - name: &cron Cron
     if: type = cron
   - name: &build_stable Deploy Pants Pex
@@ -212,7 +212,7 @@ linux_with_fuse: &linux_with_fuse
 
 base_linux_build_engine: &base_linux_build_engine
   <<: *native_engine_cache_config
-  stage: *test
+  stage: *bootstrap
   services:
     - docker
   env:
@@ -259,7 +259,7 @@ py3_linux_build_engine: &py3_linux_build_engine
 
 base_osx_build_engine: &base_osx_build_engine
   <<: *native_engine_cache_config
-  stage: *test
+  stage: *bootstrap
   # We request the oldest image we can (corresponding to OSX 10.11) for maximum compatibility.
   # We use 10.11 as a minimum to avoid https://github.com/rust-lang/regex/issues/489.
   # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
@@ -529,7 +529,7 @@ osx_rust_tests: &osx_rust_tests
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3
   name: "OSX Rust tests (No PEX)"
-  stage: *bootstrap
+  stage: *test
   addons:
     homebrew:
       casks:


### PR DESCRIPTION
Prior to #7047 and #7012, a significant portion of CI was spent on repeatedly bootstrapping Pants. So, we combined some jobs that did not have much logical connection in order to save CI time.

In general, it is acceptable to combine unrelated jobs into the same shard when there are benefits, as it does still avoid some shard startup cost. 

Here, however, we get some benefits from splitting these two shards into four.

* "Lint, self-checks, and JVM tests" -> "Lint and self checks" + "JVM tests"
    - Lint fails more quickly. This is one of the shards most likely to fail, so we want to surface the failure quickly. Meanwhile, we do not often modify JVM code, so JVM tests are far less likely to fail from the average PR.
   - Allows us to move JVM tests later in the CI run, as again they are less likely to fail from the average PR.
* "OSX Rust + platform-specific tests" -> "OSX Rust tests" + "OSX platform specific tests"
   - Allows us to mark "OSX Rust tests" as no pex, which saves some CI time by not installing `aws-cli` and simplifies `.travis.yml` to not need `py2` and `py3` variants of the shard.
   - Allows us to extract a common `base_rust_tests` config between `linux_rust_tests` and osx_rust_tests`.
   - Thanks to the extracted `base_rust_tests`, we now setup `native_engine_cache` for the `osx_rust_tests` shard, which we did not have before. This caches the rust bootstrap.