### PR TITLE
Hotfix for #6981 breaking release.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ stages:
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable
+    if: tag IS NOT present AND type NOT IN (pull_request, cron)
 
 # -------------------------------------------------------------------------
 # Cache config

--- a/.travis.yml
+++ b/.travis.yml
@@ -320,6 +320,7 @@ py3_osx_build_engine: &py3_osx_build_engine
 # -------------------------------------------------------------------------
 
 base_build_wheels: &base_build_wheels
+  stage: *test
   env:
     - &base_build_wheels_env RUN_PANTS_FROM_PEX=1 PREPARE_DEPLOY=1
   script:
@@ -338,7 +339,6 @@ osx_build_wheels: &osx_build_wheels
   <<: *py2_osx_test_config
   <<: *base_build_wheels
   name: "Build OSX wheels (No PEX)"
-  stage: *test
   osx_image: xcode8
   env:
     - *py2_osx_test_config_env

--- a/.travis.yml
+++ b/.travis.yml
@@ -255,7 +255,7 @@ base_linux_build_engine: &base_linux_build_engine
       -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest
       sh -c "./build-support/bin/ci.sh ${BOOTSTRAP_ARGS} && ./build-support/bin/release.sh -f"
-    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.linux
 
 py2_linux_build_engine: &py2_linux_build_engine
   <<: *py2_linux_config
@@ -290,7 +290,7 @@ base_osx_build_engine: &base_osx_build_engine
     # With no args ci.sh just bootstraps a pants.pex. We also build fs_util, to take advantage
     # of the rust code built during bootstrapping.
     - ./build-support/bin/ci.sh ${BOOTSTRAP_ARGS} && ./build-support/bin/release.sh -f
-    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.osx
   after_failure:
     - ./build-support/bin/ci-failure.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,12 @@ env:
 stages:
   - &bootstrap Bootstrap Pants
   - name: &test Test Pants
-    if: type != cron
+    if: type == cron
   - name: &cron Cron
     if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable
-    if: tag IS NOT present AND type NOT IN (pull_request, cron)
 
 # -------------------------------------------------------------------------
 # Cache config
@@ -474,6 +473,7 @@ deploy_unstable_multiplatform_pex: &deploy_unstable_multiplatform_pex
     - CACHE_NAME=linuxpexdeployunstable
     - RUN_PANTS_FROM_PEX=1
     - PREPARE_DEPLOY=1
+    - PEX_VERBOSE=9
   script:
     - ./build-support/bin/release.sh -p && mkdir -p dist/deploy/pex/ && mv dist/pants*.pex dist/deploy/pex/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -255,7 +255,7 @@ base_linux_build_engine: &base_linux_build_engine
       -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest
       sh -c "./build-support/bin/ci.sh ${BOOTSTRAP_ARGS} && ./build-support/bin/release.sh -f"
-    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.linux
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
 
 py2_linux_build_engine: &py2_linux_build_engine
   <<: *py2_linux_config
@@ -290,7 +290,7 @@ base_osx_build_engine: &base_osx_build_engine
     # With no args ci.sh just bootstraps a pants.pex. We also build fs_util, to take advantage
     # of the rust code built during bootstrapping.
     - ./build-support/bin/ci.sh ${BOOTSTRAP_ARGS} && ./build-support/bin/release.sh -f
-    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.osx
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
   after_failure:
     - ./build-support/bin/ci-failure.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -976,4 +976,6 @@ deploy:
     condition: $PREPARE_DEPLOY = 1
     # NB: We mainly want deploys for `master` commits; but we also need new binaries for stable
     # release branches; eg `1.3.x`
+    all_branches: true
+    repo: pantsbuild/pants
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -325,41 +325,25 @@ base_build_wheels: &base_build_wheels
   script:
     - ./build-support/bin/release.sh -n
 
-py2_linux_build_wheels: &py2_linux_build_wheels
+linux_build_wheels: &linux_build_wheels
   <<: *py2_linux_test_config
   <<: *base_build_wheels
-  name: "Build Linux wheels (Py2 PEX)"
+  name: "Build Linux wheels (No PEX)"
   env:
     - *py2_linux_test_config_env
     - *base_build_wheels_env
-    - CACHE_NAME=linuxwheelsbuild.py2
+    - CACHE_NAME=linuxwheelsbuild
 
-py3_linux_build_wheels: &py3_linux_build_wheels
-  <<: *py3_linux_test_config
-  <<: *base_build_wheels
-  name: "Build Linux wheels (Py3 PEX)"
-  env:
-    - *py3_linux_test_config_env
-    - *base_build_wheels_env
-    - CACHE_NAME=linuxwheelsbuild.py3
-
-py2_osx_build_wheels: &py2_osx_build_wheels
+osx_build_wheels: &osx_build_wheels
   <<: *py2_osx_test_config
   <<: *base_build_wheels
-  name: "Build OSX wheels (Py2 PEX)"
+  name: "Build OSX wheels (No PEX)"
+  stage: *test
+  osx_image: xcode8
   env:
     - *py2_osx_test_config_env
     - *base_build_wheels_env
-    - CACHE_NAME=osxwheelsbuild.py2
-
-py3_osx_build_wheels: &py3_osx_build_wheels
-  <<: *py3_osx_test_config
-  <<: *base_build_wheels
-  name: "Build OSX wheels (Py3 PEX)"
-  env:
-    - *py3_osx_test_config_env
-    - *base_build_wheels_env
-    - CACHE_NAME=osxwheelsbuild.py3
+    - CACHE_NAME=osxwheelsbuild
 
 # -------------------------------------------------------------------------
 # OSX sanity checks
@@ -577,16 +561,8 @@ matrix:
     - <<: *py2_osx_build_engine
     - <<: *py3_osx_build_engine
 
-    # TODO(6450): add support for Py3 in the release script. This can't be done until
-    # Pants is ready to be built and released as a Py3 wheel.
-    - <<: *py2_linux_build_wheels
-      stage: *test
-    # - <<: *py3_linux_build_wheels
-
-    # TODO(6450): see above about adding support for Py3 in release script.
-    - <<: *py2_osx_build_wheels
-      stage: *test
-    # - <<: *py3_osx_build_wheels
+    - <<: *linux_build_wheels
+    - <<: *osx_build_wheels
 
     - <<: *py2_osx_10_12_sanity_check
     - <<: *py3_osx_10_12_sanity_check

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ stages:
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable
-    if: tag IS NOT present AND type NOT IN (pull_request, cron)
 
 # -------------------------------------------------------------------------
 # Cache config

--- a/.travis.yml
+++ b/.travis.yml
@@ -976,6 +976,4 @@ deploy:
     condition: $PREPARE_DEPLOY = 1
     # NB: We mainly want deploys for `master` commits; but we also need new binaries for stable
     # release branches; eg `1.3.x`
-    all_branches: true
-    repo: pantsbuild/pants
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,13 @@ env:
 stages:
   - &bootstrap Bootstrap Pants
   - name: &test Test Pants
-    if: type == cron
+    if: type != cron
   - name: &cron Cron
     if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable
+    if: tag IS NOT present AND type NOT IN (pull_request, cron)
 
 # -------------------------------------------------------------------------
 # Cache config
@@ -457,7 +458,6 @@ deploy_unstable_multiplatform_pex: &deploy_unstable_multiplatform_pex
     - CACHE_NAME=linuxpexdeployunstable
     - RUN_PANTS_FROM_PEX=1
     - PREPARE_DEPLOY=1
-    - PEX_VERBOSE=9
   script:
     - ./build-support/bin/release.sh -p && mkdir -p dist/deploy/pex/ && mv dist/pants*.pex dist/deploy/pex/
 

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -2,7 +2,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-set -e
+set -ex
 
 ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
 source ${ROOT}/build-support/common.sh

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -2,7 +2,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-set -ex
+set -e
 
 ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
 source ${ROOT}/build-support/common.sh

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -26,7 +26,6 @@ stages:
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable
-    if: tag IS NOT present AND type NOT IN (pull_request, cron)
 
 # -------------------------------------------------------------------------
 # Cache config

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -234,7 +234,7 @@ base_linux_build_engine: &base_linux_build_engine
       -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest
       sh -c "./build-support/bin/ci.sh ${BOOTSTRAP_ARGS} && ./build-support/bin/release.sh -f"
-    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.linux
 
 py2_linux_build_engine: &py2_linux_build_engine
   <<: *py2_linux_config
@@ -269,7 +269,7 @@ base_osx_build_engine: &base_osx_build_engine
     # With no args ci.sh just bootstraps a pants.pex. We also build fs_util, to take advantage
     # of the rust code built during bootstrapping.
     - ./build-support/bin/ci.sh ${BOOTSTRAP_ARGS} && ./build-support/bin/release.sh -f
-    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.osx
   after_failure:
     - ./build-support/bin/ci-failure.sh
 
@@ -452,6 +452,7 @@ deploy_unstable_multiplatform_pex: &deploy_unstable_multiplatform_pex
     - CACHE_NAME=linuxpexdeployunstable
     - RUN_PANTS_FROM_PEX=1
     - PREPARE_DEPLOY=1
+    - PEX_VERBOSE=9
   script:
     - ./build-support/bin/release.sh -p && mkdir -p dist/deploy/pex/ && mv dist/pants*.pex dist/deploy/pex/
 

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -20,12 +20,13 @@ env:
 stages:
   - &bootstrap Bootstrap Pants
   - name: &test Test Pants
-    if: type == cron
+    if: type != cron
   - name: &cron Cron
     if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable
+    if: tag IS NOT present AND type NOT IN (pull_request, cron)
 
 # -------------------------------------------------------------------------
 # Cache config

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -20,13 +20,12 @@ env:
 stages:
   - &bootstrap Bootstrap Pants
   - name: &test Test Pants
-    if: type != cron
+    if: type == cron
   - name: &cron Cron
     if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable
-    if: tag IS NOT present AND type NOT IN (pull_request, cron)
 
 # -------------------------------------------------------------------------
 # Cache config

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -26,6 +26,7 @@ stages:
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable
+    if: tag IS NOT present AND type NOT IN (pull_request, cron)
 
 # -------------------------------------------------------------------------
 # Cache config

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -299,6 +299,7 @@ py3_osx_build_engine: &py3_osx_build_engine
 # -------------------------------------------------------------------------
 
 base_build_wheels: &base_build_wheels
+  stage: *test
   env:
     - &base_build_wheels_env RUN_PANTS_FROM_PEX=1 PREPARE_DEPLOY=1
   script:
@@ -317,7 +318,6 @@ osx_build_wheels: &osx_build_wheels
   <<: *py2_osx_test_config
   <<: *base_build_wheels
   name: "Build OSX wheels (No PEX)"
-  stage: *test
   osx_image: xcode8
   env:
     - *py2_osx_test_config_env

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -653,3 +653,5 @@ deploy:
     condition: $PREPARE_DEPLOY = 1
     # NB: We mainly want deploys for `master` commits; but we also need new binaries for stable
     # release branches; eg `1.3.x`
+    all_branches: true
+    repo: pantsbuild/pants

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -234,7 +234,7 @@ base_linux_build_engine: &base_linux_build_engine
       -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest
       sh -c "./build-support/bin/ci.sh ${BOOTSTRAP_ARGS} && ./build-support/bin/release.sh -f"
-    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.linux
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
 
 py2_linux_build_engine: &py2_linux_build_engine
   <<: *py2_linux_config
@@ -269,7 +269,7 @@ base_osx_build_engine: &base_osx_build_engine
     # With no args ci.sh just bootstraps a pants.pex. We also build fs_util, to take advantage
     # of the rust code built during bootstrapping.
     - ./build-support/bin/ci.sh ${BOOTSTRAP_ARGS} && ./build-support/bin/release.sh -f
-    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.osx
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
   after_failure:
     - ./build-support/bin/ci-failure.sh
 
@@ -436,7 +436,6 @@ deploy_unstable_multiplatform_pex: &deploy_unstable_multiplatform_pex
     - CACHE_NAME=linuxpexdeployunstable
     - RUN_PANTS_FROM_PEX=1
     - PREPARE_DEPLOY=1
-    - PEX_VERBOSE=9
   script:
     - ./build-support/bin/release.sh -p && mkdir -p dist/deploy/pex/ && mv dist/pants*.pex dist/deploy/pex/
 

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -653,5 +653,3 @@ deploy:
     condition: $PREPARE_DEPLOY = 1
     # NB: We mainly want deploys for `master` commits; but we also need new binaries for stable
     # release branches; eg `1.3.x`
-    all_branches: true
-    repo: pantsbuild/pants

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -304,41 +304,25 @@ base_build_wheels: &base_build_wheels
   script:
     - ./build-support/bin/release.sh -n
 
-py2_linux_build_wheels: &py2_linux_build_wheels
+linux_build_wheels: &linux_build_wheels
   <<: *py2_linux_test_config
   <<: *base_build_wheels
-  name: "Build Linux wheels (Py2 PEX)"
+  name: "Build Linux wheels (No PEX)"
   env:
     - *py2_linux_test_config_env
     - *base_build_wheels_env
-    - CACHE_NAME=linuxwheelsbuild.py2
+    - CACHE_NAME=linuxwheelsbuild
 
-py3_linux_build_wheels: &py3_linux_build_wheels
-  <<: *py3_linux_test_config
-  <<: *base_build_wheels
-  name: "Build Linux wheels (Py3 PEX)"
-  env:
-    - *py3_linux_test_config_env
-    - *base_build_wheels_env
-    - CACHE_NAME=linuxwheelsbuild.py3
-
-py2_osx_build_wheels: &py2_osx_build_wheels
+osx_build_wheels: &osx_build_wheels
   <<: *py2_osx_test_config
   <<: *base_build_wheels
-  name: "Build OSX wheels (Py2 PEX)"
+  name: "Build OSX wheels (No PEX)"
+  stage: *test
+  osx_image: xcode8
   env:
     - *py2_osx_test_config_env
     - *base_build_wheels_env
-    - CACHE_NAME=osxwheelsbuild.py2
-
-py3_osx_build_wheels: &py3_osx_build_wheels
-  <<: *py3_osx_test_config
-  <<: *base_build_wheels
-  name: "Build OSX wheels (Py3 PEX)"
-  env:
-    - *py3_osx_test_config_env
-    - *base_build_wheels_env
-    - CACHE_NAME=osxwheelsbuild.py3
+    - CACHE_NAME=osxwheelsbuild
 
 # -------------------------------------------------------------------------
 # OSX sanity checks
@@ -556,16 +540,8 @@ matrix:
     - <<: *py2_osx_build_engine
     - <<: *py3_osx_build_engine
 
-    # TODO(6450): add support for Py3 in the release script. This can't be done until
-    # Pants is ready to be built and released as a Py3 wheel.
-    - <<: *py2_linux_build_wheels
-      stage: *test
-    # - <<: *py3_linux_build_wheels
-
-    # TODO(6450): see above about adding support for Py3 in release script.
-    - <<: *py2_osx_build_wheels
-      stage: *test
-    # - <<: *py3_osx_build_wheels
+    - <<: *linux_build_wheels
+    - <<: *osx_build_wheels
 
     - <<: *py2_osx_10_12_sanity_check
     - <<: *py3_osx_10_12_sanity_check


### PR DESCRIPTION
## Problem
#6981 led to the `Deploy unstable multiplatform pants.pex` shard failing consistently. The error can be reproduced locally via `./build-support/bin/release.sh -p`. The error message, however, is not very descriptive, even with `set -x` and `PANTS_VERBOSE=9`.

## Solution
The likely culprit is removing `osx_image: xcode8` from the `OSX build wheels` shard. We had this hardcoded before #7091 for a reason, and removing it is probably what messed things up. The removal was not intentional, merely an oversight.

Also, this changes the wheel shards to not have py2 vs py3 setups, as they don't use a PEX so the distinction is not meaningful at the moment.

## Result
The result *cannot* be verified until being merged into master. This is because Travis never allows the `deploy` stage to happen from pull requests, as it's a security concern.