### PR TITLE
Bump default Node.js to v10.13.0 and Yarnpkg to v1.12.3

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -34,7 +34,7 @@ class NodeDistribution(NativeTool):
 
   options_scope = 'node-distribution'
   name = 'node'
-  default_version = 'v8.11.3'
+  default_version = 'v10.13.0'
   archive_type = 'tgz'
 
   @classmethod

--- a/contrib/node/src/python/pants/contrib/node/subsystems/yarnpkg_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/yarnpkg_distribution.py
@@ -17,5 +17,5 @@ class YarnpkgDistribution(NativeTool):
 
   options_scope = 'yarnpkg-distribution'
   name = 'yarnpkg'
-  default_version = 'v1.6.0'
+  default_version = 'v1.12.3'
   archive_type = 'tgz'


### PR DESCRIPTION
This bump will have Pants default to the latest LTS Node.js, the same version now used at Twitter.