### PR TITLE
Deploy wheels from the py2 bootstrap shard for maximum compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -236,8 +236,6 @@ base_linux_build_engine: &base_linux_build_engine
   stage: *bootstrap
   services:
     - docker
-  env:
-    - &base_linux_build_engine_env PREPARE_DEPLOY=1  # To deploy fs_util.
   before_script:
     - ulimit -c unlimited
   script:
@@ -263,7 +261,10 @@ py2_linux_build_engine: &py2_linux_build_engine
   <<: *base_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py2 PEX)"
   env:
-    - *base_linux_build_engine_env
+    # NB: Only the Py2 shard sets PREPARE_DEPLOY to cause its release wheels and fs_util binary to
+    # be uploaded to S3. This needs to be the Py2 shard due to:
+    #   https://github.com/pantsbuild/pants/issues/6985
+    - PREPARE_DEPLOY=1
     - CACHE_NAME=linuxpexbuild.py2
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py2.linux
     - BOOTSTRAP_ARGS='-2'
@@ -273,7 +274,6 @@ py3_linux_build_engine: &py3_linux_build_engine
   <<: *base_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py3 PEX)"
   env:
-    - *base_linux_build_engine_env
     - CACHE_NAME=linuxpexbuild.py3
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py3.linux
     - BOOTSTRAP_ARGS=''
@@ -317,33 +317,38 @@ py3_osx_build_engine: &py3_osx_build_engine
     - BOOTSTRAP_ARGS=''
 
 # -------------------------------------------------------------------------
-# Build wheels
+# Test wheels
 # -------------------------------------------------------------------------
 
-base_build_wheels: &base_build_wheels
+base_test_wheels: &base_test_wheels
   stage: *test
   env:
-    - &base_build_wheels_env RUN_PANTS_FROM_PEX=1 PREPARE_DEPLOY=1
+    - &base_test_wheels_env RUN_PANTS_FROM_PEX=1
   script:
+    # Runs a dry run release to test that all wheels are installable.
+    #
+    # Note that these shards do not actually deploy the wheels to S3 via `PREPARE_DEPLOY`: that
+    # is accomplished in the bootstrap shardis, which necessarily build the wheels in order to
+    # build a pex.
     - ./build-support/bin/release.sh -n
 
-linux_build_wheels: &linux_build_wheels
+linux_test_wheels: &linux_test_wheels
   <<: *py2_linux_test_config
-  <<: *base_build_wheels
-  name: "Build Linux wheels (No PEX)"
+  <<: *base_test_wheels
+  name: "Test Linux wheels (No PEX)"
   env:
     - *py2_linux_test_config_env
-    - *base_build_wheels_env
+    - *base_test_wheels_env
     - CACHE_NAME=linuxwheelsbuild
 
-osx_build_wheels: &osx_build_wheels
+osx_test_wheels: &osx_test_wheels
   <<: *py2_osx_test_config
-  <<: *base_build_wheels
-  name: "Build OSX wheels (No PEX)"
+  <<: *base_test_wheels
+  name: "Test OSX wheels (No PEX)"
   osx_image: xcode8
   env:
     - *py2_osx_test_config_env
-    - *base_build_wheels_env
+    - *base_test_wheels_env
     - CACHE_NAME=osxwheelsbuild
 
 # -------------------------------------------------------------------------
@@ -593,8 +598,8 @@ matrix:
     - <<: *py2_osx_build_engine
     - <<: *py3_osx_build_engine
 
-    - <<: *linux_build_wheels
-    - <<: *osx_build_wheels
+    - <<: *linux_test_wheels
+    - <<: *osx_test_wheels
 
     - <<: *py2_osx_10_12_sanity_check
     - <<: *py3_osx_10_12_sanity_check

--- a/.travis.yml
+++ b/.travis.yml
@@ -328,7 +328,7 @@ base_test_wheels: &base_test_wheels
     # Runs a dry run release to test that all wheels are installable.
     #
     # Note that these shards do not actually deploy the wheels to S3 via `PREPARE_DEPLOY`: that
-    # is accomplished in the bootstrap shardis, which necessarily build the wheels in order to
+    # is accomplished in the bootstrap shards, which necessarily build the wheels in order to
     # build a pex.
     - ./build-support/bin/release.sh -n
 

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -307,7 +307,7 @@ base_test_wheels: &base_test_wheels
     # Runs a dry run release to test that all wheels are installable.
     #
     # Note that these shards do not actually deploy the wheels to S3 via `PREPARE_DEPLOY`: that
-    # is accomplished in the bootstrap shardis, which necessarily build the wheels in order to
+    # is accomplished in the bootstrap shards, which necessarily build the wheels in order to
     # build a pex.
     - ./build-support/bin/release.sh -n
 

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -215,8 +215,6 @@ base_linux_build_engine: &base_linux_build_engine
   stage: *bootstrap
   services:
     - docker
-  env:
-    - &base_linux_build_engine_env PREPARE_DEPLOY=1  # To deploy fs_util.
   before_script:
     - ulimit -c unlimited
   script:
@@ -242,7 +240,10 @@ py2_linux_build_engine: &py2_linux_build_engine
   <<: *base_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py2 PEX)"
   env:
-    - *base_linux_build_engine_env
+    # NB: Only the Py2 shard sets PREPARE_DEPLOY to cause its release wheels and fs_util binary to
+    # be uploaded to S3. This needs to be the Py2 shard due to:
+    #   https://github.com/pantsbuild/pants/issues/6985
+    - PREPARE_DEPLOY=1
     - CACHE_NAME=linuxpexbuild.py2
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py2.linux
     - BOOTSTRAP_ARGS='-2'
@@ -252,7 +253,6 @@ py3_linux_build_engine: &py3_linux_build_engine
   <<: *base_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py3 PEX)"
   env:
-    - *base_linux_build_engine_env
     - CACHE_NAME=linuxpexbuild.py3
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py3.linux
     - BOOTSTRAP_ARGS=''
@@ -296,33 +296,38 @@ py3_osx_build_engine: &py3_osx_build_engine
     - BOOTSTRAP_ARGS=''
 
 # -------------------------------------------------------------------------
-# Build wheels
+# Test wheels
 # -------------------------------------------------------------------------
 
-base_build_wheels: &base_build_wheels
+base_test_wheels: &base_test_wheels
   stage: *test
   env:
-    - &base_build_wheels_env RUN_PANTS_FROM_PEX=1 PREPARE_DEPLOY=1
+    - &base_test_wheels_env RUN_PANTS_FROM_PEX=1
   script:
+    # Runs a dry run release to test that all wheels are installable.
+    #
+    # Note that these shards do not actually deploy the wheels to S3 via `PREPARE_DEPLOY`: that
+    # is accomplished in the bootstrap shardis, which necessarily build the wheels in order to
+    # build a pex.
     - ./build-support/bin/release.sh -n
 
-linux_build_wheels: &linux_build_wheels
+linux_test_wheels: &linux_test_wheels
   <<: *py2_linux_test_config
-  <<: *base_build_wheels
-  name: "Build Linux wheels (No PEX)"
+  <<: *base_test_wheels
+  name: "Test Linux wheels (No PEX)"
   env:
     - *py2_linux_test_config_env
-    - *base_build_wheels_env
+    - *base_test_wheels_env
     - CACHE_NAME=linuxwheelsbuild
 
-osx_build_wheels: &osx_build_wheels
+osx_test_wheels: &osx_test_wheels
   <<: *py2_osx_test_config
-  <<: *base_build_wheels
-  name: "Build OSX wheels (No PEX)"
+  <<: *base_test_wheels
+  name: "Test OSX wheels (No PEX)"
   osx_image: xcode8
   env:
     - *py2_osx_test_config_env
-    - *base_build_wheels_env
+    - *base_test_wheels_env
     - CACHE_NAME=osxwheelsbuild
 
 # -------------------------------------------------------------------------
@@ -572,8 +577,8 @@ matrix:
     - <<: *py2_osx_build_engine
     - <<: *py3_osx_build_engine
 
-    - <<: *linux_build_wheels
-    - <<: *osx_build_wheels
+    - <<: *linux_test_wheels
+    - <<: *osx_test_wheels
 
     - <<: *py2_osx_10_12_sanity_check
     - <<: *py3_osx_10_12_sanity_check


### PR DESCRIPTION
### Problem

Currently we're deploying wheels (via `PREPARE_DEPLOY`) from multiple shards, which results in multiple overwrites of those wheels. The last written copy of the wheels comes directly from the travis Ubuntu environment (rather that our Centos6 compatibility docker container). See #7086 for the result.

### Solution

Don't deploy from the "wheel building" shards, and rename them to "wheel test". Additionally, only deploy from the Py2 Linux bootstrap shard.

### Result

(Hopefully) fixes #7086.