### PR TITLE
Avoid ORing interpreter bounds by default

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -373,7 +373,7 @@ verify_commit: False
 # require Python 3.6+ to run Pants.
 # Note this does not mean client code has to use these specified versions, only that
 # an appropriate interpreter must be discoverable.
-interpreter_constraints: ["CPython>=2.7,<3","CPython>=3.6,<4"]
+interpreter_constraints: ["CPython>=2.7,<3"]
 interpreter_cache_dir: %(pants_bootstrapdir)s/python_cache/interpreters
 resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
 

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -26,10 +26,12 @@ class PythonSetup(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(PythonSetup, cls).register_options(register)
-    register('--interpreter-constraints', advanced=True, default=['CPython>=2.7,<3', 'CPython>=3.6,<4'], type=list,
+    # TODO: ORd bounds do not work in all situations, so this currently continues to constrain
+    # to Py2 by default. See https://github.com/pantsbuild/pants/issues/7097
+    register('--interpreter-constraints', advanced=True, default=['CPython>=2.7,<3'], type=list,
              metavar='<requirement>',
              help="Constrain the selected Python interpreter.  Specify with requirement syntax, "
-                  "e.g. 'CPython>=2.7,<3' (A CPython interpreter with version >=2.7 AND version <3)"
+                  "e.g. 'CPython>=2.7,<3' (A CPython interpreter with version >=2.7 AND version <3) "
                   "or 'PyPy' (A pypy interpreter of any version). Multiple constraint strings will "
                   "be ORed together. These constraints are applied in addition to any "
                   "compatibilities required by the relevant targets.")


### PR DESCRIPTION
### Problem

Currently, OR'd interpreter bounds do not have the intended affect on `./pants run`. See #7097 for more info.

### Solution

Revert the recent change intended to allow either 2 or 3 to be picked up as a default interpreter.

### Result

Users will not encounter #7097 unless they attempt to set this kind of bound explicitly.