### PR TITLE
Use docker on wheel builder shard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -227,24 +227,27 @@ linux_with_fuse: &linux_with_fuse
     - sudo chmod 666 /dev/fuse
     - sudo chown root:$USER /etc/fuse.conf
 
-# -------------------------------------------------------------------------
-# Bootstrap engine shards
-# -------------------------------------------------------------------------
-
-base_linux_build_engine: &base_linux_build_engine
-  <<: *native_engine_cache_config
-  stage: *bootstrap
+travis_docker_image: &travis_docker_image
   services:
     - docker
   before_script:
     - ulimit -c unlimited
-  script:
     - docker build --rm -t travis_ci
       --build-arg "TRAVIS_USER=$(id -un)"
       --build-arg "TRAVIS_UID=$(id -u)"
       --build-arg "TRAVIS_GROUP=$(id -gn)"
       --build-arg "TRAVIS_GID=$(id -g)"
       build-support/docker/travis_ci/
+
+# -------------------------------------------------------------------------
+# Bootstrap engine shards
+# -------------------------------------------------------------------------
+
+base_linux_build_engine: &base_linux_build_engine
+  <<: *native_engine_cache_config
+  <<: *travis_docker_image
+  stage: *bootstrap
+  script:
     # Note that:
     # * We mount ${HOME} to cache the ${HOME}/.cache/pants/rust-toolchain.
     # * With no args ci.sh just bootstraps a pants.pex.
@@ -316,39 +319,43 @@ py3_osx_build_engine: &py3_osx_build_engine
     - BOOTSTRAP_ARGS=''
 
 # -------------------------------------------------------------------------
-# Test wheels
+# Build wheels
 # -------------------------------------------------------------------------
 
-base_test_wheels: &base_test_wheels
+base_build_wheels: &base_build_wheels
   stage: *test
   env:
-    - &base_test_wheels_env RUN_PANTS_FROM_PEX=1
-  script:
-    # Runs a dry run release to test that all wheels are installable.
-    #
-    # Note that these shards do not actually deploy the wheels to S3 via `PREPARE_DEPLOY`: that
-    # is accomplished in the bootstrap shards, which necessarily build the wheels in order to
-    # build a pex.
-    - ./build-support/bin/release.sh -n
+    - &base_build_wheels_env RUN_PANTS_FROM_PEX=1 PREPARE_DEPLOY=1
 
-linux_test_wheels: &linux_test_wheels
+linux_build_wheels: &linux_build_wheels
+  # Similar to the bootstrap shard, we build Linux wheels in a docker image to maximize
+  # compatibility. This is a Py2 shard, so it is not subject to #6985.
+  <<: *travis_docker_image
   <<: *py2_linux_test_config
-  <<: *base_test_wheels
-  name: "Test Linux wheels (No PEX)"
+  <<: *base_build_wheels
+  name: "Build Linux wheels (No PEX)"
   env:
     - *py2_linux_test_config_env
-    - *base_test_wheels_env
+    - *base_build_wheels_env
     - CACHE_NAME=linuxwheelsbuild
+  script:
+    - docker run --rm -t
+      -v "${HOME}:/travis/home"
+      -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest
+      sh -c "RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
 
-osx_test_wheels: &osx_test_wheels
+osx_build_wheels: &osx_build_wheels
   <<: *py2_osx_test_config
-  <<: *base_test_wheels
-  name: "Test OSX wheels (No PEX)"
+  <<: *base_build_wheels
+  name: "Build OSX wheels (No PEX)"
   osx_image: xcode8
   env:
     - *py2_osx_test_config_env
-    - *base_test_wheels_env
+    - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild
+  script:
+    - ./build-support/bin/release.sh -n
 
 # -------------------------------------------------------------------------
 # OSX sanity checks
@@ -597,8 +604,8 @@ matrix:
     - <<: *py2_osx_build_engine
     - <<: *py3_osx_build_engine
 
-    - <<: *linux_test_wheels
-    - <<: *osx_test_wheels
+    - <<: *linux_build_wheels
+    - <<: *osx_build_wheels
 
     - <<: *py2_osx_10_12_sanity_check
     - <<: *py3_osx_10_12_sanity_check

--- a/.travis.yml
+++ b/.travis.yml
@@ -232,7 +232,10 @@ travis_docker_image: &travis_docker_image
     - docker
   before_script:
     - ulimit -c unlimited
-    - docker build --rm -t travis_ci
+  script:
+    # NB: This script definition is very likely to be overridden in a consumer, so we alias it
+    # for re-inclusion.
+    - &travis_docker_image_launch docker build --rm -t travis_ci
       --build-arg "TRAVIS_USER=$(id -un)"
       --build-arg "TRAVIS_UID=$(id -u)"
       --build-arg "TRAVIS_GROUP=$(id -gn)"
@@ -248,6 +251,7 @@ base_linux_build_engine: &base_linux_build_engine
   <<: *travis_docker_image
   stage: *bootstrap
   script:
+    - *travis_docker_image_launch
     # Note that:
     # * We mount ${HOME} to cache the ${HOME}/.cache/pants/rust-toolchain.
     # * With no args ci.sh just bootstraps a pants.pex.
@@ -339,6 +343,7 @@ linux_build_wheels: &linux_build_wheels
     - *base_build_wheels_env
     - CACHE_NAME=linuxwheelsbuild
   script:
+    - *travis_docker_image_launch
     - docker run --rm -t
       -v "${HOME}:/travis/home"
       -v "${TRAVIS_BUILD_DIR}:/travis/workdir"

--- a/.travis.yml
+++ b/.travis.yml
@@ -236,8 +236,6 @@ base_linux_build_engine: &base_linux_build_engine
   stage: *bootstrap
   services:
     - docker
-  env:
-    - &base_linux_build_engine_env PREPARE_DEPLOY=1  # To deploy fs_util.
   before_script:
     - ulimit -c unlimited
   script:
@@ -263,7 +261,9 @@ py2_linux_build_engine: &py2_linux_build_engine
   <<: *base_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py2 PEX)"
   env:
-    - *base_linux_build_engine_env
+    # NB: Only the Py2 shard sets PREPARE_DEPLOY to cause the fs_util binary to be uploaded to S3:
+    # either linux shard could upload this binary, since it does not depend on python at all.
+    - PREPARE_DEPLOY=1
     - CACHE_NAME=linuxpexbuild.py2
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py2.linux
     - BOOTSTRAP_ARGS='-2'
@@ -273,7 +273,6 @@ py3_linux_build_engine: &py3_linux_build_engine
   <<: *base_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py3 PEX)"
   env:
-    - *base_linux_build_engine_env
     - CACHE_NAME=linuxpexbuild.py3
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py3.linux
     - BOOTSTRAP_ARGS=''
@@ -317,33 +316,38 @@ py3_osx_build_engine: &py3_osx_build_engine
     - BOOTSTRAP_ARGS=''
 
 # -------------------------------------------------------------------------
-# Build wheels
+# Test wheels
 # -------------------------------------------------------------------------
 
-base_build_wheels: &base_build_wheels
+base_test_wheels: &base_test_wheels
   stage: *test
   env:
-    - &base_build_wheels_env RUN_PANTS_FROM_PEX=1 PREPARE_DEPLOY=1
+    - &base_test_wheels_env RUN_PANTS_FROM_PEX=1
   script:
+    # Runs a dry run release to test that all wheels are installable.
+    #
+    # Note that these shards do not actually deploy the wheels to S3 via `PREPARE_DEPLOY`: that
+    # is accomplished in the bootstrap shards, which necessarily build the wheels in order to
+    # build a pex.
     - ./build-support/bin/release.sh -n
 
-linux_build_wheels: &linux_build_wheels
+linux_test_wheels: &linux_test_wheels
   <<: *py2_linux_test_config
-  <<: *base_build_wheels
-  name: "Build Linux wheels (No PEX)"
+  <<: *base_test_wheels
+  name: "Test Linux wheels (No PEX)"
   env:
     - *py2_linux_test_config_env
-    - *base_build_wheels_env
+    - *base_test_wheels_env
     - CACHE_NAME=linuxwheelsbuild
 
-osx_build_wheels: &osx_build_wheels
+osx_test_wheels: &osx_test_wheels
   <<: *py2_osx_test_config
-  <<: *base_build_wheels
-  name: "Build OSX wheels (No PEX)"
+  <<: *base_test_wheels
+  name: "Test OSX wheels (No PEX)"
   osx_image: xcode8
   env:
     - *py2_osx_test_config_env
-    - *base_build_wheels_env
+    - *base_test_wheels_env
     - CACHE_NAME=osxwheelsbuild
 
 # -------------------------------------------------------------------------
@@ -593,8 +597,8 @@ matrix:
     - <<: *py2_osx_build_engine
     - <<: *py3_osx_build_engine
 
-    - <<: *linux_build_wheels
-    - <<: *osx_build_wheels
+    - <<: *linux_test_wheels
+    - <<: *osx_test_wheels
 
     - <<: *py2_osx_10_12_sanity_check
     - <<: *py3_osx_10_12_sanity_check

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -215,8 +215,6 @@ base_linux_build_engine: &base_linux_build_engine
   stage: *bootstrap
   services:
     - docker
-  env:
-    - &base_linux_build_engine_env PREPARE_DEPLOY=1  # To deploy fs_util.
   before_script:
     - ulimit -c unlimited
   script:
@@ -242,7 +240,9 @@ py2_linux_build_engine: &py2_linux_build_engine
   <<: *base_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py2 PEX)"
   env:
-    - *base_linux_build_engine_env
+    # NB: Only the Py2 shard sets PREPARE_DEPLOY to cause the fs_util binary to be uploaded to S3:
+    # either linux shard could upload this binary, since it does not depend on python at all.
+    - PREPARE_DEPLOY=1
     - CACHE_NAME=linuxpexbuild.py2
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py2.linux
     - BOOTSTRAP_ARGS='-2'
@@ -252,7 +252,6 @@ py3_linux_build_engine: &py3_linux_build_engine
   <<: *base_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py3 PEX)"
   env:
-    - *base_linux_build_engine_env
     - CACHE_NAME=linuxpexbuild.py3
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py3.linux
     - BOOTSTRAP_ARGS=''

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -206,24 +206,27 @@ linux_with_fuse: &linux_with_fuse
     - sudo chmod 666 /dev/fuse
     - sudo chown root:$USER /etc/fuse.conf
 
-# -------------------------------------------------------------------------
-# Bootstrap engine shards
-# -------------------------------------------------------------------------
-
-base_linux_build_engine: &base_linux_build_engine
-  <<: *native_engine_cache_config
-  stage: *bootstrap
+travis_docker_image: &travis_docker_image
   services:
     - docker
   before_script:
     - ulimit -c unlimited
-  script:
     - docker build --rm -t travis_ci
       --build-arg "TRAVIS_USER=$(id -un)"
       --build-arg "TRAVIS_UID=$(id -u)"
       --build-arg "TRAVIS_GROUP=$(id -gn)"
       --build-arg "TRAVIS_GID=$(id -g)"
       build-support/docker/travis_ci/
+
+# -------------------------------------------------------------------------
+# Bootstrap engine shards
+# -------------------------------------------------------------------------
+
+base_linux_build_engine: &base_linux_build_engine
+  <<: *native_engine_cache_config
+  <<: *travis_docker_image
+  stage: *bootstrap
+  script:
     # Note that:
     # * We mount ${HOME} to cache the ${HOME}/.cache/pants/rust-toolchain.
     # * With no args ci.sh just bootstraps a pants.pex.
@@ -302,10 +305,11 @@ base_build_wheels: &base_build_wheels
   stage: *test
   env:
     - &base_build_wheels_env RUN_PANTS_FROM_PEX=1 PREPARE_DEPLOY=1
-  script:
-    - ./build-support/bin/release.sh -n
 
 linux_build_wheels: &linux_build_wheels
+  # Similar to the bootstrap shard, we build Linux wheels in a docker image to maximize
+  # compatibility. This is a Py2 shard, so it is not subject to #6985.
+  <<: *travis_docker_image
   <<: *py2_linux_test_config
   <<: *base_build_wheels
   name: "Build Linux wheels (No PEX)"
@@ -313,6 +317,12 @@ linux_build_wheels: &linux_build_wheels
     - *py2_linux_test_config_env
     - *base_build_wheels_env
     - CACHE_NAME=linuxwheelsbuild
+  script:
+    - docker run --rm -t
+      -v "${HOME}:/travis/home"
+      -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest
+      sh -c "RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
 
 osx_build_wheels: &osx_build_wheels
   <<: *py2_osx_test_config
@@ -323,6 +333,8 @@ osx_build_wheels: &osx_build_wheels
     - *py2_osx_test_config_env
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild
+  script:
+    - ./build-support/bin/release.sh -n
 
 # -------------------------------------------------------------------------
 # OSX sanity checks

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -211,7 +211,10 @@ travis_docker_image: &travis_docker_image
     - docker
   before_script:
     - ulimit -c unlimited
-    - docker build --rm -t travis_ci
+  script:
+    # NB: This script definition is very likely to be overridden in a consumer, so we alias it
+    # for re-inclusion.
+    - &travis_docker_image_launch docker build --rm -t travis_ci
       --build-arg "TRAVIS_USER=$(id -un)"
       --build-arg "TRAVIS_UID=$(id -u)"
       --build-arg "TRAVIS_GROUP=$(id -gn)"
@@ -227,6 +230,7 @@ base_linux_build_engine: &base_linux_build_engine
   <<: *travis_docker_image
   stage: *bootstrap
   script:
+    - *travis_docker_image_launch
     # Note that:
     # * We mount ${HOME} to cache the ${HOME}/.cache/pants/rust-toolchain.
     # * With no args ci.sh just bootstraps a pants.pex.
@@ -318,6 +322,7 @@ linux_build_wheels: &linux_build_wheels
     - *base_build_wheels_env
     - CACHE_NAME=linuxwheelsbuild
   script:
+    - *travis_docker_image_launch
     - docker run --rm -t
       -v "${HOME}:/travis/home"
       -v "${TRAVIS_BUILD_DIR}:/travis/workdir"


### PR DESCRIPTION
### Problem

The linux wheel builder shard is currently running directly in the travis Ubuntu environment (rather that our Centos6 compatibility docker container). See #7086 for the result.

### Solution

Extract most of the docker setup into an alias that is merged into both the bootstrap and wheel building shards.

### Result

(Hopefully) fixes #7086.