### PR TITLE
Bump twitter.common dependencies to 0.3.10 to pull in Py3 fixes.

### DIFF
--- a/3rdparty/python/twitter/commons/requirements.txt
+++ b/3rdparty/python/twitter/commons/requirements.txt
@@ -1,3 +1,3 @@
-twitter.common.collections>=0.3.1,<0.4
-twitter.common.confluence>=0.3.1,<0.4
-twitter.common.dirutil>=0.3.1,<0.4
+twitter.common.collections>=0.3.10,<0.4
+twitter.common.confluence>=0.3.10,<0.4
+twitter.common.dirutil>=0.3.10,<0.4


### PR DESCRIPTION
### Problem

Use of `twitter.common.*==0.3.9` under Python 3 triggered deprecation warnings, which were fixed upstream in https://github.com/twitter/commons/pull/474

### Solution

Pull in `twitter.common.*==0.3.10` to remove the deprecation warnings.