### PR TITLE
Continue to reexport stable_json_hash from its previous location.

### DIFF
--- a/src/python/pants/base/payload_field.py
+++ b/src/python/pants/base/payload_field.py
@@ -11,9 +11,13 @@ from hashlib import sha1
 from future.utils import PY3
 from twitter.common.collections import OrderedSet
 
-from pants.base.hash_utils import stable_json_sha1
+from pants.base.hash_utils import stable_json_hash, stable_json_sha1
 from pants.util.meta import AbstractClass
 from pants.util.strutil import ensure_binary
+
+
+# NB: A deprecated alias/re-export.
+stable_json_hash = stable_json_hash
 
 
 def combine_hashes(hashes):


### PR DESCRIPTION
### Problem

#6475 moved `stable_json_hash`, but did not re-export it from its previous location.

### Solution

Export it from its previous location.

### Result

Confirmed that this avoids an import-time breakage on an older consumer of this API.