### PR TITLE
Only clippy on CI on one shard

### DIFF
--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -17,7 +17,10 @@ echo "* Checking for banned imports" && ./build-support/bin/check_banned_imports
 
 if git diff master --name-only | grep '\.rs$' > /dev/null; then
   echo "* Checking formatting of rust files" && ./build-support/bin/check_rust_formatting.sh || exit 1
-  echo "* Running cargo clippy" && ./build-support/bin/check_clippy.sh || exit 1
+  # Clippy happens on a different shard because of separate caching concerns.
+  if [[ "${RUNNING_ON_TRAVIS}" != "1" ]]; then
+    echo "* Running cargo clippy" && ./build-support/bin/check_clippy.sh || exit 1
+  fi
   echo "* Checking rust target headers" && build-support/bin/check_rust_target_headers.sh || exit 1
 fi
 

--- a/build-support/bin/travis-ci.sh
+++ b/build-support/bin/travis-ci.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+export RUNNING_ON_TRAVIS=1
+
 PYENV="$(which pyenv 2>/dev/null)"
 PYENV_ROOT="$(pyenv root 2>/dev/null || true)"
 


### PR DESCRIPTION
Currently if any rust files were changed, we trigger clippy on the
checks shard and the clippy shard, and the checks shard fails because we
don't install fuse there. This ensures that we only run clippy on the
clippy shard when on CI.