### PR TITLE
 Ignore 3rd party deprecation warnings for unmaintained libraries

### DIFF
--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -10,7 +10,6 @@ tests/python/pants_test/backend/python/tasks:integration
 tests/python/pants_test/backend/python/tasks:isort_run_integration
 tests/python/pants_test/backend/python/tasks:python_native_code_testing_1
 tests/python/pants_test/backend/python:integration
-tests/python/pants_test/base:exception_sink_integration
 tests/python/pants_test/base:exiter_integration
 tests/python/pants_test/engine/legacy:changed_integration
 tests/python/pants_test/engine/legacy:console_rule_integration

--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -36,6 +36,9 @@ class PantsLoader(object):
     # TODO: Future has a pending PR to fix deprecation warnings at https://github.com/PythonCharmers/python-future/pull/421.
     # Remove this filter once that gets merged.
     warnings.filterwarnings('ignore', categry=DeprecationWarning, module="future")
+    # TODO: Eric-Arellano has emailed the author to see if he is willing to accept a PR fixing the deprecation warnings
+    # and to release the fix. If he says yes, remove this once fixed.
+    warnings.filterwarnings('ignore', categry=DeprecationWarning, module="ansicolors")
 
   @classmethod
   def ensure_locale(cls):

--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -28,8 +28,14 @@ class PantsLoader(object):
     # We want to present warnings to the user, set this up before importing any of our own code,
     # to ensure all deprecation warnings are seen, including module deprecations.
     # The "default" action displays a warning for a particular file and line number exactly once.
-    # See https://docs.python.org/2/library/warnings.html#the-warnings-filter for the complete list.
-    warnings.simplefilter('default', DeprecationWarning)
+    # See https://docs.python.org/3/library/warnings.html#the-warnings-filter for the complete list.
+    #
+    # However, we do turn off deprecation warnings for libraries that Pants uses for which we do not have a fixed
+    # upstream version, often if the library is no longer maintained.
+    warnings.simplefilter('default', category=DeprecationWarning)
+    # TODO: Future has a pending PR to fix deprecation warnings at https://github.com/PythonCharmers/python-future/pull/421.
+    # Remove this filter once that gets merged.
+    warnings.filterwarnings('ignore', categry=DeprecationWarning, module="future")
 
   @classmethod
   def ensure_locale(cls):

--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -31,7 +31,7 @@ class PantsLoader(object):
     # See https://docs.python.org/3/library/warnings.html#the-warnings-filter for the complete list.
     #
     # However, we do turn off deprecation warnings for libraries that Pants uses for which we do not have a fixed
-    # upstream version, often if the library is no longer maintained.
+    # upstream version, typically because the library is no longer maintained.
     warnings.simplefilter('default', category=DeprecationWarning)
     # TODO: Future has a pending PR to fix deprecation warnings at https://github.com/PythonCharmers/python-future/pull/421.
     # Remove this filter once that gets merged.

--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -35,10 +35,10 @@ class PantsLoader(object):
     warnings.simplefilter('default', category=DeprecationWarning)
     # TODO: Future has a pending PR to fix deprecation warnings at https://github.com/PythonCharmers/python-future/pull/421.
     # Remove this filter once that gets merged.
-    warnings.filterwarnings('ignore', categry=DeprecationWarning, module="future")
+    warnings.filterwarnings('ignore', category=DeprecationWarning, module="future")
     # TODO: Eric-Arellano has emailed the author to see if he is willing to accept a PR fixing the deprecation warnings
     # and to release the fix. If he says yes, remove this once fixed.
-    warnings.filterwarnings('ignore', categry=DeprecationWarning, module="ansicolors")
+    warnings.filterwarnings('ignore', category=DeprecationWarning, module="ansicolors")
 
   @classmethod
   def ensure_locale(cls):


### PR DESCRIPTION
### Problem
Certain libraries, e.g. Future, have not yet fixed their deprecation warnings, even with people submitting PRs to do so. They may not ever fix them if they are unmaintained.

We do not want to show these errors as there is nothing Pants or its users can reasonably do to fix the issue.

### Solution
Filter out problematic libraries.

See https://docs.python.org/3/library/warnings.html#warnings.filterwarnings.

#### Alternative solution considered - fork
We could fork the libraries and fix the warnings ourselves. However, this solution was rejected as it disproportionally increases the complexity of the code we must maintain and ship