### PR TITLE
Update psutil to fix deprecation warnings

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -17,7 +17,7 @@ packaging==16.8
 parameterized==0.6.1
 pathspec==0.5.9
 pex==1.5.3
-psutil==4.3.0
+psutil==5.4.8
 protobuf==3.6.1
 pycodestyle==2.4.0
 pyflakes==2.0.0

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 
 from future.utils import PY3
 from mock import MagicMock
-from psutil.tests import safe_remove
+from psutil.tests import safe_rmpath
 
 from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
                                                                     PinnedJarArtifactSet)
@@ -247,7 +247,7 @@ class CoursierResolveTest(JvmToolTaskTestBase):
         conf, path = jar_cp[0]
 
         # Remove the hard link under .pants.d/
-        safe_remove(path)
+        safe_rmpath(path)
 
         # Remove coursier's cache
         safe_rmtree(couriser_cache_dir)


### PR DESCRIPTION
### Problem
On Linux, `./pants3` results in about 10 deprecation warnings coming from the psutil library (see https://travis-ci.org/pantsbuild/pants/jobs/481546379#L458). 

### Solution
Update to the most-up-to-date version of psutil, which beyond fixing the deprecation warnings brings speedups and bug fixes.