### PR TITLE
Take deploy_jar_rules into account when detecting duplicates

### DIFF
--- a/tests/python/pants_test/backend/jvm/tasks/test_detect_duplicates.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_detect_duplicates.py
@@ -8,7 +8,7 @@ import os
 
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
-from pants.backend.jvm.targets.jvm_binary import JvmBinary, JarRules, Duplicate, Skip
+from pants.backend.jvm.targets.jvm_binary import Duplicate, JarRules, JvmBinary, Skip
 from pants.backend.jvm.tasks.detect_duplicates import DuplicateDetector
 from pants.base.exceptions import TaskError
 from pants.java.jar.jar_dependency import JarDependency

--- a/tests/python/pants_test/backend/jvm/tasks/test_detect_duplicates.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_detect_duplicates.py
@@ -8,7 +8,7 @@ import os
 
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
-from pants.backend.jvm.targets.jvm_binary import Duplicate, JarRules, JvmBinary, Skip
+from pants.backend.jvm.targets.jvm_binary import JarRules, JvmBinary, Skip
 from pants.backend.jvm.tasks.detect_duplicates import DuplicateDetector
 from pants.base.exceptions import TaskError
 from pants.java.jar.jar_dependency import JarDependency


### PR DESCRIPTION
### Problem

When addressing duplicates detected in a `jar_binary` bundle using the `deploy_jar_rules` target option the detect duplicates task still reports the issues, leaving the user with a constant warning even when it has been handled.

### Solution

By evaluating the JarRules' regex pattern applied to the target on the detected duplicates the warning is removed.