### PR TITLE
convert usages of TypeConstraint to TypeId for rule products in the engine

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -296,9 +296,18 @@ class _FFISpecification(object):
 
   @_extern_decl('Ident', ['ExternContext*', 'Handle*'])
   def extern_identify(self, context_handle, val):
-    """Return a representation of the object's identity, including a hash."""
+    """Return a representation of the object's identity, including a hash and TypeId.
+
+    `extern_get_type_for()` also returns a TypeId, but doesn't hash the object -- this allows that
+    method to be used on unhashable objects. `extern_identify()` returns a TypeId as well to avoid
+    having to make two separate Python calls when interning a Python object in interning.rs, which
+    requires both the hash and type.
+    """
+    c = self._ffi.from_handle(context_handle)
     obj = self._ffi.from_handle(val[0])
-    return (hash(obj),)
+    hash_ = hash(obj)
+    type_id = c.to_id(type(obj))
+    return (hash_, TypeId(type_id))
 
   @_extern_decl('_Bool', ['ExternContext*', 'Handle*', 'Handle*'])
   def extern_equals(self, context_handle, val1, val2):

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -282,7 +282,7 @@ class _FFISpecification(object):
     c = self._ffi.from_handle(context_handle)
     obj = self._ffi.from_handle(val[0])
     # TODO: determine if this assertion has any performance implications.
-    assert(isinstance(obj, type))
+    assert isinstance(obj, type)
     tid = c.to_id(obj)
     return (hash(tid), TypeId(tid))
 
@@ -466,10 +466,6 @@ class Key(datatype(['tup_0', 'type_id'])):
 
 
 class Function(datatype(['key'])):
-  """Corresponds to the native object of the same name."""
-
-
-class TypeConstraint(datatype(['key'])):
   """Corresponds to the native object of the same name."""
 
 
@@ -714,8 +710,8 @@ class Native(Singleton):
                     type_url_to_fetch):
     """Create and return an ExternContext and native Scheduler."""
 
-    def func(constraint):
-      return Function(self.context.to_key(constraint))
+    def func(fn):
+      return Function(self.context.to_key(fn))
     def ti(type_obj):
       return TypeId(self.context.to_id(type_obj))
 

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -276,15 +276,15 @@ class _FFISpecification(object):
     msg = bytes(self._ffi.buffer(msg_ptr, msg_len)).decode('utf-8')
     logger.log(level, msg)
 
-  @_extern_decl('ProductTypeId', ['ExternContext*', 'Handle*'])
+  @_extern_decl('TypeId', ['ExternContext*', 'Handle*'])
   def extern_product_type(self, context_handle, val):
-    """Return a ProductTypeId for the given Handle, which must be a `type`."""
+    """Return a TypeId for the given Handle, which must be a `type`."""
     c = self._ffi.from_handle(context_handle)
     obj = self._ffi.from_handle(val[0])
     # TODO: determine if this assertion has any performance implications.
     assert isinstance(obj, type)
     tid = c.to_id(obj)
-    return (hash(tid), TypeId(tid))
+    return TypeId(tid)
 
   @_extern_decl('TypeId', ['ExternContext*', 'Handle*'])
   def extern_get_type_for(self, context_handle, val):

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -286,14 +286,19 @@ class _FFISpecification(object):
     tid = c.to_id(obj)
     return (hash(tid), TypeId(tid))
 
-  @_extern_decl('Ident', ['ExternContext*', 'Handle*'])
-  def extern_identify(self, context_handle, val):
-    """Return an Ident containing the __hash__ and TypeId for the given Handle."""
+  @_extern_decl('TypeId', ['ExternContext*', 'Handle*'])
+  def extern_get_type_for(self, context_handle, val):
+    """Return a representation of the object's type."""
     c = self._ffi.from_handle(context_handle)
     obj = self._ffi.from_handle(val[0])
-    hash_ = hash(obj)
     type_id = c.to_id(type(obj))
-    return (hash_, TypeId(type_id))
+    return TypeId(type_id)
+
+  @_extern_decl('Ident', ['ExternContext*', 'Handle*'])
+  def extern_identify(self, context_handle, val):
+    """Return a representation of the object's identity, including a hash."""
+    obj = self._ffi.from_handle(val[0])
+    return (hash(obj),)
 
   @_extern_decl('_Bool', ['ExternContext*', 'Handle*', 'Handle*'])
   def extern_equals(self, context_handle, val1, val2):
@@ -620,6 +625,7 @@ class Native(Singleton):
                            self.ffi_lib.extern_generator_send,
                            self.ffi_lib.extern_eval,
                            self.ffi_lib.extern_product_type,
+                           self.ffi_lib.extern_get_type_for,
                            self.ffi_lib.extern_identify,
                            self.ffi_lib.extern_equals,
                            self.ffi_lib.extern_clone_val,

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -22,7 +22,7 @@ from pants.util.collections import assert_single_element
 from pants.util.collections_abc_backport import Iterable, OrderedDict
 from pants.util.memo import memoized
 from pants.util.meta import AbstractClass
-from pants.util.objects import Exactly, SubclassesOf, datatype
+from pants.util.objects import SubclassesOf, datatype
 
 
 logger = logging.getLogger(__name__)
@@ -252,17 +252,14 @@ def _make_rule(output_type, input_selectors, for_goal=None, cacheable=True):
 
     def resolve_type(name):
       resolved = caller_frame.f_globals.get(name) or caller_frame.f_builtins.get(name)
-      if not isinstance(resolved, (type, Exactly)):
-        # TODO: should this say "...or Exactly instance;"?
-        raise ValueError('Expected either a `type` constructor or TypeConstraint instance; '
-                         'got: {}'.format(name))
+      if not isinstance(resolved, type):
+        raise ValueError('Expected a `type` constructor, but got: {}'.format(name))
       return resolved
 
     gets = OrderedSet()
     rule_func_node = assert_single_element(
       node for node in ast.iter_child_nodes(module_ast)
-      if isinstance(node, ast.FunctionDef) and node.name == func.__name__
-    )
+      if isinstance(node, ast.FunctionDef) and node.name == func.__name__)
 
     parents_table = {}
     for parent in ast.walk(rule_func_node):
@@ -303,7 +300,7 @@ def _make_rule(output_type, input_selectors, for_goal=None, cacheable=True):
         wrapped_func,
         input_gets=tuple(gets),
         goal=for_goal,
-        cacheable=cacheable
+        cacheable=cacheable,
       )
 
     return wrapped_func

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -449,12 +449,12 @@ class RuleIndex(datatype(['rules', 'roots', 'union_rules'])):
   @classmethod
   def create(cls, rule_entries, union_rules=None):
     """Creates a RuleIndex with tasks indexed by their output type."""
-    # TODO: make a defaultdict-like wrapper for OrderedDict (and other types?)!
     serializable_rules = OrderedDict()
     serializable_roots = OrderedSet()
     union_rules = OrderedDict(union_rules or ())
 
     def add_task(product_type, rule):
+      # TODO(#7311): make a defaultdict-like wrapper for OrderedDict if more widely used.
       if product_type not in serializable_rules:
         serializable_rules[product_type] = OrderedSet()
       serializable_rules[product_type].add(rule)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -248,7 +248,7 @@ class EngineInitializer(object):
           'could not map goal `{}` to rule `{}`: already claimed by product `{}`'
           .format(goal, rule, goal_map[goal])
         )
-      goal_map[goal] = rule.output_constraint
+      goal_map[goal] = rule.output_type
     return goal_map
 
   @staticmethod

--- a/src/rust/engine/src/cffi_build.rs
+++ b/src/rust/engine/src/cffi_build.rs
@@ -129,6 +129,9 @@ fn main() -> Result<(), CffiBuildError> {
   let cffi_bootstrapper = build_root.join("build-support/bin/native/bootstrap_cffi.sh");
   mark_for_change_detection(&cffi_bootstrapper);
 
+  // TODO: bootstrap_c_source() is used to generate C source code from @_extern_decl methods in
+  // native.py. It would be very useful to be able to detect when those /declarations/ haven't
+  // changed and avoid rebuilding the engine crate if we are just iterating on the implementations.
   mark_for_change_detection(&build_root.join("src/python/pants/engine/native.py"));
 
   // N.B. The filename of this source code - at generation time - must line up 1:1 with the

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -147,6 +147,14 @@ pub const ANY_TYPE: TypeId = TypeId(0);
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Function(pub Key);
 
+impl fmt::Display for Function {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let Function(key) = self;
+    let name = externs::project_str(&externs::val_for(&key), "__name__");
+    write!(f, "{}()", name)
+  }
+}
+
 ///
 /// Wraps a type id for use as a key in HashMaps and sets.
 ///

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -142,11 +142,6 @@ impl fmt::Display for TypeId {
 // On the python side, the 0th type id is used as an anonymous id
 pub const ANY_TYPE: TypeId = TypeId(0);
 
-// A type constraint, which a TypeId may or may-not satisfy.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct TypeConstraint(pub Key);
-
 // An identifier for a python function.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -119,23 +119,25 @@ pub type Id = u64;
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TypeId(pub Id);
 
-impl fmt::Debug for TypeId {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    if *self == ANY_TYPE {
+impl TypeId {
+  fn pretty_print(self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    if self == ANY_TYPE {
       write!(f, "Any")
     } else {
-      write!(f, "{}", externs::type_to_str(*self))
+      write!(f, "{}", externs::type_to_str(self))
     }
+  }
+}
+
+impl fmt::Debug for TypeId {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    self.pretty_print(f)
   }
 }
 
 impl fmt::Display for TypeId {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    if *self == ANY_TYPE {
-      write!(f, "Any")
-    } else {
-      write!(f, "{}", externs::type_to_str(*self))
-    }
+    self.pretty_print(f)
   }
 }
 
@@ -144,14 +146,26 @@ pub const ANY_TYPE: TypeId = TypeId(0);
 
 // An identifier for a python function.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct Function(pub Key);
 
-impl fmt::Display for Function {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Function {
+  fn pretty_print(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let Function(key) = self;
     let name = externs::project_str(&externs::val_for(&key), "__name__");
     write!(f, "{}()", name)
+  }
+}
+
+impl fmt::Display for Function {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    self.pretty_print(f)
+  }
+}
+
+impl fmt::Debug for Function {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    self.pretty_print(f)
   }
 }
 

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -24,6 +24,10 @@ pub fn product_type(val: &Value) -> ProductTypeId {
   with_externs(|e| (e.product_type)(e.context, val as &Handle))
 }
 
+pub fn get_type_for(val: &Value) -> TypeId {
+  with_externs(|e| (e.get_type_for)(e.context, val as &Handle))
+}
+
 pub fn identify(val: &Value) -> Ident {
   with_externs(|e| (e.identify)(e.context, val as &Handle))
 }
@@ -338,6 +342,7 @@ pub struct Externs {
   pub generator_send: GeneratorSendExtern,
   pub eval: EvalExtern,
   pub product_type: ProductTypeExtern,
+  pub get_type_for: GetTypeForExtern,
   pub identify: IdentifyExtern,
   pub equals: EqualsExtern,
   pub clone_val: CloneValExtern,
@@ -364,6 +369,8 @@ unsafe impl Send for Externs {}
 pub type LogExtern = extern "C" fn(*const ExternContext, u8, str_ptr: *const u8, str_len: u64);
 
 pub type ProductTypeExtern = extern "C" fn(*const ExternContext, *const Handle) -> ProductTypeId;
+
+pub type GetTypeForExtern = extern "C" fn(*const ExternContext, *const Handle) -> TypeId;
 
 pub type IdentifyExtern = extern "C" fn(*const ExternContext, *const Handle) -> Ident;
 
@@ -499,12 +506,11 @@ pub struct ProductTypeId {
 }
 
 ///
-/// The result of an `identify` call, including the __hash__ of a Handle and its TypeId.
+/// The result of an `identify` call, including the __hash__ of a Handle.
 ///
 #[repr(C)]
 pub struct Ident {
   pub hash: i64,
-  pub type_id: TypeId,
 }
 
 ///

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -189,7 +189,8 @@ pub fn create_exception(msg: &str) -> Value {
   with_externs(|e| (e.create_exception)(e.context, msg.as_ptr(), msg.len() as u64).into())
 }
 
-// NB: This method is currently unused, but kept as an example of how to call methods on objects.
+// TODO: This method is currently unused, but kept as an example of how to call methods on objects.
+#[allow(dead_code)]
 pub fn call_method(value: &Value, method: &str, args: &[Value]) -> Result<Value, Failure> {
   call(&project_ignoring_type(&value, method), args)
 }

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -20,7 +20,7 @@ pub fn eval(python: &str) -> Result<Value, Failure> {
   with_externs(|e| (e.eval)(e.context, python.as_ptr(), python.len() as u64)).into()
 }
 
-pub fn product_type(val: &Value) -> ProductTypeId {
+pub fn product_type(val: &Value) -> TypeId {
   with_externs(|e| (e.product_type)(e.context, val as &Handle))
 }
 
@@ -368,7 +368,7 @@ unsafe impl Send for Externs {}
 
 pub type LogExtern = extern "C" fn(*const ExternContext, u8, str_ptr: *const u8, str_len: u64);
 
-pub type ProductTypeExtern = extern "C" fn(*const ExternContext, *const Handle) -> ProductTypeId;
+pub type ProductTypeExtern = extern "C" fn(*const ExternContext, *const Handle) -> TypeId;
 
 pub type GetTypeForExtern = extern "C" fn(*const ExternContext, *const Handle) -> TypeId;
 
@@ -492,17 +492,6 @@ pub enum GeneratorResponse {
   Break(Value),
   Get(Get),
   GetMulti(Vec<Get>),
-}
-
-///
-/// We need to make sure each type object is registered in `ExternContext#_types` in native.py by
-/// running it through an extern before wrapping it in a `TypeId`, so we codify that by wrapping it
-/// in this struct after going through a `product_type` call.
-///
-#[repr(C)]
-pub struct ProductTypeId {
-  pub hash: i64,
-  pub type_id: TypeId,
 }
 
 ///

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -231,16 +231,16 @@ pub fn generator_send(generator: &Value, arg: &Value) -> Result<GeneratorRespons
     PyGeneratorResponseType::GetMulti => {
       let mut interns = INTERNS.write();
       let PyGeneratorResponse {
-        values: values_buf,
         products: products_buf,
+        values: values_buf,
         ..
       } = response;
-      let values = values_buf.to_vec();
       let products = products_buf.to_vec();
-      assert_eq!(values.len(), products.len());
-      let continues: Vec<Get> = values
+      let values = values_buf.to_vec();
+      assert_eq!(products.len(), values.len());
+      let continues: Vec<Get> = products
         .into_iter()
-        .zip(products.into_iter())
+        .zip(values.into_iter())
         .map(|(p, v)| Get {
           product: *interns.insert_product(p).type_id(),
           subject: interns.insert(v),
@@ -506,11 +506,13 @@ pub struct ProductTypeId {
 }
 
 ///
-/// The result of an `identify` call, including the __hash__ of a Handle.
+/// The result of an `identify` call, including the __hash__ of a Handle and a TypeId representing
+/// the object's type.
 ///
 #[repr(C)]
 pub struct Ident {
   pub hash: i64,
+  pub type_id: TypeId,
 }
 
 ///

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -62,8 +62,7 @@ impl Interns {
   }
 
   pub fn insert(&mut self, v: Value) -> Key {
-    let type_id = externs::get_type_for(&v);
-    let Ident { hash } = externs::identify(&v);
+    let Ident { hash, type_id } = externs::identify(&v);
     let mut inserted = false;
     let id_generator = self.id_generator;
     let key = *self

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -62,7 +62,8 @@ impl Interns {
   }
 
   pub fn insert(&mut self, v: Value) -> Key {
-    let Ident { hash, type_id } = externs::identify(&v);
+    let type_id = externs::get_type_for(&v);
+    let Ident { hash } = externs::identify(&v);
     let mut inserted = false;
     let id_generator = self.id_generator;
     let key = *self

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -603,8 +603,8 @@ pub extern "C" fn rule_subgraph_visualize(
   })
 }
 
-// TODO: This produces "thread panicked while processing panic. aborting." on my linux laptop,
-// requiring me to set RUST_BACKTRACE=1 (or "full") to get the panic message.
+// TODO(#4884): This produces "thread panicked while processing panic. aborting." on my linux
+// laptop, requiring me to set RUST_BACKTRACE=1 (or "full") to get the panic message.
 #[no_mangle]
 pub extern "C" fn set_panic_handler() {
   panic::set_hook(Box::new(|panic_info| {

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -59,8 +59,8 @@ use crate::externs::{
   Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionExtern, DropHandlesExtern,
   EqualsExtern, EvalExtern, ExternContext, Externs, GeneratorSendExtern, HandleBuffer,
   IdentifyExtern, LogExtern, ProductTypeExtern, ProjectIgnoringTypeExtern, ProjectMultiExtern,
-  PyResult, StoreBoolExtern, StoreBytesExtern, StoreF64Extern, StoreI64Extern, StoreTupleExtern, StoreUtf8Extern,
-  TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
+  PyResult, StoreBoolExtern, StoreBytesExtern, StoreF64Extern, StoreI64Extern, StoreTupleExtern,
+  StoreUtf8Extern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
 };
 use crate::handles::Handle;
 use crate::rule_graph::{GraphMaker, RuleGraph};

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -601,6 +601,8 @@ pub extern "C" fn rule_subgraph_visualize(
   })
 }
 
+// TODO: This produces "thread panicked while processing panic. aborting." on my linux laptop,
+// requiring me to set RUST_BACKTRACE=1 (or "full") to get the panic message.
 #[no_mangle]
 pub extern "C" fn set_panic_handler() {
   panic::set_hook(Box::new(|panic_info| {

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -57,10 +57,10 @@ use crate::context::Core;
 use crate::core::{Function, Key, Params, TypeId, Value};
 use crate::externs::{
   Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionExtern, DropHandlesExtern,
-  EqualsExtern, EvalExtern, ExternContext, Externs, GeneratorSendExtern, HandleBuffer,
-  IdentifyExtern, LogExtern, ProductTypeExtern, ProjectIgnoringTypeExtern, ProjectMultiExtern,
-  PyResult, StoreBoolExtern, StoreBytesExtern, StoreF64Extern, StoreI64Extern, StoreTupleExtern,
-  StoreUtf8Extern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
+  EqualsExtern, EvalExtern, ExternContext, Externs, GeneratorSendExtern, GetTypeForExtern,
+  HandleBuffer, IdentifyExtern, LogExtern, ProductTypeExtern, ProjectIgnoringTypeExtern,
+  ProjectMultiExtern, PyResult, StoreBoolExtern, StoreBytesExtern, StoreF64Extern, StoreI64Extern,
+  StoreTupleExtern, StoreUtf8Extern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
 };
 use crate::handles::Handle;
 use crate::rule_graph::{GraphMaker, RuleGraph};
@@ -104,6 +104,7 @@ pub extern "C" fn externs_set(
   generator_send: GeneratorSendExtern,
   eval: EvalExtern,
   product_type: ProductTypeExtern,
+  get_type_for: GetTypeForExtern,
   identify: IdentifyExtern,
   equals: EqualsExtern,
   clone_val: CloneValExtern,
@@ -130,6 +131,7 @@ pub extern "C" fn externs_set(
     generator_send,
     eval,
     product_type,
+    get_type_for,
     identify,
     equals,
     clone_val,

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -54,13 +54,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::context::Core;
-use crate::core::{Function, Key, Params, TypeConstraint, TypeId, Value};
+use crate::core::{Function, Key, Params, TypeId, Value};
 use crate::externs::{
   Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionExtern, DropHandlesExtern,
   EqualsExtern, EvalExtern, ExternContext, Externs, GeneratorSendExtern, HandleBuffer,
-  IdentifyExtern, LogExtern, ProjectIgnoringTypeExtern, ProjectMultiExtern, PyResult,
-  SatisfiedByExtern, SatisfiedByTypeExtern, StoreBoolExtern, StoreBytesExtern, StoreF64Extern,
-  StoreI64Extern, StoreTupleExtern, StoreUtf8Extern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
+  IdentifyExtern, LogExtern, ProductTypeExtern, ProjectIgnoringTypeExtern, ProjectMultiExtern,
+  PyResult, StoreBoolExtern, StoreBytesExtern, StoreF64Extern, StoreI64Extern, StoreTupleExtern, StoreUtf8Extern,
+  TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
 };
 use crate::handles::Handle;
 use crate::rule_graph::{GraphMaker, RuleGraph};
@@ -103,14 +103,13 @@ pub extern "C" fn externs_set(
   call: CallExtern,
   generator_send: GeneratorSendExtern,
   eval: EvalExtern,
+  product_type: ProductTypeExtern,
   identify: IdentifyExtern,
   equals: EqualsExtern,
   clone_val: CloneValExtern,
   drop_handles: DropHandlesExtern,
   type_to_str: TypeToStrExtern,
   val_to_str: ValToStrExtern,
-  satisfied_by: SatisfiedByExtern,
-  satisfied_by_type: SatisfiedByTypeExtern,
   store_tuple: StoreTupleExtern,
   store_set: StoreTupleExtern,
   store_dict: StoreTupleExtern,
@@ -122,7 +121,6 @@ pub extern "C" fn externs_set(
   project_ignoring_type: ProjectIgnoringTypeExtern,
   project_multi: ProjectMultiExtern,
   create_exception: CreateExceptionExtern,
-  py_str_type: TypeId,
 ) {
   externs::set_externs(Externs {
     context,
@@ -131,14 +129,13 @@ pub extern "C" fn externs_set(
     call,
     generator_send,
     eval,
+    product_type,
     identify,
     equals,
     clone_val,
     drop_handles,
     type_to_str,
     val_to_str,
-    satisfied_by,
-    satisfied_by_type,
     store_tuple,
     store_set,
     store_dict,
@@ -150,7 +147,6 @@ pub extern "C" fn externs_set(
     project_ignoring_type,
     project_multi,
     create_exception,
-    py_str_type,
   });
 }
 
@@ -178,19 +174,19 @@ pub extern "C" fn scheduler_create(
   construct_file_content: Function,
   construct_files_content: Function,
   construct_process_result: Function,
-  type_address: TypeConstraint,
-  type_path_globs: TypeConstraint,
-  type_directory_digest: TypeConstraint,
-  type_snapshot: TypeConstraint,
-  type_merge_directories_request: TypeConstraint,
-  type_files_content: TypeConstraint,
-  type_dir: TypeConstraint,
-  type_file: TypeConstraint,
-  type_link: TypeConstraint,
-  type_process_request: TypeConstraint,
-  type_process_result: TypeConstraint,
-  type_generator: TypeConstraint,
-  type_url_to_fetch: TypeConstraint,
+  type_address: TypeId,
+  type_path_globs: TypeId,
+  type_directory_digest: TypeId,
+  type_snapshot: TypeId,
+  type_merge_directories_request: TypeId,
+  type_files_content: TypeId,
+  type_dir: TypeId,
+  type_file: TypeId,
+  type_link: TypeId,
+  type_process_request: TypeId,
+  type_process_result: TypeId,
+  type_generator: TypeId,
+  type_url_to_fetch: TypeId,
   type_string: TypeId,
   type_bytes: TypeId,
   build_root_buf: Buffer,
@@ -375,7 +371,7 @@ pub extern "C" fn execution_add_root_select(
   scheduler_ptr: *mut Scheduler,
   execution_request_ptr: *mut ExecutionRequest,
   param_vals: HandleBuffer,
-  product: TypeConstraint,
+  product: TypeId,
 ) -> PyResult {
   with_scheduler(scheduler_ptr, |scheduler| {
     with_execution_request(execution_request_ptr, |execution_request| {
@@ -393,13 +389,9 @@ pub extern "C" fn tasks_create() -> *const Tasks {
 }
 
 #[no_mangle]
-pub extern "C" fn tasks_singleton_add(
-  tasks_ptr: *mut Tasks,
-  handle: Handle,
-  output_constraint: TypeConstraint,
-) {
+pub extern "C" fn tasks_singleton_add(tasks_ptr: *mut Tasks, handle: Handle, output_type: TypeId) {
   with_tasks(tasks_ptr, |tasks| {
-    tasks.singleton_add(handle.into(), output_constraint);
+    tasks.singleton_add(handle.into(), output_type);
   })
 }
 
@@ -407,7 +399,7 @@ pub extern "C" fn tasks_singleton_add(
 pub extern "C" fn tasks_task_begin(
   tasks_ptr: *mut Tasks,
   func: Function,
-  output_type: TypeConstraint,
+  output_type: TypeId,
   cacheable: bool,
 ) {
   with_tasks(tasks_ptr, |tasks| {
@@ -416,14 +408,14 @@ pub extern "C" fn tasks_task_begin(
 }
 
 #[no_mangle]
-pub extern "C" fn tasks_add_get(tasks_ptr: *mut Tasks, product: TypeConstraint, subject: TypeId) {
+pub extern "C" fn tasks_add_get(tasks_ptr: *mut Tasks, product: TypeId, subject: TypeId) {
   with_tasks(tasks_ptr, |tasks| {
     tasks.add_get(product, subject);
   })
 }
 
 #[no_mangle]
-pub extern "C" fn tasks_add_select(tasks_ptr: *mut Tasks, product: TypeConstraint) {
+pub extern "C" fn tasks_add_select(tasks_ptr: *mut Tasks, product: TypeId) {
   with_tasks(tasks_ptr, |tasks| {
     tasks.add_select(product);
   })
@@ -594,7 +586,7 @@ pub extern "C" fn rule_graph_visualize(
 pub extern "C" fn rule_subgraph_visualize(
   scheduler_ptr: *mut Scheduler,
   subject_type: TypeId,
-  product_type: TypeConstraint,
+  product_type: TypeId,
   path_ptr: *const raw::c_char,
 ) {
   with_scheduler(scheduler_ptr, |scheduler| {
@@ -808,13 +800,9 @@ fn graph_full(scheduler: &Scheduler, subject_types: Vec<TypeId>) -> RuleGraph {
   graph_maker.full_graph()
 }
 
-fn graph_sub(
-  scheduler: &Scheduler,
-  subject_type: TypeId,
-  product_type: TypeConstraint,
-) -> RuleGraph {
+fn graph_sub(scheduler: &Scheduler, subject_type: TypeId, product_type: TypeId) -> RuleGraph {
   let graph_maker = GraphMaker::new(&scheduler.core.tasks, vec![subject_type]);
-  graph_maker.sub_graph(subject_type, &product_type)
+  graph_maker.sub_graph(subject_type, product_type)
 }
 
 fn write_to_file(path: &Path, graph: &RuleGraph) -> io::Result<()> {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -15,7 +15,7 @@ use url::Url;
 
 use crate::context::{Context, Core};
 use crate::core::{throw, Failure, Key, Params, TypeId, Value};
-use crate::externs::{self, Ident};
+use crate::externs;
 use crate::rule_graph;
 use crate::selectors;
 use crate::tasks::{self, Intrinsic};
@@ -902,7 +902,8 @@ impl WrappedNode for Task {
       })
       .then(move |task_result| match task_result {
         Ok(val) => {
-          let Ident { type_id, .. } = externs::identify(&val);
+          let type_id = externs::get_type_for(&val);
+          // TODO: figure out if this can/should be turned into a `match` statement!
           if type_id == context.core.types.generator {
             Self::generate(context, params, entry, val)
           } else if type_id == product {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -901,20 +901,14 @@ impl WrappedNode for Task {
         Err(failure) => Err(failure),
       })
       .then(move |task_result| match task_result {
-        Ok(val) => {
-          let type_id = externs::get_type_for(&val);
-          // TODO: figure out if this can/should be turned into a `match` statement!
-          if type_id == context.core.types.generator {
-            Self::generate(context, params, entry, val)
-          } else if type_id == product {
-            ok(val)
-          } else {
-            err(throw(&format!(
-              "{:?} returned a result value that did not satisfy its constraints: {:?}",
-              func, val
-            )))
-          }
-        }
+        Ok(val) => match externs::get_type_for(&val) {
+          t if t == context.core.types.generator => Self::generate(context, params, entry, val),
+          t if t == product => ok(val),
+          _ => err(throw(&format!(
+            "{:?} returned a result value that did not satisfy its constraints: {:?}",
+            func, val
+          ))),
+        },
         Err(failure) => err(failure),
       })
       .to_boxed()

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -866,10 +866,7 @@ impl fmt::Debug for Task {
     write!(
       f,
       "Task({}, {}, {}, {})",
-      externs::project_str(&externs::val_for(&self.task.func.0), "__name__"),
-      self.params,
-      self.product,
-      self.task.cacheable,
+      self.task.func, self.params, self.product, self.task.cacheable,
     )
   }
 }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use futures::future::{self, Future};
 
 use crate::context::{Context, Core};
-use crate::core::{Failure, Params, TypeConstraint, Value};
+use crate::core::{Failure, Params, TypeId, Value};
 use crate::nodes::{NodeKey, Select, Tracer, TryInto, Visualizer};
 use crate::selectors;
 use graph::{EntryId, Graph, InvalidationResult, NodeContext};
@@ -107,7 +107,7 @@ impl Scheduler {
     &self,
     request: &mut ExecutionRequest,
     params: Params,
-    product: TypeConstraint,
+    product: TypeId,
   ) -> Result<(), String> {
     let edges = self
       .core

--- a/src/rust/engine/src/selectors.rs
+++ b/src/rust/engine/src/selectors.rs
@@ -1,33 +1,28 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use crate::core::{TypeConstraint, TypeId};
-use crate::externs;
+use crate::core::TypeId;
 use std::fmt;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Get {
-  pub product: TypeConstraint,
+  pub product: TypeId,
   pub subject: TypeId,
 }
 
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub struct Select {
-  pub product: TypeConstraint,
+  pub product: TypeId,
 }
 
 impl Select {
-  pub fn new(product: TypeConstraint) -> Select {
+  pub fn new(product: TypeId) -> Select {
     Select { product: product }
   }
 }
 
 impl fmt::Debug for Select {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-    write!(
-      f,
-      "Select {{ product: {} }}",
-      externs::key_to_str(&self.product.0)
-    )
+    write!(f, "Select {{ product: {} }}", self.product,)
   }
 }

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -24,7 +24,7 @@ pub struct Task {
 pub struct Tasks {
   // output product type -> Intrinsic providing it
   intrinsics: HashMap<TypeId, Vec<Intrinsic>, FNV>,
-  // Singleton Values to be returned for a given TypeConstraint.
+  // Singleton Values to be returned for a given TypeId.
   singletons: HashMap<TypeId, (Key, Value), FNV>,
   // output product type -> list of tasks providing it
   tasks: HashMap<TypeId, Vec<Task>, FNV>,

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -3,14 +3,14 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::core::{Function, Key, TypeConstraint, TypeId, Value, FNV};
+use crate::core::{Function, Key, TypeId, Value, FNV};
 use crate::externs;
 use crate::selectors::{Get, Select};
 use crate::types::Types;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Task {
-  pub product: TypeConstraint,
+  pub product: TypeId,
   pub clause: Vec<Select>,
   pub gets: Vec<Get>,
   pub func: Function,
@@ -23,11 +23,11 @@ pub struct Task {
 #[derive(Clone, Debug)]
 pub struct Tasks {
   // output product type -> Intrinsic providing it
-  intrinsics: HashMap<TypeConstraint, Vec<Intrinsic>, FNV>,
+  intrinsics: HashMap<TypeId, Vec<Intrinsic>, FNV>,
   // Singleton Values to be returned for a given TypeConstraint.
-  singletons: HashMap<TypeConstraint, (Key, Value), FNV>,
+  singletons: HashMap<TypeId, (Key, Value), FNV>,
   // output product type -> list of tasks providing it
-  tasks: HashMap<TypeConstraint, Vec<Task>, FNV>,
+  tasks: HashMap<TypeId, Vec<Task>, FNV>,
   // Used during the construction of the tasks map.
   preparing: Option<Task>,
 }
@@ -53,7 +53,7 @@ impl Tasks {
     }
   }
 
-  pub fn all_product_types(&self) -> HashSet<TypeConstraint> {
+  pub fn all_product_types(&self) -> HashSet<TypeId> {
     self
       .singletons
       .keys()
@@ -75,16 +75,16 @@ impl Tasks {
       .collect()
   }
 
-  pub fn gen_singleton(&self, product: &TypeConstraint) -> Option<&(Key, Value)> {
-    self.singletons.get(product)
+  pub fn gen_singleton(&self, product: TypeId) -> Option<&(Key, Value)> {
+    self.singletons.get(&product)
   }
 
-  pub fn gen_intrinsic(&self, product: &TypeConstraint) -> Option<&Vec<Intrinsic>> {
-    self.intrinsics.get(product)
+  pub fn gen_intrinsic(&self, product: TypeId) -> Option<&Vec<Intrinsic>> {
+    self.intrinsics.get(&product)
   }
 
-  pub fn gen_tasks(&self, product: &TypeConstraint) -> Option<&Vec<Task>> {
-    self.tasks.get(product)
+  pub fn gen_tasks(&self, product: TypeId) -> Option<&Vec<Task>> {
+    self.tasks.get(&product)
   }
 
   pub fn intrinsics_set(&mut self, types: &Types) {
@@ -121,7 +121,7 @@ impl Tasks {
     }
   }
 
-  pub fn singleton_add(&mut self, value: Value, product: TypeConstraint) {
+  pub fn singleton_add(&mut self, value: Value, product: TypeId) {
     if let Some(&(_, ref existing_value)) = self.singletons.get(&product) {
       panic!(
         "More than one Singleton rule was installed for the product {:?}: {:?} vs {:?}",
@@ -136,7 +136,7 @@ impl Tasks {
   ///
   /// The following methods define the Task registration lifecycle.
   ///
-  pub fn task_begin(&mut self, func: Function, product: TypeConstraint, cacheable: bool) {
+  pub fn task_begin(&mut self, func: Function, product: TypeId, cacheable: bool) {
     assert!(
       self.preparing.is_none(),
       "Must `end()` the previous task creation before beginning a new one!"
@@ -151,7 +151,7 @@ impl Tasks {
     });
   }
 
-  pub fn add_get(&mut self, product: TypeConstraint, subject: TypeId) {
+  pub fn add_get(&mut self, product: TypeId, subject: TypeId) {
     self
       .preparing
       .as_mut()
@@ -163,7 +163,7 @@ impl Tasks {
       });
   }
 
-  pub fn add_select(&mut self, product: TypeConstraint) {
+  pub fn add_select(&mut self, product: TypeId) {
     self
       .preparing
       .as_mut()
@@ -194,6 +194,6 @@ impl Tasks {
 
 #[derive(Eq, Hash, PartialEq, Clone, Copy, Debug)]
 pub struct Intrinsic {
-  pub product: TypeConstraint,
-  pub input: TypeConstraint,
+  pub product: TypeId,
+  pub input: TypeId,
 }

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -1,4 +1,4 @@
-use crate::core::{Function, TypeConstraint, TypeId};
+use crate::core::{Function, TypeId};
 
 pub struct Types {
   pub construct_directory_digest: Function,
@@ -6,19 +6,19 @@ pub struct Types {
   pub construct_file_content: Function,
   pub construct_files_content: Function,
   pub construct_process_result: Function,
-  pub address: TypeConstraint,
-  pub path_globs: TypeConstraint,
-  pub directory_digest: TypeConstraint,
-  pub snapshot: TypeConstraint,
-  pub merged_directories: TypeConstraint,
-  pub files_content: TypeConstraint,
-  pub dir: TypeConstraint,
-  pub file: TypeConstraint,
-  pub link: TypeConstraint,
-  pub process_request: TypeConstraint,
-  pub process_result: TypeConstraint,
-  pub generator: TypeConstraint,
-  pub url_to_fetch: TypeConstraint,
+  pub address: TypeId,
+  pub path_globs: TypeId,
+  pub directory_digest: TypeId,
+  pub snapshot: TypeId,
+  pub merged_directories: TypeId,
+  pub files_content: TypeId,
+  pub dir: TypeId,
+  pub file: TypeId,
+  pub link: TypeId,
+  pub process_request: TypeId,
+  pub process_result: TypeId,
+  pub generator: TypeId,
+  pub url_to_fetch: TypeId,
   pub string: TypeId,
   pub bytes: TypeId,
 }

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -227,7 +227,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
     self.assert_equal_with_printing(dedent('''
       Rules with errors: 1
-        (MyFloat, [Select(MyInt)], upcast):
+        (MyFloat, [Select(MyInt)], upcast()):
           No rule was available to compute MyInt. Maybe declare it as a RootRule(MyInt)?
         ''').strip(),
       str(cm.exception)

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -123,8 +123,8 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
     self.assert_equal_with_printing(dedent('''
       1 Exception encountered:
-      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, Exactly(A))
-        Computing Task(nested_raise, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, Exactly(A), true)
+      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, A)
+        Computing Task(nested_raise(), <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, A, true)
           Throw(An exception for B)
             Traceback (most recent call last):
               File LOCATION-INFO, in call
@@ -175,9 +175,9 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
     self.assert_equal_with_printing(dedent('''
       1 Exception encountered:
-      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, Exactly(A))
-        Computing Task(a_from_c_and_d, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, Exactly(A), true)
-          Computing Task(d_from_b_nested_raise, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =D, true)
+      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, A)
+        Computing Task(a_from_c_and_d(), <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, A, true)
+          Computing Task(d_from_b_nested_raise(), <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =D, true)
             Throw(An exception for B)
               Traceback (most recent call last):
                 File LOCATION-INFO, in call
@@ -189,9 +189,9 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
               Exception: An exception for B
 
 
-      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, Exactly(A))
-        Computing Task(a_from_c_and_d, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, Exactly(A), true)
-          Computing Task(c_from_b_nested_raise, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =C, true)
+      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, A)
+        Computing Task(a_from_c_and_d(), <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, A, true)
+          Computing Task(c_from_b_nested_raise(), <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =C, true)
             Throw(An exception for B)
               Traceback (most recent call last):
                 File LOCATION-INFO, in call

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -17,7 +17,6 @@ from pants.engine.mapper import AddressMapper
 from pants.engine.rules import (RootRule, RuleIndex, SingletonRule, _GoalProduct, _RuleVisitor,
                                 console_rule, rule)
 from pants.engine.selectors import Get, Select
-from pants.util.objects import Exactly
 from pants_test.engine.examples.parsers import JsonParser
 from pants_test.engine.util import (TargetTable, assert_equal_with_printing, create_scheduler,
                                     run_rule)
@@ -97,7 +96,7 @@ class RulesetValidatorTest(unittest.TestCase):
 
     self.assert_equal_with_printing(dedent("""
                      Rules with errors: 1
-                       (A, [Select(B)], a_from_b_noop):
+                       (A, [Select(B)], a_from_b_noop()):
                          No rule was available to compute B with parameter type SubA
                      """).strip(),
                                     str(cm.exception))
@@ -129,10 +128,10 @@ class RulesetValidatorTest(unittest.TestCase):
 
     self.assert_equal_with_printing(dedent("""
                      Rules with errors: 1
-                       (D, [Select(A)], d_from_a):
+                       (D, [Select(A)], d_from_a()):
                          ambiguous rules for Select(A) with parameter types (B+C):
-                           (A, [Select(B), Select(C)], a_from_b_and_c) for (B+C)
-                           (A, [Select(C), Select(B)], a_from_c_and_b) for (B+C)
+                           (A, [Select(B), Select(C)], a_from_b_and_c()) for (B+C)
+                           (A, [Select(C), Select(B)], a_from_c_and_b()) for (B+C)
                      """).strip(),
       str(cm.exception))
 
@@ -147,7 +146,7 @@ class RulesetValidatorTest(unittest.TestCase):
 
     self.assert_equal_with_printing(dedent("""
                      Rules with errors: 1
-                       (A, [Select(B), Select(C)], a_from_b_and_c):
+                       (A, [Select(B), Select(C)], a_from_b_and_c()):
                          No rule was available to compute B with parameter type SubA
                          No rule was available to compute C with parameter type SubA
                      """).strip(),
@@ -180,27 +179,12 @@ class RulesetValidatorTest(unittest.TestCase):
       create_scheduler(rules)
     self.assert_equal_with_printing(dedent("""
                                       Rules with errors: 2
-                                        (A, [Select(B)], a_from_b):
+                                        (A, [Select(B)], a_from_b()):
                                           No rule was available to compute B with parameter type C
-                                        (B, [Select(SubA)], b_from_suba):
+                                        (B, [Select(SubA)], b_from_suba()):
                                           No rule was available to compute SubA with parameter type C
                                       """).strip(),
                                     str(cm.exception))
-
-  def test_ruleset_with_explicit_type_constraint(self):
-    @rule(Exactly(A), [Select(B)])
-    def a_from_b(b):
-      pass
-
-    @rule(B, [Select(A)])
-    def b_from_a(a):
-      pass
-
-    rules = _suba_root_rules + [
-      a_from_b,
-      b_from_a,
-    ]
-    create_scheduler(rules)
 
   def test_ruleset_with_failure_due_to_incompatible_subject_for_singleton(self):
     @rule(D, [Select(C)])
@@ -219,7 +203,7 @@ class RulesetValidatorTest(unittest.TestCase):
     # This error message could note near matches like the singleton.
     self.assert_equal_with_printing(dedent("""
                                       Rules with errors: 1
-                                        (D, [Select(C)], d_from_c):
+                                        (D, [Select(C)], d_from_c()):
                                           No rule was available to compute C with parameter type A
                                       """).strip(),
                                     str(cm.exception))
@@ -251,9 +235,9 @@ class RulesetValidatorTest(unittest.TestCase):
 
     self.assert_equal_with_printing(dedent("""
                       Rules with errors: 2
-                        (B, [Select(D)], b_from_d):
+                        (B, [Select(D)], b_from_d()):
                           No rule was available to compute D with parameter type SubA
-                        (D, [Select(A), Select(SubA)], [Get(A, C)], d_from_a_and_suba):
+                        (D, [Select(A), Select(SubA)], [Get(A, C)], d_from_a_and_suba()):
                           No rule was available to compute A with parameter type SubA
                       """).strip(),
         str(cm.exception))
@@ -265,7 +249,7 @@ class RuleGraphMakerTest(unittest.TestCase):
   # TODO HasProducts?
 
   def test_smallest_full_test(self):
-    @rule(Exactly(A), [Select(SubA)])
+    @rule(A, [Select(SubA)])
     def a_from_suba(suba):
       pass
 
@@ -280,9 +264,9 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(SubA)], a_from_suba()) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA)], a_from_suba) for SubA" -> {"Param(SubA)"}
+                         "(A, [Select(SubA)], a_from_suba()) for SubA" -> {"Param(SubA)"}
                      }""").strip(), fullgraph)
 
   def test_full_graph_for_planner_example(self):
@@ -341,20 +325,20 @@ class RuleGraphMakerTest(unittest.TestCase):
                          "Select(A) for A" [color=blue]
                          "Select(A) for A" -> {"Param(A)"}
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(SubA)], a_from_suba()) for SubA"}
                          "Select(B) for A" [color=blue]
-                         "Select(B) for A" -> {"(B, [Select(A)], b_from_a) for A"}
+                         "Select(B) for A" -> {"(B, [Select(A)], b_from_a()) for A"}
                          "Select(B) for SubA" [color=blue]
-                         "Select(B) for SubA" -> {"(B, [Select(A)], b_from_a) for SubA"}
+                         "Select(B) for SubA" -> {"(B, [Select(A)], b_from_a()) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA)], a_from_suba) for SubA" -> {"Param(SubA)"}
-                         "(B, [Select(A)], b_from_a) for A" -> {"Param(A)"}
-                         "(B, [Select(A)], b_from_a) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
+                         "(A, [Select(SubA)], a_from_suba()) for SubA" -> {"Param(SubA)"}
+                         "(B, [Select(A)], b_from_a()) for A" -> {"Param(A)"}
+                         "(B, [Select(A)], b_from_a()) for SubA" -> {"(A, [Select(SubA)], a_from_suba()) for SubA"}
                      }""").strip(),
                      fullgraph)
 
   def test_single_rule_depending_on_subject_selection(self):
-    @rule(Exactly(A), [Select(SubA)])
+    @rule(A, [Select(SubA)])
     def a_from_suba(suba):
       pass
 
@@ -369,14 +353,14 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(SubA)], a_from_suba()) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA)], a_from_suba) for SubA" -> {"Param(SubA)"}
+                         "(A, [Select(SubA)], a_from_suba()) for SubA" -> {"Param(SubA)"}
                      }""").strip(),
       subgraph)
 
   def test_multiple_selects(self):
-    @rule(Exactly(A), [Select(SubA), Select(B)])
+    @rule(A, [Select(SubA), Select(B)])
     def a_from_suba_and_b(suba, b):
       pass
 
@@ -396,15 +380,15 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(SubA), Select(B)], a_from_suba_and_b) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(SubA), Select(B)], a_from_suba_and_b()) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA), Select(B)], a_from_suba_and_b) for SubA" -> {"(B, [], b) for ()" "Param(SubA)"}
-                         "(B, [], b) for ()" -> {}
+                         "(A, [Select(SubA), Select(B)], a_from_suba_and_b()) for SubA" -> {"(B, [], b()) for ()" "Param(SubA)"}
+                         "(B, [], b()) for ()" -> {}
                      }""").strip(),
       subgraph)
 
   def test_one_level_of_recursion(self):
-    @rule(Exactly(A), [Select(B)])
+    @rule(A, [Select(B)])
     def a_from_b(b):
       pass
 
@@ -424,19 +408,19 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(B)], a_from_b) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(B)], a_from_b()) for SubA"}
                        // internal entries
-                         "(A, [Select(B)], a_from_b) for SubA" -> {"(B, [Select(SubA)], b_from_suba) for SubA"}
-                         "(B, [Select(SubA)], b_from_suba) for SubA" -> {"Param(SubA)"}
+                         "(A, [Select(B)], a_from_b()) for SubA" -> {"(B, [Select(SubA)], b_from_suba()) for SubA"}
+                         "(B, [Select(SubA)], b_from_suba()) for SubA" -> {"Param(SubA)"}
                      }""").strip(),
       subgraph)
 
   def test_noop_removal_in_subgraph(self):
-    @rule(Exactly(A), [Select(C)])
+    @rule(A, [Select(C)])
     def a_from_c(c):
       pass
 
-    @rule(Exactly(A), [])
+    @rule(A, [])
     def a():
       pass
 
@@ -453,18 +437,18 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for ()" [color=blue]
-                         "Select(A) for ()" -> {"(A, [], a) for ()"}
+                         "Select(A) for ()" -> {"(A, [], a()) for ()"}
                        // internal entries
-                         "(A, [], a) for ()" -> {}
+                         "(A, [], a()) for ()" -> {}
                      }""").strip(),
       subgraph)
 
   def test_noop_removal_full_single_subject_type(self):
-    @rule(Exactly(A), [Select(C)])
+    @rule(A, [Select(C)])
     def a_from_c(c):
       pass
 
-    @rule(Exactly(A), [])
+    @rule(A, [])
     def a():
       pass
 
@@ -480,9 +464,9 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for ()" [color=blue]
-                         "Select(A) for ()" -> {"(A, [], a) for ()"}
+                         "Select(A) for ()" -> {"(A, [], a()) for ()"}
                        // internal entries
-                         "(A, [], a) for ()" -> {}
+                         "(A, [], a()) for ()" -> {}
                      }""").strip(),
       fullgraph)
 
@@ -509,12 +493,12 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: C, D
                        // root entries
                          "Select(A) for C" [color=blue]
-                         "Select(A) for C" -> {"(A, [Select(C)], a_from_c) for C"}
+                         "Select(A) for C" -> {"(A, [Select(C)], a_from_c()) for C"}
                          "Select(B) for (C+D)" [color=blue]
-                         "Select(B) for (C+D)" -> {"(B, [Select(D), Select(A)], b_from_d_and_a) for (C+D)"}
+                         "Select(B) for (C+D)" -> {"(B, [Select(D), Select(A)], b_from_d_and_a()) for (C+D)"}
                        // internal entries
-                         "(A, [Select(C)], a_from_c) for C" -> {"Param(C)"}
-                         "(B, [Select(D), Select(A)], b_from_d_and_a) for (C+D)" -> {"(A, [Select(C)], a_from_c) for C" "Param(D)"}
+                         "(A, [Select(C)], a_from_c()) for C" -> {"Param(C)"}
+                         "(B, [Select(D), Select(A)], b_from_d_and_a()) for (C+D)" -> {"(A, [Select(C)], a_from_c()) for C" "Param(D)"}
                      }""").strip(),
       fullgraph)
 
@@ -522,15 +506,15 @@ class RuleGraphMakerTest(unittest.TestCase):
     # If a noop-able rule has rules that depend on it,
     # they should be removed from the graph.
 
-    @rule(Exactly(B), [Select(C)])
+    @rule(B, [Select(C)])
     def b_from_c(c):
       pass
 
-    @rule(Exactly(A), [Select(B)])
+    @rule(A, [Select(B)])
     def a_from_b(b):
       pass
 
-    @rule(Exactly(A), [])
+    @rule(A, [])
     def a():
       pass
 
@@ -546,14 +530,14 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for ()" [color=blue]
-                         "Select(A) for ()" -> {"(A, [], a) for ()"}
+                         "Select(A) for ()" -> {"(A, [], a()) for ()"}
                        // internal entries
-                         "(A, [], a) for ()" -> {}
+                         "(A, [], a()) for ()" -> {}
                      }""").strip(),
       subgraph)
 
   def test_get_with_matching_singleton(self):
-    @rule(Exactly(A), [Select(SubA)])
+    @rule(A, [Select(SubA)])
     def a_from_suba(suba):
       _ = yield Get(B, C, C())  # noqa: F841
 
@@ -569,9 +553,9 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(SubA)], [Get(B, C)], a_from_suba) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(SubA)], [Get(B, C)], a_from_suba()) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA)], [Get(B, C)], a_from_suba) for SubA" -> {"Param(SubA)" "Singleton(B(), B)"}
+                         "(A, [Select(SubA)], [Get(B, C)], a_from_suba()) for SubA" -> {"Param(SubA)" "Singleton(B(), B)"}
                      }""").strip(),
       subgraph)
 
@@ -601,10 +585,10 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(B) for SubA" [color=blue]
-                         "Select(B) for SubA" -> {"(B, [Select(A)], b_from_a) for SubA"}
+                         "Select(B) for SubA" -> {"(B, [Select(A)], b_from_a()) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA)], a_from_suba) for SubA" -> {"Param(SubA)"}
-                         "(B, [Select(A)], b_from_a) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
+                         "(A, [Select(SubA)], a_from_suba()) for SubA" -> {"Param(SubA)"}
+                         "(B, [Select(A)], b_from_a()) for SubA" -> {"(A, [Select(SubA)], a_from_suba()) for SubA"}
                      }""").strip(),
       subgraph)
 
@@ -634,20 +618,20 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [Select(SubA)], a_from_suba()) for SubA"}
                          "Select(B) for SubA" [color=blue]
-                         "Select(B) for SubA" -> {"(B, [Select(A)], b_from_a) for SubA"}
+                         "Select(B) for SubA" -> {"(B, [Select(A)], b_from_a()) for SubA"}
                          "Select(C) for SubA" [color=blue]
-                         "Select(C) for SubA" -> {"(C, [Select(A)], c_from_a) for SubA"}
+                         "Select(C) for SubA" -> {"(C, [Select(A)], c_from_a()) for SubA"}
                        // internal entries
-                         "(A, [Select(SubA)], a_from_suba) for SubA" -> {"Param(SubA)"}
-                         "(B, [Select(A)], b_from_a) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
-                         "(C, [Select(A)], c_from_a) for SubA" -> {"(A, [Select(SubA)], a_from_suba) for SubA"}
+                         "(A, [Select(SubA)], a_from_suba()) for SubA" -> {"Param(SubA)"}
+                         "(B, [Select(A)], b_from_a()) for SubA" -> {"(A, [Select(SubA)], a_from_suba()) for SubA"}
+                         "(C, [Select(A)], c_from_a()) for SubA" -> {"(A, [Select(SubA)], a_from_suba()) for SubA"}
                      }""").strip(),
       subgraph)
 
   def test_get_simple(self):
-    @rule(Exactly(A), [])
+    @rule(A, [])
     def a():
       _ = yield Get(B, D, D())  # noqa: F841
 
@@ -667,10 +651,10 @@ class RuleGraphMakerTest(unittest.TestCase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for ()" [color=blue]
-                         "Select(A) for ()" -> {"(A, [], [Get(B, D)], a) for ()"}
+                         "Select(A) for ()" -> {"(A, [], [Get(B, D)], a()) for ()"}
                        // internal entries
-                         "(A, [], [Get(B, D)], a) for ()" -> {"(B, [Select(D)], b_from_d) for D"}
-                         "(B, [Select(D)], b_from_d) for D" -> {"Param(D)"}
+                         "(A, [], [Get(B, D)], a()) for ()" -> {"(B, [Select(D)], b_from_d()) for D"}
+                         "(B, [Select(D)], b_from_d()) for D" -> {"Param(D)"}
                      }""").strip(),
                                     subgraph)
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -185,7 +185,7 @@ class SchedulerTest(TestBase):
     self.assertTrue(isinstance(a, A))
     # Fails due to no union relationship from A -> UnionBase.
     expected_msg = """\
-Exception: WithDeps(Inner(InnerEntry { params: {UnionWrapper}, rule: Task(Task { product: TypeConstraint(Exactly(A)), clause: [Select { product: Exactly(UnionWrapper) }], gets: [Get { product: TypeConstraint(Exactly(A)), subject: UnionA }, Get { product: TypeConstraint(Exactly(A)), subject: UnionB }], func: Function(<function a_union_test at 0xEEEEEEEEE>), cacheable: true }) })) did not declare a dependency on JustGet(Get { product: TypeConstraint(Exactly(A)), subject: A })
+Exception: WithDeps(Inner(InnerEntry { params: {UnionWrapper}, rule: Task(Task { product: A, clause: [Select { product: UnionWrapper }], gets: [Get { product: A, subject: UnionA }, Get { product: A, subject: UnionB }], func: a_union_test(), cacheable: true }) })) did not declare a dependency on JustGet(Get { product: A, subject: A })
 """
     with self._assert_execution_error(expected_msg):
       self.scheduler.product_request(A, [Params(UnionWrapper(A()))])
@@ -193,7 +193,7 @@ Exception: WithDeps(Inner(InnerEntry { params: {UnionWrapper}, rule: Task(Task {
   def test_get_type_match_failure(self):
     """Test that Get(...)s are now type-checked during rule execution, to allow for union types."""
     expected_msg = """\
-Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Task(Task { product: TypeConstraint(Exactly(A)), clause: [Select { product: Exactly(TypeCheckFailWrapper) }], gets: [Get { product: TypeConstraint(Exactly(A)), subject: B }], func: Function(<function a_typecheck_fail_test at 0xEEEEEEEEE>), cacheable: true }) })) did not declare a dependency on JustGet(Get { product: TypeConstraint(Exactly(A)), subject: A })
+Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Task(Task { product: A, clause: [Select { product: TypeCheckFailWrapper }], gets: [Get { product: A, subject: B }], func: a_typecheck_fail_test(), cacheable: true }) })) did not declare a dependency on JustGet(Get { product: A, subject: A })
 """
     with self._assert_execution_error(expected_msg):
       # `a_typecheck_fail_test` above expects `wrapper.inner` to be a `B`.

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -221,8 +221,8 @@ class SchedulerTraceTest(unittest.TestCase):
     trace = remove_locations_from_traceback(trace)
 
     assert_equal_with_printing(self, dedent('''
-                     Computing Select(<pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, Exactly(A))
-                       Computing Task(nested_raise, <pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, Exactly(A), true)
+                     Computing Select(<pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, A)
+                       Computing Task(nested_raise(), <pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, A, true)
                          Throw(An exception for B)
                            Traceback (most recent call last):
                              File LOCATION-INFO, in call


### PR DESCRIPTION
### Problem

See #4535 and #4005, in particular [this comment on #4535](https://github.com/pantsbuild/pants/issues/4535#issuecomment-455735882). `TypeConstraint` is a pretty general construct that we would like to do more with, for example #6936, and as of [the current discussion in #4535](https://github.com/pantsbuild/pants/issues/4535#issuecomment-455704544) we realize we can emulate union types in `@rule`s without it, matching just against a specific type.

### Solution

- Convert `output_constraint` in the `Rule` subclasses in `rules.py` into `output_type`, and add a `SubclassesOf(type)` type check in `datatype` fields in those classes to ensure this.
- Remove `satisfied_by()` and `satisfied_by_type()` externs, and add a `product_type()` extern used to intern a python `type` as a `TypeId`.
- Convert all `TypeConstraint`s passed to the engine for intrinsics (e.g. `Snapshot`) into `TypeId`s.
- Match whether a rule's result matches its declared output type by simply using `==`!
- Manually implement `fmt::Debug` for `TypeId` to be the same as `Display` (we may want to do these differently in the future, but it is very useful to see the actual type name when debugging).

### Result

Everything is the same, but now we don't have the additional complexity of `TypeConstraint` down in the engine when we can do simple `TypeId` equality. This lets us get more creative with `TypeConstraint` on the python side, while type checking on the rust side is a little less complex (and probably more efficient to some degree).