### PR TITLE
add a TypedCollection type constraint to reduce boilerplate for datatype tuple fields

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -50,6 +50,7 @@ python_library(
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:future',
+    ':objects',
     ':rules',
     ':selectors',
     'src/python/pants/base:project_tree',
@@ -121,7 +122,10 @@ python_library(
   name='objects',
   sources=['objects.py'],
   dependencies=[
+    '3rdparty/python:future',
     'src/python/pants/util:meta',
+    'src/python/pants/util:memo',
+    'src/python/pants/util:objects',
   ]
 )
 
@@ -172,6 +176,7 @@ python_library(
     ':isolated_process',
     ':native',
     ':nodes',
+    ':objects',
     ':rules',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:specs',

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -11,9 +11,9 @@ from functools import update_wrapper
 from future.utils import string_types
 
 from pants.build_graph.address import Address, BuildFileAddress
-from pants.engine.objects import Resolvable, Serializable
+from pants.engine.objects import Collection, Resolvable, Serializable
 from pants.util.collections_abc_backport import MutableMapping, MutableSequence
-from pants.util.objects import Collection, TypeConstraintError
+from pants.util.objects import TypeConstraintError
 
 
 Addresses = Collection.of(Address)

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -7,10 +7,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from future.utils import binary_type, text_type
 
 from pants.base.project_tree import Dir, File
+from pants.engine.objects import Collection
 from pants.engine.rules import RootRule
 from pants.option.custom_types import GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
-from pants.util.objects import Collection, datatype
+from pants.util.objects import datatype
 
 
 class FileContent(datatype([('path', text_type), ('content', binary_type)])):

--- a/src/python/pants/engine/legacy/BUILD
+++ b/src/python/pants/engine/legacy/BUILD
@@ -75,6 +75,7 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/engine:build_files',
     'src/python/pants/engine:mapper',
+    'src/python/pants/engine:objects',
     'src/python/pants/engine:parser',
     'src/python/pants/engine:selectors',
     'src/python/pants/option',

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -26,13 +26,14 @@ from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
 from pants.engine.legacy.structs import BundleAdaptor, BundlesField, SourcesField, TargetAdaptor
 from pants.engine.mapper import AddressMapper
+from pants.engine.objects import Collection
 from pants.engine.parser import SymbolTable, TargetAdaptorContainer
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, Select
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.source.filespec import any_matches_filespec
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetRelPathWrapper
-from pants.util.objects import Collection, datatype
+from pants.util.objects import datatype
 
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/engine/objects.py
+++ b/src/python/pants/engine/objects.py
@@ -171,11 +171,8 @@ class Collection(object):
       type_name = type_name.encode('utf-8')
     type_checked_collection_class = datatype([
       # Create a datatype with a single field 'dependencies' which is type-checked on construction
-      # to be a collection containing elements of only the exact `element_types` specified, and
-      # which is converted into a tuple upon construction. A tuple `wrapper_type` is required for
-      # the resulting datatype to be hashable, so we set it explicitly here although it is the
-      # default.
-      ('dependencies', TypedCollection(Exactly(*element_types), wrapper_type=tuple))
+      # to be a collection containing elements of only the exact `element_types` specified.
+      ('dependencies', TypedCollection(Exactly(*element_types)))
     ], superclass_name=cls.__name__)
     supertypes = (cls, type_checked_collection_class)
     properties = {'element_types': element_types}

--- a/src/python/pants/engine/objects.py
+++ b/src/python/pants/engine/objects.py
@@ -161,6 +161,8 @@ class Collection(object):
   which may be consumed e.g. over FFI from the engine.
 
   Python consumers of a Collection should prefer to use its standard iteration API.
+
+  Note that elements of a Collection are type-checked upon construction.
   """
 
   @memoized_classmethod

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -19,12 +19,13 @@ from pants.engine.fs import (Digest, DirectoryToMaterialize, FileContent, FilesC
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.engine.native import Function, TypeConstraint, TypeId
 from pants.engine.nodes import Return, Throw
+from pants.engine.objects import Collection
 from pants.engine.rules import RuleIndex, SingletonRule, TaskRule
 from pants.engine.selectors import Params, Select, constraint_for
 from pants.rules.core.exceptions import GracefulTerminationException
 from pants.util.contextutil import temporary_file_path
 from pants.util.dirutil import check_no_overlapping_paths
-from pants.util.objects import Collection, datatype
+from pants.util.objects import datatype
 from pants.util.strutil import pluralize
 
 

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -476,7 +476,9 @@ class TypedCollection(TypeConstraint):
 
   def __init__(self, constraint, wrapper_type=tuple):
 
-    assert(isinstance(constraint, BasicTypeConstraint))
+    if not isinstance(constraint, BasicTypeConstraint):
+      raise TypeError("constraint for collection must be a {}! was: {}"
+                      .format(BasicTypeConstraint.__name__, constraint))
     self._constraint = constraint
 
     super(TypedCollection, self).__init__(
@@ -496,7 +498,7 @@ class TypedCollection(TypeConstraint):
     return type(self) == type(other) and self._constraint == other._constraint
 
   def __repr__(self):
-    return ('{type_constraint_type}({constraint!r}, wrapper_type={wrapper_type!r})'
+    return ('{type_constraint_type}({constraint!r}, wrapper_type={wrapper_type})'
             .format(type_constraint_type=type(self).__name__,
                     constraint=self._constraint,
-                    wrapper_type=self._wrapper_type))
+                    wrapper_type=self._wrapper_type.__name__))

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -485,9 +485,13 @@ class TypedCollection(TypeConstraint):
     return '[{}]'.format(constraint._variance_symbol)
 
   def __init__(self, constraint, wrapper_type=tuple):
-    """
-    :param BasicTypeConstraint constraint: ???
-    :param type wrapper_type:
+    """Create a TypeConstraint which validates each member of a collection with `constraint`.
+
+    :param BasicTypeConstraint constraint: the TypeConstraint to apply to each element. This is
+                                           currently required to be a BasicTypeConstraint to avoid
+                                           complex prototypal type relationships.
+    :param type wrapper_type: the type of the returned collection when invoking
+                              validate_satisfied_by().
     """
 
     if not isinstance(constraint, BasicTypeConstraint):

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -66,23 +66,76 @@ def datatype(field_decls, superclass_name=None, **kwargs):
       if not hasattr(cls.__eq__, '_eq_override_canary'):
         raise cls.make_type_error('Should not override __eq__.')
 
-      try:
-        this_object = super(DataType, cls).__new__(cls, *args, **kwargs)
-      except TypeError as e:
-        raise cls.make_type_error(e)
+      # NB: `TypeConstraint#validate_satisfied_by()` can return a different result than its input if
+      # a `wrapper_type` argument is provided to the base class constructor. Because `namedtuple` is
+      # immutable, we have to do any modifications here. The extra work in this method which
+      # duplicates the positional and keyword argument checking in `namedtuple` reduces a
+      # significant amount of boilerplate when creating `datatype` objects which accept collections,
+      # allowing the object's creator to pass in any type of collection as an argument and ensure
+      # the object is still hashable (by converting it to a tuple). We can also improve the quality
+      # of the argument checking error messages and ensure they are consistent across python
+      # versions.
+      if len(args) > len(field_names):
+        raise cls.make_type_error(
+          """\
+too many positional arguments: {} arguments for {} fields!
+args: {}
+fields: {}"""
+          .format(len(args), len(field_names), args, field_names))
+
+      # Create a dictionary of the positional and keyword arguments.
+      # NB: We use an OrderedDict() to ensure reproducible error messages.
+      arg_dict = OrderedDict()
+      selected_field_names = []
+      for field_index, arg_value in enumerate(args):
+        field_name = field_names[field_index]
+        arg_dict[field_name] = arg_value
+        selected_field_names.append(field_name)
+
+      # Raise if an argument was specified positionally and with a keyword.
+      overlapping_field_names = frozenset(selected_field_names) & frozenset(kwargs.keys())
+      if overlapping_field_names:
+        raise cls.make_type_error(
+          """\
+arguments were specified positionally and by keyword: {}!
+args: {}
+kwargs: {}""".format(list(overlapping_field_names), args, kwargs))
+
+      # The arguments were non-overlapping, so we can safely populate the arg dict.
+      arg_dict.update(kwargs)
+
+      # Check that we don't have any unknown arguments *before* we perform type checking.
+      unrecognized_args = frozenset(arg_dict.keys()) - frozenset(field_names)
+      if unrecognized_args:
+        raise cls.make_type_error("unrecognized arguments: {}".format(list(unrecognized_args)))
+      # Check that we have specified all of the non-optional arguments.
+      missing_args = frozenset(field_names) - frozenset(arg_dict.keys())
+      if missing_args:
+        raise cls.make_type_error("missing arguments: {}".format(list(missing_args)))
 
       # TODO: Make this kind of exception pattern (filter for errors then display them all at once)
       # more ergonomic.
       type_failure_msgs = []
-      for field_name, field_constraint in fields_with_constraints.items():
-        field_value = getattr(this_object, field_name)
-        try:
-          field_constraint.validate_satisfied_by(field_value)
-        except TypeConstraintError as e:
-          type_failure_msgs.append(
-            "field '{}' was invalid: {}".format(field_name, e))
+      for arg_name, arg_value in arg_dict.items():
+        field_constraint = fields_with_constraints.get(arg_name, None)
+        if field_constraint:
+          try:
+            new_arg_val = field_constraint.validate_satisfied_by(arg_value)
+          except TypeConstraintError as e:
+            type_failure_msgs.append("field '{}' was invalid: {}".format(arg_name, e))
+            new_arg_val = 'ERROR: {}'.format(e)
+        else:
+          new_arg_val = arg_value
+        arg_dict[arg_name] = new_arg_val
       if type_failure_msgs:
         raise cls.make_type_error('\n'.join(type_failure_msgs))
+
+      # NB: We haven't checked that we specified all of the non-optional arguments -- we let the
+      # `namedtuple` constructor do that checking for us.
+      try:
+        this_object = super(DataType, cls).__new__(cls, **arg_dict)
+      except TypeError as e:
+        raise cls.make_type_error(e)
 
       return this_object
 
@@ -302,7 +355,8 @@ class TypeConstraint(AbstractClass):
   def validate_satisfied_by(self, obj):
     """Return `obj` if the object satisfies this type constraint, or raise.
 
-    # TODO: consider disallowing overriding this too?
+    If this `TypeConstraint` instance provided a `wrapper_type` to the base class constructor, the
+    result will be of the type `self._wrapper_type`.
 
     :raises: `TypeConstraintError` if `obj` does not satisfy the constraint.
     """

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -130,8 +130,6 @@ kwargs: {}""".format(list(overlapping_field_names), args, kwargs))
       if type_failure_msgs:
         raise cls.make_type_error('\n'.join(type_failure_msgs))
 
-      # NB: We haven't checked that we specified all of the non-optional arguments -- we let the
-      # `namedtuple` constructor do that checking for us.
       try:
         this_object = super(DataType, cls).__new__(cls, **arg_dict)
       except TypeError as e:

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -378,12 +378,14 @@ class TypeConstraint(AbstractClass):
 
 
 class BasicTypeConstraint(TypeConstraint):
-  """???"""
+  """A `TypeConstraint` predicated only on the object's type."""
 
+  # TODO: make an @abstract_classproperty decorator to do this boilerplate!
   @classproperty
   def _variance_symbol(cls):
-    """???"""
-    raise NotImplementedError('???')
+    """This is propagated to the the `TypeConstraint` constructor."""
+    raise NotImplementedError('{} must implement the _variance_symbol classproperty!'
+                              .format(cls.__name__))
 
   def __init__(self, *types):
     """Creates a type constraint centered around the given types.
@@ -411,6 +413,12 @@ class BasicTypeConstraint(TypeConstraint):
 
     # NB: This is made into a tuple so that we can use self._types in issubclass() and others!
     self._types = tuple(types)
+
+  # TODO(#7114): remove this after the engine is converted to use `TypeId` instead of
+  # `TypeConstraint`!
+  @property
+  def types(self):
+    return self._types
 
   @abstractmethod
   def satisfied_by_type(self, obj_type):

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -338,7 +338,10 @@ class TypeConstraint(AbstractClass):
     :param str description: A description for this constraint if the list of types is too long.
     """
     assert(variance_symbol)
-    assert(wrapper_type is None or isinstance(wrapper_type, type))
+    if wrapper_type is not None:
+      if not isinstance(wrapper_type, type):
+        raise TypeError("wrapper_type must be a type! was: {} (type '{}')"
+                        .format(wrapper_type, type(wrapper_type).__name__))
     self._variance_symbol = variance_symbol
     self._wrapper_type = wrapper_type
     self._description = description
@@ -475,12 +478,17 @@ class SubclassesOf(BasicTypeConstraint):
 
 
 class TypedCollection(TypeConstraint):
+  """A `TypeConstraint` which accepts a BasicTypeConstraint and validates a collection."""
 
   @classmethod
   def _generate_variance_symbol(cls, constraint):
     return '[{}]'.format(constraint._variance_symbol)
 
   def __init__(self, constraint, wrapper_type=tuple):
+    """
+    :param BasicTypeConstraint constraint: ???
+    :param type wrapper_type:
+    """
 
     if not isinstance(constraint, BasicTypeConstraint):
       raise TypeError("constraint for collection must be a {}! was: {}"

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -350,10 +350,8 @@ class TypeConstraint(AbstractClass):
     :rtype: bool
     """
 
-  # NB: we currently use the return value and drop the input in all usages of this method, to allow
-  # for the possibility of modifying the returned value in the future.
   def validate_satisfied_by(self, obj):
-    """Return `obj` if the object satisfies this type constraint, or raise.
+    """Return some version of `obj` if the object satisfies this type constraint, or raise.
 
     If this `TypeConstraint` instance provided a `wrapper_type` to the base class constructor, the
     result will be of the type `self._wrapper_type`.

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -295,7 +295,7 @@ class TypeConstraint(AbstractClass):
 
   def make_type_constraint_error(self, obj, constraint):
     return TypeConstraintError(
-      "value {!r} (with type {!r}) must satisfy this type constraint: {!r}."
+      "value {!r} (with type {!r}) must satisfy this type constraint: {}."
       .format(obj, type(obj).__name__, constraint))
 
   # TODO: disallow overriding this method with some form of mixin/decorator along with datatype
@@ -447,7 +447,7 @@ class TypedCollection(TypeConstraint):
 
   def make_collection_type_constraint_error(self, base_obj, el):
     base_error = self.make_type_constraint_error(el, self._constraint)
-    return TypeConstraintError("in wrapped constraint {!r} matching iterable object {!r}: {}"
+    return TypeConstraintError("in wrapped constraint {} matching iterable object {}: {}"
                                .format(self, base_obj, base_error))
 
   def validate_satisfied_by(self, obj):
@@ -459,7 +459,7 @@ class TypedCollection(TypeConstraint):
 
     base_iterable_error = self.make_type_constraint_error(obj, self._iterable_constraint)
     raise TypeConstraintError(
-      "in wrapped constraint {!r}: {}".format(self, base_iterable_error))
+      "in wrapped constraint {}: {}".format(self, base_iterable_error))
 
   def __hash__(self):
     return hash((type(self), self._constraint))

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -156,6 +156,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/engine:build_files',
     'src/python/pants/engine:mapper',
+    'src/python/pants/engine:objects',
     'src/python/pants/engine:struct',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/engine/examples:mapper_test',
@@ -231,4 +232,13 @@ python_library(
     'src/python/pants/engine:scheduler',
     'src/python/pants/util:dirutil',
   ]
+)
+
+python_tests(
+  name='objects',
+  sources=['test_objects.py'],
+  dependencies=[
+    'src/python/pants/engine:objects',
+    'tests/python/pants_test:test_base',
+  ],
 )

--- a/tests/python/pants_test/engine/legacy/test_graph_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_graph_integration.py
@@ -61,12 +61,12 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
   _ERR_TARGETS = {
     'testprojects/src/python/sources:some-missing-some-not': [
       "globs('*.txt', '*.rs')",
-      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/python/sources/*.txt\', {unicode_literal}\'testprojects/src/python/sources/*.rs\'), exclude=(), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=GlobExpansionConjunction>=GlobExpansionConjunction(conjunction=all_match)))".format(unicode_literal='u' if PY2 else ''),
+      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/python/sources/*.txt\', {unicode_literal}\'testprojects/src/python/sources/*.rs\'), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(conjunction=all_match)))".format(unicode_literal='u' if PY2 else ''),
       "Globs did not match. Excludes were: []. Unmatched globs were: [\"testprojects/src/python/sources/*.rs\"].",
     ],
     'testprojects/src/python/sources:missing-sources': [
       "*.scala",
-      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/python/sources/*.scala\',), exclude=({unicode_literal}\'testprojects/src/python/sources/*Test.scala\', {unicode_literal}\'testprojects/src/python/sources/*Spec.scala\'), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=GlobExpansionConjunction>=GlobExpansionConjunction(conjunction=any_match)))".format(unicode_literal='u' if PY2 else ''),
+      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/python/sources/*.scala\',), exclude=({unicode_literal}\'testprojects/src/python/sources/*Test.scala\', {unicode_literal}\'testprojects/src/python/sources/*Spec.scala\'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(conjunction=any_match)))".format(unicode_literal='u' if PY2 else ''),
       "Globs did not match. Excludes were: [\"testprojects/src/python/sources/*Test.scala\", \"testprojects/src/python/sources/*Spec.scala\"]. Unmatched globs were: [\"testprojects/src/python/sources/*.scala\"].",
     ],
     'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-bundle-fileset': [
@@ -75,7 +75,7 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       "Globs('*.aaaa')",
       "ZGlobs('**/*.abab')",
       "['file1.aaaa', 'file2.aaaa']",
-      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<=GlobMatchErrorBehavior>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<=GlobExpansionConjunction>=GlobExpansionConjunction(conjunction=all_match)))".format(unicode_literal='u' if PY2 else ''),
+      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(conjunction=all_match)))".format(unicode_literal='u' if PY2 else ''),
       "Globs did not match. Excludes were: []. Unmatched globs were: [\"testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\"].",
     ]
   }

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -123,8 +123,8 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
     self.assert_equal_with_printing(dedent('''
       1 Exception encountered:
-      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
-        Computing Task(nested_raise, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A, true)
+      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, Exactly(A))
+        Computing Task(nested_raise, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, Exactly(A), true)
           Throw(An exception for B)
             Traceback (most recent call last):
               File LOCATION-INFO, in call
@@ -175,8 +175,8 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
 
     self.assert_equal_with_printing(dedent('''
       1 Exception encountered:
-      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
-        Computing Task(a_from_c_and_d, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A, true)
+      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, Exactly(A))
+        Computing Task(a_from_c_and_d, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, Exactly(A), true)
           Computing Task(d_from_b_nested_raise, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =D, true)
             Throw(An exception for B)
               Traceback (most recent call last):
@@ -189,8 +189,8 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
               Exception: An exception for B
 
 
-      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
-        Computing Task(a_from_c_and_d, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A, true)
+      Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, Exactly(A))
+        Computing Task(a_from_c_and_d, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, Exactly(A), true)
           Computing Task(c_from_b_nested_raise, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =C, true)
             Throw(An exception for B)
               Traceback (most recent call last):

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -17,12 +17,12 @@ from pants.engine.build_files import UnhydratedStruct, create_graph_rules
 from pants.engine.fs import create_fs_rules
 from pants.engine.mapper import (AddressFamily, AddressMap, AddressMapper, DifferingFamiliesError,
                                  DuplicateNameError, UnaddressableObjectError)
+from pants.engine.objects import Collection
 from pants.engine.parser import SymbolTable
 from pants.engine.rules import rule
 from pants.engine.selectors import Get, Select
 from pants.engine.struct import Struct
 from pants.util.dirutil import safe_open
-from pants.util.objects import Collection
 from pants_test.engine.examples.parsers import JsonParser
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
 from pants_test.engine.util import Target, TargetTable

--- a/tests/python/pants_test/engine/test_objects.py
+++ b/tests/python/pants_test/engine/test_objects.py
@@ -27,5 +27,5 @@ field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(
     IntOrStringColl = Collection.of(int, text_type)
     self.assertEqual([3, "hello"], [x for x in IntOrStringColl([3, "hello"])])
     with self.assertRaisesRegexp(TypeCheckError, re.escape("""\
-field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int, unicode)) matching iterable object [{}]: value {} (with type 'dict') must satisfy this type constraint: Exactly(int, unicode).""")):
+field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int, unicode)) matching iterable object [{}]: value {} (with type 'dict') must satisfy this type constraint: Exactly(int or unicode).""")):
       IntOrStringColl([{}])

--- a/tests/python/pants_test/engine/test_objects.py
+++ b/tests/python/pants_test/engine/test_objects.py
@@ -1,0 +1,13 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from pants.engine.objects import Collection
+from pants_test.test_base import TestBase
+
+
+class CollectionTest(TestBase):
+  def test_collection_iteration(self):
+    self.assertEqual([1, 2], [x for x in Collection.of(int)([1, 2])])

--- a/tests/python/pants_test/engine/test_objects.py
+++ b/tests/python/pants_test/engine/test_objects.py
@@ -4,10 +4,28 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import re
+
+from future.utils import PY3, text_type
+
 from pants.engine.objects import Collection
+from pants.util.objects import TypeCheckError
 from pants_test.test_base import TestBase
 
 
 class CollectionTest(TestBase):
   def test_collection_iteration(self):
     self.assertEqual([1, 2], [x for x in Collection.of(int)([1, 2])])
+
+  def test_element_typechecking(self):
+    IntColl = Collection.of(int)
+    with self.assertRaisesRegexp(TypeCheckError, re.escape("""\
+field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'hello']: value {u}'hello' (with type 'unicode') must satisfy this type constraint: Exactly(int)."""
+                                                           .format(u='' if PY3 else 'u'))):
+      IntColl([3, "hello"])
+
+    IntOrStringColl = Collection.of(int, text_type)
+    self.assertEqual([3, "hello"], [x for x in IntOrStringColl([3, "hello"])])
+    with self.assertRaisesRegexp(TypeCheckError, re.escape("""\
+field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int, unicode)) matching iterable object [{}]: value {} (with type 'dict') must satisfy this type constraint: Exactly(int, unicode).""")):
+      IntOrStringColl([{}])

--- a/tests/python/pants_test/engine/test_objects.py
+++ b/tests/python/pants_test/engine/test_objects.py
@@ -20,12 +20,14 @@ class CollectionTest(TestBase):
   def test_element_typechecking(self):
     IntColl = Collection.of(int)
     with self.assertRaisesRegexp(TypeCheckError, re.escape("""\
-field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'hello']: value {u}'hello' (with type 'unicode') must satisfy this type constraint: Exactly(int)."""
-                                                           .format(u='' if PY3 else 'u'))):
+field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'hello']: value {u}'hello' (with type '{string_type}') must satisfy this type constraint: Exactly(int)."""
+                                                           .format(u='' if PY3 else 'u',
+                                                                   string_type='str' if PY3 else 'unicode'))):
       IntColl([3, "hello"])
 
     IntOrStringColl = Collection.of(int, text_type)
     self.assertEqual([3, "hello"], [x for x in IntOrStringColl([3, "hello"])])
     with self.assertRaisesRegexp(TypeCheckError, re.escape("""\
-field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int or unicode)) matching iterable object [{}]: value {} (with type 'dict') must satisfy this type constraint: Exactly(int or unicode).""")):
-      IntOrStringColl([{}])
+field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int or {string_type})) matching iterable object [()]: value () (with type 'tuple') must satisfy this type constraint: Exactly(int or {string_type})."""
+                                                           .format(string_type='str' if PY3 else 'unicode'))):
+      IntOrStringColl([()])

--- a/tests/python/pants_test/engine/test_objects.py
+++ b/tests/python/pants_test/engine/test_objects.py
@@ -27,5 +27,5 @@ field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(
     IntOrStringColl = Collection.of(int, text_type)
     self.assertEqual([3, "hello"], [x for x in IntOrStringColl([3, "hello"])])
     with self.assertRaisesRegexp(TypeCheckError, re.escape("""\
-field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int, unicode)) matching iterable object [{}]: value {} (with type 'dict') must satisfy this type constraint: Exactly(int or unicode).""")):
+field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int or unicode)) matching iterable object [{}]: value {} (with type 'dict') must satisfy this type constraint: Exactly(int or unicode).""")):
       IntOrStringColl([{}])

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -122,8 +122,8 @@ class SchedulerTraceTest(unittest.TestCase):
     trace = remove_locations_from_traceback(trace)
 
     assert_equal_with_printing(self, dedent('''
-                     Computing Select(<pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, =A)
-                       Computing Task(nested_raise, <pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, =A, true)
+                     Computing Select(<pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, Exactly(A))
+                       Computing Task(nested_raise, <pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, Exactly(A), true)
                          Throw(An exception for B)
                            Traceback (most recent call last):
                              File LOCATION-INFO, in call

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -38,7 +38,6 @@ class SuperclassesOfTest(TypeConstraintTestBase):
 
   def test_single(self):
     superclasses_of_b = SuperclassesOf(self.B)
-    self.assertEqual((self.B,), superclasses_of_b.types)
     self.assertTrue(superclasses_of_b.satisfied_by(self.A()))
     self.assertTrue(superclasses_of_b.satisfied_by(self.B()))
     self.assertFalse(superclasses_of_b.satisfied_by(self.BPrime()))
@@ -46,7 +45,6 @@ class SuperclassesOfTest(TypeConstraintTestBase):
 
   def test_multiple(self):
     superclasses_of_a_or_b = SuperclassesOf(self.A, self.B)
-    self.assertEqual((self.A, self.B), superclasses_of_a_or_b.types)
     self.assertTrue(superclasses_of_a_or_b.satisfied_by(self.A()))
     self.assertTrue(superclasses_of_a_or_b.satisfied_by(self.B()))
     self.assertFalse(superclasses_of_a_or_b.satisfied_by(self.BPrime()))
@@ -60,7 +58,6 @@ class ExactlyTest(TypeConstraintTestBase):
 
   def test_single(self):
     exactly_b = Exactly(self.B)
-    self.assertEqual((self.B,), exactly_b.types)
     self.assertFalse(exactly_b.satisfied_by(self.A()))
     self.assertTrue(exactly_b.satisfied_by(self.B()))
     self.assertFalse(exactly_b.satisfied_by(self.BPrime()))
@@ -68,7 +65,6 @@ class ExactlyTest(TypeConstraintTestBase):
 
   def test_multiple(self):
     exactly_a_or_b = Exactly(self.A, self.B)
-    self.assertEqual((self.A, self.B), exactly_a_or_b.types)
     self.assertTrue(exactly_a_or_b.satisfied_by(self.A()))
     self.assertTrue(exactly_a_or_b.satisfied_by(self.B()))
     self.assertFalse(exactly_a_or_b.satisfied_by(self.BPrime()))
@@ -79,10 +75,6 @@ class ExactlyTest(TypeConstraintTestBase):
       Exactly([1])
 
   def test_str_and_repr(self):
-    exactly_b_types = Exactly(self.B, description='B types')
-    self.assertEqual("=(B types)", str(exactly_b_types))
-    self.assertEqual("Exactly(B types)", repr(exactly_b_types))
-
     exactly_b = Exactly(self.B)
     self.assertEqual("=B", str(exactly_b))
     self.assertEqual("Exactly(B)", repr(exactly_b))
@@ -103,7 +95,6 @@ class SubclassesOfTest(TypeConstraintTestBase):
 
   def test_single(self):
     subclasses_of_b = SubclassesOf(self.B)
-    self.assertEqual((self.B,), subclasses_of_b.types)
     self.assertFalse(subclasses_of_b.satisfied_by(self.A()))
     self.assertTrue(subclasses_of_b.satisfied_by(self.B()))
     self.assertFalse(subclasses_of_b.satisfied_by(self.BPrime()))
@@ -111,7 +102,6 @@ class SubclassesOfTest(TypeConstraintTestBase):
 
   def test_multiple(self):
     subclasses_of_b_or_c = SubclassesOf(self.B, self.C)
-    self.assertEqual((self.B, self.C), subclasses_of_b_or_c.types)
     self.assertTrue(subclasses_of_b_or_c.satisfied_by(self.B()))
     self.assertTrue(subclasses_of_b_or_c.satisfied_by(self.C()))
     self.assertFalse(subclasses_of_b_or_c.satisfied_by(self.BPrime()))

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -12,14 +12,9 @@ from builtins import object, str
 
 from future.utils import PY2, PY3, text_type
 
-from pants.util.objects import (Collection, Exactly, SubclassesOf, SuperclassesOf, TypeCheckError,
+from pants.util.objects import (Exactly, SubclassesOf, SuperclassesOf, TypeCheckError,
                                 TypedDatatypeInstanceConstructionError, datatype, enum)
 from pants_test.test_base import TestBase
-
-
-class CollectionTest(TestBase):
-  def test_collection_iteration(self):
-    self.assertEqual([1, 2], [x for x in Collection.of(int)([1, 2])])
 
 
 class TypeConstraintTestBase(TestBase):

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -548,42 +548,42 @@ class TypedDatatypeTest(TestBase):
   def test_instance_construction_errors(self):
     with self.assertRaises(TypeError) as cm:
       SomeTypedDatatype(something=3)
-    expected_msg = """\
-error: in constructor of type SomeTypedDatatype: type check error:
-unrecognized arguments: ['something']"""
+    expected_msg = "error: in constructor of type SomeTypedDatatype: type check error:\n__new__() got an unexpected keyword argument 'something'"
     self.assertEqual(str(cm.exception), expected_msg)
 
     # not providing all the fields
     with self.assertRaises(TypeError) as cm:
       SomeTypedDatatype()
-    expected_msg = """\
-error: in constructor of type SomeTypedDatatype: type check error:
-missing arguments: [{}'val']""".format('u' if PY2 else '')
+    expected_msg_ending = (
+      "__new__() missing 1 required positional argument: 'val'"
+      if PY3 else
+      "__new__() takes exactly 2 arguments (1 given)"
+    )
+    expected_msg = "error: in constructor of type SomeTypedDatatype: type check error:\n" + expected_msg_ending
     self.assertEqual(str(cm.exception), expected_msg)
 
     # unrecognized fields
     with self.assertRaises(TypeError) as cm:
       SomeTypedDatatype(3, 4)
-    expected_msg = """\
-error: in constructor of type SomeTypedDatatype: type check error:
-too many positional arguments: 2 arguments for 1 fields!
-args: (3, 4)
-fields: [{}'val']""".format('u' if PY2 else '')
+    expected_msg_ending = (
+      "__new__() takes 2 positional arguments but 3 were given"
+      if PY3 else
+      "__new__() takes exactly 2 arguments (3 given)"
+    )
+    expected_msg = "error: in constructor of type SomeTypedDatatype: type check error:\n" + expected_msg_ending
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypedDatatypeInstanceConstructionError) as cm:
       CamelCaseWrapper(nonneg_int=3)
-    expected_msg = """\
-error: in constructor of type CamelCaseWrapper: type check error:
-field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(NonNegativeInt)."""
+    expected_msg = (
+      """error: in constructor of type CamelCaseWrapper: type check error:
+field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(NonNegativeInt).""")
     self.assertEqual(str(cm.exception), expected_msg)
 
     # test that kwargs with keywords that aren't field names fail the same way
     with self.assertRaises(TypeError) as cm:
       CamelCaseWrapper(4, a=3)
-    expected_msg = """\
-error: in constructor of type CamelCaseWrapper: type check error:
-unrecognized arguments: ['a']"""
+    expected_msg = "error: in constructor of type CamelCaseWrapper: type check error:\n__new__() got an unexpected keyword argument 'a'"
     self.assertEqual(str(cm.exception), expected_msg)
 
   def test_type_check_errors(self):
@@ -678,9 +678,9 @@ field 'dependencies' was invalid: value [3, {}'asdf'] (with type 'list') must sa
 
     with self.assertRaises(TypeCheckError) as cm:
       obj.copy(nonexistent_field=3)
-    expected_msg = """\
-error: in constructor of type AnotherTypedDatatype: type check error:
-unrecognized arguments: ['nonexistent_field']"""
+    expected_msg = (
+      """error: in constructor of type AnotherTypedDatatype: type check error:
+__new__() got an unexpected keyword argument 'nonexistent_field'""")
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypeCheckError) as cm:

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -130,6 +130,11 @@ class SubclassesOfTest(TypeConstraintTestBase):
 
 
 class TypedCollectionTest(TypeConstraintTestBase):
+  def test_construction_errors(self):
+    with self.assertRaisesRegexp(TypeError, re.escape(
+        "wrapper_type must be a type! was: 3 (type 'int')")):
+      TypedCollection(Exactly(self.B), wrapper_type=3)
+
   def test_str_and_repr(self):
     collection_of_exactly_b = TypedCollection(Exactly(self.B))
     self.assertEqual("[=]B", str(collection_of_exactly_b))

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -678,7 +678,8 @@ field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(
       WithCollectionTypeConstraint([3, "asdf"])
     expected_msg = """\
 error: in constructor of type WithCollectionTypeConstraint: type check error:
-field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'asdf']: value {u}'asdf' (with type 'unicode') must satisfy this type constraint: Exactly(int).""".format(u='u' if PY2 else '')
+field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'asdf']: value {u}'asdf' (with type '{string_type}') must satisfy this type constraint: Exactly(int).\
+""".format(u='u' if PY2 else '', string_type='unicode' if PY2 else 'str')
     self.assertEqual(str(cm.exception), expected_msg)
 
   def test_copy(self):

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -456,42 +456,42 @@ class TypedDatatypeTest(TestBase):
   def test_instance_construction_errors(self):
     with self.assertRaises(TypeError) as cm:
       SomeTypedDatatype(something=3)
-    expected_msg = "error: in constructor of type SomeTypedDatatype: type check error:\n__new__() got an unexpected keyword argument 'something'"
+    expected_msg = """\
+error: in constructor of type SomeTypedDatatype: type check error:
+unrecognized arguments: ['something']"""
     self.assertEqual(str(cm.exception), expected_msg)
 
     # not providing all the fields
     with self.assertRaises(TypeError) as cm:
       SomeTypedDatatype()
-    expected_msg_ending = (
-      "__new__() missing 1 required positional argument: 'val'"
-      if PY3 else
-      "__new__() takes exactly 2 arguments (1 given)"
-    )
-    expected_msg = "error: in constructor of type SomeTypedDatatype: type check error:\n" + expected_msg_ending
+    expected_msg = """\
+error: in constructor of type SomeTypedDatatype: type check error:
+missing arguments: [u'val']"""
     self.assertEqual(str(cm.exception), expected_msg)
 
     # unrecognized fields
     with self.assertRaises(TypeError) as cm:
       SomeTypedDatatype(3, 4)
-    expected_msg_ending = (
-      "__new__() takes 2 positional arguments but 3 were given"
-      if PY3 else
-      "__new__() takes exactly 2 arguments (3 given)"
-    )
-    expected_msg = "error: in constructor of type SomeTypedDatatype: type check error:\n" + expected_msg_ending
+    expected_msg = """\
+error: in constructor of type SomeTypedDatatype: type check error:
+too many positional arguments: 2 arguments for 1 fields!
+args: (3, 4)
+fields: [u'val']"""
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypedDatatypeInstanceConstructionError) as cm:
       CamelCaseWrapper(nonneg_int=3)
-    expected_msg = (
-      """error: in constructor of type CamelCaseWrapper: type check error:
-field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(NonNegativeInt).""")
+    expected_msg = """\
+error: in constructor of type CamelCaseWrapper: type check error:
+field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(NonNegativeInt)."""
     self.assertEqual(str(cm.exception), expected_msg)
 
     # test that kwargs with keywords that aren't field names fail the same way
     with self.assertRaises(TypeError) as cm:
       CamelCaseWrapper(4, a=3)
-    expected_msg = "error: in constructor of type CamelCaseWrapper: type check error:\n__new__() got an unexpected keyword argument 'a'"
+    expected_msg = """\
+error: in constructor of type CamelCaseWrapper: type check error:
+unrecognized arguments: ['a']"""
     self.assertEqual(str(cm.exception), expected_msg)
 
   def test_type_check_errors(self):
@@ -572,9 +572,9 @@ field 'some_value' was invalid: value 3 (with type 'int') must satisfy this type
 
     with self.assertRaises(TypeCheckError) as cm:
       obj.copy(nonexistent_field=3)
-    expected_msg = (
-      """error: in constructor of type AnotherTypedDatatype: type check error:
-__new__() got an unexpected keyword argument 'nonexistent_field'""")
+    expected_msg = """\
+error: in constructor of type AnotherTypedDatatype: type check error:
+unrecognized arguments: ['nonexistent_field']"""
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypeCheckError) as cm:

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -558,7 +558,7 @@ unrecognized arguments: ['something']"""
       SomeTypedDatatype()
     expected_msg = """\
 error: in constructor of type SomeTypedDatatype: type check error:
-missing arguments: [u'val']"""
+missing arguments: [{}'val']""".format('u' if PY2 else '')
     self.assertEqual(str(cm.exception), expected_msg)
 
     # unrecognized fields
@@ -568,7 +568,7 @@ missing arguments: [u'val']"""
 error: in constructor of type SomeTypedDatatype: type check error:
 too many positional arguments: 2 arguments for 1 fields!
 args: (3, 4)
-fields: [u'val']"""
+fields: [{}'val']""".format('u' if PY2 else '')
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypedDatatypeInstanceConstructionError) as cm:
@@ -662,7 +662,7 @@ field 'dependencies' was invalid: value 3 (with type 'int') must satisfy this ty
       WithCollectionTypeConstraint([3, "asdf"])
     expected_msg = """\
 error: in constructor of type WithCollectionTypeConstraint: type check error:
-field 'dependencies' was invalid: value [3, u'asdf'] (with type 'list') must satisfy this type constraint: TypedCollection(Exactly(int), wrapper_type=tuple)."""
+field 'dependencies' was invalid: value [3, {}'asdf'] (with type 'list') must satisfy this type constraint: TypedCollection(Exactly(int), wrapper_type=tuple).""".format('u' if PY2 else '')
     self.assertEqual(str(cm.exception), expected_msg)
 
   def test_copy(self):


### PR DESCRIPTION
### Problem

*Resolves #6936.*

There's been a [TODO in `pants.util.objects.Collection`](https://github.com/pantsbuild/pants/blob/c342fd3432aa0d73e402d2db7e013ecfcc76e9c8/src/python/pants/util/objects.py#L413) for a while to typecheck datatype tuple fields.

#6936 has some thoughts on how to do this, but after realizing I could split out `TypeConstraint` into a base class and then introduce `BasicTypeConstraint` for type constraints which only act on the type, I think that ticket is invalidated as this solution is much cleaner.

### Solution

- Split out logic for basic type checking (without looking at the object itself) into a `BasicTypeConstraint` class, which `Exactly` and friends inherit from.
- Create the `TypedCollection` type constraint, which checks that its argument is iterable and then validates each element of the collection with a `BasicTypeConstraint` constructor argument.
  - Note that `TypedCollection` is a `TypeConstraint`, but not a `BasicTypeConstraint`, as it has to inspect the actual object object to determine whether each element matches the provided `BasicTypeConstraint`.
- Move `pants.util.objects.Collection` into `src/python/pants/engine/objects.py`, as it is specifically for engine objects.
- Use `TypedCollection` for the `dependencies` field of the datatype returned by `Collection.of()`.

### Result

- `datatype` consumers and creators no longer have to have lots of boilerplate when using collections arguments, and those arguments can now be typechecked and made hashable for free!

### TODO in followup: `wrapper_type`

See #7172.