### PR TITLE
Allow flags to be logged to stats server

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -220,7 +220,7 @@ class LocalPantsRunner(object):
     # Launch RunTracker as early as possible (just after Subsystem options are initialized).
     run_tracker = RunTracker.global_instance()
     reporting = Reporting.global_instance()
-    reporting.initialize(run_tracker, self._run_start_time)
+    reporting.initialize(run_tracker, self._options, self._run_start_time)
 
     try:
       # Capture a repro of the 'before' state for this build, if needed.

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -101,6 +101,7 @@ python_library(
     'src/python/pants/base:run_info',
     'src/python/pants/base:worker_pool',
     'src/python/pants/base:workunit',
+    'src/python/pants/option',
     'src/python/pants/reporting', # XXX(fixme)
     'src/python/pants/stats',
     'src/python/pants/subsystem',

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -549,9 +549,6 @@ class RunTracker(Subsystem):
     """
     scope_to_look_up = scope if scope != 'GLOBAL' else ''
     try:
-      # Yeah, it's a little sketchy to be looking up Subsystem._options here, but... Someone went
-      # to some care to make sure that Subsystems only get scoped options, and we need to
-      # circumvent that in this one specific place...
       value = self._all_options.for_scope(scope_to_look_up, inherit_from_enclosing_scope=False).as_dict()
       if option is None:
         return value

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -86,6 +86,9 @@ class OptionValueContainer(object):
     for k, v in other._value_map.items():
       self._set(k, v)
 
+  def as_dict(self):
+    return {key: self.get(key) for key in self._value_map}
+
   def _get_underlying_value(self, key):
     # Note that the key may exist with a value of None, so we can't just
     # test self._value_map.get() for None.

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -47,13 +47,13 @@ class Reporting(Subsystem):
                   '{workunits}.  Possible formatting values are {formats}'.format(
                workunits=list(WorkUnitLabel.keys()), formats=list(ToolOutputFormat.keys())))
 
-  def initialize(self, run_tracker, start_time=None):
+  def initialize(self, run_tracker, all_options, start_time=None):
     """Initialize with the given RunTracker.
 
     TODO: See `RunTracker.start`.
     """
 
-    run_id = run_tracker.initialize()
+    run_id = run_tracker.initialize(all_options)
     run_dir = os.path.join(self.get_options().reports_dir, run_id)
 
     html_dir = os.path.join(run_dir, 'html')

--- a/tests/python/pants_test/goal/test_run_tracker_integration.py
+++ b/tests/python/pants_test/goal/test_run_tracker_integration.py
@@ -18,7 +18,7 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
       pants_run = self.run_pants([
         'test',
         '--run-tracker-stats-local-json-file={}'.format(tmpfile),
-        '--run-tracker-stats-option-scopes-to-record=["GLOBAL", "GLOBAL.enable_pantsd", "compile.zinc.execution_strategy"]',
+        '--run-tracker-stats-option-scopes-to-record=["GLOBAL", "GLOBAL^enable_pantsd", "compile.zinc^execution_strategy"]',
         'testprojects/src/java/org/pantsbuild/testproject/unicode/main',
       ])
       self.assert_success(pants_run)
@@ -36,8 +36,8 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
         self.assertIn('GLOBAL', stats_json['recorded_options'])
         self.assertIs(stats_json['recorded_options']['GLOBAL']['enable_pantsd'], False)
         self.assertEqual(stats_json['recorded_options']['GLOBAL']['level'], 'info')
-        self.assertIs(stats_json['recorded_options']['GLOBAL.enable_pantsd'], False)
-        self.assertEqual(stats_json['recorded_options']['compile.zinc.execution_strategy'], 'nailgun')
+        self.assertIs(stats_json['recorded_options']['GLOBAL^enable_pantsd'], False)
+        self.assertEqual(stats_json['recorded_options']['compile.zinc^execution_strategy'], 'nailgun')
 
   def test_workunit_failure(self):
     pants_run = self.run_pants([

--- a/tests/python/pants_test/goal/test_run_tracker_integration.py
+++ b/tests/python/pants_test/goal/test_run_tracker_integration.py
@@ -18,7 +18,7 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
       pants_run = self.run_pants([
         'test',
         '--run-tracker-stats-local-json-file={}'.format(tmpfile),
-        '--run-tracker-stats-option-scopes-to-record=["GLOBAL", "GLOBAL^enable_pantsd", "compile.zinc^execution_strategy"]',
+        '--run-tracker-stats-option-scopes-to-record=["GLOBAL", "GLOBAL^enable_pantsd", "compile.zinc^capture_classpath"]',
         'testprojects/src/java/org/pantsbuild/testproject/unicode/main',
       ])
       self.assert_success(pants_run)
@@ -37,7 +37,7 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
         self.assertIs(stats_json['recorded_options']['GLOBAL']['enable_pantsd'], False)
         self.assertEqual(stats_json['recorded_options']['GLOBAL']['level'], 'info')
         self.assertIs(stats_json['recorded_options']['GLOBAL^enable_pantsd'], False)
-        self.assertEqual(stats_json['recorded_options']['compile.zinc^execution_strategy'], 'nailgun')
+        self.assertEqual(stats_json['recorded_options']['compile.zinc^capture_classpath'], True)
 
   def test_workunit_failure(self):
     pants_run = self.run_pants([


### PR DESCRIPTION
This makes it easier to ask questions like "what effect does pantsd
have?" accurately.

By default, nothing extra is logged, but a list of option scopes, or
specific flags, can be logged.