### PR TITLE
deprecate implicit usage of binary_mode=True and mode='wb' in dirutil methods

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -34,7 +34,7 @@ from pants.java.jar.jar_dependency import JarDependency
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.util.contextutil import Timer
 from pants.util.dirutil import (fast_relpath, fast_relpath_optional, maybe_read_file,
-                                safe_file_dump, safe_mkdir)
+                                safe_file_write, safe_mkdir)
 from pants.util.memo import memoized_property
 
 
@@ -60,9 +60,11 @@ def stdout_contents(wu):
     return f.read().rstrip()
 
 
-def dump_digest(output_dir, digest):
-  safe_file_dump('{}.digest'.format(output_dir),
-    '{}:{}'.format(digest.fingerprint, digest.serialized_bytes_length), mode='w')
+def write_digest(output_dir, digest):
+  safe_file_write(
+    '{}.digest'.format(output_dir),
+    mode='w',
+    payload='{}:{}'.format(digest.fingerprint, digest.serialized_bytes_length))
 
 
 def load_digest(output_dir):
@@ -823,7 +825,7 @@ class RscCompile(ZincCompile):
       raise TaskError(res.stderr)
 
     if output_dir:
-      dump_digest(output_dir, res.output_directory_digest)
+      write_digest(output_dir, res.output_directory_digest)
       self.context._scheduler.materialize_directories((
         DirectoryToMaterialize(
           # NB the first element here is the root to materialize into, not the dir to snapshot

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -34,7 +34,7 @@ from pants.java.jar.jar_dependency import JarDependency
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.util.contextutil import Timer
 from pants.util.dirutil import (fast_relpath, fast_relpath_optional, maybe_read_file,
-                                safe_file_write, safe_mkdir)
+                                safe_file_dump, safe_mkdir)
 from pants.util.memo import memoized_property
 
 
@@ -61,7 +61,7 @@ def stdout_contents(wu):
 
 
 def write_digest(output_dir, digest):
-  safe_file_write(
+  safe_file_dump(
     '{}.digest'.format(output_dir),
     mode='w',
     payload='{}:{}'.format(digest.fingerprint, digest.serialized_bytes_length))

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -31,7 +31,7 @@ from pants.option.config import Config
 from pants.reporting.report import Report
 from pants.stats.statsdb import StatsDBFactory
 from pants.subsystem.subsystem import Subsystem
-from pants.util.dirutil import relative_symlink, safe_file_dump
+from pants.util.dirutil import relative_symlink, safe_file_write
 
 
 class RunTracker(Subsystem):
@@ -412,7 +412,7 @@ class RunTracker(Subsystem):
     stats_file = os.path.join(get_pants_cachedir(), 'stats',
                               '{}.json'.format(self.run_info.get_info('id')))
     mode = 'w' if PY3 else 'wb'
-    safe_file_dump(stats_file, json.dumps(stats), mode=mode)
+    safe_file_write(stats_file, json.dumps(stats), mode=mode)
 
     # Add to local stats db.
     StatsDBFactory.global_instance().get_db().insert_stats(stats)

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -31,7 +31,7 @@ from pants.option.config import Config
 from pants.reporting.report import Report
 from pants.stats.statsdb import StatsDBFactory
 from pants.subsystem.subsystem import Subsystem
-from pants.util.dirutil import relative_symlink, safe_file_write
+from pants.util.dirutil import relative_symlink, safe_file_dump
 
 
 class RunTracker(Subsystem):
@@ -412,7 +412,7 @@ class RunTracker(Subsystem):
     stats_file = os.path.join(get_pants_cachedir(), 'stats',
                               '{}.json'.format(self.run_info.get_info('id')))
     mode = 'w' if PY3 else 'wb'
-    safe_file_write(stats_file, json.dumps(stats), mode=mode)
+    safe_file_dump(stats_file, json.dumps(stats), mode=mode)
 
     # Add to local stats db.
     StatsDBFactory.global_instance().get_db().insert_stats(stats)

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -20,7 +20,7 @@ from pants.base.build_environment import get_buildroot
 from pants.java.executor import Executor, SubprocessExecutor
 from pants.java.nailgun_client import NailgunClient
 from pants.pantsd.process_manager import FingerprintedProcessManager, ProcessGroup
-from pants.util.dirutil import read_file, safe_file_write, safe_open
+from pants.util.dirutil import read_file, safe_file_dump, safe_open
 
 
 logger = logging.getLogger(__name__)
@@ -228,8 +228,8 @@ class NailgunExecutor(Executor, FingerprintedProcessManager):
   def _spawn_nailgun_server(self, fingerprint, jvm_options, classpath, stdout, stderr, stdin):
     """Synchronously spawn a new nailgun server."""
     # Truncate the nailguns stdout & stderr.
-    safe_file_write(self._ng_stdout, b'', mode='wb')
-    safe_file_write(self._ng_stderr, b'', mode='wb')
+    safe_file_dump(self._ng_stdout, b'', mode='wb')
+    safe_file_dump(self._ng_stderr, b'', mode='wb')
 
     jvm_options = jvm_options + [self._PANTS_NG_BUILDROOT_ARG,
                                  self._create_owner_arg(self._workdir),

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -20,7 +20,7 @@ from pants.base.build_environment import get_buildroot
 from pants.java.executor import Executor, SubprocessExecutor
 from pants.java.nailgun_client import NailgunClient
 from pants.pantsd.process_manager import FingerprintedProcessManager, ProcessGroup
-from pants.util.dirutil import read_file, safe_file_dump, safe_open
+from pants.util.dirutil import read_file, safe_file_write, safe_open
 
 
 logger = logging.getLogger(__name__)
@@ -228,8 +228,8 @@ class NailgunExecutor(Executor, FingerprintedProcessManager):
   def _spawn_nailgun_server(self, fingerprint, jvm_options, classpath, stdout, stderr, stdin):
     """Synchronously spawn a new nailgun server."""
     # Truncate the nailguns stdout & stderr.
-    safe_file_dump(self._ng_stdout, b'')
-    safe_file_dump(self._ng_stderr, b'')
+    safe_file_write(self._ng_stdout, b'', mode='wb')
+    safe_file_write(self._ng_stderr, b'', mode='wb')
 
     jvm_options = jvm_options + [self._PANTS_NG_BUILDROOT_ARG,
                                  self._create_owner_arg(self._workdir),

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -103,7 +103,7 @@ class OptionsBootstrapper(datatype([
     short_flags = set()
 
     def filecontent_for(path):
-      return FileContent(ensure_text(path), read_file(path))
+      return FileContent(ensure_text(path), read_file(path, binary_mode=True))
 
     def capture_the_flags(*args, **kwargs):
       for arg in args:

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -18,7 +18,7 @@ import psutil
 from pants.base.build_environment import get_buildroot
 from pants.process.lock import OwnerPrintingInterProcessFileLock
 from pants.process.subprocess import Subprocess
-from pants.util.dirutil import read_file, rm_rf, safe_file_write, safe_mkdir
+from pants.util.dirutil import read_file, rm_rf, safe_file_dump, safe_mkdir
 from pants.util.memo import memoized_property
 from pants.util.process_handler import subprocess
 
@@ -191,7 +191,7 @@ class ProcessMetadataManager(object):
     """
     self._maybe_init_metadata_dir_by_name(name)
     file_path = self._metadata_file_path(name, metadata_key)
-    safe_file_write(file_path, metadata_value)
+    safe_file_dump(file_path, metadata_value, mode='w')
 
   def await_metadata_by_name(self, name, metadata_key, timeout, caster=None):
     """Block up to a timeout for process metadata to arrive on disk.

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -18,7 +18,7 @@ import psutil
 from pants.base.build_environment import get_buildroot
 from pants.process.lock import OwnerPrintingInterProcessFileLock
 from pants.process.subprocess import Subprocess
-from pants.util.dirutil import read_file, rm_rf, safe_file_dump, safe_mkdir
+from pants.util.dirutil import read_file, rm_rf, safe_file_write, safe_mkdir
 from pants.util.memo import memoized_property
 from pants.util.process_handler import subprocess
 
@@ -191,7 +191,7 @@ class ProcessMetadataManager(object):
     """
     self._maybe_init_metadata_dir_by_name(name)
     file_path = self._metadata_file_path(name, metadata_key)
-    safe_file_dump(file_path, metadata_value, binary_mode=False)
+    safe_file_write(file_path, metadata_value)
 
   def await_metadata_by_name(self, name, metadata_key, timeout, caster=None):
     """Block up to a timeout for process metadata to arrive on disk.

--- a/src/python/pants/pantsd/watchman.py
+++ b/src/python/pants/pantsd/watchman.py
@@ -13,7 +13,7 @@ from collections import namedtuple
 
 from pants.pantsd.process_manager import ProcessManager
 from pants.pantsd.watchman_client import StreamableWatchmanClient
-from pants.util.dirutil import safe_file_dump, safe_mkdir
+from pants.util.dirutil import safe_file_write, safe_mkdir
 from pants.util.retry import retry_on_exception
 
 
@@ -82,7 +82,7 @@ class Watchman(ProcessManager):
   def _maybe_init_metadata(self):
     safe_mkdir(self._watchman_work_dir)
     # Initialize watchman with an empty, but valid statefile so it doesn't complain on startup.
-    safe_file_dump(self._state_file, b'{}')
+    safe_file_write(self._state_file, b'{}', mode='wb')
 
   def _construct_cmd(self, cmd_parts, state_file, sock_file, pid_file, log_file, log_level):
     return [part for part in cmd_parts] + ['--no-save-state',

--- a/src/python/pants/pantsd/watchman.py
+++ b/src/python/pants/pantsd/watchman.py
@@ -13,7 +13,7 @@ from collections import namedtuple
 
 from pants.pantsd.process_manager import ProcessManager
 from pants.pantsd.watchman_client import StreamableWatchmanClient
-from pants.util.dirutil import safe_file_write, safe_mkdir
+from pants.util.dirutil import safe_file_dump, safe_mkdir
 from pants.util.retry import retry_on_exception
 
 
@@ -82,7 +82,7 @@ class Watchman(ProcessManager):
   def _maybe_init_metadata(self):
     safe_mkdir(self._watchman_work_dir)
     # Initialize watchman with an empty, but valid statefile so it doesn't complain on startup.
-    safe_file_write(self._state_file, b'{}', mode='wb')
+    safe_file_dump(self._state_file, b'{}', mode='wb')
 
   def _construct_cmd(self, cmd_parts, state_file, sock_file, pid_file, log_file, log_level):
     return [part for part in cmd_parts] + ['--no-save-state',

--- a/src/python/pants/releases/reversion.py
+++ b/src/python/pants/releases/reversion.py
@@ -15,7 +15,7 @@ import zipfile
 from builtins import open, str
 
 from pants.util.contextutil import open_zip, temporary_dir
-from pants.util.dirutil import read_file, safe_file_dump
+from pants.util.dirutil import read_file, safe_file_write
 
 
 def replace_in_file(workspace, src_file_path, from_str, to_str):
@@ -30,7 +30,7 @@ def replace_in_file(workspace, src_file_path, from_str, to_str):
     return None
 
   dst_file_path = src_file_path.replace(from_str, to_str)
-  safe_file_dump(os.path.join(workspace, dst_file_path), data.replace(from_bytes, to_bytes))
+  safe_file_write(os.path.join(workspace, dst_file_path), data.replace(from_bytes, to_bytes), mode='wb')
   if src_file_path != dst_file_path:
     os.unlink(os.path.join(workspace, src_file_path))
   return dst_file_path
@@ -88,7 +88,7 @@ def rewrite_record_file(workspace, src_record_file, mutated_file_tuples):
       output_line = line
     output_records.append(output_line)
 
-  safe_file_dump(file_name, '\r\n'.join(output_records) + '\r\n', binary_mode=False)
+  safe_file_write(file_name, '\r\n'.join(output_records) + '\r\n')
 
 
 # The wheel METADATA file will contain a line like: `Version: 1.11.0.dev3+7951ec01`.

--- a/src/python/pants/releases/reversion.py
+++ b/src/python/pants/releases/reversion.py
@@ -15,7 +15,7 @@ import zipfile
 from builtins import open, str
 
 from pants.util.contextutil import open_zip, temporary_dir
-from pants.util.dirutil import read_file, safe_file_write
+from pants.util.dirutil import read_file, safe_file_dump
 
 
 def replace_in_file(workspace, src_file_path, from_str, to_str):
@@ -30,7 +30,7 @@ def replace_in_file(workspace, src_file_path, from_str, to_str):
     return None
 
   dst_file_path = src_file_path.replace(from_str, to_str)
-  safe_file_write(os.path.join(workspace, dst_file_path), data.replace(from_bytes, to_bytes), mode='wb')
+  safe_file_dump(os.path.join(workspace, dst_file_path), data.replace(from_bytes, to_bytes), mode='wb')
   if src_file_path != dst_file_path:
     os.unlink(os.path.join(workspace, src_file_path))
   return dst_file_path
@@ -88,7 +88,7 @@ def rewrite_record_file(workspace, src_record_file, mutated_file_tuples):
       output_line = line
     output_records.append(output_line)
 
-  safe_file_write(file_name, '\r\n'.join(output_records) + '\r\n')
+  safe_file_dump(file_name, '\r\n'.join(output_records) + '\r\n', mode='w')
 
 
 # The wheel METADATA file will contain a line like: `Version: 1.11.0.dev3+7951ec01`.

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -56,6 +56,7 @@ python_library(
   dependencies = [
     ':strutil',
     '3rdparty/python:future',
+    'src/python/pants/base:deprecated',
   ],
 )
 

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -16,7 +16,7 @@ from builtins import open
 from collections import defaultdict
 from contextlib import contextmanager
 
-from pants.base.deprecated import deprecated
+from pants.base.deprecated import deprecated, deprecated_conditional
 from pants.util.strutil import ensure_text
 
 
@@ -136,8 +136,8 @@ def safe_file_write(filename, mode=None, payload=None):
   This method is "safe" to the extent that `safe_open` is "safe". See the explanation on the method
   doc there.
 
-  When `payload` is an empty string, this method can be used as a concise way to create an empty
-  file along with its containing directory or truncate it if it already exists.
+  When `payload` is an empty string (the default), this method can be used as a concise way to
+  create an empty file along with its containing directory or truncate it if it already exists.
 
   :param string filename: The filename of the file to write to.
   :param string mode: A mode argument for the python `open` builtin. Defaults to 'w' (text).
@@ -147,7 +147,7 @@ def safe_file_write(filename, mode=None, payload=None):
     f.write(payload or '')
 
 
-def maybe_read_file(filename, binary_mode=True):
+def maybe_read_file(filename, binary_mode=None):
   """Read and return the contents of a file in a single file.read().
 
   :param string filename: The filename of the file to read.
@@ -155,13 +155,21 @@ def maybe_read_file(filename, binary_mode=True):
   :returns: The contents of the file, or opening the file fails for any reason
   :rtype: string
   """
+  deprecated_conditional(
+    lambda: binary_mode is None,
+    removal_version='1.16.0.dev2',
+    entity_description='Not specifying binary_mode explicitly in maybe_read_file()',
+    hint_message='This will default to unicode when pants migrates to python 3!')
+  if binary_mode is None:
+    binary_mode = True
+
   try:
     return read_file(filename, binary_mode=binary_mode)
   except IOError:
     return None
 
 
-def read_file(filename, binary_mode=True):
+def read_file(filename, binary_mode=None):
   """Read and return the contents of a file in a single file.read().
 
   :param string filename: The filename of the file to read.
@@ -169,6 +177,14 @@ def read_file(filename, binary_mode=True):
   :returns: The contents of the file.
   :rtype: string
   """
+  deprecated_conditional(
+    lambda: binary_mode is None,
+    removal_version='1.16.0.dev2',
+    entity_description='Not specifying binary_mode explicitly in read_file()',
+    hint_message='This will default to unicode when pants migrates to python 3!')
+  if binary_mode is None:
+    binary_mode = True
+
   mode = 'rb' if binary_mode else 'r'
   with open(filename, mode) as f:
     return f.read()

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -155,6 +155,7 @@ def maybe_read_file(filename, binary_mode=None):
   :returns: The contents of the file, or opening the file fails for any reason
   :rtype: string
   """
+  # TODO(#7121): Default binary_mode=False after the python 3 switchover!
   deprecated_conditional(
     lambda: binary_mode is None,
     removal_version='1.16.0.dev2',
@@ -177,6 +178,7 @@ def read_file(filename, binary_mode=None):
   :returns: The contents of the file.
   :rtype: string
   """
+  # TODO(#7121): Default binary_mode=False after the python 3 switchover!
   deprecated_conditional(
     lambda: binary_mode is None,
     removal_version='1.16.0.dev2',

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -101,7 +101,9 @@ def safe_mkdir_for_all(paths):
       created_dirs.add(dir_to_make)
 
 
-@deprecated('1.16.0.dev2', hint_message='Use safe_file_write() instead!')
+@deprecated(
+  '1.16.0.dev2',
+  hint_message='Use safe_file_write() instead. It removes the deprecated `binary_mode` argument to instead only allow `mode`. It also defaults to writing unicode, rather than defaulting to bytes.')
 def safe_file_dump(filename, payload, binary_mode=None, mode=None):
   """Write a string to a file.
 
@@ -130,7 +132,10 @@ def safe_file_dump(filename, payload, binary_mode=None, mode=None):
   safe_file_write(filename, payload=payload, mode=mode)
 
 
-def safe_file_write(filename, payload=None, mode=None):
+# TODO(#6742): payload should be Union[str, bytes] in type hint syntax, but from
+# https://pythonhosted.org/an_example_pypi_project/sphinx.html#full-code-example it doesn't appear
+# that is possible to represent in docstring type syntax.
+def safe_file_write(filename, payload='', mode='w'):
   """Write a string to a file.
 
   This method is "safe" to the extent that `safe_open` is "safe". See the explanation on the method
@@ -140,12 +145,10 @@ def safe_file_write(filename, payload=None, mode=None):
   create an empty file along with its containing directory (or truncate it if it already exists).
 
   :param string filename: The filename of the file to write to.
-  :param string payload: The string to write to the file. Defaults to the empty string.
-  :param string mode: A mode argument for the python `open` builtin. Defaults to 'w' (text).
+  :param string payload: The string to write to the file.
+  :param string mode: A mode argument for the python `open` builtin.
   """
-  if payload is None:
-    payload = ''
-  with safe_open(filename, mode=mode or 'w') as f:
+  with safe_open(filename, mode=mode) as f:
     f.write(payload)
 
 
@@ -162,7 +165,7 @@ def maybe_read_file(filename, binary_mode=None):
     lambda: binary_mode is None,
     removal_version='1.16.0.dev2',
     entity_description='Not specifying binary_mode explicitly in maybe_read_file()',
-    hint_message='This will default to unicode when pants migrates to python 3!')
+    hint_message='Function will default to unicode when pants migrates to python 3!')
   if binary_mode is None:
     binary_mode = True
 
@@ -185,7 +188,7 @@ def read_file(filename, binary_mode=None):
     lambda: binary_mode is None,
     removal_version='1.16.0.dev2',
     entity_description='Not specifying binary_mode explicitly in read_file()',
-    hint_message='This will default to unicode when pants migrates to python 3!')
+    hint_message='Function will default to unicode when pants migrates to python 3!')
   if binary_mode is None:
     binary_mode = True
 

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -137,7 +137,7 @@ def safe_file_write(filename, payload=None, mode=None):
   doc there.
 
   When `payload` is an empty string (the default), this method can be used as a concise way to
-  create an empty file along with its containing directory or truncate it if it already exists.
+  create an empty file along with its containing directory (or truncate it if it already exists).
 
   :param string filename: The filename of the file to write to.
   :param string payload: The string to write to the file. Defaults to the empty string.

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -16,6 +16,7 @@ from builtins import open
 from collections import defaultdict
 from contextlib import contextmanager
 
+from pants.base.deprecated import deprecated
 from pants.util.strutil import ensure_text
 
 
@@ -100,6 +101,7 @@ def safe_mkdir_for_all(paths):
       created_dirs.add(dir_to_make)
 
 
+@deprecated('1.16.0.dev2', hint_message='Use safe_file_write() instead!')
 def safe_file_dump(filename, payload, binary_mode=None, mode=None):
   """Write a string to a file.
 
@@ -125,8 +127,24 @@ def safe_file_dump(filename, payload, binary_mode=None, mode=None):
     else:
       mode = 'wb'
 
-  with safe_open(filename, mode=mode) as f:
-    f.write(payload)
+  safe_file_write(filename, mode=mode, payload=payload)
+
+
+def safe_file_write(filename, mode=None, payload=None):
+  """Write a string to a file.
+
+  This method is "safe" to the extent that `safe_open` is "safe". See the explanation on the method
+  doc there.
+
+  When `payload` is an empty string, this method can be used as a concise way to create an empty
+  file along with its containing directory or truncate it if it already exists.
+
+  :param string filename: The filename of the file to write to.
+  :param string mode: A mode argument for the python `open` builtin. Defaults to 'w' (text).
+  :param string payload: The string to write to the file. Defaults to the empty string.
+  """
+  with safe_open(filename, mode=mode or 'w') as f:
+    f.write(payload or '')
 
 
 def maybe_read_file(filename, binary_mode=True):

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -127,10 +127,10 @@ def safe_file_dump(filename, payload, binary_mode=None, mode=None):
     else:
       mode = 'wb'
 
-  safe_file_write(filename, mode=mode, payload=payload)
+  safe_file_write(filename, payload=payload, mode=mode)
 
 
-def safe_file_write(filename, mode=None, payload=None):
+def safe_file_write(filename, payload=None, mode=None):
   """Write a string to a file.
 
   This method is "safe" to the extent that `safe_open` is "safe". See the explanation on the method
@@ -140,8 +140,8 @@ def safe_file_write(filename, mode=None, payload=None):
   create an empty file along with its containing directory or truncate it if it already exists.
 
   :param string filename: The filename of the file to write to.
-  :param string mode: A mode argument for the python `open` builtin. Defaults to 'w' (text).
   :param string payload: The string to write to the file. Defaults to the empty string.
+  :param string mode: A mode argument for the python `open` builtin. Defaults to 'w' (text).
   """
   with safe_open(filename, mode=mode or 'w') as f:
     f.write(payload or '')

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -143,8 +143,10 @@ def safe_file_write(filename, payload=None, mode=None):
   :param string payload: The string to write to the file. Defaults to the empty string.
   :param string mode: A mode argument for the python `open` builtin. Defaults to 'w' (text).
   """
+  if payload is None:
+    payload = ''
   with safe_open(filename, mode=mode or 'w') as f:
-    f.write(payload or '')
+    f.write(payload)
 
 
 def maybe_read_file(filename, binary_mode=None):

--- a/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
@@ -12,7 +12,7 @@ from textwrap import dedent
 
 from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_file_write
+from pants.util.dirutil import safe_file_dump
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -37,7 +37,7 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
   def tmp_scalastyle_config(self):
     with temporary_dir(root_dir=get_buildroot()) as scalastyle_dir:
       path = os.path.join(scalastyle_dir, 'config.xml')
-      safe_file_write(path, '''<scalastyle/>''')
+      safe_file_dump(path, '''<scalastyle/>''', mode='w')
       yield '--lint-scalastyle-config={}'.format(path)
 
   def pants_run(self, options=None):

--- a/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
@@ -12,7 +12,7 @@ from textwrap import dedent
 
 from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_file_dump
+from pants.util.dirutil import safe_file_write
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -37,7 +37,7 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
   def tmp_scalastyle_config(self):
     with temporary_dir(root_dir=get_buildroot()) as scalastyle_dir:
       path = os.path.join(scalastyle_dir, 'config.xml')
-      safe_file_dump(path, '''<scalastyle/>''', binary_mode=False)
+      safe_file_write(path, '''<scalastyle/>''')
       yield '--lint-scalastyle-config={}'.format(path)
 
   def pants_run(self, options=None):

--- a/tests/python/pants_test/backend/jvm/tasks/test_bundle_create.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_bundle_create.py
@@ -15,7 +15,7 @@ from pants.backend.jvm.tasks.classpath_products import ClasspathProducts, Missin
 from pants.build_graph.resources import Resources
 from pants.java.jar.jar_dependency import JarDependency
 from pants.util.contextutil import open_zip
-from pants.util.dirutil import safe_file_dump, safe_mkdir, safe_mkdtemp
+from pants.util.dirutil import safe_file_write, safe_mkdir, safe_mkdtemp
 from pants_test.backend.jvm.tasks.jvm_binary_task_test_base import JvmBinaryTaskTestBase
 
 
@@ -38,7 +38,7 @@ class TestBundleCreate(JvmBinaryTaskTestBase):
     entry_path = safe_mkdtemp(dir=target_dir)
     classpath_dir = safe_mkdtemp(dir=target_dir)
     for rel_path, content in files_dict.items():
-      safe_file_dump(os.path.join(entry_path, rel_path), content, binary_mode=False)
+      safe_file_write(os.path.join(entry_path, rel_path), content)
 
     # Create Jar to mimic consolidate classpath behavior.
     jarpath = os.path.join(classpath_dir, 'output-0.jar')
@@ -71,12 +71,12 @@ class TestBundleCreate(JvmBinaryTaskTestBase):
                                           JarDependency(org='org.gnu', name='gary', rev='4.0.0',
                                                         ext='tar.gz')])
 
-    safe_file_dump(os.path.join(self.build_root, 'resources/foo/file'), '// dummy content', binary_mode=False)
+    safe_file_write(os.path.join(self.build_root, 'resources/foo/file'), '// dummy content')
     self.resources_target = self.make_target('//resources:foo-resources', Resources,
                                              sources=['foo/file'])
 
     # This is so that payload fingerprint can be computed.
-    safe_file_dump(os.path.join(self.build_root, 'foo/Foo.java'), '// dummy content', binary_mode=False)
+    safe_file_write(os.path.join(self.build_root, 'foo/Foo.java'), '// dummy content')
     self.java_lib_target = self.make_target('//foo:foo-library', JavaLibrary, sources=['Foo.java'])
 
     self.binary_target = self.make_target(spec='//foo:foo-binary',

--- a/tests/python/pants_test/backend/jvm/tasks/test_bundle_create.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_bundle_create.py
@@ -15,7 +15,7 @@ from pants.backend.jvm.tasks.classpath_products import ClasspathProducts, Missin
 from pants.build_graph.resources import Resources
 from pants.java.jar.jar_dependency import JarDependency
 from pants.util.contextutil import open_zip
-from pants.util.dirutil import safe_file_write, safe_mkdir, safe_mkdtemp
+from pants.util.dirutil import safe_file_dump, safe_mkdir, safe_mkdtemp
 from pants_test.backend.jvm.tasks.jvm_binary_task_test_base import JvmBinaryTaskTestBase
 
 
@@ -38,7 +38,7 @@ class TestBundleCreate(JvmBinaryTaskTestBase):
     entry_path = safe_mkdtemp(dir=target_dir)
     classpath_dir = safe_mkdtemp(dir=target_dir)
     for rel_path, content in files_dict.items():
-      safe_file_write(os.path.join(entry_path, rel_path), content)
+      safe_file_dump(os.path.join(entry_path, rel_path), content, mode='w')
 
     # Create Jar to mimic consolidate classpath behavior.
     jarpath = os.path.join(classpath_dir, 'output-0.jar')
@@ -71,12 +71,12 @@ class TestBundleCreate(JvmBinaryTaskTestBase):
                                           JarDependency(org='org.gnu', name='gary', rev='4.0.0',
                                                         ext='tar.gz')])
 
-    safe_file_write(os.path.join(self.build_root, 'resources/foo/file'), '// dummy content')
+    safe_file_dump(os.path.join(self.build_root, 'resources/foo/file'), '// dummy content', mode='w')
     self.resources_target = self.make_target('//resources:foo-resources', Resources,
                                              sources=['foo/file'])
 
     # This is so that payload fingerprint can be computed.
-    safe_file_write(os.path.join(self.build_root, 'foo/Foo.java'), '// dummy content')
+    safe_file_dump(os.path.join(self.build_root, 'foo/Foo.java'), '// dummy content', mode='w')
     self.java_lib_target = self.make_target('//foo:foo-library', JavaLibrary, sources=['Foo.java'])
 
     self.binary_target = self.make_target(spec='//foo:foo-binary',

--- a/tests/python/pants_test/backend/jvm/tasks/test_consolidate_classpath.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_consolidate_classpath.py
@@ -13,7 +13,7 @@ from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.tasks.consolidate_classpath import ConsolidateClasspath
 from pants.build_graph.resources import Resources
 from pants.java.jar.jar_dependency import JarDependency
-from pants.util.dirutil import safe_file_dump
+from pants.util.dirutil import safe_file_write
 from pants_test.backend.jvm.tasks.jvm_binary_task_test_base import JvmBinaryTaskTestBase
 
 
@@ -48,12 +48,12 @@ class TestConsolidateClasspath(JvmBinaryTaskTestBase):
                                           JarDependency(org='org.gnu', name='gary', rev='4.0.0',
                                                         ext='tar.gz')])
 
-    safe_file_dump(os.path.join(self.build_root, 'resources/foo/file'), '// dummy content', binary_mode=False)
+    safe_file_write(os.path.join(self.build_root, 'resources/foo/file'), '// dummy content')
     self.resources_target = self.make_target('//resources:foo-resources', Resources,
                                              sources=['foo/file'])
 
     # This is so that payload fingerprint can be computed.
-    safe_file_dump(os.path.join(self.build_root, 'foo/Foo.java'), '// dummy content', binary_mode=False)
+    safe_file_write(os.path.join(self.build_root, 'foo/Foo.java'), '// dummy content')
     self.java_lib_target = self.make_target('//foo:foo-library', JavaLibrary, sources=['Foo.java'])
 
     self.binary_target = self.make_target(spec='//foo:foo-binary',

--- a/tests/python/pants_test/backend/jvm/tasks/test_consolidate_classpath.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_consolidate_classpath.py
@@ -13,7 +13,7 @@ from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.tasks.consolidate_classpath import ConsolidateClasspath
 from pants.build_graph.resources import Resources
 from pants.java.jar.jar_dependency import JarDependency
-from pants.util.dirutil import safe_file_write
+from pants.util.dirutil import safe_file_dump
 from pants_test.backend.jvm.tasks.jvm_binary_task_test_base import JvmBinaryTaskTestBase
 
 
@@ -48,12 +48,12 @@ class TestConsolidateClasspath(JvmBinaryTaskTestBase):
                                           JarDependency(org='org.gnu', name='gary', rev='4.0.0',
                                                         ext='tar.gz')])
 
-    safe_file_write(os.path.join(self.build_root, 'resources/foo/file'), '// dummy content')
+    safe_file_dump(os.path.join(self.build_root, 'resources/foo/file'), '// dummy content',  mode='w')
     self.resources_target = self.make_target('//resources:foo-resources', Resources,
                                              sources=['foo/file'])
 
     # This is so that payload fingerprint can be computed.
-    safe_file_write(os.path.join(self.build_root, 'foo/Foo.java'), '// dummy content')
+    safe_file_dump(os.path.join(self.build_root, 'foo/Foo.java'), '// dummy content', mode='w')
     self.java_lib_target = self.make_target('//foo:foo-library', JavaLibrary, sources=['Foo.java'])
 
     self.binary_target = self.make_target(spec='//foo:foo-binary',

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -27,7 +27,7 @@ from pants.ivy.ivy_subsystem import IvySubsystem
 from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
 from pants.util.contextutil import environment_as, temporary_dir
-from pants.util.dirutil import safe_file_write, touch
+from pants.util.dirutil import safe_file_dump, touch
 from pants.util.process_handler import subprocess
 from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
 from pants_test.subsystem.subsystem_util import global_subsystem_instance, init_subsystem
@@ -218,7 +218,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
 
     # Existing files (with and without the method name) should trigger.
     srcfile = os.path.join(self.test_workdir, 'this.is.a.source.file.scala')
-    safe_file_write(srcfile, 'content!')
+    safe_file_dump(srcfile, 'content!', mode='w')
     self.assertTrue(JUnitRun.request_classes_by_source([srcfile]))
     self.assertTrue(JUnitRun.request_classes_by_source(['{}#method'.format(srcfile)]))
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -27,7 +27,7 @@ from pants.ivy.ivy_subsystem import IvySubsystem
 from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
 from pants.util.contextutil import environment_as, temporary_dir
-from pants.util.dirutil import safe_file_dump, touch
+from pants.util.dirutil import safe_file_write, touch
 from pants.util.process_handler import subprocess
 from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
 from pants_test.subsystem.subsystem_util import global_subsystem_instance, init_subsystem
@@ -218,7 +218,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
 
     # Existing files (with and without the method name) should trigger.
     srcfile = os.path.join(self.test_workdir, 'this.is.a.source.file.scala')
-    safe_file_dump(srcfile, 'content!', binary_mode=False)
+    safe_file_write(srcfile, 'content!')
     self.assertTrue(JUnitRun.request_classes_by_source([srcfile]))
     self.assertTrue(JUnitRun.request_classes_by_source(['{}#method'.format(srcfile)]))
 

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -14,7 +14,7 @@ from pants.backend.native.subsystems.native_build_step import ToolchainVariant
 from pants.option.scope import GLOBAL_SCOPE_CONFIG_SECTION
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import is_executable, read_file, safe_file_write
+from pants.util.dirutil import is_executable, read_file, safe_file_dump
 from pants.util.process_handler import subprocess
 from pants_test.backend.python.tasks.python_task_test_base import name_and_platform
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
@@ -130,7 +130,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       orig_wrapped_math_build = read_file(self._wrapped_math_build_file, binary_mode=False)
       without_strict_deps_wrapped_math_build = re.sub(
         'strict_deps=False,', '', orig_wrapped_math_build)
-      safe_file_write(self._wrapped_math_build_file, without_strict_deps_wrapped_math_build)
+      safe_file_dump(self._wrapped_math_build_file, without_strict_deps_wrapped_math_build, mode='w')
 
       # This should fail because it does not turn on strict_deps for a target which requires it.
       pants_binary_strict_deps_failure = self.run_pants_with_workdir(

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -14,7 +14,7 @@ from pants.backend.native.subsystems.native_build_step import ToolchainVariant
 from pants.option.scope import GLOBAL_SCOPE_CONFIG_SECTION
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import is_executable, read_file, safe_file_dump
+from pants.util.dirutil import is_executable, read_file, safe_file_write
 from pants.util.process_handler import subprocess
 from pants_test.backend.python.tasks.python_task_test_base import name_and_platform
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
@@ -130,7 +130,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       orig_wrapped_math_build = read_file(self._wrapped_math_build_file, binary_mode=False)
       without_strict_deps_wrapped_math_build = re.sub(
         'strict_deps=False,', '', orig_wrapped_math_build)
-      safe_file_dump(self._wrapped_math_build_file, without_strict_deps_wrapped_math_build, mode='w')
+      safe_file_write(self._wrapped_math_build_file, without_strict_deps_wrapped_math_build)
 
       # This should fail because it does not turn on strict_deps for a target which requires it.
       pants_binary_strict_deps_failure = self.run_pants_with_workdir(

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from pants.base.build_environment import get_buildroot
 from pants.base.exception_sink import ExceptionSink
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import read_file, safe_file_write, safe_mkdir, touch
+from pants.util.dirutil import read_file, safe_file_dump, safe_mkdir, touch
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 from pants_test.testutils.py2_compat import assertRegex
 
@@ -198,7 +198,7 @@ Current thread [^\n]+ \\(most recent call first\\):
 
     with temporary_dir() as tmpdir:
       some_file = os.path.join(tmpdir, 'some_file')
-      safe_file_write(some_file, b'', mode='wb')
+      safe_file_dump(some_file, b'', mode='wb')
       redirected_pants_run = self.run_pants([
         "--lifecycle-stubs-new-interactive-stream-output-file={}".format(some_file),
       ] + lifecycle_stub_cmdline)

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from pants.base.build_environment import get_buildroot
 from pants.base.exception_sink import ExceptionSink
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import read_file, safe_file_dump, safe_mkdir, touch
+from pants.util.dirutil import read_file, safe_file_write, safe_mkdir, touch
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 from pants_test.testutils.py2_compat import assertRegex
 
@@ -198,7 +198,7 @@ Current thread [^\n]+ \\(most recent call first\\):
 
     with temporary_dir() as tmpdir:
       some_file = os.path.join(tmpdir, 'some_file')
-      safe_file_dump(some_file, b'', binary_mode=True)
+      safe_file_write(some_file, b'', mode='wb')
       redirected_pants_run = self.run_pants([
         "--lifecycle-stubs-new-interactive-stream-output-file={}".format(some_file),
       ] + lifecycle_stub_cmdline)

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -346,7 +346,7 @@ class BinaryUtilTest(TestBase):
     """Test invoking binary_util.py as a standalone script."""
     with temporary_dir() as tmp_dir:
       config_file_loc = os.path.join(tmp_dir, 'pants.ini')
-      safe_file_dump(config_file_loc, """\
+      safe_file_dump(config_file_loc, mode='w', payload="""\
 [GLOBAL]
 allow_external_binary_tool_downloads: True
 pants_bootstrapdir: {}

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -17,7 +17,7 @@ from pants.binaries.binary_util import (BinaryRequest, BinaryToolFetcher, Binary
 from pants.net.http.fetcher import Fetcher
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import environment_as, temporary_dir
-from pants.util.dirutil import is_readable_dir, safe_file_write, safe_open
+from pants.util.dirutil import is_readable_dir, safe_file_dump, safe_open
 from pants_test.test_base import TestBase
 
 
@@ -346,7 +346,7 @@ class BinaryUtilTest(TestBase):
     """Test invoking binary_util.py as a standalone script."""
     with temporary_dir() as tmp_dir:
       config_file_loc = os.path.join(tmp_dir, 'pants.ini')
-      safe_file_write(config_file_loc, """\
+      safe_file_dump(config_file_loc, """\
 [GLOBAL]
 allow_external_binary_tool_downloads: True
 pants_bootstrapdir: {}

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -17,7 +17,7 @@ from pants.binaries.binary_util import (BinaryRequest, BinaryToolFetcher, Binary
 from pants.net.http.fetcher import Fetcher
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import environment_as, temporary_dir
-from pants.util.dirutil import is_readable_dir, safe_file_dump, safe_open
+from pants.util.dirutil import is_readable_dir, safe_file_write, safe_open
 from pants_test.test_base import TestBase
 
 
@@ -346,11 +346,11 @@ class BinaryUtilTest(TestBase):
     """Test invoking binary_util.py as a standalone script."""
     with temporary_dir() as tmp_dir:
       config_file_loc = os.path.join(tmp_dir, 'pants.ini')
-      safe_file_dump(config_file_loc, """\
+      safe_file_write(config_file_loc, """\
 [GLOBAL]
 allow_external_binary_tool_downloads: True
 pants_bootstrapdir: {}
-""".format(tmp_dir), binary_mode=False)
+""".format(tmp_dir))
       expected_output_glob = os.path.join(
         tmp_dir, 'bin', 'cmake', '*', '*', '3.9.5', 'cmake')
       with environment_as(PANTS_CONFIG_FILES='[{!r}]'.format(config_file_loc)):

--- a/tests/python/pants_test/build_graph/test_subproject_integration.py
+++ b/tests/python/pants_test/build_graph/test_subproject_integration.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from contextlib import contextmanager
 from textwrap import dedent
 
-from pants.util.dirutil import safe_file_write, safe_rmtree
+from pants.util.dirutil import safe_file_dump, safe_rmtree
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -76,7 +76,7 @@ testprojects/
 def harness():
   try:
     for name, content in BUILD_FILES.items():
-      safe_file_write(name, dedent(content))
+      safe_file_dump(name, dedent(content), mode='w')
     yield
   finally:
     safe_rmtree(SUBPROJ_SPEC)

--- a/tests/python/pants_test/build_graph/test_subproject_integration.py
+++ b/tests/python/pants_test/build_graph/test_subproject_integration.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from contextlib import contextmanager
 from textwrap import dedent
 
-from pants.util.dirutil import safe_file_dump, safe_rmtree
+from pants.util.dirutil import safe_file_write, safe_rmtree
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -76,7 +76,7 @@ testprojects/
 def harness():
   try:
     for name, content in BUILD_FILES.items():
-      safe_file_dump(name, dedent(content), binary_mode=False)
+      safe_file_write(name, dedent(content))
     yield
   finally:
     safe_rmtree(SUBPROJ_SPEC)
@@ -102,7 +102,7 @@ class SubprojectIntegrationTest(PantsRunIntegrationTest):
     """
     with harness():
       # Has dependencies below the subproject.
-      pants_args = ['--subproject-roots={}'.format(SUBPROJ_ROOT), 
+      pants_args = ['--subproject-roots={}'.format(SUBPROJ_ROOT),
                     'dependencies', SUBPROJ_SPEC]
       self.assert_success(self.run_pants(pants_args))
 

--- a/tests/python/pants_test/engine/legacy/test_address_mapper.py
+++ b/tests/python/pants_test/engine/legacy/test_address_mapper.py
@@ -15,7 +15,7 @@ from pants.build_graph.address_mapper import AddressMapper
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
 from pants.engine.nodes import Throw
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_file_dump, safe_mkdir
+from pants.util.dirutil import safe_file_write, safe_mkdir
 from pants_test.test_base import TestBase
 
 
@@ -40,15 +40,15 @@ class LegacyAddressMapperTest(TestBase):
     safe_mkdir(dir_b)
     safe_mkdir(dir_a_subdir)
 
-    safe_file_dump(os.path.join(self.build_root, 'BUILD'), 'target(name="a")\ntarget(name="b")', binary_mode=False)
-    safe_file_dump(os.path.join(self.build_root, 'BUILD.other'), 'target(name="c")', binary_mode=False)
+    safe_file_write(os.path.join(self.build_root, 'BUILD'), 'target(name="a")\ntarget(name="b")')
+    safe_file_write(os.path.join(self.build_root, 'BUILD.other'), 'target(name="c")')
 
-    safe_file_dump(os.path.join(dir_a, 'BUILD'), 'target(name="a")\ntarget(name="b")', binary_mode=False)
-    safe_file_dump(os.path.join(dir_a, 'BUILD.other'), 'target(name="c")', binary_mode=False)
+    safe_file_write(os.path.join(dir_a, 'BUILD'), 'target(name="a")\ntarget(name="b")')
+    safe_file_write(os.path.join(dir_a, 'BUILD.other'), 'target(name="c")')
 
-    safe_file_dump(os.path.join(dir_b, 'BUILD'), 'target(name="a")', binary_mode=False)
+    safe_file_write(os.path.join(dir_b, 'BUILD'), 'target(name="a")')
 
-    safe_file_dump(os.path.join(dir_a_subdir, 'BUILD'), 'target(name="a")', binary_mode=False)
+    safe_file_write(os.path.join(dir_a_subdir, 'BUILD'), 'target(name="a")')
 
   def test_is_valid_single_address(self):
     self.create_build_files()

--- a/tests/python/pants_test/engine/legacy/test_address_mapper.py
+++ b/tests/python/pants_test/engine/legacy/test_address_mapper.py
@@ -15,7 +15,7 @@ from pants.build_graph.address_mapper import AddressMapper
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
 from pants.engine.nodes import Throw
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_file_write, safe_mkdir
+from pants.util.dirutil import safe_file_dump, safe_mkdir
 from pants_test.test_base import TestBase
 
 
@@ -40,15 +40,15 @@ class LegacyAddressMapperTest(TestBase):
     safe_mkdir(dir_b)
     safe_mkdir(dir_a_subdir)
 
-    safe_file_write(os.path.join(self.build_root, 'BUILD'), 'target(name="a")\ntarget(name="b")')
-    safe_file_write(os.path.join(self.build_root, 'BUILD.other'), 'target(name="c")')
+    safe_file_dump(os.path.join(self.build_root, 'BUILD'), 'target(name="a")\ntarget(name="b")', mode='w')
+    safe_file_dump(os.path.join(self.build_root, 'BUILD.other'), 'target(name="c")', mode='w')
 
-    safe_file_write(os.path.join(dir_a, 'BUILD'), 'target(name="a")\ntarget(name="b")')
-    safe_file_write(os.path.join(dir_a, 'BUILD.other'), 'target(name="c")')
+    safe_file_dump(os.path.join(dir_a, 'BUILD'), 'target(name="a")\ntarget(name="b")', mode='w')
+    safe_file_dump(os.path.join(dir_a, 'BUILD.other'), 'target(name="c")', mode='w')
 
-    safe_file_write(os.path.join(dir_b, 'BUILD'), 'target(name="a")')
+    safe_file_dump(os.path.join(dir_b, 'BUILD'), 'target(name="a")', mode='w')
 
-    safe_file_write(os.path.join(dir_a_subdir, 'BUILD'), 'target(name="a")')
+    safe_file_dump(os.path.join(dir_a_subdir, 'BUILD'), 'target(name="a")', mode='w')
 
   def test_is_valid_single_address(self):
     self.create_build_files()

--- a/tests/python/pants_test/engine/legacy/test_console_rule_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_console_rule_integration.py
@@ -9,7 +9,7 @@ import time
 
 from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import fast_relpath, safe_file_dump
+from pants.util.dirutil import fast_relpath, safe_file_write
 from pants_test.pants_run_integration_test import ensure_daemon
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 
@@ -78,7 +78,7 @@ class TestConsoleRuleIntegration(PantsDaemonIntegrationTestBase):
       rel_tmpdir = fast_relpath(tmpdir, get_buildroot())
 
       def dump(content):
-        safe_file_dump(os.path.join(tmpdir, 'BUILD'), content, mode="w")
+        safe_file_write(os.path.join(tmpdir, 'BUILD'), content)
 
       # Dump an initial target before starting the loop.
       dump('target(name="one")')

--- a/tests/python/pants_test/engine/legacy/test_console_rule_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_console_rule_integration.py
@@ -9,7 +9,7 @@ import time
 
 from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import fast_relpath, safe_file_write
+from pants.util.dirutil import fast_relpath, safe_file_dump
 from pants_test.pants_run_integration_test import ensure_daemon
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 
@@ -78,7 +78,7 @@ class TestConsoleRuleIntegration(PantsDaemonIntegrationTestBase):
       rel_tmpdir = fast_relpath(tmpdir, get_buildroot())
 
       def dump(content):
-        safe_file_write(os.path.join(tmpdir, 'BUILD'), content)
+        safe_file_dump(os.path.join(tmpdir, 'BUILD'), content, mode='w')
 
       # Dump an initial target before starting the loop.
       dump('target(name="one")')

--- a/tests/python/pants_test/jvm/jvm_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_task_test_base.py
@@ -8,7 +8,7 @@ import os
 
 from pants.backend.jvm.subsystems.resolve_subsystem import JvmResolveSubsystem
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
-from pants.util.dirutil import safe_file_write, safe_mkdir, safe_mkdtemp
+from pants.util.dirutil import safe_file_dump, safe_mkdir, safe_mkdtemp
 from pants_test.subsystem.subsystem_util import init_subsystem
 from pants_test.task_test_base import TaskTestBase
 
@@ -53,7 +53,7 @@ class JvmTaskTestBase(TaskTestBase):
     safe_mkdir(target_dir)
     classpath_dir = safe_mkdtemp(dir=target_dir)
     for rel_path, content in files_dict.items():
-      safe_file_write(os.path.join(classpath_dir, rel_path), content)
+      safe_file_dump(os.path.join(classpath_dir, rel_path), content, mode='w')
     # Add to the classpath.
     runtime_classpath.add_for_target(tgt, [('default', classpath_dir)])
 

--- a/tests/python/pants_test/jvm/jvm_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_task_test_base.py
@@ -8,7 +8,7 @@ import os
 
 from pants.backend.jvm.subsystems.resolve_subsystem import JvmResolveSubsystem
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
-from pants.util.dirutil import safe_file_dump, safe_mkdir, safe_mkdtemp
+from pants.util.dirutil import safe_file_write, safe_mkdir, safe_mkdtemp
 from pants_test.subsystem.subsystem_util import init_subsystem
 from pants_test.task_test_base import TaskTestBase
 
@@ -53,7 +53,7 @@ class JvmTaskTestBase(TaskTestBase):
     safe_mkdir(target_dir)
     classpath_dir = safe_mkdtemp(dir=target_dir)
     for rel_path, content in files_dict.items():
-      safe_file_dump(os.path.join(classpath_dir, rel_path), content, binary_mode=False)
+      safe_file_write(os.path.join(classpath_dir, rel_path), content)
     # Add to the classpath.
     runtime_classpath.add_for_target(tgt, [('default', classpath_dir)])
 

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -13,7 +13,7 @@ import unittest
 from builtins import open, range, zip
 
 from pants.util.contextutil import environment_as, temporary_dir
-from pants.util.dirutil import rm_rf, safe_file_write, safe_mkdir, touch
+from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, touch
 from pants_test.pants_run_integration_test import read_pantsd_log
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 from pants_test.testutils.process_test_util import no_lingering_process_by_command
@@ -358,17 +358,17 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         pantsd_run(['help'])
         checker.assert_started()
 
-        safe_file_write(test_build_file, "python_library(sources=globs('some_non_existent_file.py'))")
+        safe_file_dump(test_build_file, "python_library(sources=globs('some_non_existent_file.py'))", mode='w')
         result = pantsd_run(export_cmd)
         checker.assert_running()
         assertNotRegex(self, result.stdout_data, has_source_root_regex)
 
-        safe_file_write(test_build_file, "python_library(sources=globs('*.py'))")
+        safe_file_dump(test_build_file, "python_library(sources=globs('*.py'))", mode='w')
         result = pantsd_run(export_cmd)
         checker.assert_running()
         assertNotRegex(self, result.stdout_data, has_source_root_regex)
 
-        safe_file_write(test_src_file, 'import this\n')
+        safe_file_dump(test_src_file, 'import this\n', mode='w')
         result = pantsd_run(export_cmd)
         checker.assert_running()
         assertRegex(self, result.stdout_data, has_source_root_regex)
@@ -385,7 +385,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
 
     try:
       safe_mkdir(test_path, clean=True)
-      safe_file_write(test_build_file, "{}()".format(invalid_symbol))
+      safe_file_dump(test_build_file, "{}()".format(invalid_symbol), mode='w')
       for _ in range(3):
         with self.pantsd_run_context(success=False) as (pantsd_run, checker, _, _):
           result = pantsd_run(['list', 'testprojects::'])

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -13,7 +13,7 @@ import unittest
 from builtins import open, range, zip
 
 from pants.util.contextutil import environment_as, temporary_dir
-from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, touch
+from pants.util.dirutil import rm_rf, safe_file_write, safe_mkdir, touch
 from pants_test.pants_run_integration_test import read_pantsd_log
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 from pants_test.testutils.process_test_util import no_lingering_process_by_command
@@ -358,17 +358,17 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         pantsd_run(['help'])
         checker.assert_started()
 
-        safe_file_dump(test_build_file, "python_library(sources=globs('some_non_existent_file.py'))", binary_mode=False)
+        safe_file_write(test_build_file, "python_library(sources=globs('some_non_existent_file.py'))")
         result = pantsd_run(export_cmd)
         checker.assert_running()
         assertNotRegex(self, result.stdout_data, has_source_root_regex)
 
-        safe_file_dump(test_build_file, "python_library(sources=globs('*.py'))", binary_mode=False)
+        safe_file_write(test_build_file, "python_library(sources=globs('*.py'))")
         result = pantsd_run(export_cmd)
         checker.assert_running()
         assertNotRegex(self, result.stdout_data, has_source_root_regex)
 
-        safe_file_dump(test_src_file, 'import this\n', binary_mode=False)
+        safe_file_write(test_src_file, 'import this\n')
         result = pantsd_run(export_cmd)
         checker.assert_running()
         assertRegex(self, result.stdout_data, has_source_root_regex)
@@ -385,7 +385,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
 
     try:
       safe_mkdir(test_path, clean=True)
-      safe_file_dump(test_build_file, "{}()".format(invalid_symbol), binary_mode=False)
+      safe_file_write(test_build_file, "{}()".format(invalid_symbol))
       for _ in range(3):
         with self.pantsd_run_context(success=False) as (pantsd_run, checker, _, _):
           result = pantsd_run(['list', 'testprojects::'])

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -16,7 +16,7 @@ import psutil
 from pants.pantsd.process_manager import (ProcessGroup, ProcessManager, ProcessMetadataManager,
                                           swallow_psutil_exceptions)
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_file_write
+from pants.util.dirutil import safe_file_dump
 from pants.util.process_handler import subprocess
 from pants_test.test_base import TestBase
 
@@ -149,7 +149,7 @@ class TestProcessMetadataManager(TestBase):
   def test_wait_for_file(self):
     with temporary_dir() as td:
       test_filename = os.path.join(td, 'test.out')
-      safe_file_write(test_filename, 'test')
+      safe_file_dump(test_filename, 'test')
       self.pmm._wait_for_file(test_filename, timeout=.1)
 
   def test_wait_for_file_timeout(self):

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -16,7 +16,7 @@ import psutil
 from pants.pantsd.process_manager import (ProcessGroup, ProcessManager, ProcessMetadataManager,
                                           swallow_psutil_exceptions)
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_file_dump
+from pants.util.dirutil import safe_file_write
 from pants.util.process_handler import subprocess
 from pants_test.test_base import TestBase
 
@@ -149,7 +149,7 @@ class TestProcessMetadataManager(TestBase):
   def test_wait_for_file(self):
     with temporary_dir() as td:
       test_filename = os.path.join(td, 'test.out')
-      safe_file_dump(test_filename, 'test', binary_mode=False)
+      safe_file_write(test_filename, 'test')
       self.pmm._wait_for_file(test_filename, timeout=.1)
 
   def test_wait_for_file_timeout(self):

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -149,7 +149,7 @@ class TestProcessMetadataManager(TestBase):
   def test_wait_for_file(self):
     with temporary_dir() as td:
       test_filename = os.path.join(td, 'test.out')
-      safe_file_dump(test_filename, 'test')
+      safe_file_dump(test_filename, 'test', mode='w')
       self.pmm._wait_for_file(test_filename, timeout=.1)
 
   def test_wait_for_file_timeout(self):

--- a/tests/python/pants_test/pantsd/test_watchman.py
+++ b/tests/python/pants_test/pantsd/test_watchman.py
@@ -59,11 +59,11 @@ class TestWatchman(TestBase):
   def test_maybe_init_metadata(self):
     # TODO(#7106): is this the right path to patch?
     with mock.patch('pants.pantsd.watchman.safe_mkdir', **self.PATCH_OPTS) as mock_mkdir, \
-         mock.patch('pants.pantsd.watchman.safe_file_dump', **self.PATCH_OPTS) as mock_file_dump:
+         mock.patch('pants.pantsd.watchman.safe_file_write', **self.PATCH_OPTS) as mock_file_write:
       self.watchman._maybe_init_metadata()
 
       mock_mkdir.assert_called_once_with(self._watchman_dir)
-      mock_file_dump.assert_called_once_with(self._state_file, b'{}')
+      mock_file_write.assert_called_once_with(self._state_file, b'{}', mode='wb')
 
   def test_construct_cmd(self):
     output = self.watchman._construct_cmd(['cmd', 'parts', 'etc'],

--- a/tests/python/pants_test/pantsd/test_watchman.py
+++ b/tests/python/pants_test/pantsd/test_watchman.py
@@ -59,11 +59,11 @@ class TestWatchman(TestBase):
   def test_maybe_init_metadata(self):
     # TODO(#7106): is this the right path to patch?
     with mock.patch('pants.pantsd.watchman.safe_mkdir', **self.PATCH_OPTS) as mock_mkdir, \
-         mock.patch('pants.pantsd.watchman.safe_file_dump', **self.PATCH_OPTS) as mock_file_write:
+         mock.patch('pants.pantsd.watchman.safe_file_dump', **self.PATCH_OPTS) as mock_file_dump:
       self.watchman._maybe_init_metadata()
 
       mock_mkdir.assert_called_once_with(self._watchman_dir)
-      mock_file_write.assert_called_once_with(self._state_file, b'{}', mode='wb')
+      mock_file_dump.assert_called_once_with(self._state_file, b'{}', mode='wb')
 
   def test_construct_cmd(self):
     output = self.watchman._construct_cmd(['cmd', 'parts', 'etc'],

--- a/tests/python/pants_test/pantsd/test_watchman.py
+++ b/tests/python/pants_test/pantsd/test_watchman.py
@@ -57,6 +57,7 @@ class TestWatchman(TestBase):
                                metadata_base_dir=self.subprocess_dir)
 
   def test_maybe_init_metadata(self):
+    # TODO(#7106): is this the right path to patch?
     with mock.patch('pants.pantsd.watchman.safe_mkdir', **self.PATCH_OPTS) as mock_mkdir, \
          mock.patch('pants.pantsd.watchman.safe_file_dump', **self.PATCH_OPTS) as mock_file_dump:
       self.watchman._maybe_init_metadata()

--- a/tests/python/pants_test/pantsd/test_watchman.py
+++ b/tests/python/pants_test/pantsd/test_watchman.py
@@ -59,7 +59,7 @@ class TestWatchman(TestBase):
   def test_maybe_init_metadata(self):
     # TODO(#7106): is this the right path to patch?
     with mock.patch('pants.pantsd.watchman.safe_mkdir', **self.PATCH_OPTS) as mock_mkdir, \
-         mock.patch('pants.pantsd.watchman.safe_file_write', **self.PATCH_OPTS) as mock_file_write:
+         mock.patch('pants.pantsd.watchman.safe_file_dump', **self.PATCH_OPTS) as mock_file_write:
       self.watchman._maybe_init_metadata()
 
       mock_mkdir.assert_called_once_with(self._watchman_dir)

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -36,7 +36,7 @@ from pants.source.source_root import SourceRootConfig
 from pants.subsystem.subsystem import Subsystem
 from pants.task.goal_options_mixin import GoalOptionsMixin
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import (recursive_dirname, relative_symlink, safe_file_write, safe_mkdir,
+from pants.util.dirutil import (recursive_dirname, relative_symlink, safe_file_dump, safe_mkdir,
                                 safe_mkdtemp, safe_open, safe_rmtree)
 from pants.util.memo import memoized_method
 from pants_test.base.context_utils import create_context_from_options
@@ -632,7 +632,7 @@ class TestBase(unittest.TestCase):
     """
     with temporary_dir() as temp_dir:
       for file_name, content in files.items():
-        safe_file_write(os.path.join(temp_dir, file_name), content)
+        safe_file_dump(os.path.join(temp_dir, file_name), content, mode='w')
       return self.scheduler.capture_snapshots((
         PathGlobsAndRoot(PathGlobs(('**',)), text_type(temp_dir)),
       ))[0]

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -36,7 +36,7 @@ from pants.source.source_root import SourceRootConfig
 from pants.subsystem.subsystem import Subsystem
 from pants.task.goal_options_mixin import GoalOptionsMixin
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import (recursive_dirname, relative_symlink, safe_file_dump, safe_mkdir,
+from pants.util.dirutil import (recursive_dirname, relative_symlink, safe_file_write, safe_mkdir,
                                 safe_mkdtemp, safe_open, safe_rmtree)
 from pants.util.memo import memoized_method
 from pants_test.base.context_utils import create_context_from_options
@@ -632,7 +632,7 @@ class TestBase(unittest.TestCase):
     """
     with temporary_dir() as temp_dir:
       for file_name, content in files.items():
-        safe_file_dump(os.path.join(temp_dir, file_name), content)
+        safe_file_write(os.path.join(temp_dir, file_name), content)
       return self.scheduler.capture_snapshots((
         PathGlobsAndRoot(PathGlobs(('**',)), text_type(temp_dir)),
       ))[0]

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -393,29 +393,29 @@ class DirutilTest(unittest.TestCase):
       touch(file_name)
       rm_rf(file_name)
 
-  def assert_dump_and_read(self, test_content, dump_kwargs, read_kwargs):
+  def assert_write_and_read(self, test_content, write_kwargs, read_kwargs):
     with temporary_dir() as td:
       test_filename = os.path.join(td, 'test.out')
-      safe_file_dump(test_filename, test_content, **dump_kwargs)
+      safe_file_dump(test_filename, test_content, **write_kwargs)
       self.assertEqual(read_file(test_filename, **read_kwargs), test_content)
 
   def test_readwrite_file_binary(self):
-    self.assert_dump_and_read(b'333', {'binary_mode': True}, {'binary_mode': True})
-    self.assert_dump_and_read(b'333', {'mode': 'wb'}, {'binary_mode': True})
+    self.assert_write_and_read(b'333', {'binary_mode': True}, {'binary_mode': True})
+    self.assert_write_and_read(b'333', {'mode': 'wb'}, {'binary_mode': True})
     with self.assertRaises(Exception):
       # File is not opened as binary.
-      self.assert_dump_and_read(b'333', {'mode': 'w'}, {'binary_mode': True})
+      self.assert_write_and_read(b'333', {'mode': 'w'}, {'binary_mode': True})
     with self.assertRaises(AssertionError):
       # Both `binary_mode` and `mode` specified.
       # TODO: Should be removed along with https://github.com/pantsbuild/pants/issues/6543
-      self.assert_dump_and_read(b'333', {'binary_mode': True, 'mode': 'wb'}, {'binary_mode': True})
+      self.assert_write_and_read(b'333', {'binary_mode': True, 'mode': 'wb'}, {'binary_mode': True})
 
   def test_readwrite_file_unicode(self):
-    self.assert_dump_and_read('✓', {'binary_mode': False}, {'binary_mode': False})
-    self.assert_dump_and_read('✓', {'mode': 'w'}, {'binary_mode': False})
+    self.assert_write_and_read('✓', {'binary_mode': False}, {'binary_mode': False})
+    self.assert_write_and_read('✓', {'mode': 'w'}, {'binary_mode': False})
     with self.assertRaises(Exception):
       # File is opened as binary.
-      self.assert_dump_and_read('✓', {'mode': 'wb'}, {'binary_mode': True})
+      self.assert_write_and_read('✓', {'mode': 'wb'}, {'binary_mode': True})
 
   def test_safe_concurrent_creation(self):
     with temporary_dir() as td:

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -396,8 +396,8 @@ class DirutilTest(unittest.TestCase):
   def assert_write_and_read(self, test_content, write_kwargs, read_kwargs):
     with temporary_dir() as td:
       test_filename = os.path.join(td, 'test.out')
-      # TODO: remove all tests of safe_file_dump() and convert the relevant ones to
-      # safe_file_dump() after the deprecation period is over!
+      # TODO: remove all deprecated usages of `binary_mode` and `mode` arguments to safe_file_dump()
+      # in this file when the deprecation period is over!
       safe_file_dump(test_filename, test_content, **write_kwargs)
       self.assertEqual(read_file(test_filename, **read_kwargs), test_content)
 

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -393,7 +393,7 @@ class DirutilTest(unittest.TestCase):
       touch(file_name)
       rm_rf(file_name)
 
-  def assert_write_and_read(self, test_content, write_kwargs, read_kwargs):
+  def assert_dump_and_read(self, test_content, write_kwargs, read_kwargs):
     with temporary_dir() as td:
       test_filename = os.path.join(td, 'test.out')
       # TODO: remove all deprecated usages of `binary_mode` and `mode` arguments to safe_file_dump()
@@ -402,22 +402,22 @@ class DirutilTest(unittest.TestCase):
       self.assertEqual(read_file(test_filename, **read_kwargs), test_content)
 
   def test_readwrite_file_binary(self):
-    self.assert_write_and_read(b'333', {'binary_mode': True}, {'binary_mode': True})
-    self.assert_write_and_read(b'333', {'mode': 'wb'}, {'binary_mode': True})
+    self.assert_dump_and_read(b'333', {'binary_mode': True}, {'binary_mode': True})
+    self.assert_dump_and_read(b'333', {'mode': 'wb'}, {'binary_mode': True})
     with self.assertRaises(Exception):
       # File is not opened as binary.
-      self.assert_write_and_read(b'333', {'mode': 'w'}, {'binary_mode': True})
+      self.assert_dump_and_read(b'333', {'mode': 'w'}, {'binary_mode': True})
     with self.assertRaises(AssertionError):
       # Both `binary_mode` and `mode` specified.
       # TODO: Should be removed along with https://github.com/pantsbuild/pants/issues/6543
-      self.assert_write_and_read(b'333', {'binary_mode': True, 'mode': 'wb'}, {'binary_mode': True})
+      self.assert_dump_and_read(b'333', {'binary_mode': True, 'mode': 'wb'}, {'binary_mode': True})
 
   def test_readwrite_file_unicode(self):
-    self.assert_write_and_read('✓', {'binary_mode': False}, {'binary_mode': False})
-    self.assert_write_and_read('✓', {'mode': 'w'}, {'binary_mode': False})
+    self.assert_dump_and_read('✓', {'binary_mode': False}, {'binary_mode': False})
+    self.assert_dump_and_read('✓', {'mode': 'w'}, {'binary_mode': False})
     with self.assertRaises(Exception):
       # File is opened as binary.
-      self.assert_write_and_read('✓', {'mode': 'wb'}, {'binary_mode': True})
+      self.assert_dump_and_read('✓', {'mode': 'wb'}, {'binary_mode': True})
 
   def test_safe_concurrent_creation(self):
     with temporary_dir() as td:

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -393,12 +393,12 @@ class DirutilTest(unittest.TestCase):
       touch(file_name)
       rm_rf(file_name)
 
-  def assert_dump_and_read(self, test_content, write_kwargs, read_kwargs):
+  def assert_dump_and_read(self, test_content, dump_kwargs, read_kwargs):
     with temporary_dir() as td:
       test_filename = os.path.join(td, 'test.out')
       # TODO: remove all deprecated usages of `binary_mode` and `mode` arguments to safe_file_dump()
       # in this file when the deprecation period is over!
-      safe_file_dump(test_filename, test_content, **write_kwargs)
+      safe_file_dump(test_filename, test_content, **dump_kwargs)
       self.assertEqual(read_file(test_filename, **read_kwargs), test_content)
 
   def test_readwrite_file_binary(self):

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -396,6 +396,8 @@ class DirutilTest(unittest.TestCase):
   def assert_write_and_read(self, test_content, write_kwargs, read_kwargs):
     with temporary_dir() as td:
       test_filename = os.path.join(td, 'test.out')
+      # TODO: remove all tests of safe_file_dump() and convert the relevant ones to
+      # safe_file_write() after the deprecation period is over!
       safe_file_dump(test_filename, test_content, **write_kwargs)
       self.assertEqual(read_file(test_filename, **read_kwargs), test_content)
 

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -397,7 +397,7 @@ class DirutilTest(unittest.TestCase):
     with temporary_dir() as td:
       test_filename = os.path.join(td, 'test.out')
       # TODO: remove all tests of safe_file_dump() and convert the relevant ones to
-      # safe_file_write() after the deprecation period is over!
+      # safe_file_dump() after the deprecation period is over!
       safe_file_dump(test_filename, test_content, **write_kwargs)
       self.assertEqual(read_file(test_filename, **read_kwargs), test_content)
 

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -396,8 +396,8 @@ class DirutilTest(unittest.TestCase):
   def assert_dump_and_read(self, test_content, dump_kwargs, read_kwargs):
     with temporary_dir() as td:
       test_filename = os.path.join(td, 'test.out')
-      # TODO: remove all deprecated usages of `binary_mode` and `mode` arguments to safe_file_dump()
-      # in this file when the deprecation period is over!
+      # TODO(#7121): remove all deprecated usages of `binary_mode` and `mode` arguments to
+      # safe_file_dump() in this file when the deprecation period is over!
       safe_file_dump(test_filename, test_content, **dump_kwargs)
       self.assertEqual(read_file(test_filename, **read_kwargs), test_content)
 
@@ -409,7 +409,7 @@ class DirutilTest(unittest.TestCase):
       self.assert_dump_and_read(b'333', {'mode': 'w'}, {'binary_mode': True})
     with self.assertRaises(AssertionError):
       # Both `binary_mode` and `mode` specified.
-      # TODO: Should be removed along with https://github.com/pantsbuild/pants/issues/6543
+      # TODO(#6543): Should be removed along with https://github.com/pantsbuild/pants/issues/6543
       self.assert_dump_and_read(b'333', {'binary_mode': True, 'mode': 'wb'}, {'binary_mode': True})
 
   def test_readwrite_file_unicode(self):


### PR DESCRIPTION
### Problem

*Resolves #6543. See also [the python 3 migration project](https://github.com/pantsbuild/pants/projects/10).*

There has been [a TODO](https://github.com/pantsbuild/pants/blob/6fcd7f7d0f8787910cfac01ec2895cdbd5cee66f/src/python/pants/util/dirutil.py#L109) pointing to #6543 to deprecate the `binary_mode` argument to `pants.util.dirutil.safe_file_dump()`, which wasn't canonicalized with a `deprecated_conditional`. This is because `binary_mode` doesn't quite make sense the way it does with file read methods `read_file()` and `maybe_read_file()`, because a file can be appended to as well as truncated (as opposed to reads).

Separately, defaulting `binary_mode=True` for file read methods means more explicit conversions to unicode in a python 3 world,

### Solution

- Deprecate the `binary_mode` argument to `safe_file_dump()`, as well as not explicitly specifying the `mode` argument.
  - `safe_file_dump()` now also defaults `payload=''`.
  - Also deprecate not specifying the `mode='wb'` argument in `safe_file_dump()`.
- Deprecate not explicitly specifying the `binary_mode` argument in `{maybe_,}read_file()` and `temporary_file()` so that it can be given a default of unicode when pants finishes [migrating to python 3](https://github.com/pantsbuild/pants/projects/10) -- see #7121.
- Update usages of `safe_file_dump()` across the repo.

### Result

Pants plugins will see a deprecation warning if they fail to explicitly specify the `binary_mode` for file read methods in preparation for switching the default to unicode for [the python 3 switchover](https://github.com/pantsbuild/pants/projects/10). Several ambiguities in the `safe_file_dump()` method are alleviated.

#7121 covers the eventual switchover to a default of `binary_mode=False` after the python 3 migration completes.