### PR TITLE
Fix various backend/jvm/task Python 3 and unicode issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -642,7 +642,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard0
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 0/13
+        - ./build-support/bin/travis-ci.sh -c -i 0/14
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 1 (Py3 PEX)"
@@ -650,7 +650,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard1
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 1/13
+        - ./build-support/bin/travis-ci.sh -c -i 1/14
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 2 (Py3 PEX)"
@@ -658,7 +658,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard2
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 2/13
+        - ./build-support/bin/travis-ci.sh -c -i 2/14
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 3 (Py3 PEX)"
@@ -666,7 +666,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard3
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 3/13
+        - ./build-support/bin/travis-ci.sh -c -i 3/14
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 4 (Py3 PEX)"
@@ -674,7 +674,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard4
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 4/13
+        - ./build-support/bin/travis-ci.sh -c -i 4/14
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 5 (Py3 PEX)"
@@ -682,7 +682,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard5
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 5/13
+        - ./build-support/bin/travis-ci.sh -c -i 5/14
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 6 (Py3 PEX)"
@@ -690,7 +690,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard6
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 6/13
+        - ./build-support/bin/travis-ci.sh -c -i 6/14
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 7 (Py3 PEX)"
@@ -698,7 +698,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard7
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 7/13
+        - ./build-support/bin/travis-ci.sh -c -i 7/14
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 8 (Py3 PEX)"
@@ -706,7 +706,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard8
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 8/13
+        - ./build-support/bin/travis-ci.sh -c -i 8/14
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 9 (Py3 PEX)"
@@ -714,7 +714,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard9
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 9/13
+        - ./build-support/bin/travis-ci.sh -c -i 9/14
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 10 (Py3 PEX)"
@@ -722,7 +722,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard10
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 10/13
+        - ./build-support/bin/travis-ci.sh -c -i 10/14
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 11 (Py3 PEX)"
@@ -730,7 +730,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard11
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 11/13
+        - ./build-support/bin/travis-ci.sh -c -i 11/14
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 12 (Py3 PEX)"
@@ -738,7 +738,15 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard12
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 12/13
+        - ./build-support/bin/travis-ci.sh -c -i 12/14
+
+    - <<: *py3_linux_test_config
+      name: "Integration tests for pants - shard 13 (Py3 PEX)"
+      env:
+        - *py3_linux_test_config_env
+        - CACHE_NAME=integrationshard13
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 13/14
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 0 (Py2 PEX w/ Py3 constraints)"
@@ -748,7 +756,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard0.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 0/7
+        - ./build-support/bin/travis-ci.sh -c2w -i 0/6
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 1 (Py2 PEX w/ Py3 constraints)"
@@ -758,7 +766,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard1.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 1/7
+        - ./build-support/bin/travis-ci.sh -c2w -i 1/6
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 2 (Py2 PEX w/ Py3 constraints)"
@@ -768,7 +776,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard2.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 2/7
+        - ./build-support/bin/travis-ci.sh -c2w -i 2/6
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 3 (Py2 PEX w/ Py3 constraints)"
@@ -778,7 +786,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard3.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 3/7
+        - ./build-support/bin/travis-ci.sh -c2w -i 3/6
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 4 (Py2 PEX w/ Py3 constraints)"
@@ -788,7 +796,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard4.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 4/7
+        - ./build-support/bin/travis-ci.sh -c2w -i 4/6
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 5 (Py2 PEX w/ Py3 constraints)"
@@ -798,17 +806,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard5.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 5/7
-
-    - <<: *py2_linux_test_config
-      name: "Blacklisted integration tests for pants - shard 6 (Py2 PEX w/ Py3 constraints)"
-      stage: *test
-      env:
-        - *py2_linux_test_config_env
-        - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
-        - CACHE_NAME=integrationshard6.py2blacklist
-      script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 6/7
+        - ./build-support/bin/travis-ci.sh -c2w -i 5/6
 
     - <<: *py2_linux_test_config
       name: "Integration tests for pants - shard 0 (Py2 PEX)"

--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,5 +1,4 @@
 tests/python/pants_test/backend/jvm/tasks:classmap_integration
-tests/python/pants_test/backend/jvm/tasks:jar_publish_integration
 tests/python/pants_test/backend/jvm/tasks:jvm_platform_analysis_integration
 tests/python/pants_test/backend/jvm/tasks:scala_repl_integration
 tests/python/pants_test/backend/project_info/tasks:idea_plugin_integration

--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,4 +1,3 @@
-tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:zinc_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc:rsc_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile:declared_deps_integration
 tests/python/pants_test/backend/jvm/tasks:classmap_integration

--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,4 +1,3 @@
-tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc:rsc_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile:declared_deps_integration
 tests/python/pants_test/backend/jvm/tasks:classmap_integration
 tests/python/pants_test/backend/jvm/tasks:jar_publish_integration

--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,4 +1,3 @@
-tests/python/pants_test/backend/jvm/tasks/jvm_compile:declared_deps_integration
 tests/python/pants_test/backend/jvm/tasks:classmap_integration
 tests/python/pants_test/backend/jvm/tasks:jar_publish_integration
 tests/python/pants_test/backend/jvm/tasks:jvm_platform_analysis_integration

--- a/build-support/travis/generate_travis_yml.py
+++ b/build-support/travis/generate_travis_yml.py
@@ -8,8 +8,8 @@ import pkg_resources
 import pystache
 
 
-num_py3_integration_shards = 13
-num_py2_blacklist_integration_shards = 7
+num_py3_integration_shards = 14
+num_py2_blacklist_integration_shards = 6
 num_cron_integration_shards = 20
 
 

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -632,6 +632,9 @@ python_library(
 python_library(
   name = 'resolve_shared',
   sources = ['resolve_shared.py'],
+  dependencies = [
+    '3rdparty/python:future',
+  ],
 )
 
 python_library(

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -882,12 +882,12 @@ class JarPublish(TransitiveOptionRegistrar, HasTransitiveOptionMixin, ScmPublish
     # TODO(Tejal Desai): pantsbuild/pants/65: Remove java_sources attribute for ScalaLibrary
     if isinstance(target, ScalaLibrary):
       for java_source in sorted(target.java_sources):
-        sha.update(java_source.invalidation_hash())
+        sha.update(java_source.invalidation_hash().encode('utf-8'))
 
     # TODO(John Sirois): handle resources
 
     for jarsig in sorted([jar_coordinate(j) for j in target.jar_dependencies if j.rev]):
-      sha.update(jarsig)
+      sha.update(jarsig.encode('utf-8'))
 
     # TODO(tdesai) Handle resource type in get_db.
     internal_dependencies = sorted(target_internal_dependencies(target), key=lambda t: t.id)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -10,7 +10,7 @@ import logging
 import os
 import re
 
-from six import text_type
+from future.utils import text_type
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext  # noqa
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
@@ -62,11 +62,11 @@ def stdout_contents(wu):
 
 def dump_digest(output_dir, digest):
   safe_file_dump('{}.digest'.format(output_dir),
-    '{}:{}'.format(digest.fingerprint, digest.serialized_bytes_length))
+    '{}:{}'.format(digest.fingerprint, digest.serialized_bytes_length), mode='w')
 
 
 def load_digest(output_dir):
-  read_file = maybe_read_file('{}.digest'.format(output_dir))
+  read_file = maybe_read_file('{}.digest'.format(output_dir), binary_mode=False)
   if read_file:
     fingerprint, length = read_file.split(':')
     return Digest(fingerprint, int(length))
@@ -330,7 +330,7 @@ class RscCompile(ZincCompile):
 
       metacp_inputs = tuple(jvm_lib_jars_abs)
 
-      counter_val = str(counter()).rjust(counter.format_length(), b' ')
+      counter_val = str(counter()).rjust(counter.format_length(), ' ')
       counter_str = '[{}/{}] '.format(counter_val, counter.size)
       self.context.log.info(
         counter_str,
@@ -409,7 +409,7 @@ class RscCompile(ZincCompile):
       tgt, = vts.targets
 
       if not hit_cache:
-        counter_val = str(counter()).rjust(counter.format_length(), b' ')
+        counter_val = str(counter()).rjust(counter.format_length(), ' ')
         counter_str = '[{}/{}] '.format(counter_val, counter.size)
         self.context.log.info(
           counter_str,
@@ -524,7 +524,7 @@ class RscCompile(ZincCompile):
       metacp_inputs = []
       metacp_inputs.extend(classpath_rel)
 
-      counter_val = str(counter()).rjust(counter.format_length(), b' ')
+      counter_val = str(counter()).rjust(counter.format_length(), ' ')
       counter_str = '[{}/{}] '.format(counter_val, counter.size)
       self.context.log.info(
         counter_str,

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_analyzer.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_analyzer.py
@@ -103,7 +103,7 @@ class JvmDependencyAnalyzer(object):
   def _jar_classfiles(self, jar_file):
     """Returns an iterator over the classfiles inside jar_file."""
     for cls in ClasspathUtil.classpath_entries_contents([jar_file]):
-      if cls.endswith(b'.class'):
+      if cls.endswith('.class'):
         yield cls
 
   def count_products(self, target):

--- a/src/python/pants/backend/jvm/tasks/resolve_shared.py
+++ b/src/python/pants/backend/jvm/tasks/resolve_shared.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import next
+
 from pants.base.build_environment import get_buildroot
 from pants.engine.fs import PathGlobs, PathGlobsAndRoot
 from pants.java.jar.jar_dependency_utils import ResolvedJar
@@ -59,7 +61,7 @@ class JvmResolverBase(TaskBase):
       snapshotted_jars = [ResolvedJar(coordinate=jar.coordinate,
                                       cache_path=jar.cache_path,
                                       pants_path=jar.pants_path,
-                                      directory_digest=digest_iterator.next()) for jar in jars_to_snapshot]
+                                      directory_digest=next(digest_iterator)) for jar in jars_to_snapshot]
       snapshotted_targets_and_jars.append((target, snapshotted_jars))
 
     return snapshotted_targets_and_jars

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -810,6 +810,7 @@ python_tests(
   sources = ['test_classmap_integration.py'],
   dependencies = [
     'tests/python/pants_test:task_test_base',
+    'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
 )


### PR DESCRIPTION
Fixes various unicode issues discovered when running `./pants3`.

Also redistributes CI shards by one in favor of Py3. Note we are still keeping a lot of py2 shards because the blacklisted targets are quite large, e.g. `testprojects` and `python/tasks`.