### PR TITLE
Add Zipkin tracing to pants v1

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -37,3 +37,4 @@ subprocess32==3.2.7 ; python_version<'3'
 thrift>=0.10.0
 wheel==0.31.1
 www-authenticate==0.9.2
+py_zipkin==0.16.1

--- a/src/python/pants/reporting/BUILD
+++ b/src/python/pants/reporting/BUILD
@@ -8,6 +8,7 @@ python_library(
     '3rdparty/python:ansicolors',
     '3rdparty/python:pystache',
     '3rdparty/python:six',
+    '3rdparty/python:py-zipkin',
     ':report',
     ':reporting_resources',
     'src/python/pants/base:build_environment',

--- a/src/python/pants/reporting/BUILD
+++ b/src/python/pants/reporting/BUILD
@@ -9,6 +9,7 @@ python_library(
     '3rdparty/python:pystache',
     '3rdparty/python:six',
     '3rdparty/python:py-zipkin',
+    '3rdparty/python:requests',
     ':report',
     ':reporting_resources',
     'src/python/pants/base:build_environment',

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -19,6 +19,7 @@ from pants.reporting.quiet_reporter import QuietReporter
 from pants.reporting.report import Report
 from pants.reporting.reporter import ReporterDestination
 from pants.reporting.reporting_server import ReportingServerManager
+from pants.reporting.zipkin_reporter import ZipkinReporter
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import relative_symlink, safe_mkdir
 
@@ -46,6 +47,10 @@ class Reporting(Subsystem):
              help='Controls the printing of workunit tool output to the console. Workunit types are '
                   '{workunits}.  Possible formatting values are {formats}'.format(
                workunits=list(WorkUnitLabel.keys()), formats=list(ToolOutputFormat.keys())))
+    register('--zipkin-endpoint', advanced=True, default=None,
+              help='Enables Zipkin reporter and sets the endpoint')
+    register('--zipkin-encoding', choices=['json', 'x-thrift'], advanced=True, default='x-thrift',
+              help='Sets the encoding format for Zipkin trace')
 
   def initialize(self, run_tracker, start_time=None):
     """Initialize with the given RunTracker.
@@ -81,6 +86,16 @@ class Reporting(Subsystem):
                                                    template_dir=self.get_options().template_dir)
     html_reporter = HtmlReporter(run_tracker, html_reporter_settings)
     report.add_reporter('html', html_reporter)
+
+    # Set up Zipkin reporting.
+    zipkin_endpoint = self.get_options().zipkin_endpoint
+    if zipkin_endpoint is not None:
+      zipkin_encoding = self.get_options().zipkin_encoding
+      zipkin_reporter_settings = ZipkinReporter.Settings(log_level=Report.INFO)
+      zipkin_reporter = ZipkinReporter(
+        run_tracker, zipkin_reporter_settings, zipkin_endpoint, zipkin_encoding
+      )
+      report.add_reporter('zipkin', zipkin_reporter)
 
     # Add some useful RunInfo.
     run_tracker.run_info.add_info('default_report', html_reporter.report_path())

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -48,9 +48,8 @@ class Reporting(Subsystem):
                   '{workunits}.  Possible formatting values are {formats}'.format(
                workunits=list(WorkUnitLabel.keys()), formats=list(ToolOutputFormat.keys())))
     register('--zipkin-endpoint', advanced=True, default=None,
-              help='Enables Zipkin reporter and sets the endpoint')
-    register('--zipkin-encoding', choices=['json', 'x-thrift'], advanced=True, default='x-thrift',
-              help='Sets the encoding format for Zipkin trace')
+              help='The full HTTP URL of a zipkin server to which traces should be posted.'
+                    'No traces will be made if this is not set.')
 
   def initialize(self, run_tracker, start_time=None):
     """Initialize with the given RunTracker.
@@ -90,11 +89,8 @@ class Reporting(Subsystem):
     # Set up Zipkin reporting.
     zipkin_endpoint = self.get_options().zipkin_endpoint
     if zipkin_endpoint is not None:
-      zipkin_encoding = self.get_options().zipkin_encoding
       zipkin_reporter_settings = ZipkinReporter.Settings(log_level=Report.INFO)
-      zipkin_reporter = ZipkinReporter(
-        run_tracker, zipkin_reporter_settings, zipkin_endpoint, zipkin_encoding
-      )
+      zipkin_reporter = ZipkinReporter(run_tracker, zipkin_reporter_settings, zipkin_endpoint)
       report.add_reporter('zipkin', zipkin_reporter)
 
     # Add some useful RunInfo.

--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -1,0 +1,87 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import requests
+from py_zipkin import Encoding
+from py_zipkin.transport import BaseTransportHandler
+from py_zipkin.zipkin import zipkin_span
+
+from pants.reporting.reporter import Reporter
+
+
+class HTTPTransportHandler(BaseTransportHandler):
+  def __init__(self, endpoint, encoding):
+    self.endpoint = endpoint
+    self.encoding = encoding
+
+  def get_max_payload_bytes(self):
+    return None
+
+  def send(self, payload):
+    try:
+      requests.post(
+        # Twitter endpoint 'https://zipkin.twitter.biz/api/v1/spans',
+        # Local endpoint 'http://localhost:9411/api/v1/spans',
+        self.endpoint,
+        data=payload,
+        headers={'Content-Type': 'application/{}'.format(self.encoding)},
+      )
+    except Exception as err:
+      err
+
+
+class ZipkinReporter(Reporter):
+  """Reporter that implements Zipkin tracing .
+  """
+
+  def __init__(self, run_tracker, settings, endpoint, encoding):
+    super(ZipkinReporter, self).__init__(run_tracker, settings)
+    # We keep track of connection between workunits and spans
+    self._workunits_to_spans = {}
+    self.encoding = encoding
+    # Create a transport handler
+    self.handler = HTTPTransportHandler(endpoint, encoding)
+
+  def open(self):
+    pass
+
+  def close(self):
+    pass
+
+  def start_workunit(self, workunit):
+    """Implementation of Reporter callback."""
+    # Check if it is the first workunit
+    first_span = not self._workunits_to_spans
+    if first_span:
+      span = zipkin_span(
+        service_name='pants_v1',
+        span_name=workunit.name,
+        transport_handler=self.handler,
+        sample_rate=100.0, # Value between 0.0 and 100.0
+        encoding=self.set_encoding()
+      )
+    else:
+      span = zipkin_span(
+        service_name='pants_v1',
+        span_name=workunit.name,
+      )
+    self._workunits_to_spans[workunit] = span
+    span.start()
+    span.start_timestamp = workunit.start_time
+    if first_span:
+      span.logging_context.start_timestamp = workunit.start_time
+
+  def end_workunit(self, workunit):
+    """Implementation of Reporter callback."""
+    if workunit in self._workunits_to_spans:
+      span = self._workunits_to_spans.pop(workunit)
+      span.stop()
+
+  def set_encoding(self):
+    if self.encoding == 'json':
+      return Encoding.V1_JSON
+    else:
+      return Encoding.V1_THRIFT

--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -1,21 +1,26 @@
 # coding=utf-8
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
 
 import requests
 from py_zipkin import Encoding
 from py_zipkin.transport import BaseTransportHandler
 from py_zipkin.zipkin import zipkin_span
 
+from pants.base.workunit import WorkUnitLabel
 from pants.reporting.reporter import Reporter
 
 
+log = logging.getLogger(__name__)
+
+
 class HTTPTransportHandler(BaseTransportHandler):
-  def __init__(self, endpoint, encoding):
+  def __init__(self, endpoint):
     self.endpoint = endpoint
-    self.encoding = encoding
 
   def get_max_payload_bytes(self):
     return None
@@ -23,53 +28,53 @@ class HTTPTransportHandler(BaseTransportHandler):
   def send(self, payload):
     try:
       requests.post(
-        # Twitter endpoint 'https://zipkin.twitter.biz/api/v1/spans',
-        # Local endpoint 'http://localhost:9411/api/v1/spans',
         self.endpoint,
         data=payload,
-        headers={'Content-Type': 'application/{}'.format(self.encoding)},
+        headers={'Content-Type': 'application/x-thrift'},
       )
     except Exception as err:
-      err
+      log.error("Failed to post the payload to zipkin server. Error {}".format(err))
 
 
 class ZipkinReporter(Reporter):
   """Reporter that implements Zipkin tracing .
   """
 
-  def __init__(self, run_tracker, settings, endpoint, encoding):
+  def __init__(self, run_tracker, settings, endpoint):
     super(ZipkinReporter, self).__init__(run_tracker, settings)
     # We keep track of connection between workunits and spans
     self._workunits_to_spans = {}
-    self.encoding = encoding
     # Create a transport handler
-    self.handler = HTTPTransportHandler(endpoint, encoding)
-
-  def open(self):
-    pass
-
-  def close(self):
-    pass
+    self.handler = HTTPTransportHandler(endpoint)
 
   def start_workunit(self, workunit):
     """Implementation of Reporter callback."""
+    if workunit.has_label(WorkUnitLabel.GOAL):
+      service_name = "pants goal"
+    elif workunit.has_label(WorkUnitLabel.TASK):
+      service_name = "pants task"
+    else:
+      service_name = "pants workunit"
+
     # Check if it is the first workunit
     first_span = not self._workunits_to_spans
     if first_span:
       span = zipkin_span(
-        service_name='pants_v1',
+        service_name=service_name,
         span_name=workunit.name,
         transport_handler=self.handler,
         sample_rate=100.0, # Value between 0.0 and 100.0
-        encoding=self.set_encoding()
+        encoding=Encoding.V1_THRIFT
       )
     else:
       span = zipkin_span(
-        service_name='pants_v1',
+        service_name=service_name,
         span_name=workunit.name,
       )
     self._workunits_to_spans[workunit] = span
     span.start()
+    # Goals and tasks save their start time at the beginning of their run.
+    # This start time is passed to workunit, because the workunit may be created much later.
     span.start_timestamp = workunit.start_time
     if first_span:
       span.logging_context.start_timestamp = workunit.start_time
@@ -79,9 +84,3 @@ class ZipkinReporter(Reporter):
     if workunit in self._workunits_to_spans:
       span = self._workunits_to_spans.pop(workunit)
       span.stop()
-
-  def set_encoding(self):
-    if self.encoding == 'json':
-      return Encoding.V1_JSON
-    else:
-      return Encoding.V1_THRIFT

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -16,6 +16,7 @@ python_tests(
   dependencies = [
     '3rdparty/python:future',
     '3rdparty/python:parameterized',
+    '3rdparty/python:py-zipkin',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test'
   ],

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -16,7 +16,6 @@ python_tests(
   dependencies = [
     '3rdparty/python:future',
     '3rdparty/python:parameterized',
-    '3rdparty/python:py-zipkin',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test'
   ],

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -9,18 +9,14 @@ import os.path
 import re
 import unittest
 from builtins import open
+from http.server import BaseHTTPRequestHandler
 
-from future.utils import PY2
 from parameterized import parameterized
+from py_zipkin import Encoding
+from py_zipkin.encoding import convert_spans
 
 from pants.util.contextutil import http_server
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
-
-
-if PY2:
-  from BaseHTTPServer import BaseHTTPRequestHandler
-else:
-  from http.server import BaseHTTPRequestHandler
 
 
 _HEADER = 'invocation_id,task_name,targets_hash,target_id,cache_key_id,cache_key_hash,phase,valid\n'
@@ -169,7 +165,6 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
       endpoint = "http://localhost:{}".format(port)
       command = [
         '--reporting-zipkin-endpoint={}'.format(endpoint),
-        '--reporting-zipkin-encoding=json',
         'cloc',
         'src/python/pants:version'
       ]
@@ -177,32 +172,33 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
       pants_run = self.run_pants(command)
       self.assert_success(pants_run)
 
-      num_of_traces = len(ZipkinHandler._traces)
+      num_of_traces = len(ZipkinHandler.traces)
       self.assertEqual(num_of_traces, 1)
 
-      trace = ZipkinHandler._traces[-1]
+      trace = ZipkinHandler.traces[-1]
       main_span = self.find_span_by_name(trace, 'main')
       self.assertEqual(len(main_span), 1)
 
-      parent_id = main_span[0]
+      parent_id = main_span[0]['id']
       main_children = self.find_span_by_parentId(trace, parent_id)
       self.assertTrue(main_children)
-      self.assertTrue(any(name == 'cloc' for name in main_children))
+      self.assertTrue(any(span['name'] == 'cloc' for span in main_children))
 
   @staticmethod
   def find_span_by_name(trace, name):
-    return [span['id'] for span in trace if span['name'] == name]
+    return [span for span in trace if span['name'] == name]
 
   @staticmethod
   def find_span_by_parentId(trace, parent_id):
-    return [span['name'] for span in trace if span.get('parentId') == parent_id]
+    return [span for span in trace if span.get('parentId') == parent_id]
 
 
 class ZipkinHandler(BaseHTTPRequestHandler):
-  _traces = []
+  traces = []
 
   def do_POST(self):
-    trace = json.loads(self.rfile.read(int(self.headers.getheader('content-length'))))
-    self.__class__._traces.append(trace)
-    code = 200 if trace else 404
-    self.send_response(code)
+    thrift_trace = self.rfile.read(int(self.headers.getheader('content-length')))
+    json_trace = convert_spans(thrift_trace, Encoding.V1_JSON, Encoding.V1_THRIFT)
+    trace = json.loads(json_trace)
+    self.__class__.traces.append(trace)
+    self.send_response(200)


### PR DESCRIPTION
Add Zipkin tracing to pants v1.
Zipkin keeps track of workunits and is implemented as a child of Reporter class. 
Integration test is for JSON encoding.

Reason: Other companies that use Zipkin may find it useful. 
Later there will be updates that will allow it to be in a larger trace for systems that invoke Pants.
Also later Zipkin tracing may be added to pants v2 rules