### PR TITLE
add a coerce_collections key_factory for @memoized to reduce boilerplate

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -182,7 +182,6 @@ class RscCompile(ZincCompile):
       ]
     )
 
-  # TODO: allow @memoized_method to convert lists into tuples so they can be hashed!
   @memoized_property
   def _nailgunnable_combined_classpath(self):
     """Register all of the component tools of the rsc compile task as a "combined" jvm tool.

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -88,6 +88,7 @@ python_library(
   name = 'memo',
   sources = ['memo.py'],
   dependencies = [
+      '3rdparty/python/twitter/commons:twitter.common.collections',
       ':meta'
   ],
 )


### PR DESCRIPTION
### Problem

I accidentally [left a TODO](https://github.com/pantsbuild/pants/blob/96f4af5156ee6ccfbf03e23771e5ac50103bd1ed/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py#L185) in a previous PR to allow `@memoized_method` to coerce lists into tuples instead of erroring out (because lists aren't hashable), which I [left again](https://github.com/pantsbuild/pants/pull/7126/files#diff-959e980b9c9cfd4b5ded5256b97447a8R62) in #7126.

It would be nice to not make things tuples everywhere (weird and unclear syntax, imho) just so we can memoize them.

### Solution

- Introduce `coercing_arg_normalizer` to apply a dict of type coercions to arguments for a `key_factory`.
- Introduce `coerce_collections{,_per_instance}` as `key_factory`s for `@memoized` to coerce `list` and `OrderedSet` inputs to `tuple`s so they can be hashed.
- Add testing.

### Result

Some boilerplate is removed when interacting with functions or instance methods decorated with forms of `@memoized`.