### PR TITLE
Bump cucumber version to get jar with correct unicode encoding 

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -75,7 +75,7 @@ jar_library(name='commons-lang',
 
 jar_library(name='cucumber-java',
             jars=[
-              jar(org='info.cukes', name='cucumber-java', rev='1.1.7'),
+              jar(org='info.cukes', name='cucumber-java', rev='1.2.5'),
             ])
 
 jar_library(name='ivy',

--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,7 +1,6 @@
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:zinc_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc:rsc_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile:declared_deps_integration
-tests/python/pants_test/backend/jvm/tasks:classmap_integration
 tests/python/pants_test/backend/jvm/tasks:jar_publish_integration
 tests/python/pants_test/backend/jvm/tasks:jvm_platform_analysis_integration
 tests/python/pants_test/backend/jvm/tasks:scala_repl_integration

--- a/testprojects/3rdparty/cucumber/BUILD
+++ b/testprojects/3rdparty/cucumber/BUILD
@@ -3,13 +3,13 @@
 
 jar_library(name='cuke-core',
   jars=[
-    jar(org='info.cukes', name='cucumber-core', rev='1.2.4')
+    jar(org='info.cukes', name='cucumber-core', rev='1.2.5')
   ],
 )
 
 jar_library(name='cuke-guice',
   jars=[
-    jar(org='info.cukes', name='cucumber-guice', rev='1.2.4'),
+    jar(org='info.cukes', name='cucumber-guice', rev='1.2.5'),
   ],
   dependencies=[
     # The cucumber-guice jar has a 'provided' scope dep on guice itself so we're forced to adjoin
@@ -20,13 +20,13 @@ jar_library(name='cuke-guice',
 
 jar_library(name='cuke-java',
   jars=[
-    jar(org='info.cukes', name='cucumber-java', rev='1.2.4')
+    jar(org='info.cukes', name='cucumber-java', rev='1.2.5')
   ],
 )
 
 jar_library(name='cuke-junit',
   jars=[
-    jar(org='info.cukes', name='cucumber-junit', rev='1.2.4')
+    jar(org='info.cukes', name='cucumber-junit', rev='1.2.5')
   ],
 )
 

--- a/testprojects/3rdparty/managed/BUILD
+++ b/testprojects/3rdparty/managed/BUILD
@@ -4,7 +4,7 @@
 
 managed_jar_libraries(
   artifacts=[
-    jar('info.cukes', 'cucumber-core', '1.2.4'),
+    jar('info.cukes', 'cucumber-core', '1.2.5'),
     jar('org.eclipse.jetty', 'jetty-jsp', '9.2.9.v20150224'),
     jar('jersey', 'jersey', '0.7-ea', classifier='sources'),
     ':args4j.args4j',

--- a/tests/python/pants_test/backend/jvm/tasks/test_classmap_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classmap_integration.py
@@ -42,5 +42,8 @@ class ClassmapTaskIntegrationTest(PantsRunIntegrationTest):
     self.assertNotIn(self.EXTERNAL_MAPPING, pants_run.stdout_data)
 
   def test_classmap_unicode(self):
+    # N.B. Our classmap goal assumes that the JAR/Zip file has correctly marked itself as utf-8
+    # in order for us to properly render unicode, due to how Python 3's Zipfile decodes filenames.
+    # See https://github.com/pantsbuild/pants/issues/7123 for further information
     pants_run = self.do_command('classmap', self.UNICODE_TEST_TARGET, success=True)
     self.assertIn(self.UNICODE_MAPPING, pants_run.stdout_data)


### PR DESCRIPTION
New version has correct jar encoding set.

### Problem
Cucumber jar was setting wrong encoding, see https://github.com/pantsbuild/pants/issues/7123.

### Solution
Bump cucumber version, newer jar is correct.

### Result
