### PR TITLE
Fix test_jvm_platform_analysis_integration.py using unknown platforms

### DIFF
--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,4 +1,3 @@
-tests/python/pants_test/backend/jvm/tasks:jvm_platform_analysis_integration
 tests/python/pants_test/backend/jvm/tasks:scala_repl_integration
 tests/python/pants_test/backend/project_info/tasks:idea_plugin_integration
 tests/python/pants_test/backend/python/tasks:integration

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis_integration.py
@@ -94,7 +94,7 @@ class JvmPlatformAnalysisIntegrationTest(PantsRunIntegrationTest):
       self.assert_success(sandbox.clean_all())
       run = sandbox.jvm_platform_validate('one', 'two')
       self.assert_failure(run)
-      self.assertIn(cls.FAILURE_MESSAGE, run.stdout_data)
+      self.assertIn(self.FAILURE_MESSAGE, run.stdout_data)
 
   def test_good_then_bad(self):
     with self.setup_sandbox() as sandbox:
@@ -105,7 +105,7 @@ class JvmPlatformAnalysisIntegrationTest(PantsRunIntegrationTest):
       sandbox.write_build_file(self._bad_one_two)
       bad_run = sandbox.jvm_platform_validate('one', 'two')
       self.assert_failure(bad_run)
-      self.assertIn(cls.FAILURE_MESSAGE, bad_run.stdout_data)
+      self.assertIn(self.FAILURE_MESSAGE, bad_run.stdout_data)
 
   def test_bad_then_good(self):
     with self.setup_sandbox() as sandbox:
@@ -113,7 +113,7 @@ class JvmPlatformAnalysisIntegrationTest(PantsRunIntegrationTest):
       self.assert_success(sandbox.clean_all())
       bad_run = sandbox.jvm_platform_validate('one', 'two')
       self.assert_failure(bad_run)
-      self.assertIn(cls.FAILURE_MESSAGE, bad_run.stdout_data)
+      self.assertIn(self.FAILURE_MESSAGE, bad_run.stdout_data)
       sandbox.write_build_file(self._good_one_two)
       good_run = sandbox.jvm_platform_validate('one', 'two')
       self.assert_success(good_run)
@@ -125,10 +125,10 @@ class JvmPlatformAnalysisIntegrationTest(PantsRunIntegrationTest):
       self.assert_success(sandbox.clean_all())
       first_run = sandbox.jvm_platform_validate('one', 'two')
       self.assert_success(first_run)
-      self.assertIn(cls.CACHE_MESSAGE, first_run.stdout_data)
+      self.assertIn(self.CACHE_MESSAGE, first_run.stdout_data)
       second_run = sandbox.jvm_platform_validate('one', 'two')
       self.assert_success(second_run)
-      self.assertNotIn(cls.CACHE_MESSAGE, second_run.stdout_data)
+      self.assertNotIn(self.CACHE_MESSAGE, second_run.stdout_data)
 
   def test_bad_caching(self):
     # Make sure targets aren't cached after a bad run.
@@ -137,7 +137,7 @@ class JvmPlatformAnalysisIntegrationTest(PantsRunIntegrationTest):
       self.assert_success(sandbox.clean_all())
       first_run = sandbox.jvm_platform_validate('one', 'two')
       self.assert_failure(first_run)
-      self.assertIn(cls.CACHE_MESSAGE, first_run.stdout_data)
+      self.assertIn(self.CACHE_MESSAGE, first_run.stdout_data)
       second_run = sandbox.jvm_platform_validate('one', 'two')
       self.assert_failure(second_run)
-      self.assertIn(cls.CACHE_MESSAGE, second_run.stdout_data)
+      self.assertIn(self.CACHE_MESSAGE, second_run.stdout_data)

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis_integration.py
@@ -17,6 +17,7 @@ class JvmPlatformAnalysisIntegrationTest(PantsRunIntegrationTest):
   """Make sure jvm-platform-analysis runs properly, especially with respect to caching behavior."""
 
   FAILURE_MESSAGE = "Dependencies cannot have a higher java target level than dependees!"
+  CACHE_MESSAGE = "Invalidated 2 targets"
 
   class JavaSandbox(object):
     """Testing sandbox for making temporary java_library targets."""
@@ -124,10 +125,10 @@ class JvmPlatformAnalysisIntegrationTest(PantsRunIntegrationTest):
       self.assert_success(sandbox.clean_all())
       first_run = sandbox.jvm_platform_validate('one', 'two')
       self.assert_success(first_run)
-      self.assertIn('Invalidated 2 targets', first_run.stdout_data)
+      self.assertIn(cls.CACHE_MESSAGE, first_run.stdout_data)
       second_run = sandbox.jvm_platform_validate('one', 'two')
       self.assert_success(second_run)
-      self.assertNotIn('Invalidated 2 targets', second_run.stdout_data)
+      self.assertNotIn(cls.CACHE_MESSAGE, second_run.stdout_data)
 
   def test_bad_caching(self):
     # Make sure targets aren't cached after a bad run.
@@ -136,7 +137,7 @@ class JvmPlatformAnalysisIntegrationTest(PantsRunIntegrationTest):
       self.assert_success(sandbox.clean_all())
       first_run = sandbox.jvm_platform_validate('one', 'two')
       self.assert_failure(first_run)
-      self.assertIn('Invalidated 2 targets', first_run.stdout_data)
+      self.assertIn(cls.CACHE_MESSAGE, first_run.stdout_data)
       second_run = sandbox.jvm_platform_validate('one', 'two')
       self.assert_failure(second_run)
-      self.assertIn('Invalidated 2 targets', second_run.stdout_data)
+      self.assertIn(cls.CACHE_MESSAGE, second_run.stdout_data)

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis_integration.py
@@ -59,11 +59,11 @@ class JvmPlatformAnalysisIntegrationTest(PantsRunIntegrationTest):
   def _good_one_two(self):
     return dedent("""
       java_library(name='one',
-        platform='1.7',
+        platform='java7',
       )
 
       java_library(name='two',
-        platform='1.8',
+        platform='java8',
       )
     """)
 
@@ -71,12 +71,12 @@ class JvmPlatformAnalysisIntegrationTest(PantsRunIntegrationTest):
   def _bad_one_two(self):
     return dedent("""
       java_library(name='one',
-        platform='1.7',
+        platform='java7',
         dependencies=[':two'],
       )
 
       java_library(name='two',
-        platform='1.8',
+        platform='java8',
       )
     """)
 


### PR DESCRIPTION
### Problem
This whole time, we've been using an unrecognized JVM platform in `test_jvm_platform_analysis_integration.py`. The tests do not recognize `1.7`, only `java7`.

We were not detecting this issue when ran with Python 2 due to https://github.com/pantsbuild/pants/issues/7139 and our tests not being specific enough in the expected error message. 

However, the failure properly hit us when ran with Python 3.

### Solution
Rename `1.7` and `1.8` to `java7` and `java8`, respectively.

Also tighten the tests' expected failure message to avoid something like https://github.com/pantsbuild/pants/issues/7139 from happening again.