### PR TITLE
Remove option integration test from Python 3 blacklist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -642,7 +642,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard0
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 0/14
+        - ./build-support/bin/travis-ci.sh -c -i 0/15
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 1 (Py3 PEX)"
@@ -650,7 +650,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard1
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 1/14
+        - ./build-support/bin/travis-ci.sh -c -i 1/15
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 2 (Py3 PEX)"
@@ -658,7 +658,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard2
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 2/14
+        - ./build-support/bin/travis-ci.sh -c -i 2/15
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 3 (Py3 PEX)"
@@ -666,7 +666,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard3
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 3/14
+        - ./build-support/bin/travis-ci.sh -c -i 3/15
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 4 (Py3 PEX)"
@@ -674,7 +674,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard4
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 4/14
+        - ./build-support/bin/travis-ci.sh -c -i 4/15
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 5 (Py3 PEX)"
@@ -682,7 +682,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard5
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 5/14
+        - ./build-support/bin/travis-ci.sh -c -i 5/15
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 6 (Py3 PEX)"
@@ -690,7 +690,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard6
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 6/14
+        - ./build-support/bin/travis-ci.sh -c -i 6/15
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 7 (Py3 PEX)"
@@ -698,7 +698,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard7
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 7/14
+        - ./build-support/bin/travis-ci.sh -c -i 7/15
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 8 (Py3 PEX)"
@@ -706,7 +706,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard8
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 8/14
+        - ./build-support/bin/travis-ci.sh -c -i 8/15
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 9 (Py3 PEX)"
@@ -714,7 +714,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard9
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 9/14
+        - ./build-support/bin/travis-ci.sh -c -i 9/15
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 10 (Py3 PEX)"
@@ -722,7 +722,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard10
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 10/14
+        - ./build-support/bin/travis-ci.sh -c -i 10/15
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 11 (Py3 PEX)"
@@ -730,7 +730,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard11
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 11/14
+        - ./build-support/bin/travis-ci.sh -c -i 11/15
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 12 (Py3 PEX)"
@@ -738,7 +738,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard12
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 12/14
+        - ./build-support/bin/travis-ci.sh -c -i 12/15
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 13 (Py3 PEX)"
@@ -746,7 +746,15 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard13
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 13/14
+        - ./build-support/bin/travis-ci.sh -c -i 13/15
+
+    - <<: *py3_linux_test_config
+      name: "Integration tests for pants - shard 14 (Py3 PEX)"
+      env:
+        - *py3_linux_test_config_env
+        - CACHE_NAME=integrationshard14
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 14/15
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 0 (Py2 PEX w/ Py3 constraints)"
@@ -756,7 +764,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard0.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 0/6
+        - ./build-support/bin/travis-ci.sh -c2w -i 0/5
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 1 (Py2 PEX w/ Py3 constraints)"
@@ -766,7 +774,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard1.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 1/6
+        - ./build-support/bin/travis-ci.sh -c2w -i 1/5
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 2 (Py2 PEX w/ Py3 constraints)"
@@ -776,7 +784,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard2.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 2/6
+        - ./build-support/bin/travis-ci.sh -c2w -i 2/5
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 3 (Py2 PEX w/ Py3 constraints)"
@@ -786,7 +794,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard3.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 3/6
+        - ./build-support/bin/travis-ci.sh -c2w -i 3/5
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 4 (Py2 PEX w/ Py3 constraints)"
@@ -796,17 +804,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard4.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 4/6
-
-    - <<: *py2_linux_test_config
-      name: "Blacklisted integration tests for pants - shard 5 (Py2 PEX w/ Py3 constraints)"
-      stage: *test
-      env:
-        - *py2_linux_test_config_env
-        - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
-        - CACHE_NAME=integrationshard5.py2blacklist
-      script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 5/6
+        - ./build-support/bin/travis-ci.sh -c2w -i 4/5
 
     - <<: *py2_linux_test_config
       name: "Integration tests for pants - shard 0 (Py2 PEX)"

--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -11,7 +11,6 @@ tests/python/pants_test/engine/legacy:console_rule_integration
 tests/python/pants_test/engine/legacy:graph_integration
 tests/python/pants_test/engine/legacy:owners_integration
 tests/python/pants_test/engine:scheduler_integration
-tests/python/pants_test/option:options_integration
 tests/python/pants_test/pantsd:pantsd_integration
 tests/python/pants_test/projects:testprojects_integration
 tests/python/pants_test/rules:test_integration

--- a/build-support/travis/generate_travis_yml.py
+++ b/build-support/travis/generate_travis_yml.py
@@ -8,8 +8,8 @@ import pkg_resources
 import pystache
 
 
-num_py3_integration_shards = 14
-num_py2_blacklist_integration_shards = 6
+num_py3_integration_shards = 15
+num_py2_blacklist_integration_shards = 5
 num_cron_integration_shards = 20
 
 


### PR DESCRIPTION
I'm not sure why it was added to begin with. Even back in #6959, which first introduced `./pants3`, the tests were passing.

Maybe it was a flaky test? But I can't find a ticket for that. So maybe it was a typo?