### PR TITLE
Fix setup_py.py unicode issue with Python 3

### DIFF
--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -4,7 +4,6 @@ tests/python/pants_test/backend/project_info/tasks:idea_plugin_integration
 tests/python/pants_test/backend/python/tasks:integration
 tests/python/pants_test/backend/python/tasks:isort_run_integration
 tests/python/pants_test/backend/python/tasks:python_native_code_testing_1
-tests/python/pants_test/backend/python:integration
 tests/python/pants_test/base:exiter_integration
 tests/python/pants_test/engine/legacy:changed_integration
 tests/python/pants_test/engine/legacy:console_rule_integration

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -14,7 +14,6 @@ from abc import abstractmethod
 from builtins import bytes, map, object, str, zip
 from collections import defaultdict
 
-from future.utils import PY2
 from pex.installer import InstallerBase, Packager
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
@@ -501,7 +500,7 @@ class SetupPy(Task):
       # and then writing it out after the process has finished like we do here.
       def write(stream_name, data):
         stream = workunit.output(stream_name)
-        stream.write(ensure_binary(data) if PY2 else ensure_text(data))
+        stream.write(ensure_binary(data))
         stream.flush()
 
       write('stdout', stdout)


### PR DESCRIPTION
We must always write to the outstream with bytes, because `rwbuf` uses bytes and we decided to try to unify our treatment of outstreams (e.g. use sys.stdout in Py2 and equivalent sys.stdout.buffer in Py3).

This issue causes multiple CI failures for Python 3, including the build wheels jobs, the contrib, some backend/python/tasks tests, and some backend/python tests.