### PR TITLE
make GoTest subclass PartitionedTestRunnerTaskMixin to test transitively

### DIFF
--- a/contrib/go/examples/src/go/libB/b.go
+++ b/contrib/go/examples/src/go/libB/b.go
@@ -4,8 +4,16 @@ import (
 	"libD"
 )
 
+func SpeakPrologue() string {
+	return "Hello from libB!"
+}
+
+func SpeakEpilogue() string {
+	return "Bye from libB!"
+}
+
 func Speak() {
-	println("Hello from libB!")
+	println(SpeakPrologue())
 	libD.Speak()
-	println("Bye from libB!")
+	println(SpeakEpilogue())
 }

--- a/contrib/go/examples/src/go/libB/b_test.go
+++ b/contrib/go/examples/src/go/libB/b_test.go
@@ -1,0 +1,16 @@
+package libB
+
+import (
+	"testing"
+)
+
+func TestSpeak(t *testing.T) {
+	got, exp := SpeakPrologue(), "Hello from libB!"
+	if got != exp {
+		t.Fatalf("got: %d, expected: %d", got, exp)
+	}
+	got2, exp2 := SpeakEpilogue(), "Bye from libB!"
+	if got2 != exp2 {
+		t.Fatalf("got: %d, expected: %d", got2, exp2)
+	}
+}

--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
@@ -129,7 +129,7 @@ class GoDistribution(NativeTool):
     :returns: A tuple of the exit code and the go command that was run.
     :rtype: (int, :class:`GoDistribution.GoCommand`)
     """
-    go_cmd = self.GoCommand._create(self.goroot, cmd, go_env=self.go_env(gopath=gopath), args=args)
+    go_cmd = self.create_go_cmd(cmd, gopath=gopath, args=args)
     if workunit_factory is None:
       return go_cmd.spawn(**kwargs).wait()
     else:

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -96,7 +96,7 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
     return get_buildroot()
 
   def run_tests(self, fail_fast, test_targets, args_by_target):
-    with self._chroot(test_targets, self._maybe_workdir) as chroot:
+    with self.chroot(test_targets, self._maybe_workdir) as chroot:
       cmdline_args = self._build_and_test_flags + [
         args_by_target[t].import_path for t in test_targets
       ] + self.get_passthru_args()
@@ -109,5 +109,5 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
       with self.context.new_workunit(
           name='go test', cmd=safe_shlex_join(go_cmd.cmdline), labels=workunit_labels) as workunit:
 
-        exit_code = self._spawn_and_wait(workunit=workunit, go_cmd=go_cmd, cwd=chroot)
+        exit_code = self.spawn_and_wait(workunit=workunit, go_cmd=go_cmd, cwd=chroot)
         return TestResult.rc(exit_code)

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
@@ -9,6 +9,7 @@ from textwrap import dedent
 
 from pants.util.dirutil import safe_open
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.testutils.py2_compat import assertRegex
 
 
 class GoTestIntegrationTest(PantsRunIntegrationTest):
@@ -17,6 +18,19 @@ class GoTestIntegrationTest(PantsRunIntegrationTest):
             'contrib/go/examples/src/go/libA']
     pants_run = self.run_pants(args)
     self.assert_success(pants_run)
+    # libA depends on libB, so both tests should be run.
+    assertRegex(self, pants_run.stdout_data, r'ok\s+libA')
+    assertRegex(self, pants_run.stdout_data, r'ok\s+libB')
+
+  def test_no_fast(self):
+    args = ['test.go',
+            '--no-fast',
+            'contrib/go/examples/src/go/libA']
+    pants_run = self.run_pants(args)
+    self.assert_success(pants_run)
+    # libA depends on libB, so both tests should be run.
+    assertRegex(self, pants_run.stdout_data, r'ok\s+libA')
+    assertRegex(self, pants_run.stdout_data, r'ok\s+libB')
 
   def test_go_test_unstyle(self):
     with self.temporary_sourcedir() as srcdir:

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
@@ -39,15 +39,15 @@ class NodeTest(TestRunnerTaskMixin, NodeTask):
 
     This is what is ultimately used to run the Command.
     It must return the return code of the process. The base implementation just calls
-    command.run immediately. We override here to invoke TestRunnerTaskMixin._spawn_and_wait,
+    command.run immediately. We override here to invoke TestRunnerTaskMixin.spawn_and_wait,
     which ultimately invokes _spawn, which finally calls command.run.
     """
-    return self._spawn_and_wait(command, workunit)
+    return self.spawn_and_wait(command, workunit)
 
   def _get_test_targets_for_spawn(self):
     """Overrides TestRunnerTaskMixin._get_test_targets_for_spawn.
 
-    TestRunnerTaskMixin._spawn_and_wait uses this method to know what targets are being run.
+    TestRunnerTaskMixin.spawn_and_wait uses this method to know what targets are being run.
     By default it returns all test targets - here we override it with the list
     self._currently_executing_test_targets, which _execute sets.
     """

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -420,11 +420,11 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
 
       batch_test_specs = [test.render_test_spec() for test in batch]
       with argfile.safe_args(batch_test_specs, self.get_options()) as batch_tests:
-        with self._chroot(relevant_targets, workdir) as chroot:
+        with self.chroot(relevant_targets, workdir) as chroot:
           self.context.log.debug('CWD = {}'.format(chroot))
           self.context.log.debug('platform = {}'.format(platform))
           with environment_as(**dict(target_env_vars)):
-            subprocess_result = self._spawn_and_wait(
+            subprocess_result = self.spawn_and_wait(
               executor=SubprocessExecutor(distribution),
               distribution=distribution,
               classpath=complete_classpath,

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -517,10 +517,10 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
       with self.context.new_workunit(name='run',
                                      cmd=' '.join(pex.cmdline(args)),
                                      labels=[WorkUnitLabel.TOOL, WorkUnitLabel.TEST]) as workunit:
-        rc = self._spawn_and_wait(pex, workunit=workunit, args=args, setsid=True, env=env)
+        rc = self.spawn_and_wait(pex, workunit=workunit, args=args, setsid=True, env=env)
         return PytestResult.rc(rc)
     except ErrorWhileTesting:
-      # _spawn_and_wait wraps the test runner in a timeout, so it could
+      # spawn_and_wait wraps the test runner in a timeout, so it could
       # fail with a ErrorWhileTesting. We can't just set PythonTestResult
       # to a failure because the resultslog doesn't have all the failures
       # when tests are killed with a timeout. Therefore we need to re-raise

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -247,16 +247,16 @@ class TestRunnerTaskMixin(object):
     return tests_in_path
 
   def _get_test_targets_for_spawn(self):
-    """Invoked by _spawn_and_wait to know targets being executed. Defaults to _get_test_targets().
+    """Invoked by spawn_and_wait to know targets being executed. Defaults to _get_test_targets().
 
-    _spawn_and_wait passes all its arguments through to _spawn, but it needs to know what targets
-    are being executed by _spawn. A caller to _spawn_and_wait can override this method to return
-    the targets being executed by the current _spawn_and_wait. By default it returns
+    spawn_and_wait passes all its arguments through to _spawn, but it needs to know what targets
+    are being executed by _spawn. A caller to spawn_and_wait can override this method to return
+    the targets being executed by the current spawn_and_wait. By default it returns
     _get_test_targets(), which is all test targets.
     """
     return self._get_test_targets()
 
-  def _spawn_and_wait(self, *args, **kwargs):
+  def spawn_and_wait(self, *args, **kwargs):
     """Spawn the actual test runner process, and wait for it to complete."""
 
     test_targets = self._get_test_targets_for_spawn()
@@ -449,7 +449,7 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
         shutil.copy(src, dest)
 
   @contextmanager
-  def _chroot(self, targets, workdir):
+  def chroot(self, targets, workdir):
     if workdir is not None:
       yield workdir
     else:

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -4,16 +4,22 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import functools
 import os
 import re
+import shutil
 import xml.etree.ElementTree as ET
 from abc import abstractmethod
 from builtins import filter, next, object, str
+from contextlib import contextmanager
 
+from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import ErrorWhileTesting, TaskError
 from pants.build_graph.files import Files
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.task.task import Task
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import safe_mkdir, safe_mkdir_for
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.process_handler import subprocess
 
@@ -432,6 +438,29 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
     :rtype: bool
     """
     return self.get_options().chroot
+
+  @staticmethod
+  def _copy_files(dest_dir, target):
+    if isinstance(target, Files):
+      for source in target.sources_relative_to_buildroot():
+        src = os.path.join(get_buildroot(), source)
+        dest = os.path.join(dest_dir, source)
+        safe_mkdir_for(dest)
+        shutil.copy(src, dest)
+
+  @contextmanager
+  def _chroot(self, targets, workdir):
+    if workdir is not None:
+      yield workdir
+    else:
+      root_dir = os.path.join(self.workdir, '_chroots')
+      safe_mkdir(root_dir)
+      with temporary_dir(root_dir=root_dir) as chroot:
+        self.context.build_graph.walk_transitive_dependency_graph(
+          addresses=[t.address for t in targets],
+          work=functools.partial(self._copy_files, chroot)
+        )
+        yield chroot
 
   def _execute(self, all_targets):
     test_targets = self._get_test_targets()

--- a/tests/python/pants_test/task/test_testrunner_task_mixin.py
+++ b/tests/python/pants_test/task/test_testrunner_task_mixin.py
@@ -41,7 +41,7 @@ class TestRunnerTaskMixinTest(TaskTestBase):
 
       def _execute(self, all_targets):
         self.call_list.append(['_execute', all_targets])
-        self._spawn_and_wait()
+        self.spawn_and_wait()
 
       def _spawn(self, *args, **kwargs):
         self.call_list.append(['_spawn', args, kwargs])
@@ -147,7 +147,7 @@ class TestRunnerTaskMixinSimpleTimeoutTest(TaskTestBase):
       waited_for = None
 
       def _execute(self, all_targets):
-        self._spawn_and_wait()
+        self.spawn_and_wait()
 
       def _spawn(self, *args, **kwargs):
         timeouts = self.get_options().timeouts
@@ -236,7 +236,7 @@ class TestRunnerTaskMixinGracefulTimeoutTest(TaskTestBase):
 
       def _execute(self, all_targets):
         self.call_list.append(['_execute', all_targets])
-        self._spawn_and_wait()
+        self.spawn_and_wait()
 
       def _spawn(self, *args, **kwargs):
         self.call_list.append(['_spawn', args, kwargs])
@@ -322,7 +322,7 @@ class TestRunnerTaskMixinMultipleTargets(TaskTestBase):
       wait_time = None
 
       def _execute(self, all_targets):
-        self._spawn_and_wait()
+        self.spawn_and_wait()
 
       def _spawn(self, *args, **kwargs):
         terminate_wait = self.get_options().timeout_terminate_wait


### PR DESCRIPTION
### Problem

Resolves #6935.

### Solution

- Extract some logic around chrooting from `JUnitRun` into `PartitionedTestRunnerTaskMixin`.
- Make `GoTest` mix in `PartitionedTestRunnerTaskMixin` and implement all of the `@abstractmethod`s (everything worked first try, which makes me very suspicious as well as grateful).
- Add an integration test for `go test`ing dependent targets.

### Result

`./pants test.go` now has some funky features like `--chroot` or `--no-fast`, and tests dependent targets by default instead of requiring this to be done manually.