### PR TITLE
run clean-all before switching pants python version runner scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,5 @@ GRTAGS
 GSYMS
 GTAGS
 .mypy_cache/
-# TODO(#7152): remove this after the python 3 migration!
+# Stores the version of python last used to run pants. See ./pants.
 /.pants-python-version

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ GRTAGS
 GSYMS
 GTAGS
 .mypy_cache/
+# TODO(#7152): remove this after the python 3 migration!
+/.pants-python-version

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ GRTAGS
 GSYMS
 GTAGS
 .mypy_cache/
+# Stores the version of python last used to run pants. See ./pants.
+/.python-interpreter-constraints

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,3 @@ GRTAGS
 GSYMS
 GTAGS
 .mypy_cache/
-# Stores the version of python last used to run pants. See ./pants.
-/.pants-python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -399,7 +399,7 @@ cargo_audit: &cargo_audit
 base_build_wheels: &base_build_wheels
   stage: *test
   env:
-    - &base_build_wheels_env PREPARE_DEPLOY=1 ONLY_USING_SINGLE_PYTHON_VERSION='true'
+    - &base_build_wheels_env PREPARE_DEPLOY=1
 
 py27_linux_build_wheels_no_ucs: &py27_linux_build_wheels_no_ucs
   # Similar to the bootstrap shard, we build Linux wheels in a docker image to maximize
@@ -466,7 +466,7 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - CACHE_NAME=osxwheelsbuild.ucs2
   script:
     - ./build-support/bin/check_pants_pex_abi.py cp27m
-    - RUN_PANTS_FROM_PEX=1 ONLY_USING_SINGLE_PYTHON_VERSION='true' ./build-support/bin/release.sh -n
+    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   <<: *py27_osx_config
@@ -499,7 +499,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   script:
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu
-    - RUN_PANTS_FROM_PEX=1 ONLY_USING_SINGLE_PYTHON_VERSION='true' ./build-support/bin/release.sh -n
+    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 # -------------------------------------------------------------------------
 # Rust tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - PYTEST_PASSTHRU_ARGS="-v --duration=3"
     - LC_ALL="en_US.UTF-8"
     # TODO(#7152): this tells the ./pants runner script to avoid trying to clean the workspace when
-    # changing python versions. Remove this after the python 3 migration!
+    # changing python versions. Remove all instances of this after the python 3 migration!
     - ONLY_USING_SINGLE_PYTHON_VERSION='true'
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org
     - BOOTSTRAPPED_PEX_KEY_PREFIX=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}/pants.pex
@@ -465,7 +465,7 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - CACHE_NAME=osxwheelsbuild.ucs2
   script:
     - ./build-support/bin/check_pants_pex_abi.py cp27m
-    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
+    - RUN_PANTS_FROM_PEX=1 ONLY_USING_SINGLE_PYTHON_VERSION='true' ./build-support/bin/release.sh -n
 
 py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   <<: *py27_osx_config
@@ -498,7 +498,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   script:
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu
-    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
+    - RUN_PANTS_FROM_PEX=1 ONLY_USING_SINGLE_PYTHON_VERSION='true' ./build-support/bin/release.sh -n
 
 # -------------------------------------------------------------------------
 # Rust tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ env:
     - PANTS_CONFIG_FILES="${TRAVIS_BUILD_DIR}/pants.travis-ci.ini"
     - PYTEST_PASSTHRU_ARGS="-v --duration=3"
     - LC_ALL="en_US.UTF-8"
-    # TODO(#7152): this tells the ./pants runner script to avoid trying to clean the workspace when
-    # changing python versions. Remove all instances of this after the python 3 migration!
+    # This tells the ./pants runner script to avoid trying to clean the workspace when changing
+    # python versions. CI starts off without the .pants-python-version file, so it would otherwise
+    # run a clean-all without this env var.
     - ONLY_USING_SINGLE_PYTHON_VERSION='true'
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org
     - BOOTSTRAPPED_PEX_KEY_PREFIX=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}/pants.pex

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ env:
     - PANTS_CONFIG_FILES="${TRAVIS_BUILD_DIR}/pants.travis-ci.ini"
     - PYTEST_PASSTHRU_ARGS="-v --duration=3"
     - LC_ALL="en_US.UTF-8"
+    # TODO(#7152): this tells the ./pants runner script to avoid trying to clean the workspace when
+    # changing python versions. Remove this after the python 3 migration!
+    - ONLY_USING_SINGLE_PYTHON_VERSION='true'
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org
     - BOOTSTRAPPED_PEX_KEY_PREFIX=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}/pants.pex
     - BOOTSTRAPPED_PEX_URL_PREFIX=s3://${BOOTSTRAPPED_PEX_BUCKET}/${BOOTSTRAPPED_PEX_KEY_PREFIX}

--- a/.travis.yml
+++ b/.travis.yml
@@ -398,7 +398,7 @@ cargo_audit: &cargo_audit
 base_build_wheels: &base_build_wheels
   stage: *test
   env:
-    - &base_build_wheels_env PREPARE_DEPLOY=1
+    - &base_build_wheels_env PREPARE_DEPLOY=1 ONLY_USING_SINGLE_PYTHON_VERSION='true'
 
 py27_linux_build_wheels_no_ucs: &py27_linux_build_wheels_no_ucs
   # Similar to the bootstrap shard, we build Linux wheels in a docker image to maximize

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - PYTEST_PASSTHRU_ARGS="-v --duration=3"
     - LC_ALL="en_US.UTF-8"
     # This tells the ./pants runner script to avoid trying to clean the workspace when changing
-    # python versions. CI starts off without the .pants-python-version file, so it would otherwise
+    # python versions. CI starts off without the .python-interpreter-constraints file, so it would otherwise
     # run a clean-all without this env var.
     - ONLY_USING_SINGLE_PYTHON_VERSION='true'
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
     - PANTS_CONFIG_FILES="${TRAVIS_BUILD_DIR}/pants.travis-ci.ini"
     - PYTEST_PASSTHRU_ARGS="-v --duration=3"
     - LC_ALL="en_US.UTF-8"
+    # TODO(#7152): remove this after the python 3 migration!
+    - NO_PANTS3_CLEAN='y'
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org
     - BOOTSTRAPPED_PEX_KEY_PREFIX=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}/pants.pex
     - BOOTSTRAPPED_PEX_URL_PREFIX=s3://${BOOTSTRAPPED_PEX_BUCKET}/${BOOTSTRAPPED_PEX_KEY_PREFIX}

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ env:
     - PANTS_CONFIG_FILES="${TRAVIS_BUILD_DIR}/pants.travis-ci.ini"
     - PYTEST_PASSTHRU_ARGS="-v --duration=3"
     - LC_ALL="en_US.UTF-8"
-    # TODO(#7152): remove this after the python 3 migration!
-    - NO_PANTS3_CLEAN='y'
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org
     - BOOTSTRAPPED_PEX_KEY_PREFIX=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}/pants.pex
     - BOOTSTRAPPED_PEX_URL_PREFIX=s3://${BOOTSTRAPPED_PEX_BUCKET}/${BOOTSTRAPPED_PEX_KEY_PREFIX}

--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -22,7 +22,7 @@ USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 ENV LC_ALL="en_US.UTF-8"
 
 # This tells the ./pants runner script to avoid trying to clean the workspace when changing python
-# versions. CI starts off without the .pants-python-version file, so it would otherwise run a
+# versions. CI starts off without the .python-interpreter-constraints file, so it would otherwise run a
 # clean-all without this env var.
 ENV ONLY_USING_SINGLE_PYTHON_VERSION 'true'
 

--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -21,4 +21,8 @@ USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 # Our newly created user is unlikely to have a sane environment: set a locale at least.
 ENV LC_ALL="en_US.UTF-8"
 
+# TODO(#7152): this tells the ./pants runner script to avoid trying to clean the workspace when
+# changing python versions. Remove all instances of this after the python 3 migration!
+ENV ONLY_USING_SINGLE_PYTHON_VERSION 'true'
+
 WORKDIR /travis/workdir

--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -21,8 +21,9 @@ USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 # Our newly created user is unlikely to have a sane environment: set a locale at least.
 ENV LC_ALL="en_US.UTF-8"
 
-# TODO(#7152): this tells the ./pants runner script to avoid trying to clean the workspace when
-# changing python versions. Remove all instances of this after the python 3 migration!
+# This tells the ./pants runner script to avoid trying to clean the workspace when changing python
+# versions. CI starts off without the .pants-python-version file, so it would otherwise run a
+# clean-all without this env var.
 ENV ONLY_USING_SINGLE_PYTHON_VERSION 'true'
 
 WORKDIR /travis/workdir

--- a/build-support/docker/travis_ci_py27_ucs2/Dockerfile
+++ b/build-support/docker/travis_ci_py27_ucs2/Dockerfile
@@ -46,8 +46,9 @@ USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 # Our newly created user is unlikely to have a sane environment: set a locale at least.
 ENV LC_ALL="en_US.UTF-8"
 
-# TODO(#7152): this tells the ./pants runner script to avoid trying to clean the workspace when
-# changing python versions. Remove all instances of this after the python 3 migration!
+# This tells the ./pants runner script to avoid trying to clean the workspace when changing python
+# versions. CI starts off without the .pants-python-version file, so it would otherwise run a
+# clean-all without this env var.
 ENV ONLY_USING_SINGLE_PYTHON_VERSION 'true'
 
 WORKDIR /travis/workdir

--- a/build-support/docker/travis_ci_py27_ucs2/Dockerfile
+++ b/build-support/docker/travis_ci_py27_ucs2/Dockerfile
@@ -47,7 +47,7 @@ USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 ENV LC_ALL="en_US.UTF-8"
 
 # This tells the ./pants runner script to avoid trying to clean the workspace when changing python
-# versions. CI starts off without the .pants-python-version file, so it would otherwise run a
+# versions. CI starts off without the .python-interpreter-constraints file, so it would otherwise run a
 # clean-all without this env var.
 ENV ONLY_USING_SINGLE_PYTHON_VERSION 'true'
 

--- a/build-support/docker/travis_ci_py27_ucs2/Dockerfile
+++ b/build-support/docker/travis_ci_py27_ucs2/Dockerfile
@@ -46,4 +46,8 @@ USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 # Our newly created user is unlikely to have a sane environment: set a locale at least.
 ENV LC_ALL="en_US.UTF-8"
 
+# TODO(#7152): this tells the ./pants runner script to avoid trying to clean the workspace when
+# changing python versions. Remove all instances of this after the python 3 migration!
+ENV ONLY_USING_SINGLE_PYTHON_VERSION 'true'
+
 WORKDIR /travis/workdir

--- a/build-support/docker/travis_ci_py36/Dockerfile
+++ b/build-support/docker/travis_ci_py36/Dockerfile
@@ -43,8 +43,9 @@ USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 # Our newly created user is unlikely to have a sane environment: set a locale at least.
 ENV LC_ALL="en_US.UTF-8"
 
-# TODO(#7152): this tells the ./pants runner script to avoid trying to clean the workspace when
-# changing python versions. Remove all instances of this after the python 3 migration!
+# This tells the ./pants runner script to avoid trying to clean the workspace when changing python
+# versions. CI starts off without the .pants-python-version file, so it would otherwise run a
+# clean-all without this env var.
 ENV ONLY_USING_SINGLE_PYTHON_VERSION 'true'
 
 WORKDIR /travis/workdir

--- a/build-support/docker/travis_ci_py36/Dockerfile
+++ b/build-support/docker/travis_ci_py36/Dockerfile
@@ -43,4 +43,8 @@ USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 # Our newly created user is unlikely to have a sane environment: set a locale at least.
 ENV LC_ALL="en_US.UTF-8"
 
+# TODO(#7152): this tells the ./pants runner script to avoid trying to clean the workspace when
+# changing python versions. Remove all instances of this after the python 3 migration!
+ENV ONLY_USING_SINGLE_PYTHON_VERSION 'true'
+
 WORKDIR /travis/workdir

--- a/build-support/docker/travis_ci_py36/Dockerfile
+++ b/build-support/docker/travis_ci_py36/Dockerfile
@@ -44,7 +44,7 @@ USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 ENV LC_ALL="en_US.UTF-8"
 
 # This tells the ./pants runner script to avoid trying to clean the workspace when changing python
-# versions. CI starts off without the .pants-python-version file, so it would otherwise run a
+# versions. CI starts off without the .python-interpreter-constraints file, so it would otherwise run a
 # clean-all without this env var.
 ENV ONLY_USING_SINGLE_PYTHON_VERSION 'true'
 

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -13,7 +13,7 @@ env:
     - PYTEST_PASSTHRU_ARGS="-v --duration=3"
     - LC_ALL="en_US.UTF-8"
     # This tells the ./pants runner script to avoid trying to clean the workspace when changing
-    # python versions. CI starts off without the .pants-python-version file, so it would otherwise
+    # python versions. CI starts off without the .python-interpreter-constraints file, so it would otherwise
     # run a clean-all without this env var.
     - ONLY_USING_SINGLE_PYTHON_VERSION='true'
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -12,8 +12,9 @@ env:
     - PANTS_CONFIG_FILES="${TRAVIS_BUILD_DIR}/pants.travis-ci.ini"
     - PYTEST_PASSTHRU_ARGS="-v --duration=3"
     - LC_ALL="en_US.UTF-8"
-    # TODO(#7152): this tells the ./pants runner script to avoid trying to clean the workspace when
-    # changing python versions. Remove all instances of this after the python 3 migration!
+    # This tells the ./pants runner script to avoid trying to clean the workspace when changing
+    # python versions. CI starts off without the .pants-python-version file, so it would otherwise
+    # run a clean-all without this env var.
     - ONLY_USING_SINGLE_PYTHON_VERSION='true'
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org
     - BOOTSTRAPPED_PEX_KEY_PREFIX=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}/pants.pex

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -362,7 +362,7 @@ cargo_audit: &cargo_audit
 base_build_wheels: &base_build_wheels
   stage: *test
   env:
-    - &base_build_wheels_env PREPARE_DEPLOY=1
+    - &base_build_wheels_env PREPARE_DEPLOY=1 ONLY_USING_SINGLE_PYTHON_VERSION='true'
 
 py27_linux_build_wheels_no_ucs: &py27_linux_build_wheels_no_ucs
   # Similar to the bootstrap shard, we build Linux wheels in a docker image to maximize

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -12,8 +12,6 @@ env:
     - PANTS_CONFIG_FILES="${TRAVIS_BUILD_DIR}/pants.travis-ci.ini"
     - PYTEST_PASSTHRU_ARGS="-v --duration=3"
     - LC_ALL="en_US.UTF-8"
-    # TODO(#7152): remove this after the python 3 migration!
-    - NO_PANTS3_CLEAN='y'
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org
     - BOOTSTRAPPED_PEX_KEY_PREFIX=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}/pants.pex
     - BOOTSTRAPPED_PEX_URL_PREFIX=s3://${BOOTSTRAPPED_PEX_BUCKET}/${BOOTSTRAPPED_PEX_KEY_PREFIX}

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -363,7 +363,7 @@ cargo_audit: &cargo_audit
 base_build_wheels: &base_build_wheels
   stage: *test
   env:
-    - &base_build_wheels_env PREPARE_DEPLOY=1 ONLY_USING_SINGLE_PYTHON_VERSION='true'
+    - &base_build_wheels_env PREPARE_DEPLOY=1
 
 py27_linux_build_wheels_no_ucs: &py27_linux_build_wheels_no_ucs
   # Similar to the bootstrap shard, we build Linux wheels in a docker image to maximize
@@ -419,7 +419,7 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - CACHE_NAME=osxwheelsbuild.ucs2
   script:
     - ./build-support/bin/check_pants_pex_abi.py cp27m
-    - RUN_PANTS_FROM_PEX=1 ONLY_USING_SINGLE_PYTHON_VERSION='true' ./build-support/bin/release.sh -n
+    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   <<: *py27_osx_config
@@ -446,7 +446,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   script:
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu
-    - RUN_PANTS_FROM_PEX=1 ONLY_USING_SINGLE_PYTHON_VERSION='true' ./build-support/bin/release.sh -n
+    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 # -------------------------------------------------------------------------
 # Rust tests

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -12,6 +12,8 @@ env:
     - PANTS_CONFIG_FILES="${TRAVIS_BUILD_DIR}/pants.travis-ci.ini"
     - PYTEST_PASSTHRU_ARGS="-v --duration=3"
     - LC_ALL="en_US.UTF-8"
+    # TODO(#7152): remove this after the python 3 migration!
+    - NO_PANTS3_CLEAN='y'
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org
     - BOOTSTRAPPED_PEX_KEY_PREFIX=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}/pants.pex
     - BOOTSTRAPPED_PEX_URL_PREFIX=s3://${BOOTSTRAPPED_PEX_BUCKET}/${BOOTSTRAPPED_PEX_KEY_PREFIX}

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -12,6 +12,9 @@ env:
     - PANTS_CONFIG_FILES="${TRAVIS_BUILD_DIR}/pants.travis-ci.ini"
     - PYTEST_PASSTHRU_ARGS="-v --duration=3"
     - LC_ALL="en_US.UTF-8"
+    # TODO(#7152): this tells the ./pants runner script to avoid trying to clean the workspace when
+    # changing python versions. Remove this after the python 3 migration!
+    - ONLY_USING_SINGLE_PYTHON_VERSION='true'
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org
     - BOOTSTRAPPED_PEX_KEY_PREFIX=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}/pants.pex
     - BOOTSTRAPPED_PEX_URL_PREFIX=s3://${BOOTSTRAPPED_PEX_BUCKET}/${BOOTSTRAPPED_PEX_KEY_PREFIX}

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -13,7 +13,7 @@ env:
     - PYTEST_PASSTHRU_ARGS="-v --duration=3"
     - LC_ALL="en_US.UTF-8"
     # TODO(#7152): this tells the ./pants runner script to avoid trying to clean the workspace when
-    # changing python versions. Remove this after the python 3 migration!
+    # changing python versions. Remove all instances of this after the python 3 migration!
     - ONLY_USING_SINGLE_PYTHON_VERSION='true'
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org
     - BOOTSTRAPPED_PEX_KEY_PREFIX=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}/pants.pex
@@ -418,7 +418,7 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - CACHE_NAME=osxwheelsbuild.ucs2
   script:
     - ./build-support/bin/check_pants_pex_abi.py cp27m
-    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
+    - RUN_PANTS_FROM_PEX=1 ONLY_USING_SINGLE_PYTHON_VERSION='true' ./build-support/bin/release.sh -n
 
 py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   <<: *py27_osx_config
@@ -445,7 +445,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   script:
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu
-    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
+    - RUN_PANTS_FROM_PEX=1 ONLY_USING_SINGLE_PYTHON_VERSION='true' ./build-support/bin/release.sh -n
 
 # -------------------------------------------------------------------------
 # Rust tests

--- a/pants
+++ b/pants
@@ -8,29 +8,31 @@ REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P)
 function clean_if_interpreter_changed() {
   _python_version_to_run="$1"
 
+  if [[ -n "${_recursive_pants_shell_script_invocation:-}" ]]; then
+    return 0
+  fi
+
   _python_version_file="${REPO_ROOT}/.pants-python-version"
 
-  if [[ -z "$_recursive_pants_shell_script_invocation" ]]; then
-    if [[ -f "$_python_version_file" ]]; then
-      _prev_run_python_version="$(cat "$_python_version_file")"
-    else
-      cat >&2 <<EOF
+  if [[ -f "$_python_version_file" ]]; then
+    _prev_run_python_version="$(cat "$_python_version_file")"
+    if [[ "$_python_version_to_run" == "$_prev_run_python_version" ]]; then
+      return 0
+    fi
+  else
+    cat >&2 <<EOF
 ${_python_version_file} not found. Forcing an initial clean-all...
 EOF
-      _prev_run_python_version=''
-    fi
+  fi
 
-    if [[ "$_python_version_to_run" != "$_prev_run_python_version" ]]; then
-      export _recursive_pants_shell_script_invocation='y'
-      cat >&2 <<EOF
+  export _recursive_pants_shell_script_invocation='y'
+  cat >&2 <<EOF
 Caches must be cleared before switching pants Python versions in this repo.
 Preparing a Python ${_python_version_to_run} invocation...
 EOF
-      ./pants clean-all
-      echo "$_python_version_to_run" > "$_python_version_file"
-      unset _recursive_pants_shell_script_invocation
-    fi
-  fi
+  ./pants clean-all
+  echo "$_python_version_to_run" > "$_python_version_file"
+  unset _recursive_pants_shell_script_invocation
 }
 
 # This bootstrap script runs pants from the live sources in this repo.
@@ -98,7 +100,7 @@ export PY="${PY:-python3}"
 py_major_minor_patch=$(${PY} -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')
 
 # We can currently assume the CI environment does not switch python versions within a shard.
-if [[ "$ONLY_USING_SINGLE_PYTHON_VERSION" != 'true' ]]; then
+if [[ "${ONLY_USING_SINGLE_PYTHON_VERSION:-false}" != 'true' ]]; then
   clean_if_interpreter_changed "$py_major_minor_patch"
 fi
 

--- a/pants
+++ b/pants
@@ -4,6 +4,8 @@
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P)
 
+_interpreter_version_sentinel_filename='.pants-python-version'
+
 # TODO(#7152): remove this after the python 3 migration!
 function clean_if_interpreter_changed() {
   _python_version_to_run="$1"
@@ -12,7 +14,7 @@ function clean_if_interpreter_changed() {
     return 0
   fi
 
-  _python_version_file="${REPO_ROOT}/.pants-python-version"
+  _python_version_file="${REPO_ROOT}/${_interpreter_version_sentinel_filename}"
 
   if [[ -f "$_python_version_file" ]]; then
     _prev_run_python_version="$(cat "$_python_version_file")"
@@ -21,14 +23,14 @@ function clean_if_interpreter_changed() {
     fi
   else
     cat >&2 <<EOF
-${_python_version_file} not found. Forcing an initial clean-all...
+${_interpreter_version_sentinel_filename} not found in the buildroot. Forcing an initial clean-all...
 EOF
   fi
 
   export _recursive_pants_shell_script_invocation='y'
   cat >&2 <<EOF
-Caches must be cleared before switching pants Python versions in this repo.
-Preparing a Python ${_python_version_to_run} invocation...
+Different Python interpreter version detected compared to the previous Pants run.
+Clearing the cache and preparing a Python ${_python_version_to_run} run...
 EOF
   ./pants clean-all
   echo "$_python_version_to_run" > "$_python_version_file"

--- a/pants
+++ b/pants
@@ -2,6 +2,32 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+function expected_python_version_to_run() {
+  if [[ "$PANTS_USE_PYTHON3" == 'true' ]]; then
+    echo '3'
+  else
+    echo '2'
+  fi
+}
+
+_PYTHON_VERSION_FILE="./.pants-python-version"
+
+if [[ -z "$_RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION" ]]; then
+  _EXPECTED_PYTHON_VERSION="$(expected_python_version_to_run)"
+  _PREV_RUN_PYTHON_VERSION="$(cat 2>/dev/null "$_PYTHON_VERSION_FILE")"
+
+  if [[ "$_EXPECTED_PYTHON_VERSION" != "$_PREV_RUN_PYTHON_VERSION" ]]; then
+    export _RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION='y'
+    cat >&2 <<EOF
+Caches must be cleared before switching pants python versions in this repo.
+Preparing a python ${_EXPECTED_PYTHON_VERSION} invocation...
+EOF
+    ./pants clean-all
+    echo "$_EXPECTED_PYTHON_VERSION" > "$_PYTHON_VERSION_FILE"
+    unset _RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION
+  fi
+fi
+
 # This bootstrap script runs pants from the live sources in this repo.
 #
 # Further support is added for projects wrapping pants with custom external extensions.  In the

--- a/pants
+++ b/pants
@@ -29,7 +29,9 @@ EOF
   fi
 }
 
-if [[ -z "$NO_PANTS3_CLEAN" ]]; then
+# If we are running at a terminal, run the cleaning process if necessary. This should return false
+# in CI.
+if [[ -t 0 ]]; then
   pants3_maybe_clean
 fi
 

--- a/pants
+++ b/pants
@@ -2,6 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+set -x
+
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd .. && pwd -P)
 
 # TODO(#7152): remove this after the python 3 migration!

--- a/pants
+++ b/pants
@@ -37,7 +37,7 @@ EOF
 }
 
 # We can currently assume the CI environment does not switch python versions within a shard.
-if [[ -z "$RUNNING_VIA_TRAVIS_CI_SCRIPT" ]]; then
+if [[ "$ONLY_USING_SINGLE_PYTHON_VERSION" != 'true' ]]; then
   pants3_maybe_clean
 fi
 

--- a/pants
+++ b/pants
@@ -4,9 +4,11 @@
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P)
 
-interpreter_constraints_sentinel_file_path='.pants.d/.python-interpreter-constraints'
+interpreter_constraints_sentinel_file_path='.python-interpreter-constraints'
 
 function clean_if_interpreter_constraints_changed() {
+  new_interpreter_constraints="$1"
+
   if [[ -n "${recursive_pants_shell_script_invocation:-}" ]]; then
     return 0
   fi
@@ -15,7 +17,7 @@ function clean_if_interpreter_constraints_changed() {
 
   if [[ -f "${interpreter_constraints_file}" ]]; then
     previous_interpreter_constraints="$(cat "${interpreter_constraints_file}")"
-    if [[ "${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS}" == "${previous_interpreter_constraints}" ]]; then
+    if [[ "${new_interpreter_constraints}" == "${previous_interpreter_constraints}" ]]; then
       return 0
     fi
   else
@@ -29,10 +31,10 @@ EOF
   cat >&2 <<EOF
 Different interpreter constraints were set than were used in the previous Pants run.
 Clearing the cache and preparing a Python environment with these interpreter constraints:
-${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS}
+${new_interpreter_constraints}
 EOF
   ./pants clean-all
-  echo "${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS}" > "${interpreter_constraints_file}"
+  echo "${new_interpreter_constraints}" > "${interpreter_constraints_file}"
   unset recursive_pants_shell_script_invocation
 }
 
@@ -103,7 +105,7 @@ export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="${PANTS_PYTHON_SETUP_INTERPRE
 
 # We can currently assume the CI environment does not switch python versions within a shard.
 if [[ "${ONLY_USING_SINGLE_PYTHON_VERSION:-false}" != 'true' ]]; then
-  clean_if_interpreter_constraints_changed
+  clean_if_interpreter_constraints_changed "${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS}"
 fi
 
 PANTS_EXE="${HERE}/src/python/pants/bin/pants_loader.py"

--- a/pants
+++ b/pants
@@ -14,7 +14,14 @@ function pants3_maybe_clean() {
   _PYTHON_VERSION_FILE="${REPO_ROOT}/.pants-python-version"
 
   if [[ -z "$_RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION" ]]; then
-    _PREV_RUN_PYTHON_VERSION="$(cat 2>/dev/null "$_PYTHON_VERSION_FILE")"
+    if [[ -f "$_PYTHON_VERSION_FILE" ]]; then
+      _PREV_RUN_PYTHON_VERSION="$(cat "$_PYTHON_VERSION_FILE")"
+    else
+      cat >&2 <<EOF
+${_PYTHON_VERSION_FILE} not found. Forcing an initial clean-all...
+EOF
+      _PREV_RUN_PYTHON_VERSION=''
+    fi
 
     if [[ "$_PYTHON_VERSION_TO_RUN" != "$_PREV_RUN_PYTHON_VERSION" ]]; then
       export _RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION='y'
@@ -29,9 +36,8 @@ EOF
   fi
 }
 
-# If we are running at a terminal, run the cleaning process if necessary. This should return false
-# in CI.
-if [[ -t 0 ]]; then
+# We can currently assume the CI environment does not switch python versions within a shard.
+if [[ -z "$RUNNING_VIA_TRAVIS_CI_SCRIPT" ]]; then
   pants3_maybe_clean
 fi
 

--- a/pants
+++ b/pants
@@ -7,8 +7,6 @@ REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P)
 _interpreter_version_sentinel_file_path='.pants.d/.pants-python-version'
 
 function clean_if_interpreter_changed() {
-  _python_version_to_run="$1"
-
   if [[ -n "${_recursive_pants_shell_script_invocation:-}" ]]; then
     return 0
   fi
@@ -17,7 +15,7 @@ function clean_if_interpreter_changed() {
 
   if [[ -f "$_python_version_file" ]]; then
     _prev_run_python_version="$(cat "$_python_version_file")"
-    if [[ "$_python_version_to_run" == "$_prev_run_python_version" ]]; then
+    if [[ "$PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS" == "$_prev_run_python_version" ]]; then
       return 0
     fi
   else
@@ -29,11 +27,11 @@ EOF
 
   export _recursive_pants_shell_script_invocation='y'
   cat >&2 <<EOF
-Different Python interpreter version detected compared to the previous Pants run.
-Clearing the cache and preparing a Python ${_python_version_to_run} run...
+Different \$PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS were set compared to the previous Pants run.
+Clearing the cache and preparing a Python environment for ${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS}...
 EOF
   ./pants clean-all
-  echo "$_python_version_to_run" > "$_python_version_file"
+  echo "$PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS" > "$_python_version_file"
   unset _recursive_pants_shell_script_invocation
 }
 
@@ -101,12 +99,12 @@ export PY="${PY:-python3}"
 # we could end up using a different Python minor version for subprocesses than we do for Pants.
 py_major_minor_patch=$(${PY} -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')
 
+export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS:-['CPython==${py_major_minor_patch}']}"
+
 # We can currently assume the CI environment does not switch python versions within a shard.
 if [[ "${ONLY_USING_SINGLE_PYTHON_VERSION:-false}" != 'true' ]]; then
   clean_if_interpreter_changed "$py_major_minor_patch"
 fi
-
-export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS:-['CPython==${py_major_minor_patch}']}"
 
 PANTS_EXE="${HERE}/src/python/pants/bin/pants_loader.py"
 

--- a/pants
+++ b/pants
@@ -2,8 +2,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-set -x
-
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd .. && pwd -P)
 
 # TODO(#7152): remove this after the python 3 migration!

--- a/pants
+++ b/pants
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd .. && pwd -P)
+REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P)
 
 # TODO(#7152): remove this after the python 3 migration!
 function pants3_maybe_clean() {
-  _PYTHON_VERSION_TO_RUN='2'
-  if [[ "$PANTS_USE_PYTHON3" == 'true' ]]; then
-    _PYTHON_VERSION_TO_RUN='3'
+  _PYTHON_VERSION_TO_RUN='3'
+  if [[ "$_PANTS_USING_PYTHON2" == 'true' ]]; then
+    _PYTHON_VERSION_TO_RUN='2'
   fi
 
   _PYTHON_VERSION_FILE="${REPO_ROOT}/.pants-python-version"

--- a/pants
+++ b/pants
@@ -6,7 +6,6 @@ REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P)
 
 _interpreter_version_sentinel_filename='.pants-python-version'
 
-# TODO(#7152): remove this after the python 3 migration!
 function clean_if_interpreter_changed() {
   _python_version_to_run="$1"
 

--- a/pants
+++ b/pants
@@ -4,7 +4,7 @@
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P)
 
-_interpreter_version_sentinel_filename='.pants-python-version'
+_interpreter_version_sentinel_file_path='.pants.d/.pants-python-version'
 
 function clean_if_interpreter_changed() {
   _python_version_to_run="$1"
@@ -13,7 +13,7 @@ function clean_if_interpreter_changed() {
     return 0
   fi
 
-  _python_version_file="${REPO_ROOT}/${_interpreter_version_sentinel_filename}"
+  _python_version_file="${REPO_ROOT}/${_interpreter_version_sentinel_file_path}"
 
   if [[ -f "$_python_version_file" ]]; then
     _prev_run_python_version="$(cat "$_python_version_file")"
@@ -22,7 +22,8 @@ function clean_if_interpreter_changed() {
     fi
   else
     cat >&2 <<EOF
-${_interpreter_version_sentinel_filename} not found in the buildroot. Forcing an initial clean-all...
+${_interpreter_version_sentinel_file_path} not found in the buildroot.
+Forcing an initial clean-all.
 EOF
   fi
 

--- a/pants
+++ b/pants
@@ -5,41 +5,33 @@
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P)
 
 # TODO(#7152): remove this after the python 3 migration!
-function pants3_maybe_clean() {
-  _PYTHON_VERSION_TO_RUN='3'
-  if [[ "$_PANTS_USING_PYTHON2" == 'true' ]]; then
-    _PYTHON_VERSION_TO_RUN='2'
-  fi
+function clean_if_interpreter_changed() {
+  _python_version_to_run="$1"
 
-  _PYTHON_VERSION_FILE="${REPO_ROOT}/.pants-python-version"
+  _python_version_file="${REPO_ROOT}/.pants-python-version"
 
-  if [[ -z "$_RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION" ]]; then
-    if [[ -f "$_PYTHON_VERSION_FILE" ]]; then
-      _PREV_RUN_PYTHON_VERSION="$(cat "$_PYTHON_VERSION_FILE")"
+  if [[ -z "$_recursive_pants_shell_script_invocation" ]]; then
+    if [[ -f "$_python_version_file" ]]; then
+      _prev_run_python_version="$(cat "$_python_version_file")"
     else
       cat >&2 <<EOF
-${_PYTHON_VERSION_FILE} not found. Forcing an initial clean-all...
+${_python_version_file} not found. Forcing an initial clean-all...
 EOF
-      _PREV_RUN_PYTHON_VERSION=''
+      _prev_run_python_version=''
     fi
 
-    if [[ "$_PYTHON_VERSION_TO_RUN" != "$_PREV_RUN_PYTHON_VERSION" ]]; then
-      export _RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION='y'
+    if [[ "$_python_version_to_run" != "$_prev_run_python_version" ]]; then
+      export _recursive_pants_shell_script_invocation='y'
       cat >&2 <<EOF
 Caches must be cleared before switching pants Python versions in this repo.
-Preparing a Python ${_PYTHON_VERSION_TO_RUN} invocation...
+Preparing a Python ${_python_version_to_run} invocation...
 EOF
       ./pants clean-all
-      echo "$_PYTHON_VERSION_TO_RUN" > "$_PYTHON_VERSION_FILE"
-      unset _RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION
+      echo "$_python_version_to_run" > "$_python_version_file"
+      unset _recursive_pants_shell_script_invocation
     fi
   fi
 }
-
-# We can currently assume the CI environment does not switch python versions within a shard.
-if [[ "$ONLY_USING_SINGLE_PYTHON_VERSION" != 'true' ]]; then
-  pants3_maybe_clean
-fi
 
 # This bootstrap script runs pants from the live sources in this repo.
 #
@@ -104,6 +96,12 @@ export PY="${PY:-python3}"
 # Pants will try to use Python 2 for subprocesses. Without setting minor version constraints, when using Python 3
 # we could end up using a different Python minor version for subprocesses than we do for Pants.
 py_major_minor_patch=$(${PY} -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')
+
+# We can currently assume the CI environment does not switch python versions within a shard.
+if [[ "$ONLY_USING_SINGLE_PYTHON_VERSION" != 'true' ]]; then
+  clean_if_interpreter_changed "$py_major_minor_patch"
+fi
+
 export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS:-['CPython==${py_major_minor_patch}']}"
 
 PANTS_EXE="${HERE}/src/python/pants/bin/pants_loader.py"

--- a/pants
+++ b/pants
@@ -2,28 +2,26 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-function expected_python_version_to_run() {
-  if [[ "$PANTS_USE_PYTHON3" == 'true' ]]; then
-    echo '3'
-  else
-    echo '2'
-  fi
-}
+REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd .. && pwd -P)
 
-_PYTHON_VERSION_FILE="./.pants-python-version"
+_PYTHON_VERSION_TO_RUN='2'
+if [[ "$PANTS_USE_PYTHON3" == 'true' ]]; then
+  _PYTHON_VERSION_TO_RUN='3'
+fi
+
+_PYTHON_VERSION_FILE="${REPO_ROOT}/.pants-python-version"
 
 if [[ -z "$_RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION" ]]; then
-  _EXPECTED_PYTHON_VERSION="$(expected_python_version_to_run)"
   _PREV_RUN_PYTHON_VERSION="$(cat 2>/dev/null "$_PYTHON_VERSION_FILE")"
 
-  if [[ "$_EXPECTED_PYTHON_VERSION" != "$_PREV_RUN_PYTHON_VERSION" ]]; then
+  if [[ "$_PYTHON_VERSION_TO_RUN" != "$_PREV_RUN_PYTHON_VERSION" ]]; then
     export _RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION='y'
     cat >&2 <<EOF
-Caches must be cleared before switching pants python versions in this repo.
-Preparing a python ${_EXPECTED_PYTHON_VERSION} invocation...
+Caches must be cleared before switching pants Python versions in this repo.
+Preparing a Python ${_PYTHON_VERSION_TO_RUN} invocation...
 EOF
     ./pants clean-all
-    echo "$_EXPECTED_PYTHON_VERSION" > "$_PYTHON_VERSION_FILE"
+    echo "$_PYTHON_VERSION_TO_RUN" > "$_PYTHON_VERSION_FILE"
     unset _RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION
   fi
 fi

--- a/pants
+++ b/pants
@@ -4,35 +4,36 @@
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P)
 
-_interpreter_version_sentinel_file_path='.pants.d/.pants-python-version'
+interpreter_constraints_sentinel_file_path='.pants.d/.python-interpreter-constraints'
 
-function clean_if_interpreter_changed() {
-  if [[ -n "${_recursive_pants_shell_script_invocation:-}" ]]; then
+function clean_if_interpreter_constraints_changed() {
+  if [[ -n "${recursive_pants_shell_script_invocation:-}" ]]; then
     return 0
   fi
 
-  _python_version_file="${REPO_ROOT}/${_interpreter_version_sentinel_file_path}"
+  interpreter_constraints_file="${REPO_ROOT}/${interpreter_constraints_sentinel_file_path}"
 
-  if [[ -f "$_python_version_file" ]]; then
-    _prev_run_python_version="$(cat "$_python_version_file")"
-    if [[ "$PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS" == "$_prev_run_python_version" ]]; then
+  if [[ -f "${interpreter_constraints_file}" ]]; then
+    previous_interpreter_constraints="$(cat "${interpreter_constraints_file}")"
+    if [[ "${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS}" == "${previous_interpreter_constraints}" ]]; then
       return 0
     fi
   else
     cat >&2 <<EOF
-${_interpreter_version_sentinel_file_path} not found in the buildroot.
+${interpreter_constraints_sentinel_file_path} not found in the buildroot.
 Forcing an initial clean-all.
 EOF
   fi
 
-  export _recursive_pants_shell_script_invocation='y'
+  export recursive_pants_shell_script_invocation='y'
   cat >&2 <<EOF
-Different \$PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS were set compared to the previous Pants run.
-Clearing the cache and preparing a Python environment for ${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS}...
+Different interpreter constraints were set than were used in the previous Pants run.
+Clearing the cache and preparing a Python environment with these interpreter constraints:
+${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS}
 EOF
   ./pants clean-all
-  echo "$PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS" > "$_python_version_file"
-  unset _recursive_pants_shell_script_invocation
+  echo "${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS}" > "${interpreter_constraints_file}"
+  unset recursive_pants_shell_script_invocation
 }
 
 # This bootstrap script runs pants from the live sources in this repo.
@@ -98,12 +99,11 @@ export PY="${PY:-python3}"
 # Pants will try to use Python 2 for subprocesses. Without setting minor version constraints, when using Python 3
 # we could end up using a different Python minor version for subprocesses than we do for Pants.
 py_major_minor_patch=$(${PY} -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')
-
 export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS:-['CPython==${py_major_minor_patch}']}"
 
 # We can currently assume the CI environment does not switch python versions within a shard.
 if [[ "${ONLY_USING_SINGLE_PYTHON_VERSION:-false}" != 'true' ]]; then
-  clean_if_interpreter_changed "$py_major_minor_patch"
+  clean_if_interpreter_constraints_changed
 fi
 
 PANTS_EXE="${HERE}/src/python/pants/bin/pants_loader.py"

--- a/pants
+++ b/pants
@@ -4,26 +4,33 @@
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd .. && pwd -P)
 
-_PYTHON_VERSION_TO_RUN='2'
-if [[ "$PANTS_USE_PYTHON3" == 'true' ]]; then
-  _PYTHON_VERSION_TO_RUN='3'
-fi
+# TODO(#7152): remove this after the python 3 migration!
+function pants3_maybe_clean() {
+  _PYTHON_VERSION_TO_RUN='2'
+  if [[ "$PANTS_USE_PYTHON3" == 'true' ]]; then
+    _PYTHON_VERSION_TO_RUN='3'
+  fi
 
-_PYTHON_VERSION_FILE="${REPO_ROOT}/.pants-python-version"
+  _PYTHON_VERSION_FILE="${REPO_ROOT}/.pants-python-version"
 
-if [[ -z "$_RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION" ]]; then
-  _PREV_RUN_PYTHON_VERSION="$(cat 2>/dev/null "$_PYTHON_VERSION_FILE")"
+  if [[ -z "$_RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION" ]]; then
+    _PREV_RUN_PYTHON_VERSION="$(cat 2>/dev/null "$_PYTHON_VERSION_FILE")"
 
-  if [[ "$_PYTHON_VERSION_TO_RUN" != "$_PREV_RUN_PYTHON_VERSION" ]]; then
-    export _RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION='y'
-    cat >&2 <<EOF
+    if [[ "$_PYTHON_VERSION_TO_RUN" != "$_PREV_RUN_PYTHON_VERSION" ]]; then
+      export _RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION='y'
+      cat >&2 <<EOF
 Caches must be cleared before switching pants Python versions in this repo.
 Preparing a Python ${_PYTHON_VERSION_TO_RUN} invocation...
 EOF
-    ./pants clean-all
-    echo "$_PYTHON_VERSION_TO_RUN" > "$_PYTHON_VERSION_FILE"
-    unset _RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION
+      ./pants clean-all
+      echo "$_PYTHON_VERSION_TO_RUN" > "$_PYTHON_VERSION_FILE"
+      unset _RECURSIVE_PANTS_SHELL_SCRIPT_INVOCATION
+    fi
   fi
+}
+
+if [[ -z "$NO_PANTS3_CLEAN" ]]; then
+  pants3_maybe_clean
 fi
 
 # This bootstrap script runs pants from the live sources in this repo.

--- a/pants2
+++ b/pants2
@@ -11,4 +11,6 @@ export PY="${PY:-python2.7}"
 # interpreter selection will default to using Python 2 as this is the minimum acceptable interpreter.
 export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS:-['CPython>=2.7,<3','CPython>=3.6,<4']}"
 
+export _PANTS_USING_PYTHON2='true'
+
 ./pants "$@"

--- a/pants2
+++ b/pants2
@@ -11,6 +11,4 @@ export PY="${PY:-python2.7}"
 # interpreter selection will default to using Python 2 as this is the minimum acceptable interpreter.
 export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS:-['CPython>=2.7,<3','CPython>=3.6,<4']}"
 
-export _PANTS_USING_PYTHON2='true'
-
 ./pants "$@"

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -183,6 +183,10 @@ class PantsRunIntegrationTest(unittest.TestCase):
         # Ensure that the underlying ./pants invocation doesn't run from sources
         # (and therefore bootstrap) if we don't want it to.
         'RUN_PANTS_FROM_PEX',
+        # This tells the ./pants runner script to avoid trying to clean the workspace when changing
+        # python versions. CI starts off without the .python-interpreter-constraints file, so it
+        # would otherwise run a clean-all without this env var.
+        'ONLY_USING_SINGLE_PYTHON_VERSION',
       ]
 
   def setUp(self):


### PR DESCRIPTION
### Problem

When running `./pants` vs `./pants2`, or changing python interpreter version via `PY=python3.6 ./pants` to `PY=python3.7 ./pants`, it is currently necessary to run `clean-all` first before switching which python interpreter is used to run pants. Anyone testing with different python interpreter versions has to remember to run `clean-all` in between invocations. I find this difficult to remember.

### Solution

- Make `./pants` write the python version string to a sentinel file `.pants-python-version` at the repo root containing the python version we're running with before doing anything else, and if the version differs from the python version we are currently running pants under, run a `clean-all`.
- Add `ONLY_USING_SINGLE_PYTHON_VERSION` env var to CI to avoid running `clean-all` or needing to generate this sentinel file.

### Result

Many weird errors no longer occur when switching between `./pants2` and `./pants`, or using the `$PY` env var to switch between interpreter versions when running pants.

### Followup Issues
- #7355 -- fix reporting not picking up a run if `clean-all` is one of the goals, which would let us avoid having to make two separate pants invocations here.