### PR TITLE
Add Python 3 support to Pytest with V2 engine

### DIFF
--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -9,4 +9,3 @@ tests/python/pants_test/engine/legacy:owners_integration
 tests/python/pants_test/engine:scheduler_integration
 tests/python/pants_test/pantsd:pantsd_integration
 tests/python/pants_test/projects:testprojects_integration
-tests/python/pants_test/rules:test_integration

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -31,11 +31,14 @@ def run_python_test(transitive_hydrated_target):
   target_root = transitive_hydrated_target.root
 
   # TODO: Inject versions and digests here through some option, rather than hard-coding it.
+  interpreter_major, interpreter_minor = sys.version_info[0:2]
   pex_name, digest = {
     (2, 7): ("pex27", Digest('0ecbf48e3e240a413189194a9f829aec10446705c84db310affe36e23e741dbc', 1812737)),
     (3, 6): ("pex36", Digest('ba865e7ce7a840070d58b7ba24e7a67aff058435cfa34202abdd878e7b5d351d', 1812158)),
     (3, 7): ("pex37", Digest('51bf8e84d5290fe5ff43d45be78d58eaf88cf2a5e995101c8ff9e6a73a73343d', 1813189))
-  }[sys.version_info[0:2]]
+  }.get((interpreter_major, interpreter_minor), (None, None))
+  if pex_name is None:
+    raise OSError("Current interpreter {}.{} is not supported, as there is no corresponding PEX to download.".format(interpreter_major, interpreter_minor))
 
   pex_snapshot = yield Get(Snapshot,
     UrlToFetch("https://github.com/pantsbuild/pex/releases/download/v1.6.1/{}".format(pex_name), digest))

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -38,7 +38,7 @@ def run_python_test(transitive_hydrated_target):
     (3, 7): ("pex37", Digest('51bf8e84d5290fe5ff43d45be78d58eaf88cf2a5e995101c8ff9e6a73a73343d', 1813189))
   }.get((interpreter_major, interpreter_minor), (None, None))
   if pex_name is None:
-    raise OSError("Current interpreter {}.{} is not supported, as there is no corresponding PEX to download.".format(interpreter_major, interpreter_minor))
+    raise ValueError("Current interpreter {}.{} is not supported, as there is no corresponding PEX to download.".format(interpreter_major, interpreter_minor))
 
   pex_snapshot = yield Get(Snapshot,
     UrlToFetch("https://github.com/pantsbuild/pex/releases/download/v1.6.1/{}".format(pex_name), digest))

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -31,8 +31,14 @@ def run_python_test(transitive_hydrated_target):
   target_root = transitive_hydrated_target.root
 
   # TODO: Inject versions and digests here through some option, rather than hard-coding it.
-  pex_snapshot = yield Get(Snapshot, UrlToFetch("https://github.com/pantsbuild/pex/releases/download/v1.5.2/pex27",
-                                                Digest('8053a79a5e9c2e6e9ace3999666c9df910d6289555853210c1bbbfa799c3ecda', 1757011)))
+  pex_name, digest = {
+    (2, 7): ("pex27", Digest('0ecbf48e3e240a413189194a9f829aec10446705c84db310affe36e23e741dbc', 1812737)),
+    (3, 6): ("pex36", Digest('ba865e7ce7a840070d58b7ba24e7a67aff058435cfa34202abdd878e7b5d351d', 1812158)),
+    (3, 7): ("pex37", Digest('51bf8e84d5290fe5ff43d45be78d58eaf88cf2a5e995101c8ff9e6a73a73343d', 1813189))
+  }[sys.version_info[0:2]]
+
+  pex_snapshot = yield Get(Snapshot,
+    UrlToFetch("https://github.com/pantsbuild/pex/releases/download/v1.6.1/{}".format(pex_name), digest))
 
   all_targets = [target_root] + [dep.root for dep in transitive_hydrated_target.dependencies]
 
@@ -102,4 +108,4 @@ def run_python_test(transitive_hydrated_target):
   # TODO: Do something with stderr?
   status = Status.SUCCESS if result.exit_code == 0 else Status.FAILURE
 
-  yield PyTestResult(status=status, stdout=str(result.stdout))
+  yield PyTestResult(status=status, stdout=result.stdout.decode('utf-8'))

--- a/src/python/pants/rules/core/core_test_model.py
+++ b/src/python/pants/rules/core/core_test_model.py
@@ -4,21 +4,21 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import str
+from future.utils import text_type
 
 from pants.util.objects import datatype
 
 
 class Status(object):
-  SUCCESS = str('SUCCESS')
-  FAILURE = str('FAILURE')
+  SUCCESS = 'SUCCESS'
+  FAILURE = 'FAILURE'
 
 
 class TestResult(datatype([
   # One of the Status pseudo-enum values capturing whether the run was successful.
-  ('status', str),
+  ('status', text_type),
   # The stdout of the test runner (which may or may not include actual testcase output).
-  ('stdout', str)
+  ('stdout', text_type)
 ])):
   # Prevent this class from being detected by pytest as a test class.
   __test__ = False

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -4,8 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import str
-
 from pants.backend.python.rules.python_test_runner import PyTestResult
 from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
@@ -27,15 +25,15 @@ def fast_test(console, addresses):
     # Assume \n-terminated
     console.write_stdout(test_result.stdout)
     if test_result.stdout and not test_result.stdout[-1] == '\n':
-      console.write_stdout(str('\n'))
+      console.write_stdout('\n')
     if test_result.status == Status.FAILURE:
       did_any_fail = True
 
   if wrote_any_stdout:
-    console.write_stdout(str('\n'))
+    console.write_stdout('\n')
 
   for address, test_result in zip(addresses, test_results):
-    console.print_stdout(str('{0:80}.....{1:>10}'.format(address.reference(), test_result.status)))
+    console.print_stdout('{0:80}.....{1:>10}'.format(address.reference(), test_result.status))
 
   if did_any_fail:
     raise GracefulTerminationException("Tests failed", exit_code=1)

--- a/tests/python/pants_test/rules/test_test.py
+++ b/tests/python/pants_test/rules/test_test.py
@@ -38,7 +38,7 @@ class TestTest(TestBase, SchedulerTestBase, AbstractClass):
 
   def test_outputs_success(self):
     self.single_target_test(
-      TestResult(status=Status.SUCCESS, stdout=str('Here is some output from a test')),
+      TestResult(status=Status.SUCCESS, stdout='Here is some output from a test'),
       """Here is some output from a test
 
 some/target                                                                     .....   SUCCESS
@@ -48,7 +48,7 @@ some/target                                                                     
   def test_output_failure(self):
     with self.assertRaises(GracefulTerminationException) as cm:
       self.single_target_test(
-        TestResult(status=Status.FAILURE, stdout=str('Here is some output from a test')),
+        TestResult(status=Status.FAILURE, stdout='Here is some output from a test'),
         """Here is some output from a test
 
 some/target                                                                     .....   FAILURE
@@ -58,7 +58,7 @@ some/target                                                                     
 
   def test_output_no_trailing_newline(self):
     self.single_target_test(
-      TestResult(status=Status.SUCCESS, stdout=str('Here is some output from a test')),
+      TestResult(status=Status.SUCCESS, stdout='Here is some output from a test'),
       """Here is some output from a test
 
 some/target                                                                     .....   SUCCESS
@@ -67,7 +67,7 @@ some/target                                                                     
 
   def test_output_trailing_newline(self):
     self.single_target_test(
-      TestResult(status=Status.SUCCESS, stdout=str('Here is some output from a test\n')),
+      TestResult(status=Status.SUCCESS, stdout='Here is some output from a test\n'),
       """Here is some output from a test
 
 some/target                                                                     .....   SUCCESS
@@ -81,9 +81,9 @@ some/target                                                                     
 
     def make_result(target):
       if target == target1:
-        return TestResult(status=Status.SUCCESS, stdout=str('I passed'))
+        return TestResult(status=Status.SUCCESS, stdout='I passed')
       elif target == target2:
-        return TestResult(status=Status.FAILURE, stdout=str('I failed'))
+        return TestResult(status=Status.FAILURE, stdout='I failed')
       else:
         raise Exception("Unrecognised target")
 
@@ -104,17 +104,17 @@ testprojects/tests/python/pants/fails                                           
     target_adaptor = PythonTestsAdaptor(type_alias='python_tests')
 
     result = run_rule(coordinator_of_tests, HydratedTarget(Address.parse("some/target"), target_adaptor, ()), {
-      (PyTestResult, HydratedTarget): lambda _: PyTestResult(status=Status.FAILURE, stdout=str('foo')),
+      (PyTestResult, HydratedTarget): lambda _: PyTestResult(status=Status.FAILURE, stdout='foo'),
     })
 
-    self.assertEqual(result, TestResult(status=Status.FAILURE, stdout=str('foo')))
+    self.assertEqual(result, TestResult(status=Status.FAILURE, stdout='foo'))
 
   def test_coordinator_unknown_test(self):
     target_adaptor = PythonTestsAdaptor(type_alias='unknown_tests')
 
     with self.assertRaises(Exception) as cm:
       run_rule(coordinator_of_tests, HydratedTarget(Address.parse("some/target"), target_adaptor, ()), {
-        (PyTestResult, HydratedTarget): lambda _: PyTestResult(status=Status.FAILURE, stdout=str('foo')),
+        (PyTestResult, HydratedTarget): lambda _: PyTestResult(status=Status.FAILURE, stdout='foo'),
       })
 
     self.assertEqual(str(cm.exception), "Didn't know how to run tests for type unknown_tests")


### PR DESCRIPTION
### Problem
`./pants3 --no-v1 --v2 test testprojects/tests/python/pants/dummies:passing_target` would fail to execute because we hardcoded the PEX we grab to always use Python 2, rather than matching the current interpreter.

Even after fixing this, the command would succeed but output the results as a byte string without `\n` rendered properly, due to improper unicode handling.

### Solution
Grab the PEX that corresponds to the current interpreter.

Also change the `datatype` for some V2 abstractions to `text_type`, rather than `str`. This is because `datatype()` requires the type to _exactly_ match, and the future backport `str` actually is of type `newstr` in Py2 rather than `unicode`. See https://github.com/pantsbuild/pants/pull/6098 for further context on how we support Py2 and Py3 with `datatype()`.

### Result
`./pants3 --no-v1 --v2 test testprojects/tests/python/pants/dummies:passing_target` works for both Python 2 and Python 3, including when switching between the two repeatedly.

@illicitonion and I discussed over Slack potential concerns with caching and the interpreter not changing properly, but this does not seem to be an issue.