### PR TITLE
Resolve all platforms from all python targets

### DIFF
--- a/examples/src/python/example/3rdparty_py.md
+++ b/examples/src/python/example/3rdparty_py.md
@@ -80,6 +80,9 @@ with which your binary is intended to be compatible in the `platforms` field of 
 <a href="https://pip.pypa.io/en/stable/reference/pip_wheel/">wheel</a> files for each package
 and platform available at build time.
 
+Pants will use the explicitly specified `platforms` field of your <a pantsref="bdict_python_binary">`python_binary`</a>
+target if set for both itself and its dependencies, or will otherwise fall back to the `python-setup.platforms` option value.
+
 Pants will look for those files in the location specified in the
 [[`python-repos`|pants('src/docs:setup_repo')#redirecting-python-requirements-to-other-servers]] field
 in pants.ini. It can understand either a simple local directory of .whl files or a "find links"-friendly

--- a/src/python/pants/backend/python/subsystems/pex_build_util.py
+++ b/src/python/pants/backend/python/subsystems/pex_build_util.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import os
 from builtins import str
+from collections import defaultdict
 
 from future.utils import PY2
 from pex.fetcher import Fetcher
@@ -48,6 +49,19 @@ def has_resources(tgt):
 
 def has_python_requirements(tgt):
   return isinstance(tgt, PythonRequirementLibrary)
+
+
+def can_have_python_platform(tgt):
+  return isinstance(tgt, (PythonBinary, PythonDistribution))
+
+
+def targets_by_platform(targets, python_setup):
+  d = defaultdict(OrderedSet)
+  for target in targets:
+    if can_have_python_platform(target):
+      for platform in target.platforms if target.platforms else python_setup.platforms:
+        d[platform].add(target)
+  return d
 
 
 def _create_source_dumper(builder, tgt):

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -5,14 +5,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from builtins import str
-from collections import defaultdict
 
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.subsystems import pex_build_util
 from pants.backend.python.subsystems.python_setup import PythonSetup
-from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_distribution import PythonDistribution
 from pants.base.exceptions import IncompatiblePlatformsError
 from pants.binaries.executable_pex_tool import ExecutablePexTool

--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -14,7 +14,7 @@ from pex.pex_builder import PEXBuilder
 
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.subsystems import pex_build_util
-from pants.backend.python.subsystems.pex_build_util import PexBuilderWrapper, is_python_target
+from pants.backend.python.subsystems.pex_build_util import PexBuilderWrapper
 from pants.backend.python.subsystems.python_native_code import PythonNativeCode
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary

--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -13,8 +13,10 @@ from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 
 from pants.backend.python.python_requirement import PythonRequirement
-from pants.backend.python.subsystems.pex_build_util import PexBuilderWrapper
+from pants.backend.python.subsystems import pex_build_util
+from pants.backend.python.subsystems.pex_build_util import PexBuilderWrapper, is_python_target
 from pants.backend.python.subsystems.python_native_code import PythonNativeCode
+from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.base.hash_utils import hash_all
 from pants.invalidation.cache_manager import VersionedTargetSet
@@ -36,11 +38,16 @@ class ResolveRequirementsTaskBase(Task):
     return super(ResolveRequirementsTaskBase, cls).subsystem_dependencies() + (
       PexBuilderWrapper.Factory,
       PythonNativeCode.scoped(cls),
+      PythonSetup.scoped(cls),
     )
 
   @memoized_property
   def _python_native_code_settings(self):
     return PythonNativeCode.scoped_instance(self)
+
+  @memoized_property
+  def _python_setup(self):
+    return PythonSetup.global_instance()
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -70,11 +77,11 @@ class ResolveRequirementsTaskBase(Task):
 
       # We need to ensure that we are resolving for only the current platform if we are
       # including local python dist targets that have native extensions.
-      tgts = self.context.targets()
-      if self._python_native_code_settings.check_build_for_current_platform_only(tgts):
-        maybe_platforms = ['current']
+      targets_by_platform = pex_build_util.targets_by_platform(self.context.targets(), self._python_setup)
+      if self._python_native_code_settings.check_build_for_current_platform_only(targets_by_platform):
+        platforms = ['current']
       else:
-        maybe_platforms = None
+        platforms = list(sorted(targets_by_platform.keys()))
 
       path = os.path.realpath(os.path.join(self.workdir, str(interpreter.identity), target_set_id))
       # Note that we check for the existence of the directory, instead of for invalid_vts,
@@ -84,7 +91,7 @@ class ResolveRequirementsTaskBase(Task):
           pex_builder = PexBuilderWrapper.Factory.create(
             builder=PEXBuilder(path=safe_path, interpreter=interpreter, copy=True),
             log=self.context.log)
-          pex_builder.add_requirement_libs_from(req_libs, platforms=maybe_platforms)
+          pex_builder.add_requirement_libs_from(req_libs, platforms=platforms)
           pex_builder.freeze()
     return PEX(path, interpreter=interpreter)
 

--- a/src/python/pants/build_graph/build_graph.py
+++ b/src/python/pants/build_graph/build_graph.py
@@ -448,7 +448,7 @@ class BuildGraph(AbstractClass):
       _walk_rec(address)
 
   def transitive_dependees_of_addresses(self, addresses, predicate=None, postorder=False):
-    """Returns all transitive dependees of `address`.
+    """Returns all transitive dependees of `addresses`.
 
     Note that this uses `walk_transitive_dependee_graph` and the predicate is passed through,
     hence it trims graphs rather than just filtering out Targets that do not match the predicate.

--- a/tests/python/pants_test/backend/python/tasks/test_python_binary_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_binary_integration.py
@@ -20,6 +20,7 @@ _LINUX_WHEEL_SUBSTRING = "manylinux"
 _OSX_PLATFORM = "macosx-10.13-x86_64"
 _OSX_WHEEL_SUBSTRING = "macosx"
 
+
 class PythonBinaryIntegrationTest(PantsRunIntegrationTest):
   @staticmethod
   @contextmanager


### PR DESCRIPTION
Don't just use the default configured targets.

This means that _all_ transitive 3rdparty python will need to be
resolvable in _all_ platforms in any target in the graph. This is not
ideal (we really want to be doing per-root resolves), but because we
currently do one global resolve, this is a decent fit.