### PR TITLE
blacklist idea plugin gen from faulty earlier edit

### DIFF
--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,4 +1,5 @@
 tests/python/pants_test/backend/jvm/tasks:scala_repl_integration
+tests/python/pants_test/backend/project_info/tasks:idea_plugin_integration
 tests/python/pants_test/backend/python/tasks:integration
 tests/python/pants_test/backend/python/tasks:isort_run_integration
 tests/python/pants_test/backend/python/tasks:python_native_code_testing_1


### PR DESCRIPTION
### Problem

See #7150. The idea plugin gen integration test became flaky on py3 as of #7141.

### Solution

Blacklist test on py3 as per [slack discussion](https://pantsbuild.slack.com/archives/CBNMV1LRH/p1548436157036300).