### PR TITLE
Remove scala_repl_integration and testprojects_integration from Python 3 blacklist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -642,7 +642,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard0
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 0/17
+        - ./build-support/bin/travis-ci.sh -c -i 0/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 1 (Py3 PEX)"
@@ -650,7 +650,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard1
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 1/17
+        - ./build-support/bin/travis-ci.sh -c -i 1/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 2 (Py3 PEX)"
@@ -658,7 +658,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard2
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 2/17
+        - ./build-support/bin/travis-ci.sh -c -i 2/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 3 (Py3 PEX)"
@@ -666,7 +666,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard3
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 3/17
+        - ./build-support/bin/travis-ci.sh -c -i 3/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 4 (Py3 PEX)"
@@ -674,7 +674,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard4
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 4/17
+        - ./build-support/bin/travis-ci.sh -c -i 4/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 5 (Py3 PEX)"
@@ -682,7 +682,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard5
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 5/17
+        - ./build-support/bin/travis-ci.sh -c -i 5/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 6 (Py3 PEX)"
@@ -690,7 +690,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard6
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 6/17
+        - ./build-support/bin/travis-ci.sh -c -i 6/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 7 (Py3 PEX)"
@@ -698,7 +698,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard7
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 7/17
+        - ./build-support/bin/travis-ci.sh -c -i 7/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 8 (Py3 PEX)"
@@ -706,7 +706,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard8
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 8/17
+        - ./build-support/bin/travis-ci.sh -c -i 8/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 9 (Py3 PEX)"
@@ -714,7 +714,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard9
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 9/17
+        - ./build-support/bin/travis-ci.sh -c -i 9/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 10 (Py3 PEX)"
@@ -722,7 +722,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard10
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 10/17
+        - ./build-support/bin/travis-ci.sh -c -i 10/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 11 (Py3 PEX)"
@@ -730,7 +730,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard11
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 11/17
+        - ./build-support/bin/travis-ci.sh -c -i 11/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 12 (Py3 PEX)"
@@ -738,7 +738,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard12
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 12/17
+        - ./build-support/bin/travis-ci.sh -c -i 12/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 13 (Py3 PEX)"
@@ -746,7 +746,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard13
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 13/17
+        - ./build-support/bin/travis-ci.sh -c -i 13/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 14 (Py3 PEX)"
@@ -754,7 +754,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard14
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 14/17
+        - ./build-support/bin/travis-ci.sh -c -i 14/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 15 (Py3 PEX)"
@@ -762,7 +762,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard15
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 15/17
+        - ./build-support/bin/travis-ci.sh -c -i 15/18
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 16 (Py3 PEX)"
@@ -770,7 +770,15 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard16
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 16/17
+        - ./build-support/bin/travis-ci.sh -c -i 16/18
+
+    - <<: *py3_linux_test_config
+      name: "Integration tests for pants - shard 17 (Py3 PEX)"
+      env:
+        - *py3_linux_test_config_env
+        - CACHE_NAME=integrationshard17
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 17/18
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 0 (Py2 PEX w/ Py3 constraints)"
@@ -780,7 +788,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard0.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 0/3
+        - ./build-support/bin/travis-ci.sh -c2w -i 0/2
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 1 (Py2 PEX w/ Py3 constraints)"
@@ -790,17 +798,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard1.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 1/3
-
-    - <<: *py2_linux_test_config
-      name: "Blacklisted integration tests for pants - shard 2 (Py2 PEX w/ Py3 constraints)"
-      stage: *test
-      env:
-        - *py2_linux_test_config_env
-        - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
-        - CACHE_NAME=integrationshard2.py2blacklist
-      script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 2/3
+        - ./build-support/bin/travis-ci.sh -c2w -i 1/2
 
     - <<: *py2_linux_test_config
       name: "Integration tests for pants - shard 0 (Py2 PEX)"

--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,6 +1,1 @@
-tests/python/pants_test/backend/jvm/tasks:scala_repl_integration
 tests/python/pants_test/backend/project_info/tasks:idea_plugin_integration
-tests/python/pants_test/backend/python/tasks:integration
-tests/python/pants_test/engine/legacy:console_rule_integration
-tests/python/pants_test/pantsd:pantsd_integration
-tests/python/pants_test/projects:testprojects_integration

--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,1 +1,4 @@
 tests/python/pants_test/backend/project_info/tasks:idea_plugin_integration
+tests/python/pants_test/backend/python/tasks:integration
+tests/python/pants_test/engine/legacy:console_rule_integration
+tests/python/pants_test/pantsd:pantsd_integration

--- a/build-support/travis/generate_travis_yml.py
+++ b/build-support/travis/generate_travis_yml.py
@@ -8,8 +8,8 @@ import pkg_resources
 import pystache
 
 
-num_py3_integration_shards = 17
-num_py2_blacklist_integration_shards = 3
+num_py3_integration_shards = 18
+num_py2_blacklist_integration_shards = 2
 num_cron_integration_shards = 20
 
 


### PR DESCRIPTION
`backend/jvm/tasks:scala_repl_integration` and `projects:testprojects_integration` now work with Python 3 thanks to prior work improving Python 3 support. For example, https://github.com/pantsbuild/pants/pull/7067 fixed several issues with `testprojects_integration`.

This PR removes those targets from the blacklists and redistributes CI integration shards in favor of Python 3.