### PR TITLE
[WIP] Cached local process execution

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -740,6 +740,7 @@ class Native(Singleton):
         self.context.utf8_buf(build_root),
         self.context.utf8_buf(work_dir),
         self.context.utf8_buf(local_store_dir),
+        self.context.utf8_buf(execution_options.local_execution_process_cache_namespace or ""),
         self.context.utf8_buf_buf(ignore_patterns),
         self.to_ids_buf(root_subject_types),
         # Remote execution config.

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -88,6 +88,8 @@ class Scheduler(object):
     self._tasks = native.new_tasks()
     self._register_rules(rule_index)
 
+    # TODO: we REALLY need to have a datatype for all of these so that we don't mix up arguments by
+    # order.
     self._scheduler = native.new_scheduler(
       tasks=self._tasks,
       root_subject_types=self._root_subject_types,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -30,6 +30,7 @@ class GlobMatchErrorBehavior(enum('failure_behavior', ['ignore', 'warn', 'error'
 
 
 class ExecutionOptions(datatype([
+  'local_execution_process_cache_namespace',
   'remote_store_server',
   'remote_store_thread_count',
   'remote_execution_server',
@@ -52,6 +53,7 @@ class ExecutionOptions(datatype([
   @classmethod
   def from_bootstrap_options(cls, bootstrap_options):
     return cls(
+      local_execution_process_cache_namespace=bootstrap_options.local_execution_process_cache_namespace,
       remote_store_server=bootstrap_options.remote_store_server,
       remote_execution_server=bootstrap_options.remote_execution_server,
       remote_store_thread_count=bootstrap_options.remote_store_thread_count,
@@ -68,6 +70,7 @@ class ExecutionOptions(datatype([
 
 
 DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
+    local_execution_process_cache_namespace=None,
     remote_store_server=[],
     remote_store_thread_count=1,
     remote_execution_server=None,
@@ -291,6 +294,11 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              # This default is also hard-coded into the engine's rust code in
              # fs::Store::default_path
              default=os.path.expanduser('~/.cache/pants/lmdb_store'))
+    register('--local-execution-process-cache-namespace', advanced=True,
+             help="The cache namespace for local process execution. "
+                  "Bump this to invalidate every artifact's local execution. "
+                  "This is the hermetic execution equivalent of the legacy cache-key-gen-version "
+                  "flag.")
     register('--remote-store-server', advanced=True, type=list, default=[],
              help='host:port of grpc server to use as remote execution file store.')
     register('--remote-store-thread-count', type=int, advanced=True,

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -529,6 +529,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -25,6 +25,7 @@ lazy_static = "1"
 lmdb = { git = "https://github.com/pantsbuild/lmdb-rs.git", rev = "06bdfbfc6348f6804127176e561843f214fc17f8" }
 log = "0.4"
 parking_lot = "0.6"
+prost = "0.4"
 protobuf = { version = "2.0.4", features = ["with-bytes"] }
 serverset = { path = "../serverset" }
 sha2 = "0.8"

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -145,6 +145,7 @@ impl Store {
   ///
   /// Store a file locally.
   ///
+  // TODO: use an enum instead of a bool, and describe in that struct what `initial_lease` means!
   pub fn store_file_bytes(&self, bytes: Bytes, initial_lease: bool) -> BoxFuture<Digest, String> {
     self
       .local

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -2572,14 +2572,12 @@ mod tests {
   use crate::pool::ResettablePool;
   use bazel_protos;
   use bytes::Bytes;
-  use digest::{Digest as DigestTrait, FixedOutput};
   use futures::Future;
   use futures_timer::TimerHandle;
   use hashing::{Digest, Fingerprint};
   use mock::StubCAS;
   use protobuf::Message;
   use serverset::BackoffConfig;
-  use sha2::Sha256;
   use std;
   use std::collections::HashMap;
   use std::fs::File;

--- a/src/rust/engine/process_execution/src/cached_execution.rs
+++ b/src/rust/engine/process_execution/src/cached_execution.rs
@@ -1,0 +1,487 @@
+// Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+#![deny(unused_must_use)]
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![deny(
+  clippy::all,
+  clippy::default_trait_access,
+  clippy::expl_impl_clone_on_copy,
+  clippy::if_not_else,
+  clippy::needless_continue,
+  clippy::single_match_else,
+  clippy::unseparated_literal_suffix,
+  clippy::used_underscore_binding
+)]
+// It is often more clear to show that nothing is being moved.
+#![allow(clippy::match_ref_pats)]
+// Subjective style.
+#![allow(
+  clippy::len_without_is_empty,
+  clippy::redundant_field_names,
+  clippy::too_many_arguments
+)]
+// Default isn't as big a deal as people seem to think it is.
+#![allow(
+  clippy::new_without_default,
+  clippy::new_without_default_derive,
+  clippy::new_ret_no_self
+)]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![allow(clippy::mutex_atomic)]
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use boxfuture::{try_future, BoxFuture, Boxable};
+use bytes::Bytes;
+use futures::future::{self, Future};
+use protobuf::{self, Message as GrpcioMessage};
+
+use fs::{File, PathStat};
+use hashing::Digest;
+
+use super::{CacheableExecuteProcessRequest, CacheableExecuteProcessResult};
+
+// Environment variable which is exclusively used for cache key invalidation.
+// This may be not specified in an ExecuteProcessRequest, and may be populated only by the
+// CommandRunner.
+const CACHE_KEY_GEN_VERSION_ENV_VAR_NAME: &str = "PANTS_CACHE_KEY_GEN_VERSION";
+
+/// ???/just a neat way to separate logic as this interface evolves, not really necessary right now
+pub trait SerializableProcessExecutionCodec<
+    // TODO: add some constraints to these?
+    ProcessRequest,
+    SerializableRequest,
+    ProcessResult,
+    SerializableResult,
+    ErrorType,
+  >: Send + Sync {
+  fn convert_request(
+    &self,
+    req: ProcessRequest
+  ) -> Result<SerializableRequest, ErrorType>;
+
+  fn convert_response(
+    &self,
+    res: ProcessResult,
+  ) -> Result<SerializableResult, ErrorType>;
+
+  fn extract_response(
+    &self,
+    serializable_response: SerializableResult,
+  ) -> BoxFuture<ProcessResult, ErrorType>;
+}
+
+#[derive(Clone)]
+pub struct BazelProtosProcessExecutionCodec {
+  store: fs::Store,
+}
+
+impl BazelProtosProcessExecutionCodec {
+  pub fn new(store: fs::Store) -> Self {
+    BazelProtosProcessExecutionCodec { store }
+  }
+
+  fn digest_bytes(bytes: &Bytes) -> Digest {
+    let fingerprint = fs::Store::fingerprint_from_bytes_unsafe(&bytes);
+    Digest(fingerprint, bytes.len())
+  }
+
+  pub fn digest_message(message: &dyn GrpcioMessage) -> Result<Digest, String> {
+    let bytes = message.write_to_bytes().map_err(|e| format!("{:?}", e))?;
+    Ok(Self::digest_bytes(&Bytes::from(bytes.as_slice())))
+  }
+
+  fn convert_digest(digest: Digest) -> bazel_protos::remote_execution::Digest {
+    let mut digest_proto = bazel_protos::remote_execution::Digest::new();
+    let Digest(fingerprint, bytes_len) = digest;
+    digest_proto.set_hash(fingerprint.to_hex());
+    digest_proto.set_size_bytes(bytes_len as i64);
+    digest_proto
+  }
+
+  fn make_command(
+    req: CacheableExecuteProcessRequest,
+  ) -> Result<bazel_protos::remote_execution::Command, String> {
+    let CacheableExecuteProcessRequest {
+      req,
+      cache_key_gen_version,
+    } = req;
+    let mut command = bazel_protos::remote_execution::Command::new();
+    command.set_arguments(protobuf::RepeatedField::from_vec(req.argv.clone()));
+
+    for (ref name, ref value) in &req.env {
+      if name.as_str() == CACHE_KEY_GEN_VERSION_ENV_VAR_NAME {
+        return Err(format!(
+          "Cannot set env var with name {} as that is reserved for internal use by pants",
+          CACHE_KEY_GEN_VERSION_ENV_VAR_NAME
+        ));
+      }
+      let mut env = bazel_protos::remote_execution::Command_EnvironmentVariable::new();
+      env.set_name(name.to_string());
+      env.set_value(value.to_string());
+      command.mut_environment_variables().push(env);
+    }
+    if let Some(cache_key_gen_version) = cache_key_gen_version {
+      let mut env = bazel_protos::remote_execution::Command_EnvironmentVariable::new();
+      env.set_name(CACHE_KEY_GEN_VERSION_ENV_VAR_NAME.to_string());
+      env.set_value(cache_key_gen_version.to_string());
+      command.mut_environment_variables().push(env);
+    }
+    let mut output_files = req
+      .output_files
+      .iter()
+      .map(|p| {
+        p.to_str()
+          .map(|s| s.to_owned())
+          .ok_or_else(|| format!("Non-UTF8 output file path: {:?}", p))
+      })
+      .collect::<Result<Vec<String>, String>>()?;
+    output_files.sort();
+    command.set_output_files(protobuf::RepeatedField::from_vec(output_files));
+
+    let mut output_directories = req
+      .output_directories
+      .iter()
+      .map(|p| {
+        p.to_str()
+          .map(|s| s.to_owned())
+          .ok_or_else(|| format!("Non-UTF8 output directory path: {:?}", p))
+      })
+      .collect::<Result<Vec<String>, String>>()?;
+    output_directories.sort();
+    command.set_output_directories(protobuf::RepeatedField::from_vec(output_directories));
+
+    // Ideally, the JDK would be brought along as part of the input directory, but we don't currently
+    // have support for that. The platform with which we're experimenting for remote execution
+    // supports this property, and will symlink .jdk to a system-installed JDK:
+    // https://github.com/twitter/scoot/pull/391
+    if req.jdk_home.is_some() {
+      command.set_platform({
+        let mut platform = bazel_protos::remote_execution::Platform::new();
+        platform.mut_properties().push({
+          let mut property = bazel_protos::remote_execution::Platform_Property::new();
+          property.set_name("JDK_SYMLINK".to_owned());
+          property.set_value(".jdk".to_owned());
+          property
+        });
+        platform
+      });
+    }
+
+    Ok(command)
+  }
+
+  pub fn make_action_with_command(
+    req: CacheableExecuteProcessRequest,
+  ) -> Result<
+    (
+      bazel_protos::remote_execution::Action,
+      bazel_protos::remote_execution::Command,
+    ),
+    String,
+  > {
+    let command = Self::make_command(req.clone())?;
+    let mut action = bazel_protos::remote_execution::Action::new();
+    action.set_command_digest((&Self::digest_message(&command)?).into());
+    action.set_input_root_digest((&req.req.input_files).into());
+    Ok((action, command))
+  }
+
+  fn extract_stdout(
+    &self,
+    result: bazel_protos::remote_execution::ActionResult,
+  ) -> BoxFuture<Bytes, String> {
+    if let Some(ref stdout_digest) = result.stdout_digest.into_option() {
+      let stdout_digest_result: Result<Digest, String> = stdout_digest.into();
+      let stdout_digest = try_future!(
+        stdout_digest_result.map_err(|err| format!("Error extracting stdout: {}", err))
+      );
+      self
+        .store
+        .load_file_bytes_with(stdout_digest, |v| v)
+        .map_err(move |error| {
+          format!(
+            "Error fetching stdout digest ({:?}): {:?}",
+            stdout_digest, error
+          )
+        })
+        .and_then(move |maybe_value| {
+          maybe_value.ok_or_else(|| {
+            format!(
+              "Couldn't find stdout digest ({:?}), when fetching.",
+              stdout_digest
+            )
+          })
+        })
+        .to_boxed()
+    } else {
+      let stdout_raw = result.stdout_raw;
+      let stdout_copy = stdout_raw.clone();
+      self
+        .store
+        .store_file_bytes(stdout_raw, true)
+        .map_err(move |error| format!("Error storing raw stdout: {:?}", error))
+        .map(|_| stdout_copy)
+        .to_boxed()
+    }
+  }
+
+  fn extract_stderr(
+    &self,
+    result: bazel_protos::remote_execution::ActionResult,
+  ) -> BoxFuture<Bytes, String> {
+    if let Some(ref stderr_digest) = result.stderr_digest.into_option() {
+      let stderr_digest_result: Result<Digest, String> = stderr_digest.into();
+      let stderr_digest = try_future!(
+        stderr_digest_result.map_err(|err| format!("Error extracting stderr: {}", err))
+      );
+      self
+        .store
+        .load_file_bytes_with(stderr_digest, |v| v)
+        .map_err(move |error| {
+          format!(
+            "Error fetching stderr digest ({:?}): {:?}",
+            stderr_digest, error
+          )
+        })
+        .and_then(move |maybe_value| {
+          maybe_value.ok_or_else(|| {
+            format!(
+              "Couldn't find stderr digest ({:?}), when fetching.",
+              stderr_digest
+            )
+          })
+        })
+        .to_boxed()
+    } else {
+      let stderr_raw = result.stderr_raw;
+      let stderr_copy = stderr_raw.clone();
+      self
+        .store
+        .store_file_bytes(stderr_raw, true)
+        .map_err(move |error| format!("Error storing raw stderr: {:?}", error))
+        .map(|_| stderr_copy)
+        .to_boxed()
+    }
+  }
+
+  fn extract_output_files(
+    &self,
+    result: bazel_protos::remote_execution::ActionResult,
+  ) -> BoxFuture<Digest, String> {
+    // Get Digests of output Directories.
+    // Then we'll make a Directory for the output files, and merge them.
+    let output_directories = result.output_directories.clone();
+    let mut directory_digests = Vec::with_capacity(output_directories.len() + 1);
+    for dir in output_directories.into_iter() {
+      let digest_result: Result<Digest, String> = (&dir.tree_digest.unwrap()).into();
+      let mut digest = future::done(digest_result).to_boxed();
+      for component in dir.path.rsplit('/') {
+        let component = component.to_owned();
+        let store = self.store.clone();
+        digest = digest
+          .and_then(move |digest| {
+            let mut directory = bazel_protos::remote_execution::Directory::new();
+            directory.mut_directories().push({
+              let mut node = bazel_protos::remote_execution::DirectoryNode::new();
+              node.set_name(component);
+              node.set_digest((&digest).into());
+              node
+            });
+            store.record_directory(&directory, true)
+          })
+          .to_boxed();
+      }
+      directory_digests
+        .push(digest.map_err(|err| format!("Error saving remote output directory: {}", err)));
+    }
+
+    // Make a directory for the files
+    let mut path_map = HashMap::new();
+    let output_files = result.output_files.clone();
+    let path_stats_result: Result<Vec<PathStat>, String> = output_files
+      .into_iter()
+      .map(|output_file| {
+        let output_file_path_buf = PathBuf::from(output_file.path);
+        let digest = output_file
+          .digest
+          .into_option()
+          .ok_or_else(|| "No digest on remote execution output file".to_string())?;
+        let digest: Result<Digest, String> = (&digest).into();
+        path_map.insert(output_file_path_buf.clone(), digest?);
+        Ok(PathStat::file(
+          output_file_path_buf.clone(),
+          File {
+            path: output_file_path_buf,
+            is_executable: output_file.is_executable,
+          },
+        ))
+      })
+      .collect();
+
+    let path_stats = try_future!(path_stats_result);
+
+    #[derive(Clone)]
+    struct StoreOneOffRemoteDigest {
+      map_of_paths_to_digests: HashMap<PathBuf, Digest>,
+    }
+
+    impl StoreOneOffRemoteDigest {
+      fn new(map: HashMap<PathBuf, Digest>) -> StoreOneOffRemoteDigest {
+        StoreOneOffRemoteDigest {
+          map_of_paths_to_digests: map,
+        }
+      }
+    }
+
+    impl fs::StoreFileByDigest<String> for StoreOneOffRemoteDigest {
+      fn store_by_digest(&self, file: File) -> BoxFuture<Digest, String> {
+        match self.map_of_paths_to_digests.get(&file.path) {
+          Some(digest) => future::ok(*digest),
+          None => future::err(format!(
+            "Didn't know digest for path in remote execution response: {:?}",
+            file.path
+          )),
+        }
+        .to_boxed()
+      }
+    }
+
+    let store = self.store.clone();
+    fs::Snapshot::digest_from_path_stats(
+      self.store.clone(),
+      &StoreOneOffRemoteDigest::new(path_map),
+      &path_stats,
+    )
+    .map_err(move |error| {
+      format!(
+        "Error when storing the output file directory info in the remote CAS: {:?}",
+        error
+      )
+    })
+    .join(future::join_all(directory_digests))
+    .and_then(|(files_digest, mut directory_digests)| {
+      directory_digests.push(files_digest);
+      fs::Snapshot::merge_directories(store, directory_digests)
+        .map_err(|err| format!("Error when merging output files and directories: {}", err))
+    })
+    .to_boxed()
+  }
+}
+
+impl
+  SerializableProcessExecutionCodec<
+    CacheableExecuteProcessRequest,
+    bazel_protos::remote_execution::Action,
+    CacheableExecuteProcessResult,
+    bazel_protos::remote_execution::ActionResult,
+    // TODO: better error type?
+    String,
+  > for BazelProtosProcessExecutionCodec
+{
+  fn convert_request(
+    &self,
+    req: CacheableExecuteProcessRequest,
+  ) -> Result<bazel_protos::remote_execution::Action, String> {
+    let (action, _) = Self::make_action_with_command(req)?;
+    Ok(action)
+  }
+
+  fn convert_response(
+    &self,
+    res: CacheableExecuteProcessResult,
+  ) -> Result<bazel_protos::remote_execution::ActionResult, String> {
+    let mut action_proto = bazel_protos::remote_execution::ActionResult::new();
+    let mut output_directory = bazel_protos::remote_execution::OutputDirectory::new();
+    let output_directory_digest = Self::convert_digest(res.output_directory);
+    output_directory.set_tree_digest(output_directory_digest);
+    action_proto.set_output_directories(protobuf::RepeatedField::from_vec(vec![output_directory]));
+    action_proto.set_exit_code(res.exit_code);
+    action_proto.set_stdout_raw(res.stdout.clone());
+    action_proto.set_stdout_digest(Self::convert_digest(Self::digest_bytes(&res.stdout)));
+    action_proto.set_stderr_raw(res.stderr.clone());
+    action_proto.set_stderr_digest(Self::convert_digest(Self::digest_bytes(&res.stderr)));
+    Ok(action_proto)
+  }
+
+  fn extract_response(
+    &self,
+    res: bazel_protos::remote_execution::ActionResult,
+  ) -> BoxFuture<CacheableExecuteProcessResult, String> {
+    self
+      .extract_stdout(res.clone())
+      .join(self.extract_stderr(res.clone()))
+      .join(self.extract_output_files(res.clone()))
+      .map(
+        move |((stdout, stderr), output_directory)| CacheableExecuteProcessResult {
+          stdout,
+          stderr,
+          exit_code: res.exit_code,
+          output_directory,
+        },
+      )
+      .to_boxed()
+  }
+}
+
+/// ???/it's called "immediate" because it's a best-effort thing located locally (???)
+pub trait ImmediateExecutionCache<ProcessRequest, ProcessResult>: Send + Sync {
+  fn record_process_result(&self, req: ProcessRequest, res: ProcessResult)
+    -> BoxFuture<(), String>;
+
+  fn load_process_result(&self, req: ProcessRequest) -> BoxFuture<Option<ProcessResult>, String>;
+}
+
+/// ???
+#[derive(Clone)]
+pub struct ActionCache {
+  store: fs::Store,
+  process_execution_codec: BazelProtosProcessExecutionCodec,
+}
+
+impl ActionCache {
+  pub fn new(store: fs::Store) -> Self {
+    ActionCache {
+      store: store.clone(),
+      process_execution_codec: BazelProtosProcessExecutionCodec::new(store),
+    }
+  }
+}
+
+impl ImmediateExecutionCache<CacheableExecuteProcessRequest, CacheableExecuteProcessResult>
+  for ActionCache
+{
+  fn record_process_result(
+    &self,
+    req: CacheableExecuteProcessRequest,
+    res: CacheableExecuteProcessResult,
+  ) -> BoxFuture<(), String> {
+    let codec = self.process_execution_codec.clone();
+    let converted_key_value_protos = codec
+      .convert_request(req)
+      .and_then(|req| codec.convert_response(res).map(|res| (req, res)));
+    let store = self.store.clone();
+    future::result(converted_key_value_protos)
+      .and_then(move |(action_request, action_result)| {
+        store.record_process_result(action_request, action_result)
+      })
+      .to_boxed()
+  }
+
+  fn load_process_result(
+    &self,
+    req: CacheableExecuteProcessRequest,
+  ) -> BoxFuture<Option<CacheableExecuteProcessResult>, String> {
+    let codec = self.process_execution_codec.clone();
+    let store = self.store.clone();
+    future::result(codec.convert_request(req))
+      .and_then(move |action_proto| store.load_process_result(action_proto))
+      .and_then(move |maybe_action_result| match maybe_action_result {
+        Some(action_result) => codec.extract_response(action_result).map(Some).to_boxed(),
+        None => future::result(Ok(None)).to_boxed(),
+      })
+      .to_boxed()
+  }
+}

--- a/src/rust/engine/process_execution/src/cached_execution.rs
+++ b/src/rust/engine/process_execution/src/cached_execution.rs
@@ -40,7 +40,7 @@ use futures::future::{self, Future};
 use log::debug;
 
 use fs::{File, PathStat};
-use hashing::Digest;
+use hashing::{Digest, Fingerprint};
 
 use super::{CommandRunner, ExecuteProcessRequest, ExecutionStats, FallibleExecuteProcessResult};
 
@@ -90,6 +90,12 @@ impl CacheableExecuteProcessResult {
   }
 }
 
+/// ???
+pub enum OutputDirWrapping {
+  Direct,
+  TopLevelWrapped,
+}
+
 /// ???/it's called "immediate" because it's a best-effort thing located locally (???)
 pub trait ImmediateExecutionCache<ProcessRequest, ProcessResult>: Send + Sync {
   fn record_process_result(
@@ -110,6 +116,13 @@ pub struct ActionSerializer {
 impl ActionSerializer {
   pub fn new(store: fs::Store) -> Self {
     ActionSerializer { store }
+  }
+
+  fn extract_digest(
+    digest: &bazel_protos::build::bazel::remote::execution::v2::Digest,
+  ) -> Result<Digest, String> {
+    let fingerprint = Fingerprint::from_hex_string(&digest.hash)?;
+    Ok(Digest(fingerprint, digest.size_bytes as usize))
   }
 
   pub fn convert_digest(
@@ -315,10 +328,43 @@ impl ActionSerializer {
     }
   }
 
+  fn extract_output_files_with_single_containing_directory(
+    result: &bazel_protos::build::bazel::remote::execution::v2::ActionResult,
+  ) -> Result<Digest, String> {
+    let invalid_containing_dir = || {
+      format!("Error: invalid output directory for result {:?}. An process execution extracted as an ActionResult from the process execution cache must will always contain a single top-level directory with the path \"\".",
+              result)
+    };
+
+    if result.output_files.is_empty() && result.output_directories.len() == 1 {
+      // A single directory (with a provided digest), which should be at the path "".
+      let dir = result.output_directories.last().unwrap();
+      if dir.path.is_empty() {
+        let proto_digest = dir.tree_digest.clone().unwrap();
+        Self::extract_digest(&proto_digest)
+      } else {
+        Err(invalid_containing_dir())
+      }
+    } else {
+      Err(invalid_containing_dir())
+    }
+  }
+
   fn extract_output_files(
     &self,
     result: &bazel_protos::build::bazel::remote::execution::v2::ActionResult,
+    wrapping: OutputDirWrapping,
   ) -> BoxFuture<Digest, String> {
+    match wrapping {
+      OutputDirWrapping::Direct => (),
+      OutputDirWrapping::TopLevelWrapped => {
+        return future::result(Self::extract_output_files_with_single_containing_directory(
+          result,
+        ))
+        .to_boxed();
+      }
+    }
+
     // Get Digests of output Directories.
     // Then we'll make a Directory for the output files, and merge them.
     let output_directories = result.output_directories.clone();
@@ -447,12 +493,13 @@ impl ActionSerializer {
   pub fn extract_action_result(
     &self,
     res: &bazel_protos::build::bazel::remote::execution::v2::ActionResult,
+    wrapping: OutputDirWrapping,
   ) -> BoxFuture<CacheableExecuteProcessResult, String> {
     let exit_code = res.exit_code;
     self
       .extract_stdout(&res)
       .join(self.extract_stderr(&res))
-      .join(self.extract_output_files(&res))
+      .join(self.extract_output_files(&res, wrapping))
       .map(
         move |((stdout, stderr), output_directory)| CacheableExecuteProcessResult {
           stdout,
@@ -505,7 +552,11 @@ impl ImmediateExecutionCache<CacheableExecuteProcessRequest, CacheableExecutePro
       .and_then(move |action_proto| store.load_process_result(&action_proto))
       .and_then(move |maybe_action_result| match maybe_action_result {
         Some(action_result) => cache
-          .extract_action_result(&action_result)
+          // NB: FallibleExecuteProcessResult always wraps everything in a *single* output
+          // directory, which is then converted into an OutputDirectory for the ActionResult proto
+          // at the path "" in convert_result_to_action_result(), so we have to pull the contents
+          // out of that single dir with the path "".
+          .extract_action_result(&action_result, OutputDirWrapping::TopLevelWrapped)
           .map(Some)
           .to_boxed(),
         None => future::result(Ok(None)).to_boxed(),
@@ -602,31 +653,105 @@ impl CommandRunner for CachingCommandRunner {
 mod tests {
   use super::{
     ActionSerializer, CacheableExecuteProcessRequest, CacheableExecuteProcessResult,
-    CachingCommandRunner, CommandRunner, ExecuteProcessRequest, ImmediateExecutionCache,
+    CachingCommandRunner, CommandRunner, ExecuteProcessRequest, FallibleExecuteProcessResult,
+    ImmediateExecutionCache,
   };
+  use crate::local::testutils::find_bash;
   use futures::future::Future;
+  use hashing::{Digest, Fingerprint};
   use std::collections::{BTreeMap, BTreeSet};
   use std::ops::Deref;
   use std::path::Path;
+  use std::path::PathBuf;
   use std::sync::Arc;
   use std::time::Duration;
   use tempfile::TempDir;
+  use testutil::data::{TestData, TestDirectory};
   use testutil::owned_string_vec;
 
-  // // TODO: test codec back and forth
-  // #[test]
-  // fn bazel_proto_process_execution_codec() {
-  //   let req = ExecuteProcessRequest {
-  //     argv: owned_string_vec(&["ls", "-R", "/"]),
-  //     env: BTreeMap::new(),
-  //     input_files: fs::EMPTY_DIGEST,
-  //     output_files:
-  //   }
-  // }
+  #[test]
+  fn encode_action() {
+    let input_directory = TestDirectory::containing_roland();
+    let req = ExecuteProcessRequest {
+      argv: owned_string_vec(&["/bin/echo", "yo"]),
+      env: vec![("SOME".to_owned(), "value".to_owned())]
+        .into_iter()
+        .collect(),
+      input_files: input_directory.digest(),
+      // Intentionally poorly sorted:
+      output_files: vec!["path/to/file", "other/file"]
+        .into_iter()
+        .map(PathBuf::from)
+        .collect(),
+      output_directories: vec!["directory/name"]
+        .into_iter()
+        .map(PathBuf::from)
+        .collect(),
+      timeout: Duration::from_millis(1000),
+      description: "some description".to_owned(),
+      jdk_home: None,
+    };
+
+    let want_action = bazel_protos::build::bazel::remote::execution::v2::Action {
+      command_digest: Some(ActionSerializer::convert_digest(&Digest(
+        Fingerprint::from_hex_string(
+          "cc4ddd3085aaffbe0abce22f53b30edbb59896bb4a4f0d76219e48070cd0afe1",
+        )
+        .unwrap(),
+        72,
+      ))),
+      input_root_digest: Some(ActionSerializer::convert_digest(&input_directory.digest())),
+      ..Default::default()
+    };
+
+    assert_eq!(
+      Ok(want_action),
+      ActionSerializer::convert_request_to_action(&CacheableExecuteProcessRequest::new(req, None))
+    );
+  }
+
+  #[test]
+  fn encode_empty_action_result() {
+    let testdata_empty = TestData::empty();
+
+    let empty_proto_digest = bazel_protos::build::bazel::remote::execution::v2::Digest {
+      hash: fs::EMPTY_DIGEST.0.to_hex(),
+      size_bytes: fs::EMPTY_DIGEST.1 as i64,
+    };
+
+    let want_action_result = bazel_protos::build::bazel::remote::execution::v2::ActionResult {
+      output_files: vec![],
+      output_directories: vec![
+        bazel_protos::build::bazel::remote::execution::v2::OutputDirectory {
+          path: "".to_string(),
+          tree_digest: Some(empty_proto_digest.clone()),
+        },
+      ],
+      exit_code: 0,
+      stdout_raw: vec![],
+      stdout_digest: Some(empty_proto_digest.clone()),
+      stderr_raw: vec![],
+      stderr_digest: Some(empty_proto_digest.clone()),
+      execution_metadata: None,
+    };
+
+    let empty_result = FallibleExecuteProcessResult {
+      stdout: testdata_empty.bytes(),
+      stderr: testdata_empty.bytes(),
+      exit_code: 0,
+      output_directory: fs::EMPTY_DIGEST,
+      execution_attempts: vec![],
+    };
+
+    assert_eq!(
+      want_action_result,
+      ActionSerializer::convert_result_to_action_result(&empty_result.into_cacheable())
+    );
+  }
 
   #[test]
   #[cfg(unix)]
-  fn cached_process_execution() {
+  fn cached_process_execution_stdout() {
     let random_perl = output_only_process_request(owned_string_vec(&[
       "/usr/bin/perl",
       "-e",
@@ -647,6 +772,9 @@ mod tests {
     );
     let caching_runner = make_caching_runner(base_runner.clone(), action_serializer.clone(), None);
     let process_result = caching_runner.run(random_perl.clone()).wait().unwrap();
+    // The process run again without caching is different.
+    let base_process_result = base_runner.run(random_perl.clone()).wait().unwrap();
+    assert!(base_process_result != process_result);
     assert_eq!(0, process_result.exit_code);
     // A "cacheable" process execution result won't have e.g. the number of attempts that the
     // process was tried, for idempotency, but everything else should be the same.
@@ -744,6 +872,54 @@ mod tests {
     // The new result is distinct from all the previously cached invocations.
     assert!(second_string_perl_number != perl_number);
     assert!(second_string_perl_number != new_perl_number);
+  }
+
+  #[test]
+  #[cfg(unix)]
+  fn cached_process_execution_output_files() {
+    let make_file = ExecuteProcessRequest {
+      argv: vec![
+        find_bash(),
+        "-c".to_owned(),
+        "/usr/bin/perl -e 'print(rand(10))' > wow.txt".to_string(),
+      ],
+      env: BTreeMap::new(),
+      input_files: fs::EMPTY_DIGEST,
+      output_files: vec!["wow.txt"].into_iter().map(PathBuf::from).collect(),
+      output_directories: BTreeSet::new(),
+      timeout: Duration::from_millis(1000),
+      description: "make a nondeterministic file".to_string(),
+      jdk_home: None,
+    };
+    let store_dir = TempDir::new().unwrap();
+    let work_dir = TempDir::new().unwrap();
+    let (_, base_runner, action_serializer) = cache_in_dir(store_dir.path(), work_dir.path());
+    let cacheable_make_file = CacheableExecuteProcessRequest {
+      req: make_file.clone(),
+      cache_key_gen_version: None,
+    };
+    assert_eq!(
+      Ok(None),
+      action_serializer
+        .load_process_result(&cacheable_make_file)
+        .wait()
+    );
+    let caching_runner = make_caching_runner(base_runner.clone(), action_serializer.clone(), None);
+    let base_process_result = base_runner.run(make_file.clone()).wait().unwrap();
+    let process_result = caching_runner.run(make_file.clone()).wait().unwrap();
+    // The process run again without caching is different.
+    assert!(base_process_result != process_result);
+    assert_eq!(0, process_result.exit_code);
+    assert_eq!(
+      process_result.clone().into_cacheable(),
+      action_serializer
+        .load_process_result(&cacheable_make_file)
+        .wait()
+        .unwrap()
+        .unwrap()
+    );
+    let second_process_result = caching_runner.run(make_file.clone()).wait().unwrap();
+    assert_eq!(second_process_result, process_result);
   }
 
   fn output_only_process_request(argv: Vec<String>) -> ExecuteProcessRequest {

--- a/src/rust/engine/process_execution/src/cached_execution.rs
+++ b/src/rust/engine/process_execution/src/cached_execution.rs
@@ -207,7 +207,7 @@ impl ActionSerializer {
     })
   }
 
-  fn encode_command_proto(
+  pub fn encode_command_proto(
     command: &bazel_protos::build::bazel::remote::execution::v2::Command,
   ) -> Result<Bytes, String> {
     fs::Store::encode_proto(command)
@@ -642,7 +642,7 @@ mod tests {
     assert_eq!(
       Ok(None),
       action_serializer
-        .load_process_result(cacheable_perl.clone())
+        .load_process_result(&cacheable_perl)
         .wait()
     );
     let caching_runner = make_caching_runner(base_runner.clone(), action_serializer.clone(), None);
@@ -653,7 +653,7 @@ mod tests {
     assert_eq!(
       process_result.clone().into_cacheable(),
       action_serializer
-        .load_process_result(cacheable_perl)
+        .load_process_result(&cacheable_perl)
         .wait()
         .unwrap()
         .unwrap()
@@ -678,7 +678,7 @@ mod tests {
     assert_eq!(
       Ok(None),
       action_serializer
-        .load_process_result(new_cacheable_perl.clone())
+        .load_process_result(&new_cacheable_perl)
         .wait()
     );
     let new_caching_runner = make_caching_runner(
@@ -693,7 +693,7 @@ mod tests {
     assert_eq!(
       new_process_result.clone().into_cacheable(),
       action_serializer
-        .load_process_result(new_cacheable_perl)
+        .load_process_result(&new_cacheable_perl)
         .wait()
         .unwrap()
         .unwrap()
@@ -715,7 +715,7 @@ mod tests {
     assert_eq!(
       Ok(None),
       action_serializer
-        .load_process_result(second_cache_string_perl.clone())
+        .load_process_result(&second_cache_string_perl)
         .wait()
     );
     let second_string_caching_runner = make_caching_runner(
@@ -731,7 +731,7 @@ mod tests {
     assert_eq!(
       second_string_process_result.clone().into_cacheable(),
       action_serializer
-        .load_process_result(second_cache_string_perl)
+        .load_process_result(&second_cache_string_perl)
         .wait()
         .unwrap()
         .unwrap()

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -109,10 +109,10 @@ pub struct FallibleExecuteProcessResult {
 }
 
 impl FallibleExecuteProcessResult {
-  pub fn without_execution_attempts(&self) -> CacheableExecuteProcessResult {
+  pub fn into_cacheable(self) -> CacheableExecuteProcessResult {
     CacheableExecuteProcessResult {
-      stdout: self.stdout.clone(),
-      stderr: self.stderr.clone(),
+      stdout: self.stdout,
+      stderr: self.stderr,
       exit_code: self.exit_code,
       output_directory: self.output_directory,
     }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -44,9 +44,8 @@ pub mod cached_execution;
 pub mod local;
 pub mod remote;
 pub use crate::cached_execution::{
-  ActionCache, BazelProtosProcessExecutionCodec, CacheableExecuteProcessRequest,
-  CacheableExecuteProcessResult, CachingCommandRunner, ImmediateExecutionCache,
-  SerializableProcessExecutionCodec,
+  ActionSerializer, CacheableExecuteProcessRequest, CacheableExecuteProcessResult,
+  CachingCommandRunner, ImmediateExecutionCache,
 };
 
 ///

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -118,15 +118,6 @@ impl FallibleExecuteProcessResult {
   }
 }
 
-// TODO: remove this method!
-#[cfg(test)]
-impl FallibleExecuteProcessResult {
-  pub fn without_execution_attempts(mut self) -> Self {
-    self.execution_attempts = vec![];
-    self
-  }
-}
-
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ExecutionStats {
   uploaded_bytes: usize,

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -30,9 +30,8 @@
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
-use boxfuture::{BoxFuture, Boxable};
+use boxfuture::BoxFuture;
 use bytes::Bytes;
-use futures::future::{self, Future};
 use std::collections::{BTreeMap, BTreeSet};
 use std::ops::AddAssign;
 use std::path::PathBuf;
@@ -45,7 +44,8 @@ pub mod cached_execution;
 pub mod local;
 pub mod remote;
 pub use crate::cached_execution::{
-  ActionCache, BazelProtosProcessExecutionCodec, ImmediateExecutionCache,
+  ActionCache, BazelProtosProcessExecutionCodec, CacheableExecuteProcessRequest,
+  CacheableExecuteProcessResult, CachingCommandRunner, ImmediateExecutionCache,
   SerializableProcessExecutionCodec,
 };
 
@@ -92,23 +92,6 @@ pub struct ExecuteProcessRequest {
   pub jdk_home: Option<PathBuf>,
 }
 
-/// ???/DON'T LET THE `cache_key_gen_version` BECOME A KITCHEN SINK!!!
-#[derive(Clone)]
-pub struct CacheableExecuteProcessRequest {
-  req: ExecuteProcessRequest,
-  // TODO: give this a better type than Option<String> (everywhere)!
-  cache_key_gen_version: Option<String>,
-}
-
-impl CacheableExecuteProcessRequest {
-  fn new(req: ExecuteProcessRequest, cache_key_gen_version: Option<String>) -> Self {
-    CacheableExecuteProcessRequest {
-      req,
-      cache_key_gen_version,
-    }
-  }
-}
-
 ///
 /// The result of running a process.
 ///
@@ -126,35 +109,12 @@ pub struct FallibleExecuteProcessResult {
 }
 
 impl FallibleExecuteProcessResult {
-  fn without_execution_attempts(&self) -> CacheableExecuteProcessResult {
+  pub fn without_execution_attempts(&self) -> CacheableExecuteProcessResult {
     CacheableExecuteProcessResult {
       stdout: self.stdout.clone(),
       stderr: self.stderr.clone(),
       exit_code: self.exit_code,
       output_directory: self.output_directory,
-    }
-  }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CacheableExecuteProcessResult {
-  pub stdout: Bytes,
-  pub stderr: Bytes,
-  pub exit_code: i32,
-  pub output_directory: hashing::Digest,
-}
-
-impl CacheableExecuteProcessResult {
-  fn with_execution_attempts(
-    &self,
-    execution_attempts: Vec<ExecutionStats>,
-  ) -> FallibleExecuteProcessResult {
-    FallibleExecuteProcessResult {
-      stdout: self.stdout.clone(),
-      stderr: self.stderr.clone(),
-      exit_code: self.exit_code,
-      output_directory: self.output_directory,
-      execution_attempts,
     }
   }
 }
@@ -212,75 +172,5 @@ impl CommandRunner for BoundedCommandRunner {
   fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<FallibleExecuteProcessResult, String> {
     let inner = self.inner.clone();
     self.inner.1.with_acquired(move || inner.0.run(req))
-  }
-}
-
-///
-/// A CommandRunner wrapper that attempts to cache process executions.
-///
-#[derive(Clone)]
-pub struct CachingCommandRunner {
-  inner: Arc<Box<dyn CommandRunner>>,
-  cache: Arc<
-    Box<dyn ImmediateExecutionCache<CacheableExecuteProcessRequest, CacheableExecuteProcessResult>>,
-  >,
-  cache_key_gen_version: Option<String>,
-}
-
-impl CachingCommandRunner {
-  pub fn from_store(
-    inner: Box<dyn CommandRunner>,
-    store: fs::Store,
-    cache_key_gen_version: Option<String>,
-  ) -> Self {
-    let action_cache = ActionCache::new(store);
-    let boxed_cache = Box::new(action_cache)
-      as Box<
-        dyn ImmediateExecutionCache<CacheableExecuteProcessRequest, CacheableExecuteProcessResult>,
-      >;
-    Self::new(inner, boxed_cache, cache_key_gen_version)
-  }
-
-  pub fn new(
-    inner: Box<dyn CommandRunner>,
-    cache: Box<
-      dyn ImmediateExecutionCache<CacheableExecuteProcessRequest, CacheableExecuteProcessResult>,
-    >,
-    cache_key_gen_version: Option<String>,
-  ) -> Self {
-    CachingCommandRunner {
-      inner: Arc::new(inner),
-      cache: Arc::new(cache),
-      cache_key_gen_version,
-    }
-  }
-}
-
-impl CommandRunner for CachingCommandRunner {
-  fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<FallibleExecuteProcessResult, String> {
-    let cacheable_request =
-      CacheableExecuteProcessRequest::new(req.clone(), self.cache_key_gen_version.clone());
-    let cache = self.cache.clone();
-    let inner = self.inner.clone();
-    cache
-      .load_process_result(cacheable_request.clone())
-      .and_then(move |cache_fetch| match cache_fetch {
-        // We have a cache hit!
-        Some(cached_execution_result) => future::result(Ok(cached_execution_result)).to_boxed(),
-        // We have to actually run the process now.
-        None => inner
-          .run(req)
-          .and_then(move |res| {
-            let cacheable_process_result = res.without_execution_attempts();
-            cache
-              .record_process_result(cacheable_request, cacheable_process_result.clone())
-              .map(|()| cacheable_process_result)
-          })
-          .to_boxed(),
-      })
-      // NB: We clear metadata about execution attempts when returning a cacheable process execution
-      // request.
-      .map(|cacheable_process_result| cacheable_process_result.with_execution_attempts(vec![]))
-      .to_boxed()
   }
 }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -21,6 +21,7 @@ use super::{ExecuteProcessRequest, FallibleExecuteProcessResult};
 
 use bytes::{Bytes, BytesMut};
 
+#[derive(Clone)]
 pub struct CommandRunner {
   store: fs::Store,
   fs_pool: Arc<fs::ResettablePool>,

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -293,6 +293,7 @@ impl super::CommandRunner for CommandRunner {
             })
             .map(Arc::new)
             .and_then(|posix_fs| {
+              eprintln!("output_file_paths: {:?}", output_file_paths);
               CommandRunner::construct_output_snapshot(
                 store,
                 posix_fs,
@@ -337,13 +338,12 @@ mod tests {
 
   use super::super::CommandRunner as CommandRunnerTrait;
   use super::{ExecuteProcessRequest, FallibleExecuteProcessResult};
+  use crate::local::testutils::*;
   use fs;
   use futures::Future;
   use std;
   use std::collections::{BTreeMap, BTreeSet};
-  use std::env;
-  use std::os::unix::fs::PermissionsExt;
-  use std::path::{Path, PathBuf};
+  use std::path::PathBuf;
   use std::sync::Arc;
   use std::time::Duration;
   use tempfile::TempDir;
@@ -883,8 +883,15 @@ mod tests {
     };
     runner.run(req).wait()
   }
+}
 
-  fn find_bash() -> String {
+#[cfg(test)]
+pub mod testutils {
+  use std::env;
+  use std::os::unix::fs::PermissionsExt;
+  use std::path::{Path, PathBuf};
+
+  pub fn find_bash() -> String {
     which("bash")
       .expect("No bash on PATH")
       .to_str()
@@ -892,7 +899,7 @@ mod tests {
       .to_owned()
   }
 
-  fn which(executable: &str) -> Option<PathBuf> {
+  pub fn which(executable: &str) -> Option<PathBuf> {
     if let Some(paths) = env::var_os("PATH") {
       for path in env::split_paths(&paths) {
         let executable_path = path.join(executable);
@@ -904,7 +911,7 @@ mod tests {
     None
   }
 
-  fn is_executable(path: &Path) -> bool {
+  pub fn is_executable(path: &Path) -> bool {
     std::fs::metadata(path)
       .map(|meta| meta.permissions().mode() & 0o100 == 0o100)
       .unwrap_or(false)

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -171,6 +171,73 @@ impl BazelProtosProcessExecutionCodecV2 {
     resulting_output_dir
   }
 
+  fn convert_timestamp(timestamp: prost_types::Timestamp) -> protobuf::well_known_types::Timestamp {
+    let mut resulting_timestamp = protobuf::well_known_types::Timestamp::new();
+    resulting_timestamp.set_seconds(timestamp.seconds);
+    resulting_timestamp.set_nanos(timestamp.nanos);
+    resulting_timestamp
+  }
+
+  fn convert_execution_metadata(
+    exec_metadata: bazel_protos::build::bazel::remote::execution::v2::ExecutedActionMetadata,
+  ) -> bazel_protos::remote_execution::ExecutedActionMetadata {
+    let mut resulting_exec_metadata = bazel_protos::remote_execution::ExecutedActionMetadata::new();
+    resulting_exec_metadata.set_worker(exec_metadata.worker);
+    if let Some(queued_timestamp) = exec_metadata.queued_timestamp.map(Self::convert_timestamp) {
+      resulting_exec_metadata.set_queued_timestamp(queued_timestamp);
+    }
+    if let Some(worker_start_timestamp) = exec_metadata
+      .worker_start_timestamp
+      .map(Self::convert_timestamp)
+    {
+      resulting_exec_metadata.set_worker_start_timestamp(worker_start_timestamp);
+    }
+    if let Some(worker_completed_timestamp) = exec_metadata
+      .worker_completed_timestamp
+      .map(Self::convert_timestamp)
+    {
+      resulting_exec_metadata.set_worker_completed_timestamp(worker_completed_timestamp);
+    }
+    if let Some(input_fetch_start_timestamp) = exec_metadata
+      .input_fetch_start_timestamp
+      .map(Self::convert_timestamp)
+    {
+      resulting_exec_metadata.set_input_fetch_start_timestamp(input_fetch_start_timestamp);
+    }
+    if let Some(input_fetch_completed_timestamp) = exec_metadata
+      .input_fetch_completed_timestamp
+      .map(Self::convert_timestamp)
+    {
+      resulting_exec_metadata.set_input_fetch_completed_timestamp(input_fetch_completed_timestamp);
+    }
+    if let Some(execution_start_timestamp) = exec_metadata
+      .execution_start_timestamp
+      .map(Self::convert_timestamp)
+    {
+      resulting_exec_metadata.set_execution_start_timestamp(execution_start_timestamp);
+    }
+    if let Some(execution_completed_timestamp) = exec_metadata
+      .execution_completed_timestamp
+      .map(Self::convert_timestamp)
+    {
+      resulting_exec_metadata.set_execution_completed_timestamp(execution_completed_timestamp);
+    }
+    if let Some(output_upload_start_timestamp) = exec_metadata
+      .output_upload_start_timestamp
+      .map(Self::convert_timestamp)
+    {
+      resulting_exec_metadata.set_output_upload_start_timestamp(output_upload_start_timestamp);
+    }
+    if let Some(output_upload_completed_timestamp) = exec_metadata
+      .output_upload_completed_timestamp
+      .map(Self::convert_timestamp)
+    {
+      resulting_exec_metadata
+        .set_output_upload_completed_timestamp(output_upload_completed_timestamp);
+    }
+    resulting_exec_metadata
+  }
+
   fn convert_action_result(
     action_result: bazel_protos::build::bazel::remote::execution::v2::ActionResult,
   ) -> bazel_protos::remote_execution::ActionResult {
@@ -181,7 +248,7 @@ impl BazelProtosProcessExecutionCodecV2 {
         .iter()
         .cloned()
         .map(Self::convert_output_file)
-        .collect::<Vec<_>>(),
+        .collect(),
     ));
     resulting_action_result.set_output_directories(protobuf::RepeatedField::from_vec(
       action_result
@@ -200,7 +267,12 @@ impl BazelProtosProcessExecutionCodecV2 {
     if let Some(digest) = action_result.stderr_digest.map(Self::convert_digest) {
       resulting_action_result.set_stderr_digest(digest);
     }
-    // TODO: resulting_action_result.set_execution_metadata();
+    if let Some(execution_metadata) = action_result
+      .execution_metadata
+      .map(Self::convert_execution_metadata)
+    {
+      resulting_action_result.set_execution_metadata(execution_metadata);
+    }
     resulting_action_result
   }
 }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1095,13 +1095,12 @@ mod tests {
     let result = run_command_remote(mock_server.address(), execute_request).unwrap();
 
     assert_eq!(
-      result.without_execution_attempts(),
-      FallibleExecuteProcessResult {
+      result.into_cacheable(),
+      CacheableExecuteProcessResult {
         stdout: as_bytes("foo"),
         stderr: as_bytes(""),
         exit_code: 0,
         output_directory: fs::EMPTY_DIGEST,
-        execution_attempts: vec![],
       }
     );
   }
@@ -1124,8 +1123,8 @@ mod tests {
         .unwrap()
       )
       .unwrap()
-      .without_execution_attempts(),
-      FallibleExecuteProcessResult {
+      .into_cacheable(),
+      CacheableExecuteProcessResult {
         stdout: testdata.bytes(),
         stderr: testdata_empty.bytes(),
         exit_code: 0,
@@ -1153,8 +1152,8 @@ mod tests {
         .unwrap()
       )
       .unwrap()
-      .without_execution_attempts(),
-      FallibleExecuteProcessResult {
+      .into_cacheable(),
+      CacheableExecuteProcessResult {
         stdout: testdata_empty.bytes(),
         stderr: testdata.bytes(),
         exit_code: 0,
@@ -1221,8 +1220,8 @@ mod tests {
     let result = rt.block_on(cmd_runner.run(echo_roland_request())).unwrap();
     rt.shutdown_now().wait().unwrap();
     assert_eq!(
-      result.without_execution_attempts(),
-      FallibleExecuteProcessResult {
+      result.into_cacheable(),
+      CacheableExecuteProcessResult {
         stdout: test_stdout.bytes(),
         stderr: test_stderr.bytes(),
         exit_code: 0,
@@ -1282,8 +1281,8 @@ mod tests {
     let result = run_command_remote(mock_server.address(), execute_request).unwrap();
 
     assert_eq!(
-      result.without_execution_attempts(),
-      FallibleExecuteProcessResult {
+      result.into_cacheable(),
+      CacheableExecuteProcessResult {
         stdout: as_bytes("foo"),
         stderr: as_bytes(""),
         exit_code: 0,
@@ -1358,8 +1357,8 @@ mod tests {
     let result = run_command_remote(mock_server.address(), execute_request).unwrap();
 
     assert_eq!(
-      result.without_execution_attempts(),
-      FallibleExecuteProcessResult {
+      result.into_cacheable(),
+      CacheableExecuteProcessResult {
         stdout: as_bytes("foo"),
         stderr: as_bytes(""),
         exit_code: 0,
@@ -1601,8 +1600,8 @@ mod tests {
     );
     rt.shutdown_now().wait().unwrap();
     assert_eq!(
-      result.unwrap().without_execution_attempts(),
-      FallibleExecuteProcessResult {
+      result.unwrap().into_cacheable(),
+      CacheableExecuteProcessResult {
         stdout: roland.bytes(),
         stderr: Bytes::from(""),
         exit_code: 0,
@@ -1790,12 +1789,11 @@ mod tests {
 
   #[test]
   fn extract_execute_response_success() {
-    let want_result = FallibleExecuteProcessResult {
+    let want_result = CacheableExecuteProcessResult {
       stdout: as_bytes("roland"),
       stderr: Bytes::from("simba"),
       exit_code: 17,
       output_directory: TestDirectory::nested().digest(),
-      execution_attempts: vec![],
     };
 
     let response = bazel_protos::build::bazel::remote::execution::v2::ExecuteResponse {
@@ -1831,7 +1829,7 @@ mod tests {
     assert_eq!(
       extract_execute_response(operation)
         .unwrap()
-        .without_execution_attempts(),
+        .into_cacheable(),
       want_result
     );
   }

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -198,6 +198,7 @@ pub extern "C" fn scheduler_create(
   build_root_buf: Buffer,
   work_dir_buf: Buffer,
   local_store_dir_buf: Buffer,
+  // TODO: need some testing modifying this variable!
   local_execution_process_cache_namespace: Buffer,
   ignore_patterns_buf: BufferBuffer,
   root_type_ids: TypeIdBuffer,

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -198,6 +198,7 @@ pub extern "C" fn scheduler_create(
   build_root_buf: Buffer,
   work_dir_buf: Buffer,
   local_store_dir_buf: Buffer,
+  local_execution_process_cache_namespace: Buffer,
   ignore_patterns_buf: BufferBuffer,
   root_type_ids: TypeIdBuffer,
   remote_store_servers_buf: BufferBuffer,
@@ -245,6 +246,9 @@ pub extern "C" fn scheduler_create(
   };
   let mut tasks = with_tasks(tasks_ptr, |tasks| tasks.clone());
   tasks.intrinsics_set(&types);
+  let local_execution_process_cache_namespace_string = local_execution_process_cache_namespace
+    .to_string()
+    .expect("local_execution_process_cache_namespace was not valid UTF8");
   // Allocate on the heap via `Box` and return a raw pointer to the boxed value.
   let remote_store_servers_vec = remote_store_servers_buf
     .to_strings()
@@ -285,6 +289,11 @@ pub extern "C" fn scheduler_create(
     &ignore_patterns,
     PathBuf::from(work_dir_buf.to_os_string()),
     PathBuf::from(local_store_dir_buf.to_os_string()),
+    if local_execution_process_cache_namespace_string.is_empty() {
+      None
+    } else {
+      Some(local_execution_process_cache_namespace_string)
+    },
     remote_store_servers_vec,
     if remote_execution_server_string.is_empty() {
       None

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -25,7 +25,7 @@ use fs::{
   PathGlobs, PathStat, StoreFileByDigest, StrictGlobMatching, VFS,
 };
 use hashing;
-use process_execution::{self, CommandRunner};
+use process_execution;
 
 use graph::{Entry, Node, NodeError, NodeTracer, NodeVisualizer};
 


### PR DESCRIPTION
*WIP because this is truly massive and also addresses the tower protos migration a bit by converting `Action` and `Command` in `remote.rs` into the new protos (that usage was also moved to `cached_execution.rs`). That part wasn't intentional, but it happens to make all of the below a lot simpler and avoid converting between different proto types completely. I can clean this up if this is an appropriate scope.*

### Problem

Resolves #6898.

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

- add an `lmdb::Database` to `fs::local::ByteStore` as a k/v store for `bazel_protos::build::bazel::remote::execution::v2::Action{,Result}` (from the new tower protos)
- canonicalize encoding/decoding of lots of protos through public methods on `fs::Store`
- create a new file `cached_execution.rs` which contains `CacheableExecuteProcessRe{quest,sult}` analogs to `ExecuteProcessRequest` and `FallibleExecuteProcessResult`, but which either contain caching information or don't contain information relevant to a specific process invocation, so that they can deterministically be serialized into `Action{,Result}` into the `ByteStore`
- move a lot of proto encoding/decoding logic from `remote.rs` into `cached_execution.rs`
- create `CachingCommandRunner` which `impl`s `process_execution::CommandRunner` and serializes process invocations into `Action`s, and when complete, stores the result into an `ActionResult` in the process execution k/v db added to `fs::local::ByteStore` earlier.
- switch usage of `bazel_protos::remote_execution::{Action,Command}` in `remote.rs` to the new tower protos

(_describe the modifications you've made._)

### Result

`./pants -ldebug cloc ::` is instantaneous with pantsd on, for one. This alone is a fantastic reason for tasks to consider switching to v2 rules, or at the very least a v2 process invocation (which is easier to keep cacheable when the process request is created using v2 rules). The only remaining `bazel_protos::remote_execution::*` protos I saw were `Directory` and `File` in `fs::Store` -- this is likely not hard to finish, as that remaining usage was still 100% orthogonal to this PR.

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)