### PR TITLE
virtualenv always finds git root

### DIFF
--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -6,11 +6,7 @@ set -e
 VIRTUALENV_VERSION=15.2.0
 VIRTUALENV_PACKAGE_LOCATION=${VIRTUALENV_PACKAGE_LOCATION:-https://pypi.io/packages/source/v/virtualenv}
 
-if [[ $GIT_HOOK == 1 ]] ; then
-  REPO_ROOT=.
-else
-  REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && git rev-parse --show-toplevel)
-fi
+REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && git rev-parse --show-toplevel)
 source ${REPO_ROOT}/build-support/common.sh
 
 if [[ -z "${PY}" ]]; then


### PR DESCRIPTION
I'm seeing this fail when checking some rust code at some point in a git
hook, because it's invoked from src/rust/engine - this fixes that.

I have no idea why this only recently stated failing for me.