### PR TITLE
Move example/testproject-only deps out of core pants

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -10,7 +10,6 @@ fasteners==0.14.1
 faulthandler==2.6 ; python_version<'3'
 future==0.16.0
 futures==3.0.5 ; python_version<'3'
-grpcio==1.16.1
 Markdown==2.1.1
 mock==2.0.0
 packaging==16.8
@@ -18,7 +17,6 @@ parameterized==0.6.1
 pathspec==0.5.9
 pex==1.5.3
 psutil==5.4.8
-protobuf==3.6.1
 pycodestyle==2.4.0
 pyflakes==2.0.0
 Pygments==2.3.1
@@ -35,6 +33,5 @@ setproctitle==1.1.10
 setuptools==40.4.3
 six>=1.9.0,<2
 subprocess32==3.2.7 ; python_version<'3'
-thrift>=0.10.0
 wheel==0.31.1
 www-authenticate==0.9.2

--- a/examples/3rdparty/python/BUILD
+++ b/examples/3rdparty/python/BUILD
@@ -1,10 +1,5 @@
-# coding=utf-8
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_grpcio_library(
-  sources=['service.proto'],
-  dependencies=[
-    'examples/3rdparty/python:protobuf',
-  ]
-)
+# see/edit requirements.txt in this directory to change deps.
+python_requirements()

--- a/examples/3rdparty/python/requirements.txt
+++ b/examples/3rdparty/python/requirements.txt
@@ -1,0 +1,3 @@
+grpcio==1.16.1
+protobuf==3.6.1
+thrift>=0.10.0

--- a/examples/src/protobuf/org/pantsbuild/example/grpcio/imports/BUILD
+++ b/examples/src/protobuf/org/pantsbuild/example/grpcio/imports/BUILD
@@ -5,7 +5,7 @@
 python_grpcio_library(
   sources=['imports.proto'],
   dependencies=[
-    '3rdparty/python:protobuf',
+    'examples/3rdparty/python:protobuf',
     'examples/src/protobuf/org/pantsbuild/example/grpcio/service'
   ]
 )

--- a/examples/src/python/example/grpcio/client/BUILD
+++ b/examples/src/python/example/grpcio/client/BUILD
@@ -4,8 +4,7 @@
 python_binary(
   name='service',
   dependencies=[
-    '3rdparty/python:grpcio',
-
+    'examples/3rdparty/python:grpcio',
     'examples/src/protobuf/org/pantsbuild/example/grpcio/service',
   ],
   source='service_client.py',
@@ -14,8 +13,7 @@ python_binary(
 python_binary(
   name='imports',
   dependencies=[
-    '3rdparty/python:grpcio',
-
+    'examples/3rdparty/python:grpcio',
     'examples/src/protobuf/org/pantsbuild/example/grpcio/imports',
   ],
   source='imports_client.py',

--- a/examples/src/python/example/grpcio/server/BUILD
+++ b/examples/src/python/example/grpcio/server/BUILD
@@ -5,8 +5,7 @@
 python_binary(
   name='server',
   dependencies=[
-    '3rdparty/python:grpcio',
-
+    'examples/3rdparty/python:grpcio',
     'examples/src/protobuf/org/pantsbuild/example/grpcio/service',
     'examples/src/protobuf/org/pantsbuild/example/grpcio/imports',
   ],

--- a/examples/tests/python/example_test/usethriftpy/BUILD
+++ b/examples/tests/python/example_test/usethriftpy/BUILD
@@ -6,6 +6,7 @@
 python_tests(name='usethrift',
   sources=['use_thrift_test.py',],
   dependencies=[
+    'examples/3rdparty/python:thrift',
     'examples/src/thrift/org/pantsbuild/example/distance:distance-python',
     'examples/src/thrift/org/pantsbuild/example/precipitation:precipitation-python',
   ],

--- a/pants.ini
+++ b/pants.ini
@@ -152,7 +152,7 @@ deps: ["3rdparty:thrift"]
 
 
 [gen.thrift-py]
-deps: ["3rdparty/python:thrift"]
+deps: ["examples/3rdparty/python:thrift"]
 
 
 [gen.thrifty]


### PR DESCRIPTION
### Problem

Codegen dependencies are either injected into targets at pants' runtime, or consumed by examples within the repo. In either case, they do not actually need to be baked into pants' binary.

### Solution

Move them to `examples/3rdparty`.

### Result

Fewer deps for core pants, and possibly reduced build/CI time.