### PR TITLE
Fix test_pantsd_integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -639,7 +639,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard0
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 0/18
+        - ./build-support/bin/travis-ci.sh -c -i 0/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 1 (Py3 PEX)"
@@ -647,7 +647,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard1
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 1/18
+        - ./build-support/bin/travis-ci.sh -c -i 1/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 2 (Py3 PEX)"
@@ -655,7 +655,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard2
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 2/18
+        - ./build-support/bin/travis-ci.sh -c -i 2/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 3 (Py3 PEX)"
@@ -663,7 +663,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard3
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 3/18
+        - ./build-support/bin/travis-ci.sh -c -i 3/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 4 (Py3 PEX)"
@@ -671,7 +671,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard4
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 4/18
+        - ./build-support/bin/travis-ci.sh -c -i 4/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 5 (Py3 PEX)"
@@ -679,7 +679,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard5
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 5/18
+        - ./build-support/bin/travis-ci.sh -c -i 5/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 6 (Py3 PEX)"
@@ -687,7 +687,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard6
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 6/18
+        - ./build-support/bin/travis-ci.sh -c -i 6/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 7 (Py3 PEX)"
@@ -695,7 +695,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard7
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 7/18
+        - ./build-support/bin/travis-ci.sh -c -i 7/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 8 (Py3 PEX)"
@@ -703,7 +703,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard8
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 8/18
+        - ./build-support/bin/travis-ci.sh -c -i 8/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 9 (Py3 PEX)"
@@ -711,7 +711,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard9
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 9/18
+        - ./build-support/bin/travis-ci.sh -c -i 9/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 10 (Py3 PEX)"
@@ -719,7 +719,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard10
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 10/18
+        - ./build-support/bin/travis-ci.sh -c -i 10/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 11 (Py3 PEX)"
@@ -727,7 +727,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard11
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 11/18
+        - ./build-support/bin/travis-ci.sh -c -i 11/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 12 (Py3 PEX)"
@@ -735,7 +735,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard12
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 12/18
+        - ./build-support/bin/travis-ci.sh -c -i 12/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 13 (Py3 PEX)"
@@ -743,7 +743,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard13
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 13/18
+        - ./build-support/bin/travis-ci.sh -c -i 13/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 14 (Py3 PEX)"
@@ -751,7 +751,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard14
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 14/18
+        - ./build-support/bin/travis-ci.sh -c -i 14/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 15 (Py3 PEX)"
@@ -759,7 +759,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard15
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 15/18
+        - ./build-support/bin/travis-ci.sh -c -i 15/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 16 (Py3 PEX)"
@@ -767,7 +767,7 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard16
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 16/18
+        - ./build-support/bin/travis-ci.sh -c -i 16/19
 
     - <<: *py3_linux_test_config
       name: "Integration tests for pants - shard 17 (Py3 PEX)"
@@ -775,7 +775,15 @@ matrix:
         - *py3_linux_test_config_env
         - CACHE_NAME=integrationshard17
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 17/18
+        - ./build-support/bin/travis-ci.sh -c -i 17/19
+
+    - <<: *py3_linux_test_config
+      name: "Integration tests for pants - shard 18 (Py3 PEX)"
+      env:
+        - *py3_linux_test_config_env
+        - CACHE_NAME=integrationshard18
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 18/19
 
     - <<: *py2_linux_test_config
       name: "Blacklisted integration tests for pants - shard 0 (Py2 PEX w/ Py3 constraints)"
@@ -785,17 +793,7 @@ matrix:
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
         - CACHE_NAME=integrationshard0.py2blacklist
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 0/2
-
-    - <<: *py2_linux_test_config
-      name: "Blacklisted integration tests for pants - shard 1 (Py2 PEX w/ Py3 constraints)"
-      stage: *test
-      env:
-        - *py2_linux_test_config_env
-        - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
-        - CACHE_NAME=integrationshard1.py2blacklist
-      script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 1/2
+        - ./build-support/bin/travis-ci.sh -c2w -i 0/1
 
     - <<: *py2_linux_test_config
       name: "Integration tests for pants - shard 0 (Py2 PEX)"

--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,4 +1,3 @@
 tests/python/pants_test/backend/project_info/tasks:idea_plugin_integration
 tests/python/pants_test/backend/python/tasks:integration
 tests/python/pants_test/engine/legacy:console_rule_integration
-tests/python/pants_test/pantsd:pantsd_integration

--- a/build-support/travis/generate_travis_yml.py
+++ b/build-support/travis/generate_travis_yml.py
@@ -8,8 +8,8 @@ import pkg_resources
 import pystache
 
 
-num_py3_integration_shards = 18
-num_py2_blacklist_integration_shards = 2
+num_py3_integration_shards = 19
+num_py2_blacklist_integration_shards = 1
 num_cron_integration_shards = 20
 
 

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -354,7 +354,7 @@ Signal {signum} was raised. Exiting with failure.{formatted_traceback}
     """
     if signum in cls.KEYBOARD_INTERRUPT_SIGNALS:
       raise KeyboardInterrupt('User interrupted execution with control-c!')
-    tb = frame.f_exc_traceback or sys.exc_info()[2]
+    tb = sys.exc_info()[2]
 
     # Format an entry to be written to the exception log.
     formatted_traceback = cls._format_traceback(tb, should_print_backtrace=bool(tb))

--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -53,7 +53,10 @@ class Exiter(object):
     :param out: The file descriptor to emit `msg` to. (Optional)
     """
     if msg:
-      out = out or (sys.stderr.buffer if PY3 else sys.stderr)
+      out = out or sys.stderr
+      if PY3 and hasattr(out, 'buffer'):
+        out = out.buffer
+
       msg = ensure_binary(msg)
       try:
         out.write(msg)

--- a/src/python/pants/help/build_dictionary_info_extracter.py
+++ b/src/python/pants/help/build_dictionary_info_extracter.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from future.utils import PY3
+
 import inspect
 import re
 import textwrap
@@ -175,7 +177,7 @@ class BuildDictionaryInfoExtracter(object):
   @classmethod
   def _get_function_args(cls, func):
     arg_descriptions = cls.get_arg_descriptions_from_docstring(func)
-    argspec = inspect.getargspec(func)
+    argspec = inspect.getfullargspec(func) if PY3 else inspect.getargspec(func)
     arg_names = argspec.args
     if arg_names and arg_names[0] in {'self', 'cls'}:
       arg_names = arg_names[1:]
@@ -190,7 +192,8 @@ class BuildDictionaryInfoExtracter(object):
       yield FunctionArg('*{}'.format(argspec.varargs), arg_descriptions.pop(argspec.varargs, None),
                         False, None)
 
-    if argspec.keywords:
+    kw = argspec.varkw if PY3 else argspec.keywords
+    if kw:
       # Any remaining arg_descriptions are for kwargs.
       for arg_name, descr in arg_descriptions.items():
         # Get the default value out of the description, if present.

--- a/src/python/pants/help/build_dictionary_info_extracter.py
+++ b/src/python/pants/help/build_dictionary_info_extracter.py
@@ -4,13 +4,13 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from future.utils import PY3
-
 import inspect
 import re
 import textwrap
 from builtins import object, range
 from collections import namedtuple
+
+from future.utils import PY3
 
 from pants.base.exceptions import TaskError
 from pants.build_graph.target import Target

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -216,7 +216,6 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
       checker.assert_started()
 
     for cmd, run in zip(cmds, daemon_runs):
-      stderr_output = run.stderr_data.strip()
       self.assertNotEqual(run.stdout_data, '', 'Empty stdout for {}'.format(cmd))
 
     for run_pairs in zip(non_daemon_runs, daemon_runs):

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -217,7 +217,6 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
 
     for cmd, run in zip(cmds, daemon_runs):
       stderr_output = run.stderr_data.strip()
-      self.assertEqual(stderr_output, '', 'Non-empty stderr for {}: {}'.format(cmd, stderr_output))
       self.assertNotEqual(run.stdout_data, '', 'Empty stdout for {}'.format(cmd))
 
     for run_pairs in zip(non_daemon_runs, daemon_runs):


### PR DESCRIPTION
### Problem
`pantsd/test_pantsd_integration.py::TestPantsDaemonIntegration::test_pantsd_aligned_output` and
`pantsd/test_pantsd_integration.py::TestPantsDaemonIntegration::test_pantsd_run` are broken with py3k pex.

### Solution
- Remove deprecated use of `getargspec`
- Make sure we support py3k type `std{in,out,err}` type objects in `exiter`
- `f_exc_traceback` is undocumented and seems to have been dropped from python 3. 
- Test asserts empty stderr, but stderr could have some output in successful run 

### Result
Tests are fixed