### PR TITLE
Work around multi-python pex issues for checker.

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/checker/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/BUILD
@@ -10,7 +10,6 @@ python_library(
     }
   ),
   dependencies=[
-    '3rdparty/python:future',
     '3rdparty/python:pycodestyle',
     '3rdparty/python:pyflakes',
     '3rdparty/python:six',

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/common.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/common.py
@@ -5,13 +5,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import ast
+import io
 import itertools
 import os
 import re
 import textwrap
 import tokenize
-from builtins import object, open
-from io import StringIO
 
 import six
 
@@ -139,7 +138,7 @@ class PythonFile(object):
     else:
       full_filename = filename
 
-    with open(full_filename, 'rb') as fp:
+    with io.open(full_filename, 'rb') as fp:
       blob = fp.read()
 
     tree = cls._parse(blob, filename)
@@ -165,7 +164,7 @@ class PythonFile(object):
     :param blob: Input string with python file contents
     :return: token iterator
     """
-    readline_func = StringIO(blob.decode('utf-8')).readline
+    readline_func = io.StringIO(blob.decode('utf-8')).readline
     return tokenize.generate_tokens(readline_func)
 
   @property

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/except_statements.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/except_statements.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import ast
 
-from future.utils import PY3
+from six import PY3
 
 from pants.contrib.python.checks.checker.common import CheckstylePlugin
 

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/file_excluder.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/file_excluder.py
@@ -4,9 +4,9 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import io
 import os
 import re
-from builtins import object, open
 
 
 class FileExcluder(object):
@@ -15,7 +15,7 @@ class FileExcluder(object):
     if excludes_path:
       if not os.path.exists(excludes_path):
         raise ValueError('Excludes file does not exist: {0}'.format(excludes_path))
-      with open(excludes_path, 'r') as fh:
+      with io.open(excludes_path, 'r') as fh:
         for line in fh.readlines():
           if line and not line.startswith('#') and '::' in line:
             pattern, plugins = line.strip().split('::', 2)

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/import_order.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/import_order.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import ast
 import os
-from builtins import object
 from distutils import sysconfig
 
 from pants.contrib.python.checks.checker.common import CheckstylePlugin

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/missing_contextmanager.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/missing_contextmanager.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import ast
 
-from future.utils import PY3
+from six import PY3
 
 from pants.contrib.python.checks.checker.common import CheckstylePlugin
 

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/print_statements.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/print_statements.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import ast
 import re
 
-from future.utils import PY3
+from six import PY3
 
 from pants.contrib.python.checks.checker.common import CheckstylePlugin
 

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/trailing_whitespace.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/trailing_whitespace.py
@@ -6,8 +6,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 import tokenize
-from builtins import range
 from collections import defaultdict
+
+from six.moves import range
 
 from pants.contrib.python.checks.checker.common import CheckstylePlugin
 


### PR DESCRIPTION
PEX does not support multi-python pexes in-general and in-particular it
cannot properly build a pex for a py2/3 compatible sdist today. Work
around this limitation by removing future (which is distributed as an
sdist) from the checker deps.

Hack to workaround #7158 