### PR TITLE
Add setup workunit to critical_path_timings for all main workunits

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -23,7 +23,7 @@ from pants.auth.cookies import Cookies
 from pants.base.build_environment import get_pants_cachedir
 from pants.base.run_info import RunInfo
 from pants.base.worker_pool import SubprocPool, WorkerPool
-from pants.base.workunit import WorkUnit
+from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.goal.aggregated_timings import AggregatedTimings
 from pants.goal.artifact_cache_stats import ArtifactCacheStats
 from pants.goal.pantsd_stats import PantsDaemonStats
@@ -32,6 +32,7 @@ from pants.reporting.report import Report
 from pants.stats.statsdb import StatsDBFactory
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import relative_symlink, safe_file_dump
+
 
 
 class RunTracker(Subsystem):
@@ -491,25 +492,39 @@ class RunTracker(Subsystem):
     """
     Get the cumulative timings of each goal and all of the goals it (transitively) depended on.
     """
+    setup_workunit = WorkUnitLabel.SETUP.lower()
     transitive_dependencies = dict()
     for goal_info in self._sorted_goal_infos:
       deps = transitive_dependencies.setdefault(goal_info.goal.name, set())
       for dep in goal_info.goal_dependencies:
         deps.add(dep.name)
         deps.update(transitive_dependencies.get(dep.name))
-
+      # Add setup workunit as a dep manually, as its unaccounted for, otherwise.
+      deps.add(setup_workunit)
     raw_timings = dict()
     for entry in self.cumulative_timings.get_all():
       raw_timings[entry["label"]] = entry["timing"]
 
-    timings = AggregatedTimings()
+    critical_path_timings = AggregatedTimings()
+
+    def add_to_timings(goal, dep):
+      tracking_label = get_label(goal)
+      timing_label = get_label(dep)
+      critical_path_timings.add_timing(tracking_label, raw_timings.get(timing_label, 0.0))
+
+    def get_label(dep):
+      return "{}:{}".format(RunTracker.DEFAULT_ROOT_NAME, dep)
+
+    # Add setup workunit to critical_path_timings manually, as its unaccounted for, otherwise.
+    add_to_timings(setup_workunit, setup_workunit)
+
     for goal, deps in transitive_dependencies.items():
-      label = "{}:{}".format(RunTracker.DEFAULT_ROOT_NAME, goal)
-      timings.add_timing(label, raw_timings.get(label, 0.0))
+      add_to_timings(goal, goal)
       for dep in deps:
-        dep_label = "{}:{}".format(RunTracker.DEFAULT_ROOT_NAME, dep)
-        timings.add_timing(label, raw_timings.get(dep_label, 0.0))
-    return timings
+        add_to_timings(goal, dep)
+
+    return critical_path_timings
+
 
   def get_background_root_workunit(self):
     if self._background_root_workunit is None:


### PR DESCRIPTION
### Problem

`[setup]` time is not included in the timings for goals for `critical_path_timings` tracking

### Solution

Add `[main:setup]` as one of entries in `Critical Path Timings` and add its timing towards other goals like `compile` and `test`
### Result
Compare `compile` timings and addition of `main:setup`
Before:
```"critical_path_timings": [
        {
            "is_tool": false,
            "label": "main:test",
            "timing": 2.12162184715271
        },
        {
            "is_tool": false,
            **"label": "main:compile",
            "timing": 1.8445978164672852**
        },
        {
            "is_tool": false,
            "label": "main:resources",
            "timing": 1.4501447677612305
        },
        {
            "is_tool": false,
            "label": "main:resolve",
            "timing": 1.4405217170715332
        },
        {
            "is_tool": false,
            "label": "main:pyprep",
            "timing": 1.269568681716919
        },
        {
            "is_tool": false,
            "label": "main:link",
            "timing": 1.0777568817138672
        },
        {
            "is_tool": false,
            "label": "main:native-compile",
            "timing": 0.9784009456634521
        },
        {
            "is_tool": false,
            "label": "main:gen",
            "timing": 0.17583870887756348
        },
        {
            "is_tool": false,
            "label": "main:deferred-sources",
            "timing": 0.11075377464294434
        },
        {
            "is_tool": false,
            "label": "main:unpack-jars",
            "timing": 0.10501575469970703
        },
        {
            "is_tool": false,
            "label": "main:imports",
            "timing": 0.07145094871520996
        },
        {
            "is_tool": false,
            "label": "main:bootstrap",
            "timing": 0.0667879581451416
        },
        {
            "is_tool": false,
            "label": "main:jvm-platform-validate",
            "timing": 0.037153005599975586
        }
    ],```

After:
``` "critical_path_timings": [
        {
            "is_tool": false,
            "label": "main:test",
            "timing": 2.794638156890869
        },
        {
            "is_tool": false,
            **"label": "main:compile",
            "timing": 2.454322338104248**
        },
        {
            "is_tool": false,
            "label": "main:resources",
            "timing": 2.01420521736145
        },
        {
            "is_tool": false,
            "label": "main:resolve",
            "timing": 2.0027732849121094
        },
        {
            "is_tool": false,
            "label": "main:pyprep",
            "timing": 1.6531901359558105
        },
        {
            "is_tool": false,
            "label": "main:link",
            "timing": 1.4219202995300293
        },
        {
            "is_tool": false,
            "label": "main:native-compile",
            "timing": 1.2992281913757324
        },
        {
            "is_tool": false,
            "label": "main:gen",
            "timing": 0.6150481700897217
        },
        {
            "is_tool": false,
            "label": "main:deferred-sources",
            "timing": 0.5316061973571777
        },
        {
            "is_tool": false,
            "label": "main:unpack-jars",
            "timing": 0.5286293029785156
        },
        {
            "is_tool": false,
            "label": "main:imports",
            "timing": 0.4866981506347656
        },
        {
            "is_tool": false,
            "label": "main:bootstrap",
            "timing": 0.48249101638793945
        },
        {
            "is_tool": false,
            "label": "main:jvm-platform-validate",
            "timing": 0.45739316940307617
        },
        {
            "is_tool": false,
            **"label": "main:setup",**
            "timing": 0.4088921546936035
        }
    ],
```