### PR TITLE
Add ability to specify Python minor version when running `./pants`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,9 @@ native_engine_cache_config: &native_engine_cache_config
     timeout: 500
     directories:
       - ${HOME}/.cache/pants/rust/cargo
-      - build-support/pants_dev_deps.py2.venv
-      - build-support/pants_dev_deps.py3.venv
+      - build-support/pants_dev_deps.py27.venv
+      - build-support/pants_dev_deps.py36.venv
+      - build-support/pants_dev_deps.py37.venv
       - src/rust/engine/target
 
 # Travis cache config for jobs that run a bootstrapped pants.pex.

--- a/.travis.yml
+++ b/.travis.yml
@@ -455,7 +455,10 @@ osx_rust_tests: &osx_rust_tests
       casks:
       - osxfuse
   script:
-    - ./build-support/bin/travis-ci.sh -e
+  # N.B. We run this with Python 2 because this osx_image does not have
+  # Python 3.6 in its environment. We do not care which Python version
+  # we use and do not want to incur the cost of using pyenv to get 3.6.
+    - ./build-support/bin/travis-ci.sh -e2
 
 # -------------------------------------------------------------------------
 # OSX sanity checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,11 +116,11 @@ base_linux_config: &base_linux_config
   after_failure:
     - ./build-support/bin/ci-failure.sh
 
-py2_linux_config: &py2_linux_config
+py27_linux_config: &py27_linux_config
   <<: *base_linux_config
   python: &python2_version "2.7"
 
-py3_linux_config: &py3_linux_config
+py36_linux_config: &py36_linux_config
   <<: *base_linux_config
   python: &python3_version "3.6"
 
@@ -137,19 +137,19 @@ base_linux_test_config: &base_linux_test_config
   before_script:
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
 
-py2_linux_test_config: &py2_linux_test_config
-  <<: *py2_linux_config
+py27_linux_test_config: &py27_linux_test_config
+  <<: *py27_linux_config
   <<: *base_linux_test_config
   stage: *cron
   env:
-    - &py2_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py2.linux
+    - &py27_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.linux
 
-py3_linux_test_config: &py3_linux_test_config
-  <<: *py3_linux_config
+py36_linux_test_config: &py36_linux_test_config
+  <<: *py36_linux_config
   <<: *base_linux_test_config
   stage: *test
   env:
-    - &py3_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py3.linux
+    - &py36_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
 
 base_osx_config: &base_osx_config
   os: osx
@@ -159,18 +159,18 @@ base_osx_config: &base_osx_config
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
 
-py2_osx_config: &py2_osx_config
+py27_osx_config: &py27_osx_config
   <<: *base_osx_config
 
-py3_osx_config: &py3_osx_config
+py36_osx_config: &py36_osx_config
   <<: *base_osx_config
   addons:
     brew:
-      packages: &py3_osx_config_brew_packages
+      packages: &py36_osx_config_brew_packages
       - openssl
   env:
     # Fix Python 3 issue linking to OpenSSL
-    - &py3_osx_config_env >
+    - &py36_osx_config_env >
       PATH="/usr/local/opt/openssl/bin:$PATH"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
@@ -193,26 +193,26 @@ base_osx_test_config: &base_osx_test_config
     - ulimit -n 8192
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
 
-py2_osx_test_config: &py2_osx_test_config
-  <<: *py2_osx_config
+py27_osx_test_config: &py27_osx_test_config
+  <<: *py27_osx_config
   <<: *base_osx_test_config
   stage: *cron
   env:
-    - &py2_osx_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py2.osx
+    - &py27_osx_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
 
-py3_osx_test_config: &py3_osx_test_config
-  <<: *py3_osx_config
+py36_osx_test_config: &py36_osx_test_config
+  <<: *py36_osx_config
   <<: *base_osx_test_config
   stage: *test
   env:
-    # Must duplicate py3_osx_config's env because it cannot be merged into a new anchor
-    - &py3_osx_test_config_env >
+    # Must duplicate py36_osx_config's env because it cannot be merged into a new anchor
+    - &py36_osx_test_config_env >
       PATH="/usr/local/opt/openssl/bin:$PATH"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
       PYENV_ROOT="${HOME}/.pyenv"
       PATH="${PYENV_ROOT}/shims:${PATH}"
-      BOOTSTRAPPED_PEX_KEY_SUFFIX=py3.osx
+      BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
 
 linux_with_fuse: &linux_with_fuse
   before_install:
@@ -262,25 +262,25 @@ base_linux_build_engine: &base_linux_build_engine
       sh -c "./build-support/bin/ci.sh ${BOOTSTRAP_ARGS} && ./build-support/bin/release.sh -f"
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
 
-py2_linux_build_engine: &py2_linux_build_engine
-  <<: *py2_linux_config
+py27_linux_build_engine: &py27_linux_build_engine
+  <<: *py27_linux_config
   <<: *base_linux_build_engine
-  name: "Build Linux native engine and pants.pex (Py2 PEX)"
+  name: "Build Linux native engine and pants.pex (Py2.7 PEX)"
   env:
-    # NB: Only the Py2 shard sets PREPARE_DEPLOY to cause the fs_util binary to be uploaded to S3:
+    # NB: Only the Py2.7 shard sets PREPARE_DEPLOY to cause the fs_util binary to be uploaded to S3:
     # either linux shard could upload this binary, since it does not depend on python at all.
     - PREPARE_DEPLOY=1
-    - CACHE_NAME=linuxpexbuild.py2
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py2.linux
+    - CACHE_NAME=linuxpexbuild.py27
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.linux
     - BOOTSTRAP_ARGS='-2b'
 
-py3_linux_build_engine: &py3_linux_build_engine
-  <<: *py3_linux_config
+py36_linux_build_engine: &py36_linux_build_engine
+  <<: *py36_linux_config
   <<: *base_linux_build_engine
-  name: "Build Linux native engine and pants.pex (Py3 PEX)"
+  name: "Build Linux native engine and pants.pex (Py3.6 PEX)"
   env:
-    - CACHE_NAME=linuxpexbuild.py3
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py3.linux
+    - CACHE_NAME=linuxpexbuild.py36
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - BOOTSTRAP_ARGS='-b'
 
 base_osx_build_engine: &base_osx_build_engine
@@ -299,46 +299,46 @@ base_osx_build_engine: &base_osx_build_engine
   after_failure:
     - ./build-support/bin/ci-failure.sh
 
-py2_osx_build_engine: &py2_osx_build_engine
-  <<: *py2_osx_config
+py27_osx_build_engine: &py27_osx_build_engine
+  <<: *py27_osx_config
   <<: *base_osx_build_engine
-  name: "Build OSX native engine and pants.pex (Py2 PEX)"
+  name: "Build OSX native engine and pants.pex (Py2.7 PEX)"
   env:
     - *base_osx_build_engine_env
-    - CACHE_NAME=osxpexbuild.py2
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py2.osx
+    - CACHE_NAME=osxpexbuild.py27
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
     - BOOTSTRAP_ARGS='-2b'
 
-py3_osx_build_engine: &py3_osx_build_engine
-  <<: *py3_osx_config
+py36_osx_build_engine: &py36_osx_build_engine
+  <<: *py36_osx_config
   <<: *base_osx_build_engine
-  name: "Build OSX native engine and pants.pex (Py3 PEX)"
+  name: "Build OSX native engine and pants.pex (Py3.6 PEX)"
   env:
     - *base_osx_build_engine_env
-    - *py3_osx_config_env
-    - CACHE_NAME=osxpexbuild.py3
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py3.osx
+    - *py36_osx_config_env
+    - CACHE_NAME=osxpexbuild.py36
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
     - BOOTSTRAP_ARGS='-b'
 
 # -------------------------------------------------------------------------
 # Lint
 # -------------------------------------------------------------------------
 
-py2_lint: &py2_lint
-  <<: *py2_linux_test_config
-  name: "Self-checks and lint (Py2 PEX)"
+py27_lint: &py27_lint
+  <<: *py27_linux_test_config
+  name: "Self-checks and lint (Py2.7 PEX)"
   env:
-    - *py2_linux_test_config_env
-    - CACHE_NAME=linuxselfchecks.py2
+    - *py27_linux_test_config_env
+    - CACHE_NAME=linuxselfchecks.py27
   script:
     - ./build-support/bin/travis-ci.sh -fmrt2
 
-py3_lint: &py3_lint
-  <<: *py3_linux_test_config
-  name: "Self-checks and lint (Py3 PEX)"
+py36_lint: &py36_lint
+  <<: *py36_linux_test_config
+  name: "Self-checks and lint (Py3.6 PEX)"
   env:
-    - *py3_linux_test_config_env
-    - CACHE_NAME=linuxselfchecks.py3
+    - *py36_linux_test_config_env
+    - CACHE_NAME=linuxselfchecks.py36
   script:
     - ./build-support/bin/travis-ci.sh -fmrt
 
@@ -387,13 +387,13 @@ base_build_wheels: &base_build_wheels
 
 linux_build_wheels: &linux_build_wheels
   # Similar to the bootstrap shard, we build Linux wheels in a docker image to maximize
-  # compatibility. This is a Py2 shard, so it is not subject to #6985.
+  # compatibility. This is a Py2.7 shard, so it is not subject to #6985.
   <<: *travis_docker_image
-  <<: *py2_linux_test_config
+  <<: *py27_linux_test_config
   <<: *base_build_wheels
   name: "Build Linux wheels (No PEX)"
   env:
-    - *py2_linux_test_config_env
+    - *py27_linux_test_config_env
     - *base_build_wheels_env
     - CACHE_NAME=linuxwheelsbuild
   script:
@@ -405,12 +405,12 @@ linux_build_wheels: &linux_build_wheels
       sh -c "RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
 
 osx_build_wheels: &osx_build_wheels
-  <<: *py2_osx_test_config
+  <<: *py27_osx_test_config
   <<: *base_build_wheels
   name: "Build OSX wheels (No PEX)"
   osx_image: xcode8
   env:
-    - *py2_osx_test_config_env
+    - *py27_osx_test_config_env
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild
   script:
@@ -469,61 +469,61 @@ base_osx_10_12_sanity_check: &base_osx_10_12_sanity_check
   <<: *base_osx_sanity_check
   osx_image: xcode9.2
 
-py2_osx_10_12_sanity_check: &py2_osx_10_12_sanity_check
-  <<: *py2_osx_test_config
+py27_osx_10_12_sanity_check: &py27_osx_10_12_sanity_check
+  <<: *py27_osx_test_config
   <<: *base_osx_10_12_sanity_check
-  name: "OSX 10.12 sanity check (Py2 PEX)"
+  name: "OSX 10.12 sanity check (Py2.7 PEX)"
   env:
-    - *py2_osx_test_config_env
-    - CACHE_NAME=macos10.12sanity.py2
+    - *py27_osx_test_config_env
+    - CACHE_NAME=macos10.12sanity.py27
 
-py3_osx_10_12_sanity_check: &py3_osx_10_12_sanity_check
-  <<: *py3_osx_test_config
+py36_osx_10_12_sanity_check: &py36_osx_10_12_sanity_check
+  <<: *py36_osx_test_config
   <<: *base_osx_10_12_sanity_check
-  name: "OSX 10.12 sanity check (Py3 PEX)"
+  name: "OSX 10.12 sanity check (Py3.6 PEX)"
   env:
-    - *py3_osx_test_config_env
-    - CACHE_NAME=macos10.12sanity.py3
+    - *py36_osx_test_config_env
+    - CACHE_NAME=macos10.12sanity.py36
 
 base_osx_10_13_sanity_check: &base_osx_10_13_sanity_check
   <<: *base_osx_sanity_check
   osx_image: xcode10.1
 
-py2_osx_10_13_sanity_check: &py2_osx_10_13_sanity_check
-  <<: *py2_osx_test_config
+py27_osx_10_13_sanity_check: &py27_osx_10_13_sanity_check
+  <<: *py27_osx_test_config
   <<: *base_osx_10_13_sanity_check
-  name: "OSX 10.13 sanity check (Py2 PEX)"
+  name: "OSX 10.13 sanity check (Py2.7 PEX)"
   env:
-    - *py2_osx_test_config_env
-    - CACHE_NAME=macos10.13sanity.py2
+    - *py27_osx_test_config_env
+    - CACHE_NAME=macos10.13sanity.py27
 
-py3_osx_10_13_sanity_check: &py3_osx_10_13_sanity_check
-  <<: *py3_osx_test_config
+py36_osx_10_13_sanity_check: &py36_osx_10_13_sanity_check
+  <<: *py36_osx_test_config
   <<: *base_osx_10_13_sanity_check
-  name: "OSX 10.13 sanity check (Py3 PEX)"
+  name: "OSX 10.13 sanity check (Py3.6 PEX)"
   env:
-    - *py3_osx_test_config_env
-    - CACHE_NAME=macos10.13sanity.py3
+    - *py36_osx_test_config_env
+    - CACHE_NAME=macos10.13sanity.py36
 
 # -------------------------------------------------------------------------
 # Platform specific tests
 # -------------------------------------------------------------------------
 
-py2_osx_platform_tests: &py2_osx_platform_tests
-  <<: *py2_osx_test_config
-  name: "OSX platform-specific tests (Py2 PEX)"
+py27_osx_platform_tests: &py27_osx_platform_tests
+  <<: *py27_osx_test_config
+  name: "OSX platform-specific tests (Py2.7 PEX)"
   env:
-    - *py2_osx_test_config_env
-    - CACHE_NAME=macosplatformtests.py2
+    - *py27_osx_test_config_env
+    - CACHE_NAME=macosplatformtests.py27
   script:
     - ./build-support/bin/travis-ci.sh -z2
 
-py3_osx_platform_tests: &py3_osx_platform_tests
-  <<: *py3_osx_test_config
-  name: "OSX platform-specific tests (Py3 PEX)"
+py36_osx_platform_tests: &py36_osx_platform_tests
+  <<: *py36_osx_test_config
+  name: "OSX platform-specific tests (Py3.6 PEX)"
   env:
-    - *py3_osx_test_config_env
-    - CACHE_NAME=macosplatformtests.py3
+    - *py36_osx_test_config_env
+    - CACHE_NAME=macosplatformtests.py36
   script:
     - ./build-support/bin/travis-ci.sh -z
 
@@ -534,23 +534,23 @@ py3_osx_platform_tests: &py3_osx_platform_tests
 base_jvm_tests: &base_jvm_tests
   <<: *linux_with_fuse
 
-py2_jvm_tests: &py2_jvm_tests
-  <<: *py2_linux_test_config
+py27_jvm_tests: &py27_jvm_tests
+  <<: *py27_linux_test_config
   <<: *base_jvm_tests
-  name: "JVM tests (Py2 PEX)"
+  name: "JVM tests (Py2.7 PEX)"
   env:
-    - *py2_linux_test_config_env
-    - CACHE_NAME=linuxjvmtests.py2
+    - *py27_linux_test_config_env
+    - CACHE_NAME=linuxjvmtests.py27
   script:
     - ./build-support/bin/travis-ci.sh -j2
 
-py3_jvm_tests: &py3_jvm_tests
-  <<: *py3_linux_test_config
+py36_jvm_tests: &py36_jvm_tests
+  <<: *py36_linux_test_config
   <<: *base_jvm_tests
-  name: "JVM tests (Py3 PEX)"
+  name: "JVM tests (Py3.6 PEX)"
   env:
-    - *py3_linux_test_config_env
-    - CACHE_NAME=linuxjvmtests.py3
+    - *py36_linux_test_config_env
+    - CACHE_NAME=linuxjvmtests.py36
   script:
     - ./build-support/bin/travis-ci.sh -j
 
@@ -601,14 +601,14 @@ deploy_unstable_multiplatform_pex: &deploy_unstable_multiplatform_pex
 
 matrix:
   include:
-    - <<: *py2_linux_build_engine
-    - <<: *py3_linux_build_engine
+    - <<: *py27_linux_build_engine
+    - <<: *py36_linux_build_engine
 
-    - <<: *py2_osx_build_engine
-    - <<: *py3_osx_build_engine
+    - <<: *py27_osx_build_engine
+    - <<: *py36_osx_build_engine
 
-    - <<: *py2_lint
-    - <<: *py3_lint
+    - <<: *py27_lint
+    - <<: *py36_lint
 
     - <<: *linux_rust_clippy
     - <<: *cargo_audit
@@ -616,343 +616,343 @@ matrix:
     - <<: *linux_build_wheels
     - <<: *osx_build_wheels
 
-    - <<: *py2_linux_test_config
-      name: "Unit tests for pants and pants-plugins (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Unit tests for pants and pants-plugins (Py2.7 PEX)"
       stage: *test
       env:
-        - *py2_linux_test_config_env
-        - CACHE_NAME=linuxunittests.py2
+        - *py27_linux_test_config_env
+        - CACHE_NAME=linuxunittests.py27
       script:
         - ./build-support/bin/travis-ci.sh -2lp
 
-    - <<: *py3_linux_test_config
-      name: "Unit tests for pants and pants-plugins (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Unit tests for pants and pants-plugins (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
-        - CACHE_NAME=linuxunittests.py3
+        - *py36_linux_test_config_env
+        - CACHE_NAME=linuxunittests.py36
       script:
         - ./build-support/bin/travis-ci.sh -lp
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 0 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 0 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard0
       script:
         - ./build-support/bin/travis-ci.sh -c -i 0/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 1 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 1 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard1
       script:
         - ./build-support/bin/travis-ci.sh -c -i 1/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 2 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 2 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard2
       script:
         - ./build-support/bin/travis-ci.sh -c -i 2/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 3 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 3 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard3
       script:
         - ./build-support/bin/travis-ci.sh -c -i 3/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 4 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 4 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard4
       script:
         - ./build-support/bin/travis-ci.sh -c -i 4/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 5 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 5 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard5
       script:
         - ./build-support/bin/travis-ci.sh -c -i 5/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 6 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 6 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard6
       script:
         - ./build-support/bin/travis-ci.sh -c -i 6/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 7 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 7 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard7
       script:
         - ./build-support/bin/travis-ci.sh -c -i 7/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 8 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 8 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard8
       script:
         - ./build-support/bin/travis-ci.sh -c -i 8/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 9 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 9 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard9
       script:
         - ./build-support/bin/travis-ci.sh -c -i 9/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 10 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 10 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard10
       script:
         - ./build-support/bin/travis-ci.sh -c -i 10/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 11 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 11 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard11
       script:
         - ./build-support/bin/travis-ci.sh -c -i 11/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 12 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 12 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard12
       script:
         - ./build-support/bin/travis-ci.sh -c -i 12/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 13 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 13 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard13
       script:
         - ./build-support/bin/travis-ci.sh -c -i 13/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 14 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 14 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard14
       script:
         - ./build-support/bin/travis-ci.sh -c -i 14/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 15 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 15 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard15
       script:
         - ./build-support/bin/travis-ci.sh -c -i 15/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 16 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 16 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard16
       script:
         - ./build-support/bin/travis-ci.sh -c -i 16/18
 
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard 17 (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard 17 (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard17
       script:
         - ./build-support/bin/travis-ci.sh -c -i 17/18
 
-    - <<: *py2_linux_test_config
-      name: "Blacklisted integration tests for pants - shard 0 (Py2 PEX w/ Py3 constraints)"
+    - <<: *py27_linux_test_config
+      name: "Blacklisted integration tests for pants - shard 0 (Py2.7 PEX w/ Py3.6 constraints)"
       stage: *test
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
-        - CACHE_NAME=integrationshard0.py2blacklist
+        - CACHE_NAME=integrationshard0.py27blacklist
       script:
         - ./build-support/bin/travis-ci.sh -c2w -i 0/2
 
-    - <<: *py2_linux_test_config
-      name: "Blacklisted integration tests for pants - shard 1 (Py2 PEX w/ Py3 constraints)"
+    - <<: *py27_linux_test_config
+      name: "Blacklisted integration tests for pants - shard 1 (Py2.7 PEX w/ Py3.6 constraints)"
       stage: *test
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
-        - CACHE_NAME=integrationshard1.py2blacklist
+        - CACHE_NAME=integrationshard1.py27blacklist
       script:
         - ./build-support/bin/travis-ci.sh -c2w -i 1/2
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 0 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 0 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard0
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 0/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 1 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 1 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard1
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 1/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 2 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 2 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard2
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 2/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 3 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 3 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard3
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 3/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 4 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 4 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard4
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 4/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 5 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 5 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard5
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 5/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 6 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 6 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard6
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 6/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 7 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 7 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard7
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 7/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 8 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 8 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard8
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 8/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 9 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 9 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard9
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 9/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 10 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 10 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard10
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 10/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 11 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 11 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard11
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 11/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 12 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 12 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard12
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 12/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 13 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 13 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard13
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 13/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 14 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 14 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard14
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 14/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 15 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 15 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard15
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 15/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 16 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 16 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard16
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 16/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 17 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 17 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard17
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 17/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 18 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 18 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard18
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 18/20
 
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard 19 (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard 19 (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard19
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 19/20
@@ -961,34 +961,34 @@ matrix:
     - <<: *linux_rust_tests
     - <<: *osx_rust_tests
 
-    - <<: *py2_linux_test_config
-      name: "Python contrib tests (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Python contrib tests (Py2.7 PEX)"
       stage: *test
       env:
-        - *py2_linux_test_config_env
-        - CACHE_NAME=linuxcontribtests.py2
+        - *py27_linux_test_config_env
+        - CACHE_NAME=linuxcontribtests.py27
       script:
         - ./build-support/bin/travis-ci.sh -2n
 
-    - <<: *py3_linux_test_config
-      name: "Python contrib tests (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Python contrib tests (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
-        - CACHE_NAME=linuxcontribtests.py3
+        - *py36_linux_test_config_env
+        - CACHE_NAME=linuxcontribtests.py36
       script:
         - ./build-support/bin/travis-ci.sh -n
 
-    - <<: *py2_osx_10_12_sanity_check
-    - <<: *py3_osx_10_12_sanity_check
+    - <<: *py27_osx_10_12_sanity_check
+    - <<: *py36_osx_10_12_sanity_check
 
-    - <<: *py2_osx_10_13_sanity_check
-    - <<: *py3_osx_10_13_sanity_check
+    - <<: *py27_osx_10_13_sanity_check
+    - <<: *py36_osx_10_13_sanity_check
 
-    - <<: *py2_osx_platform_tests
-    - <<: *py3_osx_platform_tests
+    - <<: *py27_osx_platform_tests
+    - <<: *py36_osx_platform_tests
 
-    - <<: *py2_jvm_tests
-    - <<: *py3_jvm_tests
+    - <<: *py27_jvm_tests
+    - <<: *py36_jvm_tests
 
     - <<: *deploy_stable_multiplatform_pex
     - <<: *deploy_unstable_multiplatform_pex

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -111,7 +111,7 @@ export PANTS_DEV=1
 if [[ "${python_two:-false}" == "false" ]]; then
   py_version_number="3.6"
   bootstrap_pants_script="./pants3"
-  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${py_version_number}.*]'"
+  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${py_version_number}.*']"
 else
   py_version_number="2.7"
   bootstrap_pants_script="./pants"

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -111,13 +111,12 @@ export PANTS_DEV=1
 if [[ "${python_two:-false}" == "false" ]]; then
   py_version_number="3.6"
   bootstrap_pants_script="./pants3"
-  export PY="python3.6"
-  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS='["CPython==3.6.*"]'
+  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${py_version_number}.*]'"
 else
   py_version_number="2.7"
   bootstrap_pants_script="./pants"
-  export PY="python2.7"
 fi
+export PY="python${py_version_number}"
 banner "Using Python ${py_version_number} to execute spawned subprocesses (e.g. tests)"
 
 if [[ "${run_bootstrap:-false}" == "true" ]]; then

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -13,10 +13,9 @@ function usage() {
   cat <<EOF
 Runs commons tests for local or hosted CI.
 
-Usage: $0 (-h|-27fxbkmrjlpuneycitzsw)
+Usage: $0 (-h|-2fxbkmrjlpuneycitzsw)
  -h           print out this help message
  -2           Run using Python 2.7 (defaults to using Python 3.6).
- -7           Run using Python 3.7 (defaults to using Python 3.6).
  -f           run python code formatting checks
  -x           run bootstrap clean-all (assume bootstrapping from a
               fresh clone)
@@ -60,11 +59,10 @@ python_unit_shard="0/1"
 python_contrib_shard="0/1"
 python_intg_shard="0/1"
 
-while getopts "h27fxbmrjlpeasu:ny:ci:tzw" opt; do
+while getopts "h2fxbmrjlpeasu:ny:ci:tzw" opt; do
   case ${opt} in
     h) usage ;;
     2) python_two="true" ;;
-    7) python_three_seven="true" ;;
     f) run_pre_commit_checks="true" ;;
     x) run_bootstrap_clean="true" ;;
     b) run_bootstrap="true" ;;
@@ -110,13 +108,9 @@ export PANTS_DEV=1
 # Order matters here. We must constrain subprocesses before running the bootstrap stage,
 # or we will encounter the _Py_Dealloc error when bootstrapping a Python 3 PEX (#6985).
 if [[ "${python_two:-false}" == "false" ]]; then
-  # default to Python 3.6
-  py_version_number="3.6"
-  if [[ "${python_three_seven:-true}" == "false" ]]; then
-    py_version_number="3.7"
-  fi
+  py_version_number="3.7"
   bootstrap_pants_script="./pants3"
-  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=${py_version_number},<4']"
+  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS='["CPython>=3.6,<4"]'
 else
   py_version_number="2.7"
   bootstrap_pants_script="./pants"

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -109,7 +109,8 @@ export PANTS_DEV=1
 # or we will encounter the _Py_Dealloc error when bootstrapping a Python 3 PEX (#6985).
 if [[ "${python_two:-false}" == "false" ]]; then
   py_version_number="3.6"
-  bootstrap_pants_script="PY=python3.6 ./pants3"
+  bootstrap_pants_script="./pants3"
+  export PY="python3.6"
   export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS='["CPython==3.6.*"]'
 else
   py_version_number="2.7"

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -108,7 +108,7 @@ export PANTS_DEV=1
 # Order matters here. We must constrain subprocesses before running the bootstrap stage,
 # or we will encounter the _Py_Dealloc error when bootstrapping a Python 3 PEX (#6985).
 if [[ "${python_two:-false}" == "false" ]]; then
-  py_version_number="3.7"
+  py_version_number="3.6"
   bootstrap_pants_script="./pants3"
   export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS='["CPython>=3.6,<4"]'
 else

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -104,10 +104,13 @@ esac
 # We're running against a Pants clone.
 export PANTS_DEV=1
 
-# Note that we still must set PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS for Python 3, even though
-# ./pants3 does this already, because the constraints are only set when first bootstrapping the shard,
-# and will not apply for new shards. Without setting PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS, we
-# would be using a Python 3 PEX with Python 2 subprocesses, which results in the _Py_Dealloc error (#6985).
+# Note that we set PY, and when running with Python 3, also set PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS.
+# This would usually not be necessary when developing locally, because the `./pants` and `./pants3`
+# scripts set these constraints for us already. However, we must set the values here because in non-bootstrap shards
+# we run CI using `./pants.pex` instead of the scripts `./pants` and `./pants3`, so those scripts cannot set
+# the relevant environment variables. Without setting these environment variables, the Python 3 shards will try to
+# execute subprocesses using Python 2, which results in the _Py_Dealloc error (#6985), and shards that do not
+# pull down `./pants.pex` but still use a virtualenv (such as Rust Tests) will fail to execute.
 if [[ "${python_two:-false}" == "false" ]]; then
   py_version_number="3.6"
   bootstrap_pants_script="./pants3"

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -116,6 +116,7 @@ if [[ "${python_two:-false}" == "false" ]]; then
 else
   py_version_number="2.7"
   bootstrap_pants_script="./pants"
+  export PY="python2.7"
 fi
 banner "Using Python ${py_version_number} to execute spawned subprocesses (e.g. tests)"
 

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -109,8 +109,8 @@ export PANTS_DEV=1
 # or we will encounter the _Py_Dealloc error when bootstrapping a Python 3 PEX (#6985).
 if [[ "${python_two:-false}" == "false" ]]; then
   py_version_number="3.6"
-  bootstrap_pants_script="./pants3"
-  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS='["CPython>=3.6,<4"]'
+  bootstrap_pants_script="PY=python3.6 ./pants3"
+  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS='["CPython==3.6.*"]'
 else
   py_version_number="2.7"
   bootstrap_pants_script="./pants"

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -104,9 +104,10 @@ esac
 # We're running against a Pants clone.
 export PANTS_DEV=1
 
-# Determine which Python interpreter to use for bootstrapping pex and for executing subprocesses.
-# Order matters here. We must constrain subprocesses before running the bootstrap stage,
-# or we will encounter the _Py_Dealloc error when bootstrapping a Python 3 PEX (#6985).
+# Note that we still must set PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS for Python 3, even though
+# ./pants3 does this already, because the constraints are only set when first bootstrapping the shard,
+# and will not apply for new shards. Without setting PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS, we
+# would be using a Python 3 PEX with Python 2 subprocesses, which results in the _Py_Dealloc error (#6985).
 if [[ "${python_two:-false}" == "false" ]]; then
   py_version_number="3.6"
   bootstrap_pants_script="./pants3"

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -13,9 +13,10 @@ function usage() {
   cat <<EOF
 Runs commons tests for local or hosted CI.
 
-Usage: $0 (-h|-2fxbkmrjlpuneycitzsw)
+Usage: $0 (-h|-27fxbkmrjlpuneycitzsw)
  -h           print out this help message
- -2           Run using Python 2 (defaults to using Python 3).
+ -2           Run using Python 2.7 (defaults to using Python 3.6).
+ -7           Run using Python 3.7 (defaults to using Python 3.6).
  -f           run python code formatting checks
  -x           run bootstrap clean-all (assume bootstrapping from a
               fresh clone)
@@ -58,12 +59,12 @@ EOF
 python_unit_shard="0/1"
 python_contrib_shard="0/1"
 python_intg_shard="0/1"
-python_two="false"
 
-while getopts "h2fxbmrjlpeasu:ny:ci:tzw" opt; do
+while getopts "h27fxbmrjlpeasu:ny:ci:tzw" opt; do
   case ${opt} in
     h) usage ;;
     2) python_two="true" ;;
+    7) python_three_seven="true" ;;
     f) run_pre_commit_checks="true" ;;
     x) run_bootstrap_clean="true" ;;
     b) run_bootstrap="true" ;;
@@ -107,13 +108,17 @@ export PANTS_DEV=1
 
 # Determine which Python interpreter to use for bootstrapping pex and for executing subprocesses.
 # Order matters here. We must constrain subprocesses before running the bootstrap stage,
-# or we will encounter the _Py_Dealloc error when bootstrapping a Python 3 PEX.
+# or we will encounter the _Py_Dealloc error when bootstrapping a Python 3 PEX (#6985).
 if [[ "${python_two:-false}" == "false" ]]; then
-  py_version_number="3"
+  # default to Python 3.6
+  py_version_number="3.6"
+  if [[ "${python_three_seven:-true}" == "false" ]]; then
+    py_version_number="3.7"
+  fi
   bootstrap_pants_script="./pants3"
-  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS='["CPython>=3.6,<4"]'
+  export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=${py_version_number},<4']"
 else
-  py_version_number="2"
+  py_version_number="2.7"
   bootstrap_pants_script="./pants"
 fi
 banner "Using Python ${py_version_number} to execute spawned subprocesses (e.g. tests)"

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -11,26 +11,57 @@ REQUIREMENTS=(
   ${REPO_ROOT}/pants-plugins/3rdparty/python/requirements.txt
 )
 
+venv_dir_prefix="${REPO_ROOT}/build-support/pants_dev_deps"
+
+# N.B. this function would better belong in `virutalenv`, which focuses on discovering which Python
+# binary to use and thus is a natural fit for this function. However, this must be defined here
+# to avoid a circular dependency, as `pants_venv` calls `virtualenv` so cannot rely on a function
+# defined within `virtualenv`. This function will resolve to the same Python binary that
+# `virtualenv` resolves to because both will use the same command `python3` when
+# PANTS_USE_PYTHON3_UNCONSTRAINED is true.
+function determine_specific_py3_version() {
+  version_number="$(python3 -c 'import sys; print(sys.version_info[1])')"
+  case "${version_number}" in
+    6) echo "36" ;;
+    7) echo "37" ;;
+    *) die "Pants cannot run with Python 3.${version_number}. You must use either Python 2.7, 3.6, or 3.7." ;;
+  esac
+}
+
 function venv_dir() {
-  py_version="py2"; [ "${PANTS_USE_PYTHON3}" = true ] && py_version="py3"
-  echo ${REPO_ROOT}/build-support/pants_dev_deps.${py_version}.venv
+  if [ "${PANTS_USE_PYTHON3_UNCONSTRAINED}" = true ]; then
+    py_venv_version="$(determine_specific_py3_version)"
+  elif [ "${PANTS_USE_PYTHON36}" = true ]; then
+    py_venv_version="36"
+  elif [ "${PANTS_USE_PYTHON37}" = true ]; then
+    py_venv_version="37"
+  else
+    py_venv_version="27"
+  fi
+  echo "${venv_dir_prefix}.py${py_venv_version}.venv"
 }
 
 function activate_venv() {
   source "$(venv_dir)/bin/activate"
 }
 
-function create_venv() {
+function remove_venv() {
   rm -rf "$(venv_dir)"
-  # If `pants_dev_deps.venv` still exists, delete both its legacy folder and the cached
-  # Python interpreter folder, which contains problematic symlinks.
+  # If `pants_dev_deps.venv` or `pants_dev_deps.py{2,3}.venv` still exist, delete both the legacy folders
+  # and the cached Python interpreter folder, which contains problematic symlinks.
   # Note we only perform these removals for the first time, to avoid continually deleting
-  # the cache when switching between using `pants_dev_deps.py2.venv` and `pants_dev_deps.py3.venv`.
-  legacy_venv_dir="${REPO_ROOT}/build-support/pants_dev_deps.venv"
-  if [ -d "${legacy_venv_dir}" ]; then
-    rm -rf "${legacy_venv_dir}"
-    rm -rf "${HOME}/.cache/pants/python_cache/interpreters"
-  fi
+  # the cache when switching between using `pants_dev_deps.py{27,36,37}.venv`.
+  legacy_venv_dirs=("${venv_dir_prefix}.venv" "${venv_dir_prefix}.py2.venv" "${venv_dir_prefix}.py3.venv")
+  for legacy_venv_dir in "${legacy_venv_dirs[@]}"; do
+    if [ -d "${legacy_venv_dir}" ]; then
+      rm -rf "${legacy_venv_dirs[@]}"
+      rm -rf "${HOME}/.cache/pants/python_cache/interpreters"
+    fi
+  done
+}
+
+function create_venv() {
+  remove_venv
   "${REPO_ROOT}/build-support/virtualenv" "$(venv_dir)"
 }
 

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -14,7 +14,7 @@ REQUIREMENTS=(
 venv_dir_prefix="${REPO_ROOT}/build-support/pants_dev_deps"
 
 function venv_dir() {
-  py_venv_version=$(${PY:-python2.7} -c 'import sys; print("".join(map(str, sys.version_info[0:2])))')
+  py_venv_version=$(${PY} -c 'import sys; print("".join(map(str, sys.version_info[0:2])))')
   echo "${venv_dir_prefix}.py${py_venv_version}.venv"
 }
 

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -13,31 +13,25 @@ REQUIREMENTS=(
 
 venv_dir_prefix="${REPO_ROOT}/build-support/pants_dev_deps"
 
-# N.B. this function would better belong in `virutalenv`, which focuses on discovering which Python
-# binary to use and thus is a natural fit for this function. However, this must be defined here
-# to avoid a circular dependency, as `pants_venv` calls `virtualenv` so cannot rely on a function
-# defined within `virtualenv`. This function will resolve to the same Python binary that
-# `virtualenv` resolves to because both will use the same command `python3` when
-# PANTS_USE_PYTHON3_UNCONSTRAINED is true.
 function determine_specific_py3_version() {
-  version_number="$(python3 -c 'import sys; print(sys.version_info[1])')"
+  version_number="$(${PY} -c 'import sys; print(sys.version_info[1])')"
   case "${version_number}" in
     6) echo "36" ;;
     7) echo "37" ;;
-    *) die "Pants cannot run with Python 3.${version_number}. You must use either Python 2.7, 3.6, or 3.7." ;;
+    8) echo "38" ;;
+    *) die "Pants cannot run with Python 3.${version_number}." ;;
   esac
 }
 
 function venv_dir() {
-  if [ "${PANTS_USE_PYTHON3_UNCONSTRAINED}" = true ]; then
-    py_venv_version="$(determine_specific_py3_version)"
-  elif [ "${PANTS_USE_PYTHON36}" = true ]; then
-    py_venv_version="36"
-  elif [ "${PANTS_USE_PYTHON37}" = true ]; then
-    py_venv_version="37"
-  else
-    py_venv_version="27"
-  fi
+  case "${PY}" in
+    'python3') py_venv_version="$(determine_specific_py3_version)" ;;
+    'python3.6') py_venv_version="36" ;;
+    'python3.7') py_venv_version="37" ;;
+    'python3.8') py_venv_version="38" ;;
+    # If $PY not pre-set by caller, default to Python 2.7
+    *) py_venv_version="27"
+  esac
   echo "${venv_dir_prefix}.py${py_venv_version}.venv"
 }
 

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -56,6 +56,7 @@ function remove_venv() {
     if [ -d "${legacy_venv_dir}" ]; then
       rm -rf "${legacy_venv_dirs[@]}"
       rm -rf "${HOME}/.cache/pants/python_cache/interpreters"
+      break
     fi
   done
 }

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -13,25 +13,8 @@ REQUIREMENTS=(
 
 venv_dir_prefix="${REPO_ROOT}/build-support/pants_dev_deps"
 
-function determine_specific_py3_version() {
-  version_number="$(${PY} -c 'import sys; print(sys.version_info[1])')"
-  case "${version_number}" in
-    6) echo "36" ;;
-    7) echo "37" ;;
-    8) echo "38" ;;
-    *) die "Pants cannot run with Python 3.${version_number}." ;;
-  esac
-}
-
 function venv_dir() {
-  case "${PY}" in
-    'python3') py_venv_version="$(determine_specific_py3_version)" ;;
-    'python3.6') py_venv_version="36" ;;
-    'python3.7') py_venv_version="37" ;;
-    'python3.8') py_venv_version="38" ;;
-    # If $PY not pre-set by caller, default to Python 2.7
-    *) py_venv_version="27"
-  esac
+  py_venv_version=$(${PY:-python2.7} -c 'import sys; print("".join(map(str, sys.version_info[0:2])))')
   echo "${venv_dir_prefix}.py${py_venv_version}.venv"
 }
 
@@ -42,9 +25,9 @@ function activate_venv() {
 function remove_venv() {
   rm -rf "$(venv_dir)"
   # If `pants_dev_deps.venv` or `pants_dev_deps.py{2,3}.venv` still exist, delete both the legacy folders
-  # and the cached Python interpreter folder, which contains problematic symlinks.
-  # Note we only perform these removals for the first time, to avoid continually deleting
-  # the cache when switching between using `pants_dev_deps.py{27,36,37}.venv`.
+  # and the cached Python interpreter folder, which contains problematic symlinks. Note we only perform
+  # these removals for the first time, to avoid continually deleting the cache when switching
+  # between valid venvs.
   legacy_venv_dirs=("${venv_dir_prefix}.venv" "${venv_dir_prefix}.py2.venv" "${venv_dir_prefix}.py3.venv")
   for legacy_venv_dir in "${legacy_venv_dirs[@]}"; do
     if [ -d "${legacy_venv_dir}" ]; then

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -434,7 +434,10 @@ osx_rust_tests: &osx_rust_tests
       casks:
       - osxfuse
   script:
-    - ./build-support/bin/travis-ci.sh -e
+  # N.B. We run this with Python 2 because this osx_image does not have
+  # Python 3.6 in its environment. We do not care which Python version
+  # we use and do not want to incur the cost of using pyenv to get 3.6.
+    - ./build-support/bin/travis-ci.sh -e2
 
 # -------------------------------------------------------------------------
 # OSX sanity checks

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -109,11 +109,11 @@ base_linux_config: &base_linux_config
   after_failure:
     - ./build-support/bin/ci-failure.sh
 
-py2_linux_config: &py2_linux_config
+py27_linux_config: &py27_linux_config
   <<: *base_linux_config
   python: &python2_version "2.7"
 
-py3_linux_config: &py3_linux_config
+py36_linux_config: &py36_linux_config
   <<: *base_linux_config
   python: &python3_version "3.6"
 
@@ -125,19 +125,19 @@ base_linux_test_config: &base_linux_test_config
   before_script:
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
 
-py2_linux_test_config: &py2_linux_test_config
-  <<: *py2_linux_config
+py27_linux_test_config: &py27_linux_test_config
+  <<: *py27_linux_config
   <<: *base_linux_test_config
   stage: *cron
   env:
-    - &py2_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py2.linux
+    - &py27_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.linux
 
-py3_linux_test_config: &py3_linux_test_config
-  <<: *py3_linux_config
+py36_linux_test_config: &py36_linux_test_config
+  <<: *py36_linux_config
   <<: *base_linux_test_config
   stage: *test
   env:
-    - &py3_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py3.linux
+    - &py36_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
 
 base_osx_config: &base_osx_config
   os: osx
@@ -145,18 +145,18 @@ base_osx_config: &base_osx_config
   before_install:
     {{>before_install_osx}}
 
-py2_osx_config: &py2_osx_config
+py27_osx_config: &py27_osx_config
   <<: *base_osx_config
 
-py3_osx_config: &py3_osx_config
+py36_osx_config: &py36_osx_config
   <<: *base_osx_config
   addons:
     brew:
-      packages: &py3_osx_config_brew_packages
+      packages: &py36_osx_config_brew_packages
       - openssl
   env:
     # Fix Python 3 issue linking to OpenSSL
-    - &py3_osx_config_env >
+    - &py36_osx_config_env >
       PATH="/usr/local/opt/openssl/bin:$PATH"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
@@ -177,26 +177,26 @@ base_osx_test_config: &base_osx_test_config
     - ulimit -n 8192
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
 
-py2_osx_test_config: &py2_osx_test_config
-  <<: *py2_osx_config
+py27_osx_test_config: &py27_osx_test_config
+  <<: *py27_osx_config
   <<: *base_osx_test_config
   stage: *cron
   env:
-    - &py2_osx_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py2.osx
+    - &py27_osx_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
 
-py3_osx_test_config: &py3_osx_test_config
-  <<: *py3_osx_config
+py36_osx_test_config: &py36_osx_test_config
+  <<: *py36_osx_config
   <<: *base_osx_test_config
   stage: *test
   env:
-    # Must duplicate py3_osx_config's env because it cannot be merged into a new anchor
-    - &py3_osx_test_config_env >
+    # Must duplicate py36_osx_config's env because it cannot be merged into a new anchor
+    - &py36_osx_test_config_env >
       PATH="/usr/local/opt/openssl/bin:$PATH"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
       PYENV_ROOT="${HOME}/.pyenv"
       PATH="${PYENV_ROOT}/shims:${PATH}"
-      BOOTSTRAPPED_PEX_KEY_SUFFIX=py3.osx
+      BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
 
 linux_with_fuse: &linux_with_fuse
   before_install:
@@ -241,25 +241,25 @@ base_linux_build_engine: &base_linux_build_engine
       sh -c "./build-support/bin/ci.sh ${BOOTSTRAP_ARGS} && ./build-support/bin/release.sh -f"
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
 
-py2_linux_build_engine: &py2_linux_build_engine
-  <<: *py2_linux_config
+py27_linux_build_engine: &py27_linux_build_engine
+  <<: *py27_linux_config
   <<: *base_linux_build_engine
-  name: "Build Linux native engine and pants.pex (Py2 PEX)"
+  name: "Build Linux native engine and pants.pex (Py2.7 PEX)"
   env:
-    # NB: Only the Py2 shard sets PREPARE_DEPLOY to cause the fs_util binary to be uploaded to S3:
+    # NB: Only the Py2.7 shard sets PREPARE_DEPLOY to cause the fs_util binary to be uploaded to S3:
     # either linux shard could upload this binary, since it does not depend on python at all.
     - PREPARE_DEPLOY=1
-    - CACHE_NAME=linuxpexbuild.py2
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py2.linux
+    - CACHE_NAME=linuxpexbuild.py27
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.linux
     - BOOTSTRAP_ARGS='-2b'
 
-py3_linux_build_engine: &py3_linux_build_engine
-  <<: *py3_linux_config
+py36_linux_build_engine: &py36_linux_build_engine
+  <<: *py36_linux_config
   <<: *base_linux_build_engine
-  name: "Build Linux native engine and pants.pex (Py3 PEX)"
+  name: "Build Linux native engine and pants.pex (Py3.6 PEX)"
   env:
-    - CACHE_NAME=linuxpexbuild.py3
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py3.linux
+    - CACHE_NAME=linuxpexbuild.py36
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - BOOTSTRAP_ARGS='-b'
 
 base_osx_build_engine: &base_osx_build_engine
@@ -278,46 +278,46 @@ base_osx_build_engine: &base_osx_build_engine
   after_failure:
     - ./build-support/bin/ci-failure.sh
 
-py2_osx_build_engine: &py2_osx_build_engine
-  <<: *py2_osx_config
+py27_osx_build_engine: &py27_osx_build_engine
+  <<: *py27_osx_config
   <<: *base_osx_build_engine
-  name: "Build OSX native engine and pants.pex (Py2 PEX)"
+  name: "Build OSX native engine and pants.pex (Py2.7 PEX)"
   env:
     - *base_osx_build_engine_env
-    - CACHE_NAME=osxpexbuild.py2
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py2.osx
+    - CACHE_NAME=osxpexbuild.py27
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
     - BOOTSTRAP_ARGS='-2b'
 
-py3_osx_build_engine: &py3_osx_build_engine
-  <<: *py3_osx_config
+py36_osx_build_engine: &py36_osx_build_engine
+  <<: *py36_osx_config
   <<: *base_osx_build_engine
-  name: "Build OSX native engine and pants.pex (Py3 PEX)"
+  name: "Build OSX native engine and pants.pex (Py3.6 PEX)"
   env:
     - *base_osx_build_engine_env
-    - *py3_osx_config_env
-    - CACHE_NAME=osxpexbuild.py3
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py3.osx
+    - *py36_osx_config_env
+    - CACHE_NAME=osxpexbuild.py36
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
     - BOOTSTRAP_ARGS='-b'
 
 # -------------------------------------------------------------------------
 # Lint
 # -------------------------------------------------------------------------
 
-py2_lint: &py2_lint
-  <<: *py2_linux_test_config
-  name: "Self-checks and lint (Py2 PEX)"
+py27_lint: &py27_lint
+  <<: *py27_linux_test_config
+  name: "Self-checks and lint (Py2.7 PEX)"
   env:
-    - *py2_linux_test_config_env
-    - CACHE_NAME=linuxselfchecks.py2
+    - *py27_linux_test_config_env
+    - CACHE_NAME=linuxselfchecks.py27
   script:
     - ./build-support/bin/travis-ci.sh -fmrt2
 
-py3_lint: &py3_lint
-  <<: *py3_linux_test_config
-  name: "Self-checks and lint (Py3 PEX)"
+py36_lint: &py36_lint
+  <<: *py36_linux_test_config
+  name: "Self-checks and lint (Py3.6 PEX)"
   env:
-    - *py3_linux_test_config_env
-    - CACHE_NAME=linuxselfchecks.py3
+    - *py36_linux_test_config_env
+    - CACHE_NAME=linuxselfchecks.py36
   script:
     - ./build-support/bin/travis-ci.sh -fmrt
 
@@ -366,13 +366,13 @@ base_build_wheels: &base_build_wheels
 
 linux_build_wheels: &linux_build_wheels
   # Similar to the bootstrap shard, we build Linux wheels in a docker image to maximize
-  # compatibility. This is a Py2 shard, so it is not subject to #6985.
+  # compatibility. This is a Py2.7 shard, so it is not subject to #6985.
   <<: *travis_docker_image
-  <<: *py2_linux_test_config
+  <<: *py27_linux_test_config
   <<: *base_build_wheels
   name: "Build Linux wheels (No PEX)"
   env:
-    - *py2_linux_test_config_env
+    - *py27_linux_test_config_env
     - *base_build_wheels_env
     - CACHE_NAME=linuxwheelsbuild
   script:
@@ -384,12 +384,12 @@ linux_build_wheels: &linux_build_wheels
       sh -c "RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
 
 osx_build_wheels: &osx_build_wheels
-  <<: *py2_osx_test_config
+  <<: *py27_osx_test_config
   <<: *base_build_wheels
   name: "Build OSX wheels (No PEX)"
   osx_image: xcode8
   env:
-    - *py2_osx_test_config_env
+    - *py27_osx_test_config_env
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild
   script:
@@ -448,61 +448,61 @@ base_osx_10_12_sanity_check: &base_osx_10_12_sanity_check
   <<: *base_osx_sanity_check
   osx_image: xcode9.2
 
-py2_osx_10_12_sanity_check: &py2_osx_10_12_sanity_check
-  <<: *py2_osx_test_config
+py27_osx_10_12_sanity_check: &py27_osx_10_12_sanity_check
+  <<: *py27_osx_test_config
   <<: *base_osx_10_12_sanity_check
-  name: "OSX 10.12 sanity check (Py2 PEX)"
+  name: "OSX 10.12 sanity check (Py2.7 PEX)"
   env:
-    - *py2_osx_test_config_env
-    - CACHE_NAME=macos10.12sanity.py2
+    - *py27_osx_test_config_env
+    - CACHE_NAME=macos10.12sanity.py27
 
-py3_osx_10_12_sanity_check: &py3_osx_10_12_sanity_check
-  <<: *py3_osx_test_config
+py36_osx_10_12_sanity_check: &py36_osx_10_12_sanity_check
+  <<: *py36_osx_test_config
   <<: *base_osx_10_12_sanity_check
-  name: "OSX 10.12 sanity check (Py3 PEX)"
+  name: "OSX 10.12 sanity check (Py3.6 PEX)"
   env:
-    - *py3_osx_test_config_env
-    - CACHE_NAME=macos10.12sanity.py3
+    - *py36_osx_test_config_env
+    - CACHE_NAME=macos10.12sanity.py36
 
 base_osx_10_13_sanity_check: &base_osx_10_13_sanity_check
   <<: *base_osx_sanity_check
   osx_image: xcode10.1
 
-py2_osx_10_13_sanity_check: &py2_osx_10_13_sanity_check
-  <<: *py2_osx_test_config
+py27_osx_10_13_sanity_check: &py27_osx_10_13_sanity_check
+  <<: *py27_osx_test_config
   <<: *base_osx_10_13_sanity_check
-  name: "OSX 10.13 sanity check (Py2 PEX)"
+  name: "OSX 10.13 sanity check (Py2.7 PEX)"
   env:
-    - *py2_osx_test_config_env
-    - CACHE_NAME=macos10.13sanity.py2
+    - *py27_osx_test_config_env
+    - CACHE_NAME=macos10.13sanity.py27
 
-py3_osx_10_13_sanity_check: &py3_osx_10_13_sanity_check
-  <<: *py3_osx_test_config
+py36_osx_10_13_sanity_check: &py36_osx_10_13_sanity_check
+  <<: *py36_osx_test_config
   <<: *base_osx_10_13_sanity_check
-  name: "OSX 10.13 sanity check (Py3 PEX)"
+  name: "OSX 10.13 sanity check (Py3.6 PEX)"
   env:
-    - *py3_osx_test_config_env
-    - CACHE_NAME=macos10.13sanity.py3
+    - *py36_osx_test_config_env
+    - CACHE_NAME=macos10.13sanity.py36
 
 # -------------------------------------------------------------------------
 # Platform specific tests
 # -------------------------------------------------------------------------
 
-py2_osx_platform_tests: &py2_osx_platform_tests
-  <<: *py2_osx_test_config
-  name: "OSX platform-specific tests (Py2 PEX)"
+py27_osx_platform_tests: &py27_osx_platform_tests
+  <<: *py27_osx_test_config
+  name: "OSX platform-specific tests (Py2.7 PEX)"
   env:
-    - *py2_osx_test_config_env
-    - CACHE_NAME=macosplatformtests.py2
+    - *py27_osx_test_config_env
+    - CACHE_NAME=macosplatformtests.py27
   script:
     - ./build-support/bin/travis-ci.sh -z2
 
-py3_osx_platform_tests: &py3_osx_platform_tests
-  <<: *py3_osx_test_config
-  name: "OSX platform-specific tests (Py3 PEX)"
+py36_osx_platform_tests: &py36_osx_platform_tests
+  <<: *py36_osx_test_config
+  name: "OSX platform-specific tests (Py3.6 PEX)"
   env:
-    - *py3_osx_test_config_env
-    - CACHE_NAME=macosplatformtests.py3
+    - *py36_osx_test_config_env
+    - CACHE_NAME=macosplatformtests.py36
   script:
     - ./build-support/bin/travis-ci.sh -z
 
@@ -513,23 +513,23 @@ py3_osx_platform_tests: &py3_osx_platform_tests
 base_jvm_tests: &base_jvm_tests
   <<: *linux_with_fuse
 
-py2_jvm_tests: &py2_jvm_tests
-  <<: *py2_linux_test_config
+py27_jvm_tests: &py27_jvm_tests
+  <<: *py27_linux_test_config
   <<: *base_jvm_tests
-  name: "JVM tests (Py2 PEX)"
+  name: "JVM tests (Py2.7 PEX)"
   env:
-    - *py2_linux_test_config_env
-    - CACHE_NAME=linuxjvmtests.py2
+    - *py27_linux_test_config_env
+    - CACHE_NAME=linuxjvmtests.py27
   script:
     - ./build-support/bin/travis-ci.sh -j2
 
-py3_jvm_tests: &py3_jvm_tests
-  <<: *py3_linux_test_config
+py36_jvm_tests: &py36_jvm_tests
+  <<: *py36_linux_test_config
   <<: *base_jvm_tests
-  name: "JVM tests (Py3 PEX)"
+  name: "JVM tests (Py3.6 PEX)"
   env:
-    - *py3_linux_test_config_env
-    - CACHE_NAME=linuxjvmtests.py3
+    - *py36_linux_test_config_env
+    - CACHE_NAME=linuxjvmtests.py36
   script:
     - ./build-support/bin/travis-ci.sh -j
 
@@ -580,14 +580,14 @@ deploy_unstable_multiplatform_pex: &deploy_unstable_multiplatform_pex
 
 matrix:
   include:
-    - <<: *py2_linux_build_engine
-    - <<: *py3_linux_build_engine
+    - <<: *py27_linux_build_engine
+    - <<: *py36_linux_build_engine
 
-    - <<: *py2_osx_build_engine
-    - <<: *py3_osx_build_engine
+    - <<: *py27_osx_build_engine
+    - <<: *py36_osx_build_engine
 
-    - <<: *py2_lint
-    - <<: *py3_lint
+    - <<: *py27_lint
+    - <<: *py36_lint
 
     - <<: *linux_rust_clippy
     - <<: *cargo_audit
@@ -595,50 +595,50 @@ matrix:
     - <<: *linux_build_wheels
     - <<: *osx_build_wheels
 
-    - <<: *py2_linux_test_config
-      name: "Unit tests for pants and pants-plugins (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Unit tests for pants and pants-plugins (Py2.7 PEX)"
       stage: *test
       env:
-        - *py2_linux_test_config_env
-        - CACHE_NAME=linuxunittests.py2
+        - *py27_linux_test_config_env
+        - CACHE_NAME=linuxunittests.py27
       script:
         - ./build-support/bin/travis-ci.sh -2lp
 
-    - <<: *py3_linux_test_config
-      name: "Unit tests for pants and pants-plugins (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Unit tests for pants and pants-plugins (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
-        - CACHE_NAME=linuxunittests.py3
+        - *py36_linux_test_config_env
+        - CACHE_NAME=linuxunittests.py36
       script:
         - ./build-support/bin/travis-ci.sh -lp
 
 {{#py3_integration_shards}}
-    - <<: *py3_linux_test_config
-      name: "Integration tests for pants - shard {{.}} (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Integration tests for pants - shard {{.}} (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
+        - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard{{.}}
       script:
         - ./build-support/bin/travis-ci.sh -c -i {{.}}/{{py3_integration_shards_length}}
 
 {{/py3_integration_shards}}
 {{#py2_blacklist_integration_shards}}
-    - <<: *py2_linux_test_config
-      name: "Blacklisted integration tests for pants - shard {{.}} (Py2 PEX w/ Py3 constraints)"
+    - <<: *py27_linux_test_config
+      name: "Blacklisted integration tests for pants - shard {{.}} (Py2.7 PEX w/ Py3.6 constraints)"
       stage: *test
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
-        - CACHE_NAME=integrationshard{{.}}.py2blacklist
+        - CACHE_NAME=integrationshard{{.}}.py27blacklist
       script:
         - ./build-support/bin/travis-ci.sh -c2w -i {{.}}/{{py2_blacklist_integration_shards_length}}
 
 {{/py2_blacklist_integration_shards}}
 {{#cron_integration_shards}}
-    - <<: *py2_linux_test_config
-      name: "Integration tests for pants - shard {{.}} (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Integration tests for pants - shard {{.}} (Py2.7 PEX)"
       env:
-        - *py2_linux_test_config_env
+        - *py27_linux_test_config_env
         - CACHE_NAME=cronshard{{.}}
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i {{.}}/{{cron_integration_shards_length}}
@@ -648,34 +648,34 @@ matrix:
     - <<: *linux_rust_tests
     - <<: *osx_rust_tests
 
-    - <<: *py2_linux_test_config
-      name: "Python contrib tests (Py2 PEX)"
+    - <<: *py27_linux_test_config
+      name: "Python contrib tests (Py2.7 PEX)"
       stage: *test
       env:
-        - *py2_linux_test_config_env
-        - CACHE_NAME=linuxcontribtests.py2
+        - *py27_linux_test_config_env
+        - CACHE_NAME=linuxcontribtests.py27
       script:
         - ./build-support/bin/travis-ci.sh -2n
 
-    - <<: *py3_linux_test_config
-      name: "Python contrib tests (Py3 PEX)"
+    - <<: *py36_linux_test_config
+      name: "Python contrib tests (Py3.6 PEX)"
       env:
-        - *py3_linux_test_config_env
-        - CACHE_NAME=linuxcontribtests.py3
+        - *py36_linux_test_config_env
+        - CACHE_NAME=linuxcontribtests.py36
       script:
         - ./build-support/bin/travis-ci.sh -n
 
-    - <<: *py2_osx_10_12_sanity_check
-    - <<: *py3_osx_10_12_sanity_check
+    - <<: *py27_osx_10_12_sanity_check
+    - <<: *py36_osx_10_12_sanity_check
 
-    - <<: *py2_osx_10_13_sanity_check
-    - <<: *py3_osx_10_13_sanity_check
+    - <<: *py27_osx_10_13_sanity_check
+    - <<: *py36_osx_10_13_sanity_check
 
-    - <<: *py2_osx_platform_tests
-    - <<: *py3_osx_platform_tests
+    - <<: *py27_osx_platform_tests
+    - <<: *py36_osx_platform_tests
 
-    - <<: *py2_jvm_tests
-    - <<: *py3_jvm_tests
+    - <<: *py27_jvm_tests
+    - <<: *py36_jvm_tests
 
     - <<: *deploy_stable_multiplatform_pex
     - <<: *deploy_unstable_multiplatform_pex

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -47,8 +47,9 @@ native_engine_cache_config: &native_engine_cache_config
     timeout: 500
     directories:
       - ${HOME}/.cache/pants/rust/cargo
-      - build-support/pants_dev_deps.py2.venv
-      - build-support/pants_dev_deps.py3.venv
+      - build-support/pants_dev_deps.py27.venv
+      - build-support/pants_dev_deps.py36.venv
+      - build-support/pants_dev_deps.py37.venv
       - src/rust/engine/target
 
 # Travis cache config for jobs that run a bootstrapped pants.pex.

--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -9,26 +9,18 @@ VIRTUALENV_PACKAGE_LOCATION=${VIRTUALENV_PACKAGE_LOCATION:-https://pypi.io/packa
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && git rev-parse --show-toplevel)
 source ${REPO_ROOT}/build-support/common.sh
 
-function determine_python_bin_name() {
-  if [ "${PANTS_USE_PYTHON3_UNCONSTRAINED}" = true ]; then
-    py_version="3"
-  elif [ "${PANTS_USE_PYTHON36}" = true ]; then
-    py_version="3.6"
-  elif [ "${PANTS_USE_PYTHON37}" = true ]; then
-    py_version="3.7"
-  else
-    py_version="2.7"
-  fi
-  echo "python${py_version}"
-}
-
+# Note the caller may set $PY to whichever Python version
+# they want. If not set, we default to Python 2.7.
 if [[ -z "${PY}" ]]; then
-  python_bin_name="$(determine_python_bin_name)"
-  if which "${python_bin_name}" >/dev/null; then
-    PY=`which ${python_bin_name}`
-  else
-    die "No ${python_bin_name} interpreter found on the path. Python will not work!"
-  fi
+  PY="python2.7"
+fi
+
+# Locate the binary's path to log to user or
+# die gracefully if not found.
+if which "${PY}" >/dev/null; then
+  PY=`which ${PY}`
+else
+  die "No ${PY} interpreter found on the path. Python will not work!"
 fi
 
 log "Using python at ${PY}"

--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -9,8 +9,21 @@ VIRTUALENV_PACKAGE_LOCATION=${VIRTUALENV_PACKAGE_LOCATION:-https://pypi.io/packa
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && git rev-parse --show-toplevel)
 source ${REPO_ROOT}/build-support/common.sh
 
+function determine_python_bin_name() {
+  if [ "${PANTS_USE_PYTHON3_UNCONSTRAINED}" = true ]; then
+    py_version="3"
+  elif [ "${PANTS_USE_PYTHON36}" = true ]; then
+    py_version="3.6"
+  elif [ "${PANTS_USE_PYTHON37}" = true ]; then
+    py_version="3.7"
+  else
+    py_version="2.7"
+  fi
+  echo "python${py_version}"
+}
+
 if [[ -z "${PY}" ]]; then
-  python_bin_name="python2.7"; [ "${PANTS_USE_PYTHON3}" = true ] && python_bin_name="python3"
+  python_bin_name="$(determine_python_bin_name)"
   if which "${python_bin_name}" >/dev/null; then
     PY=`which ${python_bin_name}`
   else

--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -9,12 +9,6 @@ VIRTUALENV_PACKAGE_LOCATION=${VIRTUALENV_PACKAGE_LOCATION:-https://pypi.io/packa
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && git rev-parse --show-toplevel)
 source ${REPO_ROOT}/build-support/common.sh
 
-# Note the caller may set $PY to whichever Python version
-# they want. If not set, we default to Python 2.7.
-if [[ -z "${PY}" ]]; then
-  PY="python2.7"
-fi
-
 # Locate the binary's path to log to user or die gracefully if not found.
 if which "${PY}" >/dev/null; then
   PY=`which ${PY}`

--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -15,8 +15,7 @@ if [[ -z "${PY}" ]]; then
   PY="python2.7"
 fi
 
-# Locate the binary's path to log to user or
-# die gracefully if not found.
+# Locate the binary's path to log to user or die gracefully if not found.
 if which "${PY}" >/dev/null; then
   PY=`which ${PY}`
 else

--- a/pants
+++ b/pants
@@ -53,6 +53,9 @@ source ${HERE}/build-support/pants_venv
 # + bootstrap_native_code: Builds target-specific native engine binaries.
 source ${HERE}/build-support/bin/native/bootstrap_code.sh
 
+# Default to using Python 2.7 if not otherwise specified.
+export PY="${PY:-python2.7}"
+
 PANTS_EXE="${HERE}/src/python/pants/bin/pants_loader.py"
 
 if [[ ! -z "${WRAPPER_REQUIREMENTS}" ]]; then

--- a/pants3
+++ b/pants3
@@ -19,18 +19,19 @@ fi
 # Determine Py3 version
 if [ "${python_three_six}" = true ]; then
   export PANTS_USE_PYTHON36=true
-  py_version_number="3.6"
+  py_lower_bound="3.6"
+  py_upper_bound="3.7"
 elif [ "${python_three_seven}" = true ]; then
   export PANTS_USE_PYTHON37=true
-  py_version_number="3.7"
+  py_lower_bound="3.7"
+  py_upper_bound="3.8"
 else
   export PANTS_USE_PYTHON3_UNCONSTRAINED=true
-  # This only sets a lower bounds on acceptable Python 3 interpreters.
-  # The actual interpreter and venv to be used will be set by `pants_venv` and `virtualenv`.
-  py_version_number="3.6"
+  py_lower_bound="3.6"
+  py_upper_bound="4"
 fi
 
 # Use Py3 for subprocesses
-export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=${py_version_number},<4']"
+export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=${py_lower_bound},<${py_upper_bound}']"
 
 ./pants "$@"

--- a/pants3
+++ b/pants3
@@ -4,8 +4,7 @@
 
 # This bootstrap script invokes Pants using a Python 3 interpreter.
 #
-# To constrain to a specific Python 3 version, such as 3.7,
-# prefix the script with `PY=python3.7`.
+# To constrain to a specific Python 3 version, such as 3.7, prefix the script with `PY=python3.7`.
 
 # Default to using Python 3 if user did not specify otherwise.
 if [[ -z "${PY}" ]]; then
@@ -14,13 +13,12 @@ if [[ -z "${PY}" ]]; then
   py_upper_bound="4"
 fi
 
-# Determine interpreter constraints. Note that $PY only impacts which
-# virtualenv we use for the parent Pants process; we must also set
-# PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS to constrain spawned subprocesses
-# such as tests. Without any interpreter constraints, we get the
-# _Py_Dealloc exception (#6985) as Pants will try to use Python 2 for subprocesses.
-# Without the tightened constraints when the user defines $PY, we may end up using
-# a different Python 3 version for subprocess than we do for Pants.
+# Determine interpreter constraints. Note that $PY only impacts which virtualenv we use
+# for the parent Pants process; we must also set PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS
+# to constrain spawned subprocesses such as tests. Without any interpreter constraints, we get
+# the _Py_Dealloc exception (#6985) as Pants will try to use Python 2 for subprocesses. Without
+# the tightened constraints when the user defines $PY, we may end up using a different Python 3
+# version for subprocesses than we do for Pants.
 case "${PY}" in
   'python3')
     py_lower_bound="3.6"

--- a/pants3
+++ b/pants3
@@ -4,10 +4,33 @@
 
 # This bootstrap script invokes Pants using a Python 3 interpreter.
 
-# Use Py3 under-the-hood
-export PANTS_USE_PYTHON3=true
+# Defaults to allowing either Python 3.6 or 3.7, and allows the user to further constrain to a specific version
+# by passing `-6` or `-7`.
+
+# Check for -6 and -7 flags.
+if [[ "$1" == "-6" ]]; then
+  python_three_six=true
+  shift
+elif [[ "$1" == "-7" ]]; then
+  python_three_seven=true
+  shift
+fi
+
+# Determine Py3 version
+if [ "${python_three_six}" = true ]; then
+  export PANTS_USE_PYTHON36=true
+  py_version_number="3.6"
+elif [ "${python_three_seven}" = true ]; then
+  export PANTS_USE_PYTHON37=true
+  py_version_number="3.7"
+else
+  export PANTS_USE_PYTHON3_UNCONSTRAINED=true
+  # This only sets a lower bounds on acceptable Python 3 interpreters.
+  # The actual interpreter and venv to be used will be set by `pants_venv` and `virtualenv`.
+  py_version_number="3.6"
+fi
 
 # Use Py3 for subprocesses
-export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS='["CPython>=3.6,<4"]'
+export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=${py_version_number},<4']"
 
 ./pants "$@"

--- a/pants3
+++ b/pants3
@@ -3,33 +3,42 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 # This bootstrap script invokes Pants using a Python 3 interpreter.
+#
+# To constrain to a specific Python 3 version, such as 3.7,
+# prefix the script with `PY=python3.7`.
 
-# Defaults to allowing either Python 3.6 or 3.7, and allows the user to further constrain to a specific version
-# by passing `-6` or `-7`.
-
-# Check for -6 and -7 flags.
-if [[ "$1" == "-6" ]]; then
-  python_three_six=true
-  shift
-elif [[ "$1" == "-7" ]]; then
-  python_three_seven=true
-  shift
-fi
-
-# Determine Py3 version
-if [ "${python_three_six}" = true ]; then
-  export PANTS_USE_PYTHON36=true
-  py_lower_bound="3.6"
-  py_upper_bound="3.7"
-elif [ "${python_three_seven}" = true ]; then
-  export PANTS_USE_PYTHON37=true
-  py_lower_bound="3.7"
-  py_upper_bound="3.8"
-else
-  export PANTS_USE_PYTHON3_UNCONSTRAINED=true
+# Default to using Python 3 if user did not specify otherwise.
+if [[ -z "${PY}" ]]; then
+  export PY="python3"
   py_lower_bound="3.6"
   py_upper_bound="4"
 fi
+
+# Determine interpreter constraints. Note that $PY only impacts which
+# virtualenv we use for the parent Pants process; we must also set
+# PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS to constrain spawned subprocesses
+# such as tests. Without any interpreter constraints, we get the
+# _Py_Dealloc exception (#6985) as Pants will try to use Python 2 for subprocesses.
+# Without the tightened constraints when the user defines $PY, we may end up using
+# a different Python 3 version for subprocess than we do for Pants.
+case "${PY}" in
+  'python3')
+    py_lower_bound="3.6"
+    py_upper_bound="4"
+    ;;
+  'python3.6')
+    py_lower_bound="3.6"
+    py_upper_bound="3.7"
+    ;;
+  'python3.7')
+    py_lower_bound="3.6"
+    py_upper_bound="3.8"
+    ;;
+  'python3.8')
+    py_lower_bound="3.8"
+    py_upper_bound="3.9"
+    ;;
+esac
 
 # Use Py3 for subprocesses
 export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=${py_lower_bound},<${py_upper_bound}']"

--- a/pants3
+++ b/pants3
@@ -37,8 +37,6 @@ case "${PY}" in
     py_upper_bound="3.9"
     ;;
 esac
-
-# Use Py3 for subprocesses
 export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=${py_lower_bound},<${py_upper_bound}']"
 
 ./pants "$@"

--- a/pants3
+++ b/pants3
@@ -9,30 +9,13 @@
 # Default to using Python 3 if not otherwise specified.
 export PY="${PY:-python3}"
 
-# Determine interpreter constraints. Note that $PY only impacts which virtualenv we use
-# for the parent Pants process; we must also set PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS
-# to constrain spawned subprocesses such as tests. Without any interpreter constraints, we get
-# the _Py_Dealloc exception (#6985) as Pants will try to use Python 2 for subprocesses. Without
-# the tightened constraints when the user defines $PY, we may end up using a different Python 3
-# version for subprocesses than we do for Pants.
-case "${PY}" in
-  'python3')
-    py_lower_bound="3.6"
-    py_upper_bound="4"
-    ;;
-  'python3.6')
-    py_lower_bound="3.6"
-    py_upper_bound="3.7"
-    ;;
-  'python3.7')
-    py_lower_bound="3.6"
-    py_upper_bound="3.8"
-    ;;
-  'python3.8')
-    py_lower_bound="3.8"
-    py_upper_bound="3.9"
-    ;;
-esac
-export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=${py_lower_bound},<${py_upper_bound}']"
+# Set interpreter constraints to exactly match the interpreter used for the venv.
+# Note that $PY only impacts which virtualenv we use for the parent Pants process; we must also set
+# PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS to constrain spawned subprocesses such as tests. Without
+# any interpreter constraints, we get the _Py_Dealloc exception (#6985) as Pants will try to use Python 2
+# for subprocesses. Without the exact constraints we set, we could end up using a different Python 3
+# minor version for subprocesses than we do for Pants.
+py_major_minor=$(${PY} -c 'import sys; print(".".join(map(str, sys.version_info[0:2])))')
+export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${py_major_minor}.*']"
 
 ./pants "$@"

--- a/pants3
+++ b/pants3
@@ -6,12 +6,8 @@
 #
 # To constrain to a specific Python 3 version, such as 3.7, prefix the script with `PY=python3.7`.
 
-# Default to using Python 3 if user did not specify otherwise.
-if [[ -z "${PY}" ]]; then
-  export PY="python3"
-  py_lower_bound="3.6"
-  py_upper_bound="4"
-fi
+# Default to using Python 3 if not otherwise specified.
+export PY="${PY:-python3}"
 
 # Determine interpreter constraints. Note that $PY only impacts which virtualenv we use
 # for the parent Pants process; we must also set PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS

--- a/src/rust/engine/src/cffi_build.rs
+++ b/src/rust/engine/src/cffi_build.rs
@@ -114,7 +114,9 @@ fn main() -> Result<(), CffiBuildError> {
   // When built with Python 2, it works with both Python 2 and Python 3.
   // So, we check to see if the under-the-hood interpreter has changed and rebuild the native engine
   // when needed.
-  println!("cargo:rerun-if-env-changed=PANTS_USE_PYTHON3");
+  println!("cargo:rerun-if-env-changed=PANTS_USE_PYTHON36");
+  println!("cargo:rerun-if-env-changed=PANTS_USE_PYTHON37");
+  println!("cargo:rerun-if-env-changed=PANTS_USE_PYTHON3_UNCONSTRAINED");
 
   if cfg!(target_os = "linux") {
     println!("cargo:rustc-link-lib=static=stdc++");

--- a/src/rust/engine/src/cffi_build.rs
+++ b/src/rust/engine/src/cffi_build.rs
@@ -114,9 +114,7 @@ fn main() -> Result<(), CffiBuildError> {
   // When built with Python 2, it works with both Python 2 and Python 3.
   // So, we check to see if the under-the-hood interpreter has changed and rebuild the native engine
   // when needed.
-  println!("cargo:rerun-if-env-changed=PANTS_USE_PYTHON36");
-  println!("cargo:rerun-if-env-changed=PANTS_USE_PYTHON37");
-  println!("cargo:rerun-if-env-changed=PANTS_USE_PYTHON3_UNCONSTRAINED");
+  println!("cargo:rerun-if-env-changed=PY");
 
   if cfg!(target_os = "linux") {
     println!("cargo:rustc-link-lib=static=stdc++");


### PR DESCRIPTION
## Problem
There are three issues when trying to run `./pants3` and switching between Python 3.6 and Python 3.7.

1) You must first `rm -rf build-support/pants_dev_deps.py3.venv` and then `rm -rf ~/.cache/pants/python_cache/interpreters` because the cache will have a bad symlink to the prior Python 3 interpreter. This is inconvenient, and the latter is surprising and difficult to remember.
2) If both Python 3.6 and Python 3.7 are discoverable on the `PATH`, there is no reliable way to specify that you want to use Python 3.7. The `virtualenv` code works by invoking `python3`, which defaults in most systems to the minimum version. The only workaround is to ensure `python3` points first to `python3.7` by messing with the PATH. While this is possible, it is not obvious to the user and it would be best to provide a solution that does not require messing with the PATH.
3) When running `./pants3`, we always override `PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS` to allow Python 3.6, so it is impossible at the moment to set a tighter constraint without modifying source code. Even if we resolve issues 1 and 2, we must address this issue to ensure that spawned subprocesses use the correct interpreter.

## Solution 
### Part 1 - renamed `venv` folders
Rename `py2.venv` -> `py27.venv` and split out `py3.venv` into `py36.venv` and `py37.venv`.

This allows us to have a distinct venv for each Python version, which is necessary to avoid redownloading/resymlinking dependencies anytime we change from 3.6 to 3.7. It is also necessary to fix problem #1 of having to run `rm -rf build-support/pants_dev_deps.py3.venv ~/.cache/pants/python_cache/interpreters` whenever making this change.

### Part 2 - `$PY` env var
We refactor `virtualenv` and `pants_venv` to require the caller to pre-set the env var `$PY`. This value stores the bin name, such as `python3.7`, to be used in setting up the venv.

If the user wants to constrain `./pants3` to a specific Python 3 interpreter, they may do so by prefixing the command with `PY=python3.7 ./pants3`. Otherwise, `./pants` will default to `python2.7` and `./pants3` will default to `python3` as before.

### Also changed - renames in `.travis.yml`
Update `ci.sh` and `.travis.yml` to specify the exact Python versions as Python 2.7 and 3.6, rather than Python 2 and Python 3. `ci.sh` does make a semantic change in that it now requires exactly Python 3.6 for Py3 shards, whereas earlier it only used Py3.6 de facto. Meanwhile, `.travis.yml` changes the OSX rust tests to use Python 2.7 to fix an issue with requiring exactly Python 3.6, updates the cache directories to use the new `venv` naming scheme, and renames `py2`->`py27` and `py3`->`py36` everywhere.

This is pre-work to make the Python 3.7 CI pull request easier to review.

## Alternative solutions considered
### `./pants3` interpreter flags
Originally this PR added the CI flags `./pants -6` and `./pants -7` to allow forcing Pants to use only Python 3.6 or 3.7, respectively.

This solution was rejected for being over-constrained and too complex.

### `./pants37`
Originally we considered adding a new script `./pants37` to specify Python 3.7, rather than `./pants3 -7`. 

This was rejected because it results in too many root-level scripts that are prefixed `./pants`, which is confusing. 

Further, it is not often that Pants devs will need to switch between Python 3.6 and 3.7—we certainly will not expect them to do this frequently (whereas we do encourage frequently changing between `./pants` and `./pants3`). We merely want the ability to run with Python 3.7, particularly for CI; it is not important for the option to be especially discoverable. 

## Result
Calling `./pants` or `./pants3` for the first time will delete the legacy venv folders and use the new naming scheme.

Scripts now behave as follows:
* `./pants` will use Python 2.7 as before
* `./pants3` will use the first `python3` bin on the PATH, as before
* `PY=python3.6 ./pants3` will use only Python 3.6
* `PY=python3.7 ./pants3` will use only Python 3.7

Switching between these options will trigger an engine rebuild the first time, and then after that will change the interpreter used with no cost.