### PR TITLE
Add scala_exclude to append the Scala major version in BUILD files

### DIFF
--- a/3rdparty/jvm/org/scala-sbt/BUILD
+++ b/3rdparty/jvm/org/scala-sbt/BUILD
@@ -6,8 +6,8 @@ jar_library(
   jars=[
     scala_jar(org='org.scala-sbt', name='zinc', rev='1.1.7',
               excludes=[
-                exclude(org='org.scala-sbt', name='io_2.12'),
-                exclude(org='org.scala-sbt', name='util-logging_2.12'),
+                scala_exclude(org='org.scala-sbt', name='io'),
+                scala_exclude(org='org.scala-sbt', name='util-logging'),
               ]),
   ],
   dependencies=[

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -25,6 +25,7 @@ from pants.backend.jvm.targets.jvm_binary import Duplicate, JarRules, JvmBinary,
 from pants.backend.jvm.targets.jvm_prep_command import JvmPrepCommand
 from pants.backend.jvm.targets.managed_jar_dependencies import (ManagedJarDependencies,
                                                                 ManagedJarLibraries)
+from pants.backend.jvm.targets.scala_exclude import ScalaExclude
 from pants.backend.jvm.targets.scala_jar_dependency import ScalaJarDependency
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.targets.scalac_plugin import ScalacPlugin
@@ -118,6 +119,7 @@ def build_file_aliases():
       'Duplicate': Duplicate,
       'exclude': Exclude,
       'scala_jar': ScalaJarDependency,
+      'scala_exclude': ScalaExclude,
       'jar_rules': JarRules,
       'repository': repo,
       'Skip': Skip,

--- a/src/python/pants/backend/jvm/targets/BUILD
+++ b/src/python/pants/backend/jvm/targets/BUILD
@@ -74,6 +74,7 @@ python_library(
     'scala_library.py',
     'scalac_plugin.py',
     'scala_jar_dependency.py',
+    'scala_exclude.py',
   ],
   dependencies = [
     ':jvm',

--- a/src/python/pants/backend/jvm/targets/scala_exclude.py
+++ b/src/python/pants/backend/jvm/targets/scala_exclude.py
@@ -1,0 +1,24 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
+from pants.java.jar.exclude import Exclude
+
+
+class ScalaExclude(Exclude):
+  """Similar to its superclass, represents a (set of) jar coordinates to exclude.
+
+  Overrides the `name` of the exclusion to append the '--scala-platform-version'. This allows
+  for more natural consumption of cross-published scala libraries, which have their scala
+  version/platform appended to the artifact name.
+
+  :API: public
+  """
+
+  @property
+  def name(self):
+    base_name = super(ScalaExclude, self).name
+    return ScalaPlatform.global_instance().suffix_version(base_name)

--- a/src/python/pants/backend/jvm/targets/scala_jar_dependency.py
+++ b/src/python/pants/backend/jvm/targets/scala_jar_dependency.py
@@ -9,7 +9,7 @@ from pants.java.jar.jar_dependency import JarDependency
 
 
 class ScalaJarDependency(JarDependency):
-  """A JarDependency with the configured 'scala-compile: platform-version' automatically appended.
+  """A JarDependency with the configured '--scala-platform-version' automatically appended.
 
   This allows for more natural consumption of cross-published scala libraries, which have their
   scala version/platform appended to the artifact name.

--- a/src/python/pants/java/jar/exclude.py
+++ b/src/python/pants/java/jar/exclude.py
@@ -21,7 +21,11 @@ class Exclude(object):
       everything if unspecified.
     """
     self.org = org
-    self.name = name
+    self._name = name
+
+  @property
+  def name(self):
+    return self._name
 
   def __eq__(self, other):
     return all([other,

--- a/tests/python/pants_test/backend/jvm/targets/BUILD
+++ b/tests/python/pants_test/backend/jvm/targets/BUILD
@@ -14,8 +14,9 @@ python_tests(
   name='jar_dependency',
   sources=['test_jar_dependency.py'],
   dependencies=[
-    'src/python/pants/java/jar',
     'src/python/pants/backend/jvm/targets:scala',
+    'src/python/pants/java/jar',
+    'tests/python/pants_test/subsystem:subsystem_utils',
   ]
 )
 

--- a/tests/python/pants_test/backend/jvm/targets/test_jar_dependency.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jar_dependency.py
@@ -6,10 +6,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import unittest
 
+from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
+from pants.backend.jvm.targets.scala_exclude import ScalaExclude
 from pants.backend.jvm.targets.scala_jar_dependency import ScalaJarDependency
 from pants.base.build_environment import get_buildroot
 from pants.java.jar.exclude import Exclude
 from pants.java.jar.jar_dependency import JarDependency
+from pants_test.subsystem.subsystem_util import init_subsystem
 
 
 class JarDependencyTest(unittest.TestCase):
@@ -24,6 +27,17 @@ class JarDependencyTest(unittest.TestCase):
 
   def test_scala_jar_dependency_copy(self):
     self._test_copy(self._mkjardep(tpe=ScalaJarDependency))
+
+  def test_scala_exclude(self):
+    init_subsystem(ScalaPlatform)
+
+    name = 'foo_lib'
+    suffixed_name = ScalaPlatform.global_instance().suffix_version(name)
+
+    self.assertEqual(
+        suffixed_name,
+        ScalaExclude(org='example.com', name=name).name
+      )
 
   def test_get_url(self):
     """Test using relative url and absolute url are equivalent."""


### PR DESCRIPTION
### Problem

`scala_jar` and `scala_artifact` have existed for a long time, but have not had a corresponding way to declare a major-version specific `exclude`.

### Solution

Add `scala_exclude`.