### PR TITLE
Refactor packages.py in preparation for adding Python 3 support

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -7,6 +7,54 @@ set -e
 ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
 source ${ROOT}/build-support/common.sh
 
+function usage() {
+  echo "With no options all packages are built, smoke tested and published to"
+  echo "PyPi.  Credentials are needed for this as described in the"
+  echo "release docs: http://pantsbuild.org/release.html"
+  echo
+  echo "Usage: $0 [-d] [-c] (-h|-n|-f|-t|-l|-o|-e|-p)"
+  echo " -d  Enables debug mode (verbose output, script pauses after venv creation)"
+  echo " -h  Prints out this help message."
+  echo " -n  Performs a release dry run."
+  echo "       All package distributions will be built, installed locally in"
+  echo "       an ephemeral virtualenv and exercised to validate basic"
+  echo "       functioning."
+  echo " -f  Build the fs_util binary."
+  echo " -t  Tests a live release."
+  echo "       Ensures the latest packages have been propagated to PyPi"
+  echo "       and can be installed in an ephemeral virtualenv."
+  echo " -l  Lists all pantsbuild packages that this script releases."
+  echo " -o  Lists all pantsbuild package owners."
+  echo " -e  Check that wheels are prebuilt for this release."
+  echo " -p  Build a pex from prebuilt wheels for this release."
+  echo " -q  Build a pex which only works on the host platform, using the code as exists on disk."
+  echo
+  echo "All options (except for '-d') are mutually exclusive."
+
+  if (( $# > 0 )); then
+    die "$@"
+  else
+    exit 0
+  fi
+}
+
+while getopts "hdnftcloepqw" opt; do
+  case ${opt} in
+    h) usage ;;
+    d) debug="true" ;;
+    n) dry_run="true" ;;
+    f) run_build_fs_util="true" ;;
+    t) test_release="true" ;;
+    l) run_list="true" ;;
+    o) run_list_owners="true";;
+    e) run_fetch_and_check_prebuilt_wheels="true" ;;
+    p) run_build_pex_fetch="true" ;;
+    q) run_build_pex_build="true" ;;
+    w) run_list_prebuilt_wheels="true" ;;
+    *) usage "Invalid option: -${OPTARG}" ;;
+  esac
+done
+
 PY=$(which python2.7 || exit 0)
 [[ -n "${PY}" ]] || die "You must have python2.7 installed and on the path to release."
 export PY
@@ -614,57 +662,32 @@ function publish_packages() {
   end_travis_section
 }
 
-function usage() {
-  echo "With no options all packages are built, smoke tested and published to"
-  echo "PyPi.  Credentials are needed for this as described in the"
-  echo "release docs: http://pantsbuild.org/release.html"
-  echo
-  echo "Usage: $0 [-d] [-c] (-h|-n|-f|-t|-l|-o|-e|-p)"
-  echo " -d  Enables debug mode (verbose output, script pauses after venv creation)"
-  echo " -h  Prints out this help message."
-  echo " -n  Performs a release dry run."
-  echo "       All package distributions will be built, installed locally in"
-  echo "       an ephemeral virtualenv and exercised to validate basic"
-  echo "       functioning."
-  echo " -f  Build the fs_util binary."
-  echo " -t  Tests a live release."
-  echo "       Ensures the latest packages have been propagated to PyPi"
-  echo "       and can be installed in an ephemeral virtualenv."
-  echo " -l  Lists all pantsbuild packages that this script releases."
-  echo " -o  Lists all pantsbuild package owners."
-  echo " -e  Check that wheels are prebuilt for this release."
-  echo " -p  Build a pex from prebuilt wheels for this release."
-  echo " -q  Build a pex which only works on the host platform, using the code as exists on disk."
-  echo
-  echo "All options (except for '-d') are mutually exclusive."
-
-  if (( $# > 0 )); then
-    die "$@"
-  else
-    exit 0
-  fi
-}
-
-while getopts "hdnftcloepqw" opt; do
-  case ${opt} in
-    h) usage ;;
-    d) debug="true" ;;
-    n) dry_run="true" ;;
-    f) build_fs_util ; exit $? ;;
-    t) test_release="true" ;;
-    l) run_packages_script list ; exit $? ;;
-    o) run_packages_script list-owners ; exit $? ;;
-    e) fetch_and_check_prebuilt_wheels ; exit $? ;;
-    p) build_pex fetch ; exit $? ;;
-    q) build_pex build ; exit $? ;;
-    w) list_prebuilt_wheels ; exit $? ;;
-    *) usage "Invalid option: -${OPTARG}" ;;
-  esac
-done
-
 if [[ "${debug}" == "true" ]]; then
   set -x
   pause_after_venv_creation="true"
+fi
+
+if [[ "${run_build_fs_util}" == "true" ]]; then
+  build_fs_util
+  exit $?
+elif [[ "${run_list}" == "true" ]]; then
+  run_packages_script list
+  exit $?
+elif [[ "${run_list_owners}" == "true" ]]; then
+  run_packages_script list-owners
+  exit $?
+elif [[ "${run_fetch_and_check_prebuilt_wheels}" == "true" ]]; then
+  fetch_and_check_prebuilt_wheels
+  exit $?
+elif [[ "${run_build_pex_fetch}" == "true" ]]; then
+  build_pex fetch
+  exit $?
+elif [[ "${run_build_pex_build}" == "true" ]]; then
+  build_pex build
+  exit $?
+elif [[ "${run_list_prebuilt_wheels}" == "true" ]]; then
+  list_prebuilt_wheels
+  exit $?
 fi
 
 if [[ "${dry_run}" == "true" && "${test_release}" == "true" ]]; then

--- a/src/python/pants/releases/packages.py
+++ b/src/python/pants/releases/packages.py
@@ -242,19 +242,23 @@ def check_ownership(users, minimum_owner_count=3):
     sys.exit(1)
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument("command", choices=["list", "list-owners", "check-my-ownership", "build_and_print"])
-parser.add_argument("--with-packages", action="store_true")
-parser.add_argument("version", nargs="?", default=None)
+def _create_parser():
+  parser = argparse.ArgumentParser()
+  subparsers = parser.add_subparsers(dest="command")
+  # list
+  parser_list = subparsers.add_parser('list')
+  parser_list.add_argument("--with-packages", action="store_true")
+  # list-owners
+  subparsers.add_parser("list-owners")
+  # check-ownership
+  subparsers.add_parser("check-ownership")
+  # build_and_print
+  parser_build_and_print = subparsers.add_parser("build_and_print")
+  parser_build_and_print.add_argument("version")
+  return parser
 
-args = parser.parse_args()
 
-if args.with_packages and args.command != "list":
-  raise argparse.ArgumentError("--with-packages may only be used with the 'list' command.")
-if args.command == "build_and_print" and args.version is None:
-  raise argparse.ArgumentError("When running 'build_and_print', you must supply a version.")
-if args.command != "build_and_print" and args.version is not None:
-  raise argparse.ArgumentParser("version may only be used with 'build_and_print' command.")
+args = _create_parser().parse_args()
 
 if args.command == "list":
   if args.with_packages:

--- a/src/python/pants/releases/packages.py
+++ b/src/python/pants/releases/packages.py
@@ -253,6 +253,8 @@ if args.with_packages and args.command != "list":
   raise argparse.ArgumentError("--with-packages may only be used with the 'list' command.")
 if args.command == "build_and_print" and args.version is None:
   raise argparse.ArgumentError("When running 'build_and_print', you must supply a version.")
+if args.command != "build_and_print" and args.version is not None:
+  raise argparse.ArgumentParser("version may only be used with 'build_and_print' command.")
 
 if args.command == "list":
   if args.with_packages:

--- a/src/python/pants/releases/packages.py
+++ b/src/python/pants/releases/packages.py
@@ -270,7 +270,7 @@ if args.command == "list":
 elif args.command == "list-owners":
   for package in sorted(all_packages()):
     if not package.exists():
-      sys.stderr.write("The {} package is new! There are no owners yet.".format(package.name))
+      print("The {} package is new!  There are no owners yet.".format(package.name), file=sys.stderr)
       continue
     print("Owners of {}:".format(package.name))
     for owner in sorted(package.owners()):


### PR DESCRIPTION
### Problem
While working on adding Python 3 support to `release.sh`, the command line parsing in `packages.py` became confusing in trying to support an optional flag `--py3`. The current implementation of `sys.argv[1:]` works at the moment, but is difficult to work with for more complex command line configurations.

### Solution
Use argparse, which is Python's official library for CLI flags.

Focus on preserving the original semantics, while also making the code more readable and option parsing more robust.

### Result
Script functions the same as before and is ready for adding Python 3 support.