### PR TITLE
Fix setting conan remotes

### DIFF
--- a/examples/src/python/example/tensorflow_custom_op/README.md
+++ b/examples/src/python/example/tensorflow_custom_op/README.md
@@ -11,7 +11,7 @@ This directory implements the `ZeroOut` custom TensorFlow operator described in 
 Note that due to a current limitation (see [#6848](https://github.com/pantsbuild/pants/issues/6848)), this can only be run with the LLVM toolchain on OSX, which can be done with:
 
 ``` bash
-./pants --native-build-settings-toolchain-variant=llvm test examples/tests/python/example_test/tensorflow_custom_op:: -- -vs
+./pants --native-build-step-toolchain-variant=llvm test examples/tests/python/example_test/tensorflow_custom_op:: -- -vs
 ```
 
 or by setting the toolchain variant [option in `pants.ini`](https://www.pantsbuild.org/options.html).

--- a/pants.ini
+++ b/pants.ini
@@ -406,17 +406,17 @@ fragment: True
 [sitegen]
 config_path: src/docs/docsite.json
 
+# TODO(#6848, #7122): A gcc toolchain is currently required to build the tensorflow_custom_op example. This
+# should be removed when we can fully support both toolchains, and select between them with constraints.
+[native-build-step]
+toolchain_variant: gnu
+
 [native-build-step.cpp-compile-settings]
 compiler_option_sets_enabled_args: {
     # TensorFlow custom operators cannot be built against the C++11 ABI yet: see
     # https://www.tensorflow.org/guide/extend/op.
     'glibcxx_use_old_abi': ['-D_GLIBCXX_USE_CXX11_ABI=0'],
   }
-
-# TODO(#6848, #7122): A gcc toolchain is currently required to build the tensorflow_custom_op example. This
-# should be removed when we can fully support both toolchains, and select between them with constraints.
-[native-build-step]
-toolchain_variant: gnu
 
 [libc]
 enable_libc_search: True

--- a/src/python/pants/backend/native/register.py
+++ b/src/python/pants/backend/native/register.py
@@ -48,7 +48,8 @@ def register_goals():
   # TODO(#5962): register these under the 'compile' goal when we eliminate the product transitive
   # dependency from export -> compile.
   task(name='conan-prep', action=ConanPrep).install('native-compile')
-  task(name='conan-fetch', action=ConanFetch).install('native-compile')
+  # TODO: deprecate the `native-third-party-fetch` task name in favor of `conan-fetch` somehow!
+  task(name='native-third-party-fetch', action=ConanFetch).install('native-compile')
   task(name='c-for-ctypes', action=CCompile).install('native-compile')
   task(name='cpp-for-ctypes', action=CppCompile).install('native-compile')
   task(name='shared-libraries', action=LinkSharedLibraries).install('link')

--- a/src/python/pants/backend/native/register.py
+++ b/src/python/pants/backend/native/register.py
@@ -48,7 +48,7 @@ def register_goals():
   # TODO(#5962): register these under the 'compile' goal when we eliminate the product transitive
   # dependency from export -> compile.
   task(name='conan-prep', action=ConanPrep).install('native-compile')
-  task(name='native-third-party-fetch', action=ConanFetch).install('native-compile')
+  task(name='conan-fetch', action=ConanFetch).install('native-compile')
   task(name='c-for-ctypes', action=CCompile).install('native-compile')
   task(name='cpp-for-ctypes', action=CppCompile).install('native-compile')
   task(name='shared-libraries', action=LinkSharedLibraries).install('link')

--- a/src/python/pants/backend/native/register.py
+++ b/src/python/pants/backend/native/register.py
@@ -48,8 +48,7 @@ def register_goals():
   # TODO(#5962): register these under the 'compile' goal when we eliminate the product transitive
   # dependency from export -> compile.
   task(name='conan-prep', action=ConanPrep).install('native-compile')
-  # TODO: deprecate the `native-third-party-fetch` task name in favor of `conan-fetch` somehow!
-  task(name='native-third-party-fetch', action=ConanFetch).install('native-compile')
+  task(name='conan-fetch', action=ConanFetch).install('native-compile')
   task(name='c-for-ctypes', action=CCompile).install('native-compile')
   task(name='cpp-for-ctypes', action=CppCompile).install('native-compile')
   task(name='shared-libraries', action=LinkSharedLibraries).install('link')

--- a/src/python/pants/backend/native/subsystems/native_build_settings.py
+++ b/src/python/pants/backend/native/subsystems/native_build_settings.py
@@ -7,14 +7,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from pants.backend.native.subsystems.utils.mirrored_target_option_mixin import \
   MirroredTargetOptionMixin
 from pants.subsystem.subsystem import Subsystem
-from pants.util.objects import enum
-
-
-class ToolchainVariant(enum('descriptor', ['gnu', 'llvm'])):
-
-  @property
-  def is_gnu(self):
-    return self.descriptor == 'gnu'
 
 
 class NativeBuildSettings(Subsystem, MirroredTargetOptionMixin):

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -10,7 +10,7 @@ from pants.backend.native.subsystems.binaries.binutils import Binutils
 from pants.backend.native.subsystems.binaries.gcc import GCC
 from pants.backend.native.subsystems.binaries.llvm import LLVM
 from pants.backend.native.subsystems.libc_dev import LibcDev
-from pants.backend.native.subsystems.native_build_settings import ToolchainVariant
+from pants.backend.native.subsystems.native_build_step import ToolchainVariant
 from pants.backend.native.subsystems.xcode_cli_tools import XCodeCLITools
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, Select

--- a/src/python/pants/backend/native/targets/external_native_library.py
+++ b/src/python/pants/backend/native/targets/external_native_library.py
@@ -107,7 +107,7 @@ class ExternalNativeLibrary(Target):
       warn_or_error('1.16.0.dev1',
                     'Raw strings as conan package descriptors',
                     hint='Use conan_requirement(...) instead! Error was: {}'.format(str(e)),
-                    stacklevel=2)
+                    stacklevel=2, context=0)
       packages = [ConanRequirement(s) if not isinstance(s, ConanRequirement) else s
                   for s in packages]
 

--- a/src/python/pants/backend/native/targets/native_library.py
+++ b/src/python/pants/backend/native/targets/native_library.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.native.subsystems.native_build_settings import ToolchainVariant
+from pants.backend.native.subsystems.native_build_step import ToolchainVariant
 from pants.backend.native.targets.native_artifact import NativeArtifact
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload

--- a/src/python/pants/backend/native/tasks/c_compile.py
+++ b/src/python/pants/backend/native/tasks/c_compile.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.native.subsystems.native_build_step_settings import CCompileSettings
+from pants.backend.native.subsystems.native_build_step import CCompileSettings
 from pants.backend.native.targets.native_library import CLibrary
 from pants.backend.native.tasks.native_compile import NativeCompile
 from pants.util.objects import SubclassesOf

--- a/src/python/pants/backend/native/tasks/conan_fetch.py
+++ b/src/python/pants/backend/native/tasks/conan_fetch.py
@@ -16,8 +16,9 @@ from pants.base.build_environment import get_pants_cachedir
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.task.simple_codegen_task import SimpleCodegenTask
-from pants.util.dirutil import mergetree, safe_concurrent_creation, safe_file_dump
-from pants.util.memo import memoized_property
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import mergetree, safe_file_dump, safe_mkdir
+from pants.util.memo import memoized_method, memoized_property
 
 
 class ConanFetch(SimpleCodegenTask):
@@ -53,27 +54,65 @@ class ConanFetch(SimpleCodegenTask):
     super(ConanFetch, cls).prepare(options, round_manager)
     round_manager.require_data(ConanPrep.tool_instance_cls)
 
+  class ConanConfigError(TaskError): pass
+
   class ConanFetchError(TaskError): pass
 
-  @memoized_property
-  def _conan_user_home(self):
+  @property
+  def _remotes_txt_content(self):
+    """Generate a file containing overrides for Conan remotes which get applied to registry.json."""
+    return '{}\n'.format('\n'.join(
+      '{name} {url} {is_ssl}'.format(
+        name=name,
+        url=url,
+        is_ssl=re.match(r'^https://', url) is not None)
+        for name, url in self.get_options().conan_remotes.items()))
+
+  @memoized_method
+  def _conan_user_home(self, conan_pex):
+    """Create the CONAN_USER_HOME for this task fingerprint and initialize the Conan remotes.
+
+    See https://docs.conan.io/en/latest/reference/commands/consumer/config.html#conan-config-install
+    for docs on configuring remotes.
+    """
     user_home_base = os.path.join(get_pants_cachedir(), 'conan-support', 'conan-user-home')
-    # Find a specific subdirectory of the pants shared cachedir specific to this task's option
-    # values.
+    # Locate the subdirectory of the pants shared cachedir specific to this task's option values.
     user_home = os.path.join(user_home_base, self.fingerprint)
-    # Write a file overriding the conan remote's configuration with this task's options. See
-    # https://docs.conan.io/en/latest/reference/commands/consumer/config.html#conan-config-install
-    # for docs on configuring remotes.
-    remotes_txt = os.path.join(user_home, 'remotes.txt')
-    if not os.path.isfile(remotes_txt):
-      with safe_concurrent_creation(remotes_txt) as remotes_path:
-        remotes_description = '{}\n'.format('\n'.join(
-          '{name} {url} {is_ssl}'.format(
-            name=name,
-            url=url,
-            is_ssl=re.match(r'^https://', url) is not None)
-          for name, url in self.get_options().conan_remotes.items()))
-        safe_file_dump(remotes_path, remotes_description, binary_mode=False)
+    conan_install_base = os.path.join(user_home, '.conan')
+    # Conan doesn't copy remotes.txt into the .conan subdir after the "config install" command, it
+    # simply edits registry.json. However, it is valid to have this file there, and Conan won't
+    # touch it, so we use its presence to detect whether we have appropriately initialized the
+    # Conan installation.
+    remotes_txt_sentinel = os.path.join(conan_install_base, 'remotes.txt')
+    if not os.path.isfile(remotes_txt_sentinel):
+      safe_mkdir(conan_install_base)
+      # Conan doesn't consume the remotes.txt file just by being in the conan directory -- we need
+      # to create another directory containing any selection of files detailed in
+      # https://docs.conan.io/en/latest/reference/commands/consumer/config.html#conan-config-install
+      # and "install" from there to our desired conan directory.
+      with temporary_dir() as remotes_install_dir:
+        # Create an artificial conan configuration dir containing just remotes.txt.
+        remotes_txt_for_install = os.path.join(remotes_install_dir, 'remotes.txt')
+        safe_file_dump(remotes_txt_for_install, self._remotes_txt_content, binary_mode=False)
+        # Configure the desired user home from this artificial config dir.
+        argv = ['config', 'install', remotes_install_dir]
+        workunit_factory = functools.partial(
+          self.context.new_workunit,
+          name='initial-conan-config',
+          labels=[WorkUnitLabel.TOOL])
+        env = {
+          'CONAN_USER_HOME': user_home,
+        }
+        cmdline, exit_code = conan_pex.run(workunit_factory, argv, env=env)
+        if exit_code != 0:
+          raise self.ConanConfigError(
+            'Error configuring conan with argv {} and environment {}: exited non-zero ({}).'
+            .format(cmdline, env, exit_code),
+            exit_code=exit_code)
+      # Generate the sentinel file so that we know the remotes have been successfully configured for
+      # this particular task fingerprint in successive pants runs.
+      safe_file_dump(remotes_txt_sentinel)
+
     return user_home
 
   @memoized_property
@@ -123,7 +162,7 @@ class ConanFetch(SimpleCodegenTask):
       # CONAN_USER_HOME is somewhat documented at
       # https://docs.conan.io/en/latest/mastering/sharing_settings_and_config.html.
       env = {
-        'CONAN_USER_HOME': self._conan_user_home,
+        'CONAN_USER_HOME': self._conan_user_home(conan),
       }
 
       with conan.run_with(workunit_factory, argv, env=env) as (cmdline, exit_code, workunit):

--- a/src/python/pants/backend/native/tasks/conan_fetch.py
+++ b/src/python/pants/backend/native/tasks/conan_fetch.py
@@ -23,9 +23,6 @@ from pants.util.memo import memoized_property
 
 class ConanFetch(SimpleCodegenTask):
 
-  deprecated_options_scope = 'native-third-party-fetch'
-  deprecated_options_scope_removal_version = '1.16.0.dev0'
-
   gentarget_type = ExternalNativeLibrary
 
   sources_globs = ('include/**/*', 'lib/*',)
@@ -168,8 +165,9 @@ class ConanFetch(SimpleCodegenTask):
         labels=[WorkUnitLabel.TOOL])
       # CONAN_USER_HOME is somewhat documented at
       # https://docs.conan.io/en/latest/mastering/sharing_settings_and_config.html.
+      user_home = self._conan_user_home(conan)
       env = {
-        'CONAN_USER_HOME': self._conan_user_home(conan),
+        'CONAN_USER_HOME': user_home,
       }
 
       with conan.run_with(workunit_factory, argv, env=env) as (cmdline, exit_code, workunit):
@@ -185,7 +183,7 @@ class ConanFetch(SimpleCodegenTask):
         pkg_sha = conan_requirement.parse_conan_stdout_for_pkg_sha(conan_install_stdout)
 
       installed_data_dir = os.path.join(
-        self._conan_user_home,
+        user_home,
         '.conan', 'data',
         conan_requirement.directory_path,
         'package',

--- a/src/python/pants/backend/native/tasks/conan_fetch.py
+++ b/src/python/pants/backend/native/tasks/conan_fetch.py
@@ -23,6 +23,9 @@ from pants.util.memo import memoized_property
 
 class ConanFetch(SimpleCodegenTask):
 
+  deprecated_scope = 'native-third-party-fetch'
+  deprecated_scope_removal_version = '1.16.0.dev0'
+
   gentarget_type = ExternalNativeLibrary
 
   sources_globs = ('include/**/*', 'lib/*',)

--- a/src/python/pants/backend/native/tasks/cpp_compile.py
+++ b/src/python/pants/backend/native/tasks/cpp_compile.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.native.subsystems.native_build_step_settings import CppCompileSettings
+from pants.backend.native.subsystems.native_build_step import CppCompileSettings
 from pants.backend.native.targets.native_library import CppLibrary
 from pants.backend.native.tasks.native_compile import NativeCompile
 from pants.util.objects import SubclassesOf

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -123,7 +123,7 @@ class NativeCompile(NativeTask, AbstractClass):
 
   @abstractmethod
   def get_compile_settings(self):
-    """Return an instance of NativeBuildStepSettings.
+    """Return an instance of NativeBuildStep.
 
     NB: Subclasses will be queried for the compile settings once and the result cached.
     """
@@ -161,7 +161,7 @@ class NativeCompile(NativeTask, AbstractClass):
       include_dirs.append(external_lib_include_dir)
 
     sources_and_headers = self.get_sources_headers_for_target(target)
-    compiler_option_sets = (self._compile_settings.native_build_step_settings
+    compiler_option_sets = (self._compile_settings.native_build_step
                                 .get_compiler_option_sets_for_target(target))
 
     compile_request = NativeCompileRequest(
@@ -169,7 +169,7 @@ class NativeCompile(NativeTask, AbstractClass):
       include_dirs=include_dirs,
       sources=sources_and_headers,
       compiler_options=(self._compile_settings
-                            .native_build_step_settings
+                            .native_build_step
                             .get_merged_args_for_compiler_option_sets(compiler_option_sets)),
       output_dir=versioned_target.results_dir,
       header_file_extensions=self._compile_settings.header_file_extensions)

--- a/src/python/pants/backend/native/tasks/native_task.py
+++ b/src/python/pants/backend/native/tasks/native_task.py
@@ -8,7 +8,7 @@ from builtins import filter
 
 from pants.backend.native.config.environment import CppToolchain, CToolchain
 from pants.backend.native.subsystems.native_build_settings import NativeBuildSettings
-from pants.backend.native.subsystems.native_build_step_settings import NativeBuildStepSettings
+from pants.backend.native.subsystems.native_build_step import NativeBuildStep
 from pants.backend.native.subsystems.native_toolchain import (NativeToolchain,
                                                               ToolchainVariantRequest)
 from pants.backend.native.targets.native_library import NativeLibrary
@@ -81,8 +81,8 @@ class NativeTask(Task):
 
   # TODO(#7183): remove this global subsystem dependency!
   @memoized_property
-  def _native_build_step_settings(self):
-    return NativeBuildStepSettings.global_instance()
+  def _native_build_step(self):
+    return NativeBuildStep.global_instance()
 
   @memoized_property
   def _native_toolchain(self):
@@ -100,7 +100,7 @@ class NativeTask(Task):
     return self._get_toolchain_variant(CppToolchain, native_library_target)
 
   def _get_toolchain_variant(self, toolchain_type, native_library_target):
-    selected_variant = self._native_build_step_settings.get_toolchain_variant_for_target(
+    selected_variant = self._native_build_step.get_toolchain_variant_for_target(
       native_library_target)
     return self._request_single(toolchain_type, self._toolchain_variant_request(selected_variant))
 

--- a/src/python/pants/backend/python/tasks/python_tool_prep_base.py
+++ b/src/python/pants/backend/python/tasks/python_tool_prep_base.py
@@ -31,16 +31,16 @@ class PythonToolInstance(object):
   def _pretty_cmdline(self, args):
     return safe_shlex_join(self._pex.cmdline(args))
 
-  def output(self, args, input=None, binary_mode=False, **kwargs):
+  def output(self, args, stdin_payload=None, binary_mode=False, **kwargs):
     process = self._pex.run(args,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
                             with_chroot=False,
                             blocking=False,
                             **kwargs)
-    if input is not None:
-      input = ensure_binary(input)
-    (stdout, stderr) = process.communicate(input=input)
+    if stdin_payload is not None:
+      stdin_payload = ensure_binary(stdin_payload)
+    (stdout, stderr) = process.communicate(stdin_payload=stdin_payload)
     if not binary_mode:
       stdout = stdout.decode('utf-8')
       stderr = stderr.decode('utf-8')

--- a/src/python/pants/backend/python/tasks/python_tool_prep_base.py
+++ b/src/python/pants/backend/python/tasks/python_tool_prep_base.py
@@ -40,7 +40,7 @@ class PythonToolInstance(object):
                             **kwargs)
     if stdin_payload is not None:
       stdin_payload = ensure_binary(stdin_payload)
-    (stdout, stderr) = process.communicate(stdin_payload=stdin_payload)
+    (stdout, stderr) = process.communicate(input=stdin_payload)
     if not binary_mode:
       stdout = stdout.decode('utf-8')
       stderr = stderr.decode('utf-8')

--- a/tests/python/pants_test/backend/native/tasks/test_conan_fetch.py
+++ b/tests/python/pants_test/backend/native/tasks/test_conan_fetch.py
@@ -1,0 +1,37 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+from pants.backend.native.tasks.conan_fetch import ConanFetch
+from pants.backend.native.tasks.conan_prep import ConanPrep
+from pants_test.task_test_base import TaskTestBase
+
+
+class ConanFetchTest(TaskTestBase):
+
+  @classmethod
+  def task_type(cls):
+    return ConanFetch
+
+  def test_rewrites_remotes_according_to_options(self):
+    self.set_options(conan_remotes={'pants-conan': 'https://conan.bintray.com'})
+    conan_prep_task_type = self.synthesize_task_subtype(ConanPrep, 'conan_prep_scope')
+    context = self.context(for_task_types=[conan_prep_task_type])
+    conan_prep = conan_prep_task_type(context, os.path.join(self.pants_workdir, 'conan_prep'))
+    conan_fetch = self.create_task(context, os.path.join(self.pants_workdir, 'conan_fetch'))
+    conan_prep.execute()
+    conan_fetch.execute()
+    conan_pex = context.products.get_data(ConanPrep.tool_instance_cls)
+    user_home = conan_fetch._conan_user_home(conan_pex, in_workdir=True)
+
+    (stdout, stderr, exit_code, _) = conan_pex.output(['remote', 'list'], env={
+      'CONAN_USER_HOME': user_home,
+    })
+    self.assertEqual(0, exit_code)
+    self.assertEqual(b'', stderr)
+    self.assertEqual(stdout.decode('utf-8'),
+                     'pants-conan: https://conan.bintray.com [Verify SSL: True]\n')

--- a/tests/python/pants_test/backend/native/tasks/test_conan_fetch.py
+++ b/tests/python/pants_test/backend/native/tasks/test_conan_fetch.py
@@ -32,6 +32,5 @@ class ConanFetchTest(TaskTestBase):
       'CONAN_USER_HOME': user_home,
     })
     self.assertEqual(0, exit_code)
-    self.assertEqual(b'', stderr)
-    self.assertEqual(stdout.decode('utf-8'),
-                     'pants-conan: https://conan.bintray.com [Verify SSL: True]\n')
+    self.assertEqual('', stderr)
+    self.assertEqual(stdout, 'pants-conan: https://conan.bintray.com [Verify SSL: True]\n')

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -10,7 +10,7 @@ import re
 from zipfile import ZipFile
 
 from pants.backend.native.config.environment import Platform
-from pants.backend.native.subsystems.native_build_settings import ToolchainVariant
+from pants.backend.native.subsystems.native_build_step import ToolchainVariant
 from pants.option.scope import GLOBAL_SCOPE_CONFIG_SECTION
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import temporary_dir
@@ -238,7 +238,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       'native-build-step': {
         'toolchain_variant': toolchain_variant,
       },
-      'native-build-settings.cpp-compile-settings': {
+      'native-build-step.cpp-compile-settings': {
         'compiler_option_sets_enabled_args': {
           'asdf': ['-D_ASDF=1'],
         },

--- a/tests/python/pants_test/repo_scripts/test_git_hooks.py
+++ b/tests/python/pants_test/repo_scripts/test_git_hooks.py
@@ -53,7 +53,7 @@ class PreCommitHookTest(unittest.TestCase):
       stdout=subprocess.PIPE,
       stderr=subprocess.PIPE,
     )
-    (stdout_data, stderr_data) = proc.communicate(stdin_payload=ensure_binary(stdin_payload))
+    (stdout_data, stderr_data) = proc.communicate(input=ensure_binary(stdin_payload))
     # Attempting to call '{}\n{}'.format(...) on bytes in python 3 gives you the string:
     #   "b'<the first string>'\nb'<the second string>'"
     # So we explicitly decode both stdout and stderr here.


### PR DESCRIPTION
### Problem

#7060 refactored the `ConanFetch` task, and in the process broke setting remotes, which didn't come up in testing because we didn't try using any other remotes.

### Solution

Read through the sprawling Conan docs to realize that we need to:
- create a "config" directory with the `remotes.txt` which overrides the remotes that Conan pre-populates (we make a temp dir for this).
- run `conan config install /path/to/the/config/dir`.
- write a `remotes.txt` to the Conan config dir even though it is not consumed by Conan so that we can detect if we've already done such an initialization.

Also:
- add a `.output()` method to `PythonToolInstance` so we can invoke python tools as pexes for their stdout (in this case, used to test `conan remote list`).

### Result

`ConanFetch` can set alternate remote repositories again.