### PR TITLE
Consume the PyTest Subsystem to stabilize the pytest version.

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -8,7 +8,7 @@ from pants.backend.python.pants_requirement import PantsRequirement
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.python_requirements import PythonRequirements
-from pants.backend.python.rules.python_test_runner import run_python_test
+from pants.backend.python.rules import python_test_runner
 from pants.backend.python.targets.python_app import PythonApp
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_distribution import PythonDistribution
@@ -81,4 +81,4 @@ def register_goals():
 
 
 def rules():
-  return (run_python_test,)
+  return tuple(python_test_runner.rules())

--- a/src/python/pants/backend/python/rules/BUILD
+++ b/src/python/pants/backend/python/rules/BUILD
@@ -1,5 +1,11 @@
 python_library(
   dependencies=[
     'src/python/pants/backend/python/subsystems',
+    'src/python/pants/engine/legacy:graph',
+    'src/python/pants/engine:fs',
+    'src/python/pants/engine:isolated_process',
+    'src/python/pants/engine:rules',
+    'src/python/pants/engine:selectors',
+    'src/python/pants/rules/core',
   ],
 )

--- a/src/python/pants/backend/python/rules/BUILD
+++ b/src/python/pants/backend/python/rules/BUILD
@@ -1,1 +1,5 @@
-python_library()
+python_library(
+  dependencies=[
+    'src/python/pants/backend/python/subsystems',
+  ],
+)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -10,7 +10,7 @@ from builtins import object
 from pants.backend.docgen.targets.doc import Page
 from pants.backend.jvm.targets.jvm_app import JvmApp
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
-from pants.backend.python.rules.python_test_runner import run_python_test
+from pants.backend.python.rules import python_test_runner
 from pants.backend.python.targets.python_app import PythonApp
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
@@ -356,7 +356,7 @@ class EngineInitializer(object):
       create_graph_rules(address_mapper) +
       create_options_parsing_rules() +
       # TODO: This should happen automatically, but most tests (e.g. tests/python/pants_test/auth) fail if it's not here:
-      [run_python_test] +
+      python_test_runner.rules() +
       rules
     )
 

--- a/tests/python/pants_test/rules/test_test_integration.py
+++ b/tests/python/pants_test/rules/test_test_integration.py
@@ -71,6 +71,7 @@ class TestIntegrationTest(PantsRunIntegrationTest):
 ============================= test session starts ==============================
 platform SOME_TEXT
 rootdir: SOME_TEXT
+plugins: SOME_TEXT
 collected 1 item
 
 testprojects/tests/python/pants/dummies/test_pass.py .                   [100%]
@@ -90,6 +91,7 @@ testprojects/tests/python/pants/dummies:passing_target                          
 ============================= test session starts ==============================
 platform SOME_TEXT
 rootdir: SOME_TEXT
+plugins: SOME_TEXT
 collected 1 item
 
 testprojects/tests/python/pants/dummies/test_fail.py F                   [100%]
@@ -117,6 +119,7 @@ testprojects/tests/python/pants/dummies:failing_target                          
 ============================= test session starts ==============================
 platform SOME_TEXT
 rootdir: SOME_TEXT
+plugins: SOME_TEXT
 collected 1 item
 
 testprojects/tests/python/pants/dummies/test_with_source_dep.py .        [100%]
@@ -135,6 +138,7 @@ testprojects/tests/python/pants/dummies:target_with_source_dep                  
 ============================= test session starts ==============================
 platform SOME_TEXT
 rootdir: SOME_TEXT
+plugins: SOME_TEXT
 collected 1 item
 
 testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py .    [100%]
@@ -155,6 +159,7 @@ testprojects/tests/python/pants/dummies:target_with_thirdparty_dep              
 ============================= test session starts ==============================
 platform SOME_TEXT
 rootdir: SOME_TEXT
+plugins: SOME_TEXT
 collected 1 item
 
 testprojects/tests/python/pants/dummies/test_fail.py F                   [100%]
@@ -171,6 +176,7 @@ testprojects/tests/python/pants/dummies/test_fail.py:2: AssertionError
 ============================= test session starts ==============================
 platform SOME_TEXT
 rootdir: SOME_TEXT
+plugins: SOME_TEXT
 collected 1 item
 
 testprojects/tests/python/pants/dummies/test_pass.py .                   [100%]


### PR DESCRIPTION
### Problem

Master is currently broken with python 2 due to a floating pytest version resulting in a lovely new Py2k warning overnight.

### Solution

Pin the v2 pytest runner to the pytest requirement string(s) provided by the `PyTest` `Subsystem`.

### Result

Less-floaty pytest versions.