### PR TITLE
Set default PY in cargo wrapper

### DIFF
--- a/build-support/bin/native/cargo.sh
+++ b/build-support/bin/native/cargo.sh
@@ -4,6 +4,8 @@ set -e
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd ../../.. && pwd -P)
 
+export PY=${PY:-python2.7}
+
 # Exports:
 # + CARGO_HOME: The CARGO_HOME of the Pants-controlled rust toolchain.
 # Exposes:


### PR DESCRIPTION
It calls virtualenv so needs one set. Some scripts call it bare.