### PR TITLE
WIP: Audit if `test_console_rule_integration.py` now works with Py3

### DIFF
--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,3 +1,2 @@
 tests/python/pants_test/backend/project_info/tasks:idea_plugin_integration
 tests/python/pants_test/backend/python/tasks:integration
-tests/python/pants_test/engine/legacy:console_rule_integration


### PR DESCRIPTION
Neither tests fails locally anymore. Audit if all is good now.

Note I suspect `test_v2_goal_validation` is flaky, as it failed the first few times then mysteriously started succeeding consistently. This one needs to be run against CI multiple times to ensure we aren't introducing a flake.