### PR TITLE
Fix release script ownership check command name

### DIFF
--- a/src/python/pants/releases/packages.py
+++ b/src/python/pants/releases/packages.py
@@ -250,8 +250,8 @@ def _create_parser():
   parser_list.add_argument("--with-packages", action="store_true")
   # list-owners
   subparsers.add_parser("list-owners")
-  # check-ownership
-  subparsers.add_parser("check-ownership")
+  # check-my-ownership
+  subparsers.add_parser("check-my-ownership")
   # build_and_print
   parser_build_and_print = subparsers.add_parser("build_and_print")
   parser_build_and_print.add_argument("version")


### PR DESCRIPTION
### Problem

The `check-my-ownership` script command name went out of sync with actual usages, which broke running the release script.

### Solution

Fix parser's command name.

### Result

Releases work.