### PR TITLE
Output non-empty digest for empty directory as output_directories when running ExecuteProcessRequest

### DIFF
--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -52,10 +52,10 @@ impl CommandRunner {
     let output_paths: Result<Vec<String>, String> = output_dir_paths
       .into_iter()
       .flat_map(|p| {
-        let mut dir = p.into_os_string();
-        let dir_glob = dir.clone();
-        dir.push("/**");
-        vec![dir_glob, dir]
+        let mut dir_glob = p.into_os_string();
+        let dir = dir_glob.clone();
+        dir_glob.push("/**");
+        vec![dir, dir_glob]
       })
       .chain(output_file_paths.into_iter().map(|p| p.into_os_string()))
       .map(|s| {

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -52,10 +52,10 @@ impl CommandRunner {
     let output_paths: Result<Vec<String>, String> = output_dir_paths
       .into_iter()
       .flat_map(|p| {
-        let mut s = p.into_os_string();
-        let s_dir = s.clone();
-        s.push("/**");
-        vec![s_dir, s]
+        let mut dir = p.into_os_string();
+        let dir_glob = dir.clone();
+        dir.push("/**");
+        vec![dir_glob, dir]
       })
       .chain(output_file_paths.into_iter().map(|p| p.into_os_string()))
       .map(|s| {
@@ -847,7 +847,7 @@ mod tests {
         stdout: as_bytes(""),
         stderr: as_bytes(""),
         exit_code: 0,
-        output_directory: TestDirectory::nested().digest(),
+        output_directory: TestDirectory::nested_dir_and_file().digest(),
         execution_attempts: vec![],
       }
     )
@@ -856,11 +856,15 @@ mod tests {
   #[test]
   fn output_empty_dir() {
     let result = run_command_locally(ExecuteProcessRequest {
-      argv: vec![find_bash(), "-c".to_owned(), "/bin/mkdir dogs".to_string()],
+      argv: vec![
+        find_bash(),
+        "-c".to_owned(),
+        "/bin/mkdir falcons".to_string(),
+      ],
       env: BTreeMap::new(),
       input_files: fs::EMPTY_DIGEST,
       output_files: BTreeSet::new(),
-      output_directories: vec![PathBuf::from("dogs")].into_iter().collect(),
+      output_directories: vec![PathBuf::from("falcons")].into_iter().collect(),
       timeout: Duration::from_millis(1000),
       description: "bash".to_string(),
       jdk_home: None,
@@ -872,7 +876,7 @@ mod tests {
         stdout: as_bytes(""),
         stderr: as_bytes(""),
         exit_code: 0,
-        output_directory: TestDirectory::containing_cats_dir().digest(),
+        output_directory: TestDirectory::containing_falcons_dir().digest(),
         execution_attempts: vec![],
       }
     )

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -74,13 +74,34 @@ impl TestDirectory {
 
   // Directory structure:
   //
-  // /dogs/
-  pub fn containing_cats_dir() -> TestDirectory {
+  // /falcons/
+  pub fn containing_falcons_dir() -> TestDirectory {
     let mut directory = bazel_protos::remote_execution::Directory::new();
     directory.mut_directories().push({
       let mut subdir = bazel_protos::remote_execution::DirectoryNode::new();
-      subdir.set_name("dogs".to_string());
+      subdir.set_name("falcons".to_string());
       subdir.set_digest((&TestDirectory::empty().digest()).into());
+      subdir
+    });
+    TestDirectory { directory }
+  }
+
+  // Directory structure:
+  //
+  // birds/falcons/
+  // cats/roland
+  pub fn nested_dir_and_file() -> TestDirectory {
+    let mut directory = bazel_protos::remote_execution::Directory::new();
+    directory.mut_directories().push({
+      let mut subdir = bazel_protos::remote_execution::DirectoryNode::new();
+      subdir.set_name("birds".to_string());
+      subdir.set_digest((&TestDirectory::containing_falcons_dir().digest()).into());
+      subdir
+    });
+    directory.mut_directories().push({
+      let mut subdir = bazel_protos::remote_execution::DirectoryNode::new();
+      subdir.set_name("cats".to_string());
+      subdir.set_digest((&TestDirectory::containing_roland().digest()).into());
       subdir
     });
     TestDirectory { directory }

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -74,6 +74,20 @@ impl TestDirectory {
 
   // Directory structure:
   //
+  // /dogs/
+  pub fn containing_cats_dir() -> TestDirectory {
+    let mut directory = bazel_protos::remote_execution::Directory::new();
+    directory.mut_directories().push({
+      let mut subdir = bazel_protos::remote_execution::DirectoryNode::new();
+      subdir.set_name("dogs".to_string());
+      subdir.set_digest((&TestDirectory::empty().digest()).into());
+      subdir
+    });
+    TestDirectory { directory }
+  }
+
+  // Directory structure:
+  //
   // /roland
   pub fn containing_roland() -> TestDirectory {
     let mut directory = bazel_protos::remote_execution::Directory::new();


### PR DESCRIPTION
### Problem
When running `process_execution::ExecuteProcessRequest` and `output_directories` field is empty directory the `output_directory` for `FallibleExecuteProcessResult` is empty digest.

### Result
The result of `process_execution::ExecuteProcessRequest` command returns non-empty digest for `result.unwrap().output_directory`