### PR TITLE
Add flag reporting-zipkin-sample-rate that sets the sample rate at which to sample Zipkin traces

### DIFF
--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -60,6 +60,8 @@ class Reporting(Subsystem):
               help='The 64-bit ID for a parent span that invokes Pants. '
                    'zipkin-trace-id and zipkin-parent-id must both either be set or not set '
                    'when run Pants command')
+    register('--zipkin-sample-rate', advanced=True, default=100.0,
+              help='Rate at which to sample Zipkin traces. Value 0.0 - 100.0.')
 
   def initialize(self, run_tracker, all_options, start_time=None):
     """Initialize with the given RunTracker.
@@ -100,6 +102,7 @@ class Reporting(Subsystem):
     zipkin_endpoint = self.get_options().zipkin_endpoint
     trace_id = self.get_options().zipkin_trace_id
     parent_id = self.get_options().zipkin_parent_id
+    sample_rate = self.get_options().zipkin_sample_rate
 
     if zipkin_endpoint is None and trace_id is not None and parent_id is not None:
       raise ValueError(
@@ -113,7 +116,7 @@ class Reporting(Subsystem):
     if zipkin_endpoint is not None:
       zipkin_reporter_settings = ZipkinReporter.Settings(log_level=Report.INFO)
       zipkin_reporter = ZipkinReporter(
-        run_tracker, zipkin_reporter_settings, zipkin_endpoint, trace_id, parent_id
+        run_tracker, zipkin_reporter_settings, zipkin_endpoint, trace_id, parent_id, sample_rate
       )
       report.add_reporter('zipkin', zipkin_reporter)
 


### PR DESCRIPTION
### Problem
In the current implementation, every time the pants command is run with zipkin tracing turned on all the zipkin traces will be collected. It is not very convenient when the number of runs is very big. 

### Solution
Possibility to set the sample rate will allow us to have the number of traces that fits the constraints of Zipkin server. 

### Result
A flag `reporting-zipkin-sample-rate` was added that sets the sample rate at which to sample Zipkin traces. If flags `reporting-zipkin-trace-id` and `reporting-zipkin-parent-id` are set the sample rate will always be 100.0 (no matter what is set in `reporting-zipkin-sample-rate` flag).