### PR TITLE
Only run master-dependent commithooks on master

### DIFF
--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -51,36 +51,37 @@ printf "%s\n" "${ADDED_FILES[@]}" \
 echo "* Checking for banned imports"
 ./build-support/bin/check_banned_imports.sh
 
-if git diff master --name-only | grep '\.rs$' > /dev/null; then
-  echo "* Checking formatting of rust files" && ./build-support/bin/check_rust_formatting.sh || exit 1
-  # Clippy happens on a different shard because of separate caching concerns.
-  if [[ "${RUNNING_VIA_TRAVIS_CI_SCRIPT}" != "1" ]]; then
-    echo "* Running cargo clippy" && ./build-support/bin/check_clippy.sh || exit 1
-  fi
-  echo "* Checking rust target headers" && build-support/bin/check_rust_target_headers.sh || exit 1
-fi
-
 echo "* Checking for bad shell patterns" && ./build-support/bin/check_shell.sh || exit 1
 
-$(git rev-parse --verify master > /dev/null 2>&1)
-if [[ $? -eq 0 ]]; then
+# When travis builds a tag, it does so in a shallow clone without master fetched, which
+# fails in pants changed.
+master_present=$(git rev-parse --verify master > /dev/null 2>&1 || echo "Nope!")
+if [[ "$master_present" != "Nope!" ]]; then
   echo "* Checking imports" && ./build-support/bin/isort.sh || \
     die "To fix import sort order, run \`\"$(pwd)/build-support/bin/isort.sh\" -f\`"
+
   # TODO(CMLivingston) Make lint use `-q` option again after addressing proper workunit labeling:
   # https://github.com/pantsbuild/pants/issues/6633
   # TODO: add a test case for this while including a pexrc file, as python checkstyle currently fails
   # quite often with a pexrc available.
   echo "* Checking lint" && ./pants --exclude-target-regexp='testprojects/.*' --changed-parent=master lint || exit 1
-else
-  # When travis builds a tag, it does so in a shallow clone without master fetched, which
-  # fails in pants changed.
-  echo "* Skipping import/lint checks in partial working copy."
-fi
 
-if git diff master --name-only | grep build-support/travis > /dev/null; then
-  echo "* Checking .travis.yml generation" && \
-  actual_travis_yml=$(<.travis.yml) && \
-  expected_travis_yml=$(./pants --quiet run build-support/travis:generate_travis_yml) && \
-  [ "${expected_travis_yml}" == "${actual_travis_yml}" ] || \
-  die "Travis config generator changed but .travis.yml file not regenerated. See top of that file for instructions."
+  if git diff master --name-only | grep '\.rs$' > /dev/null; then
+    echo "* Checking formatting of rust files" && ./build-support/bin/check_rust_formatting.sh || exit 1
+    # Clippy happens on a different shard because of separate caching concerns.
+    if [[ "${RUNNING_VIA_TRAVIS_CI_SCRIPT}" != "1" ]]; then
+      echo "* Running cargo clippy" && ./build-support/bin/check_clippy.sh || exit 1
+    fi
+    echo "* Checking rust target headers" && build-support/bin/check_rust_target_headers.sh || exit 1
+  fi
+
+  if git diff master --name-only | grep build-support/travis > /dev/null; then
+    echo "* Checking .travis.yml generation" && \
+    actual_travis_yml=$(<.travis.yml) && \
+    expected_travis_yml=$(./pants --quiet run build-support/travis:generate_travis_yml) && \
+    [ "${expected_travis_yml}" == "${actual_travis_yml}" ] || \
+    die "Travis config generator changed but .travis.yml file not regenerated. See top of that file for instructions."
+  fi
+else
+  echo "* Skipping import/lint checks in partial working copy."
 fi

--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -55,8 +55,7 @@ echo "* Checking for bad shell patterns" && ./build-support/bin/check_shell.sh |
 
 # When travis builds a tag, it does so in a shallow clone without master fetched, which
 # fails in pants changed.
-master_present=$(git rev-parse --verify master > /dev/null 2>&1 || echo "Nope!")
-if [[ "$master_present" != "Nope!" ]]; then
+if git rev-parse --verify "master" &>/dev/null; then
   echo "* Checking imports" && ./build-support/bin/isort.sh || \
     die "To fix import sort order, run \`\"$(pwd)/build-support/bin/isort.sh\" -f\`"
 


### PR DESCRIPTION
### Problem

See #7213: some commit hooks are only valid in a context where master is present (and should otherwise be skipped).

### Solution

Move more hooks that reference `master` under the check for the presence of `master`. 

### Result

Fixes #7213, and unblocks further iteration on the `1.14.x` stable branch.