### PR TITLE
Validate and maybe prune interpreter cache run over run

### DIFF
--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -97,7 +97,6 @@ class PythonInterpreterCache(Subsystem):
 
     tgts_by_compatibilities, total_filter_set = self.partition_targets_by_compatibility(targets)
     allowed_interpreters = set(self.setup(filters=total_filter_set))
-
     # Constrain allowed_interpreters based on each target's compatibility requirements.
     for compatibility in tgts_by_compatibilities:
       compatible_with_target = set(self._matching(allowed_interpreters, compatibility))
@@ -118,9 +117,11 @@ class PythonInterpreterCache(Subsystem):
   def _interpreter_from_path(self, path, filters=()):
     try:
       executable = os.readlink(os.path.join(path, 'python'))
+      if not os.path.exists(executable):
+        if os.path.dirname(path) == self._cache_dir:
+          self._purge_interpreter(path)
+        return None
     except OSError:
-      if os.path.dirname(path) == self._cache_dir:
-        self._purge_interpreter(path)
       return None
     interpreter = PythonInterpreter.from_binary(executable, include_site_extras=False)
     if self._matches(interpreter, filters=filters):

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -97,6 +97,7 @@ class PythonInterpreterCache(Subsystem):
 
     tgts_by_compatibilities, total_filter_set = self.partition_targets_by_compatibility(targets)
     allowed_interpreters = set(self.setup(filters=total_filter_set))
+
     # Constrain allowed_interpreters based on each target's compatibility requirements.
     for compatibility in tgts_by_compatibilities:
       compatible_with_target = set(self._matching(allowed_interpreters, compatibility))

--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -99,10 +99,8 @@ class SelectInterpreter(Task):
     return os.path.join(self.workdir, target_set_id, 'interpreter.info')
 
   def _detect_and_purge_invalid_interpreter(self, interpreter_path_file):
-    with open(interpreter_path_file, 'r') as infile:
-      lines = infile.readlines()
-    binary = lines[0].strip()
-    if not os.path.exists(binary):
+    interpreter = self._get_interpreter(interpreter_path_file)
+    if not os.path.exists(interpreter.binary):
       self.context.log.info('Stale interpreter reference detected: {}, removing reference and '
                             'selecting a new interpreter.'.format(binary))
       os.remove(interpreter_path_file)

--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -102,7 +102,7 @@ class SelectInterpreter(Task):
     interpreter = self._get_interpreter(interpreter_path_file)
     if not os.path.exists(interpreter.binary):
       self.context.log.info('Stale interpreter reference detected: {}, removing reference and '
-                            'selecting a new interpreter.'.format(binary))
+                            'selecting a new interpreter.'.format(interpreter.binary))
       os.remove(interpreter_path_file)
       return True
     return False


### PR DESCRIPTION
### Problem
Fix needed for https://github.com/pantsbuild/pants/issues/3416
### Solution
Add validation logic to interpreter selection that verifies the executable of cached interpreters in two places: 1) by validating the exe marked in the interpreteter.info manifest during select_interpreter.py task and 2) by ensuring that the exe exists when we load an interpreter from a path in the `_interpreter_from_path` of interpreter_cache.py

### Result
Users will not experience stale cache problems as outlined in https://github.com/pantsbuild/pants/issues/3416