### PR TITLE
Canonicalize enum pattern matching for execution strategy, platform, and elsewhere

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -201,7 +201,7 @@ class RscCompile(ZincCompile):
 
   # Overrides the normal zinc compiler classpath, which only contains zinc.
   def get_zinc_compiler_classpath(self):
-    return self.execution_strategy_enum.do_for_enum_variant({
+    return self.execution_strategy_enum.resolve_for_enum_variant({
       self.HERMETIC: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.SUBPROCESS: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.NAILGUN: lambda: self._nailgunnable_combined_classpath,
@@ -861,7 +861,7 @@ class RscCompile(ZincCompile):
   def _runtool(self, main, tool_name, args, distribution,
                tgt=None, input_files=tuple(), input_digest=None, output_dir=None):
     with self.context.new_workunit(tool_name) as wu:
-      return self.execution_strategy_enum.do_for_enum_variant({
+      return self.execution_strategy_enum.resolve_for_enum_variant({
         self.HERMETIC: lambda: self._runtool_hermetic(
           main, tool_name, args, distribution,
           tgt=tgt, input_files=input_files, input_digest=input_digest, output_dir=output_dir),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -201,7 +201,7 @@ class RscCompile(ZincCompile):
 
   # Overrides the normal zinc compiler classpath, which only contains zinc.
   def get_zinc_compiler_classpath(self):
-    return self.do_for_execution_strategy_variant({
+    return self.execution_strategy_enum.do_for_enum_variant({
       self.HERMETIC: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.SUBPROCESS: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.NAILGUN: lambda: self._nailgunnable_combined_classpath,
@@ -861,7 +861,7 @@ class RscCompile(ZincCompile):
   def _runtool(self, main, tool_name, args, distribution,
                tgt=None, input_files=tuple(), input_digest=None, output_dir=None):
     with self.context.new_workunit(tool_name) as wu:
-      return self.do_for_execution_strategy_variant({
+      return self.execution_strategy_enum.do_for_enum_variant({
         self.HERMETIC: lambda: self._runtool_hermetic(
           main, tool_name, args, distribution,
           tgt=tgt, input_files=input_files, input_digest=input_digest, output_dir=output_dir),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -869,7 +869,7 @@ class RscCompile(ZincCompile):
           wu, self.tool_classpath(tool_name), main, tool_name, args, distribution),
         self.NAILGUN: lambda: self._runtool_nonhermetic(
           wu, self._nailgunnable_combined_classpath, main, tool_name, args, distribution),
-      })
+      })()
 
   def _run_metai_tool(self,
                       distribution,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -205,7 +205,7 @@ class RscCompile(ZincCompile):
       self.HERMETIC: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.SUBPROCESS: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.NAILGUN: lambda: self._nailgunnable_combined_classpath,
-    })
+    })()
 
   def register_extra_products_from_contexts(self, targets, compile_contexts):
     super(RscCompile, self).register_extra_products_from_contexts(targets, compile_contexts)

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -47,6 +47,13 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
                                           rev='0.9.1'),
                           ])
 
+  @memoized_property
+  def execution_strategy_enum(self):
+    # TODO: This .create() call can be removed when the enum interface is more stable as the option
+    # is converted into an instance of self.ExecutionStrategy vai the `type` argument through
+    # register_enum_option().
+    return self.ExecutionStrategy.create(self.get_options().execution_strategy)
+
   @classmethod
   def subsystem_dependencies(cls):
     return super(NailgunTaskBase, cls).subsystem_dependencies() + (Subprocess.Factory,)
@@ -62,10 +69,6 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
     self._identity = '_'.join(id_tuple)
     self._executor_workdir = os.path.join(self.context.options.for_global_scope().pants_workdir,
                                           *id_tuple)
-
-  @memoized_property
-  def execution_strategy_enum(self):
-    return self.ExecutionStrategy.create(self.get_options().execution_strategy)
 
   # TODO: eventually deprecate this when we can move all subclasses to use the enum!
   @property

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -50,7 +50,7 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
   @memoized_property
   def execution_strategy_enum(self):
     # TODO: This .create() call can be removed when the enum interface is more stable as the option
-    # is converted into an instance of self.ExecutionStrategy vai the `type` argument through
+    # is converted into an instance of self.ExecutionStrategy via the `type` argument through
     # register_enum_option().
     return self.ExecutionStrategy.create(self.get_options().execution_strategy)
 

--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -44,9 +44,9 @@ class GCC(NativeTool):
 
   @memoized_method
   def _common_lib_dirs(self, platform):
-    lib64_tuples = platform.resolve_platform_specific({
-      'darwin': lambda: [],
-      'linux': lambda: [('lib64',)],
+    lib64_tuples = platform.resolve_for_enum_variant({
+      'darwin': [],
+      'linux': [('lib64',)],
     })
     return self._filemap(lib64_tuples + [
       ('lib',),

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -80,16 +80,13 @@ class LLVM(NativeTool):
   def path_entries(self):
     return self._filemap([('bin',)])
 
-  _PLATFORM_SPECIFIC_LINKER_NAME = {
-    'darwin': lambda: 'ld64.lld',
-    'linux': lambda: 'lld',
-  }
-
   def linker(self, platform):
     return Linker(
       path_entries=self.path_entries,
-      exe_filename=platform.resolve_platform_specific(
-        self._PLATFORM_SPECIFIC_LINKER_NAME),
+      exe_filename=platform.resolve_for_enum_variant({
+        'darwin': 'ld64.lld',
+        'linux': 'lld',
+      }),
       library_dirs=[],
       linking_library_dirs=[],
       extra_args=[],

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -10,14 +10,10 @@ from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
 from pants.util.meta import classproperty
-from pants.util.objects import enum
+from pants.util.objects import enum, register_enum_option
 
 
-class ToolchainVariant(enum('descriptor', ['gnu', 'llvm'])):
-
-  @property
-  def is_gnu(self):
-    return self.descriptor == 'gnu'
+class ToolchainVariant(enum(['gnu', 'llvm'])): pass
 
 
 class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsystem):
@@ -39,11 +35,10 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
              help='The default for the "compiler_option_sets" argument '
                   'for targets of this language.')
 
-    register('--toolchain-variant', type=str, fingerprint=True, advanced=True,
-             choices=ToolchainVariant.allowed_values,
-             default=ToolchainVariant.default_value,
-             help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
-                  "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
+    register_enum_option(
+      register, ToolchainVariant, '--toolchain-variant', type=str, advanced=True,
+      help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
+           "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
 
   def get_compiler_option_sets_for_target(self, target):
     return self.get_target_mirrored_option('compiler_option_sets', target)

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -36,7 +36,7 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
                   'for targets of this language.')
 
     register_enum_option(
-      register, ToolchainVariant, '--toolchain-variant', type=str, advanced=True,
+      register, ToolchainVariant, '--toolchain-variant', advanced=True,
       help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
            "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -87,10 +87,11 @@ class LLVMCppToolchain(datatype([('cpp_toolchain', CppToolchain)])): pass
 
 @rule(LibcObjects, [Select(Platform), Select(NativeToolchain)])
 def select_libc_objects(platform, native_toolchain):
-  paths = platform.resolve_platform_specific({
+  # We use lambdas here to avoid searching for libc on osx, where it will fail.
+  paths = platform.resolve_for_enum_variant({
     'darwin': lambda: [],
     'linux': lambda: native_toolchain._libc_dev.get_libc_objects(),
-  })
+  })()
   yield LibcObjects(paths)
 
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -344,8 +344,12 @@ class ToolchainVariantRequest(datatype([
 @rule(CToolchain, [Select(ToolchainVariantRequest)])
 def select_c_toolchain(toolchain_variant_request):
   native_toolchain = toolchain_variant_request.toolchain
-  # TODO: make an enum exhaustiveness checking method that works with `yield Get(...)` statements!
-  if toolchain_variant_request.variant.is_gnu:
+  # TODO(#5933): make an enum exhaustiveness checking method that works with `yield Get(...)`!
+  use_gcc = toolchain_variant_request.variant.resolve_for_enum_variant({
+    'gnu': True,
+    'llvm': False,
+  })
+  if use_gcc:
     toolchain_resolved = yield Get(GCCCToolchain, NativeToolchain, native_toolchain)
   else:
     toolchain_resolved = yield Get(LLVMCToolchain, NativeToolchain, native_toolchain)
@@ -355,7 +359,12 @@ def select_c_toolchain(toolchain_variant_request):
 @rule(CppToolchain, [Select(ToolchainVariantRequest)])
 def select_cpp_toolchain(toolchain_variant_request):
   native_toolchain = toolchain_variant_request.toolchain
-  if toolchain_variant_request.variant.is_gnu:
+  # TODO(#5933): make an enum exhaustiveness checking method that works with `yield Get(...)`!
+  use_gcc = toolchain_variant_request.variant.resolve_for_enum_variant({
+    'gnu': True,
+    'llvm': False,
+  })
+  if use_gcc:
     toolchain_resolved = yield Get(GCCCppToolchain, NativeToolchain, native_toolchain)
   else:
     toolchain_resolved = yield Get(LLVMCppToolchain, NativeToolchain, native_toolchain)

--- a/src/python/pants/backend/native/targets/native_artifact.py
+++ b/src/python/pants/backend/native/targets/native_artifact.py
@@ -22,9 +22,9 @@ class NativeArtifact(datatype(['lib_name']), PayloadField):
 
   def as_shared_lib(self, platform):
     # TODO: check that the name conforms to some format in the constructor (e.g. no dots?).
-    return platform.resolve_platform_specific({
-      'darwin': lambda: 'lib{}.dylib'.format(self.lib_name),
-      'linux': lambda: 'lib{}.so'.format(self.lib_name),
+    return platform.resolve_for_enum_variant({
+      'darwin': 'lib{}.dylib'.format(self.lib_name),
+      'linux': 'lib{}.so'.format(self.lib_name),
     })
 
   def _compute_fingerprint(self):

--- a/src/python/pants/backend/native/tasks/conan_fetch.py
+++ b/src/python/pants/backend/native/tasks/conan_fetch.py
@@ -124,9 +124,9 @@ class ConanFetch(SimpleCodegenTask):
 
   @memoized_property
   def _conan_os_name(self):
-    return Platform.create().resolve_platform_specific({
-      'darwin': lambda: 'Macos',
-      'linux': lambda: 'Linux',
+    return Platform.create().resolve_for_enum_variant({
+      'darwin': 'Macos',
+      'linux': 'Linux',
     })
 
   @property

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -142,11 +142,6 @@ class LinkSharedLibraries(NativeTask):
 
     return link_request
 
-  _SHARED_CMDLINE_ARGS = {
-    'darwin': lambda: ['-Wl,-dylib'],
-    'linux': lambda: ['-shared'],
-  }
-
   def _execute_link_request(self, link_request):
     object_files = link_request.object_files
 
@@ -163,7 +158,10 @@ class LinkSharedLibraries(NativeTask):
     self.context.log.debug("resulting_shared_lib_path: {}".format(resulting_shared_lib_path))
     # We are executing in the results_dir, so get absolute paths for everything.
     cmd = ([linker.exe_filename] +
-           self.platform.resolve_platform_specific(self._SHARED_CMDLINE_ARGS) +
+           self.platform.resolve_for_enum_variant({
+             'darwin': ['-Wl,-dylib'],
+             'linux': ['-shared'],
+           }) +
            linker.extra_args +
            ['-o', os.path.abspath(resulting_shared_lib_path)] +
            ['-L{}'.format(lib_dir) for lib_dir in link_request.external_lib_dirs] +

--- a/src/python/pants/backend/python/tasks/unpack_wheels.py
+++ b/src/python/pants/backend/python/tasks/unpack_wheels.py
@@ -105,9 +105,9 @@ class UnpackWheels(UnpackRemoteSourcesBase):
 
   @memoized_classproperty
   def _current_platform_abbreviation(cls):
-    return NativeBackendPlatform.create().resolve_platform_specific({
-      'darwin': lambda: 'macosx',
-      'linux': lambda: 'linux',
+    return NativeBackendPlatform.create().resolve_for_enum_variant({
+      'darwin': 'macosx',
+      'linux': 'linux',
     })
 
   @classmethod

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -57,8 +57,9 @@ class PathGlobs(datatype([
       cls,
       include=tuple(include),
       exclude=tuple(exclude),
-      glob_match_error_behavior=GlobMatchErrorBehavior.create(glob_match_error_behavior),
-      conjunction=GlobExpansionConjunction.create(conjunction))
+      glob_match_error_behavior=GlobMatchErrorBehavior.create(glob_match_error_behavior,
+                                                              none_is_default=True),
+      conjunction=GlobExpansionConjunction.create(conjunction, none_is_default=True))
 
 
 class PathGlobsAndRoot(datatype([('path_globs', PathGlobs), ('root', text_type)])):

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -346,7 +346,8 @@ class EngineInitializer(object):
     rules = (
       [
         RootRule(Console),
-        SingletonRule.from_instance(GlobMatchErrorBehavior.create(glob_match_error_behavior)),
+        SingletonRule.from_instance(GlobMatchErrorBehavior.create(glob_match_error_behavior,
+                                                                  none_is_default=True)),
         SingletonRule.from_instance(build_configuration),
         SingletonRule(SymbolTable, symbol_table),
       ] +

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -196,7 +196,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   '(e.g. BUILD file scanning, glob matching, etc). '
                   'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore).')
     register_enum_option(
-      register, GlobMatchErrorBehavior, '--glob-expansion-failure', default='warn', type=str,
+      # TODO: allow using the attribute `GlobMatchErrorBehavior.warn` for more safety!
+      register, GlobMatchErrorBehavior, '--glob-expansion-failure', default='warn',
       advanced=True,
       help="Raise an exception if any targets declaring source files "
            "fail to match any glob provided in the 'sources' argument.")

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -16,7 +16,7 @@ from pants.option.errors import OptionsError
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
-from pants.util.objects import datatype, enum
+from pants.util.objects import datatype, enum, register_enum_option
 
 
 class GlobMatchErrorBehavior(enum('failure_behavior', ['ignore', 'warn', 'error'])):
@@ -25,8 +25,6 @@ class GlobMatchErrorBehavior(enum('failure_behavior', ['ignore', 'warn', 'error'
   NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
   be aware of any changes to this object's definition.
   """
-
-  default_option_value = 'warn'
 
 
 class ExecutionOptions(datatype([
@@ -197,12 +195,11 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help='Paths to ignore for all filesystem operations performed by pants '
                   '(e.g. BUILD file scanning, glob matching, etc). '
                   'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore).')
-    register('--glob-expansion-failure', type=str,
-             choices=GlobMatchErrorBehavior.allowed_values,
-             default=GlobMatchErrorBehavior.default_option_value,
-             advanced=True,
-             help="Raise an exception if any targets declaring source files "
-                  "fail to match any glob provided in the 'sources' argument.")
+    register_enum_option(
+      register, GlobMatchErrorBehavior, '--glob-expansion-failure', default='warn', type=str,
+      advanced=True,
+      help="Raise an exception if any targets declaring source files "
+           "fail to match any glob provided in the 'sources' argument.")
 
     register('--exclude-target-regexp', advanced=True, type=list, default=[], daemon=False,
              metavar='<regexp>', help='Exclude target roots that match these regexes.')

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -342,20 +342,17 @@ def enum(*args):
       NB: This method is exposed for testing enum variants easily. resolve_for_enum_variant() should
       be used for performing conditional logic based on an enum instance's value.
       """
-      # TODO: use this method to register attributes on the generated type object for each of the
-      # singletons!
+      # TODO(#7232): use this method to register attributes on the generated type object for each of
+      # the singletons!
       return cls._singletons.values()
 
   return ChoiceDatatype
 
 
-# TODO: allow usage of the normal register() by using an enum class as the `type` argument by
-# extending option registration to allow extracting `choices` and `default` value from the `type`!
+# TODO(#7233): allow usage of the normal register() by using an enum class as the `type` argument!
 def register_enum_option(register, enum_cls, *args, **kwargs):
   """A helper method for declaring a pants option from an `enum()`."""
   default_value = kwargs.pop('default', enum_cls.default_value)
-  # TODO: the `choices` argument is checked against after the `type` is applied, which then produces
-  # the enum type check error message instead of the `choices` error message. This should be fixed.
   register(*args, choices=enum_cls._allowed_values, default=default_value, **kwargs)
 
 

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -28,6 +28,9 @@ class TypedDatatypeInstanceConstructionError(TypeCheckError):
   """Raised when a datatype()'s fields fail a type check upon construction."""
 
 
+# TODO: create a mixin which declares/implements the methods we define on the generated class in
+# datatype() and enum() to decouple the class's logic from the way it's created. This may also make
+# migration to python 3 dataclasses as per #7074 easier.
 def datatype(field_decls, superclass_name=None, **kwargs):
   """A wrapper for `namedtuple` that accounts for the type of the object in equality.
 
@@ -318,6 +321,15 @@ def enum(*args):
           .format(list(self.allowed_values), list(keys)))
       match_for_variant = mapping[self._get_value(self)]
       return match_for_variant
+
+    @classmethod
+    def iterate_enum_variants(cls):
+      """Iterate over all instances of this enum, in the declared order.
+
+      NB: This method is exposed for testing enum variants easily. resolve_for_enum_variant() should
+      be used for performing conditional logic based on an enum instance's value.
+      """
+      return [cls.create(variant_value) for variant_value in cls.allowed_values]
 
   return ChoiceDatatype
 

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -15,6 +15,19 @@ from pants.util.memo import memoized_classproperty
 from pants.util.meta import AbstractClass, classproperty
 
 
+class TypeCheckError(TypeError):
+
+  # TODO: make some wrapper exception class to make this kind of
+  # prefixing easy (maybe using a class field format string?).
+  def __init__(self, type_name, msg, *args, **kwargs):
+    formatted_msg = "type check error in class {}: {}".format(type_name, msg)
+    super(TypeCheckError, self).__init__(formatted_msg, *args, **kwargs)
+
+
+class TypedDatatypeInstanceConstructionError(TypeCheckError):
+  """Raised when a datatype()'s fields fail a type check upon construction."""
+
+
 def datatype(field_decls, superclass_name=None, **kwargs):
   """A wrapper for `namedtuple` that accounts for the type of the object in equality.
 
@@ -56,9 +69,20 @@ def datatype(field_decls, superclass_name=None, **kwargs):
   namedtuple_cls = namedtuple(superclass_name, field_names, **kwargs)
 
   class DataType(namedtuple_cls):
+    @classproperty
+    def type_check_error_type(cls):
+      """The exception type to use in make_type_error()."""
+      return TypedDatatypeInstanceConstructionError
+
     @classmethod
     def make_type_error(cls, msg, *args, **kwargs):
-      return TypeCheckError(cls.__name__, msg, *args, **kwargs)
+      """A helper method to generate an exception type for type checking errors.
+
+      This method uses `cls.type_check_error_type` to ensure that type checking errors can be caught
+      with a reliable exception type. The type returned by `cls.type_check_error_type` should ensure
+      that the exception messages are prefixed with enough context to be useful and *not* confusing.
+      """
+      return cls.type_check_error_type(cls.__name__, msg, *args, **kwargs)
 
     def __new__(cls, *args, **kwargs):
       # TODO: Ideally we could execute this exactly once per `cls` but it should be a
@@ -69,7 +93,8 @@ def datatype(field_decls, superclass_name=None, **kwargs):
       try:
         this_object = super(DataType, cls).__new__(cls, *args, **kwargs)
       except TypeError as e:
-        raise cls.make_type_error(e)
+        raise cls.make_type_error(
+          "error in namedtuple() base constructor: {}".format(e))
 
       # TODO: Make this kind of exception pattern (filter for errors then display them all at once)
       # more ergonomic.
@@ -82,7 +107,9 @@ def datatype(field_decls, superclass_name=None, **kwargs):
           type_failure_msgs.append(
             "field '{}' was invalid: {}".format(field_name, e))
       if type_failure_msgs:
-        raise cls.make_type_error('\n'.join(type_failure_msgs))
+        raise cls.make_type_error(
+          'errors type checking constructor arguments:\n{}'
+          .format('\n'.join(type_failure_msgs)))
 
       return this_object
 
@@ -168,17 +195,30 @@ def datatype(field_decls, superclass_name=None, **kwargs):
     return type(superclass_name.encode('utf-8'), (DataType,), {})
 
 
-def enum(field_name, all_values):
+class EnumVariantSelectionError(TypeCheckError):
+  """Raised when an invalid variant for an enum() is constructed or matched against."""
+
+
+def enum(*args):
   """A datatype which can take on a finite set of values. This method is experimental and unstable.
 
   Any enum subclass can be constructed with its create() classmethod. This method will use the first
-  element of `all_values` as the enum value if none is specified.
+  element of `all_values` as the default value, but enum classes can override this behavior by
+  setting `default_value` in the class body.
 
-  :param field_name: A string used as the field for the datatype. Note that enum does not yet
-                     support type checking as with datatype.
-  :param all_values: An iterable of objects representing all possible values for the enum.
-                     NB: `all_values` must be a finite, non-empty iterable with unique values!
+  :param string field_name: A string used as the field for the datatype. This positional argument is
+                            optional, and defaults to 'value'. Note that `enum()` does not yet
+                            support type checking as with `datatype()`.
+  :param Iterable all_values: An iterable of objects representing all possible values for the enum.
+                              This argument must be a finite, non-empty iterable with unique values.
   """
+  if len(args) == 1:
+    field_name = 'value'
+    all_values, = args
+  elif len(args) == 2:
+    field_name, all_values = args
+  else:
+    raise ValueError("enum() accepts only 1 or 2 args! args = {!r}".format(args))
 
   # This call to list() will eagerly evaluate any `all_values` which would otherwise be lazy, such
   # as a generator.
@@ -195,6 +235,15 @@ def enum(field_name, all_values):
     allowed_values = allowed_values_set
     default_value = next(iter(allowed_values))
 
+    # Overriden from datatype() so providing an invalid variant is catchable as a TypeCheckError,
+    # but more specific.
+    type_check_error_type = EnumVariantSelectionError
+
+    @classmethod
+    def _get_value(cls, obj):
+      """Helper method to avoid using `field_name` in the class implementation a lot."""
+      return getattr(obj, field_name)
+
     @memoized_classproperty
     def _singletons(cls):
       """Generate memoized instances of this enum wrapping each of this enum's allowed values."""
@@ -208,15 +257,35 @@ def enum(field_name, all_values):
           .format(value, field_name, cls.allowed_values))
 
     @classmethod
-    def create(cls, value=None):
+    def create(cls, *args, **kwargs):
+      """Create an instance of this enum, using the default value if specified.
+
+      :param value: Use this as the enum value. If `value` is an instance of this class, return it,
+                    otherwise it is checked against `cls.allowed_values`. This positional argument
+                    is optional, and if not specified, `cls.default_value` is used.
+      :param bool none_is_default: If this is True, a None `value` is converted into
+                                   `cls.default_value` before being checked against
+                                   `cls.allowed_values`.
+      """
+      none_is_default = kwargs.pop('none_is_default', False)
+      if kwargs:
+        raise ValueError('unrecognized keyword arguments for {}.create(): {!r}'
+                         .format(cls.__name__, kwargs))
+
+      if len(args) == 0:
+        value = cls.default_value
+      elif len(args) == 1:
+        value = args[0]
+        if none_is_default and value is None:
+          value = cls.default_value
+      else:
+        raise ValueError('{}.create() accepts 0 or 1 positional args! *args = {!r}'
+                         .format(cls.__name__, args))
+
       # If we get an instance of this enum class, just return it. This means you can call .create()
-      # on None, an allowed value for the enum, or an existing instance of the enum.
+      # on an allowed value for the enum, or an existing instance of the enum.
       if isinstance(value, cls):
         return value
-
-      # Providing an explicit value that is not None will *not* use the default value!
-      if value is None:
-        value = cls.default_value
 
       # We actually circumvent the constructor in this method due to the cls._singletons
       # memoized_classproperty, but we want to raise the same error, so we move checking into a
@@ -227,41 +296,37 @@ def enum(field_name, all_values):
 
     def __new__(cls, *args, **kwargs):
       this_object = super(ChoiceDatatype, cls).__new__(cls, *args, **kwargs)
-
-      field_value = getattr(this_object, field_name)
-
-      cls._check_value(field_value)
-
+      cls._check_value(cls._get_value(this_object))
       return this_object
+
+    def resolve_for_enum_variant(self, mapping):
+      """Return the object in `mapping` with the key corresponding to the enum value.
+
+      `mapping` is a dict mapping enum variant value -> arbitrary object. All variant values must be
+      provided.
+
+      NB: The objects in `mapping` should be made into lambdas if lazy execution is desired, as this
+      will "evaluate" all of the values in `mapping`.
+      """
+      # Equality between a frozenset() and an OrderedSet() is done without respect to ordering,
+      # which is what we want here. We only maintain an OrderedSet() in self.allowed_values so that
+      # we can present error messages with the same arguments used in the constructor.
+      keys = frozenset(mapping.keys())
+      if keys != self.allowed_values:
+        raise self.make_type_error(
+          "pattern matching must have exactly the keys {} (was: {})"
+          .format(list(self.allowed_values), list(keys)))
+      match_for_variant = mapping[self._get_value(self)]
+      return match_for_variant
 
   return ChoiceDatatype
 
 
-class TypedDatatypeClassConstructionError(Exception):
-
-  # TODO: make some wrapper exception class to make this kind of
-  # prefixing easy (maybe using a class field format string?).
-  def __init__(self, type_name, msg, *args, **kwargs):
-    full_msg =  "error: while trying to generate typed datatype {}: {}".format(
-      type_name, msg)
-    super(TypedDatatypeClassConstructionError, self).__init__(
-      full_msg, *args, **kwargs)
-
-
-class TypedDatatypeInstanceConstructionError(TypeError):
-
-  def __init__(self, type_name, msg, *args, **kwargs):
-    full_msg = "error: in constructor of type {}: {}".format(type_name, msg)
-    super(TypedDatatypeInstanceConstructionError, self).__init__(
-      full_msg, *args, **kwargs)
-
-
-class TypeCheckError(TypedDatatypeInstanceConstructionError):
-
-  def __init__(self, type_name, msg, *args, **kwargs):
-    formatted_msg = "type check error:\n{}".format(msg)
-    super(TypeCheckError, self).__init__(
-      type_name, formatted_msg, *args, **kwargs)
+# TODO: allow declaring option type automatically as well?
+def register_enum_option(register, enum_cls, *args, **kwargs):
+  """A helper method for declaring a pants option from an `enum()`."""
+  default_value = kwargs.pop('default', enum_cls.default_value)
+  register(*args, choices=enum_cls.allowed_values, default=default_value, **kwargs)
 
 
 # TODO: make these members of the `TypeConstraint` class!

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -209,11 +209,18 @@ def enum(*args):
   element of `all_values` as the default value, but enum classes can override this behavior by
   setting `default_value` in the class body.
 
+  NB: Relying on the `field_name` directly is discouraged in favor of using
+  resolve_for_enum_variant() in Python code. The `field_name` argument is exposed to make enum
+  instances more readable when printed, and to allow code in another language using an FFI to
+  reliably extract the value from an enum instance.
+
   :param string field_name: A string used as the field for the datatype. This positional argument is
                             optional, and defaults to 'value'. Note that `enum()` does not yet
                             support type checking as with `datatype()`.
-  :param Iterable all_values: An iterable of objects representing all possible values for the enum.
-                              This argument must be a finite, non-empty iterable with unique values.
+  :param Iterable all_values: A nonempty iterable of objects representing all possible values for
+                              the enum.  This argument must be a finite, non-empty iterable with
+                              unique values.
+  :raises: :class:`ValueError`
   """
   if len(args) == 1:
     field_name = 'value'
@@ -229,46 +236,61 @@ def enum(*args):
   # `OrderedSet` maintains the order of the input iterable, but is faster to check membership.
   allowed_values_set = OrderedSet(all_values_realized)
 
-  if len(allowed_values_set) < len(all_values_realized):
+  if len(allowed_values_set) == 0:
+    raise ValueError("all_values must be a non-empty iterable!")
+  elif len(allowed_values_set) < len(all_values_realized):
     raise ValueError("When converting all_values ({}) to a set, at least one duplicate "
                      "was detected. The unique elements of all_values were: {}."
-                     .format(all_values_realized, allowed_values_set))
+                     .format(all_values_realized, list(allowed_values_set)))
 
   class ChoiceDatatype(datatype([field_name])):
-    allowed_values = allowed_values_set
-    default_value = next(iter(allowed_values))
+    default_value = next(iter(allowed_values_set))
 
     # Overriden from datatype() so providing an invalid variant is catchable as a TypeCheckError,
     # but more specific.
     type_check_error_type = EnumVariantSelectionError
 
-    @classmethod
-    def _get_value(cls, obj):
-      """Helper method to avoid using `field_name` in the class implementation a lot."""
-      return getattr(obj, field_name)
-
     @memoized_classproperty
     def _singletons(cls):
-      """Generate memoized instances of this enum wrapping each of this enum's allowed values."""
-      return { value: cls(value) for value in cls.allowed_values }
+      """Generate memoized instances of this enum wrapping each of this enum's allowed values.
+
+      NB: The implementation of enum() should use this property as the source of truth for allowed
+      values and enum instances from those values.
+      """
+      return OrderedDict((value, cls._make_singleton(value)) for value in allowed_values_set)
 
     @classmethod
-    def _check_value(cls, value):
-      if value not in cls.allowed_values:
-        raise cls.make_type_error(
-          "Value {!r} for '{}' must be one of: {!r}."
-          .format(value, field_name, cls.allowed_values))
+    def _make_singleton(cls, value):
+      """
+      We convert uses of the constructor to call create(), so we then need to go around __new__ to
+      bootstrap singleton creation from datatype()'s __new__.
+      """
+      return super(ChoiceDatatype, cls).__new__(cls, value)
+
+    @classproperty
+    def _allowed_values(cls):
+      """The values provided to the enum() type constructor, for use in error messages."""
+      return list(cls._singletons.keys())
+
+    def __new__(cls, value):
+      """Forward `value` to the .create() factory method.
+
+      The .create() factory method is preferred, but forwarding the constructor like this allows us
+      to use the generated enum type both as a type to check against with isinstance() as well as a
+      function to create instances with. This makes it easy to use as a pants option type.
+      """
+      return cls.create(value)
 
     @classmethod
     def create(cls, *args, **kwargs):
       """Create an instance of this enum, using the default value if specified.
 
       :param value: Use this as the enum value. If `value` is an instance of this class, return it,
-                    otherwise it is checked against `cls.allowed_values`. This positional argument
-                    is optional, and if not specified, `cls.default_value` is used.
+                    otherwise it is checked against the enum's allowed values. This positional
+                    argument is optional, and if not specified, `cls.default_value` is used.
       :param bool none_is_default: If this is True, a None `value` is converted into
-                                   `cls.default_value` before being checked against
-                                   `cls.allowed_values`.
+                                   `cls.default_value` before being checked against the enum's
+                                   allowed values.
       """
       none_is_default = kwargs.pop('none_is_default', False)
       if kwargs:
@@ -290,17 +312,11 @@ def enum(*args):
       if isinstance(value, cls):
         return value
 
-      # We actually circumvent the constructor in this method due to the cls._singletons
-      # memoized_classproperty, but we want to raise the same error, so we move checking into a
-      # common method.
-      cls._check_value(value)
-
+      if value not in cls._singletons:
+        raise cls.make_type_error(
+          "Value {!r} for '{}' must be one of: {!r}."
+          .format(value, field_name, cls._allowed_values))
       return cls._singletons[value]
-
-    def __new__(cls, *args, **kwargs):
-      this_object = super(ChoiceDatatype, cls).__new__(cls, *args, **kwargs)
-      cls._check_value(cls._get_value(this_object))
-      return this_object
 
     def resolve_for_enum_variant(self, mapping):
       """Return the object in `mapping` with the key corresponding to the enum value.
@@ -311,15 +327,12 @@ def enum(*args):
       NB: The objects in `mapping` should be made into lambdas if lazy execution is desired, as this
       will "evaluate" all of the values in `mapping`.
       """
-      # Equality between a frozenset() and an OrderedSet() is done without respect to ordering,
-      # which is what we want here. We only maintain an OrderedSet() in self.allowed_values so that
-      # we can present error messages with the same arguments used in the constructor.
       keys = frozenset(mapping.keys())
-      if keys != self.allowed_values:
+      if keys != frozenset(self._allowed_values):
         raise self.make_type_error(
           "pattern matching must have exactly the keys {} (was: {})"
-          .format(list(self.allowed_values), list(keys)))
-      match_for_variant = mapping[self._get_value(self)]
+          .format(self._allowed_values, list(keys)))
+      match_for_variant = mapping[getattr(self, field_name)]
       return match_for_variant
 
     @classmethod
@@ -329,16 +342,21 @@ def enum(*args):
       NB: This method is exposed for testing enum variants easily. resolve_for_enum_variant() should
       be used for performing conditional logic based on an enum instance's value.
       """
-      return [cls.create(variant_value) for variant_value in cls.allowed_values]
+      # TODO: use this method to register attributes on the generated type object for each of the
+      # singletons!
+      return cls._singletons.values()
 
   return ChoiceDatatype
 
 
-# TODO: allow declaring option type automatically as well?
+# TODO: allow usage of the normal register() by using an enum class as the `type` argument by
+# extending option registration to allow extracting `choices` and `default` value from the `type`!
 def register_enum_option(register, enum_cls, *args, **kwargs):
   """A helper method for declaring a pants option from an `enum()`."""
   default_value = kwargs.pop('default', enum_cls.default_value)
-  register(*args, choices=enum_cls.allowed_values, default=default_value, **kwargs)
+  # TODO: the `choices` argument is checked against after the `type` is applied, which then produces
+  # the enum type check error message instead of the `choices` error message. This should be fixed.
+  register(*args, choices=enum_cls._allowed_values, default=default_value, **kwargs)
 
 
 # TODO: make these members of the `TypeConstraint` class!

--- a/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
+++ b/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
@@ -70,6 +70,7 @@ class CppCompileTest(NativeTaskTestBase, NativeCompileTestMixin):
 
     task = self.create_task(self.context(target_roots=[cpp_lib_target]))
     compiler = task.get_compiler(cpp_lib_target)
+    # TODO(#6866): test specifically which compiler is selected, traversing the PATH if necessary.
     self.assertIn('llvm', compiler.path_entries[0])
 
   def test_target_level_toolchain_variant_default_llvm(self):

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import glob
 import os
 import re
+from functools import wraps
 from zipfile import ZipFile
 
 from pants.backend.native.config.environment import Platform
@@ -24,6 +25,14 @@ def invoke_pex_for_output(pex_file_to_run):
   return subprocess.check_output([pex_file_to_run], stderr=subprocess.STDOUT)
 
 
+def _toolchain_variants(func):
+  @wraps(func)
+  def wrapper(*args, **kwargs):
+    for variant in ToolchainVariant.iterate_enum_variants():
+      func(*args, toolchain_variant=variant, **kwargs)
+  return wrapper
+
+
 class CTypesIntegrationTest(PantsRunIntegrationTest):
 
   _binary_target_dir = 'testprojects/src/python/python_distribution/ctypes'
@@ -38,32 +47,16 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     'testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags:bin'
   )
 
-  def test_ctypes_binary_creation(self):
+  @_toolchain_variants
+  def test_ctypes_binary_creation(self, toolchain_variant):
     """Create a python_binary() with all native toolchain variants, and test the result."""
-    # TODO: this pattern could be made more ergonomic for `enum()`, along with exhaustiveness
-    # checking.
-    for variant in ToolchainVariant.allowed_values:
-      self._assert_ctypes_binary_creation(variant)
-
-  _compiler_names_for_variant = {
-    'gnu': ['gcc', 'g++'],
-    'llvm': ['clang', 'clang++'],
-  }
-
-  # All of our toolchains currently use the C++ compiler's filename as argv[0] for the linker.
-  _linker_names_for_variant = {
-    'gnu': ['g++'],
-    'llvm': ['clang++'],
-  }
-
-  def _assert_ctypes_binary_creation(self, toolchain_variant):
     with temporary_dir() as tmp_dir:
       pants_run = self.run_pants(command=['binary', self._binary_target], config={
         GLOBAL_SCOPE_CONFIG_SECTION: {
           'pants_distdir': tmp_dir,
         },
         'native-build-step': {
-          'toolchain_variant': toolchain_variant,
+          'toolchain_variant': toolchain_variant.value,
         },
       })
 
@@ -71,12 +64,23 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
       # Check that we have selected the appropriate compilers for our selected toolchain variant,
       # for both C and C++ compilation.
-      # TODO(#6866): don't parse info logs for testing!
-      for compiler_name in self._compiler_names_for_variant[toolchain_variant]:
+      # TODO(#6866): don't parse info logs for testing! There is a TODO in test_cpp_compile.py
+      # in the native backend testing to traverse the PATH to find the selected compiler.
+      compiler_names_to_check = toolchain_variant.resolve_for_enum_variant({
+        'gnu': ['gcc', 'g++'],
+        'llvm': ['clang', 'clang++'],
+      })
+      for compiler_name in compiler_names_to_check:
         self.assertIn("selected compiler exe name: '{}'".format(compiler_name),
                       pants_run.stdout_data)
 
-      for linker_name in self._linker_names_for_variant[toolchain_variant]:
+      # All of our toolchains currently use the C++ compiler's filename as argv[0] for the linker,
+      # so there is only one name to check.
+      linker_names_to_check = toolchain_variant.resolve_for_enum_variant({
+        'gnu': ['g++'],
+        'llvm': ['clang++'],
+      })
+      for linker_name in linker_names_to_check:
         self.assertIn("selected linker exe name: '{}'".format(linker_name),
                       pants_run.stdout_data)
 
@@ -110,16 +114,8 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       binary_run_output = invoke_pex_for_output(pex)
       self.assertEqual(b'x=3, f(x)=17\n', binary_run_output)
 
-  def test_ctypes_native_language_interop(self):
-    for variant in ToolchainVariant.allowed_values:
-      self._assert_ctypes_interop_with_mock_buildroot(variant)
-
-  _include_not_found_message_for_variant = {
-    'gnu': "fatal error: some_math.h: No such file or directory",
-    'llvm': "fatal error: 'some_math.h' file not found"
-  }
-
-  def _assert_ctypes_interop_with_mock_buildroot(self, toolchain_variant):
+  @_toolchain_variants
+  def test_ctypes_native_language_interop(self, toolchain_variant):
     # TODO: consider making this mock_buildroot/run_pants_with_workdir into a
     # PantsRunIntegrationTest method!
     with self.mock_buildroot(
@@ -138,7 +134,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         # Explicitly set to True (although this is the default).
         config={
           'native-build-step': {
-            'toolchain_variant': toolchain_variant,
+            'toolchain_variant': toolchain_variant.value,
           },
           # TODO(#6848): don't make it possible to forget to add the toolchain_variant option!
           'native-build-settings': {
@@ -148,19 +144,25 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         workdir=os.path.join(buildroot.new_buildroot, '.pants.d'),
         build_root=buildroot.new_buildroot)
       self.assert_failure(pants_binary_strict_deps_failure)
-      self.assertIn(self._include_not_found_message_for_variant[toolchain_variant],
+      self.assertIn(toolchain_variant.resolve_for_enum_variant({
+        'gnu': "fatal error: some_math.h: No such file or directory",
+        'llvm': "fatal error: 'some_math.h' file not found",
+      }),
                     pants_binary_strict_deps_failure.stdout_data)
 
     # TODO(#6848): we need to provide the libstdc++.so.6.dylib which comes with gcc on osx in the
     # DYLD_LIBRARY_PATH during the 'run' goal somehow.
     attempt_pants_run = Platform.create().resolve_for_enum_variant({
-      'darwin': toolchain_variant != 'gnu',
+      'darwin': toolchain_variant.resolve_for_enum_variant({
+        'gnu': False,
+        'llvm': True,
+      }),
       'linux': True,
     })
     if attempt_pants_run:
       pants_run_interop = self.run_pants(['-q', 'run', self._binary_target_with_interop], config={
         'native-build-step': {
-          'toolchain_variant': toolchain_variant,
+          'toolchain_variant': toolchain_variant.value,
         },
         'native-build-settings': {
           'strict_deps': True,
@@ -169,14 +171,11 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       self.assert_success(pants_run_interop)
       self.assertEqual('x=3, f(x)=299\n', pants_run_interop.stdout_data)
 
-  def test_ctypes_third_party_integration(self):
-    for variant in ToolchainVariant.allowed_values:
-      self._assert_ctypes_third_party_integration(variant)
-
-  def _assert_ctypes_third_party_integration(self, toolchain_variant):
+  @_toolchain_variants
+  def test_ctypes_third_party_integration(self, toolchain_variant):
     pants_binary = self.run_pants(['binary', self._binary_target_with_third_party], config={
       'native-build-step': {
-        'toolchain_variant': toolchain_variant,
+        'toolchain_variant': toolchain_variant.value,
       },
     })
     self.assert_success(pants_binary)
@@ -190,7 +189,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     if attempt_pants_run:
       pants_run = self.run_pants(['-q', 'run', self._binary_target_with_third_party], config={
         'native-build-step': {
-          'toolchain_variant': toolchain_variant,
+          'toolchain_variant': toolchain_variant.value,
         },
       })
       self.assert_success(pants_run)
@@ -220,23 +219,20 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     self.assert_success(pants_run)
     self.assertIn('x=3, f(x)=17', pants_run.stdout_data)
 
-  def test_native_compiler_option_sets_integration(self):
+  @_toolchain_variants
+  def test_native_compiler_option_sets_integration(self, toolchain_variant):
     """Test that native compilation includes extra compiler flags from target definitions.
 
     This target uses the ndebug and asdf option sets.
     If either of these are not present (disabled), this test will fail.
     """
-    for variant in ToolchainVariant.allowed_values:
-      self._assert_ctypes_third_party_integration(variant)
-
-  def _assert_native_compiler_option_sets_integration(self, toolchain_variant):
     command = [
       'run',
       self._binary_target_with_compiler_option_sets
     ]
     pants_run = self.run_pants(command=command, config={
       'native-build-step': {
-        'toolchain_variant': toolchain_variant,
+        'toolchain_variant': toolchain_variant.value,
       },
       'native-build-step.cpp-compile-settings': {
         'compiler_option_sets_enabled_args': {

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -92,9 +92,9 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
       dist_name, dist_version, wheel_platform = name_and_platform(wheel_dist)
       self.assertEqual(dist_name, 'ctypes_test')
-      contains_current_platform = Platform.create().resolve_platform_specific({
-        'darwin': lambda: wheel_platform.startswith('macosx'),
-        'linux': lambda: wheel_platform.startswith('linux'),
+      contains_current_platform = Platform.create().resolve_for_enum_variant({
+        'darwin': wheel_platform.startswith('macosx'),
+        'linux': wheel_platform.startswith('linux'),
       })
       self.assertTrue(contains_current_platform)
 
@@ -153,9 +153,9 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
     # TODO(#6848): we need to provide the libstdc++.so.6.dylib which comes with gcc on osx in the
     # DYLD_LIBRARY_PATH during the 'run' goal somehow.
-    attempt_pants_run = Platform.create().resolve_platform_specific({
-      'darwin': lambda: toolchain_variant != 'gnu',
-      'linux': lambda: True,
+    attempt_pants_run = Platform.create().resolve_for_enum_variant({
+      'darwin': toolchain_variant != 'gnu',
+      'linux': True,
     })
     if attempt_pants_run:
       pants_run_interop = self.run_pants(['-q', 'run', self._binary_target_with_interop], config={
@@ -183,9 +183,9 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
     # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
     # be available on the runtime library path.
-    attempt_pants_run = Platform.create().resolve_platform_specific({
-      'darwin': lambda: toolchain_variant != 'gnu',
-      'linux': lambda: True,
+    attempt_pants_run = Platform.create().resolve_for_enum_variant({
+      'darwin': toolchain_variant != 'gnu',
+      'linux': True,
     })
     if attempt_pants_run:
       pants_run = self.run_pants(['-q', 'run', self._binary_target_with_third_party], config={

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -12,9 +12,11 @@ from builtins import object, str
 
 from future.utils import PY2, PY3, text_type
 
-from pants.util.objects import (Exactly, SubclassesOf, SuperclassesOf, TypeCheckError,
-                                TypeConstraintError, TypedCollection,
-                                TypedDatatypeInstanceConstructionError, datatype, enum)
+from pants.util.collections_abc_backport import OrderedDict
+from pants.util.objects import (EnumVariantSelectionError, Exactly, SubclassesOf,
+                                SuperclassesOf, TypeCheckError, TypeConstraintError,
+                                TypedCollection, TypedDatatypeInstanceConstructionError, datatype,
+                                enum)
 from pants_test.test_base import TestBase
 
 
@@ -564,7 +566,7 @@ class TypedDatatypeTest(TestBase):
   def test_instance_construction_errors(self):
     with self.assertRaises(TypeError) as cm:
       SomeTypedDatatype(something=3)
-    expected_msg = "error: in constructor of type SomeTypedDatatype: type check error:\n__new__() got an unexpected keyword argument 'something'"
+    expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: __new__() got an unexpected keyword argument 'something'"
     self.assertEqual(str(cm.exception), expected_msg)
 
     # not providing all the fields
@@ -575,7 +577,7 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "__new__() takes exactly 2 arguments (1 given)"
     )
-    expected_msg = "error: in constructor of type SomeTypedDatatype: type check error:\n" + expected_msg_ending
+    expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: {}".format(expected_msg_ending)
     self.assertEqual(str(cm.exception), expected_msg)
 
     # unrecognized fields
@@ -586,20 +588,20 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "__new__() takes exactly 2 arguments (3 given)"
     )
-    expected_msg = "error: in constructor of type SomeTypedDatatype: type check error:\n" + expected_msg_ending
+    expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: {}".format(expected_msg_ending)
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypedDatatypeInstanceConstructionError) as cm:
       CamelCaseWrapper(nonneg_int=3)
     expected_msg = (
-      """error: in constructor of type CamelCaseWrapper: type check error:
+      """type check error in class CamelCaseWrapper: errors type checking constructor arguments:
 field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(NonNegativeInt).""")
     self.assertEqual(str(cm.exception), expected_msg)
 
     # test that kwargs with keywords that aren't field names fail the same way
     with self.assertRaises(TypeError) as cm:
       CamelCaseWrapper(4, a=3)
-    expected_msg = "error: in constructor of type CamelCaseWrapper: type check error:\n__new__() got an unexpected keyword argument 'a'"
+    expected_msg = "type check error in class CamelCaseWrapper: error in namedtuple() base constructor: __new__() got an unexpected keyword argument 'a'"
     self.assertEqual(str(cm.exception), expected_msg)
 
   def test_type_check_errors(self):
@@ -607,7 +609,7 @@ field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type
     with self.assertRaises(TypeCheckError) as cm:
       SomeTypedDatatype([])
     expected_msg = (
-      """error: in constructor of type SomeTypedDatatype: type check error:
+      """type check error in class SomeTypedDatatype: errors type checking constructor arguments:
 field 'val' was invalid: value [] (with type 'list') must satisfy this type constraint: Exactly(int).""")
     self.assertEqual(str(cm.exception), expected_msg)
 
@@ -616,7 +618,7 @@ field 'val' was invalid: value [] (with type 'list') must satisfy this type cons
       AnotherTypedDatatype(text_type('correct'), text_type('should be list'))
     def compare_str(unicode_type_name, include_unicode=False):
       expected_message = (
-        """error: in constructor of type AnotherTypedDatatype: type check error:
+        """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
 field 'elements' was invalid: value {unicode_literal}'should be list' (with type '{type_name}') must satisfy this type constraint: Exactly(list)."""
       .format(type_name=unicode_type_name, unicode_literal='u' if include_unicode else ''))
       self.assertEqual(str(cm.exception), expected_message)
@@ -630,7 +632,7 @@ field 'elements' was invalid: value {unicode_literal}'should be list' (with type
       AnotherTypedDatatype(3, text_type('should be list'))
     def compare_str(unicode_type_name, include_unicode=False):
       expected_message = (
-        """error: in constructor of type AnotherTypedDatatype: type check error:
+        """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
 field 'string' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly({type_name}).
 field 'elements' was invalid: value {unicode_literal}'should be list' (with type '{type_name}') must satisfy this type constraint: Exactly(list)."""
           .format(type_name=unicode_type_name, unicode_literal='u' if include_unicode else ''))
@@ -644,7 +646,7 @@ field 'elements' was invalid: value {unicode_literal}'should be list' (with type
       NonNegativeInt(text_type('asdf'))
     def compare_str(unicode_type_name, include_unicode=False):
       expected_message = (
-        """error: in constructor of type NonNegativeInt: type check error:
+        """type check error in class NonNegativeInt: errors type checking constructor arguments:
 field 'an_int' was invalid: value {unicode_literal}'asdf' (with type '{type_name}') must satisfy this type constraint: Exactly(int)."""
           .format(type_name=unicode_type_name, unicode_literal='u' if include_unicode else ''))
       self.assertEqual(str(cm.exception), expected_message)
@@ -655,31 +657,28 @@ field 'an_int' was invalid: value {unicode_literal}'asdf' (with type '{type_name
 
     with self.assertRaises(TypeCheckError) as cm:
       NonNegativeInt(-3)
-    expected_msg = (
-      """error: in constructor of type NonNegativeInt: type check error:
-value is negative: -3.""")
+    expected_msg = "type check error in class NonNegativeInt: value is negative: -3."
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypeCheckError) as cm:
       WithSubclassTypeConstraint(3)
     expected_msg = (
-      """error: in constructor of type WithSubclassTypeConstraint: type check error:
+      """type check error in class WithSubclassTypeConstraint: errors type checking constructor arguments:
 field 'some_value' was invalid: value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(SomeBaseClass).""")
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypeCheckError) as cm:
       WithCollectionTypeConstraint(3)
     expected_msg = """\
-error: in constructor of type WithCollectionTypeConstraint: type check error:
+type check error in class WithCollectionTypeConstraint: errors type checking constructor arguments:
 field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)): value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(Iterable)."""
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypeCheckError) as cm:
       WithCollectionTypeConstraint([3, "asdf"])
     expected_msg = """\
-error: in constructor of type WithCollectionTypeConstraint: type check error:
-field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'asdf']: value {u}'asdf' (with type '{string_type}') must satisfy this type constraint: Exactly(int).\
-""".format(u='u' if PY2 else '', string_type='unicode' if PY2 else 'str')
+type check error in class WithCollectionTypeConstraint: errors type checking constructor arguments:
+field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, u'asdf']: value u'asdf' (with type 'unicode') must satisfy this type constraint: Exactly(int).""".format(u='u' if PY2 else '', string_type='unicode' if PY2 else 'str')
     self.assertEqual(str(cm.exception), expected_msg)
 
   def test_copy(self):
@@ -696,14 +695,13 @@ field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(
     with self.assertRaises(TypeCheckError) as cm:
       obj.copy(nonexistent_field=3)
     expected_msg = (
-      """error: in constructor of type AnotherTypedDatatype: type check error:
-__new__() got an unexpected keyword argument 'nonexistent_field'""")
+      """type check error in class AnotherTypedDatatype: error in namedtuple() base constructor: __new__() got an unexpected keyword argument 'nonexistent_field'""")
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypeCheckError) as cm:
       obj.copy(elements=3)
     expected_msg = (
-      """error: in constructor of type AnotherTypedDatatype: type check error:
+      """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
 field 'elements' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(list).""")
     self.assertEqual(str(cm.exception), expected_msg)
 
@@ -723,15 +721,65 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
   def test_enum_instance_creation_errors(self):
     expected_rx = re.escape(
       "Value 3 for 'x' must be one of: OrderedSet([1, 2]).")
-    with self.assertRaisesRegexp(TypeCheckError, expected_rx):
+    with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx):
       SomeEnum.create(3)
-    with self.assertRaisesRegexp(TypeCheckError, expected_rx):
+    with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx):
       SomeEnum(3)
-    with self.assertRaisesRegexp(TypeCheckError, expected_rx):
+    with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx):
       SomeEnum(x=3)
+
+    # Test that None is not used as the default unless none_is_default=True.
+    with self.assertRaisesRegexp(EnumVariantSelectionError, re.escape(
+        "Value None for 'x' must be one of: OrderedSet([1, 2])."
+    )):
+      SomeEnum.create(None)
+    self.assertEqual(1, SomeEnum.create(None, none_is_default=True).x)
 
     expected_rx_falsy_value = re.escape(
       "Value {}'' for 'x' must be one of: OrderedSet([1, 2])."
       .format('u' if PY2 else ''))
-    with self.assertRaisesRegexp(TypeCheckError, expected_rx_falsy_value):
+    with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx_falsy_value):
       SomeEnum(x='')
+
+  def test_enum_resolve_variant(self):
+    one_enum_instance = SomeEnum(1)
+    two_enum_instance = SomeEnum(2)
+    self.assertEqual(3, one_enum_instance.resolve_for_enum_variant({
+      1: 3,
+      2: 4,
+    }))
+    self.assertEqual(4, two_enum_instance.resolve_for_enum_variant({
+      1: 3,
+      2: 4,
+    }))
+
+    # Test that an unrecognized variant raises an error.
+    with self.assertRaisesRegexp(EnumVariantSelectionError, re.escape("""\
+type check error in class SomeEnum: pattern matching must have exactly the keys [1, 2] (was: [1, 2, 3])""",
+    )):
+      one_enum_instance.resolve_for_enum_variant({
+        1: 3,
+        2: 4,
+        3: 5,
+      })
+
+    # Test that not providing all the variants raises an error.
+    with self.assertRaisesRegexp(EnumVariantSelectionError, re.escape("""\
+type check error in class SomeEnum: pattern matching must have exactly the keys [1, 2] (was: [1])""")):
+      one_enum_instance.resolve_for_enum_variant({
+        1: 3,
+      })
+
+    # Test that the ordering of the values in the enum constructor is not relevant for testing
+    # whether all variants are provided.
+    class OutOfOrderEnum(enum([2, 1, 3])): pass
+    two_out_of_order_instance = OutOfOrderEnum(2)
+    # This OrderedDict mapping is in a different order than in the enum constructor. This test means
+    # we can rely on providing simply a literal dict to resolve_for_enum_variant() and not worry
+    # that the dict ordering will cause an error.
+    letter = two_out_of_order_instance.resolve_for_enum_variant(OrderedDict([
+      (1, 'b'),
+      (2, 'a'),
+      (3, 'c'),
+    ]))
+    self.assertEqual(letter, 'a')

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -708,7 +708,7 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
   def test_enum_class_creation_errors(self):
     expected_rx = re.escape(
       "When converting all_values ([1, 2, 3, 1]) to a set, at least one duplicate "
-      "was detected. The unique elements of all_values were: OrderedSet([1, 2, 3]).")
+      "was detected. The unique elements of all_values were: [1, 2, 3].")
     with self.assertRaisesRegexp(ValueError, expected_rx):
       class DuplicateAllowedValues(enum('x', [1, 2, 3, 1])): pass
 
@@ -716,30 +716,31 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
     self.assertEqual(1, SomeEnum.create().x)
     self.assertEqual(2, SomeEnum.create(2).x)
     self.assertEqual(1, SomeEnum(1).x)
-    self.assertEqual(2, SomeEnum(x=2).x)
 
   def test_enum_instance_creation_errors(self):
     expected_rx = re.escape(
-      "Value 3 for 'x' must be one of: OrderedSet([1, 2]).")
+      "Value 3 for 'x' must be one of: [1, 2].")
     with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx):
       SomeEnum.create(3)
     with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx):
       SomeEnum(3)
-    with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx):
+
+    # Specifying the value by keyword argument is not allowed.
+    with self.assertRaisesRegexp(TypeError, re.escape("__new__() got an unexpected keyword argument 'x'")):
       SomeEnum(x=3)
 
     # Test that None is not used as the default unless none_is_default=True.
     with self.assertRaisesRegexp(EnumVariantSelectionError, re.escape(
-        "Value None for 'x' must be one of: OrderedSet([1, 2])."
+        "Value None for 'x' must be one of: [1, 2]."
     )):
       SomeEnum.create(None)
     self.assertEqual(1, SomeEnum.create(None, none_is_default=True).x)
 
     expected_rx_falsy_value = re.escape(
-      "Value {}'' for 'x' must be one of: OrderedSet([1, 2])."
+      "Value {}'' for 'x' must be one of: [1, 2]."
       .format('u' if PY2 else ''))
     with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx_falsy_value):
-      SomeEnum(x='')
+      SomeEnum('')
 
   def test_enum_resolve_variant(self):
     one_enum_instance = SomeEnum(1)


### PR DESCRIPTION
### Problem

In #7092 we added [`NailgunTask#do_for_execution_strategy_variant()`](https://github.com/cosmicexplorer/pants/blob/70977ef064305b78406a627e07f4dae3a60e4ae4/src/python/pants/backend/jvm/tasks/nailgun_task.py#L31-L43), which allowed performing more declarative execution strategy-specific logic in nailgunnable tasks. Further work with rsc will do even more funky things with our nailgunnable task logic, and while we will eventually have a unified story again for nailgun and subprocess invocations with the v2 engine (see #7079), for now having this check that we have performed the logic we expect all execution strategy variants is very useful.

This PR puts that pattern matching logic into `enum()`: https://github.com/pantsbuild/pants/blob/84cf9a75dbf68cf7126fe8372ab9b2f48720464d/src/python/pants/util/objects.py#L173-L174, among other things.

**Note:** `TypeCheckError` and other exceptions are moved up from further down in `objects.py`.

### Solution

- add `resolve_for_enum_variant()` method to `enum` which does the job of the previous `do_for_execution_strategy_variant()`
- make the native backend's `Platform` into an enum.
- stop silently converting a `None` argument to the enum's `create()` classmethod into its`default_value`.
- add `register_enum_option()` helper method to register options based on enum types.

### Result

We have a low-overhead way to convert potentially-tricky conditional logic into a checked pattern matching-style interface with `enum()`, and it is easier to register enum options.