### PR TITLE
[WIP, pending performance investigations] remote hermetic experiments revisited

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -400,8 +400,15 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     invalid_targets = [vt.target for vt in invalidation_check.invalid_vts]
     valid_targets = [vt.target for vt in invalidation_check.all_vts if vt.valid]
 
-    if self.execution_strategy in {self.HERMETIC, self.HERMETIC_WITH_NAILGUN}:
-      self._set_directory_digests_for_valid_target_classpath_directories(valid_targets, compile_contexts)
+    def set_directory_digests_for_hermetic():
+      self._set_directory_digests_for_valid_target_classpath_directories(
+        valid_targets, compile_contexts)
+    self.execution_strategy_enum.resolve_for_enum_variant({
+      self.HERMETIC: set_directory_digests_for_hermetic,
+      self.HERMETIC_WITH_NAILGUN: set_directory_digests_for_hermetic,
+      self.SUBPROCESS: lambda: None,
+      self.NAILGUN: lambda: None,
+    })()
 
     for valid_target in valid_targets:
       cc = self.select_runtime_context(compile_contexts[valid_target])

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -401,7 +401,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     valid_targets = [vt.target for vt in invalidation_check.all_vts if vt.valid]
 
     if self.execution_strategy == self.HERMETIC:
-      self._set_direcotry_digests_for_valid_target_classpath_directories(valid_targets, compile_contexts)
+      self._set_directory_digests_for_valid_target_classpath_directories(valid_targets, compile_contexts)
 
     for valid_target in valid_targets:
       cc = self.select_runtime_context(compile_contexts[valid_target])

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -400,7 +400,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     invalid_targets = [vt.target for vt in invalidation_check.invalid_vts]
     valid_targets = [vt.target for vt in invalidation_check.all_vts if vt.valid]
 
-    if self.execution_strategy == self.HERMETIC:
+    if self.execution_strategy in {self.HERMETIC, self.HERMETIC_WITH_NAILGUN}:
       self._set_directory_digests_for_valid_target_classpath_directories(valid_targets, compile_contexts)
 
     for valid_target in valid_targets:
@@ -451,12 +451,12 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     with open(path, 'w') as f:
       f.write(text)
 
-  def _set_direcotry_digests_for_valid_target_classpath_directories(self, valid_targets, compile_contexts):
+  def _set_directory_digests_for_valid_target_classpath_directories(self, valid_targets, compile_contexts):
     snapshots = self.context._scheduler.capture_snapshots(
       tuple(PathGlobsAndRoot(PathGlobs(
         [self._get_relative_classes_dir_from_target(target, compile_contexts)]
       ), get_buildroot()) for target in valid_targets))
-    [self._set_direcotry_digest_for_compile_context(
+    [self._set_directory_digest_for_compile_context(
       snapshot.directory_digest, target, compile_contexts)
       for target, snapshot in list(zip(valid_targets, snapshots))]
 
@@ -464,7 +464,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     cc = self.select_runtime_context(compile_contexts[target])
     return fast_relpath(cc.classes_dir.path, get_buildroot()) + '/**'
 
-  def _set_direcotry_digest_for_compile_context(self, directory_digest, target, compile_contexts):
+  def _set_directory_digest_for_compile_context(self, directory_digest, target, compile_contexts):
     cc = self.select_runtime_context(compile_contexts[target])
     new_classpath_entry = ClasspathEntry(cc.classes_dir.path, directory_digest)
     cc.classes_dir = new_classpath_entry

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -201,7 +201,7 @@ class RscCompile(ZincCompile):
 
   # Overrides the normal zinc compiler classpath, which only contains zinc.
   def get_zinc_compiler_classpath(self):
-    return self.execution_strategy_enum.do_for_enum_variant({
+    return self.execution_strategy_enum.resolve_for_enum_variant({
       self.HERMETIC: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.SUBPROCESS: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.NAILGUN: lambda: self._nailgunnable_combined_classpath,
@@ -861,7 +861,7 @@ class RscCompile(ZincCompile):
   def _runtool(self, main, tool_name, args, distribution,
                tgt=None, input_files=tuple(), input_digest=None, output_dir=None):
     with self.context.new_workunit(tool_name) as wu:
-      return self.execution_strategy_enum.do_for_enum_variant({
+      return self.execution_strategy_enum.resolve_for_enum_variant({
         self.HERMETIC: lambda: self._runtool_hermetic(
           main, tool_name, args, distribution,
           tgt=tgt, input_files=input_files, input_digest=input_digest, output_dir=output_dir),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -201,7 +201,7 @@ class RscCompile(ZincCompile):
 
   # Overrides the normal zinc compiler classpath, which only contains zinc.
   def get_zinc_compiler_classpath(self):
-    return self.do_for_execution_strategy_variant({
+    return self.execution_strategy_enum.do_for_enum_variant({
       self.HERMETIC: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.SUBPROCESS: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.NAILGUN: lambda: self._nailgunnable_combined_classpath,
@@ -861,7 +861,7 @@ class RscCompile(ZincCompile):
   def _runtool(self, main, tool_name, args, distribution,
                tgt=None, input_files=tuple(), input_digest=None, output_dir=None):
     with self.context.new_workunit(tool_name) as wu:
-      return self.do_for_execution_strategy_variant({
+      return self.execution_strategy_enum.do_for_enum_variant({
         self.HERMETIC: lambda: self._runtool_hermetic(
           main, tool_name, args, distribution,
           tgt=tgt, input_files=input_files, input_digest=input_digest, output_dir=output_dir),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -869,7 +869,7 @@ class RscCompile(ZincCompile):
           wu, self.tool_classpath(tool_name), main, tool_name, args, distribution),
         self.NAILGUN: lambda: self._runtool_nonhermetic(
           wu, self._nailgunnable_combined_classpath, main, tool_name, args, distribution),
-      })
+      })()
 
   def _run_metai_tool(self,
                       distribution,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -205,7 +205,7 @@ class RscCompile(ZincCompile):
       self.HERMETIC: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.SUBPROCESS: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.NAILGUN: lambda: self._nailgunnable_combined_classpath,
-    })
+    })()
 
   def register_extra_products_from_contexts(self, targets, compile_contexts):
     super(RscCompile, self).register_extra_products_from_contexts(targets, compile_contexts)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -5,18 +5,16 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import functools
-import json
 import logging
 import os
 import re
 
 from future.utils import PY3, text_type
+from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext  # noqa
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.subsystems.shader import Shader
-from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.classpath_entry import ClasspathEntry
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
@@ -26,16 +24,16 @@ from pants.backend.jvm.tasks.jvm_compile.zinc.zinc_compile import ZincCompile
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
-from pants.build_graph.address import Address
-from pants.build_graph.target import Target
-from pants.engine.fs import Digest, DirectoryToMaterialize, PathGlobs, PathGlobsAndRoot
+from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, Digest, DirectoryToMaterialize, PathGlobs,
+                             PathGlobsAndRoot)
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.java.jar.jar_dependency import JarDependency
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.util.contextutil import Timer
 from pants.util.dirutil import (fast_relpath, fast_relpath_optional, maybe_read_file,
                                 safe_file_dump, safe_mkdir)
-from pants.util.memo import memoized_property
+from pants.util.memo import memoized_method, memoized_property
+from pants.util.objects import enum
 
 
 #
@@ -48,9 +46,8 @@ from pants.util.memo import memoized_property
 logger = logging.getLogger(__name__)
 
 
-def fast_relpath_collection(collection):
-  buildroot = get_buildroot()
-  return [fast_relpath_optional(c, buildroot) or c for c in collection]
+def fast_relpath_collection(collection, root=get_buildroot()):
+  return [fast_relpath_optional(c, root) or c for c in collection]
 
 
 def stdout_contents(wu):
@@ -99,12 +96,22 @@ def _paths_from_classpath(classpath_tuples, collection_type=list):
   return collection_type(y[1] for y in classpath_tuples)
 
 
+# write to both rsc classpath and runtime classpath
+class CompositeProductAdder(object):
+  def __init__(self, *products):
+    self.products = products
+
+  def add_for_target(self, *args, **kwargs):
+    for product in self.products:
+      product.add_for_target(*args, **kwargs)
+
+
 class RscCompileContext(CompileContext):
   def __init__(self,
                target,
                analysis_file,
                classes_dir,
-               rsc_mjar_file,
+               rsc_jar_file,
                jar_file,
                log_dir,
                zinc_args_file,
@@ -112,11 +119,11 @@ class RscCompileContext(CompileContext):
                rsc_index_dir):
     super(RscCompileContext, self).__init__(target, analysis_file, classes_dir, jar_file,
                                                log_dir, zinc_args_file, sources)
-    self.rsc_mjar_file = rsc_mjar_file
+    self.rsc_jar_file = rsc_jar_file
     self.rsc_index_dir = rsc_index_dir
 
   def ensure_output_dirs_exist(self):
-    safe_mkdir(os.path.dirname(self.rsc_mjar_file))
+    safe_mkdir(os.path.dirname(self.rsc_jar_file))
     safe_mkdir(self.rsc_index_dir)
 
 
@@ -135,11 +142,28 @@ class RscCompile(ZincCompile):
     return super(RscCompile, cls).implementation_version() + [('RscCompile', 171)]
 
   @classmethod
+  def product_types(cls):
+    return super(RscCompile, cls).product_types() + [
+      'rsc_classpath',
+      'zinc_scala_classpath_from_rsc',
+    ]
+
+  @classmethod
   def register_options(cls, register):
     super(RscCompile, cls).register_options(register)
 
+    register('--rsc-compatible-target-tag', default='rsc-compatible', metavar='<tag>',
+             help='Always compile any target with rsc marked with this tag.')
+    register('--include-rsc-compatible-target-regexps', type=list, member_type=str,
+             metavar='<regexp>',
+             help='If a target matches this regexp, compile it with rsc, unless the target also '
+                  'matches an exlcude regexp.')
+    register('--exclude-rsc-compatible-target-regexps', type=list, member_type=str,
+             metavar='<regexp>',
+             help="If a target isn't tagged as rsc-compatible, but matches any of these regexps, "
+                  "compile it with zinc instead.")
+
     rsc_toolchain_version = '0.0.0-446-c64e6937'
-    scalameta_toolchain_version = '4.0.0'
 
     cls.register_jvm_tool(
       register,
@@ -155,34 +179,6 @@ class RscCompile(ZincCompile):
         Shader.exclude_package('rsc', recursive=True),
       ]
     )
-    cls.register_jvm_tool(
-      register,
-      'metacp',
-      classpath=[
-          JarDependency(
-            org='org.scalameta',
-            name='metacp_2.11',
-            rev=scalameta_toolchain_version,
-          ),
-      ],
-      custom_rules=[
-        Shader.exclude_package('scala', recursive=True),
-      ]
-    )
-    cls.register_jvm_tool(
-      register,
-      'metai',
-      classpath=[
-          JarDependency(
-            org='org.scalameta',
-            name='metai_2.11',
-            rev=scalameta_toolchain_version,
-          ),
-      ],
-      custom_rules=[
-        Shader.exclude_package('scala', recursive=True),
-      ]
-    )
 
   # TODO: allow @memoized_method to convert lists into tuples so they can be hashed!
   @memoized_property
@@ -193,8 +189,7 @@ class RscCompile(ZincCompile):
     #7092). We still invoke their classpaths separately when not using nailgun, however.
     """
     cp = []
-    for component_tool_name in ['rsc', 'metai', 'metacp']:
-      cp.extend(self.tool_classpath(component_tool_name))
+    cp.extend(self.tool_classpath('rsc'))
     # Add zinc's classpath so that it can be invoked from the same nailgun instance.
     cp.extend(super(RscCompile, self).get_zinc_compiler_classpath())
     return cp
@@ -206,6 +201,52 @@ class RscCompile(ZincCompile):
       self.SUBPROCESS: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.NAILGUN: lambda: self._nailgunnable_combined_classpath,
     })()
+
+  class _JvmTargetType(enum(['zinc-scala', 'zinc-java', 'rsc-scala', 'rsc-java'])): pass
+
+  @memoized_property
+  def _exclude_regexps(self):
+    return [re.compile(pat) for pat in self.get_options().exclude_rsc_compatible_target_regexps]
+
+  @memoized_property
+  def _include_regexps(self):
+    return [re.compile(pat) for pat in self.get_options().include_rsc_compatible_target_regexps]
+
+  def _identify_rsc_compatible_target(self, target):
+    if self.get_options().rsc_compatible_target_tag in target.tags:
+      return True
+    spec = target.address.spec
+    for no_thanks_do_not_use_rsc_regexp in self._exclude_regexps:
+      if no_thanks_do_not_use_rsc_regexp.match(target.address.spec):
+        self.context.log.debug("Target {} matched regexp '{}' marking it as rsc-incompatible! "
+                               "Compiling with zinc..."
+                               .format(target, no_thanks_do_not_use_rsc_regexp.pattern))
+        return False
+    for yes_please_use_rsc_regexp in self._include_regexps:
+      if yes_please_use_rsc_regexp.match(spec):
+        self.context.log.debug("Target {} matched regexp '{}' -- compiling with rsc!"
+                               .format(target, yes_please_use_rsc_regexp.pattern))
+        return True
+    return False
+
+  @memoized_method
+  def _classify_compile_target(self, target):
+    if self._identify_rsc_compatible_target(target):
+      if target.has_sources('.java'):
+      # TODO: Currently rsc header jars are not consumable by javac, so we need to make sure any
+      # java compilation occurs after all of its dependencies are compiled with zinc.
+        target_type = self._JvmTargetType.create('rsc-java')
+      elif target.has_sources('.scala'):
+        target_type = self._JvmTargetType.create('rsc-scala')
+      else:
+        target_type = None
+    elif target.has_sources('.java'):
+      target_type = self._JvmTargetType.create('zinc-java')
+    elif target.has_sources('.scala'):
+      target_type = self._JvmTargetType.create('zinc-scala')
+    else:
+      target_type = None
+    return target_type
 
   def register_extra_products_from_contexts(self, targets, compile_contexts):
     super(RscCompile, self).register_extra_products_from_contexts(targets, compile_contexts)
@@ -235,39 +276,31 @@ class RscCompile(ZincCompile):
     def confify(entries):
       return [(conf, e) for e in entries for conf in self._confs]
 
+    # TODO: there's a little bit of duplication here -- in the super() call, ZincCompile will
+    # populate classpaths for zinc invocations, but we only need to populate the classpaths from the
+    # rsc outputs here because we call register_extra_products_from_contexts() manually in
+    # work_for_vts_rsc().
     for target in targets:
-      rsc_cc, compile_cc = compile_contexts[target]
-      if self._only_zinc_compilable(target):
-        self.context.products.get_data('rsc_classpath').add_for_target(
-          compile_cc.target,
-          confify([compile_cc.jar_file])
-        )
-      elif self._rsc_compilable(target):
-        self.context.products.get_data('rsc_classpath').add_for_target(
-          rsc_cc.target,
-          confify(to_classpath_entries([rsc_cc.rsc_mjar_file], self.context._scheduler)))
-      elif self._metacpable(target):
-        # Walk the metacp results dir and add classpath entries for all the files there.
-        # TODO exercise this with a test.
-        # TODO, this should only list the files/directories in the first directory under the index dir
-
-        elements_in_index_dir = [os.path.join(rsc_cc.rsc_index_dir, s)
-                                 for s in os.listdir(rsc_cc.rsc_index_dir)]
-
-        entries = to_classpath_entries(elements_in_index_dir, self.context._scheduler)
-        self._metacp_jars_classpath_product.add_for_target(
-          rsc_cc.target, confify(entries))
-      else:
-        pass
-
-  def _metacpable(self, target):
-    return isinstance(target, JarLibrary)
-
-  def _rsc_compilable(self, target):
-    return target.has_sources('.scala') and not target.has_sources('.java')
-
-  def _only_zinc_compilable(self, target):
-    return target.has_sources('.java')
+      target_compile_type = self._classify_compile_target(target)
+      if target_compile_type is not None:
+        rsc_cc, compile_cc = compile_contexts[target]
+        # TODO: rsc's produced header jars don't yet work with javac, so we introduce the
+        # 'zinc_scala_classpath_from_rsc' intermediate product, which contains rsc header jars and
+        # zinc output. zinc compilations for java targets then are scheduled strictly after zinc
+        # compilations of their dependencies, and only use the 'runtime_classpath' product.
+        mixed_zinc_rsc_product = CompositeProductAdder(
+          self.context.products.get_data('rsc_classpath'),
+          self.context.products.get_data('zinc_scala_classpath_from_rsc'))
+        target_compile_type.resolve_for_enum_variant({
+          'zinc-java': lambda: None,
+          'zinc-scala': lambda: None,
+          'rsc-java': lambda: mixed_zinc_rsc_product.add_for_target(
+            rsc_cc.target,
+            confify(to_classpath_entries([rsc_cc.rsc_jar_file], self.context._scheduler))),
+          'rsc-scala': lambda: mixed_zinc_rsc_product.add_for_target(
+            rsc_cc.target,
+            confify(to_classpath_entries([rsc_cc.rsc_jar_file], self.context._scheduler))),
+        })()
 
   def _is_scala_core_library(self, target):
     return target.address.spec in ('//:scala-library', '//:scala-library-synthetic')
@@ -282,119 +315,32 @@ class RscCompile(ZincCompile):
     else:
       classpath_product.update(compile_classpath)
 
+    zinc_nonjava_classpath_product = self.context.products.get_data('zinc_scala_classpath_from_rsc')
+    if not zinc_nonjava_classpath_product:
+      self.context.products.get_data('zinc_scala_classpath_from_rsc', compile_classpath.copy)
+    else:
+      zinc_nonjava_classpath_product.update(compile_classpath)
+
   def select(self, target):
-    # Require that targets are marked for JVM compilation, to differentiate from
-    # targets owned by the scalajs contrib module.
-    if self._metacpable(target):
-      return True
     if not isinstance(target, JvmTarget):
       return False
-    return self._only_zinc_compilable(target) or self._rsc_compilable(target)
+    if self._classify_compile_target(target) is not None:
+      return True
+    return False
+
+  def _mixed_zinc_or_rsc_key_for_target_as_dep(self, compile_target):
+    return self._classify_compile_target(compile_target).resolve_for_enum_variant({
+      'zinc-java': lambda: self._zinc_key_for_target(compile_target),
+      'zinc-scala': lambda: self._zinc_key_for_target(compile_target),
+      'rsc-java': lambda: self._rsc_key_for_target(compile_target),
+      'rsc-scala': lambda: self._rsc_key_for_target(compile_target),
+    })()
 
   def _rsc_key_for_target(self, compile_target):
-    if self._only_zinc_compilable(compile_target):
-      # rsc outlining with java dependencies depends on the output of a second metacp job.
-      return self._metacp_key_for_target(compile_target)
-    elif self._rsc_compilable(compile_target):
-      return "rsc({})".format(compile_target.address.spec)
-    elif self._metacpable(compile_target):
-      return self._metacp_key_for_target(compile_target)
-    else:
-      raise TaskError('unexpected target for compiling with rsc .... {}'.format(compile_target))
+    return 'rsc({})'.format(compile_target.address.spec)
 
-  def _metacp_dep_key_for_target(self, compile_target):
-    if self._only_zinc_compilable(compile_target):
-      # rsc outlining with java dependencies depends on the output of a second metacp job.
-      return self._metacp_key_for_target(compile_target)
-    elif self._rsc_compilable(compile_target):
-      return self._compile_against_rsc_key_for_target(compile_target)
-    elif self._metacpable(compile_target):
-      return self._metacp_key_for_target(compile_target)
-    else:
-      raise TaskError('unexpected target for compiling with rsc .... {}'.format(compile_target))
-
-  def _metacp_key_for_target(self, compile_target):
-    return "metacp({})".format(compile_target.address.spec)
-
-  def _compile_against_rsc_key_for_target(self, compile_target):
-    return "compile_against_rsc({})".format(compile_target.address.spec)
-
-  def pre_compile_jobs(self, counter):
-
-    # Create a target for the jdk outlining so that it'll only be done once per run.
-    target = Target('jdk', Address('', 'jdk'), self.context.build_graph)
-    index_dir = os.path.join(self.versioned_workdir, '--jdk--', 'index')
-
-    def work_for_vts_rsc_jdk():
-      distribution = self._get_jvm_distribution()
-      jvm_lib_jars_abs = distribution.find_libs(['rt.jar', 'dt.jar', 'jce.jar', 'tools.jar'])
-      self._jvm_lib_jars_abs = jvm_lib_jars_abs
-
-      metacp_inputs = tuple(jvm_lib_jars_abs)
-
-      counter_val = str(counter()).rjust(counter.format_length(), ' ' if PY3 else b' ')
-      counter_str = '[{}/{}] '.format(counter_val, counter.size)
-      self.context.log.info(
-        counter_str,
-        'Metacp-ing ',
-        items_to_report_element(metacp_inputs, 'jar'),
-        ' in the jdk')
-
-      # NB: Metacp doesn't handle the existence of possibly stale semanticdb jars,
-      # so we explicitly clean the directory to keep it happy.
-      safe_mkdir(index_dir, clean=True)
-
-      with Timer() as timer:
-        # Step 1: Convert classpath to SemanticDB
-        # ---------------------------------------
-        rsc_index_dir = fast_relpath(index_dir, get_buildroot())
-        args = [
-          '--verbose',
-          # NB: The directory to dump the semanticdb jars generated by metacp.
-          '--out', rsc_index_dir,
-          os.pathsep.join(metacp_inputs),
-        ]
-        metacp_wu = self._runtool(
-          'scala.meta.cli.Metacp',
-          'metacp',
-          args,
-          distribution,
-          tgt=target,
-          input_files=tuple(
-            # NB: no input files because the jdk is expected to exist on the system in a known
-            #     location.
-            #     Related: https://github.com/pantsbuild/pants/issues/6416
-          ),
-          output_dir=rsc_index_dir)
-        metacp_stdout = stdout_contents(metacp_wu)
-        metacp_result = json.loads(metacp_stdout)
-
-        metai_classpath = self._collect_metai_classpath(metacp_result, jvm_lib_jars_abs)
-
-        # Step 1.5: metai Index the semanticdbs
-        # -------------------------------------
-        self._run_metai_tool(distribution, metai_classpath, rsc_index_dir, tgt=target)
-
-        self._jvm_lib_metacp_classpath = [os.path.join(get_buildroot(), x) for x in metai_classpath]
-
-      self._record_target_stats(target,
-        len(self._jvm_lib_metacp_classpath),
-        len([]),
-        timer.elapsed,
-        False,
-        'metacp'
-      )
-
-    return [
-      Job(
-        'metacp(jdk)',
-        functools.partial(
-          work_for_vts_rsc_jdk
-        ),
-        [],
-        self._size_estimator([]),
-      ),
-    ]
+  def _zinc_key_for_target(self, compile_target):
+    return 'zinc({})'.format(compile_target.address.spec)
 
   def create_compile_jobs(self,
                           compile_target,
@@ -436,56 +382,61 @@ class RscCompile(ZincCompile):
 
         dependencies_for_target = list(
           DependencyContext.global_instance().dependencies_respecting_strict_deps(target))
+        self.context.log.debug('DEPS: {}={}'.format(target, dependencies_for_target))
 
-        jar_deps = [t for t in dependencies_for_target if isinstance(t, JarLibrary)]
 
-        def is_java_compile_target(t):
-          return isinstance(t, JavaLibrary) or t.has_sources('.java')
-        java_deps = [t for t in dependencies_for_target
-                     if is_java_compile_target(t)]
-        non_java_deps = [t for t in dependencies_for_target
-                         if not (is_java_compile_target(t)) and not isinstance(t, JarLibrary)]
+        rsc_deps_classpath_unprocessed = _paths_from_classpath(
+          self.context.products.get_data('rsc_classpath').get_for_targets(dependencies_for_target),
+          collection_type=OrderedSet)
 
-        metacped_jar_classpath_abs = _paths_from_classpath(
-          self._metacp_jars_classpath_product.get_for_targets(jar_deps + java_deps)
-        )
-        metacped_jar_classpath_abs.extend(self._jvm_lib_metacp_classpath)
-        metacped_jar_classpath_rel = fast_relpath_collection(metacped_jar_classpath_abs)
-
-        non_java_paths = _paths_from_classpath(
-          self.context.products.get_data('rsc_classpath').get_for_targets(non_java_deps),
-          collection_type=set)
-        non_java_rel = fast_relpath_collection(non_java_paths)
+        rsc_classpath_rel = fast_relpath_collection(list(rsc_deps_classpath_unprocessed))
 
         ctx.ensure_output_dirs_exist()
 
-        distribution = self._get_jvm_distribution()
         with Timer() as timer:
           # Outline Scala sources into SemanticDB
           # ---------------------------------------------
-          rsc_mjar_file = fast_relpath(ctx.rsc_mjar_file, get_buildroot())
+          rsc_jar_file = fast_relpath(ctx.rsc_jar_file, get_buildroot())
 
-          # TODO remove non-rsc entries from non_java_rel in a better way
-          rsc_semanticdb_classpath = metacped_jar_classpath_rel + \
-                                     [j for j in non_java_rel if 'compile/rsc/' in j]
+          sources_snapshot = ctx.target.sources_snapshot(scheduler=self.context._scheduler)
+
+          def hermetic_digest_classpath():
+            hermetic_dist = self._hermetic_jvm_distribution()
+            jdk_libs_rel, jdk_libs_digest = self._jdk_libs_paths_and_digest(hermetic_dist)
+            merged_sources_and_jdk_digest = self.context._scheduler.merge_directories(
+              (jdk_libs_digest, sources_snapshot.directory_digest))
+            classpath_rel_jdk = rsc_classpath_rel + jdk_libs_rel
+            return (merged_sources_and_jdk_digest, classpath_rel_jdk, hermetic_dist)
+          def nonhermetic_digest_classpath():
+            nonhermetic_dist = self._nonhermetic_jvm_distribution()
+            empty_digest = EMPTY_DIRECTORY_DIGEST
+            classpath_abs_jdk = rsc_classpath_rel + self._jdk_libs_abs(nonhermetic_dist)
+            return (empty_digest, classpath_abs_jdk, nonhermetic_dist)
+
+          (input_digest, classpath_entry_paths, distribution) = self.execution_strategy_enum.resolve_for_enum_variant({
+            self.HERMETIC: hermetic_digest_classpath,
+            self.SUBPROCESS: nonhermetic_digest_classpath,
+            self.NAILGUN: nonhermetic_digest_classpath,
+          })()
+
           target_sources = ctx.sources
           args = [
-                   '-cp', os.pathsep.join(rsc_semanticdb_classpath),
-                   '-d', rsc_mjar_file,
+                   '-cp', os.pathsep.join(classpath_entry_paths),
+                   '-d', rsc_jar_file,
                  ] + target_sources
-          sources_snapshot = ctx.target.sources_snapshot(scheduler=self.context._scheduler)
+
           self._runtool(
             'rsc.cli.Main',
             'rsc',
             args,
             distribution,
             tgt=tgt,
-            input_files=tuple(rsc_semanticdb_classpath),
-            input_digest=sources_snapshot.directory_digest,
-            output_dir=os.path.dirname(rsc_mjar_file))
+            input_files=tuple(rsc_classpath_rel),
+            input_digest=input_digest,
+            output_dir=os.path.dirname(rsc_jar_file))
 
         self._record_target_stats(tgt,
-          len(rsc_semanticdb_classpath),
+          len(rsc_classpath_rel),
           len(target_sources),
           timer.elapsed,
           False,
@@ -497,112 +448,6 @@ class RscCompile(ZincCompile):
       # Update the products with the latest classes.
       self.register_extra_products_from_contexts([ctx.target], compile_contexts)
 
-    def work_for_vts_metacp(vts, ctx, classpath_product_key):
-      metacp_dependencies_entries = self._zinc.compile_classpath_entries(
-        classpath_product_key,
-        ctx.target,
-        extra_cp_entries=self._extra_compile_time_classpath)
-
-      metacp_dependencies = fast_relpath_collection(c.path for c in metacp_dependencies_entries)
-
-
-      metacp_dependencies_digests = [c.directory_digest for c in metacp_dependencies_entries
-                                     if c.directory_digest]
-      metacp_dependencies_paths_without_digests = fast_relpath_collection(
-        c.path for c in metacp_dependencies_entries if not c.directory_digest)
-
-      classpath_entries = [
-        cp_entry for (conf, cp_entry) in
-        self.context.products.get_data(classpath_product_key).get_classpath_entries_for_targets(
-          [ctx.target])
-      ]
-      classpath_digests = [c.directory_digest for c in classpath_entries if c.directory_digest]
-      classpath_paths_without_digests = fast_relpath_collection(
-        c.path for c in classpath_entries if not c.directory_digest)
-
-      classpath_abs = [c.path for c in classpath_entries]
-      classpath_rel = fast_relpath_collection(classpath_abs)
-
-      metacp_inputs = []
-      metacp_inputs.extend(classpath_rel)
-
-      counter_val = str(counter()).rjust(counter.format_length(), ' ' if PY3 else b' ')
-      counter_str = '[{}/{}] '.format(counter_val, counter.size)
-      self.context.log.info(
-        counter_str,
-        'Metacp-ing ',
-        items_to_report_element(metacp_inputs, 'jar'),
-        ' in ',
-        items_to_report_element([t.address.reference() for t in vts.targets], 'target'),
-        ' (',
-        ctx.target.address.spec,
-        ').')
-
-      ctx.ensure_output_dirs_exist()
-
-      tgt, = vts.targets
-      with Timer() as timer:
-        # Step 1: Convert classpath to SemanticDB
-        # ---------------------------------------
-        rsc_index_dir = fast_relpath(ctx.rsc_index_dir, get_buildroot())
-        args = [
-          '--verbose',
-          '--stub-broken-signatures',
-          '--dependency-classpath', os.pathsep.join(
-            metacp_dependencies +
-            fast_relpath_collection(self._jvm_lib_jars_abs)
-          ),
-          # NB: The directory to dump the semanticdb jars generated by metacp.
-          '--out', rsc_index_dir,
-          os.pathsep.join(metacp_inputs),
-        ]
-
-        # NB: If we're building a scala library jar,
-        #     also request that metacp generate the indices
-        #     for the scala synthetics.
-        if self._is_scala_core_library(tgt):
-          args = [
-            '--include-scala-library-synthetics',
-          ] + args
-        distribution = self._get_jvm_distribution()
-
-        input_digest = self.context._scheduler.merge_directories(
-          tuple(classpath_digests + metacp_dependencies_digests))
-
-        metacp_wu = self._runtool(
-          'scala.meta.cli.Metacp',
-          'metacp',
-          args,
-          distribution,
-          tgt=tgt,
-          input_digest=input_digest,
-          input_files=tuple(classpath_paths_without_digests +
-                            metacp_dependencies_paths_without_digests),
-          output_dir=rsc_index_dir)
-        metacp_result = json.loads(stdout_contents(metacp_wu))
-
-        metai_classpath = self._collect_metai_classpath(metacp_result, classpath_rel)
-
-        # Step 1.5: metai Index the semanticdbs
-        # -------------------------------------
-        self._run_metai_tool(distribution, metai_classpath, rsc_index_dir, tgt)
-
-        abs_output = [(conf, os.path.join(get_buildroot(), x))
-                      for conf in self._confs for x in metai_classpath]
-
-        self._metacp_jars_classpath_product.add_for_target(
-          ctx.target,
-          abs_output,
-        )
-
-      self._record_target_stats(tgt,
-          len(abs_output),
-          len([]),
-          timer.elapsed,
-          False,
-          'metacp'
-        )
-
     rsc_jobs = []
     zinc_jobs = []
 
@@ -612,127 +457,89 @@ class RscCompile(ZincCompile):
 
     # Create the rsc job.
     # Currently, rsc only supports outlining scala.
-    if self._only_zinc_compilable(compile_target):
-      pass
-    elif self._rsc_compilable(compile_target):
-      rsc_key = self._rsc_key_for_target(compile_target)
-      rsc_jobs.append(
-        Job(
-          rsc_key,
-          functools.partial(
-            work_for_vts_rsc,
-            ivts,
-            compile_context_pair[0]),
-          [self._rsc_key_for_target(target) for target in invalid_dependencies] + ['metacp(jdk)'],
+    def all_mixed_zinc_rsc_invalid_dep_keys(invalid_deps):
+      for tgt in invalid_deps:
+        # None can occur for e.g. JarLibrary deps, which we don't need to compile as they are
+        # populated in the resolve goal.
+        if self._classify_compile_target(tgt) is not None:
+          # Rely on the results of zinc compiles for zinc-compatible targets
+          yield self._mixed_zinc_or_rsc_key_for_target_as_dep(tgt)
+
+    def make_rsc_job(target, dep_targets):
+      return Job(
+        self._rsc_key_for_target(target),
+        functools.partial(
+          work_for_vts_rsc,
+          ivts,
+          compile_context_pair[0]),
+          # The rsc jobs depend on other rsc jobs, and on zinc jobs for zinc-scala targets.
+          list(all_mixed_zinc_rsc_invalid_dep_keys(dep_targets)),
+          # TODO: It's not clear where compile_context_pair is coming from here.
           self._size_estimator(compile_context_pair[0].sources),
-        )
+        on_success=ivts.update,
+        on_failure=ivts.force_invalidate,
       )
-    elif self._metacpable(compile_target):
-      rsc_key = self._rsc_key_for_target(compile_target)
-      rsc_jobs.append(
-        Job(
-          rsc_key,
-          functools.partial(
-            work_for_vts_metacp,
-            ivts,
-            compile_context_pair[0],
-            'compile_classpath'),
-          [self._rsc_key_for_target(target) for target in invalid_dependencies] + ['metacp(jdk)'],
-          self._size_estimator(compile_context_pair[0].sources),
-          on_success=ivts.update,
-          on_failure=ivts.force_invalidate,
-        )
-      )
-    else:
-      raise TaskError("Unexpected target for rsc compile {} with type {}"
-        .format(compile_target, type(compile_target)))
+
+    self._classify_compile_target(compile_target).resolve_for_enum_variant({
+      # zinc-scala targets have no rsc job.
+      'zinc-java': lambda: None,
+      'zinc-scala': lambda: None,
+      'rsc-java': lambda: rsc_jobs.append(make_rsc_job(compile_target, invalid_dependencies)),
+      'rsc-scala': lambda: rsc_jobs.append(make_rsc_job(compile_target, invalid_dependencies)),
+    })()
 
     # Create the zinc compile jobs.
     # - Scala zinc compile jobs depend on the results of running rsc on the scala target.
     # - Java zinc compile jobs depend on the zinc compiles of their dependencies, because we can't
-    #   generate mjars that make javac happy at this point.
+    #   generate jars that make javac happy at this point.
 
-    invalid_dependencies_without_jar_metacps = [t for t in invalid_dependencies
-      if not self._metacpable(t)]
-    if self._rsc_compilable(compile_target):
-      full_key = self._compile_against_rsc_key_for_target(compile_target)
-      zinc_jobs.append(
-        Job(
-          full_key,
-          functools.partial(
-            self._default_work_for_vts,
-            ivts,
-            compile_context_pair[1],
-            'rsc_classpath',
-            counter,
-            compile_contexts,
-            runtime_classpath_product),
-          [
-            self._rsc_key_for_target(compile_target)
-          ] + [
-            self._rsc_key_for_target(target)
-            for target in invalid_dependencies_without_jar_metacps
-          ] + [
-            'metacp(jdk)'
-          ],
-          self._size_estimator(compile_context_pair[1].sources),
-          # NB: right now, only the last job will write to the cache, because we don't
-          #     do multiple cache entries per target-task tuple.
-          on_success=ivts.update,
-          on_failure=ivts.force_invalidate,
-        )
-      )
-    elif self._only_zinc_compilable(compile_target):
-      # write to both rsc classpath and runtime classpath
-      class CompositeProductAdder(object):
-        def __init__(self, runtime_classpath_product, rsc_classpath_product):
-          self.rsc_classpath_product = rsc_classpath_product
-          self.runtime_classpath_product = runtime_classpath_product
+    def only_zinc_invalid_dep_keys(invalid_deps):
+      for tgt in invalid_deps:
+        if self._classify_compile_target(tgt) is not None:
+          yield self._zinc_key_for_target(tgt)
 
-        def add_for_target(self, *args, **kwargs):
-          self.runtime_classpath_product.add_for_target(*args, **kwargs)
-          self.rsc_classpath_product.add_for_target(*args, **kwargs)
-
-      zinc_key = self._compile_against_rsc_key_for_target(compile_target)
-      zinc_jobs.append(
-        Job(
-          zinc_key,
-          functools.partial(
-            self._default_work_for_vts,
-            ivts,
-            compile_context_pair[1],
-            'runtime_classpath',
-            counter,
-            compile_contexts,
-            CompositeProductAdder(
-              runtime_classpath_product,
-              self.context.products.get_data('rsc_classpath'))),
-          [
-            self._compile_against_rsc_key_for_target(target)
-            for target in invalid_dependencies_without_jar_metacps],
-          self._size_estimator(compile_context_pair[1].sources),
-          on_failure=ivts.force_invalidate,
-        )
+    # NB: zinc jobs for rsc-compatible targets never depend on their own corresponding rsc jobs,
+    # just the rsc jobs of their dependencies!
+    def make_zinc_job(target, input_product_key, dep_keys):
+      return Job(key=self._zinc_key_for_target(target),
+                 fn=functools.partial(
+                   self._default_work_for_vts,
+                   ivts,
+                   compile_context_pair[1],
+                   input_product_key,
+                   counter,
+                   compile_contexts,
+                   CompositeProductAdder(
+                     runtime_classpath_product,
+                     self.context.products.get_data('zinc_scala_classpath_from_rsc'),
+                     self.context.products.get_data('rsc_classpath'))),
+                 dependencies=list(dep_keys),
+                 size=self._size_estimator(compile_context_pair[1].sources),
+                 on_success=ivts.update,
+                 on_failure=ivts.force_invalidate,
       )
 
-      metacp_key = self._metacp_key_for_target(compile_target)
-      rsc_jobs.append(
-        Job(
-          metacp_key,
-          functools.partial(
-            work_for_vts_metacp,
-            ivts,
-            compile_context_pair[0],
-            'runtime_classpath'),
-            [self._metacp_dep_key_for_target(target) for target in invalid_dependencies] + [
-              'metacp(jdk)',
-              zinc_key,
-            ],
-          self._size_estimator(compile_context_pair[0].sources),
-          on_success=ivts.update,
-          on_failure=ivts.force_invalidate,
-        )
-      )
+    # TODO: (this is noted in two other places as well) rsc's produced header jars don't yet work
+    # with javac, so we introduce the 'zinc_scala_classpath_from_rsc' intermediate product, which
+    # contains rsc header jars and zinc output. zinc compilations for java targets then are
+    # scheduled strictly after zinc compilations of their dependencies, and only use the
+    # 'runtime_classpath' product.
+    self._classify_compile_target(compile_target).resolve_for_enum_variant({
+      'zinc-java': lambda: zinc_jobs.append(
+        make_zinc_job(compile_target, 'runtime_classpath',
+                      only_zinc_invalid_dep_keys(invalid_dependencies))),
+      # zinc-scala targets will depend on the rsc jobs of rsc-scala targets and zinc jobs of
+      # zinc-scala dependencies.
+      'zinc-scala': lambda: zinc_jobs.append(
+        make_zinc_job(compile_target, 'zinc_scala_classpath_from_rsc',
+                      all_mixed_zinc_rsc_invalid_dep_keys(invalid_dependencies))),
+      'rsc-java': lambda: zinc_jobs.append(
+        make_zinc_job(compile_target, 'runtime_classpath',
+                      only_zinc_invalid_dep_keys(invalid_dependencies))),
+      'rsc-scala': lambda: zinc_jobs.append(
+        make_zinc_job(compile_target, 'zinc_scala_classpath_from_rsc',
+                      all_mixed_zinc_rsc_invalid_dep_keys(invalid_dependencies))),
+    })()
 
     return rsc_jobs + zinc_jobs
 
@@ -760,7 +567,7 @@ class RscCompile(ZincCompile):
         classes_dir=None,
         jar_file=None,
         zinc_args_file=None,
-        rsc_mjar_file=os.path.join(rsc_dir, 'm.jar'),
+        rsc_jar_file=os.path.join(rsc_dir, 'm.jar'),
         log_dir=os.path.join(rsc_dir, 'logs'),
         sources=sources,
         rsc_index_dir=os.path.join(rsc_dir, 'index'),
@@ -780,14 +587,12 @@ class RscCompile(ZincCompile):
     tool_classpath_abs = self.tool_classpath(tool_name)
     tool_classpath = fast_relpath_collection(tool_classpath_abs)
 
-    classpath_for_cmd = os.pathsep.join(tool_classpath)
     cmd = [
       distribution.java,
-    ]
-    cmd.extend(self.get_options().jvm_options)
-    cmd.extend(['-cp', classpath_for_cmd])
-    cmd.extend([main])
-    cmd.extend(args)
+    ] + self.get_options().jvm_options + [
+      '-cp', os.pathsep.join(tool_classpath),
+      main,
+    ] + args
 
     pathglobs = list(tool_classpath)
     pathglobs.extend(f if os.path.isfile(f) else '{}/**'.format(f) for f in input_files)
@@ -799,11 +604,9 @@ class RscCompile(ZincCompile):
       # dont capture snapshot, if pathglobs is empty
       path_globs_input_digest = self.context._scheduler.capture_snapshots((root,))[0].directory_digest
 
-    if path_globs_input_digest and input_digest:
-      epr_input_files = self.context._scheduler.merge_directories(
-          (path_globs_input_digest, input_digest))
-    else:
-      epr_input_files = path_globs_input_digest or input_digest
+    epr_input_files = self.context._scheduler.merge_directories(
+      ((path_globs_input_digest,) if path_globs_input_digest else ())
+      + ((input_digest,) if input_digest else ()))
 
     epr = ExecuteProcessRequest(
       argv=tuple(cmd),
@@ -822,7 +625,7 @@ class RscCompile(ZincCompile):
       [WorkUnitLabel.TOOL])
 
     if res.exit_code != 0:
-      raise TaskError(res.stderr)
+      raise TaskError(res.stderr, exit_code=res.exit_code)
 
     if output_dir:
       write_digest(output_dir, res.output_directory_digest)
@@ -871,90 +674,58 @@ class RscCompile(ZincCompile):
           wu, self._nailgunnable_combined_classpath, main, tool_name, args, distribution),
       })()
 
-  def _run_metai_tool(self,
-                      distribution,
-                      metai_classpath,
-                      rsc_index_dir,
-                      tgt,
-                      extra_input_files=()):
-    # TODO have metai write to a different spot than metacp
-    # Currently, the metai step depends on the fact that materializing
-    # ignores existing files. It should write the files to a different
-    # location, either by providing inputs from a different location,
-    # or invoking a script that does the copying
-    args = [
-      '--verbose',
-      os.pathsep.join(metai_classpath)
-    ]
-    self._runtool(
-      'scala.meta.cli.Metai',
-      'metai',
-      args,
-      distribution,
-      tgt=tgt,
-      input_files=tuple(metai_classpath) + tuple(extra_input_files),
-      output_dir=rsc_index_dir
-    )
+  _JDK_LIB_NAMES = ['rt.jar', 'dt.jar', 'jce.jar', 'tools.jar']
 
-  def _collect_metai_classpath(self, metacp_result, relative_input_paths):
-    metai_classpath = []
+  @memoized_method
+  def _jdk_libs_paths_and_digest(self, hermetic_dist):
+    jdk_libs_rel, jdk_libs_globs = hermetic_dist.find_libs_path_globs(self._JDK_LIB_NAMES)
+    jdk_libs_digest = self.context._scheduler.capture_snapshots(
+      (jdk_libs_globs,))[0].directory_digest
+    return (jdk_libs_rel, jdk_libs_digest)
 
-    relative_workdir = fast_relpath(
-      self.context.options.for_global_scope().pants_workdir,
-      get_buildroot())
-    # NB The json uses absolute paths pointing into either the buildroot or
-    #    the temp directory of the hermetic build. This relativizes the keys.
-    #    TODO remove this after https://github.com/scalameta/scalameta/issues/1791 is released
-    desandboxify = _create_desandboxify_fn(
-      [
-        os.path.join(relative_workdir, 'resolve', 'coursier', '[^/]*', 'cache', '.*'),
-        os.path.join(relative_workdir, 'resolve', 'ivy', '[^/]*', 'ivy', 'jars', '.*'),
-        os.path.join(relative_workdir, 'compile', 'rsc', '.*'),
-        os.path.join(relative_workdir, r'\.jdk', '.*'),
-        os.path.join(r'\.jdk', '.*'),
-      ]
-      )
+  @memoized_method
+  def _jdk_libs_abs(self, nonhermetic_dist):
+    return nonhermetic_dist.find_libs(self._JDK_LIB_NAMES)
 
-    status_elements = {
-      desandboxify(k): desandboxify(v)
-      for k,v in metacp_result["status"].items()
-    }
+  class _HermeticDistribution(object):
+    def __init__(self, home_path, distribution):
+      self._underlying = distribution
+      self._home = home_path
 
-    for cp_entry in relative_input_paths:
-      metai_classpath.append(status_elements[cp_entry])
+    def find_libs(self, names):
+      underlying_libs = self._underlying.find_libs(names)
+      return [os.path.join(self.home, self._unroot_lib_path(l)) for l in underlying_libs]
 
-    scala_lib_synthetics = metacp_result["scalaLibrarySynthetics"]
-    if scala_lib_synthetics:
-      metai_classpath.append(desandboxify(scala_lib_synthetics))
+    def find_libs_path_globs(self, names):
+      libs_abs = self._underlying.find_libs(names)
+      libs_unrooted = [self._unroot_lib_path(l) for l in libs_abs]
+      path_globs = PathGlobsAndRoot(
+        PathGlobs(tuple(libs_unrooted)),
+        text_type(self._underlying.home))
+      return (libs_unrooted, path_globs)
 
-    return metai_classpath
+    @property
+    def java(self):
+      return os.path.join(self._home, 'bin', 'java')
 
-  def _get_jvm_distribution(self):
+    def _unroot_lib_path(self, path):
+      return path[len(self._underlying.home)+1:]
+
+    def _rehome(self, l):
+      return os.path.join(self._home, self._unroot_lib_path(l))
+
+  @memoized_method
+  def _hermetic_jvm_distribution(self):
     # TODO We may want to use different jvm distributions depending on what
     # java version the target expects to be compiled against.
     # See: https://github.com/pantsbuild/pants/issues/6416 for covering using
     #      different jdks in remote builds.
     local_distribution = JvmPlatform.preferred_jvm_distribution([], strict=True)
-    if self.execution_strategy == self.HERMETIC and self.get_options().remote_execution_server:
-      class HermeticDistribution(object):
-        def __init__(self, home_path, distribution):
-          self._underlying = distribution
-          self._home = home_path
+    return self._HermeticDistribution('.jdk', local_distribution)
 
-        def find_libs(self, names):
-          underlying_libs = self._underlying.find_libs(names)
-          return [self._rehome(l) for l in underlying_libs]
-
-        @property
-        def java(self):
-          return os.path.join(self._home, 'bin', 'java')
-
-        def _rehome(self, l):
-          return os.path.join(self._home, l[len(self._underlying.home)+1:])
-
-      return HermeticDistribution('.jdk', local_distribution)
-    else:
-      return local_distribution
+  @memoized_method
+  def _nonhermetic_jvm_distribution(self):
+    return JvmPlatform.preferred_jvm_distribution([], strict=True)
 
   def _on_invalid_compile_dependency(self, dep, compile_target):
     """Decide whether to continue searching for invalid targets to use in the execution graph.

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -401,7 +401,8 @@ class BaseZincCompile(JvmCompile):
       self.NAILGUN: lambda: self._compile_nonhermetic(jvm_options, zinc_args),
     })()
 
-  class ZincCompileError(TaskError): pass
+  class ZincCompileError(TaskError):
+    """An exception type specifically to signal a failed zinc execution."""
 
   def _compile_nonhermetic(self, jvm_options, zinc_args):
     exit_code = self.runjava(classpath=self.get_zinc_compiler_classpath(),
@@ -462,7 +463,7 @@ class BaseZincCompile(JvmCompile):
       req, self.name(), [WorkUnitLabel.COMPILER])
 
     if res.exit_code != 0:
-      raise TaskError(res.stderr, exit_code=res.exit_code)
+      raise self.ZincCompileError(res.stderr, exit_code=res.exit_code)
 
     # TODO: Materialize as a batch in do_compile or somewhere
     self.context._scheduler.materialize_directories((

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -349,12 +349,19 @@ class BaseZincCompile(JvmCompile):
     scala_path = [classpath_entry.path for classpath_entry in scalac_classpath_entries]
 
     zinc_args = []
+    # TODO: The scopt option parsing from rsc-and-zinc.jar says -classpath alone isn't recognized.
+    classpath_arg_name = self.execution_strategy_enum.resolve_for_enum_variant({
+      self.HERMETIC_WITH_NAILGUN: '--classpath',
+      self.HERMETIC: '-classpath',
+      self.SUBPROCESS: '-classpath',
+      self.NAILGUN: '-classpath',
+    })
     zinc_args.extend([
       # TODO: for some reason this argument isn't accepted (although it is also later on the command
       # line, and that appears to work -- unclear)!
       # '-log-level', self.get_options().level,
       '-analysis-cache', analysis_cache,
-      '--classpath', ':'.join(relative_classpath),
+      classpath_arg_name, ':'.join(relative_classpath),
       '-d', classes_dir,
     ])
     if not self.get_options().colors:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -386,71 +386,91 @@ class BaseZincCompile(JvmCompile):
     with open(ctx.zinc_args_file, 'w') as fp:
       for arg in zinc_args:
         # NB: in Python 2, options are stored sometimes as bytes and sometimes as unicode in the OptionValueContainer.
-        # This is due to how Python 2 natively stores attributes as a map of `str` (aka `bytes`) to their value. So, 
+        # This is due to how Python 2 natively stores attributes as a map of `str` (aka `bytes`) to their value. So,
         # the setattr() and getattr() functions sometimes use bytes.
         if PY2:
           arg = ensure_text(arg)
         fp.write(arg)
         fp.write('\n')
 
-    if self.execution_strategy == self.HERMETIC:
-      zinc_relpath = fast_relpath(self._zinc.zinc, get_buildroot())
+    return self.execution_strategy_enum.resolve_for_enum_variant({
+      self.HERMETIC: lambda: self._compile_hermetic(
+        jvm_options, ctx, classes_dir, zinc_args, compiler_bridge_classpath_entry, dependency_classpath,
+        scalac_classpath_entries),
+      self.SUBPROCESS: lambda: self._compile_nonhermetic(jvm_options, zinc_args),
+      self.NAILGUN: lambda: self._compile_nonhermetic(jvm_options, zinc_args),
+    })()
 
-      snapshots = [
-        self._zinc.snapshot(self.context._scheduler),
-        ctx.target.sources_snapshot(self.context._scheduler),
-      ]
+  class ZincCompileError(TaskError): pass
 
-      relevant_classpath_entries = dependency_classpath + [compiler_bridge_classpath_entry]
-      directory_digests = tuple(
-        entry.directory_digest for entry in relevant_classpath_entries if entry.directory_digest
-      )
-      if len(directory_digests) != len(relevant_classpath_entries):
-        for dep in relevant_classpath_entries:
-          if dep.directory_digest is None:
-            logger.warning(
-              "ClasspathEntry {} didn't have a Digest, so won't be present for hermetic "
-              "execution".format(dep)
-            )
+  def _compile_nonhermetic(self, jvm_options, zinc_args):
+    exit_code = self.runjava(classpath=self.get_zinc_compiler_classpath(),
+                             main=Zinc.ZINC_COMPILE_MAIN,
+                             jvm_options=jvm_options,
+                             args=zinc_args,
+                             workunit_name=self.name(),
+                             workunit_labels=[WorkUnitLabel.COMPILER],
+                             dist=self._zinc.dist)
+    if exit_code != 0:
+      raise self.ZincCompileError('Zinc compile failed.', exit_code=exit_code)
 
-      snapshots.extend(
-        classpath_entry.directory_digest for classpath_entry in scalac_classpath_entries
-      )
+  def _compile_hermetic(self, jvm_options, ctx, classes_dir, zinc_args, compiler_bridge_classpath_entry,
+                        dependency_classpath, scalac_classpath_entries):
+    zinc_relpath = fast_relpath(self._zinc.zinc, get_buildroot())
 
-      merged_input_digest = self.context._scheduler.merge_directories(
-        tuple(s.directory_digest for s in (snapshots)) + directory_digests
-      )
+    snapshots = [
+      self._zinc.snapshot(self.context._scheduler),
+      ctx.target.sources_snapshot(self.context._scheduler),
+    ]
 
-      # TODO: Extract something common from Executor._create_command to make the command line
-      # TODO: Lean on distribution for the bin/java appending here
-      argv = tuple(['.jdk/bin/java'] + jvm_options + ['-cp', zinc_relpath, Zinc.ZINC_COMPILE_MAIN] + zinc_args)
-      req = ExecuteProcessRequest(
-        argv=argv,
-        input_files=merged_input_digest,
-        output_directories=(classes_dir,),
-        description="zinc compile for {}".format(ctx.target.address.spec),
-        # TODO: These should always be unicodes
-        # Since this is always hermetic, we need to use `underlying_dist`
-        jdk_home=text_type(self._zinc.underlying_dist.home),
-      )
-      res = self.context.execute_process_synchronously_or_raise(req, self.name(), [WorkUnitLabel.COMPILER])
+    relevant_classpath_entries = dependency_classpath + [compiler_bridge_classpath_entry]
+    directory_digests = tuple(
+      entry.directory_digest for entry in relevant_classpath_entries if entry.directory_digest
+    )
+    if len(directory_digests) != len(relevant_classpath_entries):
+      for dep in relevant_classpath_entries:
+        if dep.directory_digest is None:
+          logger.warning(
+            "ClasspathEntry {} didn't have a Digest, so won't be present for hermetic "
+            "execution".format(dep)
+          )
 
-      # TODO: Materialize as a batch in do_compile or somewhere
-      self.context._scheduler.materialize_directories((
-        DirectoryToMaterialize(get_buildroot(), res.output_directory_digest),
-      ))
+    snapshots.extend(
+      classpath_entry.directory_digest for classpath_entry in scalac_classpath_entries
+    )
 
-      # TODO: This should probably return a ClasspathEntry rather than a Digest
-      return res.output_directory_digest
-    else:
-      if self.runjava(classpath=self.get_zinc_compiler_classpath(),
-                      main=Zinc.ZINC_COMPILE_MAIN,
-                      jvm_options=jvm_options,
-                      args=zinc_args,
-                      workunit_name=self.name(),
-                      workunit_labels=[WorkUnitLabel.COMPILER],
-                      dist=self._zinc.dist):
-        raise TaskError('Zinc compile failed.')
+    # TODO: Extract something common from Executor._create_command to make the command line
+    # TODO: Lean on distribution for the bin/java appending here
+    merged_input_digest = self.context._scheduler.merge_directories(
+      tuple(s.directory_digest for s in (snapshots)) + directory_digests
+    )
+    argv = ['.jdk/bin/java'] + jvm_options + [
+      '-cp', zinc_relpath,
+      Zinc.ZINC_COMPILE_MAIN
+    ] + zinc_args
+
+    req = ExecuteProcessRequest(
+      argv=tuple(argv),
+      input_files=merged_input_digest,
+      output_directories=(classes_dir,),
+      description="zinc compile for {}".format(ctx.target.address.spec),
+      # TODO: These should always be unicodes
+      # Since this is always hermetic, we need to use `underlying_dist`
+      jdk_home=text_type(self._zinc.underlying_dist.home),
+    )
+    res = self.context.execute_process_synchronously_or_raise(
+      req, self.name(), [WorkUnitLabel.COMPILER])
+
+    if res.exit_code != 0:
+      raise TaskError(res.stderr, exit_code=res.exit_code)
+
+    # TODO: Materialize as a batch in do_compile or somewhere
+    self.context._scheduler.materialize_directories((
+      DirectoryToMaterialize(get_buildroot(), res.output_directory_digest),
+    ))
+
+    # TODO: This should probably return a ClasspathEntry rather than a Digest
+    return res.output_directory_digest
 
   def get_zinc_compiler_classpath(self):
     """Get the classpath for the zinc compiler JVM tool.

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -47,6 +47,13 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
                                           rev='0.9.1'),
                           ])
 
+  @memoized_property
+  def execution_strategy_enum(self):
+    # TODO: This .create() call can be removed when the enum interface is more stable as the option
+    # is converted into an instance of self.ExecutionStrategy vai the `type` argument through
+    # register_enum_option().
+    return self.ExecutionStrategy.create(self.get_options().execution_strategy)
+
   @classmethod
   def subsystem_dependencies(cls):
     return super(NailgunTaskBase, cls).subsystem_dependencies() + (Subprocess.Factory,)
@@ -62,10 +69,6 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
     self._identity = '_'.join(id_tuple)
     self._executor_workdir = os.path.join(self.context.options.for_global_scope().pants_workdir,
                                           *id_tuple)
-
-  @memoized_property
-  def execution_strategy_enum(self):
-    return self.ExecutionStrategy.create(self.get_options().execution_strategy)
 
   # TODO: eventually deprecate this when we can move all subclasses to use the enum!
   @property

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -24,8 +24,9 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
   NAILGUN = 'nailgun'
   SUBPROCESS = 'subprocess'
   HERMETIC = 'hermetic'
+  HERMETIC_WITH_NAILGUN = 'hermetic-with-nailgun'
 
-  class ExecutionStrategy(enum([NAILGUN, SUBPROCESS, HERMETIC])): pass
+  class ExecutionStrategy(enum([NAILGUN, SUBPROCESS, HERMETIC, HERMETIC_WITH_NAILGUN])): pass
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -44,9 +44,9 @@ class GCC(NativeTool):
 
   @memoized_method
   def _common_lib_dirs(self, platform):
-    lib64_tuples = platform.resolve_platform_specific({
-      'darwin': lambda: [],
-      'linux': lambda: [('lib64',)],
+    lib64_tuples = platform.resolve_for_enum_variant({
+      'darwin': [],
+      'linux': [('lib64',)],
     })
     return self._filemap(lib64_tuples + [
       ('lib',),

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -80,16 +80,13 @@ class LLVM(NativeTool):
   def path_entries(self):
     return self._filemap([('bin',)])
 
-  _PLATFORM_SPECIFIC_LINKER_NAME = {
-    'darwin': lambda: 'ld64.lld',
-    'linux': lambda: 'lld',
-  }
-
   def linker(self, platform):
     return Linker(
       path_entries=self.path_entries,
-      exe_filename=platform.resolve_platform_specific(
-        self._PLATFORM_SPECIFIC_LINKER_NAME),
+      exe_filename=platform.resolve_for_enum_variant({
+        'darwin': 'ld64.lld',
+        'linux': 'lld',
+      }),
       library_dirs=[],
       linking_library_dirs=[],
       extra_args=[],

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -10,14 +10,10 @@ from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
 from pants.util.meta import classproperty
-from pants.util.objects import enum
+from pants.util.objects import enum, register_enum_option
 
 
-class ToolchainVariant(enum('descriptor', ['gnu', 'llvm'])):
-
-  @property
-  def is_gnu(self):
-    return self.descriptor == 'gnu'
+class ToolchainVariant(enum(['gnu', 'llvm'])): pass
 
 
 class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsystem):
@@ -39,11 +35,10 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
              help='The default for the "compiler_option_sets" argument '
                   'for targets of this language.')
 
-    register('--toolchain-variant', type=str, fingerprint=True, advanced=True,
-             choices=ToolchainVariant.allowed_values,
-             default=ToolchainVariant.default_value,
-             help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
-                  "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
+    register_enum_option(
+      register, ToolchainVariant, '--toolchain-variant', type=str, advanced=True,
+      help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
+           "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
 
   def get_compiler_option_sets_for_target(self, target):
     return self.get_target_mirrored_option('compiler_option_sets', target)

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -36,7 +36,7 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
                   'for targets of this language.')
 
     register_enum_option(
-      register, ToolchainVariant, '--toolchain-variant', type=str, advanced=True,
+      register, ToolchainVariant, '--toolchain-variant', advanced=True,
       help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
            "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -87,10 +87,11 @@ class LLVMCppToolchain(datatype([('cpp_toolchain', CppToolchain)])): pass
 
 @rule(LibcObjects, [Select(Platform), Select(NativeToolchain)])
 def select_libc_objects(platform, native_toolchain):
-  paths = platform.resolve_platform_specific({
+  # We use lambdas here to avoid searching for libc on osx, where it will fail.
+  paths = platform.resolve_for_enum_variant({
     'darwin': lambda: [],
     'linux': lambda: native_toolchain._libc_dev.get_libc_objects(),
-  })
+  })()
   yield LibcObjects(paths)
 
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -344,8 +344,12 @@ class ToolchainVariantRequest(datatype([
 @rule(CToolchain, [Select(ToolchainVariantRequest)])
 def select_c_toolchain(toolchain_variant_request):
   native_toolchain = toolchain_variant_request.toolchain
-  # TODO: make an enum exhaustiveness checking method that works with `yield Get(...)` statements!
-  if toolchain_variant_request.variant.is_gnu:
+  # TODO(#5933): make an enum exhaustiveness checking method that works with `yield Get(...)`!
+  use_gcc = toolchain_variant_request.variant.resolve_for_enum_variant({
+    'gnu': True,
+    'llvm': False,
+  })
+  if use_gcc:
     toolchain_resolved = yield Get(GCCCToolchain, NativeToolchain, native_toolchain)
   else:
     toolchain_resolved = yield Get(LLVMCToolchain, NativeToolchain, native_toolchain)
@@ -355,7 +359,12 @@ def select_c_toolchain(toolchain_variant_request):
 @rule(CppToolchain, [Select(ToolchainVariantRequest)])
 def select_cpp_toolchain(toolchain_variant_request):
   native_toolchain = toolchain_variant_request.toolchain
-  if toolchain_variant_request.variant.is_gnu:
+  # TODO(#5933): make an enum exhaustiveness checking method that works with `yield Get(...)`!
+  use_gcc = toolchain_variant_request.variant.resolve_for_enum_variant({
+    'gnu': True,
+    'llvm': False,
+  })
+  if use_gcc:
     toolchain_resolved = yield Get(GCCCppToolchain, NativeToolchain, native_toolchain)
   else:
     toolchain_resolved = yield Get(LLVMCppToolchain, NativeToolchain, native_toolchain)

--- a/src/python/pants/backend/native/targets/native_artifact.py
+++ b/src/python/pants/backend/native/targets/native_artifact.py
@@ -22,9 +22,9 @@ class NativeArtifact(datatype(['lib_name']), PayloadField):
 
   def as_shared_lib(self, platform):
     # TODO: check that the name conforms to some format in the constructor (e.g. no dots?).
-    return platform.resolve_platform_specific({
-      'darwin': lambda: 'lib{}.dylib'.format(self.lib_name),
-      'linux': lambda: 'lib{}.so'.format(self.lib_name),
+    return platform.resolve_for_enum_variant({
+      'darwin': 'lib{}.dylib'.format(self.lib_name),
+      'linux': 'lib{}.so'.format(self.lib_name),
     })
 
   def _compute_fingerprint(self):

--- a/src/python/pants/backend/native/tasks/conan_fetch.py
+++ b/src/python/pants/backend/native/tasks/conan_fetch.py
@@ -124,9 +124,9 @@ class ConanFetch(SimpleCodegenTask):
 
   @memoized_property
   def _conan_os_name(self):
-    return Platform.create().resolve_platform_specific({
-      'darwin': lambda: 'Macos',
-      'linux': lambda: 'Linux',
+    return Platform.create().resolve_for_enum_variant({
+      'darwin': 'Macos',
+      'linux': 'Linux',
     })
 
   @property

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -142,11 +142,6 @@ class LinkSharedLibraries(NativeTask):
 
     return link_request
 
-  _SHARED_CMDLINE_ARGS = {
-    'darwin': lambda: ['-Wl,-dylib'],
-    'linux': lambda: ['-shared'],
-  }
-
   def _execute_link_request(self, link_request):
     object_files = link_request.object_files
 
@@ -163,7 +158,10 @@ class LinkSharedLibraries(NativeTask):
     self.context.log.debug("resulting_shared_lib_path: {}".format(resulting_shared_lib_path))
     # We are executing in the results_dir, so get absolute paths for everything.
     cmd = ([linker.exe_filename] +
-           self.platform.resolve_platform_specific(self._SHARED_CMDLINE_ARGS) +
+           self.platform.resolve_for_enum_variant({
+             'darwin': ['-Wl,-dylib'],
+             'linux': ['-shared'],
+           }) +
            linker.extra_args +
            ['-o', os.path.abspath(resulting_shared_lib_path)] +
            ['-L{}'.format(lib_dir) for lib_dir in link_request.external_lib_dirs] +

--- a/src/python/pants/backend/python/tasks/unpack_wheels.py
+++ b/src/python/pants/backend/python/tasks/unpack_wheels.py
@@ -105,9 +105,9 @@ class UnpackWheels(UnpackRemoteSourcesBase):
 
   @memoized_classproperty
   def _current_platform_abbreviation(cls):
-    return NativeBackendPlatform.create().resolve_platform_specific({
-      'darwin': lambda: 'macosx',
-      'linux': lambda: 'linux',
+    return NativeBackendPlatform.create().resolve_for_enum_variant({
+      'darwin': 'macosx',
+      'linux': 'linux',
     })
 
   @classmethod

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -57,8 +57,9 @@ class PathGlobs(datatype([
       cls,
       include=tuple(include),
       exclude=tuple(exclude),
-      glob_match_error_behavior=GlobMatchErrorBehavior.create(glob_match_error_behavior),
-      conjunction=GlobExpansionConjunction.create(conjunction))
+      glob_match_error_behavior=GlobMatchErrorBehavior.create(glob_match_error_behavior,
+                                                              none_is_default=True),
+      conjunction=GlobExpansionConjunction.create(conjunction, none_is_default=True))
 
 
 class PathGlobsAndRoot(datatype([('path_globs', PathGlobs), ('root', text_type)])):

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -346,7 +346,8 @@ class EngineInitializer(object):
     rules = (
       [
         RootRule(Console),
-        SingletonRule.from_instance(GlobMatchErrorBehavior.create(glob_match_error_behavior)),
+        SingletonRule.from_instance(GlobMatchErrorBehavior.create(glob_match_error_behavior,
+                                                                  none_is_default=True)),
         SingletonRule.from_instance(build_configuration),
         SingletonRule(SymbolTable, symbol_table),
       ] +

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -196,7 +196,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   '(e.g. BUILD file scanning, glob matching, etc). '
                   'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore).')
     register_enum_option(
-      register, GlobMatchErrorBehavior, '--glob-expansion-failure', default='warn', type=str,
+      # TODO: allow using the attribute `GlobMatchErrorBehavior.warn` for more safety!
+      register, GlobMatchErrorBehavior, '--glob-expansion-failure', default='warn',
       advanced=True,
       help="Raise an exception if any targets declaring source files "
            "fail to match any glob provided in the 'sources' argument.")

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -16,7 +16,7 @@ from pants.option.errors import OptionsError
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
-from pants.util.objects import datatype, enum
+from pants.util.objects import datatype, enum, register_enum_option
 
 
 class GlobMatchErrorBehavior(enum('failure_behavior', ['ignore', 'warn', 'error'])):
@@ -25,8 +25,6 @@ class GlobMatchErrorBehavior(enum('failure_behavior', ['ignore', 'warn', 'error'
   NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
   be aware of any changes to this object's definition.
   """
-
-  default_option_value = 'warn'
 
 
 class ExecutionOptions(datatype([
@@ -197,12 +195,11 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help='Paths to ignore for all filesystem operations performed by pants '
                   '(e.g. BUILD file scanning, glob matching, etc). '
                   'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore).')
-    register('--glob-expansion-failure', type=str,
-             choices=GlobMatchErrorBehavior.allowed_values,
-             default=GlobMatchErrorBehavior.default_option_value,
-             advanced=True,
-             help="Raise an exception if any targets declaring source files "
-                  "fail to match any glob provided in the 'sources' argument.")
+    register_enum_option(
+      register, GlobMatchErrorBehavior, '--glob-expansion-failure', default='warn', type=str,
+      advanced=True,
+      help="Raise an exception if any targets declaring source files "
+           "fail to match any glob provided in the 'sources' argument.")
 
     register('--exclude-target-regexp', advanced=True, type=list, default=[], daemon=False,
              metavar='<regexp>', help='Exclude target roots that match these regexes.')

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -342,20 +342,17 @@ def enum(*args):
       NB: This method is exposed for testing enum variants easily. resolve_for_enum_variant() should
       be used for performing conditional logic based on an enum instance's value.
       """
-      # TODO: use this method to register attributes on the generated type object for each of the
-      # singletons!
+      # TODO(#7232): use this method to register attributes on the generated type object for each of
+      # the singletons!
       return cls._singletons.values()
 
   return ChoiceDatatype
 
 
-# TODO: allow usage of the normal register() by using an enum class as the `type` argument by
-# extending option registration to allow extracting `choices` and `default` value from the `type`!
+# TODO(#7233): allow usage of the normal register() by using an enum class as the `type` argument!
 def register_enum_option(register, enum_cls, *args, **kwargs):
   """A helper method for declaring a pants option from an `enum()`."""
   default_value = kwargs.pop('default', enum_cls.default_value)
-  # TODO: the `choices` argument is checked against after the `type` is applied, which then produces
-  # the enum type check error message instead of the `choices` error message. This should be fixed.
   register(*args, choices=enum_cls._allowed_values, default=default_value, **kwargs)
 
 

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -263,10 +263,6 @@ def enum(*args):
     # but more specific.
     type_check_error_type = EnumVariantSelectionError
 
-    # Overriden from datatype() so providing an invalid variant is catchable as a TypeCheckError,
-    # but more specific.
-    type_check_error_type = EnumVariantSelectionError
-
     @memoized_classproperty
     def _singletons(cls):
       """Generate memoized instances of this enum wrapping each of this enum's allowed values.

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -267,11 +267,6 @@ def enum(*args):
     # but more specific.
     type_check_error_type = EnumVariantSelectionError
 
-    @classmethod
-    def _get_value(cls, obj):
-      """Helper method to avoid using `field_name` in the class implementation a lot."""
-      return getattr(obj, field_name)
-
     @memoized_classproperty
     def _singletons(cls):
       """Generate memoized instances of this enum wrapping each of this enum's allowed values.

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -28,6 +28,9 @@ class TypedDatatypeInstanceConstructionError(TypeCheckError):
   """Raised when a datatype()'s fields fail a type check upon construction."""
 
 
+# TODO: create a mixin which declares/implements the methods we define on the generated class in
+# datatype() and enum() to decouple the class's logic from the way it's created. This may also make
+# migration to python 3 dataclasses as per #7074 easier.
 def datatype(field_decls, superclass_name=None, **kwargs):
   """A wrapper for `namedtuple` that accounts for the type of the object in equality.
 
@@ -318,6 +321,15 @@ def enum(*args):
           .format(list(self.allowed_values), list(keys)))
       match_for_variant = mapping[self._get_value(self)]
       return match_for_variant
+
+    @classmethod
+    def iterate_enum_variants(cls):
+      """Iterate over all instances of this enum, in the declared order.
+
+      NB: This method is exposed for testing enum variants easily. resolve_for_enum_variant() should
+      be used for performing conditional logic based on an enum instance's value.
+      """
+      return [cls.create(variant_value) for variant_value in cls.allowed_values]
 
   return ChoiceDatatype
 

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -15,6 +15,19 @@ from pants.util.memo import memoized_classproperty
 from pants.util.meta import AbstractClass, classproperty
 
 
+class TypeCheckError(TypeError):
+
+  # TODO: make some wrapper exception class to make this kind of
+  # prefixing easy (maybe using a class field format string?).
+  def __init__(self, type_name, msg, *args, **kwargs):
+    formatted_msg = "type check error in class {}: {}".format(type_name, msg)
+    super(TypeCheckError, self).__init__(formatted_msg, *args, **kwargs)
+
+
+class TypedDatatypeInstanceConstructionError(TypeCheckError):
+  """Raised when a datatype()'s fields fail a type check upon construction."""
+
+
 def datatype(field_decls, superclass_name=None, **kwargs):
   """A wrapper for `namedtuple` that accounts for the type of the object in equality.
 
@@ -56,9 +69,20 @@ def datatype(field_decls, superclass_name=None, **kwargs):
   namedtuple_cls = namedtuple(superclass_name, field_names, **kwargs)
 
   class DataType(namedtuple_cls):
+    @classproperty
+    def type_check_error_type(cls):
+      """The exception type to use in make_type_error()."""
+      return TypedDatatypeInstanceConstructionError
+
     @classmethod
     def make_type_error(cls, msg, *args, **kwargs):
-      return TypeCheckError(cls.__name__, msg, *args, **kwargs)
+      """A helper method to generate an exception type for type checking errors.
+
+      This method uses `cls.type_check_error_type` to ensure that type checking errors can be caught
+      with a reliable exception type. The type returned by `cls.type_check_error_type` should ensure
+      that the exception messages are prefixed with enough context to be useful and *not* confusing.
+      """
+      return cls.type_check_error_type(cls.__name__, msg, *args, **kwargs)
 
     def __new__(cls, *args, **kwargs):
       # TODO: Ideally we could execute this exactly once per `cls` but it should be a
@@ -69,7 +93,8 @@ def datatype(field_decls, superclass_name=None, **kwargs):
       try:
         this_object = super(DataType, cls).__new__(cls, *args, **kwargs)
       except TypeError as e:
-        raise cls.make_type_error(e)
+        raise cls.make_type_error(
+          "error in namedtuple() base constructor: {}".format(e))
 
       # TODO: Make this kind of exception pattern (filter for errors then display them all at once)
       # more ergonomic.
@@ -82,7 +107,9 @@ def datatype(field_decls, superclass_name=None, **kwargs):
           type_failure_msgs.append(
             "field '{}' was invalid: {}".format(field_name, e))
       if type_failure_msgs:
-        raise cls.make_type_error('\n'.join(type_failure_msgs))
+        raise cls.make_type_error(
+          'errors type checking constructor arguments:\n{}'
+          .format('\n'.join(type_failure_msgs)))
 
       return this_object
 
@@ -168,17 +195,30 @@ def datatype(field_decls, superclass_name=None, **kwargs):
     return type(superclass_name.encode('utf-8'), (DataType,), {})
 
 
-def enum(field_name, all_values):
+class EnumVariantSelectionError(TypeCheckError):
+  """Raised when an invalid variant for an enum() is constructed or matched against."""
+
+
+def enum(*args):
   """A datatype which can take on a finite set of values. This method is experimental and unstable.
 
   Any enum subclass can be constructed with its create() classmethod. This method will use the first
-  element of `all_values` as the enum value if none is specified.
+  element of `all_values` as the default value, but enum classes can override this behavior by
+  setting `default_value` in the class body.
 
-  :param field_name: A string used as the field for the datatype. Note that enum does not yet
-                     support type checking as with datatype.
-  :param all_values: An iterable of objects representing all possible values for the enum.
-                     NB: `all_values` must be a finite, non-empty iterable with unique values!
+  :param string field_name: A string used as the field for the datatype. This positional argument is
+                            optional, and defaults to 'value'. Note that `enum()` does not yet
+                            support type checking as with `datatype()`.
+  :param Iterable all_values: An iterable of objects representing all possible values for the enum.
+                              This argument must be a finite, non-empty iterable with unique values.
   """
+  if len(args) == 1:
+    field_name = 'value'
+    all_values, = args
+  elif len(args) == 2:
+    field_name, all_values = args
+  else:
+    raise ValueError("enum() accepts only 1 or 2 args! args = {!r}".format(args))
 
   # This call to list() will eagerly evaluate any `all_values` which would otherwise be lazy, such
   # as a generator.
@@ -195,6 +235,15 @@ def enum(field_name, all_values):
     allowed_values = allowed_values_set
     default_value = next(iter(allowed_values))
 
+    # Overriden from datatype() so providing an invalid variant is catchable as a TypeCheckError,
+    # but more specific.
+    type_check_error_type = EnumVariantSelectionError
+
+    @classmethod
+    def _get_value(cls, obj):
+      """Helper method to avoid using `field_name` in the class implementation a lot."""
+      return getattr(obj, field_name)
+
     @memoized_classproperty
     def _singletons(cls):
       """Generate memoized instances of this enum wrapping each of this enum's allowed values."""
@@ -208,15 +257,35 @@ def enum(field_name, all_values):
           .format(value, field_name, cls.allowed_values))
 
     @classmethod
-    def create(cls, value=None):
+    def create(cls, *args, **kwargs):
+      """Create an instance of this enum, using the default value if specified.
+
+      :param value: Use this as the enum value. If `value` is an instance of this class, return it,
+                    otherwise it is checked against `cls.allowed_values`. This positional argument
+                    is optional, and if not specified, `cls.default_value` is used.
+      :param bool none_is_default: If this is True, a None `value` is converted into
+                                   `cls.default_value` before being checked against
+                                   `cls.allowed_values`.
+      """
+      none_is_default = kwargs.pop('none_is_default', False)
+      if kwargs:
+        raise ValueError('unrecognized keyword arguments for {}.create(): {!r}'
+                         .format(cls.__name__, kwargs))
+
+      if len(args) == 0:
+        value = cls.default_value
+      elif len(args) == 1:
+        value = args[0]
+        if none_is_default and value is None:
+          value = cls.default_value
+      else:
+        raise ValueError('{}.create() accepts 0 or 1 positional args! *args = {!r}'
+                         .format(cls.__name__, args))
+
       # If we get an instance of this enum class, just return it. This means you can call .create()
-      # on None, an allowed value for the enum, or an existing instance of the enum.
+      # on an allowed value for the enum, or an existing instance of the enum.
       if isinstance(value, cls):
         return value
-
-      # Providing an explicit value that is not None will *not* use the default value!
-      if value is None:
-        value = cls.default_value
 
       # We actually circumvent the constructor in this method due to the cls._singletons
       # memoized_classproperty, but we want to raise the same error, so we move checking into a
@@ -227,41 +296,37 @@ def enum(field_name, all_values):
 
     def __new__(cls, *args, **kwargs):
       this_object = super(ChoiceDatatype, cls).__new__(cls, *args, **kwargs)
-
-      field_value = getattr(this_object, field_name)
-
-      cls._check_value(field_value)
-
+      cls._check_value(cls._get_value(this_object))
       return this_object
+
+    def resolve_for_enum_variant(self, mapping):
+      """Return the object in `mapping` with the key corresponding to the enum value.
+
+      `mapping` is a dict mapping enum variant value -> arbitrary object. All variant values must be
+      provided.
+
+      NB: The objects in `mapping` should be made into lambdas if lazy execution is desired, as this
+      will "evaluate" all of the values in `mapping`.
+      """
+      # Equality between a frozenset() and an OrderedSet() is done without respect to ordering,
+      # which is what we want here. We only maintain an OrderedSet() in self.allowed_values so that
+      # we can present error messages with the same arguments used in the constructor.
+      keys = frozenset(mapping.keys())
+      if keys != self.allowed_values:
+        raise self.make_type_error(
+          "pattern matching must have exactly the keys {} (was: {})"
+          .format(list(self.allowed_values), list(keys)))
+      match_for_variant = mapping[self._get_value(self)]
+      return match_for_variant
 
   return ChoiceDatatype
 
 
-class TypedDatatypeClassConstructionError(Exception):
-
-  # TODO: make some wrapper exception class to make this kind of
-  # prefixing easy (maybe using a class field format string?).
-  def __init__(self, type_name, msg, *args, **kwargs):
-    full_msg =  "error: while trying to generate typed datatype {}: {}".format(
-      type_name, msg)
-    super(TypedDatatypeClassConstructionError, self).__init__(
-      full_msg, *args, **kwargs)
-
-
-class TypedDatatypeInstanceConstructionError(TypeError):
-
-  def __init__(self, type_name, msg, *args, **kwargs):
-    full_msg = "error: in constructor of type {}: {}".format(type_name, msg)
-    super(TypedDatatypeInstanceConstructionError, self).__init__(
-      full_msg, *args, **kwargs)
-
-
-class TypeCheckError(TypedDatatypeInstanceConstructionError):
-
-  def __init__(self, type_name, msg, *args, **kwargs):
-    formatted_msg = "type check error:\n{}".format(msg)
-    super(TypeCheckError, self).__init__(
-      type_name, formatted_msg, *args, **kwargs)
+# TODO: allow declaring option type automatically as well?
+def register_enum_option(register, enum_cls, *args, **kwargs):
+  """A helper method for declaring a pants option from an `enum()`."""
+  default_value = kwargs.pop('default', enum_cls.default_value)
+  register(*args, choices=enum_cls.allowed_values, default=default_value, **kwargs)
 
 
 # TODO: make these members of the `TypeConstraint` class!

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -209,11 +209,18 @@ def enum(*args):
   element of `all_values` as the default value, but enum classes can override this behavior by
   setting `default_value` in the class body.
 
+  NB: Relying on the `field_name` directly is discouraged in favor of using
+  resolve_for_enum_variant() in Python code. The `field_name` argument is exposed to make enum
+  instances more readable when printed, and to allow code in another language using an FFI to
+  reliably extract the value from an enum instance.
+
   :param string field_name: A string used as the field for the datatype. This positional argument is
                             optional, and defaults to 'value'. Note that `enum()` does not yet
                             support type checking as with `datatype()`.
-  :param Iterable all_values: An iterable of objects representing all possible values for the enum.
-                              This argument must be a finite, non-empty iterable with unique values.
+  :param Iterable all_values: A nonempty iterable of objects representing all possible values for
+                              the enum.  This argument must be a finite, non-empty iterable with
+                              unique values.
+  :raises: :class:`ValueError`
   """
   if len(args) == 1:
     field_name = 'value'
@@ -229,46 +236,61 @@ def enum(*args):
   # `OrderedSet` maintains the order of the input iterable, but is faster to check membership.
   allowed_values_set = OrderedSet(all_values_realized)
 
-  if len(allowed_values_set) < len(all_values_realized):
+  if len(allowed_values_set) == 0:
+    raise ValueError("all_values must be a non-empty iterable!")
+  elif len(allowed_values_set) < len(all_values_realized):
     raise ValueError("When converting all_values ({}) to a set, at least one duplicate "
                      "was detected. The unique elements of all_values were: {}."
-                     .format(all_values_realized, allowed_values_set))
+                     .format(all_values_realized, list(allowed_values_set)))
 
   class ChoiceDatatype(datatype([field_name])):
-    allowed_values = allowed_values_set
-    default_value = next(iter(allowed_values))
+    default_value = next(iter(allowed_values_set))
 
     # Overriden from datatype() so providing an invalid variant is catchable as a TypeCheckError,
     # but more specific.
     type_check_error_type = EnumVariantSelectionError
 
-    @classmethod
-    def _get_value(cls, obj):
-      """Helper method to avoid using `field_name` in the class implementation a lot."""
-      return getattr(obj, field_name)
-
     @memoized_classproperty
     def _singletons(cls):
-      """Generate memoized instances of this enum wrapping each of this enum's allowed values."""
-      return { value: cls(value) for value in cls.allowed_values }
+      """Generate memoized instances of this enum wrapping each of this enum's allowed values.
+
+      NB: The implementation of enum() should use this property as the source of truth for allowed
+      values and enum instances from those values.
+      """
+      return OrderedDict((value, cls._make_singleton(value)) for value in allowed_values_set)
 
     @classmethod
-    def _check_value(cls, value):
-      if value not in cls.allowed_values:
-        raise cls.make_type_error(
-          "Value {!r} for '{}' must be one of: {!r}."
-          .format(value, field_name, cls.allowed_values))
+    def _make_singleton(cls, value):
+      """
+      We convert uses of the constructor to call create(), so we then need to go around __new__ to
+      bootstrap singleton creation from datatype()'s __new__.
+      """
+      return super(ChoiceDatatype, cls).__new__(cls, value)
+
+    @classproperty
+    def _allowed_values(cls):
+      """The values provided to the enum() type constructor, for use in error messages."""
+      return list(cls._singletons.keys())
+
+    def __new__(cls, value):
+      """Forward `value` to the .create() factory method.
+
+      The .create() factory method is preferred, but forwarding the constructor like this allows us
+      to use the generated enum type both as a type to check against with isinstance() as well as a
+      function to create instances with. This makes it easy to use as a pants option type.
+      """
+      return cls.create(value)
 
     @classmethod
     def create(cls, *args, **kwargs):
       """Create an instance of this enum, using the default value if specified.
 
       :param value: Use this as the enum value. If `value` is an instance of this class, return it,
-                    otherwise it is checked against `cls.allowed_values`. This positional argument
-                    is optional, and if not specified, `cls.default_value` is used.
+                    otherwise it is checked against the enum's allowed values. This positional
+                    argument is optional, and if not specified, `cls.default_value` is used.
       :param bool none_is_default: If this is True, a None `value` is converted into
-                                   `cls.default_value` before being checked against
-                                   `cls.allowed_values`.
+                                   `cls.default_value` before being checked against the enum's
+                                   allowed values.
       """
       none_is_default = kwargs.pop('none_is_default', False)
       if kwargs:
@@ -290,17 +312,11 @@ def enum(*args):
       if isinstance(value, cls):
         return value
 
-      # We actually circumvent the constructor in this method due to the cls._singletons
-      # memoized_classproperty, but we want to raise the same error, so we move checking into a
-      # common method.
-      cls._check_value(value)
-
+      if value not in cls._singletons:
+        raise cls.make_type_error(
+          "Value {!r} for '{}' must be one of: {!r}."
+          .format(value, field_name, cls._allowed_values))
       return cls._singletons[value]
-
-    def __new__(cls, *args, **kwargs):
-      this_object = super(ChoiceDatatype, cls).__new__(cls, *args, **kwargs)
-      cls._check_value(cls._get_value(this_object))
-      return this_object
 
     def resolve_for_enum_variant(self, mapping):
       """Return the object in `mapping` with the key corresponding to the enum value.
@@ -311,15 +327,12 @@ def enum(*args):
       NB: The objects in `mapping` should be made into lambdas if lazy execution is desired, as this
       will "evaluate" all of the values in `mapping`.
       """
-      # Equality between a frozenset() and an OrderedSet() is done without respect to ordering,
-      # which is what we want here. We only maintain an OrderedSet() in self.allowed_values so that
-      # we can present error messages with the same arguments used in the constructor.
       keys = frozenset(mapping.keys())
-      if keys != self.allowed_values:
+      if keys != frozenset(self._allowed_values):
         raise self.make_type_error(
           "pattern matching must have exactly the keys {} (was: {})"
-          .format(list(self.allowed_values), list(keys)))
-      match_for_variant = mapping[self._get_value(self)]
+          .format(self._allowed_values, list(keys)))
+      match_for_variant = mapping[getattr(self, field_name)]
       return match_for_variant
 
     @classmethod
@@ -329,16 +342,21 @@ def enum(*args):
       NB: This method is exposed for testing enum variants easily. resolve_for_enum_variant() should
       be used for performing conditional logic based on an enum instance's value.
       """
-      return [cls.create(variant_value) for variant_value in cls.allowed_values]
+      # TODO: use this method to register attributes on the generated type object for each of the
+      # singletons!
+      return cls._singletons.values()
 
   return ChoiceDatatype
 
 
-# TODO: allow declaring option type automatically as well?
+# TODO: allow usage of the normal register() by using an enum class as the `type` argument by
+# extending option registration to allow extracting `choices` and `default` value from the `type`!
 def register_enum_option(register, enum_cls, *args, **kwargs):
   """A helper method for declaring a pants option from an `enum()`."""
   default_value = kwargs.pop('default', enum_cls.default_value)
-  register(*args, choices=enum_cls.allowed_values, default=default_value, **kwargs)
+  # TODO: the `choices` argument is checked against after the `type` is applied, which then produces
+  # the enum type check error message instead of the `choices` error message. This should be fixed.
+  register(*args, choices=enum_cls._allowed_values, default=default_value, **kwargs)
 
 
 # TODO: make these members of the `TypeConstraint` class!

--- a/src/scala/org/pantsbuild/zinc/bootstrapper/BootstrapperUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/bootstrapper/BootstrapperUtils.scala
@@ -7,10 +7,7 @@ package org.pantsbuild.zinc.bootstrapper
 
 import org.pantsbuild.buck.util.zip.ZipScrubber
 import java.io.File
-import xsbti.compile.{
-  ClasspathOptionsUtil,
-  ScalaInstance => XScalaInstance
-}
+import xsbti.compile.{ClasspathOptionsUtil, ScalaInstance}
 import sbt.internal.inc.{AnalyzingCompiler, RawCompiler}
 import sbt.util.Logger
 
@@ -18,7 +15,7 @@ object BootstrapperUtils {
   val CompilerInterfaceId = "compiler-interface"
   val JavaClassVersion = System.getProperty("java.class.version")
 
-  def compilerInterface(output: File, compilerBridgeSrc: File, compilerInterface: File, scalaInstance: XScalaInstance, log: Logger): Unit = {
+  def compilerInterface(output: File, compilerBridgeSrc: File, compilerInterface: File, scalaInstance: ScalaInstance, log: Logger): Unit = {
     def compile(targetJar: File): Unit =
       AnalyzingCompiler.compileSources(
         Seq(compilerBridgeSrc),

--- a/src/scala/org/pantsbuild/zinc/compiler/BUILD
+++ b/src/scala/org/pantsbuild/zinc/compiler/BUILD
@@ -25,3 +25,22 @@ scala_library(
   strict_deps=True,
   platform='java8',
 )
+
+jvm_binary(
+    name = "rsc-and-zinc",
+    dependencies = [
+        ":rsc",
+        ":compiler",
+    ],
+)
+
+jar_library(
+    name = "rsc",
+    jars = [
+        jar(
+            org = "com.twitter",
+            name = "rsc_2.11",
+            rev = "0.0.0-665-31f0e61a",
+        ),
+    ],
+)

--- a/src/scala/org/pantsbuild/zinc/compiler/BUILD
+++ b/src/scala/org/pantsbuild/zinc/compiler/BUILD
@@ -31,7 +31,6 @@ jvm_binary(
     dependencies = [
         ":rsc",
         ":compiler",
-        ":semanticdb",
     ],
 )
 

--- a/src/scala/org/pantsbuild/zinc/compiler/BUILD
+++ b/src/scala/org/pantsbuild/zinc/compiler/BUILD
@@ -9,6 +9,7 @@ scala_library(
     publication_metadata=pants_library('The SBT incremental compiler for nailgun')
   ),
   dependencies=[
+    '3rdparty/jvm/com/github/scopt',
     '3rdparty/jvm/com/martiansoftware:nailgun-server',
     '3rdparty/jvm/org/scala-lang/modules:scala-java8-compat',
     '3rdparty/jvm/org/scala-sbt:io',
@@ -18,7 +19,6 @@ scala_library(
     '3rdparty:jsr305',
     'src/scala/org/pantsbuild/zinc/analysis',
     'src/scala/org/pantsbuild/zinc/cache',
-    'src/scala/org/pantsbuild/zinc/options',
     'src/scala/org/pantsbuild/zinc/scalautil',
     'src/scala/org/pantsbuild/zinc/util',
   ],

--- a/src/scala/org/pantsbuild/zinc/compiler/BUILD
+++ b/src/scala/org/pantsbuild/zinc/compiler/BUILD
@@ -31,6 +31,7 @@ jvm_binary(
     dependencies = [
         ":rsc",
         ":compiler",
+        ":semanticdb",
     ],
 )
 
@@ -39,8 +40,11 @@ jar_library(
     jars = [
         jar(
             org = "com.twitter",
-            name = "rsc_2.11",
-            rev = "0.0.0-665-31f0e61a",
+            # NB: Rsc must be published with 2.12 to keep up with the recent change in upstream
+            # pants which uses zinc with 2.12! This causes one test to fail in the rsc repo and must
+            # be published with publish-m2 (ivy publishes don't produce a pom, or something).
+            name = "rsc_2.12",
+            rev = "0.0.0-733-05951a97-20190208-1804",
         ),
     ],
 )

--- a/src/scala/org/pantsbuild/zinc/compiler/BUILD
+++ b/src/scala/org/pantsbuild/zinc/compiler/BUILD
@@ -41,9 +41,23 @@ jar_library(
             org = "com.twitter",
             # NB: Rsc must be published with 2.12 to keep up with the recent change in upstream
             # pants which uses zinc with 2.12! This causes one test to fail in the rsc repo and must
-            # be published with publish-m2 (ivy publishes don't produce a pom, or something).
+            # be published with publish-m2 (ivy publishes don't produce a pom, or something)
             name = "rsc_2.12",
             rev = "0.0.0-733-05951a97-20190208-1804",
+            url = 'file:///Users/dmcclanahan/.ivy2/local/com.twitter/rsc_2.12/0.0.0-733-05951a97-20190208-1736/jars/rsc_2.12.jar',
+            mutable = True,
+        ),
+        jar(
+          org = 'com.twitter',
+          name = 'scalasig_2.12',
+          rev = 'xxx',
+          url = 'file:///Users/dmcclanahan/.m2/repository/com/twitter/scalasig_2.12/0.0.0-733-05951a97-20190211-1714/scalasig_2.12-0.0.0-733-05951a97-20190211-1714.jar',
+          mutable = True,
+        ),
+        jar(
+          org = 'org.scalameta',
+          name = 'semanticdb-scalac_2.12.8',
+          rev = '4.1.1',
         ),
     ],
 )

--- a/src/scala/org/pantsbuild/zinc/compiler/CompilerCache.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/CompilerCache.scala
@@ -1,0 +1,71 @@
+package org.pantsbuild.zinc.compiler
+
+import com.google.common.hash.{HashCode, Hashing}
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{FileAlreadyExistsException, Files, StandardCopyOption}
+import java.util.concurrent.Callable
+import org.pantsbuild.zinc.cache.Cache
+import org.pantsbuild.zinc.compiler.CompilerUtils.newScalaCompiler
+import org.pantsbuild.zinc.compiler.InputUtils.ScalaJars
+import org.pantsbuild.zinc.scalautil.ScalaUtils
+import sbt.internal.inc.ZincUtil
+import xsbti.compile.{ClasspathOptionsUtil, Compilers}
+
+class CompilerCache(limit: Int) {
+  val cache = Cache[HashCode, Compilers](limit)
+
+  def make(scalaJars: ScalaJars, javaHome: Option[File], compiledBridgeJar: DigestedFile): Compilers = {
+    val instance = ScalaUtils.scalaInstance(scalaJars.compiler.file, scalaJars.extra.map { _.file }, scalaJars.library.file)
+    ZincUtil.compilers(instance, ClasspathOptionsUtil.auto, javaHome, newScalaCompiler(instance, compiledBridgeJar.file))
+  }
+
+  def get(compilerCacheDir: File, scalaJars: ScalaJars, javaHome: Option[File], compiledBridgeJar: DigestedFile): Compilers = {
+    val cacheKeyBuilder = Hashing.sha256().newHasher();
+
+    for (file <- Seq(scalaJars.compiler, scalaJars.library) ++ scalaJars.extra) {
+      cacheKeyBuilder.putBytes(HashCode.fromString(file.digest.fingerprintHex).asBytes)
+      cacheKeyBuilder.putLong(file.digest.sizeBytes)
+    }
+
+    javaHome match {
+      case Some(file) => cacheKeyBuilder.putString(file.getCanonicalPath, StandardCharsets.UTF_8)
+      case None => {}
+    }
+
+    val cacheKey = cacheKeyBuilder.hash()
+    cache.get(cacheKey, new Callable[Compilers] { def call(): Compilers = {
+      val versionedCompilerCacheDir = new File(compilerCacheDir, cacheKey.toString)
+
+      val newScalaCompilerJar = CompilerCache.rename(scalaJars.compiler, versionedCompilerCacheDir, "scala-compiler")
+      val newScalaLibraryJar = CompilerCache.rename(scalaJars.library, versionedCompilerCacheDir, "scala-library")
+      val newScalaExtraJars = scalaJars.extra.map { CompilerCache.rename(_, versionedCompilerCacheDir, "scala-extra") }
+      val newCompiledBridgeJar = CompilerCache.rename(compiledBridgeJar, versionedCompilerCacheDir, "compiled-bridge")
+      if (!versionedCompilerCacheDir.exists) {
+        val tempVersionedCompilerCacheDir = compilerCacheDir.toPath
+          .resolve(s"${ cacheKey.toString }.tmp")
+        Files.createDirectories(tempVersionedCompilerCacheDir)
+        Files.copy(scalaJars.compiler.file.toPath, tempVersionedCompilerCacheDir.resolve(newScalaCompilerJar.file.getName))
+        Files.copy(scalaJars.library.file.toPath, tempVersionedCompilerCacheDir.resolve(newScalaLibraryJar.file.getName))
+        for ((oldExtra, newExtra) <- scalaJars.extra zip newScalaExtraJars)
+          Files.copy(oldExtra.file.toPath, tempVersionedCompilerCacheDir.resolve(newExtra.file.getName))
+        Files.copy(compiledBridgeJar.file.toPath, tempVersionedCompilerCacheDir.resolve(newCompiledBridgeJar.file.getName))
+        try {
+          Files.move(tempVersionedCompilerCacheDir, versionedCompilerCacheDir.toPath, StandardCopyOption.ATOMIC_MOVE)
+        } catch {
+          case _: FileAlreadyExistsException => {
+            // Ignore - trust that someone else atomically created the directory properly
+          }
+        }
+      }
+
+      make(ScalaJars(newScalaCompilerJar, newScalaLibraryJar, newScalaExtraJars), javaHome, newCompiledBridgeJar)
+    }})
+  }
+}
+
+object CompilerCache {
+  def rename(file: DigestedFile, dir: File, namePrefix: String): DigestedFile = {
+    DigestedFile(new File(dir, s"${namePrefix}-${file.digest.fingerprintHex}-${file.digest.sizeBytes}.jar"), Some(file.digest))
+  }
+}

--- a/src/scala/org/pantsbuild/zinc/compiler/CompilerUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/CompilerUtils.scala
@@ -6,53 +6,16 @@ package org.pantsbuild.zinc.compiler
 
 import java.io.File
 import java.net.URLClassLoader
-import sbt.internal.inc.{
-  AnalyzingCompiler,
-  CompileOutput,
-  IncrementalCompilerImpl,
-  RawCompiler,
-  ScalaInstance,
-  javac,
-  ZincUtil
-}
+import sbt.internal.inc.AnalyzingCompiler
 import sbt.internal.inc.classpath.ClassLoaderCache
 import sbt.io.Path
-import sbt.io.syntax._
-import sbt.util.Logger
-import xsbti.compile.{
-  ClasspathOptionsUtil,
-  CompilerCache,
-  Compilers,
-  GlobalsCache,
-  Inputs,
-  JavaTools,
-  ScalaCompiler,
-  ScalaInstance => XScalaInstance,
-  ZincCompilerUtil
-}
-
-import scala.compat.java8.OptionConverters._
-
-import org.pantsbuild.zinc.cache.Cache
-import org.pantsbuild.zinc.cache.Cache.Implicits
+import xsbti.compile.{ClasspathOptionsUtil, CompilerCache => XCompilerCache, GlobalsCache, ZincCompilerUtil, ScalaInstance}
 import org.pantsbuild.zinc.util.Util
 
 object CompilerUtils {
   val JavaClassVersion = System.getProperty("java.class.version")
 
-  private val compilerCacheLimit = Util.intProperty("zinc.compiler.cache.limit", 5)
   private val residentCacheLimit = Util.intProperty("zinc.resident.cache.limit", 0)
-
-  /**
-   * Static cache for resident scala compilers.
-   */
-  private val residentCache: GlobalsCache = {
-    val maxCompilers = residentCacheLimit
-    if (maxCompilers <= 0)
-      CompilerCache.fresh
-    else
-      CompilerCache.createCacheFor(maxCompilers)
-  }
 
   /**
    * Cache of classloaders: see https://github.com/pantsbuild/pants/issues/4744
@@ -61,14 +24,9 @@ object CompilerUtils {
     Some(new ClassLoaderCache(new URLClassLoader(Array())))
 
   /**
-   * Get the instance of the GlobalsCache.
-   */
-  def getGlobalsCache = residentCache
-
-  /**
    * Create a new scala compiler.
    */
-  def newScalaCompiler(instance: XScalaInstance, bridgeJar: File): AnalyzingCompiler =
+  def newScalaCompiler(instance: ScalaInstance, bridgeJar: File): AnalyzingCompiler =
     new AnalyzingCompiler(
       instance,
       ZincCompilerUtil.constantBridgeProvider(instance, bridgeJar),

--- a/src/scala/org/pantsbuild/zinc/compiler/DigestedFile.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/DigestedFile.scala
@@ -1,0 +1,50 @@
+package org.pantsbuild.zinc.compiler
+
+import com.google.common.hash.HashCode
+import java.io.File
+import java.nio.file.{Files, Path}
+import java.security.MessageDigest
+import org.pantsbuild.zinc.util.Util
+
+case class Digest(fingerprintHex: String, sizeBytes: Long)
+
+case class DigestedFile(file: File, private val _digest: Option[Digest] = None) extends scopt.Read[DigestedFile] {
+
+  lazy val digest = _digest.getOrElse { DigestedFile.digest(file.toPath) }
+
+  override def arity: Int = 1
+
+  override def reads: String => DigestedFile = DigestedFile.fromString
+
+  def normalise(relativeTo: File): DigestedFile = {
+    DigestedFile(Util.normalise(Some(relativeTo))(file), _digest)
+  }
+}
+
+object DigestedFile {
+  def digest(path: Path): Digest = {
+    val digest = MessageDigest.getInstance("SHA-256")
+    val bytes = Files.readAllBytes(path)
+    Digest(HashCode.fromBytes(digest.digest(bytes)).toString, bytes.size)
+  }
+
+  def fromString(s: String): DigestedFile = {
+    s.split("=", 2) match {
+      case arr if arr.size == 1 => {
+        val file = new File(arr(0))
+        DigestedFile(file, None)
+      }
+      case arr if arr.size == 2 => {
+        val file = new File(arr(0))
+        val digest = arr(1).split("-", 2) match {
+          case digestParts if digestParts.size == 2 => Digest(digestParts(0), digestParts(1).toLong)
+          case _ => throw new RuntimeException(s"Bad digest: ${arr(1)}")
+        }
+        DigestedFile(file, Some(digest))
+      }
+    }
+  }
+
+  implicit def digestedFileRead: scopt.Read[DigestedFile] = scopt.Read.stringRead.map { DigestedFile.fromString }
+
+}

--- a/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
@@ -4,28 +4,14 @@
 
 package org.pantsbuild.zinc.compiler
 
-import java.io.{File}
-import java.util.function.{ Function => JFunction }
-
+import java.io.File
+import java.util.function.{Function => JFunction}
 import scala.compat.java8.OptionConverters._
-
-import sbt.internal.inc.ZincUtil
 import sbt.io.IO
 import sbt.util.Logger
-import xsbti.{Position, Problem, Severity, ReporterConfig, ReporterUtil}
-import xsbti.compile.{
-  AnalysisStore,
-  ClasspathOptionsUtil,
-  CompileOptions,
-  CompileOrder,
-  Compilers,
-  Inputs,
-  PreviousResult,
-  Setup
-}
+import xsbti.{Position, ReporterUtil}
+import xsbti.compile.{AnalysisStore, CompileOptions, CompilerCache => XCompilerCache, Compilers, Inputs, PreviousResult, Setup}
 import org.pantsbuild.zinc.analysis.AnalysisMap
-import org.pantsbuild.zinc.scalautil.ScalaUtils
-import org.pantsbuild.zinc.compiler.CompilerUtils.newScalaCompiler
 
 object InputUtils {
   /**
@@ -33,16 +19,12 @@ object InputUtils {
    */
   def create(
     settings: Settings,
+    compilers: Compilers,
     analysisMap: AnalysisMap,
     previousResult: PreviousResult,
     log: Logger
   ): Inputs = {
     import settings._
-
-    val scalaJars = InputUtils.selectScalaJars(settings.scala)
-
-    val instance = ScalaUtils.scalaInstance(scalaJars.compiler, scalaJars.extra, scalaJars.library)
-    val compilers = ZincUtil.compilers(instance, ClasspathOptionsUtil.auto, settings.javaHome, newScalaCompiler(instance, settings.compiledBridgeJar.get))
 
     // TODO: Remove duplication once on Scala 2.12.x.
     val positionMapper =
@@ -81,7 +63,7 @@ object InputUtils {
         analysisMap.getPCELookup,
         false,
         settings.analysis.cache,
-        CompilerUtils.getGlobalsCache,
+        XCompilerCache.fresh,
         incOptions.options(log),
         reporter,
         None.asJava,
@@ -133,7 +115,7 @@ object InputUtils {
   def autoClasspath(classesDirectory: File, allScalaJars: Seq[File], javaOnly: Boolean, classpath: Seq[File]): Seq[File] = {
     if (javaOnly) classesDirectory +: classpath
     else splitScala(allScalaJars) match {
-      case Some(scalaJars) => classesDirectory +: scalaJars.library +: classpath
+      case Some(scalaJars) => classesDirectory +: scalaJars.library.file +: classpath
       case None            => classesDirectory +: classpath
     }
   }
@@ -160,7 +142,7 @@ object InputUtils {
     val filtered = jars filterNot (excluded contains _.getName)
     val (compiler, other) = filtered partition (_.getName matches ScalaCompiler.pattern)
     val (library, extra) = other partition (_.getName matches ScalaLibrary.pattern)
-    if (compiler.nonEmpty && library.nonEmpty) Some(ScalaJars(compiler(0), library(0), extra)) else None
+    if (compiler.nonEmpty && library.nonEmpty) Some(ScalaJars(DigestedFile(compiler(0)), DigestedFile(library(0)), extra.map { DigestedFile(_) })) else None
   }
 
   //
@@ -178,7 +160,7 @@ object InputUtils {
     val scalaCompiler        = ScalaCompiler.default
     val scalaLibrary         = ScalaLibrary.default
     val scalaExtra           = Seq(ScalaReflect.default)
-    val scalaJars            = ScalaJars(scalaCompiler, scalaLibrary, scalaExtra)
+    val scalaJars            = ScalaJars(DigestedFile(scalaCompiler), DigestedFile(scalaLibrary), scalaExtra.map { DigestedFile(_) })
     val scalaExcluded = Set("jansi.jar", "jline.jar", "scala-partest.jar", "scala-swing.jar", "scalacheck.jar", "scalap.jar")
   }
 
@@ -200,5 +182,5 @@ object InputUtils {
   /**
    * The scala jars split into compiler, library, and extra.
    */
-  case class ScalaJars(compiler: File, library: File, extra: Seq[File])
+  case class ScalaJars(compiler: DigestedFile, library: DigestedFile, extra: Seq[DigestedFile])
 }

--- a/src/scala/org/pantsbuild/zinc/compiler/Main.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Main.scala
@@ -8,21 +8,16 @@ import com.martiansoftware.nailgun.NGContext
 import java.io.File
 import java.nio.file.Paths
 import sbt.internal.inc.IncrementalCompilerImpl
-import sbt.internal.util.{ ConsoleLogger, ConsoleOut }
+import sbt.internal.util.{ConsoleLogger, ConsoleOut}
 import sbt.util.Level
 import xsbti.CompileFailed
-
 import org.pantsbuild.zinc.analysis.AnalysisMap
-import org.pantsbuild.zinc.options.Parsed
 import org.pantsbuild.zinc.util.Util
 
 /**
  * Command-line main class.
  */
 object Main {
-  val Command = "zinc-compiler"
-  val Description = "scala incremental compiler"
-
   /**
    * Full zinc version info.
    */
@@ -49,12 +44,7 @@ object Main {
     else published
   }
 
-  /**
-   * Print the zinc version to standard out.
-   */
-  def printVersion(): Unit = println("%s (%s) %s" format (Command, Description, versionString))
-
-  def mkLogger(settings: Settings) = {
+  def mkLogger(settings: Settings): ConsoleLogger = {
     // If someone has not explicitly enabled log4j2 JMX, disable it.
     if (!Util.isSetProperty("log4j2.disable.jmx")) {
       Util.setProperty("log4j2.disable.jmx", "true")
@@ -73,56 +63,94 @@ object Main {
     cl
   }
 
+  def preprocessArgs(args: Array[String]): Array[String] = {
+    val fixedArgs = args.flatMap { arg =>
+      arg match {
+        case x if x.startsWith("-C") || x.startsWith("-S") => {
+          val tup = arg.splitAt(2)
+          Seq(tup._1, tup._2)
+        }
+        case arg => Seq(arg)
+      }
+    }
+    for (i <- 1 to fixedArgs.size) {
+      if (fixedArgs(i - 1) == "-classpath") {
+        fixedArgs(i - 1) = "--classpath"
+      }
+      if (fixedArgs(i - 1) == "--classpath" || fixedArgs(i - 1) == "-cp"
+        || fixedArgs(i - 1) == "--scala-path" || fixedArgs(i - 1) == "-scala-path") {
+        fixedArgs(i) = fixedArgs(i).replace(":", ",")
+      }
+      if (fixedArgs(i - 1) == "--analysis-map" || fixedArgs(i - 1) == "-analysis-map") {
+        fixedArgs(i) = fixedArgs(i).replace(":", "=")
+      }
+    }
+    fixedArgs
+  }
+
+  private val compilerCacheLimit = Util.intProperty("zinc.compiler.cache.limit", 5)
+
+  private val compilerCache = new CompilerCache(compilerCacheLimit)
+
   /**
    * Run a compile.
    */
   def main(args: Array[String]): Unit = {
     val startTime = System.currentTimeMillis
 
-    val Parsed(settings, residual, errors) = Settings.parse(args)
+    val settings = Settings.SettingsParser.parse(preprocessArgs(args), Settings()) match {
+      case Some(settings) => settings.copy(compilerCacheDir = None)
+      case None => {
+        println("See zinc-compiler --help for information about options")
+        sys.exit(1)
+      }
+    }
 
-    mainImpl(settings.withAbsolutePaths(Paths.get(".").toAbsolutePath.toFile), errors, startTime)
+    mainImpl(settings.withAbsolutePaths(Paths.get(".").toAbsolutePath.toFile), startTime)
   }
 
   def nailMain(context: NGContext): Unit = {
     val startTime = System.currentTimeMillis
 
-    val Parsed(settings, residual, errors) = Settings.parse(context.getArgs)
-
-    mainImpl(settings.withAbsolutePaths(new File(context.getWorkingDirectory)), errors, startTime)
-  }
-
-  def mainImpl(settings: Settings, errors: Seq[String], startTime: Long): Unit = {
-    val log = mkLogger(settings)
-    val isDebug = settings.consoleLog.logLevel <= Level.Debug
-
-    // bail out on any command-line option errors
-    if (errors.nonEmpty) {
-      for (error <- errors) log.error(error)
-      log.error("See %s -help for information about options" format Command)
-      sys.exit(1)
+    var settings = Settings.SettingsParser.parse(preprocessArgs(context.getArgs), Settings()) match {
+      case Some(settings) => settings
+      case None => {
+        println("See zinc-compiler --help for information about options")
+        sys.exit(1)
+      }
     }
 
-    if (settings.version) printVersion()
+//    if (!settings.compilerCacheDir.isDefined) {
+//      settings = settings.copy(compilerCacheDir = Some(new File(System.getProperty("user.home"), ".cache/zinc/compiler-cache")))
+//    }
 
-    if (settings.help) Settings.printUsage(Command, residualArgs = "<sources>")
+    mainImpl(settings.withAbsolutePaths(new File(context.getWorkingDirectory)), startTime)
+  }
+
+  def mainImpl(settings: Settings, startTime: Long): Unit = {
+    val log = mkLogger(settings)
+
+    val isDebug = settings.consoleLog.logLevel <= Level.Debug
 
     // if there are no sources provided, print outputs based on current analysis if requested,
     // else print version and usage by default
     if (settings.sources.isEmpty) {
-      if (!settings.version && !settings.help) {
-        printVersion()
-        Settings.printUsage(Command)
-        sys.exit(1)
-      }
-      sys.exit(0)
+      sys.exit(1)
     }
 
     // Load the existing analysis for the destination, if any.
     val analysisMap = AnalysisMap.create(settings.analysis)
     val (targetAnalysisStore, previousResult) =
       InputUtils.loadDestinationAnalysis(settings, analysisMap, log)
-    val inputs = InputUtils.create(settings, analysisMap, previousResult, log)
+
+    val scalaJars = InputUtils.selectScalaJars(settings.scala)
+
+    val compilers = settings.compilerCacheDir match {
+      case Some(cacheDir) => compilerCache.get(cacheDir, scalaJars, settings.javaHome, settings.compiledBridgeJar.get)
+      case None => compilerCache.make(scalaJars, settings.javaHome, settings.compiledBridgeJar.get)
+    }
+
+    val inputs = InputUtils.create(settings, compilers, analysisMap, previousResult, log)
 
     if (isDebug) {
       log.debug(s"Inputs: $inputs")

--- a/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
@@ -4,38 +4,26 @@
 
 package org.pantsbuild.zinc.compiler
 
+import com.google.common.base.Joiner
 import java.io.File
-import sbt.internal.util.{ ConsoleLogger, ConsoleOut }
 import java.nio.file.{Files, Path}
-import java.lang.{ Boolean => JBoolean }
-import java.util.function.{ Function => JFunction }
-import java.util.{ List => JList, logging => jlogging }
-
+import java.lang.{Boolean => JBoolean}
+import java.util.function.{Function => JFunction}
+import java.util.{List => JList, logging => jlogging}
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.util.matching.Regex
-
-import sbt.io.Path._
 import sbt.io.syntax._
 import sbt.util.{Level, Logger}
-import xsbti.compile.{
-  ClassFileManagerType,
-  CompileOrder,
-  IncOptionsUtil,
-  TransactionalManagerType
-}
+import xsbti.compile.{ClassFileManagerType, CompileOrder, TransactionalManagerType}
 import xsbti.compile.{IncOptions => ZincIncOptions}
-
 import org.pantsbuild.zinc.analysis.AnalysisOptions
-import org.pantsbuild.zinc.options.OptionSet
 import org.pantsbuild.zinc.util.Util
 
 /**
  * All parsed command-line options.
  */
 case class Settings(
-  help: Boolean                     = false,
-  version: Boolean                  = false,
   consoleLog: ConsoleOptions        = ConsoleOptions(),
   _sources: Seq[File]               = Seq.empty,
   classpath: Seq[File]              = Seq.empty,
@@ -50,7 +38,8 @@ case class Settings(
   _incOptions: IncOptions           = IncOptions(),
   analysis: AnalysisOptions         = AnalysisOptions(),
   creationTime: Long                = 0,
-  compiledBridgeJar: Option[File]= None
+  compiledBridgeJar: Option[DigestedFile]   = None,
+  compilerCacheDir: Option[File]    = None
 ) {
   import Settings._
 
@@ -87,7 +76,7 @@ case class Settings(
       javaHome = normaliseOpt(javaHome),
       _incOptions = _incOptions.withAbsolutePaths(relativeTo),
       analysis = analysis.withAbsolutePaths(relativeTo),
-      compiledBridgeJar = normaliseOpt(compiledBridgeJar)
+      compiledBridgeJar = compiledBridgeJar.map { digestedFile => digestedFile.normalise(relativeTo) }
     )
   }
 }
@@ -142,9 +131,9 @@ case class ConsoleOptions(
 case class ScalaLocation(
   home: Option[File]     = None,
   path: Seq[File]        = Seq.empty,
-  compiler: Option[File] = None,
-  library: Option[File]  = None,
-  extra: Seq[File]       = Seq.empty
+  compiler: Option[DigestedFile] = None,
+  library: Option[DigestedFile]  = None,
+  extra: Seq[DigestedFile]       = Seq.empty
 ) {
   def withAbsolutePaths(relativeTo: File): ScalaLocation = {
     def normaliseSeq(seq: Seq[File]): Seq[File] = Util.normaliseSeq(Some(relativeTo))(seq)
@@ -156,9 +145,9 @@ case class ScalaLocation(
     this.copy(
       home = normaliseOpt(home),
       path = normaliseSeq(path),
-      compiler = normaliseOpt(compiler),
-      library = normaliseOpt(library),
-      extra = normaliseSeq(extra)
+      compiler = compiler.map { _.normalise(relativeTo) },
+      library = library.map { _.normalise(relativeTo) },
+      extra = extra.map { _.normalise(relativeTo) }
     )
   }
 }
@@ -170,9 +159,9 @@ object ScalaLocation {
   def create(
     home: File,
     path: JList[File],
-    compiler: File,
-    library: File,
-    extra: JList[File]): ScalaLocation =
+    compiler: DigestedFile,
+    library: DigestedFile,
+    extra: JList[DigestedFile]): ScalaLocation =
   ScalaLocation(
     Option(home),
     path.asScala,
@@ -234,76 +223,219 @@ case class IncOptions(
   }
 }
 
-object Settings extends OptionSet[Settings] {
-  val DestinationOpt = "-d"
-  val JarDestinationOpt = "-jar"
 
-  override def empty = Settings()
 
-  override def applyResidual(t: Settings, residualArgs: Seq[String]) =
-    t.copy(_sources = residualArgs map (new File(_)))
+object Settings {
+  val logLevels = Set("debug", "info", "warn", "error")
 
-  override val options = Seq(
-    header("Output options:"),
-    boolean(  ("-help", "-h"),                 "Print this usage message",                   (s: Settings) => s.copy(help = true)),
-    boolean(   "-version",                     "Print version",                              (s: Settings) => s.copy(version = true)),
+  val SettingsParser = new scopt.OptionParser[Settings]("zinc-compiler") {
+    head("pants-zinc-compiler", "0.0.10")
+    help("help").text("Prints this usage message")
+    version("version").text("Print version")
 
-    header("Logging Options:"),
-    boolean(   "-debug",                       "Set log level for stdout to debug",
-      (s: Settings) => s.copy(consoleLog = s.consoleLog.copy(logLevel = Level.Debug))),
-    string(    "-log-level", "level",          "Set log level for stdout (debug|info|warn|error)",
-      (s: Settings, l: String) => s.copy(consoleLog = s.consoleLog.copy(logLevel = Level.withName(l)))),
-    boolean(   "-no-color",                    "No color in logging to stdout",
-      (s: Settings) => s.copy(consoleLog = s.consoleLog.copy(color = false))),
-    string(    "-msg-filter", "regex",         "Filter warning messages matching the given regex",
-      (s: Settings, re: String) => s.copy(consoleLog = s.consoleLog.copy(msgFilters = s.consoleLog.msgFilters :+ re.r))),
-    string(    "-file-filter", "regex",        "Filter warning messages from filenames matching the given regex",
-      (s: Settings, re: String) => s.copy(consoleLog = s.consoleLog.copy(fileFilters = s.consoleLog.fileFilters :+ re.r))),
+    opt[DigestedFile]("compiled-bridge-jar")
+      .abbr("compiled-bridge-jar")
+      .required()
+      .valueName("<file>")
+      .action((x, c) => c.copy(compiledBridgeJar = Some(x)))
+      .text("Path to pre-compiled compiler interface.")
 
-    header("Compile options:"),
-    path(     ("-classpath", "-cp"), "path",   "Specify the classpath",                      (s: Settings, cp: Seq[File]) => s.copy(classpath = cp)),
-    file(     DestinationOpt, "directory",     "Destination for compiled classes",           (s: Settings, f: File) => s.copy(_classesDirectory = Some(f))),
-    file(     JarDestinationOpt, "directory",     "Jar destination for compiled classes",           (s: Settings, f: File) => s.copy(outputJar = Some(f))),
-    long("-jar-creation-time", "n",        "Creation timestamp for compiled jars, default is current time", (s: Settings, l: Long) => s.copy(creationTime = l)),
+    opt[Long]("jar-creation-time")
+      .abbr("jar-creation-time")
+      .action((x, c) => c.copy(creationTime = x))
+      .text("Creation timestamp for compiled jars, default is current time")
 
-    header("Scala options:"),
-    file(      "-scala-home", "directory",     "Scala home directory (for locating jars)",   (s: Settings, f: File) => s.copy(scala = s.scala.copy(home = Some(f)))),
-    path(      "-scala-path", "path",          "Specify all Scala jars directly",            (s: Settings, sp: Seq[File]) => s.copy(scala = s.scala.copy(path = sp))),
-    file(      "-scala-compiler", "file",      "Specify Scala compiler jar directly" ,       (s: Settings, f: File) => s.copy(scala = s.scala.copy(compiler = Some(f)))),
-    file(      "-scala-library", "file",       "Specify Scala library jar directly" ,        (s: Settings, f: File) => s.copy(scala = s.scala.copy(library = Some(f)))),
-    path(      "-scala-extra", "path",         "Specify extra Scala jars directly",          (s: Settings, e: Seq[File]) => s.copy(scala = s.scala.copy(extra = e))),
-    prefix(    "-S", "<scalac-option>",        "Pass option to scalac",                      (s: Settings, o: String) => s.copy(scalacOptions = s.scalacOptions :+ o)),
+    opt[Unit]("debug")
+      .abbr("debug")
+      .action((x, c) => c.copy(consoleLog = c.consoleLog.copy(logLevel = Level.Debug)))
+      .text("Set log level for stdout to debug")
 
-    header("Java options:"),
-    file(      "-java-home", "directory",      "Select javac home directory (and fork)",     (s: Settings, f: File) => s.copy(javaHome = Some(f))),
-    string(    "-compile-order", "order",      "Compile order for Scala and Java sources",   (s: Settings, o: String) => s.copy(compileOrder = compileOrder(o))),
-    boolean(   "-java-only",                   "Don't add scala library to classpath",       (s: Settings) => s.copy(javaOnly = true)),
-    prefix(    "-C", "<javac-option>",         "Pass option to javac",                       (s: Settings, o: String) => s.copy(javacOptions = s.javacOptions :+ o)),
+    opt[String]("log-level")
+      .abbr("log-level")
+      .valueName("level")
+      .unbounded()
+      .validate { level => {
+        if (logLevels.contains(level)) success else failure(s"Level must be one of $logLevels.")
+      }}
+      .action((x, c) => c.copy(consoleLog = c.consoleLog.copy(logLevel = Level.withName(x))))
+      .text(s"Set log level for stdout (${Joiner.on('|').join(logLevels.asJava)})")
 
-    header("sbt options:"),
-    file("-compiled-bridge-jar", "file", "Path to pre-compiled compiler interface", (s: Settings, f: File) => s.copy(compiledBridgeJar = Some(f))),
+    opt[Unit]("no-color")
+      .abbr("no-color")
+      .action((x, c) => c.copy(consoleLog =  c.consoleLog.copy(color = false)))
+      .text("No color in logging to stdout")
 
-    header("Incremental compiler options:"),
-    int(       "-transitive-step", "n",        "Steps before transitive closure",            (s: Settings, i: Int) => s.copy(_incOptions = s._incOptions.copy(transitiveStep = i))),
-    fraction(  "-recompile-all-fraction", "x", "Limit before recompiling all sources",       (s: Settings, d: Double) => s.copy(_incOptions = s._incOptions.copy(recompileAllFraction = d))),
-    boolean(   "-debug-relations",             "Enable debug logging of analysis relations", (s: Settings) => s.copy(_incOptions = s._incOptions.copy(relationsDebug = true))),
-    boolean(   "-debug-api",                   "Enable analysis API debugging",              (s: Settings) => s.copy(_incOptions = s._incOptions.copy(apiDebug = true))),
-    file(      "-api-dump", "directory",       "Destination for analysis API dump",          (s: Settings, f: File) => s.copy(_incOptions = s._incOptions.copy(apiDumpDirectory = Some(f)))),
-    int(       "-api-diff-context-size", "n",  "Diff context size (in lines) for API debug", (s: Settings, i: Int) => s.copy(_incOptions = s._incOptions.copy(apiDiffContextSize = i))),
-    boolean(   "-transactional",               "Restore previous class files on failure",    (s: Settings) => s.copy(_incOptions = s._incOptions.copy(transactional = true))),
-    boolean(   "-no-zinc-file-manager",        "Disable zinc provided file manager",           (s: Settings) => s.copy(_incOptions = s._incOptions.copy(useZincFileManager = false))),
-    file(      "-backup", "directory",         "Backup location (if transactional)",         (s: Settings, f: File) => s.copy(_incOptions = s._incOptions.copy(backup = Some(f)))),
+    opt[String]("msg-filter")
+      .abbr("msg-filter")
+      .valueName("<regex>")
+      .unbounded()
+      .action((x, c) => c.copy(consoleLog = c.consoleLog.copy(msgFilters = c.consoleLog.msgFilters :+ x.r)))
+      .text("Filter warning messages matching the given regex")
 
-    header("Analysis options:"),
-    file(      "-analysis-cache", "file",      "Cache file for compile analysis",            (s: Settings, f: File) => s.copy(analysis =
-      s.analysis.copy(_cache = Some(f)))),
-    fileMap(   "-analysis-map",                "Upstream analysis mapping (file:file,...)",
-      (s: Settings, m: Map[File, File]) => s.copy(analysis = s.analysis.copy(cacheMap = m))),
-    fileMap(   "-rebase-map",                  "Source and destination paths to rebase in persisted analysis (file:file,...)",
-      (s: Settings, m: Map[File, File]) => s.copy(analysis = s.analysis.copy(rebaseMap = m))),
-    boolean(   "-no-clear-invalid-analysis",   "If set, zinc will fail rather than purging illegal analysis.",
-      (s: Settings) => s.copy(analysis = s.analysis.copy(clearInvalid = false)))
-  )
+    opt[String]("file-filter")
+      .abbr("file-filter")
+      .valueName("<regex>")
+      .unbounded()
+      .action((x, c) => c.copy(consoleLog = c.consoleLog.copy(fileFilters = c.consoleLog.fileFilters :+ x.r)))
+      .text("Filter warning messages from filenames matching the given regex")
+
+    opt[Seq[File]]("classpath")
+      .abbr("cp")
+      .action((x, c) => c.copy(classpath = x))
+      .text("Specify the classpath")
+
+    opt[File]("class-destination")
+      .abbr("d")
+      .action((x, c) => c.copy(_classesDirectory = Some(x)))
+      .text("Destination for compiled classes")
+
+    opt[File]("jar-destination")
+      .abbr("jar")
+      .action((x, c) => c.copy(outputJar =  Some(x)))
+      .text("Jar destination for compiled classes")
+
+    opt[File]("scala-home")
+      .abbr("scala-home")
+      .valueName("<directory>")
+      .action((x, c) => c.copy(scala = c.scala.copy(home = Some(x))))
+      .text("Scala home directory (for locating jars)")
+
+    opt[Seq[File]]("scala-path")
+      .abbr("scala-path")
+      .valueName("<path>")
+      .action((x, c) => c.copy(scala = c.scala.copy(path = x)))
+      .text("Specify all Scala jars directly")
+
+    opt[DigestedFile]("scala-compiler")
+      .abbr("scala-compiler")
+      .valueName("<file>")
+      .action((x, c) => c.copy(scala = c.scala.copy(compiler = Some(x))))
+      .text("Specify Scala compiler jar directly")
+
+    opt[DigestedFile]("scala-library")
+      .abbr("scala-library")
+      .valueName("<file>")
+      .action((x, c) => c.copy(scala = c.scala.copy(library = Some(x))))
+      .text("Specify Scala library jar directly")
+
+    opt[Seq[DigestedFile]]("scala-extra")
+      .abbr("scala-extra")
+      .valueName("<path>")
+      .action((x, c) => c.copy(scala = c.scala.copy(extra = x)))
+      .text("Specify extra Scala jars directly")
+
+    opt[File]("java-home")
+      .abbr("java-home")
+      .valueName("<directory>")
+      .action((x, c) => c.copy(javaHome = Some(x)))
+      .text("Select javac home directory (and fork)")
+
+    opt[String]("compile-order")
+      .abbr("compile-order")
+      .action((x, c) => c.copy(compileOrder = compileOrder(x)))
+      .text("Compile order for Scala and Java sources")
+
+    opt[Unit]("java-only")
+      .abbr("java-only")
+      .action((x, c) => c.copy(javaOnly = true))
+      .text("Don't add scala library to classpath")
+
+    opt[Int]("transitive-step")
+      .abbr("transitive-step")
+      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(transitiveStep = x)))
+      .text("Steps before transitive closure")
+
+    opt[Double]("recompile-all-fraction")
+      .abbr("recompile-all-fraction")
+      .validate{ fraction => {
+        if (0 <= fraction && fraction <= 1) success else failure("recompile-all-fraction must be between 0 and 1")
+      }}
+      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(recompileAllFraction = x)))
+      .text("Limit before recompiling all sources")
+
+    opt[Unit]("debug-relations")
+      .abbr("debug-relations")
+      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(relationsDebug = true)))
+      .text("Enable debug logging of analysis relations")
+
+    opt[Unit]("debug-api")
+      .abbr("debug-api")
+      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(apiDebug = true)))
+      .text("Enable analysis API debugging")
+
+    opt[File]("api-dump")
+      .abbr("api-dump")
+      .valueName("directory")
+      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(apiDumpDirectory = Some(x))))
+      .text("Destination for analysis API dump")
+
+    opt[Int]("api-diff-context-size")
+      .abbr("api-diff-context-size")
+      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(apiDiffContextSize = x)))
+      .text("Diff context size (in lines) for API debug")
+
+    opt[Unit]("transactional")
+      .abbr("transactional")
+      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(transactional = true)))
+      .text("Restore previous class files on failure")
+
+    opt[Unit]("no-zinc-file-manager")
+      .abbr("no-zinc-file-manager")
+      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(useZincFileManager = false)))
+      .text("Disable zinc provided file manager")
+
+    opt[File]("backup")
+      .abbr("backup")
+      .valueName("<directory>")
+      .action((x, c) => c.copy(_incOptions = c._incOptions.copy(backup = Some(x))))
+      .text("Backup location (if transactional)")
+
+    opt[File]("analysis-cache")
+      .abbr("analysis-cache")
+      .valueName("<file>")
+      .action((x, c) => c.copy(analysis = c.analysis.copy(_cache = Some(x))))
+      .text("Cache file to compile analysis")
+
+    opt[Map[File, File]]("analysis-map")
+      .abbr("analysis-map")
+      .action((x, c) => c.copy(analysis = c.analysis.copy(cacheMap = x)))
+      .text("Upstream analysis mapping (file=file,...)")
+
+    opt[Map[File, File]]("rebase-map")
+      .abbr("rebase-map")
+      .action((x, c) => c.copy(analysis = c.analysis.copy(rebaseMap = x)))
+      .text("Source and destination paths to rebase in persisted analysis (file=file,...)")
+
+    opt[Unit]("no-clear-invalid-analysis")
+      .abbr("no-clear-invalid-analysis")
+      .action((x, c) => c.copy(analysis = c.analysis.copy(clearInvalid = false)))
+      .text("If set, zinc will fail rather than purging illegal analysis.")
+
+    opt[String]("scalac-option")
+      .abbr("S")
+      .valueName("<scalac-option>")
+      .unbounded()
+      .action((x, c) => c.copy(scalacOptions = c.scalacOptions :+ x))
+      .text("Pass option to scalac")
+
+    opt[String]("javac-option")
+      .abbr("C")
+      .valueName("<javac-option>")
+      .unbounded()
+      .action((x, c) => c.copy(javacOptions = c.javacOptions :+ x))
+      .text("Pass option to javac")
+
+    opt[File]("nailgun-compiler-cache-dir")
+      .valueName("<dir>")
+      .optional()
+      .action((x, c) => c.copy(compilerCacheDir = Some(x)))
+      .text("Directory in which to cache compiler jar files when used in nailgun mode")
+
+    arg[File]("<file>...")
+      .unbounded()
+      .action((x, c) => c.copy(_sources = c._sources :+ x))
+      .text("Sources to compile")
+  }
 
   /**
    * Create a CompileOrder value based on string input.

--- a/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
+++ b/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
@@ -70,6 +70,7 @@ class CppCompileTest(NativeTaskTestBase, NativeCompileTestMixin):
 
     task = self.create_task(self.context(target_roots=[cpp_lib_target]))
     compiler = task.get_compiler(cpp_lib_target)
+    # TODO(#6866): test specifically which compiler is selected, traversing the PATH if necessary.
     self.assertIn('llvm', compiler.path_entries[0])
 
   def test_target_level_toolchain_variant_default_llvm(self):

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import glob
 import os
 import re
+from functools import wraps
 from zipfile import ZipFile
 
 from pants.backend.native.config.environment import Platform
@@ -24,6 +25,14 @@ def invoke_pex_for_output(pex_file_to_run):
   return subprocess.check_output([pex_file_to_run], stderr=subprocess.STDOUT)
 
 
+def _toolchain_variants(func):
+  @wraps(func)
+  def wrapper(*args, **kwargs):
+    for variant in ToolchainVariant.iterate_enum_variants():
+      func(*args, toolchain_variant=variant, **kwargs)
+  return wrapper
+
+
 class CTypesIntegrationTest(PantsRunIntegrationTest):
 
   _binary_target_dir = 'testprojects/src/python/python_distribution/ctypes'
@@ -38,32 +47,16 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     'testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags:bin'
   )
 
-  def test_ctypes_binary_creation(self):
+  @_toolchain_variants
+  def test_ctypes_binary_creation(self, toolchain_variant):
     """Create a python_binary() with all native toolchain variants, and test the result."""
-    # TODO: this pattern could be made more ergonomic for `enum()`, along with exhaustiveness
-    # checking.
-    for variant in ToolchainVariant.allowed_values:
-      self._assert_ctypes_binary_creation(variant)
-
-  _compiler_names_for_variant = {
-    'gnu': ['gcc', 'g++'],
-    'llvm': ['clang', 'clang++'],
-  }
-
-  # All of our toolchains currently use the C++ compiler's filename as argv[0] for the linker.
-  _linker_names_for_variant = {
-    'gnu': ['g++'],
-    'llvm': ['clang++'],
-  }
-
-  def _assert_ctypes_binary_creation(self, toolchain_variant):
     with temporary_dir() as tmp_dir:
       pants_run = self.run_pants(command=['binary', self._binary_target], config={
         GLOBAL_SCOPE_CONFIG_SECTION: {
           'pants_distdir': tmp_dir,
         },
         'native-build-step': {
-          'toolchain_variant': toolchain_variant,
+          'toolchain_variant': toolchain_variant.value,
         },
       })
 
@@ -71,12 +64,23 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
       # Check that we have selected the appropriate compilers for our selected toolchain variant,
       # for both C and C++ compilation.
-      # TODO(#6866): don't parse info logs for testing!
-      for compiler_name in self._compiler_names_for_variant[toolchain_variant]:
+      # TODO(#6866): don't parse info logs for testing! There is a TODO in test_cpp_compile.py
+      # in the native backend testing to traverse the PATH to find the selected compiler.
+      compiler_names_to_check = toolchain_variant.resolve_for_enum_variant({
+        'gnu': ['gcc', 'g++'],
+        'llvm': ['clang', 'clang++'],
+      })
+      for compiler_name in compiler_names_to_check:
         self.assertIn("selected compiler exe name: '{}'".format(compiler_name),
                       pants_run.stdout_data)
 
-      for linker_name in self._linker_names_for_variant[toolchain_variant]:
+      # All of our toolchains currently use the C++ compiler's filename as argv[0] for the linker,
+      # so there is only one name to check.
+      linker_names_to_check = toolchain_variant.resolve_for_enum_variant({
+        'gnu': ['g++'],
+        'llvm': ['clang++'],
+      })
+      for linker_name in linker_names_to_check:
         self.assertIn("selected linker exe name: '{}'".format(linker_name),
                       pants_run.stdout_data)
 
@@ -110,16 +114,8 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       binary_run_output = invoke_pex_for_output(pex)
       self.assertEqual(b'x=3, f(x)=17\n', binary_run_output)
 
-  def test_ctypes_native_language_interop(self):
-    for variant in ToolchainVariant.allowed_values:
-      self._assert_ctypes_interop_with_mock_buildroot(variant)
-
-  _include_not_found_message_for_variant = {
-    'gnu': "fatal error: some_math.h: No such file or directory",
-    'llvm': "fatal error: 'some_math.h' file not found"
-  }
-
-  def _assert_ctypes_interop_with_mock_buildroot(self, toolchain_variant):
+  @_toolchain_variants
+  def test_ctypes_native_language_interop(self, toolchain_variant):
     # TODO: consider making this mock_buildroot/run_pants_with_workdir into a
     # PantsRunIntegrationTest method!
     with self.mock_buildroot(
@@ -138,7 +134,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         # Explicitly set to True (although this is the default).
         config={
           'native-build-step': {
-            'toolchain_variant': toolchain_variant,
+            'toolchain_variant': toolchain_variant.value,
           },
           # TODO(#6848): don't make it possible to forget to add the toolchain_variant option!
           'native-build-settings': {
@@ -148,19 +144,25 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         workdir=os.path.join(buildroot.new_buildroot, '.pants.d'),
         build_root=buildroot.new_buildroot)
       self.assert_failure(pants_binary_strict_deps_failure)
-      self.assertIn(self._include_not_found_message_for_variant[toolchain_variant],
+      self.assertIn(toolchain_variant.resolve_for_enum_variant({
+        'gnu': "fatal error: some_math.h: No such file or directory",
+        'llvm': "fatal error: 'some_math.h' file not found",
+      }),
                     pants_binary_strict_deps_failure.stdout_data)
 
     # TODO(#6848): we need to provide the libstdc++.so.6.dylib which comes with gcc on osx in the
     # DYLD_LIBRARY_PATH during the 'run' goal somehow.
     attempt_pants_run = Platform.create().resolve_for_enum_variant({
-      'darwin': toolchain_variant != 'gnu',
+      'darwin': toolchain_variant.resolve_for_enum_variant({
+        'gnu': False,
+        'llvm': True,
+      }),
       'linux': True,
     })
     if attempt_pants_run:
       pants_run_interop = self.run_pants(['-q', 'run', self._binary_target_with_interop], config={
         'native-build-step': {
-          'toolchain_variant': toolchain_variant,
+          'toolchain_variant': toolchain_variant.value,
         },
         'native-build-settings': {
           'strict_deps': True,
@@ -169,14 +171,11 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       self.assert_success(pants_run_interop)
       self.assertEqual('x=3, f(x)=299\n', pants_run_interop.stdout_data)
 
-  def test_ctypes_third_party_integration(self):
-    for variant in ToolchainVariant.allowed_values:
-      self._assert_ctypes_third_party_integration(variant)
-
-  def _assert_ctypes_third_party_integration(self, toolchain_variant):
+  @_toolchain_variants
+  def test_ctypes_third_party_integration(self, toolchain_variant):
     pants_binary = self.run_pants(['binary', self._binary_target_with_third_party], config={
       'native-build-step': {
-        'toolchain_variant': toolchain_variant,
+        'toolchain_variant': toolchain_variant.value,
       },
     })
     self.assert_success(pants_binary)
@@ -190,7 +189,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     if attempt_pants_run:
       pants_run = self.run_pants(['-q', 'run', self._binary_target_with_third_party], config={
         'native-build-step': {
-          'toolchain_variant': toolchain_variant,
+          'toolchain_variant': toolchain_variant.value,
         },
       })
       self.assert_success(pants_run)
@@ -220,23 +219,20 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     self.assert_success(pants_run)
     self.assertIn('x=3, f(x)=17', pants_run.stdout_data)
 
-  def test_native_compiler_option_sets_integration(self):
+  @_toolchain_variants
+  def test_native_compiler_option_sets_integration(self, toolchain_variant):
     """Test that native compilation includes extra compiler flags from target definitions.
 
     This target uses the ndebug and asdf option sets.
     If either of these are not present (disabled), this test will fail.
     """
-    for variant in ToolchainVariant.allowed_values:
-      self._assert_ctypes_third_party_integration(variant)
-
-  def _assert_native_compiler_option_sets_integration(self, toolchain_variant):
     command = [
       'run',
       self._binary_target_with_compiler_option_sets
     ]
     pants_run = self.run_pants(command=command, config={
       'native-build-step': {
-        'toolchain_variant': toolchain_variant,
+        'toolchain_variant': toolchain_variant.value,
       },
       'native-build-step.cpp-compile-settings': {
         'compiler_option_sets_enabled_args': {

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -92,9 +92,9 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
       dist_name, dist_version, wheel_platform = name_and_platform(wheel_dist)
       self.assertEqual(dist_name, 'ctypes_test')
-      contains_current_platform = Platform.create().resolve_platform_specific({
-        'darwin': lambda: wheel_platform.startswith('macosx'),
-        'linux': lambda: wheel_platform.startswith('linux'),
+      contains_current_platform = Platform.create().resolve_for_enum_variant({
+        'darwin': wheel_platform.startswith('macosx'),
+        'linux': wheel_platform.startswith('linux'),
       })
       self.assertTrue(contains_current_platform)
 
@@ -153,9 +153,9 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
     # TODO(#6848): we need to provide the libstdc++.so.6.dylib which comes with gcc on osx in the
     # DYLD_LIBRARY_PATH during the 'run' goal somehow.
-    attempt_pants_run = Platform.create().resolve_platform_specific({
-      'darwin': lambda: toolchain_variant != 'gnu',
-      'linux': lambda: True,
+    attempt_pants_run = Platform.create().resolve_for_enum_variant({
+      'darwin': toolchain_variant != 'gnu',
+      'linux': True,
     })
     if attempt_pants_run:
       pants_run_interop = self.run_pants(['-q', 'run', self._binary_target_with_interop], config={
@@ -183,9 +183,9 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
     # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
     # be available on the runtime library path.
-    attempt_pants_run = Platform.create().resolve_platform_specific({
-      'darwin': lambda: toolchain_variant != 'gnu',
-      'linux': lambda: True,
+    attempt_pants_run = Platform.create().resolve_for_enum_variant({
+      'darwin': toolchain_variant != 'gnu',
+      'linux': True,
     })
     if attempt_pants_run:
       pants_run = self.run_pants(['-q', 'run', self._binary_target_with_third_party], config={

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -12,9 +12,11 @@ from builtins import object, str
 
 from future.utils import PY2, PY3, text_type
 
-from pants.util.objects import (Exactly, SubclassesOf, SuperclassesOf, TypeCheckError,
-                                TypeConstraintError, TypedCollection,
-                                TypedDatatypeInstanceConstructionError, datatype, enum)
+from pants.util.collections_abc_backport import OrderedDict
+from pants.util.objects import (EnumVariantSelectionError, Exactly, SubclassesOf,
+                                SuperclassesOf, TypeCheckError, TypeConstraintError,
+                                TypedCollection, TypedDatatypeInstanceConstructionError, datatype,
+                                enum)
 from pants_test.test_base import TestBase
 
 
@@ -564,7 +566,7 @@ class TypedDatatypeTest(TestBase):
   def test_instance_construction_errors(self):
     with self.assertRaises(TypeError) as cm:
       SomeTypedDatatype(something=3)
-    expected_msg = "error: in constructor of type SomeTypedDatatype: type check error:\n__new__() got an unexpected keyword argument 'something'"
+    expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: __new__() got an unexpected keyword argument 'something'"
     self.assertEqual(str(cm.exception), expected_msg)
 
     # not providing all the fields
@@ -575,7 +577,7 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "__new__() takes exactly 2 arguments (1 given)"
     )
-    expected_msg = "error: in constructor of type SomeTypedDatatype: type check error:\n" + expected_msg_ending
+    expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: {}".format(expected_msg_ending)
     self.assertEqual(str(cm.exception), expected_msg)
 
     # unrecognized fields
@@ -586,20 +588,20 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "__new__() takes exactly 2 arguments (3 given)"
     )
-    expected_msg = "error: in constructor of type SomeTypedDatatype: type check error:\n" + expected_msg_ending
+    expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: {}".format(expected_msg_ending)
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypedDatatypeInstanceConstructionError) as cm:
       CamelCaseWrapper(nonneg_int=3)
     expected_msg = (
-      """error: in constructor of type CamelCaseWrapper: type check error:
+      """type check error in class CamelCaseWrapper: errors type checking constructor arguments:
 field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(NonNegativeInt).""")
     self.assertEqual(str(cm.exception), expected_msg)
 
     # test that kwargs with keywords that aren't field names fail the same way
     with self.assertRaises(TypeError) as cm:
       CamelCaseWrapper(4, a=3)
-    expected_msg = "error: in constructor of type CamelCaseWrapper: type check error:\n__new__() got an unexpected keyword argument 'a'"
+    expected_msg = "type check error in class CamelCaseWrapper: error in namedtuple() base constructor: __new__() got an unexpected keyword argument 'a'"
     self.assertEqual(str(cm.exception), expected_msg)
 
   def test_type_check_errors(self):
@@ -607,7 +609,7 @@ field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type
     with self.assertRaises(TypeCheckError) as cm:
       SomeTypedDatatype([])
     expected_msg = (
-      """error: in constructor of type SomeTypedDatatype: type check error:
+      """type check error in class SomeTypedDatatype: errors type checking constructor arguments:
 field 'val' was invalid: value [] (with type 'list') must satisfy this type constraint: Exactly(int).""")
     self.assertEqual(str(cm.exception), expected_msg)
 
@@ -616,7 +618,7 @@ field 'val' was invalid: value [] (with type 'list') must satisfy this type cons
       AnotherTypedDatatype(text_type('correct'), text_type('should be list'))
     def compare_str(unicode_type_name, include_unicode=False):
       expected_message = (
-        """error: in constructor of type AnotherTypedDatatype: type check error:
+        """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
 field 'elements' was invalid: value {unicode_literal}'should be list' (with type '{type_name}') must satisfy this type constraint: Exactly(list)."""
       .format(type_name=unicode_type_name, unicode_literal='u' if include_unicode else ''))
       self.assertEqual(str(cm.exception), expected_message)
@@ -630,7 +632,7 @@ field 'elements' was invalid: value {unicode_literal}'should be list' (with type
       AnotherTypedDatatype(3, text_type('should be list'))
     def compare_str(unicode_type_name, include_unicode=False):
       expected_message = (
-        """error: in constructor of type AnotherTypedDatatype: type check error:
+        """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
 field 'string' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly({type_name}).
 field 'elements' was invalid: value {unicode_literal}'should be list' (with type '{type_name}') must satisfy this type constraint: Exactly(list)."""
           .format(type_name=unicode_type_name, unicode_literal='u' if include_unicode else ''))
@@ -644,7 +646,7 @@ field 'elements' was invalid: value {unicode_literal}'should be list' (with type
       NonNegativeInt(text_type('asdf'))
     def compare_str(unicode_type_name, include_unicode=False):
       expected_message = (
-        """error: in constructor of type NonNegativeInt: type check error:
+        """type check error in class NonNegativeInt: errors type checking constructor arguments:
 field 'an_int' was invalid: value {unicode_literal}'asdf' (with type '{type_name}') must satisfy this type constraint: Exactly(int)."""
           .format(type_name=unicode_type_name, unicode_literal='u' if include_unicode else ''))
       self.assertEqual(str(cm.exception), expected_message)
@@ -655,31 +657,28 @@ field 'an_int' was invalid: value {unicode_literal}'asdf' (with type '{type_name
 
     with self.assertRaises(TypeCheckError) as cm:
       NonNegativeInt(-3)
-    expected_msg = (
-      """error: in constructor of type NonNegativeInt: type check error:
-value is negative: -3.""")
+    expected_msg = "type check error in class NonNegativeInt: value is negative: -3."
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypeCheckError) as cm:
       WithSubclassTypeConstraint(3)
     expected_msg = (
-      """error: in constructor of type WithSubclassTypeConstraint: type check error:
+      """type check error in class WithSubclassTypeConstraint: errors type checking constructor arguments:
 field 'some_value' was invalid: value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(SomeBaseClass).""")
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypeCheckError) as cm:
       WithCollectionTypeConstraint(3)
     expected_msg = """\
-error: in constructor of type WithCollectionTypeConstraint: type check error:
+type check error in class WithCollectionTypeConstraint: errors type checking constructor arguments:
 field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)): value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(Iterable)."""
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypeCheckError) as cm:
       WithCollectionTypeConstraint([3, "asdf"])
     expected_msg = """\
-error: in constructor of type WithCollectionTypeConstraint: type check error:
-field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'asdf']: value {u}'asdf' (with type '{string_type}') must satisfy this type constraint: Exactly(int).\
-""".format(u='u' if PY2 else '', string_type='unicode' if PY2 else 'str')
+type check error in class WithCollectionTypeConstraint: errors type checking constructor arguments:
+field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, u'asdf']: value u'asdf' (with type 'unicode') must satisfy this type constraint: Exactly(int).""".format(u='u' if PY2 else '', string_type='unicode' if PY2 else 'str')
     self.assertEqual(str(cm.exception), expected_msg)
 
   def test_copy(self):
@@ -696,14 +695,13 @@ field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(
     with self.assertRaises(TypeCheckError) as cm:
       obj.copy(nonexistent_field=3)
     expected_msg = (
-      """error: in constructor of type AnotherTypedDatatype: type check error:
-__new__() got an unexpected keyword argument 'nonexistent_field'""")
+      """type check error in class AnotherTypedDatatype: error in namedtuple() base constructor: __new__() got an unexpected keyword argument 'nonexistent_field'""")
     self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypeCheckError) as cm:
       obj.copy(elements=3)
     expected_msg = (
-      """error: in constructor of type AnotherTypedDatatype: type check error:
+      """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
 field 'elements' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(list).""")
     self.assertEqual(str(cm.exception), expected_msg)
 
@@ -723,15 +721,65 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
   def test_enum_instance_creation_errors(self):
     expected_rx = re.escape(
       "Value 3 for 'x' must be one of: OrderedSet([1, 2]).")
-    with self.assertRaisesRegexp(TypeCheckError, expected_rx):
+    with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx):
       SomeEnum.create(3)
-    with self.assertRaisesRegexp(TypeCheckError, expected_rx):
+    with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx):
       SomeEnum(3)
-    with self.assertRaisesRegexp(TypeCheckError, expected_rx):
+    with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx):
       SomeEnum(x=3)
+
+    # Test that None is not used as the default unless none_is_default=True.
+    with self.assertRaisesRegexp(EnumVariantSelectionError, re.escape(
+        "Value None for 'x' must be one of: OrderedSet([1, 2])."
+    )):
+      SomeEnum.create(None)
+    self.assertEqual(1, SomeEnum.create(None, none_is_default=True).x)
 
     expected_rx_falsy_value = re.escape(
       "Value {}'' for 'x' must be one of: OrderedSet([1, 2])."
       .format('u' if PY2 else ''))
-    with self.assertRaisesRegexp(TypeCheckError, expected_rx_falsy_value):
+    with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx_falsy_value):
       SomeEnum(x='')
+
+  def test_enum_resolve_variant(self):
+    one_enum_instance = SomeEnum(1)
+    two_enum_instance = SomeEnum(2)
+    self.assertEqual(3, one_enum_instance.resolve_for_enum_variant({
+      1: 3,
+      2: 4,
+    }))
+    self.assertEqual(4, two_enum_instance.resolve_for_enum_variant({
+      1: 3,
+      2: 4,
+    }))
+
+    # Test that an unrecognized variant raises an error.
+    with self.assertRaisesRegexp(EnumVariantSelectionError, re.escape("""\
+type check error in class SomeEnum: pattern matching must have exactly the keys [1, 2] (was: [1, 2, 3])""",
+    )):
+      one_enum_instance.resolve_for_enum_variant({
+        1: 3,
+        2: 4,
+        3: 5,
+      })
+
+    # Test that not providing all the variants raises an error.
+    with self.assertRaisesRegexp(EnumVariantSelectionError, re.escape("""\
+type check error in class SomeEnum: pattern matching must have exactly the keys [1, 2] (was: [1])""")):
+      one_enum_instance.resolve_for_enum_variant({
+        1: 3,
+      })
+
+    # Test that the ordering of the values in the enum constructor is not relevant for testing
+    # whether all variants are provided.
+    class OutOfOrderEnum(enum([2, 1, 3])): pass
+    two_out_of_order_instance = OutOfOrderEnum(2)
+    # This OrderedDict mapping is in a different order than in the enum constructor. This test means
+    # we can rely on providing simply a literal dict to resolve_for_enum_variant() and not worry
+    # that the dict ordering will cause an error.
+    letter = two_out_of_order_instance.resolve_for_enum_variant(OrderedDict([
+      (1, 'b'),
+      (2, 'a'),
+      (3, 'c'),
+    ]))
+    self.assertEqual(letter, 'a')

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -708,7 +708,7 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
   def test_enum_class_creation_errors(self):
     expected_rx = re.escape(
       "When converting all_values ([1, 2, 3, 1]) to a set, at least one duplicate "
-      "was detected. The unique elements of all_values were: OrderedSet([1, 2, 3]).")
+      "was detected. The unique elements of all_values were: [1, 2, 3].")
     with self.assertRaisesRegexp(ValueError, expected_rx):
       class DuplicateAllowedValues(enum('x', [1, 2, 3, 1])): pass
 
@@ -716,30 +716,31 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
     self.assertEqual(1, SomeEnum.create().x)
     self.assertEqual(2, SomeEnum.create(2).x)
     self.assertEqual(1, SomeEnum(1).x)
-    self.assertEqual(2, SomeEnum(x=2).x)
 
   def test_enum_instance_creation_errors(self):
     expected_rx = re.escape(
-      "Value 3 for 'x' must be one of: OrderedSet([1, 2]).")
+      "Value 3 for 'x' must be one of: [1, 2].")
     with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx):
       SomeEnum.create(3)
     with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx):
       SomeEnum(3)
-    with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx):
+
+    # Specifying the value by keyword argument is not allowed.
+    with self.assertRaisesRegexp(TypeError, re.escape("__new__() got an unexpected keyword argument 'x'")):
       SomeEnum(x=3)
 
     # Test that None is not used as the default unless none_is_default=True.
     with self.assertRaisesRegexp(EnumVariantSelectionError, re.escape(
-        "Value None for 'x' must be one of: OrderedSet([1, 2])."
+        "Value None for 'x' must be one of: [1, 2]."
     )):
       SomeEnum.create(None)
     self.assertEqual(1, SomeEnum.create(None, none_is_default=True).x)
 
     expected_rx_falsy_value = re.escape(
-      "Value {}'' for 'x' must be one of: OrderedSet([1, 2])."
+      "Value {}'' for 'x' must be one of: [1, 2]."
       .format('u' if PY2 else ''))
     with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx_falsy_value):
-      SomeEnum(x='')
+      SomeEnum('')
 
   def test_enum_resolve_variant(self):
     one_enum_instance = SomeEnum(1)


### PR DESCRIPTION
*This is based off of #7227: see https://github.com/cosmicexplorer/pants/compare/cosmicexplorer:mixed-rsc-zinc-compiles...cosmicexplorer:remoting-FINAL?expand=1. The previous commits will be removed when that PR is merged.*

*The scala edits in this commit should be unchanged from https://github.com/twitter/pants/commit/3e798c123e406b629b06b838734c9cb3ceca00d2.*

### Problem

One interesting possibility for distributed rsc compilation is to have individual remote execution workers maintain a nailgun instance which individual process executions connect to. This removes JVM startup time and allows the JIT to warm up (vaguely). This is pretty difficult to set up (as described below) but if the relative performance is convincing, may deserve more investigation.

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

- Edit the pants zinc wrapper to convert non-absolute paths on the provided classpath to be relative to the working directory provided by the nailgun connection, as opposed to the directory where the nailgun server was invoked in.
- Introduce `hermetic-with-nailgun` execution strategy to connect to a remote execution server which is running its own nailgun server in the background.
  - This nailgun server should have the jar produced by `./pants binary src/scala/org/pantsbuild/zinc/compiler:rsc-and-zinc` on its classpath.
  - The remote execution worker is expected to set `NAILGUN_PORT` in its execution sandbox -- this is difficult to set up and likely insecure, along with other concerns I am less familiar with.

Please look at the `--ng-client-input-digest` and `--ng-client-input-digest-length` option descriptions to understand the requirements for the `ng` command-line client used to perform this connection: https://github.com/cosmicexplorer/pants/blob/a33b43dc15898a71c7f8e8f41478da5564a0fbc2/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py#L178-L188

(_describe the modifications you've made._)

### Result

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)