### PR TITLE
cache python tools in ~/.cache/pants

### DIFF
--- a/src/python/pants/backend/native/subsystems/conan.py
+++ b/src/python/pants/backend/native/subsystems/conan.py
@@ -20,7 +20,7 @@ class Conan(PythonToolBase):
     'pylint==1.9.3',
   ]
   default_entry_point = 'conans.conan'
-  default_interpreter_constraints = ['CPython>=3.6']
+  default_interpreter_constraints = ['CPython>=2.7,<4']
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/native/subsystems/conan.py
+++ b/src/python/pants/backend/native/subsystems/conan.py
@@ -20,6 +20,7 @@ class Conan(PythonToolBase):
     'pylint==1.9.3',
   ]
   default_entry_point = 'conans.conan'
+  default_interpreter_constraints = ['CPython>=3.6']
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -13,16 +13,24 @@ class PythonToolBase(Subsystem):
   # Subclasses must set.
   default_requirements = None
   default_entry_point = None
+  # Subclasses need not override.
+  default_interpreter_constraints = []
 
   @classmethod
   def register_options(cls, register):
     super(PythonToolBase, cls).register_options(register)
+    register('--interpreter-constraints', type=list, advanced=True, fingerprint=True,
+             default=cls.default_interpreter_constraints,
+             help='Python interpreter constraints for this tool.')
     register('--requirements', type=list, advanced=True, fingerprint=True,
              default=cls.default_requirements,
              help='Python requirement strings for the tool.')
     register('--entry-point', type=str, advanced=True, fingerprint=True,
              default=cls.default_entry_point,
              help='The main module for the tool.')
+
+  def get_interpreter_constraints(self):
+    return self.get_options().interpreter_constraints
 
   def get_requirement_specs(self):
     return self.get_options().requirements

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -21,7 +21,8 @@ class PythonToolBase(Subsystem):
     super(PythonToolBase, cls).register_options(register)
     register('--interpreter-constraints', type=list, advanced=True, fingerprint=True,
              default=cls.default_interpreter_constraints,
-             help='Python interpreter constraints for this tool.')
+             help='Python interpreter constraints for this tool. An empty list uses the default '
+                  'interpreter constraints for the repo.')
     register('--requirements', type=list, advanced=True, fingerprint=True,
              default=cls.default_requirements,
              help='Python requirement strings for the tool.')

--- a/src/python/pants/backend/python/tasks/python_tool_prep_base.py
+++ b/src/python/pants/backend/python/tasks/python_tool_prep_base.py
@@ -106,6 +106,11 @@ class PythonToolPrepBase(Task):
       pex_builder.freeze()
 
   def _generate_fingerprinted_pex_path(self, tool_subsystem, interpreter):
+    # `tool_subsystem.get_requirement_specs()` is a list, but order shouldn't actually matter. This
+    # should probably be sorted, but it's possible a user could intentionally tweak order to work
+    # around a particular requirement resolution resolve-order issue. In practice the lists are
+    # expected to be mostly static, so we accept the risk of too-fine-grained caching creating lots
+    # of pexes in the cache dir.
     specs_fingerprint = stable_json_sha1(tool_subsystem.get_requirement_specs())
     return os.path.join(
       get_pants_cachedir(),

--- a/src/python/pants/backend/python/tasks/python_tool_prep_base.py
+++ b/src/python/pants/backend/python/tasks/python_tool_prep_base.py
@@ -71,6 +71,12 @@ class PythonToolInstance(object):
       return cmdline, exit_code
 
 
+# TODO: This python tool setup ends up eagerly generating each pex for each task in every goal which
+# is transitively required by the command-line goals, even for tasks which no-op. This requires each
+# pex for each relevant python tool to be buildable on the current host, even if it may never be
+# intended to be invoked. Especially given the existing clear separation of concerns into
+# PythonToolBase/PythonToolInstance/PythonToolPrepBase, this seems like an extremely ripe use case
+# for some v2 rules for free caching and no-op when not required for the command-line goals.
 class PythonToolPrepBase(Task):
   """Base class for tasks that resolve a python tool to be invoked out-of-process."""
 

--- a/tests/python/pants_test/backend/python/tasks/test_python_tool.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_tool.py
@@ -42,10 +42,6 @@ class ToolTask(Task):
     super(ToolTask, cls).prepare(options, round_manager)
     round_manager.require_data(ToolPrep.tool_instance_cls)
 
-  @classmethod
-  def product_types(cls):
-    return ['test_pex']
-
   def execute(self):
     tool_for_pex = self.context.products.get_data(ToolPrep.tool_instance_cls)
     stdout, stderr, exit_code, _ = tool_for_pex.output(['--version'])

--- a/tests/python/pants_test/backend/python/tasks/test_python_tool.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_tool.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import glob
+import os
+
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.tasks.python_tool_prep_base import PythonToolInstance, PythonToolPrepBase
+from pants.task.task import Task
+from pants.util.collections import assert_single_element
+from pants.util.contextutil import environment_as, temporary_dir
+from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
+
+
+class Tool(PythonToolBase):
+  options_scope = 'test-tool'
+  default_requirements = [
+    'pex==1.5.3',
+  ]
+  default_entry_point = 'pex.bin.pex:main',
+
+
+class ToolInstance(PythonToolInstance):
+  pass
+
+
+class ToolPrep(PythonToolPrepBase):
+  options_scope = 'tool-prep-task'
+  tool_subsystem_cls = Tool
+  tool_instance_cls = ToolInstance
+
+
+class ToolTask(Task):
+  options_scope = 'tool-task'
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(ToolTask, cls).prepare(options, round_manager)
+    round_manager.require_data(ToolPrep.tool_instance_cls)
+
+  @classmethod
+  def product_types(cls):
+    return ['test_pex']
+
+  def execute(self):
+    tool_for_pex = self.context.products.get_data(ToolPrep.tool_instance_cls)
+    self.context.products.register_data('test_pex', tool_for_pex)
+
+
+class PythonToolPrepTest(PythonTaskTestBase):
+
+  @classmethod
+  def task_type(cls):
+    return ToolTask
+
+  def _assert_tool_execution_for_python_version(self, is_py3=True):
+    scope_string = '3' if is_py3 else '2'
+    constraint_string = 'CPython>=3' if is_py3 else 'CPython<3'
+    tool_prep_type = self.synthesize_task_subtype(ToolPrep, 'tp_scope_py{}'.format(scope_string))
+    context = self.context(for_task_types=[tool_prep_type], for_subsystems=[Tool], options={
+      'test-tool': {
+        'interpreter_constraints': [constraint_string],
+      },
+    })
+    # XDG_CACHE_HOME overrides the location of the cache dir.
+    with temporary_dir() as tmp_dir, environment_as(XDG_CACHE_HOME=tmp_dir):
+      tool_prep_task = tool_prep_type(context, os.path.join(
+        self.pants_workdir, 'tp_py{}'.format(scope_string)))
+      tool_prep_task.execute()
+      # Check that the tool is in an interpreter-specific subdir of the cache dir.
+      constructed_tool_location_glob = os.path.join(
+        tmp_dir, 'pants', 'python',
+        'CPython-{}*'.format(scope_string),
+        tool_prep_task.fingerprint,
+        'test-tool-*.pex',
+      )
+      tool_location = assert_single_element(glob.glob(constructed_tool_location_glob))
+      self.assertTrue(os.path.isdir(tool_location))
+
+      # Check that the tool can be executed successfully.
+      self.create_task(context).execute()
+      pex_tool = context.products.get_data('test_pex')
+      self.assertTrue(pex_tool.interpreter.identity.matches(constraint_string))
+      self.maxDiff = None
+      stdout, stderr, exit_code, _ = pex_tool.output('--version')
+      self.assertEqual('', stderr)
+      self.assertEqual('pex 1.5.3', stdout)
+      self.assertEqual(0, exit_code)
+
+  def test_tool_execution(self):
+    self._assert_tool_execution_for_python_version(is_py3=True)
+    self._assert_tool_execution_for_python_version(is_py3=False)

--- a/tests/python/pants_test/backend/python/tasks/test_python_tool.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_tool.py
@@ -44,8 +44,7 @@ class ToolTask(Task):
 
   def execute(self):
     tool_for_pex = self.context.products.get_data(ToolPrep.tool_instance_cls)
-    stdout, stderr, exit_code, _ = tool_for_pex.output(['--version'])
-    assert '' == stderr
+    stdout, _, exit_code, _ = tool_for_pex.output(['--version'])
     assert re.match(r'.*\.pex 1.5.3', stdout)
     assert 0 == exit_code
 


### PR DESCRIPTION
### Problem

This runs for (on my laptop) about 16 seconds every time I do a `clean-all`:
```
22:27:23 00:02   [native-compile]
22:27:23 00:02     [conan-prep]
22:27:23 00:02       [create-conan-pex]
22:27:39 00:18     [conan-fetch]
```

It doesn't seem like we need to be putting this tool in the task workdir as the python requirements list is pretty static. Conan in particular will be instantiated by invoking almost every goal, and it is a nontrivial piece of software to resolve each time.

Also, we aren't mixing in interpreter identity to the generated pex filename, which is a bug that has so far gone undetected: see https://github.com/pantsbuild/pants/pull/7236#discussion_r256078554.

### Solution

- Take the `stable_json_sha1()` of the requirements of each python tool generated by `PythonToolPrepBase` to generate a fingerprinted pex filename.
- Stick it in the pants cachedir so it doesn't get blown away by a clean-all.
- Add an `--interpreter-constraints` option to pex tools (where previously the repo's `--python-setup-interpreter-constraints` were implicitly used).
- Ensure the selected interpreter identity is mixed into the fingerprinted filename.
- Add a test for the pex filename fingerprinting and that the pex can be successfully executed for python 2 and 3 constraints.

### Result

A significant amount of time spent waiting after clean builds is removed, and pex tools can have their own interpreter constraints as necessary.