### PR TITLE
Pin pytest version to avoid induced breakage from more-itertools transitive dep

### DIFF
--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -14,7 +14,7 @@ class PyTest(Subsystem):
   def register_options(cls, register):
     super(PyTest, cls).register_options(register)
     # TODO: This is currently bounded below `3.7` due to #6282.
-    register('--requirements', advanced=True, default='pytest>=3.0.7,<3.7',
+    register('--requirements', advanced=True, default='pytest==3.0.7',
              help='Requirements string for the pytest library.')
     register('--timeout-requirements', advanced=True, default='pytest-timeout>=1.2,<1.3',
              help='Requirements string for the pytest-timeout library.')

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -14,6 +14,8 @@ class PyTest(Subsystem):
   def register_options(cls, register):
     super(PyTest, cls).register_options(register)
     # TODO: This is currently bounded below `3.7` due to #6282.
+    # TODO: Additionally, this is temporarily pinned to 3.0.7 due to more-itertools 6.0.0 dropping
+    # Python 2 support: https://github.com/pytest-dev/pytest/issues/4770.
     register('--requirements', advanced=True, default='pytest==3.0.7',
              help='Requirements string for the pytest library.')
     register('--timeout-requirements', advanced=True, default='pytest-timeout>=1.2,<1.3',

--- a/tests/python/pants_test/rules/test_test_integration.py
+++ b/tests/python/pants_test/rules/test_test_integration.py
@@ -72,7 +72,7 @@ class TestIntegrationTest(PantsRunIntegrationTest):
 platform SOME_TEXT
 rootdir: SOME_TEXT
 plugins: SOME_TEXT
-collected 1 item
+collected 1 items
 
 testprojects/tests/python/pants/dummies/test_pass.py .                   [100%]
 
@@ -92,7 +92,7 @@ testprojects/tests/python/pants/dummies:passing_target                          
 platform SOME_TEXT
 rootdir: SOME_TEXT
 plugins: SOME_TEXT
-collected 1 item
+collected 1 items
 
 testprojects/tests/python/pants/dummies/test_fail.py F                   [100%]
 
@@ -120,7 +120,7 @@ testprojects/tests/python/pants/dummies:failing_target                          
 platform SOME_TEXT
 rootdir: SOME_TEXT
 plugins: SOME_TEXT
-collected 1 item
+collected 1 items
 
 testprojects/tests/python/pants/dummies/test_with_source_dep.py .        [100%]
 
@@ -139,7 +139,7 @@ testprojects/tests/python/pants/dummies:target_with_source_dep                  
 platform SOME_TEXT
 rootdir: SOME_TEXT
 plugins: SOME_TEXT
-collected 1 item
+collected 1 items
 
 testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py .    [100%]
 
@@ -160,7 +160,7 @@ testprojects/tests/python/pants/dummies:target_with_thirdparty_dep              
 platform SOME_TEXT
 rootdir: SOME_TEXT
 plugins: SOME_TEXT
-collected 1 item
+collected 1 items
 
 testprojects/tests/python/pants/dummies/test_fail.py F                   [100%]
 
@@ -177,7 +177,7 @@ testprojects/tests/python/pants/dummies/test_fail.py:2: AssertionError
 platform SOME_TEXT
 rootdir: SOME_TEXT
 plugins: SOME_TEXT
-collected 1 item
+collected 1 items
 
 testprojects/tests/python/pants/dummies/test_pass.py .                   [100%]
 


### PR DESCRIPTION
### Problem

A floating transitive dependency of pytest, `more-itertools`, dropped support for python 2 in its 6.0.0 release -- see pytest-dev/pytest#4770. This is currently breaking our and our users' CI: see https://travis-ci.org/pantsbuild/pants/jobs/492004734. We could pin that dep, but as mentioned in https://github.com/pytest-dev/pytest/issues/4770#issuecomment-462869367, pinning transitive deps of pytest would impose requirement constraints on users of pytest in pants.

### Solution

- Pin `pytest==3.0.7` for now.

### Result

python tests should no longer be broken.