### PR TITLE
fix expected pytest output for pytest integration after pinning to 3.0.7

### DIFF
--- a/tests/python/pants_test/rules/test_test_integration.py
+++ b/tests/python/pants_test/rules/test_test_integration.py
@@ -74,7 +74,7 @@ rootdir: SOME_TEXT
 plugins: SOME_TEXT
 collected 1 items
 
-testprojects/tests/python/pants/dummies/test_pass.py .                   [100%]
+testprojects/tests/python/pants/dummies/test_pass.py .
 
 =========================== 1 passed in SOME_TEXT ===========================
 
@@ -94,7 +94,7 @@ rootdir: SOME_TEXT
 plugins: SOME_TEXT
 collected 1 items
 
-testprojects/tests/python/pants/dummies/test_fail.py F                   [100%]
+testprojects/tests/python/pants/dummies/test_fail.py F
 
 =================================== FAILURES ===================================
 __________________________________ test_fail ___________________________________
@@ -122,7 +122,7 @@ rootdir: SOME_TEXT
 plugins: SOME_TEXT
 collected 1 items
 
-testprojects/tests/python/pants/dummies/test_with_source_dep.py .        [100%]
+testprojects/tests/python/pants/dummies/test_with_source_dep.py .
 
 =========================== 1 passed in SOME_TEXT ===========================
 
@@ -141,7 +141,7 @@ rootdir: SOME_TEXT
 plugins: SOME_TEXT
 collected 1 items
 
-testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py .    [100%]
+testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py .
 
 =========================== 1 passed in SOME_TEXT ===========================
 
@@ -162,7 +162,7 @@ rootdir: SOME_TEXT
 plugins: SOME_TEXT
 collected 1 items
 
-testprojects/tests/python/pants/dummies/test_fail.py F                   [100%]
+testprojects/tests/python/pants/dummies/test_fail.py F
 
 =================================== FAILURES ===================================
 __________________________________ test_fail ___________________________________
@@ -179,7 +179,7 @@ rootdir: SOME_TEXT
 plugins: SOME_TEXT
 collected 1 items
 
-testprojects/tests/python/pants/dummies/test_pass.py .                   [100%]
+testprojects/tests/python/pants/dummies/test_pass.py .
 
 =========================== 1 passed in SOME_TEXT ===========================
 

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -13,10 +13,9 @@ from builtins import object, str
 from future.utils import PY2, PY3, text_type
 
 from pants.util.collections_abc_backport import OrderedDict
-from pants.util.objects import (EnumVariantSelectionError, Exactly, SubclassesOf,
-                                SuperclassesOf, TypeCheckError, TypeConstraintError,
-                                TypedCollection, TypedDatatypeInstanceConstructionError, datatype,
-                                enum)
+from pants.util.objects import (EnumVariantSelectionError, Exactly, SubclassesOf, SuperclassesOf,
+                                TypeCheckError, TypeConstraintError, TypedCollection,
+                                TypedDatatypeInstanceConstructionError, datatype, enum)
 from pants_test.test_base import TestBase
 
 
@@ -678,7 +677,7 @@ field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(
       WithCollectionTypeConstraint([3, "asdf"])
     expected_msg = """\
 type check error in class WithCollectionTypeConstraint: errors type checking constructor arguments:
-field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, u'asdf']: value u'asdf' (with type 'unicode') must satisfy this type constraint: Exactly(int).""".format(u='u' if PY2 else '', string_type='unicode' if PY2 else 'str')
+field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'asdf']: value {u}'asdf' (with type '{string_type}') must satisfy this type constraint: Exactly(int).""".format(u='u' if PY2 else '', string_type='unicode' if PY2 else 'str')
     self.assertEqual(str(cm.exception), expected_msg)
 
   def test_copy(self):


### PR DESCRIPTION
### Problem

#7238 attempted to fix an upstream pytest issue (and therefore unbreak our CI) by pinning the default pytest version in our pytest subsystem to `pytest==3.0.7`. This worked, but broke a few of our other tests which relied on specific pytest output, and master is broken now (sorry!).

I also hastily merged #7226, which introduced another test failure, which I have fixed. These are the only failing tests, and these all now pass locally on my laptop.

### Solution

- Fix expected pytest output in pytest runner testing.

### Result

I think it's still a good idea to string match pytest output unless we suddenly have to change pytest versions drastically like this again.