### PR TITLE
Fix nightly cron ctypes enum failure

### DIFF
--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -281,6 +281,15 @@ def enum(*args):
       """
       return cls.create(value)
 
+    # TODO: figure out if there's a way to make the opposite direction of `==` raise
+    # (e.g. 1 == SomeEnum(1), which currently just returns False).
+    def __eq__(self, other):
+      """Redefine equality to raise to nudge people to use static pattern matching."""
+      raise self.make_type_error(
+        "enum equality is defined to be an error -- use .resolve_for_enum_variant() instead!")
+    # Redefine the canary so datatype __new__ doesn't raise.
+    __eq__._eq_override_canary = None
+
     @classmethod
     def create(cls, *args, **kwargs):
       """Create an instance of this enum, using the default value if specified.

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -132,9 +132,9 @@ def datatype(field_decls, superclass_name=None, **kwargs):
     def __ne__(self, other):
       return not (self == other)
 
-    # NB: it appears that in Python 3, whenever __eq__ is overridden, __hash__() must also be
-    # explicitly implemented, otherwise Python will raise "unhashable type". It's not clear whether
-    # or where this behavior is documented.
+    # NB: in Python 3, whenever __eq__ is overridden, __hash__() must also be
+    # explicitly implemented, otherwise Python will raise "unhashable type". See
+    # https://docs.python.org/3/reference/datamodel.html#object.__hash__.
     def __hash__(self):
       return super(DataType, self).__hash__()
 
@@ -294,7 +294,7 @@ def enum(*args):
     __eq__._eq_override_canary = None
 
     # NB: as noted in datatype(), __hash__ must be explicitly implemented whenever __eq__ is
-    # overridden in Python 3. This behavior appears to be undocumented.
+    # overridden. See https://docs.python.org/3/reference/datamodel.html#object.__hash__.
     def __hash__(self):
       return super(ChoiceDatatype, self).__hash__()
 

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -281,8 +281,8 @@ def enum(*args):
       """
       return cls.create(value)
 
-    # TODO: figure out if there's a way to make the opposite direction of `==` raise
-    # (e.g. 1 == SomeEnum(1), which currently just returns False).
+    # TODO: figure out if this will always trigger on primitives like strings, and what situations
+    # won't call this __eq__ (and therefore won't raise like we want).
     def __eq__(self, other):
       """Redefine equality to raise to nudge people to use static pattern matching."""
       raise self.make_type_error(

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -132,13 +132,10 @@ def datatype(field_decls, superclass_name=None, **kwargs):
     def __ne__(self, other):
       return not (self == other)
 
-    def __hash__(self):
-      return super(DataType, self).__hash__()
-
     # NB: As datatype is not iterable, we need to override both __iter__ and all of the
     # namedtuple methods that expect self to be iterable.
     def __iter__(self):
-      raise TypeError("'{}' object is not iterable".format(type(self).__name__))
+      raise self.make_type_error("datatype object is not iterable")
 
     def _super_iter(self):
       return super(DataType, self).__iter__()
@@ -285,6 +282,9 @@ def enum(*args):
     # won't call this __eq__ (and therefore won't raise like we want).
     def __eq__(self, other):
       """Redefine equality to raise to nudge people to use static pattern matching."""
+      # TODO: determine why this is necessary for hashability.
+      # if type(self) == type(other):
+      #   return super(ChoiceDatatype, self).__eq__(other)
       raise self.make_type_error(
         "enum equality is defined to be an error -- use .resolve_for_enum_variant() instead!")
     # Redefine the canary so datatype __new__ doesn't raise.

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -132,6 +132,12 @@ def datatype(field_decls, superclass_name=None, **kwargs):
     def __ne__(self, other):
       return not (self == other)
 
+    # NB: it appears that in Python 3, whenever __eq__ is overridden, __hash__() must also be
+    # explicitly implemented, otherwise Python will raise "unhashable type". It's not clear whether
+    # or where this behavior is documented.
+    def __hash__(self):
+      return super(DataType, self).__hash__()
+
     # NB: As datatype is not iterable, we need to override both __iter__ and all of the
     # namedtuple methods that expect self to be iterable.
     def __iter__(self):
@@ -282,13 +288,15 @@ def enum(*args):
     # won't call this __eq__ (and therefore won't raise like we want).
     def __eq__(self, other):
       """Redefine equality to raise to nudge people to use static pattern matching."""
-      # TODO: determine why this is necessary for hashability.
-      # if type(self) == type(other):
-      #   return super(ChoiceDatatype, self).__eq__(other)
       raise self.make_type_error(
         "enum equality is defined to be an error -- use .resolve_for_enum_variant() instead!")
     # Redefine the canary so datatype __new__ doesn't raise.
     __eq__._eq_override_canary = None
+
+    # NB: as noted in datatype(), __hash__ must be explicitly implemented whenever __eq__ is
+    # overridden in Python 3. This behavior appears to be undocumented.
+    def __hash__(self):
+      return super(ChoiceDatatype, self).__hash__()
 
     @classmethod
     def create(cls, *args, **kwargs):

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -183,7 +183,10 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
     # be available on the runtime library path.
     attempt_pants_run = Platform.create().resolve_for_enum_variant({
-      'darwin': toolchain_variant != 'gnu',
+      'darwin': toolchain_variant.resolve_for_enum_variant({
+        'gnu': False,
+        'llvm': True,
+      }),
       'linux': True,
     })
     if attempt_pants_run:

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -741,6 +741,18 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
     with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx_falsy_value):
       SomeEnum('')
 
+  def test_enum_comparison_fails(self):
+    enum_instance = SomeEnum(1)
+    with self.assertRaisesRegexp(TypeCheckError,
+                                 re.escape("enum equality is defined to be an error")):
+      enum_instance == enum_instance
+    # Test that comparison also fails against another type.
+    with self.assertRaisesRegexp(TypeCheckError,
+                                 re.escape("enum equality is defined to be an error")):
+      enum_instance == 1
+    # TODO: figure out if there's a way to make this direction raise as well!
+    self.assertNotEqual(1, enum_instance)
+
   def test_enum_resolve_variant(self):
     one_enum_instance = SomeEnum(1)
     two_enum_instance = SomeEnum(2)

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -743,15 +743,21 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
 
   def test_enum_comparison_fails(self):
     enum_instance = SomeEnum(1)
-    with self.assertRaisesRegexp(TypeCheckError,
-                                 re.escape("enum equality is defined to be an error")):
+    rx_str = re.escape("enum equality is defined to be an error")
+    with self.assertRaisesRegexp(TypeCheckError, rx_str):
       enum_instance == enum_instance
     # Test that comparison also fails against another type.
-    with self.assertRaisesRegexp(TypeCheckError,
-                                 re.escape("enum equality is defined to be an error")):
+    with self.assertRaisesRegexp(TypeCheckError, rx_str):
       enum_instance == 1
-    # TODO: figure out if there's a way to make this direction raise as well!
-    self.assertNotEqual(1, enum_instance)
+    with self.assertRaisesRegexp(TypeCheckError, rx_str):
+      1 == enum_instance
+
+    class StrEnum(enum(['a'])): pass
+    enum_instance = StrEnum('a')
+    with self.assertRaisesRegexp(TypeCheckError, rx_str):
+      enum_instance == 'a'
+    with self.assertRaisesRegexp(TypeCheckError, rx_str):
+      'a' == enum_instance
 
   def test_enum_resolve_variant(self):
     one_enum_instance = SomeEnum(1)

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -744,12 +744,10 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
   def test_enum_comparison_fails(self):
     enum_instance = SomeEnum(1)
     rx_str = re.escape("enum equality is defined to be an error")
-    # # TODO: Figure out a way to raise on any use of `==` without breaking hashability for use by the
-    # # engine.
-    # self.assertEqual(enum_instance, SomeEnum(1))
-    # self.assertNotEqual(enum_instance, SomeEnum(2))
     with self.assertRaisesRegexp(TypeCheckError, rx_str):
       enum_instance == enum_instance
+    with self.assertRaisesRegexp(TypeCheckError, rx_str):
+      enum_instance != enum_instance
     # Test that comparison also fails against another type.
     with self.assertRaisesRegexp(TypeCheckError, rx_str):
       enum_instance == 1

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -744,6 +744,10 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
   def test_enum_comparison_fails(self):
     enum_instance = SomeEnum(1)
     rx_str = re.escape("enum equality is defined to be an error")
+    # # TODO: Figure out a way to raise on any use of `==` without breaking hashability for use by the
+    # # engine.
+    # self.assertEqual(enum_instance, SomeEnum(1))
+    # self.assertNotEqual(enum_instance, SomeEnum(2))
     with self.assertRaisesRegexp(TypeCheckError, rx_str):
       enum_instance == enum_instance
     # Test that comparison also fails against another type.


### PR DESCRIPTION
### Problem

Resolves #7247. `ToolchainVariant('gnu')` does not in fact `== 'gnu'`.

### Solution

- Use `.resolve_for_enum_variant()` instead of comparing with equality in that one failing test (I missed this in #7226, I fixed the instance earlier in the file though).
- Raise an error when trying to use `==` on an enum to avoid this from happening again.
- Note that in Python 3 it appears that `__hash__` must be explicitly implemented whenever `__eq__` is overridden, and this appears undocumented.

### Result

The nightly cron job should be fixed, and enums are now a little more difficult to screw up.

# Open Questions
It's a little unclear why this didn't fail in CI -- either the test was cached, or some but not all travis osx images are provisioned with the correct dylib, causing a nondeterministic error, or something else?