### PR TITLE
Scheduler returns metrics as a dictionary instead of a tuple of tuples

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -278,8 +278,7 @@ class Scheduler(object):
     return self._visualize_to_dir
 
   def _metrics(self, session):
-    metrics_val = self._native.lib.scheduler_metrics(self._scheduler, session)
-    return {k: v for k, v in self._from_value(metrics_val)}
+    return self._from_value(self._native.lib.scheduler_metrics(self._scheduler, session))
 
   def with_fork_context(self, func):
     """See the rustdocs for `scheduler_fork_context` for more information."""

--- a/src/python/pants/goal/pantsd_stats.py
+++ b/src/python/pants/goal/pantsd_stats.py
@@ -11,24 +11,18 @@ class PantsDaemonStats(object):
   """Tracks various stats about the daemon."""
 
   def __init__(self):
-    self.target_root_size = 0
-    self.affected_targets_size = 0
-    self.affected_targets_file_count = 0
     self.scheduler_metrics = {}
 
   def set_scheduler_metrics(self, scheduler_metrics):
     self.scheduler_metrics = scheduler_metrics
 
   def set_target_root_size(self, size):
-    self.target_root_size = size
+    self.scheduler_metrics['target_root_size'] = size
 
   def set_affected_targets_size(self, size):
-    self.affected_targets_size = size
+    self.scheduler_metrics['affected_targets_size'] = size
 
   def get_all(self):
-    res = dict(self.scheduler_metrics)
-    res.update({
-      'target_root_size': self.target_root_size,
-      'affected_targets_size': self.affected_targets_size,
-    })
-    return res
+    for key in ['target_root_size', 'affected_targets_size']:
+      self.scheduler_metrics.setdefault(key, 0)
+    return self.scheduler_metrics

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -82,7 +82,6 @@ pub fn store_set<I: Iterator<Item = Value>>(values: I) -> Value {
 ///
 /// The underlying slice _must_ contain an even number of elements.
 ///
-#[allow(dead_code)]
 pub fn store_dict(keys_and_values_interleaved: &[(Value)]) -> Value {
   if keys_and_values_interleaved.len() % 2 != 0 {
     panic!("store_dict requires an even number of elements");

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -307,8 +307,9 @@ pub extern "C" fn scheduler_create(
 }
 
 ///
-/// Returns a Handle representing a tuple of tuples of metric name string and metric value int.
-///
+/// Returns a Handle representing a dictionary where key is metric name string and value is
+/// metric value int.
+/// 
 #[no_mangle]
 pub extern "C" fn scheduler_metrics(
   scheduler_ptr: *mut Scheduler,

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -319,11 +319,11 @@ pub extern "C" fn scheduler_metrics(
       let values = scheduler
         .metrics(session)
         .into_iter()
-        .map(|(metric, value)| {
-          externs::store_tuple(&[externs::store_utf8(metric), externs::store_i64(value)])
+        .flat_map(|(metric, value)| {
+          vec![externs::store_utf8(metric), externs::store_i64(value)]
         })
         .collect::<Vec<_>>();
-      externs::store_tuple(&values).into()
+      externs::store_dict(&values).into()
     })
   })
 }

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -309,7 +309,7 @@ pub extern "C" fn scheduler_create(
 ///
 /// Returns a Handle representing a dictionary where key is metric name string and value is
 /// metric value int.
-/// 
+///
 #[no_mangle]
 pub extern "C" fn scheduler_metrics(
   scheduler_ptr: *mut Scheduler,
@@ -320,9 +320,7 @@ pub extern "C" fn scheduler_metrics(
       let values = scheduler
         .metrics(session)
         .into_iter()
-        .flat_map(|(metric, value)| {
-          vec![externs::store_utf8(metric), externs::store_i64(value)]
-        })
+        .flat_map(|(metric, value)| vec![externs::store_utf8(metric), externs::store_i64(value)])
         .collect::<Vec<_>>();
       externs::store_dict(&values).into()
     })


### PR DESCRIPTION
### Problem
Scheduler returns metrics as a tuple of tuples (key, value). And later this tuple is transformed into a dictionary.
It is considered to use metrics to return to python part zipkin span info and dict type will be more convenient.

### Solution
Scheduler_metrics returns a store_dict  instead of store_tuple.
