### PR TITLE
Allow passing floating point numbers from rust to python

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -376,6 +376,12 @@ class _FFISpecification(object):
     c = self._ffi.from_handle(context_handle)
     return c.to_value(i64)
 
+  @_extern_decl('Handle', ['ExternContext*', 'double'])
+  def extern_store_f64(self, context_handle, f64):
+    """Given a context and double, return a new Handle to represent the double."""
+    c = self._ffi.from_handle(context_handle)
+    return c.to_value(f64)
+
   @_extern_decl('Handle', ['ExternContext*', '_Bool'])
   def extern_store_bool(self, context_handle, b):
     """Given a context and _Bool, return a new Handle to represent the _Bool."""
@@ -634,6 +640,7 @@ class Native(Singleton):
                            self.ffi_lib.extern_store_bytes,
                            self.ffi_lib.extern_store_utf8,
                            self.ffi_lib.extern_store_i64,
+                           self.ffi_lib.extern_store_f64,
                            self.ffi_lib.extern_store_bool,
                            self.ffi_lib.extern_project_ignoring_type,
                            self.ffi_lib.extern_project_multi,

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -121,6 +121,11 @@ pub fn store_i64(val: i64) -> Value {
 }
 
 #[allow(dead_code)]
+pub fn store_f64(val: f64) -> Value {
+  with_externs(|e| (e.store_f64)(e.context, val).into())
+}
+
+#[allow(dead_code)]
 pub fn store_bool(val: bool) -> Value {
   with_externs(|e| (e.store_bool)(e.context, val).into())
 }
@@ -343,6 +348,7 @@ pub struct Externs {
   pub store_bytes: StoreBytesExtern,
   pub store_utf8: StoreUtf8Extern,
   pub store_i64: StoreI64Extern,
+  pub store_f64: StoreF64Extern,
   pub store_bool: StoreBoolExtern,
   pub project_ignoring_type: ProjectIgnoringTypeExtern,
   pub project_multi: ProjectMultiExtern,
@@ -381,6 +387,8 @@ pub type StoreBytesExtern = extern "C" fn(*const ExternContext, *const u8, u64) 
 pub type StoreUtf8Extern = extern "C" fn(*const ExternContext, *const u8, u64) -> Handle;
 
 pub type StoreI64Extern = extern "C" fn(*const ExternContext, i64) -> Handle;
+
+pub type StoreF64Extern = extern "C" fn(*const ExternContext, f64) -> Handle;
 
 pub type StoreBoolExtern = extern "C" fn(*const ExternContext, bool) -> Handle;
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -62,7 +62,7 @@ use crate::externs::{
   Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionExtern, DropHandlesExtern,
   EqualsExtern, EvalExtern, ExternContext, Externs, GeneratorSendExtern, HandleBuffer,
   IdentifyExtern, LogExtern, ProjectIgnoringTypeExtern, ProjectMultiExtern, PyResult,
-  SatisfiedByExtern, SatisfiedByTypeExtern, StoreBoolExtern, StoreBytesExtern, StoreI64Extern,
+  SatisfiedByExtern, SatisfiedByTypeExtern, StoreBoolExtern, StoreBytesExtern, StoreF64Extern, StoreI64Extern,
   StoreTupleExtern, StoreUtf8Extern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
 };
 use crate::handles::Handle;
@@ -119,6 +119,7 @@ pub extern "C" fn externs_set(
   store_bytes: StoreBytesExtern,
   store_utf8: StoreUtf8Extern,
   store_i64: StoreI64Extern,
+  store_f64: StoreF64Extern,
   store_bool: StoreBoolExtern,
   project_ignoring_type: ProjectIgnoringTypeExtern,
   project_multi: ProjectMultiExtern,
@@ -146,6 +147,7 @@ pub extern "C" fn externs_set(
     store_bytes,
     store_utf8,
     store_i64,
+    store_f64,
     store_bool,
     project_ignoring_type,
     project_multi,

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -62,8 +62,8 @@ use crate::externs::{
   Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionExtern, DropHandlesExtern,
   EqualsExtern, EvalExtern, ExternContext, Externs, GeneratorSendExtern, HandleBuffer,
   IdentifyExtern, LogExtern, ProjectIgnoringTypeExtern, ProjectMultiExtern, PyResult,
-  SatisfiedByExtern, SatisfiedByTypeExtern, StoreBoolExtern, StoreBytesExtern, StoreF64Extern, StoreI64Extern,
-  StoreTupleExtern, StoreUtf8Extern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
+  SatisfiedByExtern, SatisfiedByTypeExtern, StoreBoolExtern, StoreBytesExtern, StoreF64Extern,
+  StoreI64Extern, StoreTupleExtern, StoreUtf8Extern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
 };
 use crate::handles::Handle;
 use crate::rule_graph::{GraphMaker, RuleGraph};


### PR DESCRIPTION
PR allows passing float points from Rust to Python.
externs::store_f64(v: f64)
