### PR TITLE
enum cleanup

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -118,9 +118,9 @@ class _JvmCompileWorkflowType(enum(['zinc-only', 'rsc-then-zinc'])):
     if target.has_sources('.java') or \
       isinstance(target, JUnitTests) or \
       (isinstance(target, ScalaLibrary) and tuple(target.java_sources)):
-      target_type = _JvmCompileWorkflowType.create('zinc-only')
+      target_type = _JvmCompileWorkflowType('zinc-only')
     elif target.has_sources('.scala'):
-      target_type = _JvmCompileWorkflowType.create('rsc-then-zinc')
+      target_type = _JvmCompileWorkflowType('rsc-then-zinc')
     else:
       target_type = None
     return target_type

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -31,7 +31,7 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
   def register_options(cls, register):
     super(NailgunTaskBase, cls).register_options(register)
     register_enum_option(
-      register, cls.ExecutionStrategy, '--execution-strategy',
+      register, cls.ExecutionStrategy, '--execution-strategy', default=cls.NAILGUN,
       help='If set to nailgun, nailgun will be enabled and repeated invocations of this '
            'task will be quicker. If set to subprocess, then the task will be run without nailgun. '
            'Hermetic execution is an experimental subprocess execution framework.')
@@ -52,7 +52,7 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
     # TODO: This .create() call can be removed when the enum interface is more stable as the option
     # is converted into an instance of self.ExecutionStrategy via the `type` argument through
     # register_enum_option().
-    return self.ExecutionStrategy.create(self.get_options().execution_strategy)
+    return self.ExecutionStrategy(self.get_options().execution_strategy)
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -15,9 +15,12 @@ from pants.util.osutil import all_normalized_os_names, get_normalized_os_name
 from pants.util.strutil import create_path_env_var
 
 
-class Platform(enum('normalized_os_name', all_normalized_os_names())):
+class Platform(enum(all_normalized_os_names())):
 
-  default_value = get_normalized_os_name()
+  # TODO: try to turn all of these accesses into v2 dependency injections!
+  @memoized_classproperty
+  def current(cls):
+    return cls(get_normalized_os_name())
 
 
 def _list_field(func):
@@ -155,7 +158,7 @@ class _Executable(_ExtensibleAlgebraic):
     :rtype: list of str
     """
 
-  _platform = Platform.create()
+  _platform = Platform.current
 
   @property
   def invocation_environment_dict(self):
@@ -299,5 +302,5 @@ class HostLibcDev(datatype(['crti_object', 'fingerprint'])): pass
 
 def create_native_environment_rules():
   return [
-    SingletonRule(Platform, Platform.create()),
+    SingletonRule(Platform, Platform.current),
   ]

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -44,7 +44,13 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
     return self.get_target_mirrored_option('compiler_option_sets', target)
 
   def get_toolchain_variant_for_target(self, target):
-    return ToolchainVariant(self.get_target_mirrored_option('toolchain_variant', target))
+    # TODO(#7233): convert this option into an enum instance using the `type` argument in option
+    # registration!
+    enum_or_value = self.get_target_mirrored_option('toolchain_variant', target)
+    if isinstance(enum_or_value, ToolchainVariant):
+      return enum_or_value
+    else:
+      return ToolchainVariant(enum_or_value)
 
   @classproperty
   def get_compiler_option_sets_enabled_default_value(cls):

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -36,7 +36,7 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
                   'for targets of this language.')
 
     register_enum_option(
-      register, ToolchainVariant, '--toolchain-variant', advanced=True,
+      register, ToolchainVariant, '--toolchain-variant', advanced=True, default='gnu',
       help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
            "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
 
@@ -44,7 +44,7 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
     return self.get_target_mirrored_option('compiler_option_sets', target)
 
   def get_toolchain_variant_for_target(self, target):
-    return ToolchainVariant.create(self.get_target_mirrored_option('toolchain_variant', target))
+    return ToolchainVariant(self.get_target_mirrored_option('toolchain_variant', target))
 
   @classproperty
   def get_compiler_option_sets_enabled_default_value(cls):

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -110,7 +110,7 @@ def select_libc_objects(platform, native_toolchain):
 
 @rule(Assembler, [Select(Platform), Select(NativeToolchain)])
 def select_assembler(platform, native_toolchain):
-  if platform == Platform('darwin'):
+  if platform == Platform.darwin:
     assembler = yield Get(Assembler, XCodeCLITools, native_toolchain._xcode_cli_tools)
   else:
     assembler = yield Get(Assembler, Binutils, native_toolchain._binutils)
@@ -127,7 +127,7 @@ class BaseLinker(datatype([('linker', Linker)])):
 # TODO: select the appropriate `Platform` in the `@rule` decl using variants!
 @rule(BaseLinker, [Select(Platform), Select(NativeToolchain)])
 def select_base_linker(platform, native_toolchain):
-  if platform == Platform('darwin'):
+  if platform == Platform.darwin:
     # TODO(#5663): turn this into LLVM when lld works.
     linker = yield Get(Linker, XCodeCLITools, native_toolchain._xcode_cli_tools)
   else:
@@ -172,7 +172,7 @@ def select_gcc_install_location(gcc):
 def select_llvm_c_toolchain(platform, native_toolchain):
   provided_clang = yield Get(CCompiler, LLVM, native_toolchain._llvm)
 
-  if platform == Platform('darwin'):
+  if platform == Platform.darwin:
     xcode_clang = yield Get(CCompiler, XCodeCLITools, native_toolchain._xcode_cli_tools)
     joined_c_compiler = provided_clang.sequence(xcode_clang)
   else:
@@ -200,7 +200,7 @@ def select_llvm_cpp_toolchain(platform, native_toolchain):
 
   # On OSX, we use the libc++ (LLVM) C++ standard library implementation. This is feature-complete
   # for OSX, but not for Linux (see https://libcxx.llvm.org/ for more info).
-  if platform == Platform('darwin'):
+  if platform == Platform.darwin:
     xcode_clangpp = yield Get(CppCompiler, XCodeCLITools, native_toolchain._xcode_cli_tools)
     joined_cpp_compiler = provided_clangpp.sequence(xcode_clangpp)
     extra_llvm_linking_library_dirs = []
@@ -242,7 +242,7 @@ def select_llvm_cpp_toolchain(platform, native_toolchain):
 def select_gcc_c_toolchain(platform, native_toolchain):
   provided_gcc = yield Get(CCompiler, GCC, native_toolchain._gcc)
 
-  if platform == Platform('darwin'):
+  if platform == Platform.darwin:
     # GCC needs access to some headers that are only provided by the XCode toolchain
     # currently (e.g. "_stdio.h"). These headers are unlikely to change across versions, so this is
     # probably safe.
@@ -267,7 +267,7 @@ def select_gcc_c_toolchain(platform, native_toolchain):
 def select_gcc_cpp_toolchain(platform, native_toolchain):
   provided_gpp = yield Get(CppCompiler, GCC, native_toolchain._gcc)
 
-  if platform == Platform('darwin'):
+  if platform == Platform.darwin:
     # GCC needs access to some headers that are only provided by the XCode toolchain
     # currently (e.g. "_stdio.h"). These headers are unlikely to change across versions, so this is
     # probably safe.

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -110,7 +110,7 @@ def select_libc_objects(platform, native_toolchain):
 
 @rule(Assembler, [Select(Platform), Select(NativeToolchain)])
 def select_assembler(platform, native_toolchain):
-  if platform.normalized_os_name == 'darwin':
+  if platform == Platform('darwin'):
     assembler = yield Get(Assembler, XCodeCLITools, native_toolchain._xcode_cli_tools)
   else:
     assembler = yield Get(Assembler, Binutils, native_toolchain._binutils)
@@ -127,7 +127,7 @@ class BaseLinker(datatype([('linker', Linker)])):
 # TODO: select the appropriate `Platform` in the `@rule` decl using variants!
 @rule(BaseLinker, [Select(Platform), Select(NativeToolchain)])
 def select_base_linker(platform, native_toolchain):
-  if platform.normalized_os_name == 'darwin':
+  if platform == Platform('darwin'):
     # TODO(#5663): turn this into LLVM when lld works.
     linker = yield Get(Linker, XCodeCLITools, native_toolchain._xcode_cli_tools)
   else:
@@ -172,7 +172,7 @@ def select_gcc_install_location(gcc):
 def select_llvm_c_toolchain(platform, native_toolchain):
   provided_clang = yield Get(CCompiler, LLVM, native_toolchain._llvm)
 
-  if platform.normalized_os_name == 'darwin':
+  if platform == Platform('darwin'):
     xcode_clang = yield Get(CCompiler, XCodeCLITools, native_toolchain._xcode_cli_tools)
     joined_c_compiler = provided_clang.sequence(xcode_clang)
   else:
@@ -200,9 +200,9 @@ def select_llvm_cpp_toolchain(platform, native_toolchain):
 
   # On OSX, we use the libc++ (LLVM) C++ standard library implementation. This is feature-complete
   # for OSX, but not for Linux (see https://libcxx.llvm.org/ for more info).
-  if platform.normalized_os_name == 'darwin':
-    xcode_clang = yield Get(CppCompiler, XCodeCLITools, native_toolchain._xcode_cli_tools)
-    joined_cpp_compiler = provided_clangpp.sequence(xcode_clang)
+  if platform == Platform('darwin'):
+    xcode_clangpp = yield Get(CppCompiler, XCodeCLITools, native_toolchain._xcode_cli_tools)
+    joined_cpp_compiler = provided_clangpp.sequence(xcode_clangpp)
     extra_llvm_linking_library_dirs = []
     linker_extra_args = []
   else:
@@ -242,7 +242,7 @@ def select_llvm_cpp_toolchain(platform, native_toolchain):
 def select_gcc_c_toolchain(platform, native_toolchain):
   provided_gcc = yield Get(CCompiler, GCC, native_toolchain._gcc)
 
-  if platform.normalized_os_name == 'darwin':
+  if platform == Platform('darwin'):
     # GCC needs access to some headers that are only provided by the XCode toolchain
     # currently (e.g. "_stdio.h"). These headers are unlikely to change across versions, so this is
     # probably safe.
@@ -267,7 +267,7 @@ def select_gcc_c_toolchain(platform, native_toolchain):
 def select_gcc_cpp_toolchain(platform, native_toolchain):
   provided_gpp = yield Get(CppCompiler, GCC, native_toolchain._gcc)
 
-  if platform.normalized_os_name == 'darwin':
+  if platform == Platform('darwin'):
     # GCC needs access to some headers that are only provided by the XCode toolchain
     # currently (e.g. "_stdio.h"). These headers are unlikely to change across versions, so this is
     # probably safe.

--- a/src/python/pants/backend/native/targets/native_library.py
+++ b/src/python/pants/backend/native/targets/native_library.py
@@ -51,7 +51,7 @@ class NativeLibrary(Target, AbstractClass):
     if not self.payload.toolchain_variant:
       return None
 
-    return ToolchainVariant.create(self.payload.toolchain_variant)
+    return ToolchainVariant(self.payload.toolchain_variant)
 
   @property
   def strict_deps(self):

--- a/src/python/pants/backend/native/tasks/conan_fetch.py
+++ b/src/python/pants/backend/native/tasks/conan_fetch.py
@@ -124,7 +124,7 @@ class ConanFetch(SimpleCodegenTask):
 
   @memoized_property
   def _conan_os_name(self):
-    return Platform.create().resolve_for_enum_variant({
+    return Platform.current.resolve_for_enum_variant({
       'darwin': 'Macos',
       'linux': 'Linux',
     })

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -64,7 +64,7 @@ class LinkSharedLibraries(NativeTask):
   @memoized_property
   def platform(self):
     # TODO: convert this to a v2 engine dependency injection.
-    return Platform.create()
+    return Platform.current
 
   def execute(self):
     targets_providing_artifacts = self.context.targets(NativeLibrary.produces_ctypes_native_library)

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -52,16 +52,15 @@ class PathGlobs(datatype([
 
     :param include: A list of filespecs to include.
     :param exclude: A list of filespecs to exclude.
-    :param glob_match_error_behavior: The value to pass to GlobMatchErrorBehavior.create()
+    :param glob_match_error_behavior: The value to pass to the GlobMatchErrorBehavior constructor.
     :rtype: :class:`PathGlobs`
     """
     return super(PathGlobs, cls).__new__(
       cls,
       include=tuple(include),
       exclude=tuple(exclude),
-      glob_match_error_behavior=GlobMatchErrorBehavior.create(glob_match_error_behavior,
-                                                              none_is_default=True),
-      conjunction=GlobExpansionConjunction.create(conjunction, none_is_default=True))
+      glob_match_error_behavior=GlobMatchErrorBehavior.create(glob_match_error_behavior),
+      conjunction=GlobExpansionConjunction.create(conjunction))
 
 
 class Digest(datatype([('fingerprint', text_type), ('serialized_bytes_length', int)])):

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -62,8 +62,8 @@ class PathGlobs(datatype([
       cls,
       include=tuple(include),
       exclude=tuple(exclude),
-      glob_match_error_behavior=GlobMatchErrorBehavior.create(glob_match_error_behavior),
-      conjunction=GlobExpansionConjunction.create(conjunction))
+      glob_match_error_behavior=(glob_match_error_behavior or GlobMatchErrorBehavior('ignore')),
+      conjunction=(conjunction or GlobExpansionConjunction('any_match')))
 
 
 class Digest(datatype([('fingerprint', text_type), ('serialized_bytes_length', int)])):

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -62,8 +62,8 @@ class PathGlobs(datatype([
       cls,
       include=tuple(include),
       exclude=tuple(exclude),
-      glob_match_error_behavior=(glob_match_error_behavior or GlobMatchErrorBehavior('ignore')),
-      conjunction=(conjunction or GlobExpansionConjunction('any_match')))
+      glob_match_error_behavior=(glob_match_error_behavior or GlobMatchErrorBehavior.error),
+      conjunction=(conjunction or GlobExpansionConjunction.any_match))
 
 
 class Digest(datatype([('fingerprint', text_type), ('serialized_bytes_length', int)])):

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -62,7 +62,7 @@ class PathGlobs(datatype([
       cls,
       include=tuple(include),
       exclude=tuple(exclude),
-      glob_match_error_behavior=(glob_match_error_behavior or GlobMatchErrorBehavior.error),
+      glob_match_error_behavior=(glob_match_error_behavior or GlobMatchErrorBehavior.ignore),
       conjunction=(conjunction or GlobExpansionConjunction.any_match))
 
 

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -52,7 +52,10 @@ class PathGlobs(datatype([
 
     :param include: A list of filespecs to include.
     :param exclude: A list of filespecs to exclude.
-    :param glob_match_error_behavior: The value to pass to the GlobMatchErrorBehavior constructor.
+    :param GlobMatchErrorBehavior glob_match_error_behavior: How to respond to globs matching no
+                                                             files.
+    :param GlobExpansionConjunction conjunction: Whether all globs are expected to match at least
+                                                 one file, or if any glob matching is ok.
     :rtype: :class:`PathGlobs`
     """
     return super(PathGlobs, cls).__new__(

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -66,13 +66,13 @@ class TargetAdaptor(StructWithDeps):
         globs = Globs(*self.default_sources_globs,
                       spec_path=self.address.spec_path,
                       exclude=self.default_sources_exclude_globs or [])
-        conjunction_globs = GlobsWithConjunction(globs, GlobExpansionConjunction.create('any_match'))
+        conjunction_globs = GlobsWithConjunction(globs, GlobExpansionConjunction('any_match'))
       else:
         globs = None
         conjunction_globs = None
     else:
       globs = BaseGlobs.from_sources_field(sources, self.address.spec_path)
-      conjunction_globs = GlobsWithConjunction(globs, GlobExpansionConjunction.create('all_match'))
+      conjunction_globs = GlobsWithConjunction(globs, GlobExpansionConjunction('all_match'))
 
     return conjunction_globs
 
@@ -235,7 +235,7 @@ class AppAdaptor(TargetAdaptor):
       # TODO: we want to have this field set from the global option --glob-expansion-failure, or
       # something set on the target. Should we move --glob-expansion-failure to be a bootstrap
       # option? See #5864.
-      path_globs = base_globs.to_path_globs(rel_root, GlobExpansionConjunction.create('all_match'))
+      path_globs = base_globs.to_path_globs(rel_root, GlobExpansionConjunction('all_match'))
 
       filespecs_list.append(base_globs.filespecs)
       path_globs_list.append(path_globs)
@@ -263,7 +263,7 @@ class PythonTargetAdaptor(TargetAdaptor):
       if getattr(self, 'resources', None) is None:
         return field_adaptors
       base_globs = BaseGlobs.from_sources_field(self.resources, self.address.spec_path)
-      path_globs = base_globs.to_path_globs(self.address.spec_path, GlobExpansionConjunction.create('all_match'))
+      path_globs = base_globs.to_path_globs(self.address.spec_path, GlobExpansionConjunction('all_match'))
       sources_field = SourcesField(self.address,
                                    'resources',
                                    base_globs.filespecs,
@@ -425,4 +425,4 @@ class GlobsWithConjunction(datatype([
 
   @classmethod
   def for_literal_files(cls, file_paths, spec_path):
-    return cls(Files(*file_paths, spec_path=spec_path), GlobExpansionConjunction.create('all_match'))
+    return cls(Files(*file_paths, spec_path=spec_path), GlobExpansionConjunction('all_match'))

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -66,13 +66,13 @@ class TargetAdaptor(StructWithDeps):
         globs = Globs(*self.default_sources_globs,
                       spec_path=self.address.spec_path,
                       exclude=self.default_sources_exclude_globs or [])
-        conjunction_globs = GlobsWithConjunction(globs, GlobExpansionConjunction('any_match'))
+        conjunction_globs = GlobsWithConjunction(globs, GlobExpansionConjunction.any_match)
       else:
         globs = None
         conjunction_globs = None
     else:
       globs = BaseGlobs.from_sources_field(sources, self.address.spec_path)
-      conjunction_globs = GlobsWithConjunction(globs, GlobExpansionConjunction('all_match'))
+      conjunction_globs = GlobsWithConjunction(globs, GlobExpansionConjunction.all_match)
 
     return conjunction_globs
 
@@ -235,7 +235,7 @@ class AppAdaptor(TargetAdaptor):
       # TODO: we want to have this field set from the global option --glob-expansion-failure, or
       # something set on the target. Should we move --glob-expansion-failure to be a bootstrap
       # option? See #5864.
-      path_globs = base_globs.to_path_globs(rel_root, GlobExpansionConjunction('all_match'))
+      path_globs = base_globs.to_path_globs(rel_root, GlobExpansionConjunction.all_match)
 
       filespecs_list.append(base_globs.filespecs)
       path_globs_list.append(path_globs)
@@ -263,7 +263,7 @@ class PythonTargetAdaptor(TargetAdaptor):
       if getattr(self, 'resources', None) is None:
         return field_adaptors
       base_globs = BaseGlobs.from_sources_field(self.resources, self.address.spec_path)
-      path_globs = base_globs.to_path_globs(self.address.spec_path, GlobExpansionConjunction('all_match'))
+      path_globs = base_globs.to_path_globs(self.address.spec_path, GlobExpansionConjunction.all_match)
       sources_field = SourcesField(self.address,
                                    'resources',
                                    base_globs.filespecs,
@@ -425,4 +425,4 @@ class GlobsWithConjunction(datatype([
 
   @classmethod
   def for_literal_files(cls, file_paths, spec_path):
-    return cls(Files(*file_paths, spec_path=spec_path), GlobExpansionConjunction('all_match'))
+    return cls(Files(*file_paths, spec_path=spec_path), GlobExpansionConjunction.all_match)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -348,7 +348,7 @@ class EngineInitializer(object):
     rules = (
       [
         RootRule(Console),
-        SingletonRule.from_instance(glob_match_error_behavior or GlobMatchErrorBehavior('ignore')),
+        SingletonRule.from_instance(glob_match_error_behavior or GlobMatchErrorBehavior.error),
         SingletonRule.from_instance(build_configuration),
         SingletonRule(SymbolTable, symbol_table),
       ] +

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -346,8 +346,7 @@ class EngineInitializer(object):
     rules = (
       [
         RootRule(Console),
-        SingletonRule.from_instance(GlobMatchErrorBehavior.create(glob_match_error_behavior,
-                                                                  none_is_default=True)),
+        SingletonRule.from_instance(GlobMatchErrorBehavior.create(glob_match_error_behavior)),
         SingletonRule.from_instance(build_configuration),
         SingletonRule(SymbolTable, symbol_table),
       ] +

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -262,7 +262,9 @@ class EngineInitializer(object):
       options_bootstrapper,
       build_configuration,
       native=native,
-      glob_match_error_behavior=bootstrap_options.glob_expansion_failure,
+      # TODO(#7233): convert this into an enum instance using the `type` argument in option
+      # registration!
+      glob_match_error_behavior=GlobMatchErrorBehavior(bootstrap_options.glob_expansion_failure),
       build_ignore_patterns=bootstrap_options.build_ignore,
       exclude_target_regexps=bootstrap_options.exclude_target_regexp,
       subproject_roots=bootstrap_options.subproject_roots,
@@ -346,7 +348,7 @@ class EngineInitializer(object):
     rules = (
       [
         RootRule(Console),
-        SingletonRule.from_instance(GlobMatchErrorBehavior.create(glob_match_error_behavior)),
+        SingletonRule.from_instance(glob_match_error_behavior or GlobMatchErrorBehavior('ignore')),
         SingletonRule.from_instance(build_configuration),
         SingletonRule(SymbolTable, symbol_table),
       ] +

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -348,7 +348,7 @@ class EngineInitializer(object):
     rules = (
       [
         RootRule(Console),
-        SingletonRule.from_instance(glob_match_error_behavior or GlobMatchErrorBehavior.error),
+        SingletonRule.from_instance(glob_match_error_behavior or GlobMatchErrorBehavior.ignore),
         SingletonRule.from_instance(build_configuration),
         SingletonRule(SymbolTable, symbol_table),
       ] +

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -317,5 +317,6 @@ class GlobExpansionConjunction(enum(['any_match', 'all_match'], field_name='conj
 
   @classmethod
   def create(cls, value=None):
+    # TODO: add testing for this value!
     value = value or 'any_match'
     return cls(value)

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -308,9 +308,14 @@ class DictValueComponent(object):
     return '{} {}'.format(self.action, self.val)
 
 
-class GlobExpansionConjunction(enum('conjunction', ['any_match', 'all_match'])):
+class GlobExpansionConjunction(enum(['any_match', 'all_match'], field_name='conjunction')):
+  """Describe whether to require that only some or all glob strings match in a target's sources.
 
-  # NB: The `default_value` is automatically the first element of the value list, but can be
-  # overridden or made more explicit in the body of the class. We want to be explicit here about
-  # which behavior we have when merging globs, as that can affect performance.
-  default_value = 'any_match'
+  NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
+  be aware of any changes to this object's definition.
+  """
+
+  @classmethod
+  def create(cls, value=None):
+    value = None or 'any_match'
+    return cls(value)

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -317,5 +317,5 @@ class GlobExpansionConjunction(enum(['any_match', 'all_match'], field_name='conj
 
   @classmethod
   def create(cls, value=None):
-    value = None or 'any_match'
+    value = value or 'any_match'
     return cls(value)

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -308,7 +308,7 @@ class DictValueComponent(object):
     return '{} {}'.format(self.action, self.val)
 
 
-class GlobExpansionConjunction(enum(['any_match', 'all_match'], field_name='conjunction')):
+class GlobExpansionConjunction(enum(['any_match', 'all_match'])):
   """Describe whether to require that only some or all glob strings match in a target's sources.
 
   NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
@@ -319,4 +319,8 @@ class GlobExpansionConjunction(enum(['any_match', 'all_match'], field_name='conj
   def create(cls, value=None):
     # TODO: add testing for this value!
     value = value or 'any_match'
+    # If passed an instance of the object, just return it. This makes copying glob expansion
+    # settings from elsewhere when constructing PathGlobs more ergonomic.
+    if isinstance(value, cls):
+      return value
     return cls(value)

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -314,13 +314,3 @@ class GlobExpansionConjunction(enum(['any_match', 'all_match'])):
   NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
   be aware of any changes to this object's definition.
   """
-
-  @classmethod
-  def create(cls, value=None):
-    # TODO: add testing for this value!
-    value = value or 'any_match'
-    # If passed an instance of the object, just return it. This makes copying glob expansion
-    # settings from elsewhere when constructing PathGlobs more ergonomic.
-    if isinstance(value, cls):
-      return value
-    return cls(value)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -28,6 +28,7 @@ class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'], field_name='failu
 
   @classmethod
   def create(cls, value=None):
+    # TODO: add testing for this value!
     value = value or 'ignore'
     return cls(value)
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -28,7 +28,7 @@ class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'], field_name='failu
 
   @classmethod
   def create(cls, value=None):
-    value = None or 'ignore'
+    value = value or 'ignore'
     return cls(value)
 
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -26,16 +26,6 @@ class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'])):
   be aware of any changes to this object's definition.
   """
 
-  @classmethod
-  def create(cls, value=None):
-    # TODO: add testing for this value!
-    value = value or 'ignore'
-    # If passed an instance of the object, just return it. This makes copying glob expansion
-    # settings from elsewhere when constructing PathGlobs more ergonomic.
-    if isinstance(value, cls):
-      return value
-    return cls(value)
-
 
 class ExecutionOptions(datatype([
   'remote_store_server',

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -19,7 +19,7 @@ from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 from pants.util.objects import datatype, enum, register_enum_option
 
 
-class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'], field_name='failure_behavior')):
+class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'])):
   """Describe the action to perform when matching globs in BUILD files to source files.
 
   NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
@@ -30,6 +30,10 @@ class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'], field_name='failu
   def create(cls, value=None):
     # TODO: add testing for this value!
     value = value or 'ignore'
+    # If passed an instance of the object, just return it. This makes copying glob expansion
+    # settings from elsewhere when constructing PathGlobs more ergonomic.
+    if isinstance(value, cls):
+      return value
     return cls(value)
 
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -19,12 +19,17 @@ from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 from pants.util.objects import datatype, enum, register_enum_option
 
 
-class GlobMatchErrorBehavior(enum('failure_behavior', ['ignore', 'warn', 'error'])):
+class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'], field_name='failure_behavior')):
   """Describe the action to perform when matching globs in BUILD files to source files.
 
   NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
   be aware of any changes to this object's definition.
   """
+
+  @classmethod
+  def create(cls, value=None):
+    value = None or 'ignore'
+    return cls(value)
 
 
 class ExecutionOptions(datatype([

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -115,6 +115,7 @@ python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:future',
+    '3rdparty/python:six',
     ':collections_abc_backport',
     ':memo',
     ':meta',

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -8,6 +8,7 @@ from abc import abstractmethod
 from builtins import zip
 from collections import namedtuple
 
+import six
 from twitter.common.collections import OrderedSet
 
 from pants.util.collections_abc_backport import Iterable, OrderedDict
@@ -205,7 +206,7 @@ class EnumVariantSelectionError(TypeCheckError):
   """Raised when an invalid variant for an enum() is constructed or matched against."""
 
 
-def enum(*args):
+def enum(all_values, field_name='value'):
   """A datatype which can take on a finite set of values. This method is experimental and unstable.
 
   Any enum subclass can be constructed with its create() classmethod. This method will use the first
@@ -217,21 +218,12 @@ def enum(*args):
   instances more readable when printed, and to allow code in another language using an FFI to
   reliably extract the value from an enum instance.
 
-  :param string field_name: A string used as the field for the datatype. This positional argument is
-                            optional, and defaults to 'value'. Note that `enum()` does not yet
-                            support type checking as with `datatype()`.
   :param Iterable all_values: A nonempty iterable of objects representing all possible values for
                               the enum.  This argument must be a finite, non-empty iterable with
                               unique values.
+  :param string field_name: A string used as the field for the datatype.
   :raises: :class:`ValueError`
   """
-  if len(args) == 1:
-    field_name = 'value'
-    all_values, = args
-  elif len(args) == 2:
-    field_name, all_values = args
-  else:
-    raise ValueError("enum() accepts only 1 or 2 args! args = {!r}".format(args))
 
   # This call to list() will eagerly evaluate any `all_values` which would otherwise be lazy, such
   # as a generator.
@@ -247,8 +239,6 @@ def enum(*args):
                      .format(all_values_realized, list(allowed_values_set)))
 
   class ChoiceDatatype(datatype([field_name])):
-    default_value = next(iter(allowed_values_set))
-
     # Overriden from datatype() so providing an invalid variant is catchable as a TypeCheckError,
     # but more specific.
     type_check_error_type = EnumVariantSelectionError
@@ -276,56 +266,11 @@ def enum(*args):
       return list(cls._singletons.keys())
 
     def __new__(cls, value):
-      """Forward `value` to the .create() factory method.
-
-      The .create() factory method is preferred, but forwarding the constructor like this allows us
-      to use the generated enum type both as a type to check against with isinstance() as well as a
-      function to create instances with. This makes it easy to use as a pants option type.
-      """
-      return cls.create(value)
-
-    # TODO: figure out if this will always trigger on primitives like strings, and what situations
-    # won't call this __eq__ (and therefore won't raise like we want).
-    def __eq__(self, other):
-      """Redefine equality to raise to nudge people to use static pattern matching."""
-      raise self.make_type_error(
-        "enum equality is defined to be an error -- use .resolve_for_enum_variant() instead!")
-    # Redefine the canary so datatype __new__ doesn't raise.
-    __eq__._eq_override_canary = None
-
-    # NB: as noted in datatype(), __hash__ must be explicitly implemented whenever __eq__ is
-    # overridden. See https://docs.python.org/3/reference/datamodel.html#object.__hash__.
-    def __hash__(self):
-      return super(ChoiceDatatype, self).__hash__()
-
-    @classmethod
-    def create(cls, *args, **kwargs):
-      """Create an instance of this enum, using the default value if specified.
+      """Create an instance of this enum.
 
       :param value: Use this as the enum value. If `value` is an instance of this class, return it,
-                    otherwise it is checked against the enum's allowed values. This positional
-                    argument is optional, and if not specified, `cls.default_value` is used.
-      :param bool none_is_default: If this is True, a None `value` is converted into
-                                   `cls.default_value` before being checked against the enum's
-                                   allowed values.
+                    otherwise it is checked against the enum's allowed values.
       """
-      none_is_default = kwargs.pop('none_is_default', False)
-      if kwargs:
-        raise ValueError('unrecognized keyword arguments for {}.create(): {!r}'
-                         .format(cls.__name__, kwargs))
-
-      if len(args) == 0:
-        value = cls.default_value
-      elif len(args) == 1:
-        value = args[0]
-        if none_is_default and value is None:
-          value = cls.default_value
-      else:
-        raise ValueError('{}.create() accepts 0 or 1 positional args! *args = {!r}'
-                         .format(cls.__name__, args))
-
-      # If we get an instance of this enum class, just return it. This means you can call .create()
-      # on an allowed value for the enum, or an existing instance of the enum.
       if isinstance(value, cls):
         return value
 
@@ -334,6 +279,22 @@ def enum(*args):
           "Value {!r} for '{}' must be one of: {!r}."
           .format(value, field_name, cls._allowed_values))
       return cls._singletons[value]
+
+    # TODO: figure out if this will always trigger on primitives like strings, and what situations
+    # won't call this __eq__ (and therefore won't raise like we want).
+    def __eq__(self, other):
+      """Redefine equality to avoid accidentally comparing against a non-enum."""
+      if type(self) != type(other):
+        raise self.make_type_error(
+          "enum equality is only defined for instances of the same enum class!")
+      return super(ChoiceDatatype, self).__eq__(other)
+    # Redefine the canary so datatype __new__ doesn't raise.
+    __eq__._eq_override_canary = None
+
+    # NB: as noted in datatype(), __hash__ must be explicitly implemented whenever __eq__ is
+    # overridden. See https://docs.python.org/3/reference/datamodel.html#object.__hash__.
+    def __hash__(self):
+      return super(ChoiceDatatype, self).__hash__()
 
     def resolve_for_enum_variant(self, mapping):
       """Return the object in `mapping` with the key corresponding to the enum value.
@@ -369,8 +330,7 @@ def enum(*args):
 # TODO(#7233): allow usage of the normal register() by using an enum class as the `type` argument!
 def register_enum_option(register, enum_cls, *args, **kwargs):
   """A helper method for declaring a pants option from an `enum()`."""
-  default_value = kwargs.pop('default', enum_cls.default_value)
-  register(*args, choices=enum_cls._allowed_values, default=default_value, **kwargs)
+  register(*args, choices=enum_cls._allowed_values, **kwargs)
 
 
 # TODO: make these members of the `TypeConstraint` class!

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -219,15 +219,15 @@ def enum(all_values):
   class MyResult(enum(['success', 'failure'])):
     pass
 
-  MyResult.success # The same as: MyResult(success)
-  MyResult.failure # The same as: MyResult(failure)
+  MyResult.success # The same as: MyResult('success')
+  MyResult.failure # The same as: MyResult('failure')
 
   :param Iterable all_values: A nonempty iterable of objects representing all possible values for
                               the enum.  This argument must be a finite, non-empty iterable with
                               unique values.
   :raises: :class:`ValueError`
   """
-  # namedtuple() raises a ValueError if you try to use a field with an underscore.
+  # namedtuple() raises a ValueError if you try to use a field with a leading underscore.
   field_name = 'value'
 
   # This call to list() will eagerly evaluate any `all_values` which would otherwise be lazy, such

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -295,7 +295,9 @@ def enum(all_values, field_name='value'):
       """Redefine equality to avoid accidentally comparing against a non-enum."""
       if type(self) != type(other):
         raise self.make_type_error(
-          "enum equality is only defined for instances of the same enum class!")
+          "when comparing against {!r} with type '{}': "
+          "enum equality is only defined for instances of the same enum class!"
+          .format(other, type(other).__name__))
       return super(ChoiceDatatype, self).__eq__(other)
     # Redefine the canary so datatype __new__ doesn't raise.
     __eq__._eq_override_canary = None

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -504,11 +504,11 @@ impl Snapshot {
 
     let glob_match_error_behavior =
       externs::project_ignoring_type(item, "glob_match_error_behavior");
-    let failure_behavior = externs::project_str(&glob_match_error_behavior, "failure_behavior");
+    let failure_behavior = externs::project_str(&glob_match_error_behavior, "value");
     let strict_glob_matching = StrictGlobMatching::create(failure_behavior.as_str())?;
 
     let conjunction_obj = externs::project_ignoring_type(item, "conjunction");
-    let conjunction_string = externs::project_str(&conjunction_obj, "conjunction");
+    let conjunction_string = externs::project_str(&conjunction_obj, "value");
     let conjunction = GlobExpansionConjunction::create(&conjunction_string)?;
 
     PathGlobs::create(&include, &exclude, strict_glob_matching, conjunction).map_err(|e| {

--- a/tests/python/pants_test/backend/native/subsystems/test_libc_resolution.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_libc_resolution.py
@@ -23,7 +23,7 @@ class TestLibcDirectorySearchFailure(TestBase):
     })
 
     self.libc = global_subsystem_instance(LibcDev)
-    self.platform = Platform.create()
+    self.platform = Platform.current
 
   def test_libc_search_failure(self):
     with self.assertRaises(LibcDev.HostLibcDevResolutionError) as cm:
@@ -44,7 +44,7 @@ class TestLibcSearchDisabled(TestBase):
     })
 
     self.libc = global_subsystem_instance(LibcDev)
-    self.platform = Platform.create()
+    self.platform = Platform.current
 
   def test_libc_disabled_search(self):
     self.assertEqual([], self.libc.get_libc_objects())
@@ -61,7 +61,7 @@ class TestLibcCompilerSearchFailure(TestBase):
     })
 
     self.libc = global_subsystem_instance(LibcDev)
-    self.platform = Platform.create()
+    self.platform = Platform.current
 
   @platform_specific('linux')
   def test_libc_compiler_search_failure(self):

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -36,7 +36,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
       },
     })
 
-    self.platform = Platform.create()
+    self.platform = Platform.current
     self.toolchain = global_subsystem_instance(NativeToolchain)
     self.rules = native_backend_rules()
 

--- a/tests/python/pants_test/backend/native/util/platform_utils.py
+++ b/tests/python/pants_test/backend/native/util/platform_utils.py
@@ -14,11 +14,7 @@ def platform_specific(normalized_os_name):
 
   def decorator(test_fn):
     def wrapper(self, *args, **kwargs):
-      # TODO: This should be drawn from the v2 engine somehow.
-      platform = Platform.create()
-
-      if platform.normalized_os_name == normalized_os_name:
+      if Platform.current == Platform(normalized_os_name):
         test_fn(self, *args, **kwargs)
-
     return wrapper
   return decorator

--- a/tests/python/pants_test/backend/python/targets/test_unpacked_whls.py
+++ b/tests/python/pants_test/backend/python/targets/test_unpacked_whls.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import str
 from textwrap import dedent
 
 from pants.backend.python.python_requirement import PythonRequirement
@@ -56,6 +57,9 @@ class UnpackedWheelsTest(TestBase):
     def assert_dep(reqA, reqB):
       self.assertEqual(reqA.requirement, reqB.requirement)
 
+    def sort_requirements(reqs):
+      return list(sorted(reqs, key=lambda r: str(r.requirement)))
+
     self.add_to_build_file('BUILD', dedent('''
     python_requirement_library(name='lib1',
       requirements=[
@@ -80,13 +84,13 @@ class UnpackedWheelsTest(TestBase):
 
     lib2 = self.target('//:lib2')
     self.assertIsInstance(lib2, PythonRequirementLibrary)
-    lib2_reqs = list(lib2.requirements)
+    lib2_reqs = sort_requirements(lib2.requirements)
     self.assertEqual(2, len(lib2_reqs))
     assert_dep(lib2_reqs[0], PythonRequirement('testName2==456'))
     assert_dep(lib2_reqs[1], PythonRequirement('testName3==789'))
 
     unpacked_lib = self.target('//:unpacked-lib')
-    unpacked_req_libs = unpacked_lib.all_imported_requirements
+    unpacked_req_libs = sort_requirements(unpacked_lib.all_imported_requirements)
 
     self.assertEqual(3, len(unpacked_req_libs))
     assert_dep(unpacked_req_libs[0], PythonRequirement('testName1==123'))

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -96,7 +96,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
       dist_name, dist_version, wheel_platform = name_and_platform(wheel_dist)
       self.assertEqual(dist_name, 'ctypes_test')
-      contains_current_platform = Platform.create().resolve_for_enum_variant({
+      contains_current_platform = Platform.current.resolve_for_enum_variant({
         'darwin': wheel_platform.startswith('macosx'),
         'linux': wheel_platform.startswith('linux'),
       })
@@ -152,11 +152,8 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
     # TODO(#6848): we need to provide the libstdc++.so.6.dylib which comes with gcc on osx in the
     # DYLD_LIBRARY_PATH during the 'run' goal somehow.
-    attempt_pants_run = Platform.create().resolve_for_enum_variant({
-      'darwin': toolchain_variant.resolve_for_enum_variant({
-        'gnu': False,
-        'llvm': True,
-      }),
+    attempt_pants_run = Platform.current.resolve_for_enum_variant({
+      'darwin': toolchain_variant == ToolchainVariant('llvm'),
       'linux': True,
     })
     if attempt_pants_run:
@@ -182,11 +179,8 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
     # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
     # be available on the runtime library path.
-    attempt_pants_run = Platform.create().resolve_for_enum_variant({
-      'darwin': toolchain_variant.resolve_for_enum_variant({
-        'gnu': False,
-        'llvm': True,
-      }),
+    attempt_pants_run = Platform.current.resolve_for_enum_variant({
+      'darwin': toolchain_variant == ToolchainVariant('llvm'),
       'linux': True,
     })
     if attempt_pants_run:

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -56,7 +56,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
           'pants_distdir': tmp_dir,
         },
         'native-build-step': {
-          'toolchain_variant': toolchain_variant.value,
+          'toolchain_variant': toolchain_variant.underlying(),
         },
       })
 
@@ -134,7 +134,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         # Explicitly set to True (although this is the default).
         config={
           'native-build-step': {
-            'toolchain_variant': toolchain_variant.value,
+            'toolchain_variant': toolchain_variant.underlying(),
           },
           # TODO(#6848): don't make it possible to forget to add the toolchain_variant option!
           'native-build-settings': {
@@ -153,13 +153,13 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     # TODO(#6848): we need to provide the libstdc++.so.6.dylib which comes with gcc on osx in the
     # DYLD_LIBRARY_PATH during the 'run' goal somehow.
     attempt_pants_run = Platform.current.resolve_for_enum_variant({
-      'darwin': toolchain_variant == ToolchainVariant('llvm'),
+      'darwin': toolchain_variant == ToolchainVariant.llvm,
       'linux': True,
     })
     if attempt_pants_run:
       pants_run_interop = self.run_pants(['-q', 'run', self._binary_target_with_interop], config={
         'native-build-step': {
-          'toolchain_variant': toolchain_variant.value,
+          'toolchain_variant': toolchain_variant.underlying(),
         },
         'native-build-settings': {
           'strict_deps': True,
@@ -172,7 +172,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
   def test_ctypes_third_party_integration(self, toolchain_variant):
     pants_binary = self.run_pants(['binary', self._binary_target_with_third_party], config={
       'native-build-step': {
-        'toolchain_variant': toolchain_variant.value,
+        'toolchain_variant': toolchain_variant.underlying(),
       },
     })
     self.assert_success(pants_binary)
@@ -180,13 +180,13 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
     # be available on the runtime library path.
     attempt_pants_run = Platform.current.resolve_for_enum_variant({
-      'darwin': toolchain_variant == ToolchainVariant('llvm'),
+      'darwin': toolchain_variant == ToolchainVariant.llvm,
       'linux': True,
     })
     if attempt_pants_run:
       pants_run = self.run_pants(['-q', 'run', self._binary_target_with_third_party], config={
         'native-build-step': {
-          'toolchain_variant': toolchain_variant.value,
+          'toolchain_variant': toolchain_variant.underlying(),
         },
       })
       self.assert_success(pants_run)
@@ -241,7 +241,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     ]
     pants_run = self.run_pants(command=command, config={
       'native-build-step': {
-        'toolchain_variant': toolchain_variant.value,
+        'toolchain_variant': toolchain_variant.underlying(),
       },
       'native-build-step.cpp-compile-settings': {
         'compiler_option_sets_enabled_args': {

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -225,11 +225,8 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     """
     # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
     # be available on the runtime library path.
-    attempt_pants_run = Platform.create().resolve_for_enum_variant({
-      'darwin': toolchain_variant.resolve_for_enum_variant({
-        'gnu': False,
-        'llvm': True,
-      }),
+    attempt_pants_run = Platform.current.resolve_for_enum_variant({
+      'darwin': toolchain_variant == ToolchainVariant.llvm,
       'linux': True,
     })
     if not attempt_pants_run:

--- a/tests/python/pants_test/engine/legacy/test_graph_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_graph_integration.py
@@ -61,12 +61,12 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
   _ERR_TARGETS = {
     'testprojects/src/python/sources:some-missing-some-not': [
       "globs('*.txt', '*.rs')",
-      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/python/sources/*.txt\', {unicode_literal}\'testprojects/src/python/sources/*.rs\'), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(conjunction=all_match)))".format(unicode_literal='u' if PY2 else ''),
+      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/python/sources/*.txt\', {unicode_literal}\'testprojects/src/python/sources/*.rs\'), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))".format(unicode_literal='u' if PY2 else ''),
       "Globs did not match. Excludes were: []. Unmatched globs were: [\"testprojects/src/python/sources/*.rs\"].",
     ],
     'testprojects/src/python/sources:missing-sources': [
       "*.scala",
-      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/python/sources/*.scala\',), exclude=({unicode_literal}\'testprojects/src/python/sources/*Test.scala\', {unicode_literal}\'testprojects/src/python/sources/*Spec.scala\'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(conjunction=any_match)))".format(unicode_literal='u' if PY2 else ''),
+      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/python/sources/*.scala\',), exclude=({unicode_literal}\'testprojects/src/python/sources/*Test.scala\', {unicode_literal}\'testprojects/src/python/sources/*Spec.scala\'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=any_match)))".format(unicode_literal='u' if PY2 else ''),
       "Globs did not match. Excludes were: [\"testprojects/src/python/sources/*Test.scala\", \"testprojects/src/python/sources/*Spec.scala\"]. Unmatched globs were: [\"testprojects/src/python/sources/*.scala\"].",
     ],
     'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-bundle-fileset': [
@@ -75,7 +75,7 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       "Globs('*.aaaa')",
       "ZGlobs('**/*.abab')",
       "['file1.aaaa', 'file2.aaaa']",
-      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(failure_behavior=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(conjunction=all_match)))".format(unicode_literal='u' if PY2 else ''),
+      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))".format(unicode_literal='u' if PY2 else ''),
       "Globs did not match. Excludes were: []. Unmatched globs were: [\"testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\"].",
     ]
   }

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -376,7 +376,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       self.assert_walk_files(PathGlobs(
         include=['not-a-file.txt'],
         exclude=[],
-        glob_match_error_behavior=GlobMatchErrorBehavior('error'),
+        glob_match_error_behavior=GlobMatchErrorBehavior.error,
       ), [])
     expected_msg = (
       "Globs did not match. Excludes were: []. Unmatched globs were: [\"not-a-file.txt\"].")
@@ -387,7 +387,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       self.assert_walk_files(PathGlobs(
         include=['*.txt'],
         exclude=['4.txt'],
-        glob_match_error_behavior=GlobMatchErrorBehavior('error'),
+        glob_match_error_behavior=GlobMatchErrorBehavior.error,
       ), [])
     expected_msg = (
       "Globs did not match. Excludes were: [\"4.txt\"]. Unmatched globs were: [\"*.txt\"].")
@@ -398,7 +398,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       self.assert_walk_files(PathGlobs(
         include=['not-a-file.txt'],
         exclude=[''],
-        glob_match_error_behavior=GlobMatchErrorBehavior('ignore'),
+        glob_match_error_behavior=GlobMatchErrorBehavior.ignore,
       ), [])
       self.assertEqual(0, len(captured.warnings()))
 
@@ -408,7 +408,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       self.assert_walk_files(PathGlobs(
         include=['not-a-file.txt'],
         exclude=[''],
-        glob_match_error_behavior=GlobMatchErrorBehavior('warn'),
+        glob_match_error_behavior=GlobMatchErrorBehavior.warn,
       ), [])
       all_warnings = captured.warnings()
       self.assertEqual(1, len(all_warnings))

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -17,6 +17,7 @@ from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, Digest, DirectoryToMaterial
                              MergedDirectories, PathGlobs, PathGlobsAndRoot, Snapshot, UrlToFetch,
                              create_fs_rules)
 from pants.engine.scheduler import ExecutionError
+from pants.option.global_options import GlobMatchErrorBehavior
 from pants.util.contextutil import http_server, temporary_dir
 from pants.util.dirutil import relative_symlink
 from pants.util.meta import AbstractClass
@@ -375,7 +376,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       self.assert_walk_files(PathGlobs(
         include=['not-a-file.txt'],
         exclude=[],
-        glob_match_error_behavior='error',
+        glob_match_error_behavior=GlobMatchErrorBehavior('error'),
       ), [])
     expected_msg = (
       "Globs did not match. Excludes were: []. Unmatched globs were: [\"not-a-file.txt\"].")
@@ -386,7 +387,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       self.assert_walk_files(PathGlobs(
         include=['*.txt'],
         exclude=['4.txt'],
-        glob_match_error_behavior='error',
+        glob_match_error_behavior=GlobMatchErrorBehavior('error'),
       ), [])
     expected_msg = (
       "Globs did not match. Excludes were: [\"4.txt\"]. Unmatched globs were: [\"*.txt\"].")
@@ -397,7 +398,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       self.assert_walk_files(PathGlobs(
         include=['not-a-file.txt'],
         exclude=[''],
-        glob_match_error_behavior='ignore',
+        glob_match_error_behavior=GlobMatchErrorBehavior('ignore'),
       ), [])
       self.assertEqual(0, len(captured.warnings()))
 
@@ -407,7 +408,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
       self.assert_walk_files(PathGlobs(
         include=['not-a-file.txt'],
         exclude=[''],
-        glob_match_error_behavior='warn',
+        glob_match_error_behavior=GlobMatchErrorBehavior('warn'),
       ), [])
       all_warnings = captured.warnings()
       self.assertEqual(1, len(all_warnings))

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -736,7 +736,9 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
     self.assertNotEqual(enum_instance, another_enum_instance)
 
     # Test that comparison fails against another type.
-    rx_str = re.escape("enum equality is only defined for instances of the same enum class!")
+    rx_str = re.escape(
+      "when comparing against 1 with type 'int': "
+      "enum equality is only defined for instances of the same enum class!")
     with self.assertRaisesRegexp(TypeCheckError, rx_str):
       enum_instance == 1
     with self.assertRaisesRegexp(TypeCheckError, rx_str):
@@ -744,6 +746,10 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
 
     class StrEnum(enum(['a'])): pass
     enum_instance = StrEnum('a')
+    rx_str = re.escape(
+      "when comparing against {u}'a' with type '{string_type}': "
+      "enum equality is only defined for instances of the same enum class!"
+      .format(u='u' if PY2 else '', string_type='unicode' if PY2 else 'str'))
     with self.assertRaisesRegexp(TypeCheckError, rx_str):
       enum_instance == 'a'
     with self.assertRaisesRegexp(TypeCheckError, rx_str):

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -723,6 +723,11 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
     with self.assertRaisesRegexp(TypeError, re.escape("__new__() got an unexpected keyword argument 'x'")):
       SomeEnum(x=3)
 
+  def test_enum_generated_attrs(self):
+    class HasAttrs(enum(['a', 'b'])): pass
+    self.assertEqual(HasAttrs.a, HasAttrs('a'))
+    self.assertEqual(type(HasAttrs.a), HasAttrs)
+    self.assertEqual(HasAttrs.b, HasAttrs('b'))
 
   def test_enum_comparison(self):
     enum_instance = SomeEnum(1)

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -287,7 +287,7 @@ class ReturnsNotImplemented(object):
     return NotImplemented
 
 
-class SomeEnum(enum([1, 2], field_name='x')): pass
+class SomeEnum(enum([1, 2])): pass
 
 
 class DatatypeTest(TestBase):
@@ -712,16 +712,13 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
       class DuplicateAllowedValues(enum([1, 2, 3, 1])): pass
 
   def test_enum_instance_creation(self):
-    self.assertEqual(2, SomeEnum(2).x)
+    self.assertEqual(2, SomeEnum(2).value)
+    self.assertEqual(SomeEnum(2), SomeEnum(value=2))
 
     expected_rx = re.escape(
-      "Value 3 for 'x' must be one of: [1, 2].")
+      "Value 3 must be one of: [1, 2].")
     with self.assertRaisesRegexp(EnumVariantSelectionError, expected_rx):
       SomeEnum(3)
-
-    # Specifying the value by keyword argument is not allowed.
-    with self.assertRaisesRegexp(TypeError, re.escape("__new__() got an unexpected keyword argument 'x'")):
-      SomeEnum(x=3)
 
   def test_enum_generated_attrs(self):
     class HasAttrs(enum(['a', 'b'])): pass
@@ -737,7 +734,7 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
 
     # Test that comparison fails against another type.
     rx_str = re.escape(
-      "when comparing against 1 with type 'int': "
+      "when comparing SomeEnum(value=1) against 1 with type 'int': "
       "enum equality is only defined for instances of the same enum class!")
     with self.assertRaisesRegexp(TypeCheckError, rx_str):
       enum_instance == 1
@@ -747,7 +744,7 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
     class StrEnum(enum(['a'])): pass
     enum_instance = StrEnum('a')
     rx_str = re.escape(
-      "when comparing against {u}'a' with type '{string_type}': "
+      "when comparing StrEnum(value={u}'a') against {u}'a' with type '{string_type}': "
       "enum equality is only defined for instances of the same enum class!"
       .format(u='u' if PY2 else '', string_type='unicode' if PY2 else 'str'))
     with self.assertRaisesRegexp(TypeCheckError, rx_str):


### PR DESCRIPTION
### Problem

Resolves #7232, resolves #7248, and addresses https://github.com/pantsbuild/pants/pull/7249#discussion_r257653836.

### Solution

- Remove enum defaults and the `.create()` method with complicated argument handling.
- Allow enums to be `==` compared as long as they're the same type.
- Allow accessing enum instances with class attributes.

### Result

enums are nicer!