### PR TITLE
[rsc-compile] bump version; rm metacp jobs; update tests

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -5,18 +5,17 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import functools
-import json
 import logging
 import os
 import re
 
 from future.utils import PY3, text_type
+from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext  # noqa
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.subsystems.shader import Shader
-from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.backend.jvm.targets.junit_tests import JUnitTests
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.classpath_entry import ClasspathEntry
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
@@ -26,15 +25,15 @@ from pants.backend.jvm.tasks.jvm_compile.zinc.zinc_compile import ZincCompile
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
-from pants.build_graph.address import Address
-from pants.build_graph.target import Target
-from pants.engine.fs import Digest, DirectoryToMaterialize, PathGlobs, PathGlobsAndRoot
+from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, Digest, DirectoryToMaterialize, PathGlobs,
+                             PathGlobsAndRoot)
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.java.jar.jar_dependency import JarDependency
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.util.contextutil import Timer
 from pants.util.dirutil import fast_relpath, fast_relpath_optional, safe_mkdir
-from pants.util.memo import memoized_property
+from pants.util.memo import memoized_method, memoized_property
+from pants.util.objects import enum
 
 
 #
@@ -82,12 +81,57 @@ def _paths_from_classpath(classpath_tuples, collection_type=list):
   return collection_type(y[1] for y in classpath_tuples)
 
 
+class CompositeProductAdder(object):
+  def __init__(self, *products):
+    self.products = products
+
+  def add_for_target(self, *args, **kwargs):
+    for product in self.products:
+      product.add_for_target(*args, **kwargs)
+
+
+class _JvmCompileWorkflowType(enum(['zinc-only', 'rsc-then-zinc'])):
+  """Target classifications used to correctly schedule Zinc and Rsc jobs.
+
+  There are some limitations we have to work around before we can compile everything through Rsc
+  and followed by Zinc.
+  - rsc is not able to outline all scala code just yet (this is also being addressed through
+    automated rewrites).
+  - javac is unable to consume rsc's jars just yet.
+  - rsc is not able to outline all java code just yet (this is likely to *not* require rewrites,
+    just some more work on rsc).
+
+  As we work on improving our Rsc integration, we'll need to create more workflows to more closely
+  map the supported features of Rsc. This enum class allows us to do that.
+
+    - zinc-only: compiles targets just with Zinc and uses the Zinc products of their dependencies.
+    - rsc-then-zinc: compiles targets with Rsc to create "header" jars, then runs Zinc against the
+      Rsc products of their dependencies. The Rsc compile uses the Rsc products of Rsc compatible
+      targets and the Zinc products of zinc-only targets.
+  """
+
+  @classmethod
+  def classify_target(cls, target):
+    # NB: Java targets, Scala+Java targets, and some test targets are not currently supported for
+    # compile with Rsc.
+    # TODO: Rsc's produced header jars don't yet work with javac. Once this is resolved, we may add
+    #       additional workflow types.
+    if target.has_sources('.java') or \
+      isinstance(target, JUnitTests):
+      target_type = _JvmCompileWorkflowType.create('zinc-only')
+    elif target.has_sources('.scala'):
+      target_type = _JvmCompileWorkflowType.create('rsc-then-zinc')
+    else:
+      target_type = None
+    return target_type
+
+
 class RscCompileContext(CompileContext):
   def __init__(self,
                target,
                analysis_file,
                classes_dir,
-               rsc_mjar_file,
+               rsc_jar_file,
                jar_file,
                log_dir,
                zinc_args_file,
@@ -95,11 +139,11 @@ class RscCompileContext(CompileContext):
                rsc_index_dir):
     super(RscCompileContext, self).__init__(target, analysis_file, classes_dir, jar_file,
                                                log_dir, zinc_args_file, sources)
-    self.rsc_mjar_file = rsc_mjar_file
+    self.rsc_jar_file = rsc_jar_file
     self.rsc_index_dir = rsc_index_dir
 
   def ensure_output_dirs_exist(self):
-    safe_mkdir(os.path.dirname(self.rsc_mjar_file))
+    safe_mkdir(os.path.dirname(self.rsc_jar_file))
     safe_mkdir(self.rsc_index_dir)
 
 
@@ -121,49 +165,18 @@ class RscCompile(ZincCompile):
   def register_options(cls, register):
     super(RscCompile, cls).register_options(register)
 
-    rsc_toolchain_version = '0.0.0-446-c64e6937'
-    scalameta_toolchain_version = '4.0.0'
-
     cls.register_jvm_tool(
       register,
       'rsc',
       classpath=[
-          JarDependency(
-              org='com.twitter',
-              name='rsc_2.11',
-              rev=rsc_toolchain_version,
-          ),
+        JarDependency(
+          org='com.twitter',
+          name='rsc_2.11',
+          rev='0.0.0-733-05951a97',
+        ),
       ],
       custom_rules=[
         Shader.exclude_package('rsc', recursive=True),
-      ]
-    )
-    cls.register_jvm_tool(
-      register,
-      'metacp',
-      classpath=[
-          JarDependency(
-            org='org.scalameta',
-            name='metacp_2.11',
-            rev=scalameta_toolchain_version,
-          ),
-      ],
-      custom_rules=[
-        Shader.exclude_package('scala', recursive=True),
-      ]
-    )
-    cls.register_jvm_tool(
-      register,
-      'metai',
-      classpath=[
-          JarDependency(
-            org='org.scalameta',
-            name='metai_2.11',
-            rev=scalameta_toolchain_version,
-          ),
-      ],
-      custom_rules=[
-        Shader.exclude_package('scala', recursive=True),
       ]
     )
 
@@ -176,8 +189,7 @@ class RscCompile(ZincCompile):
     #7092). We still invoke their classpaths separately when not using nailgun, however.
     """
     cp = []
-    for component_tool_name in ['rsc', 'metai', 'metacp']:
-      cp.extend(self.tool_classpath(component_tool_name))
+    cp.extend(self.tool_classpath('rsc'))
     # Add zinc's classpath so that it can be invoked from the same nailgun instance.
     cp.extend(super(RscCompile, self).get_zinc_compiler_classpath())
     return cp
@@ -206,51 +218,31 @@ class RscCompile(ZincCompile):
       paths_without_digests = [p for (p, d) in path_and_digests if not d]
       if paths_without_digests:
         self.context.log.debug('Expected to find digests for {}, capturing them.'
-                               .format(paths_without_digests))
+          .format(paths_without_digests))
       paths_with_digests = [(p, d) for (p, d) in path_and_digests if d]
       # list of path -> list path, captured snapshot -> list of path with digest
       snapshots = scheduler.capture_snapshots(tuple(pathglob_for(p) for p in paths_without_digests))
       captured_paths_and_digests = [(p, s.directory_digest)
-                                    for (p, s) in zip(paths_without_digests, snapshots)]
+        for (p, s) in zip(paths_without_digests, snapshots)]
       # merge and classpath ify
       return [ClasspathEntry(p, d) for (p, d) in paths_with_digests + captured_paths_and_digests]
 
     def confify(entries):
       return [(conf, e) for e in entries for conf in self._confs]
 
+    # Ensure that the jar/rsc jar is on the rsc_classpath.
     for target in targets:
       rsc_cc, compile_cc = compile_contexts[target]
-      if self._only_zinc_compilable(target):
+      target_compile_type = self._classify_compile_target(target)
+      if target_compile_type is not None:
+        cp_entries = target_compile_type.resolve_for_enum_variant({
+          'zinc-only': lambda : confify([compile_cc.jar_file]),
+          'rsc-then-zinc': lambda : confify(
+            to_classpath_entries([rsc_cc.rsc_jar_file], self.context._scheduler)),
+        })()
         self.context.products.get_data('rsc_classpath').add_for_target(
-          compile_cc.target,
-          confify([compile_cc.jar_file])
-        )
-      elif self._rsc_compilable(target):
-        self.context.products.get_data('rsc_classpath').add_for_target(
-          rsc_cc.target,
-          confify(to_classpath_entries([rsc_cc.rsc_mjar_file], self.context._scheduler)))
-      elif self._metacpable(target):
-        # Walk the metacp results dir and add classpath entries for all the files there.
-        # TODO exercise this with a test.
-        # TODO, this should only list the files/directories in the first directory under the index dir
-
-        elements_in_index_dir = [os.path.join(rsc_cc.rsc_index_dir, s)
-                                 for s in os.listdir(rsc_cc.rsc_index_dir)]
-
-        entries = to_classpath_entries(elements_in_index_dir, self.context._scheduler)
-        self._metacp_jars_classpath_product.add_for_target(
-          rsc_cc.target, confify(entries))
-      else:
-        pass
-
-  def _metacpable(self, target):
-    return isinstance(target, JarLibrary)
-
-  def _rsc_compilable(self, target):
-    return target.has_sources('.scala') and not target.has_sources('.java')
-
-  def _only_zinc_compilable(self, target):
-    return target.has_sources('.java')
+          target,
+          cp_entries)
 
   def _is_scala_core_library(self, target):
     return target.address.spec in ('//:scala-library', '//:scala-library-synthetic')
@@ -266,118 +258,29 @@ class RscCompile(ZincCompile):
       classpath_product.update(compile_classpath)
 
   def select(self, target):
-    # Require that targets are marked for JVM compilation, to differentiate from
-    # targets owned by the scalajs contrib module.
-    if self._metacpable(target):
-      return True
     if not isinstance(target, JvmTarget):
       return False
-    return self._only_zinc_compilable(target) or self._rsc_compilable(target)
+    if self._classify_compile_target(target) is not None:
+      return True
+    return False
+
+  def _classify_compile_target(self, target):
+    return _JvmCompileWorkflowType.classify_target(target)
+
+  def _key_for_target_as_dep(self, compile_target):
+    return self._classify_compile_target(compile_target).resolve_for_enum_variant({
+      'zinc-only': lambda: self._zinc_key_for_target(compile_target),
+      'rsc-then-zinc': lambda: self._rsc_key_for_target(compile_target),
+    })()
 
   def _rsc_key_for_target(self, compile_target):
-    if self._only_zinc_compilable(compile_target):
-      # rsc outlining with java dependencies depends on the output of a second metacp job.
-      return self._metacp_key_for_target(compile_target)
-    elif self._rsc_compilable(compile_target):
-      return "rsc({})".format(compile_target.address.spec)
-    elif self._metacpable(compile_target):
-      return self._metacp_key_for_target(compile_target)
-    else:
-      raise TaskError('unexpected target for compiling with rsc .... {}'.format(compile_target))
+    return 'rsc({})'.format(compile_target.address.spec)
 
-  def _metacp_dep_key_for_target(self, compile_target):
-    if self._only_zinc_compilable(compile_target):
-      # rsc outlining with java dependencies depends on the output of a second metacp job.
-      return self._metacp_key_for_target(compile_target)
-    elif self._rsc_compilable(compile_target):
-      return self._compile_against_rsc_key_for_target(compile_target)
-    elif self._metacpable(compile_target):
-      return self._metacp_key_for_target(compile_target)
-    else:
-      raise TaskError('unexpected target for compiling with rsc .... {}'.format(compile_target))
-
-  def _metacp_key_for_target(self, compile_target):
-    return "metacp({})".format(compile_target.address.spec)
-
-  def _compile_against_rsc_key_for_target(self, compile_target):
-    return "compile_against_rsc({})".format(compile_target.address.spec)
-
-  def pre_compile_jobs(self, counter):
-
-    # Create a target for the jdk outlining so that it'll only be done once per run.
-    target = Target('jdk', Address('', 'jdk'), self.context.build_graph)
-    index_dir = os.path.join(self.versioned_workdir, '--jdk--', 'index')
-
-    def work_for_vts_rsc_jdk():
-      distribution = self._get_jvm_distribution()
-      jvm_lib_jars_abs = distribution.find_libs(['rt.jar', 'dt.jar', 'jce.jar', 'tools.jar'])
-      self._jvm_lib_jars_abs = jvm_lib_jars_abs
-
-      metacp_inputs = tuple(jvm_lib_jars_abs)
-
-      counter_val = str(counter()).rjust(counter.format_length(), ' ' if PY3 else b' ')
-      counter_str = '[{}/{}] '.format(counter_val, counter.size)
-      self.context.log.info(
-        counter_str,
-        'Metacp-ing ',
-        items_to_report_element(metacp_inputs, 'jar'),
-        ' in the jdk')
-
-      # NB: Metacp doesn't handle the existence of possibly stale semanticdb jars,
-      # so we explicitly clean the directory to keep it happy.
-      safe_mkdir(index_dir, clean=True)
-
-      with Timer() as timer:
-        # Step 1: Convert classpath to SemanticDB
-        # ---------------------------------------
-        rsc_index_dir = fast_relpath(index_dir, get_buildroot())
-        args = [
-          '--verbose',
-          # NB: The directory to dump the semanticdb jars generated by metacp.
-          '--out', rsc_index_dir,
-          os.pathsep.join(metacp_inputs),
-        ]
-        metacp_wu = self._runtool(
-          'scala.meta.cli.Metacp',
-          'metacp',
-          args,
-          distribution,
-          tgt=target,
-          input_files=tuple(
-            # NB: no input files because the jdk is expected to exist on the system in a known
-            #     location.
-            #     Related: https://github.com/pantsbuild/pants/issues/6416
-          ),
-          output_dir=rsc_index_dir)
-        metacp_stdout = stdout_contents(metacp_wu)
-        metacp_result = json.loads(metacp_stdout)
-
-        metai_classpath = self._collect_metai_classpath(metacp_result, jvm_lib_jars_abs)
-
-        # Step 1.5: metai Index the semanticdbs
-        # -------------------------------------
-        self._run_metai_tool(distribution, metai_classpath, rsc_index_dir, tgt=target)
-
-        self._jvm_lib_metacp_classpath = [os.path.join(get_buildroot(), x) for x in metai_classpath]
-
-      self._record_target_stats(target,
-        len(self._jvm_lib_metacp_classpath),
-        len([]),
-        timer.elapsed,
-        False,
-        'metacp'
-      )
-
-    return [
-      Job(
-        'metacp(jdk)',
-        functools.partial(
-          work_for_vts_rsc_jdk
-        ),
-        [],
-        self._size_estimator([]),
-      ),
-    ]
+  def _zinc_key_for_target(self, compile_target):
+    return self._classify_compile_target(compile_target).resolve_for_enum_variant({
+      'zinc-only': lambda: 'zinc({})'.format(compile_target.address.spec),
+      'rsc-then-zinc': lambda: 'zinc_against_rsc({})'.format(compile_target.address.spec),
+    })()
 
   def create_compile_jobs(self,
                           compile_target,
@@ -407,68 +310,64 @@ class RscCompile(ZincCompile):
           ').')
 
         # This does the following
-        # - collect jar dependencies and metacp-classpath entries for them
-        # - collect the non-java targets and their classpath entries
-        # - break out java targets and their javac'd classpath entries
-        # metacp
-        # - metacp the java targets
-        # rsc
-        # - combine the metacp outputs for jars, previous scala targets and the java metacp
-        #   classpath
-        # - run Rsc on the current target with those as dependencies
+        # - Collect the rsc classpath elements, including zinc compiles of rsc incompatible targets
+        #   and rsc compiles of rsc compatible targets.
+        # - Run Rsc on the current target with those as dependencies.
 
         dependencies_for_target = list(
           DependencyContext.global_instance().dependencies_respecting_strict_deps(target))
 
-        jar_deps = [t for t in dependencies_for_target if isinstance(t, JarLibrary)]
+        rsc_deps_classpath_unprocessed = _paths_from_classpath(
+          self.context.products.get_data('rsc_classpath').get_for_targets(dependencies_for_target),
+          collection_type=OrderedSet)
 
-        def is_java_compile_target(t):
-          return isinstance(t, JavaLibrary) or t.has_sources('.java')
-        java_deps = [t for t in dependencies_for_target
-                     if is_java_compile_target(t)]
-        non_java_deps = [t for t in dependencies_for_target
-                         if not (is_java_compile_target(t)) and not isinstance(t, JarLibrary)]
-
-        metacped_jar_classpath_abs = _paths_from_classpath(
-          self._metacp_jars_classpath_product.get_for_targets(jar_deps + java_deps)
-        )
-        metacped_jar_classpath_abs.extend(self._jvm_lib_metacp_classpath)
-        metacped_jar_classpath_rel = fast_relpath_collection(metacped_jar_classpath_abs)
-
-        non_java_paths = _paths_from_classpath(
-          self.context.products.get_data('rsc_classpath').get_for_targets(non_java_deps),
-          collection_type=set)
-        non_java_rel = fast_relpath_collection(non_java_paths)
+        rsc_classpath_rel = fast_relpath_collection(list(rsc_deps_classpath_unprocessed))
 
         ctx.ensure_output_dirs_exist()
 
-        distribution = self._get_jvm_distribution()
         with Timer() as timer:
-          # Outline Scala sources into SemanticDB
+          # Outline Scala sources into SemanticDB / scalac compatible header jars.
           # ---------------------------------------------
-          rsc_mjar_file = fast_relpath(ctx.rsc_mjar_file, get_buildroot())
+          rsc_jar_file = fast_relpath(ctx.rsc_jar_file, get_buildroot())
 
-          # TODO remove non-rsc entries from non_java_rel in a better way
-          rsc_semanticdb_classpath = metacped_jar_classpath_rel + \
-                                     [j for j in non_java_rel if 'compile/rsc/' in j]
+          sources_snapshot = ctx.target.sources_snapshot(scheduler=self.context._scheduler)
+
+          def hermetic_digest_classpath():
+            hermetic_dist = self._hermetic_jvm_distribution()
+            jdk_libs_rel, jdk_libs_digest = self._jdk_libs_paths_and_digest(hermetic_dist)
+            merged_sources_and_jdk_digest = self.context._scheduler.merge_directories(
+              (jdk_libs_digest, sources_snapshot.directory_digest))
+            classpath_rel_jdk = rsc_classpath_rel + jdk_libs_rel
+            return (merged_sources_and_jdk_digest, classpath_rel_jdk, hermetic_dist)
+          def nonhermetic_digest_classpath():
+            nonhermetic_dist = self._nonhermetic_jvm_distribution()
+            classpath_abs_jdk = rsc_classpath_rel + self._jdk_libs_abs(nonhermetic_dist)
+            return ((EMPTY_DIRECTORY_DIGEST), classpath_abs_jdk, nonhermetic_dist)
+
+          (input_digest, classpath_entry_paths, distribution) = self.execution_strategy_enum.resolve_for_enum_variant({
+            self.HERMETIC: hermetic_digest_classpath,
+            self.SUBPROCESS: nonhermetic_digest_classpath,
+            self.NAILGUN: nonhermetic_digest_classpath,
+          })()
+
           target_sources = ctx.sources
           args = [
-                   '-cp', os.pathsep.join(rsc_semanticdb_classpath),
-                   '-d', rsc_mjar_file,
+                   '-cp', os.pathsep.join(classpath_entry_paths),
+                   '-d', rsc_jar_file,
                  ] + target_sources
-          sources_snapshot = ctx.target.sources_snapshot(scheduler=self.context._scheduler)
+
           self._runtool(
             'rsc.cli.Main',
             'rsc',
             args,
             distribution,
             tgt=tgt,
-            input_files=tuple(rsc_semanticdb_classpath),
-            input_digest=sources_snapshot.directory_digest,
-            output_dir=os.path.dirname(rsc_mjar_file))
+            input_files=tuple(rsc_classpath_rel),
+            input_digest=input_digest,
+            output_dir=os.path.dirname(rsc_jar_file))
 
         self._record_target_stats(tgt,
-          len(rsc_semanticdb_classpath),
+          len(rsc_classpath_rel),
           len(target_sources),
           timer.elapsed,
           False,
@@ -480,242 +379,88 @@ class RscCompile(ZincCompile):
       # Update the products with the latest classes.
       self.register_extra_products_from_contexts([ctx.target], compile_contexts)
 
-    def work_for_vts_metacp(vts, ctx, classpath_product_key):
-      metacp_dependencies_entries = self._zinc.compile_classpath_entries(
-        classpath_product_key,
-        ctx.target,
-        extra_cp_entries=self._extra_compile_time_classpath)
-
-      metacp_dependencies = fast_relpath_collection(c.path for c in metacp_dependencies_entries)
-
-
-      metacp_dependencies_digests = [c.directory_digest for c in metacp_dependencies_entries
-                                     if c.directory_digest]
-      metacp_dependencies_paths_without_digests = fast_relpath_collection(
-        c.path for c in metacp_dependencies_entries if not c.directory_digest)
-
-      classpath_entries = [
-        cp_entry for (conf, cp_entry) in
-        self.context.products.get_data(classpath_product_key).get_classpath_entries_for_targets(
-          [ctx.target])
-      ]
-      classpath_digests = [c.directory_digest for c in classpath_entries if c.directory_digest]
-      classpath_paths_without_digests = fast_relpath_collection(
-        c.path for c in classpath_entries if not c.directory_digest)
-
-      classpath_abs = [c.path for c in classpath_entries]
-      classpath_rel = fast_relpath_collection(classpath_abs)
-
-      metacp_inputs = []
-      metacp_inputs.extend(classpath_rel)
-
-      counter_val = str(counter()).rjust(counter.format_length(), ' ' if PY3 else b' ')
-      counter_str = '[{}/{}] '.format(counter_val, counter.size)
-      self.context.log.info(
-        counter_str,
-        'Metacp-ing ',
-        items_to_report_element(metacp_inputs, 'jar'),
-        ' in ',
-        items_to_report_element([t.address.reference() for t in vts.targets], 'target'),
-        ' (',
-        ctx.target.address.spec,
-        ').')
-
-      ctx.ensure_output_dirs_exist()
-
-      tgt, = vts.targets
-      with Timer() as timer:
-        # Step 1: Convert classpath to SemanticDB
-        # ---------------------------------------
-        rsc_index_dir = fast_relpath(ctx.rsc_index_dir, get_buildroot())
-        args = [
-          '--verbose',
-          '--stub-broken-signatures',
-          '--dependency-classpath', os.pathsep.join(
-            metacp_dependencies +
-            fast_relpath_collection(self._jvm_lib_jars_abs)
-          ),
-          # NB: The directory to dump the semanticdb jars generated by metacp.
-          '--out', rsc_index_dir,
-          os.pathsep.join(metacp_inputs),
-        ]
-
-        # NB: If we're building a scala library jar,
-        #     also request that metacp generate the indices
-        #     for the scala synthetics.
-        if self._is_scala_core_library(tgt):
-          args = [
-            '--include-scala-library-synthetics',
-          ] + args
-        distribution = self._get_jvm_distribution()
-
-        input_digest = self.context._scheduler.merge_directories(
-          tuple(classpath_digests + metacp_dependencies_digests))
-
-        metacp_wu = self._runtool(
-          'scala.meta.cli.Metacp',
-          'metacp',
-          args,
-          distribution,
-          tgt=tgt,
-          input_digest=input_digest,
-          input_files=tuple(classpath_paths_without_digests +
-                            metacp_dependencies_paths_without_digests),
-          output_dir=rsc_index_dir)
-        metacp_result = json.loads(stdout_contents(metacp_wu))
-
-        metai_classpath = self._collect_metai_classpath(metacp_result, classpath_rel)
-
-        # Step 1.5: metai Index the semanticdbs
-        # -------------------------------------
-        self._run_metai_tool(distribution, metai_classpath, rsc_index_dir, tgt)
-
-        abs_output = [(conf, os.path.join(get_buildroot(), x))
-                      for conf in self._confs for x in metai_classpath]
-
-        self._metacp_jars_classpath_product.add_for_target(
-          ctx.target,
-          abs_output,
-        )
-
-      self._record_target_stats(tgt,
-          len(abs_output),
-          len([]),
-          timer.elapsed,
-          False,
-          'metacp'
-        )
-
     rsc_jobs = []
     zinc_jobs = []
 
     # Invalidated targets are a subset of relevant targets: get the context for this one.
     compile_target = ivts.target
-    compile_context_pair = compile_contexts[compile_target]
+    rsc_compile_context, zinc_compile_context = compile_contexts[compile_target]
 
     # Create the rsc job.
     # Currently, rsc only supports outlining scala.
-    if self._only_zinc_compilable(compile_target):
-      pass
-    elif self._rsc_compilable(compile_target):
-      rsc_key = self._rsc_key_for_target(compile_target)
-      rsc_jobs.append(
-        Job(
-          rsc_key,
-          functools.partial(
-            work_for_vts_rsc,
-            ivts,
-            compile_context_pair[0]),
-          [self._rsc_key_for_target(target) for target in invalid_dependencies] + ['metacp(jdk)'],
-          self._size_estimator(compile_context_pair[0].sources),
-        )
+    def all_zinc_rsc_invalid_dep_keys(invalid_deps):
+      for tgt in invalid_deps:
+        # None can occur for e.g. JarLibrary deps, which we don't need to compile as they are
+        # populated in the resolve goal.
+        if self._classify_compile_target(tgt) is not None:
+          # Rely on the results of zinc compiles for zinc-compatible targets
+          yield self._key_for_target_as_dep(tgt)
+
+    def make_rsc_job(target, dep_targets):
+      return Job(
+        self._rsc_key_for_target(target),
+        functools.partial(
+          work_for_vts_rsc,
+          ivts,
+          rsc_compile_context),
+        # The rsc jobs depend on other rsc jobs, and on zinc jobs for targets that are not
+        # processed by rsc.
+        list(all_zinc_rsc_invalid_dep_keys(dep_targets)),
+        self._size_estimator(rsc_compile_context.sources),
+        # TODO maybe add a force_invalidate here? A test case that validates that with caching
+        # enabled, a rsc compile failure will prevent the target from being considered valid.
       )
-    elif self._metacpable(compile_target):
-      rsc_key = self._rsc_key_for_target(compile_target)
-      rsc_jobs.append(
-        Job(
-          rsc_key,
-          functools.partial(
-            work_for_vts_metacp,
-            ivts,
-            compile_context_pair[0],
-            'compile_classpath'),
-          [self._rsc_key_for_target(target) for target in invalid_dependencies] + ['metacp(jdk)'],
-          self._size_estimator(compile_context_pair[0].sources),
-          on_success=ivts.update,
-          on_failure=ivts.force_invalidate,
-        )
-      )
-    else:
-      raise TaskError("Unexpected target for rsc compile {} with type {}"
-        .format(compile_target, type(compile_target)))
+
+    self._classify_compile_target(compile_target).resolve_for_enum_variant({
+      'zinc-only': lambda: None,
+      'rsc-then-zinc': lambda: rsc_jobs.append(make_rsc_job(compile_target, invalid_dependencies)),
+    })()
 
     # Create the zinc compile jobs.
     # - Scala zinc compile jobs depend on the results of running rsc on the scala target.
     # - Java zinc compile jobs depend on the zinc compiles of their dependencies, because we can't
-    #   generate mjars that make javac happy at this point.
+    #   generate jars that make javac happy at this point.
 
-    invalid_dependencies_without_jar_metacps = [t for t in invalid_dependencies
-      if not self._metacpable(t)]
-    if self._rsc_compilable(compile_target):
-      full_key = self._compile_against_rsc_key_for_target(compile_target)
-      zinc_jobs.append(
-        Job(
-          full_key,
-          functools.partial(
-            self._default_work_for_vts,
-            ivts,
-            compile_context_pair[1],
-            'rsc_classpath',
-            counter,
-            compile_contexts,
-            runtime_classpath_product),
-          [
-            self._rsc_key_for_target(compile_target)
-          ] + [
-            self._rsc_key_for_target(target)
-            for target in invalid_dependencies_without_jar_metacps
-          ] + [
-            'metacp(jdk)'
+    def only_zinc_invalid_dep_keys(invalid_deps):
+      for tgt in invalid_deps:
+        if self._classify_compile_target(tgt) is not None:
+          yield self._zinc_key_for_target(tgt)
+
+    # NB: zinc jobs for rsc-compatible targets never depend on their own corresponding rsc jobs,
+    # just the rsc jobs of their dependencies!
+    # In order to implement sub-target compiles, that will need to change.
+    def make_zinc_job(target, input_product_key, output_products, dep_keys):
+      return Job(key=self._zinc_key_for_target(target),
+        fn=functools.partial(
+          self._default_work_for_vts,
+          ivts,
+          zinc_compile_context,
+          input_product_key,
+          counter,
+          compile_contexts,
+          CompositeProductAdder(*output_products)),
+        dependencies=list(dep_keys),
+        size=self._size_estimator(zinc_compile_context.sources),
+        on_success=ivts.update,
+        on_failure=ivts.force_invalidate,
+      )
+
+    self._classify_compile_target(compile_target).resolve_for_enum_variant({
+      'zinc-only': lambda: zinc_jobs.append(
+        make_zinc_job(compile_target,
+          input_product_key='runtime_classpath',
+          output_products=[
+            runtime_classpath_product,
+            self.context.products.get_data('rsc_classpath')],
+          dep_keys=only_zinc_invalid_dep_keys(invalid_dependencies))),
+      'rsc-then-zinc': lambda: zinc_jobs.append(
+        make_zinc_job(compile_target,
+          input_product_key='rsc_classpath',
+          output_products=[
+            runtime_classpath_product,
           ],
-          self._size_estimator(compile_context_pair[1].sources),
-          # NB: right now, only the last job will write to the cache, because we don't
-          #     do multiple cache entries per target-task tuple.
-          on_success=ivts.update,
-          on_failure=ivts.force_invalidate,
-        )
-      )
-    elif self._only_zinc_compilable(compile_target):
-      # write to both rsc classpath and runtime classpath
-      class CompositeProductAdder(object):
-        def __init__(self, runtime_classpath_product, rsc_classpath_product):
-          self.rsc_classpath_product = rsc_classpath_product
-          self.runtime_classpath_product = runtime_classpath_product
-
-        def add_for_target(self, *args, **kwargs):
-          self.runtime_classpath_product.add_for_target(*args, **kwargs)
-          self.rsc_classpath_product.add_for_target(*args, **kwargs)
-
-      zinc_key = self._compile_against_rsc_key_for_target(compile_target)
-      zinc_jobs.append(
-        Job(
-          zinc_key,
-          functools.partial(
-            self._default_work_for_vts,
-            ivts,
-            compile_context_pair[1],
-            'runtime_classpath',
-            counter,
-            compile_contexts,
-            CompositeProductAdder(
-              runtime_classpath_product,
-              self.context.products.get_data('rsc_classpath'))),
-          [
-            self._compile_against_rsc_key_for_target(target)
-            for target in invalid_dependencies_without_jar_metacps],
-          self._size_estimator(compile_context_pair[1].sources),
-          on_failure=ivts.force_invalidate,
-        )
-      )
-
-      metacp_key = self._metacp_key_for_target(compile_target)
-      rsc_jobs.append(
-        Job(
-          metacp_key,
-          functools.partial(
-            work_for_vts_metacp,
-            ivts,
-            compile_context_pair[0],
-            'runtime_classpath'),
-            [self._metacp_dep_key_for_target(target) for target in invalid_dependencies] + [
-              'metacp(jdk)',
-              zinc_key,
-            ],
-          self._size_estimator(compile_context_pair[0].sources),
-          on_success=ivts.update,
-          on_failure=ivts.force_invalidate,
-        )
-      )
+          dep_keys=all_zinc_rsc_invalid_dep_keys(invalid_dependencies))),
+    })()
 
     return rsc_jobs + zinc_jobs
 
@@ -743,7 +488,7 @@ class RscCompile(ZincCompile):
         classes_dir=None,
         jar_file=None,
         zinc_args_file=None,
-        rsc_mjar_file=os.path.join(rsc_dir, 'm.jar'),
+        rsc_jar_file=os.path.join(rsc_dir, 'm.jar'),
         log_dir=os.path.join(rsc_dir, 'logs'),
         sources=sources,
         rsc_index_dir=os.path.join(rsc_dir, 'index'),
@@ -763,30 +508,26 @@ class RscCompile(ZincCompile):
     tool_classpath_abs = self.tool_classpath(tool_name)
     tool_classpath = fast_relpath_collection(tool_classpath_abs)
 
-    classpath_for_cmd = os.pathsep.join(tool_classpath)
     cmd = [
-      distribution.java,
-    ]
-    cmd.extend(self.get_options().jvm_options)
-    cmd.extend(['-cp', classpath_for_cmd])
-    cmd.extend([main])
-    cmd.extend(args)
+            distribution.java,
+          ] + self.get_options().jvm_options + [
+            '-cp', os.pathsep.join(tool_classpath),
+            main,
+          ] + args
 
     pathglobs = list(tool_classpath)
     pathglobs.extend(f if os.path.isfile(f) else '{}/**'.format(f) for f in input_files)
 
     if pathglobs:
       root = PathGlobsAndRoot(
-      PathGlobs(tuple(pathglobs)),
-      text_type(get_buildroot()))
+        PathGlobs(tuple(pathglobs)),
+        text_type(get_buildroot()))
       # dont capture snapshot, if pathglobs is empty
       path_globs_input_digest = self.context._scheduler.capture_snapshots((root,))[0].directory_digest
 
-    if path_globs_input_digest and input_digest:
-      epr_input_files = self.context._scheduler.merge_directories(
-          (path_globs_input_digest, input_digest))
-    else:
-      epr_input_files = path_globs_input_digest or input_digest
+    epr_input_files = self.context._scheduler.merge_directories(
+      ((path_globs_input_digest,) if path_globs_input_digest else ())
+      + ((input_digest,) if input_digest else ()))
 
     epr = ExecuteProcessRequest(
       argv=tuple(cmd),
@@ -805,7 +546,7 @@ class RscCompile(ZincCompile):
       [WorkUnitLabel.TOOL])
 
     if res.exit_code != 0:
-      raise TaskError(res.stderr)
+      raise TaskError(res.stderr, exit_code=res.exit_code)
 
     if output_dir:
       res.output_directory_digest.dump(output_dir)
@@ -822,12 +563,12 @@ class RscCompile(ZincCompile):
   # execution requests.
   def _runtool_nonhermetic(self, parent_workunit, classpath, main, tool_name, args, distribution):
     result = self.runjava(classpath=classpath,
-                          main=main,
-                          jvm_options=self.get_options().jvm_options,
-                          args=args,
-                          workunit_name=tool_name,
-                          workunit_labels=[WorkUnitLabel.TOOL],
-                          dist=distribution
+      main=main,
+      jvm_options=self.get_options().jvm_options,
+      args=args,
+      workunit_name=tool_name,
+      workunit_labels=[WorkUnitLabel.TOOL],
+      dist=distribution
     )
     if result != 0:
       raise TaskError('Running {} failed'.format(tool_name))
@@ -842,7 +583,7 @@ class RscCompile(ZincCompile):
     return runjava_workunit
 
   def _runtool(self, main, tool_name, args, distribution,
-               tgt=None, input_files=tuple(), input_digest=None, output_dir=None):
+    tgt=None, input_files=tuple(), input_digest=None, output_dir=None):
     with self.context.new_workunit(tool_name) as wu:
       return self.execution_strategy_enum.resolve_for_enum_variant({
         self.HERMETIC: lambda: self._runtool_hermetic(
@@ -854,90 +595,58 @@ class RscCompile(ZincCompile):
           wu, self._nailgunnable_combined_classpath, main, tool_name, args, distribution),
       })()
 
-  def _run_metai_tool(self,
-                      distribution,
-                      metai_classpath,
-                      rsc_index_dir,
-                      tgt,
-                      extra_input_files=()):
-    # TODO have metai write to a different spot than metacp
-    # Currently, the metai step depends on the fact that materializing
-    # ignores existing files. It should write the files to a different
-    # location, either by providing inputs from a different location,
-    # or invoking a script that does the copying
-    args = [
-      '--verbose',
-      os.pathsep.join(metai_classpath)
-    ]
-    self._runtool(
-      'scala.meta.cli.Metai',
-      'metai',
-      args,
-      distribution,
-      tgt=tgt,
-      input_files=tuple(metai_classpath) + tuple(extra_input_files),
-      output_dir=rsc_index_dir
-    )
+  _JDK_LIB_NAMES = ['rt.jar', 'dt.jar', 'jce.jar', 'tools.jar']
 
-  def _collect_metai_classpath(self, metacp_result, relative_input_paths):
-    metai_classpath = []
+  @memoized_method
+  def _jdk_libs_paths_and_digest(self, hermetic_dist):
+    jdk_libs_rel, jdk_libs_globs = hermetic_dist.find_libs_path_globs(self._JDK_LIB_NAMES)
+    jdk_libs_digest = self.context._scheduler.capture_snapshots(
+      (jdk_libs_globs,))[0].directory_digest
+    return (jdk_libs_rel, jdk_libs_digest)
 
-    relative_workdir = fast_relpath(
-      self.context.options.for_global_scope().pants_workdir,
-      get_buildroot())
-    # NB The json uses absolute paths pointing into either the buildroot or
-    #    the temp directory of the hermetic build. This relativizes the keys.
-    #    TODO remove this after https://github.com/scalameta/scalameta/issues/1791 is released
-    desandboxify = _create_desandboxify_fn(
-      [
-        os.path.join(relative_workdir, 'resolve', 'coursier', '[^/]*', 'cache', '.*'),
-        os.path.join(relative_workdir, 'resolve', 'ivy', '[^/]*', 'ivy', 'jars', '.*'),
-        os.path.join(relative_workdir, 'compile', 'rsc', '.*'),
-        os.path.join(relative_workdir, r'\.jdk', '.*'),
-        os.path.join(r'\.jdk', '.*'),
-      ]
-      )
+  @memoized_method
+  def _jdk_libs_abs(self, nonhermetic_dist):
+    return nonhermetic_dist.find_libs(self._JDK_LIB_NAMES)
 
-    status_elements = {
-      desandboxify(k): desandboxify(v)
-      for k,v in metacp_result["status"].items()
-    }
+  class _HermeticDistribution(object):
+    def __init__(self, home_path, distribution):
+      self._underlying = distribution
+      self._home = home_path
 
-    for cp_entry in relative_input_paths:
-      metai_classpath.append(status_elements[cp_entry])
+    def find_libs(self, names):
+      underlying_libs = self._underlying.find_libs(names)
+      return [self._rehome(l) for l in underlying_libs]
 
-    scala_lib_synthetics = metacp_result["scalaLibrarySynthetics"]
-    if scala_lib_synthetics:
-      metai_classpath.append(desandboxify(scala_lib_synthetics))
+    def find_libs_path_globs(self, names):
+      libs_abs = self._underlying.find_libs(names)
+      libs_unrooted = [self._unroot_lib_path(l) for l in libs_abs]
+      path_globs = PathGlobsAndRoot(
+        PathGlobs(tuple(libs_unrooted)),
+        text_type(self._underlying.home))
+      return (libs_unrooted, path_globs)
 
-    return metai_classpath
+    @property
+    def java(self):
+      return os.path.join(self._home, 'bin', 'java')
 
-  def _get_jvm_distribution(self):
+    def _unroot_lib_path(self, path):
+      return path[len(self._underlying.home)+1:]
+
+    def _rehome(self, l):
+      return os.path.join(self._home, self._unroot_lib_path(l))
+
+  @memoized_method
+  def _hermetic_jvm_distribution(self):
     # TODO We may want to use different jvm distributions depending on what
     # java version the target expects to be compiled against.
     # See: https://github.com/pantsbuild/pants/issues/6416 for covering using
     #      different jdks in remote builds.
     local_distribution = JvmPlatform.preferred_jvm_distribution([], strict=True)
-    if self.execution_strategy == self.HERMETIC and self.get_options().remote_execution_server:
-      class HermeticDistribution(object):
-        def __init__(self, home_path, distribution):
-          self._underlying = distribution
-          self._home = home_path
+    return self._HermeticDistribution('.jdk', local_distribution)
 
-        def find_libs(self, names):
-          underlying_libs = self._underlying.find_libs(names)
-          return [self._rehome(l) for l in underlying_libs]
-
-        @property
-        def java(self):
-          return os.path.join(self._home, 'bin', 'java')
-
-        def _rehome(self, l):
-          return os.path.join(self._home, l[len(self._underlying.home)+1:])
-
-      return HermeticDistribution('.jdk', local_distribution)
-    else:
-      return local_distribution
+  @memoized_method
+  def _nonhermetic_jvm_distribution(self):
+    return JvmPlatform.preferred_jvm_distribution([], strict=True)
 
   def _on_invalid_compile_dependency(self, dep, compile_target):
     """Decide whether to continue searching for invalid targets to use in the execution graph.

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -172,7 +172,7 @@ class RscCompile(ZincCompile):
         JarDependency(
           org='com.twitter',
           name='rsc_2.11',
-          rev='0.0.0-733-05951a97',
+          rev='0.0.0-734-e57e96eb',
         ),
       ],
       custom_rules=[

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -19,7 +19,6 @@ from pants.backend.jvm.targets.junit_tests import JUnitTests
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.classpath_entry import ClasspathEntry
-from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.jvm_compile.compile_context import CompileContext
 from pants.backend.jvm.tasks.jvm_compile.execution_graph import Job
 from pants.backend.jvm.tasks.jvm_compile.zinc.zinc_compile import ZincCompile
@@ -137,16 +136,13 @@ class RscCompileContext(CompileContext):
                jar_file,
                log_dir,
                zinc_args_file,
-               sources,
-               rsc_index_dir):
+               sources):
     super(RscCompileContext, self).__init__(target, analysis_file, classes_dir, jar_file,
                                                log_dir, zinc_args_file, sources)
     self.rsc_jar_file = rsc_jar_file
-    self.rsc_index_dir = rsc_index_dir
 
   def ensure_output_dirs_exist(self):
     safe_mkdir(os.path.dirname(self.rsc_jar_file))
-    safe_mkdir(self.rsc_index_dir)
 
 
 class RscCompile(ZincCompile):
@@ -154,10 +150,6 @@ class RscCompile(ZincCompile):
 
   _name = 'rsc' # noqa
   compiler_name = 'rsc'
-
-  def __init__(self, *args, **kwargs):
-    super(RscCompile, self).__init__(*args, **kwargs)
-    self._metacp_jars_classpath_product = ClasspathProducts(self.get_options().pants_workdir)
 
   @classmethod
   def implementation_version(cls):
@@ -478,7 +470,6 @@ class RscCompile(ZincCompile):
   def create_compile_context(self, target, target_workdir):
     # workdir layout:
     # rsc/
-    #   - index/   -- metacp results
     #   - outline/ -- semanticdbs for the current target as created by rsc
     #   - m.jar    -- reified scala signature jar
     # zinc/
@@ -499,7 +490,6 @@ class RscCompile(ZincCompile):
         rsc_jar_file=os.path.join(rsc_dir, 'm.jar'),
         log_dir=os.path.join(rsc_dir, 'logs'),
         sources=sources,
-        rsc_index_dir=os.path.join(rsc_dir, 'index'),
       ),
       CompileContext(
         target=target,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -540,8 +540,9 @@ class RscCompile(ZincCompile):
       timeout_seconds=15*60,
       description='run {} for {}'.format(tool_name, tgt),
       # TODO: These should always be unicodes
-      # Since this is always hermetic, we need to use `underlying_dist`
-      jdk_home=text_type(self._zinc.underlying_dist.home),
+      # Since this is always hermetic, we need to use `underlying.home` because
+      # ExecuteProcessRequest requires an existing, local jdk location.
+      jdk_home=text_type(distribution.underlying_home),
     )
     res = self.context.execute_process_synchronously_without_raising(
       epr,
@@ -565,7 +566,8 @@ class RscCompile(ZincCompile):
   # The classpath is parameterized so that we can have a single nailgun instance serving all of our
   # execution requests.
   def _runtool_nonhermetic(self, parent_workunit, classpath, main, tool_name, args, distribution):
-    result = self.runjava(classpath=classpath,
+    result = self.runjava(
+      classpath=classpath,
       main=main,
       jvm_options=self.get_options().jvm_options,
       args=args,
@@ -631,6 +633,14 @@ class RscCompile(ZincCompile):
     @property
     def java(self):
       return os.path.join(self._home, 'bin', 'java')
+
+    @property
+    def home(self):
+      return self._home
+
+    @property
+    def underlying_home(self):
+      return self._underlying.home
 
     def _unroot_lib_path(self, path):
       return path[len(self._underlying.home)+1:]

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -70,10 +70,6 @@ class RscCompileIntegration(BaseCompileIT):
           'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/rsc',
           'm.jar')
         self.assertTrue(os.path.exists(path))
-        path = os.path.join(
-          workdir,
-          'compile/rsc/current/.scala-library-synthetic/current/rsc/index/scala-library-synthetics.jar')
-        self.assertTrue(os.path.exists(path))
 
   @_execution_strategies(['nailgun', 'subprocess'], [2])
   def test_executing_multi_target_binary_nonhermetic(self, execution_strategy, worker_count):


### PR DESCRIPTION
Rsc has been updated so that it can consume regular classpaths in all cases, eliminating the need to run metacp before and after rsc. This removes all the extra jobs. It is based on @cosmicexplorer's https://github.com/pantsbuild/pants/pull/7227.

The compile portions are ready for a first pass of review, but I still need to do more work on the tests.

Travis will fail on it right now, because the newer Rsc version hasn't been pushed to maven central yet.

It depends on https://github.com/pantsbuild/pants/pull/7268, but has no additional changes to zinc_compile.py