### PR TITLE
Add filtering subsystem to permit skipping targets by tags

### DIFF
--- a/src/python/pants/build_graph/target_filter_subsystem.py
+++ b/src/python/pants/build_graph/target_filter_subsystem.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class TargetFilter(Subsystem):
-  """Filter out targets matching given options.
+  """Filter targets matching configured criteria.
 
   :API: public
   """

--- a/src/python/pants/build_graph/target_filter_subsystem.py
+++ b/src/python/pants/build_graph/target_filter_subsystem.py
@@ -30,12 +30,15 @@ class TargetFilter(Subsystem):
 
   def apply(self, targets):
     exclude_tags = set(self.get_options().exclude_tags)
-    return TargetFiltering.apply_tag_blacklist(exclude_tags, targets)
+    return TargetFiltering(targets, exclude_tags).apply_tag_blacklist()
 
 
 class TargetFiltering(object):
   """Apply filtering logic against targets."""
 
-  @staticmethod
-  def apply_tag_blacklist(exclude_tags, targets):
-    return [t for t in targets if not exclude_tags.intersection(t.tags)]
+  def __init__(self, targets, exclude_tags):
+    self.targets = targets
+    self.exclude_tags = exclude_tags
+
+  def apply_tag_blacklist(self):
+    return [t for t in self.targets if not self.exclude_tags.intersection(t.tags)]

--- a/src/python/pants/build_graph/target_filter_subsystem.py
+++ b/src/python/pants/build_graph/target_filter_subsystem.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+from pants.subsystem.subsystem import Subsystem
+
+
+logger = logging.getLogger(__name__)
+
+
+class TargetFilter(Subsystem):
+  """Filter out targets matching given options.
+
+  :API: public
+  """
+
+  options_scope = 'target-filter'
+
+  @classmethod
+  def register_options(cls, register):
+    super(TargetFilter, cls).register_options(register)
+
+    register('--exclude-tags', type=list,
+             default=[],
+             help='Skip targets with given tag(s).')
+
+  def apply(self, targets):
+    exclude_tags = set(self.get_options().exclude_tags)
+    return TargetFiltering.apply_tag_blacklist(exclude_tags, targets)
+
+
+class TargetFiltering(object):
+  """Apply filtering logic against targets."""
+
+  @staticmethod
+  def apply_tag_blacklist(exclude_tags, targets):
+    return [t for t in targets if not exclude_tags.intersection(t.tags)]

--- a/src/python/pants/build_graph/target_filter_subsystem.py
+++ b/src/python/pants/build_graph/target_filter_subsystem.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+from builtins import object, set
 
 from pants.subsystem.subsystem import Subsystem
 

--- a/src/python/pants/build_graph/target_filter_subsystem.py
+++ b/src/python/pants/build_graph/target_filter_subsystem.py
@@ -25,7 +25,7 @@ class TargetFilter(Subsystem):
     super(TargetFilter, cls).register_options(register)
 
     register('--exclude-tags', type=list,
-             default=[],
+             default=[], fingerprint=True,
              help='Skip targets with given tag(s).')
 
   def apply(self, targets):

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import sys
 from abc import abstractmethod
-from builtins import filter, map, object, str, zip
+from builtins import filter, map, object, set, str, zip
 from contextlib import contextmanager
 from hashlib import sha1
 from itertools import repeat

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -16,9 +16,9 @@ from future.utils import PY3
 
 from pants.base.exceptions import TaskError
 from pants.base.worker_pool import Work
+from pants.build_graph.target_filter_subsystem import TargetFilter
 from pants.cache.artifact_cache import UnreadableArtifact, call_insert, call_use_cached_files
 from pants.cache.cache_setup import CacheSetup
-from pants.build_graph.target_filter_subsystem import TargetFilter
 from pants.invalidation.build_invalidator import (BuildInvalidator, CacheKeyGenerator,
                                                   UncacheableCacheKeyGenerator)
 from pants.invalidation.cache_manager import InvalidationCacheManager, InvalidationCheck

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -146,3 +146,13 @@ python_tests(
     'tests/python/pants_test:test_base',
   ]
 )
+
+python_tests(
+  name = 'target_filter_subsystem',
+  sources = ['test_target_filter_subsystem.py'],
+  dependencies = [
+    '3rdparty/python:future',
+    'src/python/pants/build_graph',
+    'tests/python/pants_test:task_test_base',
+  ]
+)

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -151,8 +151,8 @@ python_tests(
   name = 'target_filter_subsystem',
   sources = ['test_target_filter_subsystem.py'],
   dependencies = [
-    '3rdparty/python:future',
     'src/python/pants/build_graph',
+    'src/python/pants/task',
     'tests/python/pants_test:task_test_base',
   ]
 )

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -151,6 +151,7 @@ python_tests(
   name = 'target_filter_subsystem',
   sources = ['test_target_filter_subsystem.py'],
   dependencies = [
+    '3rdparty/python:future',
     'src/python/pants/build_graph',
     'src/python/pants/task',
     'tests/python/pants_test:task_test_base',

--- a/tests/python/pants_test/build_graph/test_target_filter_subsystem.py
+++ b/tests/python/pants_test/build_graph/test_target_filter_subsystem.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import set
+
 from pants.build_graph.target_filter_subsystem import TargetFilter, TargetFiltering
 from pants.task.task import Task
 from pants_test.task_test_base import TaskTestBase

--- a/tests/python/pants_test/build_graph/test_target_filter_subsystem.py
+++ b/tests/python/pants_test/build_graph/test_target_filter_subsystem.py
@@ -1,0 +1,45 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from pants.build_graph.target_filter_subsystem import TargetFiltering
+from pants.task.task import Task
+from pants_test.task_test_base import TaskTestBase
+
+
+class TestTargetFilter(TaskTestBase):
+
+  class DummyTask(Task):
+    options_scope = 'dummy'
+
+    def execute(self): pass
+
+  @classmethod
+  def task_type(cls):
+    return cls.DummyTask
+
+  def test_filtering_single_tag(self):
+    a = self.make_target('a', tags=[])
+    b = self.make_target('b', tags=['skip-me'])
+    c = self.make_target('c', tags=['tag1', 'skip-me'])
+
+    filtered_targets = TargetFiltering.apply_tag_blacklist({'skip-me'}, [a, b, c])
+    self.assertEqual([a], filtered_targets)
+
+  def test_filtering_multiple_tags(self):
+    a = self.make_target('a', tags=['tag1', 'skip-me'])
+    b = self.make_target('b', tags=['tag1', 'tag2', 'skip-me'])
+    c = self.make_target('c', tags=['tag2'])
+
+    filtered_targets = TargetFiltering.apply_tag_blacklist({'skip-me', 'tag2'}, [a, b, c])
+    self.assertEqual([], filtered_targets)
+
+  def test_filtering_no_tags(self):
+    a = self.make_target('a', tags=['tag1'])
+    b = self.make_target('b', tags=['tag1', 'tag2'])
+    c = self.make_target('c', tags=['tag2'])
+
+    filtered_targets = TargetFiltering.apply_tag_blacklist(set(), [a, b, c])
+    self.assertEqual([a, b, c], filtered_targets)

--- a/tests/python/pants_test/build_graph/test_target_filter_subsystem.py
+++ b/tests/python/pants_test/build_graph/test_target_filter_subsystem.py
@@ -39,7 +39,7 @@ class TestTargetFilter(TaskTestBase):
     b = self.make_target('b', tags=['skip-me'])
     c = self.make_target('c', tags=['tag1', 'skip-me'])
 
-    filtered_targets = TargetFiltering.apply_tag_blacklist({'skip-me'}, [a, b, c])
+    filtered_targets = TargetFiltering([a, b, c], {'skip-me'}).apply_tag_blacklist()
     self.assertEqual([a], filtered_targets)
 
   def test_filtering_multiple_tags(self):
@@ -47,7 +47,7 @@ class TestTargetFilter(TaskTestBase):
     b = self.make_target('b', tags=['tag1', 'tag2', 'skip-me'])
     c = self.make_target('c', tags=['tag2'])
 
-    filtered_targets = TargetFiltering.apply_tag_blacklist({'skip-me', 'tag2'}, [a, b, c])
+    filtered_targets = TargetFiltering([a, b, c], {'skip-me', 'tag2'}).apply_tag_blacklist()
     self.assertEqual([], filtered_targets)
 
   def test_filtering_no_tags(self):
@@ -55,5 +55,5 @@ class TestTargetFilter(TaskTestBase):
     b = self.make_target('b', tags=['tag1', 'tag2'])
     c = self.make_target('c', tags=['tag2'])
 
-    filtered_targets = TargetFiltering.apply_tag_blacklist(set(), [a, b, c])
+    filtered_targets = TargetFiltering([a, b, c], set()).apply_tag_blacklist()
     self.assertEqual([a, b, c], filtered_targets)


### PR DESCRIPTION
### Problem

Related issue: 
- https://github.com/pantsbuild/pants/issues/6902

Related PRs/work:
- https://github.com/pantsbuild/pants/pull/6947 

From the related issue:
>Chances are when folks want to enable any linter/formatter, not all targets can be compliant at the same time, and normally this would be an incremental process.
>Therefore a generic mechanism to allow incremental fmt/lint tasks migration would be beneficial, i.e. blacklist, whitelist, or both.

### Solution

Add a `TargetFilter` subsystem that will exclude from the task any targets matching the given criteria (in the initial case of this, using tags)

<details>
<summary>Example</summary>

Adding the tag `skip-tag` to the target that we'd like to skip (in this case, `examples/src/python/example/hello:greet`)

```bash
$./pants lint examples/src/python/example/hello:: --target-filter-lint-pythonstyle-exclude-tags=skip-tag

14:23:07 00:00 [main]
               (To run a reporting server: ./pants server)
14:23:09 00:02   [setup]
14:23:09 00:02     [parse]
               Executing tasks in goals: bootstrap -> imports -> unpack-jars -> unpack-wheels -> deferred-sources -> gen -> jvm-platform-validate -> native-compile -> resolve -> lint
...
14:23:23 00:16     [pythonstyle]
                   1 targets excluded
                   Invalidated 1 target.
...
```

</details>

### Possible followup work:
- Implement a mechanism that would apply tags to targets from a single file (ex. YAML) to avoid needing to add tags to each BUILD