### PR TITLE
don't do a pants run on osx where it's not yet supported to fix the cron job again

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -229,6 +229,18 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     This target uses the ndebug and asdf option sets.
     If either of these are not present (disabled), this test will fail.
     """
+    # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
+    # be available on the runtime library path.
+    attempt_pants_run = Platform.create().resolve_for_enum_variant({
+      'darwin': toolchain_variant.resolve_for_enum_variant({
+        'gnu': False,
+        'llvm': True,
+      }),
+      'linux': True,
+    })
+    if not attempt_pants_run:
+      return
+
     command = [
       'run',
       self._binary_target_with_compiler_option_sets


### PR DESCRIPTION
### Problem

Fixes #7247, catching a case that was otherwise missed.

### Solution

- Don't do a `./pants run` on osx using the gnu toolchain in testing, as it doesn't work yet.

### Result

As noted in #7249, it's strange that that PR passes but the nightly job fails -- it may be nondeterministic.