### PR TITLE
Allow tasks to opt-in to target filtering

### DIFF
--- a/src/python/pants/task/fmt_task_mixin.py
+++ b/src/python/pants/task/fmt_task_mixin.py
@@ -11,3 +11,4 @@ from pants.task.target_restriction_mixins import (HasSkipAndTransitiveGoalOption
 class FmtTaskMixin(HasSkipAndTransitiveGoalOptionsMixin):
   """A mixin to combine with code formatting tasks."""
   goal_options_registrar_cls = SkipAndTransitiveGoalOptionsRegistrar
+  target_filtering_enabled = True

--- a/src/python/pants/task/lint_task_mixin.py
+++ b/src/python/pants/task/lint_task_mixin.py
@@ -11,3 +11,4 @@ from pants.task.target_restriction_mixins import (HasSkipAndTransitiveGoalOption
 class LintTaskMixin(HasSkipAndTransitiveGoalOptionsMixin):
   """A mixin to combine with lint tasks."""
   goal_options_registrar_cls = SkipAndTransitiveGoalOptionsRegistrar
+  target_filtering_enabled = True

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -255,9 +255,12 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
 
     if not self.target_filtering_enabled:
       return initial_targets
+    else: 
+      return self._filter_targets(initial_targets)
 
-    included_targets = TargetFilter.scoped_instance(self).apply(initial_targets)
-    excluded_targets = set(initial_targets).difference(included_targets)
+  def _filter_targets(self, targets):
+    included_targets = TargetFilter.scoped_instance(self).apply(targets)
+    excluded_targets = set(targets).difference(included_targets)
 
     if excluded_targets:
       self.context.log.info("{} target(s) excluded".format(len(excluded_targets)))

--- a/tests/python/pants_test/build_graph/test_target_filter_subsystem.py
+++ b/tests/python/pants_test/build_graph/test_target_filter_subsystem.py
@@ -15,6 +15,7 @@ class TestTargetFilter(TaskTestBase):
 
   class DummyTask(Task):
     options_scope = 'dummy'
+    target_filtering_enabled = True
 
     def execute(self):
       self.context.products.safe_create_data('task_targets', self.get_targets)

--- a/tests/python/pants_test/task/test_task.py
+++ b/tests/python/pants_test/task/test_task.py
@@ -154,6 +154,7 @@ class TaskWithTargetFiltering(DummyTask):
   options_scope = 'task-with-target-filtering'
   target_filtering_enabled = True
 
+
 class TaskTest(TaskTestBase):
 
   _filename = 'f'

--- a/tests/python/pants_test/task/test_task.py
+++ b/tests/python/pants_test/task/test_task.py
@@ -13,6 +13,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.files import Files
+from pants.build_graph.target_filter_subsystem import TargetFilter
 from pants.cache.cache_setup import CacheSetup
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.subsystem.subsystem import Subsystem
@@ -148,6 +149,10 @@ class TaskWithTransitiveSubsystemDependencies(Task):
   def execute(self):
     pass
 
+
+class TaskWithTargetFiltering(DummyTask):
+  options_scope = 'task-with-target-filtering'
+  target_filtering_enabled = True
 
 class TaskTest(TaskTestBase):
 
@@ -650,3 +655,9 @@ files(
     fp3 = self._synth_fp(cls=TaskWithTransitiveSubsystemDependencies,
                          options_fingerprintable=option_spec)
     self.assertNotEqual(fp1, fp3)
+
+  def test_target_filtering_enabled(self):
+    self.assertNotIn(TargetFilter.scoped(DummyTask),
+                     DummyTask.subsystem_dependencies())
+    self.assertIn(TargetFilter.scoped(TaskWithTargetFiltering), 
+                  TaskWithTargetFiltering.subsystem_dependencies())


### PR DESCRIPTION
Followup to https://github.com/pantsbuild/pants/pull/7275 following [discussion](https://github.com/pantsbuild/pants/pull/7275#discussion_r259557791) that the target filter was being applied to tasks that do not support it (e.g. tasks that don't access targets via `get_targets()`)

This adds a class property to `Task` that allows subclasses to effectively opt-in to the new behavior - and sets that flag to `True` for `fmt` and `lint` tasks.