### PR TITLE
add a lint to warn on implicit string concatenation

### DIFF
--- a/build-support/checkstyle/python_suppressions.txt
+++ b/build-support/checkstyle/python_suppressions.txt
@@ -1,0 +1,1 @@
+.*\.py::implicit-string-concatenation

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/BUILD
@@ -10,6 +10,7 @@ python_library(
     }
   ),
   dependencies=[
+    '3rdparty/python:asttokens',
     '3rdparty/python:future',
     '3rdparty/python:pycodestyle',
     '3rdparty/python:pyflakes',

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/checker.py
@@ -17,10 +17,8 @@ from pants.contrib.python.checks.checker.constant_logic import ConstantLogic
 from pants.contrib.python.checks.checker.except_statements import ExceptStatements
 from pants.contrib.python.checks.checker.file_excluder import FileExcluder
 from pants.contrib.python.checks.checker.future_compatibility import FutureCompatibility
-# TODO(#7307): figure out how to selectively turn on and off checkers with a pants option, since
-# this will make a lot of noise if turned on in this repo!
-# from pants.contrib.python.checks.checker.implicit_string_concatenation import \
-#   ImplicitStringConcatenation
+from pants.contrib.python.checks.checker.implicit_string_concatenation import \
+  ImplicitStringConcatenation
 from pants.contrib.python.checks.checker.import_order import ImportOrder
 from pants.contrib.python.checks.checker.indentation import Indentation
 from pants.contrib.python.checks.checker.missing_contextmanager import MissingContextManager
@@ -136,9 +134,7 @@ def plugins():
     ConstantLogic,
     ExceptStatements,
     FutureCompatibility,
-    # TODO(#7307): figure out how to selectively turn on and off checkers with a pants option, since
-    # this will make a lot of noise if turned on in this repo!
-    # ImplicitStringConcatenation,
+    ImplicitStringConcatenation,
     ImportOrder,
     Indentation,
     MissingContextManager,

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/checker.py
@@ -17,8 +17,6 @@ from pants.contrib.python.checks.checker.constant_logic import ConstantLogic
 from pants.contrib.python.checks.checker.except_statements import ExceptStatements
 from pants.contrib.python.checks.checker.file_excluder import FileExcluder
 from pants.contrib.python.checks.checker.future_compatibility import FutureCompatibility
-from pants.contrib.python.checks.checker.implicit_string_concatenation import \
-  ImplicitStringConcatenation
 from pants.contrib.python.checks.checker.import_order import ImportOrder
 from pants.contrib.python.checks.checker.indentation import Indentation
 from pants.contrib.python.checks.checker.missing_contextmanager import MissingContextManager

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/checker.py
@@ -17,6 +17,8 @@ from pants.contrib.python.checks.checker.constant_logic import ConstantLogic
 from pants.contrib.python.checks.checker.except_statements import ExceptStatements
 from pants.contrib.python.checks.checker.file_excluder import FileExcluder
 from pants.contrib.python.checks.checker.future_compatibility import FutureCompatibility
+from pants.contrib.python.checks.checker.implicit_string_concatenation import \
+  ImplicitStringConcatenation
 from pants.contrib.python.checks.checker.import_order import ImportOrder
 from pants.contrib.python.checks.checker.indentation import Indentation
 from pants.contrib.python.checks.checker.missing_contextmanager import MissingContextManager
@@ -132,6 +134,7 @@ def plugins():
     ConstantLogic,
     ExceptStatements,
     FutureCompatibility,
+    ImplicitStringConcatenation,
     ImportOrder,
     Indentation,
     MissingContextManager,

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/checker.py
@@ -134,7 +134,9 @@ def plugins():
     ConstantLogic,
     ExceptStatements,
     FutureCompatibility,
-    ImplicitStringConcatenation,
+    # TODO(#7307): figure out how to selectively turn on and off checkers with a pants option, since
+    # this will make a lot of noise if turned on in this repo!
+    # ImplicitStringConcatenation,
     ImportOrder,
     Indentation,
     MissingContextManager,

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/checker.py
@@ -17,6 +17,10 @@ from pants.contrib.python.checks.checker.constant_logic import ConstantLogic
 from pants.contrib.python.checks.checker.except_statements import ExceptStatements
 from pants.contrib.python.checks.checker.file_excluder import FileExcluder
 from pants.contrib.python.checks.checker.future_compatibility import FutureCompatibility
+# TODO(#7307): figure out how to selectively turn on and off checkers with a pants option, since
+# this will make a lot of noise if turned on in this repo!
+# from pants.contrib.python.checks.checker.implicit_string_concatenation import \
+#   ImplicitStringConcatenation
 from pants.contrib.python.checks.checker.import_order import ImportOrder
 from pants.contrib.python.checks.checker.indentation import Indentation
 from pants.contrib.python.checks.checker.missing_contextmanager import MissingContextManager

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/common.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/common.py
@@ -12,6 +12,7 @@ import re
 import textwrap
 import tokenize
 
+import asttokens
 import six
 
 
@@ -105,6 +106,7 @@ class PythonFile(object):
   def __init__(self, blob, tree, root, filename):
     self._blob = self._remove_coding_header(blob)
     self.tree = tree
+    self.tokenized_file_body = asttokens.ASTTokens(self._blob, tree=self.tree, filename=filename)
     self.lines = OffByOneList(self._blob.decode('utf-8').split('\n'))
     self._root = root
     self.filename = filename

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/implicit_string_concatenation.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/implicit_string_concatenation.py
@@ -1,0 +1,40 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import ast
+import re
+
+from pants.contrib.python.checks.checker.common import CheckstylePlugin
+
+
+class ImplicitStringConcatenation(CheckstylePlugin):
+  """Detect instances of implicit string concatenation without a plus sign."""
+
+  @classmethod
+  def name(cls):
+    return 'implicit-string-concatenation'
+
+  @classmethod
+  def iter_strings(cls, tree):
+    for ast_node in ast.walk(tree):
+      if isinstance(ast_node, ast.Str):
+        yield ast_node
+
+  def maybe_uses_implicit_concatenation(self, expr):
+    str_node_text = self.python_file.tokenized_file_body.get_text(expr)
+    if re.match(r"^\s*(('[^']*'|\"[^\"]*\")\s+('[^']*'|\"[^\"]*\")|('[^']+'|\"[^\"]+\")\s*('[^']*'|\"[^\"]*\"))",
+                str_node_text):
+      return True
+
+  def nits(self):
+    for str_node in self.iter_strings(self.python_file.tree):
+      if self.maybe_uses_implicit_concatenation(str_node):
+        yield self.warning(
+          'T806',
+          """\
+Implicit string concatenation by separating string literals with a space was detected. Using an
+explicit `+` operator can lead to less error-prone code.""",
+          str_node)

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/implicit_string_concatenation.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/implicit_string_concatenation.py
@@ -25,7 +25,10 @@ class ImplicitStringConcatenation(CheckstylePlugin):
 
   def maybe_uses_implicit_concatenation(self, expr):
     str_node_text = self.python_file.tokenized_file_body.get_text(expr)
-    if re.match(r"^\s*(('[^']*'|\"[^\"]*\")\s+('[^']*'|\"[^\"]*\")|('[^']+'|\"[^\"]+\")\s*('[^']*'|\"[^\"]*\"))",
+    # Search for string nodes of the form 'a' 'b', using any combination of single or double quotes,
+    # with any spacing in between them, but don't flag instances of """. This searches from the
+    # start of the string node and parses backslashes.
+    if re.match(r"^\s*(('([^']|(\\)*')*'|\"([^\"]|(\\)*\")*\")\s+('([^']|(\\)*')*'|\"([^\"]|(\\)*\")*\")|('([^']|(\\)*')+'|\"([^\"]|(\\)*\")+\")\s*('([^']|(\\)*')+'|\"([^\"]|(\\)*\")+\"))",
                 str_node_text):
       return True
 

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/implicit_string_concatenation.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/implicit_string_concatenation.py
@@ -9,6 +9,8 @@ import token
 import tokenize
 from io import StringIO
 
+from future.utils import PY3
+
 from pants.contrib.python.checks.checker.common import CheckstylePlugin
 
 
@@ -28,7 +30,8 @@ class ImplicitStringConcatenation(CheckstylePlugin):
   @classmethod
   def string_node_token_names(cls, str_node_text):
     for tok in tokenize.generate_tokens(StringIO(str_node_text).readline):
-      yield token.tok_name[tok.type]
+      token_type = tok.type if PY3 else tok[0]
+      yield token.tok_name[token_type]
 
   @classmethod
   def has_multiple_strings(cls, token_names):

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/implicit_string_concatenation.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/implicit_string_concatenation.py
@@ -26,11 +26,16 @@ class ImplicitStringConcatenation(CheckstylePlugin):
   def maybe_uses_implicit_concatenation(self, expr):
     str_node_text = self.python_file.tokenized_file_body.get_text(expr)
     # Search for string nodes of the form 'a' 'b', using any combination of single or double quotes,
-    # with any spacing in between them, but don't flag instances of """. This searches from the
-    # start of the string node and parses backslashes.
+    # with any spacing in between them, but don't flag instances of """ or '''. This searches from
+    # the start of the string node and parses backslashes.
+    # TODO: consider just parsing the string for string components and then raising if there is more
+    # than one. This would also allow for more complex logic like reaching into triple-quoted
+    # strings.
     if re.match(r"^\s*(('([^']|(\\)*')*'|\"([^\"]|(\\)*\")*\")\s+('([^']|(\\)*')*'|\"([^\"]|(\\)*\")*\")|('([^']|(\\)*')+'|\"([^\"]|(\\)*\")+\")\s*('([^']|(\\)*')+'|\"([^\"]|(\\)*\")+\"))",
                 str_node_text):
       return True
+    # TODO: also consider checking when triple-quoted strings are used -- e.g. '''''a''' becomes
+    # "''a", but '''a''''' is just "a", which is confusing.
 
   def nits(self):
     for str_node in self.iter_strings(self.python_file.tree):

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/checker/test_implicit_string_concatenation.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/checker/test_implicit_string_concatenation.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from pants_test.contrib.python.checks.checker.plugin_test_base import CheckstylePluginTestBase
+
+from pants.contrib.python.checks.checker.common import Nit
+from pants.contrib.python.checks.checker.implicit_string_concatenation import \
+  ImplicitStringConcatenation
+
+
+class ImplicitStringConcatenationTest(CheckstylePluginTestBase):
+  plugin_type = ImplicitStringConcatenation
+
+  def test_implicit_string_concatenation(self):
+    self.assertNit("'a' 'b'", 'T806', Nit.WARNING)
+    self.assertNit('"a" "b"', 'T806', Nit.WARNING)
+    self.assertNit("'a' \"b\"", 'T806', Nit.WARNING)
+    self.assertNit("('a'\n'b')", 'T806', Nit.WARNING)
+    self.assertNit("('a''b')", 'T806', Nit.WARNING)
+    self.assertNit("'a''b'", 'T806', Nit.WARNING)
+    self.assertNoNits("'a' + 'b'")
+    self.assertNoNits("('a' + 'b')")
+    self.assertNoNits("'''hello!'''")
+    self.assertNoNits('"""hello"""')

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/checker/test_implicit_string_concatenation.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/checker/test_implicit_string_concatenation.py
@@ -21,6 +21,7 @@ class ImplicitStringConcatenationTest(CheckstylePluginTestBase):
     self.assertNit("('a'\n'b')", 'T806', Nit.WARNING)
     self.assertNit("('a''b')", 'T806', Nit.WARNING)
     self.assertNit("'a''b'", 'T806', Nit.WARNING)
+    self.assertNit("'a \\'' 'b'", 'T806', Nit.WARNING)
     self.assertNoNits("'a' + 'b'")
     self.assertNoNits("('a' + 'b')")
     self.assertNoNits("'''hello!'''")

--- a/pants.ini
+++ b/pants.ini
@@ -242,6 +242,9 @@ configuration: %(pants_supportdir)s/checkstyle/coding_style.xml
 [lint.google-java-format]
 skip: True
 
+[lint.pythonstyle]
+suppress: %(pants_supportdir)s/checkstyle/python_suppressions.txt
+
 [lint.python-eval]
 # After we fix the cycles from the engine refactor we should re-enable this.
 # https://github.com/pantsbuild/pants/issues/4601


### PR DESCRIPTION
### Problem

It's occasionally possible to make mistakes when formatting strings using the "implicit" syntax of just placing two string literals next to each other. Although this pattern is used extremely commonly in the codebase right now, it would be nice to be able to point this out.

### Solution

- Add a linter for string concatenations of the form e.g. `'a' 'b'`.
- Add a suppressions file which turns it off for all python files in this repo.

### Result

It's possible this could lead to fewer errors. However, there is currently a lot of noise induced by turning this on and it would be nice to avoid that by eventually fixing code to remove it (e.g. by using triple-quoted `"""` strings instead), but for now, it has been suppressed. Other repos can freely use this lint, however.