### PR TITLE
move wheel extraction for UnpackWheels into PexBuilderWrapper and resolve for a single platform only

### DIFF
--- a/examples/3rdparty/python/BUILD
+++ b/examples/3rdparty/python/BUILD
@@ -23,4 +23,5 @@ unpacked_whls(
     'include/**/*',
     './*.so',
   ],
+  within_purelib_dir=True,
 )

--- a/examples/3rdparty/python/BUILD
+++ b/examples/3rdparty/python/BUILD
@@ -23,5 +23,5 @@ unpacked_whls(
     'include/**/*',
     './*.so',
   ],
-  within_purelib_dir=True,
+  within_data_subdir='purelib/tensorflow',
 )

--- a/src/python/pants/backend/python/subsystems/pex_build_util.py
+++ b/src/python/pants/backend/python/subsystems/pex_build_util.py
@@ -171,7 +171,7 @@ class PexBuilderWrapper(object):
       ))
     except (StopIteration, ValueError) as e:
       raise self.SingleDistExtractionError(
-        "exactly one dist was expected to match name {} in requirements {}: {}"
+        "Exactly one dist was expected to match name {} in requirements {}: {}"
         .format(dist_key, reqs, e))
     return matched_dist
 

--- a/src/python/pants/backend/python/subsystems/pex_build_util.py
+++ b/src/python/pants/backend/python/subsystems/pex_build_util.py
@@ -26,6 +26,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.build_graph.files import Files
 from pants.subsystem.subsystem import Subsystem
+from pants.util.collections import assert_single_element
 
 
 def is_python_target(tgt):
@@ -156,25 +157,22 @@ class PexBuilderWrapper(object):
     :param list reqs: A list of :class:`PythonRequirement` to resolve.
     :param str dist_key: The value of `distribution.key` to match for a `distribution` from the
                          resolved requirements.
-    :return: A path to a wheel containing the single distribution specified by `dist_key`.
+    :return: The single :class:`pkg_resources.Distribution` matching `dist_key`.
     :raises: :class:`self.SingleDistExtractionError` if no dists or multiple dists matched the given
              `dist_key`.
     """
     distributions = self._resolve_distributions_by_platform(reqs, platforms=['current'])
-    matched_dist = None
-    for _, dists in distributions.items():
-      for dist in dists:
-        if dist.key == dist_key:
-          if matched_dist is not None:
-            raise self.SingleDistExtractionError(
-              "multiple dists from requirements {} were resolved matching the key {}: {}, {}. "
-              "this is expected to only match a single dist!"
-              .format(reqs, dist_key, matched_dist, dist.location))
-          matched_dist = dist.location
-    if matched_dist is None:
+    try:
+      matched_dist = assert_single_element(list(
+        dist
+        for _, dists in distributions.items()
+        for dist in dists
+        if dist.key == dist_key
+      ))
+    except (StopIteration, ValueError) as e:
       raise self.SingleDistExtractionError(
-        "no dist matched key {} from requirements {}."
-        .format(dist_key, reqs))
+        "exactly one dist was expected to match name {} in requirements {}: {}"
+        .format(dist_key, reqs, e))
     return matched_dist
 
   def _resolve_distributions_by_platform(self, reqs, platforms):

--- a/src/python/pants/backend/python/targets/unpacked_whls.py
+++ b/src/python/pants/backend/python/targets/unpacked_whls.py
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 class UnpackedWheels(ImportWheelsMixin, Target):
   """A set of sources extracted from JAR files.
 
+  NB: Currently, wheels are always resolved for the 'current' platform.
+
   :API: public
   """
 
@@ -56,6 +58,7 @@ class UnpackedWheels(ImportWheelsMixin, Target):
       'exclude_patterns' : PrimitiveField(exclude_patterns or ()),
       'compatibility': PrimitiveField(maybe_list(compatibility or ())),
       # TODO: consider supporting transitive deps like UnpackedJars!
+      # TODO: consider supporting `platforms` as in PythonBinary!
     })
     super(UnpackedWheels, self).__init__(payload=payload, **kwargs)
 

--- a/src/python/pants/backend/python/targets/unpacked_whls.py
+++ b/src/python/pants/backend/python/targets/unpacked_whls.py
@@ -37,7 +37,7 @@ class UnpackedWheels(ImportWheelsMixin, Target):
     pass
 
   def __init__(self, module_name, libraries=None, include_patterns=None, exclude_patterns=None,
-               compatibility=None, payload=None, **kwargs):
+               compatibility=None, within_purelib_dir=False, payload=None, **kwargs):
     """
     :param str module_name: The name of the specific python module containing headers and/or
                             libraries to extract (e.g. 'tensorflow').
@@ -49,6 +49,9 @@ class UnpackedWheels(ImportWheelsMixin, Target):
     :param compatibility: Python interpreter constraints used to create the pex for the requirement
                           target. If unset, the default interpreter constraints are used. This
                           argument is unnecessary unless the native code depends on libpython.
+    :param bool within_purelib_dir: Whether to descend into '<name>-<version>.data/purelib/' when
+                                    matching `include_patterns`. This layout is used in the
+                                    tensorflow wheel, for example.
     """
     payload = payload or Payload()
     payload.add_fields({
@@ -57,6 +60,7 @@ class UnpackedWheels(ImportWheelsMixin, Target):
       'include_patterns' : PrimitiveField(include_patterns or ()),
       'exclude_patterns' : PrimitiveField(exclude_patterns or ()),
       'compatibility': PrimitiveField(maybe_list(compatibility or ())),
+      'within_purelib_dir': PrimitiveField(within_purelib_dir),
       # TODO: consider supporting transitive deps like UnpackedJars!
       # TODO: consider supporting `platforms` as in PythonBinary!
     })
@@ -73,3 +77,7 @@ class UnpackedWheels(ImportWheelsMixin, Target):
   @property
   def compatibility(self):
     return self.payload.compatibility
+
+  @property
+  def within_purelib_dir(self):
+    return self.payload.within_purelib_dir

--- a/src/python/pants/backend/python/targets/unpacked_whls.py
+++ b/src/python/pants/backend/python/targets/unpacked_whls.py
@@ -36,8 +36,10 @@ class UnpackedWheels(ImportWheelsMixin, Target):
     """Thrown when the target has no libraries defined."""
     pass
 
+  # TODO: consider introducing some form of source roots instead of the manual `within_data_subdir`
+  # kwarg!
   def __init__(self, module_name, libraries=None, include_patterns=None, exclude_patterns=None,
-               compatibility=None, within_purelib_dir=False, payload=None, **kwargs):
+               compatibility=None, within_data_subdir=None, payload=None, **kwargs):
     """
     :param str module_name: The name of the specific python module containing headers and/or
                             libraries to extract (e.g. 'tensorflow').
@@ -49,9 +51,14 @@ class UnpackedWheels(ImportWheelsMixin, Target):
     :param compatibility: Python interpreter constraints used to create the pex for the requirement
                           target. If unset, the default interpreter constraints are used. This
                           argument is unnecessary unless the native code depends on libpython.
-    :param bool within_purelib_dir: Whether to descend into '<name>-<version>.data/purelib/' when
-                                    matching `include_patterns`. This layout is used in the
-                                    tensorflow wheel, for example.
+    :param str within_data_subdir: If provided, descend into '<name>-<version>.data/<subdir>' when
+                                   matching `include_patterns`. For python wheels which declare any
+                                   non-code data, this is usually needed to extract that without
+                                   manually specifying the relative path, including the package
+                                   version. For example, when `data_files` is used in a setup.py,
+                                   `within_data_subdir='data'` will allow specifying
+                                   `include_patterns` matching exactly what is specified in the
+                                   setup.py.
     """
     payload = payload or Payload()
     payload.add_fields({
@@ -60,7 +67,7 @@ class UnpackedWheels(ImportWheelsMixin, Target):
       'include_patterns' : PrimitiveField(include_patterns or ()),
       'exclude_patterns' : PrimitiveField(exclude_patterns or ()),
       'compatibility': PrimitiveField(maybe_list(compatibility or ())),
-      'within_purelib_dir': PrimitiveField(within_purelib_dir),
+      'within_data_subdir': PrimitiveField(within_data_subdir),
       # TODO: consider supporting transitive deps like UnpackedJars!
       # TODO: consider supporting `platforms` as in PythonBinary!
     })
@@ -79,5 +86,5 @@ class UnpackedWheels(ImportWheelsMixin, Target):
     return self.payload.compatibility
 
   @property
-  def within_purelib_dir(self):
-    return self.payload.within_purelib_dir
+  def within_data_subdir(self):
+    return self.payload.within_data_subdir

--- a/src/python/pants/backend/python/tasks/unpack_wheels.py
+++ b/src/python/pants/backend/python/tasks/unpack_wheels.py
@@ -85,10 +85,11 @@ class UnpackWheels(UnpackRemoteSourcesBase):
                                                 unpacked_whls.all_imported_requirements,
                                                 unpacked_whls.module_name)
         ZIP.extract(matched_dist.location, extract_dir)
-        if unpacked_whls.within_purelib_dir:
-          data_dir_prefix = '{name}-{version}.data/purelib/{name}'.format(
+        if unpacked_whls.within_data_subdir:
+          data_dir_prefix = '{name}-{version}.data/{subdir}'.format(
             name=matched_dist.project_name,
             version=matched_dist.version,
+            subdir=unpacked_whls.within_data_subdir,
           )
           dist_data_dir = os.path.join(extract_dir, data_dir_prefix)
         else:

--- a/src/python/pants/backend/python/tasks/unpack_wheels.py
+++ b/src/python/pants/backend/python/tasks/unpack_wheels.py
@@ -4,29 +4,24 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
-import re
 from builtins import str
 from hashlib import sha1
 
 from future.utils import PY3
-from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
-from pex.platforms import Platform
 
-from pants.backend.native.config.environment import Platform as NativeBackendPlatform
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
 from pants.backend.python.subsystems.pex_build_util import PexBuilderWrapper
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.unpacked_whls import UnpackedWheels
 from pants.base.exceptions import TaskError
 from pants.base.fingerprint_strategy import DefaultFingerprintHashingMixin, FingerprintStrategy
+from pants.fs.archive import ZIP
 from pants.task.unpack_remote_sources_base import UnpackRemoteSourcesBase
-from pants.util.contextutil import temporary_dir, temporary_file
-from pants.util.dirutil import mergetree, safe_concurrent_creation
-from pants.util.memo import memoized_classproperty, memoized_method
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import safe_concurrent_creation
+from pants.util.memo import memoized_method
 from pants.util.objects import SubclassesOf
-from pants.util.process_handler import subprocess
 
 
 class UnpackWheelsFingerprintStrategy(DefaultFingerprintHashingMixin, FingerprintStrategy):
@@ -62,88 +57,14 @@ class UnpackWheels(UnpackRemoteSourcesBase):
 
   class _NativeCodeExtractionSetupFailure(Exception): pass
 
-  @staticmethod
-  def _exercise_module(pex, expected_module):
-    # Ripped from test_resolve_requirements.py.
-    with temporary_file(binary_mode=False) as f:
-      f.write('import {m}; print({m}.__file__)'.format(m=expected_module))
-      f.close()
-      proc = pex.run(args=[f.name], blocking=False,
-                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-      stdout, stderr = proc.communicate()
-      return (stdout.decode('utf-8'), stderr.decode('utf-8'))
-
-  @classmethod
-  def _get_wheel_dir(cls, pex, module_name):
-    """Get the directory of a specific wheel contained within an unpacked pex."""
-    stdout_data, stderr_data = cls._exercise_module(pex, module_name)
-    if stderr_data != '':
-      raise cls._NativeCodeExtractionSetupFailure(
-        "Error extracting module '{}' from pex at {}.\nstdout:\n{}\n----\nstderr:\n{}"
-        .format(module_name, pex.path, stdout_data, stderr_data))
-
-    module_path = stdout_data.strip()
-    wheel_dir = os.path.join(
-      module_path[0:module_path.find('{sep}.deps{sep}'.format(sep=os.sep))],
-      '.deps',
-    )
-    if not os.path.isdir(wheel_dir):
-      raise cls._NativeCodeExtractionSetupFailure(
-        "Wheel dir for module '{}' was not found in path '{}' of pex at '{}'."
-        .format(module_name, module_path, pex.path))
-    return wheel_dir
-
-  @staticmethod
-  def _name_and_platform(whl):
-    # The wheel filename is of the format
-    # {distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl
-    # See https://www.python.org/dev/peps/pep-0425/.
-    # We don't care about the python or abi versions because we expect pex to resolve the
-    # appropriate versions for the current host.
-    parts = os.path.splitext(whl)[0].split('-')
-    return '{}-{}'.format(parts[0], parts[1]), parts[-1]
-
-  @memoized_classproperty
-  def _current_platform_abbreviation(cls):
-    return NativeBackendPlatform.create().resolve_for_enum_variant({
-      'darwin': 'macosx',
-      'linux': 'linux',
-    })
-
-  @classmethod
-  def _get_matching_wheel_dir(cls, wheel_dir, module_name):
-    wheels = os.listdir(wheel_dir)
-
-    names_and_platforms = {w:cls._name_and_platform(w) for w in wheels}
-    for whl_filename, (name, platform) in names_and_platforms.items():
-      if cls._current_platform_abbreviation in platform:
-        # TODO: this guards against packages which have names that are prefixes of other packages by
-        # checking if there is a version number beginning -- is there a more canonical way to do
-        # this?
-        if re.match(r'^{}\-[0-9]'.format(re.escape(module_name)), name):
-          return os.path.join(wheel_dir, whl_filename, module_name)
-
-    raise cls._NativeCodeExtractionSetupFailure(
-      "Could not find wheel in dir '{wheel_dir}' matching module name '{module_name}' "
-      "for current platform '{pex_current_platform}', when looking for platforms containing the "
-      "substring {cur_platform_abbrev}.\n"
-      "wheels: {wheels}"
-      .format(wheel_dir=wheel_dir,
-              module_name=module_name,
-              pex_current_platform=Platform.current().platform,
-              cur_platform_abbrev=cls._current_platform_abbreviation,
-              wheels=wheels))
-
-  def _generate_requirements_pex(self, pex_path, interpreter, requirements):
-    if not os.path.exists(pex_path):
-      with self.context.new_workunit('extract-native-wheels'):
-        with safe_concurrent_creation(pex_path) as chroot:
-          pex_builder = PexBuilderWrapper.Factory.create(
-            builder=PEXBuilder(path=chroot, interpreter=interpreter),
-            log=self.context.log)
-          pex_builder.add_resolved_requirements(requirements)
-          pex_builder.freeze()
-    return PEX(pex_path, interpreter=interpreter)
+  def _get_matching_wheel(self, pex_path, interpreter, requirements, module_name):
+    """Use PexBuilderWrapper to resolve a single wheel from the requirement specs using pex."""
+    with self.context.new_workunit('extract-native-wheels'):
+      with safe_concurrent_creation(pex_path) as chroot:
+        pex_builder = PexBuilderWrapper.Factory.create(
+          builder=PEXBuilder(path=chroot, interpreter=interpreter),
+          log=self.context.log)
+        return pex_builder.extract_single_dist_for_current_platform(requirements, module_name)
 
   @memoized_method
   def _compatible_interpreter(self, unpacked_whls):
@@ -157,17 +78,12 @@ class UnpackWheels(UnpackRemoteSourcesBase):
     interpreter = self._compatible_interpreter(unpacked_whls)
 
     with temporary_dir() as tmp_dir:
-      # NB: The pex needs to be in a subdirectory for some reason, and pants task caching ensures it
-      # is the only member of this directory, so the dirname doesn't matter.
-      pex_path = os.path.join(tmp_dir, 'xxx.pex')
       try:
-        pex = self._generate_requirements_pex(pex_path, interpreter,
-                                              unpacked_whls.all_imported_requirements)
-        wheel_dir = self._get_wheel_dir(pex, unpacked_whls.module_name)
-        matching_wheel_dir = self._get_matching_wheel_dir(wheel_dir, unpacked_whls.module_name)
+        wheel_path = self._get_matching_wheel(tmp_dir, interpreter,
+                                              unpacked_whls.all_imported_requirements,
+                                              unpacked_whls.module_name)
         unpack_filter = self.get_unpack_filter(unpacked_whls)
-        # Copy over the module's data files into `unpack_dir`.
-        mergetree(matching_wheel_dir, unpack_dir, file_filter=unpack_filter)
+        ZIP.extract(wheel_path, unpack_dir, filter_func=unpack_filter)
       except Exception as e:
         raise self.NativeCodeExtractionError(
           "Error extracting wheel for target {}: {}"

--- a/src/python/pants/task/unpack_remote_sources_base.py
+++ b/src/python/pants/task/unpack_remote_sources_base.py
@@ -100,12 +100,12 @@ class UnpackRemoteSourcesBase(Task, AbstractClass):
                                             field_name='include_patterns',
                                             spec=spec)
     logger.debug('include_patterns: {}'
-                 .format(p.pattern for p in include_patterns))
+                 .format(list(p.pattern for p in include_patterns)))
     exclude_patterns = cls.compile_patterns(excludes or [],
                                             field_name='exclude_patterns',
                                             spec=spec)
     logger.debug('exclude_patterns: {}'
-                 .format(p.pattern for p in exclude_patterns))
+                 .format(list(p.pattern for p in exclude_patterns)))
     return lambda f: cls._file_filter(f, include_patterns, exclude_patterns)
 
   @classmethod

--- a/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
@@ -42,6 +42,7 @@ class UnpackedJarsTest(TestBase):
 
   def test_bad_libraries_ref(self):
     self.make_target(':right-type', JarLibrary, jars=[JarDependency('foo', 'bar', '123')])
+    # Making a target which is not a jar library, which causes an error.
     self.make_target(':wrong-type', UnpackedJars, libraries=[':right-type'])
     target = self.make_target(':foo', UnpackedJars, libraries=[':wrong-type'])
     with self.assertRaises(ImportJarsMixin.WrongTargetTypeError):
@@ -85,6 +86,6 @@ class UnpackedJarsTest(TestBase):
     unpacked_jar_deps = unpacked_lib.all_imported_jar_deps
 
     self.assertEqual(3, len(unpacked_jar_deps))
-    assert_dep(lib1.jar_dependencies[0], 'testOrg1', 'testName1', '123')
-    assert_dep(lib2.jar_dependencies[0], 'testOrg2', 'testName2', '456')
-    assert_dep(lib2.jar_dependencies[1], 'testOrg3', 'testName3', '789')
+    assert_dep(unpacked_jar_deps[0], 'testOrg1', 'testName1', '123')
+    assert_dep(unpacked_jar_deps[1], 'testOrg2', 'testName2', '456')
+    assert_dep(unpacked_jar_deps[2], 'testOrg3', 'testName3', '789')

--- a/tests/python/pants_test/backend/jvm/tasks/test_unpack_jars.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_unpack_jars.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import functools
 import os
-import unittest
 from contextlib import contextmanager
 
 from pants.backend.jvm.targets.jar_library import JarLibrary
@@ -35,45 +34,6 @@ class UnpackJarsTest(TaskTestBase):
         proto_jarfile.writestr('a/b/c/{}.txt'.format(name), 'Some text')
         proto_jarfile.writestr('a/b/c/{}.proto'.format(name), 'message Msg {}')
       yield jar_name
-
-  def test_invalid_pattern(self):
-    with self.assertRaises(UnpackJars.InvalidPatternError):
-      UnpackJars.compile_patterns([45])
-
-  @staticmethod
-  def _run_filter(filename, include_patterns=None, exclude_patterns=None):
-    return UnpackJars._file_filter(
-      filename,
-      UnpackJars.compile_patterns(include_patterns or []),
-      UnpackJars.compile_patterns(exclude_patterns or []))
-
-  def test_file_filter(self):
-    # If no patterns are specified, everything goes through
-    self.assertTrue(self._run_filter("foo/bar.java"))
-
-    self.assertTrue(self._run_filter("foo/bar.java", include_patterns=["**/*.java"]))
-    self.assertTrue(self._run_filter("bar.java", include_patterns=["**/*.java"]))
-    self.assertTrue(self._run_filter("bar.java", include_patterns=["**/*.java", "*.java"]))
-    self.assertFalse(self._run_filter("foo/bar.java", exclude_patterns=["**/bar.*"]))
-    self.assertFalse(self._run_filter("foo/bar.java",
-                                      include_patterns=["**/*/java"],
-                                      exclude_patterns=["**/bar.*"]))
-
-    # exclude patterns should be computed before include patterns
-    self.assertFalse(self._run_filter("foo/bar.java",
-                                      include_patterns=["foo/*.java"],
-                                      exclude_patterns=["foo/b*.java"]))
-    self.assertTrue(self._run_filter("foo/bar.java",
-                                     include_patterns=["foo/*.java"],
-                                     exclude_patterns=["foo/x*.java"]))
-
-  @unittest.expectedFailure
-  def test_problematic_cases(self):
-    """These should pass, but don't"""
-    # See https://github.com/twitter/commons/issues/380.  'foo*bar' doesn't match 'foobar'
-    self.assertFalse(self._run_filter("foo/bar.java",
-                                      include_patterns=['foo/*.java'],
-                                      exclude_patterns=['foo/bar*.java']))
 
   def _make_jar_library(self, coord):
     return self.make_target(spec='unpack/jars:foo-jars',

--- a/tests/python/pants_test/backend/python/targets/BUILD
+++ b/tests/python/pants_test/backend/python/targets/BUILD
@@ -1,0 +1,11 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_tests(
+  dependencies=[
+    'src/python/pants/backend/python/targets',
+    'src/python/pants/backend/python:python_requirement',
+    'src/python/pants/util:collections',
+    'tests/python/pants_test:test_base',
+  ]
+)

--- a/tests/python/pants_test/backend/python/targets/test_unpacked_whls.py
+++ b/tests/python/pants_test/backend/python/targets/test_unpacked_whls.py
@@ -1,0 +1,94 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from textwrap import dedent
+
+from pants.backend.python.python_requirement import PythonRequirement
+from pants.backend.python.targets.import_wheels_mixin import ImportWheelsMixin
+from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
+from pants.backend.python.targets.unpacked_whls import UnpackedWheels
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.util.collections import assert_single_element
+from pants_test.test_base import TestBase
+
+
+class UnpackedWheelsTest(TestBase):
+
+  @classmethod
+  def alias_groups(cls):
+    return BuildFileAliases(
+      targets={
+        'python_requirement_library': PythonRequirementLibrary,
+        'unpacked_whls': UnpackedWheels,
+      },
+      objects={'python_requirement': PythonRequirement})
+
+  def test_empty_libraries(self):
+    with self.assertRaises(UnpackedWheels.ExpectedLibrariesError):
+      self.make_target(':foo', UnpackedWheels, module_name='foo')
+
+  def test_simple(self):
+    self.make_target(':import_whls', PythonRequirementLibrary, requirements=[
+      PythonRequirement('foo==123'),
+    ])
+    target = self.make_target(':foo', UnpackedWheels, libraries=[':import_whls'], module_name='foo')
+
+    self.assertIsInstance(target, UnpackedWheels)
+    dependency_specs = [spec for spec in target.compute_dependency_specs(payload=target.payload)]
+    self.assertSequenceEqual([':import_whls'], dependency_specs)
+    import_whl_dep = assert_single_element(target.all_imported_requirements)
+    self.assertIsInstance(import_whl_dep, PythonRequirement)
+
+  def test_bad_libraries_ref(self):
+    self.make_target(':right-type', PythonRequirementLibrary, requirements=[
+      PythonRequirement('foo==123'),
+    ])
+    # Making a target which is not a requirement library, which causes an error.
+    self.make_target(':wrong-type', UnpackedWheels, libraries=[':right-type'], module_name='foo')
+    target = self.make_target(':foo', UnpackedWheels, libraries=[':wrong-type'], module_name='foo')
+    with self.assertRaises(ImportWheelsMixin.WrongTargetTypeError):
+      target.imported_targets
+
+  def test_has_all_imported_req_libs(self):
+    def assert_dep(reqA, reqB):
+      self.assertEqual(reqA.requirement, reqB.requirement)
+
+    self.add_to_build_file('BUILD', dedent('''
+    python_requirement_library(name='lib1',
+      requirements=[
+        python_requirement('testName1==123'),
+      ],
+    )
+    python_requirement_library(name='lib2',
+      requirements=[
+        python_requirement('testName2==456'),
+        python_requirement('testName3==789'),
+      ],
+    )
+    unpacked_whls(name='unpacked-lib',
+      libraries=[':lib1', ':lib2'],
+      module_name='foo',
+    )
+    '''))
+    lib1 = self.target('//:lib1')
+    self.assertIsInstance(lib1, PythonRequirementLibrary)
+    assert_dep(assert_single_element(lib1.requirements),
+               PythonRequirement('testName1==123'))
+
+    lib2 = self.target('//:lib2')
+    self.assertIsInstance(lib2, PythonRequirementLibrary)
+    lib2_reqs = list(lib2.requirements)
+    self.assertEqual(2, len(lib2_reqs))
+    assert_dep(lib2_reqs[0], PythonRequirement('testName2==456'))
+    assert_dep(lib2_reqs[1], PythonRequirement('testName3==789'))
+
+    unpacked_lib = self.target('//:unpacked-lib')
+    unpacked_req_libs = unpacked_lib.all_imported_requirements
+
+    self.assertEqual(3, len(unpacked_req_libs))
+    assert_dep(unpacked_req_libs[0], PythonRequirement('testName1==123'))
+    assert_dep(unpacked_req_libs[1], PythonRequirement('testName2==456'))
+    assert_dep(unpacked_req_libs[2], PythonRequirement('testName3==789'))

--- a/tests/python/pants_test/backend/python/tasks/test_python_tool.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_tool.py
@@ -16,6 +16,7 @@ from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTest
 
 class Tool(PythonToolBase):
   options_scope = 'test-tool'
+  # TODO: make a fake pex tool instead of depending on a real python requirement!
   default_requirements = [
     'pex==1.5.3',
   ]

--- a/tests/python/pants_test/backend/python/tasks/test_unpack_wheels.py
+++ b/tests/python/pants_test/backend/python/tasks/test_unpack_wheels.py
@@ -65,10 +65,10 @@ class UnpackWheelsTest(TaskTestBase):
       pex_requirement,
       include_patterns=['pex/pex.py', 'pex/__init__.py'],
       module_name=module_name,
-      # TODO: `within_purelib_dir=True` is only tested implicitly by the tensorflow_custom_op target
-      # in examples/! Make a fake wheel, resolve it, and test that `within_purelib_dir=True`
+      # TODO: `within_data_subdir` is only tested implicitly by the tensorflow_custom_op target
+      # in examples/! Make a fake wheel, resolve it, and test that `within_data_subdir`
       # descends into the correct directory!
-      within_purelib_dir=False)
+      within_data_subdir=None)
     context = self.context(target_roots=[unpacked_wheel_tgt])
     unpack_task = self.create_task(context)
     unpack_task.execute()
@@ -86,5 +86,5 @@ class UnpackWheelsTest(TaskTestBase):
 
   def test_unpack_missing_module_name(self):
     with self.assertRaisesRegexp(UnpackWheels.WheelUnpackingError, re.escape(
-        'Error extracting wheel for target UnpackedWheels(unpack:foo): exactly one dist was expected to match name not-a-real-module')):
+        'Error extracting wheel for target UnpackedWheels(unpack:foo): Exactly one dist was expected to match name not-a-real-module')):
       self._assert_unpacking(module_name='not-a-real-module')

--- a/tests/python/pants_test/backend/python/tasks/test_unpack_wheels.py
+++ b/tests/python/pants_test/backend/python/tasks/test_unpack_wheels.py
@@ -1,0 +1,90 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import functools
+import re
+
+from pants.backend.python.python_requirement import PythonRequirement
+from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
+from pants.backend.python.targets.unpacked_whls import UnpackedWheels
+from pants.backend.python.tasks.unpack_wheels import UnpackWheels, UnpackWheelsFingerprintStrategy
+from pants.task.unpack_remote_sources_base import UnpackedArchives
+from pants.util.collections import assert_single_element
+from pants_test.task_test_base import TaskTestBase
+
+
+class UnpackWheelsTest(TaskTestBase):
+
+  @classmethod
+  def task_type(cls):
+    return UnpackWheels
+
+  def _make_req_library(self, requirement):
+    return self.make_target(spec='unpack/whls:foo-whls',
+                            target_type=PythonRequirementLibrary,
+                            requirements=[requirement])
+
+  def _make_unpacked_wheel(self, requirement, include_patterns, module_name='foo', **kwargs):
+    reqlib = self._make_req_library(requirement)
+    return self.make_target(spec='unpack:foo',
+                            target_type=UnpackedWheels,
+                            libraries=[reqlib.address.spec],
+                            module_name=module_name,
+                            include_patterns=include_patterns,
+                            **kwargs)
+
+  def test_unpack_wheels_fingerprint_strategy(self):
+    fingerprint_strategy = UnpackWheelsFingerprintStrategy()
+
+    make_unpacked_wheel = functools.partial(self._make_unpacked_wheel, include_patterns=['bar'])
+    req1 = PythonRequirement('com.example.bar==0.0.1')
+    target = make_unpacked_wheel(req1)
+    fingerprint1 = fingerprint_strategy.compute_fingerprint(target)
+
+    # Now, replace the build file with a different version.
+    self.reset_build_graph()
+    target = make_unpacked_wheel(PythonRequirement('com.example.bar==0.0.2'))
+    fingerprint2 = fingerprint_strategy.compute_fingerprint(target)
+    self.assertNotEqual(fingerprint1, fingerprint2)
+
+    # Go back to the original library.
+    self.reset_build_graph()
+    target = make_unpacked_wheel(req1)
+    fingerprint3 = fingerprint_strategy.compute_fingerprint(target)
+
+    self.assertEqual(fingerprint1, fingerprint3)
+
+  def _assert_unpacking(self, module_name):
+    # TODO: figure out how to generate a nice fake wheel that the pex resolve will accept instead of
+    # depending on a real wheel!
+    pex_requirement = PythonRequirement('pex==1.5.3')
+    unpacked_wheel_tgt = self._make_unpacked_wheel(
+      pex_requirement,
+      include_patterns=['pex/pex.py', 'pex/__init__.py'],
+      module_name=module_name,
+      # TODO: `within_purelib_dir=True` is only tested implicitly by the tensorflow_custom_op target
+      # in examples/! Make a fake wheel, resolve it, and test that `within_purelib_dir=True`
+      # descends into the correct directory!
+      within_purelib_dir=False)
+    context = self.context(target_roots=[unpacked_wheel_tgt])
+    unpack_task = self.create_task(context)
+    unpack_task.execute()
+
+    expected_files = {'pex/__init__.py', 'pex/pex.py'}
+
+    with unpack_task.invalidated([unpacked_wheel_tgt]) as invalidation_check:
+      vt = assert_single_element(invalidation_check.all_vts)
+      self.assertEqual(vt.target, unpacked_wheel_tgt)
+      archives = context.products.get_data(UnpackedArchives, dict)[vt.target]
+      self.assertEqual(expected_files, set(archives.found_files))
+
+  def test_unpacking(self):
+    self._assert_unpacking(module_name='pex')
+
+  def test_unpack_missing_module_name(self):
+    with self.assertRaisesRegexp(UnpackWheels.WheelUnpackingError, re.escape(
+        'Error extracting wheel for target UnpackedWheels(unpack:foo): exactly one dist was expected to match name not-a-real-module')):
+      self._assert_unpacking(module_name='not-a-real-module')

--- a/tests/python/pants_test/task/BUILD
+++ b/tests/python/pants_test/task/BUILD
@@ -82,3 +82,12 @@ python_tests(
     'tests/python/pants_test:task_test_base',
   ]
 )
+
+python_tests(
+  name='unpack_remote_sources_base',
+  sources=['test_unpack_remote_sources_base.py'],
+  dependencies=[
+    'src/python/pants/task',
+    'tests/python/pants_test:test_base',
+  ],
+)

--- a/tests/python/pants_test/task/test_unpack_remote_sources_base.py
+++ b/tests/python/pants_test/task/test_unpack_remote_sources_base.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+from pants.task.unpack_remote_sources_base import UnpackRemoteSourcesBase
+from pants_test.test_base import TestBase
+
+
+class UnpackRemoteSourcesTest(TestBase):
+  """Test common functionality for tasks unpacking remote sources, including file filtering."""
+
+  def test_invalid_pattern(self):
+    with self.assertRaises(UnpackRemoteSourcesBase.InvalidPatternError):
+      UnpackRemoteSourcesBase.compile_patterns([45])
+
+  @staticmethod
+  def _run_filter(filename, include_patterns=None, exclude_patterns=None):
+    return UnpackRemoteSourcesBase._file_filter(
+      filename,
+      UnpackRemoteSourcesBase.compile_patterns(include_patterns or []),
+      UnpackRemoteSourcesBase.compile_patterns(exclude_patterns or []))
+
+  def test_file_filter(self):
+    # If no patterns are specified, everything goes through
+    self.assertTrue(self._run_filter("foo/bar.java"))
+
+    self.assertTrue(self._run_filter("foo/bar.java", include_patterns=["**/*.java"]))
+    self.assertTrue(self._run_filter("bar.java", include_patterns=["**/*.java"]))
+    self.assertTrue(self._run_filter("bar.java", include_patterns=["**/*.java", "*.java"]))
+    self.assertFalse(self._run_filter("foo/bar.java", exclude_patterns=["**/bar.*"]))
+    self.assertFalse(self._run_filter("foo/bar.java",
+                                      include_patterns=["**/*/java"],
+                                      exclude_patterns=["**/bar.*"]))
+
+    # exclude patterns should be computed before include patterns
+    self.assertFalse(self._run_filter("foo/bar.java",
+                                      include_patterns=["foo/*.java"],
+                                      exclude_patterns=["foo/b*.java"]))
+    self.assertTrue(self._run_filter("foo/bar.java",
+                                     include_patterns=["foo/*.java"],
+                                     exclude_patterns=["foo/x*.java"]))
+
+  @unittest.expectedFailure
+  def test_problematic_cases(self):
+    """These should pass, but don't"""
+    # See https://github.com/twitter/commons/issues/380.  'foo*bar' doesn't match 'foobar'
+    self.assertFalse(self._run_filter("foo/bar.java",
+                                      include_patterns=['foo/*.java'],
+                                      exclude_patterns=['foo/bar*.java']))


### PR DESCRIPTION
### Problem

Resolves #7245. We are seeing wheels getting unpacked for the wrong platform nondeterministically in our internal repo, where we have multiple platforms in `python-setup.platforms`.

### Solution

- Resolve wheels for `UnpackWheels` for the current platform only.
- Ensure that there is exactly a single wheel resolved for the desired distribution name.

### Result

The complex and unnecessary dist resolution / location process in `UnpackWheels` is a lot smoother, we resolve for only a single platform, and we check to ensure only a single dist can be located from the resolved requirements. 