### PR TITLE
Bugfix for stale interpreter.info purging when binary exe is no longer on the filesystem

### DIFF
--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -24,18 +24,8 @@ function activate_venv() {
 
 function remove_venv() {
   rm -rf "$(venv_dir)"
-  # If `pants_dev_deps.venv` or `pants_dev_deps.py{2,3}.venv` still exist, delete both the legacy folders
-  # and the cached Python interpreter folder, which contains problematic symlinks. Note we only perform
-  # these removals for the first time, to avoid continually deleting the cache when switching
-  # between valid venvs.
-  legacy_venv_dirs=("${venv_dir_prefix}.venv" "${venv_dir_prefix}.py2.venv" "${venv_dir_prefix}.py3.venv")
-  for legacy_venv_dir in "${legacy_venv_dirs[@]}"; do
-    if [ -d "${legacy_venv_dir}" ]; then
-      rm -rf "${legacy_venv_dirs[@]}"
-      rm -rf "${HOME}/.cache/pants/python_cache/interpreters"
-      break
-    fi
-  done
+  # Also remove legacy folders.
+  rm -rf "${venv_dir_prefix}.venv" "${venv_dir_prefix}.py{2,3}.venv"
 }
 
 function create_venv() {

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import glob
 import os
 
+from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 
 from pants.util.contextutil import temporary_dir

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import glob
 import os
 
+from pex.interpreter import PythonInterpreter
+
 from pants.util.contextutil import temporary_dir
 from pants.util.process_handler import subprocess
 from pants_test.backend.python.interpreter_selection_utils import (PY_3, PY_27, skip_unless_python3,
@@ -116,8 +118,13 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
 
       def _validate_good_interpreter_path_file(path):
         with open(path, 'r') as fp:
-          interpreter_binary = fp.readline()
-          return os.path.exists(interpreter_binary)
+          lines = fp.readlines()
+          binary = lines[0].strip()
+          try:
+            interpreter = PythonInterpreter.from_binary(binary)
+            return True if interpreter else False
+          except Executor.ExecutableNotFound:
+            return False
 
       # Mangle interpreter.info.
       for path in glob.glob(os.path.join(workdir, 'pyprep/interpreter/*/interpreter.info')):

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import glob
 import os
 
 from pants.util.contextutil import temporary_dir
@@ -90,3 +91,36 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
         ]
     command = ['binary', binary_target] + args
     return self.run_pants(command=command, config=config)
+
+  def test_stale_interpreter_purge_integration(self):
+    target = '{}:{}'.format(self.testproject, 'echo_interpreter_version')
+    config = {
+      'python-setup': {
+        'interpreter_constraints': ['CPython>=2.7,<4'],
+      }
+    }
+    with self.temporary_workdir() as workdir:
+      pants_run = self.run_pants_with_workdir(
+        ["run", target],
+        workdir=workdir,
+        config=config
+      )
+      self.assert_success(pants_run)
+
+      def _prepend_to_interpreter_path_file(path):
+        with open(path, 'r') as fp:
+          file_data = fp.readlines()
+          file_data[0] = '/my/bogus/interpreter/python2.7'
+        with open(path, 'w') as fp:
+          fp.writelines(file_data)
+
+      # Mangle interpreter.info.
+      for path in glob.glob(os.path.join(workdir, 'pyprep/interpreter/*/interpreter.info')):
+        _prepend_to_interpreter_path_file(path)
+
+      pants_run = self.run_pants_with_workdir(
+        ["run", target],
+        workdir=workdir,
+        config=config
+      )
+      self.assert_success(pants_run)


### PR DESCRIPTION
The stale interpreter purge logic was not handling interpreter.info file correctly due to inaccurate mocking during manual testing, resulting in a `ExecutableNotFound` error when it encounters a interpreter.info file written by Pants. 

This change wraps calls to `_get_interpreter` with a try/except so we do not try to load a `PythonInterpreter` object from a binary that does not exist on the filesystem.

To test this, I used the source workflow in our monorepo, and removed the cached Python 3.7 binary executable itself from the filesystem, resulting in the following output:
```
$ ./pants run python/tests/interpreter_verification:python3_main

14:08:13 00:00 [main]
               (To run a reporting server: ./pants server)
14:08:15 00:02   [setup]
14:08:15 00:02     [parse]
...
14:08:17 00:04   [native-compile]
14:08:17 00:04     [conan-prep]INFO] Detected stale interpreter `/Users/clivingston/workspace/source3/.pants.d/python-setup/interpreters/CPython-2.7.15` in the interpreter cache, purging.
INFO] Detected stale interpreter `/Users/clivingston/workspace/source3/.pants.d/python-setup/interpreters/CPython-3.7.2` in the interpreter cache, purging.

14:08:22 00:09     [conan-fetch]
...
14:08:22 00:09   [pyprep]
14:08:22 00:09     [interpreter]
                   Stale interpreter reference detected: /Users/clivingston/workspace/source3/.pants.d/pyprep/interpreter/a31e7e1381463c9d3652d70ba8f9f7b6345ddf8b/interpreter.info, removing reference and selecting a new interpreter.
...
14:08:26 00:13   [run]
14:08:26 00:13     [py]
14:08:27 00:14       [run]
Python 3 in Source!