### PR TITLE
Deprecate Context.build_file_parser.

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -125,7 +125,7 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
   @memoized_method
   def _target_type_for_language(self, language):
     alias_for_lang = self._registered_language_aliases()[language]
-    registered_aliases = self.context.build_file_parser.registered_aliases()
+    registered_aliases = self.context.build_configuration.registered_aliases()
     target_types = registered_aliases.target_types_by_alias.get(alias_for_lang, None)
     if not target_types:
       raise TaskError('Registered target type `{0}` for language `{1}` does not exist!'.format(alias_for_lang, language))

--- a/src/python/pants/backend/docgen/tasks/generate_pants_reference.py
+++ b/src/python/pants/backend/docgen/tasks/generate_pants_reference.py
@@ -85,7 +85,7 @@ class GeneratePantsReference(Task):
     self.context.products.register_data(self.PANTS_REFERENCE_PRODUCT, ref_page)
 
   def _gen_build_dictionary(self):
-    buildfile_aliases = self.context.build_file_parser.registered_aliases()
+    buildfile_aliases = self.context.build_configuration.registered_aliases()
     extracter = BuildDictionaryInfoExtracter(buildfile_aliases)
     target_type_infos = extracter.get_target_type_info()
     other_infos = sorted(extracter.get_object_info() + extracter.get_object_factory_info())

--- a/src/python/pants/backend/graph_info/tasks/target_filter_task_mixin.py
+++ b/src/python/pants/backend/graph_info/tasks/target_filter_task_mixin.py
@@ -25,7 +25,7 @@ class TargetFilterTaskMixin(Task):
     :raises :class:`TargetFilterTaskMixin.InvalidTargetType`: when no target types correspond to
                                                               the given `alias`.
     """
-    registered_aliases = self.context.build_file_parser.registered_aliases()
+    registered_aliases = self.context.build_configuration.registered_aliases()
     target_types = registered_aliases.target_types_by_alias.get(alias, None)
     if not target_types:
       raise self.InvalidTargetType('Not a target type: {}'.format(alias))

--- a/src/python/pants/backend/jvm/tasks/rewrite_base.py
+++ b/src/python/pants/backend/jvm/tasks/rewrite_base.py
@@ -46,7 +46,7 @@ class RewriteBase(NailgunTask, AbstractClass):
   @memoized_property
   def _formatted_target_types(self):
     aliases = set(self.get_options().target_types)
-    registered_aliases = self.context.build_file_parser.registered_aliases()
+    registered_aliases = self.context.build_configuration.registered_aliases()
     return tuple({target_type
                   for alias in aliases
                   for target_type in registered_aliases.target_types_by_alias[alias]})

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -375,7 +375,7 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
 
   @memoized_property
   def target_aliases_map(self):
-    registered_aliases = self.context.build_file_parser.registered_aliases()
+    registered_aliases = self.context.build_configuration.registered_aliases()
     mapping = {}
     for alias, target_types in registered_aliases.target_types_by_alias.items():
       # If a target class is registered under multiple aliases returns the last one.

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -114,6 +114,7 @@ class GoalRunnerFactory(object):
                         requested_goals=self._options.goals,
                         build_graph=build_graph,
                         build_file_parser=build_file_parser,
+                        build_configuration=self._build_config,
                         address_mapper=address_mapper,
                         invalidation_report=invalidation_report,
                         scheduler=self._graph_session.scheduler_session)

--- a/src/python/pants/core_tasks/targets_help.py
+++ b/src/python/pants/core_tasks/targets_help.py
@@ -21,7 +21,7 @@ class TargetsHelp(ConsoleTask):
     register('--details', help='Show details about this target type.')
 
   def console_output(self, targets):
-    buildfile_aliases = self.context.build_file_parser.registered_aliases()
+    buildfile_aliases = self.context.build_configuration.registered_aliases()
     extracter = BuildDictionaryInfoExtracter(buildfile_aliases)
 
     alias = self.get_options().details

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -39,6 +39,7 @@ python_library(
     ':workspace',
     'src/python/pants/base:build_environment',
     'src/python/pants/build_graph', # XXX(fixme)
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:worker_pool',
     'src/python/pants/base:workunit',
     'src/python/pants/java/distribution:distribution',

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -14,6 +14,7 @@ from future.utils import PY3
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot, get_scm
+from pants.base.deprecated import deprecated
 from pants.base.worker_pool import SubprocPool
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.build_graph.target import Target
@@ -41,11 +42,13 @@ class Context(object):
   # repository of attributes?
   def __init__(self, options, run_tracker, target_roots,
                requested_goals=None, target_base=None, build_graph=None,
-               build_file_parser=None, address_mapper=None, console_outstream=None, scm=None,
+               build_file_parser=None, build_configuration=None,
+               address_mapper=None, console_outstream=None, scm=None,
                workspace=None, invalidation_report=None, scheduler=None):
     self._options = options
     self.build_graph = build_graph
-    self.build_file_parser = build_file_parser
+    self._build_file_parser = build_file_parser
+    self.build_configuration = build_configuration
     self.address_mapper = address_mapper
     self.run_tracker = run_tracker
     self._log = run_tracker.logger
@@ -62,6 +65,11 @@ class Context(object):
     self._replace_targets(target_roots)
     self._invalidation_report = invalidation_report
     self._scheduler = scheduler
+
+  @property
+  @deprecated('1.17.0.dev2', hint_message='Use the build_configuration property.')
+  def build_file_parser(self):
+    return self._build_file_parser
 
   @property
   def options(self):

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -119,8 +119,8 @@ class TestContext(Context):
 
 
 def create_context_from_options(options, target_roots=None, build_graph=None,
-                                build_file_parser=None, address_mapper=None, console_outstream=None,
-                                workspace=None, scheduler=None):
+                                build_configuration=None, address_mapper=None,
+                                console_outstream=None, workspace=None, scheduler=None):
   """Creates a ``Context`` with the given options and no targets by default.
 
   :param options: An :class:`pants.option.options.Option`-alike object that supports read methods.
@@ -130,6 +130,6 @@ def create_context_from_options(options, target_roots=None, build_graph=None,
   run_tracker = TestContext.DummyRunTracker()
   target_roots = maybe_list(target_roots, Target) if target_roots else []
   return TestContext(options=options, run_tracker=run_tracker, target_roots=target_roots,
-                     build_graph=build_graph, build_file_parser=build_file_parser,
+                     build_graph=build_graph, build_configuration=build_configuration,
                      address_mapper=address_mapper, console_outstream=console_outstream,
                      workspace=workspace, scheduler=scheduler)

--- a/tests/python/pants_test/build_graph/test_build_file_parser.py
+++ b/tests/python/pants_test/build_graph/test_build_file_parser.py
@@ -25,12 +25,13 @@ class ErrorTarget(Target):
     assert False, "This fake target should never be initialized in this test!"
 
 
-class BuildFileParserBasicsTest(TestBase):
-
+class TestWithBuildFileParser(TestBase):
   def setUp(self):
-    super(BuildFileParserBasicsTest, self).setUp()
+    super(TestWithBuildFileParser, self).setUp()
     self.build_file_parser = BuildFileParser(self._build_configuration, self.build_root)
 
+
+class BuildFileParserBasicsTest(TestWithBuildFileParser):
   @classmethod
   def alias_groups(cls):
     return BuildFileAliases(targets={'jvm_binary': ErrorTarget,
@@ -119,7 +120,7 @@ class BuildFileParserBasicsTest(TestBase):
     self.build_file_parser.parse_build_file(build_file)
 
 
-class BuildFileParserTargetTest(TestBase):
+class BuildFileParserTargetTest(TestWithBuildFileParser):
   @classmethod
   def alias_groups(cls):
     return BuildFileAliases(targets={'fake': ErrorTarget})
@@ -209,8 +210,7 @@ class BuildFileParserTargetTest(TestBase):
         BuildFile.get_build_files_family(FileSystemProjectTree(self.build_root), '.'))
 
 
-class BuildFileParserExposedObjectTest(TestBase):
-
+class BuildFileParserExposedObjectTest(TestWithBuildFileParser):
   @classmethod
   def alias_groups(cls):
     return BuildFileAliases(objects={'fake_object': object()})
@@ -222,7 +222,7 @@ class BuildFileParserExposedObjectTest(TestBase):
     self.assertEqual(len(address_map), 0)
 
 
-class BuildFileParserExposedContextAwareObjectFactoryTest(TestBase):
+class BuildFileParserExposedContextAwareObjectFactoryTest(TestWithBuildFileParser):
 
   Jar = namedtuple('Jar', ['org', 'name', 'rev'])
   Repository = namedtuple('Repository', ['name', 'url', 'push_db_basedir'])

--- a/tests/python/pants_test/build_graph/test_build_file_parser.py
+++ b/tests/python/pants_test/build_graph/test_build_file_parser.py
@@ -28,7 +28,7 @@ class ErrorTarget(Target):
 class BuildFileParserBasicsTest(TestBase):
 
   def setUp(self):
-    super(TestBase, self).setUp()
+    super(BuildFileParserBasicsTest, self).setUp()
     self.build_file_parser = BuildFileParser(self._build_configuration, self.build_root)
 
   @classmethod

--- a/tests/python/pants_test/build_graph/test_build_file_parser.py
+++ b/tests/python/pants_test/build_graph/test_build_file_parser.py
@@ -27,6 +27,10 @@ class ErrorTarget(Target):
 
 class BuildFileParserBasicsTest(TestBase):
 
+  def setUp(self):
+    super(TestBase, self).setUp()
+    self.build_file_parser = BuildFileParser(self._build_configuration, self.build_root)
+
   @classmethod
   def alias_groups(cls):
     return BuildFileAliases(targets={'jvm_binary': ErrorTarget,

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -23,7 +23,6 @@ from pants.base.target_roots import TargetRoots
 from pants.build_graph.address import Address
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.build_graph.build_file_parser import BuildFileParser
 from pants.build_graph.target import Target
 from pants.engine.fs import PathGlobs, PathGlobsAndRoot
 from pants.engine.legacy.graph import HydratedField
@@ -319,8 +318,6 @@ class TestBase(unittest.TestCase):
     }
 
     self._build_configuration = self.build_config()
-    self._build_file_parser = BuildFileParser(self._build_configuration, self.build_root)
-
     self._inited_target = False
 
   def buildroot_files(self, relpath=None):
@@ -362,10 +359,6 @@ class TestBase(unittest.TestCase):
   @property
   def build_root(self):
     return self._build_root()
-
-  @property
-  def build_file_parser(self):
-    return self._build_file_parser
 
   @property
   def pants_workdir(self):
@@ -498,7 +491,7 @@ class TestBase(unittest.TestCase):
     context = create_context_from_options(fake_options,
                                           target_roots=target_roots,
                                           build_graph=self.build_graph,
-                                          build_file_parser=self._build_file_parser,
+                                          build_configuration=self._build_configuration,
                                           address_mapper=address_mapper,
                                           console_outstream=console_outstream,
                                           workspace=workspace,


### PR DESCRIPTION
Some tasks rely on it for access to target aliases.
These can be retrieved from the BuildConfiguration instead.

However since Context is public API, we go through a deprecation
cycle before removing the build_file_parser property.

Once this deprecation is complete, we can get rid of BuildFileParser
entirely.

