### PR TITLE
Add requirement for more-itertools that works on python 2

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -12,6 +12,8 @@ future==0.17.1
 futures==3.0.5 ; python_version<'3'
 Markdown==2.1.1
 mock==2.0.0
+# TODO(6282): once we can upgrade Pytest to 4.2.1+, we can remove the more-itertools requirement
+more-itertools<6.0.0 ; python_version<'3'
 packaging==16.8
 parameterized==0.6.1
 pathspec==0.5.9

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -14,9 +14,7 @@ class PyTest(Subsystem):
   def register_options(cls, register):
     super(PyTest, cls).register_options(register)
     # TODO: This is currently bounded below `3.7` due to #6282.
-    # TODO: Additionally, this is temporarily pinned to 3.0.7 due to more-itertools 6.0.0 dropping
-    # Python 2 support: https://github.com/pytest-dev/pytest/issues/4770.
-    register('--requirements', advanced=True, default='pytest==3.0.7',
+    register('--requirements', advanced=True, default='pytest>=3.0.7,<3.7',
              help='Requirements string for the pytest library.')
     register('--timeout-requirements', advanced=True, default='pytest-timeout>=1.2,<1.3',
              help='Requirements string for the pytest-timeout library.')
@@ -32,7 +30,9 @@ class PyTest(Subsystem):
     Make sure the requirements are satisfied in any environment used for running tests.
     """
     opts = self.get_options()
+    # TODO(6282): once we can upgrade Pytest to 4.2.1+, we can remove the more-itertools requirement
     return (
+      "more-itertools<6.0.0 ; python_version<'3'",
       opts.requirements,
       opts.timeout_requirements,
       opts.cov_requirements,

--- a/tests/python/pants_test/rules/test_test_integration.py
+++ b/tests/python/pants_test/rules/test_test_integration.py
@@ -72,9 +72,9 @@ class TestIntegrationTest(PantsRunIntegrationTest):
 platform SOME_TEXT
 rootdir: SOME_TEXT
 plugins: SOME_TEXT
-collected 1 items
+collected 1 item
 
-testprojects/tests/python/pants/dummies/test_pass.py .
+testprojects/tests/python/pants/dummies/test_pass.py .                   [100%]
 
 =========================== 1 passed in SOME_TEXT ===========================
 
@@ -92,9 +92,9 @@ testprojects/tests/python/pants/dummies:passing_target                          
 platform SOME_TEXT
 rootdir: SOME_TEXT
 plugins: SOME_TEXT
-collected 1 items
+collected 1 item
 
-testprojects/tests/python/pants/dummies/test_fail.py F
+testprojects/tests/python/pants/dummies/test_fail.py F                   [100%]
 
 =================================== FAILURES ===================================
 __________________________________ test_fail ___________________________________
@@ -120,9 +120,9 @@ testprojects/tests/python/pants/dummies:failing_target                          
 platform SOME_TEXT
 rootdir: SOME_TEXT
 plugins: SOME_TEXT
-collected 1 items
+collected 1 item
 
-testprojects/tests/python/pants/dummies/test_with_source_dep.py .
+testprojects/tests/python/pants/dummies/test_with_source_dep.py .        [100%]
 
 =========================== 1 passed in SOME_TEXT ===========================
 
@@ -139,9 +139,9 @@ testprojects/tests/python/pants/dummies:target_with_source_dep                  
 platform SOME_TEXT
 rootdir: SOME_TEXT
 plugins: SOME_TEXT
-collected 1 items
+collected 1 item
 
-testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py .
+testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py .    [100%]
 
 =========================== 1 passed in SOME_TEXT ===========================
 
@@ -160,9 +160,9 @@ testprojects/tests/python/pants/dummies:target_with_thirdparty_dep              
 platform SOME_TEXT
 rootdir: SOME_TEXT
 plugins: SOME_TEXT
-collected 1 items
+collected 1 item
 
-testprojects/tests/python/pants/dummies/test_fail.py F
+testprojects/tests/python/pants/dummies/test_fail.py F                   [100%]
 
 =================================== FAILURES ===================================
 __________________________________ test_fail ___________________________________
@@ -177,9 +177,9 @@ testprojects/tests/python/pants/dummies/test_fail.py:2: AssertionError
 platform SOME_TEXT
 rootdir: SOME_TEXT
 plugins: SOME_TEXT
-collected 1 items
+collected 1 item
 
-testprojects/tests/python/pants/dummies/test_pass.py .
+testprojects/tests/python/pants/dummies/test_pass.py .                   [100%]
 
 =========================== 1 passed in SOME_TEXT ===========================
 


### PR DESCRIPTION
### Problem

The latest release of more-itertools (6.0.0) only works on Python 3.  https://github.com/erikrose/more-itertools/releases.  more-itertools is a requirement of pytest.

When running with python2 I get

```
  File "/tmp/.pants.d/test/pytest-prep/CPython-2.7.10/15d60b3366ef43c7a4ae6b5f5e2d7567a95fe5f4/.deps/pytest-3.6.4-py2.py3-none-any.whl/pytest.py", line 10, in <module>
    from _pytest.fixtures import fixture, yield_fixture
  File "/tmp/.pants.d/test/pytest-prep/CPython-2.7.10/15d60b3366ef43c7a4ae6b5f5e2d7567a95fe5f4/.deps/pytest-3.6.4-py2.py3-none-any.whl/_pytest/fixtures.py", line 8, in <module>
    from more_itertools import flatten
  File "/tmp/.pants.d/test/pytest-prep/CPython-2.7.10/15d60b3366ef43c7a4ae6b5f5e2d7567a95fe5f4/.deps/more_itertools-6.0.0-py2-none-any.whl/more_itertools/__init__.py", line 1, in <module>
    from more_itertools.more import *  # noqa
  File "/tmp/.pants.d/test/pytest-prep/CPython-2.7.10/15d60b3366ef43c7a4ae6b5f5e2d7567a95fe5f4/.deps/more_itertools-6.0.0-py2-none-any.whl/more_itertools/more.py", line 329
    def _collate(*iterables, key=lambda a: a, reverse=False):
```

This has been fixed on the latest version of pytest but I'm not sure if we can update to that version or not?  https://github.com/pytest-dev/pytest/pull/4774

### Solution

Add requirements where we use pytest so we don't get incompatible versions of more-itertools

### Result

pytest invocations continue to work on Python 2