### PR TITLE
Add junit html-report-error-on-conflict option

### DIFF
--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -181,6 +181,8 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
              help='Use experimental junit-runner logic for more options for parallelism.')
     register('--html-report', type=bool, fingerprint=True,
              help='If true, generate an html summary report of tests that were run.')
+    register('--html-report-error-on-conflict', type=bool, default=True,
+             help='If true, error when duplicate test cases are found in html results')
     register('--open', type=bool,
              help='Attempt to open the html summary report in a browser (implies --html-report)')
 
@@ -632,7 +634,7 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
       junit_html_report = JUnitHtmlReport.create(xml_dir=output_dir,
                                                  open_report=self.get_options().open,
                                                  logger=self.context.log,
-                                                 error_on_conflict=True)
+                                                 error_on_conflict=self.get_options().html_report_error_on_conflict)
     else:
       junit_html_report = NoJunitHtmlReport()
 

--- a/src/python/pants/backend/jvm/tasks/reports/junit_html_report.py
+++ b/src/python/pants/backend/jvm/tasks/reports/junit_html_report.py
@@ -71,10 +71,10 @@ class ReportTestSuite(object):
           if error_on_conflict:
             raise cls.MergeError(suites, cases)
           else:
-            logger.warning('Found duplicate test case results in suite {!r} from files: {}, '
-                           'using first result:\n -> {}'.format(suite_name,
-                                                                ', '.join(s.file for s in suites),
-                                                                '\n    '.join(map(str, cases))))
+            logger.warn('Found duplicate test case results in suite {!r} from files: {}, '
+                        'using first result:\n -> {}'.format(suite_name,
+                                                             ', '.join(s.file for s in suites),
+                                                             '\n    '.join(map(str, cases))))
         case = next(iter(cases))
         tests += 1
         time += case.time


### PR DESCRIPTION
### Problem

There is no way to configure if tests fail when there is a duplicate test case found in the html results.

### Solution

Add option to junit run to allow users to set if they want merge conflicts to fail tests

### Result

The default behavior still fails when there is a junit merge conflict but it can be configured so only warnings are printed instead of failing. 
