### PR TITLE
Port owners-discovery PathGlob matching to rust

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -55,7 +55,6 @@ python_library(
     ':selectors',
     'src/python/pants/base:project_tree',
     'src/python/pants/option',
-    'src/python/pants/source',
     'src/python/pants/util:meta',
     'src/python/pants/util:objects',
   ]

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -674,6 +674,12 @@ class Native(Singleton):
     result = self.lib.decompress_tarball(tarfile_path, dest_dir)
     return self.context.raise_or_return(result)
 
+  def match_path_globs(self, path_globs, paths):
+    path_globs = self.context.to_value(path_globs)
+    paths_buf = self.context.utf8_buf_buf(tuple(paths))
+    result = self.lib.match_path_globs(path_globs, paths_buf)
+    return self.context.raise_or_return(result)
+
   def new_tasks(self):
     return self.gc(self.lib.tasks_create(), self.lib.tasks_destroy)
 

--- a/src/python/pants/source/BUILD
+++ b/src/python/pants/source/BUILD
@@ -10,6 +10,8 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:payload_field',
     'src/python/pants/base:project_tree',
+    'src/python/pants/engine:fs',
+    'src/python/pants/engine:native',
     'src/python/pants/option',
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',

--- a/src/python/pants/source/filespec.py
+++ b/src/python/pants/source/filespec.py
@@ -4,60 +4,13 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import re
-
-
-def glob_to_regex(pattern):
-  """Given a glob pattern, return an equivalent regex expression.
-
-  TODO: Replace with implementation in `fs.rs`. See https://github.com/pantsbuild/pants/issues/6795.
-
-  :param string glob: The glob pattern. "**" matches 0 or more dirs recursively.
-                      "*" only matches patterns in a single dir.
-  :returns: A regex string that matches same paths as the input glob does.
-  """
-  out = ['^']
-  components = pattern.strip('/').replace('.', '[.]').replace('$','[$]').split('/')
-  doublestar = False
-  for component in components:
-    if len(out) == 1:
-      if pattern.startswith('/'):
-        out.append('/')
-    else:
-      if not doublestar:
-        out.append('/')
-
-    if '**' in component:
-      if component != '**':
-        raise ValueError('Invalid usage of "**", use "*" instead.')
-
-      if not doublestar:
-        out.append('(([^/]+/)*)')
-        doublestar = True
-    else:
-      out.append(component.replace('*', '[^/]*'))
-      doublestar = False
-
-  if doublestar:
-    out.append('[^/]*')
-
-  out.append('$')
-
-  return ''.join(out)
+from pants.engine.fs import PathGlobs
+from pants.engine.native import Native
 
 
 def globs_matches(paths, patterns, exclude_patterns):
-  def excluded(path):
-    if excluded.regexes is None:
-      excluded.regexes = [re.compile(glob_to_regex(ex)) for ex in exclude_patterns]
-    return any(ex.match(path) for ex in excluded.regexes)
-  excluded.regexes = None
-  for pattern in patterns:
-    regex = re.compile(glob_to_regex(pattern))
-    for path in paths:
-      if regex.match(path) and not excluded(path):
-        return True
-  return False
+  path_globs = PathGlobs(include=patterns, exclude=exclude_patterns)
+  return Native().match_path_globs(path_globs, paths)
 
 
 def matches_filespec(path, spec):
@@ -65,8 +18,6 @@ def matches_filespec(path, spec):
 
 
 def any_matches_filespec(paths, spec):
-  if not paths or not spec:
-    return False
   exclude_patterns = []
   for exclude_spec in spec.get('exclude', []):
     exclude_patterns.extend(exclude_spec.get('globs', []))

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -54,6 +54,7 @@ use std::mem;
 use std::os::raw;
 use std::panic;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::context::Core;
@@ -70,6 +71,7 @@ use crate::rule_graph::{GraphMaker, RuleGraph};
 use crate::scheduler::{ExecutionRequest, RootResult, Scheduler, Session};
 use crate::tasks::Tasks;
 use crate::types::Types;
+use fs::{GlobMatching, MemFS, PathStat};
 use futures::Future;
 use hashing::Digest;
 use log::error;
@@ -651,6 +653,36 @@ pub extern "C" fn lease_files_in_graph(scheduler_ptr: *mut Scheduler) {
       Err(err) => error!("{}", &err),
     }
   });
+}
+
+#[no_mangle]
+pub extern "C" fn match_path_globs(path_globs: Handle, paths_buf: BufferBuffer) -> PyResult {
+  let path_globs = match nodes::Snapshot::lift_path_globs(&path_globs.into()) {
+    Ok(path_globs) => path_globs,
+    Err(msg) => {
+      let e: Result<(), _> = Err(msg);
+      return e.into();
+    }
+  };
+
+  let static_fs = Arc::new(MemFS::new(
+    paths_buf
+      .to_os_strings()
+      .into_iter()
+      .map(PathBuf::from)
+      .collect(),
+  ));
+
+  static_fs
+    .expand(path_globs)
+    .wait()
+    .map(|path_stats| {
+      externs::store_bool(path_stats.iter().any(|p| match p {
+        PathStat::File { .. } => true,
+        PathStat::Dir { .. } => false,
+      }))
+    })
+    .into()
 }
 
 #[no_mangle]

--- a/tests/python/pants_test/source/test_filespec.py
+++ b/tests/python/pants_test/source/test_filespec.py
@@ -4,111 +4,96 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import re
 import unittest
 
-from pants.source.filespec import glob_to_regex
+from pants.source.filespec import matches_filespec
 
 
-class GlobToRegexTest(unittest.TestCase):
+class FilespecTest(unittest.TestCase):
   def assert_rule_match(self, glob, expected_matches, negate=False):
     if negate:
-      asserter, match_state = self.assertIsNone, 'erroneously matches'
+      asserter, match_state = self.assertFalse, 'erroneously matches'
     else:
-      asserter, match_state = self.assertIsNotNone, "doesn't match"
+      asserter, match_state = self.assertTrue, "doesn't match"
 
-    regex = glob_to_regex(glob)
     for expected in expected_matches:
-      asserter(re.match(regex, expected), 'glob_to_regex(`{}`) -> `{}` {} path `{}`'
-                                          .format(glob, regex, match_state, expected))
+      asserter(
+          matches_filespec(expected, {'globs': [glob]}),
+          '{} {} path `{}`'.format(glob, match_state, expected),
+      )
 
-  def test_glob_to_regex_single_star_0(self):
+  def test_matches_single_star_0(self):
     self.assert_rule_match('a/b/*/f.py', ('a/b/c/f.py', 'a/b/q/f.py'))
 
-  def test_glob_to_regex_single_star_0_neg(self):
+  def test_matches_single_star_0_neg(self):
     self.assert_rule_match('a/b/*/f.py', ('a/b/c/d/f.py','a/b/f.py'), negate=True)
 
-  def test_glob_to_regex_single_star_1(self):
+  def test_matches_single_star_1(self):
     self.assert_rule_match('foo/bar/*', ('foo/bar/baz', 'foo/bar/bar'))
 
-  def test_glob_to_regex_single_star_2(self):
+  def test_matches_single_star_2(self):
     self.assert_rule_match('*/bar/b*', ('foo/bar/baz', 'foo/bar/bar'))
 
-  def test_glob_to_regex_single_star_2_neg(self):
+  def test_matches_single_star_2_neg(self):
     self.assert_rule_match('*/bar/b*', ('foo/koo/bar/baz', 'foo/bar/bar/zoo'), negate=True)
 
-  def test_glob_to_regex_single_star_3(self):
-    self.assert_rule_match('/*/[be]*/b*', ('/foo/bar/baz', '/foo/bar/bar'))
+  def test_matches_single_star_3(self):
+    self.assert_rule_match('*/[be]*/b*', ('foo/bar/baz', 'foo/bar/bar'))
 
-  def test_glob_to_regex_single_star_4(self):
-    self.assert_rule_match('/foo*/bar', ('/foofighters/bar', '/foofighters.venv/bar'))
+  def test_matches_single_star_4(self):
+    self.assert_rule_match('foo*/bar', ('foofighters/bar', 'foofighters.venv/bar'))
 
-  def test_glob_to_regex_single_star_4_neg(self):
-    self.assert_rule_match('/foo*/bar', ('/foofighters/baz/bar',), negate=True)
+  def test_matches_single_star_4_neg(self):
+    self.assert_rule_match('foo*/bar', ('foofighters/baz/bar',), negate=True)
 
-  def test_glob_to_regex_double_star_0(self):
+  def test_matches_double_star_0(self):
     self.assert_rule_match('**', ('a/b/c', 'a'))
 
-  def test_glob_to_regex_double_star_1(self):
+  def test_matches_double_star_1(self):
     self.assert_rule_match('a/**/f', ('a/f', 'a/b/c/d/e/f'))
 
-  def test_glob_to_regex_double_star_2(self):
+  def test_matches_double_star_2(self):
     self.assert_rule_match('a/b/**', ('a/b/c', 'a/b/c/d/e/f'))
 
-  def test_glob_to_regex_double_star_2_neg(self):
+  def test_matches_double_star_2_neg(self):
     self.assert_rule_match('a/b/**', ('a/b'), negate=True)
 
-  def test_glob_to_regex_leading_slash_0(self):
-    self.assert_rule_match('/a/*', ('/a/a', '/a/b.py'))
+  def test_matches_dots(self):
+    self.assert_rule_match('.*', ('.pants.d', '.pids'))
 
-  def test_glob_to_regex_leading_slash_0_neg(self):
-    self.assert_rule_match('/a/*', ('a/a', 'a/b.py'), negate=True)
+  def test_matches_dots_relative(self):
+    self.assert_rule_match('./*.py', ('f.py', 'g.py'))
 
-  def test_glob_to_regex_leading_slash_1(self):
-    self.assert_rule_match('/*', ('/a', '/a.py'))
-
-  def test_glob_to_regex_leading_slash_1_neg(self):
-    self.assert_rule_match('/*', ('a', 'a.py'), negate=True)
-
-  def test_glob_to_regex_leading_slash_2(self):
-    self.assert_rule_match('/**', ('/a', '/a/b/c/d/e/f'))
-
-  def test_glob_to_regex_leading_slash_2_neg(self):
-    self.assert_rule_match('/**', ('a', 'a/b/c/d/e/f'), negate=True)
-
-  def test_glob_to_regex_dots(self):
-    self.assert_rule_match('.*', ('.pants.d', '.', '..', '.pids'))
-
-  def test_glob_to_regex_dots_neg(self):
+  def test_matches_dots_neg(self):
     self.assert_rule_match(
       '.*',
       ('a', 'a/non/dot/dir/file.py', 'dist', 'all/nested/.dot', '.some/hidden/nested/dir/file.py'),
       negate=True
     )
 
-  def test_glob_to_regex_dirs(self):
+  def test_matches_dirs(self):
     self.assert_rule_match('dist/', ('dist',))
 
-  def test_glob_to_regex_dirs_neg(self):
+  def test_matches_dirs_neg(self):
     self.assert_rule_match('dist/', ('not_dist', 'cdist', 'dist.py', 'dist/dist'), negate=True)
 
-  def test_glob_to_regex_dirs_dots(self):
+  def test_matches_dirs_dots(self):
     self.assert_rule_match(
       'build-support/*.venv/',
       ('build-support/*.venv',
        'build-support/rbt.venv')
     )
 
-  def test_glob_to_regex_dirs_dots_neg(self):
+  def test_matches_dirs_dots_neg(self):
     self.assert_rule_match('build-support/*.venv/',
                            ('build-support/rbt.venv.but_actually_a_file',),
                            negate=True)
 
-  def test_glob_to_regex_literals(self):
+  def test_matches_literals(self):
     self.assert_rule_match('a', ('a',))
 
-  def test_glob_to_regex_literal_dir(self):
+  def test_matches_literal_dir(self):
     self.assert_rule_match('a/b/c', ('a/b/c',))
 
-  def test_glob_to_regex_literal_file(self):
+  def test_matches_literal_file(self):
     self.assert_rule_match('a/b/c.py', ('a/b/c.py',))


### PR DESCRIPTION
### Problem

As described in #6795, we have python code with functionality that duplicates rust `PathGlob` matching, which is undesirable. So undesirable, in fact, that we recently noticed a bug where `--changed` and `--owner-of` (using that code) would not correct identify a file as being owned (globs like `./*.py` would never match).

### Solution

`PathGlob` expansion is currently implemented by lazily traversing a filesystem, and it is unclear how to decouple the lazy traversal from the glob matching without double-matching paths (once to implement the laziness, and then again to accept a complete path). Additionally, the codepath we are replacing is not particularly performance sensitive.

So: this patch takes the approach of implementing a small `impl VFS for MemFS` against which to expand `PathGlobs`. This means we pay the cost of the laziness, but it ensures an identical implementation of glob matching (assuming that the small `MemFS` is correct).

### Result

Fixes #6795, and ensures that matching `PathGlobs` against a set of in memory file paths has identical behaviour to expanding against a filesystem.