### PR TITLE
add self.assertRaisesWithMessageContaining() to TestBase and use it to clean up test_objects.py

### DIFF
--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -617,21 +617,21 @@ class TestBase(unittest.TestCase):
       self.assertIn(string, content, '"{}" is not in the file {}:\n{}'.format(string, f.name, content))
 
   @contextmanager
-  def assertRaisesWithMessageContaining(self, exception_type, error_text, substring_match=False):
+  def assertRaisesWithMessageContaining(self, exception_type, error_text, exact=True):
     """Verifies that a string appears in an exception message.
 
     :param type exception_type: The exception type which is expected to be raised within the body.
     :param str error_text: Text that the exception message should either contain or match exactly.
-    :param bool substring_match: If True, use `self.assertIn()` instead of `self.assertEqual()` to
-                                 match the exception text.
+    :param bool exact: If False, use `self.assertIn()` instead of `self.assertEqual()` to match the
+                       exception text.
     :API: public
     """
     with self.assertRaises(exception_type) as cm:
       yield cm
-    if substring_match:
-      self.assertIn(error_text, str(cm.exception))
-    else:
+    if exact:
       self.assertEqual(error_text, str(cm.exception))
+    else:
+      self.assertIn(error_text, str(cm.exception))
 
   def get_bootstrap_options(self, cli_options=()):
     """Retrieves bootstrap options.

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -8,7 +8,7 @@ import itertools
 import logging
 import os
 import unittest
-from builtins import object, open
+from builtins import object, open, str
 from collections import defaultdict
 from contextlib import contextmanager
 from tempfile import mkdtemp
@@ -615,6 +615,23 @@ class TestBase(unittest.TestCase):
     with open(file_path, 'r') as f:
       content = f.read()
       self.assertIn(string, content, '"{}" is not in the file {}:\n{}'.format(string, f.name, content))
+
+  @contextmanager
+  def assertRaisesWithMessageContaining(self, exception_type, error_text, exact=False):
+    """Verifies that a string appears in an exception message.
+
+    :param type exception_type: The exception type which is expected to be raised within the body.
+    :param str error_text: Text that the exception message should either contain or match exactly.
+    :param bool exact: If True, use `self.assertEqual()` instead of `self.assertIn()` to match the
+                       exception text. This provides a stronger guarantee but may not be necessary.
+    :API: public
+    """
+    with self.assertRaises(exception_type) as cm:
+      yield cm
+    if exact:
+      self.assertEqual(error_text, str(cm.exception))
+    else:
+      self.assertIn(error_text, str(cm.exception))
 
   def get_bootstrap_options(self, cli_options=()):
     """Retrieves bootstrap options.

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -617,21 +617,29 @@ class TestBase(unittest.TestCase):
       self.assertIn(string, content, '"{}" is not in the file {}:\n{}'.format(string, f.name, content))
 
   @contextmanager
-  def assertRaisesWithMessageContaining(self, exception_type, error_text, exact=True):
-    """Verifies that a string appears in an exception message.
+  def assertRaisesWithMessage(self, exception_type, error_text):
+    """Verifies than an exception message is equal to `error_text`.
 
     :param type exception_type: The exception type which is expected to be raised within the body.
-    :param str error_text: Text that the exception message should either contain or match exactly.
-    :param bool exact: If False, use `self.assertIn()` instead of `self.assertEqual()` to match the
-                       exception text.
+    :param str error_text: Text that the exception message should match exactly with
+                           `self.assertEqual()`.
     :API: public
     """
     with self.assertRaises(exception_type) as cm:
       yield cm
-    if exact:
-      self.assertEqual(error_text, str(cm.exception))
-    else:
-      self.assertIn(error_text, str(cm.exception))
+    self.assertEqual(error_text, str(cm.exception))
+
+  @contextmanager
+  def assertRaisesWithMessageContaining(self, exception_type, error_text):
+    """Verifies that the string `error_text` appears in an exception message.
+
+    :param type exception_type: The exception type which is expected to be raised within the body.
+    :param str error_text: Text that the exception message should contain with `self.assertIn()`.
+    :API: public
+    """
+    with self.assertRaises(exception_type) as cm:
+      yield cm
+    self.assertIn(error_text, str(cm.exception))
 
   def get_bootstrap_options(self, cli_options=()):
     """Retrieves bootstrap options.

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -617,21 +617,21 @@ class TestBase(unittest.TestCase):
       self.assertIn(string, content, '"{}" is not in the file {}:\n{}'.format(string, f.name, content))
 
   @contextmanager
-  def assertRaisesWithMessageContaining(self, exception_type, error_text, exact=False):
+  def assertRaisesWithMessageContaining(self, exception_type, error_text, substring_match=False):
     """Verifies that a string appears in an exception message.
 
     :param type exception_type: The exception type which is expected to be raised within the body.
     :param str error_text: Text that the exception message should either contain or match exactly.
-    :param bool exact: If True, use `self.assertEqual()` instead of `self.assertIn()` to match the
-                       exception text. This provides a stronger guarantee but may not be necessary.
+    :param bool substring_match: If True, use `self.assertIn()` instead of `self.assertEqual()` to
+                                 match the exception text.
     :API: public
     """
     with self.assertRaises(exception_type) as cm:
       yield cm
-    if exact:
-      self.assertEqual(error_text, str(cm.exception))
-    else:
+    if substring_match:
       self.assertIn(error_text, str(cm.exception))
+    else:
+      self.assertEqual(error_text, str(cm.exception))
 
   def get_bootstrap_options(self, cli_options=()):
     """Retrieves bootstrap options.

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -368,7 +368,9 @@ class DatatypeTest(TestBase):
   def test_invalid_field_name(self):
     with self.assertRaisesWithMessageContaining(
         ValueError,
-        "Type names and field names must be valid identifiers: '0isntanallowedfirstchar'",
+        "Type names and field names must be valid identifiers: '0isntanallowedfirstchar'"
+        if PY3 else
+        "Type names and field names cannot start with a number: '0isntanallowedfirstchar'",
         exact=True):
       datatype(['0isntanallowedfirstchar'])
     with self.assertRaisesWithMessageContaining(
@@ -398,13 +400,18 @@ class DatatypeTest(TestBase):
   def test_double_passed_arg(self):
     bar = datatype(['val', 'zal'])
     with self.assertRaisesWithMessageContaining(
-        TypeError, "__new__() got multiple values for argument 'val'"):
+        TypeError,
+        "__new__() got multiple values for {kw}argument 'val'"
+        .format(kw='' if PY3 else 'keyword ')):
       bar(1, val=1)
 
   def test_too_many_args(self):
     bar = datatype(['val', 'zal'])
     with self.assertRaisesWithMessageContaining(
-        TypeError, '__new__() takes 3 positional arguments but 4 were given'):
+        TypeError,
+        '__new__() takes 3 positional arguments but 4 were given'
+        if PY3 else
+        '__new__() takes exactly 3 arguments (4 given)'):
       bar(1, 1, 1)
 
   def test_unexpect_kwarg(self):

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -42,7 +42,7 @@ class TypeConstraintTestBase(TestBase):
 
 class SuperclassesOfTest(TypeConstraintTestBase):
   def test_none(self):
-    with self.assertRaisesWithMessageContaining(ValueError, 'Must supply at least one type'):
+    with self.assertRaisesWithMessage(ValueError, 'Must supply at least one type'):
       SubclassesOf()
 
   def test_str_and_repr(self):
@@ -72,7 +72,7 @@ class SuperclassesOfTest(TypeConstraintTestBase):
     superclasses_of_a_or_b = SuperclassesOf(self.A, self.B)
     self.assertEqual(self.A(), superclasses_of_a_or_b.validate_satisfied_by(self.A()))
     self.assertEqual(self.B(), superclasses_of_a_or_b.validate_satisfied_by(self.B()))
-    with self.assertRaisesWithMessageContaining(
+    with self.assertRaisesWithMessage(
         TypeConstraintError,
         "value C() (with type 'C') must satisfy this type constraint: SuperclassesOf(A or B)."):
       superclasses_of_a_or_b.validate_satisfied_by(self.C())
@@ -80,7 +80,7 @@ class SuperclassesOfTest(TypeConstraintTestBase):
 
 class ExactlyTest(TypeConstraintTestBase):
   def test_none(self):
-    with self.assertRaisesWithMessageContaining(ValueError, 'Must supply at least one type'):
+    with self.assertRaisesWithMessage(ValueError, 'Must supply at least one type'):
       Exactly()
 
   def test_single(self):
@@ -98,7 +98,7 @@ class ExactlyTest(TypeConstraintTestBase):
     self.assertFalse(exactly_a_or_b.satisfied_by(self.C()))
 
   def test_disallows_unsplatted_lists(self):
-    with self.assertRaisesWithMessageContaining(TypeError,
+    with self.assertRaisesWithMessage(TypeError,
                                                 'Supplied types must be types. ([1],)'):
       Exactly([1])
 
@@ -119,7 +119,7 @@ class ExactlyTest(TypeConstraintTestBase):
     exactly_a_or_b = Exactly(self.A, self.B)
     self.assertEqual(self.A(), exactly_a_or_b.validate_satisfied_by(self.A()))
     self.assertEqual(self.B(), exactly_a_or_b.validate_satisfied_by(self.B()))
-    with self.assertRaisesWithMessageContaining(
+    with self.assertRaisesWithMessage(
         TypeConstraintError,
         "value C() (with type 'C') must satisfy this type constraint: Exactly(A or B)."):
       exactly_a_or_b.validate_satisfied_by(self.C())
@@ -127,7 +127,7 @@ class ExactlyTest(TypeConstraintTestBase):
 
 class SubclassesOfTest(TypeConstraintTestBase):
   def test_none(self):
-    with self.assertRaisesWithMessageContaining(ValueError, 'Must supply at least one type'):
+    with self.assertRaisesWithMessage(ValueError, 'Must supply at least one type'):
       SubclassesOf()
 
   def test_str_and_repr(self):
@@ -158,7 +158,7 @@ class SubclassesOfTest(TypeConstraintTestBase):
     self.assertEqual(self.A(), subclasses_of_a_or_b.validate_satisfied_by(self.A()))
     self.assertEqual(self.B(), subclasses_of_a_or_b.validate_satisfied_by(self.B()))
     self.assertEqual(self.C(), subclasses_of_a_or_b.validate_satisfied_by(self.C()))
-    with self.assertRaisesWithMessageContaining(
+    with self.assertRaisesWithMessage(
         TypeConstraintError,
         "value 1 (with type 'int') must satisfy this type constraint: SubclassesOf(A or B)."):
       subclasses_of_a_or_b.validate_satisfied_by(1)
@@ -190,7 +190,7 @@ class TypedCollectionTest(TypeConstraintTestBase):
 
   def test_no_complex_sub_constraint(self):
     sub_collection = TypedCollection(Exactly(self.A))
-    with self.assertRaisesWithMessageContaining(
+    with self.assertRaisesWithMessage(
         TypeError,
         "constraint for collection must be a TypeOnlyConstraint! was: {}".format(sub_collection)):
       TypedCollection(sub_collection)
@@ -199,11 +199,11 @@ class TypedCollectionTest(TypeConstraintTestBase):
     collection_exactly_a_or_b = TypedCollection(Exactly(self.A, self.B))
     self.assertEqual([self.A()], collection_exactly_a_or_b.validate_satisfied_by([self.A()]))
     self.assertEqual([self.B()], collection_exactly_a_or_b.validate_satisfied_by([self.B()]))
-    with self.assertRaisesWithMessageContaining(
+    with self.assertRaisesWithMessage(
         TypeConstraintError,
         "in wrapped constraint TypedCollection(Exactly(A or B)): value A() (with type 'A') must satisfy this type constraint: SubclassesOf(Iterable)."):
       collection_exactly_a_or_b.validate_satisfied_by(self.A())
-    with self.assertRaisesWithMessageContaining(
+    with self.assertRaisesWithMessage(
         TypeConstraintError,
         "in wrapped constraint TypedCollection(Exactly(A or B)) matching iterable object [C()]: value C() (with type 'C') must satisfy this type constraint: Exactly(A or B)."):
       collection_exactly_a_or_b.validate_satisfied_by([self.C()])
@@ -330,10 +330,7 @@ class DatatypeTest(TestBase):
 
   def test_not_iterable(self):
     bar = datatype(['val'])
-    with self.assertRaisesWithMessageContaining(
-        TypeError,
-        'datatype object is not iterable',
-        exact=False):
+    with self.assertRaisesWithMessageContaining(TypeError, 'datatype object is not iterable'):
       for x in bar(1):
         pass
 
@@ -361,17 +358,17 @@ class DatatypeTest(TestBase):
   def test_properties_not_assignable(self):
     bar = datatype(['val'])
     bar_inst = bar(1)
-    with self.assertRaisesWithMessageContaining(AttributeError, "can't set attribute"):
+    with self.assertRaisesWithMessage(AttributeError, "can't set attribute"):
       bar_inst.val = 2
 
   def test_invalid_field_name(self):
-    with self.assertRaisesWithMessageContaining(
+    with self.assertRaisesWithMessage(
         ValueError,
         "Type names and field names must be valid identifiers: '0isntanallowedfirstchar'"
         if PY3 else
         "Type names and field names cannot start with a number: '0isntanallowedfirstchar'"):
       datatype(['0isntanallowedfirstchar'])
-    with self.assertRaisesWithMessageContaining(
+    with self.assertRaisesWithMessage(
         ValueError,
         "Field names cannot start with an underscore: '_no_leading_underscore'"):
       datatype(['_no_leading_underscore'])
@@ -380,7 +377,7 @@ class DatatypeTest(TestBase):
     class OverridesEq(datatype(['myval'])):
       def __eq__(self, other):
         return other.myval == self.myval
-    with self.assertRaisesWithMessageContaining(TypeCheckError, 'type check error in class OverridesEq: Should not override __eq__.'):
+    with self.assertRaisesWithMessage(TypeCheckError, 'type check error in class OverridesEq: Should not override __eq__.'):
       OverridesEq(1)
 
   def test_subclass_pickleable(self):
@@ -396,10 +393,10 @@ class DatatypeTest(TestBase):
 
   def test_double_passed_arg(self):
     bar = datatype(['val', 'zal'])
-    with self.assertRaisesWithMessageContaining(TypeError,
+    with self.assertRaisesWithMessageContaining(
+        TypeError,
         "__new__() got multiple values for {kw}argument 'val'"
-        .format(kw='' if PY3 else 'keyword '),
-                                                exact=False):
+        .format(kw='' if PY3 else 'keyword ')):
       bar(1, val=1)
 
   def test_too_many_args(self):
@@ -408,16 +405,14 @@ class DatatypeTest(TestBase):
         TypeError,
         '__new__() takes 3 positional arguments but 4 were given'
         if PY3 else
-        '__new__() takes exactly 3 arguments (4 given)',
-        exact=False):
+        '__new__() takes exactly 3 arguments (4 given)'):
       bar(1, 1, 1)
 
   def test_unexpect_kwarg(self):
     bar = datatype(['val'])
     with self.assertRaisesWithMessageContaining(
         TypeError,
-        "__new__() got an unexpected keyword argument 'other'",
-        exact=False):
+        "__new__() got an unexpected keyword argument 'other'"):
       bar(other=1)
 
 
@@ -434,7 +429,7 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "Type names and field names can only contain alphanumeric characters and underscores: \"<type 'int'>\""
     )
-    with self.assertRaisesWithMessageContaining(ValueError, expected_msg):
+    with self.assertRaisesWithMessage(ValueError, expected_msg):
       class NonStrType(datatype([int])): pass
 
     # This raises a TypeError because it doesn't provide a required argument.
@@ -443,7 +438,7 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "datatype() takes at least 1 argument (0 given)"
     )
-    with self.assertRaisesWithMessageContaining(TypeError, expected_msg):
+    with self.assertRaisesWithMessage(TypeError, expected_msg):
       class NoFields(datatype()): pass
 
     expected_msg = (
@@ -451,7 +446,7 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "Type names and field names can only contain alphanumeric characters and underscores: \"<type 'unicode'>\""
     )
-    with self.assertRaisesWithMessageContaining(ValueError, expected_msg):
+    with self.assertRaisesWithMessage(ValueError, expected_msg):
       class JustTypeField(datatype([text_type])): pass
 
     expected_msg = (
@@ -459,7 +454,7 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "Type names and field names cannot start with a number: '3'"
     )
-    with self.assertRaisesWithMessageContaining(ValueError, expected_msg):
+    with self.assertRaisesWithMessage(ValueError, expected_msg):
       class NonStringField(datatype([3])): pass
 
     expected_msg = (
@@ -467,11 +462,11 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "Type names and field names cannot start with a number: '32'"
     )
-    with self.assertRaisesWithMessageContaining(ValueError, expected_msg):
+    with self.assertRaisesWithMessage(ValueError, expected_msg):
       class NonStringTypeField(datatype([(32, int)])): pass
 
     expected_msg = "Encountered duplicate field name: 'field_a'"
-    with self.assertRaisesWithMessageContaining(ValueError, expected_msg):
+    with self.assertRaisesWithMessage(ValueError, expected_msg):
       class MultipleSameName(datatype([
           'field_a',
           'field_b',
@@ -480,7 +475,7 @@ class TypedDatatypeTest(TestBase):
         pass
 
     expected_msg = "Encountered duplicate field name: 'field_a'"
-    with self.assertRaisesWithMessageContaining(ValueError, expected_msg):
+    with self.assertRaisesWithMessage(ValueError, expected_msg):
       class MultipleSameNameWithType(datatype([
             'field_a',
             ('field_a', int),
@@ -490,7 +485,7 @@ class TypedDatatypeTest(TestBase):
     expected_msg = (
       "type spec for field 'a_field' was not a type or TypeConstraint: "
       "was 2 (type 'int').")
-    with self.assertRaisesWithMessageContaining(TypeError, expected_msg):
+    with self.assertRaisesWithMessage(TypeError, expected_msg):
       class InvalidTypeSpec(datatype([('a_field', 2)])): pass
 
   def test_instance_construction_by_repr(self):
@@ -583,7 +578,7 @@ class TypedDatatypeTest(TestBase):
 
   def test_instance_construction_errors(self):
     expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: __new__() got an unexpected keyword argument 'something'"
-    with self.assertRaisesWithMessageContaining(TypeError, expected_msg):
+    with self.assertRaisesWithMessage(TypeError, expected_msg):
       SomeTypedDatatype(something=3)
 
     # not providing all the fields
@@ -593,7 +588,7 @@ class TypedDatatypeTest(TestBase):
       "__new__() takes exactly 2 arguments (1 given)"
     )
     expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: {}".format(expected_msg_ending)
-    with self.assertRaisesWithMessageContaining(TypeError, expected_msg):
+    with self.assertRaisesWithMessage(TypeError, expected_msg):
       SomeTypedDatatype()
 
     # unrecognized fields
@@ -603,19 +598,19 @@ class TypedDatatypeTest(TestBase):
       "__new__() takes exactly 2 arguments (3 given)"
     )
     expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: {}".format(expected_msg_ending)
-    with self.assertRaisesWithMessageContaining(TypeError, expected_msg):
+    with self.assertRaisesWithMessage(TypeError, expected_msg):
       SomeTypedDatatype(3, 4)
 
     expected_msg = (
       """type check error in class CamelCaseWrapper: errors type checking constructor arguments:
 field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(NonNegativeInt).""")
-    with self.assertRaisesWithMessageContaining(TypedDatatypeInstanceConstructionError,
+    with self.assertRaisesWithMessage(TypedDatatypeInstanceConstructionError,
                                                 expected_msg):
       CamelCaseWrapper(nonneg_int=3)
 
     # test that kwargs with keywords that aren't field names fail the same way
     expected_msg = "type check error in class CamelCaseWrapper: error in namedtuple() base constructor: __new__() got an unexpected keyword argument 'a'"
-    with self.assertRaisesWithMessageContaining(TypeError, expected_msg):
+    with self.assertRaisesWithMessage(TypeError, expected_msg):
       CamelCaseWrapper(4, a=3)
 
   def test_type_check_errors(self):
@@ -630,14 +625,14 @@ field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type
     expected_msg = (
       """type check error in class SomeTypedDatatype: errors type checking constructor arguments:
 field 'val' was invalid: value [] (with type 'list') must satisfy this type constraint: Exactly(int).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       SomeTypedDatatype([])
 
     # type checking failure with multiple arguments (one is correct)
     expected_msg = format_string_type_check_message(
       """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
 field 'elements' was invalid: value {u}'should be list' (with type '{str_type}') must satisfy this type constraint: Exactly(list).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       AnotherTypedDatatype(text_type('correct'), text_type('should be list'))
 
     # type checking failure on both arguments
@@ -645,35 +640,35 @@ field 'elements' was invalid: value {u}'should be list' (with type '{str_type}')
         """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
 field 'string' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly({str_type}).
 field 'elements' was invalid: value {u}'should be list' (with type '{str_type}') must satisfy this type constraint: Exactly(list).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       AnotherTypedDatatype(3, text_type('should be list'))
 
     expected_msg = format_string_type_check_message(
         """type check error in class NonNegativeInt: errors type checking constructor arguments:
 field 'an_int' was invalid: value {u}'asdf' (with type '{str_type}') must satisfy this type constraint: Exactly(int).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       NonNegativeInt(text_type('asdf'))
 
     expected_msg = "type check error in class NonNegativeInt: value is negative: -3."
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       NonNegativeInt(-3)
 
     expected_msg = (
       """type check error in class WithSubclassTypeConstraint: errors type checking constructor arguments:
 field 'some_value' was invalid: value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(SomeBaseClass).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       WithSubclassTypeConstraint(3)
 
     expected_msg = """\
 type check error in class WithCollectionTypeConstraint: errors type checking constructor arguments:
 field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)): value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(Iterable)."""
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       WithCollectionTypeConstraint(3)
 
     expected_msg = format_string_type_check_message("""\
 type check error in class WithCollectionTypeConstraint: errors type checking constructor arguments:
 field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'asdf']: value {u}'asdf' (with type '{str_type}') must satisfy this type constraint: Exactly(int).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       WithCollectionTypeConstraint([3, "asdf"])
 
   def test_copy(self):
@@ -689,20 +684,20 @@ field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(
 
     expected_msg = (
       """type check error in class AnotherTypedDatatype: error in namedtuple() base constructor: __new__() got an unexpected keyword argument 'nonexistent_field'""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       obj.copy(nonexistent_field=3)
 
     expected_msg = (
       """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
 field 'elements' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(list).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       obj.copy(elements=3)
 
   def test_enum_class_creation_errors(self):
     expected_msg = (
       "When converting all_values ([1, 2, 3, 1]) to a set, at least one duplicate "
       "was detected. The unique elements of all_values were: [1, 2, 3].")
-    with self.assertRaisesWithMessageContaining(ValueError, expected_msg):
+    with self.assertRaisesWithMessage(ValueError, expected_msg):
       class DuplicateAllowedValues(enum([1, 2, 3, 1])): pass
 
   def test_enum_instance_creation(self):
@@ -711,7 +706,7 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
 
     expected_msg = (
       "type check error in class SomeEnum: Value 3 must be one of: [1, 2].")
-    with self.assertRaisesWithMessageContaining(EnumVariantSelectionError, expected_msg):
+    with self.assertRaisesWithMessage(EnumVariantSelectionError, expected_msg):
       SomeEnum(3)
 
   def test_enum_generated_attrs(self):
@@ -730,9 +725,9 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
     expected_msg = (
       "type check error in class SomeEnum: when comparing SomeEnum(value=1) against 1 with type 'int': "
       "enum equality is only defined for instances of the same enum class!")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       enum_instance == 1
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       1 == enum_instance
 
     class StrEnum(enum(['a'])): pass
@@ -741,9 +736,9 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
       "type check error in class StrEnum: when comparing StrEnum(value={u}'a') against {u}'a' with type '{string_type}': "
       "enum equality is only defined for instances of the same enum class!"
       .format(u='u' if PY2 else '', string_type='unicode' if PY2 else 'str'))
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       enum_instance == 'a'
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
+    with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       'a' == enum_instance
 
   def test_enum_resolve_variant(self):
@@ -759,7 +754,7 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
     }))
 
     # Test that an unrecognized variant raises an error.
-    with self.assertRaisesWithMessageContaining(EnumVariantSelectionError, """\
+    with self.assertRaisesWithMessage(EnumVariantSelectionError, """\
 type check error in class SomeEnum: pattern matching must have exactly the keys [1, 2] (was: [1, 2, 3])"""):
       one_enum_instance.resolve_for_enum_variant({
         1: 3,
@@ -768,7 +763,7 @@ type check error in class SomeEnum: pattern matching must have exactly the keys 
       })
 
     # Test that not providing all the variants raises an error.
-    with self.assertRaisesWithMessageContaining(EnumVariantSelectionError, """\
+    with self.assertRaisesWithMessage(EnumVariantSelectionError, """\
 type check error in class SomeEnum: pattern matching must have exactly the keys [1, 2] (was: [1])"""):
       one_enum_instance.resolve_for_enum_variant({
         1: 3,

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -42,8 +42,7 @@ class TypeConstraintTestBase(TestBase):
 
 class SuperclassesOfTest(TypeConstraintTestBase):
   def test_none(self):
-    with self.assertRaisesWithMessageContaining(ValueError, 'Must supply at least one type',
-                                                exact=True):
+    with self.assertRaisesWithMessageContaining(ValueError, 'Must supply at least one type'):
       SubclassesOf()
 
   def test_str_and_repr(self):
@@ -81,8 +80,7 @@ class SuperclassesOfTest(TypeConstraintTestBase):
 
 class ExactlyTest(TypeConstraintTestBase):
   def test_none(self):
-    with self.assertRaisesWithMessageContaining(ValueError, 'Must supply at least one type',
-                                                exact=True):
+    with self.assertRaisesWithMessageContaining(ValueError, 'Must supply at least one type'):
       Exactly()
 
   def test_single(self):
@@ -101,8 +99,7 @@ class ExactlyTest(TypeConstraintTestBase):
 
   def test_disallows_unsplatted_lists(self):
     with self.assertRaisesWithMessageContaining(TypeError,
-                                                'Supplied types must be types. ([1],)',
-                                                exact=True):
+                                                'Supplied types must be types. ([1],)'):
       Exactly([1])
 
   def test_str_and_repr(self):
@@ -130,8 +127,7 @@ class ExactlyTest(TypeConstraintTestBase):
 
 class SubclassesOfTest(TypeConstraintTestBase):
   def test_none(self):
-    with self.assertRaisesWithMessageContaining(ValueError, 'Must supply at least one type',
-                                                exact=True):
+    with self.assertRaisesWithMessageContaining(ValueError, 'Must supply at least one type'):
       SubclassesOf()
 
   def test_str_and_repr(self):
@@ -334,7 +330,10 @@ class DatatypeTest(TestBase):
 
   def test_not_iterable(self):
     bar = datatype(['val'])
-    with self.assertRaisesWithMessageContaining(TypeError, 'datatype object is not iterable'):
+    with self.assertRaisesWithMessageContaining(
+        TypeError,
+        'datatype object is not iterable',
+        substring_match=True):
       for x in bar(1):
         pass
 
@@ -362,7 +361,7 @@ class DatatypeTest(TestBase):
   def test_properties_not_assignable(self):
     bar = datatype(['val'])
     bar_inst = bar(1)
-    with self.assertRaisesWithMessageContaining(AttributeError, "can't set attribute", exact=True):
+    with self.assertRaisesWithMessageContaining(AttributeError, "can't set attribute"):
       bar_inst.val = 2
 
   def test_invalid_field_name(self):
@@ -370,20 +369,18 @@ class DatatypeTest(TestBase):
         ValueError,
         "Type names and field names must be valid identifiers: '0isntanallowedfirstchar'"
         if PY3 else
-        "Type names and field names cannot start with a number: '0isntanallowedfirstchar'",
-        exact=True):
+        "Type names and field names cannot start with a number: '0isntanallowedfirstchar'"):
       datatype(['0isntanallowedfirstchar'])
     with self.assertRaisesWithMessageContaining(
         ValueError,
-        "Field names cannot start with an underscore: '_no_leading_underscore'",
-        exact=True):
+        "Field names cannot start with an underscore: '_no_leading_underscore'"):
       datatype(['_no_leading_underscore'])
 
   def test_override_eq_disallowed(self):
     class OverridesEq(datatype(['myval'])):
       def __eq__(self, other):
         return other.myval == self.myval
-    with self.assertRaisesWithMessageContaining(TypeCheckError, 'Should not override __eq__.'):
+    with self.assertRaisesWithMessageContaining(TypeCheckError, 'type check error in class OverridesEq: Should not override __eq__.'):
       OverridesEq(1)
 
   def test_subclass_pickleable(self):
@@ -399,10 +396,10 @@ class DatatypeTest(TestBase):
 
   def test_double_passed_arg(self):
     bar = datatype(['val', 'zal'])
-    with self.assertRaisesWithMessageContaining(
-        TypeError,
+    with self.assertRaisesWithMessageContaining(TypeError,
         "__new__() got multiple values for {kw}argument 'val'"
-        .format(kw='' if PY3 else 'keyword ')):
+        .format(kw='' if PY3 else 'keyword '),
+        substring_match=True):
       bar(1, val=1)
 
   def test_too_many_args(self):
@@ -411,13 +408,16 @@ class DatatypeTest(TestBase):
         TypeError,
         '__new__() takes 3 positional arguments but 4 were given'
         if PY3 else
-        '__new__() takes exactly 3 arguments (4 given)'):
+        '__new__() takes exactly 3 arguments (4 given)',
+        substring_match=True):
       bar(1, 1, 1)
 
   def test_unexpect_kwarg(self):
     bar = datatype(['val'])
     with self.assertRaisesWithMessageContaining(
-        TypeError, "__new__() got an unexpected keyword argument 'other'"):
+        TypeError,
+        "__new__() got an unexpected keyword argument 'other'",
+        substring_match=True):
       bar(other=1)
 
 
@@ -434,7 +434,7 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "Type names and field names can only contain alphanumeric characters and underscores: \"<type 'int'>\""
     )
-    with self.assertRaisesWithMessageContaining(ValueError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(ValueError, expected_msg):
       class NonStrType(datatype([int])): pass
 
     # This raises a TypeError because it doesn't provide a required argument.
@@ -443,7 +443,7 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "datatype() takes at least 1 argument (0 given)"
     )
-    with self.assertRaisesWithMessageContaining(TypeError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeError, expected_msg):
       class NoFields(datatype()): pass
 
     expected_msg = (
@@ -451,7 +451,7 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "Type names and field names can only contain alphanumeric characters and underscores: \"<type 'unicode'>\""
     )
-    with self.assertRaisesWithMessageContaining(ValueError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(ValueError, expected_msg):
       class JustTypeField(datatype([text_type])): pass
 
     expected_msg = (
@@ -459,7 +459,7 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "Type names and field names cannot start with a number: '3'"
     )
-    with self.assertRaisesWithMessageContaining(ValueError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(ValueError, expected_msg):
       class NonStringField(datatype([3])): pass
 
     expected_msg = (
@@ -467,11 +467,11 @@ class TypedDatatypeTest(TestBase):
       if PY3 else
       "Type names and field names cannot start with a number: '32'"
     )
-    with self.assertRaisesWithMessageContaining(ValueError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(ValueError, expected_msg):
       class NonStringTypeField(datatype([(32, int)])): pass
 
     expected_msg = "Encountered duplicate field name: 'field_a'"
-    with self.assertRaisesWithMessageContaining(ValueError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(ValueError, expected_msg):
       class MultipleSameName(datatype([
           'field_a',
           'field_b',
@@ -480,7 +480,7 @@ class TypedDatatypeTest(TestBase):
         pass
 
     expected_msg = "Encountered duplicate field name: 'field_a'"
-    with self.assertRaisesWithMessageContaining(ValueError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(ValueError, expected_msg):
       class MultipleSameNameWithType(datatype([
             'field_a',
             ('field_a', int),
@@ -490,7 +490,7 @@ class TypedDatatypeTest(TestBase):
     expected_msg = (
       "type spec for field 'a_field' was not a type or TypeConstraint: "
       "was 2 (type 'int').")
-    with self.assertRaisesWithMessageContaining(TypeError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeError, expected_msg):
       class InvalidTypeSpec(datatype([('a_field', 2)])): pass
 
   def test_instance_construction_by_repr(self):
@@ -583,7 +583,7 @@ class TypedDatatypeTest(TestBase):
 
   def test_instance_construction_errors(self):
     expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: __new__() got an unexpected keyword argument 'something'"
-    with self.assertRaisesWithMessageContaining(TypeError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeError, expected_msg):
       SomeTypedDatatype(something=3)
 
     # not providing all the fields
@@ -593,7 +593,7 @@ class TypedDatatypeTest(TestBase):
       "__new__() takes exactly 2 arguments (1 given)"
     )
     expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: {}".format(expected_msg_ending)
-    with self.assertRaisesWithMessageContaining(TypeError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeError, expected_msg):
       SomeTypedDatatype()
 
     # unrecognized fields
@@ -603,19 +603,19 @@ class TypedDatatypeTest(TestBase):
       "__new__() takes exactly 2 arguments (3 given)"
     )
     expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: {}".format(expected_msg_ending)
-    with self.assertRaisesWithMessageContaining(TypeError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeError, expected_msg):
       SomeTypedDatatype(3, 4)
 
     expected_msg = (
       """type check error in class CamelCaseWrapper: errors type checking constructor arguments:
 field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(NonNegativeInt).""")
     with self.assertRaisesWithMessageContaining(TypedDatatypeInstanceConstructionError,
-                                                expected_msg, exact=True):
+                                                expected_msg):
       CamelCaseWrapper(nonneg_int=3)
 
     # test that kwargs with keywords that aren't field names fail the same way
     expected_msg = "type check error in class CamelCaseWrapper: error in namedtuple() base constructor: __new__() got an unexpected keyword argument 'a'"
-    with self.assertRaisesWithMessageContaining(TypeError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeError, expected_msg):
       CamelCaseWrapper(4, a=3)
 
   def test_type_check_errors(self):
@@ -630,14 +630,14 @@ field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type
     expected_msg = (
       """type check error in class SomeTypedDatatype: errors type checking constructor arguments:
 field 'val' was invalid: value [] (with type 'list') must satisfy this type constraint: Exactly(int).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
       SomeTypedDatatype([])
 
     # type checking failure with multiple arguments (one is correct)
     expected_msg = format_string_type_check_message(
       """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
 field 'elements' was invalid: value {u}'should be list' (with type '{str_type}') must satisfy this type constraint: Exactly(list).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
       AnotherTypedDatatype(text_type('correct'), text_type('should be list'))
 
     # type checking failure on both arguments
@@ -645,35 +645,35 @@ field 'elements' was invalid: value {u}'should be list' (with type '{str_type}')
         """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
 field 'string' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly({str_type}).
 field 'elements' was invalid: value {u}'should be list' (with type '{str_type}') must satisfy this type constraint: Exactly(list).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
       AnotherTypedDatatype(3, text_type('should be list'))
 
     expected_msg = format_string_type_check_message(
         """type check error in class NonNegativeInt: errors type checking constructor arguments:
 field 'an_int' was invalid: value {u}'asdf' (with type '{str_type}') must satisfy this type constraint: Exactly(int).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
       NonNegativeInt(text_type('asdf'))
 
     expected_msg = "type check error in class NonNegativeInt: value is negative: -3."
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
       NonNegativeInt(-3)
 
     expected_msg = (
       """type check error in class WithSubclassTypeConstraint: errors type checking constructor arguments:
 field 'some_value' was invalid: value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(SomeBaseClass).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
       WithSubclassTypeConstraint(3)
 
     expected_msg = """\
 type check error in class WithCollectionTypeConstraint: errors type checking constructor arguments:
 field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)): value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(Iterable)."""
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
       WithCollectionTypeConstraint(3)
 
     expected_msg = format_string_type_check_message("""\
 type check error in class WithCollectionTypeConstraint: errors type checking constructor arguments:
 field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'asdf']: value {u}'asdf' (with type '{str_type}') must satisfy this type constraint: Exactly(int).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
       WithCollectionTypeConstraint([3, "asdf"])
 
   def test_copy(self):
@@ -689,13 +689,13 @@ field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(
 
     expected_msg = (
       """type check error in class AnotherTypedDatatype: error in namedtuple() base constructor: __new__() got an unexpected keyword argument 'nonexistent_field'""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
       obj.copy(nonexistent_field=3)
 
     expected_msg = (
       """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
 field 'elements' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(list).""")
-    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg, exact=True):
+    with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
       obj.copy(elements=3)
 
   def test_enum_class_creation_errors(self):
@@ -710,7 +710,7 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
     self.assertEqual(SomeEnum(2), SomeEnum(value=2))
 
     expected_msg = (
-      "Value 3 must be one of: [1, 2].")
+      "type check error in class SomeEnum: Value 3 must be one of: [1, 2].")
     with self.assertRaisesWithMessageContaining(EnumVariantSelectionError, expected_msg):
       SomeEnum(3)
 
@@ -728,7 +728,7 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
 
     # Test that comparison fails against another type.
     expected_msg = (
-      "when comparing SomeEnum(value=1) against 1 with type 'int': "
+      "type check error in class SomeEnum: when comparing SomeEnum(value=1) against 1 with type 'int': "
       "enum equality is only defined for instances of the same enum class!")
     with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):
       enum_instance == 1
@@ -738,7 +738,7 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
     class StrEnum(enum(['a'])): pass
     enum_instance = StrEnum('a')
     expected_msg = (
-      "when comparing StrEnum(value={u}'a') against {u}'a' with type '{string_type}': "
+      "type check error in class StrEnum: when comparing StrEnum(value={u}'a') against {u}'a' with type '{string_type}': "
       "enum equality is only defined for instances of the same enum class!"
       .format(u='u' if PY2 else '', string_type='unicode' if PY2 else 'str'))
     with self.assertRaisesWithMessageContaining(TypeCheckError, expected_msg):

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -333,7 +333,7 @@ class DatatypeTest(TestBase):
     with self.assertRaisesWithMessageContaining(
         TypeError,
         'datatype object is not iterable',
-        substring_match=True):
+        exact=False):
       for x in bar(1):
         pass
 
@@ -399,7 +399,7 @@ class DatatypeTest(TestBase):
     with self.assertRaisesWithMessageContaining(TypeError,
         "__new__() got multiple values for {kw}argument 'val'"
         .format(kw='' if PY3 else 'keyword '),
-        substring_match=True):
+                                                exact=False):
       bar(1, val=1)
 
   def test_too_many_args(self):
@@ -409,7 +409,7 @@ class DatatypeTest(TestBase):
         '__new__() takes 3 positional arguments but 4 were given'
         if PY3 else
         '__new__() takes exactly 3 arguments (4 given)',
-        substring_match=True):
+        exact=False):
       bar(1, 1, 1)
 
   def test_unexpect_kwarg(self):
@@ -417,7 +417,7 @@ class DatatypeTest(TestBase):
     with self.assertRaisesWithMessageContaining(
         TypeError,
         "__new__() got an unexpected keyword argument 'other'",
-        substring_match=True):
+        exact=False):
       bar(other=1)
 
 


### PR DESCRIPTION
### Problem

Resolves #7298.

### Solution

- Add `self.assertRaisesWithMessage()` to `TestBase` to clearly indicate when an exception message is being tested with `self.assertEqual()`.
  - Also add `self.assertRaisesWithMessageContaining()` to do a `self.assertIn()` check.
- Make `test_objects.py` uniformly use these methods.

### Result

We have nicer test utilities for exception messages, it's more ergonomic to test exception messages exactly, and the testing in `test_objects.py` is easier to read!