### PR TITLE
use `type=` to register enum options

### DIFF
--- a/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/indexable_java_targets.py
+++ b/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/indexable_java_targets.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import str
+
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.build_graph.target_scopes import Scope
 from pants.subsystem.subsystem import Subsystem

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -118,9 +118,9 @@ class _JvmCompileWorkflowType(enum(['zinc-only', 'rsc-then-zinc'])):
     if target.has_sources('.java') or \
       isinstance(target, JUnitTests) or \
       (isinstance(target, ScalaLibrary) and tuple(target.java_sources)):
-      target_type = _JvmCompileWorkflowType('zinc-only')
+      target_type = _JvmCompileWorkflowType.zinc_only
     elif target.has_sources('.scala'):
-      target_type = _JvmCompileWorkflowType('rsc-then-zinc')
+      target_type = _JvmCompileWorkflowType.rsc_then_zinc
     else:
       target_type = None
     return target_type

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -15,7 +15,7 @@ from pants.java.nailgun_executor import NailgunExecutor, NailgunProcessGroup
 from pants.process.subprocess import Subprocess
 from pants.task.task import Task, TaskBase
 from pants.util.memo import memoized_property
-from pants.util.objects import enum, register_enum_option
+from pants.util.objects import enum
 
 
 class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
@@ -30,8 +30,8 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
   @classmethod
   def register_options(cls, register):
     super(NailgunTaskBase, cls).register_options(register)
-    register_enum_option(
-      register, cls.ExecutionStrategy, '--execution-strategy', default=cls.NAILGUN,
+    cls.ExecutionStrategy.register_option(
+      register, '--execution-strategy', default=cls.NAILGUN,
       help='If set to nailgun, nailgun will be enabled and repeated invocations of this '
            'task will be quicker. If set to subprocess, then the task will be run without nailgun. '
            'Hermetic execution is an experimental subprocess execution framework.')
@@ -49,10 +49,7 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
 
   @memoized_property
   def execution_strategy_enum(self):
-    # TODO: This .create() call can be removed when the enum interface is more stable as the option
-    # is converted into an instance of self.ExecutionStrategy via the `type` argument through
-    # register_enum_option().
-    return self.ExecutionStrategy(self.get_options().execution_strategy)
+    return self.get_options().execution_strategy
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -14,7 +14,6 @@ from pants.java.jar.jar_dependency import JarDependency
 from pants.java.nailgun_executor import NailgunExecutor, NailgunProcessGroup
 from pants.process.subprocess import Subprocess
 from pants.task.task import Task, TaskBase
-from pants.util.memo import memoized_property
 from pants.util.objects import enum
 
 
@@ -31,7 +30,7 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
   def register_options(cls, register):
     super(NailgunTaskBase, cls).register_options(register)
     register('--execution-strategy',
-             default=cls.NAILGUN, type=cls.ExecutionStrategy,
+             default=cls.ExecutionStrategy.nailgun, type=cls.ExecutionStrategy,
              help='If set to nailgun, nailgun will be enabled and repeated invocations of this '
                   'task will be quicker. If set to subprocess, then the task will be run without '
                   'nailgun. Hermetic execution is an experimental subprocess execution framework.')
@@ -47,7 +46,7 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
                                           rev='0.9.1'),
                           ])
 
-  @memoized_property
+  @property
   def execution_strategy_enum(self):
     return self.get_options().execution_strategy
 

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -30,11 +30,11 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
   @classmethod
   def register_options(cls, register):
     super(NailgunTaskBase, cls).register_options(register)
-    cls.ExecutionStrategy.register_option(
-      register, '--execution-strategy', default=cls.NAILGUN,
-      help='If set to nailgun, nailgun will be enabled and repeated invocations of this '
-           'task will be quicker. If set to subprocess, then the task will be run without nailgun. '
-           'Hermetic execution is an experimental subprocess execution framework.')
+    register('--execution-strategy',
+             default=cls.NAILGUN, type=cls.ExecutionStrategy,
+             help='If set to nailgun, nailgun will be enabled and repeated invocations of this '
+                  'task will be quicker. If set to subprocess, then the task will be run without '
+                  'nailgun. Hermetic execution is an experimental subprocess execution framework.')
     register('--nailgun-timeout-seconds', advanced=True, default=10, type=float,
              help='Timeout (secs) for nailgun startup.')
     register('--nailgun-connect-attempts', advanced=True, default=5, type=int,

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -12,7 +12,7 @@ from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
 from pants.util.meta import classproperty
-from pants.util.objects import enum, register_enum_option
+from pants.util.objects import enum
 
 
 class ToolchainVariant(enum(['gnu', 'llvm'])): pass
@@ -37,8 +37,8 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
              help='The default for the "compiler_option_sets" argument '
                   'for targets of this language.')
 
-    register_enum_option(
-      register, ToolchainVariant, '--toolchain-variant', advanced=True, default='gnu',
+    ToolchainVariant.register_option(
+      register, '--toolchain-variant', advanced=True, default='gnu',
       help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
            "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
 

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -37,22 +37,16 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
              help='The default for the "compiler_option_sets" argument '
                   'for targets of this language.')
 
-    ToolchainVariant.register_option(
-      register, '--toolchain-variant', advanced=True, default='gnu',
-      help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
-           "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
+    register('--toolchain-variant', advanced=True,
+             default='gnu', type=ToolchainVariant,
+             help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
+                  "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
 
   def get_compiler_option_sets_for_target(self, target):
     return self.get_target_mirrored_option('compiler_option_sets', target)
 
   def get_toolchain_variant_for_target(self, target):
-    # TODO(#7233): convert this option into an enum instance using the `type` argument in option
-    # registration!
-    enum_or_value = self.get_target_mirrored_option('toolchain_variant', target)
-    if isinstance(enum_or_value, ToolchainVariant):
-      return enum_or_value
-    else:
-      return ToolchainVariant(enum_or_value)
+    return self.get_target_mirrored_option('toolchain_variant', target)
 
   @classproperty
   def get_compiler_option_sets_enabled_default_value(cls):

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -38,7 +38,7 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
                   'for targets of this language.')
 
     register('--toolchain-variant', advanced=True,
-             default='gnu', type=ToolchainVariant,
+             default=ToolchainVariant.gnu, type=ToolchainVariant,
              help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
                   "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
 

--- a/src/python/pants/backend/native/targets/external_native_library.py
+++ b/src/python/pants/backend/native/targets/external_native_library.py
@@ -9,7 +9,7 @@ import re
 from future.utils import text_type
 
 from pants.base.deprecated import warn_or_error
-from pants.base.hash_utils import stable_json_hash
+from pants.base.hash_utils import stable_json_sha1
 from pants.base.payload import Payload
 from pants.base.payload_field import PayloadField
 from pants.base.validation import assert_list
@@ -22,7 +22,7 @@ from pants.util.objects import datatype
 class ConanRequirementSetField(tuple, PayloadField):
 
   def _compute_fingerprint(self):
-    return stable_json_hash(tuple(hash(req) for req in self))
+    return stable_json_sha1(tuple(hash(req) for req in self))
 
 
 class ConanRequirement(datatype([

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -13,6 +13,7 @@ from twitter.common.collections import OrderedSet
 
 from pants.base.deprecated import deprecated
 from pants.util.collections_abc_backport import Iterable, Mapping, OrderedDict, Set
+from pants.util.objects import DatatypeMixin
 from pants.util.strutil import ensure_binary
 
 
@@ -89,6 +90,13 @@ class CoercingEncoder(json.JSONEncoder):
                         .format(cls=type(self).__name__, val=o))
       # Set order is arbitrary in python 3.6 and 3.7, so we need to keep this sorted() call.
       return sorted(self.default(i) for i in o)
+    elif isinstance(o, DatatypeMixin):
+      # datatype objects will intentionally raise in the __iter__ method, but the Iterable abstract
+      # base class will match any class with any superclass that has the attribute __iter__ in the
+      # __dict__ (see https://docs.python.org/2/library/abc.html), so we need to check for it
+      # specially here.
+      # TODO: determine if the __repr__ should be some abstractmethod on DatatypeMixin!
+      return self.default(repr(o))
     elif isinstance(o, Iterable) and not isinstance(o, (bytes, list, str)):
       return list(self.default(i) for i in o)
     return o

--- a/src/python/pants/core_tasks/explain_options_task.py
+++ b/src/python/pants/core_tasks/explain_options_task.py
@@ -11,6 +11,7 @@ from colors import black, blue, cyan, green, magenta, red, white
 from packaging.version import Version
 
 from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.options_fingerprinter import CoercingOptionEncoder
 from pants.option.ranked_value import RankedValue
 from pants.task.console_task import ConsoleTask
 from pants.version import PANTS_SEMVER
@@ -174,4 +175,4 @@ class ExplainOptionsTask(ConsoleTask):
           if self.is_json():
             inner_map["history"] = history_list
     if self.is_json():
-      yield json.dumps(output_map, indent=2, sort_keys=True)
+      yield json.dumps(output_map, indent=2, sort_keys=True, cls=CoercingOptionEncoder)

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -232,8 +232,7 @@ def _get_starting_indent(source):
 def _make_rule(output_type, input_selectors, for_goal=None, cacheable=True):
   """A @decorator that declares that a particular static function may be used as a TaskRule.
 
-  :param Constraint output_type: The return/output type for the Rule. This may be either a
-    concrete Python type, or an instance of `Exactly` representing a union of multiple types.
+  :param type output_type: The return/output type for the Rule. This must be a concrete Python type.
   :param list input_selectors: A list of Selector instances that matches the number of arguments
     to the @decorated function.
   :param str for_goal: If this is a @console_rule, which goal string it's called for.
@@ -348,8 +347,8 @@ def union(cls):
 
 
 class UnionRule(datatype([
-    ('union_base', type),
-    ('union_member', type),
+    ('union_base', _type_field),
+    ('union_member', _type_field),
 ])):
   """Specify that an instance of `union_member` can be substituted wherever `union_base` is used."""
 
@@ -487,8 +486,8 @@ class RuleIndex(datatype(['rules', 'roots', 'union_rules'])):
         add_rule(rule)
       else:
         raise TypeError("""\
-Unexpected rule type: {}. Rules either extend Rule or UnionRule, or are static functions decorated \
-with @rule.""".format(type(entry)))
+Rule entry {} had an unexpected type: {}. Rules either extend Rule or UnionRule, or are static \
+functions decorated with @rule.""".format(entry, type(entry)))
 
     return cls(serializable_rules, serializable_roots, union_rules)
 

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -388,9 +388,7 @@ class RunTracker(Subsystem):
 
   @classmethod
   def _json_dump_options(cls, stats):
-    return json.dumps(stats,
-                      ensure_ascii=True, allow_nan=False, sort_keys=True,
-                      cls=RunTrackerOptionEncoder)
+    return json.dumps(stats, cls=RunTrackerOptionEncoder)
 
   @classmethod
   def write_stats_to_json(cls, file_name, stats):

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -28,10 +28,25 @@ from pants.goal.aggregated_timings import AggregatedTimings
 from pants.goal.artifact_cache_stats import ArtifactCacheStats
 from pants.goal.pantsd_stats import PantsDaemonStats
 from pants.option.config import Config
+from pants.option.options_fingerprinter import CoercingOptionEncoder
 from pants.reporting.report import Report
 from pants.stats.statsdb import StatsDBFactory
 from pants.subsystem.subsystem import Subsystem
+from pants.util.collections_abc_backport import OrderedDict
 from pants.util.dirutil import relative_symlink, safe_file_dump
+
+
+class RunTrackerOptionEncoder(CoercingOptionEncoder):
+  """Use the json encoder we use for making options hashable to support datatypes.
+
+  This encoder also explicitly allows OrderedDict inputs, as we accept more than just option values
+  when encoding stats to json.
+  """
+
+  def default(self, o):
+    if isinstance(o, OrderedDict):
+      return o
+    return super(RunTrackerOptionEncoder, self).default(o)
 
 
 class RunTracker(Subsystem):
@@ -341,7 +356,7 @@ class RunTracker(Subsystem):
     # TODO(benjy): The upload protocol currently requires separate top-level params, with JSON
     # values.  Probably better for there to be one top-level JSON value, namely json.dumps(stats).
     # But this will first require changing the upload receiver at every shop that uses this.
-    params = {k: json.dumps(v) for (k, v) in stats.items()}
+    params = {k: cls._json_dump_options(v) for (k, v) in stats.items()}
     cookies = Cookies.global_instance()
     auth_provider = auth_provider or '<provider>'
 
@@ -372,12 +387,18 @@ class RunTracker(Subsystem):
       return error('Error: {}'.format(e))
 
   @classmethod
+  def _json_dump_options(cls, stats):
+    return json.dumps(stats,
+                      ensure_ascii=True, allow_nan=False, sort_keys=True,
+                      cls=RunTrackerOptionEncoder)
+
+  @classmethod
   def write_stats_to_json(cls, file_name, stats):
     """Write stats to a local json file.
 
     :return: True if successfully written, False otherwise.
     """
-    params = json.dumps(stats)
+    params = cls._json_dump_options(stats)
     if PY2:
       params = params.decode('utf-8')
     try:
@@ -412,7 +433,7 @@ class RunTracker(Subsystem):
     stats_file = os.path.join(get_pants_cachedir(), 'stats',
                               '{}.json'.format(self.run_info.get_info('id')))
     mode = 'w' if PY3 else 'wb'
-    safe_file_dump(stats_file, json.dumps(stats), mode=mode)
+    safe_file_dump(stats_file, self._json_dump_options(stats), mode=mode)
 
     # Add to local stats db.
     StatsDBFactory.global_instance().get_db().insert_stats(stats)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -263,9 +263,7 @@ class EngineInitializer(object):
       options_bootstrapper,
       build_configuration,
       native=native,
-      # TODO(#7233): convert this into an enum instance using the `type` argument in option
-      # registration!
-      glob_match_error_behavior=GlobMatchErrorBehavior(bootstrap_options.glob_expansion_failure),
+      glob_match_error_behavior=bootstrap_options.glob_expansion_failure,
       build_ignore_patterns=bootstrap_options.build_ignore,
       exclude_target_regexps=bootstrap_options.exclude_target_regexp,
       subproject_roots=bootstrap_options.subproject_roots,

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -10,7 +10,6 @@ import os
 import site
 from builtins import object, open
 
-from future.utils import PY3
 from pex import resolver
 from pex.base import requirement_is_exact
 from pkg_resources import Requirement
@@ -22,6 +21,7 @@ from pants.option.global_options import GlobalOptionsRegistrar
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_open
 from pants.util.memo import memoized_property
+from pants.util.strutil import ensure_text
 from pants.version import PANTS_SEMVER
 
 
@@ -99,7 +99,7 @@ class PluginResolver(object):
       tmp_plugins_list = resolved_plugins_list + '~'
       with safe_open(tmp_plugins_list, 'w') as fp:
         for plugin in self._resolve_plugins():
-          fp.write(plugin.location if PY3 else plugin.location.decode('utf-8'))
+          fp.write(ensure_text(plugin.location))
           fp.write('\n')
       os.rename(tmp_plugins_list, resolved_plugins_list)
     with open(resolved_plugins_list, 'r') as fp:

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -17,6 +17,7 @@ from pants.java.nailgun_io import NailgunStreamWriter
 from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
 from pants.util.osutil import safe_kill
 from pants.util.socket import RecvBufferedSocket
+from pants.util.strutil import ensure_text
 
 
 logger = logging.getLogger(__name__)
@@ -62,7 +63,7 @@ class NailgunClientSession(NailgunProtocol):
     """Write a payload to a given fd (if provided) and flush the fd."""
     try:
       if payload:
-        fd.write(payload)
+        fd.write(ensure_text(payload))
       fd.flush()
     except (IOError, OSError) as e:
       # If a `Broken Pipe` is encountered during a stdio fd write, we're headless - bail.

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -17,7 +17,7 @@ from pants.java.nailgun_io import NailgunStreamWriter
 from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
 from pants.util.osutil import safe_kill
 from pants.util.socket import RecvBufferedSocket
-from pants.util.strutil import ensure_text
+from pants.util.strutil import ensure_binary
 
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ class NailgunClientSession(NailgunProtocol):
     """Write a payload to a given fd (if provided) and flush the fd."""
     try:
       if payload:
-        fd.write(ensure_text(payload))
+        fd.write(ensure_binary(payload))
       fd.flush()
     except (IOError, OSError) as e:
       # If a `Broken Pipe` is encountered during a stdio fd write, we're headless - bail.

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -196,7 +196,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   '(e.g. BUILD file scanning, glob matching, etc). '
                   'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore).')
     register('--glob-expansion-failure', advanced=True,
-             default='warn', type=GlobMatchErrorBehavior,
+             default=GlobMatchErrorBehavior.warn, type=GlobMatchErrorBehavior,
              help="Raise an exception if any targets declaring source files "
                   "fail to match any glob provided in the 'sources' argument.")
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -16,7 +16,7 @@ from pants.option.errors import OptionsError
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
-from pants.util.objects import datatype, enum, register_enum_option
+from pants.util.objects import datatype, enum
 
 
 class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'])):
@@ -195,10 +195,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help='Paths to ignore for all filesystem operations performed by pants '
                   '(e.g. BUILD file scanning, glob matching, etc). '
                   'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore).')
-    register_enum_option(
-      # TODO: allow using the attribute `GlobMatchErrorBehavior.warn` for more safety!
-      register, GlobMatchErrorBehavior, '--glob-expansion-failure', default='warn',
-      advanced=True,
+    GlobMatchErrorBehavior.register_option(
+      register, '--glob-expansion-failure', default='warn', advanced=True,
       help="Raise an exception if any targets declaring source files "
            "fail to match any glob provided in the 'sources' argument.")
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -195,10 +195,10 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help='Paths to ignore for all filesystem operations performed by pants '
                   '(e.g. BUILD file scanning, glob matching, etc). '
                   'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore).')
-    GlobMatchErrorBehavior.register_option(
-      register, '--glob-expansion-failure', default='warn', advanced=True,
-      help="Raise an exception if any targets declaring source files "
-           "fail to match any glob provided in the 'sources' argument.")
+    register('--glob-expansion-failure', advanced=True,
+             default='warn', type=GlobMatchErrorBehavior,
+             help="Raise an exception if any targets declaring source files "
+                  "fail to match any glob provided in the 'sources' argument.")
 
     register('--exclude-target-regexp', advanced=True, type=list, default=[], daemon=False,
              metavar='<regexp>', help='Exclude target roots that match these regexes.')

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -557,11 +557,13 @@ class Parser(object):
     def check(val):
       if val is not None:
         choices = kwargs.get('choices')
-        # Reach into `enum` types to get the allowed `choices` if not explicitly set.
+        # If the `type` argument has an `all_variants` attribute, use that as `choices` if not
+        # already set. Using an attribute instead of checking a subclass allows `type` arguments
+        # which are functions to have an implicit fallback `choices` set as well.
         if choices is None and 'type' in kwargs:
           type_arg = kwargs.get('type')
-          if hasattr(type_arg, 'iterate_enum_variants'):
-            choices = list(type_arg.iterate_enum_variants())
+          if hasattr(type_arg, 'all_variants'):
+            choices = list(type_arg.all_variants)
         if choices is not None and val not in choices:
           raise ParseError('`{}` is not an allowed value for option {} in {}. '
                            'Must be one of: {}'.format(val, dest, self._scope_str(), choices))

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -12,6 +12,7 @@ class SingletonMetaclass(type):
   """Singleton metaclass."""
 
   def __call__(cls, *args, **kwargs):
+    # TODO: convert this into an `@memoized_classproperty`!
     if not hasattr(cls, 'instance'):
       cls.instance = super(SingletonMetaclass, cls).__call__(*args, **kwargs)
     return cls.instance
@@ -20,12 +21,10 @@ class SingletonMetaclass(type):
 class ClassPropertyDescriptor(object):
   """Define a readable attribute on a class, given a function."""
 
-  # TODO: it seems overriding __set__ and __delete__ would require defining a metaclass or
-  # overriding __setattr__/__delattr__ (see
-  # https://stackoverflow.com/questions/5189699/how-to-make-a-class-property). The current solution
-  # doesn't require any modifications to the class definition beyond declaring a @classproperty.  If
-  # we can set __delete__ and have it work, we can use that e.g. to clear the cache for a new
-  # `@memoized_classproperty` decorator.
+  # The current solution is preferred as it doesn't require any modifications to the class
+  # definition beyond declaring a @classproperty.  It seems overriding __set__ and __delete__ would
+  # require defining a metaclass or overriding __setattr__/__delattr__ (see
+  # https://stackoverflow.com/questions/5189699/how-to-make-a-class-property).
   def __init__(self, fget, doc):
     self.fget = fget
     self.__doc__ = doc
@@ -94,6 +93,8 @@ def staticproperty(func):
   return ClassPropertyDescriptor(func, doc)
 
 
+# TODO: look into merging this with `enum` and `ChoicesMixin`, which describe a fixed set of
+# singletons, to decouple the enum interface from the implementation as a `datatype`.
 # Extend Singleton and your class becomes a singleton, each construction returns the same instance.
 try:  # Python3
   Singleton = SingletonMetaclass(u'Singleton', (object,), {})

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -294,11 +294,12 @@ def enum(all_values):
     def __eq__(self, other):
       """Redefine equality to avoid accidentally comparing against a non-enum."""
       # This __eq__ implementation raises on anything that's not an instance of this enum class to
-      # avoid accidental comparisons, e.g. a string not being wrapped in an enum instance. However,
-      # options parsing will use == to check whether an option's value has changed when recording
-      # where the option's value was set (in pants.ini, the command line, the environment). If the
-      # option isn't set and it falls back to the default, then there will be a comparison against
-      # None. Comparing an enum to None is not clearly an error, so we just return False here.
+      # avoid accidental comparisons, e.g. a string not being wrapped in an enum
+      # instance. Currently, options parsing will use == to check whether an option's value has
+      # changed when recording where the option's value was set (in pants.ini, the command line, the
+      # environment). If the option isn't set and it falls back to the default, then there will be a
+      # comparison against None. Comparing an enum to None is not clearly an error, so we just
+      # return False here.
       if other is None:
         return False
       if type(self) != type(other):

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -207,6 +207,18 @@ class EnumVariantSelectionError(TypeCheckError):
   """Raised when an invalid variant for an enum() is constructed or matched against."""
 
 
+# TODO: make an @abstract_classproperty which works with AbstractClass!
+class ChoicesMixin(AbstractClass):
+  """A mixin which declares that the type has a fixed set of possible instances."""
+
+  @classproperty
+  def all_variants(cls):
+    """Return an iterable containing a de-duplicated list of all possible instances of this type."""
+    raise NotImplementedError(
+      "The `all_variants` classproperty must be implemented for subclasses of {}!"
+      .format(cls.__name__))
+
+
 def enum(all_values):
   """A datatype which can take on a finite set of values. This method is experimental and unstable.
 
@@ -246,7 +258,7 @@ def enum(all_values):
                      "was detected. The unique elements of all_values were: {}."
                      .format(all_values_realized, list(unique_values)))
 
-  class ChoiceDatatype(datatype([field_name])):
+  class ChoiceDatatype(datatype([field_name]), ChoicesMixin):
     # Overriden from datatype() so providing an invalid variant is catchable as a TypeCheckError,
     # but more specific.
     type_check_error_type = EnumVariantSelectionError
@@ -328,12 +340,12 @@ def enum(all_values):
       match_for_variant = mapping[self.value]
       return match_for_variant
 
-    @classmethod
-    def iterate_enum_variants(cls):
+    @classproperty
+    def all_variants(cls):
       """Iterate over all instances of this enum, in the declared order.
 
-      NB: This method is exposed for testing enum variants easily. resolve_for_enum_variant() should
-      be used for performing conditional logic based on an enum instance's value.
+      NB: resolve_for_enum_variant() should be used instead of this method for performing
+      conditional logic based on an enum instance's value.
       """
       return cls._singletons.values()
 

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import re
 from abc import abstractmethod
 from builtins import zip
 from collections import namedtuple
@@ -216,11 +217,14 @@ def enum(all_values):
   If `all_values` contains only strings, then each variant is made into an attribute on the
   generated enum class object. This allows code such as the following:
 
-  class MyResult(enum(['success', 'failure'])):
+  class MyResult(enum(['success', 'not-success'])):
     pass
 
   MyResult.success # The same as: MyResult('success')
-  MyResult.failure # The same as: MyResult('failure')
+  MyResult.not_success # The same as: MyResult('not-success')
+
+  Note that like with option names, hyphenated ('-') enum values are converted into attribute names
+  with underscores ('_').
 
   :param Iterable all_values: A nonempty iterable of objects representing all possible values for
                               the enum.  This argument must be a finite, non-empty iterable with
@@ -338,7 +342,8 @@ def enum(all_values):
   for case in all_values_realized:
     if isinstance(case, six.string_types):
       accessor = classproperty(accessor_generator(case))
-      setattr(ChoiceDatatype, case, accessor)
+      attr_name = re.sub(r'-', '_', case)
+      setattr(ChoiceDatatype, attr_name, accessor)
 
   return ChoiceDatatype
 

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -279,10 +279,14 @@ def enum(all_values):
       :param value: Use this as the enum value. If `value` is an instance of this class, return it,
                     otherwise it is checked against the enum's allowed values.
       """
+      if isinstance(value, cls):
+        return value
+
       if value not in cls._singletons:
         raise cls.make_type_error(
           "Value {!r} must be one of: {!r}."
           .format(value, cls._allowed_values))
+
       return cls._singletons[value]
 
     # TODO: figure out if this will always trigger on primitives like strings, and what situations
@@ -336,16 +340,6 @@ def enum(all_values):
       be used for performing conditional logic based on an enum instance's value.
       """
       return cls._singletons.values()
-
-    @classmethod
-    def register_option(cls, register, *args, **kwargs):
-      """Register an option which converts the given value into the specified enum."""
-      # Since __new__ will raise if provided an instance of the enum class (as opposed to a valid
-      # /value/ for the enum), `idempotent_type_check=False` avoids wrapping any instances of this
-      # enum type again if they are already instances of this enum type.
-      register(*args, idempotent_type_check=False, type=cls,
-               choices=list(cls.iterate_enum_variants()),
-               **kwargs)
 
   # Python requires creating an explicit closure to save the value on each loop iteration.
   accessor_generator = lambda case: lambda cls: cls(case)

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -290,16 +290,11 @@ def enum(all_values):
       return cls._singletons[value]
 
     # TODO: figure out if this will always trigger on primitives like strings, and what situations
-    # won't call this __eq__ (and therefore won't raise like we want).
+    # won't call this __eq__ (and therefore won't raise like we want). Also look into whether there
+    # is a way to return something more conventional like `NotImplemented` here that maintains the
+    # extra caution we're looking for.
     def __eq__(self, other):
       """Redefine equality to avoid accidentally comparing against a non-enum."""
-      # This __eq__ implementation raises on anything that's not an instance of this enum class to
-      # avoid accidental comparisons, e.g. a string not being wrapped in an enum
-      # instance. Currently, options parsing will use == to check whether an option's value has
-      # changed when recording where the option's value was set (in pants.ini, the command line, the
-      # environment). If the option isn't set and it falls back to the default, then there will be a
-      # comparison against None. Comparing an enum to None is not clearly an error, so we just
-      # return False here.
       if other is None:
         return False
       if type(self) != type(other):

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -289,12 +289,12 @@ def enum(all_values):
     # won't call this __eq__ (and therefore won't raise like we want).
     def __eq__(self, other):
       """Redefine equality to avoid accidentally comparing against a non-enum."""
-      # Options parsing will use == to check whether an option's value has changed when recording
+      # This __eq__ implementation raises on anything that's not an instance of this enum class to
+      # avoid accidental comparisons, e.g. a string not being wrapped in an enum instance. However,
+      # options parsing will use == to check whether an option's value has changed when recording
       # where the option's value was set (in pants.ini, the command line, the environment). If the
-      # option isn't set and falls back to the default, it will be compared against None. Limiting
-      # __eq__ to raise on some comparisons is intended to avoid accidental comparisons against
-      # e.g. a string not wrapped in an enum instance -- comparing to None is much less confusing
-      # and not clearly an error, so we just return False here.
+      # option isn't set and it falls back to the default, then there will be a comparison against
+      # None. Comparing an enum to None is not clearly an error, so we just return False here.
       if other is None:
         return False
       if type(self) != type(other):

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -317,16 +317,8 @@ def enum(all_values):
         raise self.make_type_error(
           "pattern matching must have exactly the keys {} (was: {})"
           .format(self._allowed_values, list(keys)))
-      match_for_variant = mapping[self.underlying()]
+      match_for_variant = mapping[self.value]
       return match_for_variant
-
-    def underlying(self):
-      """Get the element of `all_values` corresponding to this enum instance.
-
-      This should be used only for generating option values in tests. In general, it is less
-      error-prone to deal with enum objects directly.
-      """
-      return getattr(self, field_name)
 
     @classmethod
     def iterate_enum_variants(cls):

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -22,6 +22,7 @@ from pants.backend.jvm.targets.managed_jar_dependencies import ManagedJarDepende
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.coursier_resolve import (CoursierResolve,
                                                       CoursierResolveFingerprintStrategy)
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
 from pants.java import util
 from pants.java.jar.exclude import Exclude
@@ -43,7 +44,7 @@ class CoursierResolveTest(JvmToolTaskTestBase):
 
   def setUp(self):
     super(CoursierResolveTest, self).setUp()
-    self.set_options(execution_strategy='subprocess')
+    self.set_options(execution_strategy=NailgunTask.ExecutionStrategy.subprocess)
     self.set_options_for_scope('cache.{}'.format(self.options_scope),
                                read_from=None,
                                write_to=None)

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_imports.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_imports.py
@@ -12,6 +12,7 @@ from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
 from pants.backend.jvm.tasks.ivy_imports import IvyImports
 from pants.backend.jvm.tasks.jar_import_products import JarImportProducts
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.java.jar.jar_dependency import JarDependency
 from pants.java.jar.jar_dependency_utils import M2Coordinate
 from pants.util.contextutil import open_zip, temporary_dir
@@ -52,7 +53,7 @@ class IvyImportsTest(NailgunTaskTestBase):
                                     libraries=[jar_library.address.spec],
                                     include_patterns=['a/b/c/*.proto'])
 
-      self.set_options(execution_strategy='subprocess')
+      self.set_options(execution_strategy=NailgunTask.ExecutionStrategy.subprocess)
       ivy_imports_task = self.execute(self.context(target_roots=[foo_target]))
 
       # Make sure the product is properly populated

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
@@ -21,6 +21,7 @@ from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.targets.managed_jar_dependencies import ManagedJarDependencies
 from pants.backend.jvm.tasks.ivy_resolve import IvyResolve
 from pants.backend.jvm.tasks.ivy_task_mixin import IvyResolveFingerprintStrategy
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.java.jar.exclude import Exclude
 from pants.java.jar.jar_dependency import JarDependency
@@ -45,7 +46,7 @@ class IvyResolveTest(JvmToolTaskTestBase):
 
   def setUp(self):
     super(IvyResolveTest, self).setUp()
-    self.set_options(execution_strategy='subprocess')
+    self.set_options(execution_strategy=NailgunTask.ExecutionStrategy.subprocess)
     self.set_options_for_scope('cache.{}'.format(self.options_scope),
                                read_from=None,
                                write_to=None)

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
@@ -20,6 +20,7 @@ from pants.backend.jvm.ivy_utils import (FrozenResolution, IvyFetchStep, IvyInfo
 from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.jvm.subsystems.jar_dependency_management import JarDependencyManagement
 from pants.backend.jvm.targets.jar_library import JarLibrary
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.build_environment import get_buildroot
 from pants.build_graph.register import build_file_aliases as register_core
 from pants.ivy.ivy_subsystem import IvySubsystem
@@ -401,7 +402,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
   def test_missing_ivy_report(self):
     self.set_options_for_scope(IvySubsystem.options_scope,
                                cache_dir='DOES_NOT_EXIST',
-                               execution_strategy='subprocess')
+                               execution_strategy=NailgunTask.ExecutionStrategy.subprocess)
 
     with self.assertRaises(IvyUtils.IvyResolveReportError):
       IvyUtils.parse_xml_report('default', IvyUtils.xml_report_path('INVALID_CACHE_DIR',

--- a/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
+++ b/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from textwrap import dedent
 
+from pants.backend.native.subsystems.native_build_step import ToolchainVariant
 from pants.backend.native.targets.native_library import CppLibrary, NativeLibrary
 from pants.backend.native.tasks.cpp_compile import CppCompile
 from pants.backend.native.tasks.native_compile import ObjectFiles
@@ -61,11 +62,11 @@ class CppCompileTest(NativeTaskTestBase, NativeCompileTestMixin):
     cpp_compile.execute()
 
   def test_target_level_toolchain_variant_llvm(self):
-    self.set_options_for_scope('native-build-step', toolchain_variant='gnu')
+    self.set_options_for_scope('native-build-step', toolchain_variant=ToolchainVariant.gnu)
     cpp_lib_target = self.make_target(
       '//:cpp_library',
       NativeLibrary,
-      toolchain_variant='llvm'
+      toolchain_variant=ToolchainVariant.llvm,
     )
 
     task = self.create_task(self.context(target_roots=[cpp_lib_target]))
@@ -74,7 +75,7 @@ class CppCompileTest(NativeTaskTestBase, NativeCompileTestMixin):
     self.assertIn('llvm', compiler.path_entries[0])
 
   def test_target_level_toolchain_variant_default_llvm(self):
-    self.set_options_for_scope('native-build-step', toolchain_variant='llvm')
+    self.set_options_for_scope('native-build-step', toolchain_variant=ToolchainVariant.llvm)
     cpp_lib_target = self.make_target(
       '//:cpp_library',
       NativeLibrary,
@@ -85,7 +86,7 @@ class CppCompileTest(NativeTaskTestBase, NativeCompileTestMixin):
     self.assertIn('llvm', compiler.path_entries[0])
 
   def test_target_level_toolchain_variant_default_gnu(self):
-    self.set_options_for_scope('native-build-step', toolchain_variant='gnu')
+    self.set_options_for_scope('native-build-step', toolchain_variant=ToolchainVariant.gnu)
     cpp_lib_target = self.make_target(
       '//:cpp_library',
       NativeLibrary,

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -56,7 +56,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
           'pants_distdir': tmp_dir,
         },
         'native-build-step': {
-          'toolchain_variant': toolchain_variant.underlying(),
+          'toolchain_variant': toolchain_variant.value,
         },
       })
 
@@ -134,7 +134,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         # Explicitly set to True (although this is the default).
         config={
           'native-build-step': {
-            'toolchain_variant': toolchain_variant.underlying(),
+            'toolchain_variant': toolchain_variant.value,
           },
           # TODO(#6848): don't make it possible to forget to add the toolchain_variant option!
           'native-build-settings': {
@@ -159,7 +159,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     if attempt_pants_run:
       pants_run_interop = self.run_pants(['-q', 'run', self._binary_target_with_interop], config={
         'native-build-step': {
-          'toolchain_variant': toolchain_variant.underlying(),
+          'toolchain_variant': toolchain_variant.value,
         },
         'native-build-settings': {
           'strict_deps': True,
@@ -172,7 +172,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
   def test_ctypes_third_party_integration(self, toolchain_variant):
     pants_binary = self.run_pants(['binary', self._binary_target_with_third_party], config={
       'native-build-step': {
-        'toolchain_variant': toolchain_variant.underlying(),
+        'toolchain_variant': toolchain_variant.value,
       },
     })
     self.assert_success(pants_binary)
@@ -186,7 +186,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     if attempt_pants_run:
       pants_run = self.run_pants(['-q', 'run', self._binary_target_with_third_party], config={
         'native-build-step': {
-          'toolchain_variant': toolchain_variant.underlying(),
+          'toolchain_variant': toolchain_variant.value,
         },
       })
       self.assert_success(pants_run)
@@ -238,7 +238,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     ]
     pants_run = self.run_pants(command=command, config={
       'native-build-step': {
-        'toolchain_variant': toolchain_variant.underlying(),
+        'toolchain_variant': toolchain_variant.value,
       },
       'native-build-step.cpp-compile-settings': {
         'compiler_option_sets_enabled_args': {

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -28,7 +28,7 @@ def invoke_pex_for_output(pex_file_to_run):
 def _toolchain_variants(func):
   @wraps(func)
   def wrapper(*args, **kwargs):
-    for variant in ToolchainVariant.iterate_enum_variants():
+    for variant in ToolchainVariant.all_variants:
       func(*args, toolchain_variant=variant, **kwargs)
   return wrapper
 

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -10,6 +10,7 @@ from builtins import next, str
 
 from pants.backend.native.register import rules as native_backend_rules
 from pants.backend.native.subsystems.libc_dev import LibcDev
+from pants.backend.native.subsystems.native_build_step import ToolchainVariant
 from pants.backend.python.subsystems.python_repos import PythonRepos
 from pants.backend.python.tasks.build_local_python_distributions import \
   BuildLocalPythonDistributions
@@ -82,7 +83,7 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, DeclarativeTaskT
       # TODO(#6848): we should be testing all of these with both of our toolchains.
       options={
         'native-build-step': {
-          'toolchain_variant': 'llvm',
+          'toolchain_variant': ToolchainVariant.llvm,
         },
       })
     context = result.context

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -20,6 +20,7 @@ from pants.engine.selectors import Get, Select
 from pants_test.engine.examples.parsers import JsonParser
 from pants_test.engine.util import (TargetTable, assert_equal_with_printing, create_scheduler,
                                     run_rule)
+from pants_test.test_base import TestBase
 
 
 class A(object):
@@ -73,14 +74,11 @@ class RuleTest(unittest.TestCase):
     self.assertEquals(res, _GoalProduct.for_name('example')())
 
 
-class RuleIndexTest(unittest.TestCase):
+class RuleIndexTest(TestBase):
   def test_creation_fails_with_bad_declaration_type(self):
-    with self.assertRaises(TypeError) as cm:
+    with self.assertRaisesWithMessage(TypeError, """\
+Rule entry A() had an unexpected type: <class 'pants_test.engine.test_rules.A'>. Rules either extend Rule or UnionRule, or are static functions decorated with @rule."""):
       RuleIndex.create([A()])
-    self.assertEqual("""\
-Unexpected rule type: <class 'pants_test.engine.test_rules.A'>. Rules either extend Rule or \
-UnionRule, or are static functions decorated with @rule.""",
-      str(cm.exception))
 
 
 class RulesetValidatorTest(unittest.TestCase):

--- a/tests/python/pants_test/java/test_runjava_synthetic_classpath.py
+++ b/tests/python/pants_test/java/test_runjava_synthetic_classpath.py
@@ -27,7 +27,7 @@ class SyntheticClasspathTest(JvmToolTaskTestBase):
 
   def setUp(self):
     super(SyntheticClasspathTest, self).setUp()
-    self.set_options(execution_strategy='subprocess')
+    self.set_options(execution_strategy=NailgunTask.ExecutionStrategy.subprocess)
 
   def test_execute_java_no_error_weird_path(self):
     """

--- a/tests/python/pants_test/jvm/nailgun_task_test_base.py
+++ b/tests/python/pants_test/jvm/nailgun_task_test_base.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.jvm.tasks.nailgun_task import NailgunProcessGroup
+from pants.backend.jvm.tasks.nailgun_task import NailgunProcessGroup, NailgunTask
 from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
 
 
@@ -18,7 +18,7 @@ class NailgunTaskTestBase(JvmToolTaskTestBase):
     :API: public
     """
     super(NailgunTaskTestBase, self).setUp()
-    self.set_options(execution_strategy='nailgun')
+    self.set_options(execution_strategy=NailgunTask.ExecutionStrategy.nailgun)
 
   def tearDown(self):
     """

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -7,13 +7,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import io
 import os
 import shlex
-import unittest
 import warnings
 from builtins import open, str
 from contextlib import contextmanager
 from textwrap import dedent
 
-from future.utils import PY3, text_type
+from future.utils import text_type
 
 from pants.base.deprecated import CodeRemovedError
 from pants.engine.fs import FileContent
@@ -36,6 +35,7 @@ from pants.util.collections import assert_single_element
 from pants.util.contextutil import temporary_file, temporary_file_path
 from pants.util.dirutil import safe_mkdtemp
 from pants.util.objects import enum
+from pants_test.test_base import TestBase
 
 
 def task(scope):
@@ -50,7 +50,7 @@ def subsystem(scope):
   return ScopeInfo(scope, ScopeInfo.SUBSYSTEM)
 
 
-class OptionsTest(unittest.TestCase):
+class OptionsTest(TestBase):
 
   @contextmanager
   def _write_config_to_file(self, fp, config):
@@ -813,13 +813,11 @@ class OptionsTest(unittest.TestCase):
 
   def test_enum_option_type_parse_error(self):
     self.maxDiff = None
-    with self.assertRaises(ParseError) as cm:
+    with self.assertRaisesWithMessageContaining(
+        ParseError,
+        "Error applying type 'SomeEnumOption' to option value 'invalid-value', for option '--some_enum' in scope 'enum-opt'"):
       options = self._parse('./pants enum-opt --some-enum=invalid-value')
       options.for_scope('enum-opt').some_enum
-    self.assertIn("""\
-ParseError: Error applying type 'SomeEnumOption' to option value 'invalid-value', for option '--some_enum' in scope 'enum-opt': type check error in class SomeEnumOption: Value {u}'invalid-value' must be one of: [{u}'a-value', {u}'another-value']."""
-                  .format(u='' if PY3 else 'u'),
-                  str(cm.exception))
 
   def test_deprecated_option_past_removal(self):
     """Ensure that expired options raise CodeRemovedError on attempted use."""
@@ -1401,6 +1399,7 @@ ParseError: Error applying type 'SomeEnumOption' to option value 'invalid-value'
     self.assertEqual('vv', vals1.foo)
 
 
+# TODO: Figure out why this testing is necessary.
 class OptionsTestStringPayloads(OptionsTest):
   """Runs the same tests as OptionsTest, but backed with `Config.loads` vs `Config.load`."""
 

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -13,7 +13,7 @@ from builtins import open, str
 from contextlib import contextmanager
 from textwrap import dedent
 
-from future.utils import text_type
+from future.utils import PY3, text_type
 
 from pants.base.deprecated import CodeRemovedError
 from pants.engine.fs import FileContent
@@ -817,7 +817,8 @@ class OptionsTest(unittest.TestCase):
       options = self._parse('./pants enum-opt --some-enum=invalid-value')
       options.for_scope('enum-opt').some_enum
     self.assertIn("""\
-ParseError: Error applying type 'SomeEnumOption' to option value 'invalid-value', for option '--some_enum' in scope 'enum-opt': type check error in class SomeEnumOption: Value 'invalid-value' must be one of: ['a-value', 'another-value'].""",
+ParseError: Error applying type 'SomeEnumOption' to option value 'invalid-value', for option '--some_enum' in scope 'enum-opt': type check error in class SomeEnumOption: Value {u}'invalid-value' must be one of: [{u}'a-value', {u}'another-value']."""
+                  .format(u='' if PY3 else 'u'),
                   str(cm.exception))
 
   def test_deprecated_option_past_removal(self):

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -195,7 +195,7 @@ class OptionsTest(unittest.TestCase):
                      type=self.SomeEnumOption)
     # For testing the default value
     options.register('separate-enum-opt-scope', '--some-enum-with-default',
-                     default='a-value', type=self.SomeEnumOption)
+                     default=self.SomeEnumOption.a_value, type=self.SomeEnumOption)
 
   def test_env_type_int(self):
     options = Options.create(env={'PANTS_FOO_BAR': "['123','456']"},


### PR DESCRIPTION
### Problem

Resolves #7233. We want to make it easy and natural to register enum options, and one way to improve that is to automatically convert options registered as enums to instances of those enums.

### Solution

- Convert hyphenated enum values to underscored `classproperty`s, e.g. `'zinc-only'` becomes `.zinc_only`.
- Remove `register_enum_option()` and use `type=` to automatically convert option values to enum instances.
- Make `__new__` for `enum` classes accept an instance of the enum class and pass it through so options parsing can assume the constructor is idempotent.
- Wrap the `type` checking area in options parsing in a `try` and convert to a `ParseError` with more information about the invalid option.
- Extract `.all_variants` from a `type` arg and use it for `choices` if not explicitly specified, allowing enum `type` options to automatically populate the `choices` argument to `register()`.
- Extract `datatype` and `enum` logic into `DatatypeMixin` (to do special-case logic in `stable_json_sha1()`) and `ChoicesMixin` (to do the special-case logic to get `choices`).

### Result

Registering options as enum classes is much more natural, and has a better error message!