### PR TITLE
convert many manual NotImplementedError() calls to use @abstractmethod

### DIFF
--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from abc import abstractmethod
+
 from pants.backend.native.subsystems.utils.mirrored_target_option_mixin import \
   MirroredTargetOptionMixin
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
@@ -66,8 +68,9 @@ class CompileSettingsBase(Subsystem):
     )
 
   @classproperty
+  @abstractmethod
   def header_file_extensions_default(cls):
-    raise NotImplementedError('header_file_extensions_default() must be overridden!')
+    """Default value for --header-file-extensions."""
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/native/subsystems/utils/mirrored_target_option_mixin.py
+++ b/src/python/pants/backend/native/subsystems/utils/mirrored_target_option_mixin.py
@@ -4,24 +4,24 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import object
+from abc import abstractmethod
 
-from pants.util.meta import classproperty
+from pants.util.meta import AbstractClass, classproperty
 
 
 # TODO: consider coalescing existing methods of mirroring options between a target and a subsystem
 # -- see pants.backend.jvm.subsystems.dependency_context.DependencyContext#defaulted_property()!
-class MirroredTargetOptionMixin(object):
+class MirroredTargetOptionMixin(AbstractClass):
   """Get option values which may be set in this subsystem or in a Target's keyword argument."""
 
   @classproperty
+  @abstractmethod
   def mirrored_option_to_kwarg_map(cls):
     """Subclasses should override and return a dict of (subsystem option name) -> (target kwarg).
 
     This classproperty should return a dict mapping this subsystem's options attribute name (with
     underscores) to the corresponding target's keyword argument name.
     """
-    raise NotImplementedError()
 
   def get_target_mirrored_option(self, option_name, target):
     field_name = self.mirrored_option_to_kwarg_map[option_name]

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -43,11 +43,16 @@ class NativeCompile(NativeTask, AbstractClass):
   # NB: `source_target_constraint` must be overridden.
   source_target_constraint = None
 
-  # `NativeCompile` will use `workunit_label` as the name of the workunit when executing the
-  # compiler process. `workunit_label` must be set to a string.
   @classproperty
+  @abstractmethod
   def workunit_label(cls):
-    raise NotImplementedError('subclasses of NativeCompile must override workunit_label!')
+    """A string describing the work being done during compilation.
+
+    `NativeCompile` will use `workunit_label` as the name of the workunit when executing the
+    compiler process.
+
+    :rtype: str
+    """
 
   @classmethod
   def product_types(cls):

--- a/src/python/pants/backend/native/tasks/native_task.py
+++ b/src/python/pants/backend/native/tasks/native_task.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from abc import abstractmethod
 from builtins import filter
 
 from pants.backend.native.config.environment import CppToolchain, CToolchain
@@ -24,6 +25,7 @@ from pants.util.objects import Exactly, SubclassesOf
 class NativeTask(Task):
 
   @classproperty
+  @abstractmethod
   def source_target_constraint(cls):
     """Return a type constraint which is used to filter "source" targets for this task.
 
@@ -33,7 +35,6 @@ class NativeTask(Task):
 
     :return: :class:`pants.util.objects.TypeConstraint`
     """
-    raise NotImplementedError()
 
   @classproperty
   def dependent_target_constraint(cls):

--- a/src/python/pants/build_graph/import_remote_sources_mixin.py
+++ b/src/python/pants/build_graph/import_remote_sources_mixin.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from abc import abstractmethod
 from builtins import str
 
 from future.utils import string_types
@@ -28,39 +29,31 @@ class ImportRemoteSourcesMixin(Target, AbstractClass):
     """Thrown if the wrong type of target is encountered."""
 
   @classproperty
+  @abstractmethod
   def expected_target_constraint(cls):
     """
     :returns: A type constraint which is used to validate the targets containing remote sources,
               specified `imported_target_kwargs_field` in a BUILD file.
     :rtype: TypeConstraint
     """
-    # TODO: make a utility in pants.util.meta to register these standard `NotImplementedError`s!
-    raise NotImplementedError(
-      'subclasses of ImportRemoteSourcesMixin must implement an '
-      '`expected_target_constraint` classproperty'
-    )
 
   @classproperty
+  @abstractmethod
   def imported_target_kwargs_field(cls):
     """
     :returns: string representing the keyword argument of an uninitialized target representing
               source target specs to be imported.
+    :rtype: str
     """
-    raise NotImplementedError(
-      'subclasses of ImportRemoteSourcesMixin must implement an '
-      '`imported_target_kwargs_field` classproperty'
-    )
 
   @classproperty
+  @abstractmethod
   def imported_target_payload_field(cls):
     """
     :returns: string representing the payload field of an already-initialized target containing
               source target specs to be imported.
+    :rtype: str
     """
-    raise NotImplementedError(
-      'subclasses of ImportRemoteSourcesMixin must implement an '
-      '`imported_target_payload_field` classproperty'
-    )
 
   @classmethod
   def imported_target_specs(cls, kwargs=None, payload=None):

--- a/src/python/pants/task/unpack_remote_sources_base.py
+++ b/src/python/pants/task/unpack_remote_sources_base.py
@@ -42,12 +42,12 @@ class UnpackRemoteSourcesBase(Task, AbstractClass):
     return [UnpackedArchives]
 
   @classproperty
+  @abstractmethod
   def source_target_constraint(cls):
     """Return a type constraint which is evaluated to determine "source" targets for this task.
 
     :return: :class:`pants.util.objects.TypeConstraint`
     """
-    raise NotImplementedError()
 
   @abstractmethod
   def unpack_target(unpackable_target, unpack_dir):

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -18,7 +18,7 @@ class SingletonMetaclass(type):
 
 
 class ClassPropertyDescriptor(object):
-  """Define a readable class property, given a function."""
+  """Define a readable attribute on a class, given a function."""
 
   # TODO: it seems overriding __set__ and __delete__ would require defining a metaclass or
   # overriding __setattr__/__delattr__ (see

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -412,13 +412,6 @@ class TypeOnlyConstraint(TypeConstraint):
   and easier to understand than the more complex validation allowed by `.satisfied_by()`.
   """
 
-  # TODO: make an @abstract_classproperty decorator to do this boilerplate!
-  @classproperty
-  def _variance_symbol(cls):
-    """This is propagated to the the `TypeConstraint` constructor."""
-    raise NotImplementedError('{} must implement the _variance_symbol classproperty!'
-                              .format(cls.__name__))
-
   def __init__(self, *types):
     """Creates a type constraint based on some logic to match the given types.
 

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
+from abc import abstractmethod
 from builtins import next, str
 
 from pants.backend.native.register import rules as native_backend_rules
@@ -40,9 +41,9 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, DeclarativeTaskT
     return super(BuildLocalPythonDistributionsTestBase, cls).rules() + native_backend_rules()
 
   @classproperty
+  @abstractmethod
   def dist_specs(cls):
     """Fed into `self.populate_target_dict()`."""
-    raise NotImplementedError('dist_specs must be implemented!')
 
   def setUp(self):
     super(BuildLocalPythonDistributionsTestBase, self).setUp()

--- a/tests/python/pants_test/task_test_base.py
+++ b/tests/python/pants_test/task_test_base.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import glob
 import os
+from abc import abstractmethod
 from builtins import object
 from contextlib import closing, contextmanager
 from io import BytesIO
@@ -65,12 +66,12 @@ class TaskTestBase(TestBase):
   options_scope = 'test_scope'
 
   @classmethod
+  @abstractmethod
   def task_type(cls):
     """Subclasses must return the type of the Task subclass under test.
 
     :API: public
     """
-    raise NotImplementedError()
 
   def setUp(self):
     """

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -8,7 +8,6 @@ import itertools
 import logging
 import os
 import unittest
-from abc import abstractmethod
 from builtins import object, open, str
 from collections import defaultdict
 from contextlib import contextmanager
@@ -51,7 +50,6 @@ class TestGenerator(object):
   """A mixin that facilitates test generation at runtime."""
 
   @classmethod
-  @abstractmethod
   def generate_tests(cls):
     """Generate tests for a given class.
 
@@ -63,6 +61,9 @@ class TestGenerator(object):
       ThingTest.generate_tests()
 
     """
+    # This would be an @abstractmethod, but making TestGenerator extend AbstractClass causes an
+    # error as it gets instantiated directly somehow in testing.
+    raise NotImplementedError()
 
   @classmethod
   def add_test(cls, method_name, method):

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -8,6 +8,7 @@ import itertools
 import logging
 import os
 import unittest
+from abc import abstractmethod
 from builtins import object, open, str
 from collections import defaultdict
 from contextlib import contextmanager
@@ -39,16 +40,18 @@ from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import (recursive_dirname, relative_symlink, safe_file_dump, safe_mkdir,
                                 safe_mkdtemp, safe_open, safe_rmtree)
 from pants.util.memo import memoized_method
+from pants.util.meta import AbstractClass
 from pants_test.base.context_utils import create_context_from_options
 from pants_test.engine.util import init_native
 from pants_test.option.util.fakes import create_options_for_optionables
 from pants_test.subsystem import subsystem_util
 
 
-class TestGenerator(object):
+class TestGenerator(AbstractClass):
   """A mixin that facilitates test generation at runtime."""
 
   @classmethod
+  @abstractmethod
   def generate_tests(cls):
     """Generate tests for a given class.
 
@@ -60,7 +63,6 @@ class TestGenerator(object):
       ThingTest.generate_tests()
 
     """
-    raise NotImplementedError()
 
   @classmethod
   def add_test(cls, method_name, method):

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -40,14 +40,13 @@ from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import (recursive_dirname, relative_symlink, safe_file_dump, safe_mkdir,
                                 safe_mkdtemp, safe_open, safe_rmtree)
 from pants.util.memo import memoized_method
-from pants.util.meta import AbstractClass
 from pants_test.base.context_utils import create_context_from_options
 from pants_test.engine.util import init_native
 from pants_test.option.util.fakes import create_options_for_optionables
 from pants_test.subsystem import subsystem_util
 
 
-class TestGenerator(AbstractClass):
+class TestGenerator(object):
   """A mixin that facilitates test generation at runtime."""
 
   @classmethod

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -40,6 +40,7 @@ from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import (recursive_dirname, relative_symlink, safe_file_dump, safe_mkdir,
                                 safe_mkdtemp, safe_open, safe_rmtree)
 from pants.util.memo import memoized_method
+from pants.util.meta import AbstractClass
 from pants_test.base.context_utils import create_context_from_options
 from pants_test.engine.util import init_native
 from pants_test.option.util.fakes import create_options_for_optionables
@@ -78,7 +79,7 @@ class TestGenerator(object):
     setattr(cls, method_name, method)
 
 
-class TestBase(unittest.TestCase):
+class TestBase(unittest.TestCase, AbstractClass):
   """A baseclass useful for tests requiring a temporary buildroot.
 
   :API: public


### PR DESCRIPTION
### Problem

It turns out that `@abstractmethod` can be used with `@classmethod` and friends (see https://github.com/python/cpython/blob/master/Doc/library/abc.rst and search "innermost"), but we manually raise `NotImplementedError` in several places.

### Solution

- Replace many `raise NotImplementedError('')` boilerplate calls with the use of `@abstractmethod`!
- Add `AbstractClass` to classes which don't already subclass that as it is required to use `@abstractmethod`.

### Result

Less boilerplate is used to create classes with abstract `@classproperty`s!