### PR TITLE
Filter out irrelevant env vars in OptionsBootstrapper

### DIFF
--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -96,7 +96,8 @@ class OptionsBootstrapper(datatype([
     :param env: An environment dictionary, or None to use `os.environ`.
     :param args: An args array, or None to use `sys.argv`.
     """
-    env = os.environ.copy() if env is None else env
+    env = {k: v for k, v in (os.environ if env is None else env).items()
+           if k.startswith('PANTS_')}
     args = tuple(sys.argv if args is None else args)
 
     flags = set()

--- a/tests/python/pants_test/option/test_options_bootstrapper.py
+++ b/tests/python/pants_test/option/test_options_bootstrapper.py
@@ -134,6 +134,18 @@ class BootstrapOptionsTest(unittest.TestCase):
     self.assertEqual('/qux/baz', opts.for_scope('foo').bar)
     self.assertEqual('/pear/banana', opts.for_scope('fruit').apple)
 
+  def test_bootstrapped_options_ignore_irrelevant_env(self):
+    included = 'PANTS_SUPPORTDIR'
+    excluded = 'NON_PANTS_ENV'
+    bootstrapper = OptionsBootstrapper.create(
+        env={
+          excluded: 'pear',
+          included: 'banana',
+        }
+      )
+    self.assertIn(included, bootstrapper.env)
+    self.assertNotIn(excluded, bootstrapper.env)
+
   def do_test_create_bootstrapped_multiple_config(self, create_options_bootstrapper):
     # check with multiple config files, the latest values always get taken
     # in this case worker_count will be overwritten, while fruit stays the same


### PR DESCRIPTION
### Problem

The `OptionsBootstrapper` holds the env/args/config that can eventually be fully parsed into an `Options` object that can be consumed by the rest of pants.

Options parsing only consumes `env` vars that start with `PANTS_`, but the `OptionsBootstrapper` currently captures the entire `env`. This can make the `OptionsBootstrapper` unnecessarily large (and its `__str__` unwieldy).

### Solution

Filter env vars recorded in the `OptionsBootstrapper` to only those starting with `PANTS_`.