### PR TITLE
Print trace id to console and possible URL with the zipkin trace

### DIFF
--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -63,6 +63,7 @@ class ZipkinReporter(Reporter):
     self.trace_id = trace_id
     self.parent_id = parent_id
     self.sample_rate = float(sample_rate)
+    self.endpoint = endpoint
 
   def start_workunit(self, workunit):
     """Implementation of Reporter callback."""
@@ -120,4 +121,7 @@ class ZipkinReporter(Reporter):
 
   def close(self):
     """End the report."""
-    logger.info("{}".format(self.trace_id))
+    endpoint = self.endpoint.replace("/api/v1/spans", "")
+
+    logger.info("Zipkin trace ID {}".format(self.trace_id))
+    logger.info("Zipkin trace may be located at this URL {}/traces/{}".format(endpoint, self.trace_id))

--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -16,7 +16,7 @@ from pants.base.workunit import WorkUnitLabel
 from pants.reporting.reporter import Reporter
 
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class HTTPTransportHandler(BaseTransportHandler):
@@ -34,7 +34,7 @@ class HTTPTransportHandler(BaseTransportHandler):
         headers={'Content-Type': 'application/x-thrift'},
       )
     except Exception as err:
-      log.error("Failed to post the payload to zipkin server. Error {}".format(err))
+      logger.error("Failed to post the payload to zipkin server. Error {}".format(err))
 
 
 class ZipkinReporter(Reporter):
@@ -89,6 +89,8 @@ class ZipkinReporter(Reporter):
         zipkin_attrs =  create_attrs_for_span(
           sample_rate=self.sample_rate, # Value between 0.0 and 100.0
         )
+        self.trace_id = zipkin_attrs.trace_id
+
 
       span = zipkin_span(
         service_name=service_name,
@@ -115,3 +117,7 @@ class ZipkinReporter(Reporter):
     if workunit in self._workunits_to_spans:
       span = self._workunits_to_spans.pop(workunit)
       span.stop()
+
+  def close(self):
+    """End the report."""
+    logger.info("{}".format(self.trace_id))

--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -123,5 +123,4 @@ class ZipkinReporter(Reporter):
     """End the report."""
     endpoint = self.endpoint.replace("/api/v1/spans", "")
 
-    logger.info("Zipkin trace ID {}".format(self.trace_id))
-    logger.info("Zipkin trace may be located at this URL {}/traces/{}".format(endpoint, self.trace_id))
+    logger.debug("Zipkin trace may be located at this URL {}/traces/{}".format(endpoint, self.trace_id))


### PR DESCRIPTION
### Problem
It is not obvious for the user how to find the zipkin trace after a pants run.

### Solution
One of the solutions is to print zipkin trace in the console. 
The better one could be to print a link to the Zipkin API with the trace. But endpoints to send spans to Zipkin API and to view the resulting trace may be different. The set up is not unique. 
One of the solutions is to have two flags:
--reporter-zipkin-send-endpoint  and
--reporter-zipkin-view-endpoint
Current implementation suggests a link that can point to the current zipkin trace.

I would be grateful for your comments in regard to it