### PR TITLE
Add subsystem for appending tags to targets from a single source

### DIFF
--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import json
 import logging
 import os
 from builtins import object, str

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -41,6 +41,7 @@ python_tests(
   sources = ['test_build_file_aliases.py'],
   dependencies = [
     'src/python/pants/build_graph',
+    'tests/python/pants_test/subsystem:subsystem_utils',
   ]
 )
 

--- a/tests/python/pants_test/build_graph/test_build_file_aliases.py
+++ b/tests/python/pants_test/build_graph/test_build_file_aliases.py
@@ -11,6 +11,7 @@ from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases, TargetMacro
 from pants.build_graph.mutable_build_graph import MutableBuildGraph
 from pants.build_graph.target import Target
+from pants_test.subsystem.subsystem_util import init_subsystem
 
 
 class BuildFileAliasesTest(unittest.TestCase):
@@ -19,6 +20,7 @@ class BuildFileAliasesTest(unittest.TestCase):
     pass
 
   def setUp(self):
+    init_subsystem(Target.TagAssignments)
     self.target_macro_factory = TargetMacro.Factory.wrap(
       lambda ctx: ctx.create_object(self.BlueTarget,
                                     type_alias='jill',

--- a/tests/python/pants_test/build_graph/test_target.py
+++ b/tests/python/pants_test/build_graph/test_target.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import json
 import os.path
 from builtins import range, str
 from hashlib import sha1
@@ -20,7 +19,6 @@ from pants.build_graph.address import Address
 from pants.build_graph.target import Target
 from pants.build_graph.target_scopes import Scopes
 from pants.source.wrapped_globs import Globs
-from pants.util.contextutil import temporary_file
 from pants_test.subsystem.subsystem_util import init_subsystem
 from pants_test.test_base import TestBase
 

--- a/tests/python/pants_test/build_graph/test_target.py
+++ b/tests/python/pants_test/build_graph/test_target.py
@@ -112,29 +112,27 @@ class TargetTest(TestBase):
     target = self.make_target('foo:bar', Target, foobar='barfoo')
     self.assertFalse(hasattr(target, 'foobar'))
 
-  def test_tags_applied_from_configured_json(self):
-    with temporary_file(binary_mode=False) as fp:
-      json.dump({
-        'tag_targets_mappings': {
-          'special_tag': ['foo:bar', 'path/to/target:foo', 'path/to/target'],
-          'special_tag2': ['path/to/target:target', '//base:foo']
-        }
-      }, fp)
-      fp.flush()
+  def test_tags_applied_from_configured_dict(self):
+    options = {Target.TagAssignments.options_scope: {
+      'tag_targets_mappings': {
+        'special_tag': ['foo:bar', 'path/to/target:foo', 'path/to/target'],
+        'special_tag2': ['path/to/target:target', '//base:foo'],
+        'nonextant_target_tag': ['i/dont/exist'],
+      }
+    }}
 
-      options = {Target.TagAssignments.options_scope: {'tag_targets_file': fp.name}}
-      init_subsystem(Target.TagAssignments, options)
-      target1 = self.make_target('foo:bar', Target, tags=['tag1', 'tag2'])
-      target2 = self.make_target('path/to/target:foo', Target, tags=['tag1'])
-      target3 = self.make_target('path/to/target', Target, tags=['tag2'])
-      target4 = self.make_target('//base:foo', Target, tags=['tag3'])
-      target5 = self.make_target('baz:qux', Target, tags=['tag3'])
+    init_subsystem(Target.TagAssignments, options)
+    target1 = self.make_target('foo:bar', Target, tags=['tag1', 'tag2'])
+    target2 = self.make_target('path/to/target:foo', Target, tags=['tag1'])
+    target3 = self.make_target('path/to/target', Target, tags=['tag2'])
+    target4 = self.make_target('//base:foo', Target, tags=['tag3'])
+    target5 = self.make_target('baz:qux', Target, tags=['tag3'])
 
-      self.assertEqual({'tag1', 'tag2', 'special_tag'}, target1.tags)
-      self.assertEqual({'tag1', 'special_tag'}, target2.tags)
-      self.assertEqual({'tag2', 'special_tag', 'special_tag2'}, target3.tags)
-      self.assertEqual({'tag3', 'special_tag2'}, target4.tags)
-      self.assertEqual({'tag3'}, target5.tags)
+    self.assertEqual({'tag1', 'tag2', 'special_tag'}, target1.tags)
+    self.assertEqual({'tag1', 'special_tag'}, target2.tags)
+    self.assertEqual({'tag2', 'special_tag', 'special_tag2'}, target3.tags)
+    self.assertEqual({'tag3', 'special_tag2'}, target4.tags)
+    self.assertEqual({'tag3'}, target5.tags)
 
   def test_target_id_long(self):
     long_path = 'dummy'

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -320,6 +320,7 @@ class TestBase(unittest.TestCase):
 
     self._build_configuration = self.build_config()
     self._inited_target = False
+    subsystem_util.init_subsystem(Target.TagAssignments)
 
   def buildroot_files(self, relpath=None):
     """Returns the set of all files under the test build root.


### PR DESCRIPTION
### Problem

It can be cumbersome to apply the same tags to many targets as it requires editing every associated BUILD file. Having a single source of tags would make it more straightforward to configure tags by which to filter targets (https://github.com/pantsbuild/pants/issues/6902), and can be applied to other use cases such as grouping targets with a particular suffix (ex. `_integration` in `pants`) under a single tag.

### Solution

Add a subsystem within Target responsible for fetching, parsing, and matching tags configured in a JSON file to targets. The subsystem matches against the target's address (though could be expanded to a regex to address additional use cases).

Closes https://github.com/pantsbuild/pants/issues/7302
