### PR TITLE
Re-enable https for grpc connections

### DIFF
--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -16,7 +16,7 @@ futures-cpupool = "0.1"
 # TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
 futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 glob = "0.2.11"
-grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", default_features = false, features = ["protobuf-codec"] }
+grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../hashing" }
 ignore = "0.4.4"
 indexmap = "1.0.2"

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -1763,20 +1763,20 @@ mod remote {
     ) -> Result<ByteStore, String> {
       let env = Arc::new(grpcio::Environment::new(thread_count));
 
-      let channels = cas_addresses.iter().map(|cas_address| {
-        let builder = grpcio::ChannelBuilder::new(env.clone());
-        if let Some(ref _root_ca_certs) = root_ca_certs {
-          panic!("Sorry, we dropped secure grpc support until we can either make openssl link properly, or switch to tower");
-          /*
+      let channels = cas_addresses
+        .iter()
+        .map(|cas_address| {
+          let builder = grpcio::ChannelBuilder::new(env.clone());
+          if let Some(ref root_ca_certs) = root_ca_certs {
             let creds = grpcio::ChannelCredentialsBuilder::new()
-              .root_cert(root_ca_certs)
+              .root_cert(root_ca_certs.clone())
               .build();
             builder.secure_connect(cas_address, creds)
-            */
-        } else {
-          builder.connect(cas_address)
-        }
-      }).collect();
+          } else {
+            builder.connect(cas_address)
+          }
+        })
+        .collect();
 
       let serverset = Serverset::new(channels, backoff_config, futures_timer_thread)?;
 

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -13,7 +13,7 @@ bytes = "0.4.5"
 digest = "0.8"
 fs = { path = "../fs" }
 futures = "^0.1.16"
-grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", default_features = false, features = ["protobuf-codec"] }
+grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../hashing" }
 log = "0.4"
 protobuf = { version = "2.0.4", features = ["with-bytes"] }

--- a/src/rust/engine/process_execution/bazel_protos/Cargo.toml
+++ b/src/rust/engine/process_execution/bazel_protos/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 bytes = "0.4.5"
 futures = "^0.1.16"
-grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", default_features = false, features = ["protobuf-codec"] }
+grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../../hashing" }
 prost = "0.4"
 prost-derive = "0.4"

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -310,14 +310,11 @@ impl CommandRunner {
     let env = Arc::new(grpcio::Environment::new(thread_count));
     let channel = {
       let builder = grpcio::ChannelBuilder::new(env.clone());
-      if let Some(_root_ca_certs) = root_ca_certs {
-        panic!("Sorry, we dropped secure grpc support until we can either make openssl link properly, or switch to tower");
-      /*
-      let creds = grpcio::ChannelCredentialsBuilder::new()
-        .root_cert(root_ca_certs)
-        .build();
-      builder.secure_connect(address, creds)
-      */
+      if let Some(root_ca_certs) = root_ca_certs {
+        let creds = grpcio::ChannelCredentialsBuilder::new()
+          .root_cert(root_ca_certs)
+          .build();
+        builder.secure_connect(address, creds)
       } else {
         builder.connect(address)
       }

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 bazel_protos = { path = "../../process_execution/bazel_protos" }
 bytes = "0.4.5"
 futures = "^0.1.16"
-grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", default_features = false, features = ["protobuf-codec"] }
+grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../../hashing" }
 parking_lot = "0.6"
 protobuf = { version = "2.0.4", features = ["with-bytes"] }


### PR DESCRIPTION
Reqwest no longer links openssl, so we don't need to worry about version
conflicts.