### PR TITLE
Have extern::generator_send directly produce TypeIds for product types

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -277,16 +277,6 @@ class _FFISpecification(object):
     logger.log(level, msg)
 
   @_extern_decl('TypeId', ['ExternContext*', 'Handle*'])
-  def extern_product_type(self, context_handle, val):
-    """Return a TypeId for the given Handle, which must be a `type`."""
-    c = self._ffi.from_handle(context_handle)
-    obj = self._ffi.from_handle(val[0])
-    # TODO: determine if this assertion has any performance implications.
-    assert isinstance(obj, type)
-    tid = c.to_id(obj)
-    return TypeId(tid)
-
-  @_extern_decl('TypeId', ['ExternContext*', 'Handle*'])
   def extern_get_type_for(self, context_handle, val):
     """Return a representation of the object's type."""
     c = self._ffi.from_handle(context_handle)
@@ -457,7 +447,7 @@ class _FFISpecification(object):
     return (
         tag,
         c.vals_buf([c.to_value(v) for v in values]),
-        c.vals_buf([c.to_value(v) for v in products])
+        c.type_ids_buf([TypeId(c.to_id(t)) for t in products])
       )
 
   @_extern_decl('PyResult', ['ExternContext*', 'Handle*', 'Handle**', 'uint64_t'])
@@ -633,7 +623,6 @@ class Native(Singleton):
                            self.ffi_lib.extern_call,
                            self.ffi_lib.extern_generator_send,
                            self.ffi_lib.extern_eval,
-                           self.ffi_lib.extern_product_type,
                            self.ffi_lib.extern_get_type_for,
                            self.ffi_lib.extern_identify,
                            self.ffi_lib.extern_equals,

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -208,6 +208,11 @@ pub fn call(func: &Value, args: &[Value]) -> Result<Value, Failure> {
   .into()
 }
 
+///
+/// TODO: If we added support for inserting to the `Interns` using an `Ident`, `PyGeneratorResponse`
+/// could directly return `Idents` during `Get` calls. This would also require splitting its fields
+/// further to avoid needing to "identify" the result of a `PyGeneratorResponseType::Break`.
+///
 pub fn generator_send(generator: &Value, arg: &Value) -> Result<GeneratorResponse, Failure> {
   let response =
     with_externs(|e| (e.generator_send)(e.context, generator as &Handle, arg as &Handle));
@@ -522,7 +527,11 @@ impl HandleBuffer {
     })
   }
 
+  ///
   /// Asserts that the HandleBuffer contains one value, and returns it.
+  ///
+  /// NB: Consider making generic and merging with TypeIdBuffer if we get a third copy.
+  ///
   pub fn unwrap_one(&self) -> Value {
     assert!(
       self.handles_len == 1,
@@ -549,7 +558,11 @@ impl TypeIdBuffer {
     with_vec(self.ids_ptr, self.ids_len as usize, |vec| vec.clone())
   }
 
+  ///
   /// Asserts that the TypeIdBuffer contains one TypeId, and returns it.
+  ///
+  /// NB: Consider making generic and merging with HandleBuffer if we get a third copy.
+  ///
   pub fn unwrap_one(&self) -> TypeId {
     assert!(
       self.ids_len == 1,

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -58,9 +58,9 @@ use crate::core::{Function, Key, Params, TypeId, Value};
 use crate::externs::{
   Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionExtern, DropHandlesExtern,
   EqualsExtern, EvalExtern, ExternContext, Externs, GeneratorSendExtern, GetTypeForExtern,
-  HandleBuffer, IdentifyExtern, LogExtern, ProductTypeExtern, ProjectIgnoringTypeExtern,
-  ProjectMultiExtern, PyResult, StoreBoolExtern, StoreBytesExtern, StoreF64Extern, StoreI64Extern,
-  StoreTupleExtern, StoreUtf8Extern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
+  HandleBuffer, IdentifyExtern, LogExtern, ProjectIgnoringTypeExtern, ProjectMultiExtern, PyResult,
+  StoreBoolExtern, StoreBytesExtern, StoreF64Extern, StoreI64Extern, StoreTupleExtern,
+  StoreUtf8Extern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
 };
 use crate::handles::Handle;
 use crate::rule_graph::{GraphMaker, RuleGraph};
@@ -103,7 +103,6 @@ pub extern "C" fn externs_set(
   call: CallExtern,
   generator_send: GeneratorSendExtern,
   eval: EvalExtern,
-  product_type: ProductTypeExtern,
   get_type_for: GetTypeForExtern,
   identify: IdentifyExtern,
   equals: EqualsExtern,
@@ -130,7 +129,6 @@ pub extern "C" fn externs_set(
     call,
     generator_send,
     eval,
-    product_type,
     get_type_for,
     identify,
     equals,


### PR DESCRIPTION
### Problem

#7114 set us up to use lighter-weight identification of product types in `externs::generator_send`. We can additionally avoid calling back to python to memoize product types by having methods return `TypeIds` rather than `Values` representing types. 

### Solution

Rather than a `ValueBuffer` containing type instances, memoize the types and return a `TypeIdBuffer`.

### Result

Fewer calls back to python.