### PR TITLE
Use UUID from run_id as trace_id if trace_id isn't set by a flag

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -196,10 +196,12 @@ class RunTracker(Subsystem):
 
     # Select a globally unique ID for the run, that sorts by time.
     millis = int((self._run_timestamp * 1000) % 1000)
+    # run_uuid is used as a part of run_id and also as a trace_id for Zipkin tracing
+    run_uuid = uuid.uuid4().hex
     run_id = 'pants_run_{}_{}_{}'.format(
       time.strftime('%Y_%m_%d_%H_%M_%S', time.localtime(self._run_timestamp)),
       millis,
-      uuid.uuid4().hex
+      run_uuid
     )
 
     info_dir = os.path.join(self.get_options().pants_workdir, self.options_scope)
@@ -229,7 +231,7 @@ class RunTracker(Subsystem):
 
     self._all_options = all_options
 
-    return run_id
+    return (run_id, run_uuid)
 
   def start(self, report, run_start_time=None):
     """Start tracking this pants run using the given Report.

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -112,6 +112,11 @@ class Reporting(Subsystem):
       raise ValueError(
         "Flags zipkin-trace-id and zipkin-parent-id must both either be set or not set."
       )
+
+    # If trace_id isn't set by a flag, use UUID from run_id
+    if trace_id is None:
+      _, _, trace_id = run_id.rpartition("_")
+
     if trace_id and (len(trace_id) != 16 and len(trace_id) != 32 or not is_hex_string(trace_id)):
       raise ValueError(
         "Value of the flag zipkin-trace-id must be a 16-character or 32-character hex string. "

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -69,7 +69,7 @@ class Reporting(Subsystem):
     TODO: See `RunTracker.start`.
     """
 
-    run_id = run_tracker.initialize(all_options)
+    run_id, run_uuid = run_tracker.initialize(all_options)
     run_dir = os.path.join(self.get_options().reports_dir, run_id)
 
     html_dir = os.path.join(run_dir, 'html')
@@ -115,7 +115,7 @@ class Reporting(Subsystem):
 
     # If trace_id isn't set by a flag, use UUID from run_id
     if trace_id is None:
-      _, _, trace_id = run_id.rpartition("_")
+      trace_id = run_uuid
 
     if trace_id and (len(trace_id) != 16 and len(trace_id) != 32 or not is_hex_string(trace_id)):
       raise ValueError(

--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -77,9 +77,11 @@ class ZipkinReporter(Reporter):
     # Check if it is the first workunit
     first_span = not self._workunits_to_spans
     if first_span:
-      # If trace_id and parent_id are given create zipkin_attrs
+      # If trace_id and parent_id are given as flags create zipkin_attrs
       if self.trace_id is not None and self.parent_id is not None:
         zipkin_attrs = ZipkinAttrs(
+          # trace_id and parent_id are passed to Pants by another process that collects
+          # Zipkin trace
           trace_id=self.trace_id,
           span_id=generate_random_64bit_string(),
           parent_span_id=self.parent_id,
@@ -88,7 +90,9 @@ class ZipkinReporter(Reporter):
         )
       else:
         zipkin_attrs =  create_attrs_for_span(
-          trace_id=self.trace_id, # use UUID from run_id as trace id
+          # trace_id is the same as run_uuid that is created in run_tracker and is the part of
+          # pants_run id
+          trace_id=self.trace_id,
           sample_rate=self.sample_rate, # Value between 0.0 and 100.0
         )
         self.trace_id = zipkin_attrs.trace_id

--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -78,7 +78,7 @@ class ZipkinReporter(Reporter):
     first_span = not self._workunits_to_spans
     if first_span:
       # If trace_id and parent_id are given create zipkin_attrs
-      if self.trace_id is not None:
+      if self.trace_id is not None and self.parent_id is not None:
         zipkin_attrs = ZipkinAttrs(
           trace_id=self.trace_id,
           span_id=generate_random_64bit_string(),
@@ -88,6 +88,7 @@ class ZipkinReporter(Reporter):
         )
       else:
         zipkin_attrs =  create_attrs_for_span(
+          trace_id=self.trace_id, # use UUID from run_id as trace id
           sample_rate=self.sample_rate, # Value between 0.0 and 100.0
         )
         self.trace_id = zipkin_attrs.trace_id


### PR DESCRIPTION
Every Pants run has an ID (run_id, punts_run_...) and last part of this ID is a 32 characters hex string. 
trace id in Zipkin traces is a 16 or 32 characters hex string. That means that Pants run_id can be used as a Zipkin trace id.
That may make it easier to correlate Zipkin traces with other places that we already log a run_id.
