### PR TITLE
Update README.md

### DIFF
--- a/examples/src/python/example/README.md
+++ b/examples/src/python/example/README.md
@@ -394,7 +394,7 @@ Pants runs Python tests with `pytest`. You can pass CLI options to `pytest` with
 you could run:
 
     :::bash
-    $ ./pants test.pytest --options='-k foo' examples/tests/python/example_test/hello/greet
+    $ ./pants test.pytest --options='-k req' examples/tests/python/example_test/hello/greet
     ...
                      ============== test session starts ===============
                      platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.32, pluggy-0.4.0


### PR DESCRIPTION
fix typo

### Problem

cli example didn't use the same word as the documentation one line above.

### Solution

change the cli example to match the word used in the above documentation

### Result

no more confusion due to typo