### PR TITLE
[rsc-compile] define workflow in context instead of on fly; use workf…

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -668,7 +668,8 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
       # Invalidated targets are a subset of relevant targets: get the context for this one.
       compile_target = ivts.target
       invalid_dependencies = self._collect_invalid_compile_dependencies(compile_target,
-                                                                        invalid_target_set)
+                                                                        invalid_target_set,
+                                                                        compile_contexts)
 
       jobs.extend(
         self.create_compile_jobs(compile_target, compile_contexts, invalid_dependencies, ivts,
@@ -745,7 +746,8 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     record('sources_len', sources_len)
     record('incremental', is_incremental)
 
-  def _collect_invalid_compile_dependencies(self, compile_target, invalid_target_set):
+  def _collect_invalid_compile_dependencies(self, compile_target, invalid_target_set,
+    compile_contexts):
     # Collects all invalid dependencies that are not dependencies of other invalid dependencies
     # within the closure of compile_target.
     invalid_dependencies = OrderedSet()
@@ -758,13 +760,13 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         return True
       if target in invalid_target_set:
         invalid_dependencies.add(target)
-        return self._on_invalid_compile_dependency(target, compile_target)
+        return self._on_invalid_compile_dependency(target, compile_target, compile_contexts)
       return True
 
     compile_target.walk(work, predicate)
     return invalid_dependencies
 
-  def _on_invalid_compile_dependency(self, dep, compile_target):
+  def _on_invalid_compile_dependency(self, dep, compile_target, compile_contexts):
     """Decide whether to continue searching for invalid targets to use in the execution graph.
 
     By default, don't recurse because once we have an invalid dependency, we can rely on its

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -125,15 +125,8 @@ class _JvmCompileWorkflowType(enum(['zinc-only', 'rsc-then-zinc'])):
       target_type = None
     return target_type
 
-  @classmethod
-  @property
-  def rsc_then_zinc(cls):
-    return _JvmCompileWorkflowType.create('rsc-then-zinc')
-
-  @classmethod
-  @property
-  def zinc_only(cls):
-    return _JvmCompileWorkflowType.create('zinc-only')
+_JvmCompileWorkflowType.rsc_then_zinc = _JvmCompileWorkflowType('rsc-then-zinc')
+_JvmCompileWorkflowType.zinc_only = _JvmCompileWorkflowType('zinc-only')
 
 
 class RscCompileContext(CompileContext):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -89,7 +89,7 @@ class CompositeProductAdder(object):
       product.add_for_target(*args, **kwargs)
 
 
-class _JvmCompileWorkflowType(enum(['zinc_only', 'rsc_then_zinc'])):
+class _JvmCompileWorkflowType(enum(['zinc-only', 'rsc-then-zinc'])):
   """Target classifications used to correctly schedule Zinc and Rsc jobs.
 
   There are some limitations we have to work around before we can compile everything through Rsc
@@ -103,10 +103,10 @@ class _JvmCompileWorkflowType(enum(['zinc_only', 'rsc_then_zinc'])):
   As we work on improving our Rsc integration, we'll need to create more workflows to more closely
   map the supported features of Rsc. This enum class allows us to do that.
 
-    - zinc_only: compiles targets just with Zinc and uses the Zinc products of their dependencies.
-    - rsc_then_zinc: compiles targets with Rsc to create "header" jars, then runs Zinc against the
+    - zinc-only: compiles targets just with Zinc and uses the Zinc products of their dependencies.
+    - rsc-then-zinc: compiles targets with Rsc to create "header" jars, then runs Zinc against the
       Rsc products of their dependencies. The Rsc compile uses the Rsc products of Rsc compatible
-      targets and the Zinc products of zinc_only targets.
+      targets and the Zinc products of zinc-only targets.
   """
 
   @classmethod
@@ -230,8 +230,8 @@ class RscCompile(ZincCompile):
       rsc_cc, compile_cc = compile_contexts[target]
       if rsc_cc.workflow is not None:
         cp_entries = rsc_cc.workflow.resolve_for_enum_variant({
-          'zinc_only': lambda : confify([compile_cc.jar_file]),
-          'rsc_then_zinc': lambda : confify(
+          'zinc-only': lambda : confify([compile_cc.jar_file]),
+          'rsc-then-zinc': lambda : confify(
             to_classpath_entries([rsc_cc.rsc_jar_file], self.context._scheduler)),
         })()
         self.context.products.get_data('rsc_classpath').add_for_target(
@@ -262,8 +262,8 @@ class RscCompile(ZincCompile):
   def _key_for_target_as_dep(self, target, workflow):
     # used for jobs that are either rsc jobs or zinc jobs run against rsc
     return workflow.resolve_for_enum_variant({
-      'zinc_only': lambda: self._zinc_key_for_target(target, workflow),
-      'rsc_then_zinc': lambda: self._rsc_key_for_target(target),
+      'zinc-only': lambda: self._zinc_key_for_target(target, workflow),
+      'rsc-then-zinc': lambda: self._rsc_key_for_target(target),
     })()
 
   def _rsc_key_for_target(self, target):
@@ -271,8 +271,8 @@ class RscCompile(ZincCompile):
 
   def _zinc_key_for_target(self, target, workflow):
     return workflow.resolve_for_enum_variant({
-      'zinc_only': lambda: 'zinc({})'.format(target.address.spec),
-      'rsc_then_zinc': lambda: 'zinc_against_rsc({})'.format(target.address.spec),
+      'zinc-only': lambda: 'zinc({})'.format(target.address.spec),
+      'rsc-then-zinc': lambda: 'zinc_against_rsc({})'.format(target.address.spec),
     })()
 
   def create_compile_jobs(self,
@@ -427,8 +427,8 @@ class RscCompile(ZincCompile):
     # Currently, rsc only supports outlining scala.
     workflow = rsc_compile_context.workflow
     workflow.resolve_for_enum_variant({
-      'zinc_only': lambda: None,
-      'rsc_then_zinc': lambda: rsc_jobs.append(make_rsc_job(compile_target, invalid_dependencies)),
+      'zinc-only': lambda: None,
+      'rsc-then-zinc': lambda: rsc_jobs.append(make_rsc_job(compile_target, invalid_dependencies)),
     })()
 
     # Create the zinc compile jobs.
@@ -436,8 +436,8 @@ class RscCompile(ZincCompile):
     # - Java zinc compile jobs depend on the zinc compiles of their dependencies, because we can't
     #   generate jars that make javac happy at this point.
     workflow.resolve_for_enum_variant({
-      # NB: zinc_only zinc jobs run zinc and depend on zinc compile outputs.
-      'zinc_only': lambda: zinc_jobs.append(
+      # NB: zinc-only zinc jobs run zinc and depend on zinc compile outputs.
+      'zinc-only': lambda: zinc_jobs.append(
         make_zinc_job(
           compile_target,
           input_product_key='runtime_classpath',
@@ -445,8 +445,8 @@ class RscCompile(ZincCompile):
             runtime_classpath_product,
             self.context.products.get_data('rsc_classpath')],
           dep_keys=only_zinc_invalid_dep_keys(invalid_dependencies))),
-      'rsc_then_zinc': lambda: zinc_jobs.append(
-        # NB: rsc_then_zinc jobs run zinc and depend on both rsc and zinc compile outputs.
+      'rsc-then-zinc': lambda: zinc_jobs.append(
+        # NB: rsc-then-zinc jobs run zinc and depend on both rsc and zinc compile outputs.
         make_zinc_job(
           compile_target,
           input_product_key='rsc_classpath',
@@ -612,14 +612,14 @@ class RscCompile(ZincCompile):
   def _on_invalid_compile_dependency(self, dep, compile_target, contexts):
     """Decide whether to continue searching for invalid targets to use in the execution graph.
 
-    If a necessary dep is a rsc_then_zinc dep and the root is a zinc_only one, continue to recurse
-    because otherwise we'll drop the path between Zinc compile of the zinc_only target and a Zinc
-    compile of a transitive rsc_then_zinc dependency.
+    If a necessary dep is a rsc-then-zinc dep and the root is a zinc-only one, continue to recurse
+    because otherwise we'll drop the path between Zinc compile of the zinc-only target and a Zinc
+    compile of a transitive rsc-then-zinc dependency.
 
-    This is only an issue for graphs like J -> S1 -> S2, where J is a zinc_only target,
-    S1/2 are rsc_then_zinc targets and S2 must be on the classpath to compile J successfully.
+    This is only an issue for graphs like J -> S1 -> S2, where J is a zinc-only target,
+    S1/2 are rsc-then-zinc targets and S2 must be on the classpath to compile J successfully.
     """
     return contexts[compile_target][0].workflow.resolve_for_enum_variant({
-      'zinc_only': lambda : contexts[dep][0].workflow == _JvmCompileWorkflowType.rsc_then_zinc,
-      'rsc_then_zinc': lambda : False
+      'zinc-only': lambda : contexts[dep][0].workflow == _JvmCompileWorkflowType.rsc_then_zinc,
+      'rsc-then-zinc': lambda : False
     })()

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
@@ -225,8 +225,16 @@ class RscCompileTest(TaskTestBase):
         }
       }
     )
+    init_subsystem(
+      JUnit,
+    )
     self.make_target(
       '//:scala-library',
+      target_type=JarLibrary,
+      jars=[JarDependency(org='com.example', name='scala', rev='0.0.0')]
+    )
+    self.make_target(
+      '//:junit-library',
       target_type=JarLibrary,
       jars=[JarDependency(org='com.example', name='scala', rev='0.0.0')]
     )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
@@ -7,9 +7,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 from textwrap import dedent
 
+from pants.backend.jvm.subsystems.junit import JUnit
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.backend.jvm.targets.junit_tests import JUnitTests
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.jvm_compile.execution_graph import ExecutionGraph
@@ -78,7 +80,7 @@ class RscCompileTest(TaskTestBase):
                      zinc_against_rsc(scala/classpath:scala_lib) -> {}""").strip(),
         dependee_graph)
 
-  def test_scala_dep_for_scala_and_java_targets(self):
+  def test_rsc_dep_for_scala_java_and_test_targets(self):
     self.init_dependencies_for_scala_libraries()
 
     scala_dep = self.make_target(
@@ -99,10 +101,17 @@ class RscCompileTest(TaskTestBase):
       dependencies=[scala_dep]
     )
 
+    test_target = self.make_target(
+      'scala/classpath:scala_test',
+      target_type=JUnitTests,
+      sources=['com/example/Test.scala'],
+      dependencies=[scala_target]
+    )
+
     with temporary_dir() as tmp_dir:
-      invalid_targets = [java_target, scala_target, scala_dep]
+      invalid_targets = [java_target, scala_target, scala_dep, test_target]
       task = self.create_task_with_target_roots(
-        target_roots=[java_target, scala_target]
+        target_roots=[java_target, scala_target, test_target]
       )
 
       jobs = task._create_compile_jobs(
@@ -118,15 +127,19 @@ class RscCompileTest(TaskTestBase):
                      rsc(scala/classpath:scala_lib) -> {
                        zinc_against_rsc(scala/classpath:scala_lib)
                      }
-                     zinc_against_rsc(scala/classpath:scala_lib) -> {}
+                     zinc_against_rsc(scala/classpath:scala_lib) -> {
+                       zinc(scala/classpath:scala_test)
+                     }
                      rsc(scala/classpath:scala_dep) -> {
                        rsc(scala/classpath:scala_lib),
                        zinc_against_rsc(scala/classpath:scala_lib),
                        zinc_against_rsc(scala/classpath:scala_dep)
                      }
                      zinc_against_rsc(scala/classpath:scala_dep) -> {
-                       zinc(java/classpath:java_lib)
-                     }""").strip(),
+                       zinc(java/classpath:java_lib),
+                       zinc(scala/classpath:scala_test)
+                     }
+                     zinc(scala/classpath:scala_test) -> {}""").strip(),
         dependee_graph)
 
   def test_scala_lib_with_java_sources_not_passed_to_rsc(self):
@@ -175,12 +188,6 @@ class RscCompileTest(TaskTestBase):
                      zinc(scala/classpath:scala_with_indirect_java_sources) -> {}""").strip(),
         dependee_graph)
 
-  def construct_dependee_graph_str(self, jobs, task):
-    exec_graph = ExecutionGraph(jobs, task.get_options().print_exception_stacktrace)
-    dependee_graph = exec_graph.format_dependee_graph()
-    print(dependee_graph)
-    return dependee_graph
-
   def test_desandbox_fn(self):
     # TODO remove this after https://github.com/scalameta/scalameta/issues/1791 is released
     desandbox = _create_desandboxify_fn(['.pants.d/cool/beans.*', '.pants.d/c/r/c/.*'])
@@ -198,6 +205,12 @@ class RscCompileTest(TaskTestBase):
     self.assertEqual(desandbox('/some/path/.pants.d/tmp.pants.d/cool/beans'), '.pants.d/tmp.pants.d/cool/beans')
     self.assertEqual(desandbox('/some/path/.pants.d/exec-location/.pants.d/tmp.pants.d/cool/beans'),
                                '.pants.d/tmp.pants.d/cool/beans')
+
+  def construct_dependee_graph_str(self, jobs, task):
+    exec_graph = ExecutionGraph(jobs, task.get_options().print_exception_stacktrace)
+    dependee_graph = exec_graph.format_dependee_graph()
+    print(dependee_graph)
+    return dependee_graph
 
   def wrap_in_vts(self, invalid_targets):
     return [LightWeightVTS(t) for t in invalid_targets]


### PR DESCRIPTION
…low in traversal

This pulls the workflow up into the context objects and draws them through to the places we classify targets. This way we're centralizing how we do classification and only doing it once per target.

It also fixes an issue with how we were handling the invalid dep traversal where we were depending on the sources of targets in the predicate, instead of the workflow