### PR TITLE
unrevert go test upgrades to test transitively after fixing issues

### DIFF
--- a/contrib/go/examples/src/go/libB/b.go
+++ b/contrib/go/examples/src/go/libB/b.go
@@ -4,8 +4,16 @@ import (
 	"libD"
 )
 
+func SpeakPrologue() string {
+	return "Hello from libB!"
+}
+
+func SpeakEpilogue() string {
+	return "Bye from libB!"
+}
+
 func Speak() {
-	println("Hello from libB!")
+	println(SpeakPrologue())
 	libD.Speak()
-	println("Bye from libB!")
+	println(SpeakEpilogue())
 }

--- a/contrib/go/examples/src/go/libB/b_test.go
+++ b/contrib/go/examples/src/go/libB/b_test.go
@@ -1,0 +1,16 @@
+package libB
+
+import (
+	"testing"
+)
+
+func TestSpeak(t *testing.T) {
+	got, exp := SpeakPrologue(), "Hello from libB!"
+	if got != exp {
+		t.Fatalf("got: %d, expected: %d", got, exp)
+	}
+	got2, exp2 := SpeakEpilogue(), "Bye from libB!"
+	if got2 != exp2 {
+		t.Fatalf("got: %d, expected: %d", got2, exp2)
+	}
+}

--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
@@ -129,7 +129,7 @@ class GoDistribution(NativeTool):
     :returns: A tuple of the exit code and the go command that was run.
     :rtype: (int, :class:`GoDistribution.GoCommand`)
     """
-    go_cmd = self.GoCommand._create(self.goroot, cmd, go_env=self.go_env(gopath=gopath), args=args)
+    go_cmd = self.create_go_cmd(cmd, gopath=gopath, args=args)
     if workunit_factory is None:
       return go_cmd.spawn(**kwargs).wait()
     else:

--- a/contrib/go/src/python/pants/contrib/go/targets/go_local_source.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_local_source.py
@@ -10,6 +10,7 @@ import re
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.build_graph.address import Address
+from pants.util.memo import memoized_property
 
 from pants.contrib.go.targets.go_target import GoTarget
 
@@ -71,6 +72,6 @@ class GoLocalSource(GoTarget):
     base = os.path.basename(src_path)
     return re.match(cls._test_file_regexp, base) is not None
 
-  @property
+  @memoized_property
   def has_tests(self):
     return any(self._is_test_file(src) for src in self.payload.sources.source_paths)

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_task.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_task.py
@@ -45,6 +45,10 @@ class GoTask(Task):
   def is_local_src(target):
     return isinstance(target, GoLocalSource)
 
+  @classmethod
+  def is_test_target(cls, target):
+    return cls.is_local_src(target) and target.has_tests
+
   @staticmethod
   def is_go(target):
     return isinstance(target, GoTarget)

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -59,7 +59,8 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
     reconstructed for spawning test commands regardless of how the targets are partitioned.
     """
     return {
-      t: self._GoTestTargetInfo(import_path=t.import_path, gopath=self.get_gopath(t))
+      t: self._GoTestTargetInfo(import_path=text_type(t.import_path),
+                                gopath=text_type(self.get_gopath(t)))
       for t in targets
     }
 

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import str
 from contextlib import contextmanager
 
 from future.utils import text_type
@@ -32,9 +33,7 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
   @classmethod
   def register_options(cls, register):
     super(GoTest, cls).register_options(register)
-    # TODO: turn these into a list of individually-shlexed strings and deprecate using a single
-    # string!
-    register('--build-and-test-flags', default='',
+    register('--build-and-test-flags', type=list, member_type=str, default=[],
              fingerprint=True,
              help='Flags to pass in to `go test` tool.')
 
@@ -86,7 +85,10 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
 
   @memoized_property
   def _build_and_test_flags(self):
-    return safe_shlex_split(self.get_options().build_and_test_flags)
+    return [
+      safe_shlex_split(flags_section)
+      for flags_section in self.get_options().build_and_test_flags
+    ]
 
   def _spawn(self, workunit, go_cmd, cwd):
     go_process = go_cmd.spawn(cwd=cwd,

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -4,15 +4,21 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import filter
+from contextlib import contextmanager
 
-from pants.base.exceptions import TaskError
+from future.utils import text_type
+from pants.base.build_environment import get_buildroot
 from pants.base.workunit import WorkUnitLabel
+from pants.task.testrunner_task_mixin import PartitionedTestRunnerTaskMixin, TestResult
+from pants.util.memo import memoized_property
+from pants.util.objects import datatype
+from pants.util.process_handler import SubprocessProcessHandler
+from pants.util.strutil import create_path_env_var, safe_shlex_join, safe_shlex_split
 
 from pants.contrib.go.tasks.go_workspace_task import GoWorkspaceTask
 
 
-class GoTest(GoWorkspaceTask):
+class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
   """Runs `go test` on Go packages.
 
   To run a library's tests, GoTest only requires a Go workspace to be initialized
@@ -26,6 +32,8 @@ class GoTest(GoWorkspaceTask):
   @classmethod
   def register_options(cls, register):
     super(GoTest, cls).register_options(register)
+    # TODO: turn these into a list of individually-shlexed strings and deprecate using a single
+    # string!
     register('--build-and-test-flags', default='',
              fingerprint=True,
              help='Flags to pass in to `go test` tool.')
@@ -34,20 +42,72 @@ class GoTest(GoWorkspaceTask):
   def supports_passthru_args(cls):
     return True
 
-  def execute(self):
-    # Only executes the tests from the package specified by the target roots, so
-    # we don't run the tests for _all_ dependencies of said package.
-    targets = filter(self.is_local_src, self.context.target_roots)
-    for target in targets:
-      self.ensure_workspace(target)
-      self._go_test(target)
+  def _test_target_filter(self):
+    return self.is_local_src
 
-  def _go_test(self, target):
-    args = (self.get_options().build_and_test_flags.split()
-            + [target.import_path]
-            + self.get_passthru_args())
-    result, go_cmd = self.go_dist.execute_go_cmd('test', gopath=self.get_gopath(target), args=args,
-                                                 workunit_factory=self.context.new_workunit,
-                                                 workunit_labels=[WorkUnitLabel.TEST])
-    if result != 0:
-      raise TaskError('{} failed with exit code {}'.format(go_cmd, result))
+  def _validate_target(self, target):
+    self.ensure_workspace(target)
+
+  class _GoTestTargetInfo(datatype([('import_path', text_type), ('gopath', text_type)])): pass
+
+  def _generate_args_for_targets(self, targets):
+    """
+    Generate a dict mapping target -> _GoTestTargetInfo so that the import path and gopath can be
+    reconstructed for spawning test commands regardless of how the targets are partitioned.
+    """
+    return {
+      t: self._GoTestTargetInfo(import_path=t.import_path, gopath=self.get_gopath(t))
+      for t in targets
+    }
+
+  @contextmanager
+  def partitions(self, per_target, all_targets, test_targets):
+    if per_target:
+      def iter_partitions():
+        for test_target in test_targets:
+          partition = (test_target,)
+          args = (self._generate_args_for_targets([test_target]),)
+          yield partition, args
+    else:
+      def iter_partitions():
+        if test_targets:
+          partition = tuple(test_targets)
+          args = (self._generate_args_for_targets(test_targets),)
+          yield partition, args
+    yield iter_partitions
+
+  def collect_files(self, *args):
+    pass
+
+  @memoized_property
+  def _build_and_test_flags(self):
+    return safe_shlex_split(self.get_options().build_and_test_flags)
+
+  def _spawn(self, workunit, go_cmd, cwd):
+    go_process = go_cmd.spawn(cwd=cwd,
+                              stdout=workunit.output('stdout'),
+                              stderr=workunit.output('stderr'))
+    return SubprocessProcessHandler(go_process)
+
+  @property
+  def _maybe_workdir(self):
+    if self.run_tests_in_chroot:
+      return None
+    return get_buildroot()
+
+  def run_tests(self, fail_fast, test_targets, args_by_target):
+    with self.chroot(test_targets, self._maybe_workdir) as chroot:
+      cmdline_args = self._build_and_test_flags + [
+        args_by_target[t].import_path for t in test_targets
+      ] + self.get_passthru_args()
+      gopath = create_path_env_var(
+        args_by_target[t].gopath for t in test_targets
+      )
+      go_cmd = self.go_dist.create_go_cmd('test', gopath=gopath, args=cmdline_args)
+
+      workunit_labels = [WorkUnitLabel.TOOL, WorkUnitLabel.TEST]
+      with self.context.new_workunit(
+          name='go test', cmd=safe_shlex_join(go_cmd.cmdline), labels=workunit_labels) as workunit:
+
+        exit_code = self.spawn_and_wait(workunit=workunit, go_cmd=go_cmd, cwd=chroot)
+        return TestResult.rc(exit_code)

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -34,7 +34,8 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
   def register_options(cls, register):
     super(GoTest, cls).register_options(register)
     register('--build-and-test-flags', type=str, default='', fingerprint=True,
-             removal_version='1.17.0.dev0', hint='Use --shlexed-build-and-test-flags instead!',
+             removal_version='1.17.0.dev0',
+             removal_hint='Use --shlexed-build-and-test-flags instead!',
              help='Flags to pass in to `go test` tool.')
     # TODO: make a shlexed flags option type!
     register('--shlexed-build-and-test-flags', type=list, member_type=str, fingerprint=True,

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -81,7 +81,8 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
     yield iter_partitions
 
   def collect_files(self, *args):
-    pass
+    """This task currently doesn't have any output that it would store in an artifact cache."""
+    return []
 
   @memoized_property
   def _build_and_test_flags(self):

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -108,6 +108,9 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
 
   def run_tests(self, fail_fast, test_targets, args_by_target):
     self.context.log.debug('test_targets: {}'.format(test_targets))
+    if not test_targets:
+      return TestResult.successful
+
     with self.chroot(test_targets, self._maybe_workdir) as chroot:
       cmdline_args = self._build_and_test_flags + [
         args_by_target[t].import_path for t in test_targets

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -35,7 +35,9 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
     super(GoTest, cls).register_options(register)
     register('--build-and-test-flags', type=str, default='', fingerprint=True,
              removal_version='1.17.0.dev0',
-             removal_hint='Use --shlexed-build-and-test-flags instead!',
+             removal_hint='Use --shlexed-build-and-test-flags instead! After this deprecation '
+                          'period ends, --shlexed-build-and-test-flags will then be deprecated, '
+                          'and --build-and-test-flags will always be shlexed.',
              help='Flags to pass in to `go test` tool.')
     # TODO: make a shlexed flags option type!
     register('--shlexed-build-and-test-flags', type=list, member_type=str, fingerprint=True,

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -43,15 +43,8 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
     return True
 
   def _test_target_filter(self):
-    """Filter for targets with test files which are specified on the command line.
-
-    Because go libraries have test sources within the same target, we explicitly avoid going through
-    the dependencies of the target roots, or we'd be running tests on every source dependency.
-    """
-    def filt(tgt):
-      is_test_target_on_cmdline = tgt in self.context.target_roots and self.is_test_target(tgt)
-      return is_test_target_on_cmdline
-    return filt
+    """Filter for go library targets (in the target closure) with test files."""
+    return self.is_test_target
 
   def _validate_target(self, target):
     self.ensure_workspace(target)

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -108,8 +108,6 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
 
   def run_tests(self, fail_fast, test_targets, args_by_target):
     self.context.log.debug('test_targets: {}'.format(test_targets))
-    if not test_targets:
-      return TestResult.successful
 
     with self.chroot(test_targets, self._maybe_workdir) as chroot:
       cmdline_args = self._build_and_test_flags + [

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
@@ -9,6 +9,7 @@ from textwrap import dedent
 
 from pants.util.dirutil import safe_open
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.testutils.py2_compat import assertRegex
 
 
 class GoTestIntegrationTest(PantsRunIntegrationTest):
@@ -17,6 +18,19 @@ class GoTestIntegrationTest(PantsRunIntegrationTest):
             'contrib/go/examples/src/go/libA']
     pants_run = self.run_pants(args)
     self.assert_success(pants_run)
+    # libA depends on libB, so both tests should be run.
+    assertRegex(self, pants_run.stdout_data, r'ok\s+libA')
+    assertRegex(self, pants_run.stdout_data, r'ok\s+libB')
+
+  def test_no_fast(self):
+    args = ['test.go',
+            '--no-fast',
+            'contrib/go/examples/src/go/libA']
+    pants_run = self.run_pants(args)
+    self.assert_success(pants_run)
+    # libA depends on libB, so both tests should be run.
+    assertRegex(self, pants_run.stdout_data, r'ok\s+libA')
+    assertRegex(self, pants_run.stdout_data, r'ok\s+libB')
 
   def test_go_test_unstyle(self):
     with self.temporary_sourcedir() as srcdir:

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
@@ -22,6 +22,14 @@ class GoTestIntegrationTest(PantsRunIntegrationTest):
     assertRegex(self, pants_run.stdout_data, r'ok\s+libA')
     assertRegex(self, pants_run.stdout_data, r'ok\s+libB')
 
+    # Run a second time and see that they are cached.
+    # TODO: this is better done with a unit test, and as noted in #7188, testing interaction with a
+    # remote cache should probably be added somewhere.
+    pants_run = self.run_pants(args)
+    self.assert_success(pants_run)
+    assertRegex(self, pants_run.stdout_data, r'contrib/go/examples/src/go/libA\s+\.+\s+SUCCESS')
+    assertRegex(self, pants_run.stdout_data, r'contrib/go/examples/src/go/libB\s+\.+\s+SUCCESS')
+
   def test_no_fast(self):
     args = ['test.go',
             '--no-fast',

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
@@ -39,15 +39,15 @@ class NodeTest(TestRunnerTaskMixin, NodeTask):
 
     This is what is ultimately used to run the Command.
     It must return the return code of the process. The base implementation just calls
-    command.run immediately. We override here to invoke TestRunnerTaskMixin._spawn_and_wait,
+    command.run immediately. We override here to invoke TestRunnerTaskMixin.spawn_and_wait,
     which ultimately invokes _spawn, which finally calls command.run.
     """
-    return self._spawn_and_wait(command, workunit)
+    return self.spawn_and_wait(command, workunit)
 
   def _get_test_targets_for_spawn(self):
     """Overrides TestRunnerTaskMixin._get_test_targets_for_spawn.
 
-    TestRunnerTaskMixin._spawn_and_wait uses this method to know what targets are being run.
+    TestRunnerTaskMixin.spawn_and_wait uses this method to know what targets are being run.
     By default it returns all test targets - here we override it with the list
     self._currently_executing_test_targets, which _execute sets.
     """

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -5,10 +5,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import fnmatch
-import functools
 import itertools
 import os
-import shutil
 import sys
 from abc import abstractmethod
 from builtins import object, range, str
@@ -29,7 +27,6 @@ from pants.backend.jvm.tasks.reports.junit_html_report import JUnitHtmlReport, N
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException, TaskError
 from pants.base.workunit import WorkUnitLabel
-from pants.build_graph.files import Files
 from pants.build_graph.target import Target
 from pants.build_graph.target_scopes import Scopes
 from pants.java.distribution.distribution import DistributionLocator
@@ -39,8 +36,8 @@ from pants.process.lock import OwnerPrintingInterProcessFileLock
 from pants.task.testrunner_task_mixin import PartitionedTestRunnerTaskMixin, TestResult
 from pants.util import desktop
 from pants.util.argutil import ensure_arg, remove_arg
-from pants.util.contextutil import environment_as, temporary_dir
-from pants.util.dirutil import safe_delete, safe_mkdir, safe_mkdir_for, safe_rmtree, safe_walk
+from pants.util.contextutil import environment_as
+from pants.util.dirutil import safe_delete, safe_mkdir, safe_rmtree, safe_walk
 from pants.util.memo import memoized_method
 from pants.util.meta import AbstractClass
 from pants.util.strutil import pluralize
@@ -361,29 +358,6 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
     else:
       return test_registry
 
-  @staticmethod
-  def _copy_files(dest_dir, target):
-    if isinstance(target, Files):
-      for source in target.sources_relative_to_buildroot():
-        src = os.path.join(get_buildroot(), source)
-        dest = os.path.join(dest_dir, source)
-        safe_mkdir_for(dest)
-        shutil.copy(src, dest)
-
-  @contextmanager
-  def _chroot(self, targets, workdir):
-    if workdir is not None:
-      yield workdir
-    else:
-      root_dir = os.path.join(self.workdir, '_chroots')
-      safe_mkdir(root_dir)
-      with temporary_dir(root_dir=root_dir) as chroot:
-        self.context.build_graph.walk_transitive_dependency_graph(
-          addresses=[t.address for t in targets],
-          work=functools.partial(self._copy_files, chroot)
-        )
-        yield chroot
-
   @property
   def _batched(self):
     return self._batch_size != self._BATCH_ALL
@@ -448,11 +422,11 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
 
       batch_test_specs = [test.render_test_spec() for test in batch]
       with argfile.safe_args(batch_test_specs, self.get_options()) as batch_tests:
-        with self._chroot(relevant_targets, workdir) as chroot:
+        with self.chroot(relevant_targets, workdir) as chroot:
           self.context.log.debug('CWD = {}'.format(chroot))
           self.context.log.debug('platform = {}'.format(platform))
           with environment_as(**dict(target_env_vars)):
-            subprocess_result = self._spawn_and_wait(
+            subprocess_result = self.spawn_and_wait(
               executor=SubprocessExecutor(distribution),
               distribution=distribution,
               classpath=complete_classpath,

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -365,7 +365,7 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
   def run_tests(self, fail_fast, test_targets, output_dir, coverage):
     test_registry = self._collect_test_targets(test_targets)
     if test_registry.empty:
-      return TestResult.rc(0)
+      return TestResult.successful
 
     coverage.instrument(output_dir)
 
@@ -455,7 +455,7 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
           break
 
     if result == 0:
-      return TestResult.rc(0)
+      return TestResult.successful
 
     target_to_failed_test = parse_failed_targets(test_registry, output_dir, parse_error_handler)
 

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -517,10 +517,10 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
       with self.context.new_workunit(name='run',
                                      cmd=' '.join(pex.cmdline(args)),
                                      labels=[WorkUnitLabel.TOOL, WorkUnitLabel.TEST]) as workunit:
-        rc = self._spawn_and_wait(pex, workunit=workunit, args=args, setsid=True, env=env)
+        rc = self.spawn_and_wait(pex, workunit=workunit, args=args, setsid=True, env=env)
         return PytestResult.rc(rc)
     except ErrorWhileTesting:
-      # _spawn_and_wait wraps the test runner in a timeout, so it could
+      # spawn_and_wait wraps the test runner in a timeout, so it could
       # fail with a ErrorWhileTesting. We can't just set PythonTestResult
       # to a failure because the resultslog doesn't have all the failures
       # when tests are killed with a timeout. Therefore we need to re-raise

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -559,8 +559,6 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
       # 1.) output -> output_dir
       # 2.) [iff all == invalid] output_dir -> cache: We do this manually for now.
       # 3.) [iff invalid == 0 and all > 0] cache -> workdir: Done transparently by `invalidated`.
-      if not invalid_test_tgts:
-        return TestResult.successful
 
       # 1.) Write all results that will be potentially cached to output_dir.
       result = self.run_tests(fail_fast, invalid_test_tgts, *args).checked()

--- a/tests/python/pants_test/task/test_testrunner_task_mixin.py
+++ b/tests/python/pants_test/task/test_testrunner_task_mixin.py
@@ -41,7 +41,7 @@ class TestRunnerTaskMixinTest(TaskTestBase):
 
       def _execute(self, all_targets):
         self.call_list.append(['_execute', all_targets])
-        self._spawn_and_wait()
+        self.spawn_and_wait()
 
       def _spawn(self, *args, **kwargs):
         self.call_list.append(['_spawn', args, kwargs])
@@ -147,7 +147,7 @@ class TestRunnerTaskMixinSimpleTimeoutTest(TaskTestBase):
       waited_for = None
 
       def _execute(self, all_targets):
-        self._spawn_and_wait()
+        self.spawn_and_wait()
 
       def _spawn(self, *args, **kwargs):
         timeouts = self.get_options().timeouts
@@ -236,7 +236,7 @@ class TestRunnerTaskMixinGracefulTimeoutTest(TaskTestBase):
 
       def _execute(self, all_targets):
         self.call_list.append(['_execute', all_targets])
-        self._spawn_and_wait()
+        self.spawn_and_wait()
 
       def _spawn(self, *args, **kwargs):
         self.call_list.append(['_spawn', args, kwargs])
@@ -322,7 +322,7 @@ class TestRunnerTaskMixinMultipleTargets(TaskTestBase):
       wait_time = None
 
       def _execute(self, all_targets):
-        self._spawn_and_wait()
+        self.spawn_and_wait()
 
       def _spawn(self, *args, **kwargs):
         terminate_wait = self.get_options().timeout_terminate_wait


### PR DESCRIPTION
### Problem

Resolves #7188. #7145 allowed go tests to test their transitive dependencies (necessary because go targets contain both sources and test files), but it was broken in a few ways, leading to the revert in #7212.

### Solution

- Return an iterable (`[]`) from `collect_files()` so the background cache insertion doesn't fail.
- Make `PartitionedTestRunnerTaskMixin` no-op when there are no invalid targets instead of first calling `run_tests()`.
- Turn `--build-and-test-flags` into a list of shlexed strings instead of a single string.

### Result

The go testing from #7145 should have all its issues fixed!