### PR TITLE
Deprecate the findbugs module in favor of errorprone.

### DIFF
--- a/contrib/findbugs/src/python/pants/contrib/findbugs/BUILD
+++ b/contrib/findbugs/src/python/pants/contrib/findbugs/BUILD
@@ -5,6 +5,7 @@ contrib_plugin(
   name='plugin',
   dependencies=[
     'contrib/findbugs/src/python/pants/contrib/findbugs/tasks',
+    'src/python/pants/base:deprecated',
     'src/python/pants/build_graph',
     'src/python/pants/goal:task_registrar',
   ],

--- a/contrib/findbugs/src/python/pants/contrib/findbugs/register.py
+++ b/contrib/findbugs/src/python/pants/contrib/findbugs/register.py
@@ -4,9 +4,16 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from pants.base.deprecated import deprecated_module
 from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.findbugs.tasks.findbugs import FindBugs
+
+
+deprecated_module(
+    '1.18.0.dev2',
+    hint_message='The findbugs module is deprecated in favor of the errorprone module.'
+  )
 
 
 def register_goals():


### PR DESCRIPTION
### Problem

`errorprone` has more momentum and usage than `findbugs`, but we expect to need to port both of them to `v2` `@rules`.

### Solution

Try deprecating the module to see whether anyone would like to make a case for keeping it.