### PR TITLE
Drop old deprecated options / conditionals

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -9,7 +9,6 @@ import logging
 import os
 import shutil
 
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.binaries.binary_tool import NativeTool
 from pants.option.custom_types import dir_option, file_option
@@ -82,25 +81,6 @@ class NodeDistribution(NativeTool):
           package_manager, list(NodeDistribution.VALID_PACKAGE_MANAGER_LIST.keys())
       ))
     return package_manager_obj
-
-  @memoized_method
-  def version(self, context=None):
-    # The versions reported by node and embedded in distribution package names are 'vX.Y.Z'.
-    # TODO: After the deprecation cycle is over we'll expect the values of the version option
-    # to already include the 'v' prefix, so there will be no need to normalize, and we can
-    # delete this entire method override.
-    version = super(NodeDistribution, self).version(context)
-    deprecated_conditional(
-      lambda: not version.startswith('v'), entity_description='', removal_version='1.7.0.dev0',
-      hint_message='value of --version in scope {} must be of the form '
-                   'vX.Y.Z'.format(self.options_scope))
-    return version if version.startswith('v') else 'v' + version
-
-  @classmethod
-  def _normalize_version(cls, version):
-    # The versions reported by node and embedded in distribution package names are 'vX.Y.Z' and not
-    # 'X.Y.Z'.
-    return version if version.startswith('v') else 'v' + version
 
   @memoized_property
   def eslint_setupdir(self):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -30,7 +30,6 @@ from pants.backend.jvm.tasks.jvm_compile.missing_dependency_finder import (Compi
 from pants.backend.jvm.tasks.jvm_dependency_analyzer import JvmDependencyAnalyzer
 from pants.backend.jvm.tasks.nailgun_task import NailgunTaskBase
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.worker_pool import WorkerPool
 from pants.base.workunit import WorkUnitLabel
@@ -810,14 +809,6 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     def extra_compile_classpath_iter():
       for conf in self._confs:
         for jar in self.extra_compile_time_classpath_elements():
-          if isinstance(jar, string_types):
-            # Backwards compatibility
-            deprecated_conditional(
-              lambda: True,
-              "1.12.0.dev0",
-              "Extra compile classpath auto-promotion from string to ClasspathEntry",
-            )
-            jar = ClasspathEntry(jar)
           yield (conf, jar)
 
     return list(extra_compile_classpath_iter())

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -9,7 +9,7 @@ import os
 from builtins import object, open, str
 from multiprocessing import cpu_count
 
-from future.utils import string_types, text_type
+from future.utils import text_type
 from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -66,22 +66,6 @@ class PythonSetup(Subsystem):
                   '"<PATH>" (the contents of the PATH env var), '
                   '"<PEXRC>" (paths in the PEX_PYTHON_PATH variable in a pexrc file), '
                   '"<PYENV>" (all python versions under $(pyenv root)/versions).')
-    register('--resolver-blacklist', advanced=True, type=dict, default={},
-             removal_version='1.13.0.dev2',
-             removal_hint='Now unused. Pants, via PEX, handles blacklisting automatically via '
-                          'PEP-508 environment markers anywhere Python requirements are specified '
-                          '(e.g. `requirements.txt` and `python_requirement(...)` in BUILD files): '
-                          'https://www.python.org/dev/peps/pep-0508/#environment-markers',
-             metavar='<blacklist>',
-             help='A blacklist dict (str->str) that maps package name to an interpreter '
-              'constraint. If a package name is in the blacklist and its interpreter '
-              'constraint matches the target interpreter, skip the requirement. This is needed '
-              'to ensure that universal requirement resolves for a target interpreter version do '
-              'not error out on interpreter specific requirements such as backport libs like '
-              '`functools32`. For example, a valid blacklist is {"functools32": "CPython>3"}. '
-              'NOTE: this keyword is a temporary fix and will be reverted per: '
-              'https://github.com/pantsbuild/pants/issues/5696. The long term '
-              'solution is tracked by: https://github.com/pantsbuild/pex/issues/456.')
     register('--resolver-use-manylinux', advanced=True, type=bool, default=True, fingerprint=True,
              help='Whether to consider manylinux wheels when resolving requirements for linux '
                   'platforms.')

--- a/src/python/pants/build_graph/build_file_aliases.py
+++ b/src/python/pants/build_graph/build_file_aliases.py
@@ -12,7 +12,6 @@ from collections import defaultdict
 import six
 
 from pants.base.build_file_target_factory import BuildFileTargetFactory
-from pants.base.deprecated import deprecated_conditional
 from pants.build_graph.target import Target
 from pants.util.memo import memoized_property
 
@@ -39,15 +38,8 @@ class TargetMacro(object):
       :rtype: :class:`TargetMacro.Factory`
       """
       if not target_types:
-        raise ValueError('The given `context_aware_object_factory` {} must expand at least 1 '
-                         'produced type; none were registered'.format(context_aware_object_factory))
-      deprecated_conditional(
-        lambda: len(target_types) > 1,
-        '1.12.0.dev0',
-        'TargetMacro.Factory instances that construct more than one type are no longer supported. '
-        'Consider using a `context_aware_object_factory, which can construct any number of '
-        'different objects.'
-      )
+        raise ValueError('The given `context_aware_object_factory` {} must expand 1 produced '
+                         'type; none were registered'.format(context_aware_object_factory))
 
       class Factory(cls):
         @property

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -25,7 +25,7 @@ from pants.build_graph.target_addressable import TargetAddressable
 from pants.build_graph.target_scopes import Scope
 from pants.fs.fs import safe_filename
 from pants.source.payload_fields import SourcesField
-from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetWithSpec
+from pants.source.wrapped_globs import FilesetWithSpec
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method, memoized_property
 
@@ -112,17 +112,10 @@ class Target(AbstractTarget):
       """
       ignore_params = set((self.get_options().ignored or {}).get(target.type_alias, ()))
       unknown_args = {arg: value for arg, value in kwargs.items() if arg not in ignore_params}
-      if 'source' in unknown_args and 'sources' in payload.as_dict():
-        unknown_args.pop('source')
-      if 'sources' in unknown_args:
-        if 'sources' in payload.as_dict():
-          deprecated_conditional(
-            lambda: True,
-            '1.11.0.dev0',
-            ('The source argument is deprecated - it gets automatically promoted to sources.'
-             'Target {} should just use a sources argument. No BUILD files need changing. '
-             'The source argument will stop being populated -').format(target.type_alias),
-          )
+      if 'sources' in payload.as_dict():
+        if 'source' in unknown_args:
+          unknown_args.pop('source')
+        if 'sources' in unknown_args:
           unknown_args.pop('sources')
           kwargs.pop('sources')
       ignored_args = {arg: value for arg, value in kwargs.items() if arg in ignore_params}

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -112,6 +112,12 @@ class Target(AbstractTarget):
       """
       ignore_params = set((self.get_options().ignored or {}).get(target.type_alias, ()))
       unknown_args = {arg: value for arg, value in kwargs.items() if arg not in ignore_params}
+      if 'sources' in payload.as_dict():
+        if 'source' in unknown_args:
+          unknown_args.pop('source')
+        if 'sources' in unknown_args:
+          unknown_args.pop('sources')
+          kwargs.pop('sources')
       ignored_args = {arg: value for arg, value in kwargs.items() if arg in ignore_params}
       if ignored_args:
         logger.debug('{target} ignoring the unimplemented arguments: {args}'

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -112,12 +112,6 @@ class Target(AbstractTarget):
       """
       ignore_params = set((self.get_options().ignored or {}).get(target.type_alias, ()))
       unknown_args = {arg: value for arg, value in kwargs.items() if arg not in ignore_params}
-      if 'sources' in payload.as_dict():
-        if 'source' in unknown_args:
-          unknown_args.pop('source')
-        if 'sources' in unknown_args:
-          unknown_args.pop('sources')
-          kwargs.pop('sources')
       ignored_args = {arg: value for arg, value in kwargs.items() if arg in ignore_params}
       if ignored_args:
         logger.debug('{target} ignoring the unimplemented arguments: {args}'

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -112,6 +112,7 @@ class Target(AbstractTarget):
       """
       ignore_params = set((self.get_options().ignored or {}).get(target.type_alias, ()))
       unknown_args = {arg: value for arg, value in kwargs.items() if arg not in ignore_params}
+      # TODO(#7357) Remove these checks once test issues are resolved.
       if 'sources' in payload.as_dict():
         if 'source' in unknown_args:
           unknown_args.pop('source')

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -13,7 +13,6 @@ from six import string_types
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
 from pants.base.hash_utils import hash_all
@@ -874,13 +873,5 @@ class Target(AbstractTarget):
       key_arg_section = "'{}' to be ".format(key_arg) if key_arg else ""
       raise TargetDefinitionException(self, "Expected {}a glob, an address or a list, but was {}"
                                             .format(key_arg_section, type(sources)))
-    elif not isinstance(sources, EagerFilesetWithSpec):
-      deprecated_conditional(
-        lambda: True,
-        '1.12.0.dev0',
-        ('FilesetWithSpec sources values are deprecated except for EagerFilesetWithSpec values. '
-         'Saw value of type {}').format(type(sources))
-      )
-
 
     return SourcesField(sources=sources)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -254,10 +254,6 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help='The port to bind the pants nailgun server to. Defaults to a random port.')
     register('--pantsd-log-dir', advanced=True, default=None,
              help='The directory to log pantsd output to.')
-    register('--pantsd-fs-event-workers', advanced=True, type=int, default=4,
-             removal_version='1.14.0.dev2',
-             removal_hint='Filesystem events are now handled by a single dedicated thread.',
-             help='The number of workers to use for the filesystem event service executor pool.')
     register('--pantsd-invalidation-globs', advanced=True, type=list, fromfile=True, default=[],
              help='Filesystem events matching any of these globs will trigger a daemon restart.')
 


### PR DESCRIPTION
Similar to https://github.com/pantsbuild/pants/pull/7325, came across another option that appears to be safe to remove re: [`1.14.0.dev2`](https://github.com/pantsbuild/pants/releases/tag/release_1.14.0.dev2)