### PR TITLE
Fix regression to python interpreter selection test from #7257

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
@@ -21,6 +21,10 @@ from pants_test.testutils.pexrc_util import setup_pexrc_with_pex_python_path
 class PythonRunIntegrationTest(PantsRunIntegrationTest):
   testproject = 'testprojects/src/python/interpreter_selection'
 
+  @classmethod
+  def hermetic(cls):
+    return True
+
   @skip_unless_python3
   @ensure_daemon
   def test_run_3(self):


### PR DESCRIPTION
### Problem
#7257 resulted in `test_pytest_run.py::test_target_constraints_with_no_sources` failing because `ci.sh` now sets interpreter constraints for Py2 runs whereas it earlier did not set any. So, the test is pulling in the global interpreter constraints and [failing to find an acceptable interpreter](https://travis-ci.org/pantsbuild/pants/jobs/502998214#L1310).

### Solution
Set the test to be hermetic, so that external dependencies aren't pulled in.

### Result
`PY=python2.7 PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==2.7.15']" ./pants clean-all test tests/python/pants_test/backend/python/tasks:integration -- -k test_target_constraints_with_no_sources` now passes.