### PR TITLE
Fix ./pants2 overriding desired $PY interpreter

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -111,10 +111,8 @@ export PANTS_DEV=1
 # and `./pants2`, so those scripts cannot set the relevant environment variables.
 if [[ "${python_two:-false}" == "false" ]]; then
   py_major_minor="3.6"
-  bootstrap_pants_script="./pants"
 else
   py_major_minor="2.7"
-  bootstrap_pants_script="./pants2"
 fi
 export PY="${PY:-python${py_major_minor}}"
 
@@ -133,7 +131,7 @@ if [[ "${run_bootstrap:-false}" == "true" ]]; then
     if [[ "${run_bootstrap_clean:-false}" == "true" ]]; then
       ./build-support/python/clean.sh || die "Failed to clean before bootstrapping pants."
     fi
-    ${bootstrap_pants_script} binary \
+    ./pants binary \
       src/python/pants/bin:pants_local_binary && \
     mv dist/pants_local_binary.pex pants.pex && \
     ./pants.pex -V

--- a/pants2
+++ b/pants2
@@ -4,7 +4,7 @@
 
 # This bootstrap script invokes Pants using a Python 2 interpreter.
 
-export PY="python2.7"
+export PY="${PY:-python2.7}"
 
 # Allow spawned subprocesses, such as unit tests, to execute with either Python 2 and Python 3.
 # So long as the target does not have a compatibility constraint that requires only Python 3, the


### PR DESCRIPTION
### Problem
Very similar to https://github.com/pantsbuild/pants/pull/7334 that `./pants2` was overriding interpreter constraints, it's become a problem that it also overrides `$PY`, which is to bootstrap Pants.

This led to an issue where we meant to bootstrap Pants with Python 2.7.15 but instead bootstrapped with 2.7.13. Specifically, see https://travis-ci.com/Eric-Arellano/pants/jobs/183283217#L613, where we had set $PY to point to pyenv's `python2.7`, but it is using the system Python.

### Solution
Allow the env var to be pre-set, else default to using `python2.7`.

#### Also simplify `ci.sh`
Because we override $PY and $PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS already, there is no advantage to using ./pants2 vs ./pants beyond additional complexity. So, we always use `./pants`.

### Result
`./pants2` will default to using unconstrained Python 2.7. `PY=/usr/bin/python2.7` will run with Python 2 and that specific interpreter.

Both commands will provide default interpreter constraints for spawned subprocesses.