### PR TITLE
Add python thrift namespace clash check task

### DIFF
--- a/examples/src/thrift/org/pantsbuild/example/distance/BUILD
+++ b/examples/src/thrift/org/pantsbuild/example/distance/BUILD
@@ -20,5 +20,5 @@ python_thrift_library(name='distance-python',
 )
 
 python_thrift_library(name='unexported-distance-python',
-  sources=['distance.thrift'],
+  sources=['unexported_distance.thrift'],
 )

--- a/examples/src/thrift/org/pantsbuild/example/distance/unexported_distance.thrift
+++ b/examples/src/thrift/org/pantsbuild/example/distance/unexported_distance.thrift
@@ -1,0 +1,17 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+// "Unexported" distance merely refers to the BUILD file for this target not setting a
+// provides=setup_py().
+
+namespace java org.pantsbuild.example.distance.thriftjava
+namespace py org.pantsbuild.example.unexported_distance
+
+/**
+ * Structure for expressing distance measures: 8mm, 12 parsecs, etc.
+ * Not so useful on its own.
+ */
+struct Distance {
+  1: optional string Unit;
+  2: required i64 Number;
+}

--- a/examples/src/thrift/org/pantsbuild/example/precipitation/BUILD
+++ b/examples/src/thrift/org/pantsbuild/example/precipitation/BUILD
@@ -25,7 +25,7 @@ python_thrift_library(name='precipitation-python',
 )
 
 python_thrift_library(name='monolithic-precipitation-python',
-  sources=['precipitation.thrift'],
+  sources=['monolithic_precipitation.thrift'],
   dependencies=[
     'examples/src/thrift/org/pantsbuild/example/distance:unexported-distance-python',
   ],

--- a/examples/src/thrift/org/pantsbuild/example/precipitation/monolithic_precipitation.thrift
+++ b/examples/src/thrift/org/pantsbuild/example/precipitation/monolithic_precipitation.thrift
@@ -1,0 +1,19 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+// "Monolithic" precipitation refers to this target depending on "unexported" distance, which
+// doesn't have its own provides=setup_py(), so its sources are copied into the result for this
+// target.
+
+namespace java org.pantsbuild.example.precipitation.thriftjava
+namespace py org.pantsbuild.example.monolithic_precipitation
+
+include "org/pantsbuild/example/distance/unexported_distance.thrift"
+
+/**
+ * Structure for recording weather events, e.g., 8mm of rain.
+ */
+struct Precipitation {
+  1: optional string substance = "rain";
+  2: optional unexported_distance.Distance distance;
+}

--- a/src/python/pants/backend/codegen/thrift/python/BUILD
+++ b/src/python/pants/backend/codegen/thrift/python/BUILD
@@ -9,7 +9,7 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/engine:fs',
     'src/python/pants/goal:task_registrar',
-    'src/python/pants/task:task',
+    'src/python/pants/task',
     'src/python/pants/util:collections_abc_backport',
   ],
 )

--- a/src/python/pants/backend/codegen/thrift/python/BUILD
+++ b/src/python/pants/backend/codegen/thrift/python/BUILD
@@ -6,6 +6,10 @@ python_library(
     '3rdparty/python:future',
     'src/python/pants/backend/codegen/thrift/lib',
     'src/python/pants/backend/python/targets:python',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/engine:fs',
     'src/python/pants/goal:task_registrar',
+    'src/python/pants/task:task',
+    'src/python/pants/util:collections_abc_backport',
   ],
 )

--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -23,6 +23,8 @@ class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
   solution would be to check all *thrift* libraries in the build graph, but there is currently no
   "ThriftLibraryMixin" or other way to identify targets containing thrift code generically.
   """
+  # This scope is set for testing only.
+  options_scope = 'py-thrift-namespace-clash-check'
 
   @classmethod
   def register_options(cls, register):
@@ -98,8 +100,15 @@ class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
         )
         for namespace, all_paths in clashing_namespaces.items()
       )
-      raise self.ClashingNamespaceError(
-        'clashing namespaces for python thrift library sources detected in build graph:\n{}'
-        .format(pretty_printed_clashing))
+      raise self.ClashingNamespaceError("""\
+Clashing namespaces for python thrift library sources detected in build graph. This will silently
+overwrite previously generated python sources with generated sources from thrift files declaring the
+same python namespace. This is an upstream WONTFIX in thrift, see:
+      https://issues.apache.org/jira/browse/THRIFT-515
+
+Use --{}-skip to avoid this check if this breaks your existing build.
+Errors:
+{}
+""".format(self.get_options_scope_equivalent_flag_component(), pretty_printed_clashing))
     else:
       self.context.products.register_data('_py_thrift_namespaces_by_files', namespaces_by_files)

--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -4,82 +4,15 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
 import re
-from builtins import str
-
-from future.utils import text_type
+from builtins import zip
 
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.base.exceptions import TaskError
-from pants.engine.fs import Digest, FileContent, FilesContent
-from pants.engine.legacy.graph import HydratedTarget
-from pants.engine.objects import Collection
-from pants.engine.rules import rule
-from pants.engine.selectors import Get, Select
+from pants.engine.fs import FilesContent
 from pants.task.target_restriction_mixins import HasSkipOptionMixin
 from pants.task.task import Task
-from pants.util.collections_abc_backport import defaultdict
-from pants.util.objects import datatype
-
-
-logger = logging.getLogger(__name__)
-
-
-class ParsedNamespace(datatype([
-    ('file_path', text_type),
-    ('owning_target', HydratedTarget),
-    ('py_thrift_namespace', text_type),
-])): pass
-
-
-_ParsedNamespaces = Collection.of(ParsedNamespace)
-
-
-_py_namespace_pattern = re.compile(r'^namespace\s+py\s+([^\s]+)$', flags=re.MULTILINE)
-
-
-class _NamespaceParseError(Exception): pass
-
-
-class ParseNamespaceRequest(datatype([
-    ('target', HydratedTarget),
-    ('file_content', FileContent),
-])): pass
-
-
-@rule(ParsedNamespace, [Select(ParseNamespaceRequest)])
-def parse_py_thrift_namespace(parse_namespace_request):
-  target = parse_namespace_request.target
-  file_content = parse_namespace_request.file_content
-  path = file_content.path
-  # File content is provided as a binary string, so we have to decode it to search it.
-  content = file_content.content.decode('utf-8')
-  py_namespace_match = _py_namespace_pattern.search(content)
-  if py_namespace_match is None:
-    # This debug log shows the contents of the file which failed to parse.
-    logger.debug('failing thrift content from target {} in {} is:\n{}'
-                 .format(target.address.spec, path, content))
-    raise _NamespaceParseError(
-      "no python namespace (matching the pattern '{}') found in thrift source {} from target {}!"
-      .format(_py_namespace_pattern.pattern, path, target.address.spec))
-  return ParsedNamespace(
-    file_path=path,
-    owning_target=target,
-    py_thrift_namespace=py_namespace_match.group(1),
-  )
-
-
-@rule(_ParsedNamespaces, [Select(HydratedTarget)])
-def extract_py_thrift_namespaces(hydrated_target):
-  if hasattr(hydrated_target.adaptor, 'sources'):
-    sources_snapshot = hydrated_target.adaptor.sources.snapshot
-    files_content = yield Get(FilesContent, Digest, sources_snapshot.directory_digest)
-    all_parsed_namespaces = yield [Get(ParsedNamespace, ParseNamespaceRequest(hydrated_target, fc))
-                                   for fc in files_content.dependencies]
-  else:
-    all_parsed_namespaces = []
-  yield _ParsedNamespaces(all_parsed_namespaces)
+from pants.util.collections_abc_backport import OrderedDict, defaultdict
 
 
 class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
@@ -102,7 +35,20 @@ class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
     """Populate a dict mapping thrift sources to their namespaces and owning targets for testing."""
     return ['_py_thrift_namespaces_by_files']
 
+  _py_namespace_pattern = re.compile(r'^namespace\s+py\s+([^\s]+)$', flags=re.MULTILINE)
+
   class NamespaceParseError(TaskError): pass
+
+  def _extract_py_namespace_from_content(self, target, thrift_filename, thrift_source_content):
+    py_namespace_match = self._py_namespace_pattern.search(thrift_source_content)
+    if py_namespace_match is None:
+      self.context.log.debug('failing thrift content is:\n{}'.format(thrift_source_content))
+      raise self.NamespaceParseError(
+        "no python namespace (matching the pattern '{}') found in thrift source {} from target {}!"
+        .format(self._py_namespace_pattern.pattern,
+                thrift_filename,
+                target.address.spec))
+    return py_namespace_match.group(1)
 
   class ClashingNamespaceError(TaskError): pass
 
@@ -112,21 +58,30 @@ class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
 
     # Get file contents for python thrift library targets.
     py_thrift_targets = self.get_targets(lambda tgt: isinstance(tgt, PythonThriftLibrary))
-    try:
-      unflattened_parsed_namespaces = self.context._scheduler.product_request(
-        _ParsedNamespaces,
-        [t.address for t in py_thrift_targets],
-      )
-    except _NamespaceParseError as e:
-      raise self.NamespaceParseError(str(e))
+    target_snapshots = OrderedDict(
+      (t, t.sources_snapshot(scheduler=self.context._scheduler).directory_digest)
+      for t in py_thrift_targets)
+    filescontent_by_target = OrderedDict(zip(
+      target_snapshots.keys(),
+      self.context._scheduler.product_request(FilesContent, target_snapshots.values())))
+    thrift_file_sources_by_target = OrderedDict(
+      (t, [(file_content.path, file_content.content) for file_content in all_content.dependencies])
+      for t, all_content in filescontent_by_target.items())
+
+    # Extract the python namespace from each thrift source file.
+    py_namespaces_by_target = OrderedDict(
+      (t, [
+        # File content is provided as a binary string, so we have to decode it.
+        (path, self._extract_py_namespace_from_content(t, path, content.decode('utf-8')))
+        for (path, content) in all_content
+      ])
+      for t, all_content in thrift_file_sources_by_target.items()
+    )
 
     # Check for any overlapping namespaces.
     namespaces_by_files = defaultdict(list)
-    for all_parsed_namespaces in unflattened_parsed_namespaces:
-      for parsed_namespace in all_parsed_namespaces.dependencies:
-        path = parsed_namespace.file_path
-        target = parsed_namespace.owning_target
-        namespace = parsed_namespace.py_thrift_namespace
+    for target, all_namespaces in py_namespaces_by_target.items():
+      for (path, namespace) in all_namespaces:
         namespaces_by_files[namespace].append((target, path))
 
     clashing_namespaces = {
@@ -148,10 +103,3 @@ class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
         .format(pretty_printed_clashing))
     else:
       self.context.products.register_data('_py_thrift_namespaces_by_files', namespaces_by_files)
-
-
-def rules():
-  return [
-    parse_py_thrift_namespace,
-    extract_py_thrift_namespaces,
-  ]

--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -1,0 +1,87 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import re
+from builtins import zip
+
+from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
+from pants.base.exceptions import TaskError
+from pants.engine.fs import FilesContent
+from pants.task.task import Task
+from pants.util.collections_abc_backport import OrderedDict, defaultdict
+
+
+class PyThriftNamespaceClashCheck(Task):
+  """Check that no python thrift libraries in the build graph have files with clashing namespaces.
+
+  This is a temporary workaround for https://issues.apache.org/jira/browse/THRIFT-515. A real fix
+  would ideally be to extend Scrooge to support clashing namespaces with Python code. A second-best
+  solution would be to check all *thrift* libraries in the build graph, but there is currently no
+  "ThriftLibraryMixin" or other way to identify targets containing thrift code generically.
+  """
+
+  _py_namespace_pattern = re.compile(r'^namespace py ([^\s]+)')
+
+  class NamespaceParseError(TaskError): pass
+
+  def _extract_py_namespace_from_content(self, target, thrift_filename, thrift_source_content):
+    py_namespace_match = self._py_namespace_pattern.match(thrift_source_content.decode('utf-8'))
+    if py_namespace_match is None:
+      raise self.NamespaceParseError(
+        "no python namespace (matching the pattern '{}') found in thrift source {} from target {}!"
+        .format(self._py_namespace_pattern.pattern,
+                thrift_filename,
+                target.address.spec))
+    return py_namespace_match.group(1)
+
+  class ClashingNamespaceError(TaskError): pass
+
+  def execute(self):
+    # Get file contents for python thrift library targets.
+    py_thrift_targets = self.get_targets(lambda tgt: isinstance(tgt, PythonThriftLibrary))
+    target_snapshots = OrderedDict(
+      (t, t.sources_snapshot(scheduler=self.context._scheduler).directory_digest)
+      for t in py_thrift_targets)
+    filescontent_by_target = OrderedDict(zip(
+      target_snapshots.keys(),
+      self.context._scheduler.product_request(FilesContent, target_snapshots.values())))
+    thrift_file_sources_by_target = OrderedDict(
+      (t, [(file_content.path, file_content.content) for file_content in all_content.dependencies])
+      for t, all_content in filescontent_by_target.items())
+
+    # Extract the python namespace from each thrift source file.
+    py_namespaces_by_target = OrderedDict(
+      (t, [
+        (path, self._extract_py_namespace_from_content(t, path, content))
+        for (path, content) in all_content
+      ])
+      for t, all_content in thrift_file_sources_by_target.items()
+    )
+
+    # Check for any overlapping namespaces.
+    namespaces_by_files = defaultdict(list)
+    for target, all_namespaces in py_namespaces_by_target.items():
+      for (path, namespace) in all_namespaces:
+        namespaces_by_files[namespace].append((target, path))
+
+    clashing_namespaces = {
+      namespace: all_paths
+      for namespace, all_paths in namespaces_by_files.items()
+      if len(all_paths) > 1
+    }
+
+    if clashing_namespaces:
+      pretty_printed_clashing = '\n'.join(
+        '{}: [{}]'
+        .format(
+          namespace,
+          ', '.join('({}, {})'.format(t.address.spec, path) for (t, path) in all_paths)
+        )
+        for namespace, all_paths in clashing_namespaces.items()
+      )
+      raise self.ClashingNamespaceError(
+        'clashing namespaces for python thrift library sources detected in build graph:\n{}'
+        .format(pretty_printed_clashing))

--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -4,15 +4,82 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
 import re
-from builtins import zip
+from builtins import str
+
+from future.utils import text_type
 
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.base.exceptions import TaskError
-from pants.engine.fs import FilesContent
+from pants.engine.fs import Digest, FileContent, FilesContent
+from pants.engine.legacy.graph import HydratedTarget
+from pants.engine.objects import Collection
+from pants.engine.rules import rule
+from pants.engine.selectors import Get, Select
 from pants.task.target_restriction_mixins import HasSkipOptionMixin
 from pants.task.task import Task
-from pants.util.collections_abc_backport import OrderedDict, defaultdict
+from pants.util.collections_abc_backport import defaultdict
+from pants.util.objects import datatype
+
+
+logger = logging.getLogger(__name__)
+
+
+class ParsedNamespace(datatype([
+    ('file_path', text_type),
+    ('owning_target', HydratedTarget),
+    ('py_thrift_namespace', text_type),
+])): pass
+
+
+_ParsedNamespaces = Collection.of(ParsedNamespace)
+
+
+_py_namespace_pattern = re.compile(r'^namespace\s+py\s+([^\s]+)$', flags=re.MULTILINE)
+
+
+class _NamespaceParseError(Exception): pass
+
+
+class ParseNamespaceRequest(datatype([
+    ('target', HydratedTarget),
+    ('file_content', FileContent),
+])): pass
+
+
+@rule(ParsedNamespace, [Select(ParseNamespaceRequest)])
+def parse_py_thrift_namespace(parse_namespace_request):
+  target = parse_namespace_request.target
+  file_content = parse_namespace_request.file_content
+  path = file_content.path
+  # File content is provided as a binary string, so we have to decode it to search it.
+  content = file_content.content.decode('utf-8')
+  py_namespace_match = _py_namespace_pattern.search(content)
+  if py_namespace_match is None:
+    # This debug log shows the contents of the file which failed to parse.
+    logger.debug('failing thrift content from target {} in {} is:\n{}'
+                 .format(target.address.spec, path, content))
+    raise _NamespaceParseError(
+      "no python namespace (matching the pattern '{}') found in thrift source {} from target {}!"
+      .format(_py_namespace_pattern.pattern, path, target.address.spec))
+  return ParsedNamespace(
+    file_path=path,
+    owning_target=target,
+    py_thrift_namespace=py_namespace_match.group(1),
+  )
+
+
+@rule(_ParsedNamespaces, [Select(HydratedTarget)])
+def extract_py_thrift_namespaces(hydrated_target):
+  if hasattr(hydrated_target.adaptor, 'sources'):
+    sources_snapshot = hydrated_target.adaptor.sources.snapshot
+    files_content = yield Get(FilesContent, Digest, sources_snapshot.directory_digest)
+    all_parsed_namespaces = yield [Get(ParsedNamespace, ParseNamespaceRequest(hydrated_target, fc))
+                                   for fc in files_content.dependencies]
+  else:
+    all_parsed_namespaces = []
+  yield _ParsedNamespaces(all_parsed_namespaces)
 
 
 class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
@@ -35,20 +102,7 @@ class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
     """Populate a dict mapping thrift sources to their namespaces and owning targets for testing."""
     return ['_py_thrift_namespaces_by_files']
 
-  _py_namespace_pattern = re.compile(r'^namespace\s+py\s+([^\s]+)$', flags=re.MULTILINE)
-
   class NamespaceParseError(TaskError): pass
-
-  def _extract_py_namespace_from_content(self, target, thrift_filename, thrift_source_content):
-    py_namespace_match = self._py_namespace_pattern.search(thrift_source_content)
-    if py_namespace_match is None:
-      self.context.log.debug('failing thrift content is:\n{}'.format(thrift_source_content))
-      raise self.NamespaceParseError(
-        "no python namespace (matching the pattern '{}') found in thrift source {} from target {}!"
-        .format(self._py_namespace_pattern.pattern,
-                thrift_filename,
-                target.address.spec))
-    return py_namespace_match.group(1)
 
   class ClashingNamespaceError(TaskError): pass
 
@@ -58,30 +112,21 @@ class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
 
     # Get file contents for python thrift library targets.
     py_thrift_targets = self.get_targets(lambda tgt: isinstance(tgt, PythonThriftLibrary))
-    target_snapshots = OrderedDict(
-      (t, t.sources_snapshot(scheduler=self.context._scheduler).directory_digest)
-      for t in py_thrift_targets)
-    filescontent_by_target = OrderedDict(zip(
-      target_snapshots.keys(),
-      self.context._scheduler.product_request(FilesContent, target_snapshots.values())))
-    thrift_file_sources_by_target = OrderedDict(
-      (t, [(file_content.path, file_content.content) for file_content in all_content.dependencies])
-      for t, all_content in filescontent_by_target.items())
-
-    # Extract the python namespace from each thrift source file.
-    py_namespaces_by_target = OrderedDict(
-      (t, [
-        # File content is provided as a binary string, so we have to decode it.
-        (path, self._extract_py_namespace_from_content(t, path, content.decode('utf-8')))
-        for (path, content) in all_content
-      ])
-      for t, all_content in thrift_file_sources_by_target.items()
-    )
+    try:
+      unflattened_parsed_namespaces = self.context._scheduler.product_request(
+        _ParsedNamespaces,
+        [t.address for t in py_thrift_targets],
+      )
+    except _NamespaceParseError as e:
+      raise self.NamespaceParseError(str(e))
 
     # Check for any overlapping namespaces.
     namespaces_by_files = defaultdict(list)
-    for target, all_namespaces in py_namespaces_by_target.items():
-      for (path, namespace) in all_namespaces:
+    for all_parsed_namespaces in unflattened_parsed_namespaces:
+      for parsed_namespace in all_parsed_namespaces.dependencies:
+        path = parsed_namespace.file_path
+        target = parsed_namespace.owning_target
+        namespace = parsed_namespace.py_thrift_namespace
         namespaces_by_files[namespace].append((target, path))
 
     clashing_namespaces = {
@@ -103,3 +148,10 @@ class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
         .format(pretty_printed_clashing))
     else:
       self.context.products.register_data('_py_thrift_namespaces_by_files', namespaces_by_files)
+
+
+def rules():
+  return [
+    parse_py_thrift_namespace,
+    extract_py_thrift_namespaces,
+  ]

--- a/src/python/pants/backend/codegen/thrift/python/register.py
+++ b/src/python/pants/backend/codegen/thrift/python/register.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from pants.backend.codegen.thrift.python.apache_thrift_py_gen import ApacheThriftPyGen
 from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
   PyThriftNamespaceClashCheck
+from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
+  rules as namespace_clash_rules
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task
@@ -23,3 +25,7 @@ def build_file_aliases():
 def register_goals():
   task(name='thrift-py', action=ApacheThriftPyGen).install('gen')
   task(name='py-thrift-namespace-clash-check', action=PyThriftNamespaceClashCheck).install('gen')
+
+
+def rules():
+  return namespace_clash_rules()

--- a/src/python/pants/backend/codegen/thrift/python/register.py
+++ b/src/python/pants/backend/codegen/thrift/python/register.py
@@ -5,6 +5,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants.backend.codegen.thrift.python.apache_thrift_py_gen import ApacheThriftPyGen
+from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
+  PyThriftNamespaceClashCheck
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task
@@ -20,3 +22,4 @@ def build_file_aliases():
 
 def register_goals():
   task(name='thrift-py', action=ApacheThriftPyGen).install('gen')
+  task(name='py-thrift-namespace-clash-check', action=PyThriftNamespaceClashCheck).install('gen')

--- a/src/python/pants/backend/codegen/thrift/python/register.py
+++ b/src/python/pants/backend/codegen/thrift/python/register.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from pants.backend.codegen.thrift.python.apache_thrift_py_gen import ApacheThriftPyGen
 from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
   PyThriftNamespaceClashCheck
-from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
-  rules as namespace_clash_rules
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task
@@ -25,7 +23,3 @@ def build_file_aliases():
 def register_goals():
   task(name='thrift-py', action=ApacheThriftPyGen).install('gen')
   task(name='py-thrift-namespace-clash-check', action=PyThriftNamespaceClashCheck).install('gen')
-
-
-def rules():
-  return namespace_clash_rules()

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
@@ -1,0 +1,98 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
+  PyThriftNamespaceClashCheck
+from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
+from pants_test.task_test_base import DeclarativeTaskTestMixin, TaskTestBase
+
+
+class PyThriftNamespaceClashCheckTest(TaskTestBase, DeclarativeTaskTestMixin):
+
+  @classmethod
+  def task_type(cls):
+    return PyThriftNamespaceClashCheck
+
+  _target_specs = {
+    'src/py-thrift:no-py-namespace': {
+      'target_type': PythonThriftLibrary,
+      'sources': ['bad.thrift'],
+      'filemap': {
+        'bad.thrift': """\
+#namespace scala org.pantsbuild.whatever
+namespace java org.pantsbuild.whatever
+
+struct A {}
+""",
+      },
+    },
+
+    'src/py-thrift:clashing-namespace': {
+      'target_type': PythonThriftLibrary,
+      'sources': ['a.thrift', 'b.thrift'],
+      'filemap': {
+        'a.thrift': """\
+namespace py org.pantsbuild.namespace
+
+struct A {}
+""",
+        'b.thrift': """\
+namespace py org.pantsbuild.namespace
+
+struct B {}
+""",
+      },
+    },
+
+    'src/py-thrift-clashing:clashingA': {
+      'target_type': PythonThriftLibrary,
+      'sources': ['a.thrift'],
+      'filemap': {
+        'a.thrift': """\
+namespace py org.pantsbuild.namespace
+
+struct A {}
+""",
+      },
+    },
+
+    'src/py-thrift-clashing:clashingB': {
+      'target_type': PythonThriftLibrary,
+      'sources': ['b.thrift'],
+      'filemap': {
+        'b.thrift': """\
+namespace py org.pantsbuild.namespace
+
+struct B {}
+""",
+      },
+    }
+  }
+
+  def target_dict(self):
+    return self.populate_target_dict(self._target_specs)
+
+  def test_no_py_namespace(self):
+    no_py_namespace_target = self.target_dict()['no-py-namespace']
+    with self.assertRaisesWithMessage(PyThriftNamespaceClashCheck.NamespaceParseError, """\
+no python namespace (matching the pattern '^namespace py ([^\\s]+)') \
+found in thrift source src/py-thrift/bad.thrift from target src/py-thrift:no-py-namespace!"""):
+      self.invoke_tasks(target_roots=[no_py_namespace_target])
+
+  def test_clashing_namespace_same_target(self):
+    clashing_same_target = self.target_dict()['clashing-namespace']
+    with self.assertRaisesWithMessage(PyThriftNamespaceClashCheck.ClashingNamespaceError, """\
+clashing namespaces for python thrift library sources detected in build graph:
+org.pantsbuild.namespace: [(src/py-thrift:clashing-namespace, src/py-thrift/a.thrift), (src/py-thrift:clashing-namespace, src/py-thrift/b.thrift)]"""):
+      self.invoke_tasks(target_roots=[clashing_same_target])
+
+  def test_clashing_namespace_multiple_targets(self):
+    target_dict = self.target_dict()
+    clashing_targets = [target_dict[k] for k in ['clashingA', 'clashingB']]
+    with self.assertRaisesWithMessage(PyThriftNamespaceClashCheck.ClashingNamespaceError, """\
+clashing namespaces for python thrift library sources detected in build graph:
+org.pantsbuild.namespace: [(src/py-thrift-clashing:clashingA, src/py-thrift-clashing/a.thrift), (src/py-thrift-clashing:clashingB, src/py-thrift-clashing/b.thrift)]"""):
+      self.invoke_tasks(target_roots=clashing_targets)

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
@@ -6,17 +6,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
   PyThriftNamespaceClashCheck
-from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
-  rules as namespace_clash_rules
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants_test.task_test_base import DeclarativeTaskTestMixin, TaskTestBase
 
 
 class PyThriftNamespaceClashCheckTest(TaskTestBase, DeclarativeTaskTestMixin):
-
-  @classmethod
-  def rules(cls):
-    return super(PyThriftNamespaceClashCheckTest, cls).rules() + namespace_clash_rules()
 
   @classmethod
   def task_type(cls):

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
@@ -6,11 +6,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
   PyThriftNamespaceClashCheck
+from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
+  rules as namespace_clash_rules
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants_test.task_test_base import DeclarativeTaskTestMixin, TaskTestBase
 
 
 class PyThriftNamespaceClashCheckTest(TaskTestBase, DeclarativeTaskTestMixin):
+
+  @classmethod
+  def rules(cls):
+    return super(PyThriftNamespaceClashCheckTest, cls).rules() + namespace_clash_rules()
 
   @classmethod
   def task_type(cls):

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py_integration.py
@@ -124,14 +124,14 @@ class SetupPyIntegrationTest(PantsRequirementIntegrationTestBase):
                        'org/pantsbuild/__init__.py',
                        'org/pantsbuild/example/',
                        'org/pantsbuild/example/__init__.py',
-                       'org/pantsbuild/example/distance/',
-                       'org/pantsbuild/example/distance/__init__.py',
-                       'org/pantsbuild/example/distance/constants.py',
-                       'org/pantsbuild/example/distance/ttypes.py',
-                       'org/pantsbuild/example/precipitation/',
-                       'org/pantsbuild/example/precipitation/__init__.py',
-                       'org/pantsbuild/example/precipitation/constants.py',
-                       'org/pantsbuild/example/precipitation/ttypes.py'])
+                       'org/pantsbuild/example/monolithic_precipitation/',
+                       'org/pantsbuild/example/monolithic_precipitation/__init__.py',
+                       'org/pantsbuild/example/monolithic_precipitation/constants.py',
+                       'org/pantsbuild/example/monolithic_precipitation/ttypes.py',
+                       'org/pantsbuild/example/unexported_distance/',
+                       'org/pantsbuild/example/unexported_distance/__init__.py',
+                       'org/pantsbuild/example/unexported_distance/constants.py',
+                       'org/pantsbuild/example/unexported_distance/ttypes.py'])
 
   def test_setup_py_unregistered_pants_plugin(self):
     """setup-py should succeed on a pants plugin target that:

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -740,7 +740,8 @@ class TestBase(unittest.TestCase, AbstractClass):
       # Ensure any dependencies exist in the target dict (`target_map` must then be an
       # OrderedDict).
       # The 'key' is used to access the target in `target_dict`, and defaults to `target_spec`.
-      key = unprocessed_kwargs.pop('key', target_spec)
+      target_address = Address.parse(target_spec)
+      key = unprocessed_kwargs.pop('key', target_address.target_name)
       dep_targets = []
       for dep_spec in unprocessed_kwargs.pop('dependencies', []):
         existing_tgt_key = target_map[dep_spec]['key']


### PR DESCRIPTION
### Problem

Python thrift libraries with files containing the same python namespace will silently cause errors, overwriting the generated `ttypes.py` with each successive thrift file. This is an instance of an upstream WONTFIX in thrift: https://issues.apache.org/jira/browse/THRIFT-515.

### Solution

- Add a (skippable!) task to check for clashing namespaces in/across python thrift targets in the build graph.

### Result

Silent errors where thrift structs are mysteriously missing are now eagerly turned into exceptions with a clear error message! 