### PR TITLE
Create dedicated Dockerfile with Python 3.6 to reduce CI time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -270,7 +270,6 @@ py27_linux_build_engine: &py27_linux_build_engine
     - PREPARE_DEPLOY=1
     - CACHE_NAME=linuxpexbuild.py27
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.linux
-    - BOOTSTRAP_ARGS='-2b'
 
 py36_linux_build_engine: &py36_linux_build_engine
   <<: *py36_linux_config
@@ -282,7 +281,6 @@ py36_linux_build_engine: &py36_linux_build_engine
     - docker_run_command="./build-support/bin/ci.sh -b && ./build-support/bin/release.sh -f"
     - CACHE_NAME=linuxpexbuild.py36
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
-    - BOOTSTRAP_ARGS='-b'
 
 base_osx_build_engine: &base_osx_build_engine
   <<: *native_engine_cache_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -287,7 +287,7 @@ py36_linux_build_engine: &py36_linux_build_engine
   <<: *base_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py3.6 PEX)"
   env:
-    - docker_image_name=travis_ci
+    - docker_image_name=travis_ci_py36
     - CACHE_NAME=linuxpexbuild.py36
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - BOOTSTRAP_ARGS='-b'

--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -4,19 +4,6 @@
 # Use our custom Centos6 image for binary compatibility with old linux distros.
 FROM pantsbuild/centos6:latest
 
-# TODO(7064) These changes belong in centos6/Dockerfile, because we always want that image to
-# have Py3 available and also avoid the cost of rebuilding Python 3 every time in CI. However,
-# this requires publishing an updated image to Docker hub, so we copy the code here until then.
-ARG PYTHON_3_VERSION=3.6.8
-RUN yum install sqlite-devel -y
-ENV PYENV_ROOT /pyenv-docker-build
-RUN mkdir ${PYENV_ROOT}
-RUN git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}
-RUN /usr/bin/scl enable devtoolset-7 -- bash -c '\
-    ${PYENV_ROOT}/bin/pyenv install ${PYTHON_3_VERSION} \
-    && ${PYENV_ROOT}/bin/pyenv global ${PYTHON_3_VERSION}'
-ENV PATH "${PYENV_ROOT}/shims:${PATH}"
-
 # Setup mount points for the travis ci user & workdir.
 VOLUME /travis/home
 VOLUME /travis/workdir

--- a/build-support/docker/travis_ci_py36/Dockerfile
+++ b/build-support/docker/travis_ci_py36/Dockerfile
@@ -1,0 +1,46 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# TODO(7064): this file duplicates travis_ci/Dockerfile, except it installs Python 3.6.
+# We split it out into a separate file to avoid the cost of installing Python 3.6 for Py2 only
+# shards. Ideally this file would not exist though, as these changes belong in the base
+# image Centos6! Once those changes are published to Dockerhub, this file should be deleted
+# and the shards should go back to using `travis_ci`.
+
+# Use our custom Centos6 image for binary compatibility with old linux distros.
+FROM pantsbuild/centos6:latest
+
+# ----------------------------------------------------------
+# TODO(7064) Add all the below changes to Centos6 image.
+
+RUN yum install sqlite-devel -y
+ARG PYTHON_36_VERSION=3.6.8
+ENV PYENV_ROOT /pyenv-docker-build
+RUN mkdir ${PYENV_ROOT}
+RUN git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}
+RUN /usr/bin/scl enable devtoolset-7 -- bash -c '\
+    ${PYENV_ROOT}/bin/pyenv install ${PYTHON_36_VERSION} \
+    && ${PYENV_ROOT}/bin/pyenv global ${PYTHON_36_VERSION}'
+ENV PATH "${PYENV_ROOT}/shims:${PATH}"
+
+# End TODO(7064)
+# ----------------------------------------------------------
+
+# Setup mount points for the travis ci user & workdir.
+VOLUME /travis/home
+VOLUME /travis/workdir
+
+# Setup a non-root user to execute the build under (avoids problems with npm install).
+ARG TRAVIS_USER=travis_ci
+ARG TRAVIS_UID=1000
+ARG TRAVIS_GROUP=root
+ARG TRAVIS_GID=0
+
+RUN groupadd --gid ${TRAVIS_GID} ${TRAVIS_GROUP} || true
+RUN useradd -d /travis/home -g ${TRAVIS_GROUP} --uid ${TRAVIS_UID} ${TRAVIS_USER}
+USER ${TRAVIS_USER}:${TRAVIS_GROUP}
+
+# Our newly created user is unlikely to have a sane environment: set a locale at least.
+ENV LC_ALL="en_US.UTF-8"
+
+WORKDIR /travis/workdir

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -246,7 +246,7 @@ py36_linux_build_engine: &py36_linux_build_engine
   <<: *base_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py3.6 PEX)"
   env:
-    - docker_image_name=travis_ci
+    - docker_image_name=travis_ci_py36
     - CACHE_NAME=linuxpexbuild.py36
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - BOOTSTRAP_ARGS='-b'

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -234,7 +234,6 @@ py27_linux_build_engine: &py27_linux_build_engine
     - PREPARE_DEPLOY=1
     - CACHE_NAME=linuxpexbuild.py27
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.linux
-    - BOOTSTRAP_ARGS='-2b'
 
 py36_linux_build_engine: &py36_linux_build_engine
   <<: *py36_linux_config
@@ -246,7 +245,6 @@ py36_linux_build_engine: &py36_linux_build_engine
     - docker_run_command="./build-support/bin/ci.sh -b && ./build-support/bin/release.sh -f"
     - CACHE_NAME=linuxpexbuild.py36
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
-    - BOOTSTRAP_ARGS='-b'
 
 base_osx_build_engine: &base_osx_build_engine
   <<: *native_engine_cache_config


### PR DESCRIPTION
### Problem
Every time we run a Docker shard, we spend about 3 minutes installing Python 3.6 and its dependencies, even if that shard never once uses Python 3. In particular, this slows down our `Linux Build Wheels UCS4` shard and our `Linux Build Engine Py2` for a collective cost of 6 minutes every CI run (i.e. total CI cost, not wall time).

Ideally, we would want Python 3 pre-installed on the base Centos6 image so that we never for any shard have to waste time installing Python 3 (see #7064). Until that lands, though, this is an additional unneeded burden.

### Solution
Create a new image `travis_ci_py36`.

Thanks to how we can now parametrize the docker image name in `travis.yml.mustache`, this brings no additional cognitive overload to our `.travis.yml`, which was the original reason we did not create a duplicate Dockerfile.

Also does a little cleanup from https://github.com/pantsbuild/pants/pull/7351 in removing a bad env var `$BOOTSTRAP_ARGS` for the linux build engine shards.