### PR TITLE
Add dedicated cron bootstrap stage to CI to avoid building unnecessary Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - name: &bootstrap Bootstrap Pants
-    if: type = cron
+    if: type != cron
   - name: &bootstrap_cron Bootstrap Pants (Cron)
-    if: type != cron
-  - name: &test Test Pants
     if: type = cron
-  - name: &test_cron Test Pants (Cron)
+  - name: &test Test Pants
     if: type != cron
+  - name: &test_cron Test Pants (Cron)
+    if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - &bootstrap Bootstrap Pants
-    if type = cron
+    if: type = cron
   - &bootstrap_cron Bootstrap Pants (Cron)
-    if type != cron
+    if: type != cron
   - name: &test Test Pants
     if: type = cron
   - name: &test_cron Test Pants (Cron)

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - &bootstrap Bootstrap Pants
+    if type != cron
+  - &bootstrap_cron Bootstrap Pants (Cron)
+    if type = cron
   - name: &test Test Pants
     if: type != cron
   - name: &test_cron Test Pants (Cron)
@@ -701,8 +704,13 @@ deploy_unstable_multiplatform_pex: &deploy_unstable_multiplatform_pex
 matrix:
   include:
     - <<: *py27_linux_build_engine
+    - <<: *py27_linux_build_engine
+      stage: *bootstrap_cron
     - <<: *py36_linux_build_engine
+
     - <<: *py27_osx_build_engine
+    - <<: *py27_osx_build_engine
+      stage: *bootstrap_cron
     - <<: *py36_osx_build_engine
 
     - <<: *py27_lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ stages:
   - &bootstrap Bootstrap Pants
   - name: &test Test Pants
     if: type != cron
-  - name: &cron Cron
+  - name: &test_cron Test Pants (Cron)
     if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
@@ -141,7 +141,7 @@ base_linux_test_config: &base_linux_test_config
 py27_linux_test_config: &py27_linux_test_config
   <<: *py27_linux_config
   <<: *base_linux_test_config
-  stage: *cron
+  stage: *test_cron
   env:
     - &py27_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.linux
 
@@ -196,7 +196,7 @@ base_osx_test_config: &base_osx_test_config
 py27_osx_test_config: &py27_osx_test_config
   <<: *py27_osx_config
   <<: *base_osx_test_config
-  stage: *cron
+  stage: *test_cron
   env:
     - &py27_osx_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
 
@@ -381,7 +381,7 @@ cargo_audit: &cargo_audit
   os: linux
   dist: xenial
   sudo: required
-  stage: *cron
+  stage: *test_cron
   script:
     - ./build-support/bin/travis-ci.sh -a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,14 @@ env:
 
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
-  - &bootstrap Bootstrap Pants
-    if: type != cron
-  - &bootstrap_cron Bootstrap Pants (Cron)
+  - name: &bootstrap Bootstrap Pants
     if: type = cron
+  - name: &bootstrap_cron Bootstrap Pants (Cron)
+    if: type != cron
   - name: &test Test Pants
-    if: type != cron
-  - name: &test_cron Test Pants (Cron)
     if: type = cron
+  - name: &test_cron Test Pants (Cron)
+    if: type != cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - &bootstrap Bootstrap Pants
-    if: type = cron
+    if: type != cron
   - &bootstrap_cron Bootstrap Pants (Cron)
-    if: type != cron
-  - name: &test Test Pants
     if: type = cron
-  - name: &test_cron Test Pants (Cron)
+  - name: &test Test Pants
     if: type != cron
+  - name: &test_cron Test Pants (Cron)
+    if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - &bootstrap Bootstrap Pants
-    if type != cron
-  - &bootstrap_cron Bootstrap Pants (Cron)
     if type = cron
+  - &bootstrap_cron Bootstrap Pants (Cron)
+    if type != cron
   - name: &test Test Pants
-    if: type != cron
-  - name: &test_cron Test Pants (Cron)
     if: type = cron
+  - name: &test_cron Test Pants (Cron)
+    if: type != cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -19,13 +19,13 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - name: &bootstrap Bootstrap Pants
-    if: type = cron
+    if: type != cron
   - name: &bootstrap_cron Bootstrap Pants (Cron)
-    if: type != cron
-  - name: &test Test Pants
     if: type = cron
-  - name: &test_cron Test Pants (Cron)
+  - name: &test Test Pants
     if: type != cron
+  - name: &test_cron Test Pants (Cron)
+    if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -19,13 +19,13 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - &bootstrap Bootstrap Pants
-    if type != cron
-  - &bootstrap_cron Bootstrap Pants (Cron)
     if type = cron
+  - &bootstrap_cron Bootstrap Pants (Cron)
+    if type != cron
   - name: &test Test Pants
-    if: type != cron
-  - name: &test_cron Test Pants (Cron)
     if: type = cron
+  - name: &test_cron Test Pants (Cron)
+    if: type != cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -19,9 +19,9 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - &bootstrap Bootstrap Pants
-    if type = cron
+    if: type = cron
   - &bootstrap_cron Bootstrap Pants (Cron)
-    if type != cron
+    if: type != cron
   - name: &test Test Pants
     if: type = cron
   - name: &test_cron Test Pants (Cron)

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -18,14 +18,14 @@ env:
 
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
-  - &bootstrap Bootstrap Pants
-    if: type != cron
-  - &bootstrap_cron Bootstrap Pants (Cron)
+  - name: &bootstrap Bootstrap Pants
     if: type = cron
+  - name: &bootstrap_cron Bootstrap Pants (Cron)
+    if: type != cron
   - name: &test Test Pants
-    if: type != cron
-  - name: &test_cron Test Pants (Cron)
     if: type = cron
+  - name: &test_cron Test Pants (Cron)
+    if: type != cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -21,7 +21,7 @@ stages:
   - &bootstrap Bootstrap Pants
   - name: &test Test Pants
     if: type != cron
-  - name: &cron Cron
+  - name: &test_cron Test Pants (Cron)
     if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
@@ -129,7 +129,7 @@ base_linux_test_config: &base_linux_test_config
 py27_linux_test_config: &py27_linux_test_config
   <<: *py27_linux_config
   <<: *base_linux_test_config
-  stage: *cron
+  stage: *test_cron
   env:
     - &py27_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.linux
 
@@ -176,7 +176,7 @@ base_osx_test_config: &base_osx_test_config
 py27_osx_test_config: &py27_osx_test_config
   <<: *py27_osx_config
   <<: *base_osx_test_config
-  stage: *cron
+  stage: *test_cron
   env:
     - &py27_osx_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
 
@@ -340,7 +340,7 @@ cargo_audit: &cargo_audit
   os: linux
   dist: xenial
   sudo: required
-  stage: *cron
+  stage: *test_cron
   script:
     - ./build-support/bin/travis-ci.sh -a
 

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -19,6 +19,9 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - &bootstrap Bootstrap Pants
+    if type != cron
+  - &bootstrap_cron Bootstrap Pants (Cron)
+    if type = cron
   - name: &test Test Pants
     if: type != cron
   - name: &test_cron Test Pants (Cron)
@@ -642,8 +645,13 @@ deploy_unstable_multiplatform_pex: &deploy_unstable_multiplatform_pex
 matrix:
   include:
     - <<: *py27_linux_build_engine
+    - <<: *py27_linux_build_engine
+      stage: *bootstrap_cron
     - <<: *py36_linux_build_engine
+
     - <<: *py27_osx_build_engine
+    - <<: *py27_osx_build_engine
+      stage: *bootstrap_cron
     - <<: *py36_osx_build_engine
 
     - <<: *py27_lint

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -19,13 +19,13 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - &bootstrap Bootstrap Pants
-    if: type = cron
+    if: type != cron
   - &bootstrap_cron Bootstrap Pants (Cron)
-    if: type != cron
-  - name: &test Test Pants
     if: type = cron
-  - name: &test_cron Test Pants (Cron)
+  - name: &test Test Pants
     if: type != cron
+  - name: &test_cron Test Pants (Cron)
+    if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable


### PR DESCRIPTION
### Problem
Nightly CI (i.e. the Cron job we run every night around midnight) runs exclusively with Python 2.7, yet we still bootstrap Python 3.6 every time. This adds an unnecessary 40 minutes of CI every night (total CI time, not wall time).

Further, once we add Py37 to the cron job in #7261, we will need to avoid bootstrapping Py37 during daily CI (i.e. what we run every time we open a PR or merge to master), else we add 40 minutes of total CI time (not wall time) to every single daily CI run.

This PR both helps now and is pre-work for #7261.

### Solution
* Introduce new stage `bootstrap_cron` that only runs during cron job.
* Set up `bootstrap_cron` to only run the Py27 build engine shards.
* Rename `cron` stage to `test_cron` for better parity with daily CI.

### Result
* Daily CI will run identically to before.
* Nightly CI will run with 2 less bootstrap shards, saving 40 minutes of total CI time: https://travis-ci.org/pantsbuild/pants/builds/504357528.