### PR TITLE
Fix use of legacy venv folder names leftover from #7187

### DIFF
--- a/build-support/python/clean.sh
+++ b/build-support/python/clean.sh
@@ -4,5 +4,6 @@ PANTS_BASE=$(dirname $0)/../..
 rm -rf ${HOME}/.pex
 rm -rf ${PANTS_BASE}/build-support/pants_dev_deps.venv
 rm -rf ${PANTS_BASE}/build-support/pants_dev_deps.py{2,3}.venv
+rm -rf ${PANTS_BASE}/build-support/pants_dev_deps.py{2,3}?.venv
 rm -rf ${PANTS_BASE}/.pants.d
 find ${PANTS_BASE} -name '*.pyc' | xargs rm -f

--- a/src/docs/export.md
+++ b/src/docs/export.md
@@ -101,7 +101,7 @@ The following is an abbreviated export file from a command in the pants repo:
     "python_setup": {
         "interpreters": {
             "CPython-2.7.10": {
-                "binary": "/Users/user/pants/build-support/pants_dev_deps.py2.venv/bin/python2.7",
+                "binary": "/Users/user/pants/build-support/pants_dev_deps.py27.venv/bin/python2.7",
                 "chroot": "/Users/user/pants/.pants.d/python-setup/chroots/e8da2c200f36ca0a1b8a60c12590a59209250b1a"
             }
         },

--- a/src/docs/intellij.md
+++ b/src/docs/intellij.md
@@ -44,7 +44,8 @@ SDK".
 ![image](images/intellij-new-pythonsdk.png)
 
 This will be a "local" interpreter and you'll need to select the virtual
-environment bootstrapped above; it's in `build-support/pants_dev_deps.py2.venv` if you want to use Python 2 or `build-support/pants_dev_deps.py3.venv` if you want to use Python 3 for the underlying Pants engine.
+environment bootstrapped above, along with choosing the Python version
+you want IntelliJ to use. For Python 2.7, it's in `build-support/pants_dev_deps.py27.venv`; for Python 3.6, in `build-support/pants_dev_deps.py36.venv`; and for Python 3.7, in `pants_dev_deps.py37.venv`.
 
 ![image](images/intellij-select-venv.png)
 


### PR DESCRIPTION
#7187 renamed our venv folder scheme from `py{2,3}.venv` to `py{27,36,37}.venv`.

We forgot to update two places in documentation to use the new scheme, and one one place in our `clean.sh` meaning that the script would not actually remove the current venv folders.