### PR TITLE
 Add pants_runtime_python_version global option

### DIFF
--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -108,18 +108,19 @@ class OptionsInitializer(object):
         .format(global_bootstrap_options.pants_version, pants_version())
       )
 
-    pants_engine_python_version = global_bootstrap_options.pants_engine_python_version
+    pants_runtime_python_version = global_bootstrap_options.pants_runtime_python_version
     current_python_version = '.'.join(map(str, sys.version_info[0:2]))
-    if pants_engine_python_version and pants_engine_python_version != current_python_version:
+    if pants_runtime_python_version and pants_runtime_python_version != current_python_version:
       raise BuildConfigurationError(
         'Running Pants with a different Python interpreter version than requested. '
         'You requested {}, but are running with {}.\n\n'
         'Note that Pants cannot use the value you give for `--pants-engine-python-version` to '
         'dynamically change the interpreter it uses, as it is too late for it to change once the program '
         'is already running. Instead, your setup script (e.g. `./pants`) must configure which Python '
-        'interpreter and virtualenv to use.'.format(pants_engine_python_version, current_python_version)
-        # TODO(setup#30): Once the setup script is modified to parse pants.ini to grab the requested interpreter version,
-        # add a link to the script as an example for how people might want to do this.
+        'interpreter and virtualenv to use. For example, the setup script we distribute '
+        'at https://www.pantsbuild.org/install.html#recommended-installation will read the '
+        '`pants_runtime_python_version` defined in your pants.ini to determine which Python '
+        'version to run with.'.format(pants_runtime_python_version, current_python_version)
       )
 
     # Parse and register options.

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -110,7 +110,7 @@ class OptionsInitializer(object):
 
     pants_engine_python_version = global_bootstrap_options.pants_engine_python_version
     current_python_version = '.'.join(map(str, sys.version_info[0:2]))
-    if (pants_engine_python_version and pants_engine_python_version != current_python_version):
+    if pants_engine_python_version and pants_engine_python_version != current_python_version:
       raise BuildConfigurationError(
         'Running Pants with a different Python interpreter version than requested. '
         'You requested {}, but are running with {}.\n\n'

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import sys
-from builtins import object
+from builtins import map, object
 
 import pkg_resources
 
@@ -106,6 +106,20 @@ class OptionsInitializer(object):
       raise BuildConfigurationError(
         'Version mismatch: Requested version was {}, our version is {}.'
         .format(global_bootstrap_options.pants_version, pants_version())
+      )
+
+    pants_engine_python_version = global_bootstrap_options.pants_engine_python_version
+    current_python_version = '.'.join(map(str, sys.version_info[0:2]))
+    if (pants_engine_python_version and pants_engine_python_version != current_python_version):
+      raise BuildConfigurationError(
+        'Running Pants with a different Python interpreter version than requested. '
+        'You requested {}, but are running with {}.\n\n'
+        'Note that Pants cannot use the value you give for `--pants-engine-python-version` to '
+        'dynamically change the interpreter it uses, as it is too late for it to change once the program '
+        'is already running. Instead, your setup script (e.g. `./pants`) must configure which Python '
+        'interpreter and virtualenv to use.'.format(pants_engine_python_version, current_python_version)
+        # TODO(setup#30): Once the setup script is modified to parse pants.ini to grab the requested interpreter version,
+        # add a link to the script as an example for how people might want to do this.
       )
 
     # Parse and register options.

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -115,18 +115,23 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--colors', type=bool, default=sys.stdout.isatty(), recursive=True, daemon=False,
              help='Set whether log messages are displayed in color.')
 
-    # Pants code uses this only to verify that we are of the requested version. However
-    # setup scripts, runner scripts, IDE plugins, etc., may grep this out of pants.ini
-    # and use it to select the right version.
-    # Note that to print the version of the pants instance you're running, use -v, -V or --version.
     register('--pants-version', advanced=True, default=pants_version(),
-             help='Use this pants version.')
+             help='Use this pants version. Note Pants code only uses this to verify that you are '
+                  'using the requested version, as Pants cannot dynamically change the version it '
+                  'is using once the program is already running. This option is useful to set in '
+                  'your pants.ini, however, and then you can grep the value to select which '
+                  'version to use for setup scripts (e.g. `./pants`), runner scripts, IDE plugins, '
+                  'etc. You may find the version of the pants instance you are running using -v, '
+                  '-V, or --version.')
 
-    # Like `--pants-version`, Pants code uses this only to verify that the user is using the requested interpreter
-    # version. It too may be grepped out of pants.ini to be used by things like setup scripts,
-    # runner scripts, IDE plugins, etc. in order to select which interpreter to use.
     register('--pants-engine-python-version', advanced=True,
-             help='Use this Python version to run Pants. Valid values: 2.7, 3.6, or 3.7.')
+             help='Use this Python version to run Pants. The option expects the major and minor '
+                  'version, e.g. 2.7 or 3.6. Note Pants code only uses this to verify that you are '
+                  'using the requested interpreter, as Pants cannot dynamically change the '
+                  'interpreter it is using once the program is already running. This option is '
+                  'useful to set in your pants.ini, however, and then you can grep the value to '
+                  'select which interpreter to use for setup scripts (e.g. `./pants`), runner '
+                  'scripts, IDE plugins, etc.')
 
     register('--plugins', advanced=True, type=list, help='Load these plugins.')
     register('--plugin-cache-dir', advanced=True,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -122,6 +122,12 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--pants-version', advanced=True, default=pants_version(),
              help='Use this pants version.')
 
+    # Like `--pants-version`, Pants code uses this only to verify that the user is using the requested interpreter
+    # version. It too may be grepped out of pants.ini to be used by things like setup scripts,
+    # runner scripts, IDE plugins, etc. in order to select which interpreter to use.
+    register('--pants-engine-python-version', advanced=True,
+             help='Use this Python version to run Pants.')
+
     register('--plugins', advanced=True, type=list, help='Load these plugins.')
     register('--plugin-cache-dir', advanced=True,
              default=os.path.join(get_pants_cachedir(), 'plugins'),

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -126,7 +126,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     # version. It too may be grepped out of pants.ini to be used by things like setup scripts,
     # runner scripts, IDE plugins, etc. in order to select which interpreter to use.
     register('--pants-engine-python-version', advanced=True,
-             help='Use this Python version to run Pants.')
+             help='Use this Python version to run Pants. Valid values: 2.7, 3.6, or 3.7.')
 
     register('--plugins', advanced=True, type=list, help='Load these plugins.')
     register('--plugin-cache-dir', advanced=True,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -121,17 +121,23 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   'is using once the program is already running. This option is useful to set in '
                   'your pants.ini, however, and then you can grep the value to select which '
                   'version to use for setup scripts (e.g. `./pants`), runner scripts, IDE plugins, '
-                  'etc. You may find the version of the pants instance you are running using -v, '
-                  '-V, or --version.')
+                  'etc. For example, the setup script we distribute at https://www.pantsbuild.org/install.html#recommended-installation '
+                  'uses this value to determine which Python version to run with. You may find the '
+                  'version of the pants instance you are running using -v, -V, or --version.')
 
-    register('--pants-engine-python-version', advanced=True,
+    register('--pants-runtime-python-version', advanced=True,
              help='Use this Python version to run Pants. The option expects the major and minor '
                   'version, e.g. 2.7 or 3.6. Note Pants code only uses this to verify that you are '
                   'using the requested interpreter, as Pants cannot dynamically change the '
                   'interpreter it is using once the program is already running. This option is '
                   'useful to set in your pants.ini, however, and then you can grep the value to '
                   'select which interpreter to use for setup scripts (e.g. `./pants`), runner '
-                  'scripts, IDE plugins, etc.')
+                  'scripts, IDE plugins, etc. For example, the setup script we distribute at '
+                  'https://www.pantsbuild.org/install.html#recommended-installation uses this '
+                  'value to determine which Python version to run with. Also note this does not mean '
+                  'your own code must use this Python version. See '
+                  'https://www.pantsbuild.org/python_readme.html#configure-the-python-version '
+                  'for how to configure your code\'s compatibility.')
 
     register('--plugins', advanced=True, type=list, help='Load these plugins.')
     register('--plugin-cache-dir', advanced=True,


### PR DESCRIPTION
### Problem
As discussed in https://github.com/pantsbuild/setup/issues/30, we decided to add support for using Python 3 to every day user's setup script `./pants` by having them pin the interpreter version they want to use in `pants.ini`, and then grepping that value to choose the relevant interpreter. However, this currently results in this error:

```
ERROR] Invalid option 'pants_runtime_python_version' under [GLOBAL] in /Users/eric/DocsLocal/code/projects/setup/pants.ini
Exception caught: (<class 'pants.option.config.ConfigValidationError'>)

Exception message: Invalid config entries detected. See log for details on which entries to update or remove.
(Specify --no-verify-config to disable this check.)
```

### Solution
Exactly how we handle `--pants-version`, introduce a new global option `--pants-runtime-python-version` that allows users to set `pants_runtime_python_version` in their `pants.ini`.

Even though Pants code cannot dynamically change the interpreter it runs with—as it is too late to change the interpreter once the process is already running—we can check that Pants is running with the intended interpreter and print a helpful message if it is not.

You can leave off the option, and you'll get no runtime check. Setup scripts are free to implement Python interpreter resolution in another way if they prefer.

### Result
* Including `pants_runtime_python_version` in `pants.ini` no longer results in an error.
* Running `./pants --pants-runtime-python-version=2.6` will error out. Running `./pants2 --pants-runtime-python-version=2.7` will work normally. 