### PR TITLE
add an enum for IncludeDependees for ChangedRequest and OwnersRequest

### DIFF
--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -31,8 +31,7 @@ from pants.engine.objects import Collection
 from pants.engine.parser import SymbolTable, TargetAdaptorContainer
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, Select
-from pants.option.global_options import GlobMatchErrorBehavior
-from pants.scm.subsystems.changed import IncludeDependees
+from pants.option.global_options import GlobMatchErrorBehavior, IncludeDependees
 from pants.source.filespec import any_matches_filespec
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetRelPathWrapper
 from pants.util.objects import Exactly, TypedCollection, datatype

--- a/src/python/pants/init/target_roots_calculator.py
+++ b/src/python/pants/init/target_roots_calculator.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-from builtins import object, str
+from builtins import object
 
 from twitter.common.collections import OrderedSet
 
@@ -16,7 +16,7 @@ from pants.base.target_roots import TargetRoots
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.legacy.graph import OwnersRequest
 from pants.goal.workspace import ScmWorkspace
-from pants.scm.subsystems.changed import ChangedRequest
+from pants.scm.subsystems.changed import ChangedRequest, IncludeDependees
 
 
 logger = logging.getLogger(__name__)
@@ -109,7 +109,7 @@ class TargetRootsCalculator(object):
       # We've been provided no spec roots (e.g. `./pants list`) AND a changed request. Compute
       # alternate target roots.
       request = OwnersRequest(sources=tuple(changed_files),
-                              include_dependees=str(changed_request.include_dependees))
+                              include_dependees=changed_request.include_dependees)
       changed_addresses, = session.product_request(BuildFileAddresses, [request])
       logger.debug('changed addresses: %s', changed_addresses)
       dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in changed_addresses)
@@ -118,7 +118,7 @@ class TargetRootsCalculator(object):
     if owned_files:
       # We've been provided no spec roots (e.g. `./pants list`) AND a owner request. Compute
       # alternate target roots.
-      request = OwnersRequest(sources=tuple(owned_files), include_dependees=str('none'))
+      request = OwnersRequest(sources=tuple(owned_files), include_dependees=IncludeDependees.none)
       owner_addresses, = session.product_request(BuildFileAddresses, [request])
       logger.debug('owner addresses: %s', owner_addresses)
       dependencies = tuple(SingleAddress(a.spec_path, a.target_name) for a in owner_addresses)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -333,7 +333,9 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help='Whether or not to cleanup directories used for local process execution '
                   '(primarily useful for e.g. debugging).')
 
-    register('--include-dependees', type=IncludeDependees, default=IncludeDependees.none,
+    # TODO: rename this to --include-dependees when the corresponding --changed-include-dependees is
+    # fully deprecated!
+    register('--include-dependees-behavior', type=IncludeDependees, default=IncludeDependees.none,
              help='Include direct or transitive dependees of targets specified via --changed-* or '
                   '--owner-of.')
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -27,6 +27,10 @@ class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'])):
   """
 
 
+class IncludeDependees(enum(['none', 'direct', 'transitive'])):
+  """Describe how to include the dependees of targets specified via --changed-* or --owner-of."""
+
+
 class ExecutionOptions(datatype([
   'remote_store_server',
   'remote_store_thread_count',
@@ -328,6 +332,10 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--process-execution-cleanup-local-dirs', type=bool, default=True, advanced=True,
              help='Whether or not to cleanup directories used for local process execution '
                   '(primarily useful for e.g. debugging).')
+
+    register('--include-dependees', type=IncludeDependees, default=IncludeDependees.none,
+             help='Include direct or transitive dependees of targets specified via --changed-* or '
+                  '--owner-of.')
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -47,3 +47,8 @@ class Changed(Subsystem):
              help='Calculate changes contained within given scm spec (commit range/sha/ref/etc).')
     register('--fast', type=bool,
              help='Stop searching for owners once a source is mapped to at least one owning target.')
+    register('--include-dependees', type=IncludeDependees, default=IncludeDependees.none,
+             help='Include direct or transitive dependees of targets specified via --changed-* or '
+                  '--owner-of.',
+             removal_version='1.17.0.dev0',
+             removal_hint='Use the --include-dependees-behavior global option instead.')

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -6,11 +6,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from future.utils import text_type
 
+from pants.option.global_options import IncludeDependees
 from pants.subsystem.subsystem import Subsystem
-from pants.util.objects import Exactly, datatype, enum
-
-
-class IncludeDependees(enum(['none', 'direct', 'transitive'])): pass
+from pants.util.objects import Exactly, datatype
 
 
 class ChangedRequest(datatype([
@@ -21,12 +19,12 @@ class ChangedRequest(datatype([
   """Parameters required to compute a changed file/target set."""
 
   @classmethod
-  def from_options(cls, options):
+  def from_options(cls, options, include_dependees):
     """Given an `Options` object, produce a `ChangedRequest`."""
     return cls(options.changes_since,
                options.diffspec,
-               options.include_dependees,
-               options.fast or False)
+               include_dependees=include_dependees,
+               fast=options.fast or False)
 
   def is_actionable(self):
     return bool(self.changes_since or self.diffspec)
@@ -47,7 +45,5 @@ class Changed(Subsystem):
              help='Calculate changes since this tree-ish/scm ref (defaults to current HEAD/tip).')
     register('--diffspec',
              help='Calculate changes contained within given scm spec (commit range/sha/ref/etc).')
-    register('--include-dependees', type=IncludeDependees, default=IncludeDependees.none,
-             help='Include direct or transitive dependees of changed targets.')
     register('--fast', type=bool,
              help='Stop searching for owners once a source is mapped to at least one owning target.')

--- a/tests/python/pants_test/engine/legacy/test_changed_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_changed_integration.py
@@ -268,7 +268,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
             # Mutate the working copy so we can do `--changed-parent=HEAD` deterministically.
             with mutated_working_copy([os.path.join(worktree, filename)]):
               stdout = self.run_list(
-                ['--include-dependees={}'.format(dependee_type), '--changed-parent=HEAD'],
+                ['--include-dependees-behavior={}'.format(dependee_type), '--changed-parent=HEAD'],
               )
 
               self.assertEqual(
@@ -282,7 +282,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
         )
 
   def run_list(self, extra_args, success=True):
-    list_args = ['-q', 'list'] + extra_args
+    list_args = ['-q'] + extra_args + ['list']
     pants_run = self.do_command(*list_args, success=success)
     return pants_run.stdout_data
 
@@ -300,7 +300,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
           '-ldebug',   # This ensures the changed target names show up in the pants output.
           '--exclude-target-regexp={}'.format(exclude_target_regexp),
           '--changed-parent=HEAD',
-          '--include-dependees=transitive',
+          '--include-dependees-behavior=transitive',
           'test',
         ])
 
@@ -325,7 +325,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
           '-ldebug',   # This ensures the changed target names show up in the pants output.
           '--exclude-target-regexp={}'.format(exclude_target_regexp),
           '--changed-parent=HEAD',
-          '--include-dependees=transitive',
+          '--include-dependees-behavior=transitive',
           'test',
         ])
 
@@ -367,7 +367,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
   def test_changed_with_deleted_target_transitive(self):
     with create_isolated_git_repo() as worktree:
       safe_delete(os.path.join(worktree, 'src/resources/org/pantsbuild/resourceonly/BUILD'))
-      pants_run = self.run_pants(['list', '--changed-parent=HEAD', '--include-dependees=transitive'])
+      pants_run = self.run_pants(['--changed-parent=HEAD', '--include-dependees-behavior=transitive', 'list'])
       self.assert_failure(pants_run)
       assertRegex(self, pants_run.stderr_data, 'src/resources/org/pantsbuild/resourceonly:.*did not exist')
 

--- a/tests/python/pants_test/engine/legacy/test_changed_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_changed_integration.py
@@ -268,7 +268,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
             # Mutate the working copy so we can do `--changed-parent=HEAD` deterministically.
             with mutated_working_copy([os.path.join(worktree, filename)]):
               stdout = self.run_list(
-                ['--changed-include-dependees={}'.format(dependee_type), '--changed-parent=HEAD'],
+                ['--include-dependees={}'.format(dependee_type), '--changed-parent=HEAD'],
               )
 
               self.assertEqual(
@@ -300,7 +300,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
           '-ldebug',   # This ensures the changed target names show up in the pants output.
           '--exclude-target-regexp={}'.format(exclude_target_regexp),
           '--changed-parent=HEAD',
-          '--changed-include-dependees=transitive',
+          '--include-dependees=transitive',
           'test',
         ])
 
@@ -325,7 +325,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
           '-ldebug',   # This ensures the changed target names show up in the pants output.
           '--exclude-target-regexp={}'.format(exclude_target_regexp),
           '--changed-parent=HEAD',
-          '--changed-include-dependees=transitive',
+          '--include-dependees=transitive',
           'test',
         ])
 
@@ -367,7 +367,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
   def test_changed_with_deleted_target_transitive(self):
     with create_isolated_git_repo() as worktree:
       safe_delete(os.path.join(worktree, 'src/resources/org/pantsbuild/resourceonly/BUILD'))
-      pants_run = self.run_pants(['list', '--changed-parent=HEAD', '--changed-include-dependees=transitive'])
+      pants_run = self.run_pants(['list', '--changed-parent=HEAD', '--include-dependees=transitive'])
       self.assert_failure(pants_run)
       assertRegex(self, pants_run.stderr_data, 'src/resources/org/pantsbuild/resourceonly:.*did not exist')
 

--- a/tests/python/pants_test/tasks/test_changed_target_integration.py
+++ b/tests/python/pants_test/tasks/test_changed_target_integration.py
@@ -106,7 +106,7 @@ class ChangedTargetGoalsIntegrationTest(PantsRunIntegrationTest):
         self.assertIsNone(self.find_classfile(workdir, 'Class.class'))
         self.assertIsNone(self.find_classfile(workdir, 'ClassTest.class'))
 
-        run = self.run_pants_with_workdir(cmd + ['--changed-include-dependees=direct'], workdir)
+        run = self.run_pants_with_workdir(cmd + ['--include-dependees=direct'], workdir)
         self.assert_success(run)
 
         # The changed target's and its direct dependees' (eg its tests) classfiles exist.
@@ -131,7 +131,7 @@ class ChangedTargetGoalsIntegrationTest(PantsRunIntegrationTest):
 
       self.assertFalse(os.path.exists(junit_out))
 
-      run = self.run_pants_with_workdir(cmd + ['--changed-include-dependees=direct'], workdir)
+      run = self.run_pants_with_workdir(cmd + ['--include-dependees=direct'], workdir)
       self.assert_success(run)
 
       self.assertTrue(os.path.exists(junit_out))

--- a/tests/python/pants_test/tasks/test_changed_target_integration.py
+++ b/tests/python/pants_test/tasks/test_changed_target_integration.py
@@ -106,7 +106,7 @@ class ChangedTargetGoalsIntegrationTest(PantsRunIntegrationTest):
         self.assertIsNone(self.find_classfile(workdir, 'Class.class'))
         self.assertIsNone(self.find_classfile(workdir, 'ClassTest.class'))
 
-        run = self.run_pants_with_workdir(cmd + ['--include-dependees=direct'], workdir)
+        run = self.run_pants_with_workdir(cmd + ['--include-dependees-behavior=direct'], workdir)
         self.assert_success(run)
 
         # The changed target's and its direct dependees' (eg its tests) classfiles exist.
@@ -131,7 +131,7 @@ class ChangedTargetGoalsIntegrationTest(PantsRunIntegrationTest):
 
       self.assertFalse(os.path.exists(junit_out))
 
-      run = self.run_pants_with_workdir(cmd + ['--include-dependees=direct'], workdir)
+      run = self.run_pants_with_workdir(cmd + ['--include-dependees-behavior=direct'], workdir)
       self.assert_success(run)
 
       self.assertTrue(os.path.exists(junit_out))


### PR DESCRIPTION
### Problem

There's been a TODO in `graph.py` for a bit to move `--changed-include-dependees` to a global option, and to turn it into an enum. After #7304, this has become easier.

This was split out of #7350.

### Solution

- Add types to some datatype fields for the `--changed-*` and `--owner-of` code paths.
- Make `IncludeDependees` an enum, and register it as the `--include-dependees` global option.

### Result

`--include-dependees` as logic is now separated from the `Changed` subsystem, which allows it to be used for `--owner-of` requests.