### PR TITLE
[pantsd] Implement auto-shutdown after runs

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -226,8 +226,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     # This needs to be accessed at the same time as enable_pantsd,
     # so we register it at bootstrap time.
     register('--shutdown-pantsd-after-run', advanced=True, type=bool, default=False,
-      help='Shutdown pantsd after the current run.'
-           'Will fail if pantsd was running before this invocation (Beta)')
+      help='Create a new pantsd server, and use it, and shut it down immediately after. '
+           'If pantsd is already running, it will shut it down and spawn a new instance (Beta)')
 
     # These facilitate configuring the native engine.
     register('--native-engine-visualize-to', advanced=True, default=None, type=dir_option, daemon=False,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -222,6 +222,13 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--enable-pantsd', advanced=True, type=bool, default=False,
              help='Enables use of the pants daemon (and implicitly, the v2 engine). (Beta)')
 
+    # Shutdown pantsd after the current run.
+    # This needs to be accessed at the same time as enable_pantsd,
+    # so we register it at bootstrap time.
+    register('--shutdown-pantsd-after-run', advanced=True, type=bool, default=False,
+      help='Shutdown pantsd after the current run.'
+           'Will fail if pantsd was running before this invocation (Beta)')
+
     # These facilitate configuring the native engine.
     register('--native-engine-visualize-to', advanced=True, default=None, type=dir_option, daemon=False,
              help='A directory to write execution and rule graphs to as `dot` files. The contents '

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -99,7 +99,7 @@ class PailgunServer(ThreadingMixIn, TCPServer):
   # Override the ThreadingMixIn default, to minimize the chances of zombie pailgun processes.
   daemon_threads = True
 
-  def __init__(self, server_address, runner_factory, lifecycle_lock,
+  def __init__(self, server_address, runner_factory, lifecycle_lock, request_complete_callback,
                handler_class=None, bind_and_activate=True):
     """Override of TCPServer.__init__().
 
@@ -122,6 +122,7 @@ class PailgunServer(ThreadingMixIn, TCPServer):
     self.lifecycle_lock = lifecycle_lock
     self.allow_reuse_address = True           # Allow quick reuse of TCP_WAIT sockets.
     self.server_port = None                   # Set during server_bind() once the port is bound.
+    self.request_complete_callback = request_complete_callback
 
     if bind_and_activate:
       try:
@@ -167,6 +168,8 @@ class PailgunServer(ThreadingMixIn, TCPServer):
     try:
       # Attempt to handle a request with the handler.
       handler.handle_request()
+      self.request_complete_callback()
+
     except Exception as e:
       # If that fails, (synchronously) handle the error with the error handler sans-fork.
       try:

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -111,6 +111,7 @@ class PailgunServer(ThreadingMixIn, TCPServer):
                                            execution thread during handling. All pailgun request handling
                                            will take place under care of this lock, which would be shared with
                                            a `PailgunServer`-external lifecycle manager to guard teardown.
+    :param function request_complete_callback: A callback that will be called whenever a pailgun request is completed.
     :param class handler_class: The request handler class to use for each request. (Optional)
     :param bool bind_and_activate: If True, binds and activates networking at __init__ time.
                                    (Optional)

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -181,6 +181,7 @@ class PantsDaemon(FingerprintedProcessManager):
 
       :returns: A PantsServices instance.
       """
+      should_shutdown_after_run = bootstrap_options.shutdown_pantsd_after_run
       fs_event_service = FSEventService(
         watchman,
         build_root,
@@ -208,7 +209,8 @@ class PantsDaemon(FingerprintedProcessManager):
       pailgun_service = PailgunService(
         (bootstrap_options.pantsd_pailgun_host, bootstrap_options.pantsd_pailgun_port),
         DaemonPantsRunner,
-        scheduler_service
+        scheduler_service,
+        should_shutdown_after_run
       )
 
       store_gc_service = StoreGCService(legacy_graph_scheduler.scheduler)

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -443,6 +443,17 @@ class PantsDaemon(FingerprintedProcessManager):
     if include_watchman:
       self.watchman_launcher.terminate()
 
+  def needs_restart(self, option_fingerprint):
+    """
+    Overrides ProcessManager.needs_restart, to account for the case where pantsd is running
+    but we want to shutdown after this run.
+    :param option_fingerprint: A fingeprint of the global bootstrap options.
+    :return: True if the daemon needs to restart.
+    """
+    should_shutdown_after_run = self._bootstrap_options.for_global_scope().shutdown_pantsd_after_run
+    return super(PantsDaemon, self).needs_restart(option_fingerprint) or \
+           (self.is_alive() and should_shutdown_after_run)
+
 
 def launch():
   """An external entrypoint that spawns a new pantsd instance."""

--- a/src/python/pants/pantsd/service/pailgun_service.py
+++ b/src/python/pants/pantsd/service/pailgun_service.py
@@ -23,6 +23,7 @@ class PailgunService(PantsService):
       `pants.bin` packages.
     :param SchedulerService scheduler_service: The SchedulerService instance for access to the
                                                resident scheduler.
+    :param bool shutdown_after_run: PailgunService should shut down after running the first request.
     """
     super(PailgunService, self).__init__()
     self._bind_addr = bind_addr
@@ -42,6 +43,10 @@ class PailgunService(PantsService):
   @property
   def pailgun_port(self):
     return self.pailgun.server_port
+
+  def _request_complete_callback(self):
+    if self._shutdown_after_run:
+      self.terminate()
 
   def _setup_pailgun(self):
     """Sets up a PailgunServer instance."""
@@ -63,11 +68,7 @@ class PailgunService(PantsService):
       with self.services.lifecycle_lock:
         yield
 
-    def request_complete():
-      if self._shutdown_after_run:
-        self.terminate()
-
-    return PailgunServer(self._bind_addr, runner_factory, lifecycle_lock, request_complete)
+    return PailgunServer(self._bind_addr, runner_factory, lifecycle_lock, self._request_complete_callback)
 
   def run(self):
     """Main service entrypoint. Called via Thread.start() via PantsDaemon.run()."""

--- a/tests/python/pants_test/pantsd/service/test_pailgun_service.py
+++ b/tests/python/pants_test/pantsd/service/test_pailgun_service.py
@@ -27,7 +27,8 @@ class TestPailgunService(unittest.TestCase):
     self.mock_target_roots_calculator = mock.Mock(side_effect=Exception('should not be called'))
     self.service = PailgunService(bind_addr=(None, None),
                                   runner_class=self.mock_runner_class,
-                                  scheduler_service=self.mock_scheduler_service)
+                                  scheduler_service=self.mock_scheduler_service,
+                                  shutdown_after_run=False)
 
   @mock.patch.object(PailgunService, '_setup_pailgun', **PATCH_OPTS)
   def test_pailgun_property_values(self, mock_setup):
@@ -35,3 +36,11 @@ class TestPailgunService(unittest.TestCase):
     mock_setup.return_value = fake_pailgun
     self.assertIs(self.service.pailgun, fake_pailgun)
     self.assertEqual(self.service.pailgun_port, 33333)
+
+  @mock.patch.object(PailgunService, 'terminate', **PATCH_OPTS)
+  def test_pailgun_service_closes_when_callback_is_called(self, mock_setup):
+    fake_pailgun = FakePailgun()
+    mock_setup.return_value = fake_pailgun
+    self.service._shutdown_after_run = True
+    self.service._request_complete_callback()
+    self.assertIs(self.service.terminate.called, True)


### PR DESCRIPTION
In the context of enabling pantsd in Travis in some capacity, we need to implement a mechanism to auto-shutdown Pantsd after runs, so that we can still have isolated integration tests.