### PR TITLE
Refactor test code's interpreter_selection_utils.py for better naming of util functions

### DIFF
--- a/tests/python/pants_test/backend/codegen/antlr/python/test_antlr_py_gen_integration.py
+++ b/tests/python/pants_test/backend/codegen/antlr/python/test_antlr_py_gen_integration.py
@@ -4,13 +4,13 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants_test.backend.python.interpreter_selection_utils import skip_unless_python27
+from pants_test.backend.python.interpreter_selection_utils import skip_unless_python27_present
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class AntlrPyGenIntegrationTest(PantsRunIntegrationTest):
 
-  @skip_unless_python27
+  @skip_unless_python27_present
   def test_antlr_py_gen_integration(self):
     result = self.run_pants(['run',
                              'testprojects/src/python/antlr:eval-bin',
@@ -18,7 +18,7 @@ class AntlrPyGenIntegrationTest(PantsRunIntegrationTest):
     self.assertEqual(0, result.returncode)
     self.assertIn('39483', result.stdout_data)
 
-  @skip_unless_python27
+  @skip_unless_python27_present
   def test_python_invalid_antlr_grammar_fails(self):
     result = self.run_pants(['gen',
                              'testprojects/src/antlr/python/test:antlr_failure'])

--- a/tests/python/pants_test/backend/python/interpreter_selection_utils.py
+++ b/tests/python/pants_test/backend/python/interpreter_selection_utils.py
@@ -63,7 +63,7 @@ def skip_unless_any_pythons_present(*versions):
   return skipIf(True, 'Could not find at least one of the required pythons from {} on the system. Skipping.'.format(versions))
 
 
-def skip_unless_pythons(*versions):
+def skip_unless_all_pythons_present(*versions):
   """A decorator that only runs the decorated test method if all of the specified pythons are present.
 
   :param string *versions: Python version strings, such as 2.7, 3.
@@ -79,26 +79,26 @@ def skip_unless_pythons(*versions):
     return skipIf(False, 'All required pythons present, continuing with test!')
 
 
-def skip_unless_python27(func):
+def skip_unless_python27_present(func):
   """A test skip decorator that only runs a test method if python2.7 is present."""
-  return skip_unless_pythons(PY_27)(func)
+  return skip_unless_all_pythons_present(PY_27)(func)
 
 
-def skip_unless_python3(func):
+def skip_unless_python3_present(func):
   """A test skip decorator that only runs a test method if python3 is present."""
-  return skip_unless_pythons(PY_3)(func)
+  return skip_unless_all_pythons_present(PY_3)(func)
 
 
-def skip_unless_python36(func):
+def skip_unless_python36_present(func):
   """A test skip decorator that only runs a test method if python3.6 is present."""
-  return skip_unless_pythons(PY_36)(func)
+  return skip_unless_all_pythons_present(PY_36)(func)
 
 
-def skip_unless_python27_and_python3(func):
+def skip_unless_python27_and_python3_present(func):
   """A test skip decorator that only runs a test method if python2.7 and python3 are present."""
-  return skip_unless_pythons(PY_27, PY_3)(func)
+  return skip_unless_all_pythons_present(PY_27, PY_3)(func)
 
 
-def skip_unless_python27_and_python36(func):
+def skip_unless_python27_and_python36_present(func):
   """A test skip decorator that only runs a test method if python2.7 and python3.6 are present."""
-  return skip_unless_pythons(PY_27, PY_36)(func)
+  return skip_unless_all_pythons_present(PY_27, PY_36)(func)

--- a/tests/python/pants_test/backend/python/interpreter_selection_utils.py
+++ b/tests/python/pants_test/backend/python/interpreter_selection_utils.py
@@ -22,10 +22,11 @@ PY_37 = '3.7'
 PY_38 = '3.8'
 
 
-def find_all_pythons_present():
-  """Return set of all Python versions present on the system."""
-  likely_versions_present = {PY_26, PY_27, PY_34, PY_35, PY_36, PY_37, PY_38}
-  return {version for version in likely_versions_present if has_python_version(version)}
+def find_all_pythons_present(*versions):
+  """Return sorted list of all Python versions present on the system."""
+  if not versions:
+    versions = {PY_26, PY_27, PY_34, PY_35, PY_36, PY_37, PY_38}
+  return sorted(version for version in versions if has_python_version(version))
 
 
 def has_python_version(version):

--- a/tests/python/pants_test/backend/python/interpreter_selection_utils.py
+++ b/tests/python/pants_test/backend/python/interpreter_selection_utils.py
@@ -10,9 +10,22 @@ from unittest import skipIf
 from pants.util.process_handler import subprocess
 
 
-PY_27 = '2.7'
+PY_2 = '2'
 PY_3 = '3'
+
+PY_26 = '2.6'
+PY_27 = '2.7'
+PY_34 = '3.4'
+PY_35 = '3.5'
 PY_36 = '3.6'
+PY_37 = '3.7'
+PY_38 = '3.8'
+
+
+def find_all_pythons_present():
+  """Return set of all Python versions present on the system."""
+  likely_versions_present = {PY_26, PY_27, PY_34, PY_35, PY_36, PY_37, PY_38}
+  return {version for version in likely_versions_present if has_python_version(version)}
 
 
 def has_python_version(version):
@@ -36,12 +49,22 @@ def python_interpreter_path(version):
     command = ['python{}'.format(version), '-c', 'import sys; print(sys.executable)']
     py_path = subprocess.check_output(command).decode('utf-8').strip()
     return os.path.realpath(py_path)
-  except subprocess.CalledProcessError:
+  except (subprocess.CalledProcessError, FileNotFoundError):
     return None
 
 
+def skip_unless_any_pythons_present(*versions):
+  """A decorator that only runs the decorated test method if any of the specified pythons are present.
+
+  :param string *versions: Python version strings, such as 2.7, 3.
+  """
+  if any(v for v in versions if has_python_version(v)):
+    return skipIf(False, 'At least one of the expected python versions found.')
+  return skipIf(True, 'Could not find at least one of the required pythons from {} on the system. Skipping.'.format(versions))
+
+
 def skip_unless_pythons(*versions):
-  """A decorator that only runs the decorated test method if the specified pythons are present.
+  """A decorator that only runs the decorated test method if all of the specified pythons are present.
 
   :param string *versions: Python version strings, such as 2.7, 3.
   """

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -12,8 +12,9 @@ from pex.interpreter import PythonInterpreter
 
 from pants.util.contextutil import temporary_dir
 from pants.util.process_handler import subprocess
-from pants_test.backend.python.interpreter_selection_utils import (PY_3, PY_27, skip_unless_python3,
-                                                                   skip_unless_python27)
+from pants_test.backend.python.interpreter_selection_utils import (PY_3, PY_27,
+                                                                   skip_unless_python3_present,
+                                                                   skip_unless_python27_present)
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -50,11 +51,11 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
     self.assertIn('Unable to detect a suitable interpreter for compatibilities',
                   pants_run.stdout_data)
 
-  @skip_unless_python3
+  @skip_unless_python3_present
   def test_select_3(self):
     self._test_version(PY_3)
 
-  @skip_unless_python27
+  @skip_unless_python27_present
   def test_select_27(self):
     self._test_version(PY_27)
 

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -11,9 +11,9 @@ import unittest
 from pants.util.contextutil import temporary_dir
 from pants_test.backend.python.interpreter_selection_utils import (PY_3, PY_27,
                                                                    python_interpreter_path,
-                                                                   skip_unless_python3,
-                                                                   skip_unless_python27,
-                                                                   skip_unless_python27_and_python3)
+                                                                   skip_unless_python3_present,
+                                                                   skip_unless_python27_and_python3_present,
+                                                                   skip_unless_python27_present)
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 from pants_test.testutils.pexrc_util import setup_pexrc_with_pex_python_path
 
@@ -132,7 +132,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
   @unittest.skip(
     "Upgrade PEX: https://github.com/pantsbuild/pants/pull/7186. \
       NB: Ensure https://github.com/pantsbuild/pex/pull/678 is merged into the PEX release.")
-  @skip_unless_python27_and_python3
+  @skip_unless_python27_and_python3_present
   def test_pants_test_interpreter_selection_with_pexrc(self):
     """Test the pants test goal with intepreters selected from a PEX_PYTHON_PATH
     defined in a pexrc file on disk.
@@ -159,7 +159,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
         )
         self.assert_success(pants_run_3)
 
-  @skip_unless_python27
+  @skip_unless_python27_present
   def test_pants_test_interpreter_selection_with_option_2(self):
     """
     Test that the pants test goal properly constrains the SelectInterpreter task to Python 2
@@ -182,7 +182,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
       )
       self.assert_success(pants_run_2)
 
-  @skip_unless_python3
+  @skip_unless_python3_present
   def test_pants_test_interpreter_selection_with_option_3(self):
     """
     Test that the pants test goal properly constrains the SelectInterpreter task to Python 3

--- a/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
@@ -12,9 +12,9 @@ from pex.pex_bootstrapper import get_pex_info
 from pants.util.contextutil import temporary_dir
 from pants_test.backend.python.interpreter_selection_utils import (PY_3, PY_27,
                                                                    python_interpreter_path,
-                                                                   skip_unless_python3,
-                                                                   skip_unless_python27,
-                                                                   skip_unless_python27_and_python3)
+                                                                   skip_unless_python3_present,
+                                                                   skip_unless_python27_and_python3_present,
+                                                                   skip_unless_python27_present)
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
 from pants_test.testutils.pexrc_util import setup_pexrc_with_pex_python_path
 
@@ -26,12 +26,12 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
   def hermetic(cls):
     return True
 
-  @skip_unless_python3
+  @skip_unless_python3_present
   @ensure_daemon
   def test_run_3(self):
     self._run_version(PY_3)
 
-  @skip_unless_python27
+  @skip_unless_python27_present
   @ensure_daemon
   def test_run_27(self):
     self._run_version(PY_27)
@@ -59,7 +59,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(command=command)
     return pants_run.stdout_data.splitlines()[0].strip()
 
-  @skip_unless_python27_and_python3
+  @skip_unless_python27_and_python3_present
   def test_run_27_and_then_3(self):
     with temporary_dir() as interpreters_cache:
       pants_ini_config = {'python-setup': {'interpreter_cache_dir': interpreters_cache}}
@@ -76,7 +76,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
       )
       self.assert_success(pants_run_3)
 
-  @skip_unless_python3
+  @skip_unless_python3_present
   def test_run_3_by_option(self):
     with temporary_dir() as interpreters_cache:
       pants_ini_config = {'python-setup': {'interpreter_constraints': ["CPython>=2.7,<3.7"],
@@ -88,7 +88,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
       )
       self.assert_success(pants_run_3)
 
-  @skip_unless_python27
+  @skip_unless_python27_present
   def test_run_2_by_option(self):
     with temporary_dir() as interpreters_cache:
       pants_ini_config = {'python-setup': {'interpreter_constraints': ["CPython>=2.7,<3.7"],
@@ -123,7 +123,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
   @unittest.skip(
     "Upgrade PEX: https://github.com/pantsbuild/pants/pull/7186. \
       NB: Ensure https://github.com/pantsbuild/pex/pull/678 is merged into the PEX release.")
-  @skip_unless_python27_and_python3
+  @skip_unless_python27_and_python3_present
   def test_pants_run_interpreter_selection_with_pexrc(self):
     py27_path, py3_path = python_interpreter_path(PY_27), python_interpreter_path(PY_3)
     with setup_pexrc_with_pex_python_path([py27_path, py3_path]):
@@ -147,7 +147,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
   @unittest.skip(
     "Upgrade PEX: https://github.com/pantsbuild/pants/pull/7186. \
       NB: Ensure https://github.com/pantsbuild/pex/pull/678 is merged into the PEX release.")
-  @skip_unless_python27_and_python3
+  @skip_unless_python27_and_python3_present
   def test_pants_binary_interpreter_selection_with_pexrc(self):
     py27_path, py3_path = python_interpreter_path(PY_27), python_interpreter_path(PY_3)
     with setup_pexrc_with_pex_python_path([py27_path, py3_path]):
@@ -181,7 +181,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
   @unittest.skip(
     "Upgrade PEX: https://github.com/pantsbuild/pants/pull/7186. \
       NB: Ensure https://github.com/pantsbuild/pex/pull/678 is merged into the PEX release.")
-  @skip_unless_python3
+  @skip_unless_python3_present
   def test_target_constraints_with_no_sources(self):
     with temporary_dir() as interpreters_cache:
       pants_ini_config = {

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -27,7 +27,7 @@ from pants.fs.archive import TGZ
 from pants.util.collections_abc_backport import OrderedDict
 from pants.util.contextutil import environment_as, temporary_dir, temporary_file
 from pants.util.dirutil import safe_mkdir
-from pants_test.backend.python.interpreter_selection_utils import skip_unless_python36
+from pants_test.backend.python.interpreter_selection_utils import skip_unless_python36_present
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
 from pants_test.subsystem.subsystem_util import init_subsystem
 
@@ -704,7 +704,7 @@ class TestSetupPyFindPackages(SetupPyTestBase):
   def test_find_packages(self):
     self.assert_find_packages(py36=False)
 
-  @skip_unless_python36
+  @skip_unless_python36_present
   def test_find_packages_py3(self):
     self.assert_find_packages(py36=True)
 

--- a/tests/python/pants_test/backend/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/backend/python/test_interpreter_cache.py
@@ -21,7 +21,7 @@ from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import safe_mkdir
 from pants_test.backend.python.interpreter_selection_utils import (PY_27, PY_36,
                                                                    python_interpreter_path,
-                                                                   skip_unless_python27_and_python36)
+                                                                   skip_unless_python27_and_python36_present)
 from pants_test.test_base import TestBase
 from pants_test.testutils.pexrc_util import setup_pexrc_with_pex_python_path
 from pants_test.testutils.py2_compat import assertRegex
@@ -151,7 +151,7 @@ class TestInterpreterCache(TestBase):
       self.assertFalse('.tmp.' in ' '.join(os.listdir(cache_path)),
                        'interpreter cache path contains tmp dirs!')
 
-  @skip_unless_python27_and_python36
+  @skip_unless_python27_and_python36_present
   def test_interpereter_cache_setup_using_pex_python_paths(self):
     """Test cache setup using interpreters from a mocked PEX_PYTHON_PATH."""
     py27_path, py36_path = python_interpreter_path(PY_27), python_interpreter_path(PY_36)


### PR DESCRIPTION
### Problem
We currently have multiple functions named `skip_unless_pythonX` which skip unless the Python version is present on the system. The docstring explains this.

However, the name suggests it will skip if the current interpreter itself is not python27, rather than the version being available to begin with. This could be made clearer by updating the name.

### Solution
Rename `skip_unless_pythonX` to `skip_unless_pythonX_present`. This is safe to do without a deprecation because this is internal test util code, and not exposed as an API.

Also refactor below changes:

* Define `PY_X` for more Python versions for better consistency.
* Add `skip_unless_all_pythons_present()`.
   * We have a function to check `all`, and it's helpful to check `any`.
   * For example, we might want to run the test if either Py36 or Py37 are available, and we don't care that both are.
* Add `find_all_pythons_present()`.
   * This is useful when paired with `skip_unless_all_pythons_present()`. If the test is not skipped because at least one requested version is available, this function may be used to identify which are valid.