### PR TITLE
Update docs to explain how to use Python 3

### DIFF
--- a/src/docs/howto_develop.md
+++ b/src/docs/howto_develop.md
@@ -84,9 +84,9 @@ You'll need to setup some files one-time in your own repo:
         'linux-x86_64',
         'macosx-10.4-x86_64',
       ],
-      # You may want to adjust the python interpreter constraints, but note that pants requires
-      # python2.7 currently.
-      compatibility='CPython>=2.7,<3',
+      # You may want to adjust the python interpreter constraints. Note that Pants requires
+      # Python 2.7 or 3.6+ currently.
+      compatibility=['CPython>=2.7,<3', 'CPython>=3.6,<4'],
       dependencies=[
         ':pantsbuild.pants',
         # List any other pants backend local or remote deps here, ie:

--- a/src/docs/install.md
+++ b/src/docs/install.md
@@ -23,29 +23,19 @@ in the root (ie, "buildroot") of your repo:
     :::bash
     curl -L -O https://pantsbuild.github.io/setup/pants && chmod +x pants && touch pants.ini
 
-Before running the new `./pants` script, you should pin the Python version you want to run Pants with.
-To do this, add an entry like so to `pants.ini`, choosing between `2.7`, `3.6`, or `3.7`.
-
-    :::ini
-    [GLOBAL]
-    pants_engine_python_version: 3.6
-
-If you'd like to change which Python version Pants uses, just edit the entry in `pants.ini`.
-
 The first time you run the new `./pants` script it will install the latest version of pants (using
 virtualenv) and then run it.  It's recommended though, that you pin the version of pants.  To do
 this, first find out the version of pants you just installed:
 
     :::bash
     ./pants -V
-    1.14.0
+    1.15.0.dev4
 
 Then add an entry like so to `pants.ini` with that version:
 
     :::ini
     [GLOBAL]
-    pants_engine_python_version: 3.6
-    pants_version: 1.14.0
+    pants_version: 1.15.0.dev4
 
 When you'd like to upgrade pants, just edit the version in `pants.ini` and pants will self-update on
 the next run.  This script stores the various pants versions you use centrally in
@@ -57,7 +47,7 @@ follows:
 
     :::ini
     [GLOBAL]
-    pants_version: 1.14.0
+    pants_version: 1.15.0.dev4
 
     plugins: [
         'pantsbuild.pants.contrib.go==%(pants_version)s',
@@ -68,6 +58,24 @@ Pants notices you changed your plugins and it installs them.
 NB: The formatting of the plugins list is important; all lines below the `plugins:` line must be
 indented by at least one white space to form logical continuation lines. This is standard for python
 ini files, see [[Options|pants('src/docs:options')]].
+
+Pants' runtime Python interpreter
+---------------------------------
+Pants may be ran with Python 2.7, 3.6, or 3.7. The `./pants` script defaults to using Python 2.7. It's recommeded, though, that you pin the version you'd like to use.
+
+To do this, add an entry like so to `pants.ini`, choosing between `2.7`, `3.6`, or `3.7`.
+
+    :::ini
+    [GLOBAL]
+    pants_version: 1.15.0.dev4
+    pants_runtime_python_version: 3.6
+
+If you'd like to change which Python version Pants uses, just edit the entry in `pants.ini` and `./pants` will setup the new virtual environment for you.
+
+Some considerations when choosing which interpreter to run Pants with:
+* This does not mean your Python code has to use this same Python version. See https://www.pantsbuild.org/python_readme.html#configure-the-python-version for how to configure your code's compatibility.
+* Ensure you have the pinned Python version accessible on your PATH everywhere Pants is used in your organization.
+* Pants will require Python 3.6+ to run as of release 1.17.0.
 
 The ./pants Runner Script
 -------------------------

--- a/src/docs/install.md
+++ b/src/docs/install.md
@@ -5,7 +5,7 @@ There are a few ways to get a runnable version of pants set up for your workspac
 beginning, make sure your machine fits the requirements. At a minimum, pants requires the following to run properly:
 
 * Linux or Mac OS X.
-* Python 2.7.x (the latest stable version of 2.7 is recommended).
+* Python 2.7, 3.6, or 3.7.
 * A C compiler, system headers, Python headers (to compile native Python modules) and the libffi
   library and headers (to compile and link modules that use CFFI to access native code).
 * OpenJDK or Oracle JDK 7 or greater.
@@ -23,19 +23,29 @@ in the root (ie, "buildroot") of your repo:
     :::bash
     curl -L -O https://pantsbuild.github.io/setup/pants && chmod +x pants && touch pants.ini
 
+Before running the new `./pants` script, you should pin the Python version you want to run Pants with.
+To do this, add an entry like so to `pants.ini`, choosing between `2.7`, `3.6`, or `3.7`.
+
+    :::ini
+    [GLOBAL]
+    pants_engine_python_version: 3.6
+
+If you'd like to change which Python version Pants uses, just edit the entry in `pants.ini`.
+
 The first time you run the new `./pants` script it will install the latest version of pants (using
 virtualenv) and then run it.  It's recommended though, that you pin the version of pants.  To do
 this, first find out the version of pants you just installed:
 
     :::bash
     ./pants -V
-    1.0.0
+    1.14.0
 
 Then add an entry like so to `pants.ini` with that version:
 
     :::ini
     [GLOBAL]
-    pants_version: 1.0.0
+    pants_engine_python_version: 3.6
+    pants_version: 1.14.0
 
 When you'd like to upgrade pants, just edit the version in `pants.ini` and pants will self-update on
 the next run.  This script stores the various pants versions you use centrally in
@@ -47,7 +57,7 @@ follows:
 
     :::ini
     [GLOBAL]
-    pants_version: 1.0.0
+    pants_version: 1.14.0
 
     plugins: [
         'pantsbuild.pants.contrib.go==%(pants_version)s',


### PR DESCRIPTION
### Problem
https://github.com/pantsbuild/pants/pull/7197 is adding support for releasing Py3 and https://github.com/pantsbuild/setup/pull/32 is modifying our run script we distribute to allow choosing Py3. Meanwhile, we need this PR to update the docs according to the plan laid out in https://github.com/pantsbuild/setup/issues/30.

### Solution
Explain how to pin the version. This is the first command we have the user do after `curl`, because we want them to have the Python version chosen before running Pants and setting up their venv.

Also update the pants version we show.