### PR TITLE
Replace `future` with `six` in the python style checker

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/checker/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/BUILD
@@ -10,7 +10,8 @@ python_library(
     }
   ),
   dependencies=[
-    '3rdparty/python:future',
+    # NB: See https://github.com/pantsbuild/pants/issues/7158 before introducing additional
+    # dependencies here.
     '3rdparty/python:pycodestyle',
     '3rdparty/python:pyflakes',
     '3rdparty/python:six',

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/constant_logic.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/constant_logic.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import ast
 
-from future.utils import PY3
+from six import PY3
 
 from pants.contrib.python.checks.checker.common import CheckstylePlugin
 

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/except_statements.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/except_statements.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import ast
 
-from future.utils import PY3
+from six import PY3
 
 from pants.contrib.python.checks.checker.common import CheckstylePlugin
 

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/missing_contextmanager.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/missing_contextmanager.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import ast
 
-from future.utils import PY3
+from six import PY3
 
 from pants.contrib.python.checks.checker.common import CheckstylePlugin
 

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/print_statements.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/print_statements.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import ast
 import re
 
-from future.utils import PY3
+from six import PY3
 
 from pants.contrib.python.checks.checker.common import CheckstylePlugin
 


### PR DESCRIPTION
### Problem

The workaround for #7158 was to remove usage of `future` in the python style `checker` pex, but documentation was not left behind to defend against re-addition, and so it regressed.

### Solution

Switch from `future` to `six`, and add a comment.

### Result

Checking py3 code from within a py2 pex should work.