### PR TITLE
Fix rule graph nondeterminism due to undetected ambiguity

### DIFF
--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -3,6 +3,7 @@
 
 use std::ffi::OsStr;
 use std::ffi::OsString;
+use std::fmt;
 use std::mem;
 use std::os::raw;
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
@@ -484,6 +485,17 @@ pub struct PyGeneratorResponse {
 pub struct Get {
   pub product: TypeId,
   pub subject: Key,
+}
+
+impl fmt::Display for Get {
+  fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    write!(
+      f,
+      "Get({}, {})",
+      type_to_str(self.product),
+      key_to_str(&self.subject)
+    )
+  }
 }
 
 pub enum GeneratorResponse {

--- a/testprojects/tests/python/pants/dummies/BUILD
+++ b/testprojects/tests/python/pants/dummies/BUILD
@@ -10,7 +10,10 @@ python_tests(
 
 python_library(
   name = 'example_lib',
-  sources = 'example_source.py',
+  sources = [
+    'example_source.py',
+    '__init__.py',
+  ],
 )
 
 python_tests(

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -180,10 +180,10 @@ python_tests(
   sources=['test_rules.py'],
   coverage=['pants.engine.rules'],
   dependencies=[
-    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    ':util',
+    '3rdparty/python:future',
     ':scheduler_test_base',
+    ':util',
     'src/python/pants/engine:build_files',
     'src/python/pants/engine:console',
     'src/python/pants/engine:rules',
@@ -192,6 +192,7 @@ python_tests(
     'tests/python/pants_test/engine/examples:parsers',
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test/testutils:py2_compat',
+    'tests/python/pants_test:test_base',
   ]
 )
 

--- a/tests/python/pants_test/rules/test_test_integration.py
+++ b/tests/python/pants_test/rules/test_test_integration.py
@@ -4,8 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -110,7 +108,6 @@ testprojects/tests/python/pants/dummies:failing_target                          
 """,
     )
 
-  @unittest.skip('Flaky test: https://github.com/pantsbuild/pants/issues/6782')
   def test_source_dep(self):
     pants_run = self.run_passing_pants_test([
       'testprojects/tests/python/pants/dummies:target_with_source_dep',
@@ -129,7 +126,6 @@ testprojects/tests/python/pants/dummies/test_with_source_dep.py .        [100%]
 testprojects/tests/python/pants/dummies:target_with_source_dep                  .....   SUCCESS
 """)
 
-  @unittest.skip('Flaky test: https://github.com/pantsbuild/pants/issues/6782')
   def test_thirdparty_dep(self):
     pants_run = self.run_passing_pants_test([
       'testprojects/tests/python/pants/dummies:target_with_thirdparty_dep',
@@ -148,7 +144,6 @@ testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py .    [100%]
 testprojects/tests/python/pants/dummies:target_with_thirdparty_dep              .....   SUCCESS
 """)
 
-  @unittest.skip('Flaky test: https://github.com/pantsbuild/pants/issues/6782')
   def test_mixed_python_tests(self):
     pants_run = self.run_failing_pants_test([
       'testprojects/tests/python/pants/dummies:failing_target',


### PR DESCRIPTION
### Problem

Integration tests of `@console_rules` would frequently flake (as in #6782) with rules self-cycling in a peculiar way. Investigating the failure lead to the conclusion that the `RuleGraph` was being constructed non-deterministically.

The source of the non-determinism was that we were "simplifying" all instances of one `@rule` that used the same number of `Params`, and treating them interchangeably. But that simplification was subject to rust's randomized hash ordering, and so we would choose which of the `Params` to use at random.

After fixing that non-determinism, we also needed to solve the underlying ambiguities (there were two or three) that lead to there being multiple options to choose from.

### Solution

* Change `GraphMaker::choose_dependency` to not simplify rules, and instead preserve all candidates with the current minimum `Param` set size.
* Fix the ambiguity that lead to multiple choices being available by introducing an (intuitive, I think) restriction that only subgraphs that actually use the `Param` provided by a `Get` are eligible to satisfy it. See the explanation in the test.

### Result

Unskips `@console_rule` integration tests, and adds a (previously flaky, now stable) unit test of the ambiguous case. Fixes #6782.