### PR TITLE
Hotfix Python 2 regression from #7366 using FileNotFoundError

### DIFF
--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -72,6 +72,7 @@ python_library(
   name='interpreter_selection_utils',
   sources=['interpreter_selection_utils.py'],
   dependencies=[
-    'src/python/pants/util:process_handler'
+    'src/python/pants/util:process_handler',
+    '3rdparty/python:future',
   ]
 )

--- a/tests/python/pants_test/backend/python/interpreter_selection_utils.py
+++ b/tests/python/pants_test/backend/python/interpreter_selection_utils.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 from unittest import skipIf
 
+from future.utils import PY2
+
 from pants.util.process_handler import subprocess
 
 
@@ -46,6 +48,8 @@ def python_interpreter_path(version):
   :returns: the normalized path to the interpreter binary if found; otherwise `None`
   :rtype: string
   """
+  if PY2:
+    FileNotFoundError = IOError
   try:
     command = ['python{}'.format(version), '-c', 'import sys; print(sys.executable)']
     py_path = subprocess.check_output(command).decode('utf-8').strip()

--- a/tests/python/pants_test/backend/python/interpreter_selection_utils.py
+++ b/tests/python/pants_test/backend/python/interpreter_selection_utils.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 from unittest import skipIf
 
-from future.utils import PY2
+from future.utils import PY3
 
 from pants.util.process_handler import subprocess
 
@@ -48,13 +48,11 @@ def python_interpreter_path(version):
   :returns: the normalized path to the interpreter binary if found; otherwise `None`
   :rtype: string
   """
-  if PY2:
-    FileNotFoundError = IOError
   try:
     command = ['python{}'.format(version), '-c', 'import sys; print(sys.executable)']
     py_path = subprocess.check_output(command).decode('utf-8').strip()
     return os.path.realpath(py_path)
-  except (subprocess.CalledProcessError, FileNotFoundError):
+  except (subprocess.CalledProcessError, FileNotFoundError if PY3 else IOError):
     return None
 
 


### PR DESCRIPTION
### Problem
The function `python_interpreter_path()` from `interpreter_selection_utils.py` was originally failing to execute on Py3 because it would encounter `FileNotFoundError`, which we weren't catching, so we added this to the except statement in https://github.com/pantsbuild/pants/pull/7366.

However, the exception apparently does not exist in Python 2, so the nightly cron job failed: https://travis-ci.org/pantsbuild/pants/jobs/506186166#L952.

### Solution
Alias the error `if PY2`. We use this idiom, rather than a try except, so that we can easily automatically delete this code once we drop Py2.

### Result
`PY=python2.7 ./build-support/bin/pre-commit.sh` now works again.