### PR TITLE
Strip native engine binary

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,8 @@
+# Strip the binary; on Linux this drops our .so from ~125MB to ~10MB.
+
+[build]
+rustflags = ["-C", "link-arg=-s"]
+
 # N.B. On OSX, we force weak linking by passing the param `-undefined dynamic_lookup` to
 # the underlying linker used by cargo/rustc via RUSTFLAGS. This avoids "missing symbol"
 # errors for Python symbols (e.g. `_PyImport_ImportModule`) at build time when bundling


### PR DESCRIPTION
This reduces the output size on Linux from ~125M to ~11M.

It has no effect on OSX, but we might as well be consistent unless we have a reason not to be.

This _may_ be removing debug symbols, which I should investigate...