### PR TITLE
Set PEX_PYTHON_PATH in v2 python test running

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -104,7 +104,10 @@ def run_python_test(transitive_hydrated_target, pytest):
     input_files=merged_input_files,
     description='Run pytest for {}'.format(target_root.address.reference()),
     # TODO: This should not be necessary
-    env={'PATH': os.path.dirname(python_binary)}
+    env={
+      'PATH': os.path.dirname(python_binary),
+      'PEX_PYTHON_PATH': python_binary,
+    }
   )
 
   result = yield Get(FallibleExecuteProcessResult, ExecuteProcessRequest, request)


### PR DESCRIPTION
Without this, the system's default python interpreter will be used
(possibly via pexrc).

Long term, we should probably be using a flag to specify what version of
python should be used for running tests, but in the short term, we're
currently using Pants's python interpreter to make the pex, so we should
_also_ be using it to run the pex, otherwise we get errors finding
dependencies for the correct platform.

Fixes #7385