### PR TITLE
Allow reporters to see the correct end_time for a workunit

### DIFF
--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -150,6 +150,7 @@ class WorkUnit(object):
     return self.path(), self.duration(), self._self_time(), self.has_label(WorkUnitLabel.TOOL)
 
   def close_outputs(self):
+    """Cleanup by closing all output streams."""
     for output in self._outputs.values():
       output.close()
 

--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -146,9 +146,12 @@ class WorkUnit(object):
   def end(self):
     """Mark the time at which this workunit ended."""
     self.end_time = time.time()
+
+    return self.path(), self.duration(), self._self_time(), self.has_label(WorkUnitLabel.TOOL)
+
+  def close_outputs(self):
     for output in self._outputs.values():
       output.close()
-    return self.path(), self.duration(), self._self_time(), self.has_label(WorkUnitLabel.TOOL)
 
   def outcome(self):
     """Returns the outcome of this workunit.

--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -149,7 +149,7 @@ class WorkUnit(object):
 
     return self.path(), self.duration(), self._self_time(), self.has_label(WorkUnitLabel.TOOL)
 
-  def close_outputs(self):
+  def cleanup(self):
     """Cleanup by closing all output streams."""
     for output in self._outputs.values():
       output.close()

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -494,7 +494,7 @@ class RunTracker(Subsystem):
   def end_workunit(self, workunit):
     path, duration, self_time, is_tool = workunit.end()
     self.report.end_workunit(workunit)
-    workunit.close_outputs()
+    workunit.cleanup()
 
     # These three operations may not be thread-safe, and workunits may run in separate threads
     # and thus end concurrently, so we want to lock these operations.

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -492,8 +492,9 @@ class RunTracker(Subsystem):
     return 1 if outcome in [WorkUnit.FAILURE, WorkUnit.ABORTED] else 0
 
   def end_workunit(self, workunit):
-    self.report.end_workunit(workunit)
     path, duration, self_time, is_tool = workunit.end()
+    self.report.end_workunit(workunit)
+    workunit.close_outputs()
 
     # These three operations may not be thread-safe, and workunits may run in separate threads
     # and thus end concurrently, so we want to lock these operations.


### PR DESCRIPTION
### Problem

The `end_time` for a workunit is not accessible to reports, since it's set _after_ we tell the report that the workunit is complete. 

### Solution

Set the `end_time` on the workunit before notifying reporter's that it's complete. 

### Result

Reporters can now access an accurate `end_time` for workunits. This will be used for adjacent work (in flight) that returns a more complete representation of the build than is currently returned by the `RunTracker`/reporters.