### PR TITLE
Run lint shard with Python 2 during daily CI instead of nightly cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -329,6 +329,7 @@ py36_osx_build_engine: &py36_osx_build_engine
 py27_lint: &py27_lint
   <<: *py27_linux_test_config
   name: "Self-checks and lint (Py2.7 PEX)"
+  stage: *test
   env:
     - *py27_linux_test_config_env
     - CACHE_NAME=linuxselfchecks.py27

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -293,6 +293,7 @@ py36_osx_build_engine: &py36_osx_build_engine
 py27_lint: &py27_lint
   <<: *py27_linux_test_config
   name: "Self-checks and lint (Py2.7 PEX)"
+  stage: *test
   env:
     - *py27_linux_test_config_env
     - CACHE_NAME=linuxselfchecks.py27

--- a/tests/python/pants_test/backend/python/interpreter_selection_utils.py
+++ b/tests/python/pants_test/backend/python/interpreter_selection_utils.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 from unittest import skipIf
 
-from future.utils import PY3
+from future.utils import PY2
 
 from pants.util.process_handler import subprocess
 
@@ -48,11 +48,13 @@ def python_interpreter_path(version):
   :returns: the normalized path to the interpreter binary if found; otherwise `None`
   :rtype: string
   """
+  if PY2:
+    FileNotFoundError = IOError
   try:
     command = ['python{}'.format(version), '-c', 'import sys; print(sys.executable)']
     py_path = subprocess.check_output(command).decode('utf-8').strip()
     return os.path.realpath(py_path)
-  except (subprocess.CalledProcessError, FileNotFoundError if PY3 else IOError):
+  except (subprocess.CalledProcessError, FileNotFoundError):
     return None
 
 


### PR DESCRIPTION
### Problem
The lint shard is a very cost-effective way to prevent Py2 regressions. For only about 8 minutes of extra total worker time, we can ensure we are always using defined symbols, for example.

This would have prevented https://github.com/pantsbuild/pants/pull/7381 for example. In fact, that PR didn't even properly fix the issue. Running the lint shard during daily CI would have both prevented the issue in the first place and ensured the hotfix worked.

### Solution
Run the lint shard with both Py2 and Py3 during daily CI. No longer run during nightly cron job.

Also fix the issue https://github.com/pantsbuild/pants/pull/7381 was supposed to fix.

### Result
We should have less Python 2 regressions.

While CI will take 10 minutes longer of total worker time, the wall time should not be changed (beyond when we don't have enough workers). This extra time is worth the lowered risk of regressions.