### PR TITLE
Add JSON Reporter for more detailed workunit stats

### DIFF
--- a/src/python/pants/reporting/json_reporter.py
+++ b/src/python/pants/reporting/json_reporter.py
@@ -39,7 +39,6 @@ class JsonReporter(Reporter):
 
     self._buildroot = get_buildroot()
     self._report_file = None
-    self._output_files = defaultdict(dict)
 
     # Results of the state of the build
     self._results = {}
@@ -69,9 +68,6 @@ class JsonReporter(Reporter):
       ))
       self._report_file.flush()
     self._report_file.close()
-    for files in self._output_files.values():
-      for f in files.values():
-        f.close()
 
   def start_workunit(self, workunit):
     """Implementation of Reporter callback."""
@@ -111,9 +107,6 @@ class JsonReporter(Reporter):
 
     self._stack_per_thread[root_id][-1].update(additional_data)
     self._stack_per_thread[root_id].pop()
-
-    for f in self._output_files[workunit.id].values():
-      f.close()
 
   def handle_output(self, workunit, label, stream):
     """Implementation of Reporter callback."""

--- a/src/python/pants/reporting/json_reporter.py
+++ b/src/python/pants/reporting/json_reporter.py
@@ -52,12 +52,12 @@ class JsonReporter(Reporter):
     """Implementation of Reporter callback."""
 
     with open(self.report_path, 'w+') as fp:
-      fp.write(str(json.dumps(
+      fp.write(json.dumps(
         {
           'workunits': self._results,
           'artifact_cache_stats': self.run_tracker.artifact_cache_stats.get_all(),
         }
-      )))
+      ))
 
   def start_workunit(self, workunit):
     """Implementation of Reporter callback."""

--- a/src/python/pants/reporting/json_reporter.py
+++ b/src/python/pants/reporting/json_reporter.py
@@ -1,0 +1,145 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import json
+import os
+from builtins import list, open, str
+from collections import defaultdict, namedtuple
+
+from future.moves.itertools import zip_longest
+from six import string_types
+
+from pants.base.build_environment import get_buildroot
+from pants.reporting.reporter import Reporter
+from pants.util.dirutil import safe_mkdir
+
+
+class JsonReporter(Reporter):
+  """Json reporting to files."""
+
+  _log_level_str = [
+    'FATAL',
+    'ERROR',
+    'WARN',
+    'INFO',
+    'DEBUG',
+  ]
+
+  # JSON reporting settings.
+  #   json_dir: Where the report files go.
+  Settings = namedtuple('Settings', Reporter.Settings._fields + ('json_dir',))
+
+  def __init__(self, run_tracker, settings):
+    super(JsonReporter, self).__init__(run_tracker, settings)
+    # The main report, and associated tool outputs, go under this dir.
+    self._json_dir = settings.json_dir
+
+    self._buildroot = get_buildroot()
+    self._report_file = None
+    self._output_files = defaultdict(dict)
+
+    # Results of the state of the build
+    self._results = {}
+    # Workunit stacks partitioned by thread
+    self._stack_per_thread = defaultdict(list)
+
+  def report_path(self):
+    """The path to the main report file."""
+
+    return os.path.join(self._json_dir, 'build.json')
+
+  def open(self):
+    """Implementation of Reporter callback."""
+
+    safe_mkdir(os.path.dirname(self._json_dir))
+    self._report_file = open(self.report_path(), 'w')
+
+  def close(self):
+    """Implementation of Reporter callback."""
+
+    if os.path.exists(self._json_dir):
+      self._report_file.write(json.dumps(
+        {
+          'workunits': self._results,
+          'artifact_cache_stats': self.run_tracker.artifact_cache_stats.get_all(),
+        }
+      ))
+      self._report_file.flush()
+    self._report_file.close()
+    for files in self._output_files.values():
+      for f in files.values():
+        f.close()
+
+  def start_workunit(self, workunit):
+    """Implementation of Reporter callback."""
+
+    workunit_data = {
+      'name': workunit.name,
+      'id': str(workunit.id),
+      'parent_name': workunit.parent.name if workunit.parent else '',
+      'parent_id': str(workunit.parent.id) if workunit.parent else '',
+      'labels': list(workunit.labels),
+      'cmd': workunit.cmd or '',
+      'start_time': workunit.start_time,
+      'outputs': defaultdict(str),
+      'children': [],
+      'log_entries': [],
+    }
+
+    root_id = str(workunit.root().id)
+
+    if not root_id in self._stack_per_thread:
+      self._stack_per_thread[root_id].append(workunit_data)
+      self._results[root_id] = workunit_data
+    else:
+      self._stack_per_thread[root_id][-1]['children'].append(workunit_data)
+      self._stack_per_thread[root_id].append(workunit_data)
+
+  def end_workunit(self, workunit):
+    """Implementation of Reporter callback."""
+
+    additional_data = {
+      'outcome': workunit.outcome_string(workunit.outcome()),
+      'end_time': workunit.end_time,
+      'unaccounted_time': workunit.unaccounted_time(),
+    }
+
+    root_id = str(workunit.root().id)
+
+    self._stack_per_thread[root_id][-1].update(additional_data)
+    self._stack_per_thread[root_id].pop()
+
+    for f in self._output_files[workunit.id].values():
+      f.close()
+
+  def handle_output(self, workunit, label, stream):
+    """Implementation of Reporter callback."""
+
+    self._stack_per_thread[str(workunit.root().id)][-1]['outputs'][label] += stream
+
+  def do_handle_log(self, workunit, level, *msg_elements):
+    """Implementation of Reporter callback."""
+
+    entry_info = {
+      'level': self._log_level_str[level],
+      'messages': self._render_messages(*msg_elements),
+    }
+
+    current_stack = self._stack_per_thread[str(workunit.root().id)]
+    if current_stack:
+      current_stack[-1]['log_entries'].append(entry_info)
+    else:
+      self._results[str(workunit.root().id)]['log_entries'].append(entry_info)
+
+  def _render_messages(self, *msg_elements):
+    def _message_details(element):
+      if isinstance(element, string_types):
+        element = [element]
+
+      text, detail = (x or y for x, y in zip_longest(element, ('', None)))
+      return {'text': text, 'detail': detail}
+
+    return list(map(_message_details, msg_elements))

--- a/src/python/pants/reporting/json_reporter.py
+++ b/src/python/pants/reporting/json_reporter.py
@@ -52,12 +52,12 @@ class JsonReporter(Reporter):
     """Implementation of Reporter callback."""
 
     with open(self.report_path, 'w+') as fp:
-      fp.write(json.dumps(
+      fp.write(str(json.dumps(
         {
           'workunits': self._results,
           'artifact_cache_stats': self.run_tracker.artifact_cache_stats.get_all(),
         }
-      ))
+      )))
 
   def start_workunit(self, workunit):
     """Implementation of Reporter callback."""

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -14,6 +14,7 @@ from future.utils import PY3
 from pants.base.workunit import WorkUnitLabel
 from pants.reporting.html_reporter import HtmlReporter
 from pants.reporting.invalidation_report import InvalidationReport
+from pants.reporting.json_reporter import JsonReporter
 from pants.reporting.plaintext_reporter import LabelFormat, PlainTextReporter, ToolOutputFormat
 from pants.reporting.quiet_reporter import QuietReporter
 from pants.reporting.report import Report
@@ -74,6 +75,8 @@ class Reporting(Subsystem):
 
     html_dir = os.path.join(run_dir, 'html')
     safe_mkdir(html_dir)
+    json_dir = os.path.join(run_dir, 'json')
+    safe_mkdir(json_dir)
     relative_symlink(run_dir, os.path.join(self.get_options().reports_dir, 'latest'))
 
     report = Report()
@@ -97,6 +100,11 @@ class Reporting(Subsystem):
                                                    template_dir=self.get_options().template_dir)
     html_reporter = HtmlReporter(run_tracker, html_reporter_settings)
     report.add_reporter('html', html_reporter)
+
+    # Set up JSON reporting.
+    json_reporter_settings = JsonReporter.Settings(log_level=Report.INFO, json_dir=json_dir)
+    json_reporter = JsonReporter(run_tracker, json_reporter_settings)
+    report.add_reporter('json', json_reporter)
 
     # Set up Zipkin reporting.
     zipkin_endpoint = self.get_options().zipkin_endpoint

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -40,7 +40,6 @@ python_tests(
   sources = ['test_json_reporter.py'],
   dependencies = [
     '3rdparty/python:future',
-    'src/python/pants/util:contextutil',
     'src/python/pants/base:workunit',
     'src/python/pants/reporting',
     'tests/python/pants_test:test_base',

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -45,3 +45,14 @@ python_tests(
     'tests/python/pants_test:test_base',
   ],
 )
+
+python_tests(
+  name = 'json_reporter_integration',
+  sources = 'test_json_reporter_integration.py',
+  dependencies = [
+    '3rdparty/python:future',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
+)

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -34,3 +34,15 @@ python_tests(
     'tests/python/pants_test:test_base',
   ],
 )
+
+python_tests(
+  name = 'json_reporter',
+  sources = ['test_json_reporter.py'],
+  dependencies = [
+    '3rdparty/python:future',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/base:workunit',
+    'src/python/pants/reporting',
+    'tests/python/pants_test:test_base',
+  ],
+)

--- a/tests/python/pants_test/reporting/test_json_reporter.py
+++ b/tests/python/pants_test/reporting/test_json_reporter.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
-import os
 
 from pants.base.workunit import WorkUnit
 from pants.reporting.report import Report
@@ -63,7 +62,7 @@ class JsonReporterTest(TestBase):
     reporter.open()
     generate_callbacks(root_workunit_dict, reporter)
     reporter.close()
-    result = json.loads(open(os.path.join(reporter.report_path())).read())
+    result = json.loads(open(reporter.report_path).read())
     self.assertDictEqual(root_workunit_dict, result['workunits'][root_workunit_dict['id']])
 
   def test_nested_grandchild(self):
@@ -135,8 +134,8 @@ class JsonReporterTest(TestBase):
     }
 
     with temporary_dir() as temp_dir:
-      reporter = JsonReporter(FakeRunTracker(), JsonReporter.Settings(
-          log_level=Report.INFO, json_dir=temp_dir))
+      reporter = JsonReporter(FakeRunTracker(),
+        JsonReporter.Settings(log_level=Report.INFO, json_dir=temp_dir))
 
       self._check_callbacks(expected, reporter)
 
@@ -225,7 +224,7 @@ class JsonReporterTest(TestBase):
     }
 
     with temporary_dir() as temp_dir:
-      reporter = JsonReporter(FakeRunTracker(), JsonReporter.Settings(
-          log_level=Report.INFO, json_dir=temp_dir))
+      reporter = JsonReporter(FakeRunTracker(),
+        JsonReporter.Settings(log_level=Report.INFO, json_dir=temp_dir))
 
       self._check_callbacks(expected, reporter)

--- a/tests/python/pants_test/reporting/test_json_reporter.py
+++ b/tests/python/pants_test/reporting/test_json_reporter.py
@@ -1,0 +1,160 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import json
+import os
+from contextlib import contextmanager
+
+from pants.base.workunit import WorkUnit
+from pants.reporting.report import Report
+from pants.reporting.reporting import JsonReporter
+from pants.util.contextutil import temporary_dir
+from pants_test.test_base import TestBase
+
+
+class FakeRunTracker(object):
+  reporter = None
+
+  class FakeCacheStats(object):
+    def get_all(self):
+      return []
+
+  def __init__(self):
+    self.artifact_cache_stats = self.FakeCacheStats()
+
+  def start(self):
+    self.reporter.open()
+
+  def end(self):
+    self.reporter.close()
+
+  @contextmanager
+  def new_workunit(self, workunit):
+    self.reporter.start_workunit(workunit)
+    yield workunit
+    self.reporter.end_workunit(workunit)
+
+
+class FakeWorkUnit(object):
+  def __init__(self, parent, name, **kwargs):
+    self.name = name
+    self.id = '{}_id'.format(name)
+    self.parent = parent
+    self.cmd = ''
+    self.labels = kwargs.get('labels', [])
+    self.start_time = kwargs.get('start_time', 8675309.0)
+    self.end_time = self.start_time + 10
+
+  def unaccounted_time(self):
+    return 0
+
+  def root(self):
+    ret = self
+    while ret.parent is not None:
+      ret = ret.parent
+    return ret
+
+  def outputs(self):
+    return {}
+
+  def outcome(self):
+    return WorkUnit.SUCCESS
+
+  def outcome_string(self, outcome):
+    return WorkUnit.outcome_string(outcome)
+
+
+class JsonReporterTest(TestBase):
+
+  def test_reporter_output(self):
+    expected = {
+      'workunits': {
+        'root_id': {
+          'name': 'root',
+          'id': 'root_id',
+          'parent_name': '',
+          'parent_id': '',
+          'labels': [
+            'IAMROOT'
+          ],
+          'cmd': '',
+          'start_time': -5419800.0,
+          'outputs': {},
+          'children': [
+            {
+              'name': 'child1',
+              'id': 'child1_id',
+              'parent_name': 'root',
+              'parent_id': 'root_id',
+              'labels': [],
+              'cmd': '',
+              'start_time': 31564800.0,
+              'outputs': {},
+              'children': [
+                {
+                  'name': 'grandchild',
+                  'id': 'grandchild_id',
+                  'parent_name': 'child1',
+                  'parent_id': 'child1_id',
+                  'labels': [
+                    'LABEL1'
+                  ],
+                  'cmd': '',
+                  'start_time': 479721600.0,
+                  'outputs': {},
+                  'children': [],
+                  'log_entries': [],
+                  'outcome': 'SUCCESS',
+                  'end_time': 479721610.0,
+                  'unaccounted_time': 0
+                }
+              ],
+              'log_entries': [],
+              'outcome': 'SUCCESS',
+              'end_time': 31564810.0,
+              'unaccounted_time': 0
+            },
+            {
+              'name': 'child2',
+              'id': 'child2_id',
+              'parent_name': 'root',
+              'parent_id': 'root_id',
+              'labels': [],
+              'cmd': '',
+              'start_time': 684140400.0,
+              'outputs': {},
+              'children': [],
+              'log_entries': [],
+              'outcome': 'SUCCESS',
+              'end_time': 684140410.0,
+              'unaccounted_time': 0
+            }
+          ],
+          'log_entries': [],
+          'outcome': 'SUCCESS',
+          'end_time': -5419790.0,
+          'unaccounted_time': 0
+        },
+      },
+      'artifact_cache_stats': []
+    }
+
+    with temporary_dir() as temp_dir:
+      run_tracker = FakeRunTracker()
+      reporter = JsonReporter(run_tracker, JsonReporter.Settings(log_level=Report.INFO, json_dir=temp_dir))
+      run_tracker.reporter = reporter
+
+      run_tracker.start()
+
+      with run_tracker.new_workunit(FakeWorkUnit(None, 'root', labels=['IAMROOT'], start_time=-5419800.0)) as root_workunit:
+        with run_tracker.new_workunit(FakeWorkUnit(root_workunit, 'child1', start_time=31564800.0)) as child1:
+          with run_tracker.new_workunit(FakeWorkUnit(child1, 'grandchild', labels=['LABEL1'], start_time=479721600.0)): pass
+        with run_tracker.new_workunit(FakeWorkUnit(root_workunit, 'child2', start_time=684140400.0)): pass
+
+      run_tracker.end()
+
+      result = json.loads(open(os.path.join(reporter.report_path())).read())
+      self.assertDictEqual(expected, result)

--- a/tests/python/pants_test/reporting/test_json_reporter_integration.py
+++ b/tests/python/pants_test/reporting/test_json_reporter_integration.py
@@ -1,0 +1,29 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import json
+import os
+import unittest
+
+from pants.util.contextutil import temporary_dir
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class JsonReporterIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
+  def test_json_report_generated(self):
+    with temporary_dir() as temp_dir:
+      command = ['list',
+                 'examples/src/java/org/pantsbuild/example/hello/main',
+                 '--reporting-reports-dir={}'.format(temp_dir)]
+
+      pants_run = self.run_pants(command)
+      self.assert_success(pants_run)
+
+      output = os.path.join(temp_dir, 'latest', 'json', 'build.json')
+      self.assertTrue(os.path.exists(output))
+
+      parsed_report = json.loads(open(output).read())
+      self.assertIsInstance(parsed_report['workunits'], dict)


### PR DESCRIPTION
### Problem

Currently there is no single source of detailed structured data for builds. `RunTracker` has the ability to post certain stats to external URLs or a json on the user's machine, but these stats do not include much information of each workunit. `HtmlReporter` has more detail, but not structured in a way that could be easily consumed by others.

Creating such a single source for build data could be leveraged in different use cases:
- More data that the `RunTracker` could post externally (that would survive a `clean-all`)
  - If this supported sending deltas, the build could be viewed remotely in near-real time
- Improve other reporters by having a single json that could be polled for deltas / progress

### Solution

This adds a new `JsonReporter` that collects the outputs from each workunit and writes them to (currently) a json file (similar to how the `HtmlReporter` writes outputs to an `html` dir).

There are several more steps to plug this in fully for reporting these stats to an external URL, though that work could be broken up over subsequent PRs, specifically:
- How to incorporate a `JsonReporter` into the current stats that are reported (perhaps by a versioning flag on the run tracker - which leads to the question of how tightly coupled to the `RunTracker` this should be).

Additionally, things that aren't solved here, but could be done as next steps:
- Compressing the json for a completed build, since it's conceivable that those reports could be quite large.
- Sending deltas during the build instead of a complete file at the end.
