### PR TITLE
[WIP] switch usages of `log` to `tokio_trace`

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -40,7 +40,7 @@ class LocalPantsRunner(object):
     return options, build_config, options_bootstrapper
 
   @staticmethod
-  def _maybe_init_graph_session(graph_session, options_bootstrapper,build_config, global_options):
+  def _maybe_init_graph_session(graph_session, options_bootstrapper,build_config, options):
     if graph_session:
       return graph_session
 
@@ -52,7 +52,9 @@ class LocalPantsRunner(object):
       build_config
     )
 
-    return graph_scheduler_helper.new_session(global_options.v2_ui)
+    v2_ui = options.for_global_scope().v2_ui
+    zipkin_trace_v2 = options.for_scope('reporting').zipkin_trace_v2
+    return graph_scheduler_helper.new_session(zipkin_trace_v2, v2_ui)
 
   @staticmethod
   def _maybe_init_target_roots(target_roots, graph_session, options, build_root):
@@ -106,7 +108,7 @@ class LocalPantsRunner(object):
       daemon_graph_session,
       options_bootstrapper,
       build_config,
-      global_options
+      options
     )
 
     target_roots = cls._maybe_init_target_roots(

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -683,8 +683,8 @@ class Native(Singleton):
       self.lib.execution_request_create(),
       self.lib.execution_request_destroy)
 
-  def new_session(self, scheduler, should_render_ui, ui_worker_count):
-    return self.gc(self.lib.session_create(scheduler, should_render_ui, ui_worker_count), self.lib.session_destroy)
+  def new_session(self, scheduler, should_record_zipkin_spans, should_render_ui, ui_worker_count):
+    return self.gc(self.lib.session_create(scheduler, should_record_zipkin_spans, should_render_ui, ui_worker_count), self.lib.session_destroy)
 
   def new_scheduler(self,
                     tasks,

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -446,6 +446,12 @@ class SchedulerSession(object):
     """Returns metrics for this SchedulerSession as a dict of metric name to metric value."""
     return self._scheduler._metrics(self._session)
 
+  def metrics_have_engine_workunits(self):
+    return "engine_workunits" in self.metrics()
+
+  def engine_workunits(self):
+    return self.metrics().get("engine_workunits")
+
   def with_fork_context(self, func):
     return self._scheduler.with_fork_context(func)
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -354,9 +354,11 @@ class Scheduler(object):
   def garbage_collect_store(self):
     self._native.lib.garbage_collect_store(self._scheduler)
 
-  def new_session(self, v2_ui=False):
+  def new_session(self, zipkin_trace_v2, v2_ui=False):
     """Creates a new SchedulerSession for this Scheduler."""
-    return SchedulerSession(self, self._native.new_session(self._scheduler, v2_ui, multiprocessing.cpu_count()))
+    return SchedulerSession(self, self._native.new_session(
+      self._scheduler, zipkin_trace_v2, v2_ui, multiprocessing.cpu_count())
+    )
 
 
 _PathGlobsAndRootCollection = Collection.of(PathGlobsAndRoot)

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -151,7 +151,9 @@ class Context(object):
     yield
     metrics = self._scheduler.metrics()
     self.run_tracker.pantsd_stats.set_scheduler_metrics(metrics)
-    self.run_tracker.report.bulk_record_workunits(metrics)
+    if self._scheduler.metrics_have_engine_workunits():
+      engine_workunits = self._scheduler.engine_workunits()
+      self.run_tracker.report.bulk_record_workunits(engine_workunits)
     self._set_affected_target_count_in_runtracker()
 
   def _set_target_root_count_in_runtracker(self):

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -149,7 +149,9 @@ class Context(object):
     """A contextmanager that sets metrics in the context of a (v1) engine execution."""
     self._set_target_root_count_in_runtracker()
     yield
-    self.run_tracker.pantsd_stats.set_scheduler_metrics(self._scheduler.metrics())
+    metrics = self._scheduler.metrics()
+    self.run_tracker.pantsd_stats.set_scheduler_metrics(metrics)
+    self.run_tracker.report.bulk_record_workunits(metrics)
     self._set_affected_target_count_in_runtracker()
 
   def _set_target_root_count_in_runtracker(self):

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -151,8 +151,8 @@ class Context(object):
     yield
     metrics = self._scheduler.metrics()
     self.run_tracker.pantsd_stats.set_scheduler_metrics(metrics)
-    if self._scheduler.metrics_have_engine_workunits():
-      engine_workunits = self._scheduler.engine_workunits()
+    engine_workunits = self._scheduler.engine_workunits()
+    if engine_workunits:
       self.run_tracker.report.bulk_record_workunits(engine_workunits)
     self._set_affected_target_count_in_runtracker()
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -142,8 +142,8 @@ def _tuplify(v):
 class LegacyGraphScheduler(datatype(['scheduler', 'symbol_table', 'goal_map'])):
   """A thin wrapper around a Scheduler configured with @rules for a symbol table."""
 
-  def new_session(self, v2_ui=False):
-    session = self.scheduler.new_session(v2_ui)
+  def new_session(self, zipkin_trace_v2, v2_ui=False):
+    session = self.scheduler.new_session(zipkin_trace_v2, v2_ui)
     return LegacyGraphSession(session, self.symbol_table, self.goal_map)
 
 

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -174,8 +174,9 @@ class SchedulerService(PantsService):
     if graph_len > 0:
       self._logger.debug('graph len was {}, waiting for initial watchman event'.format(graph_len))
       self._watchman_is_running.wait()
-
-    session = self._graph_helper.new_session(options.for_global_scope().v2_ui)
+    v2_ui = options.for_global_scope().v2_ui
+    zipkin_trace_v2 = options.for_scope('reporting').zipkin_trace_v2
+    session = self._graph_helper.new_session(zipkin_trace_v2, v2_ui)
     if options.for_global_scope().loop:
       return session, self._prefork_loop(session, options, options_bootstrapper)
     else:

--- a/src/python/pants/reporting/report.py
+++ b/src/python/pants/reporting/report.py
@@ -141,7 +141,7 @@ class Report(object):
           for reporter in self._reporters.values():
             reporter.handle_output(workunit, label, s)
 
-  def bulk_record_workunits(self, metrics):
+  def bulk_record_workunits(self, engine_workunits):
     with self._lock:
       for reporter in self._reporters.values():
-        reporter.bulk_record_workunits(metrics)
+        reporter.bulk_record_workunits(engine_workunits)

--- a/src/python/pants/reporting/report.py
+++ b/src/python/pants/reporting/report.py
@@ -140,3 +140,8 @@ class Report(object):
         if len(s) > 0:
           for reporter in self._reporters.values():
             reporter.handle_output(workunit, label, s)
+
+  def bulk_record_workunits(self, metrics):
+    with self._lock:
+      for reporter in self._reporters.values():
+        reporter.bulk_record_workunits(metrics)

--- a/src/python/pants/reporting/reporter.py
+++ b/src/python/pants/reporting/reporter.py
@@ -47,7 +47,7 @@ class Reporter(object):
     """A workunit has finished."""
     pass
 
-  def bulk_record_workunits(self, metrics):
+  def bulk_record_workunits(self, engine_workunits):
     """A collection of workunits from Rust (engine) part"""
     pass
 

--- a/src/python/pants/reporting/reporter.py
+++ b/src/python/pants/reporting/reporter.py
@@ -47,6 +47,10 @@ class Reporter(object):
     """A workunit has finished."""
     pass
 
+  def bulk_record_workunits(self, metrics):
+    """A collection of workunits from Rust (engine) part"""
+    pass
+
   def handle_log(self, workunit, level, *msg_elements):
     """Handle a message logged by pants code.
 

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -62,6 +62,8 @@ class Reporting(Subsystem):
                    'or not set when running a Pants command.')
     register('--zipkin-sample-rate', advanced=True, default=100.0,
               help='Rate at which to sample Zipkin traces. Value 0.0 - 100.0.')
+    register('--zipkin-trace-v2', advanced=True, type=bool, default=False,
+              help='If enabled, the zipkin spans are tracked for v2 engine execution progress.')
 
   def initialize(self, run_tracker, all_options, start_time=None):
     """Initialize with the given RunTracker.

--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -133,9 +133,8 @@ class ZipkinReporter(Reporter):
 
     logger.debug("Zipkin trace may be located at this URL {}/traces/{}".format(endpoint, self.trace_id))
 
-  def bulk_record_workunits(self, metrics):
-    """A collection of workunits from Rust (engine) part"""
-    engine_workunits = metrics["engine_workunits"]
+  def bulk_record_workunits(self, engine_workunits):
+    """A collection of workunits from v2 engine part"""
     for workunit in engine_workunits:
       duration = workunit['end_timestamp'] - workunit['start_timestamp']
 
@@ -147,8 +146,7 @@ class ZipkinReporter(Reporter):
       )
       span.zipkin_attrs = ZipkinAttrs(
         trace_id=self.trace_id,
-        span_id=generate_random_64bit_string(),
-        # span_id=workunit['span_id'],
+        span_id=workunit['span_id'],
         parent_span_id=workunit.get("parent_id", self.parent_id), # TODO change it when we properly pass parent id
         # parent_span_id=workunit.get("parent_id", None),
         flags='0', # flags: stores flags header. Currently unused

--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -97,7 +97,10 @@ class ZipkinReporter(Reporter):
           sample_rate=self.sample_rate, # Value between 0.0 and 100.0
         )
         self.trace_id = zipkin_attrs.trace_id
-        self.parent_id = zipkin_attrs.span_id # temporary code
+        # TODO delete this line when parent_id will be passed in v2 engine:
+        #  - with ExecutionRequest when Nodes from v2 engine are called by a workunit;
+        #  - when a v2 engine Node is called by another v2 engine Node.
+        self.parent_id = zipkin_attrs.span_id
 
       span = zipkin_span(
         service_name=service_name,

--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -97,6 +97,7 @@ class ZipkinReporter(Reporter):
           sample_rate=self.sample_rate, # Value between 0.0 and 100.0
         )
         self.trace_id = zipkin_attrs.trace_id
+        self.parent_id = zipkin_attrs.span_id # temporary code
 
       span = zipkin_span(
         service_name=service_name,
@@ -146,8 +147,10 @@ class ZipkinReporter(Reporter):
       )
       span.zipkin_attrs = ZipkinAttrs(
         trace_id=self.trace_id,
-        span_id=workunit['span_id'],
-        parent_span_id=workunit.get("parent_id", None),
+        span_id=generate_random_64bit_string(),
+        # span_id=workunit['span_id'],
+        parent_span_id=workunit.get("parent_id", self.parent_id), # TODO change it when we properly pass parent id
+        # parent_span_id=workunit.get("parent_id", None),
         flags='0', # flags: stores flags header. Currently unused
         is_sampled=True,
       )

--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -147,8 +147,10 @@ class ZipkinReporter(Reporter):
       span.zipkin_attrs = ZipkinAttrs(
         trace_id=self.trace_id,
         span_id=workunit['span_id'],
-        parent_span_id=workunit.get("parent_id", self.parent_id), # TODO change it when we properly pass parent id
-        # parent_span_id=workunit.get("parent_id", None),
+        # TODO change it when we properly pass parent_id to the v2 engine Nodes
+        # TODO Pass parent_id with ExecutionRequest when v2 engine is called by a workunit
+        # TODO pass parent_id when v2 engine Node is called by another v2 engine Node
+        parent_span_id=workunit.get("parent_id", self.parent_id),
         flags='0', # flags: stores flags header. Currently unused
         is_sampled=True,
       )

--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 
 import requests
-from py_zipkin import Encoding
+from py_zipkin import Encoding, storage
 from py_zipkin.transport import BaseTransportHandler
 from py_zipkin.util import generate_random_64bit_string
 from py_zipkin.zipkin import ZipkinAttrs, create_attrs_for_span, zipkin_span
@@ -64,6 +64,7 @@ class ZipkinReporter(Reporter):
     self.parent_id = parent_id
     self.sample_rate = float(sample_rate)
     self.endpoint = endpoint
+    self.span_storage = storage.default_span_storage()
 
   def start_workunit(self, workunit):
     """Implementation of Reporter callback."""
@@ -97,18 +98,19 @@ class ZipkinReporter(Reporter):
         )
         self.trace_id = zipkin_attrs.trace_id
 
-
       span = zipkin_span(
         service_name=service_name,
         span_name=workunit.name,
         transport_handler=self.handler,
         encoding=Encoding.V1_THRIFT,
-        zipkin_attrs=zipkin_attrs
+        zipkin_attrs=zipkin_attrs,
+        span_storage=self.span_storage,
       )
     else:
       span = zipkin_span(
         service_name=service_name,
         span_name=workunit.name,
+        span_storage=self.span_storage,
       )
     self._workunits_to_spans[workunit] = span
     span.start()
@@ -129,3 +131,26 @@ class ZipkinReporter(Reporter):
     endpoint = self.endpoint.replace("/api/v1/spans", "")
 
     logger.debug("Zipkin trace may be located at this URL {}/traces/{}".format(endpoint, self.trace_id))
+
+  def bulk_record_workunits(self, metrics):
+    """A collection of workunits from Rust (engine) part"""
+    engine_workunits = metrics["engine_workunits"]
+    for workunit in engine_workunits:
+      duration = workunit['end_timestamp'] - workunit['start_timestamp']
+
+      span = zipkin_span(
+        service_name="pants",
+        span_name=workunit['name'],
+        duration=duration,
+        span_storage=self.span_storage,
+      )
+      span.zipkin_attrs = ZipkinAttrs(
+        trace_id=self.trace_id,
+        span_id=workunit['span_id'],
+        parent_span_id=workunit.get("parent_id", None),
+        flags='0', # flags: stores flags header. Currently unused
+        is_sampled=True,
+      )
+      span.start()
+      span.start_timestamp = workunit['start_timestamp']
+      span.stop()

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -171,13 +171,16 @@ dependencies = [
  "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "hashing 0.0.1",
  "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serverset 0.0.1",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace 0.0.1 (git+https://github.com/tokio-rs/tokio?rev=92d51202ef5e6b99004d77300de1aba0f8835513)",
+ "tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)",
+ "tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)",
+ "tokio-trace-macros 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)",
 ]
 
 [[package]]
@@ -413,6 +416,10 @@ dependencies = [
  "tar_api 0.0.1",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace 0.0.1 (git+https://github.com/tokio-rs/tokio?rev=92d51202ef5e6b99004d77300de1aba0f8835513)",
+ "tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)",
+ "tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)",
+ "tokio-trace-macros 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)",
  "ui 0.0.1",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -524,7 +531,6 @@ dependencies = [
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb 0.8.0 (git+https://github.com/pantsbuild/lmdb-rs.git?rev=06bdfbfc6348f6804127176e561843f214fc17f8)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -534,6 +540,10 @@ dependencies = [
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
+ "tokio-trace 0.0.1 (git+https://github.com/tokio-rs/tokio?rev=92d51202ef5e6b99004d77300de1aba0f8835513)",
+ "tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)",
+ "tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)",
+ "tokio-trace-macros 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)",
  "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1269,7 +1279,6 @@ dependencies = [
  "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
  "hashing 0.0.1",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
  "protobuf 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "resettable 0.0.1",
@@ -1279,6 +1288,10 @@ dependencies = [
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace 0.0.1 (git+https://github.com/tokio-rs/tokio?rev=92d51202ef5e6b99004d77300de1aba0f8835513)",
+ "tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)",
+ "tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)",
+ "tokio-trace-macros 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)",
 ]
 
 [[package]]
@@ -1365,7 +1378,7 @@ name = "protoc"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2187,6 +2200,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-trace"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tokio#92d51202ef5e6b99004d77300de1aba0f8835513"
+dependencies = [
+ "tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-trace"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tokio?rev=92d51202ef5e6b99004d77300de1aba0f8835513#92d51202ef5e6b99004d77300de1aba0f8835513"
+dependencies = [
+ "tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-trace-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-trace-futures"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926#ee38e0030e3b249b09f0432f4d9140d15048a926"
+dependencies = [
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace 0.0.1 (git+https://github.com/tokio-rs/tokio)",
+]
+
+[[package]]
+name = "tokio-trace-log"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926#ee38e0030e3b249b09f0432f4d9140d15048a926"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace 0.0.1 (git+https://github.com/tokio-rs/tokio)",
+ "tokio-trace-subscriber 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)",
+]
+
+[[package]]
+name = "tokio-trace-macros"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926#ee38e0030e3b249b09f0432f4d9140d15048a926"
+dependencies = [
+ "tokio-trace 0.0.1 (git+https://github.com/tokio-rs/tokio)",
+]
+
+[[package]]
+name = "tokio-trace-subscriber"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926#ee38e0030e3b249b09f0432f4d9140d15048a926"
+dependencies = [
+ "tokio-trace 0.0.1 (git+https://github.com/tokio-rs/tokio)",
+]
+
+[[package]]
 name = "tokio-udp"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2757,6 +2830,13 @@ dependencies = [
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 "checksum tokio-threadpool 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "742e511f6ce2298aeb86fc9ea0d8df81c2388c6ebae3dc8a7316e8c9df0df801"
 "checksum tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2910970404ba6fa78c5539126a9ae2045d62e3713041e447f695f41405a120c6"
+"checksum tokio-trace 0.0.1 (git+https://github.com/tokio-rs/tokio)" = "<none>"
+"checksum tokio-trace 0.0.1 (git+https://github.com/tokio-rs/tokio?rev=92d51202ef5e6b99004d77300de1aba0f8835513)" = "<none>"
+"checksum tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3"
+"checksum tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)" = "<none>"
+"checksum tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)" = "<none>"
+"checksum tokio-trace-macros 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)" = "<none>"
+"checksum tokio-trace-subscriber 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?rev=ee38e0030e3b249b09f0432f4d9140d15048a926)" = "<none>"
 "checksum tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -95,7 +95,14 @@ reqwest = { version = "0.9.10", default_features = false, features = ["rustls-tl
 resettable = { path = "resettable" }
 smallvec = "0.6"
 tokio = "0.1"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio", rev = "92d51202ef5e6b99004d77300de1aba0f8835513" }
+tokio-trace-log = { git = "https://github.com/tokio-rs/tokio-trace-nursery", rev = "ee38e0030e3b249b09f0432f4d9140d15048a926" }
+tokio-trace-futures = { git = "https://github.com/tokio-rs/tokio-trace-nursery", rev = "ee38e0030e3b249b09f0432f4d9140d15048a926" }
+tokio-trace-macros = { git = "https://github.com/tokio-rs/tokio-trace-nursery", rev = "ee38e0030e3b249b09f0432f4d9140d15048a926" }
 tempfile = "3"
 ui = { path = "ui" }
 url = "1.7.1"
 tar_api = { path = "tar_api" }
+
+[patch.crates-io]
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -23,7 +23,6 @@ indexmap = "1.0.2"
 itertools = "0.7.2"
 lazy_static = "1"
 lmdb = { git = "https://github.com/pantsbuild/lmdb-rs.git", rev = "06bdfbfc6348f6804127176e561843f214fc17f8" }
-log = "0.4"
 parking_lot = "0.6"
 protobuf = { version = "2.0.4", features = ["with-bytes"] }
 serverset = { path = "../serverset" }
@@ -31,6 +30,10 @@ sha2 = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 tempfile = "3"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio", rev = "92d51202ef5e6b99004d77300de1aba0f8835513" }
+tokio-trace-log = { git = "https://github.com/tokio-rs/tokio-trace-nursery", rev = "ee38e0030e3b249b09f0432f4d9140d15048a926" }
+tokio-trace-futures = { git = "https://github.com/tokio-rs/tokio-trace-nursery", rev = "ee38e0030e3b249b09f0432f4d9140d15048a926" }
+tokio-trace-macros = { git = "https://github.com/tokio-rs/tokio-trace-nursery", rev = "ee38e0030e3b249b09f0432f4d9140d15048a926" }
 uuid = { version = "0.7.1", features = ["v4"] }
 
 [dev-dependencies]

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -18,11 +18,14 @@ futures = "^0.1.16"
 futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 hashing = { path = "../../hashing" }
 libc = "0.2.39"
-log = "0.4.1"
 parking_lot = "0.6"
 protobuf = { version = "2.0.4", features = ["with-bytes"] }
 serverset = { path = "../../serverset" }
 time = "0.1.39"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio", rev = "92d51202ef5e6b99004d77300de1aba0f8835513" }
+tokio-trace-log = { git = "https://github.com/tokio-rs/tokio-trace-nursery", rev = "ee38e0030e3b249b09f0432f4d9140d15048a926" }
+tokio-trace-futures = { git = "https://github.com/tokio-rs/tokio-trace-nursery", rev = "ee38e0030e3b249b09f0432f4d9140d15048a926" }
+tokio-trace-macros = { git = "https://github.com/tokio-rs/tokio-trace-nursery", rev = "ee38e0030e3b249b09f0432f4d9140d15048a926" }
 
 [dev-dependencies]
 bytes = "0.4.5"

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -26,6 +26,9 @@
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
+#[macro_use]
+extern crate tokio_trace;
+
 use bazel_protos;
 use clap;
 use dirs;
@@ -44,7 +47,6 @@ use time;
 
 use futures::future::Future;
 use hashing::{Digest, Fingerprint};
-use log::{debug, error, warn};
 use parking_lot::Mutex;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -11,7 +11,6 @@ use futures::future;
 use futures::Future;
 use glob::Pattern;
 use indexmap::{map::Entry::Occupied, IndexMap, IndexSet};
-use log::warn;
 
 use crate::{
   Dir, GitignoreStyleExcludes, GlobExpansionConjunction, GlobParsedSource, GlobSource,

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -26,6 +26,9 @@
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
+#[macro_use]
+extern crate tokio_trace;
+
 mod glob_matching;
 pub use crate::glob_matching::GlobMatching;
 mod snapshot;

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -691,7 +691,6 @@ mod local {
     self, Cursor, Database, DatabaseFlags, Environment, EnvironmentCopyFlags, EnvironmentFlags,
     RwTransaction, Transaction, WriteFlags,
   };
-  use log::{debug, error};
   use sha2::Sha256;
   use std;
   use std::collections::{BinaryHeap, HashMap};

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -15,7 +15,6 @@ fs = { path = "../fs" }
 futures = "^0.1.16"
 grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../hashing" }
-log = "0.4"
 protobuf = { version = "2.0.4", features = ["with-bytes"] }
 resettable = { path = "../resettable" }
 sha2 = "0.8"
@@ -25,6 +24,10 @@ futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b
 time = "0.1.40"
 tokio-codec = "0.1"
 tokio-process = "0.2.1"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio", rev = "92d51202ef5e6b99004d77300de1aba0f8835513" }
+tokio-trace-log = { git = "https://github.com/tokio-rs/tokio-trace-nursery", rev = "ee38e0030e3b249b09f0432f4d9140d15048a926" }
+tokio-trace-futures = { git = "https://github.com/tokio-rs/tokio-trace-nursery", rev = "ee38e0030e3b249b09f0432f4d9140d15048a926" }
+tokio-trace-macros = { git = "https://github.com/tokio-rs/tokio-trace-nursery", rev = "ee38e0030e3b249b09f0432f4d9140d15048a926" }
 
 [dev-dependencies]
 mock = { path = "../testutil/mock" }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -26,6 +26,9 @@
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
+#[macro_use]
+extern crate tokio_trace;
+
 use boxfuture::BoxFuture;
 use bytes::Bytes;
 use std::collections::{BTreeMap, BTreeSet};

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -1,10 +1,8 @@
-use log;
 use tempfile;
 
 use boxfuture::{try_future, BoxFuture, Boxable};
 use fs::{self, GlobExpansionConjunction, GlobMatching, PathGlobs, Snapshot, StrictGlobMatching};
 use futures::{future, Future, Stream};
-use log::info;
 use std::collections::{BTreeSet, HashSet};
 use std::ffi::OsStr;
 use std::fs::create_dir_all;

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -13,7 +13,6 @@ use futures::{future, Future, Stream};
 use futures_timer::Delay;
 use grpcio;
 use hashing::{Digest, Fingerprint};
-use log::{debug, trace, warn};
 use protobuf::{self, Message, ProtobufEnum};
 use sha2::Sha256;
 use time;

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -15,9 +15,11 @@ use crate::core::{Failure, TypeId};
 use crate::handles::maybe_drop_handles;
 use crate::nodes::{NodeKey, TryInto, WrappedNode};
 use crate::rule_graph::RuleGraph;
+use crate::scheduler::Session;
 use crate::tasks::Tasks;
 use crate::types::Types;
 use boxfuture::{BoxFuture, Boxable};
+use core::clone::Clone;
 use fs::{self, safe_create_dir_all_ioerror, PosixFS, ResettablePool, Store};
 use graph::{EntryId, Graph, NodeContext};
 use log::debug;
@@ -227,13 +229,15 @@ impl Core {
 pub struct Context {
   pub entry_id: EntryId,
   pub core: Arc<Core>,
+  pub session: Session,
 }
 
 impl Context {
-  pub fn new(entry_id: EntryId, core: Arc<Core>) -> Context {
+  pub fn new(entry_id: EntryId, core: Arc<Core>, session: Session) -> Context {
     Context {
       entry_id: entry_id,
       core: core,
+      session: session,
     }
   }
 
@@ -267,6 +271,7 @@ impl NodeContext for Context {
     Context {
       entry_id: entry_id,
       core: self.core.clone(),
+      session: self.session.clone(),
     }
   }
 

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -22,7 +22,6 @@ use boxfuture::{BoxFuture, Boxable};
 use core::clone::Clone;
 use fs::{self, safe_create_dir_all_ioerror, PosixFS, ResettablePool, Store};
 use graph::{EntryId, Graph, NodeContext};
-use log::debug;
 use process_execution::{self, BoundedCommandRunner, CommandRunner};
 use rand::seq::SliceRandom;
 use reqwest;

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -30,6 +30,9 @@
 // other unsafeness.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
+#[macro_use]
+extern crate tokio_trace;
+
 pub mod cffi_externs;
 mod context;
 mod core;
@@ -70,7 +73,6 @@ use crate::types::Types;
 use fs::{GlobMatching, MemFS, PathStat};
 use futures::Future;
 use hashing::Digest;
-use log::error;
 
 // TODO: Consider renaming and making generic for collections of PyResults.
 #[repr(C)]

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -316,7 +316,9 @@ pub extern "C" fn scheduler_metrics(
       let values = scheduler
         .metrics(session)
         .into_iter()
-        .flat_map(|(metric, value)| vec![externs::store_utf8(metric), externs::store_i64(value)])
+        .flat_map(|(metric, value)| {
+          vec![externs::store_utf8(metric), externs::store_i64(value)]
+        })
         .collect::<Vec<_>>();
       externs::store_dict(&values).into()
     })

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -319,27 +319,28 @@ pub extern "C" fn scheduler_metrics(
         .flat_map(|(metric, value)| vec![externs::store_utf8(metric), externs::store_i64(value)])
         .collect::<Vec<_>>();
       let values_ref = &mut values;
-      let workunits_option = session.get_workunits();
-      if let &Some(ref workunits_mutex) = workunits_option {
-        let workunits = workunits_mutex.lock()
-            .iter()
-            .map(|workunit| {
-              let workunit_zipkin_trace_info = vec![
-                externs::store_utf8("name"),
-                externs::store_utf8(&workunit.name),
-                externs::store_utf8("start_timestamp"),
-                externs::store_f64(workunit.start_timestamp),
-                externs::store_utf8("end_timestamp"),
-                externs::store_f64(workunit.end_timestamp),
-                externs::store_utf8("span_id"),
-                externs::store_utf8(&workunit.span_id),
-              ];
-              externs::store_dict(&workunit_zipkin_trace_info)
-            })
-            .collect::<Vec<_>>();
+      if session.should_record_zipkin_spans() {
+        let workunits = &session
+          .get_workunits()
+          .lock()
+          .iter()
+          .map(|workunit| {
+            let workunit_zipkin_trace_info = vec![
+              externs::store_utf8("name"),
+              externs::store_utf8(&workunit.name),
+              externs::store_utf8("start_timestamp"),
+              externs::store_f64(workunit.start_timestamp),
+              externs::store_utf8("end_timestamp"),
+              externs::store_f64(workunit.end_timestamp),
+              externs::store_utf8("span_id"),
+              externs::store_utf8(&workunit.span_id),
+            ];
+            externs::store_dict(&workunit_zipkin_trace_info)
+          })
+          .collect::<Vec<_>>();
         values_ref.push(externs::store_utf8("engine_workunits"));
         values_ref.push(externs::store_tuple(&workunits));
-      }
+      };
       externs::store_dict(&values).into()
     })
   })

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -332,8 +332,8 @@ pub extern "C" fn scheduler_metrics(
       workunits.push(test_workunit);
       let workunits  = workunits.iter().map(|workunit| {
         let values = vec![externs::store_utf8("name"), externs::store_utf8(&workunit.name),
-          externs::store_utf8("start_timestamp"), externs::store_i64(workunit.start_timestamp as i64),
-          externs::store_utf8("end_timestamp"), externs::store_i64(workunit.end_timestamp as i64),
+          externs::store_utf8("start_timestamp"), externs::store_f64(workunit.start_timestamp),
+          externs::store_utf8("end_timestamp"), externs::store_f64(workunit.end_timestamp),
           externs::store_utf8("span_id"), externs::store_utf8(&workunit.span_id)];
         externs::store_dict(&values)
       }).collect::<Vec<_>>();

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -71,7 +71,6 @@ use fs::{GlobMatching, MemFS, PathStat};
 use futures::Future;
 use hashing::Digest;
 use log::error;
-use crate::scheduler::WorkUnit;
 
 // TODO: Consider renaming and making generic for collections of PyResults.
 #[repr(C)]
@@ -317,26 +316,25 @@ pub extern "C" fn scheduler_metrics(
       let mut values = scheduler
         .metrics(session)
         .into_iter()
-        .flat_map(|(metric, value)| {
-          vec![externs::store_utf8(metric), externs::store_i64(value)]
+        .flat_map(|(metric, value)| vec![externs::store_utf8(metric), externs::store_i64(value)])
+        .collect::<Vec<_>>();
+      let workunits = session.get_workunits().lock();
+      let workunits = workunits
+        .iter()
+        .map(|workunit| {
+          let values = vec![
+            externs::store_utf8("name"),
+            externs::store_utf8(&workunit.name),
+            externs::store_utf8("start_timestamp"),
+            externs::store_f64(workunit.start_timestamp),
+            externs::store_utf8("end_timestamp"),
+            externs::store_f64(workunit.end_timestamp),
+            externs::store_utf8("span_id"),
+            externs::store_utf8(&workunit.span_id),
+          ];
+          externs::store_dict(&values)
         })
         .collect::<Vec<_>>();
-      let mut workunits = session.workunits.lock();
-      let start_time = std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH).unwrap().as_secs() as f64;
-      let test_workunit = WorkUnit {
-        name: "test_workunit".to_string(),
-        start_timestamp: start_time,
-        end_timestamp: start_time + 1.0,
-        span_id: "2222222222222222".to_string(),
-      };
-      workunits.push(test_workunit);
-      let workunits  = workunits.iter().map(|workunit| {
-        let values = vec![externs::store_utf8("name"), externs::store_utf8(&workunit.name),
-          externs::store_utf8("start_timestamp"), externs::store_f64(workunit.start_timestamp),
-          externs::store_utf8("end_timestamp"), externs::store_f64(workunit.end_timestamp),
-          externs::store_utf8("span_id"), externs::store_utf8(&workunit.span_id)];
-        externs::store_dict(&values)
-      }).collect::<Vec<_>>();
       values.push(externs::store_utf8("engine_workunits"));
       values.push(externs::store_tuple(&workunits));
       externs::store_dict(&values).into()
@@ -551,12 +549,14 @@ pub extern "C" fn nodes_destroy(raw_nodes_ptr: *mut RawNodes) {
 #[no_mangle]
 pub extern "C" fn session_create(
   scheduler_ptr: *mut Scheduler,
+  should_record_zipkin_spans: bool,
   should_render_ui: bool,
   ui_worker_count: u64,
 ) -> *const Session {
   with_scheduler(scheduler_ptr, |scheduler| {
     Box::into_raw(Box::new(Session::new(
       scheduler,
+      should_record_zipkin_spans,
       should_render_ui,
       ui_worker_count as usize,
     )))

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -28,7 +28,6 @@ use fs::{
 use hashing;
 use process_execution::{self, CommandRunner};
 
-use crate::scheduler::WorkUnit;
 use graph::{Entry, Node, NodeError, NodeTracer, NodeVisualizer};
 
 pub type NodeFuture<T> = BoxFuture<T, Failure>;
@@ -1041,9 +1040,9 @@ impl Node for NodeKey {
 
   fn run(self, context: Context) -> NodeFuture<NodeResult> {
     let start_timestamp = std::time::SystemTime::now()
-      .duration_since(std::time::SystemTime::UNIX_EPOCH)
-      .unwrap()
-      .as_secs() as f64;
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as f64;
     let context2 = context.clone();
     match self {
       NodeKey::DigestFile(n) => n.run(context).map(|v| v.into()).to_boxed(),
@@ -1057,16 +1056,11 @@ impl Node for NodeKey {
     }
     .inspect(move |_: &NodeResult| {
       let end_timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs() as f64;
-      let workunit = WorkUnit {
-        name: "Node".to_string(),
-        start_timestamp: start_timestamp,
-        end_timestamp: end_timestamp,
-        span_id: "aaaaaaaaaaaaaaaa".to_string(),
-      };
-      context2.session.add_workunit(workunit);
+          .duration_since(std::time::SystemTime::UNIX_EPOCH)
+          .unwrap()
+          .as_secs() as f64;
+      let node_name = "Node".to_string();
+      context2.session.add_workunit(node_name, start_timestamp, end_timestamp);
     })
     .to_boxed()
   }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -15,7 +15,6 @@ use crate::nodes::{NodeKey, Select, Tracer, TryInto, Visualizer};
 use crate::selectors;
 use graph::{EntryId, Graph, InvalidationResult, NodeContext};
 use indexmap::IndexMap;
-use log::{debug, info, warn};
 use parking_lot::Mutex;
 use ui::EngineDisplay;
 

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -33,6 +33,15 @@ pub struct Session {
   roots: Mutex<HashSet<Root>>,
   // If enabled, the display that will render the progress of the V2 engine.
   display: Option<Mutex<EngineDisplay>>,
+  // A place to store info about workunits in rust part
+  pub workunits: Arc<Mutex<Vec<WorkUnit>>>,
+}
+
+pub struct WorkUnit {
+  pub name: String,
+  pub start_timestamp: f64,
+  pub end_timestamp: f64,
+  pub span_id: String,
 }
 
 impl Session {
@@ -41,6 +50,7 @@ impl Session {
       preceding_graph_size: scheduler.core.graph.len(),
       roots: Mutex::new(HashSet::new()),
       display: EngineDisplay::create(ui_worker_count, should_render_ui).map(Mutex::new),
+      workunits: Arc::new(Mutex::new(Vec::new()))
     }
   }
 

--- a/tests/python/pants_test/engine/scheduler_test_base.py
+++ b/tests/python/pants_test/engine/scheduler_test_base.py
@@ -63,7 +63,7 @@ class SchedulerTestBase(object):
                           union_rules,
                           DEFAULT_EXECUTION_OPTIONS,
                           include_trace_on_error=include_trace_on_error)
-    return scheduler.new_session()
+    return scheduler.new_session(zipkin_trace_v2=False)
 
   def context_with_scheduler(self, scheduler, *args, **kwargs):
     return self.context(*args, scheduler=scheduler, **kwargs)

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -214,27 +214,9 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
       self.scheduler.product_request(A, [Params(TypeCheckFailWrapper(A()))])
 
   def test_trace_includes_rule_exception_traceback(self):
-<<<<<<< Updated upstream
     # Execute a request that will trigger the nested raise, and then directly inspect its trace.
     request = self.scheduler.execution_request([A], [B()])
     self.scheduler.execute(request)
-=======
-    rules = [
-      RootRule(B),
-      nested_raise,
-    ]
-
-    scheduler = create_scheduler(rules)
-    request = scheduler._native.new_execution_request()
-    subject = B()
-    scheduler.add_root_selection(request, subject, A)
-    session = scheduler.new_session(zipkin_trace_v2=False)
-    scheduler._run_and_return_roots(session._session, request)
-
-    trace = '\n'.join(scheduler.graph_trace(request))
-    # NB removing location info to make trace repeatable
-    trace = remove_locations_from_traceback(trace)
->>>>>>> Stashed changes
 
     trace = remove_locations_from_traceback('\n'.join(self.scheduler.trace(request)))
     assert_equal_with_printing(self, dedent('''

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -214,9 +214,27 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
       self.scheduler.product_request(A, [Params(TypeCheckFailWrapper(A()))])
 
   def test_trace_includes_rule_exception_traceback(self):
+<<<<<<< Updated upstream
     # Execute a request that will trigger the nested raise, and then directly inspect its trace.
     request = self.scheduler.execution_request([A], [B()])
     self.scheduler.execute(request)
+=======
+    rules = [
+      RootRule(B),
+      nested_raise,
+    ]
+
+    scheduler = create_scheduler(rules)
+    request = scheduler._native.new_execution_request()
+    subject = B()
+    scheduler.add_root_selection(request, subject, A)
+    session = scheduler.new_session(zipkin_trace_v2=False)
+    scheduler._run_and_return_roots(session._session, request)
+
+    trace = '\n'.join(scheduler.graph_trace(request))
+    # NB removing location info to make trace repeatable
+    trace = remove_locations_from_traceback(trace)
+>>>>>>> Stashed changes
 
     trace = remove_locations_from_traceback('\n'.join(self.scheduler.trace(request)))
     assert_equal_with_printing(self, dedent('''

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -399,7 +399,7 @@ class TestBase(unittest.TestCase, AbstractClass):
       options_bootstrapper=OptionsBootstrapper.create(args=['--pants-config-files=[]']),
       build_configuration=cls.build_config(),
       build_ignore_patterns=None,
-    ).new_session()
+    ).new_session(zipkin_trace_v2=False)
     cls._scheduler = graph_session.scheduler_session
     cls._build_graph, cls._address_mapper = graph_session.create_build_graph(
         TargetRoots([]), cls._build_root()


### PR DESCRIPTION
*This PR is on top of #7342, and should be merged after that one, if we decide to adopt `tokio-trace`.*

### Problem

[`tokio-trace`](https://crates.rs/crates/tokio-trace-core) is a tracing framework for asynchronous rust programs (which does *not* depend on tokio!). The developer gave a talk describing what it is, how it works, and how it can be used: [a recording is here](https://www.youtube.com/watch?v=j_kXRg3zlec). The ability to define spans and events is analogous to distributed tracing systems such as zipkin, which is the subject of #7342. It's possible that adopting `tokio-trace` will make this process easier and more automatic -- for example (shown in the talk), a `.instrument()` futures combinator is available via `tokio-trace-futures` which will very concisely create a span around the execution of the future!

### Solution

One of `tokio-trace`'s features (via [`tokio-trace-log`](https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-log)) is being able to be dropped into rust programs using `log` without too many changes. A demo in the linked talk shows how logs can actually be converted into `tokio-trace` events by using a logger which emits these events.

This PR drops in `tokio-trace_log::LogTracer` to convert logs into trace events, which at this point are still just emitted as logs.

### Result

Nothing changes at all, but this enables tracing via `tokio-trace`.

### TODO

- [ ] Figure out where to put the `tokio-trace` subscriber.
- [ ] Demonstrate that `tokio-trace` can effectively integrate with the rest of our existing zipkin tracing (very exciting!).
- [ ] Demonstrate some usage of `tokio-trace` that provides value over `log`.