### PR TITLE
Explain in contributing doc that macOS users must brew install OpenSSL

### DIFF
--- a/src/docs/howto_contribute.md
+++ b/src/docs/howto_contribute.md
@@ -117,6 +117,16 @@ the `pantsbuild/pants` repo's master branch, use these commands:
     $ git fetch upstream
     $ git checkout master && git reset --hard upstream/master
 
+**Mac users:** Pants requires a more modern OpenSSL version than the one that comes with macOS.
+To get all dependencies to resolve correctly, run the following commands the first time you
+set up Pants.
+
+    :::bash
+    $ brew install openssl
+    $ echo 'export PATH="/usr/local/opt/openssl/bin:$PATH"' >> ~/.bashrc
+    $ echo 'export LDFLAGS="-L/usr/local/opt/openssl/lib"' >> ~/.bashrc
+    $ echo 'export CPPFLAGS="-I/usr/local/opt/openssl/include"' >> ~/.bashrc
+
 ### Making the Change
 
 You might want to familiarize yourself with the


### PR DESCRIPTION
### Problem
A few distinct times, Pants contributors have been hit with this error when trying to run on macOS, especially for the first time:

```
Exception message: Package SourcePackage(u'file:///Users/ekaterina/.cache/pants/python_cache/requirements/CPython-3.6.5/cryptography-2.6.1.tar.gz') is not translateable by ChainedTranslator(WheelTranslator, EggTranslator, SourceTranslator)
```

This error is because they do not have a modern version of OpenSSL installed, so Cryptography fails to find its dependency.

### Solution
Explain in the docs the workaround: brew install openssl and configure `.bashrc` to point to the new install.