### PR TITLE
add a non-numeric prefix before the unstable package version to avoid truncation

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -53,7 +53,10 @@ function run_local_pants() {
 readonly VERSION_FILE="${ROOT}/src/python/pants/VERSION"
 PANTS_STABLE_VERSION="$(cat "${VERSION_FILE}")"
 HEAD_SHA=$(git rev-parse --verify HEAD)
-readonly PANTS_UNSTABLE_VERSION="${PANTS_STABLE_VERSION}+${HEAD_SHA:0:8}"
+# We add a non-numeric prefix 'git' before the sha in order to avoid a hex sha which happens to
+# contain only [0-9] being parsed as a number -- see #7399.
+# TODO(#7399): mix in the timestamp before the sha instead of 'git' to get monotonic ordering!
+readonly PANTS_UNSTABLE_VERSION="${PANTS_STABLE_VERSION}+git${HEAD_SHA:0:8}"
 
 readonly DEPLOY_DIR="${ROOT}/dist/deploy"
 readonly DEPLOY_3RDPARTY_WHEELS_PATH="wheels/3rdparty/${HEAD_SHA}"
@@ -123,7 +126,7 @@ function pkg_pants_install_test() {
   execute_packaged_pants_with_internal_backends list src:: || \
     die "'pants list src::' failed in venv!"
   [[ "$(execute_packaged_pants_with_internal_backends --version 2>/dev/null)" \
-     == "${version}" ]] || die "Installed version of pants does match requested version!"
+     == "${version}" ]] || die "Installed version of pants does not match requested version!"
 }
 
 function pkg_testinfra_install_test() {


### PR DESCRIPTION
### Problem

See #7399. The commit 067238335e8bbe2dacbe6442548dd4ee5a0782df experienced CI failures, because our current method of generating the "unstable" pants version to build wheels puts the hexadecimal sha as its own version component: if the sha happens to be completely numeric and begins with any zeroes, `packaging.version.Version()` will helpfully truncate it -- but our `release.sh` script wasn't aware of that.

### Solution

- Add a non-numeric prefix before the sha to generate `PANTS_UNSTABLE_VERSION` in `release.sh` to avoid possible truncation.
  - The prefix chosen was `git`.

### Result

Commit shas starting with zero and containing only numbers for the first 8 characters will no longer fail in CI.