### PR TITLE
Simplify glob matching and directly match in-memory globs as Patterns.

### DIFF
--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -10,12 +10,13 @@ use boxfuture::{BoxFuture, Boxable};
 use futures::future;
 use futures::Future;
 use glob::Pattern;
-use indexmap::{map::Entry::Occupied, IndexMap, IndexSet};
+use indexmap::IndexSet;
 use log::warn;
+use parking_lot::Mutex;
 
 use crate::{
-  Dir, GitignoreStyleExcludes, GlobExpansionConjunction, GlobParsedSource, GlobSource,
-  GlobWithSource, Link, PathGlob, PathGlobs, PathStat, Stat, VFS,
+  Dir, GitignoreStyleExcludes, GlobExpansionConjunction, Link, PathGlob, PathGlobs, PathStat, Stat,
+  VFS,
 };
 
 pub trait GlobMatching<E: Display + Send + Sync + 'static>: VFS<E> {
@@ -40,39 +41,6 @@ pub trait GlobMatching<E: Display + Send + Sync + 'static>: VFS<E> {
 }
 
 impl<E: Display + Send + Sync + 'static, T: VFS<E>> GlobMatching<E> for T {}
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-enum GlobMatch {
-  SuccessfullyMatchedSomeFiles,
-  DidNotMatchAnyFiles,
-}
-
-#[derive(Debug)]
-struct GlobExpansionCacheEntry {
-  globs: Vec<PathGlob>,
-  matched: GlobMatch,
-  sources: Vec<GlobSource>,
-}
-
-#[derive(Debug)]
-struct SingleExpansionResult {
-  sourced_glob: GlobWithSource,
-  path_stats: Vec<PathStat>,
-  globs: Vec<PathGlob>,
-}
-
-#[derive(Debug)]
-struct PathGlobsExpansion<T: Sized> {
-  context: T,
-  // Globs that have yet to be expanded, in order.
-  todo: Vec<GlobWithSource>,
-  // Paths to exclude.
-  exclude: Arc<GitignoreStyleExcludes>,
-  // Globs that have already been expanded.
-  completed: IndexMap<PathGlob, GlobExpansionCacheEntry>,
-  // Unique Paths that have been matched, in order.
-  outputs: IndexSet<PathStat>,
-}
 
 // NB: This trait exists because `expand_single()` (and its return type) should be private, but
 // traits don't allow specifying private methods (and we don't want to use a top-level `fn` because
@@ -157,246 +125,171 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
       return future::ok(vec![]).to_boxed();
     }
 
-    let init = PathGlobsExpansion {
-      context: self.clone(),
-      todo: include
-        .iter()
-        .flat_map(|entry| entry.to_sourced_globs())
-        .collect(),
-      exclude,
-      completed: IndexMap::default(),
-      outputs: IndexSet::default(),
-    };
-    future::loop_fn(init, |mut expansion| {
-      // Request the expansion of all outstanding PathGlobs as a batch.
-      let round = future::join_all({
-        let exclude = &expansion.exclude;
-        let context = &expansion.context;
-        expansion
-          .todo
-          .drain(..)
-          .map(|sourced_glob| context.expand_single(sourced_glob, exclude))
-          .collect::<Vec<_>>()
-      });
-      round.map(move |single_expansion_results| {
-        // Collect distinct new PathStats and PathGlobs
-        for exp in single_expansion_results {
-          let SingleExpansionResult {
-            sourced_glob: GlobWithSource { path_glob, source },
-            path_stats,
-            globs,
-          } = exp;
+    let result = Arc::new(Mutex::new(IndexSet::default()));
 
-          expansion.outputs.extend(path_stats.clone());
+    let mut sources = Vec::new();
+    let mut roots = Vec::new();
+    for pgie in include {
+      let source = Arc::new(pgie.input);
+      for path_glob in pgie.globs {
+        sources.push(source.clone());
+        roots.push(self.expand_single(result.clone(), exclude.clone(), path_glob));
+      }
+    }
 
-          expansion
-            .completed
-            .entry(path_glob.clone())
-            .or_insert_with(|| GlobExpansionCacheEntry {
-              globs: globs.clone(),
-              matched: if path_stats.is_empty() {
-                GlobMatch::DidNotMatchAnyFiles
-              } else {
-                GlobMatch::SuccessfullyMatchedSomeFiles
+    future::join_all(roots)
+      .and_then(move |matched| {
+        if strict_match_behavior.should_check_glob_matches() {
+          // Get all the inputs which didn't transitively expand to any files.
+          let matching_inputs = sources
+            .iter()
+            .zip(matched.into_iter())
+            .filter_map(
+              |(source, matched)| {
+                if matched {
+                  Some(source.clone())
+                } else {
+                  None
+                }
               },
-              sources: vec![],
-            })
-            .sources
-            .push(source);
+            )
+            .collect::<HashSet<_>>();
 
-          // Do we need to worry about cloning for all these `GlobSource`s (each containing a
-          // `PathGlob`)?
-          let source_for_children = GlobSource::ParentGlob(path_glob);
-          for child_glob in globs {
-            if let Occupied(mut entry) = expansion.completed.entry(child_glob.clone()) {
-              entry.get_mut().sources.push(source_for_children.clone());
+          let non_matching_inputs = sources
+            .into_iter()
+            .filter(|s| !matching_inputs.contains(s))
+            .collect::<HashSet<_>>();
+
+          let match_failed = match conjunction {
+            // All must match.
+            GlobExpansionConjunction::AllMatch => !non_matching_inputs.is_empty(),
+            // Only one needs to match.
+            GlobExpansionConjunction::AnyMatch => matching_inputs.is_empty(),
+          };
+
+          if match_failed {
+            // TODO(#5684): explain what global and/or target-specific option to set to
+            // modify this behavior!
+            let mut non_matching_inputs = non_matching_inputs
+              .iter()
+              .map(|parsed_source| parsed_source.0.clone())
+              .collect::<Vec<_>>();
+            non_matching_inputs.sort();
+            let msg = format!(
+              "Globs did not match. Excludes were: {:?}. Unmatched globs were: {:?}.",
+              exclude.exclude_patterns(),
+              non_matching_inputs,
+            );
+            if strict_match_behavior.should_throw_on_error() {
+              return future::err(Self::mk_error(&msg));
             } else {
-              expansion.todo.push(GlobWithSource {
-                path_glob: child_glob,
-                source: source_for_children.clone(),
-              });
+              // TODO(#5683): this doesn't have any useful context (the stack trace) without
+              // being thrown -- this needs to be provided, otherwise this is far less useful.
+              warn!("{}", msg);
             }
           }
         }
 
-        // If there were any new PathGlobs, continue the expansion.
-        if expansion.todo.is_empty() {
-          future::Loop::Break(expansion)
-        } else {
-          future::Loop::Continue(expansion)
-        }
+        future::ok(
+          Arc::try_unwrap(result)
+            .unwrap_or_else(|_| panic!("expand violated its contract."))
+            .into_inner()
+            .into_iter()
+            .collect::<Vec<_>>(),
+        )
       })
-    })
-    .and_then(move |final_expansion| {
-      // Finally, capture the resulting PathStats from the expansion.
-      let PathGlobsExpansion {
-        outputs,
-        mut completed,
-        exclude,
-        ..
-      } = final_expansion;
-
-      let match_results: Vec<_> = outputs.into_iter().collect();
-
-      if strict_match_behavior.should_check_glob_matches() {
-        // Each `GlobExpansionCacheEntry` stored in `completed` for some `PathGlob` has the field
-        // `matched` to denote whether that specific `PathGlob` matched any files. We propagate a
-        // positive `matched` condition to all transitive "parents" of any glob which expands to
-        // some non-empty set of `PathStat`s. The `sources` field contains the parents (see the enum
-        // `GlobSource`), which may be another glob, or it might be a `GlobParsedSource`. We record
-        // all `GlobParsedSource` inputs which transitively expanded to some file here, and below we
-        // warn or error if some of the inputs were not found.
-        let mut inputs_with_matches: HashSet<GlobParsedSource> = HashSet::new();
-
-        // `completed` is an IndexMap, and we immediately insert every glob we expand into
-        // `completed`, recording any `PathStat`s and `PathGlob`s it expanded to (and then expanding
-        // those child globs in the next iteration of the loop_fn). If we iterate in
-        // reverse order of expansion (using .rev()), we ensure that we have already visited every
-        // "child" glob of the glob we are operating on while iterating. This is a reverse
-        // "topological ordering" which preserves the partial order from parent to child globs.
-        let all_globs: Vec<PathGlob> = completed.keys().rev().cloned().collect();
-        for cur_glob in all_globs {
-          // Note that we talk of "parents" and "childen", but this structure is actually a DAG,
-          // because different `DirWildcard`s can potentially expand (transitively) to the same
-          // intermediate glob. The "parents" of each glob are stored in the `sources` field of its
-          // `GlobExpansionCacheEntry` (which is mutably updated with any new parents on each
-          // iteration of the loop_fn above). This can be considered "amortized" and/or "memoized",
-          // because we only traverse every parent -> child link once.
-          let new_matched_source_globs = match completed.get(&cur_glob).unwrap() {
-            &GlobExpansionCacheEntry {
-              ref matched,
-              ref sources,
-              ..
-            } => match matched {
-              // Neither this glob, nor any of its children, expanded to any `PathStat`s, so we have
-              // nothing to propagate.
-              &GlobMatch::DidNotMatchAnyFiles => vec![],
-              &GlobMatch::SuccessfullyMatchedSomeFiles => sources
-                .iter()
-                .filter_map(|src| match src {
-                  // This glob matched some files, so its parent also matched some files.
-                  &GlobSource::ParentGlob(ref path_glob) => Some(path_glob.clone()),
-                  // We've found one of the root inputs, coming from a glob which transitively
-                  // matched some child -- record it (this may already exist in the set).
-                  &GlobSource::ParsedInput(ref parsed_source) => {
-                    inputs_with_matches.insert(parsed_source.clone());
-                    None
-                  }
-                })
-                .collect(),
-            },
-          };
-          new_matched_source_globs.into_iter().for_each(|path_glob| {
-            // Overwrite whatever was in there before -- we now know these globs transitively
-            // expanded to some non-empty set of `PathStat`s.
-            let entry = completed.get_mut(&path_glob).unwrap();
-            entry.matched = GlobMatch::SuccessfullyMatchedSomeFiles;
-          });
-        }
-
-        // Get all the inputs which didn't transitively expand to any files.
-        let non_matching_inputs: Vec<GlobParsedSource> = include
-          .clone()
-          .into_iter()
-          .map(|entry| entry.input)
-          .filter(|parsed_source| !inputs_with_matches.contains(parsed_source))
-          .collect();
-
-        let match_failed = match conjunction {
-          // All must match.
-          GlobExpansionConjunction::AllMatch => !non_matching_inputs.is_empty(),
-          // Only one needs to match.
-          GlobExpansionConjunction::AnyMatch => include.len() <= non_matching_inputs.len(),
-        };
-
-        if match_failed {
-          // TODO(#5684): explain what global and/or target-specific option to set to
-          // modify this behavior!
-          let msg = format!(
-            "Globs did not match. Excludes were: {:?}. Unmatched globs were: {:?}.",
-            exclude.exclude_patterns(),
-            non_matching_inputs
-              .iter()
-              .map(|parsed_source| parsed_source.0.clone())
-              .collect::<Vec<_>>(),
-          );
-          if strict_match_behavior.should_throw_on_error() {
-            return future::err(Self::mk_error(&msg));
-          } else {
-            // TODO(#5683): this doesn't have any useful context (the stack trace) without
-            // being thrown -- this needs to be provided, otherwise this is far less useful.
-            warn!("{}", msg);
-          }
-        }
-      }
-
-      future::ok(match_results)
-    })
-    .to_boxed()
+      .to_boxed()
   }
 
-  ///
-  /// Apply a PathGlob, returning PathStats and additional PathGlobs that are needed for the
-  /// expansion.
-  ///
   fn expand_single(
     &self,
-    sourced_glob: GlobWithSource,
-    exclude: &Arc<GitignoreStyleExcludes>,
-  ) -> BoxFuture<SingleExpansionResult, E> {
-    match sourced_glob.path_glob.clone() {
+    result: Arc<Mutex<IndexSet<PathStat>>>,
+    exclude: Arc<GitignoreStyleExcludes>,
+    path_glob: PathGlob,
+  ) -> BoxFuture<bool, E> {
+    match path_glob {
       PathGlob::Wildcard {
         canonical_dir,
         symbolic_path,
         wildcard,
-      } =>
-      // Filter directory listing to return PathStats, with no continuation.
-      {
-        self
-          .directory_listing(canonical_dir, symbolic_path, wildcard, exclude)
-          .map(move |path_stats| SingleExpansionResult {
-            sourced_glob,
-            path_stats,
-            globs: vec![],
-          })
-          .to_boxed()
-      }
+      } => self.expand_wildcard(
+        result.clone(),
+        exclude.clone(),
+        canonical_dir,
+        symbolic_path,
+        wildcard,
+      ),
       PathGlob::DirWildcard {
         canonical_dir,
         symbolic_path,
         wildcard,
         remainder,
-      } =>
-      // Filter directory listing and request additional PathGlobs for matched Dirs.
-      {
-        self
-          .directory_listing(canonical_dir, symbolic_path, wildcard, exclude)
-          .and_then(move |path_stats| {
-            path_stats
-              .into_iter()
-              .filter_map(|ps| match ps {
-                PathStat::Dir { path, stat } => Some(
-                  PathGlob::parse_globs(stat, path, &remainder)
-                    .map_err(|e| Self::mk_error(e.as_str())),
-                ),
-                PathStat::File { .. } => None,
-              })
-              .collect::<Result<Vec<_>, E>>()
-          })
-          .map(move |path_globs| {
-            let flattened = path_globs
-              .into_iter()
-              .flat_map(|path_globs| path_globs.into_iter())
-              .collect();
-            SingleExpansionResult {
-              sourced_glob,
-              path_stats: vec![],
-              globs: flattened,
-            }
-          })
-          .to_boxed()
-      }
+      } => self.expand_dir_wildcard(
+        result.clone(),
+        exclude.clone(),
+        canonical_dir,
+        symbolic_path,
+        wildcard,
+        remainder,
+      ),
     }
+  }
+
+  fn expand_wildcard(
+    &self,
+    result: Arc<Mutex<IndexSet<PathStat>>>,
+    exclude: Arc<GitignoreStyleExcludes>,
+    canonical_dir: Dir,
+    symbolic_path: PathBuf,
+    wildcard: Pattern,
+  ) -> BoxFuture<bool, E> {
+    // Filter directory listing to append PathStats, with no continuation.
+    self
+      .directory_listing(canonical_dir, symbolic_path, wildcard, &exclude)
+      .map(move |path_stats| {
+        let mut result = result.lock();
+        let matched = !path_stats.is_empty();
+        result.extend(path_stats);
+        matched
+      })
+      .to_boxed()
+  }
+
+  fn expand_dir_wildcard(
+    &self,
+    result: Arc<Mutex<IndexSet<PathStat>>>,
+    exclude: Arc<GitignoreStyleExcludes>,
+    canonical_dir: Dir,
+    symbolic_path: PathBuf,
+    wildcard: Pattern,
+    remainder: Vec<Pattern>,
+  ) -> BoxFuture<bool, E> {
+    // Filter directory listing and recurse for matched Dirs.
+    let context = self.clone();
+    self
+      .directory_listing(canonical_dir, symbolic_path, wildcard, &exclude)
+      .and_then(move |path_stats| {
+        path_stats
+          .into_iter()
+          .filter_map(|ps| match ps {
+            PathStat::Dir { path, stat } => Some(
+              PathGlob::parse_globs(stat, path, &remainder).map_err(|e| Self::mk_error(e.as_str())),
+            ),
+            PathStat::File { .. } => None,
+          })
+          .collect::<Result<Vec<_>, E>>()
+      })
+      .and_then(move |path_globs| {
+        let child_globs = path_globs
+          .into_iter()
+          .flat_map(|path_globs| path_globs.into_iter())
+          .map(|pg| context.expand_single(result.clone(), exclude.clone(), pg))
+          .collect::<Vec<_>>();
+        future::join_all(child_globs)
+          .map(|child_matches| child_matches.into_iter().any(|m| m))
+          .to_boxed()
+      })
+      .to_boxed()
   }
 
   fn canonicalize(&self, symbolic_path: PathBuf, link: Link) -> BoxFuture<Option<PathStat>, E> {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -513,9 +513,10 @@ impl PathGlobs {
   /// Matches these PathGlobs against the given paths.
   ///
   /// NB: This implementation is independent from GlobMatchingImplementation::expand, and must be
-  /// kept in sync via unit tests in order to allow for owners detection of deleted files (see
-  /// #6790 and #5636 for more info). The lazy filesystem traversal in expand is (currently) too
-  /// expensive to use for that in-memory matching (such as via MemFS).
+  /// kept in sync via unit tests (in particular: the python FilespecTest) in order to allow for
+  /// owners detection of deleted files (see #6790 and #5636 for more info). The lazy filesystem
+  /// traversal in expand is (currently) too expensive to use for that in-memory matching (such as
+  /// via MemFS).
   ///
   pub fn matches(&self, paths: &[PathBuf]) -> Result<bool, String> {
     let patterns = self

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -217,20 +217,6 @@ pub struct PathGlobIncludeEntry {
   pub globs: Vec<PathGlob>,
 }
 
-impl PathGlobIncludeEntry {
-  fn to_sourced_globs(&self) -> Vec<GlobWithSource> {
-    self
-      .globs
-      .clone()
-      .into_iter()
-      .map(|path_glob| GlobWithSource {
-        path_glob,
-        source: GlobSource::ParsedInput(self.input.clone()),
-      })
-      .collect()
-  }
-}
-
 impl PathGlob {
   fn wildcard(canonical_dir: Dir, symbolic_path: PathBuf, wildcard: Pattern) -> PathGlob {
     PathGlob::Wildcard {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -40,10 +40,10 @@ pub use crate::pool::ResettablePool;
 pub use serverset::BackoffConfig;
 
 use std::cmp::min;
-use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::io::{self, Read};
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Component, Components, Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::{fmt, fs};
 
@@ -51,7 +51,7 @@ use ::ignore::gitignore::{Gitignore, GitignoreBuilder};
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
 use futures::future::{self, Future};
-use glob::Pattern;
+use glob::{MatchOptions, Pattern};
 use lazy_static::lazy_static;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -70,11 +70,11 @@ impl Stat {
     }
   }
 
-  fn dir(path: PathBuf) -> Stat {
+  pub fn dir(path: PathBuf) -> Stat {
     Stat::Dir(Dir(path))
   }
 
-  fn file(path: PathBuf, is_executable: bool) -> Stat {
+  pub fn file(path: PathBuf, is_executable: bool) -> Stat {
     Stat::File(File {
       path,
       is_executable,
@@ -174,7 +174,11 @@ impl GitignoreStyleExcludes {
       &Stat::Dir(_) => true,
       _ => false,
     };
-    match self.gitignore.matched(stat.path(), is_dir) {
+    self.is_ignored_path(stat.path(), is_dir)
+  }
+
+  fn is_ignored_path(&self, path: &Path, is_dir: bool) -> bool {
+    match self.gitignore.matched(path, is_dir) {
       ::ignore::Match::None | ::ignore::Match::Whitelist(_) => false,
       ::ignore::Match::Ignore(_) => true,
     }
@@ -191,6 +195,10 @@ lazy_static! {
     gitignore: Gitignore::empty(),
   });
   static ref MISSING_GLOB_SOURCE: GlobParsedSource = GlobParsedSource(String::from(""));
+  static ref PATTERN_MATCH_OPTIONS: MatchOptions = MatchOptions {
+    require_literal_separator: true,
+    ..MatchOptions::default()
+  };
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -266,21 +274,16 @@ impl PathGlob {
   }
 
   ///
-  /// Given a filespec String relative to a canonical Dir and path, split it into path components
-  /// while eliminating consecutive '**'s (to avoid repetitive traversing), and parse it to a
-  /// series of PathGlob objects.
+  /// Normalize the given glob pattern string by splitting it into path components, and dropping
+  /// references to the current directory, and consecutive '**'s.
   ///
-  fn parse(
-    canonical_dir: Dir,
-    symbolic_path: PathBuf,
-    filespec: &str,
-  ) -> Result<Vec<PathGlob>, String> {
+  fn normalize_pattern(pattern: &str) -> Result<Vec<&OsStr>, String> {
     let mut parts = Vec::new();
     let mut prev_was_doublestar = false;
-    for component in Path::new(filespec).components() {
+    for component in Path::new(pattern).components() {
       let part = match component {
         Component::Prefix(..) | Component::RootDir => {
-          return Err(format!("Absolute paths not supported: {:?}", filespec));
+          return Err(format!("Absolute paths not supported: {:?}", pattern));
         }
         Component::CurDir => continue,
         c => c.as_os_str(),
@@ -293,13 +296,29 @@ impl PathGlob {
       }
       prev_was_doublestar = cur_is_doublestar;
 
-      // NB: Because the filespec is a String input, calls to `to_str_lossy` are not lossy; the
-      // use of `Path` is strictly for os-independent Path parsing.
-      parts.push(
-        Pattern::new(&part.to_string_lossy())
-          .map_err(|e| format!("Could not parse {:?} as a glob: {:?}", filespec, e))?,
-      );
+      parts.push(part);
     }
+    Ok(parts)
+  }
+
+  ///
+  /// Given a filespec String relative to a canonical Dir and path, parse it to a normalized
+  /// series of PathGlob objects.
+  ///
+  fn parse(
+    canonical_dir: Dir,
+    symbolic_path: PathBuf,
+    filespec: &str,
+  ) -> Result<Vec<PathGlob>, String> {
+    // NB: Because the filespec is a String input, calls to `to_str_lossy` are not lossy; the
+    // use of `Path` is strictly for os-independent Path parsing.
+    let parts = Self::normalize_pattern(filespec)?
+      .into_iter()
+      .map(|part| {
+        Pattern::new(&part.to_string_lossy())
+          .map_err(|e| format!("Could not parse {:?} as a glob: {:?}", filespec, e))
+      })
+      .collect::<Result<Vec<_>, _>>()?;
 
     PathGlob::parse_globs(canonical_dir, symbolic_path, &parts)
   }
@@ -488,6 +507,36 @@ impl PathGlobs {
       StrictGlobMatching::Ignore,
       GlobExpansionConjunction::AllMatch,
     )
+  }
+
+  ///
+  /// Matches these PathGlobs against the given paths.
+  ///
+  /// NB: This implementation is independent from VFS::expand, and must be kept in sync via unit
+  /// tests. The lazy filesystem traversal in VFS::expand is (currently) too expensive to use for
+  /// in-memory matching (such as via MemFS).
+  ///
+  pub fn matches(&self, paths: &[PathBuf]) -> Result<bool, String> {
+    let patterns = self
+      .include
+      .iter()
+      .map(|pattern| {
+        PathGlob::normalize_pattern(&pattern.input.0).and_then(|components| {
+          let mut normalized_pattern = PathBuf::new();
+          for component in components {
+            normalized_pattern.push(component);
+          }
+          Pattern::new(normalized_pattern.to_str().unwrap())
+            .map_err(|e| format!("Could not parse {:?} as a glob: {:?}", pattern.input.0, e))
+        })
+      })
+      .collect::<Result<Vec<_>, String>>()?;
+    Ok(patterns.iter().any(|pattern| {
+      paths.iter().any(|path| {
+        pattern.matches_path_with(path, &PATTERN_MATCH_OPTIONS)
+          && !self.exclude.is_ignored_path(path, false)
+      })
+    }))
   }
 }
 
@@ -759,81 +808,6 @@ impl PathStatGetter<io::Error> for Arc<PosixFS> {
 }
 
 ///
-/// An in-memory implementation of VFS, useful for precisely reproducing glob matching behavior for
-/// a set of file paths.
-///
-pub struct MemFS {
-  contents: HashMap<Dir, Arc<DirectoryListing>>,
-}
-
-impl MemFS {
-  pub fn new(paths: Vec<PathBuf>) -> MemFS {
-    let mut unordered_contents = HashMap::new();
-    let empty_path = PathBuf::new();
-    for path in paths {
-      Self::add_path(&mut unordered_contents, &empty_path, path.components());
-    }
-    let contents = unordered_contents
-      .into_iter()
-      .map(|(dir, mut stats)| {
-        stats.sort_by(|a, b| a.path().cmp(b.path()));
-        (dir, Arc::new(DirectoryListing(stats)))
-      })
-      .collect();
-    MemFS { contents }
-  }
-
-  fn add_path(
-    contents: &mut HashMap<Dir, Vec<Stat>>,
-    path_so_far: &Path,
-    mut remainder: Components,
-  ) -> bool {
-    if let Some(component) = remainder.next() {
-      // The component represents a directory if it has child components: otherwise, a file.
-      let path = path_so_far.join(component);
-      let stat = if Self::add_path(contents, &path, remainder) {
-        Stat::dir(path)
-      } else {
-        Stat::file(path, false)
-      };
-      contents
-        .entry(Dir(path_so_far.to_owned()))
-        .or_insert_with(Vec::new)
-        .push(stat);
-      true
-    } else {
-      false
-    }
-  }
-}
-
-impl VFS<String> for Arc<MemFS> {
-  fn read_link(&self, link: &Link) -> BoxFuture<PathBuf, String> {
-    // The creation of a static filesystem does not allow for Links.
-    future::err(format!("{:?} does not exist within this filesystem.", link)).to_boxed()
-  }
-
-  fn scandir(&self, dir: Dir) -> BoxFuture<Arc<DirectoryListing>, String> {
-    future::result(
-      self
-        .contents
-        .get(&dir)
-        .cloned()
-        .ok_or_else(|| format!("{:?} does not exist within this filesystem.", dir)),
-    )
-    .to_boxed()
-  }
-
-  fn is_ignored(&self, _stat: &Stat) -> bool {
-    false
-  }
-
-  fn mk_error(msg: &str) -> String {
-    msg.to_owned()
-  }
-}
-
-///
 /// A context for filesystem operations parameterized on an error type 'E'.
 ///
 pub trait VFS<E: Send + Sync + 'static>: Clone + Send + Sync + 'static {
@@ -898,12 +872,13 @@ mod posixfs_test {
   use testutil;
 
   use super::{
-    Dir, DirectoryListing, File, GlobExpansionConjunction, GlobMatching, Link, MemFS, PathGlobs,
-    PathStat, PathStatGetter, PosixFS, ResettablePool, Stat, StrictGlobMatching,
+    Dir, DirectoryListing, File, GlobExpansionConjunction, GlobMatching, Link, PathGlobs, PathStat,
+    PathStatGetter, PosixFS, ResettablePool, Stat, StrictGlobMatching,
   };
   use futures::Future;
   use std;
-  use std::path::{Path, PathBuf};
+  use std::collections::HashMap;
+  use std::path::{Components, Path, PathBuf};
   use std::sync::Arc;
   use testutil::make_file;
 
@@ -1232,5 +1207,80 @@ mod posixfs_test {
       &[],
     )
     .unwrap()
+  }
+
+  ///
+  /// An in-memory implementation of VFS, useful for precisely reproducing glob matching behavior for
+  /// a set of file paths.
+  ///
+  pub struct MemFS {
+    contents: HashMap<Dir, Arc<DirectoryListing>>,
+  }
+
+  impl MemFS {
+    pub fn new(paths: Vec<PathBuf>) -> MemFS {
+      let mut unordered_contents = HashMap::new();
+      let empty_path = PathBuf::new();
+      for path in paths {
+        Self::add_path(&mut unordered_contents, &empty_path, path.components());
+      }
+      let contents = unordered_contents
+        .into_iter()
+        .map(|(dir, mut stats)| {
+          stats.sort_by(|a, b| a.path().cmp(b.path()));
+          (dir, Arc::new(DirectoryListing(stats)))
+        })
+        .collect();
+      MemFS { contents }
+    }
+
+    fn add_path(
+      contents: &mut HashMap<Dir, Vec<Stat>>,
+      path_so_far: &Path,
+      mut remainder: Components,
+    ) -> bool {
+      if let Some(component) = remainder.next() {
+        // The component represents a directory if it has child components: otherwise, a file.
+        let path = path_so_far.join(component);
+        let stat = if Self::add_path(contents, &path, remainder) {
+          Stat::dir(path)
+        } else {
+          Stat::file(path, false)
+        };
+        contents
+          .entry(Dir(path_so_far.to_owned()))
+          .or_insert_with(Vec::new)
+          .push(stat);
+        true
+      } else {
+        false
+      }
+    }
+  }
+
+  impl VFS<String> for Arc<MemFS> {
+    fn read_link(&self, link: &Link) -> BoxFuture<PathBuf, String> {
+      // The creation of a static filesystem does not allow for Links.
+      future::err(format!("{:?} does not exist within this filesystem.", link)).to_boxed()
+    }
+
+    fn scandir(&self, dir: Dir) -> BoxFuture<Arc<DirectoryListing>, String> {
+      future::result(
+        self
+          .contents
+          .get(&dir)
+          .cloned()
+          .ok_or_else(|| format!("{:?} does not exist within this filesystem.", dir)),
+      )
+      .to_boxed()
+    }
+
+    fn is_ignored(&self, _stat: &Stat) -> bool {
+      false
+    }
+
+    fn mk_error(msg: &str) -> String {
+      msg.to_owned()
+    }
   }
 }

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -50,7 +50,6 @@ use std::mem;
 use std::os::raw;
 use std::panic;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Duration;
 
 use crate::context::Core;
@@ -67,7 +66,6 @@ use crate::rule_graph::{GraphMaker, RuleGraph};
 use crate::scheduler::{ExecutionRequest, RootResult, Scheduler, Session};
 use crate::tasks::Tasks;
 use crate::types::Types;
-use fs::{GlobMatching, MemFS, PathStat};
 use futures::Future;
 use hashing::Digest;
 use log::error;
@@ -657,24 +655,12 @@ pub extern "C" fn match_path_globs(path_globs: Handle, paths_buf: BufferBuffer) 
     }
   };
 
-  let static_fs = Arc::new(MemFS::new(
-    paths_buf
-      .to_os_strings()
-      .into_iter()
-      .map(PathBuf::from)
-      .collect(),
-  ));
-
-  static_fs
-    .expand(path_globs)
-    .wait()
-    .map(|path_stats| {
-      externs::store_bool(path_stats.iter().any(|p| match p {
-        PathStat::File { .. } => true,
-        PathStat::Dir { .. } => false,
-      }))
-    })
-    .into()
+  let paths = paths_buf
+    .to_os_strings()
+    .into_iter()
+    .map(PathBuf::from)
+    .collect::<Vec<_>>();
+  path_globs.matches(&paths).map(externs::store_bool).into()
 }
 
 #[no_mangle]

--- a/tests/python/pants_test/engine/legacy/test_graph_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_graph_integration.py
@@ -23,9 +23,9 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
     'missing-rglobs': ("rglobs('*.a')", ['**/*.a']),
     'missing-zglobs': ("zglobs('**/*.a')", ['**/*.a']),
     'missing-literal-files': (
-      "['nonexistent_test_file.txt', 'another_nonexistent_file.txt']", [
-      'nonexistent_test_file.txt',
+      "['another_nonexistent_file.txt', 'nonexistent_test_file.txt']", [
       'another_nonexistent_file.txt',
+      'nonexistent_test_file.txt',
     ]),
   }
 

--- a/tests/python/pants_test/source/BUILD
+++ b/tests/python/pants_test/source/BUILD
@@ -6,6 +6,7 @@ python_tests(
   sources = ['test_filespec.py'],
   dependencies = [
     'src/python/pants/source',
+    'tests/python/pants_test:test_base',
   ]
 )
 

--- a/tests/python/pants_test/source/test_filespec.py
+++ b/tests/python/pants_test/source/test_filespec.py
@@ -4,23 +4,38 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import unittest
-
+from pants.engine.fs import PathGlobs, Snapshot
 from pants.source.filespec import matches_filespec
+from pants_test.test_base import TestBase
 
 
-class FilespecTest(unittest.TestCase):
+class FilespecTest(TestBase):
   def assert_rule_match(self, glob, expected_matches, negate=False):
+    """Tests that in-memory glob matching matches lazy-filesystem traversing globs."""
     if negate:
-      asserter, match_state = self.assertFalse, 'erroneously matches'
+      assertMatch, match_state = self.assertFalse, 'erroneously matches'
     else:
-      asserter, match_state = self.assertTrue, "doesn't match"
+      assertMatch, match_state = self.assertTrue, "doesn't match"
 
+    # Confirm in-memory behaviour.
     for expected in expected_matches:
-      asserter(
+      assertMatch(
           matches_filespec(expected, {'globs': [glob]}),
           '{} {} path `{}`'.format(glob, match_state, expected),
       )
+
+    # And confirm that it matches on-disk behaviour.
+    for expected in expected_matches:
+      if expected.endswith('/'):
+        self.create_dir(expected)
+      else:
+        self.create_file(expected)
+    snapshot, = self.scheduler.product_request(Snapshot, [PathGlobs([glob])])
+    if negate:
+      subset = set(expected_matches).intersection(set(snapshot.files))
+      self.assertEquals(subset, set(), '{} {} path(s) {}'.format(glob, match_state, subset))
+    else:
+      self.assertEquals(sorted(expected_matches), sorted(snapshot.files))
 
   def test_matches_single_star_0(self):
     self.assert_rule_match('a/b/*/f.py', ('a/b/c/f.py', 'a/b/q/f.py'))
@@ -47,19 +62,19 @@ class FilespecTest(unittest.TestCase):
     self.assert_rule_match('foo*/bar', ('foofighters/baz/bar',), negate=True)
 
   def test_matches_double_star_0(self):
-    self.assert_rule_match('**', ('a/b/c', 'a'))
+    self.assert_rule_match('**', ('a/b/c', 'b'))
 
   def test_matches_double_star_1(self):
     self.assert_rule_match('a/**/f', ('a/f', 'a/b/c/d/e/f'))
 
   def test_matches_double_star_2(self):
-    self.assert_rule_match('a/b/**', ('a/b/c', 'a/b/c/d/e/f'))
+    self.assert_rule_match('a/b/**', ('a/b/d', 'a/b/c/d/e/f'))
 
   def test_matches_double_star_2_neg(self):
-    self.assert_rule_match('a/b/**', ('a/b'), negate=True)
+    self.assert_rule_match('a/b/**', ('a/b',), negate=True)
 
   def test_matches_dots(self):
-    self.assert_rule_match('.*', ('.pants.d', '.pids'))
+    self.assert_rule_match('.*', ('.dots', '.dips'))
 
   def test_matches_dots_relative(self):
     self.assert_rule_match('./*.py', ('f.py', 'g.py'))
@@ -67,7 +82,7 @@ class FilespecTest(unittest.TestCase):
   def test_matches_dots_neg(self):
     self.assert_rule_match(
       '.*',
-      ('a', 'a/non/dot/dir/file.py', 'dist', 'all/nested/.dot', '.some/hidden/nested/dir/file.py'),
+      ('b', 'a/non/dot/dir/file.py', 'dist', 'all/nested/.dot', '.some/hidden/nested/dir/file.py'),
       negate=True
     )
 
@@ -80,7 +95,7 @@ class FilespecTest(unittest.TestCase):
   def test_matches_dirs_dots(self):
     self.assert_rule_match(
       'build-support/*.venv/',
-      ('build-support/*.venv',
+      ('build-support/blah.venv',
        'build-support/rbt.venv')
     )
 


### PR DESCRIPTION
### Problem

#7299 aligned the behaviour of in-memory (eager) and on-disk (lazy) glob matching, but unfortunately caused a serious performance regression in detection of file owners.

The on-disk (lazy) implementation of glob matching from `GlobMatchingImplementation::expand` was imposing about a 30x overhead when matching globs in memory... and unfortunately, we do that more often than I had realized.

### Solution

In two independently reviewable commits:
1. Simplify `GlobMatchingImplementation::expand` based on the realization that the `PathGlob` caching that we had been doing was a holdout from when we used to memoize them in the graph, and which would never hit due to the unique trailing components of each `PathGlob`.
2. Introduce and use `PathGlobs::matches(Vec<PathBuf>) -> bool` to replace `MemFS::expand` with an eager operation. Expand `FilespecTest` to confirm that this redundant implementation does not go out of sync.

### Result

`GlobMatchingImplementation::expand` is ~3x faster (representing a 20% speedup for `BuildGraph` hydration in a large repository), and owners detection for a command like:
```
time ./pants --changed-diffspec='2c9c338cd7^..2c9c338cd7' list
```
... runs at approximately the speed that it did before #7299.