### PR TITLE
Bump default MyPy version to 0.670

### DIFF
--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -36,7 +36,7 @@ class MypyTask(ResolveRequirementsTaskBase):
 
   @classmethod
   def register_options(cls, register):
-    register('--mypy-version', default='0.550', help='The version of mypy to use.')
+    register('--mypy-version', default='0.670', help='The version of mypy to use.')
     register('--config-file', default=None,
              help='Path mypy configuration file, relative to buildroot.')
 


### PR DESCRIPTION
MyPy has made major upgrades since 2017, including a daemon, literal types, and final modifiers for classes and methods.

This has no impact on which interpreters the plugin can be used with—compatibility remains the same.