### PR TITLE
Move with_overwritten_file_context to PantsRunIntegrationTest

### DIFF
--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -384,27 +384,6 @@ def maybe_profiled(profile_path):
 
 
 @contextmanager
-def with_overwritten_file_content(file_path):
-  """A helper that resets a file after the method runs.
-
-   It will read a file, save the content, try to run the method passed to it, then write the
-   original content to the file.
-
-  :param file_path: Absolute path to the file to be reset after the method runs.
-  :param method_to_run: The method to run before resetting the file.
-  """
-  with open(file_path, 'r') as f:
-    file_original_content = f.read()
-
-  try:
-    yield
-
-  finally:
-    with open(file_path, 'w') as f:
-      f.write(file_original_content)
-
-
-@contextmanager
 def http_server(handler_class):
   def serve(port_queue, shutdown_queue):
     httpd = TCPServer(("", 0), handler_class)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -11,7 +11,7 @@ from unittest import skipIf
 from pants.base.build_environment import get_buildroot
 from pants.build_graph.address import Address
 from pants.build_graph.target import Target
-from pants.util.contextutil import temporary_dir, with_overwritten_file_content
+from pants.util.contextutil import temporary_dir
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
 from pants_test.backend.jvm.tasks.missing_jvm_check import is_missing_jvm
 
@@ -369,7 +369,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
           path = os.path.join(compile_dir, path_suffix)
           self.assertTrue(os.path.exists(path), "Want path {} to exist".format(path))
 
-        with with_overwritten_file_content(file_abs_path):
+        with self.with_overwritten_file_content(file_abs_path):
 
           new_temp_test = '''package org.pantsbuild.example.hello.exe
                               

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -519,7 +519,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
       file_original_content = f.read()
 
     try:
-      if temporary_content:
+      if temporary_content is not None:
         with open(file_path, 'w') as f:
           f.write(temporary_content)
       yield

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -506,6 +506,29 @@ class PantsRunIntegrationTest(unittest.TestCase):
       os.unlink(path)
 
   @contextmanager
+  def with_overwritten_file_content(self, file_path, temporary_content=None):
+    """A helper that resets a file after the method runs.
+
+     It will read a file, save the content, maybe write temporary_content to it, yield, then write the
+     original content to the file.
+
+    :param file_path: Absolute path to the file to be reset after the method runs.
+    :param temporary_content: Optional content to write into the file.
+    """
+    with open(file_path, 'r') as f:
+      file_original_content = f.read()
+
+    try:
+      if temporary_content:
+        with open(file_path, 'w') as f:
+          f.write(temporary_content)
+      yield
+
+    finally:
+      with open(file_path, 'w') as f:
+        f.write(file_original_content)
+
+  @contextmanager
   def mock_buildroot(self, dirs_to_copy=None):
     """Construct a mock buildroot and return a helper object for interacting with it."""
     class Manager(datatype(['write_file', 'pushd', 'new_buildroot'])): pass


### PR DESCRIPTION
### Problem

It would be good to have this in the same place as `temporary_file_content`, as they both do the same thing and they are both used for integration tests.
This PR also adds an optional parameter to have the context manager pre-fill the contents of the file for you.

### Result

Not much has changed, but now `with_overwritten_file_context` lives in `PantsRunIntegrationTest`