### PR TITLE
Allow usage of pants2 script from other directories

### DIFF
--- a/pants2
+++ b/pants2
@@ -13,4 +13,4 @@ export PY="${PY:-python2.7}"
 # interpreter selection will default to using Python 2 as this is the minimum acceptable interpreter.
 export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS:-['CPython>=2.7,<3','CPython>=3.6,<4']}"
 
-${REPO_ROOT}/pants "$@"
+exec ${REPO_ROOT}/pants "$@"

--- a/pants2
+++ b/pants2
@@ -4,6 +4,8 @@
 
 # This bootstrap script invokes Pants using a Python 2 interpreter.
 
+REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P)
+
 export PY="${PY:-python2.7}"
 
 # Allow spawned subprocesses, such as unit tests, to execute with either Python 2 and Python 3.
@@ -11,4 +13,4 @@ export PY="${PY:-python2.7}"
 # interpreter selection will default to using Python 2 as this is the minimum acceptable interpreter.
 export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS:-['CPython>=2.7,<3','CPython>=3.6,<4']}"
 
-./pants "$@"
+${REPO_ROOT}/pants "$@"


### PR DESCRIPTION
### Problem

The `pants` script supports usage from other repositories in order to allow for running pants from sources in another buildroot. But the `pants2` script was not accounting for that usecase.

### Solution

Adapt `pants2` to locate itself in order to exec `pants`.