### PR TITLE
Loosen constraints for TensorFlow used in example code to work with Python 3.7

### DIFF
--- a/examples/3rdparty/python/requirements.txt
+++ b/examples/3rdparty/python/requirements.txt
@@ -1,4 +1,4 @@
 grpcio==1.16.1
 protobuf==3.6.1
-tensorflow==1.12.0
+tensorflow>=1.13,<2
 thrift>=0.10.0


### PR DESCRIPTION
### Problem
Tensorflow 1.12.0 only has wheels for python version up to 3.6. See: https://pypi.org/project/tensorflow/1.12.0/#files

### Solution
Bump minimum version and loosen constraint. 

### Result
CI lint checks work with python 3.7