### PR TITLE
Specify the python version to use in the unstable pex deploy shard.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -774,6 +774,8 @@ py36_deploy_unstable_multiplatform_pex: &py36_deploy_unstable_multiplatform_pex
   <<: *base_deploy_unstable_multiplatform_pex
   name: "Deploy unstable multiplatform pants.pex (Py3.6 PEX)"
   python: 3.6
+  before_install:
+    - pyenv global 3.6.3
   env:
     - *base_deploy_env
     - *base_deploy_unstable_env

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -727,6 +727,8 @@ py36_deploy_unstable_multiplatform_pex: &py36_deploy_unstable_multiplatform_pex
   <<: *base_deploy_unstable_multiplatform_pex
   name: "Deploy unstable multiplatform pants.pex (Py3.6 PEX)"
   python: 3.6
+  before_install:
+    - pyenv global 3.6.3
   env:
     - *base_deploy_env
     - *base_deploy_unstable_env


### PR DESCRIPTION
### Problem

As a follow up to #7401: we need to specify an explicit python version to use in pyenv in order to avoid https://gist.github.com/stuhood/8cfae337c99d2bb21ace0305c2c1d736.

### Solution

Specify the pyenv python version.