### PR TITLE
Fix locale test failing on Python 3.7 due to forced UTF-8 mode being used in the test

### DIFF
--- a/tests/python/pants_test/bin/test_loader_integration.py
+++ b/tests/python/pants_test/bin/test_loader_integration.py
@@ -11,13 +11,18 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 class LoaderIntegrationTest(PantsRunIntegrationTest):
   def test_invalid_locale(self):
     bypass_env = PantsLoader.ENCODING_IGNORE_ENV_VAR
-    pants_run = self.run_pants(command=['help'], extra_env={'LC_ALL': 'iNvALiD-lOcALe'})
+    pants_run = self.run_pants(
+      command=['help'],
+      extra_env={'LC_ALL': 'iNvALiD-lOcALe', "PYTHONUTF8": "0"}
+    )
     self.assert_failure(pants_run)
     self.assertIn('Pants requires', pants_run.stderr_data)
     self.assertIn(bypass_env, pants_run.stderr_data)
 
-    pants_run = self.run_pants(command=['help'], extra_env={'LC_ALL': 'iNvALiD-lOcALe',
-                                                            bypass_env: '1'})
+    pants_run = self.run_pants(
+      command=['help'],
+      extra_env={'LC_ALL': 'iNvALiD-lOcALe', "PYTHONUTF8": "0", bypass_env: '1'}
+    )
     self.assert_success(pants_run)
 
   def test_alternate_entrypoint(self):


### PR DESCRIPTION
### Problem
Python 3.7 may be optionally ran in `-x utf8` mode, meaning it runs Python using UTF-8 for everything, regardless of what the local locale is. See https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUTF8.

Because this defaults to being on in POSIX environments, in CI and locally our Pants subprocess was running with this value during the test `test_invalid_locale`, so our override of `LC_ALL` would have no actual impact. So, the test was not failing like it should have with Python 3.7.

### Solution
Set the environment variable `PYTHONUTF8` to `0` during this test to ensure the test does not run in forced UTF-8 mode.

### Result
`PY=python3.7 ./pants test tests/python/pants_test/bin: -- --verbose -k test_invalid_locale` now passes.

This has no impact when being ran with Python 2.7 or Python 3.6, as Python will simply ignore that env var.