### PR TITLE
Fix resolve test failing on Python 3.7 due to test using outdated cffi version

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/test_resolve_requirements.py
+++ b/tests/python/pants_test/backend/python/tasks/test_resolve_requirements.py
@@ -55,7 +55,7 @@ class ResolveRequirementsTest(TaskTestBase):
     self.assertTrue(path.startswith(os.path.realpath(get_buildroot())))
 
   def test_resolve_multiplatform_requirements(self):
-    cffi_tgt = self._fake_target('cffi', ['cffi==1.9.1'])
+    cffi_tgt = self._fake_target('cffi', ['cffi==1.12.2'])
 
     pex = self._resolve_requirements([cffi_tgt], {
       'python-setup': {


### PR DESCRIPTION
### Problem
CFFI 1.9.1 does not release a Python 3.7 wheel, so `PY=python3.7 ./pants test tests/python/pants_test/backend/python/tasks: -- --verbose -k test_resolve_multiplatform_requirements` would fail.

### Solution
Simply bump to the most modern CFFI, 1.12.2.

### Result
`PY=python3.7 ./pants test tests/python/pants_test/backend/python/tasks: -- --verbose -k test_resolve_multiplatform_requirements` now passes.

This does not impact end users - only fixes a test.