### PR TITLE
[WIP] python thrift namespace clash check in v2

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -155,8 +155,8 @@ deps: ["3rdparty:thrift"]
 deps: ["examples/3rdparty/python:thrift"]
 
 
-[gen.py-thrift-namespace-clash-check]
-strict: True
+[validate-python-thrift]
+fail: True
 
 
 [gen.thrifty]

--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -6,23 +6,36 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import re
-from builtins import str
 
 from future.utils import text_type
 
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
-from pants.base.exceptions import TaskError
+from pants.base.specs import Specs
 from pants.engine.fs import Digest, FileContent, FilesContent
-from pants.engine.legacy.graph import HydratedTarget
+from pants.engine.console import Console
+from pants.engine.goal import Goal, LineOriented
+from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
 from pants.engine.objects import Collection
-from pants.engine.rules import rule
+from pants.engine.rules import console_rule, rule
 from pants.engine.selectors import Get
-from pants.task.task import Task
 from pants.util.collections_abc_backport import defaultdict
 from pants.util.objects import datatype
 
 
 logger = logging.getLogger(__name__)
+
+
+# TODO: Move this up to a Validate() goal when there are more users.
+class ValidatePythonThrift(LineOriented, Goal):
+
+  name = 'validate-python-thrift'
+
+  @classmethod
+  def register_options(cls, register):
+    super(ValidatePythonThrift, cls).register_options(register)
+    # TODO: implement this for the @console_rule!!!
+    register('--fail', type=bool, default=True, fingerprint=True,
+             help='Whether to fail the build if validation fails.')
 
 
 class ParsedNamespace(datatype([
@@ -32,13 +45,59 @@ class ParsedNamespace(datatype([
 ])): pass
 
 
-_ParsedNamespaces = Collection.of(ParsedNamespace)
+ParsedNamespaces = Collection.of(ParsedNamespace)
 
 
-_py_namespace_pattern = re.compile(r'^namespace\s+py\s+([^\s]+)$', flags=re.MULTILINE)
+@console_rule(ValidatePythonThrift, [Console, ValidatePythonThrift.Options, Specs])
+def validate_python_thrift(console, options, specs):
+  """???"""
+
+  # raise NamespaceParseError('??')
+
+  target_closure = yield Get(HydratedTargets, Specs, specs)
+  # logger.debug('target_closure: {}'.format(target_closure))
+  # raise Exception('target_closure: {}'.format(target_closure))
+  all_parsed_namespaces = yield [Get(ParsedNamespaces, HydratedTarget, t) for t in target_closure]
+  # raise Exception('all_parsed_namespaces: {}'.format(all_parsed_namespaces))
+  unflattened_parsed_namespaces = [
+    single_ns
+    for namespace_set in all_parsed_namespaces
+    for single_ns in namespace_set
+  ]
+  # logger.debug('unflattened_parsed_namespaces: {}'.format(unflattened_parsed_namespaces))
+  raise Exception('unflattened_parsed_namespaces: {}'.format(unflattened_parsed_namespaces))
+
+  # Check for any overlapping namespaces.
+  namespaces_by_files = defaultdict(list)
+  for parsed_namespace in unflattened_parsed_namespaces:
+    path = parsed_namespace.file_path
+    target = parsed_namespace.owning_target
+    namespace = parsed_namespace.py_thrift_namespace
+    namespaces_by_files[namespace].append((target, path))
+
+  clashing_namespaces = {
+    namespace: all_paths
+    for namespace, all_paths in namespaces_by_files.items()
+    if len(all_paths) > 1
+  }
+
+  with ValidatePythonThrift.line_oriented(options, console) as (_print_stdout, print_stderr):
+    if clashing_namespaces:
+      print_stderr('clashing namespaces for python thrift library sources detected in build graph:')
+
+      for namespace, all_paths in clashing_namespaces.items():
+        colliding = ', '.join('({}, {})'.format(t.address.spec, path) for (t, path) in all_paths)
+        print_stderr('{}: [{}]'.format(namespace, colliding))
+      yield ValidatePythonThrift(exit_code=1)
+    else:
+      print_stderr('success!')
+      yield ValidatePythonThrift(exit_code=0)
 
 
-class _NamespaceParseError(Exception): pass
+py_namespace_pattern = re.compile(r'^namespace\s+py\s+([^\s]+)$', flags=re.MULTILINE)
+
+
+class NamespaceParseError(Exception): pass
 
 
 class ParseNamespaceRequest(datatype([
@@ -54,14 +113,14 @@ def parse_py_thrift_namespace(parse_namespace_request):
   path = file_content.path
   # File content is provided as a binary string, so we have to decode it to search it.
   content = file_content.content.decode('utf-8')
-  py_namespace_match = _py_namespace_pattern.search(content)
+  py_namespace_match = py_namespace_pattern.search(content)
   if py_namespace_match is None:
     # This debug log shows the contents of the file which failed to parse.
     logger.debug('failing thrift content from target {} in {} is:\n{}'
                  .format(target.address.spec, path, content))
-    raise _NamespaceParseError(
+    raise NamespaceParseError(
       "no python namespace (matching the pattern '{}') found in thrift source {} from target {}!"
-      .format(_py_namespace_pattern.pattern, path, target.address.spec))
+      .format(py_namespace_pattern.pattern, path, target.address.spec))
   return ParsedNamespace(
     file_path=path,
     owning_target=target,
@@ -69,91 +128,22 @@ def parse_py_thrift_namespace(parse_namespace_request):
   )
 
 
-@rule(_ParsedNamespaces, [HydratedTarget])
+@rule(ParsedNamespaces, [HydratedTarget])
 def extract_py_thrift_namespaces(hydrated_target):
-  if hasattr(hydrated_target.adaptor, 'sources'):
+  import pdb; pdb.set_trace()
+  if hydrated_target.adaptor.type_alias == PythonThriftLibrary.alias():
     sources_snapshot = hydrated_target.adaptor.sources.snapshot
     files_content = yield Get(FilesContent, Digest, sources_snapshot.directory_digest)
     all_parsed_namespaces = yield [Get(ParsedNamespace, ParseNamespaceRequest(hydrated_target, fc))
                                    for fc in files_content.dependencies]
   else:
     all_parsed_namespaces = []
-  yield _ParsedNamespaces(all_parsed_namespaces)
-
-
-class PyThriftNamespaceClashCheck(Task):
-  """Check that no python thrift libraries in the build graph have files with clashing namespaces.
-
-  This is a temporary workaround for https://issues.apache.org/jira/browse/THRIFT-515. A real fix
-  would ideally be to extend Scrooge to support clashing namespaces with Python code. A second-best
-  solution would be to check all *thrift* libraries in the build graph, but there is currently no
-  "ThriftLibraryMixin" or other way to identify targets containing thrift code generically.
-  """
-  # This scope is set for testing only.
-  options_scope = 'py-thrift-namespace-clash-check'
-
-  @classmethod
-  def register_options(cls, register):
-    super(PyThriftNamespaceClashCheck, cls).register_options(register)
-    # TODO: deprecate the --strict option in a future release!
-    register('--strict', type=bool, default=False, fingerprint=True,
-             help='Whether to fail the build if thrift sources have invalid python namespaces.')
-
-  @classmethod
-  def product_types(cls):
-    """Populate a dict mapping thrift sources to their namespaces and owning targets for testing."""
-    return ['_py_thrift_namespaces_by_files']
-
-  class NamespaceParseError(TaskError): pass
-
-  class ClashingNamespaceError(TaskError): pass
-
-  def execute(self):
-    if self.skip_execution:
-      return
-
-    # Get file contents for python thrift library targets.
-    py_thrift_targets = self.get_targets(lambda tgt: isinstance(tgt, PythonThriftLibrary))
-    try:
-      unflattened_parsed_namespaces = self.context._scheduler.product_request(
-        _ParsedNamespaces,
-        [t.address for t in py_thrift_targets],
-      )
-    except _NamespaceParseError as e:
-      raise self.NamespaceParseError(str(e))
-
-    # Check for any overlapping namespaces.
-    namespaces_by_files = defaultdict(list)
-    for all_parsed_namespaces in unflattened_parsed_namespaces:
-      for parsed_namespace in all_parsed_namespaces.dependencies:
-        path = parsed_namespace.file_path
-        target = parsed_namespace.owning_target
-        namespace = parsed_namespace.py_thrift_namespace
-        namespaces_by_files[namespace].append((target, path))
-
-    clashing_namespaces = {
-      namespace: all_paths
-      for namespace, all_paths in namespaces_by_files.items()
-      if len(all_paths) > 1
-    }
-    if clashing_namespaces:
-      pretty_printed_clashing = '\n'.join(
-        '{}: [{}]'
-        .format(
-          namespace,
-          ', '.join('({}, {})'.format(t.address.spec, path) for (t, path) in all_paths)
-        )
-        for namespace, all_paths in clashing_namespaces.items()
-      )
-      raise self.ClashingNamespaceError(
-        'clashing namespaces for python thrift library sources detected in build graph:\n{}'
-        .format(pretty_printed_clashing))
-    else:
-      self.context.products.register_data('_py_thrift_namespaces_by_files', namespaces_by_files)
+  yield ParsedNamespaces(all_parsed_namespaces)
 
 
 def rules():
   return [
+    validate_python_thrift,
     parse_py_thrift_namespace,
     extract_py_thrift_namespaces,
   ]

--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -130,7 +130,6 @@ def parse_py_thrift_namespace(parse_namespace_request):
 
 @rule(ParsedNamespaces, [HydratedTarget])
 def extract_py_thrift_namespaces(hydrated_target):
-  import pdb; pdb.set_trace()
   if hydrated_target.adaptor.type_alias == PythonThriftLibrary.alias():
     sources_snapshot = hydrated_target.adaptor.sources.snapshot
     files_content = yield Get(FilesContent, Digest, sources_snapshot.directory_digest)

--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -4,16 +4,81 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
+import logging
 import re
-from builtins import zip
+from builtins import str
+
+from future.utils import text_type
 
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.base.exceptions import TaskError
-from pants.engine.fs import FilesContent
+from pants.engine.fs import Digest, FileContent, FilesContent
+from pants.engine.legacy.graph import HydratedTarget
+from pants.engine.objects import Collection
+from pants.engine.rules import rule
+from pants.engine.selectors import Get
 from pants.task.task import Task
-from pants.util.collections_abc_backport import OrderedDict, defaultdict
-from pants.util.dirutil import safe_file_dump
+from pants.util.collections_abc_backport import defaultdict
+from pants.util.objects import datatype
+
+
+logger = logging.getLogger(__name__)
+
+
+class ParsedNamespace(datatype([
+    ('file_path', text_type),
+    ('owning_target', HydratedTarget),
+    ('py_thrift_namespace', text_type),
+])): pass
+
+
+_ParsedNamespaces = Collection.of(ParsedNamespace)
+
+
+_py_namespace_pattern = re.compile(r'^namespace\s+py\s+([^\s]+)$', flags=re.MULTILINE)
+
+
+class _NamespaceParseError(Exception): pass
+
+
+class ParseNamespaceRequest(datatype([
+    ('target', HydratedTarget),
+    ('file_content', FileContent),
+])): pass
+
+
+@rule(ParsedNamespace, [ParseNamespaceRequest])
+def parse_py_thrift_namespace(parse_namespace_request):
+  target = parse_namespace_request.target
+  file_content = parse_namespace_request.file_content
+  path = file_content.path
+  # File content is provided as a binary string, so we have to decode it to search it.
+  content = file_content.content.decode('utf-8')
+  py_namespace_match = _py_namespace_pattern.search(content)
+  if py_namespace_match is None:
+    # This debug log shows the contents of the file which failed to parse.
+    logger.debug('failing thrift content from target {} in {} is:\n{}'
+                 .format(target.address.spec, path, content))
+    raise _NamespaceParseError(
+      "no python namespace (matching the pattern '{}') found in thrift source {} from target {}!"
+      .format(_py_namespace_pattern.pattern, path, target.address.spec))
+  return ParsedNamespace(
+    file_path=path,
+    owning_target=target,
+    py_thrift_namespace=py_namespace_match.group(1),
+  )
+
+
+@rule(_ParsedNamespaces, [HydratedTarget])
+def extract_py_thrift_namespaces(hydrated_target):
+  if hasattr(hydrated_target.adaptor, 'sources'):
+    sources_snapshot = hydrated_target.adaptor.sources.snapshot
+    files_content = yield Get(FilesContent, Digest, sources_snapshot.directory_digest)
+    all_parsed_namespaces = yield [Get(ParsedNamespace, ParseNamespaceRequest(hydrated_target, fc))
+                                   for fc in files_content.dependencies]
+  else:
+    all_parsed_namespaces = []
+  yield _ParsedNamespaces(all_parsed_namespaces)
 
 
 class PyThriftNamespaceClashCheck(Task):
@@ -39,78 +104,31 @@ class PyThriftNamespaceClashCheck(Task):
     """Populate a dict mapping thrift sources to their namespaces and owning targets for testing."""
     return ['_py_thrift_namespaces_by_files']
 
-  def _get_python_thrift_library_sources(self, py_thrift_targets):
-    """Get file contents for python thrift library targets."""
-    target_snapshots = OrderedDict(
-      (t, t.sources_snapshot(scheduler=self.context._scheduler).directory_digest)
-      for t in py_thrift_targets)
-    filescontent_by_target = OrderedDict(zip(
-      target_snapshots.keys(),
-      self.context._scheduler.product_request(FilesContent, target_snapshots.values())))
-    thrift_file_sources_by_target = OrderedDict(
-      (t, [(file_content.path, file_content.content) for file_content in all_content.dependencies])
-      for t, all_content in filescontent_by_target.items())
-    return thrift_file_sources_by_target
-
-  _py_namespace_pattern = re.compile(r'^namespace\s+py\s+([^\s]+)$', flags=re.MULTILINE)
-
-  class NamespaceParseFailure(Exception): pass
-
-  def _extract_py_namespace_from_content(self, target, thrift_filename, thrift_source_content):
-    py_namespace_match = self._py_namespace_pattern.search(thrift_source_content)
-    if py_namespace_match is None:
-      raise self.NamespaceParseFailure()
-    return py_namespace_match.group(1)
-
-  class NamespaceExtractionError(TaskError):
-    def __init__(self, output_file, msg):
-      self.output_file = output_file
-      super(PyThriftNamespaceClashCheck.NamespaceExtractionError, self).__init__(msg)
-
-  def _extract_all_python_namespaces(self, thrift_file_sources_by_target):
-    """Extract the python namespace from each thrift source file."""
-    py_namespaces_by_target = OrderedDict()
-    failing_py_thrift_by_target = defaultdict(list)
-    for t, all_content in thrift_file_sources_by_target.items():
-      py_namespaces_by_target[t] = []
-      for (path, content) in all_content:
-        try:
-          py_namespaces_by_target[t].append(
-            # File content is provided as a binary string, so we have to decode it.
-            (path, self._extract_py_namespace_from_content(t, path, content.decode('utf-8'))))
-        except self.NamespaceParseFailure:
-          failing_py_thrift_by_target[t].append(path)
-
-    if failing_py_thrift_by_target:
-      # We dump the output to a file here because the output can be very long in some repos.
-      no_py_namespace_output_file = os.path.join(self.workdir, 'no-python-namespace-output.txt')
-
-      pretty_printed_failures = '\n'.join(
-        '{}: [{}]'.format(t.address.spec, ', '.join(paths))
-        for t, paths in failing_py_thrift_by_target.items())
-      error = self.NamespaceExtractionError(no_py_namespace_output_file, """\
-Python namespaces could not be extracted from some thrift sources. Declaring a `namespace py` in
-thrift sources for python thrift library targets will soon become required.
-
-{} python library target(s) contained thrift sources not declaring a python namespace. The targets
-and/or files which need to be edited will be dumped to: {}
-""".format(len(failing_py_thrift_by_target), no_py_namespace_output_file))
-
-      safe_file_dump(no_py_namespace_output_file, '{}\n'.format(pretty_printed_failures))
-
-      if self.get_options().strict:
-        raise error
-      else:
-        self.context.log.warn(error)
-    return py_namespaces_by_target
+  class NamespaceParseError(TaskError): pass
 
   class ClashingNamespaceError(TaskError): pass
 
-  def _determine_clashing_namespaces(self, py_namespaces_by_target):
-    """Check for any overlapping namespaces."""
+  def execute(self):
+    if self.skip_execution:
+      return
+
+    # Get file contents for python thrift library targets.
+    py_thrift_targets = self.get_targets(lambda tgt: isinstance(tgt, PythonThriftLibrary))
+    try:
+      unflattened_parsed_namespaces = self.context._scheduler.product_request(
+        _ParsedNamespaces,
+        [t.address for t in py_thrift_targets],
+      )
+    except _NamespaceParseError as e:
+      raise self.NamespaceParseError(str(e))
+
+    # Check for any overlapping namespaces.
     namespaces_by_files = defaultdict(list)
-    for target, all_namespaces in py_namespaces_by_target.items():
-      for (path, namespace) in all_namespaces:
+    for all_parsed_namespaces in unflattened_parsed_namespaces:
+      for parsed_namespace in all_parsed_namespaces.dependencies:
+        path = parsed_namespace.file_path
+        target = parsed_namespace.owning_target
+        namespace = parsed_namespace.py_thrift_namespace
         namespaces_by_files[namespace].append((target, path))
 
     clashing_namespaces = {
@@ -123,25 +141,19 @@ and/or files which need to be edited will be dumped to: {}
         '{}: [{}]'
         .format(
           namespace,
-          ', '.join('({}, {})'.format(t.address.spec, path) for (t, path) in all_paths))
-        for namespace, all_paths in clashing_namespaces.items())
-      error = self.ClashingNamespaceError("""\
-Clashing namespaces for python thrift library sources detected in build graph. This will silently
-overwrite previously generated python sources with generated sources from thrift files declaring the
-same python namespace. This is an upstream WONTFIX in thrift, see:
-      https://issues.apache.org/jira/browse/THRIFT-515
-Errors:
-{}
-""".format(pretty_printed_clashing))
-      if self.get_options().strict:
-        raise error
-      else:
-        self.context.log.warn(error)
-    return namespaces_by_files
+          ', '.join('({}, {})'.format(t.address.spec, path) for (t, path) in all_paths)
+        )
+        for namespace, all_paths in clashing_namespaces.items()
+      )
+      raise self.ClashingNamespaceError(
+        'clashing namespaces for python thrift library sources detected in build graph:\n{}'
+        .format(pretty_printed_clashing))
+    else:
+      self.context.products.register_data('_py_thrift_namespaces_by_files', namespaces_by_files)
 
-  def execute(self):
-    py_thrift_targets = self.get_targets(lambda tgt: isinstance(tgt, PythonThriftLibrary))
-    thrift_file_sources_by_target = self._get_python_thrift_library_sources(py_thrift_targets)
-    py_namespaces_by_target = self._extract_all_python_namespaces(thrift_file_sources_by_target)
-    namespaces_by_files = self._determine_clashing_namespaces(py_namespaces_by_target)
-    self.context.products.register_data('_py_thrift_namespaces_by_files', namespaces_by_files)
+
+def rules():
+  return [
+    parse_py_thrift_namespace,
+    extract_py_thrift_namespaces,
+  ]

--- a/src/python/pants/backend/codegen/thrift/python/python_thrift_library.py
+++ b/src/python/pants/backend/codegen/thrift/python/python_thrift_library.py
@@ -13,6 +13,10 @@ class PythonThriftLibrary(PythonTarget):
   :API: public
   """
 
+  @classmethod
+  def alias(cls):
+    return 'python_thrift_library'
+
   def __init__(self, **kwargs):
     """
     :param sources: thrift source files (If more than one tries to use the same

--- a/src/python/pants/backend/codegen/thrift/python/register.py
+++ b/src/python/pants/backend/codegen/thrift/python/register.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from pants.backend.codegen.thrift.python.apache_thrift_py_gen import ApacheThriftPyGen
 from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
   PyThriftNamespaceClashCheck
+from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
+  rules as namespace_clash_rules
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task
@@ -23,3 +25,7 @@ def build_file_aliases():
 def register_goals():
   task(name='thrift-py', action=ApacheThriftPyGen).install('gen')
   task(name='py-thrift-namespace-clash-check', action=PyThriftNamespaceClashCheck).install('gen')
+
+
+def rules():
+  return namespace_clash_rules()

--- a/src/python/pants/backend/codegen/thrift/python/register.py
+++ b/src/python/pants/backend/codegen/thrift/python/register.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from pants.backend.codegen.thrift.python.apache_thrift_py_gen import ApacheThriftPyGen
 from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
-  PyThriftNamespaceClashCheck
-from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
   rules as namespace_clash_rules
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -17,14 +15,13 @@ from pants.goal.task_registrar import TaskRegistrar as task
 def build_file_aliases():
   return BuildFileAliases(
     targets={
-      'python_thrift_library': PythonThriftLibrary,
-      }
-    )
+      PythonThriftLibrary.alias(): PythonThriftLibrary,
+    }
+  )
 
 
 def register_goals():
   task(name='thrift-py', action=ApacheThriftPyGen).install('gen')
-  task(name='py-thrift-namespace-clash-check', action=PyThriftNamespaceClashCheck).install('gen')
 
 
 def rules():

--- a/tests/python/pants_test/backend/codegen/thrift/python/BUILD
+++ b/tests/python/pants_test/backend/codegen/thrift/python/BUILD
@@ -15,6 +15,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:process_handler',
     'tests/python/pants_test/subsystem:subsystem_utils',
+    'tests/python/pants_test:console_rule_test_base',
     'tests/python/pants_test:task_test_base',
   ]
 )

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
@@ -113,7 +113,7 @@ Errors:"""
 
   def test_no_py_namespace(self):
     no_py_namespace_target = self._target_dict()['no-py-namespace']
-    with self.assertRaises(PyThriftNamespaceClashCheck.NamespaceExtractionError) as cm:
+    with self.assertRaises(PyThriftNamespaceClashCheck.NamespaceParseError) as cm:
       self._run_tasks(target_roots=[no_py_namespace_target])
     self.assertEqual(str(cm.exception), """\
 Python namespaces could not be extracted from some thrift sources. Declaring a `namespace py` in

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
@@ -4,71 +4,109 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import str
+from textwrap import dedent
 
 from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
-  PyThriftNamespaceClashCheck
+  ClashingNamespaceError, NamespaceParseError, ValidatePythonThrift
 from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
   rules as namespace_clash_rules
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
-from pants.util.dirutil import read_file
-from pants_test.task_test_base import DeclarativeTaskTestMixin, TaskTestBase
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants_test.console_rule_test_base import ConsoleRuleTestBase
 
 
-class PyThriftNamespaceClashCheckTest(TaskTestBase, DeclarativeTaskTestMixin):
+class PyThriftNamespaceClashCheckTest(ConsoleRuleTestBase):
+  goal_cls = ValidatePythonThrift
 
   @classmethod
   def rules(cls):
     return super(PyThriftNamespaceClashCheckTest, cls).rules() + namespace_clash_rules()
 
   @classmethod
-  def task_type(cls):
-    return PyThriftNamespaceClashCheck
+  def alias_groups(cls):
+    return BuildFileAliases(
+      targets={
+        PythonThriftLibrary.alias(): PythonThriftLibrary,
+      }
+    )
+
+  def setUp(self):
+    super(PyThriftNamespaceClashCheckTest, self).setUp()
+
+    # ???
+    self.create_workdir_file('src/py-thrift/with-header.thrift', dedent("""\
+      // Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+      // Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+      namespace java org.pantsbuild.whatever
+      namespace py org.pantsbuild.py_whatever
+
+      struct A {}
+      """))
+    self.add_to_build_file('src/py-thrift/BUILD', dedent("""\
+      python_thrift_library(
+        name='with-comments-and-other-namespaces',
+        sources=['with-header.thrift'],
+      )
+      """))
+
+    self.create_workdir_file('src/py-thrift/bad.thrift', dedent("""\
+      #@namespace scala org.pantsbuild.whatever
+      namespace java org.pantsbuild.whatever
+
+      struct A {}
+      """))
+    self.add_to_build_file('src/py-thrift/BUILD', dedent("""\
+      python_thrift_library(
+        name='no-py-namespace',
+        sources=['bad.thrift'],
+      )
+      """))
 
   _target_specs = {
-    'src/py-thrift:with-comments-and-other-namespaces' : {
-      'target_type': PythonThriftLibrary,
-      'sources': ['with-header.thrift'],
-      'filemap': {
-        'with-header.thrift': """\
-// Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
-// Licensed under the Apache License, Version 2.0 (see LICENSE).
+    # 'src/py-thrift:with-comments-and-other-namespaces' : {
+    #   'target_type': PythonThriftLibrary,
+    #   'sources': ['with-header.thrift'],
+    #   'filemap': {
+    #     'with-header.thrift': dedent("""\
+    #       // Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+    #       // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-namespace java org.pantsbuild.whatever
-namespace py org.pantsbuild.py_whatever
+    #       namespace java org.pantsbuild.whatever
+    #       namespace py org.pantsbuild.py_whatever
 
-struct A {}
-""",
-      },
-    },
+    #       struct A {}
+    #       """),
+    #   },
+    # },
 
-    'src/py-thrift:no-py-namespace': {
-      'target_type': PythonThriftLibrary,
-      'sources': ['bad.thrift'],
-      'filemap': {
-        'bad.thrift': """\
-#@namespace scala org.pantsbuild.whatever
-namespace java org.pantsbuild.whatever
+    # 'src/py-thrift:no-py-namespace': {
+    #   'target_type': PythonThriftLibrary,
+    #   'sources': ['bad.thrift'],
+    #   'filemap': {
+    #     'bad.thrift': dedent("""\
+    #       #@namespace scala org.pantsbuild.whatever
+    #       namespace java org.pantsbuild.whatever
 
-struct A {}
-""",
-      },
-    },
+    #       struct A {}
+    #       """),
+    #   },
+    # },
 
     'src/py-thrift:clashing-namespace': {
       'target_type': PythonThriftLibrary,
       'sources': ['a.thrift', 'b.thrift'],
       'filemap': {
-        'a.thrift': """\
-namespace py org.pantsbuild.namespace
+        'a.thrift': dedent("""\
+          namespace py org.pantsbuild.namespace
 
-struct A {}
-""",
-        'b.thrift': """\
-namespace py org.pantsbuild.namespace
+          struct A {}
+          """),
+        'b.thrift': dedent("""\
+          namespace py org.pantsbuild.namespace
 
-struct B {}
-""",
+          struct B {}
+          """),
       },
     },
 
@@ -76,11 +114,11 @@ struct B {}
       'target_type': PythonThriftLibrary,
       'sources': ['a.thrift'],
       'filemap': {
-        'a.thrift': """\
-namespace py org.pantsbuild.namespace
+        'a.thrift': dedent("""\
+          namespace py org.pantsbuild.namespace
 
-struct A {}
-""",
+          struct A {}
+          """),
       },
     },
 
@@ -88,11 +126,11 @@ struct A {}
       'target_type': PythonThriftLibrary,
       'sources': ['b.thrift'],
       'filemap': {
-        'b.thrift': """\
-namespace py org.pantsbuild.namespace
+        'b.thrift': dedent("""\
+          namespace py org.pantsbuild.namespace
 
-struct B {}
-""",
+          struct B {}
+          """),
       },
     }
   }
@@ -112,24 +150,15 @@ same python namespace. This is an upstream WONTFIX in thrift, see:
 Errors:"""
 
   def test_no_py_namespace(self):
-    no_py_namespace_target = self._target_dict()['no-py-namespace']
-    with self.assertRaises(PyThriftNamespaceClashCheck.NamespaceParseError) as cm:
-      self._run_tasks(target_roots=[no_py_namespace_target])
-    self.assertEqual(str(cm.exception), """\
-Python namespaces could not be extracted from some thrift sources. Declaring a `namespace py` in
-thrift sources for python thrift library targets will soon become required.
-
-1 python library target(s) contained thrift sources not declaring a python namespace. The targets
-and/or files which need to be edited will be dumped to: {}
-"""
-                     .format(cm.exception.output_file))
-    self.assertEqual(
-      'src/py-thrift:no-py-namespace: [src/py-thrift/bad.thrift]\n',
-      read_file(cm.exception.output_file))
+    self.assert_console_raises_with_message(
+      NamespaceParseError,
+      exc_message='?',
+      execution_error=True,
+      args=['src/py-thrift:no-py-namespace'])
 
   def test_clashing_namespace_same_target(self):
     clashing_same_target = self._target_dict()['clashing-namespace']
-    with self.assertRaisesWithMessage(PyThriftNamespaceClashCheck.ClashingNamespaceError, """{}
+    with self.assertRaisesWithMessage(ClashingNamespaceError, """{}
 org.pantsbuild.namespace: [(src/py-thrift:clashing-namespace, src/py-thrift/a.thrift), (src/py-thrift:clashing-namespace, src/py-thrift/b.thrift)]
 """.format(self._exception_prelude)):
       self._run_tasks(target_roots=[clashing_same_target])
@@ -137,7 +166,7 @@ org.pantsbuild.namespace: [(src/py-thrift:clashing-namespace, src/py-thrift/a.th
   def test_clashing_namespace_multiple_targets(self):
     target_dict = self._target_dict()
     clashing_targets = [target_dict[k] for k in ['clashingA', 'clashingB']]
-    with self.assertRaisesWithMessage(PyThriftNamespaceClashCheck.ClashingNamespaceError, """{}
+    with self.assertRaisesWithMessage(ClashingNamespaceError, """{}
 org.pantsbuild.namespace: [(src/py-thrift-clashing:clashingA, src/py-thrift-clashing/a.thrift), (src/py-thrift-clashing:clashingB, src/py-thrift-clashing/b.thrift)]
 """.format(self._exception_prelude)):
       self._run_tasks(target_roots=clashing_targets)

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
@@ -8,12 +8,18 @@ from builtins import str
 
 from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
   PyThriftNamespaceClashCheck
+from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
+  rules as namespace_clash_rules
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.util.dirutil import read_file
 from pants_test.task_test_base import DeclarativeTaskTestMixin, TaskTestBase
 
 
 class PyThriftNamespaceClashCheckTest(TaskTestBase, DeclarativeTaskTestMixin):
+
+  @classmethod
+  def rules(cls):
+    return super(PyThriftNamespaceClashCheckTest, cls).rules() + namespace_clash_rules()
 
   @classmethod
   def task_type(cls):


### PR DESCRIPTION
*WIP because it fails tests due to v2 test issues (but the code itself totally works) -- see https://github.com/pantsbuild/pants/pull/7345#issuecomment-472676767 for background for me to follow up on. This PR is on top of #7345.*

### Problem

The python thrift namespace clash check task introduced in #7345 is cool and useful, but it has a lot of pretty complex list/dict comprehensions in order to be performant. Rewriting these parts in the v2 engine makes them both performant and readable, as well as composable.

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

- Introduce v2 rules for the namespace clash check task.

(_describe the modifications you've made._)

### Result

The namespace clash check task is easier to read.

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)