### PR TITLE
hack default compiler option sets to fix tensorflow 1.13.1 on python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -211,7 +211,8 @@ py37_linux_test_config: &py37_linux_test_config
   <<: *base_linux_test_config
   stage: *test_cron
   env:
-    - &py37_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
+    # TODO(https://github.com/tensorflow/tensorflow/issues/27078): tensorflow==1.13.1 on python 3.7.2 for Linux uses the new C++ ABI, which may be an error.
+    - &py37_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_COMPILER_OPTION_SETS="[]"
 
 base_osx_config: &base_osx_config
   os: osx

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -201,7 +201,8 @@ py37_linux_test_config: &py37_linux_test_config
   <<: *base_linux_test_config
   stage: *test_cron
   env:
-    - &py37_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
+    # TODO(https://github.com/tensorflow/tensorflow/issues/27078): tensorflow==1.13.1 on python 3.7.2 for Linux uses the new C++ ABI, which may be an error.
+    - &py37_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_COMPILER_OPTION_SETS="[]"
 
 base_osx_config: &base_osx_config
   os: osx

--- a/examples/src/python/example/tensorflow_custom_op/BUILD
+++ b/examples/src/python/example/tensorflow_custom_op/BUILD
@@ -33,7 +33,6 @@ python_dist(
 
 ctypes_compatible_cpp_library(
   name='tensorflow-zero-out-op',
-  compiler_option_sets={'glibcxx_use_old_abi'},
   dependencies=[
     'examples/3rdparty/python:tensorflow-framework',
   ],

--- a/examples/tests/python/example_test/tensorflow_custom_op/test_zero_out_op.py
+++ b/examples/tests/python/example_test/tensorflow_custom_op/test_zero_out_op.py
@@ -4,9 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import sys
-import unittest
-
 import tensorflow as tf
 
 from example.tensorflow_custom_op.zero_out_custom_op import zero_out_module
@@ -15,7 +12,6 @@ from example.tensorflow_custom_op.zero_out_custom_op import zero_out_module
 # This code is from the guide in https://www.tensorflow.org/guide/extend/op.
 class ZeroOutTest(tf.test.TestCase):
 
-  @unittest.skipIf(sys.version_info[0:2] == (3, 7), "See https://github.com/pantsbuild/pants/issues/7417.")
   def test_zero_out(self):
     with self.cached_session():
       result = zero_out_module().zero_out([5, 4, 3, 2, 1])

--- a/examples/tests/python/example_test/tensorflow_custom_op/test_zero_out_op.py
+++ b/examples/tests/python/example_test/tensorflow_custom_op/test_zero_out_op.py
@@ -17,6 +17,6 @@ class ZeroOutTest(tf.test.TestCase):
 
   @unittest.skipIf(sys.version_info[0:2] == (3, 7), "See https://github.com/pantsbuild/pants/issues/7417.")
   def test_zero_out(self):
-    with self.test_session():
+    with self.cached_session():
       result = zero_out_module().zero_out([5, 4, 3, 2, 1])
       self.assertAllEqual(result.eval(), [5, 0, 0, 0, 0])

--- a/pants.ini
+++ b/pants.ini
@@ -414,10 +414,18 @@ config_path: src/docs/docsite.json
 toolchain_variant: gnu
 
 [native-build-step.cpp-compile-settings]
+# TensorFlow 1.13 on python 3.7 specifically uses a newer C++ ABI than any other TensorFlow release,
+# so in this repo's CI we override this option to avoid using the previous ABI for our python 3.7
+# testing by setting PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
+# in the environment.
+default_compiler_option_sets: ['glibcxx_use_old_abi']
 compiler_option_sets_enabled_args: {
     # TensorFlow custom operators cannot be built against the C++11 ABI yet: see
     # https://www.tensorflow.org/guide/extend/op.
     'glibcxx_use_old_abi': ['-D_GLIBCXX_USE_CXX11_ABI=0'],
+  }
+compiler_option_sets_disabled_args: {
+    'glibcxx_use_old_abi': ['-D_GLIBCXX_USE_CXX11_ABI=1'],
   }
 
 [libc]

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -167,6 +167,7 @@ class NativeCompile(NativeTask, AbstractClass):
     sources_and_headers = self.get_sources_headers_for_target(target)
     compiler_option_sets = (self._compile_settings.native_build_step
                                 .get_compiler_option_sets_for_target(target))
+    self.context.log.debug('target: {}, compiler_option_sets: {}'.format(target, compiler_option_sets))
 
     compile_request = NativeCompileRequest(
       compiler=self._compiler(target),

--- a/src/python/pants/option/compiler_option_sets_mixin.py
+++ b/src/python/pants/option/compiler_option_sets_mixin.py
@@ -4,9 +4,13 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
 from builtins import object
 
 from pants.util.meta import classproperty
+
+
+logger = logging.getLogger(__name__)
 
 
 class CompilerOptionSetsMixin(object):
@@ -21,6 +25,9 @@ class CompilerOptionSetsMixin(object):
     register('--compiler-option-sets-disabled-args', advanced=True, type=dict, fingerprint=True,
              default=cls.get_compiler_option_sets_disabled_default_value,
              help='Extra compiler args to use for each disabled option set.')
+    register('--default-compiler-option-sets', advanced=True, type=list, fingerprint=True,
+             default=cls.get_default_compiler_option_sets,
+             help="The compiler_option_sets to use for targets which don't declare any.")
 
   @classproperty
   def get_compiler_option_sets_enabled_default_value(cls):
@@ -31,6 +38,11 @@ class CompilerOptionSetsMixin(object):
   def get_compiler_option_sets_disabled_default_value(cls):
     """Override to set default for this option."""
     return {}
+
+  @classproperty
+  def get_default_compiler_option_sets(cls):
+    """Override to set the default compiler_option_sets for targets which don't declare them."""
+    return []
 
   @classproperty
   def get_fatal_warnings_enabled_args_default(cls):
@@ -45,6 +57,11 @@ class CompilerOptionSetsMixin(object):
   # TODO(mateo): The compiler_option_sets could use an API that requires implementing platforms to
   # surface documentation - this took me awhile to unwind.
   def get_merged_args_for_compiler_option_sets(self, compiler_option_sets):
+    # If no option sets are provided, use the default value.
+    if not compiler_option_sets:
+      compiler_option_sets = self.get_options().default_compiler_option_sets
+      logger.debug('using default option sets: {}'.format(compiler_option_sets))
+
     compiler_options = set()
 
     # Set values for enabled options.


### PR DESCRIPTION
*See tensorflow/tensorflow#27078 for an upstream tensorflow issue I made asking about the cause of #7417.*

### Problem

Resolves #7417. `tensorflow==1.13.1` uses the newer C++ ABI for the shared library in its python 3.7 wheel on Linux, [contradicting their docs on how to add a new custom operator](https://www.tensorflow.org/guide/extend/op#compile_the_op_using_your_system_compiler_tensorflow_binary_installation), which says that their public releases use `-D_GLIBCXX_USE_CXX11_ABI=0`. Instead, we have (on Linux):
```
> pip3 install tensorflow==1.13.1
> python3.7
Python 3.7.1 (default, Oct 22 2018, 11:21:55)
[GCC 8.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tensorflow.sysconfig as tfs
>>> dir(tfs)
['CXX11_ABI_FLAG', 'MONOLITHIC_BUILD', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', 'get_compile_flags', 'get_include', 'get_lib', 'get_link_flags']
>>> tfs.CXX11_ABI_FLAG
1
>>> tfs.get_compile_flags()
['-I/usr/local/lib/python3.7/dist-packages/tensorflow/include', '-D_GLIBCXX_USE_CXX11_ABI=1']
```

However, on OSX:
```
> pex --python=python3.7 tensorflow==1.13.1
Python 3.7.2 (default, Feb 14 2019, 13:28:01)
[Clang 10.0.0 (clang-1000.11.45.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> import tensorflow.sysconfig as tfs
>>> dir(tfs)
['CXX11_ABI_FLAG', 'MONOLITHIC_BUILD', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', 'get_compile_flags', 'get_include', 'get_lib', 'get_link_flags']
>>> tfs.CXX11_ABI_FLAG
0
>>> tfs.get_compile_flags()
['-I/private/var/folders/l_/3k9sqfqn5_z5v1zbxgrnxtyh0000gn/T/tmpgZIVDs/.deps/tensorflow-1.13.1-cp37-cp37m-macosx_10_11_x86_64.whl/tensorflow/include', '-D_GLIBCXX_USE_CXX11_ABI=0']
>>>
```

This is possibly unintentional on the part of TensorFlow, but it is perfectly reasonable for that project to eventually change to using the newer C++ ABI.

In this particular case, we want to use `-D_GLIBCXX_USE_CXX11_ABI=1`, but only when using a python 3.7 interpreter on Linux. This allows us to avoid skipping that test in python 3.7 shards in #7261.

### Solution

- Remove the explicit `glibcxx_use_old_abi` on our tensorflow custom C++ operator example, and make that one of the default option sets.
- *(in #7261, depending on which lands first)* Remove the `glibcxx_use_old_abi` from the default option sets in the python 3.7 Linux shard.

### Result

We don't have to skip the tensorflow testing for python 3.7 on Linux.