### PR TITLE
fix for pantsrc-files option

### DIFF
--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -141,7 +141,7 @@ class OptionsBootstrapper(datatype([
     # from (typically pants.ini), then config override, then rcfiles.
     full_configpaths = pre_bootstrap_config.sources()
     if bootstrap_option_values.pantsrc:
-      rcfiles = [os.path.expanduser(rcfile) for rcfile in bootstrap_option_values.pantsrc_files]
+      rcfiles = [os.path.expanduser(str(rcfile)) for rcfile in bootstrap_option_values.pantsrc_files]
       existing_rcfiles = list(filter(os.path.exists, rcfiles))
       full_configpaths.extend(existing_rcfiles)
 

--- a/tests/python/pants_test/option/test_options_bootstrapper.py
+++ b/tests/python/pants_test/option/test_options_bootstrapper.py
@@ -205,7 +205,6 @@ class BootstrapOptionsTest(unittest.TestCase):
 
     self.do_test_create_bootstrapped_multiple_config(create_options_bootstrapper)
 
-
   def test_options_pantsrc_files(self):
     def create_options_bootstrapper(*config_paths):
       return OptionsBootstrapper.create(args=['--pantsrc-files={}'.format(cp) for cp in config_paths])
@@ -215,15 +214,14 @@ class BootstrapOptionsTest(unittest.TestCase):
       resolver: coursier
       """))
       fp.close()
-    bootstrapped_options = create_options_bootstrapper(fp.name)
-    opts_single_config = bootstrapped_options.get_full_options(known_scope_infos=[
-      ScopeInfo('', ScopeInfo.GLOBAL),
-      ScopeInfo('resolver', ScopeInfo.TASK),
-    ])
-    opts_single_config.register('', '--pantsrc-files', type=list)
-    opts_single_config.register('resolver', '--resolver')
-
-    self.assertEqual('coursier', opts_single_config.for_scope('resolver').coursier)
+      bootstrapped_options = create_options_bootstrapper(fp.name)
+      opts_single_config = bootstrapped_options.get_full_options(known_scope_infos=[
+        ScopeInfo('', ScopeInfo.GLOBAL),
+        ScopeInfo('resolver', ScopeInfo.TASK),
+      ])
+      opts_single_config.register('', '--pantsrc-files', type=list)
+      opts_single_config.register('resolver', '--resolver')
+      self.assertEqual('coursier', opts_single_config.for_scope('resolver').resolver)
 
   def test_full_options_caching(self):
     with temporary_file_path() as config:

--- a/tests/python/pants_test/option/test_options_bootstrapper.py
+++ b/tests/python/pants_test/option/test_options_bootstrapper.py
@@ -205,6 +205,26 @@ class BootstrapOptionsTest(unittest.TestCase):
 
     self.do_test_create_bootstrapped_multiple_config(create_options_bootstrapper)
 
+
+  def test_options_pantsrc_files(self):
+    def create_options_bootstrapper(*config_paths):
+      return OptionsBootstrapper.create(args=['--pantsrc-files={}'.format(cp) for cp in config_paths])
+    with temporary_file(binary_mode=False) as fp:
+      fp.write(dedent("""
+      [resolver]
+      resolver: coursier
+      """))
+      fp.close()
+    bootstrapped_options = create_options_bootstrapper(fp.name)
+    opts_single_config = bootstrapped_options.get_full_options(known_scope_infos=[
+      ScopeInfo('', ScopeInfo.GLOBAL),
+      ScopeInfo('resolver', ScopeInfo.TASK),
+    ])
+    opts_single_config.register('', '--pantsrc-files', type=list)
+    opts_single_config.register('resolver', '--resolver')
+
+    self.assertEqual('coursier', opts_single_config.for_scope('resolver').coursier)
+
   def test_full_options_caching(self):
     with temporary_file_path() as config:
       args = self._config_path(config)


### PR DESCRIPTION
### Problem

Exception in initializing `path` - failed typecontraint unicode

### Solution

string representation for `rcfile` path -  `unicode` of python 2 is equivalent of `str` of python 3 

### Result

no exception raised. 