### PR TITLE
Make abstract classproperty error message nicer

### DIFF
--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -40,8 +40,7 @@ class ClassPropertyDescriptor(object):
       raise TypeError("""\
 The classproperty '{func_name}' in type '{type_name}' was an abstractproperty, meaning that type \
 {type_name} must override it by setting it as a variable in the class body or defining a method \
-with an @classproperty decorator.
-"""
+with an @classproperty decorator."""
                       .format(func_name=field_name,
                               type_name=objtype.__name__))
     else:

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from abc import ABCMeta
+from abc import ABCMeta, abstractproperty
 from builtins import object
 
 
@@ -33,7 +33,19 @@ class ClassPropertyDescriptor(object):
   def __get__(self, obj, objtype=None):
     if objtype is None:
       objtype = type(obj)
-    return self.fget.__get__(obj, objtype)()
+      # Get the callable field for this object, which may be a property.
+    callable_field = self.fget.__get__(obj, objtype)
+    if isinstance(self.fget.__func__, abstractproperty):
+      field_name = self.fget.__func__.fget.__name__
+      raise TypeError("""\
+The classproperty '{func_name}' in type '{type_name}' was an abstractproperty, meaning that type \
+{type_name} must override it by setting it as a variable in the class body or defining a method \
+with an @classproperty decorator.
+"""
+                      .format(func_name=field_name,
+                              type_name=objtype.__name__))
+    else:
+      return callable_field()
 
 
 def classproperty(func):

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -211,3 +211,36 @@ class ClassPropertyTest(TestBase):
 
     del DeleteValue.static_property
     self.assertFalse(hasattr(DeleteValue, 'static_property'))
+
+  def test_abstract_classproperty(self):
+    class Abstract(AbstractClass):
+      @classproperty
+      @abstractproperty
+      def f(cls):
+        pass
+
+    with self.assertRaisesWithMessage(TypeError, """\
+The classproperty 'f' in type 'Abstract' was an abstractproperty, meaning that type \
+Abstract must override it by setting it as a variable in the class body or defining a method \
+with an @classproperty decorator."""):
+      Abstract.f
+
+    class WithoutOverriding(Abstract):
+      """Show that subclasses failing to override the abstract classproperty will raise."""
+      pass
+
+    with self.assertRaisesWithMessage(TypeError, """\
+The classproperty 'f' in type 'WithoutOverriding' was an abstractproperty, meaning that type \
+WithoutOverriding must override it by setting it as a variable in the class body or defining a method \
+with an @classproperty decorator."""):
+      WithoutOverriding.f
+
+    class Concrete(Abstract):
+      f = 3
+    self.assertEqual(Concrete.f, 3)
+
+    class Concrete2(Abstract):
+      @classproperty
+      def f(cls):
+        return 'hello'
+    self.assertEqual(Concrete2.f, 'hello')


### PR DESCRIPTION
### Problem

https://github.com/pantsbuild/pants/blob/b963e89489ef7fd12615101f8344bf2ada425bdf/src/python/pants/util/meta.py#L39-L40

You can use `@classproperty` with `@abstractproperty`, but the error message is `'abstractproperty' object is not callable`, which is pretty opaque.

### Solution

- Check for the case where the underlying object is an `abstractproperty`, and provide a nice error message.