### PR TITLE
Fix hasattr on Payload

### DIFF
--- a/src/python/pants/base/payload.py
+++ b/src/python/pants/base/payload.py
@@ -145,11 +145,11 @@ class Payload(object):
       field.mark_dirty()
 
   def __getattr__(self, attr):
-    field = self._fields[attr]
+    try:
+      field = self._fields[attr]
+    except KeyError:
+      raise AttributeError(attr)
     if field is not None:
       return field.value
     else:
       return None
-
-  def __hasattr__(self, attr):
-    return attr in self._fields

--- a/tests/python/pants_test/base/test_payload.py
+++ b/tests/python/pants_test/base/test_payload.py
@@ -99,7 +99,7 @@ class PayloadTest(TestBase):
     self.assertEqual(None, payload.get_field_value('bar'))
     self.assertEqual(None, payload.get_field('bar', default='nothing').value)
     self.assertEqual(None, payload.get_field_value('bar', default='nothing'))
-    with self.assertRaises(KeyError):
+    with self.assertRaises(AttributeError):
       self.assertEqual(None, payload.field_doesnt_exist)
     self.assertEqual(None, payload.get_field('field_doesnt_exist'))
     self.assertEqual(None, payload.get_field_value('field_doesnt_exist'))


### PR DESCRIPTION
`__hasattr__` isn't a thing. `hasattr` calls `getattr` and looks for an `AttributeError`.

See details at https://docs.python.org/3/library/functions.html#hasattr