### PR TITLE
nailgun connect timeout error message fix

### DIFF
--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -34,8 +34,10 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
              help='If set to nailgun, nailgun will be enabled and repeated invocations of this '
                   'task will be quicker. If set to subprocess, then the task will be run without '
                   'nailgun. Hermetic execution is an experimental subprocess execution framework.')
+    register('--nailgun-subprocess-startup-timeout', advanced=True, default=10, type=float,
+             help='The time (secs) to wait for a nailgun subprocess to start.')
     register('--nailgun-timeout-seconds', advanced=True, default=10, type=float,
-             help='Timeout (secs) for nailgun startup.')
+             help='The time (secs) to wait for a nailgun subprocess to start writing to stdout.')
     register('--nailgun-connect-attempts', advanced=True, default=5, type=int,
              help='Max attempts for nailgun connects.')
     cls.register_jvm_tool(register,
@@ -83,6 +85,7 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
                              self._executor_workdir,
                              classpath,
                              dist,
+                             startup_timeout=self.get_options().nailgun_subprocess_startup_timeout,
                              connect_timeout=self.get_options().nailgun_timeout_seconds,
                              connect_attempts=self.get_options().nailgun_connect_attempts)
     else:

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -210,14 +210,6 @@ class NailgunClient(object):
         wrapped_exc=self.wrapped_exc)
       super(NailgunClient.NailgunError, self).__init__(msg, self.wrapped_exc)
 
-  def _make_nailgun_error(self, wrapped_exc):
-    return self.NailgunError(
-      address=self._address_string,
-      pid=self._maybe_last_pid(),
-      pgrp=self._maybe_last_pgrp(),
-      wrapped_exc=wrapped_exc,
-    )
-
   class NailgunConnectionError(NailgunError):
     """Indicates an error upon initial connect to the nailgun server."""
     DESCRIPTION = 'Problem connecting to nailgun server'
@@ -308,7 +300,6 @@ class NailgunClient(object):
         pid=self._maybe_last_pid(),
         pgrp=self._maybe_last_pgrp(),
         wrapped_exc=e,
-        traceback=sys.exc_info()[2],
       )
     else:
       return sock
@@ -365,7 +356,12 @@ class NailgunClient(object):
     try:
       return self._session.execute(cwd, main_class, *args, **environment)
     except (socket.error, NailgunProtocol.ProtocolError) as e:
-      raise self._make_nailgun_error(e)
+      raise self.NailgunError(
+        address=self._address_string,
+        pid=self._maybe_last_pid(),
+        pgrp=self._maybe_last_pgrp(),
+        wrapped_exc=e,
+      )
     finally:
       sock.close()
       self._session = None

--- a/tests/python/pants_test/java/BUILD
+++ b/tests/python/pants_test/java/BUILD
@@ -71,7 +71,8 @@ python_tests(
   name = 'nailgun_integration',
   sources = ['test_nailgun_integration.py'],
   dependencies = [
-    'tests/python/pants_test:int-test'
+    'tests/python/pants_test:int-test',
+    'tests/python/pants_test/testutils:py2_compat',
   ],
   tags = {'integration'},
 )

--- a/tests/python/pants_test/java/test_nailgun_client.py
+++ b/tests/python/pants_test/java/test_nailgun_client.py
@@ -158,7 +158,6 @@ class TestNailgunClient(unittest.TestCase):
       31337,
       -31336,
       Exception('oops'),
-      None
     )
 
     with self.assertRaises(NailgunClient.NailgunConnectionError):

--- a/tests/python/pants_test/java/test_nailgun_executor.py
+++ b/tests/python/pants_test/java/test_nailgun_executor.py
@@ -4,9 +4,13 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import os
+from contextlib import contextmanager
+
 import mock
 import psutil
 
+from pants.java.nailgun_client import NailgunClient
 from pants.java.nailgun_executor import NailgunExecutor
 from pants_test.test_base import TestBase
 
@@ -18,6 +22,30 @@ def fake_process(**kwargs):
   proc = mock.create_autospec(psutil.Process, spec_set=True)
   [setattr(getattr(proc, k), 'return_value', v) for k, v in kwargs.items()]
   return proc
+
+
+@contextmanager
+def rw_pipes(write_input=None):
+  """Create a pair of pipes wrapped in python file objects.
+
+  :param str write_input: If `write_input` is not None, the writable pipe will have that string
+                          written to it, then closed.
+  """
+  read_pipe, write_pipe = os.pipe()
+  read_fileobj = os.fdopen(read_pipe, 'r')
+  write_fileobj = os.fdopen(write_pipe, 'w')
+
+  if write_input is not None:
+    write_fileobj.write(write_input)
+    write_fileobj.close()
+    write_fileobj = None
+
+  yield read_fileobj, write_fileobj
+
+  read_fileobj.close()
+
+  if write_fileobj is not None:
+    write_fileobj.close()
 
 
 class NailgunExecutorTest(TestBase):
@@ -50,3 +78,15 @@ class NailgunExecutorTest(TestBase):
       )
       self.assertFalse(self.executor.is_alive())
       mock_as_process.assert_called_with(self.executor)
+
+  def test_connect_timeout(self):
+    with rw_pipes() as (stdout_read, stdout_write),\
+         rw_pipes(write_input='xxx') as (stderr_read, _):
+      with mock.patch('pants.java.nailgun_executor.safe_open') as mock_open,\
+           mock.patch('pants.java.nailgun_executor.read_file') as mock_read_file:
+        mock_open.return_value = stdout_read
+        mock_read_file.return_value = stderr_read
+        # The stdout read pipe has no input and hasn't been closed, so the select.select() should
+        # time out regardless of the timemout argument, and raise.
+        with self.assertRaisesWithMessage(NailgunClient.NailgunError, 'wow'):
+          self.executor._await_socket(timeout=0.0001)

--- a/tests/python/pants_test/java/test_nailgun_integration.py
+++ b/tests/python/pants_test/java/test_nailgun_integration.py
@@ -5,16 +5,18 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.testutils.py2_compat import assertRegex
 
 
 class TestNailgunIntegration(PantsRunIntegrationTest):
+  target = 'examples/src/scala/org/pantsbuild/example/hello/welcome'
+
   def test_scala_repl_helloworld_input(self):
     """Integration test to exercise possible closed-loop breakages in NailgunClient, NailgunSession
     and InputReader.
     """
-    target = 'examples/src/scala/org/pantsbuild/example/hello/welcome'
     pants_run = self.run_pants(
-      command=['repl', target, '--quiet'],
+      command=['repl', self.target, '--quiet'],
       stdin_data=(
         'import org.pantsbuild.example.hello.welcome.WelcomeEverybody\n'
         'println(WelcomeEverybody("World" :: Nil).head)\n'
@@ -25,3 +27,17 @@ class TestNailgunIntegration(PantsRunIntegrationTest):
     )
     self.assert_success(pants_run)
     self.assertIn('Hello, World!', pants_run.stdout_data.splitlines())
+
+  def test_nailgun_connect_timeout(self):
+    pants_run = self.run_pants(
+      ['compile', self.target],
+      # Override the PANTS_CONFIG_FILES="pants.travis-ci.ini" used within TravisCI to enable
+      # nailgun usage for the purpose of exercising that stack in the integration test.
+      config={'DEFAULT': {'execution_strategy': 'nailgun'},
+              'compile.zinc': {'nailgun_timeout_seconds': '0.00002'}}
+    )
+    self.assert_failure(pants_run)
+    assertRegex(self, pants_run.stdout_data, """\
+compile\\(examples/src/java/org/pantsbuild/example/hello/greet:greet\\) failed: \
+Problem launching via <no nailgun connection> command org\\.pantsbuild\\.zinc\\.compiler\\.Main .*: \
+Failed to read nailgun output after 2e\-05 seconds!""")


### PR DESCRIPTION
### Problem

We previously had an untested code path (`NailgunExecutor._await_socket()`) which constructed a `NailgunClient.NailgunError` upon a timeout when connecting to a started nailgun subprocess. The `NailgunError` constructor was changed a while ago to create its own error message, and instead accept arguments such as the pid and pgrp in its constructor, but this untested code path hadn't been updated to provide those arguments. This caused a strange error when this unlikely timeout occurred while compiling zinc in an osx laptop environment.

### Solution

- Raise a `self.InitialNailgunConnectTimedOut` and convert it into a `self.Error` in a try/except instead of raising a `NailgunError`.
- Add testing for nailgun connection timeouts.
- Create a separate option `--nailgun-subprocess-startup-timeout` to cover the time to wait for the nailgun subprocess to start up, using `--nailgun-timeout-seconds` to cover the time to wait after that for the nailgun subprocess to begin producing output.

### Result

Another code path in our nailgun interactions is tested, and a bug in that code path is fixed.