### PR TITLE
Consolidate JSON stats recording in RunTracker

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -19,7 +19,6 @@ import requests
 from future.utils import PY3
 
 from pants.auth.cookies import Cookies
-from pants.base.build_environment import get_pants_cachedir
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.run_info import RunInfo
 from pants.base.worker_pool import SubprocPool, WorkerPool
@@ -419,12 +418,6 @@ class RunTracker(Subsystem):
       'outcomes': self.outcomes,
       'recorded_options': self._get_options_to_record(),
     }
-
-    # Write stats json to local cache.
-    stats_file = os.path.join(get_pants_cachedir(), 'stats',
-                              '{}.json'.format(self.run_info.get_info('id')))
-
-    self.write_stats_to_json(stats_file, self._json_dump_options(stats))
 
     # Write stats to user-defined json file.
     stats_json_file_name = self.get_options().stats_local_json_file

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -67,7 +67,7 @@ class RunTrackerTest(TestBase):
 
     # Execute & verify
     with temporary_file_path() as file_name:
-      self.assertTrue(RunTracker.write_stats_to_json(file_name, stats))
+      RunTracker.write_stats_to_json(file_name, stats)
       with open(file_name, 'r') as f:
         result = json.load(f)
         self.assertEqual(stats, result)


### PR DESCRIPTION
We currently write JSON two ways - one of which doesn't seem needed at all (writing to a cache that isn't accessed anywhere). This cleans that up a bit in preparation for adding the `JsonReporter` as an option for JSON output.

📝 One thing of note is the StatsDb schema is coupled to the current stats JSON.
https://github.com/pantsbuild/pants/blob/6739a81b6008274bfb4abd3436d9adb543a19e5a/src/python/pants/stats/statsdb.py#L80-L82

If that view (`<pants server url>/stats/`) is not currently providing much value to users, there is quite a bit more that can be removed as a followup to this change.