### PR TITLE
[WIP] add hack for missing sys.excepthook at reporting server termination

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -51,7 +51,7 @@ class LocalExiter(Exiter):
           # Log the unrecognized exit code to the fatal exception log.
           ExceptionSink.log_exception(run_tracker_msg)
           # Ensure the unrecognized exit code message is also logged to the terminal.
-          additional_messages.push(run_tracker_msg)
+          additional_messages.append(run_tracker_msg)
           outcome = WorkUnit.FAILURE
 
         self._run_tracker.set_root_outcome(outcome)
@@ -62,7 +62,7 @@ class LocalExiter(Exiter):
       # so we just log that fact here and keep going.
       exception_string = str(e)
       ExceptionSink.log_exception(exception_string)
-      additional_messages.push(exception_string)
+      additional_messages.append(exception_string)
     finally:
       if self._repro:
         # TODO: Have Repro capture the 'after' state (as a diff) as well? (in reference to the below

--- a/src/python/pants/core_tasks/reporting_server_kill.py
+++ b/src/python/pants/core_tasks/reporting_server_kill.py
@@ -26,7 +26,7 @@ class ReportingServerKill(QuietTaskMixin, Task):
     pid = server.pid
 
     try:
-      logger.info('Killing server with {pid} at http://localhost:{port}'
+      logger.info('Killing server with pid {pid} at http://localhost:{port}'
                   .format(pid=pid, port=server.socket))
       server.terminate()
     except ReportingServerManager.NonResponsiveProcess:

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -533,7 +533,7 @@ class ProcessManager(ProcessMetadataManager):
     """Pre-fork callback for subclasses."""
 
   def post_fork_child(self):
-    """Pre-fork child callback for subclasses."""
+    """Post-fork child callback for subclasses."""
 
   def post_fork_parent(self):
     """Post-fork parent callback for subclasses."""

--- a/tests/python/pants_test/core_tasks/BUILD
+++ b/tests/python/pants_test/core_tasks/BUILD
@@ -80,3 +80,14 @@ python_tests(
   ],
   tags = {'integration'},
 )
+
+python_tests(
+  name = 'reporting_server_integration',
+  sources = ['test_reporting_server_integration.py'],
+  dependencies = [
+    '3rdparty/python:psutil',
+    'tests/python/pants_test:int-test',
+    'tests/python/pants_test/testutils:py2_compat',
+  ],
+  tags = {'integration'},
+)

--- a/tests/python/pants_test/core_tasks/test_reporting_server_integration.py
+++ b/tests/python/pants_test/core_tasks/test_reporting_server_integration.py
@@ -1,0 +1,36 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import re
+
+import psutil
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.testutils.py2_compat import assertRegex
+
+
+class ReportingServerIntegration(PantsRunIntegrationTest):
+
+  def test_reporting_server_lifecycle(self):
+    start_server_run = self.run_pants(['server'])
+    self.assert_success(start_server_run)
+    assertRegex(self, start_server_run.stderr_data, 'Launched server with pid ([0-9]+) at http://localhost:([0-9]+)')
+    server_pid_port_match = re.search(
+      'Launched server with pid ([0-9]+) at http://localhost:([0-9]+)',
+      start_server_run.stderr_data)
+    pid = int(server_pid_port_match.group(1))
+    self.assertTrue(psutil.pid_exists(pid))
+    port = int(server_pid_port_match.group(2))
+
+    kill_server_run = self.run_pants(['killserver'])
+    self.assert_success(kill_server_run)
+    self.assertIn('Killing server with pid {} at http://localhost:{}'.format(pid, port),
+                  kill_server_run.stderr_data)
+    assertRegex(self, kill_server_run.stderr_data, """\
+timestamp: [^\n]+
+Signal 15 \\(SIGTERM\\) was raised\\. Exiting with failure\\.
+""")
+    self.assertFalse(psutil.pid_exists(pid))


### PR DESCRIPTION
### Problem

Fixes #7445.

### Solution

- Reset the `Exiter` in `ReportingServer#post_fork_child()` in order to avoid double-cleanup of the reporting and run tracking.
- Wrap `server.start()` in a try/except since `sys.excepthook` appears to be ignored for some reason.

### Result

The reporting server successfully captures the signal and terminates upon `./pants killserver`.