### PR TITLE
Fix crash if pants.ini is missing in the buildroot

### DIFF
--- a/src/python/pants/core_tasks/generate_pants_ini.py
+++ b/src/python/pants/core_tasks/generate_pants_ini.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
+import os.path
 import sys
 from textwrap import dedent
 
@@ -27,8 +27,8 @@ class GeneratePantsIni(ConsoleTask):
       """.format(pants_version, python_version)
     )
 
-    if os.stat(pants_ini_path).st_size != 0:
-      raise TaskError("{} is not empty. To update config values, please directly modify pants.ini. "
+    if os.path.isfile(pants_ini_path):
+      raise TaskError("{} already exists. To update config values, please directly modify pants.ini. "
                       "For example, you may want to add these entries:\n\n{}".format(pants_ini_path, pants_ini_content))
 
     yield dedent("""\

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -54,7 +54,9 @@ class OptionsBootstrapper(datatype([
     flag = '--pants-config-files='
     evars = ['PANTS_GLOBAL_PANTS_CONFIG_FILES', 'PANTS_PANTS_CONFIG_FILES', 'PANTS_CONFIG_FILES']
 
-    path_list_values = [ListValueComponent.create(get_default_pants_config_file())]
+    path_list_values = []
+    if os.path.isfile(get_default_pants_config_file()):
+      path_list_values.append(ListValueComponent.create(get_default_pants_config_file()))
     for var in evars:
       if var in env:
         path_list_values.append(ListValueComponent.create(env[var]))
@@ -104,10 +106,7 @@ class OptionsBootstrapper(datatype([
     short_flags = set()
 
     def filecontent_for(path):
-      return FileContent(
-        ensure_text(path),
-        read_file(path, binary_mode=True) if os.path.isfile(path) else b""
-      )
+      return FileContent(ensure_text(path), read_file(path, binary_mode=True))
 
     def capture_the_flags(*args, **kwargs):
       for arg in args:

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -104,7 +104,10 @@ class OptionsBootstrapper(datatype([
     short_flags = set()
 
     def filecontent_for(path):
-      return FileContent(ensure_text(path), read_file(path, binary_mode=True))
+      return FileContent(
+        ensure_text(path),
+        read_file(path, binary_mode=True) if os.path.isfile(path) else b""
+      )
 
     def capture_the_flags(*args, **kwargs):
       for arg in args:

--- a/tests/python/pants_test/core_tasks/BUILD
+++ b/tests/python/pants_test/core_tasks/BUILD
@@ -40,6 +40,7 @@ python_tests(
   sources = ['test_generate_pants_ini.py'],
   dependencies = [
     'src/python/pants:version',
+    'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/core_tasks',
     'tests/python/pants_test:task_test_base',

--- a/tests/python/pants_test/core_tasks/test_generate_pants_ini.py
+++ b/tests/python/pants_test/core_tasks/test_generate_pants_ini.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import configparser
 
+from pants.base.build_environment import get_default_pants_config_file
 from pants.base.exceptions import TaskError
 from pants.core_tasks.generate_pants_ini import GeneratePantsIni
 from pants.version import VERSION
@@ -18,15 +19,14 @@ class GeneratePantsIniTest(ConsoleTaskTestBase):
   def task_type(cls):
     return GeneratePantsIni
 
-  def test_pants_ini_generated_when_empty(self):
-    temp_pants_ini_path = self.create_file("pants.ini")
+  def test_pants_ini_generated_when_missing(self):
     self.execute_task()
     config = configparser.ConfigParser()
-    config.read(temp_pants_ini_path)
+    config.read(get_default_pants_config_file())
     self.assertEqual(config["GLOBAL"]["pants_version"], VERSION)
     self.assertIn(config["GLOBAL"]["pants_runtime_python_version"], {"2.7", "3.6", "3.7"})
 
-  def test_fails_when_pants_ini_is_not_empty(self):
-    temp_pants_ini_path = self.create_file("pants.ini", contents="[GLOBAL]")
+  def test_fails_when_pants_ini_already_exists(self):
+    temp_pants_ini_path = self.create_file("pants.ini")
     with self.assertRaisesWithMessageContaining(TaskError, temp_pants_ini_path):
       self.execute_task()


### PR DESCRIPTION
### Problem
If `pants.ini` is not present, then Pants will crash with this error:

```
timestamp: 2019-03-28T18:16:34.356612
Exception caught: (exceptions.IOError)
  File "/Users/eric/.cache/pants/setup/bootstrap-Darwin-x86_64/unspecified_py27/bin/pants", line 10, in <module>
    sys.exit(main())
  File "/Users/eric/.cache/pants/setup/bootstrap-Darwin-x86_64/unspecified_py27/lib/python2.7/site-packages/pants/bin/pants_loader.py", line 85, in main
    PantsLoader.run()
  File "/Users/eric/.cache/pants/setup/bootstrap-Darwin-x86_64/unspecified_py27/lib/python2.7/site-packages/pants/bin/pants_loader.py", line 81, in run
    cls.load_and_execute(entrypoint)
  File "/Users/eric/.cache/pants/setup/bootstrap-Darwin-x86_64/unspecified_py27/lib/python2.7/site-packages/pants/bin/pants_loader.py", line 74, in load_and_execute
    entrypoint_main()
  File "/Users/eric/.cache/pants/setup/bootstrap-Darwin-x86_64/unspecified_py27/lib/python2.7/site-packages/pants/bin/pants_exe.py", line 39, in main
    PantsRunner(exiter, start_time=start_time).run()
  File "/Users/eric/.cache/pants/setup/bootstrap-Darwin-x86_64/unspecified_py27/lib/python2.7/site-packages/pants/bin/pants_runner.py", line 39, in run
    options_bootstrapper = OptionsBootstrapper.create(env=self._env, args=self._args)
  File "/Users/eric/.cache/pants/setup/bootstrap-Darwin-x86_64/unspecified_py27/lib/python2.7/site-packages/pants/option/options_bootstrapper.py", line 133, in create
    config_files_products = [filecontent_for(p) for p in config_file_paths]
  File "/Users/eric/.cache/pants/setup/bootstrap-Darwin-x86_64/unspecified_py27/lib/python2.7/site-packages/pants/option/options_bootstrapper.py", line 106, in filecontent_for
    return FileContent(ensure_text(path), read_file(path))
  File "/Users/eric/.cache/pants/setup/bootstrap-Darwin-x86_64/unspecified_py27/lib/python2.7/site-packages/pants/util/dirutil.py", line 155, in read_file
    with open(filename, mode) as f:

Exception message: [Errno 2] No such file or directory: '/Users/eric/DocsLocal/code/projects/setup/pants.ini'
```

This does not appear to be by design. Notably, we allow an empty `pants.ini` without any issue. There is no meaningful difference between an empty `pants.ini` from a non-existent `pants.ini`, so this seems to be a bug.

### Solution
First check if `pants.ini` exists before adding it to the list of config files.

This also allows us to refactor `./pants generate-pants-ini` from https://github.com/pantsbuild/pants/pull/7448 to create a new `pants.ini`, rather than requiring the user to make it. This allows us to simplify our setup instructions even more by removing the `touch pants.ini` instruction.