### PR TITLE
invalidate dependency targets if in combined mode

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
@@ -111,17 +111,18 @@ class JvmdocGen(SkipAndTransitiveOptionsRegistrar, HasSkipAndTransitiveOptionsMi
     if not targets:
       return
 
-    with self.invalidated(targets, invalidate_dependents=self.combined) as invalidation_check:
-      def find_jvmdoc_targets():
-        invalid_targets = set()
-        for vt in invalidation_check.invalid_vts:
-          invalid_targets.update(vt.targets)
-        return invalid_targets
+    if self.combined:
+      self._generate_combined(targets, create_jvmdoc_command)
+    else:
+      with self.invalidated(targets) as invalidation_check:
+        def find_jvmdoc_targets():
+          invalid_targets = set()
+          for vt in invalidation_check.invalid_vts:
+            invalid_targets.update(vt.targets)
+          return invalid_targets
 
-      jvmdoc_targets = list(find_jvmdoc_targets())
-      if self.combined:
-        self._generate_combined(jvmdoc_targets, create_jvmdoc_command)
-      else:
+        jvmdoc_targets = list(find_jvmdoc_targets())
+
         self._generate_individual(jvmdoc_targets, create_jvmdoc_command)
 
     if catalog:

--- a/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
@@ -111,7 +111,7 @@ class JvmdocGen(SkipAndTransitiveOptionsRegistrar, HasSkipAndTransitiveOptionsMi
     if not targets:
       return
 
-    with self.invalidated(targets) as invalidation_check:
+    with self.invalidated(targets, invalidate_dependents=self.combined) as invalidation_check:
       def find_jvmdoc_targets():
         invalid_targets = set()
         for vt in invalidation_check.invalid_vts:


### PR DESCRIPTION
### Problem

The doc.scaladoc task (and likely also the doc.javadoc task), when used with --combined is skipping dependencies in the graph during the 'invalidation' stage, because it is not passing invalidate_dependents in the docable predicate that is part of the base class JvmDocGen.

See issue: #7434

### Solution

In the relevant spot in `JvmDocGen` class, this change passes the `invalidate_dependents` parameter to `self.invalidate()` with attribute `self.combined` for the value which is `True` for combined doc builds and `False` otherwise. 

### Result

This causes the invalidation logic to behave as expected, specifically, invalidating the dependencies within the entire graph for a combined doc build. I tested this locally to ensure the correct behavior, and ran all relevant unit tests. 
