### PR TITLE
Fix flaky `./pants idea-plugin` when using Python 3 by properly using ConsoleTask interface

### DIFF
--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,3 +1,2 @@
-tests/python/pants_test/backend/project_info/tasks:idea_plugin_integration
 tests/python/pants_test/backend/python/tasks:integration
 tests/python/pants_test/engine/legacy:console_rule_integration

--- a/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
+++ b/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
@@ -163,7 +163,7 @@ class IdeaPluginGen(ConsoleTask):
       return output.name
 
   def console_output(self, _targets):
-    if not self.context.target_roots:
+    if not self.context.options.target_specs:
       raise TaskError("No targets specified.")
 
     # Heuristics to guess whether user tries to load a python project,

--- a/tests/python/pants_test/backend/project_info/tasks/test_idea_plugin_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_idea_plugin_integration.py
@@ -64,7 +64,7 @@ class IdeaPluginIntegrationTest(PantsRunIntegrationTest):
 
   def _get_project_dir(self, output_file):
     with open(output_file, 'r') as result:
-      return result.readlines()[0]
+      return result.readlines()[0].strip()
 
   def _run_and_check(self, target_specs, incremental_import=None):
     """


### PR DESCRIPTION
### Problem
The Idea plugin integration tests would frequently flake with Python 3.

This appears to be because the task is a `ConsoleTask`, but it overrides `execute()` when it is instead expected to override `console_output()`. With this override, we would no longer call `self._outstream.flush()`, so the tests would sometimes complain that there was no entry in the `--output-file`, as the change would not always be persisted. It makes sense that this did not start flaking until Python 3, because IO streams changed their behavior in Python 3.

Refer to `ConsoleTask` for everything we need to do to properly output to the console and files: https://github.com/pantsbuild/pants/blob/e620a9e862a245088bc5b477aed2b87e2bc6a307/src/python/pants/task/console_task.py#L52-L62

Will close https://github.com/pantsbuild/pants/issues/7150.

### Solution
No longer override `execute()` and instead move the logic into `console_output()`.

### Result
The tests no longer flake.

This was confirmed locally by creating the script `untilfail`:

```bash
#!/bin/bash

while $@; do :; done
```

Then running `./untilfail ./pants clean-all test.pytest tests/python/pants_test/backend/project_info/tasks:idea_plugin_integration -- -k test_idea_plugin_single_target` for 10 minutes on both macOS and Ubuntu without fail.