### PR TITLE
Switch to twitter.common 0.3.11 to fix DeprecationWarning when using Pants as a PEX

### DIFF
--- a/3rdparty/python/twitter/commons/requirements.txt
+++ b/3rdparty/python/twitter/commons/requirements.txt
@@ -1,3 +1,3 @@
-twitter.common.collections>=0.3.10,<0.4
-twitter.common.confluence>=0.3.10,<0.4
-twitter.common.dirutil>=0.3.10,<0.4
+twitter.common.collections>=0.3.11,<0.4
+twitter.common.confluence>=0.3.11,<0.4
+twitter.common.dirutil>=0.3.11,<0.4


### PR DESCRIPTION
### Problem

`0.3.11` was recently released containing one additional Py3 warnings fix: https://github.com/twitter/commons/pull/476

### Solution

Pull it in (explicitly, rather than floating to it).