### PR TITLE
Improve error message for isort failure in IsortRun

### DIFF
--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -33,4 +33,4 @@ do
   esac
 done
 
-./pants -q --changed-parent=master fmt.isort -- ${isort_args[@]}
+./pants --changed-parent=master fmt.isort -- ${isort_args[@]}

--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -33,4 +33,4 @@ do
   esac
 done
 
-./pants --changed-parent=master fmt.isort -- ${isort_args[@]}
+./pants --quiet --changed-parent=master fmt.isort -- ${isort_args[@]}

--- a/src/python/pants/backend/python/tasks/isort_run.py
+++ b/src/python/pants/backend/python/tasks/isort_run.py
@@ -63,7 +63,7 @@ class IsortRun(FmtTaskMixin, Task):
         cmdline, exit_code = isort.run(workunit_factory, args)
         if exit_code != 0:
           raise TaskError(
-            "Exited with return code {} while running isort with args `{}`.".format(exit_code, " ".join(args)),
+            "Exited with return code {} while running `{}`.".format(exit_code, cmdline),
             exit_code=exit_code
           )
 

--- a/src/python/pants/backend/python/tasks/isort_run.py
+++ b/src/python/pants/backend/python/tasks/isort_run.py
@@ -57,14 +57,16 @@ class IsortRun(FmtTaskMixin, ConsoleTask):
       # NB: We execute isort out of process to avoid unwanted side-effects from importing it:
       #   https://github.com/timothycrosley/isort/issues/456
       with pushd(get_buildroot()):
-        stdout, stderr, exit_code, cmdline = isort.output(args)
+        stdout, stderr, exit_code, _ = isort.output(args)
         if stdout:
           yield stdout
         if stderr:
           yield stderr
         if exit_code != 0:
-          raise TaskError("Exited non-zero ({}) while running `{}`.".format(exit_code, cmdline),
-                          exit_code=exit_code)
+          raise TaskError(
+            "Exited with return code {} while running isort with args `{}`.".format(exit_code, " ".join(args)),
+            exit_code=exit_code
+          )
 
   def _calculate_isortable_python_sources(self, targets):
     """Generate a set of source files from the given targets."""


### PR DESCRIPTION
### Problem
When `./pants fmt.isort` fails, its failure message is difficult to parse, especially because it starts with the command, rather than human readable English introducing what happened. For example:

```
FAILURE: /Users/eric/.pyenv/shims/python3.6 /Users/eric/.cache/pants/python/CPython-3.6.8/d6bcba436bdefbc27a69dd880d6ee5716e004764/isort-c201e856817dc9ae802d18e3ec45a3bfa4c2ac11.pex --check-only src/python/pants/util/tarutil.py src/python/pants/util/retry.py src/python/pants/util/osutil.py src/python/pants/util/memo.py src/python/pants/util/process_handler.py src/python/pants/util/strutil.py src/python/pants/util/py2_compat.py src/python/pants/util/meta.py src/python/pants/util/xml_parser.py src/python/pants/util/objects.py src/python/pants/util/rwbuf.py src/python/pants/util/collections_abc_backport.py ... exited non-zero (1).

FAILURE
```

### Solution
Invert the error message to be more readable.

### Result
For example:

```
FAILURE: Exited with return code 1 while running `/Users/eric/.pyenv/shims/python3.6 /Users/eric/.cache/pants/python/CPython-3.6.8/d6bcba436bdefbc27a69dd880d6ee5716e004764/isort-c201e856817dc9ae802d18e3ec45a3bfa4c2ac11.pex --check-only src/python/pants/util/tarutil.py src/python/pants/util/retry.py src/python/pants/util/osutil.py src/python/pants/util/memo.py src/python/pants/util/process_handler.py src/python/pants/util/strutil.py src/python/pants/util/py2_compat.py src/python/pants/util/meta.py src/python/pants/util/xml_parser.py src/python/pants/util/objects.py src/python/pants/util/rwbuf.py src/python/pants/util/collections_abc_backport.py`.

FAILURE
```