### PR TITLE
Remove backend/python/tasks tests from Python 3 CI blacklist and refactor their BUILD entries to be more granular

### DIFF
--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,2 +1,1 @@
-tests/python/pants_test/backend/python/tasks:integration
 tests/python/pants_test/engine/legacy:console_rule_integration

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -23,57 +23,276 @@ python_library(
 )
 
 python_tests(
-  sources=globs('test_*.py', exclude=([globs('*_integration.py')])),
-  dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.dirutil',
-    '3rdparty/python:coverage',
-    '3rdparty/python:future',
-    '3rdparty/python:mock',
+  name = 'build_local_python_distributions',
+  sources = ['test_build_local_python_distributions.py'],
+  dependencies = [
     '3rdparty/python:pex',
-    ':python_task_test_base',
-    'src/python/pants/backend/native',
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/backend/python:python_requirement',
+    'src/python/pants/backend/python/targets',
+    'tests/python/pants_test/backend/python/tasks/util',
+  ],
+)
+
+python_tests(
+  name = 'build_local_python_distributions_integration',
+  sources = ['test_build_local_python_distributions_integration.py'],
+  dependencies = [
+    'src/python/pants/util:collections',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:process_handler',
+    'tests/python/pants_test:int-test',
+    'tests/python/pants_test/testutils:py2_compat',
+  ],
+  tags = {'integration'},
+  timeout=450
+)
+
+python_tests(
+  name = 'gather_sources',
+  sources = ['test_gather_sources.py'],
+  dependencies = [
+    '3rdparty/python:future',
+    '3rdparty/python:pex',
+    'src/python/pants/backend/python:interpreter_cache',
     'src/python/pants/backend/python/subsystems',
     'src/python/pants/backend/python/targets',
     'src/python/pants/backend/python/tasks',
-    'src/python/pants/backend/python:interpreter_cache',
-    'src/python/pants/backend/python:plugin',
-    'src/python/pants/backend/python:python_artifact',
-    'src/python/pants/backend/python:python_requirement',
-    'src/python/pants/base:build_root',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/base:run_info',
     'src/python/pants/build_graph',
-    'src/python/pants/fs',
+    'src/python/pants/source',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:task_test_base',
+  ],
+)
+
+python_tests(
+  name = 'interpreter_selection_integration',
+  sources = ['test_interpreter_selection_integration.py'],
+  dependencies = [
+    '3rdparty/python:pex',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:process_handler',
+    'tests/python/pants_test:int-test',
+    'tests/python/pants_test/backend/python:interpreter_selection_utils',
+  ],
+  tags = {'integration'},
+  timeout=240,
+)
+
+python_tests(
+  name = 'isort_run',
+  sources = ['test_isort_run.py'],
+  dependencies = [
+    '3rdparty/python:future',
+    'src/python/pants/backend/python/tasks',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:process_handler',
+    'tests/python/pants_test/backend/python:interpreter_selection_utils',
+    ':python_task_test_base',
+  ],
+)
+
+python_tests(
+  name = 'isort_run_integration',
+  sources = ['test_isort_run_integration.py'],
+  dependencies = [
+    'src/python/pants/backend/python/tasks',
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
+)
+
+python_tests(
+  name = 'pytest_run',
+  sources = ['test_pytest_run.py'],
+  dependencies = [
+    '3rdparty/python:coverage',
+    '3rdparty/python:future',
+    'src/python/pants/backend/python/tasks',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/build_graph',
     'src/python/pants/source',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-    'src/python/pants/util:process_handler',
     'src/python/pants/util:py2_compat',
-    'tests/python/pants_test/backend/python:interpreter_selection_utils',
-    'tests/python/pants_test/backend/python/tasks/util',
-    'tests/python/pants_test/engine:scheduler_test_base',
+    'src/python/pants/util:process_handler',
+    'tests/python/pants_test:task_test_base',
     'tests/python/pants_test/subsystem:subsystem_utils',
+    ':python_task_test_base',
+  ],
+  timeout=240,
+)
+
+python_tests(
+  name = 'pytest_run_integration',
+  sources = ['test_pytest_run_integration.py'],
+  dependencies = [
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:int-test',
+    'tests/python/pants_test/backend/python:interpreter_selection_utils',
+    'tests/python/pants_test/testutils:pexrc_util',
+  ],
+  tags = {'integration'},
+  timeout=240,
+)
+
+python_tests(
+  name = 'python_binary_create',
+  sources = ['test_python_binary_create.py'],
+  dependencies = [
+    '3rdparty/python:future',
+    'src/python/pants/backend/python/tasks',
+    'src/python/pants/base:run_info',
+    'src/python/pants/build_graph',
+    'src/python/pants/util:process_handler',
+    ':python_task_test_base',
+  ],
+)
+
+python_tests(
+  name = 'python_binary_integration',
+  sources = ['test_python_binary_integration.py'],
+  dependencies = [
+    '3rdparty/python:pex',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
+  timeout=240
+)
+
+python_tests(
+  name = 'python_repl',
+  sources = ['test_python_repl.py'],
+  dependencies = [
+    '3rdparty/python:future',
+    'src/python/pants/backend/python/tasks',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/build_graph',
+    'src/python/pants/task',
+    'src/python/pants/util:contextutil',
+    ':python_task_test_base',
+  ],
+)
+
+python_tests(
+  name = 'python_repl_integration',
+  sources = ['test_python_repl_integration.py'],
+  dependencies = [
+    'tests/python/pants_test:int-test',
+    'tests/python/pants_test/testutils:py2_compat',
+  ],
+  tags = {'integration'},
+  timeout=120,
+)
+
+python_tests(
+  name = 'python_run_integration',
+  sources = ['test_python_run_integration.py'],
+  dependencies = [
+    '3rdparty/python:pex',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:int-test',
+    'tests/python/pants_test/backend/python:interpreter_selection_utils',
+    'tests/python/pants_test/testutils:pexrc_util',
+  ],
+  tags = {'integration'},
+  timeout=240
+)
+
+python_tests(
+  name = 'python_tool',
+  sources = ['test_python_tool.py'],
+  dependencies = [
+    'src/python/pants/backend/python/subsystems',
+    'src/python/pants/backend/python/tasks',
+    'src/python/pants/task',
+    'src/python/pants/util:contextutil',
+    ':python_task_test_base',
+  ],
+)
+
+python_tests(
+  name = 'resolve_requirements',
+  sources = ['test_resolve_requirements.py'],
+  dependencies = [
+    '3rdparty/python:future',
+    '3rdparty/python:pex',
+    'src/python/pants/backend/python:interpreter_cache',
+    'src/python/pants/backend/python:python_requirement',
+    'src/python/pants/backend/python/subsystems',
+    'src/python/pants/backend/python/targets',
+    'src/python/pants/backend/python/tasks',
+    'src/python/pants/base:build_environment',
+    'src/python/pants/task',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:process_handler',
     'tests/python/pants_test:task_test_base',
   ],
-  timeout=600
+)
+
+python_tests(
+  name = 'select_interpreter',
+  sources = ['test_select_interpreter.py'],
+  dependencies = [
+    '3rdparty/python:future',
+    '3rdparty/python:mock',
+    '3rdparty/python:pex',
+    'src/python/pants/backend/python:interpreter_cache',
+    'src/python/pants/backend/python/subsystems',
+    'src/python/pants/backend/python/targets',
+    'src/python/pants/backend/python/tasks',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test:task_test_base',
+  ],
+)
+
+python_tests(
+  name = 'setup_py',
+  sources = ['test_setup_py.py'],
+  dependencies = [
+    '3rdparty/python:future',
+    '3rdparty/python:mock',
+    '3rdparty/python:pex',
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python/twitter/commons:twitter.common.dirutil',
+    'src/python/pants/backend/python/subsystems',
+    'src/python/pants/backend/python/targets',
+    'src/python/pants/backend/python/tasks',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/build_graph',
+    'src/python/pants/fs',
+    'src/python/pants/util:collections_abc_backport',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test/backend/python:interpreter_selection_utils',
+    'tests/python/pants_test/subsystem:subsystem_utils',
+    ':python_task_test_base',
+  ],
+)
+
+python_tests(
+  name = 'setup_py_integration',
+  sources = ['test_setup_py_integration.py'],
+  dependencies = [
+    'tests/python/pants_test/backend/python:pants_requirement_integration_test_base',
+  ],
+  tags = {'integration'},
+  timeout=240,
 )
 
 
 python_tests(
-  name='integration',
-  sources=globs('*_integration.py'),
-  dependencies=[
-    '3rdparty/python:pex',
-    'src/python/pants/base:build_environment',
-    'src/python/pants/util:contextutil',
-    'src/python/pants/util:process_handler',
-    'tests/python/pants_test/backend/python/tasks:python_task_test_base',
-    'tests/python/pants_test/backend/python:interpreter_selection_utils',
-    'tests/python/pants_test/backend/python:pants_requirement_integration_test_base',
-    'tests/python/pants_test:int-test',
-    'tests/python/pants_test/testutils:py2_compat',
+  name = 'unpack_wheels',
+  sources = ['test_unpack_wheels.py'],
+  dependencies = [
+    'src/python/pants/backend/python:python_requirement',
+    'src/python/pants/backend/python/targets',
+    'src/python/pants/backend/python/tasks',
+    'src/python/pants/task',
+    'src/python/pants/util:collections',
+    'tests/python/pants_test:task_test_base',
   ],
-  tags={'integration'},
-  timeout=2400
 )

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -87,7 +87,7 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
   def _build_pex(self, binary_target, config=None, args=None, version=PY_27):
     # By default, Avoid some known-to-choke-on interpreters.
     if version == PY_3:
-      constraint = '["CPython>=3.4,<4"]'
+      constraint = '["CPython>=3.6,<4"]'
     else:
       constraint = '["CPython>=2.7,<3"]'
     args = list(args) if args is not None else [


### PR DESCRIPTION
### Problem
Currently, you can only run `./pants test tests/python/pants_test/backend/python/tasks:tasks` or `./pants test tests/python/pants_test/backend/python/tasks:integration`. 

This lack of granularity makes it difficult to develop in this folder, as the former has a test timeout of 10 minutes and the latter of 40 minutes. While you can use `./pants test.pytest -- -k test_name`, this does not get the specific file but rather the names of individual tests.

It also makes it harder to tell which tests are causing the long timeouts for this folder.

### Solution
Each test file gets its own BUILD entry, as we do in most folders.

#### Also remove tests from Py3 blacklist
All tests now pass with Python 3. This is hypothesized to be thanks to:
1) Performance improvement thanks to https://github.com/pantsbuild/pants/pull/7447. As we recall, some of the tests were timing out, and this performance fix reduces the risk of timeouts.
2) Skipping Pexrc-related tests thanks to https://github.com/pantsbuild/pants/pull/7285.

Note all integration tests were ran four times in CI to check for flakiness.

#### Also refactor `test_python_run_integration.py`'s interpreter selection
Deduplicate the constraints and update the constraints to reflect our modern interpreter usage. For example, currently Py37 may not be chosen, which means our cron job would potentially fail.