### PR TITLE
Fix typo from #7424 to properly fix TensorFlow test during Python 3.7 cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,13 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - name: &bootstrap Bootstrap Pants
-    if: type != cron
+    if: type = cron
   - name: &bootstrap_cron Bootstrap Pants (Cron)
-    if: type = cron
-  - name: &test Test Pants
     if: type != cron
-  - name: &test_cron Test Pants (Cron)
+  - name: &test Test Pants
     if: type = cron
+  - name: &test_cron Test Pants (Cron)
+    if: type != cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -212,7 +212,7 @@ py37_linux_test_config: &py37_linux_test_config
   stage: *test_cron
   env:
     # TODO(https://github.com/tensorflow/tensorflow/issues/27078): tensorflow==1.13.1 on python 3.7.2 for Linux uses the new C++ ABI, which may be an error.
-    - &py37_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_COMPILER_OPTION_SETS="[]"
+    - &py37_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
 
 base_osx_config: &base_osx_config
   os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,13 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - name: &bootstrap Bootstrap Pants
-    if: type = cron
+    if: type != cron
   - name: &bootstrap_cron Bootstrap Pants (Cron)
-    if: type != cron
-  - name: &test Test Pants
     if: type = cron
-  - name: &test_cron Test Pants (Cron)
+  - name: &test Test Pants
     if: type != cron
+  - name: &test_cron Test Pants (Cron)
+    if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -28,13 +28,13 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - name: &bootstrap Bootstrap Pants
-    if: type != cron
+    if: type = cron
   - name: &bootstrap_cron Bootstrap Pants (Cron)
-    if: type = cron
-  - name: &test Test Pants
     if: type != cron
-  - name: &test_cron Test Pants (Cron)
+  - name: &test Test Pants
     if: type = cron
+  - name: &test_cron Test Pants (Cron)
+    if: type != cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -202,7 +202,7 @@ py37_linux_test_config: &py37_linux_test_config
   stage: *test_cron
   env:
     # TODO(https://github.com/tensorflow/tensorflow/issues/27078): tensorflow==1.13.1 on python 3.7.2 for Linux uses the new C++ ABI, which may be an error.
-    - &py37_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_COMPILER_OPTION_SETS="[]"
+    - &py37_linux_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
 
 base_osx_config: &base_osx_config
   os: osx

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -28,13 +28,13 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - name: &bootstrap Bootstrap Pants
-    if: type = cron
+    if: type != cron
   - name: &bootstrap_cron Bootstrap Pants (Cron)
-    if: type != cron
-  - name: &test Test Pants
     if: type = cron
-  - name: &test_cron Test Pants (Cron)
+  - name: &test Test Pants
     if: type != cron
+  - name: &test_cron Test Pants (Cron)
+    if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable


### PR DESCRIPTION
### Problem

#7424 typoed the compiler option sets env var, so didn't actually fix #7417.

### Solution

- Correct the compiler option sets env var name which tells pants to use the new C++ ABI to compile our tensorflow custom operator.

### Result

The python 3.7 cron job passes!