### PR TITLE
Remove console_rule_integration.py from Python 3 CI blacklist

### DIFF
--- a/build-support/known_py3_pex_failures.txt
+++ b/build-support/known_py3_pex_failures.txt
@@ -1,2 +1,1 @@
 tests/python/pants_test/backend/python/tasks:integration
-tests/python/pants_test/engine/legacy:console_rule_integration


### PR DESCRIPTION
This test no longer fails with Python 3. It was likely fixed by https://github.com/pantsbuild/pants/pull/7447, as the test was timing out originally.

All Python 3 integration tests were ran three times to ensure we aren't adding a flaky test.