### PR TITLE
Hotfix #6987 breaking custom tasks' definitions of `options_scope` when using Python 2

### DIFF
--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -7,7 +7,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import functools
 import re
 from abc import abstractproperty
-from builtins import str
+from builtins import bytes, str
+
+from future.utils import PY3
 
 from pants.engine.selectors import Get
 from pants.option.errors import OptionsError
@@ -147,5 +149,6 @@ class Optionable(OptionableFactory, AbstractClass):
     # its __init__, as we do here. We usually only create a single instance of an Optionable
     # subclass anyway.
     cls = type(self)
-    if not isinstance(cls.options_scope, str):
+    # NB: Python 2 stores property names as bytes, whereas Python 3 stores them as unicode.
+    if not isinstance(cls.options_scope, str if PY3 else (str, bytes)):
       raise NotImplementedError('{} must set an options_scope class-level property.'.format(cls))


### PR DESCRIPTION
### Problem
https://github.com/pantsbuild/pants/pull/6987/files#diff-01f68d1f024aba3b37384edad4a59abdR150 introduced a bad change that requires `Optionable` classes to implement `options_scope` and for that property to be stored as unicode.

This works fine for Python 3, but conflicts with how Python 2 stores the names of attributes/properties as bytes. So, a user reported in https://pantsbuild.slack.com/archives/C046T6T9U/p1553994182033600 that their custom class could not be created when upgrading to 1.14.0 due to the property not being `str` (i.e. unicode).

### Solution
If Python 3, expect unicode. If Python 2, expect either bytes or unicode.

### Open question - why did this not impact Pants code?
With us running CI with Python 2 every night, and us having dozens of classes that provide an `options_scope`, it's unclear why this repository did not run into this issue.