### PR TITLE
Remove Python 3 CI blacklist mechanism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -657,7 +657,7 @@ base_rust_tests: &base_rust_tests
 linux_rust_tests: &linux_rust_tests
   <<: *base_rust_tests
   <<: *linux_with_fuse
-  name: "Linux Rust tests (No PEX)"
+  name: "Rust tests - Linux (No PEX)"
   env:
     - CACHE_NAME=linuxrusttests
   os: linux
@@ -670,7 +670,7 @@ linux_rust_tests: &linux_rust_tests
 
 osx_rust_tests: &osx_rust_tests
   <<: *base_rust_tests
-  name: "OSX Rust tests (No PEX)"
+  name: "Rust tests - OSX (No PEX)"
   env:
     - CACHE_NAME=macosrusttests
   os: osx
@@ -928,7 +928,7 @@ matrix:
     - <<: *cargo_audit
 
     - <<: *py27_linux_test_config
-      name: "Unit tests for pants and pants-plugins (Py2.7 PEX)"
+      name: "Unit tests (Py2.7 PEX)"
       stage: *test
       env:
         - *py27_linux_test_config_env
@@ -937,7 +937,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -2lp
 
     - <<: *py36_linux_test_config
-      name: "Unit tests for pants and pants-plugins (Py3.6 PEX)"
+      name: "Unit tests (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=linuxunittests.py36
@@ -945,7 +945,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -lp
 
     - <<: *py37_linux_test_config
-      name: "Unit tests for pants and pants-plugins (Py3.7 PEX)"
+      name: "Unit tests (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=linuxunittests.py37
@@ -961,321 +961,327 @@ matrix:
     - <<: *py36_osx_build_wheels
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 0 (Py3.6 PEX)"
+      name: "Integration tests - shard 0 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard0
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 0/19
+        - ./build-support/bin/travis-ci.sh -c -i 0/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 1 (Py3.6 PEX)"
+      name: "Integration tests - shard 1 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard1
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 1/19
+        - ./build-support/bin/travis-ci.sh -c -i 1/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 2 (Py3.6 PEX)"
+      name: "Integration tests - shard 2 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard2
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 2/19
+        - ./build-support/bin/travis-ci.sh -c -i 2/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 3 (Py3.6 PEX)"
+      name: "Integration tests - shard 3 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard3
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 3/19
+        - ./build-support/bin/travis-ci.sh -c -i 3/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 4 (Py3.6 PEX)"
+      name: "Integration tests - shard 4 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard4
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 4/19
+        - ./build-support/bin/travis-ci.sh -c -i 4/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 5 (Py3.6 PEX)"
+      name: "Integration tests - shard 5 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard5
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 5/19
+        - ./build-support/bin/travis-ci.sh -c -i 5/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 6 (Py3.6 PEX)"
+      name: "Integration tests - shard 6 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard6
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 6/19
+        - ./build-support/bin/travis-ci.sh -c -i 6/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 7 (Py3.6 PEX)"
+      name: "Integration tests - shard 7 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard7
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 7/19
+        - ./build-support/bin/travis-ci.sh -c -i 7/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 8 (Py3.6 PEX)"
+      name: "Integration tests - shard 8 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard8
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 8/19
+        - ./build-support/bin/travis-ci.sh -c -i 8/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 9 (Py3.6 PEX)"
+      name: "Integration tests - shard 9 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard9
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 9/19
+        - ./build-support/bin/travis-ci.sh -c -i 9/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 10 (Py3.6 PEX)"
+      name: "Integration tests - shard 10 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard10
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 10/19
+        - ./build-support/bin/travis-ci.sh -c -i 10/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 11 (Py3.6 PEX)"
+      name: "Integration tests - shard 11 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard11
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 11/19
+        - ./build-support/bin/travis-ci.sh -c -i 11/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 12 (Py3.6 PEX)"
+      name: "Integration tests - shard 12 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard12
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 12/19
+        - ./build-support/bin/travis-ci.sh -c -i 12/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 13 (Py3.6 PEX)"
+      name: "Integration tests - shard 13 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard13
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 13/19
+        - ./build-support/bin/travis-ci.sh -c -i 13/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 14 (Py3.6 PEX)"
+      name: "Integration tests - shard 14 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard14
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 14/19
+        - ./build-support/bin/travis-ci.sh -c -i 14/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 15 (Py3.6 PEX)"
+      name: "Integration tests - shard 15 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard15
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 15/19
+        - ./build-support/bin/travis-ci.sh -c -i 15/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 16 (Py3.6 PEX)"
+      name: "Integration tests - shard 16 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard16
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 16/19
+        - ./build-support/bin/travis-ci.sh -c -i 16/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 17 (Py3.6 PEX)"
+      name: "Integration tests - shard 17 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard17
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 17/19
+        - ./build-support/bin/travis-ci.sh -c -i 17/20
 
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard 18 (Py3.6 PEX)"
+      name: "Integration tests - shard 18 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard18
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 18/19
+        - ./build-support/bin/travis-ci.sh -c -i 18/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 19 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integrationshard19
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 19/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 0 (Py3.7 PEX)"
+      name: "Integration tests - shard 0 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard0
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 0/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 0/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 1 (Py3.7 PEX)"
+      name: "Integration tests - shard 1 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard1
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 1/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 1/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 2 (Py3.7 PEX)"
+      name: "Integration tests - shard 2 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard2
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 2/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 2/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 3 (Py3.7 PEX)"
+      name: "Integration tests - shard 3 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard3
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 3/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 3/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 4 (Py3.7 PEX)"
+      name: "Integration tests - shard 4 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard4
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 4/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 4/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 5 (Py3.7 PEX)"
+      name: "Integration tests - shard 5 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard5
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 5/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 5/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 6 (Py3.7 PEX)"
+      name: "Integration tests - shard 6 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard6
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 6/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 6/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 7 (Py3.7 PEX)"
+      name: "Integration tests - shard 7 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard7
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 7/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 7/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 8 (Py3.7 PEX)"
+      name: "Integration tests - shard 8 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard8
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 8/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 8/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 9 (Py3.7 PEX)"
+      name: "Integration tests - shard 9 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard9
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 9/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 9/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 10 (Py3.7 PEX)"
+      name: "Integration tests - shard 10 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard10
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 10/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 10/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 11 (Py3.7 PEX)"
+      name: "Integration tests - shard 11 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard11
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 11/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 11/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 12 (Py3.7 PEX)"
+      name: "Integration tests - shard 12 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard12
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 12/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 12/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 13 (Py3.7 PEX)"
+      name: "Integration tests - shard 13 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard13
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 13/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 13/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 14 (Py3.7 PEX)"
+      name: "Integration tests - shard 14 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard14
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 14/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 14/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 15 (Py3.7 PEX)"
+      name: "Integration tests - shard 15 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard15
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 15/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 15/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 16 (Py3.7 PEX)"
+      name: "Integration tests - shard 16 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard16
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 16/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 16/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 17 (Py3.7 PEX)"
+      name: "Integration tests - shard 17 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard17
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 17/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 17/20
 
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard 18 (Py3.7 PEX)"
+      name: "Integration tests - shard 18 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard18
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 18/19
+        - ./build-support/bin/travis-ci.sh -c7 -i 18/20
 
-    - <<: *py27_linux_test_config
-      name: "Blacklisted integration tests for pants - shard 0 (Py2.7 PEX w/ Py3.6 constraints)"
-      stage: *test
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 19 (Py3.7 PEX)"
       env:
-        - *py27_linux_test_config_env
-        - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
-        - CACHE_NAME=integrationshard0.py27blacklist
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integrationshard19
       script:
-        - ./build-support/bin/travis-ci.sh -c2w -i 0/1
+        - ./build-support/bin/travis-ci.sh -c7 -i 19/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 0 (Py2.7 PEX)"
+      name: "Integration tests - shard 0 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard0
@@ -1283,7 +1289,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 0/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 1 (Py2.7 PEX)"
+      name: "Integration tests - shard 1 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard1
@@ -1291,7 +1297,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 1/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 2 (Py2.7 PEX)"
+      name: "Integration tests - shard 2 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard2
@@ -1299,7 +1305,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 2/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 3 (Py2.7 PEX)"
+      name: "Integration tests - shard 3 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard3
@@ -1307,7 +1313,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 3/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 4 (Py2.7 PEX)"
+      name: "Integration tests - shard 4 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard4
@@ -1315,7 +1321,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 4/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 5 (Py2.7 PEX)"
+      name: "Integration tests - shard 5 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard5
@@ -1323,7 +1329,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 5/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 6 (Py2.7 PEX)"
+      name: "Integration tests - shard 6 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard6
@@ -1331,7 +1337,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 6/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 7 (Py2.7 PEX)"
+      name: "Integration tests - shard 7 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard7
@@ -1339,7 +1345,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 7/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 8 (Py2.7 PEX)"
+      name: "Integration tests - shard 8 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard8
@@ -1347,7 +1353,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 8/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 9 (Py2.7 PEX)"
+      name: "Integration tests - shard 9 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard9
@@ -1355,7 +1361,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 9/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 10 (Py2.7 PEX)"
+      name: "Integration tests - shard 10 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard10
@@ -1363,7 +1369,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 10/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 11 (Py2.7 PEX)"
+      name: "Integration tests - shard 11 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard11
@@ -1371,7 +1377,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 11/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 12 (Py2.7 PEX)"
+      name: "Integration tests - shard 12 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard12
@@ -1379,7 +1385,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 12/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 13 (Py2.7 PEX)"
+      name: "Integration tests - shard 13 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard13
@@ -1387,7 +1393,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 13/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 14 (Py2.7 PEX)"
+      name: "Integration tests - shard 14 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard14
@@ -1395,7 +1401,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 14/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 15 (Py2.7 PEX)"
+      name: "Integration tests - shard 15 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard15
@@ -1403,7 +1409,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 15/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 16 (Py2.7 PEX)"
+      name: "Integration tests - shard 16 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard16
@@ -1411,7 +1417,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 16/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 17 (Py2.7 PEX)"
+      name: "Integration tests - shard 17 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard17
@@ -1419,7 +1425,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 17/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 18 (Py2.7 PEX)"
+      name: "Integration tests - shard 18 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard18
@@ -1427,7 +1433,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -c2 -i 18/20
 
     - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard 19 (Py2.7 PEX)"
+      name: "Integration tests - shard 19 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard19

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -46,7 +46,6 @@ Usage: $0 (-h|-2fxbkmrjlpuneycitzsw)
               to run only even tests: '-i 0/2', odd: '-i 1/2'
  -t           run lint
  -z           test platform-specific behavior
- -w           Run only blacklisted tests
 EOF
   if (( $# > 0 )); then
     die "$@"
@@ -60,7 +59,7 @@ python_unit_shard="0/1"
 python_contrib_shard="0/1"
 python_intg_shard="0/1"
 
-while getopts "h27fxbmrjlpeasu:ny:ci:tzw" opt; do
+while getopts "h27fxbmrjlpeasu:ny:ci:tz" opt; do
   case ${opt} in
     h) usage ;;
     2) python_two="true" ;;
@@ -83,7 +82,6 @@ while getopts "h27fxbmrjlpeasu:ny:ci:tzw" opt; do
     i) python_intg_shard=${OPTARG} ;;
     t) run_lint="true" ;;
     z) test_platform_specific_behavior="true" ;;
-    w) run_blacklisted_tests_only="true" ;;
     *) usage "Invalid option: -${OPTARG}" ;;
   esac
 done
@@ -254,6 +252,7 @@ if [[ "${run_cargo_audit:-false}" == "true" ]]; then
     "${REPO_ROOT}/build-support/bin/native/cargo" ensure-installed --package=cargo-audit --version=0.5.2
     "${REPO_ROOT}/build-support/bin/native/cargo" audit -f "${REPO_ROOT}/src/rust/engine/Cargo.lock"
   ) || die "Cargo audit failure"
+  end_travis_section
 fi
 
 
@@ -262,6 +261,7 @@ if [[ "${run_rust_clippy:-false}" == "true" ]]; then
   (
     "${REPO_ROOT}/build-support/bin/check_clippy.sh"
   ) || die "Pants clippy failure"
+  end_travis_section
 fi
 
 # NB: this only tests python tests right now -- the command needs to be edited if test targets in
@@ -283,19 +283,9 @@ if [[ "${run_integration:-false}" == "true" ]]; then
   fi
   start_travis_section "IntegrationTests" "Running Pants Integration tests${shard_desc}"
   (
-    known_py3_pex_failures_file="${REPO_ROOT}/build-support/known_py3_pex_failures.txt"
-    if [[ "${python_two:-false}" == "false" ]]; then
-      targets="$(comm -23 <(./pants.pex --tag='+integration' list tests/python:: | grep '.' | sort) <(sort "${known_py3_pex_failures_file}"))"
-    else
-      if [[ "${run_blacklisted_tests_only:-false}" == "true" ]]; then
-        targets="$(cat ${known_py3_pex_failures_file})"
-      else
-        targets="tests/python::"
-      fi
-    fi
     ./pants.pex --tag='+integration' test.pytest \
       --test-pytest-test-shard=${python_intg_shard} \
-      $targets -- ${PYTEST_PASSTHRU_ARGS}
+      tests/python:: -- ${PYTEST_PASSTHRU_ARGS}
   ) || die "Pants Integration test failure"
   end_travis_section
 fi

--- a/build-support/travis/generate_travis_yml.py
+++ b/build-support/travis/generate_travis_yml.py
@@ -8,9 +8,7 @@ import pkg_resources
 import pystache
 
 
-num_py3_integration_shards = 19
-num_py2_blacklist_integration_shards = 1
-num_cron_integration_shards = 20
+num_integration_shards = 20
 
 
 HEADER = """
@@ -37,12 +35,8 @@ def generate_travis_yml():
 
   context = {
     'header': HEADER,
-    'py3_integration_shards': range(0, num_py3_integration_shards),
-    'py3_integration_shards_length': num_py3_integration_shards,
-    'py2_blacklist_integration_shards': range(0, num_py2_blacklist_integration_shards),
-    'py2_blacklist_integration_shards_length': num_py2_blacklist_integration_shards,
-    'cron_integration_shards': range(0, num_cron_integration_shards),
-    'cron_integration_shards_length': num_cron_integration_shards,
+    'integration_shards': range(0, num_integration_shards),
+    'integration_shards_length': num_integration_shards,
   }
   renderer = pystache.Renderer(partials={
     'before_install_linux': before_install_linux,

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -604,7 +604,7 @@ base_rust_tests: &base_rust_tests
 linux_rust_tests: &linux_rust_tests
   <<: *base_rust_tests
   <<: *linux_with_fuse
-  name: "Linux Rust tests (No PEX)"
+  name: "Rust tests - Linux (No PEX)"
   env:
     - CACHE_NAME=linuxrusttests
   os: linux
@@ -617,7 +617,7 @@ linux_rust_tests: &linux_rust_tests
 
 osx_rust_tests: &osx_rust_tests
   <<: *base_rust_tests
-  name: "OSX Rust tests (No PEX)"
+  name: "Rust tests - OSX (No PEX)"
   env:
     - CACHE_NAME=macosrusttests
   os: osx
@@ -875,7 +875,7 @@ matrix:
     - <<: *cargo_audit
 
     - <<: *py27_linux_test_config
-      name: "Unit tests for pants and pants-plugins (Py2.7 PEX)"
+      name: "Unit tests (Py2.7 PEX)"
       stage: *test
       env:
         - *py27_linux_test_config_env
@@ -884,7 +884,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -2lp
 
     - <<: *py36_linux_test_config
-      name: "Unit tests for pants and pants-plugins (Py3.6 PEX)"
+      name: "Unit tests (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=linuxunittests.py36
@@ -892,7 +892,7 @@ matrix:
         - ./build-support/bin/travis-ci.sh -lp
 
     - <<: *py37_linux_test_config
-      name: "Unit tests for pants and pants-plugins (Py3.7 PEX)"
+      name: "Unit tests (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=linuxunittests.py37
@@ -907,48 +907,36 @@ matrix:
     - <<: *py27_osx_build_wheels_ucs4
     - <<: *py36_osx_build_wheels
 
-{{#py3_integration_shards}}
+{{#integration_shards}}
     - <<: *py36_linux_test_config
-      name: "Integration tests for pants - shard {{.}} (Py3.6 PEX)"
+      name: "Integration tests - shard {{.}} (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=integrationshard{{.}}
       script:
-        - ./build-support/bin/travis-ci.sh -c -i {{.}}/{{py3_integration_shards_length}}
+        - ./build-support/bin/travis-ci.sh -c -i {{.}}/{{integration_shards_length}}
 
-{{/py3_integration_shards}}
-{{#py3_integration_shards}}
+{{/integration_shards}}
+{{#integration_shards}}
     - <<: *py37_linux_test_config
-      name: "Integration tests for pants - shard {{.}} (Py3.7 PEX)"
+      name: "Integration tests - shard {{.}} (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
         - CACHE_NAME=integrationshard{{.}}
       script:
-        - ./build-support/bin/travis-ci.sh -c7 -i {{.}}/{{py3_integration_shards_length}}
+        - ./build-support/bin/travis-ci.sh -c7 -i {{.}}/{{integration_shards_length}}
 
-{{/py3_integration_shards}}
-{{#py2_blacklist_integration_shards}}
+{{/integration_shards}}
+{{#integration_shards}}
     - <<: *py27_linux_test_config
-      name: "Blacklisted integration tests for pants - shard {{.}} (Py2.7 PEX w/ Py3.6 constraints)"
-      stage: *test
-      env:
-        - *py27_linux_test_config_env
-        - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']"
-        - CACHE_NAME=integrationshard{{.}}.py27blacklist
-      script:
-        - ./build-support/bin/travis-ci.sh -c2w -i {{.}}/{{py2_blacklist_integration_shards_length}}
-
-{{/py2_blacklist_integration_shards}}
-{{#cron_integration_shards}}
-    - <<: *py27_linux_test_config
-      name: "Integration tests for pants - shard {{.}} (Py2.7 PEX)"
+      name: "Integration tests - shard {{.}} (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard{{.}}
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i {{.}}/{{cron_integration_shards_length}}
+        - ./build-support/bin/travis-ci.sh -c2 -i {{.}}/{{integration_shards_length}}
 
-{{/cron_integration_shards}}
+{{/integration_shards}}
 
     - <<: *linux_rust_tests
     - <<: *osx_rust_tests


### PR DESCRIPTION
Python 3 is now completely supported.

Part of #6062.