### PR TITLE
No longer pin `pants_runtime_python_version` with `./pants generate-pants-ini`

### DIFF
--- a/src/python/pants/core_tasks/generate_pants_ini.py
+++ b/src/python/pants/core_tasks/generate_pants_ini.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os.path
-import sys
 from textwrap import dedent
 
 from pants.base.build_environment import get_default_pants_config_file
@@ -19,12 +18,10 @@ class GeneratePantsIni(ConsoleTask):
 
   def console_output(self, _targets):
     pants_ini_path = get_default_pants_config_file()
-    python_version = ".".join(str(v) for v in sys.version_info[:2])
     pants_ini_content = dedent("""\
       [GLOBAL]
       pants_version: {}
-      pants_runtime_python_version: {}
-      """.format(pants_version, python_version)
+      """.format(pants_version)
     )
 
     if os.path.isfile(pants_ini_path):
@@ -34,8 +31,7 @@ class GeneratePantsIni(ConsoleTask):
     yield dedent("""\
       Adding sensible defaults to {}:
       * Pinning `pants_version` to `{}`.
-      * Pinning `pants_runtime_python_version` to `{}`.
-      """.format(pants_ini_path, pants_version, python_version)
+      """.format(pants_ini_path, pants_version)
     )
 
     with open(pants_ini_path, "w") as f:

--- a/tests/python/pants_test/core_tasks/test_generate_pants_ini.py
+++ b/tests/python/pants_test/core_tasks/test_generate_pants_ini.py
@@ -24,7 +24,6 @@ class GeneratePantsIniTest(ConsoleTaskTestBase):
     config = configparser.ConfigParser()
     config.read(get_default_pants_config_file())
     self.assertEqual(config["GLOBAL"]["pants_version"], VERSION)
-    self.assertIn(config["GLOBAL"]["pants_runtime_python_version"], {"2.7", "3.6", "3.7"})
 
   def test_fails_when_pants_ini_already_exists(self):
     temp_pants_ini_path = self.create_file("pants.ini")


### PR DESCRIPTION
In https://github.com/pantsbuild/setup/pull/49, we're changing the setup repo's `./pants` script to default to Python 3.6, and then fall back to Python 2.7. Thanks to that, we no longer need to use `pants_runtime_python_version` to get the script to use Python 3.

In fact, we should not set `pants_runtime_python_version`. The Python version used is an implementation detail we don't want users to have to worry about, and we will be deprecating the option in 1.17.0.dev0. So, us auto-generating the option when it is not even necessary is asking for confusion and a worse experience for users.