### PR TITLE
Cache pyenv in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,8 +117,8 @@ pants_run_cache_config: &pants_run_cache_config
 
 pyenv_setup: &pyenv_setup >
   if [[ ! -x "${PYENV_BIN}" ]]; then
-    rm -rf "${PYENV_ROOT}";
-    git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}";
+    rm -rf "${PYENV_ROOT}"
+    git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}"
   fi
 
 pyenv_install_py36: &pyenv_install_py36 >

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
     # NB: Linux shards use Pyenv to pre-install Python. We must not override
     # PYENV_ROOT on those shards, or their Python will no longer work.
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
-    - PYENV_BIN="${PYENV_ROOT}/bin/pyenv"
     - PATH="${PYENV_ROOT}/shims:${PATH}"
 
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
@@ -106,36 +105,6 @@ pants_run_cache_config: &pants_run_cache_config
       # using its own isolated cache:
       #   https://github.com/pantsbuild/pants/issues/2485
       - ${HOME}/.npm
-
-# -------------------------------------------------------------------------
-# Pyenv
-# -------------------------------------------------------------------------
-
-# On several shards, the system installed Pyenv is too outdated so does not
-# have the Python versions we need, like Python 3.7. To get around this
-# we directly clone the Pyenv repo.
-
-pyenv_setup: &pyenv_setup >
-  if [[ ! -x "${PYENV_BIN}" ]]; then
-    rm -rf "${PYENV_ROOT}"
-    git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}"
-  fi
-
-pyenv_install_py36: &pyenv_install_py36 >
-  if [[ ! -d ${PYENV_ROOT}/versions/"${PYENV_PY36_VERSION}" ]]; then
-    "${PYENV_BIN}" install "${PYENV_PY36_VERSION}"
-  fi
-
-pyenv_install_py37: &pyenv_install_py37 >
-  if [[ ! -d ${PYENV_ROOT}/versions/"${PYENV_PY37_VERSION}" ]]; then
-    "${PYENV_BIN}" install "${PYENV_PY37_VERSION}"
-  fi
-
-pyenv_global_py36: &pyenv_global_py36 >
-  "${PYENV_BIN}" global "${PYENV_PY36_VERSION}"
-
-pyenv_global_py37: &pyenv_global_py37 >
-  "${PYENV_BIN}" global "${PYENV_PY37_VERSION}"
 
 # -------------------------------------------------------------------------
 # AWS
@@ -248,9 +217,7 @@ py36_osx_config: &py36_osx_config
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - *pyenv_setup
-    - *pyenv_install_py36
-    - *pyenv_global_py36
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
 
 py37_osx_config: &py37_osx_config
   <<: *base_osx_config
@@ -267,9 +234,7 @@ py37_osx_config: &py37_osx_config
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - *pyenv_setup
-    - *pyenv_install_py37
-    - *pyenv_global_py37
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY37_VERSION}"
 
 base_osx_test_config: &base_osx_test_config
   <<: *pants_run_cache_config
@@ -631,12 +596,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - *pyenv_setup
-    - >
-      if [[ ! -d ${PYENV_ROOT}/versions/2.7.13 ]]; then
-        ${PYENV_BIN} install 2.7.13
-      fi
-    - ${PYENV_BIN} global 2.7.13
+    - ./build-support/bin/install_python_for_ci.sh 2.7.13
   script:
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu

--- a/.travis.yml
+++ b/.travis.yml
@@ -631,7 +631,9 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - *pyenv_setup
     - >
-      [[ ! -d  ${PYENV_ROOT}/versions/2.7.13 ]] && ${PYENV_BIN} install 2.7.13
+      if [[ ! -d ${PYENV_ROOT}/versions/2.7.13 ]]; then
+        ${PYENV_BIN} install 2.7.13
+      fi
     - ${PYENV_BIN} global 2.7.13
   script:
     - ./build-support/bin/ci.sh -2b

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ env:
     - BOOTSTRAPPED_PEX_URL_PREFIX=s3://${BOOTSTRAPPED_PEX_BUCKET}/${BOOTSTRAPPED_PEX_KEY_PREFIX}
     - PYENV_PY36_VERSION=3.6.8
     - PYENV_PY37_VERSION=3.7.2
+    # NB: Linux shards use Pyenv to pre-install Python. We must not override
+    # PYENV_ROOT on those shards, or their Python will no longer work.
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
     - PYENV_BIN="${PYENV_ROOT}/bin/pyenv"
     - PATH="${PYENV_ROOT}/shims:${PATH}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ native_engine_cache_config: &native_engine_cache_config
     # TODO: Figure out why we have such large caches (2-7GB) and try to trim them.
     timeout: 500
     directories:
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/pants_dev_deps.py27.venv
       - build-support/pants_dev_deps.py36.venv
@@ -95,6 +96,7 @@ pants_run_cache_config: &pants_run_cache_config
     # TODO: Figure out why we have such large caches (2-7GB) and try to trim them.
     timeout: 500
     directories:
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -112,16 +114,20 @@ pants_run_cache_config: &pants_run_cache_config
 # we directly clone the Pyenv repo.
 
 pyenv_setup: &pyenv_setup >
-  if [ ! -d "${PYENV_BIN}" ]; then
-  rm -rf "${PYENV_ROOT}";
-  git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}";
+  if [[ ! -x "${PYENV_BIN}" ]]; then
+    rm -rf "${PYENV_ROOT}";
+    git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}";
   fi
 
 pyenv_install_py36: &pyenv_install_py36 >
-  "${PYENV_BIN}" install "${PYENV_PY36_VERSION}"
+  if [[ ! -d ${PYENV_ROOT}/versions/"${PYENV_PY36_VERSION}" ]]; then
+    "${PYENV_BIN}" install "${PYENV_PY36_VERSION}"
+  fi
 
 pyenv_install_py37: &pyenv_install_py37 >
-  "${PYENV_BIN}" install "${PYENV_PY37_VERSION}"
+  if [[ ! -d ${PYENV_ROOT}/versions/"${PYENV_PY37_VERSION}" ]]; then
+    "${PYENV_BIN}" install "${PYENV_PY37_VERSION}"
+  fi
 
 pyenv_global_py36: &pyenv_global_py36 >
   "${PYENV_BIN}" global "${PYENV_PY36_VERSION}"
@@ -624,7 +630,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - *pyenv_setup
-    - ${PYENV_BIN} install 2.7.13
+    - [[ ! -d  ${PYENV_ROOT}/versions/2.7.13 ]] && ${PYENV_BIN} install 2.7.13
     - ${PYENV_BIN} global 2.7.13
   script:
     - ./build-support/bin/ci.sh -2b

--- a/.travis.yml
+++ b/.travis.yml
@@ -630,7 +630,8 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - *pyenv_setup
-    - [[ ! -d  ${PYENV_ROOT}/versions/2.7.13 ]] && ${PYENV_BIN} install 2.7.13
+    - >
+      [[ ! -d  ${PYENV_ROOT}/versions/2.7.13 ]] && ${PYENV_BIN} install 2.7.13
     - ${PYENV_BIN} global 2.7.13
   script:
     - ./build-support/bin/ci.sh -2b

--- a/build-support/bin/install_python_for_ci.sh
+++ b/build-support/bin/install_python_for_ci.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Install the requested Python version(s) through Pyenv.
+
+# While Travis ships with Pyenv on both OSX and Linux, the Pyenv version is too
+# outdated on several images for installing modern Python versions like 3.7. To
+# get around this, we directly clone the Pyenv repo.
+
+source build-support/common.sh
+
+PYTHON_VERSIONS="$@"
+
+if [[ -z "${PYENV_ROOT:+''}" ]]; then
+  die "Caller of the script must set the env var PYENV_ROOT."
+fi
+PYENV_BIN="${PYENV_ROOT}/bin/pyenv"
+
+# We first check if Pyenv is already installed thanks to Travis's cache.
+if [[ ! -x "${PYENV_BIN}" ]]; then
+  rm -rf "${PYENV_ROOT}"
+  git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}"
+fi
+
+for python_version in "${PYTHON_VERSIONS[@]}"; do
+  if [[ ! -d ${PYENV_ROOT}/versions/"${python_version}" ]]; then
+    "${PYENV_BIN}" install "${python_version}"
+  fi
+done
+
+"${PYENV_BIN}" global "${PYTHON_VERSIONS[@]}"

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -58,6 +58,7 @@ native_engine_cache_config: &native_engine_cache_config
     # TODO: Figure out why we have such large caches (2-7GB) and try to trim them.
     timeout: 500
     directories:
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/pants_dev_deps.py27.venv
       - build-support/pants_dev_deps.py36.venv
@@ -88,6 +89,7 @@ pants_run_cache_config: &pants_run_cache_config
     # TODO: Figure out why we have such large caches (2-7GB) and try to trim them.
     timeout: 500
     directories:
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -105,16 +107,20 @@ pants_run_cache_config: &pants_run_cache_config
 # we directly clone the Pyenv repo.
 
 pyenv_setup: &pyenv_setup >
-  if [ ! -d "${PYENV_BIN}" ]; then
-  rm -rf "${PYENV_ROOT}";
-  git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}";
+  if [[ ! -x "${PYENV_BIN}" ]]; then
+    rm -rf "${PYENV_ROOT}";
+    git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}";
   fi
 
 pyenv_install_py36: &pyenv_install_py36 >
-  "${PYENV_BIN}" install "${PYENV_PY36_VERSION}"
+  if [[ ! -d ${PYENV_ROOT}/versions/"${PYENV_PY36_VERSION}" ]]; then
+    "${PYENV_BIN}" install "${PYENV_PY36_VERSION}"
+  fi
 
 pyenv_install_py37: &pyenv_install_py37 >
-  "${PYENV_BIN}" install "${PYENV_PY37_VERSION}"
+  if [[ ! -d ${PYENV_ROOT}/versions/"${PYENV_PY37_VERSION}" ]]; then
+    "${PYENV_BIN}" install "${PYENV_PY37_VERSION}"
+  fi
 
 pyenv_global_py36: &pyenv_global_py36 >
   "${PYENV_BIN}" global "${PYENV_PY36_VERSION}"
@@ -571,7 +577,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   before_install:
     {{>before_install_osx}}
     - *pyenv_setup
-    - ${PYENV_BIN} install 2.7.13
+    - [[ ! -d  ${PYENV_ROOT}/versions/2.7.13 ]] && ${PYENV_BIN} install 2.7.13
     - ${PYENV_BIN} global 2.7.13
   script:
     - ./build-support/bin/ci.sh -2b

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -110,8 +110,8 @@ pants_run_cache_config: &pants_run_cache_config
 
 pyenv_setup: &pyenv_setup >
   if [[ ! -x "${PYENV_BIN}" ]]; then
-    rm -rf "${PYENV_ROOT}";
-    git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}";
+    rm -rf "${PYENV_ROOT}"
+    git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}"
   fi
 
 pyenv_install_py36: &pyenv_install_py36 >

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -24,7 +24,6 @@ env:
     # NB: Linux shards use Pyenv to pre-install Python. We must not override
     # PYENV_ROOT on those shards, or their Python will no longer work.
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
-    - PYENV_BIN="${PYENV_ROOT}/bin/pyenv"
     - PATH="${PYENV_ROOT}/shims:${PATH}"
 
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
@@ -99,36 +98,6 @@ pants_run_cache_config: &pants_run_cache_config
       # using its own isolated cache:
       #   https://github.com/pantsbuild/pants/issues/2485
       - ${HOME}/.npm
-
-# -------------------------------------------------------------------------
-# Pyenv
-# -------------------------------------------------------------------------
-
-# On several shards, the system installed Pyenv is too outdated so does not
-# have the Python versions we need, like Python 3.7. To get around this
-# we directly clone the Pyenv repo.
-
-pyenv_setup: &pyenv_setup >
-  if [[ ! -x "${PYENV_BIN}" ]]; then
-    rm -rf "${PYENV_ROOT}"
-    git clone https://github.com/pyenv/pyenv "${PYENV_ROOT}"
-  fi
-
-pyenv_install_py36: &pyenv_install_py36 >
-  if [[ ! -d ${PYENV_ROOT}/versions/"${PYENV_PY36_VERSION}" ]]; then
-    "${PYENV_BIN}" install "${PYENV_PY36_VERSION}"
-  fi
-
-pyenv_install_py37: &pyenv_install_py37 >
-  if [[ ! -d ${PYENV_ROOT}/versions/"${PYENV_PY37_VERSION}" ]]; then
-    "${PYENV_BIN}" install "${PYENV_PY37_VERSION}"
-  fi
-
-pyenv_global_py36: &pyenv_global_py36 >
-  "${PYENV_BIN}" global "${PYENV_PY36_VERSION}"
-
-pyenv_global_py37: &pyenv_global_py37 >
-  "${PYENV_BIN}" global "${PYENV_PY37_VERSION}"
 
 # -------------------------------------------------------------------------
 # AWS
@@ -232,9 +201,7 @@ py36_osx_config: &py36_osx_config
       {{>env_osx_with_pyenv}}
   before_install:
     {{>before_install_osx}}
-    - *pyenv_setup
-    - *pyenv_install_py36
-    - *pyenv_global_py36
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
 
 py37_osx_config: &py37_osx_config
   <<: *base_osx_config
@@ -247,9 +214,7 @@ py37_osx_config: &py37_osx_config
       {{>env_osx_with_pyenv}}
   before_install:
     {{>before_install_osx}}
-    - *pyenv_setup
-    - *pyenv_install_py37
-    - *pyenv_global_py37
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY37_VERSION}"
 
 base_osx_test_config: &base_osx_test_config
   <<: *pants_run_cache_config
@@ -578,12 +543,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - PY=${PYENV_ROOT}/shims/python2.7
   before_install:
     {{>before_install_osx}}
-    - *pyenv_setup
-    - >
-      if [[ ! -d ${PYENV_ROOT}/versions/2.7.13 ]]; then
-        ${PYENV_BIN} install 2.7.13
-      fi
-    - ${PYENV_BIN} global 2.7.13
+    - ./build-support/bin/install_python_for_ci.sh 2.7.13
   script:
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -577,7 +577,8 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   before_install:
     {{>before_install_osx}}
     - *pyenv_setup
-    - [[ ! -d  ${PYENV_ROOT}/versions/2.7.13 ]] && ${PYENV_BIN} install 2.7.13
+    - >
+      [[ ! -d  ${PYENV_ROOT}/versions/2.7.13 ]] && ${PYENV_BIN} install 2.7.13
     - ${PYENV_BIN} global 2.7.13
   script:
     - ./build-support/bin/ci.sh -2b

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -21,6 +21,8 @@ env:
     - BOOTSTRAPPED_PEX_URL_PREFIX=s3://${BOOTSTRAPPED_PEX_BUCKET}/${BOOTSTRAPPED_PEX_KEY_PREFIX}
     - PYENV_PY36_VERSION=3.6.8
     - PYENV_PY37_VERSION=3.7.2
+    # NB: Linux shards use Pyenv to pre-install Python. We must not override
+    # PYENV_ROOT on those shards, or their Python will no longer work.
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
     - PYENV_BIN="${PYENV_ROOT}/bin/pyenv"
     - PATH="${PYENV_ROOT}/shims:${PATH}"

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -578,7 +578,9 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     {{>before_install_osx}}
     - *pyenv_setup
     - >
-      [[ ! -d  ${PYENV_ROOT}/versions/2.7.13 ]] && ${PYENV_BIN} install 2.7.13
+      if [[ ! -d ${PYENV_ROOT}/versions/2.7.13 ]]; then
+        ${PYENV_BIN} install 2.7.13
+      fi
     - ${PYENV_BIN} global 2.7.13
   script:
     - ./build-support/bin/ci.sh -2b


### PR DESCRIPTION
### Problem
Every OSX shard that uses Python 3.6 or 3.7, we waste about 2 minutes re-installing Python 3. Thanks to the insights from https://github.com/pantsbuild/setup/pull/39, we can stop wasting this time by using the Travis cache.

### Solution
Add `$PYENV_ROOT` to the cache and modify the pyenv code to first check if the relevant folders exist before git cloning and installing. We extract out all of this Pyenv logic into a new script `install_python_for_ci.sh`.

We can safely add this to the cache for all shards, even if they don't use Pyenv, because Travis will simply upload an empty folder if there is nothing there.

### Result
Overall daily CI time reduced by 8 minutes.

This also allows us to add Python 3.6 on *all* OSX shards, so that we can use Python 3 in our build-support scripts.