### PR TITLE
Fix issues with deploy shards not properly setting Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -825,7 +825,13 @@ py37_jvm_tests: &py37_jvm_tests
 
 base_deploy: &base_deploy
   os: linux
+  dist: trusty
   language: python
+  python:
+    - "2.7"
+    - "3.6"
+  before_install:
+    - pyenv global 2.7.14 3.6.3
   env:
     - &base_deploy_env RUN_PANTS_FROM_PEX=1
 
@@ -853,7 +859,6 @@ base_deploy_stable_muliplatform_pex: &base_deploy_stable_muliplatform_pex
 py27_deploy_stable_multiplatform_pex: &py27_deploy_stable_multiplatform_pex
   <<: *base_deploy_stable_muliplatform_pex
   name: "Deploy stable multiplatform pants.pex (Py2.7 PEX)"
-  python: 2.7
   env:
     - *base_deploy_env
     - *base_deploy_stable_env
@@ -863,7 +868,6 @@ py27_deploy_stable_multiplatform_pex: &py27_deploy_stable_multiplatform_pex
 py36_deploy_stable_multiplatform_pex: &py36_deploy_stable_multiplatform_pex
   <<: *base_deploy_stable_muliplatform_pex
   name: "Deploy stable multiplatform pants.pex (Py3.6 PEX)"
-  python: 3.6
   env:
     - *base_deploy_env
     - *base_deploy_stable_env
@@ -871,7 +875,7 @@ py36_deploy_stable_multiplatform_pex: &py36_deploy_stable_multiplatform_pex
     - CACHE_NAME=linuxpexdeploystable.py36
 
 base_deploy_unstable_multiplatform_pex: &base_deploy_unstable_multiplatform_pex
-  <<: *base_deploy_unstable_multiplatform_pex
+  <<: *base_deploy
   stage: *build_unstable
   env:
     - &base_deploy_unstable_env PREPARE_DEPLOY=1
@@ -883,7 +887,6 @@ base_deploy_unstable_multiplatform_pex: &base_deploy_unstable_multiplatform_pex
 py27_deploy_unstable_multiplatform_pex: &py27_deploy_unstable_multiplatform_pex
   <<: *base_deploy_unstable_multiplatform_pex
   name: "Deploy unstable multiplatform pants.pex (Py2.7 PEX)"
-  python: 2.7
   env:
     - *base_deploy_env
     - *base_deploy_unstable_env
@@ -893,9 +896,6 @@ py27_deploy_unstable_multiplatform_pex: &py27_deploy_unstable_multiplatform_pex
 py36_deploy_unstable_multiplatform_pex: &py36_deploy_unstable_multiplatform_pex
   <<: *base_deploy_unstable_multiplatform_pex
   name: "Deploy unstable multiplatform pants.pex (Py3.6 PEX)"
-  python: 3.6
-  before_install:
-    - pyenv global 3.6.3
   env:
     - *base_deploy_env
     - *base_deploy_unstable_env

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -772,7 +772,13 @@ py37_jvm_tests: &py37_jvm_tests
 
 base_deploy: &base_deploy
   os: linux
+  dist: trusty
   language: python
+  python:
+    - "2.7"
+    - "3.6"
+  before_install:
+    - pyenv global 2.7.14 3.6.3
   env:
     - &base_deploy_env RUN_PANTS_FROM_PEX=1
 
@@ -800,7 +806,6 @@ base_deploy_stable_muliplatform_pex: &base_deploy_stable_muliplatform_pex
 py27_deploy_stable_multiplatform_pex: &py27_deploy_stable_multiplatform_pex
   <<: *base_deploy_stable_muliplatform_pex
   name: "Deploy stable multiplatform pants.pex (Py2.7 PEX)"
-  python: 2.7
   env:
     - *base_deploy_env
     - *base_deploy_stable_env
@@ -810,7 +815,6 @@ py27_deploy_stable_multiplatform_pex: &py27_deploy_stable_multiplatform_pex
 py36_deploy_stable_multiplatform_pex: &py36_deploy_stable_multiplatform_pex
   <<: *base_deploy_stable_muliplatform_pex
   name: "Deploy stable multiplatform pants.pex (Py3.6 PEX)"
-  python: 3.6
   env:
     - *base_deploy_env
     - *base_deploy_stable_env
@@ -818,7 +822,7 @@ py36_deploy_stable_multiplatform_pex: &py36_deploy_stable_multiplatform_pex
     - CACHE_NAME=linuxpexdeploystable.py36
 
 base_deploy_unstable_multiplatform_pex: &base_deploy_unstable_multiplatform_pex
-  <<: *base_deploy_unstable_multiplatform_pex
+  <<: *base_deploy
   stage: *build_unstable
   env:
     - &base_deploy_unstable_env PREPARE_DEPLOY=1
@@ -830,7 +834,6 @@ base_deploy_unstable_multiplatform_pex: &base_deploy_unstable_multiplatform_pex
 py27_deploy_unstable_multiplatform_pex: &py27_deploy_unstable_multiplatform_pex
   <<: *base_deploy_unstable_multiplatform_pex
   name: "Deploy unstable multiplatform pants.pex (Py2.7 PEX)"
-  python: 2.7
   env:
     - *base_deploy_env
     - *base_deploy_unstable_env
@@ -840,9 +843,6 @@ py27_deploy_unstable_multiplatform_pex: &py27_deploy_unstable_multiplatform_pex
 py36_deploy_unstable_multiplatform_pex: &py36_deploy_unstable_multiplatform_pex
   <<: *base_deploy_unstable_multiplatform_pex
   name: "Deploy unstable multiplatform pants.pex (Py3.6 PEX)"
-  python: 3.6
-  before_install:
-    - pyenv global 3.6.3
   env:
     - *base_deploy_env
     - *base_deploy_unstable_env


### PR DESCRIPTION
There were several problems with the deploy shards introduced by https://github.com/pantsbuild/pants/pull/7401 and not completely cleaned up by https://github.com/pantsbuild/pants/pull/7411:

- Only setting `pyenv global 3.6.3` for the unstable deploy shard, even though the stable one should have this line too.
- Relying on Travis defaulting to the Trusty image. If they were to change this to Xenial, the shards would fail because the Pyenv versions would not match.
- `base_deploy_unstable_multiplatform_pex` extending itself rather than `base_deploy`.

This is also pre-work for getting Python 3.6 on all shards, so that we can use Python 3 in our `build-support` scripts.