### PR TITLE
Cache AWS CLI install in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ native_engine_cache_config: &native_engine_cache_config
     # TODO: Figure out why we have such large caches (2-7GB) and try to trim them.
     timeout: 500
     directories:
+      - /usr/local/aws
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/pants_dev_deps.py27.venv
       - build-support/pants_dev_deps.py36.venv
@@ -95,6 +96,7 @@ pants_run_cache_config: &pants_run_cache_config
     # TODO: Figure out why we have such large caches (2-7GB) and try to trim them.
     timeout: 500
     directories:
+      - /usr/local/aws
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
     - PYENV_BIN="${PYENV_ROOT}/bin/pyenv"
     - PATH="${PYENV_ROOT}/shims:${PATH}"
+    - AWS_CLI_ROOT="${HOME}/.aws_cli"
 
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
@@ -65,7 +66,7 @@ native_engine_cache_config: &native_engine_cache_config
     # TODO: Figure out why we have such large caches (2-7GB) and try to trim them.
     timeout: 500
     directories:
-      - /usr/local/aws
+      - ${AWS_CLI_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/pants_dev_deps.py27.venv
       - build-support/pants_dev_deps.py36.venv
@@ -96,7 +97,7 @@ pants_run_cache_config: &pants_run_cache_config
     # TODO: Figure out why we have such large caches (2-7GB) and try to trim them.
     timeout: 500
     directories:
-      - /usr/local/aws
+      - ${AWS_CLI_ROOT}
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants

--- a/build-support/bin/install_aws_cli_for_ci.sh
+++ b/build-support/bin/install_aws_cli_for_ci.sh
@@ -9,15 +9,24 @@ set -euo pipefail
 # to use, which slows down CI jobs significantly. This is also the installation method recommended
 # by AWS, see https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html.
 
-TMPDIR=$(mktemp -d)
+# We first check if AWS CLI is already installed thanks to Travis's cache.
+if [[ ! -d /usr/local/aws ]]; then
 
-pushd ${TMPDIR}
+  TMPDIR=$(mktemp -d)
 
-curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-unzip awscli-bundle.zip
-sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+  pushd ${TMPDIR}
 
-popd
+  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+  unzip awscli-bundle.zip
+  sudo ./awscli-bundle/install -i /usr/local/aws
+
+  popd
+
+fi
+
+# Travis does not cache symlinks (https://docs.travis-ci.com/user/caching/), so we create
+# the symlink ourselves everytime to ensure `aws` is discoverable globally.
+sudo ln -s /usr/local/aws/bin/aws /usr/local/bin/aws
 
 # Multipart operations aren't supported for anonymous users, so we set the
 # threshold high to avoid them being used automatically by the aws cli.

--- a/build-support/bin/install_aws_cli_for_ci.sh
+++ b/build-support/bin/install_aws_cli_for_ci.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euox pipefail
 
 # Install the AWS CLI in CI jobs.
 
@@ -27,6 +27,8 @@ fi
 # Travis does not cache symlinks (https://docs.travis-ci.com/user/caching/), so we create
 # the symlink ourselves everytime to ensure `aws` is discoverable globally.
 sudo ln -s /usr/local/aws/bin/aws /usr/local/bin/aws
+ls /usr/local/bin
+echo $PATH
 
 # Multipart operations aren't supported for anonymous users, so we set the
 # threshold high to avoid them being used automatically by the aws cli.

--- a/build-support/bin/install_aws_cli_for_ci.sh
+++ b/build-support/bin/install_aws_cli_for_ci.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euox pipefail
+set -euo pipefail
 
 # Install the AWS CLI in CI jobs.
 
@@ -9,8 +9,11 @@ set -euox pipefail
 # to use, which slows down CI jobs significantly. This is also the installation method recommended
 # by AWS, see https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html.
 
+INSTALL_DIR="/usr/local/aws"
+AWS_BIN="${INSTALL_DIR}/bin/aws"
+
 # We first check if AWS CLI is already installed thanks to Travis's cache.
-if [[ ! -d /usr/local/aws ]]; then
+if [[ ! -x "${AWS_BIN}" ]]; then
 
   TMPDIR=$(mktemp -d)
 
@@ -18,7 +21,7 @@ if [[ ! -d /usr/local/aws ]]; then
 
   curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
   unzip awscli-bundle.zip
-  sudo ./awscli-bundle/install --install-dir /usr/local/aws
+  sudo ./awscli-bundle/install --install-dir "${INSTALL_DIR}"
 
   popd
 
@@ -26,9 +29,7 @@ fi
 
 # Travis does not cache symlinks (https://docs.travis-ci.com/user/caching/), so we create
 # the symlink ourselves everytime to ensure `aws` is discoverable globally.
-sudo ln -s /usr/local/aws/bin/aws /usr/local/bin/aws
-ls /usr/local/bin
-echo $PATH
+sudo ln -s "${AWS_BIN}" /usr/local/bin/aws
 
 # Multipart operations aren't supported for anonymous users, so we set the
 # threshold high to avoid them being used automatically by the aws cli.

--- a/build-support/bin/install_aws_cli_for_ci.sh
+++ b/build-support/bin/install_aws_cli_for_ci.sh
@@ -18,7 +18,7 @@ if [[ ! -d /usr/local/aws ]]; then
 
   curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
   unzip awscli-bundle.zip
-  sudo ./awscli-bundle/install -i /usr/local/aws
+  sudo ./awscli-bundle/install --install-dir /usr/local/aws
 
   popd
 

--- a/build-support/bin/install_aws_cli_for_ci.sh
+++ b/build-support/bin/install_aws_cli_for_ci.sh
@@ -9,11 +9,15 @@ set -euo pipefail
 # to use, which slows down CI jobs significantly. This is also the installation method recommended
 # by AWS, see https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html.
 
-INSTALL_DIR="/usr/local/aws"
-AWS_BIN="${INSTALL_DIR}/bin/aws"
+source build-support/common.sh
+
+if [[ -z "${AWS_CLI_ROOT}" ]]; then
+  die "Caller of the script must set the env var AWS_CLI_ROOT."
+fi
+AWS_CLI_BIN="${AWS_CLI_ROOT}/bin/aws"
 
 # We first check if AWS CLI is already installed thanks to Travis's cache.
-if [[ ! -x "${AWS_BIN}" ]]; then
+if [[ ! -x "${AWS_CLI_BIN}" ]]; then
 
   TMPDIR=$(mktemp -d)
 
@@ -21,7 +25,7 @@ if [[ ! -x "${AWS_BIN}" ]]; then
 
   curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
   unzip awscli-bundle.zip
-  sudo ./awscli-bundle/install --install-dir "${INSTALL_DIR}"
+  sudo ./awscli-bundle/install --install-dir "${AWS_CLI_ROOT}"
 
   popd
 
@@ -29,7 +33,7 @@ fi
 
 # Travis does not cache symlinks (https://docs.travis-ci.com/user/caching/), so we create
 # the symlink ourselves everytime to ensure `aws` is discoverable globally.
-sudo ln -s "${AWS_BIN}" /usr/local/bin/aws
+sudo ln -s "${AWS_CLI_BIN}" /usr/local/bin/aws
 
 # Multipart operations aren't supported for anonymous users, so we set the
 # threshold high to avoid them being used automatically by the aws cli.

--- a/build-support/bin/install_aws_cli_for_ci.sh
+++ b/build-support/bin/install_aws_cli_for_ci.sh
@@ -25,7 +25,7 @@ if [[ ! -x "${AWS_CLI_BIN}" ]]; then
 
   curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
   unzip awscli-bundle.zip
-  sudo ./awscli-bundle/install --install-dir "${AWS_CLI_ROOT}"
+  ./awscli-bundle/install --install-dir "${AWS_CLI_ROOT}"
 
   popd
 

--- a/build-support/bin/install_aws_cli_for_ci.sh
+++ b/build-support/bin/install_aws_cli_for_ci.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 
 source build-support/common.sh
 
-if [[ -z "${AWS_CLI_ROOT}" ]]; then
+if [[ -z "${AWS_CLI_ROOT:+''}" ]]; then
   die "Caller of the script must set the env var AWS_CLI_ROOT."
 fi
 AWS_CLI_BIN="${AWS_CLI_ROOT}/bin/aws"

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -24,6 +24,7 @@ env:
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
     - PYENV_BIN="${PYENV_ROOT}/bin/pyenv"
     - PATH="${PYENV_ROOT}/shims:${PATH}"
+    - AWS_CLI_ROOT="${HOME}/.aws_cli"
 
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
@@ -58,7 +59,7 @@ native_engine_cache_config: &native_engine_cache_config
     # TODO: Figure out why we have such large caches (2-7GB) and try to trim them.
     timeout: 500
     directories:
-      - /usr/local/aws
+      - ${AWS_CLI_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/pants_dev_deps.py27.venv
       - build-support/pants_dev_deps.py36.venv
@@ -89,7 +90,7 @@ pants_run_cache_config: &pants_run_cache_config
     # TODO: Figure out why we have such large caches (2-7GB) and try to trim them.
     timeout: 500
     directories:
-      - /usr/local/aws
+      - ${AWS_CLI_ROOT}
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -58,6 +58,7 @@ native_engine_cache_config: &native_engine_cache_config
     # TODO: Figure out why we have such large caches (2-7GB) and try to trim them.
     timeout: 500
     directories:
+      - /usr/local/aws
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/pants_dev_deps.py27.venv
       - build-support/pants_dev_deps.py36.venv
@@ -88,6 +89,7 @@ pants_run_cache_config: &pants_run_cache_config
     # TODO: Figure out why we have such large caches (2-7GB) and try to trim them.
     timeout: 500
     directories:
+      - /usr/local/aws
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants


### PR DESCRIPTION
### Problem
We freshly install the AWS CLI program on nearly every CI shard, even though the program does not change between runs. This adds about 30 seconds to most shards.

### Solution
Modify the `install_aws_cli_for_ci.sh` script to first check if the program is installed, and only install if it is not. Also add the install folder to Travis's cache.

Note that Travis does not cache symlinks, only the actual files. So, we must re-symlink the bin every time we run the script.

### Result
Overall CI time reduced by ~13.5 minutes. Each individual shard is now an average of ~19.4 seconds faster.

See https://docs.google.com/spreadsheets/d/1KWzpHnJzUpEZwx7_m-Kt_hZ-QNYFnzoFRPbi3dX0t6c/edit#gid=60516952 for a per-shard analysis of the old time and the new time with this cache.