### PR TITLE
Add more pants run information to the json reporter

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -410,15 +410,19 @@ class RunTracker(Subsystem):
       return False
     return True
 
-  def store_stats(self):
-    """Store stats about this run in local and optionally remote stats dbs."""
+  def run_information(self):
+    """Basic information about this run."""
     run_information = self.run_info.get_as_dict()
     target_data = run_information.get('target_data', None)
     if target_data:
       run_information['target_data'] = ast.literal_eval(target_data)
+    return run_information
+
+  def store_stats(self):
+    """Store stats about this run in local and optionally remote stats dbs."""
 
     stats = {
-      'run_info': run_information,
+      'run_info': self.run_information(),
       'cumulative_timings': self.cumulative_timings.get_all(),
       'self_timings': self.self_timings.get_all(),
       'critical_path_timings': self.get_critical_path_timings().get_all(),

--- a/src/python/pants/reporting/json_reporter.py
+++ b/src/python/pants/reporting/json_reporter.py
@@ -63,6 +63,8 @@ class JsonReporter(Reporter):
       json.dumps({
         'workunits': self._results,
         'artifact_cache_stats': self.run_tracker.artifact_cache_stats.get_all(),
+        'pantsd_stats': self.run_tracker.pantsd_stats.get_all(),
+        'run_info': self.run_tracker.run_information(),
       }),
       mode=mode)
 

--- a/tests/python/pants_test/reporting/test_json_reporter.py
+++ b/tests/python/pants_test/reporting/test_json_reporter.py
@@ -19,7 +19,15 @@ class FakeRunTracker(object):
     def get_all(self):
       return []
 
+  class FakePantsdStats(object):
+    def get_all(self):
+      return {}
+
   artifact_cache_stats = FakeCacheStats()
+  pantsd_stats = FakePantsdStats()
+
+  def run_information(self):
+    return {}
 
 
 class FakeWorkUnit(object):

--- a/tests/python/pants_test/reporting/test_json_reporter_integration.py
+++ b/tests/python/pants_test/reporting/test_json_reporter_integration.py
@@ -27,3 +27,5 @@ class JsonReporterIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
 
       parsed_report = json.loads(open(output).read())
       self.assertIsInstance(parsed_report['workunits'], dict)
+      self.assertIsInstance(parsed_report['pantsd_stats'], dict)
+      self.assertIsInstance(parsed_report['run_info'], dict)


### PR DESCRIPTION
Followup to https://github.com/pantsbuild/pants/pull/7392 - this adds `run_info` and `pantsd_stats` to the json report and brings the data contained in the json reporter in line with what's returned in the current run tracker `stats` (the difference being the shape of workunit info) in preparation for introducing a configurable flag for selecting one or the other.