### PR TITLE
add some comments to the example CI script in orgs.md

### DIFF
--- a/src/docs/orgs.md
+++ b/src/docs/orgs.md
@@ -58,6 +58,9 @@ minimized=("$(./pants minimize ${dependees[@]})")
 # In other contexts we can use --target-spec-file to read the list of targets to operate on all at
 # once, but that would merge all the classpaths of all the test targets together, which may cause
 # errors. See https://www.pantsbuild.org/3rdparty_jvm.html#managing-transitive-dependencies.
+# TODO(#7480): Background cache activity when running in a loop can sometimes lead to race conditions which
+# cause pants to error. This can probably be worked around with --no-cache-compile-zinc-write. See
+# https://github.com/pantsbuild/pants/issues/7480.
 for target in $(cat minimized.txt); do
   ./pants test $target
 done


### PR DESCRIPTION
### Problem

https://www.pantsbuild.org/orgs.html#continuous-integration isn't well-documented.

### Solution

- Add some comments to the example CI script.

### Result

Users have a good example of how to run a CI script with pants!