### PR TITLE
Replace SingletonRule with zero-parameter @rules

### DIFF
--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 from abc import abstractmethod, abstractproperty
 
-from pants.engine.rules import SingletonRule
+from pants.engine.rules import rule
 from pants.util.memo import memoized_classproperty
 from pants.util.meta import AbstractClass
 from pants.util.objects import datatype, enum
@@ -300,7 +300,12 @@ class CppToolchain(datatype([('cpp_compiler', CppCompiler), ('cpp_linker', Linke
 class HostLibcDev(datatype(['crti_object', 'fingerprint'])): pass
 
 
+@rule(Platform, [])
+def platform_singleton():
+  return Platform.current
+
+
 def create_native_environment_rules():
   return [
-    SingletonRule(Platform, Platform.current),
+    platform_singleton,
   ]

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -119,7 +119,6 @@ class LocalPantsRunner(object):
       options=options,
       build_root=build_root,
       session=graph_session.scheduler_session,
-      symbol_table=graph_session.symbol_table,
       exclude_patterns=tuple(global_options.exclude_target_regexp),
       tags=tuple(global_options.tag)
     )

--- a/src/python/pants/engine/README.md
+++ b/src/python/pants/engine/README.md
@@ -177,20 +177,18 @@ dependencies.
 Currently, it is only possible to load rules into the pants scheduler in two ways: by importing and
 using them in `src/python/pants/bin/engine_initializer.py`, or by adding them to the list returned
 by a `rules()` method defined in `src/python/backend/<backend_name>/register.py`. Plugins cannot add
-new rules yet. Unit tests, however, can mix in `SchedulerTestBase` from
-`tests/python/pants_test/engine/scheduler_test_base.py` to generate and execute a scheduler from a
-given set of rules.
+new rules yet. Unit tests, however, can mix in `TestBase` from
+`tests/python/pants_test/test_base.py` to generate and execute a scheduler from a given set of
+rules.
 
-In general, there are three types of rules you can define:
+In general, there are two types of rules that you can define:
 
 1. an `@rule`, which has a single product type and selects its inputs as described above.
-2. a `SingletonRule`, which matches a product type with a value so the type can then be selected
-   as a parameter to an `@rule`.
-3. a `RootRule`, which declares a type that can be used as a *subject*, which means it can be
+2. a `RootRule`, which declares a type that can be used as a *subject*, which means it can be
    provided as an input to a `product_request()`.
 
-In more depth, a `RootRule` for some type is required when no other rule provides that type (i.e. it
-is not provided with a `SingletonRule` or as the product of any `@rule`). In the absence of a
+In more depth, a `RootRule` for some type is required when no other rule might provide that
+type (i.e. it is not provided as the product of any `@rule`) in some context. In the absence of a
 `RootRule`, any subject type involved in a request "at runtime" (i.e. via `product_request()`),
 would show up as an an unused or impossible path in the rule graph. Another potential name for
 `RootRule` might be `ParamRule`, or something similar, as it can be thought of as saying that the

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -21,7 +21,7 @@ from pants.engine.fs import Digest, FilesContent, PathGlobs, Snapshot
 from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper, ResolveError
 from pants.engine.objects import Locatable, SerializableFactory, Validatable
 from pants.engine.parser import TargetAdaptorContainer
-from pants.engine.rules import RootRule, SingletonRule, rule
+from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
 from pants.engine.struct import Struct
 from pants.util.collections_abc_backport import MutableMapping, MutableSequence
@@ -263,9 +263,13 @@ def create_graph_rules(address_mapper):
   :param address_mapper_key: The subject key for an AddressMapper instance.
   :param symbol_table: A SymbolTable instance to provide symbols for Address lookups.
   """
+
+  @rule(AddressMapper, [])
+  def address_mapper_singleton():
+    return address_mapper
+
   return [
-    # A singleton to provide the AddressMapper.
-    SingletonRule(AddressMapper, address_mapper),
+    address_mapper_singleton,
     # Support for resolving Structs from Addresses.
     hydrate_struct,
     resolve_unhydrated_struct,

--- a/src/python/pants/engine/legacy/parser.py
+++ b/src/python/pants/engine/legacy/parser.py
@@ -91,7 +91,7 @@ class LegacyPythonCallbacksParser(Parser):
         else:
           return self._object_type(*args, **kwargs)
 
-    for alias, symbol in symbol_table.table().items():
+    for alias, symbol in symbol_table.table.items():
       registrar = Registrar(parse_context, alias, symbol)
       symbols[alias] = registrar
       symbols[symbol] = registrar

--- a/src/python/pants/engine/parser.py
+++ b/src/python/pants/engine/parser.py
@@ -7,25 +7,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from abc import abstractmethod
 
 from pants.util.meta import AbstractClass
-from pants.util.objects import Exactly, datatype
+from pants.util.objects import datatype
 
 
 class ParseError(Exception):
   """Indicates an error parsing BUILD configuration."""
 
 
-class SymbolTable(AbstractClass):
-  """A one-classmethod interface exposing a symbol table dict."""
-
-  @abstractmethod
-  def table(self):
-    """Returns a dict of name to implementation class."""
-
-  def constraint(self):
-    """Returns the typeconstraint for the symbol table"""
-    # NB Sort types so that multiple calls get the same tuples.
-    symbol_table_types = sorted(set(self.table().values()), key=repr)
-    return Exactly(*symbol_table_types, description='symbol table types')
+class SymbolTable(datatype([
+  ('table', dict),
+])):
+  """A symbol table dict mapping symbol name to implementation class."""
 
 
 class TargetAdaptorContainer(datatype(["value"])):
@@ -34,11 +26,6 @@ class TargetAdaptorContainer(datatype(["value"])):
   This exists so that the rule graph can statically provide a TargetAdaptor for a target, and rules can depend on this
   without needing to depend on having a concrete instance of SymbolTable to register their input selectors.
   """
-
-
-class EmptyTable(SymbolTable):
-  def table(self):
-    return {}
 
 
 class Parser(AbstractClass):

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -425,17 +425,6 @@ class TaskRule(datatype([
                     self.dependency_optionables))
 
 
-class SingletonRule(datatype([('output_type', _type_field), 'value']), Rule):
-  """A default rule for a product, which is thus a singleton for that product."""
-
-  @classmethod
-  def from_instance(cls, obj):
-    return cls(type(obj), obj)
-
-  def __hash__(self):
-    return hash((type(self), self.output_type))
-
-
 class RootRule(datatype([('output_type', _type_field)]), Rule):
   """Represents a root input to an execution of a rule graph.
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -432,6 +432,9 @@ class SingletonRule(datatype([('output_type', _type_field), 'value']), Rule):
   def from_instance(cls, obj):
     return cls(type(obj), obj)
 
+  def __hash__(self):
+    return hash((type(self), self.output_type))
+
 
 class RootRule(datatype([('output_type', _type_field)]), Rule):
   """Represents a root input to an execution of a rule graph.

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -19,7 +19,7 @@ from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecute
 from pants.engine.native import Function, TypeId
 from pants.engine.nodes import Return, Throw
 from pants.engine.objects import Collection
-from pants.engine.rules import RuleIndex, SingletonRule, TaskRule
+from pants.engine.rules import RuleIndex, TaskRule
 from pants.engine.selectors import Params
 from pants.rules.core.exceptions import GracefulTerminationException
 from pants.util.contextutil import temporary_file_path
@@ -181,21 +181,10 @@ class Scheduler(object):
           continue
         registered.add(key)
 
-        if type(rule) is SingletonRule:
-          self._register_singleton(output_type, rule)
-        elif type(rule) is TaskRule:
+        if type(rule) is TaskRule:
           self._register_task(output_type, rule, rule_index.union_rules)
         else:
           raise ValueError('Unexpected Rule type: {}'.format(rule))
-
-  def _register_singleton(self, output_type, rule):
-    """Register the given SingletonRule.
-
-    A SingletonRule installed for a type will be the only provider for that type.
-    """
-    self._native.lib.tasks_singleton_add(self._tasks,
-                                         self._to_value(rule.value),
-                                         TypeId(self._to_id(output_type)))
 
   def _register_task(self, output_type, rule, union_rules):
     """Register the given TaskRule with the native scheduler."""

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -46,87 +46,80 @@ from pants.util.objects import datatype
 logger = logging.getLogger(__name__)
 
 
-class LegacySymbolTable(SymbolTable):
-  """A v1 SymbolTable facade for use with the v2 engine."""
+def _legacy_symbol_table(build_file_aliases):
+  """Construct a SymbolTable for the given BuildFileAliases.
 
-  def __init__(self, build_file_aliases):
-    """
-    :param build_file_aliases: BuildFileAliases to register.
-    :type build_file_aliases: :class:`pants.build_graph.build_file_aliases.BuildFileAliases`
-    """
-    self._build_file_aliases = build_file_aliases
-    self._table = {
-      alias: self._make_target_adaptor(TargetAdaptor, target_type)
-      for alias, target_type in build_file_aliases.target_types.items()
-    }
+  :param build_file_aliases: BuildFileAliases to register.
+  :type build_file_aliases: :class:`pants.build_graph.build_file_aliases.BuildFileAliases`
 
-    for alias, factory in build_file_aliases.target_macro_factories.items():
-      # TargetMacro.Factory with more than one target type is deprecated.
-      # For default sources, this means that TargetMacro Factories with more than one target_type
-      # will not parse sources through the engine, and will fall back to the legacy python sources
-      # parsing.
-      # Conveniently, multi-target_type TargetMacro.Factory, and legacy python source parsing, are
-      # targeted to be removed in the same version of pants.
-      if len(factory.target_types) == 1:
-        self._table[alias] = self._make_target_adaptor(
-          TargetAdaptor,
-          tuple(factory.target_types)[0],
-        )
+  :returns: A SymbolTable.
+  """
+  table = {
+    alias: _make_target_adaptor(TargetAdaptor, target_type)
+    for alias, target_type in build_file_aliases.target_types.items()
+  }
 
-    # TODO: The alias replacement here is to avoid elevating "TargetAdaptors" into the public
-    # API until after https://github.com/pantsbuild/pants/issues/3560 has been completed.
-    # These should likely move onto Target subclasses as the engine gets deeper into beta
-    # territory.
-    self._table['python_library'] = self._make_target_adaptor(PythonTargetAdaptor, PythonLibrary)
+  for alias, factory in build_file_aliases.target_macro_factories.items():
+    # TargetMacro.Factory with more than one target type is deprecated.
+    # For default sources, this means that TargetMacro Factories with more than one target_type
+    # will not parse sources through the engine, and will fall back to the legacy python sources
+    # parsing.
+    # Conveniently, multi-target_type TargetMacro.Factory, and legacy python source parsing, are
+    # targeted to be removed in the same version of pants.
+    if len(factory.target_types) == 1:
+      table[alias] = _make_target_adaptor(
+        TargetAdaptor,
+        tuple(factory.target_types)[0],
+      )
 
-    self._table['jvm_app'] = self._make_target_adaptor(AppAdaptor, JvmApp)
-    self._table['jvm_binary'] = self._make_target_adaptor(JvmBinaryAdaptor, JvmBinary)
-    self._table['python_app'] = self._make_target_adaptor(AppAdaptor, PythonApp)
-    self._table['python_tests'] = self._make_target_adaptor(PythonTestsAdaptor, PythonTests)
-    self._table['python_binary'] = self._make_target_adaptor(PythonBinaryAdaptor, PythonBinary)
-    self._table['remote_sources'] = self._make_target_adaptor(RemoteSourcesAdaptor, RemoteSources)
-    self._table['page'] = self._make_target_adaptor(PageAdaptor, Page)
+  # TODO: The alias replacement here is to avoid elevating "TargetAdaptors" into the public
+  # API until after https://github.com/pantsbuild/pants/issues/3560 has been completed.
+  # These should likely move onto Target subclasses as the engine gets deeper into beta
+  # territory.
+  table['python_library'] = _make_target_adaptor(PythonTargetAdaptor, PythonLibrary)
 
-    # Note that these don't call _make_target_adaptor because we don't have a handy reference to the
-    # types being constructed. They don't have any default_sources behavior, so this should be ok,
-    # but if we end up doing more things in _make_target_adaptor, we should make sure they're
-    # applied here too.
-    self._table['pants_plugin'] = PantsPluginAdaptor
-    self._table['contrib_plugin'] = PantsPluginAdaptor
+  table['jvm_app'] = _make_target_adaptor(AppAdaptor, JvmApp)
+  table['jvm_binary'] = _make_target_adaptor(JvmBinaryAdaptor, JvmBinary)
+  table['python_app'] = _make_target_adaptor(AppAdaptor, PythonApp)
+  table['python_tests'] = _make_target_adaptor(PythonTestsAdaptor, PythonTests)
+  table['python_binary'] = _make_target_adaptor(PythonBinaryAdaptor, PythonBinary)
+  table['remote_sources'] = _make_target_adaptor(RemoteSourcesAdaptor, RemoteSources)
+  table['page'] = _make_target_adaptor(PageAdaptor, Page)
 
-  def aliases(self):
-    return self._build_file_aliases
+  # Note that these don't call _make_target_adaptor because we don't have a handy reference to the
+  # types being constructed. They don't have any default_sources behavior, so this should be ok,
+  # but if we end up doing more things in _make_target_adaptor, we should make sure they're
+  # applied here too.
+  table['pants_plugin'] = PantsPluginAdaptor
+  table['contrib_plugin'] = PantsPluginAdaptor
 
-  def table(self):
-    return self._table
+  return SymbolTable(table)
 
-  @classmethod
-  def _make_target_adaptor(cls, base_class, target_type):
-    """
-    Look up the default source globs for the type, and apply them to parsing through the engine.
-    """
-    if not target_type.supports_default_sources() or target_type.default_sources_globs is None:
-      return base_class
 
-    globs = _tuplify(target_type.default_sources_globs)
-    excludes = _tuplify(target_type.default_sources_exclude_globs)
+def _make_target_adaptor(base_class, target_type):
+  """Look up the default source globs for the type, and apply them to parsing through the engine."""
+  if not target_type.supports_default_sources() or target_type.default_sources_globs is None:
+    return base_class
 
-    class GlobsHandlingTargetAdaptor(base_class):
-      @property
-      def default_sources_globs(self):
-        if globs is None:
-          return super(GlobsHandlingTargetAdaptor, self).default_sources_globs
-        else:
-          return globs
+  globs = _tuplify(target_type.default_sources_globs)
+  excludes = _tuplify(target_type.default_sources_exclude_globs)
 
-      @property
-      def default_sources_exclude_globs(self):
-        if excludes is None:
-          return super(GlobsHandlingTargetAdaptor, self).default_sources_exclude_globs
-        else:
-          return excludes
+  class GlobsHandlingTargetAdaptor(base_class):
+    @property
+    def default_sources_globs(self):
+      if globs is None:
+        return super(GlobsHandlingTargetAdaptor, self).default_sources_globs
+      else:
+        return globs
 
-    return GlobsHandlingTargetAdaptor
+    @property
+    def default_sources_exclude_globs(self):
+      if excludes is None:
+        return super(GlobsHandlingTargetAdaptor, self).default_sources_exclude_globs
+      else:
+        return excludes
+
+  return GlobsHandlingTargetAdaptor
 
 
 def _tuplify(v):
@@ -139,15 +132,15 @@ def _tuplify(v):
   return (v,)
 
 
-class LegacyGraphScheduler(datatype(['scheduler', 'symbol_table', 'goal_map'])):
+class LegacyGraphScheduler(datatype(['scheduler', 'build_file_aliases', 'goal_map'])):
   """A thin wrapper around a Scheduler configured with @rules for a symbol table."""
 
   def new_session(self, zipkin_trace_v2, v2_ui=False):
     session = self.scheduler.new_session(zipkin_trace_v2, v2_ui)
-    return LegacyGraphSession(session, self.symbol_table, self.goal_map)
+    return LegacyGraphSession(session, self.build_file_aliases, self.goal_map)
 
 
-class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'goal_map'])):
+class LegacyGraphSession(datatype(['scheduler_session', 'build_file_aliases', 'goal_map'])):
   """A thin wrapper around a SchedulerSession configured with @rules for a symbol table."""
 
   class InvalidGoals(Exception):
@@ -221,7 +214,7 @@ class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'goal_ma
     :returns: A tuple of (BuildGraph, AddressMapper).
     """
     logger.debug('target_roots are: %r', target_roots)
-    graph = LegacyBuildGraph.create(self.scheduler_session, self.symbol_table)
+    graph = LegacyBuildGraph.create(self.scheduler_session, self.build_file_aliases)
     logger.debug('build_graph is: %s', graph)
     # Ensure the entire generator is unrolled.
     for _ in graph.inject_roots_closure(target_roots):
@@ -242,13 +235,13 @@ class EngineInitializer(object):
   def _make_goal_map_from_rules(rules):
     goal_map = {}
     goal_to_rule = [(rule.goal, rule) for rule in rules if getattr(rule, 'goal', None) is not None]
-    for goal, rule in goal_to_rule:
+    for goal, r in goal_to_rule:
       if goal in goal_map:
         raise EngineInitializer.GoalMappingError(
           'could not map goal `{}` to rule `{}`: already claimed by product `{}`'
-          .format(goal, rule, goal_map[goal])
+          .format(goal, r, goal_map[goal])
         )
-      goal_map[goal] = rule.output_type
+      goal_map[goal] = r.output_type
     return goal_map
 
   @staticmethod
@@ -325,7 +318,7 @@ class EngineInitializer(object):
     build_file_aliases = build_configuration.registered_aliases()
     rules = build_configuration.rules()
 
-    symbol_table = LegacySymbolTable(build_file_aliases)
+    symbol_table = _legacy_symbol_table(build_file_aliases)
 
     project_tree = FileSystemProjectTree(build_root, pants_ignore_patterns)
 
@@ -378,4 +371,4 @@ class EngineInitializer(object):
       visualize_to_dir=bootstrap_options.native_engine_visualize_to,
     )
 
-    return LegacyGraphScheduler(scheduler, symbol_table, goal_map)
+    return LegacyGraphScheduler(scheduler, build_file_aliases, goal_map)

--- a/src/python/pants/init/target_roots_calculator.py
+++ b/src/python/pants/init/target_roots_calculator.py
@@ -60,11 +60,10 @@ class TargetRootsCalculator(object):
     return workspace.touched_files(changes_since)
 
   @classmethod
-  def create(cls, options, session, symbol_table, build_root=None, exclude_patterns=None, tags=None):
+  def create(cls, options, session, build_root=None, exclude_patterns=None, tags=None):
     """
     :param Options options: An `Options` instance to use.
     :param session: The Scheduler session
-    :param symbol_table: The symbol table
     :param string build_root: The build root.
     """
     # Determine the literal target roots.

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -203,7 +203,6 @@ class SchedulerService(PantsService):
     target_roots = TargetRootsCalculator.create(
       options=options,
       session=session.scheduler_session,
-      symbol_table=session.symbol_table,
       exclude_patterns=tuple(global_options.exclude_target_regexp) if global_options.exclude_target_regexp else tuple(),
       tags=tuple(global_options.tag) if global_options.tag else tuple()
     )

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -409,13 +409,6 @@ pub extern "C" fn tasks_create() -> *const Tasks {
 }
 
 #[no_mangle]
-pub extern "C" fn tasks_singleton_add(tasks_ptr: *mut Tasks, handle: Handle, output_type: TypeId) {
-  with_tasks(tasks_ptr, |tasks| {
-    tasks.singleton_add(handle.into(), output_type);
-  })
-}
-
-#[no_mangle]
 pub extern "C" fn tasks_task_begin(
   tasks_ptr: *mut Tasks,
   func: Function,

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -105,7 +105,6 @@ impl Select {
     params.retain(|k| match &entry {
       &rule_graph::Entry::Param(ref type_id) => type_id == k.type_id(),
       &rule_graph::Entry::WithDeps(ref with_deps) => with_deps.params().contains(k.type_id()),
-      &rule_graph::Entry::Singleton { .. } => false,
     });
     Select {
       params,
@@ -262,7 +261,6 @@ impl WrappedNode for Select {
           )))
         }
       }
-      &rule_graph::Entry::Singleton(ref key, _) => ok(externs::val_for(key)),
       &rule_graph::Entry::WithDeps(rule_graph::EntryWithDeps::Root(_)) => {
         panic!("Not a runtime-executable entry! {:?}", self.entry)
       }

--- a/tests/python/pants_test/engine/examples/parsers.py
+++ b/tests/python/pants_test/engine/examples/parsers.py
@@ -59,7 +59,7 @@ class JsonParser(Parser):
 
   @memoized_property
   def _decoder(self):
-    symbol_table = self.symbol_table.table()
+    symbol_table = self.symbol_table.table
     decoder = functools.partial(self._object_decoder,
                                 symbol_table=symbol_table.__getitem__ if symbol_table else self._as_type)
     kwargs = {
@@ -221,7 +221,7 @@ class PythonAssignmentsParser(Parser):
       return object_type(type_alias=type_alias, **kwargs)
 
     parse_globals = {}
-    for alias, symbol in self.symbol_table.table().items():
+    for alias, symbol in self.symbol_table.table.items():
       parse_globals[alias] = functools.partial(aliased, alias, symbol)
     return parse_globals
 
@@ -280,7 +280,7 @@ class PythonCallbacksParser(Parser):
         return object_type(type_alias=type_name, **kwargs)
 
     parse_globals = {}
-    for alias, symbol in self.symbol_table.table().items():
+    for alias, symbol in self.symbol_table.table.items():
       parse_globals[alias] = functools.partial(registered, alias, symbol)
     return objects, parse_globals
 

--- a/tests/python/pants_test/engine/legacy/test_parser.py
+++ b/tests/python/pants_test/engine/legacy/test_parser.py
@@ -8,14 +8,14 @@ import unittest
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.legacy.parser import LegacyPythonCallbacksParser
-from pants.engine.parser import EmptyTable
+from pants.engine.parser import SymbolTable
 
 
 class LegacyPythonCallbacksParserTest(unittest.TestCase):
 
   def test_no_import_sideeffects(self):
     # A parser with no symbols registered.
-    parser = LegacyPythonCallbacksParser(EmptyTable(), BuildFileAliases(), build_file_imports_behavior='allow')
+    parser = LegacyPythonCallbacksParser(SymbolTable({}), BuildFileAliases(), build_file_imports_behavior='allow')
     # Call to import a module should succeed.
     parser.parse('/dev/null', b'''import os; os.path.join('x', 'y')''')
     # But the imported module should not be visible as a symbol in further parses.

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -31,7 +31,7 @@ from pants_test.engine.util import Target, run_rule
 class ParseAddressFamilyTest(unittest.TestCase):
   def test_empty(self):
     """Test that parsing an empty BUILD file results in an empty AddressFamily."""
-    address_mapper = AddressMapper(JsonParser(TestTable()))
+    address_mapper = AddressMapper(JsonParser(TEST_TABLE))
     af = run_rule(parse_address_family, address_mapper, Dir('/dev/null'), {
         (Snapshot, PathGlobs): lambda _: Snapshot(Digest('abc', 10), ('/dev/null/BUILD',), ()),
         (FilesContent, Digest): lambda _: FilesContent([FileContent('/dev/null/BUILD', b'')]),
@@ -42,7 +42,7 @@ class ParseAddressFamilyTest(unittest.TestCase):
 class AddressesFromAddressFamiliesTest(unittest.TestCase):
 
   def _address_mapper(self):
-    return AddressMapper(JsonParser(TestTable()))
+    return AddressMapper(JsonParser(TEST_TABLE))
 
   def _snapshot(self):
     return Snapshot(Digest('xx', 2), ('root/BUILD',), ())
@@ -171,13 +171,13 @@ class PublishConfiguration(Struct):
     """"""
 
 
-class TestTable(SymbolTable):
-  def table(self):
-    return {'ApacheThriftConfig': ApacheThriftConfiguration,
-            'Struct': Struct,
-            'StructWithDeps': StructWithDeps,
-            'PublishConfig': PublishConfiguration,
-            'Target': Target}
+TEST_TABLE = SymbolTable({
+    'ApacheThriftConfig': ApacheThriftConfiguration,
+    'Struct': Struct,
+    'StructWithDeps': StructWithDeps,
+    'PublishConfig': PublishConfiguration,
+    'Target': Target,
+  })
 
 
 class GraphTestBase(unittest.TestCase, SchedulerTestBase):
@@ -185,13 +185,13 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
     address_mapper = AddressMapper(build_patterns=build_patterns,
                                    parser=parser)
 
-    rules = create_fs_rules() + create_graph_rules(address_mapper) + [SingletonRule(SymbolTable, TestTable())]
+    rules = create_fs_rules() + create_graph_rules(address_mapper) + [SingletonRule(SymbolTable, TEST_TABLE)]
     project_tree = self.mk_fs_tree(os.path.join(os.path.dirname(__file__), 'examples'))
     scheduler = self.mk_scheduler(rules=rules, project_tree=project_tree)
     return scheduler
 
   def create_json(self):
-    return self.create(build_patterns=('*.BUILD.json',), parser=JsonParser(TestTable()))
+    return self.create(build_patterns=('*.BUILD.json',), parser=JsonParser(TEST_TABLE))
 
   def _populate(self, scheduler, address):
     """Perform an ExecutionRequest to parse the given Address into a Struct."""
@@ -261,12 +261,12 @@ class InlinedGraphTest(GraphTestBase):
 
   def test_python(self):
     scheduler = self.create(build_patterns=('*.BUILD.python',),
-                            parser=PythonAssignmentsParser(TestTable()))
+                            parser=PythonAssignmentsParser(TEST_TABLE))
     self.do_test_codegen_simple(scheduler)
 
   def test_python_classic(self):
     scheduler = self.create(build_patterns=('*.BUILD',),
-                            parser=PythonCallbacksParser(TestTable()))
+                            parser=PythonCallbacksParser(TEST_TABLE))
     self.do_test_codegen_simple(scheduler)
 
   def test_resolve_cache(self):

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -19,7 +19,7 @@ from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.mapper import AddressFamily, AddressMapper, ResolveError
 from pants.engine.nodes import Return, Throw
 from pants.engine.parser import SymbolTable, TargetAdaptorContainer
-from pants.engine.rules import SingletonRule
+from pants.engine.rules import rule
 from pants.engine.struct import Struct, StructWithDeps
 from pants.util.objects import Exactly
 from pants_test.engine.examples.parsers import (JsonParser, PythonAssignmentsParser,
@@ -185,7 +185,10 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
     address_mapper = AddressMapper(build_patterns=build_patterns,
                                    parser=parser)
 
-    rules = create_fs_rules() + create_graph_rules(address_mapper) + [SingletonRule(SymbolTable, TEST_TABLE)]
+    @rule(SymbolTable, [])
+    def symbol_table_singleton():
+      return TEST_TABLE
+    rules = create_fs_rules() + create_graph_rules(address_mapper) + [symbol_table_singleton]
     project_tree = self.mk_fs_tree(os.path.join(os.path.dirname(__file__), 'examples'))
     scheduler = self.mk_scheduler(rules=rules, project_tree=project_tree)
     return scheduler

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -25,7 +25,7 @@ from pants.engine.struct import Struct
 from pants.util.dirutil import safe_open
 from pants_test.engine.examples.parsers import JsonParser
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
-from pants_test.engine.util import Target, TargetTable
+from pants_test.engine.util import TARGET_TABLE, Target
 
 
 class Thing(object):
@@ -42,14 +42,8 @@ class Thing(object):
     return isinstance(other, Thing) and self._key() == other._key()
 
 
-class ThingTable(SymbolTable):
-  def table(cls):
-    return {'thing': Thing}
-
-
 class AddressMapTest(unittest.TestCase):
-  _symbol_table = ThingTable()
-  _parser = JsonParser(_symbol_table)
+  _parser = JsonParser(SymbolTable({'thing': Thing}))
 
   @contextmanager
   def parse_address_map(self, json):
@@ -148,8 +142,7 @@ def unhydrated_structs(build_file_addresses):
 class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
   def setUp(self):
     # Set up a scheduler that supports address mapping.
-    symbol_table = TargetTable()
-    address_mapper = AddressMapper(parser=JsonParser(symbol_table),
+    address_mapper = AddressMapper(parser=JsonParser(TARGET_TABLE),
                                    build_patterns=('*.BUILD.json',))
 
     # We add the `unhydrated_structs` rule because it is otherwise not used in the core engine.

--- a/tests/python/pants_test/engine/test_parsers.py
+++ b/tests/python/pants_test/engine/test_parsers.py
@@ -30,16 +30,13 @@ class Bob(object):
     return isinstance(other, Bob) and self._key() == other._key()
 
 
-class TestTable(parser.SymbolTable):
-  @classmethod
-  def table(cls):
-    return {'bob': Bob}
+EMPTY_TABLE = parser.SymbolTable({})
 
 
-class TestTable2(parser.SymbolTable):
-  @classmethod
-  def table(cls):
-    return {'nancy': Bob}
+TEST_TABLE = parser.SymbolTable({'bob': Bob})
+
+
+TEST_TABLE2 = parser.SymbolTable({'nancy': Bob})
 
 
 def parse(parser, document, **args):
@@ -48,7 +45,7 @@ def parse(parser, document, **args):
 
 class JsonParserTest(unittest.TestCase):
   def parse(self, document, symbol_table=None, **kwargs):
-    symbol_table = symbol_table or parser.EmptyTable()
+    symbol_table = symbol_table or EMPTY_TABLE
     return parse(parsers.JsonParser(symbol_table), document, **kwargs)
 
   def round_trip(self, obj, symbol_table=None):
@@ -88,10 +85,10 @@ class JsonParserTest(unittest.TestCase):
       "hobbies": [1, 2, 3]
     }
     """)
-    results = self.parse(document, symbol_table=TestTable())
+    results = self.parse(document, symbol_table=TEST_TABLE)
     self.assertEqual(1, len(results))
     self.assertEqual([Bob(hobbies=[1, 2, 3])],
-                     self.round_trip(results[0], symbol_table=TestTable()))
+                     self.round_trip(results[0], symbol_table=TEST_TABLE))
     self.assertEqual('bob', results[0]._asdict()['type_alias'])
 
   def test_nested_single(self):
@@ -224,7 +221,7 @@ class JsonParserTest(unittest.TestCase):
     """).strip()
     filepath = '/dev/null'
     with self.assertRaises(parser.ParseError) as exc:
-      parsers.JsonParser(parser.EmptyTable()).parse(filepath, document)
+      parsers.JsonParser(EMPTY_TABLE).parse(filepath, document)
 
     # Strip trailing whitespace from the message since our expected literal below will have
     # trailing ws stripped via editors and code reviews calling for it.
@@ -323,7 +320,7 @@ class PythonAssignmentsParserTest(unittest.TestCase):
       hobbies=[1, 2, 3]
     )
     """)
-    results = parse(parsers.PythonAssignmentsParser(parser.EmptyTable()), document)
+    results = parse(parsers.PythonAssignmentsParser(EMPTY_TABLE), document)
     self.assertEqual([Bob(name='nancy', hobbies=[1, 2, 3])], results)
 
     # No symbol table was used so no `type_alias` plumbing can be expected.
@@ -335,7 +332,7 @@ class PythonAssignmentsParserTest(unittest.TestCase):
       hobbies=[1, 2, 3]
     )
     """)
-    results = parse(parsers.PythonAssignmentsParser(TestTable2()), document)
+    results = parse(parsers.PythonAssignmentsParser(TEST_TABLE2), document)
     self.assertEqual([Bob(name='bill', hobbies=[1, 2, 3])], results)
     self.assertEqual('nancy', results[0]._asdict()['type_alias'])
 
@@ -348,6 +345,6 @@ class PythonCallbacksParserTest(unittest.TestCase):
       hobbies=[1, 2, 3]
     )
     """)
-    results = parse(parsers.PythonCallbacksParser(TestTable2()), document)
+    results = parse(parsers.PythonCallbacksParser(TEST_TABLE2), document)
     self.assertEqual([Bob(name='bill', hobbies=[1, 2, 3])], results)
     self.assertEqual('nancy', results[0]._asdict()['type_alias'])

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -14,8 +14,7 @@ from pants.engine.build_files import create_graph_rules
 from pants.engine.console import Console
 from pants.engine.fs import create_fs_rules
 from pants.engine.mapper import AddressMapper
-from pants.engine.rules import (RootRule, RuleIndex, SingletonRule, _GoalProduct, _RuleVisitor,
-                                console_rule, rule)
+from pants.engine.rules import RootRule, RuleIndex, _GoalProduct, _RuleVisitor, console_rule, rule
 from pants.engine.selectors import Get
 from pants_test.engine.examples.parsers import JsonParser
 from pants_test.engine.util import (TARGET_TABLE, assert_equal_with_printing, create_scheduler,
@@ -192,10 +191,14 @@ class RuleGraphTest(TestBase):
     def d_from_c(c):
       pass
 
+    @rule(B, [])
+    def b_singleton():
+      return B()
+
     rules = [
       RootRule(A),
       d_from_c,
-      SingletonRule(B, B()),
+      b_singleton,
     ]
 
     with self.assertRaises(Exception) as cm:
@@ -462,10 +465,14 @@ class RuleGraphTest(TestBase):
     def a():
       pass
 
+    @rule(B, [])
+    def b_singleton():
+      return B()
+
     rules = [
       a_from_c,
       a,
-      SingletonRule(B, B()),
+      b_singleton,
     ]
 
     subgraph = self.create_subgraph(A, rules, SubA(), validate=False)
@@ -574,14 +581,18 @@ class RuleGraphTest(TestBase):
                      }""").strip(),
       subgraph)
 
-  def test_get_with_matching_singleton(self):
-    @rule(A, [SubA])
+  def test_matching_singleton(self):
+    @rule(A, [SubA, B])
     def a_from_suba(suba):
-      _ = yield Get(B, C, C())  # noqa: F841
+      return A()
+
+    @rule(B, [])
+    def b_singleton():
+      return B()
 
     rules = [
       a_from_suba,
-      SingletonRule(B, B()),
+      b_singleton,
     ]
 
     subgraph = self.create_subgraph(A, rules, SubA())
@@ -591,9 +602,10 @@ class RuleGraphTest(TestBase):
                        // root subject types: SubA
                        // root entries
                          "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, [SubA], [Get(B, C)], a_from_suba()) for SubA"}
+                         "Select(A) for SubA" -> {"(A, [SubA, B], a_from_suba()) for SubA"}
                        // internal entries
-                         "(A, [SubA], [Get(B, C)], a_from_suba()) for SubA" -> {"Param(SubA)" "Singleton(B(), B)"}
+                         "(A, [SubA, B], a_from_suba()) for SubA" -> {"(B, [], b_singleton()) for ()" "Param(SubA)"}
+                         "(B, [], b_singleton()) for ()" -> {}
                      }""").strip(),
       subgraph)
 

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -18,7 +18,7 @@ from pants.engine.rules import (RootRule, RuleIndex, SingletonRule, _GoalProduct
                                 console_rule, rule)
 from pants.engine.selectors import Get
 from pants_test.engine.examples.parsers import JsonParser
-from pants_test.engine.util import (TargetTable, assert_equal_with_printing, create_scheduler,
+from pants_test.engine.util import (TARGET_TABLE, assert_equal_with_printing, create_scheduler,
                                     run_rule)
 from pants_test.test_base import TestBase
 
@@ -265,8 +265,7 @@ class RuleGraphTest(TestBase):
                      }""").strip(), fullgraph)
 
   def test_full_graph_for_planner_example(self):
-    symbol_table = TargetTable()
-    address_mapper = AddressMapper(JsonParser(symbol_table), '*.BUILD.json')
+    address_mapper = AddressMapper(JsonParser(TARGET_TABLE), '*.BUILD.json')
     rules = create_graph_rules(address_mapper) + create_fs_rules()
 
     fullgraph_str = self.create_full_graph(rules)

--- a/tests/python/pants_test/engine/util.py
+++ b/tests/python/pants_test/engine/util.py
@@ -112,10 +112,7 @@ class Target(Struct):
     pass
 
 
-class TargetTable(SymbolTable):
-  @classmethod
-  def table(cls):
-    return {'struct': Struct, 'target': Target}
+TARGET_TABLE = SymbolTable({'struct': Struct, 'target': Target})
 
 
 def assert_equal_with_printing(test_case, expected, actual):


### PR DESCRIPTION
### Problem

In #6170, it became possible for a `@rule` to take no `Params`, meaning that its identity did not include any of its context, and it could act as a singleton. Before that change, it had always been the case that a `@rule` would have a "subject" in its identity, necessitating `SingletonRule` in order to avoid creating a new copy of the rule in the graph for each distinct subject.

### Solution

Remove `SingletonRule` in favor of definition of zero-parameter `@rules`, which reduces the total number of concepts involved in the engine. Because `SingletonRule` used to allow a declaration to lie about the exact type it was providing (and give an instance of a subclass instead), usage of `SymbolTable` first needed to be cleaned up to remove subclassing.