### PR TITLE
WIP: Ensure Python 3.6 or 3.7 is installed on all CI shards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -452,18 +452,20 @@ py37_lint: &py37_lint
 # Rust lints
 # -------------------------------------------------------------------------
 
-linux_rust_clippy: &linux_rust_clippy
+base_rust_lints: &base_rust_lints
   <<: *linux_with_fuse
+  os: linux
+  dist: xenial
+  sudo: required
+  python: "3.6"
+
+linux_rust_clippy: &linux_rust_clippy
+  <<: *base_rust_lints
   <<: *native_engine_cache_config
   name: "Linux Rust Clippy (No PEX)"
   env:
     - CACHE_NAME=linuxclippy
-  os: linux
-  dist: xenial
-  sudo: required
   stage: *test
-  language: python
-  python: "3.6"
   before_script:
     - ulimit -c unlimited
     - ulimit -n 8192
@@ -471,13 +473,10 @@ linux_rust_clippy: &linux_rust_clippy
     - ./build-support/bin/travis-ci.sh -s
 
 cargo_audit: &cargo_audit
-  <<: *linux_with_fuse
+  <<: *base_rust_lints
   name: "Cargo audit (No PEX)"
   env:
     - CACHE_NAME=linuxcargoaudit
-  os: linux
-  dist: xenial
-  sudo: required
   stage: *test_cron
   script:
     - ./build-support/bin/travis-ci.sh -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -311,6 +311,7 @@ base_linux_build_engine: &base_linux_build_engine
   # Callers of this anchor are expected to provide values in their `env` for
   # `docker_image_name` and `docker_run_command` (i.e. the bash command(s) to run).
   script:
+    - python3.6 --version
     - >
       docker build
       --rm -t ${docker_image_name}
@@ -386,6 +387,7 @@ py27_osx_build_engine: &py27_osx_build_engine
     - CACHE_NAME=osxpexbuild.py27
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
   script:
+    - python3.6 --version
     - ./build-support/bin/ci.sh -2b
     #  Also build fs_util.
     - ./build-support/bin/release.sh -f
@@ -428,7 +430,7 @@ py27_lint: &py27_lint
     - *py27_linux_test_config_env
     - CACHE_NAME=linuxselfchecks.py27
   script:
-    - ./build-support/bin/travis-ci.sh -fmrt2
+    - python3.6 --version && ./build-support/bin/travis-ci.sh -fmrt2
 
 py36_lint: &py36_lint
   <<: *py36_linux_test_config
@@ -507,6 +509,7 @@ base_linux_build_wheels: &base_linux_build_wheels
   # Callers of this anchor are expected to provide values in their `env` for
   # `docker_image_name` and `docker_run_command` (i.e. the bash command(s) to run).
   script:
+    - python3.6 --version
     - >
       docker build
       --rm -t ${docker_image_name}
@@ -575,6 +578,7 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs2
   script:
+    - python3.6 --version
     - ./build-support/bin/check_pants_pex_abi.py cp27m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
@@ -596,6 +600,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - ./build-support/bin/install_python_for_ci.sh 2.7.13
   script:
+    - python3.6 --version
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
@@ -623,7 +628,7 @@ base_rust_tests: &base_rust_tests
     - ulimit -c unlimited
     - ulimit -n 8192
   script:
-    - ./build-support/bin/travis-ci.sh -e
+    - python3.6 --version && ./build-support/bin/travis-ci.sh -e
 
 linux_rust_tests: &linux_rust_tests
   <<: *base_rust_tests
@@ -663,7 +668,7 @@ osx_rust_tests: &osx_rust_tests
 
 base_osx_sanity_check: &base_osx_sanity_check
   script:
-    - MODE=debug ./build-support/bin/travis-ci.sh -m
+    - python3.6 --version && MODE=debug ./build-support/bin/travis-ci.sh -m
 
 # TODO: Update this to use 10.14 once it is available
 base_osx_10_12_sanity_check: &base_osx_10_12_sanity_check
@@ -733,7 +738,7 @@ py27_osx_platform_tests: &py27_osx_platform_tests
     - *py27_osx_test_config_env
     - CACHE_NAME=macosplatformtests.py27
   script:
-    - ./build-support/bin/travis-ci.sh -z2
+    - python3.6 --version && ./build-support/bin/travis-ci.sh -z2
 
 py36_osx_platform_tests: &py36_osx_platform_tests
   <<: *py36_osx_test_config
@@ -768,7 +773,7 @@ py27_jvm_tests: &py27_jvm_tests
     - *py27_linux_test_config_env
     - CACHE_NAME=linuxjvmtests.py27
   script:
-    - ./build-support/bin/travis-ci.sh -j2
+    - python3.6 --version && ./build-support/bin/travis-ci.sh -j2
 
 py36_jvm_tests: &py36_jvm_tests
   <<: *py36_linux_test_config
@@ -905,7 +910,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=linuxunittests.py27
       script:
-        - ./build-support/bin/travis-ci.sh -2lp
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -2lp
 
     - <<: *py36_linux_test_config
       name: "Unit tests (Py3.6 PEX)"
@@ -1257,7 +1262,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard0
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 0/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 0/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 1 (Py2.7 PEX)"
@@ -1265,7 +1270,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard1
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 1/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 1/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 2 (Py2.7 PEX)"
@@ -1273,7 +1278,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard2
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 2/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 2/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 3 (Py2.7 PEX)"
@@ -1281,7 +1286,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard3
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 3/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 3/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 4 (Py2.7 PEX)"
@@ -1289,7 +1294,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard4
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 4/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 4/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 5 (Py2.7 PEX)"
@@ -1297,7 +1302,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard5
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 5/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 5/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 6 (Py2.7 PEX)"
@@ -1305,7 +1310,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard6
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 6/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 6/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 7 (Py2.7 PEX)"
@@ -1313,7 +1318,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard7
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 7/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 7/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 8 (Py2.7 PEX)"
@@ -1321,7 +1326,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard8
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 8/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 8/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 9 (Py2.7 PEX)"
@@ -1329,7 +1334,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard9
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 9/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 9/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 10 (Py2.7 PEX)"
@@ -1337,7 +1342,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard10
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 10/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 10/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 11 (Py2.7 PEX)"
@@ -1345,7 +1350,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard11
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 11/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 11/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 12 (Py2.7 PEX)"
@@ -1353,7 +1358,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard12
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 12/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 12/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 13 (Py2.7 PEX)"
@@ -1361,7 +1366,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard13
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 13/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 13/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 14 (Py2.7 PEX)"
@@ -1369,7 +1374,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard14
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 14/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 14/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 15 (Py2.7 PEX)"
@@ -1377,7 +1382,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard15
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 15/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 15/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 16 (Py2.7 PEX)"
@@ -1385,7 +1390,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard16
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 16/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 16/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 17 (Py2.7 PEX)"
@@ -1393,7 +1398,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard17
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 17/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 17/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 18 (Py2.7 PEX)"
@@ -1401,7 +1406,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard18
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 18/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 18/20
 
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 19 (Py2.7 PEX)"
@@ -1409,7 +1414,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard19
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i 19/20
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i 19/20
 
 
     - <<: *linux_rust_tests
@@ -1422,7 +1427,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=linuxcontribtests.py27
       script:
-        - ./build-support/bin/travis-ci.sh -2n
+        - python3.6 --version &&./build-support/bin/travis-ci.sh -2n
 
     - <<: *py36_linux_test_config
       name: "Python contrib tests (Py3.6 PEX)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,10 @@ base_linux_config: &base_linux_config
   os: linux
   dist: xenial
   sudo: required
+  python:
+    - "2.7"
+    - "3.6"
+    - "3.7"
   addons:
     apt:
       packages:
@@ -151,15 +155,12 @@ base_linux_config: &base_linux_config
 
 py27_linux_config: &py27_linux_config
   <<: *base_linux_config
-  python: &python2_version "2.7"
 
 py36_linux_config: &py36_linux_config
   <<: *base_linux_config
-  python: "3.6"
 
 py37_linux_config: &py37_linux_config
   <<: *base_linux_config
-  python: "3.7"
 
 base_linux_test_config: &base_linux_test_config
   <<: *base_linux_config
@@ -197,37 +198,34 @@ py37_linux_test_config: &py37_linux_test_config
 base_osx_config: &base_osx_config
   os: osx
   language: generic
-  before_install:
-    - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
-    - chmod 755 /usr/local/bin/jq
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-
-py27_osx_config: &py27_osx_config
-  <<: *base_osx_config
-
-py36_osx_config: &py36_osx_config
-  <<: *base_osx_config
   addons:
     brew:
-      packages: &py36_osx_config_brew_packages
+      packages:
       - openssl
-  env:
-    - &py36_osx_config_env >
-      PATH="/usr/local/opt/openssl/bin:$PATH"
-      LDFLAGS="-L/usr/local/opt/openssl/lib"
-      CPPFLAGS="-I/usr/local/opt/openssl/include"
   before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
 
+py27_osx_config: &py27_osx_config
+  <<: *base_osx_config
+  env:
+    - &py27_osx_config_env >
+      PATH="/usr/local/opt/openssl/bin:$PATH"
+      LDFLAGS="-L/usr/local/opt/openssl/lib"
+      CPPFLAGS="-I/usr/local/opt/openssl/include"
+
+py36_osx_config: &py36_osx_config
+  <<: *base_osx_config
+  env:
+    - &py36_osx_config_env >
+      PATH="/usr/local/opt/openssl/bin:$PATH"
+      LDFLAGS="-L/usr/local/opt/openssl/lib"
+      CPPFLAGS="-I/usr/local/opt/openssl/include"
+
 py37_osx_config: &py37_osx_config
   <<: *base_osx_config
-  addons:
-    brew:
-      packages: &py37_osx_config_brew_packages
-      - openssl
   env:
     - &py37_osx_config_env >
       PATH="/usr/local/opt/openssl/bin:$PATH"
@@ -251,7 +249,11 @@ py27_osx_test_config: &py27_osx_test_config
   <<: *base_osx_test_config
   stage: *test_cron
   env:
-    - &py27_osx_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
+    - &py27_osx_test_config_env >
+      PATH="/usr/local/opt/openssl/bin:$PATH"
+      LDFLAGS="-L/usr/local/opt/openssl/lib"
+      CPPFLAGS="-I/usr/local/opt/openssl/include"
+      BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
 
 py36_osx_test_config: &py36_osx_test_config
   <<: *py36_osx_config
@@ -379,6 +381,7 @@ py27_osx_build_engine: &py27_osx_build_engine
   <<: *base_osx_build_engine
   name: "Build OSX native engine and pants.pex (Py2.7 PEX)"
   env:
+    - *py27_osx_config_env
     - PREPARE_DEPLOY=1
     - CACHE_NAME=osxpexbuild.py27
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
@@ -581,17 +584,10 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   <<: *base_osx_build_wheels
   <<: *native_engine_cache_config
   name: "Build wheels - OSX and cp27mu (UCS4)"
-  addons:
-    brew:
-      packages:
-      - openssl
   env:
+    - *py27_osx_config_env
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs4
-    - >
-      PATH="/usr/local/opt/openssl/bin:$PATH"
-      LDFLAGS="-L/usr/local/opt/openssl/lib"
-      CPPFLAGS="-I/usr/local/opt/openssl/include"
     - PYTHON_CONFIGURE_OPTS=--enable-unicode=ucs4
     # We set $PY to ensure the UCS4 interpreter is used when bootstrapping the PEX.
     - PY=${PYENV_ROOT}/shims/python2.7
@@ -627,6 +623,8 @@ base_rust_tests: &base_rust_tests
   before_script:
     - ulimit -c unlimited
     - ulimit -n 8192
+  script:
+    - ./build-support/bin/travis-ci.sh -e
 
 linux_rust_tests: &linux_rust_tests
   <<: *base_rust_tests
@@ -639,26 +637,26 @@ linux_rust_tests: &linux_rust_tests
   sudo: required
   language: python
   python: "3.6"
-  script:
-    - ./build-support/bin/travis-ci.sh -e
 
 osx_rust_tests: &osx_rust_tests
   <<: *base_rust_tests
   name: "Rust tests - OSX (No PEX)"
-  env:
-    - CACHE_NAME=macosrusttests
   os: osx
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3
   addons:
     homebrew:
       casks:
+      - openssl
       - osxfuse
-  script:
-  # N.B. We run this with Python 2 because this osx_image does not have
-  # Python 3.6 or 3.7 in its environment. We do not care which Python version
-  # we use and do not want to incur the cost of using pyenv to get 3.6 or 3.7.
-    - ./build-support/bin/travis-ci.sh -e2
+  before_install:
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
+  env:
+    - >
+      PATH="/usr/local/opt/openssl/bin:$PATH"
+      LDFLAGS="-L/usr/local/opt/openssl/lib"
+      CPPFLAGS="-I/usr/local/opt/openssl/include"
+    - CACHE_NAME=macosrusttests
 
 # -------------------------------------------------------------------------
 # OSX sanity checks

--- a/build-support/bin/install_python_for_ci.sh
+++ b/build-support/bin/install_python_for_ci.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 source build-support/common.sh
 
-PYTHON_VERSIONS="$@"
+PYTHON_VERSIONS=("$@")
 
 if [[ -z "${PYENV_ROOT:+''}" ]]; then
   die "Caller of the script must set the env var PYENV_ROOT."

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -124,6 +124,10 @@ base_linux_config: &base_linux_config
   os: linux
   dist: xenial
   sudo: required
+  python:
+    - "2.7"
+    - "3.6"
+    - "3.7"
   addons:
     apt:
       packages:
@@ -144,15 +148,12 @@ base_linux_config: &base_linux_config
 
 py27_linux_config: &py27_linux_config
   <<: *base_linux_config
-  python: &python2_version "2.7"
 
 py36_linux_config: &py36_linux_config
   <<: *base_linux_config
-  python: "3.6"
 
 py37_linux_config: &py37_linux_config
   <<: *base_linux_config
-  python: "3.7"
 
 base_linux_test_config: &base_linux_test_config
   <<: *base_linux_config
@@ -187,31 +188,28 @@ py37_linux_test_config: &py37_linux_test_config
 base_osx_config: &base_osx_config
   os: osx
   language: generic
-  before_install:
-    {{>before_install_osx}}
-
-py27_osx_config: &py27_osx_config
-  <<: *base_osx_config
-
-py36_osx_config: &py36_osx_config
-  <<: *base_osx_config
   addons:
     brew:
-      packages: &py36_osx_config_brew_packages
+      packages:
       - openssl
-  env:
-    - &py36_osx_config_env >
-      {{>env_osx_with_pyenv}}
   before_install:
     {{>before_install_osx}}
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
 
+py27_osx_config: &py27_osx_config
+  <<: *base_osx_config
+  env:
+    - &py27_osx_config_env >
+      {{>env_osx_with_pyenv}}
+
+py36_osx_config: &py36_osx_config
+  <<: *base_osx_config
+  env:
+    - &py36_osx_config_env >
+      {{>env_osx_with_pyenv}}
+
 py37_osx_config: &py37_osx_config
   <<: *base_osx_config
-  addons:
-    brew:
-      packages: &py37_osx_config_brew_packages
-      - openssl
   env:
     - &py37_osx_config_env >
       {{>env_osx_with_pyenv}}
@@ -231,7 +229,9 @@ py27_osx_test_config: &py27_osx_test_config
   <<: *base_osx_test_config
   stage: *test_cron
   env:
-    - &py27_osx_test_config_env BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
+    - &py27_osx_test_config_env >
+      {{>env_osx_with_pyenv}}
+      BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
 
 py36_osx_test_config: &py36_osx_test_config
   <<: *py36_osx_config
@@ -341,6 +341,7 @@ py27_osx_build_engine: &py27_osx_build_engine
   <<: *base_osx_build_engine
   name: "Build OSX native engine and pants.pex (Py2.7 PEX)"
   env:
+    - *py27_osx_config_env
     - PREPARE_DEPLOY=1
     - CACHE_NAME=osxpexbuild.py27
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
@@ -532,15 +533,10 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   <<: *base_osx_build_wheels
   <<: *native_engine_cache_config
   name: "Build wheels - OSX and cp27mu (UCS4)"
-  addons:
-    brew:
-      packages:
-      - openssl
   env:
+    - *py27_osx_config_env
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs4
-    - >
-      {{>env_osx_with_pyenv}}
     - PYTHON_CONFIGURE_OPTS=--enable-unicode=ucs4
     # We set $PY to ensure the UCS4 interpreter is used when bootstrapping the PEX.
     - PY=${PYENV_ROOT}/shims/python2.7
@@ -574,6 +570,8 @@ base_rust_tests: &base_rust_tests
   before_script:
     - ulimit -c unlimited
     - ulimit -n 8192
+  script:
+    - ./build-support/bin/travis-ci.sh -e
 
 linux_rust_tests: &linux_rust_tests
   <<: *base_rust_tests
@@ -586,26 +584,24 @@ linux_rust_tests: &linux_rust_tests
   sudo: required
   language: python
   python: "3.6"
-  script:
-    - ./build-support/bin/travis-ci.sh -e
 
 osx_rust_tests: &osx_rust_tests
   <<: *base_rust_tests
   name: "Rust tests - OSX (No PEX)"
-  env:
-    - CACHE_NAME=macosrusttests
   os: osx
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3
   addons:
     homebrew:
       casks:
+      - openssl
       - osxfuse
-  script:
-  # N.B. We run this with Python 2 because this osx_image does not have
-  # Python 3.6 or 3.7 in its environment. We do not care which Python version
-  # we use and do not want to incur the cost of using pyenv to get 3.6 or 3.7.
-    - ./build-support/bin/travis-ci.sh -e2
+  before_install:
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
+  env:
+    - >
+      {{>env_osx_with_pyenv}}
+    - CACHE_NAME=macosrusttests
 
 # -------------------------------------------------------------------------
 # OSX sanity checks

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -412,18 +412,20 @@ py37_lint: &py37_lint
 # Rust lints
 # -------------------------------------------------------------------------
 
-linux_rust_clippy: &linux_rust_clippy
+base_rust_lints: &base_rust_lints
   <<: *linux_with_fuse
+  os: linux
+  dist: xenial
+  sudo: required
+  python: "3.6"
+
+linux_rust_clippy: &linux_rust_clippy
+  <<: *base_rust_lints
   <<: *native_engine_cache_config
   name: "Linux Rust Clippy (No PEX)"
   env:
     - CACHE_NAME=linuxclippy
-  os: linux
-  dist: xenial
-  sudo: required
   stage: *test
-  language: python
-  python: "3.6"
   before_script:
     - ulimit -c unlimited
     - ulimit -n 8192
@@ -431,13 +433,10 @@ linux_rust_clippy: &linux_rust_clippy
     - ./build-support/bin/travis-ci.sh -s
 
 cargo_audit: &cargo_audit
-  <<: *linux_with_fuse
+  <<: *base_rust_lints
   name: "Cargo audit (No PEX)"
   env:
     - CACHE_NAME=linuxcargoaudit
-  os: linux
-  dist: xenial
-  sudo: required
   stage: *test_cron
   script:
     - ./build-support/bin/travis-ci.sh -a

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -282,6 +282,7 @@ base_linux_build_engine: &base_linux_build_engine
   # Callers of this anchor are expected to provide values in their `env` for
   # `docker_image_name` and `docker_run_command` (i.e. the bash command(s) to run).
   script:
+    - python3.6 --version
     - >
       {{>docker_build_image}}
     - >
@@ -346,6 +347,7 @@ py27_osx_build_engine: &py27_osx_build_engine
     - CACHE_NAME=osxpexbuild.py27
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
   script:
+    - python3.6 --version
     - ./build-support/bin/ci.sh -2b
     #  Also build fs_util.
     - ./build-support/bin/release.sh -f
@@ -388,7 +390,7 @@ py27_lint: &py27_lint
     - *py27_linux_test_config_env
     - CACHE_NAME=linuxselfchecks.py27
   script:
-    - ./build-support/bin/travis-ci.sh -fmrt2
+    - python3.6 --version && ./build-support/bin/travis-ci.sh -fmrt2
 
 py36_lint: &py36_lint
   <<: *py36_linux_test_config
@@ -467,6 +469,7 @@ base_linux_build_wheels: &base_linux_build_wheels
   # Callers of this anchor are expected to provide values in their `env` for
   # `docker_image_name` and `docker_run_command` (i.e. the bash command(s) to run).
   script:
+    - python3.6 --version
     - >
       {{>docker_build_image}}
     - >
@@ -524,6 +527,7 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs2
   script:
+    - python3.6 --version
     - ./build-support/bin/check_pants_pex_abi.py cp27m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
@@ -543,6 +547,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     {{>before_install_osx}}
     - ./build-support/bin/install_python_for_ci.sh 2.7.13
   script:
+    - python3.6 --version
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
@@ -570,7 +575,7 @@ base_rust_tests: &base_rust_tests
     - ulimit -c unlimited
     - ulimit -n 8192
   script:
-    - ./build-support/bin/travis-ci.sh -e
+    - python3.6 --version && ./build-support/bin/travis-ci.sh -e
 
 linux_rust_tests: &linux_rust_tests
   <<: *base_rust_tests
@@ -608,7 +613,7 @@ osx_rust_tests: &osx_rust_tests
 
 base_osx_sanity_check: &base_osx_sanity_check
   script:
-    - MODE=debug ./build-support/bin/travis-ci.sh -m
+    - python3.6 --version && MODE=debug ./build-support/bin/travis-ci.sh -m
 
 # TODO: Update this to use 10.14 once it is available
 base_osx_10_12_sanity_check: &base_osx_10_12_sanity_check
@@ -678,7 +683,7 @@ py27_osx_platform_tests: &py27_osx_platform_tests
     - *py27_osx_test_config_env
     - CACHE_NAME=macosplatformtests.py27
   script:
-    - ./build-support/bin/travis-ci.sh -z2
+    - python3.6 --version && ./build-support/bin/travis-ci.sh -z2
 
 py36_osx_platform_tests: &py36_osx_platform_tests
   <<: *py36_osx_test_config
@@ -713,7 +718,7 @@ py27_jvm_tests: &py27_jvm_tests
     - *py27_linux_test_config_env
     - CACHE_NAME=linuxjvmtests.py27
   script:
-    - ./build-support/bin/travis-ci.sh -j2
+    - python3.6 --version && ./build-support/bin/travis-ci.sh -j2
 
 py36_jvm_tests: &py36_jvm_tests
   <<: *py36_linux_test_config
@@ -850,7 +855,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=linuxunittests.py27
       script:
-        - ./build-support/bin/travis-ci.sh -2lp
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -2lp
 
     - <<: *py36_linux_test_config
       name: "Unit tests (Py3.6 PEX)"
@@ -903,7 +908,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=cronshard{{.}}
       script:
-        - ./build-support/bin/travis-ci.sh -c2 -i {{.}}/{{integration_shards_length}}
+        - python3.6 --version && ./build-support/bin/travis-ci.sh -c2 -i {{.}}/{{integration_shards_length}}
 
 {{/integration_shards}}
 
@@ -917,7 +922,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=linuxcontribtests.py27
       script:
-        - ./build-support/bin/travis-ci.sh -2n
+        - python3.6 --version &&./build-support/bin/travis-ci.sh -2n
 
     - <<: *py36_linux_test_config
       name: "Python contrib tests (Py3.6 PEX)"


### PR DESCRIPTION
### Problem
Once all CI shards are guaranteed to have Python 3, we can port our more complex `build-support` scripts to Python 3, which will allow us to reduce technical debt and to bring benefits like better argument parsing. 

In particular, we want to be able to use Python 3 in those scripts so that we can use `subprocess.run()`.

### Solution
For Linux, Travis pre-installs Python 3.6 and 3.7. We simply tell Travis we want those installed, and then the `travis-ci.sh` script will resolve everything from there for no performance cost.

OSX shards do not have Python 3 installed by default (at least for certain `osx_images`), so we use Pyenv to install on all shards. This is no longer very costly to do so thanks to caching Pyenv through 
https://github.com/pantsbuild/pants/pull/7470.

### Result
All shards now have Python 3.6 or 3.7.

Once we update the Centos6 Docker image in https://github.com/pantsbuild/pants/pull/7064, we can then start using Python 3 in `build-support`.