### PR TITLE
Bump cffi (1.11.1 => 1.11.5)

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,7 +1,7 @@
 ansicolors==1.0.2
 asttokens==1.1.13
 beautifulsoup4>=4.6.0,<4.7
-cffi==1.12
+cffi==1.11.5
 configparser==3.5.0 ; python_version<'3'
 contextlib2==0.5.5
 coverage>=4.5,<4.6

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,7 +1,7 @@
 ansicolors==1.0.2
 asttokens==1.1.13
 beautifulsoup4>=4.6.0,<4.7
-cffi==1.12.2
+cffi==1.12
 configparser==3.5.0 ; python_version<'3'
 contextlib2==0.5.5
 coverage>=4.5,<4.6

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,7 +1,7 @@
 ansicolors==1.0.2
 asttokens==1.1.13
 beautifulsoup4>=4.6.0,<4.7
-cffi==1.11.1
+cffi==1.12.2
 configparser==3.5.0 ; python_version<'3'
 contextlib2==0.5.5
 coverage>=4.5,<4.6


### PR DESCRIPTION
### Problem

Updating a Django project to the latest release (`2.2` - released [yesterday](https://docs.djangoproject.com/en/2.2/releases/2.2/#django-2-2-release-notes), using Python `3.6.6`) that has `pants` as a dependency throws an error when calling `<project>/manage.py runserver`:

```bash
$ manage.py runserver
Performing system checks...

AttributeError: cffi library '_constant_time' has no function, constant or global variable named '__spec__'
```

### Solution

Bump to the ~latest~ `cffi` ([Full changelog here](https://cffi.readthedocs.io/en/latest/whatsnew.html#v1-12-2) - it looks like this specific error was addressed in [`1.11.3`](https://cffi.readthedocs.io/en/latest/whatsnew.html#v1-11-3))

📝 For context, last update for `cffi` in `pants` was in [Oct. 2017](https://github.com/pantsbuild/pants/commit/5d1dd8115ee268292a63fee1306e50cab9a21208)


---

⚠️ This initially attempted to bump to the latest version (`1.12.2`), which ran into segfault issues (as noted below / discussion in [Slack](https://pantsbuild.slack.com/archives/C0D7TNJHL/p1554330688035800)) - errors can be seen in the following TravisCI builds:
- https://travis-ci.org/pantsbuild/pants/builds/514954750
- https://travis-ci.org/pantsbuild/pants/builds/514899998
- Trace from my local machine reproducing the sig 11 error: https://gist.github.com/codealchemy/4de401a2c1c46adb9f0e1ab03e618e9f


