### PR TITLE
WIP: Run all tests with OSX during nightly cron CI run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1265,6 +1265,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 0 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard0
@@ -1273,6 +1274,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 1 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard1
@@ -1281,6 +1283,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 2 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard2
@@ -1289,6 +1292,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 3 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard3
@@ -1297,6 +1301,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 4 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard4
@@ -1305,6 +1310,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 5 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard5
@@ -1313,6 +1319,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 6 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard6
@@ -1321,6 +1328,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 7 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard7
@@ -1329,6 +1337,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 8 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard8
@@ -1337,6 +1346,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 9 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard9
@@ -1345,6 +1355,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 10 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard10
@@ -1353,6 +1364,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 11 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard11
@@ -1361,6 +1373,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 12 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard12
@@ -1369,6 +1382,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 13 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard13
@@ -1377,6 +1391,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 14 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard14
@@ -1385,6 +1400,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 15 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard15
@@ -1393,6 +1409,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 16 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard16
@@ -1401,6 +1418,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 17 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard17
@@ -1409,6 +1427,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 18 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard18
@@ -1417,6 +1436,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard 19 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard19
@@ -1606,6 +1626,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Python contrib tests - OSX (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=osxcontribtests.py36

--- a/.travis.yml
+++ b/.travis.yml
@@ -892,6 +892,8 @@ matrix:
     - <<: *py27_osx_build_engine
       stage: *bootstrap_cron
     - <<: *py36_osx_build_engine
+    - <<: *py36_osx_build_engine
+      stage: *bootstrap_cron
     - <<: *py37_osx_build_engine
 
     - <<: *py27_lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -452,7 +452,7 @@ py37_lint: &py37_lint
 linux_rust_clippy: &linux_rust_clippy
   <<: *linux_with_fuse
   <<: *native_engine_cache_config
-  name: "Linux Rust Clippy (No PEX)"
+  name: "Rust Clippy (No PEX)"
   env:
     - CACHE_NAME=linuxclippy
   os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,13 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - name: &bootstrap Bootstrap Pants
-    if: type != cron
+    if: type = cron
   - name: &bootstrap_cron Bootstrap Pants (Cron)
-    if: type = cron
-  - name: &test Test Pants
     if: type != cron
-  - name: &test_cron Test Pants (Cron)
+  - name: &test Test Pants
     if: type = cron
+  - name: &test_cron Test Pants (Cron)
+    if: type != cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -918,6 +918,15 @@ matrix:
       script:
         - ./build-support/bin/travis-ci.sh -lp
 
+    - <<: *py36_osx_test_config
+      name: "Unit tests - OSX (Py3.6 PEX)"
+      stage: *test_cron
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=osxunittests.osx.py36
+      script:
+        - ./build-support/bin/travis-ci.sh -lp
+
     - <<: *py37_linux_test_config
       name: "Unit tests (Py3.7 PEX)"
       env:
@@ -934,331 +943,11 @@ matrix:
     - <<: *py27_osx_build_wheels_ucs4
     - <<: *py36_osx_build_wheels
 
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 0 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard0
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 0/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 1 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard1
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 1/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 2 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard2
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 2/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 3 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard3
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 3/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 4 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard4
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 4/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 5 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard5
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 5/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 6 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard6
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 6/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 7 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard7
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 7/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 8 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard8
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 8/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 9 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard9
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 9/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 10 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard10
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 10/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 11 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard11
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 11/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 12 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard12
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 12/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 13 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard13
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 13/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 14 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard14
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 14/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 15 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard15
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 15/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 16 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard16
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 16/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 17 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard17
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 17/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 18 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard18
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 18/20
-
-    - <<: *py36_linux_test_config
-      name: "Integration tests - shard 19 (Py3.6 PEX)"
-      env:
-        - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard19
-      script:
-        - ./build-support/bin/travis-ci.sh -c -i 19/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 0 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard0
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 0/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 1 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard1
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 1/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 2 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard2
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 2/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 3 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard3
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 3/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 4 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard4
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 4/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 5 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard5
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 5/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 6 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard6
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 6/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 7 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard7
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 7/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 8 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard8
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 8/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 9 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard9
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 9/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 10 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard10
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 10/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 11 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard11
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 11/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 12 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard12
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 12/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 13 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard13
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 13/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 14 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard14
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 14/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 15 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard15
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 15/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 16 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard16
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 16/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 17 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard17
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 17/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 18 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard18
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 18/20
-
-    - <<: *py37_linux_test_config
-      name: "Integration tests - shard 19 (Py3.7 PEX)"
-      env:
-        - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard19
-      script:
-        - ./build-support/bin/travis-ci.sh -c7 -i 19/20
-
     - <<: *py27_linux_test_config
       name: "Integration tests - shard 0 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard0
+        - CACHE_NAME=integration.linux.py27.shard0
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 0/20
 
@@ -1266,7 +955,7 @@ matrix:
       name: "Integration tests - shard 1 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard1
+        - CACHE_NAME=integration.linux.py27.shard1
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 1/20
 
@@ -1274,7 +963,7 @@ matrix:
       name: "Integration tests - shard 2 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard2
+        - CACHE_NAME=integration.linux.py27.shard2
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 2/20
 
@@ -1282,7 +971,7 @@ matrix:
       name: "Integration tests - shard 3 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard3
+        - CACHE_NAME=integration.linux.py27.shard3
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 3/20
 
@@ -1290,7 +979,7 @@ matrix:
       name: "Integration tests - shard 4 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard4
+        - CACHE_NAME=integration.linux.py27.shard4
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 4/20
 
@@ -1298,7 +987,7 @@ matrix:
       name: "Integration tests - shard 5 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard5
+        - CACHE_NAME=integration.linux.py27.shard5
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 5/20
 
@@ -1306,7 +995,7 @@ matrix:
       name: "Integration tests - shard 6 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard6
+        - CACHE_NAME=integration.linux.py27.shard6
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 6/20
 
@@ -1314,7 +1003,7 @@ matrix:
       name: "Integration tests - shard 7 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard7
+        - CACHE_NAME=integration.linux.py27.shard7
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 7/20
 
@@ -1322,7 +1011,7 @@ matrix:
       name: "Integration tests - shard 8 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard8
+        - CACHE_NAME=integration.linux.py27.shard8
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 8/20
 
@@ -1330,7 +1019,7 @@ matrix:
       name: "Integration tests - shard 9 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard9
+        - CACHE_NAME=integration.linux.py27.shard9
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 9/20
 
@@ -1338,7 +1027,7 @@ matrix:
       name: "Integration tests - shard 10 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard10
+        - CACHE_NAME=integration.linux.py27.shard10
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 10/20
 
@@ -1346,7 +1035,7 @@ matrix:
       name: "Integration tests - shard 11 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard11
+        - CACHE_NAME=integration.linux.py27.shard11
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 11/20
 
@@ -1354,7 +1043,7 @@ matrix:
       name: "Integration tests - shard 12 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard12
+        - CACHE_NAME=integration.linux.py27.shard12
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 12/20
 
@@ -1362,7 +1051,7 @@ matrix:
       name: "Integration tests - shard 13 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard13
+        - CACHE_NAME=integration.linux.py27.shard13
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 13/20
 
@@ -1370,7 +1059,7 @@ matrix:
       name: "Integration tests - shard 14 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard14
+        - CACHE_NAME=integration.linux.py27.shard14
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 14/20
 
@@ -1378,7 +1067,7 @@ matrix:
       name: "Integration tests - shard 15 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard15
+        - CACHE_NAME=integration.linux.py27.shard15
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 15/20
 
@@ -1386,7 +1075,7 @@ matrix:
       name: "Integration tests - shard 16 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard16
+        - CACHE_NAME=integration.linux.py27.shard16
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 16/20
 
@@ -1394,7 +1083,7 @@ matrix:
       name: "Integration tests - shard 17 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard17
+        - CACHE_NAME=integration.linux.py27.shard17
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 17/20
 
@@ -1402,7 +1091,7 @@ matrix:
       name: "Integration tests - shard 18 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard18
+        - CACHE_NAME=integration.linux.py27.shard18
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 18/20
 
@@ -1410,9 +1099,489 @@ matrix:
       name: "Integration tests - shard 19 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard19
+        - CACHE_NAME=integration.linux.py27.shard19
       script:
         - ./build-support/bin/travis-ci.sh -c2 -i 19/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 0 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard0
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 0/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 1 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard1
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 1/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 2 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard2
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 2/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 3 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard3
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 3/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 4 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard4
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 4/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 5 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard5
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 5/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 6 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard6
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 6/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 7 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard7
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 7/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 8 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard8
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 8/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 9 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard9
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 9/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 10 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard10
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 10/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 11 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard11
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 11/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 12 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard12
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 12/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 13 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard13
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 13/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 14 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard14
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 14/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 15 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard15
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 15/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 16 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard16
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 16/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 17 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard17
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 17/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 18 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard18
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 18/20
+
+    - <<: *py36_linux_test_config
+      name: "Integration tests - shard 19 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=integration.linux.py36.shard19
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 19/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 0 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard0
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 0/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 1 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard1
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 1/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 2 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard2
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 2/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 3 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard3
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 3/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 4 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard4
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 4/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 5 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard5
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 5/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 6 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard6
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 6/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 7 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard7
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 7/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 8 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard8
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 8/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 9 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard9
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 9/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 10 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard10
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 10/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 11 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard11
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 11/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 12 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard12
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 12/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 13 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard13
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 13/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 14 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard14
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 14/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 15 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard15
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 15/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 16 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard16
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 16/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 17 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard17
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 17/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 18 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard18
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 18/20
+
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard 19 (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard19
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i 19/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 0 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard0
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 0/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 1 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard1
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 1/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 2 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard2
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 2/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 3 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard3
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 3/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 4 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard4
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 4/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 5 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard5
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 5/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 6 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard6
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 6/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 7 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard7
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 7/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 8 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard8
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 8/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 9 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard9
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 9/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 10 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard10
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 10/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 11 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard11
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 11/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 12 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard12
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 12/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 13 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard13
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 13/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 14 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard14
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 14/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 15 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard15
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 15/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 16 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard16
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 16/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 17 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard17
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 17/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 18 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard18
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 18/20
+
+    - <<: *py37_linux_test_config
+      name: "Integration tests - shard 19 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=integration.linux.py37.shard19
+      script:
+        - ./build-support/bin/travis-ci.sh -c7 -i 19/20
 
 
     - <<: *linux_rust_tests
@@ -1432,6 +1601,14 @@ matrix:
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=linuxcontribtests.py36
+      script:
+        - ./build-support/bin/travis-ci.sh -n
+
+    - <<: *py36_osx_test_config
+      name: "Python contrib tests - OSX (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=osxcontribtests.py36
       script:
         - ./build-support/bin/travis-ci.sh -n
 

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -30,13 +30,13 @@ env:
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
   - name: &bootstrap Bootstrap Pants
-    if: type != cron
+    if: type = cron
   - name: &bootstrap_cron Bootstrap Pants (Cron)
-    if: type = cron
-  - name: &test Test Pants
     if: type != cron
-  - name: &test_cron Test Pants (Cron)
+  - name: &test Test Pants
     if: type = cron
+  - name: &test_cron Test Pants (Cron)
+    if: type != cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -913,6 +913,7 @@ matrix:
 {{#integration_shards}}
     - <<: *py36_osx_test_config
       name: "Integration tests - OSX - shard {{.}} (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=integration.osx.py36.shard{{.}}
@@ -953,6 +954,7 @@ matrix:
 
     - <<: *py36_osx_test_config
       name: "Python contrib tests - OSX (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_osx_test_config_env
         - CACHE_NAME=osxcontribtests.py36

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -839,6 +839,8 @@ matrix:
     - <<: *py27_osx_build_engine
       stage: *bootstrap_cron
     - <<: *py36_osx_build_engine
+    - <<: *py36_osx_build_engine
+      stage: *bootstrap_cron
     - <<: *py37_osx_build_engine
 
     - <<: *py27_lint

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -414,7 +414,7 @@ py37_lint: &py37_lint
 linux_rust_clippy: &linux_rust_clippy
   <<: *linux_with_fuse
   <<: *native_engine_cache_config
-  name: "Linux Rust Clippy (No PEX)"
+  name: "Rust Clippy (No PEX)"
   env:
     - CACHE_NAME=linuxclippy
   os: linux

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -865,6 +865,15 @@ matrix:
       script:
         - ./build-support/bin/travis-ci.sh -lp
 
+    - <<: *py36_osx_test_config
+      name: "Unit tests - OSX (Py3.6 PEX)"
+      stage: *test_cron
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=osxunittests.osx.py36
+      script:
+        - ./build-support/bin/travis-ci.sh -lp
+
     - <<: *py37_linux_test_config
       name: "Unit tests (Py3.7 PEX)"
       env:
@@ -882,11 +891,31 @@ matrix:
     - <<: *py36_osx_build_wheels
 
 {{#integration_shards}}
+    - <<: *py27_linux_test_config
+      name: "Integration tests - shard {{.}} (Py2.7 PEX)"
+      env:
+        - *py27_linux_test_config_env
+        - CACHE_NAME=integration.linux.py27.shard{{.}}
+      script:
+        - ./build-support/bin/travis-ci.sh -c2 -i {{.}}/{{integration_shards_length}}
+
+{{/integration_shards}}
+{{#integration_shards}}
     - <<: *py36_linux_test_config
       name: "Integration tests - shard {{.}} (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
-        - CACHE_NAME=integrationshard{{.}}
+        - CACHE_NAME=integration.linux.py36.shard{{.}}
+      script:
+        - ./build-support/bin/travis-ci.sh -c -i {{.}}/{{integration_shards_length}}
+
+{{/integration_shards}}
+{{#integration_shards}}
+    - <<: *py36_osx_test_config
+      name: "Integration tests - OSX - shard {{.}} (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=integration.osx.py36.shard{{.}}
       script:
         - ./build-support/bin/travis-ci.sh -c -i {{.}}/{{integration_shards_length}}
 
@@ -896,19 +925,9 @@ matrix:
       name: "Integration tests - shard {{.}} (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
-        - CACHE_NAME=integrationshard{{.}}
+        - CACHE_NAME=integration.linux.py37.shard{{.}}
       script:
         - ./build-support/bin/travis-ci.sh -c7 -i {{.}}/{{integration_shards_length}}
-
-{{/integration_shards}}
-{{#integration_shards}}
-    - <<: *py27_linux_test_config
-      name: "Integration tests - shard {{.}} (Py2.7 PEX)"
-      env:
-        - *py27_linux_test_config_env
-        - CACHE_NAME=cronshard{{.}}
-      script:
-        - ./build-support/bin/travis-ci.sh -c2 -i {{.}}/{{integration_shards_length}}
 
 {{/integration_shards}}
 
@@ -929,6 +948,14 @@ matrix:
       env:
         - *py36_linux_test_config_env
         - CACHE_NAME=linuxcontribtests.py36
+      script:
+        - ./build-support/bin/travis-ci.sh -n
+
+    - <<: *py36_osx_test_config
+      name: "Python contrib tests - OSX (Py3.6 PEX)"
+      env:
+        - *py36_osx_test_config_env
+        - CACHE_NAME=osxcontribtests.py36
       script:
         - ./build-support/bin/travis-ci.sh -n
 


### PR DESCRIPTION
### Problem
We claim full support for OSX and Linux, but only run our integration and unit tests against Linux, barring a few platform-specific tests.

There have been several issues that are specific to OSX, e.g. https://github.com/pantsbuild/pants/issues/7465 and the forking issue on OSX 10.12. CI can help us to catch these issues.

### Solution
Add unit tests, integration tests, and contrib tests to the cron run with Python 3.6.

We do not modify daily CI to avoid making CI take even longer to run.

### Result
Nightly CI now tests Python 2.7, Python 3.7, and OSX with Python 3.6. See ....