### PR TITLE
Add a basic test for pantsd memory leaks.

### DIFF
--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -9,6 +9,7 @@ import os
 import time
 from contextlib import contextmanager
 
+import psutil
 from colors import bold, cyan, magenta
 
 from pants.pantsd.process_manager import ProcessManager
@@ -58,6 +59,14 @@ class PantsDaemonMonitor(ProcessManager):
     self._log()
     assert self._pid is not None and self.is_alive(), 'cannot assert that pantsd is running. Try calling assert_started before calling this method.'
     return self._pid
+
+  def current_memory_usage(self):
+    """Return the current memory usage of the pantsd process (which must be running)
+
+    :return: memory usage in bytes
+    """
+    self.assert_running()
+    return psutil.Process(self._pid).memory_info()[0]
 
   def assert_running(self):
     if not self._pid:

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -350,9 +350,9 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
   def test_pantsd_memory_usage(self):
     """Validates that after N runs, memory usage has increased by no more than X percent."""
     number_of_runs = 10
-    max_memory_increase_fraction = 0.4
+    max_memory_increase_fraction = 0.35
     with self.pantsd_successful_run_context() as (pantsd_run, checker, workdir, config):
-      cmd = ['list', 'testprojects::']
+      cmd = ['filter', 'testprojects::']
       self.assert_success(pantsd_run(cmd))
       initial_memory_usage = checker.current_memory_usage()
       for _ in range(number_of_runs):
@@ -367,7 +367,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
           )
         )
 
-      increase_fraction = (final_memory_usage / initial_memory_usage) - 1.0
+      increase_fraction = (float(final_memory_usage) / initial_memory_usage) - 1.0
       self.assertTrue(
           increase_fraction <= max_memory_increase_fraction,
           "Memory usage increased more than expected: {} -> {}: {} actual increase (expected < {})".format(


### PR DESCRIPTION
### Problem

See #7439. 

### Solution

Use `psutil` to get the current memory usage of the daemon under test. Even pre-#7390, memory usage already seems to grow roughly linearly by about 3MB per run for this particular command. 

Fixes #7439.