### PR TITLE
convert --skip to --strict in py thrift namespace clash check task

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -155,6 +155,10 @@ deps: ["3rdparty:thrift"]
 deps: ["examples/3rdparty/python:thrift"]
 
 
+[gen.py-thrift-namespace-clash-check]
+strict: True
+
+
 [gen.thrifty]
 allow_dups: True
 

--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -9,7 +9,6 @@ import re
 from builtins import zip
 
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.engine.fs import FilesContent
 from pants.task.task import Task
@@ -31,6 +30,7 @@ class PyThriftNamespaceClashCheck(Task):
   @classmethod
   def register_options(cls, register):
     super(PyThriftNamespaceClashCheck, cls).register_options(register)
+    # TODO: deprecate the --strict option in a future release!
     register('--strict', type=bool, default=False, fingerprint=True,
              help='Whether to fail the build if thrift sources have invalid python namespaces.')
 
@@ -140,16 +140,6 @@ Errors:
     return namespaces_by_files
 
   def execute(self):
-    deprecated_conditional(
-      lambda: not self.get_options().strict,
-      '1.18.0.dev0',
-      'Non-strict mode in the python thrift namespace clash check task',
-      """\
-The --{}-strict option will be removed, and python thrift sources will be required to declare a
-`namespace py` and avoid having those namespaces clash with any other python thrift source file.
-This is a strategy to mitigate the upstream bug https://issues.apache.org/jira/browse/THRIFT-515.
-""".format(self.get_options_scope_equivalent_flag_component()))
-
     py_thrift_targets = self.get_targets(lambda tgt: isinstance(tgt, PythonThriftLibrary))
     thrift_file_sources_by_target = self._get_python_thrift_library_sources(py_thrift_targets)
     py_namespaces_by_target = self._extract_all_python_namespaces(thrift_file_sources_by_target)

--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -4,18 +4,20 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import os
 import re
 from builtins import zip
 
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.engine.fs import FilesContent
-from pants.task.target_restriction_mixins import HasSkipOptionMixin
 from pants.task.task import Task
 from pants.util.collections_abc_backport import OrderedDict, defaultdict
+from pants.util.dirutil import safe_file_dump
 
 
-class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
+class PyThriftNamespaceClashCheck(Task):
   """Check that no python thrift libraries in the build graph have files with clashing namespaces.
 
   This is a temporary workaround for https://issues.apache.org/jira/browse/THRIFT-515. A real fix
@@ -29,37 +31,16 @@ class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
   @classmethod
   def register_options(cls, register):
     super(PyThriftNamespaceClashCheck, cls).register_options(register)
-    register('--skip', type=bool, default=False, fingerprint=True, recursive=True,
-             help='Skip task.')
+    register('--strict', type=bool, default=False, fingerprint=True,
+             help='Whether to fail the build if thrift sources have invalid python namespaces.')
 
   @classmethod
   def product_types(cls):
     """Populate a dict mapping thrift sources to their namespaces and owning targets for testing."""
     return ['_py_thrift_namespaces_by_files']
 
-  _py_namespace_pattern = re.compile(r'^namespace\s+py\s+([^\s]+)$', flags=re.MULTILINE)
-
-  class NamespaceParseError(TaskError): pass
-
-  def _extract_py_namespace_from_content(self, target, thrift_filename, thrift_source_content):
-    py_namespace_match = self._py_namespace_pattern.search(thrift_source_content)
-    if py_namespace_match is None:
-      self.context.log.debug('failing thrift content is:\n{}'.format(thrift_source_content))
-      raise self.NamespaceParseError(
-        "no python namespace (matching the pattern '{}') found in thrift source {} from target {}!"
-        .format(self._py_namespace_pattern.pattern,
-                thrift_filename,
-                target.address.spec))
-    return py_namespace_match.group(1)
-
-  class ClashingNamespaceError(TaskError): pass
-
-  def execute(self):
-    if self.skip_execution:
-      return
-
-    # Get file contents for python thrift library targets.
-    py_thrift_targets = self.get_targets(lambda tgt: isinstance(tgt, PythonThriftLibrary))
+  def _get_python_thrift_library_sources(self, py_thrift_targets):
+    """Get file contents for python thrift library targets."""
     target_snapshots = OrderedDict(
       (t, t.sources_snapshot(scheduler=self.context._scheduler).directory_digest)
       for t in py_thrift_targets)
@@ -69,18 +50,64 @@ class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
     thrift_file_sources_by_target = OrderedDict(
       (t, [(file_content.path, file_content.content) for file_content in all_content.dependencies])
       for t, all_content in filescontent_by_target.items())
+    return thrift_file_sources_by_target
 
-    # Extract the python namespace from each thrift source file.
-    py_namespaces_by_target = OrderedDict(
-      (t, [
-        # File content is provided as a binary string, so we have to decode it.
-        (path, self._extract_py_namespace_from_content(t, path, content.decode('utf-8')))
-        for (path, content) in all_content
-      ])
-      for t, all_content in thrift_file_sources_by_target.items()
-    )
+  _py_namespace_pattern = re.compile(r'^namespace\s+py\s+([^\s]+)$', flags=re.MULTILINE)
 
-    # Check for any overlapping namespaces.
+  class NamespaceParseFailure(Exception): pass
+
+  def _extract_py_namespace_from_content(self, target, thrift_filename, thrift_source_content):
+    py_namespace_match = self._py_namespace_pattern.search(thrift_source_content)
+    if py_namespace_match is None:
+      raise self.NamespaceParseFailure()
+    return py_namespace_match.group(1)
+
+  class NamespaceExtractionError(TaskError):
+    def __init__(self, output_file, msg):
+      self.output_file = output_file
+      super(PyThriftNamespaceClashCheck.NamespaceExtractionError, self).__init__(msg)
+
+  def _extract_all_python_namespaces(self, thrift_file_sources_by_target):
+    """Extract the python namespace from each thrift source file."""
+    py_namespaces_by_target = OrderedDict()
+    failing_py_thrift_by_target = defaultdict(list)
+    for t, all_content in thrift_file_sources_by_target.items():
+      py_namespaces_by_target[t] = []
+      for (path, content) in all_content:
+        try:
+          py_namespaces_by_target[t].append(
+            # File content is provided as a binary string, so we have to decode it.
+            (path, self._extract_py_namespace_from_content(t, path, content.decode('utf-8'))))
+        except self.NamespaceParseFailure:
+          failing_py_thrift_by_target[t].append(path)
+
+    if failing_py_thrift_by_target:
+      # We dump the output to a file here because the output can be very long in some repos.
+      no_py_namespace_output_file = os.path.join(self.workdir, 'no-python-namespace-output.txt')
+
+      pretty_printed_failures = '\n'.join(
+        '{}: [{}]'.format(t.address.spec, ', '.join(paths))
+        for t, paths in failing_py_thrift_by_target.items())
+      error = self.NamespaceExtractionError(no_py_namespace_output_file, """\
+Python namespaces could not be extracted from some thrift sources. Declaring a `namespace py` in
+thrift sources for python thrift library targets will soon become required.
+
+{} python library target(s) contained thrift sources not declaring a python namespace. The targets
+and/or files which need to be edited will be dumped to: {}
+""".format(len(failing_py_thrift_by_target), no_py_namespace_output_file))
+
+      safe_file_dump(no_py_namespace_output_file, '{}\n'.format(pretty_printed_failures), mode='w')
+
+      if self.get_options().strict:
+        raise error
+      else:
+        self.context.log.warn(error)
+    return py_namespaces_by_target
+
+  class ClashingNamespaceError(TaskError): pass
+
+  def _determine_clashing_namespaces(self, py_namespaces_by_target):
+    """Check for any overlapping namespaces."""
     namespaces_by_files = defaultdict(list)
     for target, all_namespaces in py_namespaces_by_target.items():
       for (path, namespace) in all_namespaces:
@@ -96,19 +123,35 @@ class PyThriftNamespaceClashCheck(Task, HasSkipOptionMixin):
         '{}: [{}]'
         .format(
           namespace,
-          ', '.join('({}, {})'.format(t.address.spec, path) for (t, path) in all_paths)
-        )
-        for namespace, all_paths in clashing_namespaces.items()
-      )
-      raise self.ClashingNamespaceError("""\
+          ', '.join('({}, {})'.format(t.address.spec, path) for (t, path) in all_paths))
+        for namespace, all_paths in clashing_namespaces.items())
+      error = self.ClashingNamespaceError("""\
 Clashing namespaces for python thrift library sources detected in build graph. This will silently
 overwrite previously generated python sources with generated sources from thrift files declaring the
 same python namespace. This is an upstream WONTFIX in thrift, see:
       https://issues.apache.org/jira/browse/THRIFT-515
-
-Use --{}-skip to avoid this check if this breaks your existing build.
 Errors:
 {}
-""".format(self.get_options_scope_equivalent_flag_component(), pretty_printed_clashing))
-    else:
-      self.context.products.register_data('_py_thrift_namespaces_by_files', namespaces_by_files)
+""".format(pretty_printed_clashing))
+      if self.get_options().strict:
+        raise error
+      else:
+        self.context.log.warn(error)
+    return namespaces_by_files
+
+  def execute(self):
+    deprecated_conditional(
+      lambda: not self.get_options().strict,
+      '1.18.0.dev0',
+      'Non-strict mode in the python thrift namespace clash check task',
+      """\
+The --{}-strict option will be removed, and python thrift sources will be required to declare a
+`namespace py` and avoid having those namespaces clash with any other python thrift source file.
+This is a strategy to mitigate the upstream bug https://issues.apache.org/jira/browse/THRIFT-515.
+""".format(self.get_options_scope_equivalent_flag_component()))
+
+    py_thrift_targets = self.get_targets(lambda tgt: isinstance(tgt, PythonThriftLibrary))
+    thrift_file_sources_by_target = self._get_python_thrift_library_sources(py_thrift_targets)
+    py_namespaces_by_target = self._extract_all_python_namespaces(thrift_file_sources_by_target)
+    namespaces_by_files = self._determine_clashing_namespaces(py_namespaces_by_target)
+    self.context.products.register_data('_py_thrift_namespaces_by_files', namespaces_by_files)

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
@@ -4,9 +4,12 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from builtins import str
+
 from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
   PyThriftNamespaceClashCheck
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
+from pants.util.dirutil import read_file
 from pants_test.task_test_base import DeclarativeTaskTestMixin, TaskTestBase
 
 
@@ -38,7 +41,7 @@ struct A {}
       'sources': ['bad.thrift'],
       'filemap': {
         'bad.thrift': """\
-#namespace scala org.pantsbuild.whatever
+#@namespace scala org.pantsbuild.whatever
 namespace java org.pantsbuild.whatever
 
 struct A {}
@@ -88,43 +91,54 @@ struct B {}
     }
   }
 
-  def target_dict(self):
+  def _target_dict(self):
     return self.populate_target_dict(self._target_specs)
+
+  def _run_tasks(self, target_roots):
+    self.set_options(strict=True)
+    return self.invoke_tasks(target_roots=target_roots)
 
   _exception_prelude = """\
 Clashing namespaces for python thrift library sources detected in build graph. This will silently
 overwrite previously generated python sources with generated sources from thrift files declaring the
 same python namespace. This is an upstream WONTFIX in thrift, see:
       https://issues.apache.org/jira/browse/THRIFT-515
-
-Use --test_scope-skip to avoid this check if this breaks your existing build.
 Errors:"""
 
   def test_no_py_namespace(self):
-    no_py_namespace_target = self.target_dict()['no-py-namespace']
-    with self.assertRaisesWithMessage(PyThriftNamespaceClashCheck.NamespaceParseError, """\
-no python namespace (matching the pattern '^namespace\s+py\s+([^\s]+)$') \
-found in thrift source src/py-thrift/bad.thrift from target src/py-thrift:no-py-namespace!"""):
-      self.invoke_tasks(target_roots=[no_py_namespace_target])
+    no_py_namespace_target = self._target_dict()['no-py-namespace']
+    with self.assertRaises(PyThriftNamespaceClashCheck.NamespaceExtractionError) as cm:
+      self._run_tasks(target_roots=[no_py_namespace_target])
+    self.assertEqual(str(cm.exception), """\
+Python namespaces could not be extracted from some thrift sources. Declaring a `namespace py` in
+thrift sources for python thrift library targets will soon become required.
+
+1 python library target(s) contained thrift sources not declaring a python namespace. The targets
+and/or files which need to be edited will be dumped to: {}
+"""
+                     .format(cm.exception.output_file))
+    self.assertEqual(
+      'src/py-thrift:no-py-namespace: [src/py-thrift/bad.thrift]\n',
+      read_file(cm.exception.output_file, binary_mode=False))
 
   def test_clashing_namespace_same_target(self):
-    clashing_same_target = self.target_dict()['clashing-namespace']
+    clashing_same_target = self._target_dict()['clashing-namespace']
     with self.assertRaisesWithMessage(PyThriftNamespaceClashCheck.ClashingNamespaceError, """{}
 org.pantsbuild.namespace: [(src/py-thrift:clashing-namespace, src/py-thrift/a.thrift), (src/py-thrift:clashing-namespace, src/py-thrift/b.thrift)]
 """.format(self._exception_prelude)):
-      self.invoke_tasks(target_roots=[clashing_same_target])
+      self._run_tasks(target_roots=[clashing_same_target])
 
   def test_clashing_namespace_multiple_targets(self):
-    target_dict = self.target_dict()
+    target_dict = self._target_dict()
     clashing_targets = [target_dict[k] for k in ['clashingA', 'clashingB']]
     with self.assertRaisesWithMessage(PyThriftNamespaceClashCheck.ClashingNamespaceError, """{}
 org.pantsbuild.namespace: [(src/py-thrift-clashing:clashingA, src/py-thrift-clashing/a.thrift), (src/py-thrift-clashing:clashingB, src/py-thrift-clashing/b.thrift)]
 """.format(self._exception_prelude)):
-      self.invoke_tasks(target_roots=clashing_targets)
+      self._run_tasks(target_roots=clashing_targets)
 
   def test_accepts_py_namespace_with_comments_above(self):
-    commented_thrift_source_target = self.target_dict()['with-comments-and-other-namespaces']
-    result = self.invoke_tasks(target_roots=[commented_thrift_source_target])
+    commented_thrift_source_target = self._target_dict()['with-comments-and-other-namespaces']
+    result = self._run_tasks(target_roots=[commented_thrift_source_target])
     # Check that the file was correctly mapped to the namespace parsed out of its file content.
     namespaces_by_files = result.context.products.get_data('_py_thrift_namespaces_by_files')
     self.assertEqual(


### PR DESCRIPTION
### Problem

#7345 solves its problem, but introduces another one when trying to use it on a large monorepo which generates lots of python thrift targets. Namely, not all thrift sources will have `namespace py`, and many thrift sources will declare conflicting python namespaces, since this issue was not previously known. This should be resolved, but doing it all at once is difficult and error-prone.

### Solution

- Convert `--skip` to `--strict` in the python thrift source namespace clash check task.
  - Default to non-strict, but also raise a deprecation warning explaining that this task will soon become required.
- Collect all the namespace extraction errors (for thrift sources which are used in a `python_thrift_library()`, but don't have a `namespace py` declaration) and dump them into a file instead of displaying them directly.
  - This is to avoid an overwhelming amount of output for users who may not need to care about this issue.

### Result

It is easier to introduce the namespace clash check task into a large monorepo and make fixes incrementally.