### PR TITLE
add a deprecation_start_version argument to warn_or_error()

### DIFF
--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -21,16 +21,20 @@ class DeprecationApplicationError(Exception):
   """The base exception type thrown for any form of @deprecation application error."""
 
 
-class MissingRemovalVersionError(DeprecationApplicationError):
+class MissingSemanticVersionError(DeprecationApplicationError):
   """Indicates the required removal_version was not supplied."""
 
 
-class BadRemovalVersionError(DeprecationApplicationError):
+class BadSemanticVersionError(DeprecationApplicationError):
   """Indicates the supplied removal_version was not a valid semver string."""
 
 
-class NonDevRemovalVersionError(DeprecationApplicationError):
+class NonDevSemanticVersionError(DeprecationApplicationError):
   """Indicates the supplied removal_version was not a pre-release version."""
+
+
+class InvalidSemanticVersionOrderingError(DeprecationApplicationError):
+  """Indicates that multiple semantic version strings were provided in an inconsistent ordering."""
 
 
 class CodeRemovedError(Exception):
@@ -53,34 +57,34 @@ def get_deprecated_tense(removal_version, future_tense='will be', past_tense='wa
 
 
 @memoized_method
-def validate_removal_semver(removal_version):
-  """Validates that removal_version is a valid semver.
+def validate_deprecation_semver(version_string, version_description):
+  """Validates that version_string is a valid semver.
 
   If so, returns that semver.  Raises an error otherwise.
 
-  :param str removal_version: The pantsbuild.pants version which will remove the deprecated entity.
+  :param str version_string: A pantsbuild.pants version which affects some deprecated entity.
   :rtype: `packaging.version.Version`
-  :raises DeprecationApplicationError: if the removal_version parameter is invalid.
+  :raises DeprecationApplicationError: if the version_string parameter is invalid.
   """
-  if removal_version is None:
-    raise MissingRemovalVersionError('The removal version must be provided.')
-  if not isinstance(removal_version, six.string_types):
-    raise BadRemovalVersionError('The removal_version must be a version string.')
+  if version_string is None:
+    raise MissingSemanticVersionError('The {} must be provided.'.format(version_description))
+  if not isinstance(version_string, six.string_types):
+    raise BadSemanticVersionError('The {} must be a version string.'.format(version_description))
   try:
     # NB: packaging will see versions like 1.a.0 as 1a0, and are "valid"
     # We explicitly want our versions to be of the form x.y.z.
-    v = Version(removal_version)
+    v = Version(version_string)
     if len(v.base_version.split('.')) != 3:
-      raise BadRemovalVersionError('The given removal version is not a valid version: '
-                                   '{}'.format(removal_version))
+      raise BadSemanticVersionError('The given {} is not a valid version: '
+                                   '{}'.format(version_description, version_string))
     if not v.is_prerelease:
-      raise NonDevRemovalVersionError('The given removal version is not a dev version: {}\n'
+      raise NonDevSemanticVersionError('The given {} is not a dev version: {}\n'
                                       'Features should generally be removed in the first `dev` release '
-                                      'of a release cycle.'.format(removal_version))
+                                      'of a release cycle.'.format(version_description, version_string))
     return v
   except InvalidVersion as e:
-    raise BadRemovalVersionError('The given removal version {} is not a valid version: '
-                                 '{}'.format(removal_version, e))
+    raise BadSemanticVersionError('The given {} {} is not a valid version: '
+                                 '{}'.format(version_description, version_string, e))
 
 
 def _get_frame_info(stacklevel, context=1):
@@ -99,8 +103,10 @@ def _get_frame_info(stacklevel, context=1):
   return frame_list[frame_stack_index]
 
 
-def warn_or_error(removal_version, deprecated_entity_description, hint=None, stacklevel=3,
-                  frame_info=None, context=1, ensure_stderr=False):
+# TODO: propagate `deprecation_start_version` to other methods in this file!
+def warn_or_error(removal_version, deprecated_entity_description, hint=None,
+                  deprecation_start_version=None,
+                  stacklevel=3, frame_info=None, context=1, ensure_stderr=False):
   """Check the removal_version against the current pants version.
 
   Issues a warning if the removal version is > current pants version, or an error otherwise.
@@ -110,6 +116,9 @@ def warn_or_error(removal_version, deprecated_entity_description, hint=None, sta
   :param string deprecated_entity_description: A short description of the deprecated entity, that
                                             we can embed in warning/error messages.
   :param string hint: A message describing how to migrate from the removed entity.
+  :param string deprecation_start_version: The pantsbuild.pants version at which the entity will
+                                           begin to display a deprecation warning. This must be less
+                                           than the `removal_version`.
   :param int stacklevel: The stacklevel to pass to warnings.warn.
   :param FrameInfo frame_info: If provided, use this frame info instead of getting one from
                                `stacklevel`.
@@ -118,7 +127,16 @@ def warn_or_error(removal_version, deprecated_entity_description, hint=None, sta
   :raises DeprecationApplicationError: if the removal_version parameter is invalid.
   :raises CodeRemovedError: if the current version is later than the version marked for removal.
   """
-  removal_semver = validate_removal_semver(removal_version)
+  removal_semver = validate_deprecation_semver(removal_version, 'removal version')
+  if deprecation_start_version:
+    deprecation_start_semver = validate_deprecation_semver(
+      deprecation_start_version, 'deprecation start version')
+    if deprecation_start_semver >= removal_semver:
+      raise InvalidSemanticVersionOrderingError(
+        'The deprecation start version {} must be greater than the end version {}.'
+        .format(deprecation_start_version, removal_version))
+    elif PANTS_SEMVER <= deprecation_start_semver:
+      return
 
   msg = 'DEPRECATED: {} {} removed in version {}.'.format(deprecated_entity_description,
       get_deprecated_tense(removal_version), removal_version)
@@ -149,6 +167,7 @@ def warn_or_error(removal_version, deprecated_entity_description, hint=None, sta
         filename,
         line_number,
         line=context_lines)
+    return msg
   else:
     raise CodeRemovedError(msg)
 
@@ -170,7 +189,7 @@ def deprecated_conditional(predicate,
   :param int stacklevel: How far up in the stack do we go to find the calling fn to report
   :raises DeprecationApplicationError if the deprecation is applied improperly.
   """
-  validate_removal_semver(removal_version)
+  validate_deprecation_semver(removal_version, 'removal version')
   if predicate():
     warn_or_error(removal_version, entity_description, hint_message, stacklevel=stacklevel)
 
@@ -196,7 +215,7 @@ def deprecated(removal_version, hint_message=None, subject=None, ensure_stderr=F
   :param bool ensure_stderr: Forwarded to `ensure_stderr` in warn_or_error().
   :raises DeprecationApplicationError if the @deprecation is applied improperly.
   """
-  validate_removal_semver(removal_version)
+  validate_deprecation_semver(removal_version, 'removal version')
   def decorator(func):
     if not inspect.isfunction(func):
       raise BadDecoratorNestingError('The @deprecated decorator must be applied innermost of all '

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -63,6 +63,8 @@ def validate_deprecation_semver(version_string, version_description):
   If so, returns that semver.  Raises an error otherwise.
 
   :param str version_string: A pantsbuild.pants version which affects some deprecated entity.
+  :param str version_description: A string used in exception messages to describe what the
+                                  `version_string` represents.
   :rtype: `packaging.version.Version`
   :raises DeprecationApplicationError: if the version_string parameter is invalid.
   """

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -118,7 +118,8 @@ def warn_or_error(removal_version, deprecated_entity_description, hint=None,
   :param string hint: A message describing how to migrate from the removed entity.
   :param string deprecation_start_version: The pantsbuild.pants version at which the entity will
                                            begin to display a deprecation warning. This must be less
-                                           than the `removal_version`.
+                                           than the `removal_version`. If not provided, the
+                                           deprecation warning is always displayed.
   :param int stacklevel: The stacklevel to pass to warnings.warn.
   :param FrameInfo frame_info: If provided, use this frame info instead of getting one from
                                `stacklevel`.

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -134,9 +134,9 @@ def warn_or_error(removal_version, deprecated_entity_description, hint=None,
       deprecation_start_version, 'deprecation start version')
     if deprecation_start_semver >= removal_semver:
       raise InvalidSemanticVersionOrderingError(
-        'The deprecation start version {} must be greater than the end version {}.'
+        'The deprecation start version {} must be less than the end version {}.'
         .format(deprecation_start_version, removal_version))
-    elif PANTS_SEMVER <= deprecation_start_semver:
+    elif PANTS_SEMVER < deprecation_start_semver:
       return
 
   msg = 'DEPRECATED: {} {} removed in version {}.'.format(deprecated_entity_description,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -127,15 +127,15 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
 
     register('--pants-runtime-python-version', advanced=True,
              removal_version='1.19.0.dev0',
+             deprecation_start_version='1.17.0.dev0',
              removal_hint="""\
-This option was only used to help with Pants' migration to support Python 3. Pants will now
+This option was only used to help with Pants' migration to run on Python 3. Pants will now
 correctly default to whichever Python versions are supported for the current `pants_version` you are
 using. Please make sure you are using the most up-to-date version of the `./pants` script with:
 
   curl -L -O https://pantsbuild.github.io/setup/pants
 
-and then remove this option.""",
-             deprecation_start_version='1.17.0.dev0',
+and then unset this option.""",
              help='Use this Python version to run Pants. The option expects the major and minor '
                   'version, e.g. 2.7 or 3.6. Note Pants code only uses this to verify that you are '
                   'using the requested interpreter, as Pants cannot dynamically change the '

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -126,6 +126,16 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   'version of the pants instance you are running using -v, -V, or --version.')
 
     register('--pants-runtime-python-version', advanced=True,
+             removal_version='1.19.0.dev0',
+             removal_hint="""\
+This option was only used to help with Pants' migration to support Python 3. Pants will now
+correctly default to whichever Python versions are supported for the current `pants_version` you are
+using. Please make sure you are using the most up-to-date version of the `./pants` script with:
+
+  curl -L -O https://pantsbuild.github.io/setup/pants
+
+and then remove this option.""",
+             deprecation_start_version='1.17.0.dev0',
              help='Use this Python version to run Pants. The option expects the major and minor '
                   'version, e.g. 2.7 or 3.6. Note Pants code only uses this to verify that you are '
                   'using the requested interpreter, as Pants cannot dynamically change the '

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import multiprocessing
 import os
 import sys
+from textwrap import dedent
 
 from pants.base.build_environment import (get_buildroot, get_default_pants_config_file,
                                           get_pants_cachedir, get_pants_configdir, pants_version)
@@ -128,14 +129,15 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--pants-runtime-python-version', advanced=True,
              removal_version='1.19.0.dev0',
              deprecation_start_version='1.17.0.dev0',
-             removal_hint="""
-This option was only used to help with Pants' migration to run on Python 3. Pants will now
-correctly default to whichever Python versions are supported for the current `pants_version` you are
-using. Please make sure you are using the most up-to-date version of the `./pants` script with:
+             removal_hint=dedent("""
+                  This option was only used to help with Pants' migration to run on Python 3. \
+                  Pants will now correctly default to whichever Python versions are supported for \
+                  the current `pants_version` you are using. Please make sure you are using the \
+                  most up-to-date version of the `./pants` script with:
 
-  curl -L -O https://pantsbuild.github.io/setup/pants
+                    curl -L -O https://pantsbuild.github.io/setup/pants
 
-and then unset this option.""",
+                  and then unset this option."""),
              help='Use this Python version to run Pants. The option expects the major and minor '
                   'version, e.g. 2.7 or 3.6. Note Pants code only uses this to verify that you are '
                   'using the requested interpreter, as Pants cannot dynamically change the '

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -128,7 +128,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--pants-runtime-python-version', advanced=True,
              removal_version='1.19.0.dev0',
              deprecation_start_version='1.17.0.dev0',
-             removal_hint="""\
+             removal_hint="""
 This option was only used to help with Pants' migration to run on Python 3. Pants will now
 correctly default to whichever Python versions are supported for the current `pants_version` you are
 using. Please make sure you are using the most up-to-date version of the `./pants` script with:

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 
 import six
 
-from pants.base.deprecated import validate_removal_semver, warn_or_error
+from pants.base.deprecated import validate_deprecation_semver, warn_or_error
 from pants.option.arg_splitter import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION
 from pants.option.config import Config
 from pants.option.custom_types import (DictValueComponent, ListValueComponent, UnsetBool,
@@ -388,7 +388,7 @@ class Parser(object):
 
     removal_version = kwargs.get('removal_version')
     if removal_version is not None:
-      validate_removal_semver(removal_version)
+      validate_deprecation_semver(removal_version, 'removal version')
 
   def _existing_scope(self, arg):
     if arg in self._known_args:

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -332,16 +332,18 @@ class Parser(object):
     """Checks option for deprecation and issues a warning/error if necessary."""
     removal_version = kwargs.get('removal_version', None)
     if removal_version is not None:
-      warn_or_error(removal_version,
-                    "option '{}' in {}".format(dest, self._scope_str()),
-                    kwargs.get('removal_hint', ''),
-                    stacklevel=9999)  # Out of range stacklevel to suppress printing src line.
+      warn_or_error(
+        removal_version=removal_version,
+        deprecated_entity_description="option '{}' in {}".format(dest, self._scope_str()),
+        deprecation_start_version=kwargs.get('deprecation_start_version', None),
+        hint=kwargs.get('removal_hint', None),
+        stacklevel=9999)  # Out of range stacklevel to suppress printing src line.
 
   _allowed_registration_kwargs = {
     'type', 'member_type', 'choices', 'dest', 'default', 'implicit_value', 'metavar',
     'help', 'advanced', 'recursive', 'recursive_root', 'registering_class',
-    'fingerprint', 'removal_version', 'removal_hint', 'fromfile', 'mutually_exclusive_group',
-    'daemon'
+    'fingerprint', 'removal_version', 'removal_hint', 'deprecation_start_version', 'fromfile',
+    'mutually_exclusive_group', 'daemon'
   }
 
   # TODO: Remove dict_option from here after deprecation is complete.

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -67,6 +67,7 @@ python_tests(
     'src/python/pants/base:deprecated',
     'src/python/pants/util:collections',
     'src/python/pants:version',
+    'tests/python/pants_test:test_base',
   ]
 )
 

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -63,6 +63,7 @@ python_tests(
   name = 'deprecated',
   sources = ['test_deprecated.py'],
   dependencies = [
+    '3rdparty/python:mock',
     '3rdparty/python:future',
     'src/python/pants/base:deprecated',
     'src/python/pants/util:collections',

--- a/tests/python/pants_test/base/test_deprecated.py
+++ b/tests/python/pants_test/base/test_deprecated.py
@@ -15,13 +15,8 @@ from pants.base.deprecated import (BadDecoratorNestingError, BadSemanticVersionE
                                    deprecated, deprecated_conditional, deprecated_module,
                                    warn_or_error)
 from pants.util.collections import assert_single_element
-from pants.version import PANTS_SEMVER, VERSION
-
-
-def _use_current_prerelease_semver(f):
-  return unittest.skipIf(not PANTS_SEMVER.is_prerelease,
-                         'Uses the current version as a deprecation version, which is only valid '
-                         'for prereleases.')(f)
+from pants.version import VERSION
+from pants_test.test_base import use_current_prerelease_semver
 
 
 class DeprecatedTest(unittest.TestCase):
@@ -158,7 +153,7 @@ class DeprecatedTest(unittest.TestCase):
       def test_func1a():
         pass
 
-  @_use_current_prerelease_semver
+  @use_current_prerelease_semver
   def test_removal_version_same(self):
     with self.assertRaises(CodeRemovedError):
       warn_or_error(VERSION, 'dummy description')
@@ -198,7 +193,7 @@ class DeprecatedTest(unittest.TestCase):
                     deprecated_entity_description='dummy',
                     deprecation_start_version='1.0.0.dev0')
 
-  @_use_current_prerelease_semver
+  @use_current_prerelease_semver
   def test_deprecation_start_period(self):
     with self.assertRaises(CodeRemovedError):
       warn_or_error(removal_version=VERSION,

--- a/tests/python/pants_test/option/BUILD
+++ b/tests/python/pants_test/option/BUILD
@@ -5,6 +5,7 @@ python_tests(
   name='testing',
   sources=globs('*.py', exclude=[globs('*_integration.py')]),
   dependencies=[
+    '3rdparty/python:mock',
     '3rdparty/python:future',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:deprecated',

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -40,6 +40,7 @@ from pants.util.dirutil import (recursive_dirname, relative_symlink, safe_file_d
                                 safe_mkdtemp, safe_open, safe_rmtree)
 from pants.util.memo import memoized_method
 from pants.util.meta import AbstractClass
+from pants.version import PANTS_SEMVER
 from pants_test.base.context_utils import create_context_from_options
 from pants_test.engine.util import init_native
 from pants_test.option.util.fakes import create_options_for_optionables
@@ -753,3 +754,9 @@ class TestBase(unittest.TestCase, AbstractClass):
       target_dict[key] = generated_target
 
     return target_dict
+
+
+def use_current_prerelease_semver(f):
+  return unittest.skipIf(not PANTS_SEMVER.is_prerelease,
+                         'Uses the current version as a deprecation version, which is only valid '
+                         'for prereleases.')(f)


### PR DESCRIPTION
### Problem

`--pants-runtime-python-version` is something we want to deprecate in `1.17.0.dev0`, not right now. Currently we have to rely on TODOs and memory to perform this form of delayed deprecation.

### Solution

- Add a `deprecation_start_version` option to `warn_or_error()` in `deprecated.py` before which a deprecation warning is not shown.

### Result

It's possible to schedule deprecations to occur in the future without losing track of TODOs.