### PR TITLE
allow python tools to specify a noop predicate and use it for conan

### DIFF
--- a/src/python/pants/backend/native/tasks/conan_prep.py
+++ b/src/python/pants/backend/native/tasks/conan_prep.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants.backend.native.subsystems.conan import Conan
+from pants.backend.native.targets.external_native_library import ExternalNativeLibrary
 from pants.backend.python.tasks.python_tool_prep_base import PythonToolInstance, PythonToolPrepBase
 
 
@@ -15,3 +16,6 @@ class ConanInstance(PythonToolInstance):
 class ConanPrep(PythonToolPrepBase):
   tool_subsystem_cls = Conan
   tool_instance_cls = ConanInstance
+
+  def will_be_invoked(self):
+    return len(self.get_targets(lambda t: isinstance(t, ExternalNativeLibrary))) > 0

--- a/src/python/pants/backend/native/tasks/conan_prep.py
+++ b/src/python/pants/backend/native/tasks/conan_prep.py
@@ -18,4 +18,4 @@ class ConanPrep(PythonToolPrepBase):
   tool_instance_cls = ConanInstance
 
   def will_be_invoked(self):
-    return len(self.get_targets(lambda t: isinstance(t, ExternalNativeLibrary))) > 0
+    return any(self.get_targets(lambda t: isinstance(t, ExternalNativeLibrary)))

--- a/src/python/pants/backend/python/tasks/python_tool_prep_base.py
+++ b/src/python/pants/backend/python/tasks/python_tool_prep_base.py
@@ -72,12 +72,14 @@ class PythonToolInstance(object):
       return cmdline, exit_code
 
 
-# TODO: This python tool setup ends up eagerly generating each pex for each task in every goal which
-# is transitively required by the command-line goals, even for tasks which no-op. This requires each
-# pex for each relevant python tool to be buildable on the current host, even if it may never be
-# intended to be invoked. Especially given the existing clear separation of concerns into
-# PythonToolBase/PythonToolInstance/PythonToolPrepBase, this seems like an extremely ripe use case
-# for some v2 rules for free caching and no-op when not required for the command-line goals.
+# TODO: If `.will_be_invoked()` is not overridden, this python tool setup ends up eagerly generating
+# each pex for each task in every goal which is transitively required by the command-line goals,
+# even for tasks which no-op. This requires each pex for each relevant python tool to be buildable
+# on the current host, even if it may never be intended to be invoked, unless the prep task is able
+# to know whether it will be invoked in advance. Especially given the existing clear separation of
+# concerns into PythonToolBase/PythonToolInstance/PythonToolPrepBase, this seems like an extremely
+# ripe use case for some v2 rules for free caching and no-op when not required for the command-line
+# goals.
 class PythonToolPrepBase(Task):
   """Base class for tasks that resolve a python tool to be invoked out-of-process."""
 
@@ -127,7 +129,14 @@ class PythonToolPrepBase(Task):
       '{}-{}.pex'.format(tool_subsystem.options_scope, specs_fingerprint),
     )
 
+  def will_be_invoked(self):
+    """Predicate which can be overridden to allow tool creation to no-op when not needed."""
+    return True
+
   def execute(self):
+    if not self.will_be_invoked():
+      return
+
     tool_subsystem = self.tool_subsystem_cls.scoped_instance(self)
 
     interpreter_cache = PythonInterpreterCache.global_instance()


### PR DESCRIPTION
### Problem

Resolves #7497. Conan will occasionally time out bootstrapping its pex in travis, and will regardless add an unnecessary wait time in upstream and downstream CI when most of the time it's not needed.

### Solution

- Add an overrideable `will_be_invoked()` method to `PythonToolPrepBase` which will avoid bootstrapping its pex tool if it returns False.
- Override this method in `ConanPrep` to only bootstrap the conan pex if there are `ExternalNativeLibrary` targets in play (i.e. if there are any conan packages to resolve).

### Result

We avoid an expensive bootstrap phase until it's needed.