### PR TITLE
Improve Get errors for unhashable or mismatched types

### DIFF
--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -500,19 +500,19 @@ pub struct Ident {
   pub type_id: TypeId,
 }
 
-pub trait RawBuffer<T, O> {
-  fn ptr(&self) -> *mut T;
+pub trait RawBuffer<Raw, Output> {
+  fn ptr(&self) -> *mut Raw;
   fn len(&self) -> u64;
 
   ///
   /// A buffer-specific shallow clone operation (possibly just implemented via clone).
   ///
-  fn lift(t: &T) -> O;
+  fn lift(t: &Raw) -> Output;
 
   ///
   /// Returns a Vec copy of the buffer contents.
   ///
-  fn to_vec(&self) -> Vec<O> {
+  fn to_vec(&self) -> Vec<Output> {
     with_vec(self.ptr(), self.len() as usize, |vec| {
       vec.iter().map(Self::lift).collect()
     })
@@ -521,7 +521,7 @@ pub trait RawBuffer<T, O> {
   ///
   /// Asserts that the buffer contains one item, and returns a copy of it.
   ///
-  fn unwrap_one(&self) -> O {
+  fn unwrap_one(&self) -> Output {
     assert!(
       self.len() == 1,
       "Expected exactly 1 item in Buffer, but had: {}",

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -209,35 +209,27 @@ pub fn call(func: &Value, args: &[Value]) -> Result<Value, Failure> {
   .into()
 }
 
-///
-/// TODO: If we added support for inserting to the `Interns` using an `Ident`, `PyGeneratorResponse`
-/// could directly return `Idents` during `Get` calls. This would also require splitting its fields
-/// further to avoid needing to "identify" the result of a `PyGeneratorResponseType::Break`.
-///
 pub fn generator_send(generator: &Value, arg: &Value) -> Result<GeneratorResponse, Failure> {
   let response =
     with_externs(|e| (e.generator_send)(e.context, generator as &Handle, arg as &Handle));
-  match response.res_type {
-    PyGeneratorResponseType::Break => Ok(GeneratorResponse::Break(response.values.unwrap_one())),
-    PyGeneratorResponseType::Throw => Err(PyResult::failure_from(response.values.unwrap_one())),
-    PyGeneratorResponseType::Get => {
+  match response {
+    PyGeneratorResponse::Broke(h) => Ok(GeneratorResponse::Break(Value::new(h))),
+    PyGeneratorResponse::Throw(h) => Err(PyResult::failure_from(Value::new(h))),
+    PyGeneratorResponse::Get(product, handle, ident) => {
       let mut interns = INTERNS.write();
-      let p = response.products.unwrap_one();
-      let i = response.identities.unwrap_one();
-      let v = response.values.unwrap_one();
       let g = Get {
-        product: p,
-        subject: interns.insert_with(v, i),
+        product,
+        subject: interns.insert_with(Value::new(handle), ident),
       };
       Ok(GeneratorResponse::Get(g))
     }
-    PyGeneratorResponseType::GetMulti => {
+    PyGeneratorResponse::GetMulti(products, handles, identities) => {
       let mut interns = INTERNS.write();
-      let products = response.products.to_vec();
-      let identities = response.identities.to_vec();
-      let values = response.values.to_vec();
+      let products = products.to_vec();
+      let identities = identities.to_vec();
+      let values = handles.to_vec();
       assert_eq!(products.len(), values.len());
-      let continues: Vec<Get> = products
+      let gets: Vec<Get> = products
         .into_iter()
         .zip(values.into_iter())
         .zip(identities.into_iter())
@@ -246,7 +238,7 @@ pub fn generator_send(generator: &Value, arg: &Value) -> Result<GeneratorRespons
           subject: interns.insert_with(v, i),
         })
         .collect();
-      Ok(GeneratorResponse::GetMulti(continues))
+      Ok(GeneratorResponse::GetMulti(gets))
     }
   }
 }
@@ -460,24 +452,18 @@ impl From<Result<(), String>> for PyResult {
   }
 }
 
-// Only constructed from the python side.
-// TODO: map this into a C enum with cbindgen and consume from python instead of using magic numbers
-// in extern_generator_send() in native.py!
-#[allow(dead_code)]
-#[repr(u8)]
-pub enum PyGeneratorResponseType {
-  Break = 0,
-  Throw = 1,
-  Get = 2,
-  GetMulti = 3,
-}
-
+///
+/// The response from a call to extern_generator_send. Gets include Idents for their Handles
+/// in order to avoid roundtripping to intern them, and to eagerly trigger errors for unhashable
+/// types on the python side where possible.
+///
 #[repr(C)]
-pub struct PyGeneratorResponse {
-  res_type: PyGeneratorResponseType,
-  values: HandleBuffer,
-  identities: IdentBuffer,
-  products: TypeIdBuffer,
+pub enum PyGeneratorResponse {
+  Get(TypeId, Handle, Ident),
+  GetMulti(TypeIdBuffer, HandleBuffer, IdentBuffer),
+  // NB: Broke not Break because C keyword.
+  Broke(Handle),
+  Throw(Handle),
 }
 
 #[derive(Debug)]

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -44,15 +44,19 @@ impl Interns {
   }
 
   pub fn insert(&mut self, v: Value) -> Key {
-    let Ident { hash, type_id } = externs::identify(&v);
+    let ident = externs::identify(&v);
+    self.insert_with(v, ident)
+  }
+
+  pub fn insert_with(&mut self, v: Value, ident: Ident) -> Key {
     let mut inserted = false;
     let id_generator = self.id_generator;
     let key = *self
       .forward
-      .entry(InternKey(hash, v.clone()))
+      .entry(InternKey(ident.hash, v.clone()))
       .or_insert_with(|| {
         inserted = true;
-        Key::new(id_generator, type_id)
+        Key::new(id_generator, ident.type_id)
       });
     if inserted {
       self.reverse.insert(key, v);

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -58,7 +58,7 @@ use crate::externs::{
   Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionExtern, DropHandlesExtern,
   EqualsExtern, EvalExtern, ExternContext, Externs, GeneratorSendExtern, GetTypeForExtern,
   HandleBuffer, IdentifyExtern, LogExtern, ProjectIgnoringTypeExtern, ProjectMultiExtern, PyResult,
-  StoreBoolExtern, StoreBytesExtern, StoreF64Extern, StoreI64Extern, StoreTupleExtern,
+  RawBuffer, StoreBoolExtern, StoreBytesExtern, StoreF64Extern, StoreI64Extern, StoreTupleExtern,
   StoreUtf8Extern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
 };
 use crate::handles::Handle;


### PR DESCRIPTION
### Problem

The error for unhashable types used as `Get` params is unfortunate, because the call to `identify` fails and returns a null pointer to rust, which triggers an error... somewhere else. See #7499.

### Solution

As suggested in #7499, have `extern_generator_send` directly `identify` `Get` params, meaning that failures to hash take advantage of the fact that `extern_generator_send` is already fallible. This avoids a significant number of calls back to python to identify `Values` (an optimization discussed in #7318 and #7114).

### Result

Improved usability. Fixes #7499.