### PR TITLE
Improve logging of build-support/isort.sh helper script

### DIFF
--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -34,4 +34,7 @@ do
 done
 
 # If changes were made or issues found, output with leading whitespace trimmed.
-./pants --changed-parent=master fmt.isort -- ${isort_args[@]} | grep -Eo '(Fixing|ERROR).*$'
+output="$(./pants --changed-parent=master fmt.isort -- ${isort_args[@]})"
+echo "${output}" | grep -Eo '(ERROR).*$' && exit 1
+echo "${output}" | grep -Eo '(Fixing).*$'
+exit 0

--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -33,7 +33,5 @@ do
   esac
 done
 
-# If changes were made or issues found, output those lines with any leading
-# whitespace trimmed.
-./pants --changed-parent=master fmt.isort -- ${isort_args[@]} \
-  | grep -Eo '(Fixing|ERROR).*$' \
+# If changes were made or issues found, output with leading whitespace trimmed.
+./pants --changed-parent=master fmt.isort -- ${isort_args[@]} | grep -Eo '(Fixing|ERROR).*$'

--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -33,4 +33,8 @@ do
   esac
 done
 
-./pants --quiet --changed-parent=master fmt.isort -- ${isort_args[@]}
+# If changes were made or issues found, output those lines with any leading
+# whitespace trimmed.
+./pants --changed-parent=master fmt.isort -- ${isort_args[@]} \
+  | grep -E 'Fixing|ERROR' \
+  | awk '{$1=$1};1'

--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -36,5 +36,4 @@ done
 # If changes were made or issues found, output those lines with any leading
 # whitespace trimmed.
 ./pants --changed-parent=master fmt.isort -- ${isort_args[@]} \
-  | grep -E 'Fixing|ERROR' \
-  | awk '{$1=$1};1'
+  | grep -Eo '(Fixing|ERROR).*$' \

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import re
 import shlex
-from builtins import str, bytes
+from builtins import bytes, str
 
 from future.utils import PY3
 

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import re
 import shlex
-from builtins import bytes, str
+from builtins import str, bytes
 
 from future.utils import PY3
 


### PR DESCRIPTION
### Problem
`isort.sh` suffers from two problems:

1. When not using `-f`, the output upon failure is unnecessarily wordy and does not say which files were the actual issue. For example:
```
FAILURE: Exited with return code 1 while running `/Users/eric/.pyenv/shims/python3.6 /Users/eric/.cache/pants/python/CPython-3.6.8/d6bcba436bdefbc27a69dd880d6ee5716e004764/isort-c201e856817dc9ae802d18e3ec45a3bfa4c2ac11.pex --check-only src/python/pants/util/tarutil.py src/python/pants/util/retry.py src/python/pants/util/osutil.py src/python/pants/util/memo.py src/python/pants/util/process_handler.py src/python/pants/util/strutil.py src/python/pants/util/py2_compat.py src/python/pants/util/meta.py src/python/pants/util/xml_parser.py src/python/pants/util/objects.py src/python/pants/util/rwbuf.py src/python/pants/util/collections_abc_backport.py`.

FAILURE
```

2. When using `-f`, we swallow all output. Presumably, the user would like to know which files were changed, rather than having to run `git status` to do this.

### Solution
No longer run the command as `--quiet` and use grep to parse out lines we care about.

### Result
If `--fix` is passed and files were fixed, we will output with return code 0:
```
Fixing /Users/eric/DocsLocal/code/projects/pants/src/python/pants/util/strutil.py
```

If `--fix` is left off, and files had bad sort order, we will output with return code 1:
```
ERROR: /Users/eric/DocsLocal/code/projects/pants/src/python/pants/util/strutil.py Imports are incorrectly sorted.
```