### PR TITLE
make pantsd signal integration tests more reliable by setting the timeout

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -337,6 +337,10 @@ class DaemonPantsRunner(ProcessManager):
           'Encountered graceful termination exception {}; exiting'.format(e))
         self._exiter.exit(e.exit_code)
       except Exception:
+        # TODO: We override sys.excepthook above when we call ExceptionSink.set_exiter(). That
+        # excepthook catches `SignalHandledNonLocalExit`s from signal handlers, which isn't
+        # happening here, so something is probably overriding the excepthook. By catching Exception
+        # and calling this method, we emulate the normal, expected sys.excepthook override.
         ExceptionSink._log_unhandled_exception_and_exit()
       else:
         self._exiter.exit(PANTS_SUCCEEDED_EXIT_CODE)

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -32,20 +32,23 @@ class PailgunClientSignalHandler(SignalHandler):
     self._timeout = timeout
     super(PailgunClientSignalHandler, self).__init__(*args, **kwargs)
 
-  def _forward_signal_with_timeout(self, signum):
+  def _forward_signal_with_timeout(self, signum, signame):
+    logger.info(
+      'Sending {} to pantsd-runner with pid {}, waiting up to {} seconds before sending SIGKILL...'
+      .format(signame, self._pailgun_client._maybe_last_pid(), self._timeout))
     self._pailgun_client.set_exit_timeout(
       timeout=self._timeout,
       reason=KeyboardInterrupt('Interrupted by user over pailgun client!'))
     self._pailgun_client.maybe_send_signal(signum)
 
   def handle_sigint(self, signum, _frame):
-    self._forward_signal_with_timeout(signum)
+    self._forward_signal_with_timeout(signum, 'SIGINT')
 
   def handle_sigquit(self, signum, _frame):
-    self._forward_signal_with_timeout(signum)
+    self._forward_signal_with_timeout(signum, 'SIGQUIT')
 
   def handle_sigterm(self, signum, _frame):
-    self._forward_signal_with_timeout(signum)
+    self._forward_signal_with_timeout(signum, 'SIGTERM')
 
 
 class RemotePantsRunner(object):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -276,7 +276,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help='The host to bind the pants nailgun server to.')
     register('--pantsd-pailgun-port', advanced=True, type=int, default=0,
              help='The port to bind the pants nailgun server to. Defaults to a random port.')
-    register('--pantsd-pailgun-quit-timeout', advanced=True, type=float, default=1.0,
+    # TODO(#7514): Make this default to 1.0 seconds if stdin is a tty!
+    register('--pantsd-pailgun-quit-timeout', advanced=True, type=float, default=5.0,
              help='The length of time (in seconds) to wait for further output after sending a '
                   'signal to the remote pantsd-runner process before killing it.')
     register('--pantsd-log-dir', advanced=True, default=None,

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -461,13 +461,29 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
   def test_pantsd_sigterm(self):
     self._assert_pantsd_keyboardinterrupt_signal(
       signal.SIGTERM,
-      ['Signal {signum} (SIGTERM) was raised. Exiting with failure.'.format(signum=signal.SIGTERM)])
+      messages=[
+        'Signal {signum} (SIGTERM) was raised. Exiting with failure.'.format(signum=signal.SIGTERM),
+        '\nInterrupted by user over pailgun client!\n',
+      ],
+      quit_timeout=0.01)
 
-  def test_keyboardinterrupt_signals_with_pantsd(self):
-    for interrupt_signal in [signal.SIGINT, signal.SIGQUIT]:
-      self._assert_pantsd_keyboardinterrupt_signal(
-        interrupt_signal,
-        ['\nInterrupted by user over pailgun client!\n'])
+  def test_pantsd_sigquit(self):
+    self._assert_pantsd_keyboardinterrupt_signal(
+      signal.SIGQUIT,
+      messages=[
+        'Signal {signum} (SIGQUIT) was raised. Exiting with failure.'.format(signum=signal.SIGQUIT),
+        '\nInterrupted by user over pailgun client!\n',
+      ],
+      quit_timeout=0.01)
+
+  def test_pantsd_sigint(self):
+    self._assert_pantsd_keyboardinterrupt_signal(
+      signal.SIGINT,
+      messages=[
+        'User interrupted execution with control-c!',
+        '\nInterrupted by user over pailgun client!\n',
+      ],
+      quit_timeout=0.01)
 
   def test_signal_pailgun_stream_timeout(self):
     today = datetime.date.today().isoformat()

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -514,7 +514,10 @@ Interrupted by user over pailgun client!
       signal.SIGINT,
       regexps=["""\
 ^Interrupted by user\\.
-WARN\\] timed out when attempting to gracefully shut down the remote client executing "'pantsd-runner.*'"\\. sending SIGKILL to the remote client at pid: [0-9]+\\. message: iterating over bytes from nailgun timed out with timeout interval 0\\.01 starting at {today}T[^\n]+, overtime seconds: [^\n]+
+WARN\\] timed out when attempting to gracefully shut down the remote client executing \
+"'pantsd-runner.*'"\\. sending SIGKILL to the remote client at pid: [0-9]+\\. message: iterating \
+over bytes from nailgun timed out with timeout interval 0\\.01 starting at {today}T[^\n]+, \
+overtime seconds: [^\n]+
 Interrupted by user:
 Interrupted by user over pailgun client!
 """

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -467,43 +467,46 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
     self._assert_pantsd_keyboardinterrupt_signal(
       signal.SIGTERM,
       regexps=[
+        '^INFO] Sending SIGTERM to pantsd-runner with pid [0-9]+, waiting up to 5\\.0 seconds before sending SIGKILL\\.\\.\\.',
         re.escape("\nSignal {signum} (SIGTERM) was raised. Exiting with failure.\n"
                   .format(signum=signal.SIGTERM)),
         """
 Interrupted by user:
 Interrupted by user over pailgun client!
 $"""
-      ],
-      quit_timeout=5.0)
+      ])
 
   def test_pantsd_sigquit(self):
     self._assert_pantsd_keyboardinterrupt_signal(
       signal.SIGQUIT,
       regexps=[
+        '^INFO] Sending SIGQUIT to pantsd-runner with pid [0-9]+, waiting up to 5\\.0 seconds before sending SIGKILL\\.\\.\\.',
         re.escape("\nSignal {signum} (SIGQUIT) was raised. Exiting with failure.\n"
                   .format(signum=signal.SIGQUIT)),
         """
 Interrupted by user:
 Interrupted by user over pailgun client!
-$"""],
-      quit_timeout=5.0)
+$"""])
 
   def test_pantsd_sigint(self):
     self._assert_pantsd_keyboardinterrupt_signal(
       signal.SIGINT,
       regexps=["""\
-^Interrupted by user.
+^INFO] Sending SIGINT to pantsd-runner with pid [0-9]+, waiting up to 5\\.0 seconds before sending SIGKILL\\.\\.\\.
+Interrupted by user.
 Interrupted by user:
 Interrupted by user over pailgun client!
-$"""],
-      quit_timeout=5.0)
+$"""])
 
   def test_signal_pailgun_stream_timeout(self):
+    # NB: The actual timestamp has the date and time at sub-second granularity. The date is just
+    # used here since that is known in advance in order to assert that the timestamp is well-formed.
     today = datetime.date.today().isoformat()
     self._assert_pantsd_keyboardinterrupt_signal(
       signal.SIGINT,
       regexps=["""\
-^Interrupted by user\\.
+^INFO] Sending SIGINT to pantsd-runner with pid [0-9]+, waiting up to 0\\.01 seconds before sending SIGKILL\\.\\.\\.
+Interrupted by user\\.
 WARN\\] timed out when attempting to gracefully shut down the remote client executing \
 "'pantsd-runner.*'"\\. sending SIGKILL to the remote client at pid: [0-9]+\\. message: iterating \
 over bytes from nailgun timed out with timeout interval 0\\.01 starting at {today}T[^\n]+, \


### PR DESCRIPTION
### Problem

An attempt to resolve #7425. As mentioned on that ticket, the default (reasonable) timeout for waiting for pailgun subprocesses to complete after a signal (`--pantsd-pailgun-quit-timeout`) was 1 second. I believe the remaining issue here is that some invocations in CI would actually take more than a second to quit, which would cause nondeterministic behavior.

### Solution

- Set the timeout to 5 seconds on any test which intends for its subprocess to complete within the timeout.
- Match more of the stderr contents in each error case to remove ambiguity.

### Result

`TestPantsDaemonIntegration.test_pantsd_sigterm` hopefully won't continue to flake!!