### PR TITLE
remove pyenv bootstrapping from travis_ci/Dockerfile

### DIFF
--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -5,45 +5,6 @@
 ARG BASE_IMAGE=pantsbuild/centos6:latest
 FROM ${BASE_IMAGE}
 
-# TODO(7064) These changes belong in centos6/Dockerfile, because we always want that image to
-# have Py3 available and also avoid the cost of rebuilding Python 3 every time in CI. However,
-# this requires publishing an updated image to Docker hub, so we copy the code here until then.
-
-### BEGIN CENTOS6 DOCKERFILE CHANGES
-RUN yum -y update
-# TODO: figure out why this needs to be installed first for /usr/bin/scl to work!
-RUN yum install -y centos-release-scl
-RUN yum install -y \
-        bzip2-devel \
-        devtoolset-7-gcc{,-c++} \
-        git \
-        java-1.8.0-openjdk-devel \
-        libffi-devel \
-        openssl-devel \
-        readline-devel \
-        sqlite-devel \
-        zlib-devel
-
-ARG PYTHON_27_VERSION=2.7.13
-ARG PYTHON_36_VERSION=3.6.8
-# NB: PYENV_ROOT must be set for `pyenv install` to be available. This failure mode is not mentioned
-# in https://github.com/pyenv/pyenv#basic-github-checkout.
-ENV PYENV_ROOT "${PYENV_ROOT:-/pyenv-docker-build}"
-ENV PYENV_BIN "${PYENV_ROOT}/bin/pyenv"
-ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
-RUN if [[ ! -d "${PYENV_ROOT}" ]]; then \
-  git clone https://github.com/pyenv/pyenv ${PYENV_ROOT} \
-  && /usr/bin/scl enable devtoolset-7 -- ${PYENV_BIN} install ${PYTHON_27_VERSION} \
-  && /usr/bin/scl enable devtoolset-7 -- ${PYENV_BIN} install ${PYTHON_36_VERSION} \
-  && ${PYENV_BIN} global ${PYTHON_27_VERSION} ${PYTHON_36_VERSION}; \
-  fi
-ENV PATH "${PYENV_ROOT}/shims:${PATH}"
-
-# Expose the installed gcc to the invoking shell.
-ENTRYPOINT ["/usr/bin/scl", "enable", "devtoolset-7",  "--"]
-
-### END CENTOS6 DOCKERFILE CHANGES
-
 ARG TRAVIS_HOME_DIR_PATH=/travis/home
 ARG TRAVIS_WORK_DIR_PATH=/travis/workdir
 


### PR DESCRIPTION
### Problem

The conclusion of #7064 was, after `pantsbuild/centos6:latest` was updated, to remove the pyenv bootstrapping in `travis_ci/Dockerfile` as it was now being done in the centos6 base image.

### Solution

- Remove the marked section.

### Result

This will speed up all Docker shards that had Py3 installed by 2-3 minutes. So, Linux build engine Py36 and Linux build wheels abi3.

This means overall CI is about 5 minutes faster, and the bootstrap stage 2-3 minutes faster, which is especially significant since that blocks starting other tests.

Finally, this means everywhere we run Pants in CI, we have Python 3 installed now (instead of having to install it again!).