### PR TITLE
embed a graal native-image configuration inside the zinc wrapper

### DIFF
--- a/3rdparty/jvm/com/google/protobuf/BUILD
+++ b/3rdparty/jvm/com/google/protobuf/BUILD
@@ -1,0 +1,11 @@
+jar_library(
+    name = "protobuf-java",
+    jars = [
+        jar(
+            org = "com.google.protobuf",
+            name = "protobuf-java",
+            rev = "2.5.0",
+            force = True,
+        ),
+    ],
+)

--- a/3rdparty/jvm/org/scala-sbt/BUILD
+++ b/3rdparty/jvm/org/scala-sbt/BUILD
@@ -1,10 +1,12 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+zinc_version = '1.1.7'
+
 jar_library(
   name='zinc',
   jars=[
-    scala_jar(org='org.scala-sbt', name='zinc', rev='1.1.7',
+    scala_jar(org='org.scala-sbt', name='zinc', rev=zinc_version,
               excludes=[
                 scala_exclude(org='org.scala-sbt', name='io'),
                 scala_exclude(org='org.scala-sbt', name='util-logging'),
@@ -31,5 +33,12 @@ jar_library(
     # TODO: `zinc` only declares a dep on the `tests` classifier for
     # io. We redefine the dep here to get the full package.
     scala_jar(org='org.scala-sbt', name='io', rev='1.1.4', force=True),
+  ],
+)
+
+jar_library(
+  name='sbt-compiler-bridge',
+  jars=[
+    scala_jar(org='org.scala-sbt', name='compiler-bridge', rev=zinc_version),
   ],
 )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -335,6 +335,8 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     super().__init__(*args, **kwargs)
     self._targets_to_compile_settings = None
 
+    # TODO: self._jvm_options doesn't seem to record changes from `--<scope>-jvm-options` on the
+    # command line (but this might work in pants.ini?)!
     # JVM options for running the compiler.
     self._jvm_options = self.get_options().jvm_options
 

--- a/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/BUILD
+++ b/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+resources(
+  name='zinc-native-image-configuration',
+  sources=rglobs('*'),
+)

--- a/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/README.md
+++ b/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/README.md
@@ -1,6 +1,8 @@
 native-image `META-INF/`
 ===========================
 
+**NOTE: currently, these instructions will only work when used from the script at https://github.com/cosmicexplorer/graal/tree/graal-make-zinc-again/build-zinc-rsc-native-images.bash! Image building in general is currently blocked on https://github.com/oracle/graal/issues/1448.*
+
 *This directory contains special configuration files recognized by the `native-image` tool when embedded in a jar. This embedded configuration allows any user with some version of the Graal VM to fetch the `org.pantsbuild:zinc-compiler` jar and run `native-image -jar` to produce a native executable of the pants zinc wrapper without any additional arguments.*
 
 The Graal VM's `native-image` tool[^1] converts JVM bytecode to a native compiled executable[^2] executing via the Substrate VM. The `native-image` tool is not yet immediately compatible with all JVM code[^3], but the tool is stable and featureful enough to successfully build many codebases with a mixture of (mostly) automated and (some) manual configuration.

--- a/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/README.md
+++ b/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/README.md
@@ -1,0 +1,41 @@
+native-image `META-INF/`
+===========================
+
+*This directory contains special configuration files recognized by the `native-image` tool when embedded in a jar. This embedded configuration allows any user with some version of the Graal VM to fetch the `org.pantsbuild:zinc-compiler` jar and run `native-image -jar` to produce a native executable of the pants zinc wrapper without any additional arguments.*
+
+The Graal VM's `native-image` tool[^1] converts JVM bytecode to a native compiled executable[^2] executing via the Substrate VM. The `native-image` tool is not yet immediately compatible with all JVM code[^3], but the tool is stable and featureful enough to successfully build many codebases with a mixture of (mostly) automated and (some) manual configuration.
+
+The `native-image` tool accepts JSON configuration files which overcome some of the current limitations[^3]:
+1. `reflect-config.json`: The largest file, this would typically be generated automatically[^5].
+  - Some manual edits may be necessary[^6].
+2. `resource-config.json`: Should also be generated automatically[^5].
+  - Some manual edits may be necessary[^7].
+3. `substitutions.json`: Always manually generated, mocks out code that otherwise won't compile or run via `native-image`[^8].
+4. `native-image.properties`: Read by the `native-image` tool to get command-line arguments to use when executing on the jar, and accepts a `${.}` template syntax[^4].
+  - `native-image --help` describes many high-level command-line options which are converted to longer-form options when `native-image` is executing. `native-image --expert-options-all` describes all options.
+  - The arguments `--enable-all-security-services`, `--allow-incomplete-classpath`, and `--report-unsupported-elements-at-runtime` are going to be desired for almost all builds.
+  - The argument `--delay-class-initialization-to-runtime` delays initialization of classes until runtime (the `native-image` tool otherwise executes all static initializers at build time). Determining the appropriate classes to mark in this way can sometimes be a manual process[^9].
+
+
+Note that all json resource files should be formatted by piping them into `jq --sort-keys .`[^10]. This makes diffs easier to see by consistently formatting the output and deterministically sorting string object keys.
+
+
+[^1]: https://github.com/oracle/graal/tree/master/substratevm
+
+[^2]: https://www.graalvm.org/docs/reference-manual/aot-compilation/
+
+[^3]: https://github.com/oracle/graal/blob/master/substratevm/LIMITATIONS.md
+
+[^4]: https://medium.com/graalvm/simplifying-native-image-generation-with-maven-plugin-and-embeddable-configuration-d5b283b92f57
+
+[^5]: https://github.com/oracle/graal/blob/master/substratevm/CONFIGURE.md
+
+[^6]: https://github.com/oracle/graal/blob/master/substratevm/REFLECTION.md
+
+[^7]: https://github.com/oracle/graal/blob/master/substratevm/RESOURCES.md
+
+[^8]: https://github.com/pantsbuild/pants/tree/master/src/scala/org/pantsbuild/zinc/compiler/native-image-substitutions
+
+[^9]: https://medium.com/graalvm/understanding-class-initialization-in-graalvm-native-image-generation-d765b7e4d6ed
+
+[^10]: https://stedolan.github.io/jq/

--- a/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/native-image.properties
+++ b/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/native-image.properties
@@ -1,0 +1,12 @@
+ImageName = zinc-pants-native
+Args = -H:SubstitutionResources=${.}/substitutions.json \
+       -H:ResourceConfigurationResources=${.}/resource-config.json \
+       -H:ReflectionConfigurationResources=${.}/reflect-config.json \
+       --enable-all-security-services --allow-incomplete-classpath \
+       --report-unsupported-elements-at-runtime \
+       --delay-class-initialization-to-runtime=scala.tools.nsc.interpreter.IMain \
+       --delay-class-initialization-to-runtime=scala.tools.nsc.interpreter.IMain$ \
+       --delay-class-initialization-to-runtime=scala.tools.nsc.interpreter.NamedParam \
+       --delay-class-initialization-to-runtime=sbt.internal.util.StringTypeTag \
+       --delay-class-initialization-to-runtime=scala.tools.nsc.interpreter.IBindings \
+       --delay-class-initialization-to-runtime=scala.tools.nsc.interpreter.StdReplTags$

--- a/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/reflect-config.json
+++ b/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/reflect-config.json
@@ -1,0 +1,2191 @@
+[
+  {
+    "name": "[B"
+  },
+  {
+    "name": "[J"
+  },
+  {
+    "name": "[Ljava.lang.Object;"
+  },
+  {
+    "name": "java.lang.Boolean"
+  },
+  {
+    "name": "java.lang.Byte"
+  },
+  {
+    "name": "java.lang.Byte$ByteCache"
+  },
+  {
+    "name": "java.lang.Character"
+  },
+  {
+    "name": "java.lang.Character$CharacterCache"
+  },
+  {
+    "name": "java.lang.Class"
+  },
+  {
+    "name": "java.lang.Float"
+  },
+  {
+    "name": "java.lang.Integer"
+  },
+  {
+    "name": "java.lang.Integer$IntegerCache"
+  },
+  {
+    "name": "java.lang.Long"
+  },
+  {
+    "name": "java.lang.Number"
+  },
+  {
+    "name": "java.lang.Object"
+  },
+  {
+    "fields": [
+      {
+        "name": "value"
+      }
+    ],
+    "name": "java.lang.String"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.config.AppendersPlugin"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.config.LoggersPlugin"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.logging.log4j.core.LoggerContext",
+          "org.apache.logging.log4j.core.config.ConfigurationSource",
+          "org.apache.logging.log4j.core.config.builder.api.Component"
+        ]
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.config.plugins.visitors.PluginElementVisitor"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.impl.Log4jContextFactory"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.ContextMapLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.DateLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.EnvironmentLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.JavaLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.JmxRuntimeInputArgumentsLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.JndiLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.Log4jLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.MainMapLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.MapLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.MarkerLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.ResourceBundleLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.StructuredDataLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.SystemPropertiesLookup"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.pattern.DatePatternConverter"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.pattern.LevelPatternConverter"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.pattern.LineSeparatorPatternConverter"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.pattern.LoggerPatternConverter"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.pattern.MessagePatternConverter"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.pattern.ThreadNamePatternConverter"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.message.DefaultFlowMessageFactory"
+  },
+  {
+    "name": "java.lang.System"
+  },
+  {
+    "fields": [
+      {
+        "name": "address"
+      }
+    ],
+    "name": "java.nio.Buffer"
+  },
+  {
+    "name": "jdk.vm.ci.meta.DeoptimizationAction"
+  },
+  {
+    "name": "jdk.vm.ci.meta.DeoptimizationReason"
+  },
+  {
+    "name": "jdk.vm.ci.meta.JavaKind"
+  },
+  {
+    "name": "jdk.vm.ci.services.Services"
+  },
+  {
+    "name": "org.graalvm.compiler.api.directives.GraalDirectives"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.bytecode.Bytecodes$Flags"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.core.amd64.AMD64AddressNode"
+  },
+  {
+    "name": "org.graalvm.compiler.core.common.calc.UnsignedMath"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.StandardOp$JumpOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.StandardOp$LabelOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.StandardOp$NoOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64ArrayCompareToOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64ArrayEqualsOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64ArrayIndexOfOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Binary$CommutativeTwoOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Binary$ConstOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Binary$DataTwoOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Binary$MemoryTwoOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Binary$RMIOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Binary$TwoOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64BinaryConsumer$ConstOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64BinaryConsumer$MemoryConstOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64BinaryConsumer$MemoryMROp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64BinaryConsumer$MemoryRMOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64BinaryConsumer$MemoryVMConstOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64BinaryConsumer$Op"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64BinaryConsumer$VMConstOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64BlockEndOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64ByteSwapOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Call$CallOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Call$DirectCallOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Call$DirectNearForeignCallOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Call$ForeignCallOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Call$IndirectCallOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Call$MethodCallOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64ControlFlow$BranchOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64ControlFlow$CondMoveOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64ControlFlow$CondSetOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64ControlFlow$FloatBranchOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64ControlFlow$FloatCondMoveOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64ControlFlow$StrategySwitchOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64LIRInstruction"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$AMD64PushPopStackMove"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$AMD64StackMove"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$AbstractMoveOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$CompareAndSwapOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$CompressPointerOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$LeaOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$MembarOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$MoveFromConstOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$MoveFromRegOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$MoveToRegOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$NullCheckOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$PointerCompressionOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$StackLeaOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Move$UncompressPointerOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64MulDivOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64PrefetchOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64RestoreRegistersOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64SaveRegistersOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64ShiftOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64SignExtendOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Unary$MOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Unary$MROp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Unary$MemoryOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64Unary$RMOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.AMD64VZeroUpper"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.vector.AMD64VectorBinary$AVXBinaryOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.lir.amd64.vector.AMD64VectorUnary$AVXUnaryOp"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.AbstractBeginNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.AbstractDeoptimizeNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.AbstractEndNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.AbstractFixedGuardNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.AbstractLocalNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.AbstractMergeNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.AbstractStateSplit"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.BeginNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.BeginStateSplitNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.BinaryOpLogicNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.CallTargetNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.CompressionNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ConstantNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ControlSinkNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ControlSplitNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.DeoptimizeNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.DeoptimizingFixedWithNextNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.DirectCallTargetNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.DynamicDeoptimizeNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.EndNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.EntryMarkerNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.EntryProxyNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FixedGuardNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FixedNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FixedWithNextNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FloatingAnchoredNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FloatingGuardedNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FrameState"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FrameState$TwoSlotMarker"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.GetObjectAddressNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.GuardNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.GuardProxyNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.IfNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.IndirectCallTargetNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.InvokeNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.InvokeWithExceptionNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.KillingBeginNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.LogicConstantNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.LogicNegationNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.LogicNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.LoopBeginNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.LoopEndNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.LoopExitNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.LoweredCallTargetNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.MergeNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ParameterNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.PhiNode"
+  },
+  {
+    "name": "org.graalvm.compiler.nodes.PiArrayNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.PiArrayNode$Placeholder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.PiNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.PiNode$Placeholder"
+  },
+  {
+    "name": "org.graalvm.compiler.nodes.PrefetchAllocateNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ProxyNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ReturnNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.SafepointNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ShortCircuitOrNode"
+  },
+  {
+    "name": "org.graalvm.compiler.nodes.SnippetAnchorNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.StartNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.UnaryOpLogicNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.UnwindNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ValueNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ValuePhiNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ValueProxyNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.VirtualState"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.graalvm.compiler.nodes.ValueNode",
+          "org.graalvm.compiler.nodes.ValueNode"
+        ]
+      }
+    ],
+    "name": "org.graalvm.compiler.nodes.calc.AddNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.graalvm.compiler.nodes.ValueNode",
+          "org.graalvm.compiler.nodes.ValueNode"
+        ]
+      }
+    ],
+    "name": "org.graalvm.compiler.nodes.calc.AndNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.BinaryArithmeticNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.BinaryNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.CompareNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.ConditionalNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.FixedBinaryNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.FloatConvertNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.FloatEqualsNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.FloatLessThanNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.FloatingNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.IntegerBelowNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.IntegerConvertNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.IntegerDivRemNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.IntegerEqualsNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.IntegerLessThanNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.IntegerLowerThanNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.IntegerMulHighNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.IntegerTestNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.IsNullNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.LeftShiftNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.MulNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.NarrowNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.NegateNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.NormalizeCompareNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.NotNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.ObjectEqualsNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.graalvm.compiler.nodes.ValueNode",
+          "org.graalvm.compiler.nodes.ValueNode"
+        ]
+      }
+    ],
+    "name": "org.graalvm.compiler.nodes.calc.OrNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.PointerEqualsNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.ReinterpretNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.RightShiftNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.ShiftNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.SignExtendNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.SignedDivNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.SignedRemNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.graalvm.compiler.nodes.ValueNode",
+          "org.graalvm.compiler.nodes.ValueNode"
+        ]
+      }
+    ],
+    "name": "org.graalvm.compiler.nodes.calc.SubNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.UnaryArithmeticNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.UnaryNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.graalvm.compiler.nodes.ValueNode",
+          "org.graalvm.compiler.nodes.ValueNode"
+        ]
+      }
+    ],
+    "name": "org.graalvm.compiler.nodes.calc.UnsignedRightShiftNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.graalvm.compiler.nodes.ValueNode",
+          "org.graalvm.compiler.nodes.ValueNode"
+        ]
+      }
+    ],
+    "name": "org.graalvm.compiler.nodes.calc.XorNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.ZeroExtendNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.BoxNode"
+  },
+  {
+    "name": "org.graalvm.compiler.nodes.extended.BranchProbabilityNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.BytecodeExceptionNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.FixedValueAnchorNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.ForeignCallNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.GetClassNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.IntegerSwitchNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.JavaReadNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.JavaWriteNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.LoadHubNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.LoadMethodNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.MembarNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.NullCheckNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.OSRLocalNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.OSRMonitorEnterNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.OSRStartNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.RawLoadNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.RawStoreNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.StateSplitProxyNode"
+  },
+  {
+    "name": "org.graalvm.compiler.nodes.extended.StoreHubNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.SwitchNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.UnboxNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.UnsafeAccessNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.UnsafeMemoryLoadNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.UnsafeMemoryStoreNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.extended.ValueAnchorNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.AbstractCompareAndSwapNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.AbstractNewArrayNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.AbstractNewObjectNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.AbstractUnsafeCompareAndSwapNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.AccessArrayNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.AccessFieldNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.AccessIndexedNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.AccessMonitorNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.ArrayLengthNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.ClassIsAssignableFromNode"
+  },
+  {
+    "name": "org.graalvm.compiler.nodes.java.DynamicNewArrayNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.ExceptionObjectNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.FinalFieldBarrierNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.InstanceOfDynamicNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.InstanceOfNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.LoadExceptionObjectNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.LoadFieldNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.LoadIndexedNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.LogicCompareAndSwapNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.MethodCallTargetNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.MonitorEnterNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.MonitorExitNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.MonitorIdNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.NewArrayNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.NewInstanceNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.RawMonitorEnterNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.RegisterFinalizerNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.StoreFieldNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.StoreIndexedNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.TypeSwitchNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.UnsafeCompareAndSwapNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.ValueCompareAndSwapNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.memory.AbstractMemoryCheckpoint"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.memory.AbstractWriteNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.memory.FixedAccessNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.memory.FloatableAccessNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.memory.FloatingAccessNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.memory.FloatingReadNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.memory.MemoryAnchorNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.memory.MemoryMapNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.memory.MemoryPhiNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.memory.ReadNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.memory.WriteNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.memory.address.AddressNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.memory.address.OffsetAddressNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.virtual.AllocatedObjectNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.virtual.CommitAllocationNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.virtual.EscapeObjectState"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.virtual.VirtualArrayNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.virtual.VirtualBoxingNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.virtual.VirtualInstanceNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.virtual.VirtualObjectNode"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.graalvm.compiler.replacements.ArraysSubstitutions"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.BoxingSnippets"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.ReplacementsUtil"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.SnippetCounter"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.SnippetCounterNode"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.SnippetIntegerHistogram"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.SnippetTemplate$VarargsPlaceholderNode"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.graalvm.compiler.replacements.StringSubstitutions"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.amd64.AMD64ArrayIndexOf"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.amd64.AMD64ArrayIndexOfNode"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.amd64.AMD64ConvertSnippets"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.amd64.AMD64CountLeadingZerosNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.amd64.AMD64CountTrailingZerosNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.amd64.AMD64FloatConvertNode"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.arraycopy.ArrayCopyCallNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.arraycopy.ArrayCopyNode"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.arraycopy.ArrayCopySnippets"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.arraycopy.ArrayCopySnippets$ArrayCopyTypeCheck"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.arraycopy.ArrayCopySnippets$Counters"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.arraycopy.CheckcastArrayCopyCallNode"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.arraycopy.GenericArrayCopyCallNode"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.nodes.ArrayCompareToNode"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.nodes.ArrayEqualsNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.nodes.BasicArrayCopyNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.nodes.BasicObjectCloneNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.nodes.BitCountNode"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.nodes.ExplodeLoopNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.nodes.LoadSnippetVarargParameterNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.nodes.MacroNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.nodes.MacroStateSplitNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.nodes.MethodHandleNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.nodes.ReadRegisterNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.nodes.ResolvedMethodHandleCallTargetNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.nodes.ReverseBytesNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.virtual.nodes.MaterializedObjectState"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.virtual.nodes.VirtualObjectState"
+  },
+  {
+    "name": "org.graalvm.compiler.word.Word"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.word.WordCastNode"
+  },
+  {
+    "name": "org.graalvm.word.LocationIdentity"
+  },
+  {
+    "name": "org.graalvm.word.Pointer"
+  },
+  {
+    "name": "org.graalvm.word.WordFactory"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "scala.collection.immutable.List",
+          "scala.tools.nsc.Settings"
+        ]
+      }
+    ],
+    "name": "scala.tools.nsc.CompilerCommand"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "arrayBaseOffset",
+        "parameterTypes": [
+          "java.lang.Class"
+        ]
+      },
+      {
+        "name": "copyMemory",
+        "parameterTypes": [
+          "long",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "copyMemory",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "getBoolean",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getByte",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "getByte",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getDouble",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getFloat",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getInt",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "getInt",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getLong",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "getLong",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getObject",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "objectFieldOffset",
+        "parameterTypes": [
+          "java.lang.reflect.Field"
+        ]
+      },
+      {
+        "name": "putBoolean",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "boolean"
+        ]
+      },
+      {
+        "name": "putByte",
+        "parameterTypes": [
+          "long",
+          "byte"
+        ]
+      },
+      {
+        "name": "putByte",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "byte"
+        ]
+      },
+      {
+        "name": "putDouble",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "double"
+        ]
+      },
+      {
+        "name": "putFloat",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "float"
+        ]
+      },
+      {
+        "name": "putInt",
+        "parameterTypes": [
+          "long",
+          "int"
+        ]
+      },
+      {
+        "name": "putInt",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "int"
+        ]
+      },
+      {
+        "name": "putLong",
+        "parameterTypes": [
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "putLong",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "putObject",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      }
+    ],
+    "name": "sun.misc.Unsafe"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "newCompiler",
+        "parameterTypes": [
+          "[Ljava.lang.String;",
+          "xsbti.compile.Output",
+          "xsbti.Logger",
+          "xsbti.Reporter"
+        ]
+      },
+      {
+        "name": "run",
+        "parameterTypes": [
+          "[Ljava.io.File;",
+          "xsbti.compile.DependencyChanges",
+          "xsbti.AnalysisCallback",
+          "xsbti.Logger",
+          "xsbti.Reporter",
+          "xsbti.compile.CompileProgress",
+          "xsbti.compile.CachedCompiler"
+        ]
+      }
+    ],
+    "name": "xsbt.CompilerInterface"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "scala.tools.nsc.Settings"
+        ]
+      }
+    ],
+    "name": "scala.tools.nsc.reporters.ConsoleReporter"
+  },
+  {
+    "methods": [
+      {
+        "name": "getCallerClass",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ],
+    "name": "sun.reflect.Reflection"
+  },
+  {
+    "fields": [
+      {
+        "name": "value"
+      }
+    ],
+    "name": "java.lang.String"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.config.AppendersPlugin"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.config.LoggersPlugin"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.logging.log4j.core.LoggerContext",
+          "org.apache.logging.log4j.core.config.ConfigurationSource",
+          "org.apache.logging.log4j.core.config.builder.api.Component"
+        ]
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.config.plugins.visitors.PluginElementVisitor"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.impl.Log4jContextFactory"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.ContextMapLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.DateLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.EnvironmentLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.JavaLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.JmxRuntimeInputArgumentsLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.JndiLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.Log4jLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.MainMapLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.MapLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.MarkerLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.ResourceBundleLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.StructuredDataLookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.core.lookup.SystemPropertiesLookup"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.pattern.DatePatternConverter"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.pattern.LevelPatternConverter"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.pattern.LineSeparatorPatternConverter"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.pattern.LoggerPatternConverter"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.pattern.MessagePatternConverter"
+  },
+  {
+    "allDeclaredMethods": true,
+    "name": "org.apache.logging.log4j.core.pattern.ThreadNamePatternConverter"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.logging.log4j.message.DefaultFlowMessageFactory"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.bytecode.Bytecodes$Flags"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.AbstractBeginNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.AbstractDeoptimizeNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.AbstractEndNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.AbstractFixedGuardNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.AbstractLocalNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.AbstractMergeNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.BeginNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.BeginStateSplitNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.BinaryOpLogicNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.CallTargetNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ConstantNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ControlSinkNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ControlSplitNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.DeoptimizeNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.DeoptimizingFixedWithNextNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.EndNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FixedGuardNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FixedNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FixedWithNextNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FloatingAnchoredNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FloatingGuardedNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FrameState"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.FrameState$TwoSlotMarker"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.GuardNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.IfNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.LogicNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.LoopBeginNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.LoopExitNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.MergeNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ParameterNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.PhiNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.PiNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ReturnNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.StartNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.UnaryOpLogicNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ValueNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.ValuePhiNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.VirtualState"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.graalvm.compiler.nodes.ValueNode",
+          "org.graalvm.compiler.nodes.ValueNode"
+        ]
+      }
+    ],
+    "name": "org.graalvm.compiler.nodes.calc.AddNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.BinaryArithmeticNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.BinaryNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.CompareNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.FloatingNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.IntegerConvertNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.IntegerLessThanNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.IntegerLowerThanNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.IsNullNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.LeftShiftNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.MulNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.NarrowNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.ShiftNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.SignExtendNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.SubNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.UnaryNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.calc.ZeroExtendNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.AccessArrayNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.AccessFieldNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.AccessIndexedNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.ArrayLengthNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.LoadFieldNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.LoadIndexedNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.java.MethodCallTargetNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.nodes.virtual.VirtualObjectNode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.replacements.SnippetCounterNode"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.StringSubstitutions"
+  },
+  {
+    "name": "org.graalvm.compiler.replacements.amd64.AMD64ArrayIndexOf"
+  },
+  {
+    "name": "org.graalvm.compiler.word.Word"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "org.graalvm.compiler.word.WordCastNode"
+  },
+  {
+    "fields": [
+      {
+        "name": "theUnsafe"
+      }
+    ],
+    "name": "sun.misc.Unsafe"
+  },
+  {
+    "methods": [
+      {
+        "name": "getCallerClass",
+        "parameterTypes": [
+          "int"
+        ]
+      }
+    ],
+    "name": "sun.reflect.Reflection"
+  }
+]

--- a/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/resource-config.json
+++ b/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/resource-config.json
@@ -1,0 +1,178 @@
+{
+  "resources": [
+    {
+      "pattern": "META-INF/services/jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory"
+    },
+    {
+      "pattern": "META-INF/services/jdk.vm.ci.services.JVMCIServiceLocator"
+    },
+    {
+      "pattern": "META-INF/services/org.graalvm.compiler.core.match.MatchStatementSet"
+    },
+    {
+      "pattern": "META-INF/services/org.graalvm.compiler.debug.TTYStreamProvider"
+    },
+    {
+      "pattern": "META-INF/services/org.graalvm.compiler.hotspot.CompilerConfigurationFactory"
+    },
+    {
+      "pattern": "META-INF/services/org.graalvm.compiler.hotspot.HotSpotBackendFactory"
+    },
+    {
+      "pattern": "META-INF/services/org.graalvm.compiler.hotspot.HotSpotCodeCacheListener"
+    },
+    {
+      "pattern": "META-INF/services/org.graalvm.compiler.hotspot.HotSpotGraalManagementRegistration"
+    },
+    {
+      "pattern": "META-INF/services/org.graalvm.compiler.nodes.graphbuilderconf.NodeIntrinsicPluginFactory"
+    },
+    {
+      "pattern": "META-INF/native/linux64/libjansi.so"
+    },
+    {
+      "pattern": "com/sun/jna/linux-x86-64/libjnidispatch.so"
+    },
+    {
+      "pattern": "compiler.properties"
+    },
+    {
+      "pattern": "java/lang/Boolean.class"
+    },
+    {
+      "pattern": "java/lang/Byte.class"
+    },
+    {
+      "pattern": "java/lang/Character.class"
+    },
+    {
+      "pattern": "java/lang/Float.class"
+    },
+    {
+      "pattern": "java/lang/Integer.class"
+    },
+    {
+      "pattern": "java/lang/Long.class"
+    },
+    {
+      "pattern": "java/lang/Number.class"
+    },
+    {
+      "pattern": "java/lang/String.class"
+    },
+    {
+      "pattern": "library.properties"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/amd64/AMD64ArrayIndexOfStub.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/nodes/GraalHotSpotVMConfigNode.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/HashCodeSnippets.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/HotSpotArraySubstitutions.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/HotSpotClassSubstitutions.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/HotSpotReplacementsUtil.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/InstanceOfSnippets.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/LoadExceptionObjectSnippets.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/MonitorSnippets.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/NewObjectSnippets.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/ObjectCloneSnippets.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/ObjectSubstitutions.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/ReflectionSubstitutions.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/ThreadSubstitutions.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/TypeCheckSnippetUtils.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/WriteBarrierSnippets.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/replacements/arraycopy/HotSpotArraycopySnippets.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/stubs/ExceptionHandlerStub.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/stubs/ForeignCallSnippets.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/hotspot/stubs/UnwindExceptionToCallerStub.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/nodes/PiNode.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/nodes/java/DynamicNewArrayNode.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/nodes/java/NewArrayNode.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/replacements/ArraysSubstitutions.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/replacements/BoxingSnippets.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/replacements/ReplacementsUtil.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/replacements/SnippetCounter.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/replacements/SnippetIntegerHistogram.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/replacements/StringSubstitutions.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/replacements/amd64/AMD64ArrayIndexOf.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/replacements/amd64/AMD64ConvertSnippets.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/replacements/amd64/AMD64StringSubstitutions.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/replacements/arraycopy/ArrayCopyCallNode.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/replacements/arraycopy/ArrayCopySnippets.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/replacements/nodes/ArrayEqualsNode.class"
+    },
+    {
+      "pattern": "org/graalvm/compiler/replacements/nodes/ArrayRegionEqualsNode.class"
+    },
+    {
+      "pattern": "org/graalvm/word/LocationIdentity.class"
+    }
+  ]
+}

--- a/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/substitutions.json
+++ b/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler/substitutions.json
@@ -1,0 +1,56 @@
+[
+  {
+    "annotatedClass": "org.pantsbuild.zinc.compiler.substitutions.scala.tools.nsc.Target_scala_tools_nsc_ast_TreeBrowsers$SwingBrowser",
+    "methods": [
+      {
+        "annotatedName": "browse",
+        "substitute": true
+      }
+    ],
+    "originalClass": "scala.tools.nsc.ast.TreeBrowsers$SwingBrowser"
+  },
+  {
+    "annotatedClass": "org.pantsbuild.zinc.compiler.substitutions.scala.tools.nsc.Target_sbt_io_IO$",
+    "methods": [
+      {
+        "annotatedName": "getModifiedTimeOrZero",
+        "substitute": true
+      },
+      {
+        "annotatedName": "setModifiedTimeOrFalse",
+        "substitute": true
+      }
+    ],
+    "originalClass": "sbt.io.IO$"
+  },
+  {
+    "annotatedClass": "org.pantsbuild.zinc.compiler.substitutions.scala.tools.nsc.Target_scala_reflect_internal_util_StatisticsStatics",
+    "methods": [
+      {
+        "annotatedName": "areSomeHotStatsEnabled",
+        "substitute": true
+      },
+      {
+        "annotatedName": "areSomeColdStatsEnabled",
+        "substitute": true
+      },
+      {
+        "annotatedName": "enableColdStats",
+        "substitute": true
+      },
+      {
+        "annotatedName": "disableColdStats",
+        "substitute": true
+      },
+      {
+        "annotatedName": "enableHotStats",
+        "substitute": true
+      },
+      {
+        "annotatedName": "disableHotStats",
+        "substitute": true
+      }
+    ],
+    "originalClass": "scala.reflect.internal.util.StatisticsStatics"
+  }
+]

--- a/src/scala/org/pantsbuild/zinc/analysis/AnalysisMap.scala
+++ b/src/scala/org/pantsbuild/zinc/analysis/AnalysisMap.scala
@@ -16,7 +16,6 @@ import sbt.internal.inc.{
   CompanionsStore,
   Locate
 }
-import sbt.util.Logger
 import xsbti.api.Companions
 import xsbti.compile.{
   AnalysisContents,

--- a/src/scala/org/pantsbuild/zinc/compiler/BUILD
+++ b/src/scala/org/pantsbuild/zinc/compiler/BUILD
@@ -1,6 +1,9 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+# NB: To build a native-image of zinc *for a specific scalac version*, the scala path
+# (compiler,library,reflect) has to be provided to the native-image invocation with -cp! Also, graal
+# needs to release 1.0.0rc15 with oracle/graal#1071 (a NullPointerException fix).
 scala_library(
   provides=scala_artifact(
     org='org.pantsbuild',
@@ -21,6 +24,9 @@ scala_library(
     'src/scala/org/pantsbuild/zinc/cache',
     'src/scala/org/pantsbuild/zinc/scalautil',
     'src/scala/org/pantsbuild/zinc/util',
+    'src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler:zinc-native-image-configuration',
+    'src/scala/org/pantsbuild/zinc/compiler/native-image-substitutions',
+    'src/scala/org/pantsbuild/zinc/compiler/native-image-substitutions:statics',
   ],
   strict_deps=True,
   platform='java8',

--- a/src/scala/org/pantsbuild/zinc/compiler/CompilerUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/CompilerUtils.scala
@@ -18,7 +18,6 @@ import sbt.internal.inc.{
 import sbt.internal.inc.classpath.ClassLoaderCache
 import sbt.io.Path
 import sbt.io.syntax._
-import sbt.util.Logger
 import xsbti.compile.{
   ClasspathOptionsUtil,
   CompilerCache,

--- a/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
@@ -9,6 +9,7 @@ import java.util.function.{ Function => JFunction }
 
 import scala.compat.java8.OptionConverters._
 
+import sbt.internal.inc.ReporterManager
 import sbt.internal.inc.ZincUtil
 import sbt.io.IO
 import sbt.util.Logger
@@ -66,16 +67,8 @@ object InputUtils {
         .withScalacOptions(scalacOptions.toArray)
         .withJavacOptions(javacOptions.toArray)
         .withOrder(compileOrder)
-    val reporter =
-      ReporterUtil.getDefault(
-        ReporterUtil.getDefaultReporterConfig()
-          .withMaximumErrors(Int.MaxValue)
-          .withUseColor(settings.consoleLog.color)
-          .withMsgFilters(settings.consoleLog.msgPredicates.toArray)
-          .withFileFilters(settings.consoleLog.filePredicates.toArray)
-          .withLogLevel(settings.consoleLog.javaLogLevel)
-          .withPositionMapper(positionMapper)
-      )
+    val reporter = ReporterUtil.getReporter(
+      BareBonesLogger(settings.consoleLog.logLevel), ReporterManager.getDefaultReporterConfig)
     val setup =
       Setup.create(
         analysisMap.getPCELookup,

--- a/src/scala/org/pantsbuild/zinc/compiler/native-image-substitutions/BUILD
+++ b/src/scala/org/pantsbuild/zinc/compiler/native-image-substitutions/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Substitutions for classes with static methods, which aren't available in Scala.
+java_library(name='statics')
+
+scala_library()

--- a/src/scala/org/pantsbuild/zinc/compiler/native-image-substitutions/README.md
+++ b/src/scala/org/pantsbuild/zinc/compiler/native-image-substitutions/README.md
@@ -1,0 +1,24 @@
+zinc native-image substitutions
+===============================
+
+*This directory contains source files mocking out any methods that for whatever reason won't compile or run correctly with `native-image`.*
+
+The Graal VM's `native-image` tool[^1] converts JVM bytecode to a native compiled executable[^2] executing via the Substrate VM. The tool is not yet immediately compatible with all JVM code[^3], so SubstrateVM's *substitutions* facility allows mocking out code that doesn't compile or run correctly[^4].
+
+In ScalaDays 2018, a demo was presented of executing Scalac with the `native-image` tool[^5]. This directory contains the substitutions directly from that demo's repository, along with a small additional substitution which was necessary for extending that work to cover the zinc incremental compiler[^6].
+
+As described in [^4] and demonstrated in [^5], substitutions also require a JSON configuration file to have `native-image` recognize them. That configuration is stored in `META-INF/`, see [^7].
+
+[^1]: https://github.com/oracle/graal/tree/master/substratevm
+
+[^2]: https://www.graalvm.org/docs/reference-manual/aot-compilation/
+
+[^3]: https://github.com/oracle/graal/blob/master/substratevm/LIMITATIONS.md
+
+[^4]: https://medium.com/graalvm/instant-netty-startup-using-graalvm-native-image-generation-ed6f14ff7692
+
+[^5]: https://github.com/graalvm/graalvm-demos/tree/master/scala-days-2018/scalac-native
+
+[^6]: https://github.com/sbt/zinc
+
+[^7]: https://github.com/pantsbuild/pants/tree/master/src/scala/META-INF/native-image/org/pantsbuild/zinc/compiler

--- a/src/scala/org/pantsbuild/zinc/compiler/native-image-substitutions/Substitutions.java
+++ b/src/scala/org/pantsbuild/zinc/compiler/native-image-substitutions/Substitutions.java
@@ -1,0 +1,32 @@
+package org.pantsbuild.zinc.compiler.substitutions.scala.tools.nsc;
+
+// NB: This is necessary to avoid the javadoc task erroring out due to the lack of public classes.
+public class Substitutions {}
+
+final class Target_scala_reflect_internal_util_StatisticsStatics {
+   static boolean areSomeHotStatsEnabled() {
+     return false;
+   }
+   static boolean areSomeColdStatsEnabled() {
+     return false;
+   }
+
+  public static void enableColdStats() {
+    throw new RuntimeException("Operation unsupported enable cold stats in native scala compiler.");
+  }
+
+  public static void disableColdStats() {
+    throw new RuntimeException(
+      "Operation disable cold stats is unsupported in native scala compiler.");
+  }
+
+  public static void enableHotStats() {
+    throw new RuntimeException(
+      "Operation enable hot stats is unsupported in native scala compiler.");
+  }
+
+  public static void disableHotStats() {
+    throw new RuntimeException(
+      "Operation disable hot stats is unsupported in native scala compiler.");
+  }
+}

--- a/src/scala/org/pantsbuild/zinc/compiler/native-image-substitutions/substitutions.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/native-image-substitutions/substitutions.scala
@@ -1,0 +1,12 @@
+package org.pantsbuild.zinc.compiler.substitutions.scala.tools.nsc
+
+import java.io.File
+
+final class Target_scala_tools_nsc_ast_TreeBrowsers$SwingBrowser {
+  def browse(pName: String, units: List[AnyRef]): Unit = throw new RuntimeException("Swing currently unsupported in the native compiler.")
+}
+
+final class Target_sbt_io_IO$ {
+  def getModifiedTimeOrZero(file: File): Long = file.lastModified()
+  def setModifiedTimeOrFalse(file: File, mtime: Long): Boolean = file.setLastModified(mtime)
+}

--- a/zinc/BUILD
+++ b/zinc/BUILD
@@ -6,6 +6,13 @@ jvm_binary(
   main='org.pantsbuild.zinc.compiler.Main',
   dependencies=[
     'src/scala/org/pantsbuild/zinc/compiler',
+    # NB: There is a warning generated about some "unsafe" methods used in protobuf (which is
+    # a transitive dependency) when building with native-image unless this protobuf dependency is
+    # added.
+    '3rdparty/jvm/com/google/protobuf:protobuf-java',
+    # We don't want to inject the compiler bridge into the jar we distribute, but we do want it in
+    # this jvm_binary() in order to create native-image versions of our zinc wrapper.
+    '3rdparty/jvm/org/scala-sbt:sbt-compiler-bridge',
   ],
   description='zinc compiler -- the scala compiler in nailgun',
 )


### PR DESCRIPTION
### Problem

[`native-image`](https://www.graalvm.org/docs/reference-manual/aot-compilation/) is a tool from the [Graal](https://github.com/oracle/graal) project which can compile jvm bytecode to a native executable with very short startup time.

As of [1.0.0rc13](https://github.com/oracle/graal/releases), `native-image` became able to use special files in `META-INF/` to configure the command-line arguments and json configuration it needed to run, described in https://medium.com/graalvm/simplifying-native-image-generation-with-maven-plugin-and-embeddable-configuration-d5b283b92f57. This allows us to publish a zinc artifact which works the exact same when invoked by `java`, but can also be made into a `native-image` without any further configuration.

### Solution

- Add the reflective/resource access json files into `META-INF/` in the zinc jar, as well as substitutions.
- Add descriptive readmes linking to external documentation and blog posts about Graal which were used to construct the configuration being added.

### Result

#8036 (once the artifacts from this PR are published to maven central) will be able to remove an extra git clone from its script which does all of the configuration automatically!