### PR TITLE
Pass interpreter constraint when building the release PEX

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -658,9 +658,15 @@ function build_pex() {
     platform_flags=("${platform_flags[@]}" "--platform=${platform}")
   done
 
+  interpreter_constraint="CPython==2.7.*"
+  if [[ "${python_three:-false}" == "true" ]]; then
+    interpreter_constraint="CPython==3.6.*"
+  fi
+
   execute_pex \
     -o "${dest}" \
     --script=pants \
+    --interpreter-constraint="${interpreter_constraint}" \
     "${platform_flags[@]}" \
     "${requirements[@]}"
 


### PR DESCRIPTION
### Problem
When building the Pex for release, we should be setting interpreter constraints on it to avoid someone trying to run `pants.pex36` with Python 2, for example.

This was discovered while Twitter tried upgrading to Python 3.

### Solution
Explicitly pass `--interpreter-constraint` at Pex build-time.