### PR TITLE
add option to increase recursion limit to allow writing json reporting

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -34,6 +34,7 @@ from pants.subsystem.subsystem import Subsystem
 from pants.util.collections_abc_backport import OrderedDict
 from pants.util.contextutil import recursion_limit
 from pants.util.dirutil import relative_symlink, safe_file_dump
+from pants.util.strutil import safe_shlex_join
 
 
 class RunTrackerOptionEncoder(CoercingOptionEncoder):
@@ -117,7 +118,7 @@ class RunTracker(Subsystem):
     """
     super(RunTracker, self).__init__(*args, **kwargs)
     self._run_timestamp = time.time()
-    self._cmd_line = ' '.join(['pants'] + sys.argv[1:])
+    self._cmd_line = safe_shlex_join(['pants'] + sys.argv[1:])
     self._sorted_goal_infos = tuple()
 
     # Initialized in `initialize()`.

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -403,3 +403,19 @@ def http_server(handler_class):
   finally:
     shutdown_queue.put(True)
     t.join()
+
+
+@contextmanager
+def recursion_limit(limit):
+  """Temporarily modify the allowed recursion limit.
+
+  This method is intended to be used when serializing deeply nested structures such as dicts which
+  otherwise would raise a recursion error. It will not fix recursion errors due to cyclic
+  structures.
+  """
+  prev_limit = sys.getrecursionlimit()
+  sys.setrecursionlimit(limit)
+  try:
+    yield
+  finally:
+    sys.setrecursionlimit(prev_limit)

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -407,7 +407,7 @@ def http_server(handler_class):
 
 @contextmanager
 def recursion_limit(limit):
-  """Temporarily modify the allowed recursion limit.
+  """Temporarily modify the allowed recursion limit (typically this defaults to 1000).
 
   This method is intended to be used when serializing deeply nested structures such as dicts which
   otherwise would raise a recursion error. It will not fix recursion errors due to cyclic


### PR DESCRIPTION
### Problem

The new `JsonReporter` from #7392 is wonderful, and also caused pants to silently fail at the end of every run in our monorepo. Running the failing targets individually revealed that the `stats` dict we pass to `json.dumps()` was deep enough to fail with a recursion limit exceeded error: https://github.com/pantsbuild/pants/blob/454ce5e8140d202ba41787b4cb85b2c22715657e/src/python/pants/goal/run_tracker.py#L449

The recursion limit exceeded error also occurred when trying to print the dict to the console. It's not clear right now why the stats dict in our repo would be so deeply nested, but increasing the recursion limit from the default 1000 to 3000 allowed pants to exit successfully.

This error occurred in the background, when the run tracker was being ended, so it was difficult to spot at first.

It's probably correct that there are python libraries which can write dicts to json without using recursion, but this approach seemed like a good way to support the newer json reporting changes in our repo without requiring a lot of separate development effort on the json reporter itself right now.

### Solution

- Add `recursion_limit()` to `contextutil.py`, which temporarily modifies the recursion limit.
- Add `--nested-output-max-depth` to `RunTracker` to specify the recursion limit to set when dumping the json output to file.

### Result

Pants exits successfully when running tests in our repo.