### PR TITLE
don't consider strings as collections for TypedCollection

### DIFF
--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -115,7 +115,6 @@ python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:future',
-    '3rdparty/python:six',
     ':collections_abc_backport',
     ':memo',
     ':meta',

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -205,9 +205,12 @@ class ExecuteProcessRequestTest(unittest.TestCase):
       self.assertTrue(False, "should be able to construct without error")
 
     with self.assertRaises(TypeCheckError):
-      self._default_args_execute_process_request(argv=['1'])
+      self._default_args_execute_process_request(argv=1)
     with self.assertRaises(TypeCheckError):
-      self._default_args_execute_process_request(argv=('1',), env=['foo', 'bar'])
+      self._default_args_execute_process_request(argv='1')
+    with self.assertRaises(TypeCheckError):
+      self._default_args_execute_process_request(argv=('1',), env='foo=bar')
+
 
     with self.assertRaisesRegexp(TypeCheckError, "env"):
       ExecuteProcessRequest(

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -199,13 +199,12 @@ class TypedCollectionTest(TypeConstraintTestBase):
     collection_exactly_a_or_b = TypedCollection(Exactly(self.A, self.B))
     self.assertEqual([self.A()], collection_exactly_a_or_b.validate_satisfied_by([self.A()]))
     self.assertEqual([self.B()], collection_exactly_a_or_b.validate_satisfied_by([self.B()]))
-    with self.assertRaisesWithMessage(
-        TypeConstraintError,
-        "in wrapped constraint TypedCollection(Exactly(A or B)): value A() (with type 'A') must satisfy this type constraint: SubclassesOf(Iterable). Note that objects matching SubclassesOf(str) are not considered iterable."):
+    with self.assertRaisesWithMessage(TypeConstraintError, """\
+in wrapped constraint TypedCollection(Exactly(A or B)): value A() (with type 'A') must satisfy this type constraint: SubclassesOf(Iterable).
+Note that objects matching SubclassesOf(str) are not considered iterable."""):
       collection_exactly_a_or_b.validate_satisfied_by(self.A())
-    with self.assertRaisesWithMessage(
-        TypeConstraintError,
-        "in wrapped constraint TypedCollection(Exactly(A or B)) matching iterable object [C()]: value C() (with type 'C') must satisfy this type constraint: Exactly(A or B). Note that objects matching SubclassesOf(str) are not considered iterable."):
+    with self.assertRaisesWithMessage(TypeConstraintError, """\
+in wrapped constraint TypedCollection(Exactly(A or B)) matching iterable object [C()]: value C() (with type 'C') must satisfy this type constraint: Exactly(A or B)."""):
       collection_exactly_a_or_b.validate_satisfied_by([self.C()])
 
   def test_iterable_detection(self):
@@ -216,8 +215,11 @@ class TypedCollectionTest(TypeConstraintTestBase):
 
     with self.assertRaisesWithMessage(TypeCheckError, """\
 type check error in class StringCollectionField: errors type checking constructor arguments:
-field 'hello_strings' was invalid: in wrapped constraint TypedCollection(Exactly(str)): value 'xxx' (with type 'str') must satisfy this type constraint: SubclassesOf(Iterable).
-Note that objects matching SubclassesOf(str) are not considered iterable."""):
+field 'hello_strings' was invalid: in wrapped constraint TypedCollection(Exactly({string_type})): \
+value 'xxx' (with type '{string_type}') must satisfy this type constraint: SubclassesOf(Iterable).
+Note that objects matching SubclassesOf({text_type}) are not considered iterable."""
+                                      .format(string_type=str.__name__,
+                                              text_type=text_type.__name__)):
       StringCollectionField(hello_strings='xxx')
 
 
@@ -673,7 +675,8 @@ field 'some_value' was invalid: value 3 (with type 'int') must satisfy this type
 
     expected_msg = """\
 type check error in class WithCollectionTypeConstraint: errors type checking constructor arguments:
-field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)): value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(Iterable)."""
+field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)): value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(Iterable).
+Note that objects matching SubclassesOf(str) are not considered iterable."""
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       WithCollectionTypeConstraint(3)
 

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -8,13 +8,15 @@ import copy
 import pickle
 from abc import abstractmethod
 from builtins import object, str
+from textwrap import dedent
 
 from future.utils import PY2, PY3, text_type
 
 from pants.util.collections_abc_backport import OrderedDict
 from pants.util.objects import (EnumVariantSelectionError, Exactly, SubclassesOf, SuperclassesOf,
                                 TypeCheckError, TypeConstraintError, TypedCollection,
-                                TypedDatatypeInstanceConstructionError, datatype, enum)
+                                TypedDatatypeInstanceConstructionError, _string_type_constraint,
+                                datatype, enum)
 from pants_test.test_base import TestBase
 
 
@@ -199,12 +201,13 @@ class TypedCollectionTest(TypeConstraintTestBase):
     collection_exactly_a_or_b = TypedCollection(Exactly(self.A, self.B))
     self.assertEqual([self.A()], collection_exactly_a_or_b.validate_satisfied_by([self.A()]))
     self.assertEqual([self.B()], collection_exactly_a_or_b.validate_satisfied_by([self.B()]))
-    with self.assertRaisesWithMessage(TypeConstraintError, """\
-in wrapped constraint TypedCollection(Exactly(A or B)): value A() (with type 'A') must satisfy this type constraint: SubclassesOf(Iterable).
-Note that objects matching SubclassesOf(str) are not considered iterable."""):
+    with self.assertRaisesWithMessage(TypeConstraintError, dedent("""\
+        in wrapped constraint TypedCollection(Exactly(A or B)): value A() (with type 'A') must satisfy this type constraint: SubclassesOf(Iterable).
+        Note that objects matching {} are not considered iterable.""")
+                                      .format(_string_type_constraint)):
       collection_exactly_a_or_b.validate_satisfied_by(self.A())
-    with self.assertRaisesWithMessage(TypeConstraintError, """\
-in wrapped constraint TypedCollection(Exactly(A or B)) matching iterable object [C()]: value C() (with type 'C') must satisfy this type constraint: Exactly(A or B)."""):
+    with self.assertRaisesWithMessage(TypeConstraintError, dedent("""\
+        in wrapped constraint TypedCollection(Exactly(A or B)) matching iterable object [C()]: value C() (with type 'C') must satisfy this type constraint: Exactly(A or B).""")):
       collection_exactly_a_or_b.validate_satisfied_by([self.C()])
 
   def test_iterable_detection(self):
@@ -213,13 +216,14 @@ in wrapped constraint TypedCollection(Exactly(A or B)) matching iterable object 
 
     self.assertEqual(['xxx'], StringCollectionField(hello_strings=['xxx']).hello_strings)
 
-    with self.assertRaisesWithMessage(TypeCheckError, """\
-type check error in class StringCollectionField: errors type checking constructor arguments:
-field 'hello_strings' was invalid: in wrapped constraint TypedCollection(Exactly({string_type})): \
-value 'xxx' (with type '{string_type}') must satisfy this type constraint: SubclassesOf(Iterable).
-Note that objects matching SubclassesOf({text_type}) are not considered iterable."""
-                                      .format(string_type=str.__name__,
-                                              text_type=text_type.__name__)):
+    with self.assertRaisesWithMessage(TypeCheckError, dedent("""\
+        type check error in class StringCollectionField: error(s) type checking constructor arguments:
+        field 'hello_strings' was invalid: in wrapped constraint TypedCollection(Exactly({string_type})): value {u}'xxx' (with type '{input_string_type}') must satisfy this type constraint: SubclassesOf(Iterable).
+        Note that objects matching {exclude_constraint} are not considered iterable.""")
+                                      .format(string_type=text_type.__name__,
+                                              u='u' if PY2 else '',
+                                              input_string_type=type('xxx').__name__,
+                                              exclude_constraint=_string_type_constraint)):
       StringCollectionField(hello_strings='xxx')
 
 
@@ -616,7 +620,7 @@ class TypedDatatypeTest(TestBase):
       SomeTypedDatatype(3, 4)
 
     expected_msg = (
-      """type check error in class CamelCaseWrapper: errors type checking constructor arguments:
+      """type check error in class CamelCaseWrapper: error(s) type checking constructor arguments:
 field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(NonNegativeInt).""")
     with self.assertRaisesWithMessage(TypedDatatypeInstanceConstructionError,
                                                 expected_msg):
@@ -637,28 +641,28 @@ field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type
 
     # single type checking failure
     expected_msg = (
-      """type check error in class SomeTypedDatatype: errors type checking constructor arguments:
+      """type check error in class SomeTypedDatatype: error(s) type checking constructor arguments:
 field 'val' was invalid: value [] (with type 'list') must satisfy this type constraint: Exactly(int).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       SomeTypedDatatype([])
 
     # type checking failure with multiple arguments (one is correct)
     expected_msg = format_string_type_check_message(
-      """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
+      """type check error in class AnotherTypedDatatype: error(s) type checking constructor arguments:
 field 'elements' was invalid: value {u}'should be list' (with type '{str_type}') must satisfy this type constraint: Exactly(list).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       AnotherTypedDatatype(text_type('correct'), text_type('should be list'))
 
     # type checking failure on both arguments
     expected_msg = format_string_type_check_message(
-        """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
+        """type check error in class AnotherTypedDatatype: error(s) type checking constructor arguments:
 field 'string' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly({str_type}).
 field 'elements' was invalid: value {u}'should be list' (with type '{str_type}') must satisfy this type constraint: Exactly(list).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       AnotherTypedDatatype(3, text_type('should be list'))
 
     expected_msg = format_string_type_check_message(
-        """type check error in class NonNegativeInt: errors type checking constructor arguments:
+        """type check error in class NonNegativeInt: error(s) type checking constructor arguments:
 field 'an_int' was invalid: value {u}'asdf' (with type '{str_type}') must satisfy this type constraint: Exactly(int).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       NonNegativeInt(text_type('asdf'))
@@ -668,20 +672,20 @@ field 'an_int' was invalid: value {u}'asdf' (with type '{str_type}') must satisf
       NonNegativeInt(-3)
 
     expected_msg = (
-      """type check error in class WithSubclassTypeConstraint: errors type checking constructor arguments:
+      """type check error in class WithSubclassTypeConstraint: error(s) type checking constructor arguments:
 field 'some_value' was invalid: value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(SomeBaseClass).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       WithSubclassTypeConstraint(3)
 
     expected_msg = """\
-type check error in class WithCollectionTypeConstraint: errors type checking constructor arguments:
+type check error in class WithCollectionTypeConstraint: error(s) type checking constructor arguments:
 field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)): value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(Iterable).
-Note that objects matching SubclassesOf(str) are not considered iterable."""
+Note that objects matching {} are not considered iterable.""".format(_string_type_constraint)
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       WithCollectionTypeConstraint(3)
 
     expected_msg = format_string_type_check_message("""\
-type check error in class WithCollectionTypeConstraint: errors type checking constructor arguments:
+type check error in class WithCollectionTypeConstraint: error(s) type checking constructor arguments:
 field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'asdf']: value {u}'asdf' (with type '{str_type}') must satisfy this type constraint: Exactly(int).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       WithCollectionTypeConstraint([3, "asdf"])
@@ -703,7 +707,7 @@ field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(
       obj.copy(nonexistent_field=3)
 
     expected_msg = (
-      """type check error in class AnotherTypedDatatype: errors type checking constructor arguments:
+      """type check error in class AnotherTypedDatatype: error(s) type checking constructor arguments:
 field 'elements' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(list).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       obj.copy(elements=3)


### PR DESCRIPTION
### Problem

Python considers strings to be iterables of substrings, each containing a single character. Currently, `TypedCollection(Exactly(text_type))` will accept not just collections of strings, but also just a single string, which is split into substrings.

### Solution

- Check for any string objects provided as input to a `TypedCollection()` field and avoid categorizing them as collections.
- Use `TypedCollection()` fields for `ExecuteProcessRequest`!

### Result

`TypedCollection(Exactly(text_type))` doesn't allow the user to accidentally input a single string!