### PR TITLE
avoid running a clean-all before integration tests, which are invoked in a new buildroot

### DIFF
--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -183,10 +183,6 @@ class PantsRunIntegrationTest(unittest.TestCase):
         # Ensure that the underlying ./pants invocation doesn't run from sources
         # (and therefore bootstrap) if we don't want it to.
         'RUN_PANTS_FROM_PEX',
-        # This tells the ./pants runner script to avoid trying to clean the workspace when changing
-        # python versions. CI starts off without the .python-interpreter-constraints file, so it
-        # would otherwise run a clean-all without this env var.
-        'ONLY_USING_SINGLE_PYTHON_VERSION',
       ]
 
   def setUp(self):
@@ -325,6 +321,11 @@ class PantsRunIntegrationTest(unittest.TestCase):
       env = os.environ.copy()
     if extra_env:
       env.update(extra_env)
+
+    # This tells the ./pants runner script to avoid trying to clean the workspace when changing
+    # python versions. Since integration tests are run in a new buildroot, we don't need to do the
+    # clean-all.
+    env['ONLY_USING_SINGLE_PYTHON_VERSION'] = 'true'
 
     # Don't overwrite the profile of this process in the called process.
     # Instead, write the profile into a sibling file.


### PR DESCRIPTION
### Problem

Running the below command results in a `clean-all` being run before the integration test:
```
> ./pants2 test tests/python/pants_test/backend/python/tasks:: -- -s -k test_platform_defaults_to_config
...
10:32:53 00:06     [pytest]
                   Invalidated 21 targets.
                   scrubbed PYTHONPATH=/Users/dmcclanahan/tools/pants/src/python: from py.test environment
10:32:53 00:06       [run]
                     ============== test session starts ===============
                     platform darwin -- Python 2.7.10, pytest-3.6.4, py-1.7.0, pluggy-0.7.1
                     rootdir: /Users/dmcclanahan/tools/pants/.pants.d, inifile: /Users/dmcclanahan/tools/pants/.pants.d/test/pytest-prep/CPython-2.7.10/718d17b455ce5917535680e933c8a655f6334861/pytest.ini
                     plugins: timeout-1.2.1, cov-2.4.0
                     collected 142 items / 141 deselected

                     tests/python/pants_test/backend/python/tasks/test_python_binary_integration.py .python-interpreter-constraints not found in the buildroot.
                     Forcing an initial clean-all.
                     Different interpreter constraints were set than were used in the previous Pants run.
                     Clearing the cache and preparing a Python environment with these interpreter constraints:
                     ['CPython>=2.7,<3','CPython>=3.6,<4']
...
```
This is an artifact of the changes for #7151, which tries to be safe and clean-all if the `.python-interpreter-constraints` file doesn't exist to ensure subprocesses are invoked with the right python version. But we don't need to do this for integration tests, since they're invoked in a new buildroot.

### Solution

- Add `ONLY_USING_SINGLE_PYTHON_VERSION=true` to the env in all integration tests.

### Result

Pants will no longer run a clean-all before integration tests in a new buildroot.