### PR TITLE
Fuse hydrated and unhydrated Struct parsing

### DIFF
--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -20,7 +20,7 @@ from pants.engine.addressable import AddressableDescriptor, BuildFileAddresses
 from pants.engine.fs import Digest, FilesContent, PathGlobs, Snapshot
 from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper, ResolveError
 from pants.engine.objects import Locatable, SerializableFactory, Validatable
-from pants.engine.parser import TargetAdaptorContainer
+from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
 from pants.engine.struct import Struct
@@ -76,7 +76,7 @@ def _raise_did_you_mean(address_family, name, source=None):
     raise resolve_error
 
 
-@rule(TargetAdaptorContainer, [AddressMapper, Address])
+@rule(HydratedStruct, [AddressMapper, Address])
 def hydrate_struct(address_mapper, address):
   """Given an AddressMapper and an Address, resolve a Struct from a BUILD file.
 
@@ -119,7 +119,7 @@ def hydrate_struct(address_mapper, address):
   collect_inline_dependencies(struct)
 
   # And then hydrate the inline dependencies.
-  dependencies = yield [Get(TargetAdaptorContainer, Address, a) for a in inline_dependencies]
+  dependencies = yield [Get(HydratedStruct, Address, a) for a in inline_dependencies]
   dependencies = [d.value for d in dependencies]
 
   def maybe_consume(outer_key, value):
@@ -159,7 +159,7 @@ def hydrate_struct(address_mapper, address):
         hydrated_args[key] = maybe_consume(key, value)
     return _hydrate(type(item), address.spec_path, **hydrated_args)
 
-  yield TargetAdaptorContainer(consume_dependencies(struct, args={'address': address}))
+  yield HydratedStruct(consume_dependencies(struct, args={'address': address}))
 
 
 def _hydrate(item_type, spec_path, **kwargs):

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -90,6 +90,8 @@ def hydrate_struct(address_mapper, address):
   addresses = address_family.addressables
   if not struct or address not in addresses:
     _raise_did_you_mean(address_family, address.target_name)
+  # TODO: This is effectively: "get the BuildFileAddress for this Address".
+  #  see https://github.com/pantsbuild/pants/issues/6657
   address = next(build_address for build_address in addresses if build_address == address)
 
   inline_dependencies = []
@@ -119,8 +121,8 @@ def hydrate_struct(address_mapper, address):
   collect_inline_dependencies(struct)
 
   # And then hydrate the inline dependencies.
-  dependencies = yield [Get(HydratedStruct, Address, a) for a in inline_dependencies]
-  dependencies = [d.value for d in dependencies]
+  hydrated_inline_dependencies = yield [Get(HydratedStruct, Address, a) for a in inline_dependencies]
+  dependencies = [d.value for d in hydrated_inline_dependencies]
 
   def maybe_consume(outer_key, value):
     if isinstance(value, six.string_types):

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -29,7 +29,7 @@ from pants.engine.legacy.structs import (BundleAdaptor, BundlesField, Hydrateabl
                                          SourcesField, TargetAdaptor)
 from pants.engine.mapper import AddressMapper
 from pants.engine.objects import Collection
-from pants.engine.parser import TargetAdaptorContainer
+from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -439,7 +439,7 @@ def find_owners(build_configuration, address_mapper, owners_request):
   else:
     # Otherwise: find dependees.
     all_addresses = yield Get(BuildFileAddresses, Specs((DescendantAddresses(''),)))
-    all_structs = yield [Get(TargetAdaptorContainer, Address, a.to_address()) for a in all_addresses]
+    all_structs = yield [Get(HydratedStruct, Address, a.to_address()) for a in all_addresses]
     all_structs = [s.value for s in all_structs]
 
     bfa = build_configuration.registered_aliases()
@@ -496,9 +496,9 @@ class HydratedField(datatype(['name', 'value'])):
   """A wrapper for a fully constructed replacement kwarg for a HydratedTarget."""
 
 
-@rule(HydratedTarget, [TargetAdaptorContainer])
-def hydrate_target(target_adaptor_container):
-  target_adaptor = target_adaptor_container.value
+@rule(HydratedTarget, [HydratedStruct])
+def hydrate_target(hydrated_struct):
+  target_adaptor = hydrated_struct.value
   """Construct a HydratedTarget from a TargetAdaptor and hydrated versions of its adapted fields."""
   # Hydrate the fields of the adaptor and re-construct it.
   hydrated_fields = yield [Get(HydratedField, HydrateableField, fa)

--- a/src/python/pants/engine/parser.py
+++ b/src/python/pants/engine/parser.py
@@ -20,10 +20,10 @@ class SymbolTable(datatype([
   """A symbol table dict mapping symbol name to implementation class."""
 
 
-class TargetAdaptorContainer(datatype(["value"])):
-  """A wrapper around a concrete TargetAdaptor subclass.
+class HydratedStruct(datatype(['value'])):
+  """A wrapper around a Struct subclass post hydration.
 
-  This exists so that the rule graph can statically provide a TargetAdaptor for a target, and rules can depend on this
+  This exists so that the rule graph can statically provide a struct for a target, and rules can depend on this
   without needing to depend on having a concrete instance of SymbolTable to register their input selectors.
   """
 

--- a/tests/python/pants_test/engine/examples/mapper_test/a/b/b.BUILD.json
+++ b/tests/python/pants_test/engine/examples/mapper_test/a/b/b.BUILD.json
@@ -1,9 +1,9 @@
 {
   "type_alias": "target",
   "name": "b",
-  "dependencies": ["//d:e"],
+  "dependencies": ["//a/d/e"],
   "configurations": [
-    "//a",
+    "//a/d/e",
     {
       "embedded": "yes"
     }

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -18,7 +18,7 @@ from pants.engine.fs import Digest, FileContent, FilesContent, PathGlobs, Snapsh
 from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.mapper import AddressFamily, AddressMapper, ResolveError
 from pants.engine.nodes import Return, Throw
-from pants.engine.parser import SymbolTable, TargetAdaptorContainer
+from pants.engine.parser import HydratedStruct, SymbolTable
 from pants.engine.rules import rule
 from pants.engine.struct import Struct, StructWithDeps
 from pants.util.objects import Exactly
@@ -198,7 +198,7 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
 
   def _populate(self, scheduler, address):
     """Perform an ExecutionRequest to parse the given Address into a Struct."""
-    request = scheduler.execution_request([TargetAdaptorContainer], [address])
+    request = scheduler.execution_request([HydratedStruct], [address])
     returns, throws = scheduler.execute(request)
     if returns:
       state = returns[0][1]

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -18,7 +18,7 @@ from pants.engine.fs import create_fs_rules
 from pants.engine.mapper import (AddressFamily, AddressMap, AddressMapper, DifferingFamiliesError,
                                  DuplicateNameError, UnaddressableObjectError)
 from pants.engine.objects import Collection
-from pants.engine.parser import SymbolTable, TargetAdaptorContainer
+from pants.engine.parser import HydratedStruct, SymbolTable
 from pants.engine.rules import rule
 from pants.engine.selectors import Get
 from pants.engine.struct import Struct
@@ -130,13 +130,13 @@ class AddressFamilyTest(unittest.TestCase):
                                        {'one': Thing(name='one', age=37)})])
 
 
-TargetAdaptorContainers = Collection.of(TargetAdaptorContainer)
+HydratedStructs = Collection.of(HydratedStruct)
 
 
-@rule(TargetAdaptorContainers, [BuildFileAddresses])
+@rule(HydratedStructs, [BuildFileAddresses])
 def unhydrated_structs(build_file_addresses):
-  tacs = yield [Get(TargetAdaptorContainer, Address, a) for a in build_file_addresses.addresses]
-  yield TargetAdaptorContainers(tacs)
+  tacs = yield [Get(HydratedStruct, Address, a) for a in build_file_addresses.addresses]
+  yield HydratedStructs(tacs)
 
 
 class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
@@ -161,7 +161,7 @@ class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
                              type_alias='target')
 
   def resolve(self, spec):
-    tacs, = self.scheduler.product_request(TargetAdaptorContainers, [Specs(tuple([spec]))])
+    tacs, = self.scheduler.product_request(HydratedStructs, [Specs(tuple([spec]))])
     return [tac.value for tac in tacs]
 
   def test_no_address_no_family(self):


### PR DESCRIPTION
### Problem

As described in #4535, there are a bunch of different layers to our BUILD file parsing currently, mostly because we were working up from a set of powerful experiments that @jsirois started, and down from the existing (legacy) `BuildGraph` model.

Now that `@union` and `union_rule` are in place, it's almost time to take a holistic look at what our target API should look like. Before doing that, we can remove at least one of the parsing layers to simplify things a bit.

### Solution

Merge the first two layers described in #4535 (`UnhydratedStruct` and `HydratedStruct` (nee `TargetAdaptorContainer`)) into `HydratedStruct`. This removes one datatype and one rule, and prunes some implementation-specific test code.

### Result

Fewer rules/nodes, one less concept, and slightly simpler code.