### PR TITLE
allow all string (not binary!) types for ExecuteProcessRequest args

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -537,7 +537,7 @@ class IvyModuleRef(object):
   def __eq__(self, other):
     return isinstance(other, IvyModuleRef) and self._id == other._id
 
-  # TODO(python3port): Return NotImplemented if other does not have attributes
+  # TODO(#6071): Return NotImplemented if other does not have attributes
   def __lt__(self, other):
     # We can't just re-use __repr__ or __str_ because we want to order rev last
     return ((self.org, self.name, self.classifier or '', self.ext, self.rev) <

--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -222,7 +222,7 @@ class JvmPlatformSettings(object):
   def __eq__(self, other):
     return tuple(self) == tuple(other)
 
-  # TODO(python3port): decide if this should raise NotImplemented on invalid comparisons
+  # TODO(#6071): decide if this should raise NotImplemented on invalid comparisons
   def __lt__(self, other):
     return tuple(self) < tuple(other)
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -543,9 +543,12 @@ class RscCompile(ZincCompile):
     tool_classpath_abs = self.tool_classpath(tool_name)
     tool_classpath = fast_relpath_collection(tool_classpath_abs)
 
+    # TODO(python3port): Our ExecuteProcessRequest expects a specific string type for arguments,
+    # which py2 doesn't default to. This can be removed when we drop python 2.
+    str_jvm_options = [text_type(opt) for opt in self.get_options().jvm_options]
     cmd = [
             distribution.java,
-          ] + self.get_options().jvm_options + [
+          ] + str_jvm_options + [
             '-cp', os.pathsep.join(tool_classpath),
             main,
           ] + args

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -543,7 +543,7 @@ class RscCompile(ZincCompile):
     tool_classpath_abs = self.tool_classpath(tool_name)
     tool_classpath = fast_relpath_collection(tool_classpath_abs)
 
-    # TODO(python3port): Our ExecuteProcessRequest expects a specific string type for arguments,
+    # TODO(#6071): Our ExecuteProcessRequest expects a specific string type for arguments,
     # which py2 doesn't default to. This can be removed when we drop python 2.
     str_jvm_options = [text_type(opt) for opt in self.get_options().jvm_options]
     cmd = [

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -449,6 +449,9 @@ class BaseZincCompile(JvmCompile):
       '-cp', zinc_relpath,
       Zinc.ZINC_COMPILE_MAIN
     ] + zinc_args
+    # TODO(python3port): Our ExecuteProcessRequest expects a specific string type for arguments,
+    # which py2 doesn't default to. This can be removed when we drop python 2.
+    argv = [text_type(arg) for arg in argv]
 
     req = ExecuteProcessRequest(
       argv=tuple(argv),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -449,7 +449,7 @@ class BaseZincCompile(JvmCompile):
       '-cp', zinc_relpath,
       Zinc.ZINC_COMPILE_MAIN
     ] + zinc_args
-    # TODO(python3port): Our ExecuteProcessRequest expects a specific string type for arguments,
+    # TODO(#6071): Our ExecuteProcessRequest expects a specific string type for arguments,
     # which py2 doesn't default to. This can be removed when we drop python 2.
     argv = [text_type(arg) for arg in argv]
 

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -58,7 +58,7 @@ def run_python_test(transitive_hydrated_target, pytest):
         all_requirements.append(str(py_req.requirement))
 
   # TODO: This should be configurable, both with interpreter constraints, and for remote execution.
-  python_binary = sys.executable
+  python_binary = str(sys.executable)
 
   # TODO: This is non-hermetic because the requirements will be resolved on the fly by
   # pex27, where it should be hermetically provided in some way.

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -60,6 +60,7 @@ def run_python_test(transitive_hydrated_target, pytest):
         all_requirements.append(str(py_req.requirement))
 
   # TODO: This should be configurable, both with interpreter constraints, and for remote execution.
+  # TODO(#7061): This str() can be removed after we drop py2!
   python_binary = str(sys.executable)
 
   # TODO: This is non-hermetic because the requirements will be resolved on the fly by
@@ -67,15 +68,18 @@ def run_python_test(transitive_hydrated_target, pytest):
   output_pytest_requirements_pex_filename = 'pytest-with-requirements.pex'
   requirements_pex_argv = [
     './{}'.format(pex_snapshot.files[0]),
+    # TODO(#7061): This text_type() can be removed after we drop py2!
     '--python', text_type(python_binary),
     '-e', 'pytest:main',
     '-o', output_pytest_requirements_pex_filename,
     # Sort all user requirement strings to increase the chance of cache hits across invocations.
-  ] + list(
-    text_type(req) for req in sorted(
-      list(pytest.get_requirement_strings())
-      + list(all_requirements))
-  )
+  ] + [
+    # TODO(#7061): This text_type() wrapping can be removed after we drop py2!
+    text_type(req)
+    for req in sorted(
+        list(pytest.get_requirement_strings())
+        + list(all_requirements))
+  ]
   requirements_pex_request = ExecuteProcessRequest(
     argv=tuple(requirements_pex_argv),
     input_files=pex_snapshot.directory_digest,

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -8,6 +8,8 @@ import os.path
 import sys
 from builtins import str
 
+from future.utils import text_type
+
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.engine.fs import Digest, MergedDirectories, Snapshot, UrlToFetch
 from pants.engine.isolated_process import (ExecuteProcessRequest, ExecuteProcessResult,
@@ -65,11 +67,15 @@ def run_python_test(transitive_hydrated_target, pytest):
   output_pytest_requirements_pex_filename = 'pytest-with-requirements.pex'
   requirements_pex_argv = [
     './{}'.format(pex_snapshot.files[0]),
-    '--python', python_binary,
+    '--python', text_type(python_binary),
     '-e', 'pytest:main',
     '-o', output_pytest_requirements_pex_filename,
     # Sort all user requirement strings to increase the chance of cache hits across invocations.
-  ] + list(pytest.get_requirement_strings()) + sorted(all_requirements)
+  ] + list(
+    text_type(req) for req in sorted(
+      list(pytest.get_requirement_strings())
+      + list(all_requirements))
+  )
   requirements_pex_request = ExecuteProcessRequest(
     argv=tuple(requirements_pex_argv),
     input_files=pex_snapshot.directory_digest,

--- a/src/python/pants/base/revision.py
+++ b/src/python/pants/base/revision.py
@@ -110,13 +110,13 @@ class Revision(object):
 
   def __eq__(self, other):
     if not self._is_valid_operand(other):
-      return False  # TODO(python3port): typically this should return NotImplemented.
+      return False  # TODO(#6071): typically this should return NotImplemented.
                     # Returning False for now to avoid changing prior API.
     return tuple(self._components) == tuple(other._components)
 
   def __lt__(self, other):
     if not self._is_valid_operand(other):
-      return AttributeError  # TODO(python3port): typically this should return NotImplemented.
+      return AttributeError  # TODO(#6071): typically this should return NotImplemented.
                              # Returning AttributeError for now to avoid changing prior API.
     for ours, theirs in zip_longest(self._components, other._components, fillvalue=None):
       if ours != theirs:

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -6,11 +6,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 
-from future.utils import binary_type, text_type
+from future.utils import binary_type
 
 from pants.engine.fs import Digest
 from pants.engine.rules import RootRule, rule
-from pants.util.objects import Exactly, SubclassesOf, TypedCollection, datatype
+from pants.util.objects import Exactly, datatype, string_list, string_optional, string_type
 
 
 logger = logging.getLogger(__name__)
@@ -18,21 +18,16 @@ logger = logging.getLogger(__name__)
 _default_timeout_seconds = 15 * 60
 
 
-_string_type = SubclassesOf(text_type)
-_string_list = TypedCollection(_string_type)
-_string_optional = SubclassesOf(text_type, type(None))
-
-
 class ExecuteProcessRequest(datatype([
-  ('argv', _string_list),
+  ('argv', string_list),
   ('input_files', Digest),
-  ('description', _string_type),
-  ('env', _string_list),
-  ('output_files', _string_list),
-  ('output_directories', _string_list),
+  ('description', string_type),
+  ('env', string_list),
+  ('output_files', string_list),
+  ('output_directories', string_list),
   # NB: timeout_seconds covers the whole remote operation including queuing and setup.
   ('timeout_seconds', Exactly(float, int)),
-  ('jdk_home', _string_optional),
+  ('jdk_home', string_optional),
 ])):
   """Request for execution with args and snapshots to extract."""
 

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -10,7 +10,7 @@ from future.utils import binary_type, text_type
 
 from pants.engine.fs import Digest
 from pants.engine.rules import RootRule, rule
-from pants.util.objects import Exactly, TypedCollection, datatype
+from pants.util.objects import Exactly, SubclassesOf, TypedCollection, datatype
 
 
 logger = logging.getLogger(__name__)
@@ -18,16 +18,21 @@ logger = logging.getLogger(__name__)
 _default_timeout_seconds = 15 * 60
 
 
+_string_type = SubclassesOf(text_type)
+_string_list = TypedCollection(_string_type)
+_string_optional = SubclassesOf(text_type, type(None))
+
+
 class ExecuteProcessRequest(datatype([
-  ('argv', TypedCollection(Exactly(text_type))),
+  ('argv', _string_list),
   ('input_files', Digest),
-  ('description', text_type),
-  ('env', TypedCollection(Exactly(text_type))),
-  ('output_files', TypedCollection(Exactly(text_type))),
-  ('output_directories', TypedCollection(Exactly(text_type))),
+  ('description', _string_type),
+  ('env', _string_list),
+  ('output_files', _string_list),
+  ('output_directories', _string_list),
   # NB: timeout_seconds covers the whole remote operation including queuing and setup.
   ('timeout_seconds', Exactly(float, int)),
-  ('jdk_home', Exactly(text_type, type(None))),
+  ('jdk_home', _string_optional),
 ])):
   """Request for execution with args and snapshots to extract."""
 

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -97,7 +97,7 @@ class HelpInfoExtracter(object):
       if typ == dict:
         metavar = '"{\'key1\':val1,\'key2\':val2,...}"'
       else:
-        type_name = typ.__name__ if typ != newstr else 'str'  # TODO(python3port): drop special case once Py2 removed
+        type_name = typ.__name__ if typ != newstr else 'str'  # TODO(#6071): drop special case once Py2 removed
         metavar = '<{}>'.format(type_name)
 
     return metavar

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -306,7 +306,7 @@ def open_tar(path_or_file, *args, **kwargs):
     If path_or_file is a file, caller must close it separately.
   """
   (path, fileobj) = ((path_or_file, None) if isinstance(path_or_file, string_types)
-                     else (None, path_or_file))  # TODO(python3port): stop using six.string_types
+                     else (None, path_or_file))  # TODO(#6071): stop using six.string_types
                                                  # This should only accept python3 `str`, not byte strings.
   with closing(TarFile.open(path, *args, fileobj=fileobj, **kwargs)) as tar:
     yield tar

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -585,3 +585,9 @@ class TypedCollection(TypeConstraint):
     return ('{type_constraint_type}({constraint!r})'
             .format(type_constraint_type=type(self).__name__,
                     constraint=self._constraint))
+
+
+# TODO(#6742): Useful type constraints for datatype fields before we start using mypy type hints!
+string_type = Exactly(text_type)
+string_list = TypedCollection(string_type)
+string_optional = Exactly(text_type, type(None))

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -282,7 +282,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
 
     if config:
       config_data = config.copy()
-      # TODO(python3port): RawConfigParser is legacy. Investigate updating to modern API.
+      # TODO(#6071): RawConfigParser is legacy. Investigate updating to modern API.
       ini = configparser.RawConfigParser(defaults=config_data.pop('DEFAULT', None))
       for section, section_config in config_data.items():
         ini.add_section(section)

--- a/tests/python/pants_test/rules/test_test_integration.py
+++ b/tests/python/pants_test/rules/test_test_integration.py
@@ -81,7 +81,6 @@ testprojects/tests/python/pants/dummies:passing_target                          
     )
 
   def test_failing_python_test(self):
-    self.maxDiff = None
     pants_run = self.run_failing_pants_test([
       'testprojects/tests/python/pants/dummies:failing_target',
     ])

--- a/tests/python/pants_test/rules/test_test_integration.py
+++ b/tests/python/pants_test/rules/test_test_integration.py
@@ -81,6 +81,7 @@ testprojects/tests/python/pants/dummies:passing_target                          
     )
 
   def test_failing_python_test(self):
+    self.maxDiff = None
     pants_run = self.run_failing_pants_test([
       'testprojects/tests/python/pants/dummies:failing_target',
     ])


### PR DESCRIPTION
### Problem

#7521 introduced `TypedCollection` for `ExecuteProcessRequest` arguments, and the added type strictness exposed a place where we weren't explicitly converting a binary string to a text string, failing the cron job's python 2.7 shard: https://travis-ci.org/pantsbuild/pants/jobs/518207912.

### Solution

- Use `SubclassesOf(text_type)` instead of `Exactly(text_type)` to accept any string arguments (fixing the error in `rsc_compile.py` in the noted cron job).
- Explicitly convert the python executable path in the v2 pytest runner into a string.

### Result

The cron job passes again, and people can put in whatever string type they like to ExecuteProcessRequest, as long as it's a text string.