### PR TITLE
improve `--pantsd-invalidation-globs` using fingerprint

### DIFF
--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -92,7 +92,7 @@ class SchedulerService(PantsService):
 
   def _maybe_invalidate_scheduler_batch(self):
     new_snapshot = self._get_snapshot()
-    if new_snapshot is not None and self._invalidating_snapshot is not None and \
+    if self._invalidating_snapshot and \
       new_snapshot.directory_digest != self._invalidating_snapshot.directory_digest:
       self._logger.fatal(
         'saw file events covered by invalidation globs [{}], terminating the daemon.'

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -65,13 +65,9 @@ class SchedulerService(PantsService):
     self._loop_condition = LoopCondition()
 
   def _get_snapshot(self):
-    """Returns a Snapshot of the input globs(the self._invalidation_globs)"""
+    """Returns a Snapshot of the input globs"""
     return self._scheduler_session.product_request(
       Snapshot, subjects=[PathGlobs(self._invalidation_globs)])[0]
-
-  def _get_files(self, snapshots):
-    """Returns a set of the files corresponding to the list of input snapshots"""
-    return snapshots.files
 
   def setup(self, services):
     """Service setup."""
@@ -83,7 +79,7 @@ class SchedulerService(PantsService):
     # that exist at startup are the only ones that can affect the running daemon.
     if self._invalidation_globs:
       self._invalidating_snapshot = self._get_snapshot()
-      self._invalidating_files = self._get_files(self._invalidating_snapshot)
+      self._invalidating_files = self._invalidating_snapshot.files
       self._logger.info('watching invalidating files: {}'.format(self._invalidating_files))
 
     if self._pantsd_pidfile:

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -85,7 +85,11 @@ class SchedulerService(PantsService):
     # N.B. We compute the invalidating fileset eagerly at launch with an assumption that files
     # that exist at startup are the only ones that can affect the running daemon.
     if self._invalidation_globs:
-      for glob in self._invalidation_globs:
+      invalidating_files = self._combined_invalidating_fileset_from_globs(
+        self._invalidation_globs,
+        self._build_root
+      )
+      for glob in invalidating_files:
         self._snapshot_by_glob[glob] = self._get_snapshot([glob])
       self._invalidating_files = self._get_files(self._snapshot_by_glob.values())
       self._logger.info('watching invalidating files: {}'.format(self._invalidating_files))
@@ -145,7 +149,7 @@ class SchedulerService(PantsService):
       self._loop_condition.notify_all()
 
   def _process_event_queue(self):
-    """File event notification queue processor."""
+    """File event notification queue processor. """
     try:
       event = self._event_queue.get(timeout=0.05)
     except queue.Empty:

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -12,7 +12,6 @@ import threading
 from builtins import open
 
 from future.utils import PY3
-from twitter.common.dirutil import Fileset
 
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.init.target_roots_calculator import TargetRootsCalculator
@@ -93,7 +92,8 @@ class SchedulerService(PantsService):
 
   def _maybe_invalidate_scheduler_batch(self):
     new_snapshot = self._get_snapshot()
-    if new_snapshot.directory_digest != self._invalidating_snapshot.directory_digest:
+    if new_snapshot is not None and self._invalidating_snapshot is not None and \
+      new_snapshot.directory_digest != self._invalidating_snapshot.directory_digest:
       self._logger.fatal(
         'saw file events covered by invalidation globs [{}], terminating the daemon.'
           .format(self._invalidating_files))

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -94,7 +94,10 @@ class SchedulerService(PantsService):
         self._invalidation_globs,
         self._build_root
       )
+      print('*'*10)
+      print(self._invalidating_files)
       self._invalidating_files_snapshot = self._get_invalidation_globs_snapsots()
+      print(self._invalidating_files_snapshot)
     self._logger.info('watching invalidating files: {}'.format(self._invalidating_files))
 
     if self._pantsd_pidfile:

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -14,7 +14,7 @@ import time
 from builtins import open, range, zip
 
 from pants.util.contextutil import environment_as, temporary_dir, temporary_file
-from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, touch, safe_delete
+from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, touch
 from pants_test.pants_run_integration_test import read_pantsd_log
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 from pants_test.testutils.process_test_util import no_lingering_process_by_command


### PR DESCRIPTION
It's a continuation of https://github.com/pantsbuild/pants/pull/7454

### Problem

Improve --pantsd-invalidation-globs implementation with actual fingerprinting. See https://github.com/pantsbuild/pants/issues/5567 for details

### Solution

Compute and save initial Snapshots keyed by globs. Re-compute Snapshots for every fs event and compare with originals.