### PR TITLE
add stack traces to unhashable TypeErrors in the engine

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -224,6 +224,9 @@ class SpecsMatcher(datatype([('tags', tuple), ('exclude_patterns', tuple)])):
     return self._target_tag_matches(target) and not self._excluded_by_pattern(address)
 
 
+# TODO: we can't yet express a type in terms of itself, because datatype field types are evaluated
+# eagerly (so we can't yet type-check the individual items of a tuple provided as the `dependencies`
+# field).
 class Specs(datatype([('dependencies', tuple), ('matcher', SpecsMatcher)])):
   """A collection of Specs representing Spec subclasses, and a SpecsMatcher to filter results."""
 

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -10,8 +10,7 @@ from future.utils import binary_type
 
 from pants.engine.fs import Digest
 from pants.engine.rules import RootRule, rule
-from pants.util.objects import (Exactly, datatype, hashable_string_list, string_optional,
-                                string_type)
+from pants.util.objects import Exactly, datatype, hashable_string_list, string_optional, string_type
 
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -10,8 +10,8 @@ from future.utils import binary_type
 
 from pants.engine.fs import Digest
 from pants.engine.rules import RootRule, rule
-from pants.util.objects import (Exactly, datatype, hashable_string_list, string_list,
-                                string_optional, string_type)
+from pants.util.objects import (Exactly, datatype, hashable_string_list, string_optional,
+                                string_type)
 
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -10,7 +10,8 @@ from future.utils import binary_type
 
 from pants.engine.fs import Digest
 from pants.engine.rules import RootRule, rule
-from pants.util.objects import Exactly, datatype, string_list, string_optional, string_type
+from pants.util.objects import (Exactly, datatype, hashable_string_list, string_list,
+                                string_optional, string_type)
 
 
 logger = logging.getLogger(__name__)
@@ -19,12 +20,12 @@ _default_timeout_seconds = 15 * 60
 
 
 class ExecuteProcessRequest(datatype([
-  ('argv', string_list),
+  ('argv', hashable_string_list),
   ('input_files', Digest),
   ('description', string_type),
-  ('env', string_list),
-  ('output_files', string_list),
-  ('output_directories', string_list),
+  ('env', hashable_string_list),
+  ('output_files', hashable_string_list),
+  ('output_directories', hashable_string_list),
   # NB: timeout_seconds covers the whole remote operation including queuing and setup.
   ('timeout_seconds', Exactly(float, int)),
   ('jdk_home', string_optional),

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -545,8 +545,13 @@ class ExternContext(object):
 
   def identify(self, obj):
     """Return an Ident-shaped tuple for the given object."""
-    hash_ = hash(obj)
-    type_id = self.to_id(type(obj))
+    try:
+      hash_ = hash(obj)
+      type_id = self.to_id(type(obj))
+    except TypeError as e:
+      # datatypes and other tuple types can have a TypeError when trying to hash one of their
+      # fields, and the error message doesn't otherwise have the datatype's name in it.
+      raise TypeError("For object with type '{}', error was: {}".format(type(obj).__name__, e))
     return (hash_, TypeId(type_id))
 
   def to_id(self, typ):

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -24,7 +24,7 @@ from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import read_file, safe_mkdir, safe_mkdtemp
 from pants.util.memo import memoized_classproperty, memoized_property
 from pants.util.meta import Singleton
-from pants.util.objects import datatype
+from pants.util.objects import SubclassesOf, datatype
 
 
 logger = logging.getLogger(__name__)
@@ -250,11 +250,22 @@ class _FFISpecification(object):
       + '\n'.join(extern_decls)
       + '\n}\n')
 
-  def register_cffi_externs(self):
-    """Registers the @_extern_decl methods with our ffi instance."""
+  def register_cffi_externs(self, native):
+    """Registers the @_extern_decl methods with our ffi instance.
+
+    Also establishes an `onerror` handler for each extern method which stores any exception in the
+    `native` object so that it can be retrieved later. See
+    https://cffi.readthedocs.io/en/latest/using.html#extern-python-reference for more info.
+    """
+    native.reset_cffi_extern_method_runtime_exceptions()
+
+    def exc_handler(exc_type, exc_value, traceback):
+      error_info = native.CFFIExternMethodRuntimeErrorInfo(exc_type, exc_value, traceback)
+      native.add_cffi_extern_method_runtime_exception(error_info)
+
     for field_name, _ in self._extern_fields.items():
       bound_method = getattr(self, field_name)
-      self._ffi.def_extern()(bound_method)
+      self._ffi.def_extern(onerror=exc_handler)(bound_method)
 
   def to_py_str(self, msg_ptr, msg_len):
     return bytes(self._ffi.buffer(msg_ptr, msg_len)).decode('utf-8')
@@ -568,6 +579,36 @@ class ExternContext(object):
 class Native(Singleton):
   """Encapsulates fetching a platform specific version of the native portion of the engine."""
 
+  _errors_during_execution = None
+
+  class CFFIExternMethodRuntimeErrorInfo(datatype([
+      ('exc_type', type),
+      ('exc_value', SubclassesOf(Exception)),
+      'traceback',
+  ])):
+    """Encapsulates an exception raised when a CFFI extern is called so that it can be displayed.
+
+    When an exception is raised in the body of a CFFI extern, the `onerror` handler is used to
+    capture it, storing the exception info as an instance of `CFFIExternMethodRuntimeErrorInfo` with
+    `.add_cffi_extern_method_runtime_exception()`. The scheduler will then check whether any
+    exceptions were stored by calling `.cffi_extern_method_runtime_exceptions()` after specific
+    calls to the native library which may raise. `.reset_cffi_extern_method_runtime_exceptions()`
+    should be called after the stored exception has been handled or before it is re-raised.
+
+    Some ways that exceptions in CFFI extern methods can be handled are described in
+    https://cffi.readthedocs.io/en/latest/using.html#extern-python-reference.
+    """
+
+  def reset_cffi_extern_method_runtime_exceptions(self):
+    self._errors_during_execution = []
+
+  def cffi_extern_method_runtime_exceptions(self):
+    return self._errors_during_execution
+
+  def add_cffi_extern_method_runtime_exception(self, error_info):
+    assert isinstance(error_info, self.CFFIExternMethodRuntimeErrorInfo)
+    self._errors_during_execution.append(error_info)
+
   class BinaryLocationError(Exception): pass
 
   @memoized_property
@@ -594,7 +635,7 @@ class Native(Singleton):
   def lib(self):
     """Load and return the native engine module."""
     lib = self.ffi.dlopen(self.binary)
-    _FFISpecification(self.ffi, lib).register_cffi_externs()
+    _FFISpecification(self.ffi, lib).register_cffi_externs(self)
     return lib
 
   @memoized_property

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -545,13 +545,8 @@ class ExternContext(object):
 
   def identify(self, obj):
     """Return an Ident-shaped tuple for the given object."""
-    try:
-      hash_ = hash(obj)
-      type_id = self.to_id(type(obj))
-    except TypeError as e:
-      # datatypes and other tuple types can have a TypeError when trying to hash one of their
-      # fields, and the error message doesn't otherwise have the datatype's name in it.
-      raise TypeError("For object with type '{}', error was: {}".format(type(obj).__name__, e))
+    hash_ = hash(obj)
+    type_id = self.to_id(type(obj))
     return (hash_, TypeId(type_id))
 
   def to_id(self, typ):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -511,7 +511,7 @@ class SchedulerSession(object):
     raised_exception = None
     try:
       request = self.execution_request([product], subjects)
-    except:
+    except:                     # noqa: T803
       # If there are any exceptions during CFFI extern method calls, we want to return an error with
       # them and whatever failure results from it. This typically results from unhashable types.
       if self._scheduler._native.cffi_extern_method_runtime_exceptions():

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -7,9 +7,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import multiprocessing
 import os
+import sys
 import time
 import traceback
 from builtins import object, open, str, zip
+from textwrap import dedent
 from types import GeneratorType
 
 from pants.base.project_tree import Dir, File, Link
@@ -506,13 +508,24 @@ class SchedulerSession(object):
     :returns: A list of the requested products, with length match len(subjects).
     """
     request = None
+    raised_exception = None
     try:
       request = self.execution_request([product], subjects)
-    except Exception:
-      internal_errors = self._scheduler._native.cffi_extern_method_runtime_exceptions()
-      if not internal_errors:
+    except:
+      # If there are any exceptions during CFFI extern method calls, we want to return an error with
+      # them and whatever failure results from it. This typically results from unhashable types.
+      if self._scheduler._native.cffi_extern_method_runtime_exceptions():
+        raised_exception = sys.exc_info()[0:3]
+      else:
+        # Otherwise, this is likely an exception coming from somewhere else, and we don't want to
+        # swallow that, so re-raise.
         raise
 
+    # We still want to raise whenever there are any exceptions in any CFFI extern methods, even if
+    # that didn't lead to an exception in generating the execution request for some reason, so we
+    # check the extern exceptions list again.
+    internal_errors = self._scheduler._native.cffi_extern_method_runtime_exceptions()
+    if internal_errors:
       error_tracebacks = [
         ''.join(
           traceback.format_exception(etype=error_info.exc_type,
@@ -520,16 +533,31 @@ class SchedulerSession(object):
                                      tb=error_info.traceback))
         for error_info in internal_errors
       ]
+
+      raised_exception_message = None
+      if raised_exception:
+        exc_type, exc_value, tb = raised_exception
+        raised_exception_message = dedent("""\
+          The engine execution request raised this error, which is probably due to the errors in the
+          CFFI extern methods listed above, as CFFI externs return None upon error:
+          {}
+        """).format(''.join(traceback.format_exception(etype=exc_type, value=exc_value, tb=tb)))
+
       # Zero out the errors raised in CFFI callbacks in case this one is caught and pants doesn't
       # exit.
       self._scheduler._native.reset_cffi_extern_method_runtime_exceptions()
-      raise ExecutionError(
-        '{} raised in CFFI extern methods:\n{}'
-        .format(pluralize(len(internal_errors), 'Exception'),
-                '\n++++++++++\n'.join(formatted_tb
-                                      for formatted_tb in error_tracebacks)))
-    else:
-      returns, throws = self.execute(request)
+
+      raise ExecutionError(dedent("""\
+        {error_description} raised in CFFI extern methods:
+        {joined_tracebacks}{raised_exception_message}
+        """).format(
+          error_description=pluralize(len(internal_errors), 'Exception'),
+          joined_tracebacks='\n+++++++++\n'.join(formatted_tb for formatted_tb in error_tracebacks),
+          raised_exception_message=(
+            '\n\n{}'.format(raised_exception_message) if raised_exception_message else '')
+        ))
+
+    returns, throws = self.execute(request)
 
     # Throw handling.
     if throws:

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -588,6 +588,16 @@ class TypedCollection(TypeConstraint):
 
 
 # TODO(#6742): Useful type constraints for datatype fields before we start using mypy type hints!
+hashable_collection_constraint = Exactly(tuple)
+
+
+class HashableTypedCollection(TypedCollection):
+  _iterable_constraint = hashable_collection_constraint
+
+
 string_type = Exactly(text_type)
 string_list = TypedCollection(string_type)
 string_optional = Exactly(text_type, type(None))
+
+
+hashable_string_list = HashableTypedCollection(string_type)

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -161,10 +161,9 @@ def datatype(field_decls, superclass_name=None, **kwargs):
           except TypeError as e:
             raise TypeError("For datatype object {} (type '{}'): in field '{}': {}"
                             .format(self, type(self).__name__, field_name, e))
-          else:
-            # If the error doesn't seem to be with hashing any of the fields, just re-raise the
-            # original error.
-            raise
+        # If the error doesn't seem to be with hashing any of the fields, just re-raise the
+        # original error.
+        raise
 
     # NB: As datatype is not iterable, we need to override both __iter__ and all of the
     # namedtuple methods that expect self to be iterable.

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -14,6 +14,7 @@ from twitter.common.collections import OrderedSet
 from pants.util.collections_abc_backport import Iterable, OrderedDict, namedtuple
 from pants.util.memo import memoized_classproperty
 from pants.util.meta import AbstractClass, classproperty
+from pants.util.strutil import pluralize
 
 
 class TypeCheckError(TypeError):
@@ -122,8 +123,9 @@ def datatype(field_decls, superclass_name=None, **kwargs):
             "field '{}' was invalid: {}".format(field_name, e))
       if type_failure_msgs:
         raise cls.make_type_error(
-          'error(s) type checking constructor arguments:\n{}'
-          .format('\n'.join(type_failure_msgs)))
+          '{} type checking constructor arguments:\n{}'
+          .format(pluralize(len(type_failure_msgs), 'error'),
+                  '\n'.join(type_failure_msgs)))
 
       return this_object
 

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -202,6 +202,7 @@ python_tests(
   coverage=['pants.engine.nodes', 'pants.engine.scheduler'],
   dependencies=[
     '3rdparty/python:future',
+    '3rdparty/python:mock',
     ':util',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -5,14 +5,16 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
+import sys
 from builtins import object, str
 from contextlib import contextmanager
 from textwrap import dedent
 
-from future.utils import PY3
+import mock
 
+from pants.engine.native import Native
 from pants.engine.rules import RootRule, UnionRule, rule, union
-from pants.engine.scheduler import ExecutionError
+from pants.engine.scheduler import ExecutionError, SchedulerSession
 from pants.engine.selectors import Get, Params
 from pants.util.objects import datatype
 from pants_test.engine.util import assert_equal_with_printing, remove_locations_from_traceback
@@ -240,38 +242,72 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
 
   def test_unhashable_failure(self):
     """Test that unhashable Get(...) params result in a structured error."""
-    with assert_execution_error(self, "TypeError: unhashable type: 'list'"):
-      self.scheduler.product_request(C, [Params(TypeCheckFailWrapper(A()))])
+
+    def assert_has_cffi_extern_traceback_header(exc_str):
+      self.assertTrue(exc_str.startswith(dedent("""\
+        1 Exception raised in CFFI extern methods:
+        Traceback (most recent call last):
+        """)), "exc_str was: {}".format(exc_str))
+
+    def assert_has_end_of_cffi_extern_error_traceback(exc_str):
+      self.assertIn(dedent("""\
+        Traceback (most recent call last):
+          File LOCATION-INFO, in extern_identify
+            return c.identify(obj)
+          File LOCATION-INFO, in identify
+            hash_ = hash(obj)
+          File LOCATION-INFO, in __hash__
+            .format(self, type(self).__name__, field_name, e))
+        TypeError: For datatype object CollectionType(items=[1, 2, 3]) (type 'CollectionType'): in field 'items': unhashable type: 'list'
+        """), exc_str, "exc_str was: {}".format(exc_str))
+
+    resulting_engine_error = "Exception: No installed @rules can satisfy Select(C) for input Params(Any).\n\n\n"
 
     # Test that the error contains the full traceback from within the CFFI context as well
     # (mentioning which specific extern method ended up raising the exception).
     with self.assertRaises(ExecutionError) as cm:
       self.scheduler.product_request(C, [Params(CollectionType([1, 2, 3]))])
-
     exc_str = remove_locations_from_traceback(str(cm.exception))
     # TODO: convert these manual self.assertTrue() conditionals to a self.assertStartsWith() method
     # in TestBase!
-    self.assertTrue(exc_str.startswith(dedent("""\
-      1 Exception raised in CFFI extern methods:
-      Traceback (most recent call last):
-      """)), "exc_str was: {}".format(exc_str))
-    self.assertIn(dedent("""\
-      Traceback (most recent call last):
-        File LOCATION-INFO, in extern_identify
-          return c.identify(obj)
-        File LOCATION-INFO, in identify
-          hash_ = hash(obj)
-        File LOCATION-INFO, in __hash__
-          .format(self, type(self).__name__, field_name, e))
-      TypeError: For datatype object CollectionType(items=[1, 2, 3]) (type 'CollectionType'): in field 'items': unhashable type: 'list'
-      """), exc_str, "exc_str was: {}".format(exc_str))
+    assert_has_cffi_extern_traceback_header(exc_str)
+    assert_has_end_of_cffi_extern_error_traceback(exc_str)
     self.assertIn(dedent("""\
       The engine execution request raised this error, which is probably due to the errors in the
       CFFI extern methods listed above, as CFFI externs return None upon error:
       """), exc_str)
-    self.assertTrue(exc_str.endswith(
-      "Exception: No installed @rules can satisfy Select(C) for input Params(Any).\n\n\n"),
-                    "exc_str was: {}".format(exc_str))
+    self.assertTrue(exc_str.endswith(resulting_engine_error), "exc_str was: {}".format(exc_str))
+
+    PATCH_OPTS = dict(autospec=True, spec_set=True)
+    def create_cffi_exception():
+      try:
+        raise Exception('test cffi exception')
+      except:                   # noqa: T803
+        return Native.CFFIExternMethodRuntimeErrorInfo(*sys.exc_info()[0:3])
+
+    # Test that CFFI extern method errors result in an ExecutionError, even if .execution_request()
+    # succeeds.
+    with self.assertRaises(ExecutionError) as cm:
+      with mock.patch.object(SchedulerSession, 'execution_request',
+                             **PATCH_OPTS) as mock_exe_request:
+        with mock.patch.object(Native, 'cffi_extern_method_runtime_exceptions',
+                               **PATCH_OPTS) as mock_cffi_exceptions:
+          mock_exe_request.return_value = None
+          mock_cffi_exceptions.return_value = [create_cffi_exception()]
+          self.scheduler.product_request(C, [Params(CollectionType([1, 2, 3]))])
+    exc_str = remove_locations_from_traceback(str(cm.exception))
+    assert_has_cffi_extern_traceback_header(exc_str)
+    self.assertIn("Exception: test cffi exception", exc_str)
+    self.assertNotIn(resulting_engine_error, exc_str)
+
+    # Test that an error in the .execution_request() method is propagated directly, even if there
+    # are no CFFI extern methods.
+    class TestError(Exception): pass
+    with self.assertRaisesWithMessage(TestError, 'non-CFFI error'):
+      with mock.patch.object(SchedulerSession, 'execution_request',
+                             **PATCH_OPTS) as mock_exe_request:
+        mock_exe_request.side_effect = TestError('non-CFFI error')
+        self.scheduler.product_request(C, [Params(CollectionType([1, 2, 3]))])
 
   def test_trace_includes_rule_exception_traceback(self):
     # Execute a request that will trigger the nested raise, and then directly inspect its trace.

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -238,12 +238,11 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
 
   def test_unhashable_failure(self):
     """Test that unhashable Get(...) params result in a structured error."""
-    with assert_execution_error(self, dedent("""\
-      TypeError: For object with type 'list', error was: unhashable type: 'list'""")):
+    with assert_execution_error(self, "TypeError: unhashable type: 'list'"):
       self.scheduler.product_request(C, [Params(TypeCheckFailWrapper(A()))])
 
     with assert_execution_error(self, dedent("""\
-      TypeError: For object with type 'CollectionType', error was: unhashable type: 'list'""")):
+      TypeError: For datatype object CollectionType(items=[1, 2, 3]) (type 'CollectionType'): in field 'items': error was: unhashable type: 'list'""")):
       self.scheduler.product_request(C, [Params(CollectionType([1, 2, 3]))])
 
   def test_trace_includes_rule_exception_traceback(self):

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -13,10 +13,10 @@ from textwrap import dedent
 from future.utils import PY2, PY3, text_type
 
 from pants.util.collections_abc_backport import OrderedDict
-from pants.util.objects import (EnumVariantSelectionError, Exactly, SubclassesOf, SuperclassesOf,
-                                TypeCheckError, TypeConstraintError, TypedCollection,
-                                TypedDatatypeInstanceConstructionError, _string_type_constraint,
-                                datatype, enum)
+from pants.util.objects import (EnumVariantSelectionError, Exactly, HashableTypedCollection,
+                                SubclassesOf, SuperclassesOf, TypeCheckError, TypeConstraintError,
+                                TypedCollection, TypedDatatypeInstanceConstructionError,
+                                _string_type_constraint, datatype, enum)
 from pants_test.test_base import TestBase
 
 
@@ -225,6 +225,20 @@ class TypedCollectionTest(TypeConstraintTestBase):
                                               input_string_type=type('xxx').__name__,
                                               exclude_constraint=_string_type_constraint)):
       StringCollectionField(hello_strings='xxx')
+
+  def test_hashable_collection(self):
+    class NormalCollection(datatype(['value'])):
+      pass
+
+    with self.assertRaisesWithMessage(TypeError, "unhashable type: 'list'"):
+      hash(NormalCollection([]))
+
+    class HashableIntVector(datatype([('value', HashableTypedCollection(Exactly(int)))])):
+      pass
+
+    vec = HashableIntVector((1, 2, 3,))
+    self.assertEqual(vec.value, (1, 2, 3,))
+    self.assertIsInstance(hash(vec), int)
 
 
 class ExportedDatatype(datatype(['val'])):

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -217,7 +217,7 @@ class TypedCollectionTest(TypeConstraintTestBase):
     self.assertEqual(['xxx'], StringCollectionField(hello_strings=['xxx']).hello_strings)
 
     with self.assertRaisesWithMessage(TypeCheckError, dedent("""\
-        type check error in class StringCollectionField: error(s) type checking constructor arguments:
+        type check error in class StringCollectionField: 1 error type checking constructor arguments:
         field 'hello_strings' was invalid: in wrapped constraint TypedCollection(Exactly({string_type})): value {u}'xxx' (with type '{input_string_type}') must satisfy this type constraint: SubclassesOf(Iterable).
         Note that objects matching {exclude_constraint} are not considered iterable.""")
                                       .format(string_type=text_type.__name__,
@@ -230,7 +230,9 @@ class TypedCollectionTest(TypeConstraintTestBase):
     class NormalCollection(datatype(['value'])):
       pass
 
-    with self.assertRaisesWithMessage(TypeError, "unhashable type: 'list'"):
+    with self.assertRaisesWithMessage(
+        TypeError,
+        "For datatype object NormalCollection(value=[]) (type 'NormalCollection'): in field 'value': unhashable type: 'list'"):
       hash(NormalCollection([]))
 
     class HashableIntVector(datatype([('value', HashableTypedCollection(Exactly(int)))])):
@@ -634,7 +636,7 @@ class TypedDatatypeTest(TestBase):
       SomeTypedDatatype(3, 4)
 
     expected_msg = (
-      """type check error in class CamelCaseWrapper: error(s) type checking constructor arguments:
+      """type check error in class CamelCaseWrapper: 1 error type checking constructor arguments:
 field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(NonNegativeInt).""")
     with self.assertRaisesWithMessage(TypedDatatypeInstanceConstructionError,
                                                 expected_msg):
@@ -655,28 +657,28 @@ field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type
 
     # single type checking failure
     expected_msg = (
-      """type check error in class SomeTypedDatatype: error(s) type checking constructor arguments:
+      """type check error in class SomeTypedDatatype: 1 error type checking constructor arguments:
 field 'val' was invalid: value [] (with type 'list') must satisfy this type constraint: Exactly(int).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       SomeTypedDatatype([])
 
     # type checking failure with multiple arguments (one is correct)
     expected_msg = format_string_type_check_message(
-      """type check error in class AnotherTypedDatatype: error(s) type checking constructor arguments:
+      """type check error in class AnotherTypedDatatype: 1 error type checking constructor arguments:
 field 'elements' was invalid: value {u}'should be list' (with type '{str_type}') must satisfy this type constraint: Exactly(list).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       AnotherTypedDatatype(text_type('correct'), text_type('should be list'))
 
     # type checking failure on both arguments
     expected_msg = format_string_type_check_message(
-        """type check error in class AnotherTypedDatatype: error(s) type checking constructor arguments:
+        """type check error in class AnotherTypedDatatype: 2 errors type checking constructor arguments:
 field 'string' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly({str_type}).
 field 'elements' was invalid: value {u}'should be list' (with type '{str_type}') must satisfy this type constraint: Exactly(list).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       AnotherTypedDatatype(3, text_type('should be list'))
 
     expected_msg = format_string_type_check_message(
-        """type check error in class NonNegativeInt: error(s) type checking constructor arguments:
+        """type check error in class NonNegativeInt: 1 error type checking constructor arguments:
 field 'an_int' was invalid: value {u}'asdf' (with type '{str_type}') must satisfy this type constraint: Exactly(int).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       NonNegativeInt(text_type('asdf'))
@@ -686,20 +688,20 @@ field 'an_int' was invalid: value {u}'asdf' (with type '{str_type}') must satisf
       NonNegativeInt(-3)
 
     expected_msg = (
-      """type check error in class WithSubclassTypeConstraint: error(s) type checking constructor arguments:
+      """type check error in class WithSubclassTypeConstraint: 1 error type checking constructor arguments:
 field 'some_value' was invalid: value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(SomeBaseClass).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       WithSubclassTypeConstraint(3)
 
     expected_msg = """\
-type check error in class WithCollectionTypeConstraint: error(s) type checking constructor arguments:
+type check error in class WithCollectionTypeConstraint: 1 error type checking constructor arguments:
 field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)): value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(Iterable).
 Note that objects matching {} are not considered iterable.""".format(_string_type_constraint)
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       WithCollectionTypeConstraint(3)
 
     expected_msg = format_string_type_check_message("""\
-type check error in class WithCollectionTypeConstraint: error(s) type checking constructor arguments:
+type check error in class WithCollectionTypeConstraint: 1 error type checking constructor arguments:
 field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'asdf']: value {u}'asdf' (with type '{str_type}') must satisfy this type constraint: Exactly(int).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       WithCollectionTypeConstraint([3, "asdf"])
@@ -721,7 +723,7 @@ field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(
       obj.copy(nonexistent_field=3)
 
     expected_msg = (
-      """type check error in class AnotherTypedDatatype: error(s) type checking constructor arguments:
+      """type check error in class AnotherTypedDatatype: 1 error type checking constructor arguments:
 field 'elements' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(list).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       obj.copy(elements=3)


### PR DESCRIPTION
### Problem

- When we provide an unhashable type such as `list` to a `datatype` field of an object that goes through the v2 engine, the engine will tell you there is a TypeError, but won't tell you which object it's from.
- The unhashable type error happens late (long after the datatype is constructed) and without an appropriate stacktrace. It should be easy to declare hashable collection fields (in this case, just tuples) and have them fail early (at construction).

### Solution

- Add the name of the type of the object passed to `extern_identify()` to the `TypeError` raised if one of its fields are unhashable.
- Make a `HashableTypedCollection` type constructor.
- Capture exceptions raised in CFFI extern methods using the `onerror` handler and re-raise those with their tracebacks so the `TypeError`s are actually catchable.

### Result

Unhashable type errors for datatypes going through the engine happen less, and errors happen earlier and with more context!