### PR TITLE
Temporarily turn off cron CI run to adjust the time it starts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,8 @@ env:
 stages:
   - name: &bootstrap Bootstrap Pants
     if: type != cron
-  - name: &bootstrap_cron Bootstrap Pants (Cron)
-    if: type = cron
   - name: &test Test Pants
     if: type != cron
-  - name: &test_cron Test Pants (Cron)
-    if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -30,12 +30,8 @@ env:
 stages:
   - name: &bootstrap Bootstrap Pants
     if: type != cron
-  - name: &bootstrap_cron Bootstrap Pants (Cron)
-    if: type = cron
   - name: &test Test Pants
     if: type != cron
-  - name: &test_cron Test Pants (Cron)
-    if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable


### PR DESCRIPTION
### Problem
Right now the cron job triggers at 3 AM PST, which is 11 AM London. When it’s not daylight savings, these times are 2 AM PST and 10 AM London.

This is getting in the way of London developers using CI. We originally set this time so that US developers could program at night, but it's much more common London developers are programming in their morning / the workday, so this was the wrong thing to optimize for.

### Solution
Temporarily turn off the cron job for the next day. Then, in a followup, restore the cron run at the exact time that we want the cron job to go off in the future.

Travis does not offer fine-tuned control of when the cron job starts, per https://docs.travis-ci.com/user/cron-jobs/, so we must follow this approach.