### PR TITLE
Add extra debug logging to rpc requests

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -214,7 +214,8 @@ class BaseZincCompile(JvmCompile):
       # hermetically https://github.com/pantsbuild/pants/issues/6517
       if self.get_options().incremental:
         raise TaskError("Hermetic zinc execution does not currently support incremental compiles. "
-                        "Please use --no-compile-zinc-incremental.")
+                        "Please use --no-{}-incremental."
+                        .format(self.get_options_scope_equivalent_flag_component()))
       try:
         fast_relpath(self.get_options().pants_workdir, get_buildroot())
       except ValueError:
@@ -230,7 +231,9 @@ class BaseZincCompile(JvmCompile):
         # TODO: Make this work by capturing the correct Digest and passing them around the
         # right places.
         # See https://github.com/pantsbuild/pants/issues/6432
-        raise TaskError("Hermetic zinc execution currently doesn't work with classpath jars")
+        raise TaskError("Hermetic zinc execution currently doesn't work with classpath jars. "
+                        "Please no --no-{}-use-classpath-jars."
+                        .format(self.get_options_scope_equivalent_flag_component()))
 
   def select(self, target):
     raise NotImplementedError()

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1794,8 +1794,10 @@ name = "serverset"
 version = "0.0.1"
 dependencies = [
  "boxfuture 0.0.1",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -279,7 +279,7 @@ impl super::CommandRunner for CommandRunner {
               attempts += &format!("\nAttempt {}: {:?}", i, attempt);
             }
             debug!(
-              "Finished remote exceution of {} after {} attempts: Stats: {}",
+              "Finished remote execution of {} after {} attempts: Stats: {}",
               description2,
               resp.execution_attempts.len(),
               attempts

--- a/src/rust/engine/serverset/Cargo.toml
+++ b/src/rust/engine/serverset/Cargo.toml
@@ -7,7 +7,9 @@ publish = false
 
 [dependencies]
 boxfuture = { path = "../boxfuture" }
+chrono = "0.4"
 futures = "^0.1.16"
 # TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
 futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
+log = "0.4"
 parking_lot = "0.6"

--- a/src/rust/engine/serverset/src/lib.rs
+++ b/src/rust/engine/serverset/src/lib.rs
@@ -38,7 +38,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 mod retry;
-pub use crate::retry::Retry;
+pub use crate::retry::{Retry, RetryParameters};
 
 ///
 /// A collection of resources which are observed to be healthy or unhealthy.

--- a/src/rust/engine/serverset/src/retry.rs
+++ b/src/rust/engine/serverset/src/retry.rs
@@ -124,17 +124,17 @@ mod tests {
       BackoffConfig::new(Duration::from_millis(1), 1.0, Duration::from_millis(1)).unwrap(),
       TimerHandle::default(),
     )
-    .unwrap();
-    assert_eq!(
-      Err(format!(
-        "Failed after 5 retries for identity; last failure: bad"
-      )),
-      Retry(s)
-        .all_errors_immediately(
-          |v: Result<u8, _>| v,
-          RetryParameters::new(5, "identity".to_string())
-        )
-        .wait()
-    );
+      .unwrap();
+    let result = Retry(s)
+      .all_errors_immediately(
+        |v: Result<u8, _>| v,
+        RetryParameters::new(5, "identity".to_string())
+      )
+      .wait();
+    assert!(match result {
+      // Logs may have timestamps or other preceding information, but end with the error message.
+      Err(s) => s.ends_with("Failed after 5 retries for identity; last failure: bad"),
+      Ok(_) => false,
+    });
   }
 }


### PR DESCRIPTION
### Problem

When investigating #7422, it wasn't clear which code path was leading to the `RpcFinished(None)` response, and it wasn't clear whether the error was coming from pants or https://github.com/twitter/scoot, which implements the bazel remote execution API. Furthermore, it wasn't clear whether the `RpcFinished(None)` response was merely the error that caused the final failing retry of the rpc request, or whether every retry for the rpc request was failing the same way.

### Solution

- Add a `debug!()` to `Retry::all_errors_immediately()` every time a request fails and is retried, as well as reporting the final failure.
- Add some more context about what kind of request is being retried by requiring a metadata struct with a string `description` to be passed along with the closure to `Retry::all_errors_immediately()`.
- Add timestamps to debug logs for failed requests that go through `Retry` to more easily match up the debug logs for failed requests to logs from the remote execution backend.

### Result

It is easier to debug rpc failures by not hiding the errors from individual retries, and error messages make it more clear what connection is being attempted when it fails!