### PR TITLE
Don't run CI for *.md file changes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@
 # Conditions are documented here: https://docs.travis-ci.com/user/conditions-v1
 conditions: v1
 
+if: commit_message !~ SKIP_FULL_CI
+
 # -------------------------------------------------------------------------
 # Global setup
 # -------------------------------------------------------------------------

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -3,6 +3,8 @@
 # Conditions are documented here: https://docs.travis-ci.com/user/conditions-v1
 conditions: v1
 
+if: commit_message !~ SKIP_FULL_CI
+
 # -------------------------------------------------------------------------
 # Global setup
 # -------------------------------------------------------------------------


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/7526 adds the SKIP_FULL_CI label to the commit message of commits that only touch *.md files.

This change causes CI to skip all commits with that label. This is to encourage people to fix and update documentation without incurring the overhead and nuisance of CI.

Note that we don't even build the docsite on SKIP_FULL_CI changes, because that would still require bootstrapping pants. Such changes will still require review, and it's easy to view the rendered .md files to check for rendering errors, either locally or on github.com, so for now we err on the side of streamlining. If we notice a trend of bad doc formatting because of this, we can reconsider. 

Note also that adding new doc pages will require changes to BUILD files, and so will trigger a full CI, including docsite generation.