### PR TITLE
Restore cron CI run from #7534 to adjust the time it starts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,12 @@ env:
 stages:
   - name: &bootstrap Bootstrap Pants
     if: type != cron
+  - name: &bootstrap_cron Bootstrap Pants (Cron)
+    if: type = cron
   - name: &test Test Pants
     if: type != cron
+  - name: &test_cron Test Pants (Cron)
+    if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -30,8 +30,12 @@ env:
 stages:
   - name: &bootstrap Bootstrap Pants
     if: type != cron
+  - name: &bootstrap_cron Bootstrap Pants (Cron)
+    if: type = cron
   - name: &test Test Pants
     if: type != cron
+  - name: &test_cron Test Pants (Cron)
+    if: type = cron
   - name: &build_stable Deploy Pants Pex
     if: tag IS present AND tag =~ ^release_.*$
   - name: &build_unstable Deploy Pants Pex Unstable


### PR DESCRIPTION
We want to run the cron job at 10 PM PST during non-DST and 11 PM PST during PST, so that the cron job does not run during office hours in London.

#7534 removed the cron job from our `.travis.yml` to allow this change. It turns out that PR was not at all necessary, and instead this is all managed through Travis's UI. So, this reverts the bad change. Instead, we will kick off the cron job in Travis's UI at the exact time desired.