### PR TITLE
fix go test flags bug and add integration test

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -96,8 +96,9 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
     # Maintain the non-shlexed behavior for now to avoid breakage.
     single_string_flags = self.get_options().build_and_test_flags.split()
     return single_string_flags + [
-      safe_shlex_split(flags_section)
+      single_flag
       for flags_section in self.get_options().shlexed_build_and_test_flags
+      for single_flag in safe_shlex_split(flags_section)
     ]
 
   def _spawn(self, workunit, go_cmd, cwd):

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_test_integration.py
@@ -30,6 +30,24 @@ class GoTestIntegrationTest(PantsRunIntegrationTest):
     assertRegex(self, pants_run.stdout_data, r'contrib/go/examples/src/go/libA\s+\.+\s+SUCCESS')
     assertRegex(self, pants_run.stdout_data, r'contrib/go/examples/src/go/libB\s+\.+\s+SUCCESS')
 
+    # Assert that we do *not* contain verbose output.
+    self.assertNotIn('=== RUN   TestAdd', pants_run.stdout_data)
+    self.assertNotIn('PASS', pants_run.stdout_data)
+
+  def test_go_test_with_options(self):
+    args = [
+      'test.go', '--shlexed-build-and-test-flags=["-v"]',
+      'contrib/go/examples/src/go/libA',
+    ]
+    pants_run = self.run_pants(args)
+    self.assert_success(pants_run)
+    assertRegex(self, pants_run.stdout_data, r'ok\s+libA')
+    assertRegex(self, pants_run.stdout_data, r'ok\s+libB')
+
+    # Ensure that more verbose output is presented.
+    self.assertIn('=== RUN   TestAdd', pants_run.stdout_data)
+    self.assertIn('PASS', pants_run.stdout_data)
+
   def test_no_fast(self):
     args = ['test.go',
             '--no-fast',


### PR DESCRIPTION
### Problem

#7326 added back the ability to go test transitive deps, but also failed to test adding any options (including the new `--shlexed-build-and-test-flags`) to the command line, which ends up raising an exception.

### Solution

- Correctly flatten `--shlexed-build-and-test-flags` when creating the `go test` command line.
- Add an integration test with the use of options to avoid regressions.

### Result

Go testing doesn't fail when provided extra flags!