### PR TITLE
Don't add the CI skipping label to amended commits.

### DIFF
--- a/build-support/githooks/prepare-commit-msg
+++ b/build-support/githooks/prepare-commit-msg
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
 COMMIT_MSG_FILEPATH=$1
+COMMIT_MSG_SRC=$2
 
-NUM_NON_MD_FILES=$(git status -s --porcelain | grep -v ".\md$" | wc -l)
+# Note that xargs with no args just returns the string with surrounding whitespace trimmed.
+NUM_NON_MD_FILES=$(git status -s --porcelain | grep -v ".\md$" | wc -l | xargs)
 
-if [ ${NUM_NON_MD_FILES} == '0' ]; then
+# The msg source will be "commit" if we were called with --amend.
+if [ "${COMMIT_MSG_SRC}" != "commit" ] && [ "${NUM_NON_MD_FILES}" == "0" ]; then
 cat <<EOF >> ${COMMIT_MSG_FILEPATH}
 
 # Delete this line to force a full CI run for documentation-only changes.


### PR DESCRIPTION
For two reasons:

1) The `git status` command we use to detect the files about to be added won't see any files that weren't amended, and may reach the wrong conclusion.

2) Even if we fix 1), the user may have concluded that they want to delete that label and force a CI anyway, for whatever reason, and we don't want to keep overriding that.