### PR TITLE
Fix abi3 pex check to allow abi3 wheels.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -566,7 +566,7 @@ py36_linux_build_wheels: &py36_linux_build_wheels
     - *py36_linux_test_config_env
     - *base_build_wheels_env
     - docker_image_name=travis_ci
-    - docker_run_command="./build-support/bin/check_pants_pex_abi.py cp36m
+    - docker_run_command="./build-support/bin/check_pants_pex_abi.py abi3 cp36m
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n"
     - CACHE_NAME=linuxwheelsbuild.abi3
 
@@ -617,7 +617,7 @@ py36_osx_build_wheels: &py36_osx_build_wheels
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.abi3
   script:
-    - ./build-support/bin/check_pants_pex_abi.py cp36m
+    - ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n
 
 # -------------------------------------------------------------------------

--- a/build-support/bin/check_pants_pex_abi.py
+++ b/build-support/bin/check_pants_pex_abi.py
@@ -23,30 +23,27 @@ def main():
     die("pants.pex not found! Ensure you are in the repository root, then run " \
         "'./build-support/bin/ci.sh -b' to bootstrap pants.pex with Python 3 or " \
         "'./build-support/bin/ci.sh -2b' to bootstrap pants.pex with Python 2.")
-  expected_abi = create_parser().parse_args().abi
+  expected_abis = frozenset(create_parser().parse_args().abis)
   with zipfile.ZipFile("pants.pex", "r") as pex:
     with pex.open("PEX-INFO", "r") as pex_info:
       pex_info_content = str(pex_info.readline())
-  parsed_abis = {
+  parsed_abis = frozenset(
     parse_abi_from_filename(filename)
     for filename in json.loads(pex_info_content)["distributions"].keys()
     if parse_abi_from_filename(filename) != "none"
-  }
-  if len(parsed_abis) < 1:
-    die("No abi tag found. Expected: {}.".format(expected_abi))
-  elif len(parsed_abis) > 1:
-    die("Multiple abi tags found. Expected: {}, found: {}.".format(expected_abi, parsed_abis))
-  found_abi = list(parsed_abis)[0]
-  if found_abi != expected_abi:
-    die("pants.pex was built with the incorrect ABI. Expected: {}, found: {}.".format(expected_abi, found_abi))
-  success("Success. As expected, pants.pex was built with the ABI {}.".format(expected_abi))
+  )
+  if not parsed_abis.issubset(expected_abis):
+    die("pants.pex was built with the incorrect ABI. Expected wheels with: {}, found: {}."
+        .format(' or '.join(sorted(expected_abis)), ', '.join(sorted(parsed_abis))))
+  success("Success. The pants.pex was built with wheels carrying the expected ABIs: {}."
+          .format(', '.join(sorted(parsed_abis))))
 
 
 def create_parser():
   parser = argparse.ArgumentParser(
     description="Check that ./pants.pex was built using the passed abi specification."
   )
-  parser.add_argument("abi", help="The expected abi, e.g. `cp27m` or `abi3`")
+  parser.add_argument("abis", nargs="+", help="The expected abis, e.g. `cp27m` or `abi3 cp36m`")
   return parser
 
 

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -513,7 +513,7 @@ py36_linux_build_wheels: &py36_linux_build_wheels
     - *py36_linux_test_config_env
     - *base_build_wheels_env
     - docker_image_name=travis_ci
-    - docker_run_command="./build-support/bin/check_pants_pex_abi.py cp36m
+    - docker_run_command="./build-support/bin/check_pants_pex_abi.py abi3 cp36m
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n"
     - CACHE_NAME=linuxwheelsbuild.abi3
 
@@ -562,7 +562,7 @@ py36_osx_build_wheels: &py36_osx_build_wheels
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.abi3
   script:
-    - ./build-support/bin/check_pants_pex_abi.py cp36m
+    - ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
Even though the pex Pants uses doesn't currently resolve abi3 wheels,
newer pex does and our check should support multiple wheel abis to
support abi3 pexes going forward.
