### PR TITLE
Build pexes that work on all Python patch versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -596,13 +596,17 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs4
     - PYTHON_CONFIGURE_OPTS=--enable-unicode=ucs4
-    # We set $PY to ensure the UCS4 interpreter is used when bootstrapping the PEX.
+    # We ensure selection of the the UCS4 interpreter by the pants script and pants.pex with these
+    # env vars.
+    - PYTHON_27_VERSION_UCS4=2.7.13
     - PY=${PYENV_ROOT}/shims/python2.7
+    - PEX_PYTHON_PATH=${PYENV_ROOT}/shims/python2.7
+    - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYTHON_27_VERSION_UCS4}']"
   before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - ./build-support/bin/install_python_for_ci.sh 2.7.13 ${PYENV_PY36_VERSION}
+    - ./build-support/bin/install_python_for_ci.sh ${PYTHON_27_VERSION_UCS4} ${PYENV_PY36_VERSION}
   script:
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -122,17 +122,11 @@ else
 fi
 export PY="${PY:-python${py_major_minor}}"
 
-# Also set PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS. We set this to the exact Python version
-# to resolve any potential ambiguity when multiple Python interpreters are discoverable, such as
-# Python 2.7.10 vs. 2.7.13. When running with Python 3, we must also set this constraint to ensure
-# all spawned subprocesses use Python 3 rather than the default of Python 2. This is in part
-# necessary to avoid the _Py_Dealloc error (#6985).
-py_major_minor_patch=$(${PY} -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')
-export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS:-['CPython==${py_major_minor_patch}']}"
+export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS:-['CPython==${py_major_minor}.*']}"
 banner "Setting interpreter constraints to ${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS}"
 
 if [[ "${run_bootstrap:-false}" == "true" ]]; then
-  start_travis_section "Bootstrap" "Bootstrapping pants as a Python ${py_major_minor_patch} PEX"
+  start_travis_section "Bootstrap" "Bootstrapping pants as a Python ${py_major_minor} PEX"
   (
     if [[ "${run_bootstrap_clean:-false}" == "true" ]]; then
       ./build-support/python/clean.sh || die "Failed to clean before bootstrapping pants."

--- a/build-support/docker/travis_ci_py27_ucs2/Dockerfile
+++ b/build-support/docker/travis_ci_py27_ucs2/Dockerfile
@@ -27,8 +27,11 @@ RUN /usr/bin/scl enable devtoolset-7 -- ${PYENV_BIN} install ${PYTHON_27_VERSION
 RUN /usr/bin/scl enable devtoolset-7 -- ${PYENV_BIN} global ${PYTHON_27_VERSION_UCS2}
 ENV PATH "${PYENV_ROOT}/shims:${PATH}"
 
+# We ensure selection of the the UCS4 interpreter by the pants script and pants.pex with these
+# env vars.
 ENV PY "${PYENV_ROOT}/shims/python2.7"
 ENV PEX_PYTHON_PATH "${PYENV_ROOT}/shims/python2.7"
+ENV PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYTHON_27_VERSION_UCS2}']"
 
 # Setup mount points for the travis ci user & workdir.
 VOLUME /travis/home

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -543,11 +543,15 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs4
     - PYTHON_CONFIGURE_OPTS=--enable-unicode=ucs4
-    # We set $PY to ensure the UCS4 interpreter is used when bootstrapping the PEX.
+    # We ensure selection of the the UCS4 interpreter by the pants script and pants.pex with these
+    # env vars.
+    - PYTHON_27_VERSION_UCS4=2.7.13
     - PY=${PYENV_ROOT}/shims/python2.7
+    - PEX_PYTHON_PATH=${PYENV_ROOT}/shims/python2.7
+    - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYTHON_27_VERSION_UCS4}']"
   before_install:
     {{>before_install_osx}}
-    - ./build-support/bin/install_python_for_ci.sh 2.7.13 ${PYENV_PY36_VERSION}
+    - ./build-support/bin/install_python_for_ci.sh ${PYTHON_27_VERSION_UCS4} ${PYENV_PY36_VERSION}
   script:
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu


### PR DESCRIPTION
We want to constrain pants.pex to run on CPython 2.7 or CPython 3.6,
but no further. Fixup CI to only request a specific patch-level in the
Python interpreter used in the two spots that care.
