### PR TITLE
[WIP] pretend files which can't be accessed just don't exist when glob matching

### DIFF
--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -307,6 +307,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: VFS<E> {
           })
           .unwrap_or_else(|| vec![])
       })
+      .or_else(|_e| future::ok(vec![]))
       .and_then(move |link_globs| {
         future::result(PathGlobs::from_globs(link_globs))
           .map_err(|e| Self::mk_error(e.as_str()))

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -365,16 +365,12 @@ impl PathGlob {
       // The resulting symbolic path will continue to contain a literal `..`.
       let mut canonical_dir_parent = canonical_dir;
       let mut symbolic_path_parent = symbolic_path;
-      if !canonical_dir_parent.0.pop() {
-        let mut symbolic_path = symbolic_path_parent;
-        symbolic_path.extend(parts.iter().map(Pattern::as_str));
-        return Err(format!(
-          "Globs may not traverse outside of the buildroot: {:?}",
-          symbolic_path,
-        ));
+      if canonical_dir_parent.0.pop() {
+        symbolic_path_parent.push(Path::new(*PARENT_DIR));
+        PathGlob::parse_globs(canonical_dir_parent, symbolic_path_parent, &parts[1..])
+      } else {
+        Ok(vec![])
       }
-      symbolic_path_parent.push(Path::new(*PARENT_DIR));
-      PathGlob::parse_globs(canonical_dir_parent, symbolic_path_parent, &parts[1..])
     } else if parts.len() == 1 {
       // This is the path basename.
       Ok(vec![PathGlob::wildcard(

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -267,10 +267,12 @@ impl Snapshot {
             .iter_mut()
             .map(|directory| directory.take_files().into_iter()),
         )
-        .sorted_by(|a, b| a.name.cmp(&b.name));
+        .sorted_by(|a, b| a.name.cmp(&b.name))
+        .into_iter()
+        .unique_by(|v| v.name.clone());
 
         out_dir.set_files(protobuf::RepeatedField::from_vec(
-          file_nodes.into_iter().dedup().collect(),
+          file_nodes.dedup().collect(),
         ));
         let unique_count = out_dir
           .get_files()
@@ -565,6 +567,7 @@ impl StoreFileByDigest<String> for OneOffStoreFileByDigest {
       .read_file(&file)
       .map_err(move |err| format!("Error reading file {:?}: {:?}", file, err))
       .and_then(move |content| store.store_file_bytes(content.content, true))
+      .or_else(|_e| Ok(EMPTY_DIGEST))
       .to_boxed()
   }
 }


### PR DESCRIPTION
*WIP because swallowing errors should be made toggleable (and probably only occur for path globs outside of the buildroot?)!*

### Problem

#6893 contains changes to allow a classpath to be converted into a native executable via the graal VM's `native-image` tool. The `native-image` tool requires a GCC installation along with some OSX system headers to be available when executing, and since we want to be able to remotely execute the `native-image` build, we want to execute it hermetically, and we therefore need to digest some files on the local filesystem. Currently there are errors doing so in #6893, as e.g. some of these files are absolute symlinks, and some of them aren't readable.

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

- Swallow several types of errors which occur when glob matching in the engine.

(_describe the modifications you've made._)

### Result

We can ingest files outside of the buildroot which contain e.g. system headers on OSX without erroring.

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)