### PR TITLE
allow executing scalafmt hermetically

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
@@ -5,12 +5,16 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from builtins import object
-from collections import namedtuple
 from textwrap import dedent
 
+from future.utils import text_type
+
 from pants.base.exceptions import TaskError
+from pants.engine.fs import PathGlobs, PathGlobsAndRoot
 from pants.java.distribution.distribution import DistributionLocator
 from pants.option.custom_types import target_option
+from pants.util.memo import memoized_staticmethod
+from pants.util.objects import datatype
 
 
 class JvmToolMixin(object):
@@ -23,7 +27,7 @@ class JvmToolMixin(object):
   class InvalidToolClasspath(TaskError):
     """Indicates an invalid jvm tool classpath."""
 
-  class JvmTool(namedtuple('JvmTool', ['scope', 'key', 'classpath', 'main', 'custom_rules'])):
+  class JvmTool(datatype(['scope', 'key', 'classpath', 'main', 'custom_rules'])):
     """Represents a jvm tool classpath request."""
 
     def dep_spec(self, options):
@@ -214,3 +218,21 @@ class JvmToolMixin(object):
       raise TaskError('No bootstrap callback registered for {key} in {scope}'
                       .format(key=key, scope=scope))
     return callback()
+
+  @memoized_staticmethod
+  def digest_classpath_paths_synchronously(classpath_relative_paths, root, scheduler):
+    """???
+
+    :param classpath_relative_paths: ???
+    :type classpath_relative_paths: list of string
+    :param root: ???
+    :type root: string
+    :param scheduler: ???
+    :rtype: Snapshot
+    """
+    return scheduler.capture_merged_snapshot(tuple([
+      PathGlobsAndRoot(
+        PathGlobs(include=classpath_relative_paths),
+        root=text_type(root),
+      ),
+    ]))

--- a/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
@@ -11,7 +11,7 @@ from future.utils import text_type
 
 from pants.base.exceptions import TaskError
 from pants.engine.fs import PathGlobs, PathGlobsAndRoot
-from pants.java.distribution.distribution import DistributionLocator
+from pants.java.distribution.distribution import DistributionLocator, HermeticDistribution
 from pants.option.custom_types import target_option
 from pants.util.memo import memoized_staticmethod
 from pants.util.objects import datatype
@@ -180,6 +180,10 @@ class JvmToolMixin(object):
       # Use default until told otherwise.
       self.set_distribution()
     return self._dist
+
+  @property
+  def hermetic_dist(self):
+    return HermeticDistribution.create(self.dist)
 
   @classmethod
   def tool_jar_from_products(cls, products, key, scope):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -44,7 +44,7 @@ from pants.util.fileutil import create_size_estimators
 from pants.util.memo import memoized_method, memoized_property
 
 
-class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
+class JvmCompile(NailgunTaskBase, CompilerOptionSetsMixin):
   """A common framework for JVM compilation.
 
   To subclass for a specific JVM language, implement the static values and methods
@@ -60,6 +60,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
   @classmethod
   def register_options(cls, register):
     super(JvmCompile, cls).register_options(register)
+    cls.register_compiler_option_sets_options(register)
 
     register('--args', advanced=True, type=list,
              default=list(cls.get_args_default(register.bootstrap)), fingerprint=True,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -551,7 +551,6 @@ class RscCompile(ZincCompile):
       output_directories=(output_dir,),
       timeout_seconds=15*60,
       description='run {} for {}'.format(tool_name, tgt),
-      # TODO: These should always be unicodes
       # Since this is always hermetic, we need to use `underlying.home` because
       # ExecuteProcessRequest requires an existing, local jdk location.
       jdk_home=text_type(distribution.underlying_home),

--- a/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
@@ -5,7 +5,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
+from pants.base.build_environment import get_buildroot
 from pants.task.task import TaskBase
+from pants.util.dirutil import fast_relpath_collection
+from pants.util.memo import memoized_method
 
 
 class JvmToolTaskMixin(JvmToolMixin, TaskBase):
@@ -55,3 +58,11 @@ class JvmToolTaskMixin(JvmToolMixin, TaskBase):
 
   def _scope(self, scope=None):
     return scope or self.options_scope
+
+  @memoized_method
+  def tool_classpath_snapshot(self, key, scope=None):
+    """???"""
+    cp_abs_paths = self.tool_classpath(key, scope=scope)
+    cp_rel_paths = fast_relpath_collection(cp_abs_paths, get_buildroot())
+    return self.digest_classpath_paths_synchronously(
+      tuple(cp_rel_paths), get_buildroot(), self.context._scheduler)

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -18,7 +18,7 @@ from pants.util.objects import enum
 class ToolchainVariant(enum(['gnu', 'llvm'])): pass
 
 
-class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsystem):
+class NativeBuildStep(Subsystem, CompilerOptionSetsMixin, MirroredTargetOptionMixin):
   """Settings which are specific to a target and do not need to be the same for compile and link."""
 
   options_scope = 'native-build-step'
@@ -31,6 +31,7 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
   @classmethod
   def register_options(cls, register):
     super(NativeBuildStep, cls).register_options(register)
+    cls.register_compiler_option_sets_options(register)
 
     register('--compiler-option-sets', advanced=True, default=(), type=list,
              fingerprint=True,

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -390,6 +390,8 @@ class BinaryUtil(object):
   def _get_urls(self, url_generator, binary_request):
     return url_generator.generate_urls(binary_request.version, self._host_platform())
 
+  # TODO(#7517): make a `host_platform` arg which defaults to self._host_platform() in order to
+  # resolve tools for a separate target platform for cross-compilation via remote execution!
   def select(self, binary_request):
     """Fetches a file, unpacking it if necessary."""
 

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -24,6 +24,7 @@ from pants.goal.products import Products
 from pants.goal.workspace import ScmWorkspace
 from pants.process.lock import OwnerPrintingInterProcessFileLock
 from pants.source.source_root import SourceRootConfig
+from pants.util.strutil import safe_shlex_join
 
 
 class Context(object):
@@ -384,7 +385,7 @@ class Context(object):
     with self.new_workunit(
       name=name,
       labels=labels,
-      cmd=' '.join(execute_process_request.argv),
+      cmd=safe_shlex_join(execute_process_request.argv),
     ) as workunit:
       result = self._scheduler.product_request(FallibleExecuteProcessResult, [execute_process_request])[0]
       workunit.output("stdout").write(result.stdout)

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -21,7 +21,7 @@ from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
 from pants.util.dirutil import safe_file_dump
 from pants.util.osutil import safe_kill
 from pants.util.socket import RecvBufferedSocket
-from pants.util.strutil import ensure_binary, safe_shlex_join
+from pants.util.strutil import safe_shlex_join
 
 
 logger = logging.getLogger(__name__)
@@ -95,7 +95,7 @@ class NailgunClientSession(NailgunProtocol, NailgunProtocol.TimeoutProvider):
     """Write a payload to a given fd (if provided) and flush the fd."""
     try:
       if payload:
-        fd.write(ensure_binary(payload))
+        fd.write(payload.decode('utf-8'))
       fd.flush()
     except (IOError, OSError) as e:
       # If a `Broken Pipe` is encountered during a stdio fd write, we're headless - bail.

--- a/src/python/pants/option/compiler_option_sets_mixin.py
+++ b/src/python/pants/option/compiler_option_sets_mixin.py
@@ -17,8 +17,7 @@ class CompilerOptionSetsMixin(object):
   """A mixin for language-scoped that support compiler option sets."""
 
   @classmethod
-  def register_options(cls, register):
-    super(CompilerOptionSetsMixin, cls).register_options(register)
+  def register_compiler_option_sets_options(cls, register):
     register('--compiler-option-sets-enabled-args', advanced=True, type=dict, fingerprint=True,
              default=cls.get_compiler_option_sets_enabled_default_value,
              help='Extra compiler args to use for each enabled option set.')

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -61,6 +61,11 @@ def fast_relpath_optional(path, start):
     return path[pref_end+1:]
 
 
+def fast_relpath_collection(collection, root):
+  """Apply a prefix-based relpath to an iterable of file paths."""
+  return [fast_relpath(c, root) or c for c in collection]
+
+
 def safe_mkdir(directory, clean=False):
   """Ensure a directory is present.
 

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -9,6 +9,7 @@ import sys
 from builtins import map, object
 from contextlib import contextmanager
 
+from future.utils import PY3
 from twitter.common.collections import maybe_list
 
 from pants.base.workunit import WorkUnit
@@ -41,7 +42,7 @@ class TestContext(Context):
    """
 
     def output(self, name):
-      return sys.stderr
+      return sys.stderr.buffer if PY3 else sys.stderr
 
     def set_outcome(self, outcome):
       return sys.stderr.write('\nWorkUnit outcome: {}\n'.format(WorkUnit.outcome_string(outcome)))


### PR DESCRIPTION
### Problem

#6893 allows executing scalafmt hermetically through a `native-image`. This PR was made to separate out the ergonomics fixes for hermetic execution in v1 tasks from `native-image` creation to make it easier to review.

### Solution

- Add several methods in different parts of the codebase to make it possible to just call `self.tool_classpath_snapshot('scalafmt')` in the scalafmt task to set up a hermetic JVM execution.
- Add `--use-hermetic-execution` to scalafmt to make it execute hermetically!

### Result

Scalafmt can now be executed hermetically! This paves the way for converting it into a `native-image` in #6893, which in turn enables executing zinc as a `native-image` after #7506 is merged and published.