### PR TITLE
[WIP] Add scoot tutorial and integration test shard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2049,6 +2049,54 @@ matrix:
       3.7
     stage: Test Pants (Cron)
     sudo: required
+  - addons:
+      apt:
+        packages:
+        - git
+    after_failure:
+    - ./build-support/bin/ci-failure.sh
+    before_cache:
+    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
+    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
+    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
+    - rm -rf ${HOME}/.ivy2/pants/com.example
+    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
+    before_install:
+    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
+    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - sudo sysctl fs.inotify.max_user_watches=524288
+    - ./build-support/bin/install_aws_cli_for_ci.sh
+    - pyenv global 2.7.15 3.6.7 3.7.1
+    before_script:
+    - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+    cache:
+      directories:
+      - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT_OSX}
+      - ${HOME}/.cache/pants/tools
+      - ${HOME}/.cache/pants/zinc
+      - ${HOME}/.ivy2/pants
+      - ${HOME}/.npm
+      timeout: 500
+    dist: xenial
+    env:
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
+    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
+    - CACHE_NAME=scootintegrationtests
+    go:
+    - tip
+    language: python
+    name: Integration test - Remote Execution (local Scoot cluster)
+    os: linux
+    python:
+    - '2.7'
+    - '3.6'
+    - '3.7'
+    script:
+    - ./pants --pytest-args='-vs' test src/python/pants/engine:test-remote-execution-integration
+    stage: Test Pants
+    sudo: required
   - before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
     - find build-support -name "*.py[co]" -delete

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -582,6 +582,24 @@ def integration_tests_v2(python_version: PythonVersion) -> Dict:
   safe_append(shard, "env", f"CACHE_NAME=integration.v2.py{python_version.number}")
   return shard
 
+def scoot_integration_test(python_version: PythonVersion) -> Dict:
+  shard = {
+    **linux_shard(python_version=python_version),
+    "name": f"Integration test - Remote Execution (local Scoot cluster)",
+    "before_script": ["curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh"],
+    "go": ["tip"],
+    "addons": {
+      "apt": {
+        "packages": ["git"],
+      },
+    },
+    "script": [
+      "./pants --pytest-args='-vs' test src/python/pants/engine:test-remote-execution-integration",
+    ],
+  }
+  safe_append(shard, "env", "CACHE_NAME=scootintegrationtests")
+  return shard
+
 # -------------------------------------------------------------------------
 # Rust tests
 # -------------------------------------------------------------------------
@@ -796,6 +814,7 @@ def main() -> None:
       *integration_tests_v1(PythonVersion.py36),
       *integration_tests_v1(PythonVersion.py36, use_pantsd=True),
       *integration_tests_v1(PythonVersion.py37),
+      scoot_integration_test(PythonVersion.py36),
       rust_tests_linux(),
       rust_tests_osx(),
       *[osx_platform_tests(v) for v in PythonVersion],

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -264,3 +264,14 @@ resources(
   name='native_engine_shared_library',
   sources=['native_engine.so']
 )
+
+python_tests(
+  name='test-remote-execution-integration',
+  dependencies=[
+    'src/python/pants/base:build_environment',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:process_handler',
+    'tests/python/pants_test:int-test',
+  ],
+  tags={'integration'},
+)

--- a/src/python/pants/engine/README.md
+++ b/src/python/pants/engine/README.md
@@ -218,6 +218,28 @@ $ ls viz
 run.0.dot
 ```
 
+# Remote Execution Testing
+
+Pants can execute processes invoked via the v2 engine remotely against an implementor of the [Bazel Remote Execution API](???). If `--remote-execution-sever` and `--remote-store-server` are provided on the Pants command line, Pants will remotely execute every v2 process execution. There is currently only one backend, *Scoot*.
+
+## [Scoot](https://github.com/twitter/scoot)
+- Clone the Scoot repo and follow the setup instructions (TODO: https://github.com/twitter/scoot/pull/420).
+- In the Scoot repo, run `go run ./binaries/setup-cloud-scoot/main.go --strategy local.local`.
+    - The output will contain lines such as "Serving GRPC CAS API on:" and "Serving GRPC Execution API on:" which specify host (localhost) and port.
+        - Use the "CAS API" host:port outputs as elements of `--remote-store-server` (a list option).
+        - Use the "Execution API" host:port single output as the value of `--remote-execution-server`.
+
+## Native Engine
+
+The native engine is integrated into the pants codebase via `native.py` in
+this directory along with `build-support/bin/native/bootstrap.sh` which ensures a
+pants native engine library is built and available for linking. The glue is the
+sha1 hash of the native engine source code used as its version by the `Native`
+class. This hash is maintained by `build-support/bin/native/bootstrap.sh` and
+output to the `native_engine_version` file in this directory. Any modification
+to this resource file's location will need adjustments in
+`build-support/bin/native/bootstrap.sh` to ensure the linking continues to work.
+
 ## History
 
 The need for an engine that could schedule all work as a result of linking required products to


### PR DESCRIPTION
### Problem

Pants has the ability to remotely execute more and more processes, but it's not clear how to actually do this. [Scoot](https://github.com/twitter/scoot) is what we have been using to test internally, and it would be great to bring some of the remote execution testing into upstream pants.

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

- Add instructions for testing against Scoot.
- Create a test shard which clones scoot and runs `./pants cloc ::` against it.

(_describe the modifications you've made._)

### Result

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)