### PR TITLE
Kill unused env vars in our pre-commit hook.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -147,7 +147,7 @@ export RUN_PANTS_FROM_PEX=1
 
 if [[ "${run_pre_commit_checks:-false}" == "true" ]]; then
   start_travis_section "PreCommit" "Running pre-commit checks"
-  FULL_CHECK=1 ./build-support/githooks/pre-commit || exit 1
+  ./build-support/githooks/pre-commit || exit 1
   end_travis_section
 fi
 

--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -4,11 +4,6 @@
 
 source build-support/common.sh
 
-if [[ -z $FULL_CHECK ]]
-then
-    export GIT_HOOK=1
-fi
-
 # Commit hooks set $GIT_DIR by default to .git
 # This causes git commands (notably, git rev-parse --show-toplevel) to fail if the script isn't
 # running in the git root, as it looks for a .git directory relative to the working directory.


### PR DESCRIPTION
Noticed working #7548.
