### PR TITLE
Don't assume a local `master` branch point.

### DIFF
--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -34,7 +34,7 @@ do
 done
 
 # If changes were made or issues found, output with leading whitespace trimmed.
-output="$(./pants --changed-parent=master fmt.isort -- ${isort_args[@]})"
+output="$(./pants --changed-parent="$(git_merge_base)" fmt.isort -- ${isort_args[@]})"
 echo "${output}" | grep -Eo '(ERROR).*$' && exit 1
 echo "${output}" | grep -Eo '(Fixing).*$'
 exit 0

--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -64,5 +64,6 @@ function fingerprint_data() {
 
 function git_merge_base() {
   # This prints the tracking branch if set and otherwise falls back to local "master".
-  git rev-parse --symbolic-full-name --abbrev-ref HEAD@{upstream} 2>/dev/null || echo master
+  git rev-parse --symbolic-full-name --abbrev-ref HEAD@{upstream} 2>/dev/null || echo 'master'
+
 }

--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -61,3 +61,8 @@ function end_travis_section() {
 function fingerprint_data() {
   git hash-object -t blob --stdin
 }
+
+function git_merge_base() {
+  # This prints the tracking branch if set and otherwise falls back to local "master".
+  git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo master
+}

--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -64,5 +64,5 @@ function fingerprint_data() {
 
 function git_merge_base() {
   # This prints the tracking branch if set and otherwise falls back to local "master".
-  git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo master
+  git rev-parse --symbolic-full-name --abbrev-ref HEAD@{upstream} 2>/dev/null || echo master
 }

--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -50,7 +50,8 @@ echo "* Checking for bad shell patterns" && ./build-support/bin/check_shell.sh |
 
 # When travis builds a tag, it does so in a shallow clone without master fetched, which
 # fails in pants changed.
-if git rev-parse --verify "master" &>/dev/null; then
+MERGE_BASE="$(git_merge_base)"
+if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
   echo "* Checking imports" && ./build-support/bin/isort.sh || \
     die "To fix import sort order, run \`\"$(pwd)/build-support/bin/isort.sh\" -f\`"
 
@@ -58,9 +59,9 @@ if git rev-parse --verify "master" &>/dev/null; then
   # https://github.com/pantsbuild/pants/issues/6633
   # TODO: add a test case for this while including a pexrc file, as python checkstyle currently fails
   # quite often with a pexrc available.
-  echo "* Checking lint" && ./pants --exclude-target-regexp='testprojects/.*' --changed-parent=master lint || exit 1
+  echo "* Checking lint" && ./pants --exclude-target-regexp='testprojects/.*' --changed-parent="${MERGE_BASE}" lint || exit 1
 
-  if git diff master --name-only | grep '\.rs$' > /dev/null; then
+  if git diff "${MERGE_BASE}" --name-only | grep '\.rs$' > /dev/null; then
     echo "* Checking formatting of rust files" && ./build-support/bin/check_rust_formatting.sh || exit 1
     # Clippy happens on a different Travis CI shard because of separate caching concerns.
     # The TRAVIS env var is documented here:
@@ -71,7 +72,7 @@ if git rev-parse --verify "master" &>/dev/null; then
     echo "* Checking rust target headers" && build-support/bin/check_rust_target_headers.sh || exit 1
   fi
 
-  if git diff master --name-only | grep build-support/travis > /dev/null; then
+  if git diff "${MERGE_BASE}" --name-only | grep build-support/travis > /dev/null; then
     echo "* Checking .travis.yml generation" && \
     actual_travis_yml=$(<.travis.yml) && \
     expected_travis_yml=$(./pants --quiet run build-support/travis:generate_travis_yml) && \

--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -29,6 +29,7 @@ set -e
 
 # You can use ("$()") with double quotes in zsh, I assume this splits by IFS...
 ADDED_FILES=($(./build-support/bin/get_added_files.sh))
+MERGE_BASE="$(git_merge_base)"
 
 echo "* Checking packages"
 # TODO: Determine the most *hygienic* way to split an array on the command line in portable bash,
@@ -50,7 +51,6 @@ echo "* Checking for bad shell patterns" && ./build-support/bin/check_shell.sh |
 
 # When travis builds a tag, it does so in a shallow clone without master fetched, which
 # fails in pants changed.
-MERGE_BASE="$(git_merge_base)"
 if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
   echo "* Checking imports" && ./build-support/bin/isort.sh || \
     die "To fix import sort order, run \`\"$(pwd)/build-support/bin/isort.sh\" -f\`"


### PR DESCRIPTION
I, for one, always track `upstream/master` where upstream is
https://github.com/pantsbuild/pants (ie: not my fork).

In case no tracking branch is defined we fall back to the prior
assumption of local `master`.
