### PR TITLE
[WIP] Add idea-plugin callback export style

### DIFF
--- a/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
+++ b/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
@@ -145,7 +145,8 @@ class IdeaPluginGen(ConsoleTask):
     if self.get_options().callback_export_style == self.CallbackExportStyle.raw_specs:
       abs_target_specs = [os.path.join(get_buildroot(), spec) for spec in self.context.options.target_specs]
     else:
-      abs_target_specs = [os.path.join(get_buildroot(), t.address.spec) for t in self.context.target_roots]
+      # sort them to ensure behavior consistency
+      abs_target_specs = sorted([os.path.join(get_buildroot(), t.address.spec) for t in self.context.target_roots])
 
     configured_workspace = TemplateData(
       targets=json.dumps(abs_target_specs),

--- a/tests/python/pants_test/backend/project_info/tasks/test_idea_plugin_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_idea_plugin_integration.py
@@ -136,3 +136,7 @@ class IdeaPluginIntegrationTest(PantsRunIntegrationTest):
 
     self.assertEqual(IdeaPluginGen.PROJECT_NAME_LIMIT, len(IdeaPluginGen.get_project_name(a_lot_of_targets)))
     self._run_and_check(a_lot_of_targets)
+
+  def test_idea_plugin_export_callback_target_list(self):
+    target_a = 'examples/src/scala/org/pantsbuild/example/hello::'
+    self._run_and_check([target_a])


### PR DESCRIPTION
### Problem

For example
` ./pants --tag='-py3' idea-plugin examples/::` will cause IntelliJ to call pants back with `./pants export examples/::`, hence missing the targets that should be filtered out by the tag.

Therefore this patch introduces an option `--callback-export-style` for `idea-plugin` to specify how IntelliJ should callback: `raw_specs` or `target_list`

* `raw_specs`: IntelliJ will call `./pants export examples/::`, same as the status quo. This is useful if user has an umbrella project open and can just simplify refresh the project if a new target is added.
* `target_list`: IntelliJ will call `./pants export examples:a  example:b example:c ...` i.e. all target roots explicitly after the filtering.

