### PR TITLE
pin the PEX_PYTHON{,_PATH} running the pytest pex to avoid using incompatible pytest requirements

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_prep.py
+++ b/src/python/pants/backend/python/tasks/pytest_prep.py
@@ -94,7 +94,7 @@ class PytestPrep(PythonExecutionTaskBase):
       return
     pex_info = PexInfo.default()
     pex_info.entry_point = 'pytest'
-    pytest_binary = self.create_pex(pex_info)
+    pytest_binary = self.create_pex(pex_info, pin_selected_interpreter=True)
     interpreter = self.context.products.get_data(PythonInterpreter)
     self.context.products.register_data(self.PytestBinary,
                                         self.PytestBinary(interpreter, pytest_binary))

--- a/src/python/pants/backend/python/tasks/pytest_prep.py
+++ b/src/python/pants/backend/python/tasks/pytest_prep.py
@@ -35,6 +35,7 @@ class PytestPrep(PythonExecutionTaskBase):
       pex_info.merge_pex_path(pex_path)  # We're now on the sys.path twice.
       PEXBuilder(pex_path, interpreter=interpreter, pex_info=pex_info).freeze()
       self._pex = PEX(pex=pex_path, interpreter=interpreter)
+      self._interpreter = interpreter
 
     @property
     def pex(self):
@@ -43,6 +44,14 @@ class PytestPrep(PythonExecutionTaskBase):
       :rtype: :class:`pex.pex.PEX`
       """
       return self._pex
+
+    @property
+    def interpreter(self):
+      """Return the interpreter used to build this PEX.
+
+      :rtype: :class:`pex.interpreter.PythonInterpreter`
+      """
+      return self._interpreter
 
     @property
     def config_path(self):
@@ -85,7 +94,7 @@ class PytestPrep(PythonExecutionTaskBase):
       return
     pex_info = PexInfo.default()
     pex_info.entry_point = 'pytest'
-    pytest_binary = self.create_pex(pex_info)
+    pytest_binary = self.create_pex(pex_info, pin_selected_interpreter=True)
     interpreter = self.context.products.get_data(PythonInterpreter)
     self.context.products.register_data(self.PytestBinary,
                                         self.PytestBinary(interpreter, pytest_binary))

--- a/src/python/pants/backend/python/tasks/pytest_prep.py
+++ b/src/python/pants/backend/python/tasks/pytest_prep.py
@@ -94,7 +94,7 @@ class PytestPrep(PythonExecutionTaskBase):
       return
     pex_info = PexInfo.default()
     pex_info.entry_point = 'pytest'
-    pytest_binary = self.create_pex(pex_info, pin_selected_interpreter=True)
+    pytest_binary = self.create_pex(pex_info)
     interpreter = self.context.products.get_data(PythonInterpreter)
     self.context.products.register_data(self.PytestBinary,
                                         self.PytestBinary(interpreter, pytest_binary))

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -491,8 +491,8 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
     the interpreter search path at pex runtime ensures that any resolved requirements will be
     compatible with the interpreter being used to invoke the merged pytest pex.
     """
-    pytest_prep_binary_product = self.context.products.get_data(PytestPrep.PytestBinary)
-    chosen_interpreter_binary_path = pytest_prep_binary_product.interpreter.binary
+    pytest_binary = self.context.products.get_data(PytestPrep.PytestBinary)
+    chosen_interpreter_binary_path = pytest_binary.interpreter.binary
     return {
       'PEX_IGNORE_RCFILES': '1',
       'PEX_PYTHON': chosen_interpreter_binary_path,

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -34,7 +34,7 @@ from pants.util.memo import memoized_method, memoized_property
 from pants.util.objects import datatype
 from pants.util.process_handler import SubprocessProcessHandler
 from pants.util.py2_compat import configparser
-from pants.util.strutil import create_path_env_var, safe_shlex_split
+from pants.util.strutil import safe_shlex_split
 from pants.util.xml_parser import XmlParser
 
 
@@ -483,7 +483,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
                                           pytest_binary.pex) as coverage_args:
         yield pytest_binary, [conftest] + coverage_args, get_pytest_rootdir
 
-  def _constrain_pytest_interpreter_search_path(self, args):
+  def _constrain_pytest_interpreter_search_path(self):
     """Return an environment for invoking a pex which ensures the use of the selected interpreter.
 
     When creating the merged pytest pex, we already have an interpreter, and we only invoke that pex
@@ -493,14 +493,10 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
     """
     pytest_prep_binary_product = self.context.products.get_data(PytestPrep.PytestBinary)
     chosen_interpreter_binary_path = pytest_prep_binary_product.interpreter.binary
-    env = {
+    return {
+      'PEX_PYTHON': chosen_interpreter_binary_path,
       'PEX_PYTHON_PATH': chosen_interpreter_binary_path,
-      'PEX_IGNORE_RCFILES': '1',
-      'PATH': create_path_env_var([os.path.dirname(chosen_interpreter_binary_path)],
-                                  env=os.environ, prepend=True)
     }
-
-    return (env, [chosen_interpreter_binary_path] + args)
 
   def _do_run_tests_with_args(self, pex, args):
     try:
@@ -538,9 +534,8 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
                                      cmd=' '.join(pex.cmdline(args)),
                                      labels=[WorkUnitLabel.TOOL, WorkUnitLabel.TEST]) as workunit:
         # NB: Constrain the pex environment to ensure the use of the selected interpreter!
-        extra_env, new_cmdline = self._constrain_pytest_interpreter_search_path(args)
-        env.update(extra_env)
-        rc = self.spawn_and_wait(pex, workunit=workunit, args=new_cmdline, setsid=True, env=env)
+        env.update(self._constrain_pytest_interpreter_search_path())
+        rc = self.spawn_and_wait(pex, workunit=workunit, args=args, setsid=True, env=env)
         return PytestResult.rc(rc)
     except ErrorWhileTesting:
       # spawn_and_wait wraps the test runner in a timeout, so it could
@@ -760,9 +755,8 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
                                    cmd=' '.join(pex.cmdline(args)),
                                    labels=[WorkUnitLabel.TOOL, WorkUnitLabel.TEST]) as workunit:
       # NB: Constrain the pex environment to ensure the use of the selected interpreter!
-      extra_env, new_cmdline = self._constrain_pytest_interpreter_search_path(args)
-      env.update(extra_env)
-      process = self._spawn(pex, workunit, new_cmdline, setsid=False, env=env)
+      env.update(self._constrain_pytest_interpreter_search_path())
+      process = self._spawn(pex, workunit, args, setsid=False, env=env)
       return process.wait()
 
   @contextmanager

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -34,7 +34,7 @@ from pants.util.memo import memoized_method, memoized_property
 from pants.util.objects import datatype
 from pants.util.process_handler import SubprocessProcessHandler
 from pants.util.py2_compat import configparser
-from pants.util.strutil import safe_shlex_split
+from pants.util.strutil import safe_shlex_join, safe_shlex_split
 from pants.util.xml_parser import XmlParser
 
 
@@ -494,6 +494,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
     pytest_prep_binary_product = self.context.products.get_data(PytestPrep.PytestBinary)
     chosen_interpreter_binary_path = pytest_prep_binary_product.interpreter.binary
     return {
+      'PEX_IGNORE_RCFILES': '1',
       'PEX_PYTHON': chosen_interpreter_binary_path,
       'PEX_PYTHON_PATH': chosen_interpreter_binary_path,
     }
@@ -531,7 +532,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
         env['PEX_PROFILE_FILENAME'] = '{0}.subprocess.{1:.6f}'.format(profile, time.time())
 
       with self.context.new_workunit(name='run',
-                                     cmd=' '.join(pex.cmdline(args)),
+                                     cmd=safe_shlex_join(pex.cmdline(args)),
                                      labels=[WorkUnitLabel.TOOL, WorkUnitLabel.TEST]) as workunit:
         # NB: Constrain the pex environment to ensure the use of the selected interpreter!
         env.update(self._constrain_pytest_interpreter_search_path())

--- a/src/python/pants/backend/python/tasks/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks/python_execution_task_base.py
@@ -83,7 +83,7 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
     """
     return ()
 
-  def create_pex(self, pex_info=None):
+  def create_pex(self, pex_info=None, pin_selected_interpreter=False):
     """Returns a wrapped pex that "merges" the other pexes via PEX_PATH."""
     relevant_targets = self.context.targets(
       lambda tgt: isinstance(tgt, (
@@ -116,8 +116,17 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
           # Add the extra requirements first, so they take precedence over any colliding version
           # in the target set's dependency closure.
           pexes = [extra_requirements_pex] + pexes
-        constraints = {constraint for rt in relevant_targets if is_python_target(rt)
-                       for constraint in PythonSetup.global_instance().compatibility_or_constraints(rt)}
+
+        unique_constraints = {
+          constraint for rt in relevant_targets if is_python_target(rt)
+          for constraint in PythonSetup.global_instance().compatibility_or_constraints(rt)
+        }
+        self.context.log.debug('unique_constraints:\n{}'.format(unique_constraints))
+
+        if pin_selected_interpreter:
+          constraints = {str(interpreter.identity.requirement)}
+        else:
+          constraints = unique_constraints
 
         with self.merged_pex(path, pex_info, interpreter, pexes, constraints) as builder:
           for extra_file in self.extra_files():

--- a/src/python/pants/backend/python/tasks/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks/python_execution_task_base.py
@@ -11,6 +11,7 @@ from future.utils import binary_type, text_type
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 
+from pants.backend.python.subsystems.pex_build_util import is_python_target
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_distribution import PythonDistribution
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
@@ -82,19 +83,8 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
     """
     return ()
 
-  def create_pex(self, pex_info=None):
-    """Returns a wrapped pex that "merges" other pexes produced in previous tasks via PEX_PATH.
-
-    The produced pex will have a single == interpreter constraint applied to it, for the
-    global interpreter selected by the SelectInterpreter task. The returned pex will have the
-    pexes from the ResolveRequirements and GatherSources tasks mixed into it via PEX_PATH. Any
-    3rdparty requirements declared with self.extra_requirements() will also be resolved for the
-    global interpreter, and added to the returned pex via PEX_PATH.
-
-    :param pex_info: An optional PexInfo instance to provide to self.merged_pex().
-    :type pex_info: :class:`pex.pex_info.PexInfo`, or None
-    :rtype: :class:`pex.pex.PEX`
-    """
+  def create_pex(self, pex_info=None, pin_selected_interpreter=False):
+    """Returns a wrapped pex that "merges" the other pexes via PEX_PATH."""
     relevant_targets = self.context.targets(
       lambda tgt: isinstance(tgt, (
         PythonDistribution, PythonRequirementLibrary, PythonTarget, Files)))
@@ -127,7 +117,16 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
           # in the target set's dependency closure.
           pexes = [extra_requirements_pex] + pexes
 
-        constraints = {str(interpreter.identity.requirement)}
+        unique_constraints = {
+          constraint for rt in relevant_targets if is_python_target(rt)
+          for constraint in PythonSetup.global_instance().compatibility_or_constraints(rt)
+        }
+        self.context.log.debug('unique_constraints:\n{}'.format(unique_constraints))
+
+        if pin_selected_interpreter:
+          constraints = {str(interpreter.identity.requirement)}
+        else:
+          constraints = unique_constraints
 
         with self.merged_pex(path, pex_info, interpreter, pexes, constraints) as builder:
           for extra_file in self.extra_files():

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -274,6 +274,18 @@ python_tests(
   dependencies = ["lib:core"],
   coverage = ["core"],
 )
+
+python_tests(
+  name = "py23-tests",
+  sources = ["py23_test_source.py"],
+  compatibility = ['CPython>=2.7,<4'],
+)
+
+python_tests(
+  name = "py3-and-more-tests",
+  sources = ["py3_and_more_test_source.py"],
+  compatibility = ['CPython>=3.6'],
+)
 '''
     )
 
@@ -359,6 +371,9 @@ python_tests(
         assert(False)
         """))
 
+    self.create_file('tests/py23_test_source.py', '')
+    self.create_file('tests/py3_and_more_test_source.py', '')
+
     self.create_file('tests/conftest.py', self._CONFTEST_CONTENT)
 
     self.app = self.target('tests:app')
@@ -375,6 +390,9 @@ python_tests(
     self.all = self.target('tests:all')
     self.all_with_cov = self.target('tests:all-with-coverage')
 
+    self.py23 = self.target('tests:py23-tests')
+    self.py3_and_more = self.target('tests:py3-and-more-tests')
+
   @ensure_cached(PytestRun, expected_num_artifacts=0)
   def test_error(self):
     """Test that a test that errors rather than fails shows up in ErrorWhileTesting."""
@@ -386,6 +404,10 @@ python_tests(
   def test_error_outside_function(self):
     self.run_failing_tests(targets=[self.red, self.green, self.failure_outside_function],
                            failed_targets=[self.red, self.failure_outside_function])
+
+  @ensure_cached(PytestRun, expected_num_artifacts=1)
+  def test_succeeds_for_intersecting_unique_constraints(self):
+    self.run_tests(targets=[self.py23, self.py3_and_more])
 
   @ensure_cached(PytestRun, expected_num_artifacts=1)
   def test_green(self):

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -20,10 +20,15 @@ from pants_test.testutils.pexrc_util import setup_pexrc_with_pex_python_path
 class PytestRunIntegrationTest(PantsRunIntegrationTest):
   testproject = 'testprojects/src/python/interpreter_selection'
 
+  # NB: Occasionally running a test in CI may take multiple seconds. The tests in this file which
+  # use the --timeout-default argument are not testing for performance regressions, but just for
+  # correctness of timeout behavior, so we set this to a higher value to avoid flakiness.
+  _non_flaky_timeout_seconds = 5
+
   def test_pytest_run_timeout_succeeds(self):
     pants_run = self.run_pants(['clean-all',
                                 'test.pytest',
-                                '--timeout-default=2',
+                                '--timeout-default={}'.format(self._non_flaky_timeout_seconds),
                                 'testprojects/tests/python/pants/timeout:exceeds_timeout',
                                 '--',
                                 '-kwithin_timeout'])
@@ -62,7 +67,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(['clean-all',
                                 'test.pytest',
                                 '--timeout-terminate-wait=2',
-                                '--timeout-default=5',
+                                '--timeout-default={}'.format(self._non_flaky_timeout_seconds),
                                 '--coverage=auto',
                                 '--cache-ignore',
                                 'testprojects/tests/python/pants/timeout:ignores_terminate'])
@@ -87,7 +92,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(['clean-all',
                                 'test.pytest',
                                 '--timeout-terminate-wait=2',
-                                '--timeout-default=5',
+                                '--timeout-default={}'.format(self._non_flaky_timeout_seconds),
                                 '--cache-ignore',
                                 'testprojects/tests/python/pants/timeout:terminates_self'])
     end = time.time()

--- a/tests/python/pants_test/task_test_base.py
+++ b/tests/python/pants_test/task_test_base.py
@@ -386,6 +386,7 @@ class DeclarativeTaskTestMixin(object):
       for tsk in all_task_instances:
         tsk.execute()
     except Exception as e:
+      # TODO(#7644): Remove this hack before anything more starts relying on it!
       setattr(e, '_context', context)
       raise e
 

--- a/tests/python/pants_test/task_test_base.py
+++ b/tests/python/pants_test/task_test_base.py
@@ -353,6 +353,8 @@ class DeclarativeTaskTestMixin(object):
                                     `for_task_types`.
     :return: A datatype containing the created context and the task instances which were executed.
     :rtype: :class:`DeclarativeTaskTestMixin.TaskInvocationResult`
+    :raises: If any exception is raised during task execution, the context will be attached to the
+             exception object as the attribute '_context' with setattr() before re-raising.
     """
     run_before_synthesized_task_types = self._synthesize_task_types(tuple(self.run_before_task_types))
     run_after_synthesized_task_types = self._synthesize_task_types(tuple(self.run_after_task_types))
@@ -380,8 +382,12 @@ class DeclarativeTaskTestMixin(object):
       current_task_instance
     ] + run_after_task_instances
 
-    for tsk in all_task_instances:
-      tsk.execute()
+    try:
+      for tsk in all_task_instances:
+        tsk.execute()
+    except Exception as e:
+      setattr(e, '_context', context)
+      raise e
 
     return self.TaskInvocationResult(
       context=context,


### PR DESCRIPTION
### Problem

`PytestPrep` will generate a pex merging python sources and 3rdparty requirements. This pex will have all of the unique python interpreter constraints from all targets applied to the pex before being built. When executing that pex, it appears that the wrong python interpreter may be selected when the interpreter constraint set is intersecting -- see the added test `test_succeeds_for_intersecting_unique_constraints()`. This ends up looking like:
```
Failed to execute PEX file, missing macosx_10_14_x86_64-cp-27-cp27m compatible dependencies for:
more-itertools
pytest
funcsigs
pytest-cov
coverage
```

### Solution

- Force the selected interpreter used to create the pytest pex to be used when running it by setting `PEX_PYTHON` and `PEX_PYTHON_PATH`.
- Add testing for the case of targets with intersecting interpreter constraints (such as `['CPython>=2.7,<4', 'CPython>=3.6']`).

### Result

Running python tests targets with overlapping interpreter constraints should work!