### PR TITLE
Fix help info output for option choices

### DIFF
--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -175,7 +175,7 @@ class HelpInfoExtracter(object):
       deprecated_message = 'DEPRECATED. {} removed in version: {}'.format(deprecated_tense,
                                                                           removal_version)
     removal_hint = kwargs.get('removal_hint')
-    choices = ', '.join(str(choice) for choice in kwargs.get('choices')) if kwargs.get('choices') else None
+    choices = ', '.join(str(choice) for choice in kwargs.get('choices', [])) or None
 
     ret = OptionHelpInfo(registering_class=kwargs.get('registering_class', type(None)),
                          display_args=display_args,

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -175,7 +175,7 @@ class HelpInfoExtracter(object):
       deprecated_message = 'DEPRECATED. {} removed in version: {}'.format(deprecated_tense,
                                                                           removal_version)
     removal_hint = kwargs.get('removal_hint')
-    choices = ', '.join(str(kwargs.get('choices'))) if kwargs.get('choices') else None
+    choices = ', '.join(str(choice) for choice in kwargs.get('choices')) if kwargs.get('choices') else None
 
     ret = OptionHelpInfo(registering_class=kwargs.get('registering_class', type(None)),
                          display_args=display_args,


### PR DESCRIPTION
Seen when running `./pants help` on the latest master, this was introduced in https://github.com/pantsbuild/pants/pull/7481/commits/735833d8fb292bcf5c7d4b892e62c63448102a28

<img width="1145" alt="Screen Shot 2019-04-15 at 12 14 09 PM" src="https://user-images.githubusercontent.com/4504083/56159207-f30de880-5f78-11e9-8b6f-983ab4b2d4dd.png">
