### PR TITLE
Fix empty failed target to ensure pants raises the error if python test fails

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -563,7 +563,12 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
             pytest_relpath = testcase.getAttribute('file')
             relsrc = os.path.join(buildroot_relpath, pytest_relpath)
             failed_target = relsrc_to_target.get(relsrc)
-            failed_targets.add(failed_target)
+            if failed_target is not None:
+              failed_targets.add(failed_target)
+            else:
+              # If test failure/error was not reported in junitxml, pick the first test target
+              # in targets as the failed target
+              failed_targets.add(targets[0])
     except (XmlParser.XmlError, ValueError) as e:
       raise TaskError('Error parsing xml file at {}: {}'.format(junitxml, e))
 

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -563,7 +563,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
             pytest_relpath = testcase.getAttribute('file')
             relsrc = os.path.join(buildroot_relpath, pytest_relpath)
             failed_target = relsrc_to_target.get(relsrc)
-            if failed_target is not None:
+            if failed_target:
               failed_targets.add(failed_target)
             else:
               # If test failure/error was not reported in junitxml, pick the first test target


### PR DESCRIPTION
### Problem

Users run a command like:

./pants test some_dir_path/src/test/python/app_dir:test

The pants command succeeded even though python test failed.

The root cause was the test target not recorded in `<junitxml>` file so when failure/error was detected, pants couldn't get the failed test target from `<junitxml>` file.

### Solution

If test failure/error is detected but pants can't get the failed test target from `<junitxml>` file, then pick the first test target as the failed test target.