### PR TITLE
Fix docsite link for target_aggregate

### DIFF
--- a/src/docs/docsite.json
+++ b/src/docs/docsite.json
@@ -95,6 +95,7 @@
     "setup_repo": "dist/markdown/html/src/docs/setup_repo.html",
     "styleguide": "dist/markdown/html/src/docs/styleguide.html",
     "target_addresses": "dist/markdown/html/src/docs/target_addresses.html",
+    "target_aggregate": "dist/markdown/html/src/docs/common_tasks/target_aggregate.html",
     "test": "dist/markdown/html/src/docs/common_tasks/test.html",
     "test_suite": "dist/markdown/html/src/docs/common_tasks/test_suite.html",
     "thrift_deps": "dist/markdown/html/examples/src/thrift/org/pantsbuild/example/README.html",


### PR DESCRIPTION
The link to `Create a Target Aggregate` found on the docsite [here](https://www.pantsbuild.org/common_tasks.html) currently leads to a `404`, this should resolve that issue.