### PR TITLE
Restore support for pantsbuild.pants wheel using Python 3.7+ by removing abi3 workaround

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -204,18 +204,7 @@ function build_3rdparty_packages() {
   start_travis_section "3rdparty" "Building 3rdparty whls from ${REQUIREMENTS_3RDPARTY_FILES[@]}"
   activate_tmp_venv
 
-  wheel_args=("--wheel-dir=${DEPLOY_3RDPARTY_WHEEL_DIR}/${version}")
-
-  # TODO(pex#539): This code hacks around Pex's issue in resolving abi3 values with an abi
-  # from an earlier Python 3 version. Specifically, the cryptography wheel is normally marked as cp34-abi3,
-  # meaning it supports any Python >= 3.4. But when running `release.sh -3p`, Pex will fail to
-  # resolve the cryptography wheel we have. So, we work around this by building our own cryptography
-  # wheel with `cp36-cp36m`.
-  if [[ "${python_three:-false}" == "true" ]]; then
-    wheel_args=("--no-binary=cryptography" "${wheel_args[@]}")
-  fi
-
-  pip wheel "${wheel_args[@]}" ${req_args}
+  pip wheel --wheel-dir="${DEPLOY_3RDPARTY_WHEEL_DIR}/${version}" ${req_args}
 
   deactivate
   end_travis_section


### PR DESCRIPTION
In order to release the Py36 PEX, we had to workaround an upstream Pex issue that could not properly resolve `cryptography-cp34-abi3`. Now that this is fixed, we can restore support Python 3.7+.

Will close https://github.com/pantsbuild/pants/issues/7459.