### PR TITLE
Bootstrap Python 3.6 shards in cron.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -895,12 +895,16 @@ matrix:
     - <<: *py27_linux_build_engine
       stage: *bootstrap_cron
     - <<: *py36_linux_build_engine
+    - <<: *py36_linux_build_engine
+      stage: *bootstrap_cron
     - <<: *py37_linux_build_engine
 
     - <<: *py27_osx_build_engine
     - <<: *py27_osx_build_engine
       stage: *bootstrap_cron
     - <<: *py36_osx_build_engine
+    - <<: *py36_osx_build_engine
+      stage: *bootstrap_cron
     - <<: *py37_osx_build_engine
 
     - <<: *py27_lint

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -838,12 +838,16 @@ matrix:
     - <<: *py27_linux_build_engine
       stage: *bootstrap_cron
     - <<: *py36_linux_build_engine
+    - <<: *py36_linux_build_engine
+      stage: *bootstrap_cron
     - <<: *py37_linux_build_engine
 
     - <<: *py27_osx_build_engine
     - <<: *py27_osx_build_engine
       stage: *bootstrap_cron
     - <<: *py36_osx_build_engine
+    - <<: *py36_osx_build_engine
+      stage: *bootstrap_cron
     - <<: *py37_osx_build_engine
 
     - <<: *py27_lint


### PR DESCRIPTION
### Problem

The cron job was not configured to bootstrap the 3.6 version of pants, and therefore when we added the "3.6 + pantsd" shards in #7440, these don't work.

### Solution

To add the 3.6 bootstrapping shards to the cron job.

### Result

The cron job should now work, maybe?