### PR TITLE
Use ci.sh instead of travis-ci.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1115,7 +1115,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard0_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 0/20
+        - ./build-support/bin/ci.sh -c -i 0/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 1 (Py3.6 PEX)"
@@ -1125,7 +1125,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard1_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 1/20
+        - ./build-support/bin/ci.sh -c -i 1/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 2 (Py3.6 PEX)"
@@ -1135,7 +1135,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard2_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 2/20
+        - ./build-support/bin/ci.sh -c -i 2/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 3 (Py3.6 PEX)"
@@ -1145,7 +1145,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard3_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 3/20
+        - ./build-support/bin/ci.sh -c -i 3/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 4 (Py3.6 PEX)"
@@ -1155,7 +1155,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard4_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 4/20
+        - ./build-support/bin/ci.sh -c -i 4/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 5 (Py3.6 PEX)"
@@ -1165,7 +1165,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard5_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 5/20
+        - ./build-support/bin/ci.sh -c -i 5/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 6 (Py3.6 PEX)"
@@ -1175,7 +1175,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard6_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 6/20
+        - ./build-support/bin/ci.sh -c -i 6/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 7 (Py3.6 PEX)"
@@ -1185,7 +1185,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard7_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 7/20
+        - ./build-support/bin/ci.sh -c -i 7/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 8 (Py3.6 PEX)"
@@ -1195,7 +1195,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard8_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 8/20
+        - ./build-support/bin/ci.sh -c -i 8/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 9 (Py3.6 PEX)"
@@ -1205,7 +1205,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard9_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 9/20
+        - ./build-support/bin/ci.sh -c -i 9/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 10 (Py3.6 PEX)"
@@ -1215,7 +1215,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard10_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 10/20
+        - ./build-support/bin/ci.sh -c -i 10/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 11 (Py3.6 PEX)"
@@ -1225,7 +1225,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard11_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 11/20
+        - ./build-support/bin/ci.sh -c -i 11/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 12 (Py3.6 PEX)"
@@ -1235,7 +1235,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard12_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 12/20
+        - ./build-support/bin/ci.sh -c -i 12/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 13 (Py3.6 PEX)"
@@ -1245,7 +1245,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard13_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 13/20
+        - ./build-support/bin/ci.sh -c -i 13/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 14 (Py3.6 PEX)"
@@ -1255,7 +1255,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard14_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 14/20
+        - ./build-support/bin/ci.sh -c -i 14/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 15 (Py3.6 PEX)"
@@ -1265,7 +1265,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard15_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 15/20
+        - ./build-support/bin/ci.sh -c -i 15/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 16 (Py3.6 PEX)"
@@ -1275,7 +1275,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard16_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 16/20
+        - ./build-support/bin/ci.sh -c -i 16/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 17 (Py3.6 PEX)"
@@ -1285,7 +1285,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard17_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 17/20
+        - ./build-support/bin/ci.sh -c -i 17/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 18 (Py3.6 PEX)"
@@ -1295,7 +1295,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard18_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 18/20
+        - ./build-support/bin/ci.sh -c -i 18/20
 
     - <<: *py36_linux_test_config
       name: "Integration tests with Pantsd - shard 19 (Py3.6 PEX)"
@@ -1305,7 +1305,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard19_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i 19/20
+        - ./build-support/bin/ci.sh -c -i 19/20
 
     - <<: *py37_linux_test_config
       name: "Integration tests - shard 0 (Py3.7 PEX)"
@@ -1656,7 +1656,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=linuxcontribtests.py36
       script:
-        - ./build-support/bin/travis-ci.sh -n
+        - ./build-support/bin/ci.sh -n
 
     - <<: *py37_linux_test_config
       name: "Python contrib tests (Py3.7 PEX)"

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -909,7 +909,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=integrationshard{{.}}_pantsd
       script:
-        - ./build-support/bin/travis-ci.sh -c -i {{.}}/{{integration_shards_length}}
+        - ./build-support/bin/ci.sh -c -i {{.}}/{{integration_shards_length}}
 
 {{/integration_shards}}
 {{#integration_shards}}
@@ -961,7 +961,7 @@ matrix:
         - *run_tests_under_pantsd
         - CACHE_NAME=linuxcontribtests.py36
       script:
-        - ./build-support/bin/travis-ci.sh -n
+        - ./build-support/bin/ci.sh -n
 
     - <<: *py37_linux_test_config
       name: "Python contrib tests (Py3.7 PEX)"


### PR DESCRIPTION
### Problem

Cron shards use `ci.sh` as opposed to `travis-ci.sh`.