### PR TITLE
Pin OSX wheel release shards to pyenv.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -210,7 +210,8 @@ base_osx_config: &base_osx_config
 
 py27_osx_config: &py27_osx_config
   <<: *base_osx_config
-  # NB: We ensure a python3 is available on the PATH for scripting against.
+  # NB: We ensure sane python2 and python3 interpreters are available on the PATH for scripting
+  # against.
   env:
     - &py27_osx_config_env >
       PATH="/usr/local/opt/openssl/bin:${PATH}"
@@ -232,11 +233,13 @@ py36_osx_config: &py36_osx_config
       PATH="/usr/local/opt/openssl/bin:${PATH}"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
       PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
   before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}"
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
 
 py37_osx_config: &py37_osx_config
@@ -246,11 +249,13 @@ py37_osx_config: &py37_osx_config
       PATH="/usr/local/opt/openssl/bin:${PATH}"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
       PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
   before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}"
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY37_VERSION}"
 
 base_osx_test_config: &base_osx_test_config
@@ -283,6 +288,7 @@ py36_osx_test_config: &py36_osx_test_config
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
       BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
       PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
 
 py37_osx_test_config: &py37_osx_test_config
@@ -295,6 +301,7 @@ py37_osx_test_config: &py37_osx_test_config
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
       BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
       PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
 
 linux_with_fuse: &linux_with_fuse
@@ -557,7 +564,7 @@ py27_linux_build_wheels_ucs2: &py27_linux_build_wheels_ucs2
     - *base_build_wheels_env
     - docker_image_name=travis_ci_py27_ucs2
     - docker_run_command="./build-support/bin/ci.sh -2b
-                          && \${PY} ./build-support/bin/check_pants_pex_abi.py cp27m
+                          && ./build-support/bin/check_pants_pex_abi.py cp27m
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
     - CACHE_NAME=linuxwheelsbuild.ucs2
 
@@ -571,7 +578,7 @@ py27_linux_build_wheels_ucs4: &py27_linux_build_wheels_ucs4
     - *py27_linux_test_config_env
     - *base_build_wheels_env
     - docker_image_name=travis_ci
-    - docker_run_command="\${PY} ./build-support/bin/check_pants_pex_abi.py cp27mu
+    - docker_run_command="./build-support/bin/check_pants_pex_abi.py cp27mu
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
     - CACHE_NAME=linuxwheelsbuild.ucs4
 
@@ -583,7 +590,7 @@ py36_linux_build_wheels: &py36_linux_build_wheels
     - *py36_linux_test_config_env
     - *base_build_wheels_env
     - docker_image_name=travis_ci
-    - docker_run_command="\${PY} ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
+    - docker_run_command="./build-support/bin/check_pants_pex_abi.py abi3 cp36m
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n"
     - CACHE_NAME=linuxwheelsbuild.abi3
 
@@ -605,7 +612,7 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - PY=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
-    - ${PY} ./build-support/bin/check_pants_pex_abi.py cp27m
+    - ./build-support/bin/check_pants_pex_abi.py cp27m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
@@ -624,7 +631,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
     - ./build-support/bin/ci.sh -2b
-    - ${PY} ./build-support/bin/check_pants_pex_abi.py cp27mu
+    - ./build-support/bin/check_pants_pex_abi.py cp27mu
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 py36_osx_build_wheels: &py36_osx_build_wheels
@@ -640,7 +647,7 @@ py36_osx_build_wheels: &py36_osx_build_wheels
     - PY=${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin/python
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY36_VERSION}']"
   script:
-    - ${PY} ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
+    - ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n
 
 # -------------------------------------------------------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,6 +151,8 @@ base_linux_config: &base_linux_config
   language: python
   before_install:
     - ./build-support/bin/install_aws_cli_for_ci.sh
+    # TODO(John Sirois): Get rid of this in favor of explicitly adding pyenv versions to the PATH:
+    #   https://github.com/pantsbuild/pants/issues/7601
     - pyenv global 2.7.15 3.6.7 3.7.1
   after_failure:
     - ./build-support/bin/ci-failure.sh
@@ -223,8 +225,7 @@ py27_osx_config: &py27_osx_config
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}"
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
 
 py36_osx_config: &py36_osx_config
   <<: *base_osx_config
@@ -239,8 +240,7 @@ py36_osx_config: &py36_osx_config
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}"
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
 
 py37_osx_config: &py37_osx_config
   <<: *base_osx_config
@@ -255,8 +255,7 @@ py37_osx_config: &py37_osx_config
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}"
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY37_VERSION}"
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY37_VERSION}"
 
 base_osx_test_config: &base_osx_test_config
   <<: *pants_run_cache_config
@@ -835,6 +834,8 @@ base_deploy: &base_deploy
     - "2.7"
     - "3.6"
   before_install:
+    # TODO(John Sirois): Get rid of this in favor of explicitly adding pyenv versions to the PATH:
+    #   https://github.com/pantsbuild/pants/issues/7601
     - pyenv global 2.7.14 3.6.3
   env:
     - &base_deploy_env RUN_PANTS_FROM_PEX=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -229,6 +229,8 @@ py27_osx_config: &py27_osx_config
 
 py36_osx_config: &py36_osx_config
   <<: *base_osx_config
+  # NB: We ensure sane python2 and python3 interpreters are available on the PATH for scripting
+  # against.
   env:
     - &py36_osx_config_env >
       PATH="/usr/local/opt/openssl/bin:${PATH}"
@@ -244,6 +246,8 @@ py36_osx_config: &py36_osx_config
 
 py37_osx_config: &py37_osx_config
   <<: *base_osx_config
+  # NB: We ensure sane python2 and python3 interpreters are available on the PATH for scripting
+  # against.
   env:
     - &py37_osx_config_env >
       PATH="/usr/local/opt/openssl/bin:${PATH}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -557,7 +557,7 @@ py27_linux_build_wheels_ucs2: &py27_linux_build_wheels_ucs2
     - *base_build_wheels_env
     - docker_image_name=travis_ci_py27_ucs2
     - docker_run_command="./build-support/bin/ci.sh -2b
-                          && ./build-support/bin/check_pants_pex_abi.py cp27m
+                          && \${PY} ./build-support/bin/check_pants_pex_abi.py cp27m
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
     - CACHE_NAME=linuxwheelsbuild.ucs2
 
@@ -571,7 +571,7 @@ py27_linux_build_wheels_ucs4: &py27_linux_build_wheels_ucs4
     - *py27_linux_test_config_env
     - *base_build_wheels_env
     - docker_image_name=travis_ci
-    - docker_run_command="./build-support/bin/check_pants_pex_abi.py cp27mu
+    - docker_run_command="\${PY} ./build-support/bin/check_pants_pex_abi.py cp27mu
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
     - CACHE_NAME=linuxwheelsbuild.ucs4
 
@@ -583,7 +583,7 @@ py36_linux_build_wheels: &py36_linux_build_wheels
     - *py36_linux_test_config_env
     - *base_build_wheels_env
     - docker_image_name=travis_ci
-    - docker_run_command="./build-support/bin/check_pants_pex_abi.py abi3 cp36m
+    - docker_run_command="\${PY} ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n"
     - CACHE_NAME=linuxwheelsbuild.abi3
 
@@ -600,13 +600,12 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs2
     - PYTHON_CONFIGURE_OPTS=--enable-unicode=ucs2
-    # We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
+    # We ensure selection of the the pyenv interpreter by PY aware scripts and pants.pex with these
     # env vars.
     - PY=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
-    - PEX_PYTHON_PATH=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
-    - ./build-support/bin/check_pants_pex_abi.py cp27m
+    - ${PY} ./build-support/bin/check_pants_pex_abi.py cp27m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
@@ -619,14 +618,13 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs4
     - PYTHON_CONFIGURE_OPTS=--enable-unicode=ucs4
-    # We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
+    # We ensure selection of the the pyenv interpreter by PY aware scripts and pants.pex with these
     # env vars.
     - PY=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
-    - PEX_PYTHON_PATH=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
     - ./build-support/bin/ci.sh -2b
-    - ./build-support/bin/check_pants_pex_abi.py cp27mu
+    - ${PY} ./build-support/bin/check_pants_pex_abi.py cp27mu
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 py36_osx_build_wheels: &py36_osx_build_wheels
@@ -637,13 +635,12 @@ py36_osx_build_wheels: &py36_osx_build_wheels
     - *py36_osx_test_config_env
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.abi3
-    # We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
+    # We ensure selection of the the pyenv interpreter by PY aware scripts and pants.pex with these
     # env vars.
     - PY=${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin/python
-    - PEX_PYTHON_PATH=${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin/python
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY36_VERSION}']"
   script:
-    - ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
+    - ${PY} ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n
 
 # -------------------------------------------------------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org
     - BOOTSTRAPPED_PEX_KEY_PREFIX=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}/pants.pex
     - BOOTSTRAPPED_PEX_URL_PREFIX=s3://${BOOTSTRAPPED_PEX_BUCKET}/${BOOTSTRAPPED_PEX_KEY_PREFIX}
+    - PYENV_PY27_VERSION=2.7.15
     - PYENV_PY36_VERSION=3.6.8
     - PYENV_PY37_VERSION=3.7.2
     # NB: Linux shards use Pyenv to pre-install Python. We must not override
@@ -206,35 +207,46 @@ base_osx_config: &base_osx_config
     brew:
       packages:
       - openssl
+
+py27_osx_config: &py27_osx_config
+  <<: *base_osx_config
+  # NB: We ensure a python3 is available on the PATH for scripting against.
+  env:
+    - &py27_osx_config_env >
+      PATH="/usr/local/opt/openssl/bin:${PATH}"
+      LDFLAGS="-L/usr/local/opt/openssl/lib"
+      CPPFLAGS="-I/usr/local/opt/openssl/include"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
+  before_install:
+    - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
+    - chmod 755 /usr/local/bin/jq
+    - ./build-support/bin/install_aws_cli_for_ci.sh
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}"
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
+
+py36_osx_config: &py36_osx_config
+  <<: *base_osx_config
+  env:
+    - &py36_osx_config_env >
+      PATH="/usr/local/opt/openssl/bin:${PATH}"
+      LDFLAGS="-L/usr/local/opt/openssl/lib"
+      CPPFLAGS="-I/usr/local/opt/openssl/include"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
   before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
 
-py27_osx_config: &py27_osx_config
-  <<: *base_osx_config
-  env:
-    - &py27_osx_config_env >
-      PATH="/usr/local/opt/openssl/bin:$PATH"
-      LDFLAGS="-L/usr/local/opt/openssl/lib"
-      CPPFLAGS="-I/usr/local/opt/openssl/include"
-
-py36_osx_config: &py36_osx_config
-  <<: *base_osx_config
-  env:
-    - &py36_osx_config_env >
-      PATH="/usr/local/opt/openssl/bin:$PATH"
-      LDFLAGS="-L/usr/local/opt/openssl/lib"
-      CPPFLAGS="-I/usr/local/opt/openssl/include"
-
 py37_osx_config: &py37_osx_config
   <<: *base_osx_config
   env:
     - &py37_osx_config_env >
-      PATH="/usr/local/opt/openssl/bin:$PATH"
+      PATH="/usr/local/opt/openssl/bin:${PATH}"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
   before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
@@ -254,10 +266,12 @@ py27_osx_test_config: &py27_osx_test_config
   stage: *test_cron
   env:
     - &py27_osx_test_config_env >
-      PATH="/usr/local/opt/openssl/bin:$PATH"
+      PATH="/usr/local/opt/openssl/bin:${PATH}"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
       BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
 
 py36_osx_test_config: &py36_osx_test_config
   <<: *py36_osx_config
@@ -265,10 +279,11 @@ py36_osx_test_config: &py36_osx_test_config
   stage: *test
   env:
     - &py36_osx_test_config_env >
-      PATH="/usr/local/opt/openssl/bin:$PATH"
+      PATH="/usr/local/opt/openssl/bin:${PATH}"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
       BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
 
 py37_osx_test_config: &py37_osx_test_config
   <<: *py37_osx_config
@@ -276,10 +291,11 @@ py37_osx_test_config: &py37_osx_test_config
   stage: *test_cron
   env:
     - &py37_osx_test_config_env >
-      PATH="/usr/local/opt/openssl/bin:$PATH"
+      PATH="/usr/local/opt/openssl/bin:${PATH}"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
       BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
 
 linux_with_fuse: &linux_with_fuse
   os: linux
@@ -583,6 +599,12 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - *py27_osx_test_config_env
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs2
+    - PYTHON_CONFIGURE_OPTS=--enable-unicode=ucs2
+    # We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
+    # env vars.
+    - PY=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
+    - PEX_PYTHON_PATH=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
+    - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
     - ./build-support/bin/check_pants_pex_abi.py cp27m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
@@ -597,17 +619,11 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs4
     - PYTHON_CONFIGURE_OPTS=--enable-unicode=ucs4
-    # We ensure selection of the the UCS4 interpreter by the pants script and pants.pex with these
+    # We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
     # env vars.
-    - PYTHON_27_VERSION_UCS4=2.7.13
-    - PY=${PYENV_ROOT}/shims/python2.7
-    - PEX_PYTHON_PATH=${PYENV_ROOT}/shims/python2.7
-    - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYTHON_27_VERSION_UCS4}']"
-  before_install:
-    - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64 -o /usr/local/bin/jq
-    - chmod 755 /usr/local/bin/jq
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - ./build-support/bin/install_python_for_ci.sh ${PYTHON_27_VERSION_UCS4} ${PYENV_PY36_VERSION}
+    - PY=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
+    - PEX_PYTHON_PATH=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
+    - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu
@@ -621,6 +637,11 @@ py36_osx_build_wheels: &py36_osx_build_wheels
     - *py36_osx_test_config_env
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.abi3
+    # We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
+    # env vars.
+    - PY=${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin/python
+    - PEX_PYTHON_PATH=${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin/python
+    - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY36_VERSION}']"
   script:
     - ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n
@@ -660,7 +681,7 @@ osx_rust_tests: &osx_rust_tests
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
   env:
     - >
-      PATH="/usr/local/opt/openssl/bin:$PATH"
+      PATH="/usr/local/opt/openssl/bin:${PATH}"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
     - CACHE_NAME=macosrusttests

--- a/build-support/bin/install_python_for_ci.sh
+++ b/build-support/bin/install_python_for_ci.sh
@@ -28,5 +28,3 @@ for python_version in "${PYTHON_VERSIONS[@]}"; do
     "${PYENV_BIN}" install "${python_version}"
   fi
 done
-
-"${PYENV_BIN}" global "${PYTHON_VERSIONS[@]}"

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -89,8 +89,14 @@ function run_pex() {
     pex="${pexdir}/pex"
 
     curl -sSL "${PEX_DOWNLOAD_PREFIX}/v${PEX_VERSION}/pex" > "${pex}"
-    chmod +x "${pex}"
-    "${PY}" "${pex}" "$@"
+    # We use `PEX_PYTHON_PATH="${PY}" "${PY}" "${pex}"` instead of either of:
+    # 1. PEX_PYTHON_PATH="${PY}" "${pex}"
+    # 2. "${PY}" "${pex}"
+    # This works around Pex re-exec-ing when it need not and subsequently losing constraints when
+    # it need not. The fixes for these are tracked in:
+    #   1. https://github.com/pantsbuild/pex/issues/709
+    #   2. https://github.com/pantsbuild/pex/issues/710
+    PEX_PYTHON_PATH="${PY}" "${PY}" "${pex}" "$@"
   )
 }
 

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -90,7 +90,7 @@ function run_pex() {
 
     curl -sSL "${PEX_DOWNLOAD_PREFIX}/v${PEX_VERSION}/pex" > "${pex}"
     chmod +x "${pex}"
-    PEX_VERBOSE=9 "${pex}" -vvvvvvvvv "$@"
+    "${PY}" "${pex}" "$@"
   )
 }
 

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -219,7 +219,9 @@ function build_pants_packages() {
   pants_version_set "${version}"
 
   start_travis_section "${NAME}" "Building packages"
-  packages=($(run_packages_script build_and_print "${version}"))
+  packages=(
+    $(run_packages_script build_and_print "${version}")
+  ) || die "Failed to build packages at ${version}!"
   for package in "${packages[@]}"
   do
     (
@@ -300,7 +302,9 @@ function install_and_test_packages() {
   export PANTS_PLUGIN_CACHE_DIR=$(mktemp -d -t plugins_cache.XXXXX)
   trap "rm -rf ${PANTS_PLUGIN_CACHE_DIR}" EXIT
 
-  packages=($(run_packages_script list | grep '.' | awk '{print $1}'))
+  packages=(
+    $(run_packages_script list | grep '.' | awk '{print $1}')
+  ) || die "Failed to list packages!"
 
   export PANTS_PYTHON_REPOS_REPOS="${DEPLOY_PANTS_WHEEL_DIR}/${VERSION}"
   for package in "${packages[@]}"
@@ -495,7 +499,9 @@ function fetch_and_check_prebuilt_wheels() {
   fetch_prebuilt_wheels "${check_dir}"
 
   local missing=()
-  RELEASE_PACKAGES=($(run_packages_script list | grep '.' | awk '{print $1}'))
+  RELEASE_PACKAGES=(
+    $(run_packages_script list | grep '.' | awk '{print $1}')
+  ) || die "Failed to get a list of packages to release!"
   for PACKAGE in "${RELEASE_PACKAGES[@]}"
   do
     packages=($(find_pkg "${PACKAGE}" "${PANTS_UNSTABLE_VERSION}" "${check_dir}"))

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -90,7 +90,7 @@ function run_pex() {
 
     curl -sSL "${PEX_DOWNLOAD_PREFIX}/v${PEX_VERSION}/pex" > "${pex}"
     chmod +x "${pex}"
-    "${pex}" "$@"
+    PEX_VERBOSE=9 "${pex}" -vvvvvvvvv "$@"
   )
 }
 

--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -28,7 +28,8 @@ USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 # Our newly created user is unlikely to have a sane environment: set a locale at least.
 ENV LC_ALL="en_US.UTF-8"
 
-# Expose the installed gcc to the invoking shell.
-ENTRYPOINT ["/usr/bin/scl", "enable", "devtoolset-7",  "--"]
-
 WORKDIR ${TRAVIS_WORK_DIR_PATH}
+
+# Execute any args passed to `docker run` in the context of the devtoolset-7 software collection
+# used in the base image to install requirements.
+ENTRYPOINT ["/usr/bin/scl", "enable" , "devtoolset-7", "--"]

--- a/build-support/docker/travis_ci_py27_ucs2/Dockerfile
+++ b/build-support/docker/travis_ci_py27_ucs2/Dockerfile
@@ -53,4 +53,4 @@ WORKDIR /travis/workdir
 
 # Execute any args passed to `docker run` in the context of the devtoolset-7 software collection
 # we used above to install requirements.
-ENTRYPOINT ["/usr/bin/scl", "enable" , "devtoolset-7"]
+ENTRYPOINT ["/usr/bin/scl", "enable" , "devtoolset-7", "--"]

--- a/build-support/docker/travis_ci_py27_ucs2/Dockerfile
+++ b/build-support/docker/travis_ci_py27_ucs2/Dockerfile
@@ -26,10 +26,9 @@ ENV PYTHON_CONFIGURE_OPTS --enable-unicode=ucs2
 RUN /usr/bin/scl enable devtoolset-7 -- ${PYENV_BIN} install ${PYTHON_27_VERSION_UCS2}
 ENV PATH "${PYENV_ROOT}/versions/${PYTHON_27_VERSION_UCS2}/bin:${PATH}"
 
-# We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
+# We ensure selection of the the pyenv interpreter by PY aware scripts and pants.pex with these
 # env vars.
 ENV PY "${PYENV_ROOT}/versions/${PYTHON_27_VERSION_UCS2}/bin/python"
-ENV PEX_PYTHON_PATH "${PYENV_ROOT}/versions/${PYTHON_27_VERSION_UCS2}/python/bin/python"
 ENV PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYTHON_27_VERSION_UCS2}']"
 
 # Setup mount points for the travis ci user & workdir.

--- a/build-support/docker/travis_ci_py27_ucs2/Dockerfile
+++ b/build-support/docker/travis_ci_py27_ucs2/Dockerfile
@@ -24,13 +24,12 @@ RUN if [[ ! -d "${PYENV_ROOT}" ]]; then git clone https://github.com/pyenv/pyenv
 
 ENV PYTHON_CONFIGURE_OPTS --enable-unicode=ucs2
 RUN /usr/bin/scl enable devtoolset-7 -- ${PYENV_BIN} install ${PYTHON_27_VERSION_UCS2}
-RUN /usr/bin/scl enable devtoolset-7 -- ${PYENV_BIN} global ${PYTHON_27_VERSION_UCS2}
-ENV PATH "${PYENV_ROOT}/shims:${PATH}"
+ENV PATH "${PYENV_ROOT}/versions/${PYTHON_27_VERSION_UCS2}/bin:${PATH}"
 
-# We ensure selection of the the UCS4 interpreter by the pants script and pants.pex with these
+# We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
 # env vars.
-ENV PY "${PYENV_ROOT}/shims/python2.7"
-ENV PEX_PYTHON_PATH "${PYENV_ROOT}/shims/python2.7"
+ENV PY "${PYENV_ROOT}/versions/${PYTHON_27_VERSION_UCS2}/bin/python"
+ENV PEX_PYTHON_PATH "${PYENV_ROOT}/versions/${PYTHON_27_VERSION_UCS2}/python/bin/python"
 ENV PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYTHON_27_VERSION_UCS2}']"
 
 # Setup mount points for the travis ci user & workdir.
@@ -51,3 +50,7 @@ USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 ENV LC_ALL="en_US.UTF-8"
 
 WORKDIR /travis/workdir
+
+# Execute any args passed to `docker run` in the context of the devtoolset-7 software collection
+# we used above to install requirements.
+ENTRYPOINT ["/usr/bin/scl", "enable" , "devtoolset-7"]

--- a/build-support/travis/env_osx_with_pyenv.mustache
+++ b/build-support/travis/env_osx_with_pyenv.mustache
@@ -1,5 +1,5 @@
 {{! These flags are necessary to get OpenSSL working.
 See https://github.com/pyenv/pyenv/wiki/Common-build-problems#error-the-python-ssl-extension-was-not-compiled-missing-the-openssl-lib. }}
-PATH="/usr/local/opt/openssl/bin:$PATH"
+PATH="/usr/local/opt/openssl/bin:${PATH}"
 LDFLAGS="-L/usr/local/opt/openssl/lib"
 CPPFLAGS="-I/usr/local/opt/openssl/include"

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -144,6 +144,8 @@ base_linux_config: &base_linux_config
   language: python
   before_install:
     - ./build-support/bin/install_aws_cli_for_ci.sh
+    # TODO(John Sirois): Get rid of this in favor of explicitly adding pyenv versions to the PATH:
+    #   https://github.com/pantsbuild/pants/issues/7601
     - pyenv global 2.7.15 3.6.7 3.7.1
   after_failure:
     - ./build-support/bin/ci-failure.sh
@@ -208,8 +210,7 @@ py27_osx_config: &py27_osx_config
       PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
   before_install:
     {{>before_install_osx}}
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}"
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
 
 py36_osx_config: &py36_osx_config
   <<: *base_osx_config
@@ -220,8 +221,7 @@ py36_osx_config: &py36_osx_config
       PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
   before_install:
     {{>before_install_osx}}
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}"
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
 
 py37_osx_config: &py37_osx_config
   <<: *base_osx_config
@@ -232,8 +232,7 @@ py37_osx_config: &py37_osx_config
       PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
   before_install:
     {{>before_install_osx}}
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}"
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY37_VERSION}"
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY37_VERSION}"
 
 base_osx_test_config: &base_osx_test_config
   <<: *pants_run_cache_config
@@ -778,6 +777,8 @@ base_deploy: &base_deploy
     - "2.7"
     - "3.6"
   before_install:
+    # TODO(John Sirois): Get rid of this in favor of explicitly adding pyenv versions to the PATH:
+    #   https://github.com/pantsbuild/pants/issues/7601
     - pyenv global 2.7.14 3.6.3
   env:
     - &base_deploy_env RUN_PANTS_FROM_PEX=1

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -214,6 +214,8 @@ py27_osx_config: &py27_osx_config
 
 py36_osx_config: &py36_osx_config
   <<: *base_osx_config
+  # NB: We ensure sane python2 and python3 interpreters are available on the PATH for scripting
+  # against.
   env:
     - &py36_osx_config_env >
       {{>env_osx_with_pyenv}}
@@ -225,6 +227,8 @@ py36_osx_config: &py36_osx_config
 
 py37_osx_config: &py37_osx_config
   <<: *base_osx_config
+  # NB: We ensure sane python2 and python3 interpreters are available on the PATH for scripting
+  # against.
   env:
     - &py37_osx_config_env >
       {{>env_osx_with_pyenv}}

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -502,7 +502,7 @@ py27_linux_build_wheels_ucs2: &py27_linux_build_wheels_ucs2
     - *base_build_wheels_env
     - docker_image_name=travis_ci_py27_ucs2
     - docker_run_command="./build-support/bin/ci.sh -2b
-                          && ./build-support/bin/check_pants_pex_abi.py cp27m
+                          && \${PY} ./build-support/bin/check_pants_pex_abi.py cp27m
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
     - CACHE_NAME=linuxwheelsbuild.ucs2
 
@@ -516,7 +516,7 @@ py27_linux_build_wheels_ucs4: &py27_linux_build_wheels_ucs4
     - *py27_linux_test_config_env
     - *base_build_wheels_env
     - docker_image_name=travis_ci
-    - docker_run_command="./build-support/bin/check_pants_pex_abi.py cp27mu
+    - docker_run_command="\${PY} ./build-support/bin/check_pants_pex_abi.py cp27mu
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
     - CACHE_NAME=linuxwheelsbuild.ucs4
 
@@ -528,7 +528,7 @@ py36_linux_build_wheels: &py36_linux_build_wheels
     - *py36_linux_test_config_env
     - *base_build_wheels_env
     - docker_image_name=travis_ci
-    - docker_run_command="./build-support/bin/check_pants_pex_abi.py abi3 cp36m
+    - docker_run_command="\${PY} ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n"
     - CACHE_NAME=linuxwheelsbuild.abi3
 
@@ -545,13 +545,12 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs2
     - PYTHON_CONFIGURE_OPTS=--enable-unicode=ucs2
-    # We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
+    # We ensure selection of the the pyenv interpreter by PY aware scripts and pants.pex with these
     # env vars.
     - PY=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
-    - PEX_PYTHON_PATH=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
-    - ./build-support/bin/check_pants_pex_abi.py cp27m
+    - ${PY} ./build-support/bin/check_pants_pex_abi.py cp27m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
@@ -564,14 +563,13 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs4
     - PYTHON_CONFIGURE_OPTS=--enable-unicode=ucs4
-    # We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
+    # We ensure selection of the the pyenv interpreter by PY aware scripts and pants.pex with these
     # env vars.
     - PY=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
-    - PEX_PYTHON_PATH=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
     - ./build-support/bin/ci.sh -2b
-    - ./build-support/bin/check_pants_pex_abi.py cp27mu
+    - ${PY} ./build-support/bin/check_pants_pex_abi.py cp27mu
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 py36_osx_build_wheels: &py36_osx_build_wheels
@@ -582,13 +580,12 @@ py36_osx_build_wheels: &py36_osx_build_wheels
     - *py36_osx_test_config_env
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.abi3
-    # We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
+    # We ensure selection of the the pyenv interpreter by PY aware scripts and pants.pex with these
     # env vars.
     - PY=${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin/python
-    - PEX_PYTHON_PATH=${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin/python
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY36_VERSION}']"
   script:
-    - ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
+    - ${PY} ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n
 
 # -------------------------------------------------------------------------

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -199,7 +199,8 @@ base_osx_config: &base_osx_config
 
 py27_osx_config: &py27_osx_config
   <<: *base_osx_config
-  # NB: We ensure a python3 is available on the PATH for scripting against.
+  # NB: We ensure sane python2 and python3 interpreters are available on the PATH for scripting
+  # against.
   env:
     - &py27_osx_config_env >
       {{>env_osx_with_pyenv}}
@@ -215,9 +216,11 @@ py36_osx_config: &py36_osx_config
   env:
     - &py36_osx_config_env >
       {{>env_osx_with_pyenv}}
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
       PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
   before_install:
     {{>before_install_osx}}
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}"
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
 
 py37_osx_config: &py37_osx_config
@@ -225,9 +228,11 @@ py37_osx_config: &py37_osx_config
   env:
     - &py37_osx_config_env >
       {{>env_osx_with_pyenv}}
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
       PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
   before_install:
     {{>before_install_osx}}
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}"
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY37_VERSION}"
 
 base_osx_test_config: &base_osx_test_config
@@ -256,6 +261,7 @@ py36_osx_test_config: &py36_osx_test_config
     - &py36_osx_test_config_env >
       {{>env_osx_with_pyenv}}
       BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
       PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
 
 py37_osx_test_config: &py37_osx_test_config
@@ -266,6 +272,7 @@ py37_osx_test_config: &py37_osx_test_config
     - &py37_osx_test_config_env >
       {{>env_osx_with_pyenv}}
       BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
       PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
 
 linux_with_fuse: &linux_with_fuse
@@ -502,7 +509,7 @@ py27_linux_build_wheels_ucs2: &py27_linux_build_wheels_ucs2
     - *base_build_wheels_env
     - docker_image_name=travis_ci_py27_ucs2
     - docker_run_command="./build-support/bin/ci.sh -2b
-                          && \${PY} ./build-support/bin/check_pants_pex_abi.py cp27m
+                          && ./build-support/bin/check_pants_pex_abi.py cp27m
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
     - CACHE_NAME=linuxwheelsbuild.ucs2
 
@@ -516,7 +523,7 @@ py27_linux_build_wheels_ucs4: &py27_linux_build_wheels_ucs4
     - *py27_linux_test_config_env
     - *base_build_wheels_env
     - docker_image_name=travis_ci
-    - docker_run_command="\${PY} ./build-support/bin/check_pants_pex_abi.py cp27mu
+    - docker_run_command="./build-support/bin/check_pants_pex_abi.py cp27mu
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
     - CACHE_NAME=linuxwheelsbuild.ucs4
 
@@ -528,7 +535,7 @@ py36_linux_build_wheels: &py36_linux_build_wheels
     - *py36_linux_test_config_env
     - *base_build_wheels_env
     - docker_image_name=travis_ci
-    - docker_run_command="\${PY} ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
+    - docker_run_command="./build-support/bin/check_pants_pex_abi.py abi3 cp36m
                           && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n"
     - CACHE_NAME=linuxwheelsbuild.abi3
 
@@ -550,7 +557,7 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - PY=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
-    - ${PY} ./build-support/bin/check_pants_pex_abi.py cp27m
+    - ./build-support/bin/check_pants_pex_abi.py cp27m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
@@ -569,7 +576,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
     - ./build-support/bin/ci.sh -2b
-    - ${PY} ./build-support/bin/check_pants_pex_abi.py cp27mu
+    - ./build-support/bin/check_pants_pex_abi.py cp27mu
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 py36_osx_build_wheels: &py36_osx_build_wheels
@@ -585,7 +592,7 @@ py36_osx_build_wheels: &py36_osx_build_wheels
     - PY=${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin/python
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY36_VERSION}']"
   script:
-    - ${PY} ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
+    - ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n
 
 # -------------------------------------------------------------------------

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -16,6 +16,7 @@ env:
     - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org
     - BOOTSTRAPPED_PEX_KEY_PREFIX=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}/pants.pex
     - BOOTSTRAPPED_PEX_URL_PREFIX=s3://${BOOTSTRAPPED_PEX_BUCKET}/${BOOTSTRAPPED_PEX_KEY_PREFIX}
+    - PYENV_PY27_VERSION=2.7.15
     - PYENV_PY36_VERSION=3.6.8
     - PYENV_PY37_VERSION=3.7.2
     # NB: Linux shards use Pyenv to pre-install Python. We must not override
@@ -195,27 +196,36 @@ base_osx_config: &base_osx_config
     brew:
       packages:
       - openssl
-  before_install:
-    {{>before_install_osx}}
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
 
 py27_osx_config: &py27_osx_config
   <<: *base_osx_config
+  # NB: We ensure a python3 is available on the PATH for scripting against.
   env:
     - &py27_osx_config_env >
       {{>env_osx_with_pyenv}}
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
+  before_install:
+    {{>before_install_osx}}
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}"
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
 
 py36_osx_config: &py36_osx_config
   <<: *base_osx_config
   env:
     - &py36_osx_config_env >
       {{>env_osx_with_pyenv}}
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
+  before_install:
+    {{>before_install_osx}}
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
 
 py37_osx_config: &py37_osx_config
   <<: *base_osx_config
   env:
     - &py37_osx_config_env >
       {{>env_osx_with_pyenv}}
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
   before_install:
     {{>before_install_osx}}
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY37_VERSION}"
@@ -235,6 +245,8 @@ py27_osx_test_config: &py27_osx_test_config
     - &py27_osx_test_config_env >
       {{>env_osx_with_pyenv}}
       BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
 
 py36_osx_test_config: &py36_osx_test_config
   <<: *py36_osx_config
@@ -244,6 +256,7 @@ py36_osx_test_config: &py36_osx_test_config
     - &py36_osx_test_config_env >
       {{>env_osx_with_pyenv}}
       BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
 
 py37_osx_test_config: &py37_osx_test_config
   <<: *py37_osx_config
@@ -253,6 +266,7 @@ py37_osx_test_config: &py37_osx_test_config
     - &py37_osx_test_config_env >
       {{>env_osx_with_pyenv}}
       BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
 
 linux_with_fuse: &linux_with_fuse
   os: linux
@@ -530,6 +544,12 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - *py27_osx_test_config_env
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs2
+    - PYTHON_CONFIGURE_OPTS=--enable-unicode=ucs2
+    # We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
+    # env vars.
+    - PY=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
+    - PEX_PYTHON_PATH=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
+    - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
     - ./build-support/bin/check_pants_pex_abi.py cp27m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
@@ -544,15 +564,11 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.ucs4
     - PYTHON_CONFIGURE_OPTS=--enable-unicode=ucs4
-    # We ensure selection of the the UCS4 interpreter by the pants script and pants.pex with these
+    # We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
     # env vars.
-    - PYTHON_27_VERSION_UCS4=2.7.13
-    - PY=${PYENV_ROOT}/shims/python2.7
-    - PEX_PYTHON_PATH=${PYENV_ROOT}/shims/python2.7
-    - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYTHON_27_VERSION_UCS4}']"
-  before_install:
-    {{>before_install_osx}}
-    - ./build-support/bin/install_python_for_ci.sh ${PYTHON_27_VERSION_UCS4} ${PYENV_PY36_VERSION}
+    - PY=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
+    - PEX_PYTHON_PATH=${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin/python
+    - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu
@@ -566,6 +582,11 @@ py36_osx_build_wheels: &py36_osx_build_wheels
     - *py36_osx_test_config_env
     - *base_build_wheels_env
     - CACHE_NAME=osxwheelsbuild.abi3
+    # We ensure selection of the the pyenv interpreter by the pants script and pants.pex with these
+    # env vars.
+    - PY=${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin/python
+    - PEX_PYTHON_PATH=${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin/python
+    - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY36_VERSION}']"
   script:
     - ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
     - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n


### PR DESCRIPTION
Previously we only did this for the UCS4 OSX shard which allowed the
system interpreters to leak in to interpreter discovery on the other
shards. This was problematic since the system interpreters were linked
against too-old openssl leading to HTTPS errors attempting to talk to
pypi with too-old TLS protocols.

Also switch away from pyenv shims to the explicit version we need for
maximum clarity.

Finally, ensure failures running packages.py propagate. The fact that
they did not led to the issue here going undiscovered in branch CI.

Fixes #7593