### PR TITLE
pantsd auto invalidates pants.ini and all pythonpath of pants

### DIFF
--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -241,12 +241,11 @@ class PantsDaemon(FingerprintedProcessManager):
 
     for glob in globs:
       glob_relpath = os.path.relpath(glob, buildroot)
-      if glob_relpath:
+      if glob_relpath and (not glob.startswith("../")):
         invalidation_globs.extend([glob_relpath, glob_relpath + '/**'])
-      elif os.path.exists(buildroot, glob):
-        invalidation_globs.extend([glob, glob + '/**'])
       else:
-        logging.getLogger(__name__).warning("Changes to {} will not be invalidated.".format(glob))
+        logging.getLogger(__name__).warning("Changes to {}, outside of the buildroot"
+                                            ", will not be invalidated.".format(glob))
 
     return invalidation_globs
 

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -207,7 +207,7 @@ class PantsDaemon(FingerprintedProcessManager):
         fs_event_service,
         legacy_graph_scheduler,
         build_root,
-        bootstrap_options.pantsd_invalidation_globs,
+        PantsDaemon.compute_invalidation_globs(bootstrap_options),
         pidfile,
       )
 
@@ -224,6 +224,31 @@ class PantsDaemon(FingerprintedProcessManager):
         services=(fs_event_service, scheduler_service, pailgun_service, store_gc_service),
         port_map=dict(pailgun=pailgun_service.pailgun_port),
       )
+
+  @staticmethod
+  def compute_invalidation_globs(bootstrap_options):
+    """
+    Combine --pythonpath and --pants_config_files(pants.ini) files that are in {buildroot} dir
+    with those invalidation_globs provided by users
+    :param bootstrap_options:
+    :return: A list of invalidation_globs
+    """
+    buildroot = get_buildroot()
+    invalidation_globs = []
+    globs = bootstrap_options.pythonpath + \
+      bootstrap_options.pants_config_files + \
+      bootstrap_options.pantsd_invalidation_globs
+
+    for glob in globs:
+      glob_relpath = os.path.relpath(glob, buildroot)
+      if glob_relpath:
+        invalidation_globs.extend([glob_relpath, glob_relpath + '/**'])
+      elif os.path.exists(buildroot, glob):
+        invalidation_globs.extend([glob, glob + '/**'])
+      else:
+        logging.getLogger(__name__).warning("Changes to {} will not be invalidated.".format(glob))
+
+    return invalidation_globs
 
   def __init__(self, native, build_root, work_dir, log_level, services,
                metadata_base_dir, bootstrap_options=None):

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -241,7 +241,7 @@ class PantsDaemon(FingerprintedProcessManager):
 
     for glob in globs:
       glob_relpath = os.path.relpath(glob, buildroot)
-      if glob_relpath and (not glob.startswith("../")):
+      if glob_relpath and (not glob_relpath.startswith("../")):
         invalidation_globs.extend([glob_relpath, glob_relpath + '/**'])
       else:
         logging.getLogger(__name__).warning("Changes to {}, outside of the buildroot"

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -345,20 +345,20 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
 
   def test_pantsd_invalidation_pants_ini_file(self):
     # Test tmp_pants_ini (--pants-config-files=$tmp_pants_ini)'s removal
-    tmp_pants_ini = os.path.abspath(".pants.d/tmp/tmp_pants_{}.ini".format(time.time()))
+    tmp_pants_ini = os.path.abspath("testprojects/test_pants.ini")
+
     # Create tmp_pants_ini file
     with safe_open(tmp_pants_ini, 'w') as f:
-      f.write("import that\n")
+      f.write("[DEFAULT]\n")
 
     with self.pantsd_successful_run_context() as (pantsd_run, checker, _, _):
       pantsd_run(['--pants-config-files={}'.format(tmp_pants_ini), 'help'])
       checker.assert_started()
-
       time.sleep(5)
 
       # Delete tmp_pants_ini
       os.unlink(tmp_pants_ini)
-      time.sleep(5)
+      time.sleep(10)
       checker.assert_stopped()
 
   def test_pantsd_pid_deleted(self):

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -15,7 +15,7 @@ import unittest
 from builtins import open, range, zip
 
 from pants.util.contextutil import environment_as, temporary_dir, temporary_file
-from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, touch
+from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, safe_open, touch
 from pants_test.pants_run_integration_test import read_pantsd_log
 from pants_test.pantsd.pantsd_integration_test_base import PantsDaemonIntegrationTestBase
 from pants_test.testutils.process_test_util import no_lingering_process_by_command
@@ -342,6 +342,24 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         checker.assert_stopped()
 
       self.assertIn('saw file events covered by invalidation globs', full_pantsd_log())
+
+  def test_pantsd_invalidation_pants_ini_file(self):
+    # Test tmp_pants_ini (--pants-config-files=$tmp_pants_ini)'s removal
+    tmp_pants_ini = os.path.abspath(".pants.d/tmp/tmp_pants_{}.ini".format(time.time()))
+    # Create tmp_pants_ini file
+    with safe_open(tmp_pants_ini, 'w') as f:
+      f.write("import that\n")
+
+    with self.pantsd_successful_run_context() as (pantsd_run, checker, _, _):
+      pantsd_run(['--pants-config-files={}'.format(tmp_pants_ini), 'help'])
+      checker.assert_started()
+
+      time.sleep(5)
+
+      # Delete tmp_pants_ini
+      os.unlink(tmp_pants_ini)
+      time.sleep(5)
+      checker.assert_stopped()
 
   def test_pantsd_pid_deleted(self):
     with self.pantsd_successful_run_context() as (pantsd_run, checker, workdir, config):


### PR DESCRIPTION
As Stu describes it on https://github.com/pantsbuild/pants/issues/7595

> The invalidation globs for pantsd (improved in #5567) can be manually configured to cover everything that is known to cause pantsd to need to restart. But many of the things that should trigger a restart are already known to pants. A partial list:
>  1. The content of any configured pants.ini files (due to #7022)
>  2. The pythonpath of pants itself (since changes to loose-source plugins mean the code that pantsd is running might have changed)
>
> We should automatically include these values (and likely others!) in the values that we use for --invalidation-globs. In cases where the options values point to files that exist outside of the buildroot, we should consider logging a warning (unless that ends up being too noisy).