### PR TITLE
Hotfix #7591 breaking OSX Rust tests shard due to Pyenv global issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -685,12 +685,14 @@ osx_rust_tests: &osx_rust_tests
       - openssl
       - osxfuse
   before_install:
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
   env:
     - >
       PATH="/usr/local/opt/openssl/bin:${PATH}"
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
     - CACHE_NAME=macosrusttests
 
 # -------------------------------------------------------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -692,7 +692,7 @@ osx_rust_tests: &osx_rust_tests
       LDFLAGS="-L/usr/local/opt/openssl/lib"
       CPPFLAGS="-I/usr/local/opt/openssl/include"
       PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
-      PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
     - CACHE_NAME=macosrusttests
 
 # -------------------------------------------------------------------------

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -630,10 +630,12 @@ osx_rust_tests: &osx_rust_tests
       - openssl
       - osxfuse
   before_install:
-    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
   env:
     - >
       {{>env_osx_with_pyenv}}
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
     - CACHE_NAME=macosrusttests
 
 # -------------------------------------------------------------------------

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -635,7 +635,7 @@ osx_rust_tests: &osx_rust_tests
     - >
       {{>env_osx_with_pyenv}}
       PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
-      PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
+      PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
     - CACHE_NAME=macosrusttests
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
In https://github.com/pantsbuild/pants/pull/7591, we decided that (in general) we should avoid `pyenv global` and `~/.pyenv/shims` to instead favor the more explicit `~/.pyenv/versions/{py_version}/bin`.

Because of Travis caching, we did not catch that this change would break the OSX Rust shard, until merging the PR into master. https://travis-ci.org/pantsbuild/pants/jobs/522771730#L216

Here, we teach the OSX Rust shard to point to the `versions` folder. We also install Python 2.7 through Pyenv for consistency with the other OSX shards, as system Python has an outdated OpenSSL.