### PR TITLE
Refactor uses of dirutil.py to use the new default Unicode semantics

### DIFF
--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -96,7 +96,7 @@ thrift sources for python thrift library targets will soon become required.
 and/or files which need to be edited will be dumped to: {}
 """.format(len(failing_py_thrift_by_target), no_py_namespace_output_file))
 
-      safe_file_dump(no_py_namespace_output_file, '{}\n'.format(pretty_printed_failures), mode='w')
+      safe_file_dump(no_py_namespace_output_file, '{}\n'.format(pretty_printed_failures))
 
       if self.get_options().strict:
         raise error

--- a/src/python/pants/backend/native/tasks/conan_fetch.py
+++ b/src/python/pants/backend/native/tasks/conan_fetch.py
@@ -97,7 +97,7 @@ class ConanFetch(SimpleCodegenTask):
       with temporary_dir() as remotes_install_dir:
         # Create an artificial conan configuration dir containing just remotes.txt.
         remotes_txt_for_install = os.path.join(remotes_install_dir, 'remotes.txt')
-        safe_file_dump(remotes_txt_for_install, self._remotes_txt_content, mode='w')
+        safe_file_dump(remotes_txt_for_install, self._remotes_txt_content)
         # Configure the desired user home from this artificial config dir.
         argv = ['config', 'install', remotes_install_dir]
         workunit_factory = functools.partial(
@@ -115,7 +115,7 @@ class ConanFetch(SimpleCodegenTask):
             exit_code=exit_code)
       # Generate the sentinel file so that we know the remotes have been successfully configured for
       # this particular task fingerprint in successive pants runs.
-      safe_file_dump(remotes_txt_sentinel, self._remotes_txt_content, mode='w')
+      safe_file_dump(remotes_txt_sentinel, self._remotes_txt_content)
 
     return user_home
 

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -172,7 +172,7 @@ class RemotePantsRunner(object):
     exception_text = None
     for source in sources:
       log_path = ExceptionSink.exceptions_log_path(for_pid=source)
-      exception_text = maybe_read_file(log_path, binary_mode=False)
+      exception_text = maybe_read_file(log_path)
       if exception_text:
         break
 

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -99,7 +99,7 @@ class Digest(datatype([('fingerprint', text_type), ('serialized_bytes_length', i
 
     :return: A Digest, or None if the Digest did not exist.
     """
-    read_file = maybe_read_file(cls._path(directory), binary_mode=False)
+    read_file = maybe_read_file(cls._path(directory))
     if read_file:
       fingerprint, length = read_file.split(':')
       return Digest(fingerprint, int(length))

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -109,7 +109,7 @@ class Digest(datatype([('fingerprint', text_type), ('serialized_bytes_length', i
   def dump(self, directory):
     """Dump this Digest object adjacent to the given directory."""
     payload = '{}:{}'.format(self.fingerprint, self.serialized_bytes_length)
-    safe_file_dump(self._path(directory), payload=payload, mode='w')
+    safe_file_dump(self._path(directory), payload=payload)
 
   def __repr__(self):
     return '''Digest(fingerprint={}, serialized_bytes_length={})'''.format(

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -144,7 +144,7 @@ def bootstrap_c_source(scheduler_bindings_path, output_dir, module_name=NATIVE_E
     env_script = '{}.cflags'.format(real_output_prefix)
 
     # Preprocessor directives won't parse in the .cdef calls, so we have to hide them for now.
-    scheduler_bindings_content = read_file(scheduler_bindings_path, binary_mode=False)
+    scheduler_bindings_content = read_file(scheduler_bindings_path)
     scheduler_bindings = _hackily_rewrite_scheduler_bindings(scheduler_bindings_content)
 
     ffibuilder = cffi.FFI()
@@ -166,7 +166,7 @@ def bootstrap_c_source(scheduler_bindings_path, output_dir, module_name=NATIVE_E
     # to define a module that is loadable by either 2 or 3.
     # TODO: Because PyPy uses the same `init` function name regardless of the python version, this
     # trick does not work there: we leave its conditional in place.
-    file_content = read_file(temp_c_file, binary_mode=False)
+    file_content = read_file(temp_c_file)
     if CFFI_C_PATCH_BEFORE not in file_content:
       raise Exception('The patch for the CFFI generated code will not apply cleanly.')
     file_content = file_content.replace(CFFI_C_PATCH_BEFORE, CFFI_C_PATCH_AFTER)

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -267,7 +267,7 @@ class NailgunClient(object):
   def _maybe_write_pid_file(self):
     if self._current_remote_pid and self._current_remote_pgrp:
       remote_pid_file_path = self._get_remote_pid_file_path(os.getpid())
-      safe_file_dump(remote_pid_file_path, str(self._current_remote_pid), mode='w')
+      safe_file_dump(remote_pid_file_path, str(self._current_remote_pid))
 
   def _receive_remote_pid(self, pid):
     self._current_remote_pid = pid

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -191,7 +191,7 @@ class ProcessMetadataManager(object):
     """
     self._maybe_init_metadata_dir_by_name(name)
     file_path = self._metadata_file_path(name, metadata_key)
-    safe_file_dump(file_path, metadata_value, mode='w')
+    safe_file_dump(file_path, metadata_value)
 
   def await_metadata_by_name(self, name, metadata_key, timeout, caster=None):
     """Block up to a timeout for process metadata to arrive on disk.

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -177,7 +177,7 @@ class ProcessMetadataManager(object):
     """
     file_path = self._metadata_file_path(name, metadata_key)
     try:
-      metadata = read_file(file_path, binary_mode=False).strip()
+      metadata = read_file(file_path).strip()
       return self._maybe_cast(metadata, caster)
     except (IOError, OSError):
       return None

--- a/src/python/pants/releases/reversion.py
+++ b/src/python/pants/releases/reversion.py
@@ -90,7 +90,7 @@ def rewrite_record_file(workspace, src_record_file, mutated_file_tuples):
       output_line = line
     output_records.append(output_line)
 
-  safe_file_dump(file_name, '\r\n'.join(output_records) + '\r\n', mode='w')
+  safe_file_dump(file_name, '\r\n'.join(output_records) + '\r\n')
 
 
 # The wheel METADATA file will contain a line like: `Version: 1.11.0.dev3+7951ec01`.

--- a/src/python/pants/releases/reversion.py
+++ b/src/python/pants/releases/reversion.py
@@ -81,7 +81,7 @@ def rewrite_record_file(workspace, src_record_file, mutated_file_tuples):
 
   output_records = []
   file_name = os.path.join(workspace, dst_record_file)
-  for line in read_file(file_name, binary_mode=False).splitlines():
+  for line in read_file(file_name).splitlines():
     filename, fingerprint_str, size_str = line.rsplit(',', 3)
     if filename in mutated_files:
       fingerprint_str, size_str = fingerprint_file(workspace, filename)

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
@@ -119,7 +119,7 @@ and/or files which need to be edited will be dumped to: {}
                      .format(cm.exception.output_file))
     self.assertEqual(
       'src/py-thrift:no-py-namespace: [src/py-thrift/bad.thrift]\n',
-      read_file(cm.exception.output_file, binary_mode=False))
+      read_file(cm.exception.output_file))
 
   def test_clashing_namespace_same_target(self):
     clashing_same_target = self._target_dict()['clashing-namespace']

--- a/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
@@ -37,7 +37,7 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
   def tmp_scalastyle_config(self):
     with temporary_dir(root_dir=get_buildroot()) as scalastyle_dir:
       path = os.path.join(scalastyle_dir, 'config.xml')
-      safe_file_dump(path, '''<scalastyle/>''', mode='w')
+      safe_file_dump(path, '''<scalastyle/>''')
       yield '--lint-scalastyle-config={}'.format(path)
 
   def pants_run(self, options=None):

--- a/tests/python/pants_test/backend/jvm/tasks/test_bundle_create.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_bundle_create.py
@@ -38,7 +38,7 @@ class TestBundleCreate(JvmBinaryTaskTestBase):
     entry_path = safe_mkdtemp(dir=target_dir)
     classpath_dir = safe_mkdtemp(dir=target_dir)
     for rel_path, content in files_dict.items():
-      safe_file_dump(os.path.join(entry_path, rel_path), content, mode='w')
+      safe_file_dump(os.path.join(entry_path, rel_path), content)
 
     # Create Jar to mimic consolidate classpath behavior.
     jarpath = os.path.join(classpath_dir, 'output-0.jar')
@@ -71,12 +71,12 @@ class TestBundleCreate(JvmBinaryTaskTestBase):
                                           JarDependency(org='org.gnu', name='gary', rev='4.0.0',
                                                         ext='tar.gz')])
 
-    safe_file_dump(os.path.join(self.build_root, 'resources/foo/file'), '// dummy content', mode='w')
+    safe_file_dump(os.path.join(self.build_root, 'resources/foo/file'), '// dummy content')
     self.resources_target = self.make_target('//resources:foo-resources', Resources,
                                              sources=['foo/file'])
 
     # This is so that payload fingerprint can be computed.
-    safe_file_dump(os.path.join(self.build_root, 'foo/Foo.java'), '// dummy content', mode='w')
+    safe_file_dump(os.path.join(self.build_root, 'foo/Foo.java'), '// dummy content')
     self.java_lib_target = self.make_target('//foo:foo-library', JavaLibrary, sources=['Foo.java'])
 
     self.binary_target = self.make_target(spec='//foo:foo-binary',

--- a/tests/python/pants_test/backend/jvm/tasks/test_consolidate_classpath.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_consolidate_classpath.py
@@ -48,12 +48,12 @@ class TestConsolidateClasspath(JvmBinaryTaskTestBase):
                                           JarDependency(org='org.gnu', name='gary', rev='4.0.0',
                                                         ext='tar.gz')])
 
-    safe_file_dump(os.path.join(self.build_root, 'resources/foo/file'), '// dummy content',  mode='w')
+    safe_file_dump(os.path.join(self.build_root, 'resources/foo/file'), '// dummy content')
     self.resources_target = self.make_target('//resources:foo-resources', Resources,
                                              sources=['foo/file'])
 
     # This is so that payload fingerprint can be computed.
-    safe_file_dump(os.path.join(self.build_root, 'foo/Foo.java'), '// dummy content', mode='w')
+    safe_file_dump(os.path.join(self.build_root, 'foo/Foo.java'), '// dummy content')
     self.java_lib_target = self.make_target('//foo:foo-library', JavaLibrary, sources=['Foo.java'])
 
     self.binary_target = self.make_target(spec='//foo:foo-binary',

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -218,7 +218,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
 
     # Existing files (with and without the method name) should trigger.
     srcfile = os.path.join(self.test_workdir, 'this.is.a.source.file.scala')
-    safe_file_dump(srcfile, 'content!', mode='w')
+    safe_file_dump(srcfile, 'content!')
     self.assertTrue(JUnitRun.request_classes_by_source([srcfile]))
     self.assertTrue(JUnitRun.request_classes_by_source(['{}#method'.format(srcfile)]))
 

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -135,7 +135,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       orig_wrapped_math_build = read_file(self._wrapped_math_build_file, binary_mode=False)
       without_strict_deps_wrapped_math_build = re.sub(
         'strict_deps=False,', '', orig_wrapped_math_build)
-      safe_file_dump(self._wrapped_math_build_file, without_strict_deps_wrapped_math_build, mode='w')
+      safe_file_dump(self._wrapped_math_build_file, without_strict_deps_wrapped_math_build)
 
       # This should fail because it does not turn on strict_deps for a target which requires it.
       pants_binary_strict_deps_failure = self.run_pants_with_workdir(

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -132,7 +132,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
       # Replace strict_deps=False with nothing so we can override it (because target values for this
       # option take precedence over subsystem options).
-      orig_wrapped_math_build = read_file(self._wrapped_math_build_file, binary_mode=False)
+      orig_wrapped_math_build = read_file(self._wrapped_math_build_file)
       without_strict_deps_wrapped_math_build = re.sub(
         'strict_deps=False,', '', orig_wrapped_math_build)
       safe_file_dump(self._wrapped_math_build_file, without_strict_deps_wrapped_math_build)

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -209,7 +209,7 @@ Current thread [^\n]+ \\(most recent call first\\):
 
     with temporary_dir() as tmpdir:
       some_file = os.path.join(tmpdir, 'some_file')
-      safe_file_dump(some_file, b'', mode='wb')
+      safe_file_dump(some_file, '')
       redirected_pants_run = self.run_pants([
         "--lifecycle-stubs-new-interactive-stream-output-file={}".format(some_file),
       ] + lifecycle_stub_cmdline)

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -63,9 +63,9 @@ Exception message: 1 Exception encountered:
 """)
       pid_specific_log_file, shared_log_file = self._get_log_file_paths(tmpdir, pants_run)
       self._assert_unhandled_exception_log_matches(
-        pants_run.pid, read_file(pid_specific_log_file, binary_mode=False))
+        pants_run.pid, read_file(pid_specific_log_file))
       self._assert_unhandled_exception_log_matches(
-        pants_run.pid, read_file(shared_log_file, binary_mode=False))
+        pants_run.pid, read_file(shared_log_file))
 
   def _assert_graceful_signal_log_matches(self, pid, signum, signame, contents):
     assertRegex(self, contents, """\
@@ -130,9 +130,9 @@ Signal {signum} \\({signame}\\) was raised\\. Exiting with failure\\.
         # Check that the logs show a graceful exit by SIGTERM.
         pid_specific_log_file, shared_log_file = self._get_log_file_paths(workdir, waiter_run)
         self._assert_graceful_signal_log_matches(
-          waiter_run.pid, signum, signame, read_file(pid_specific_log_file, binary_mode=False))
+          waiter_run.pid, signum, signame, read_file(pid_specific_log_file))
         self._assert_graceful_signal_log_matches(
-          waiter_run.pid, signum, signame, read_file(shared_log_file, binary_mode=False))
+          waiter_run.pid, signum, signame, read_file(shared_log_file))
 
   def test_dumps_traceback_on_sigabrt(self):
     # SIGABRT sends a traceback to the log file for the current process thanks to
@@ -140,13 +140,13 @@ Signal {signum} \\({signame}\\) was raised\\. Exiting with failure\\.
     with self._send_signal_to_waiter_handle(signal.SIGABRT) as (workdir, waiter_run):
       # Check that the logs show an abort signal and the beginning of a traceback.
       pid_specific_log_file, shared_log_file = self._get_log_file_paths(workdir, waiter_run)
-      assertRegex(self, read_file(pid_specific_log_file, binary_mode=False), """\
+      assertRegex(self, read_file(pid_specific_log_file), """\
 Fatal Python error: Aborted
 
 Thread [^\n]+ \\(most recent call first\\):
 """)
       # faulthandler.enable() only allows use of a single logging file at once for fatal tracebacks.
-      self.assertEqual('', read_file(shared_log_file, binary_mode=False))
+      self.assertEqual('', read_file(shared_log_file))
 
   def test_prints_traceback_on_sigusr2(self):
     with self._make_waiter_handle() as (workdir, pid, join):
@@ -217,4 +217,4 @@ Current thread [^\n]+ \\(most recent call first\\):
       # The Exiter prints the final error message to whatever the interactive output stream is set
       # to, so when it's redirected it won't be in stderr.
       self.assertNotIn('erroneous!', redirected_pants_run.stderr_data)
-      self.assertIn('erroneous!', read_file(some_file, binary_mode=False))
+      self.assertIn('erroneous!', read_file(some_file))

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -346,7 +346,7 @@ class BinaryUtilTest(TestBase):
     """Test invoking binary_util.py as a standalone script."""
     with temporary_dir() as tmp_dir:
       config_file_loc = os.path.join(tmp_dir, 'pants.ini')
-      safe_file_dump(config_file_loc, mode='w', payload="""\
+      safe_file_dump(config_file_loc, payload="""\
 [GLOBAL]
 allow_external_binary_tool_downloads: True
 pants_bootstrapdir: {}

--- a/tests/python/pants_test/build_graph/test_subproject_integration.py
+++ b/tests/python/pants_test/build_graph/test_subproject_integration.py
@@ -76,7 +76,7 @@ testprojects/
 def harness():
   try:
     for name, content in BUILD_FILES.items():
-      safe_file_dump(name, dedent(content), mode='w')
+      safe_file_dump(name, dedent(content))
     yield
   finally:
     safe_rmtree(SUBPROJ_SPEC)

--- a/tests/python/pants_test/engine/legacy/test_address_mapper.py
+++ b/tests/python/pants_test/engine/legacy/test_address_mapper.py
@@ -40,15 +40,15 @@ class LegacyAddressMapperTest(TestBase):
     safe_mkdir(dir_b)
     safe_mkdir(dir_a_subdir)
 
-    safe_file_dump(os.path.join(self.build_root, 'BUILD'), 'target(name="a")\ntarget(name="b")', mode='w')
-    safe_file_dump(os.path.join(self.build_root, 'BUILD.other'), 'target(name="c")', mode='w')
+    safe_file_dump(os.path.join(self.build_root, 'BUILD'), 'target(name="a")\ntarget(name="b")')
+    safe_file_dump(os.path.join(self.build_root, 'BUILD.other'), 'target(name="c")')
 
-    safe_file_dump(os.path.join(dir_a, 'BUILD'), 'target(name="a")\ntarget(name="b")', mode='w')
-    safe_file_dump(os.path.join(dir_a, 'BUILD.other'), 'target(name="c")', mode='w')
+    safe_file_dump(os.path.join(dir_a, 'BUILD'), 'target(name="a")\ntarget(name="b")')
+    safe_file_dump(os.path.join(dir_a, 'BUILD.other'), 'target(name="c")')
 
-    safe_file_dump(os.path.join(dir_b, 'BUILD'), 'target(name="a")', mode='w')
+    safe_file_dump(os.path.join(dir_b, 'BUILD'), 'target(name="a")')
 
-    safe_file_dump(os.path.join(dir_a_subdir, 'BUILD'), 'target(name="a")', mode='w')
+    safe_file_dump(os.path.join(dir_a_subdir, 'BUILD'), 'target(name="a")')
 
   def test_is_valid_single_address(self):
     self.create_build_files()

--- a/tests/python/pants_test/engine/legacy/test_console_rule_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_console_rule_integration.py
@@ -78,7 +78,7 @@ class TestConsoleRuleIntegration(PantsDaemonIntegrationTestBase):
       rel_tmpdir = fast_relpath(tmpdir, get_buildroot())
 
       def dump(content):
-        safe_file_dump(os.path.join(tmpdir, 'BUILD'), content, mode='w')
+        safe_file_dump(os.path.join(tmpdir, 'BUILD'), content)
 
       # Dump an initial target before starting the loop.
       dump('target(name="one")')

--- a/tests/python/pants_test/jvm/jvm_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_task_test_base.py
@@ -53,7 +53,7 @@ class JvmTaskTestBase(TaskTestBase):
     safe_mkdir(target_dir)
     classpath_dir = safe_mkdtemp(dir=target_dir)
     for rel_path, content in files_dict.items():
-      safe_file_dump(os.path.join(classpath_dir, rel_path), content, mode='w')
+      safe_file_dump(os.path.join(classpath_dir, rel_path), content)
     # Add to the classpath.
     runtime_classpath.add_for_target(tgt, [('default', classpath_dir)])
 

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -421,17 +421,17 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         pantsd_run(['help'])
         checker.assert_started()
 
-        safe_file_dump(test_build_file, "python_library(sources=globs('some_non_existent_file.py'))", mode='w')
+        safe_file_dump(test_build_file, "python_library(sources=globs('some_non_existent_file.py'))")
         result = pantsd_run(export_cmd)
         checker.assert_running()
         assertNotRegex(self, result.stdout_data, has_source_root_regex)
 
-        safe_file_dump(test_build_file, "python_library(sources=globs('*.py'))", mode='w')
+        safe_file_dump(test_build_file, "python_library(sources=globs('*.py'))")
         result = pantsd_run(export_cmd)
         checker.assert_running()
         assertNotRegex(self, result.stdout_data, has_source_root_regex)
 
-        safe_file_dump(test_src_file, 'import this\n', mode='w')
+        safe_file_dump(test_src_file, 'import this\n')
         result = pantsd_run(export_cmd)
         checker.assert_running()
         assertRegex(self, result.stdout_data, has_source_root_regex)
@@ -448,7 +448,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
 
     try:
       safe_mkdir(test_path, clean=True)
-      safe_file_dump(test_build_file, "{}()".format(invalid_symbol), mode='w')
+      safe_file_dump(test_build_file, "{}()".format(invalid_symbol))
       for _ in range(3):
         with self.pantsd_run_context(success=False) as (pantsd_run, checker, _, _):
           result = pantsd_run(['list', 'testprojects::'])

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -149,7 +149,7 @@ class TestProcessMetadataManager(TestBase):
   def test_wait_for_file(self):
     with temporary_dir() as td:
       test_filename = os.path.join(td, 'test.out')
-      safe_file_dump(test_filename, 'test', mode='w')
+      safe_file_dump(test_filename, 'test')
       self.pmm._wait_for_file(test_filename, timeout=.1)
 
   def test_wait_for_file_timeout(self):

--- a/tests/python/pants_test/pantsd/test_watchman.py
+++ b/tests/python/pants_test/pantsd/test_watchman.py
@@ -63,7 +63,7 @@ class TestWatchman(TestBase):
       self.watchman._maybe_init_metadata()
 
       mock_mkdir.assert_called_once_with(self._watchman_dir)
-      mock_file_dump.assert_called_once_with(self._state_file, '{}')
+      mock_file_dump.assert_called_once_with(self._state_file, b'{}', mode='wb')
 
   def test_construct_cmd(self):
     output = self.watchman._construct_cmd(['cmd', 'parts', 'etc'],

--- a/tests/python/pants_test/pantsd/test_watchman.py
+++ b/tests/python/pants_test/pantsd/test_watchman.py
@@ -63,7 +63,7 @@ class TestWatchman(TestBase):
       self.watchman._maybe_init_metadata()
 
       mock_mkdir.assert_called_once_with(self._watchman_dir)
-      mock_file_dump.assert_called_once_with(self._state_file, b'{}', mode='wb')
+      mock_file_dump.assert_called_once_with(self._state_file, '{}')
 
   def test_construct_cmd(self):
     output = self.watchman._construct_cmd(['cmd', 'parts', 'etc'],

--- a/tests/python/pants_test/repo_scripts/test_git_hooks.py
+++ b/tests/python/pants_test/repo_scripts/test_git_hooks.py
@@ -69,7 +69,7 @@ class PreCommitHookTest(unittest.TestCase):
       init_py_path = os.path.join(worktree, 'subdir/__init__.py')
 
       # Check that an invalid __init__.py errors.
-      safe_file_dump(init_py_path, 'asdf', mode='w')
+      safe_file_dump(init_py_path, 'asdf')
       self._assert_subprocess_error(worktree, [package_check_script, 'subdir'], """\
 ERROR: All '__init__.py' files should be empty or else only contain a namespace
 declaration, but the following contain code:
@@ -78,7 +78,7 @@ subdir/__init__.py
 """)
 
       # Check that a valid empty __init__.py succeeds.
-      safe_file_dump(init_py_path, '', mode='w')
+      safe_file_dump(init_py_path, '')
       self._assert_subprocess_success(worktree, [package_check_script, 'subdir'])
 
       # Check that a valid __init__.py with `pkg_resources` setup succeeds.
@@ -97,7 +97,7 @@ subdir/__init__.py
     with self._create_tiny_git_repo() as (git, worktree, _):
       # Create a new file.
       new_file = os.path.join(worktree, 'wow.txt')
-      safe_file_dump(new_file, '', mode='w')
+      safe_file_dump(new_file, '')
       # Stage the file.
       rel_new_file = os.path.relpath(new_file, worktree)
       git.add(rel_new_file)
@@ -122,13 +122,13 @@ subdir/__init__.py
           expected_excerpt=expected_excerpt)
 
       # Check that a file with an empty header fails.
-      safe_file_dump(new_py_path, '', mode='w')
+      safe_file_dump(new_py_path, '')
       assert_header_check(added_files=[], expected_excerpt="""\
 subdir/file.py: failed to parse header at all
 """)
 
       # Check that a file with a random header fails.
-      safe_file_dump(new_py_path, 'asdf', mode='w')
+      safe_file_dump(new_py_path, 'asdf')
       assert_header_check(added_files=[], expected_excerpt="""\
 subdir/file.py: failed to parse header at all
 """)
@@ -143,7 +143,7 @@ subdir/file.py: failed to parse header at all
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-""", mode='w')
+""")
       assert_header_check(added_files=[], expected_excerpt="""\
 subdir/file.py: copyright year must match '20\\d\\d' (was YYYY): current year is {}
 """.format(cur_year))

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -661,7 +661,7 @@ class TestBase(unittest.TestCase, AbstractClass):
     """
     with temporary_dir() as temp_dir:
       for file_name, content in files.items():
-        safe_file_dump(os.path.join(temp_dir, file_name), content, mode='w')
+        safe_file_dump(os.path.join(temp_dir, file_name), content)
       return self.scheduler.capture_snapshots((
         PathGlobsAndRoot(PathGlobs(('**',)), text_type(temp_dir)),
       ))[0]


### PR DESCRIPTION
Now that we finished the switchover in https://github.com/pantsbuild/pants/pull/7603 so that the dirutil functions default to Unicode, we can drop explicit arguments for simpler code.

The main motivations for using this default are:
1) Default developers to using Unicode. The majority of the time, we want them using Unicode as a it's more predictable and the default in Py3. Making the decision for them means it's more likely they'll stick to the sensible default.
2) Less cognitive overload due to a simpler API.
3) Alignment with Python's `open()` functions.