### PR TITLE
Change `./pants generate-pants-ini` to avoid a second bootstrap when using our distributed `./pants` script

### DIFF
--- a/src/python/pants/core_tasks/generate_pants_ini.py
+++ b/src/python/pants/core_tasks/generate_pants_ini.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os.path
+import sys
 from textwrap import dedent
 
 from pants.base.build_environment import get_default_pants_config_file
@@ -36,6 +37,15 @@ class GeneratePantsIni(ConsoleTask):
 
     with open(pants_ini_path, "w") as f:
       f.write(pants_ini_content)
+
+    # If the user is using our provided `./pants` script, we rename the venv folder to avoid
+    # a second bootstrap.
+    venv_folder = sys.exec_prefix
+    if os.path.basename(venv_folder).startswith("unspecified_py"):
+      py_version = venv_folder[-2:]
+      new_venv_folder = "{}/{}_py{}".format(os.path.dirname(venv_folder), pants_version, py_version)
+      os.rename(venv_folder, new_venv_folder)
+      yield "* Renaming the venv folder to `{}`.".format(new_venv_folder)
 
     yield ("You may modify these values directly in the file at any time. "
            "The ./pants script will detect any changes the next time you run it.")


### PR DESCRIPTION
### Problem
When following our install guide https://www.pantsbuild.org/install.html#recommended-installation, we end up bootstrapping *two* virtual environments and logging this to the user, which is confusing for your very first interaction with Pants.

This is because the Bash script names the venv folder as `unspecified_py*` when `pants.ini` does not have a version pinned: https://github.com/pantsbuild/setup/blob/8fca2f4a51ddc65c931d4aba4ec3fbc1acf27234/pants#L157.

### Solution
Teach `./pants generate-pants-ini` to check if the user is bootstrapping via our virtualenv-based script, and rename the folder if this is the case to use the pinned Python version.

This is apparently safe to rename the folder of the currently executing interpreter.

### Result
After running `./pants generate-pants-ini`, everything really will be ready to go.

If not using our distributed `./pants` script, then nothing will change.

If using our script, but an outdated version without the new naming scheme of using `_py36` etc, then nothing will change.