### PR TITLE
Default release script to use Python 3 in preparation for dropping Python 2 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -375,7 +375,7 @@ py27_linux_build_engine: &py27_linux_build_engine
     # TODO: While this image shouldn't have any cache to fetch anything from, it fails to find
     # libpython2.7.so.1 during the cargo build, despite the image being built with --enable-shared,
     # unless the -x argument is added. This isn't expected to affect build time too much.
-    - docker_run_command="./build-support/bin/ci.sh -2bx && ./build-support/bin/release.sh -f"
+    - docker_run_command="./build-support/bin/ci.sh -2bx && ./build-support/bin/release.sh -2f"
     - PREPARE_DEPLOY=1
     - CACHE_NAME=linuxpexbuild.py27
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.linux
@@ -427,7 +427,7 @@ py27_osx_build_engine: &py27_osx_build_engine
   script:
     - ./build-support/bin/ci.sh -2b
     #  Also build fs_util.
-    - ./build-support/bin/release.sh -f
+    - ./build-support/bin/release.sh -2f
     - *aws_deploy_pants_pex
 
 py36_osx_build_engine: &py36_osx_build_engine
@@ -568,7 +568,7 @@ py27_linux_build_wheels_ucs2: &py27_linux_build_wheels_ucs2
     - docker_image_name=travis_ci_py27_ucs2
     - docker_run_command="./build-support/bin/ci.sh -2b
                           && ./build-support/bin/check_pants_pex_abi.py cp27m
-                          && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
+                          && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -2n"
     - CACHE_NAME=linuxwheelsbuild.ucs2
 
 py27_linux_build_wheels_ucs4: &py27_linux_build_wheels_ucs4
@@ -582,7 +582,7 @@ py27_linux_build_wheels_ucs4: &py27_linux_build_wheels_ucs4
     - *base_build_wheels_env
     - docker_image_name=travis_ci
     - docker_run_command="./build-support/bin/check_pants_pex_abi.py cp27mu
-                          && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
+                          && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -2n"
     - CACHE_NAME=linuxwheelsbuild.ucs4
 
 py36_linux_build_wheels: &py36_linux_build_wheels
@@ -594,7 +594,7 @@ py36_linux_build_wheels: &py36_linux_build_wheels
     - *base_build_wheels_env
     - docker_image_name=travis_ci
     - docker_run_command="./build-support/bin/check_pants_pex_abi.py abi3 cp36m
-                          && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n"
+                          && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
     - CACHE_NAME=linuxwheelsbuild.abi3
 
 base_osx_build_wheels: &base_osx_build_wheels
@@ -616,7 +616,7 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
     - ./build-support/bin/check_pants_pex_abi.py cp27m
-    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
+    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -2n
 
 py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   <<: *py27_osx_config
@@ -635,7 +635,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   script:
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu
-    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
+    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -2n
 
 py36_osx_build_wheels: &py36_osx_build_wheels
   <<: *py36_osx_test_config
@@ -651,7 +651,7 @@ py36_osx_build_wheels: &py36_osx_build_wheels
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY36_VERSION}']"
   script:
     - ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
-    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n
+    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 # -------------------------------------------------------------------------
 # Rust tests
@@ -873,7 +873,7 @@ py27_deploy_stable_multiplatform_pex: &py27_deploy_stable_multiplatform_pex
   env:
     - *base_deploy_env
     - *base_deploy_stable_env
-    - RELEASE_ARGS=""
+    - RELEASE_ARGS="-2"
     - CACHE_NAME=linuxpexdeploystable.py27
 
 py36_deploy_stable_multiplatform_pex: &py36_deploy_stable_multiplatform_pex
@@ -882,7 +882,7 @@ py36_deploy_stable_multiplatform_pex: &py36_deploy_stable_multiplatform_pex
   env:
     - *base_deploy_env
     - *base_deploy_stable_env
-    - RELEASE_ARGS="-3"
+    - RELEASE_ARGS=""
     - CACHE_NAME=linuxpexdeploystable.py36
 
 base_deploy_unstable_multiplatform_pex: &base_deploy_unstable_multiplatform_pex
@@ -901,7 +901,7 @@ py27_deploy_unstable_multiplatform_pex: &py27_deploy_unstable_multiplatform_pex
   env:
     - *base_deploy_env
     - *base_deploy_unstable_env
-    - RELEASE_ARGS=""
+    - RELEASE_ARGS="-2"
     - CACHE_NAME=linuxpexdeployunstable.py27
 
 py36_deploy_unstable_multiplatform_pex: &py36_deploy_unstable_multiplatform_pex
@@ -910,7 +910,7 @@ py36_deploy_unstable_multiplatform_pex: &py36_deploy_unstable_multiplatform_pex
   env:
     - *base_deploy_env
     - *base_deploy_unstable_env
-    - RELEASE_ARGS="-3"
+    - RELEASE_ARGS=""
     - CACHE_NAME=linuxpexdeployunstable.py36
 
 # -------------------------------------------------------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -336,11 +336,10 @@ travis_docker_image: &travis_docker_image
 # Bootstrap engine shards
 # -------------------------------------------------------------------------
 
-# Note for each platform, we have the Python 2.7 shard also create fs_util and
+# Note for each platform, we have the Python 3.6 shard also create fs_util and
 # upload to S3, to take advantage of the Rust code built during
-# bootstrapping. We must use the Python 2.7 shard, as it is the only Build Engine
-# shard to run during both daily and nightly CI. This requires setting
-# PREPARE_DEPLOY=1.
+# bootstrapping. We use the Python 3.6 shard, as it runs during both daily and
+# nightly CI. This requires setting PREPARE_DEPLOY=1.
 
 base_linux_build_engine: &base_linux_build_engine
   <<: *native_engine_cache_config
@@ -375,8 +374,7 @@ py27_linux_build_engine: &py27_linux_build_engine
     # TODO: While this image shouldn't have any cache to fetch anything from, it fails to find
     # libpython2.7.so.1 during the cargo build, despite the image being built with --enable-shared,
     # unless the -x argument is added. This isn't expected to affect build time too much.
-    - docker_run_command="./build-support/bin/ci.sh -2bx && ./build-support/bin/release.sh -2f"
-    - PREPARE_DEPLOY=1
+    - docker_run_command="./build-support/bin/ci.sh -2bx"
     - CACHE_NAME=linuxpexbuild.py27
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.linux
 
@@ -386,7 +384,8 @@ py36_linux_build_engine: &py36_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py3.6 PEX)"
   env:
     - docker_image_name=travis_ci
-    - docker_run_command="./build-support/bin/ci.sh -b"
+    - docker_run_command="./build-support/bin/ci.sh -b && ./build-support/bin/release.sh -f"
+    - PREPARE_DEPLOY=1
     - CACHE_NAME=linuxpexbuild.py36
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
 
@@ -421,13 +420,10 @@ py27_osx_build_engine: &py27_osx_build_engine
   name: "Build OSX native engine and pants.pex (Py2.7 PEX)"
   env:
     - *py27_osx_config_env
-    - PREPARE_DEPLOY=1
     - CACHE_NAME=osxpexbuild.py27
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
   script:
     - ./build-support/bin/ci.sh -2b
-    #  Also build fs_util.
-    - ./build-support/bin/release.sh -2f
     - *aws_deploy_pants_pex
 
 py36_osx_build_engine: &py36_osx_build_engine
@@ -436,10 +432,12 @@ py36_osx_build_engine: &py36_osx_build_engine
   name: "Build OSX native engine and pants.pex (Py3.6 PEX)"
   env:
     - *py36_osx_config_env
+    - PREPARE_DEPLOY=1
     - CACHE_NAME=osxpexbuild.py36
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
   script:
     - ./build-support/bin/ci.sh -b
+    - ./build-support/bin/release.sh -f
     - *aws_deploy_pants_pex
 
 py37_osx_build_engine: &py37_osx_build_engine

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -700,10 +700,10 @@ function usage() {
   echo "PyPi.  Credentials are needed for this as described in the"
   echo "release docs: http://pantsbuild.org/release.html"
   echo
-  echo "Usage: $0 [-d] [-c] [-3] (-h|-n|-f|-t|-l|-o|-e|-p)"
+  echo "Usage: $0 [-d] [-c] [-2] (-h|-n|-f|-t|-l|-o|-e|-p)"
   echo " -d  Enables debug mode (verbose output, script pauses after venv creation)"
   echo " -h  Prints out this help message."
-  echo " -3  Release any non-universal wheels (i.e. pantsbuild.pants) as Python 3. Defaults to Python 2."
+  echo " -2  Release any non-universal wheels (i.e. pantsbuild.pants) as Python 2. Defaults to Python 3."
   echo " -n  Performs a release dry run."
   echo "       All package distributions will be built, installed locally in"
   echo "       an ephemeral virtualenv and exercised to validate basic"

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -303,11 +303,10 @@ travis_docker_image: &travis_docker_image
 # Bootstrap engine shards
 # -------------------------------------------------------------------------
 
-# Note for each platform, we have the Python 2.7 shard also create fs_util and
+# Note for each platform, we have the Python 3.6 shard also create fs_util and
 # upload to S3, to take advantage of the Rust code built during
-# bootstrapping. We must use the Python 2.7 shard, as it is the only Build Engine
-# shard to run during both daily and nightly CI. This requires setting
-# PREPARE_DEPLOY=1.
+# bootstrapping. We use the Python 3.6 shard, as it runs during both daily and
+# nightly CI. This requires setting PREPARE_DEPLOY=1.
 
 base_linux_build_engine: &base_linux_build_engine
   <<: *native_engine_cache_config
@@ -331,8 +330,7 @@ py27_linux_build_engine: &py27_linux_build_engine
     # TODO: While this image shouldn't have any cache to fetch anything from, it fails to find
     # libpython2.7.so.1 during the cargo build, despite the image being built with --enable-shared,
     # unless the -x argument is added. This isn't expected to affect build time too much.
-    - docker_run_command="./build-support/bin/ci.sh -2bx && ./build-support/bin/release.sh -2f"
-    - PREPARE_DEPLOY=1
+    - docker_run_command="./build-support/bin/ci.sh -2bx"
     - CACHE_NAME=linuxpexbuild.py27
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.linux
 
@@ -342,7 +340,8 @@ py36_linux_build_engine: &py36_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py3.6 PEX)"
   env:
     - docker_image_name=travis_ci
-    - docker_run_command="./build-support/bin/ci.sh -b"
+    - docker_run_command="./build-support/bin/ci.sh -b && ./build-support/bin/release.sh -f"
+    - PREPARE_DEPLOY=1
     - CACHE_NAME=linuxpexbuild.py36
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
 
@@ -377,13 +376,10 @@ py27_osx_build_engine: &py27_osx_build_engine
   name: "Build OSX native engine and pants.pex (Py2.7 PEX)"
   env:
     - *py27_osx_config_env
-    - PREPARE_DEPLOY=1
     - CACHE_NAME=osxpexbuild.py27
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.osx
   script:
     - ./build-support/bin/ci.sh -2b
-    #  Also build fs_util.
-    - ./build-support/bin/release.sh -2f
     - *aws_deploy_pants_pex
 
 py36_osx_build_engine: &py36_osx_build_engine
@@ -392,10 +388,12 @@ py36_osx_build_engine: &py36_osx_build_engine
   name: "Build OSX native engine and pants.pex (Py3.6 PEX)"
   env:
     - *py36_osx_config_env
+    - PREPARE_DEPLOY=1
     - CACHE_NAME=osxpexbuild.py36
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
   script:
     - ./build-support/bin/ci.sh -b
+    - ./build-support/bin/release.sh -f
     - *aws_deploy_pants_pex
 
 py37_osx_build_engine: &py37_osx_build_engine

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -331,7 +331,7 @@ py27_linux_build_engine: &py27_linux_build_engine
     # TODO: While this image shouldn't have any cache to fetch anything from, it fails to find
     # libpython2.7.so.1 during the cargo build, despite the image being built with --enable-shared,
     # unless the -x argument is added. This isn't expected to affect build time too much.
-    - docker_run_command="./build-support/bin/ci.sh -2bx && ./build-support/bin/release.sh -f"
+    - docker_run_command="./build-support/bin/ci.sh -2bx && ./build-support/bin/release.sh -2f"
     - PREPARE_DEPLOY=1
     - CACHE_NAME=linuxpexbuild.py27
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py27.linux
@@ -383,7 +383,7 @@ py27_osx_build_engine: &py27_osx_build_engine
   script:
     - ./build-support/bin/ci.sh -2b
     #  Also build fs_util.
-    - ./build-support/bin/release.sh -f
+    - ./build-support/bin/release.sh -2f
     - *aws_deploy_pants_pex
 
 py36_osx_build_engine: &py36_osx_build_engine
@@ -513,7 +513,7 @@ py27_linux_build_wheels_ucs2: &py27_linux_build_wheels_ucs2
     - docker_image_name=travis_ci_py27_ucs2
     - docker_run_command="./build-support/bin/ci.sh -2b
                           && ./build-support/bin/check_pants_pex_abi.py cp27m
-                          && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
+                          && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -2n"
     - CACHE_NAME=linuxwheelsbuild.ucs2
 
 py27_linux_build_wheels_ucs4: &py27_linux_build_wheels_ucs4
@@ -527,7 +527,7 @@ py27_linux_build_wheels_ucs4: &py27_linux_build_wheels_ucs4
     - *base_build_wheels_env
     - docker_image_name=travis_ci
     - docker_run_command="./build-support/bin/check_pants_pex_abi.py cp27mu
-                          && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
+                          && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -2n"
     - CACHE_NAME=linuxwheelsbuild.ucs4
 
 py36_linux_build_wheels: &py36_linux_build_wheels
@@ -539,7 +539,7 @@ py36_linux_build_wheels: &py36_linux_build_wheels
     - *base_build_wheels_env
     - docker_image_name=travis_ci
     - docker_run_command="./build-support/bin/check_pants_pex_abi.py abi3 cp36m
-                          && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n"
+                          && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
     - CACHE_NAME=linuxwheelsbuild.abi3
 
 base_osx_build_wheels: &base_osx_build_wheels
@@ -561,7 +561,7 @@ py27_osx_build_wheels_ucs2: &py27_osx_build_wheels_ucs2
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY27_VERSION}']"
   script:
     - ./build-support/bin/check_pants_pex_abi.py cp27m
-    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
+    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -2n
 
 py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   <<: *py27_osx_config
@@ -580,7 +580,7 @@ py27_osx_build_wheels_ucs4: &py27_osx_build_wheels_ucs4
   script:
     - ./build-support/bin/ci.sh -2b
     - ./build-support/bin/check_pants_pex_abi.py cp27mu
-    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
+    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -2n
 
 py36_osx_build_wheels: &py36_osx_build_wheels
   <<: *py36_osx_test_config
@@ -596,7 +596,7 @@ py36_osx_build_wheels: &py36_osx_build_wheels
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY36_VERSION}']"
   script:
     - ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
-    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -3n
+    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
 
 # -------------------------------------------------------------------------
 # Rust tests
@@ -816,7 +816,7 @@ py27_deploy_stable_multiplatform_pex: &py27_deploy_stable_multiplatform_pex
   env:
     - *base_deploy_env
     - *base_deploy_stable_env
-    - RELEASE_ARGS=""
+    - RELEASE_ARGS="-2"
     - CACHE_NAME=linuxpexdeploystable.py27
 
 py36_deploy_stable_multiplatform_pex: &py36_deploy_stable_multiplatform_pex
@@ -825,7 +825,7 @@ py36_deploy_stable_multiplatform_pex: &py36_deploy_stable_multiplatform_pex
   env:
     - *base_deploy_env
     - *base_deploy_stable_env
-    - RELEASE_ARGS="-3"
+    - RELEASE_ARGS=""
     - CACHE_NAME=linuxpexdeploystable.py36
 
 base_deploy_unstable_multiplatform_pex: &base_deploy_unstable_multiplatform_pex
@@ -844,7 +844,7 @@ py27_deploy_unstable_multiplatform_pex: &py27_deploy_unstable_multiplatform_pex
   env:
     - *base_deploy_env
     - *base_deploy_unstable_env
-    - RELEASE_ARGS=""
+    - RELEASE_ARGS="-2"
     - CACHE_NAME=linuxpexdeployunstable.py27
 
 py36_deploy_unstable_multiplatform_pex: &py36_deploy_unstable_multiplatform_pex
@@ -853,7 +853,7 @@ py36_deploy_unstable_multiplatform_pex: &py36_deploy_unstable_multiplatform_pex
   env:
     - *base_deploy_env
     - *base_deploy_unstable_env
-    - RELEASE_ARGS="-3"
+    - RELEASE_ARGS=""
     - CACHE_NAME=linuxpexdeployunstable.py36
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
In 1.17.0.dev0, we will no longer release Python 2 wheels or PEX. This is prework to make for a smaller diff when removing that support.

Beyond defaulting to Py3 in `release.sh` and `packages.py`, we now build fs util with the Py36 shards. This is now possible because we now build the Py36 engine during the cron run thanks to Pantsd testing.