### PR TITLE
fix cron job by wrapping the python binary in text_type() in v2 pytest

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -52,7 +52,7 @@ def run_python_test(transitive_hydrated_target, pytest):
 
   # TODO: This should be configurable, both with interpreter constraints, and for remote execution.
   # TODO(#7061): This str() can be removed after we drop py2!
-  python_binary = str(sys.executable)
+  python_binary = text_type(sys.executable)
 
   # TODO: This is non-hermetic because the requirements will be resolved on the fly by
   # pex27, where it should be hermetically provided in some way.


### PR DESCRIPTION
### Problem

The cron job is failing due to a type check error in an ExecuteProcessRequest creation: see https://travis-ci.org/pantsbuild/pants/jobs/522402485.

### Solution

- Wrap `sys.executable` in `text_type()` not `str()`.
  - This is necessary after the changes in #7529.

### Result

The cron job passes! This fix can be verified by running `./pants2 --print-exception-stacktrace --v2 --no-v1 test testprojects/tests/python/pants/dummies:target_with_source_dep` and seeing that it passes.