### PR TITLE
Fix typo in How to Contribute docs.

### DIFF
--- a/src/docs/howto_contribute.md
+++ b/src/docs/howto_contribute.md
@@ -208,7 +208,7 @@ If your pull request fails in travis, you can look at the shard logs to see the
 failure cause. From that log, you can figure out what tests you need to run to reproduce the failure
 locally. If you cannot reproduce the failure locally and it looks unrelated to your change, please
 open an issue for it with the label
-(`flaky-test`)[https://github.com/pantsbuild/pants/labels/flaky-test]. You can also ping slack to
+[`flaky-test`](https://github.com/pantsbuild/pants/labels/flaky-test). You can also ping slack to
 ask for someone to restart the failing shard.
 (<a pantsref="dev_run_all_tests">More on checking CI test runs here</a>)
 


### PR DESCRIPTION
### Problem
The typo mistake in how to contribute doc.
![image](https://user-images.githubusercontent.com/8607745/56618902-80b89a80-6641-11e9-80ab-c344391f3e72.png)

### Solution
Corrected the typo by changing the respective file.

### Result
Now the link won't be visible instead the text will be having the hyperlink.
![image](https://user-images.githubusercontent.com/8607745/56618992-ba89a100-6641-11e9-9cb6-413d84bbaf3a.png)
