### PR TITLE
download rustup-init without --proto to work around outdated centos6 curl version

### DIFF
--- a/build-support/bin/native/bootstrap_rust.sh
+++ b/build-support/bin/native/bootstrap_rust.sh
@@ -17,6 +17,27 @@ function cargo_bin() {
   "${RUSTUP}" which cargo
 }
 
+# TODO(7288): RustUp tries to use a more secure protocol to avoid downgrade attacks. This, however,
+# broke support for Centos6 (https://github.com/rust-lang/rustup.rs/issues/1794). So, we first try
+# to use their recommend install, and downgrade to their workaround if necessary.
+function curl_rustup_init_script_while_maybe_downgrading() {
+  if ! curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs; then
+    case "$(uname)" in
+      Darwin)
+        host_triple='x86_64-apple-darwin'
+      ;;
+      Linux)
+        host_triple='x86_64-unknown-linux-gnu'
+      ;;
+      *)
+        die "unrecognized platform $(uname) -- could not bootstrap rustup!"
+      ;;
+    esac
+    full_rustup_backup_url="https://static.rust-lang.org/rustup/dist/${host_triple}/rustup-init"
+    curl -sSf "$full_rustup_backup_url"
+  fi
+}
+
 function bootstrap_rust() {
   RUST_TOOLCHAIN="$(cat ${REPO_ROOT}/rust-toolchain)"
   RUST_COMPONENTS=(
@@ -26,12 +47,11 @@ function bootstrap_rust() {
   )
 
   # Control a pants-specific rust toolchain.
-  if [[ ! -x "${RUSTUP}" ]]
-  then
+  if [[ ! -x "${RUSTUP}" ]]; then
     log "A pants owned rustup installation could not be found, installing via the instructions at" \
         "https://www.rustup.rs ..."
     local -r rustup_tmp=$(mktemp -t pants.rustup.XXXXXX)
-    curl https://sh.rustup.rs -sSf > ${rustup_tmp}
+    curl_rustup_init_script_while_maybe_downgrading > ${rustup_tmp}
     # NB: rustup installs itself into CARGO_HOME, but fetches toolchains into RUSTUP_HOME.
     sh ${rustup_tmp} -y --no-modify-path --default-toolchain none 1>&2
     rm -f ${rustup_tmp}
@@ -40,8 +60,7 @@ function bootstrap_rust() {
   local -r cargo="${CARGO_HOME}/bin/cargo"
   local -r cargo_components_fp=$(echo "${RUST_COMPONENTS[@]}" | fingerprint_data)
   local -r cargo_versioned="cargo-${RUST_TOOLCHAIN}-${cargo_components_fp}"
-  if [[ ! -x "${rust_toolchain_root}/${cargo_versioned}" || "${RUST_TOOLCHAIN}" == "nightly" ]]
-  then
+  if [[ ! -x "${rust_toolchain_root}/${cargo_versioned}" || "${RUST_TOOLCHAIN}" == "nightly" ]]; then
     # If rustup was already bootstrapped against a different toolchain in the past, freshen it and
     # ensure the toolchain and components we need are installed.
     "${RUSTUP}" self update


### PR DESCRIPTION
### Problem

Our CI is broken right now, failing to build `pants.pex` in our Linux shards running CentOS6, e.g. https://travis-ci.org/pantsbuild/pants/jobs/523606246. This appears to be an instance of an upstream rustup development, noted by @Eric-Arellano in https://github.com/rust-lang/rustup.rs/issues/1794#issuecomment-485942630. While there may be a solution which maintains the security that the rustup folks desire, this diff should work around the issue for now.

### Solution

- Download the backup script as per https://github.com/rust-lang/rustup.rs/issues/1794#issuecomment-485739036 if the original request fails.

### Result

CI should pass!