### PR TITLE
use upstream rustup init script download workaround for old curl version on CentOS6

### DIFF
--- a/build-support/bin/native/bootstrap_rust.sh
+++ b/build-support/bin/native/bootstrap_rust.sh
@@ -33,6 +33,8 @@ function bootstrap_rust() {
     # This is the recommended installation method for Unix when '--proto' is not available on curl
     # (as in CentOS6), see # https://github.com/rust-lang/rustup.rs#other-installation-methods.
     # The workaround was added in https://github.com/rust-lang/rustup.rs/pull/1803.
+    # TODO(7288): Once we migrate to Centos7, we can go back to using RustUp's preferred and more
+    # secure installation method. Convert this to the snippet from https://rustup.rs.
     curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain none 1>&2
   fi
 

--- a/build-support/bin/native/bootstrap_rust.sh
+++ b/build-support/bin/native/bootstrap_rust.sh
@@ -32,6 +32,7 @@ function bootstrap_rust() {
         "https://www.rustup.rs ..."
     # This is the recommended installation method for Unix when '--proto' is not available on curl
     # (as in CentOS6), see # https://github.com/rust-lang/rustup.rs#other-installation-methods.
+    # The workaround was added in https://github.com/rust-lang/rustup.rs/pull/1803.
     curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain none 1>&2
   fi
 


### PR DESCRIPTION
### Problem

See #7615, where we had to work around a sudden error downloading rustup on our CentOS6 docker image bootstrap shards. A workaround was made available from rustup via rust-lang/rustup.rs#1803, so we can remove our own workaround.

### Solution

- Remove platform-specific logic from `bootstrap_rust.sh`.
- Remove the need to output the `rustup-init` script to a temporary file.

### Result

Our bootstrap shards should continue working!