### PR TITLE
Add the possibility to ignore sigint from other threads

### DIFF
--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -5,15 +5,14 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-import signal
 
 from pex.pex_info import PexInfo
 
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks.python_execution_task_base import PythonExecutionTaskBase
+from pants.base.exception_sink import ExceptionSink
 from pants.task.repl_task_mixin import ReplTaskMixin
-from pants.util.contextutil import signal_handler_as
 
 
 class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
@@ -55,8 +54,6 @@ class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
     # While the repl subprocess is synchronously spawned, we rely on process group
     # signalling for a SIGINT to reach the repl subprocess directly - and want to
     # do nothing in response on the parent side.
-    def ignore_control_c(signum, frame): pass
-
-    with signal_handler_as(signal.SIGINT, ignore_control_c):
+    with ExceptionSink.ignoring_sigint():
       env = pex_run_kwargs.pop('env', os.environ).copy()
       pex.run(env=env, **pex_run_kwargs)

--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -5,14 +5,15 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
+import signal
 
 from pex.pex_info import PexInfo
 
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks.python_execution_task_base import PythonExecutionTaskBase
-from pants.base.exception_sink import ExceptionSink
 from pants.task.repl_task_mixin import ReplTaskMixin
+from pants.util.contextutil import signal_handler_as
 
 
 class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
@@ -54,6 +55,8 @@ class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
     # While the repl subprocess is synchronously spawned, we rely on process group
     # signalling for a SIGINT to reach the repl subprocess directly - and want to
     # do nothing in response on the parent side.
-    with ExceptionSink.ignoring_sigint():
+    def ignore_control_c(signum, frame): pass
+
+    with signal_handler_as(signal.SIGINT, ignore_control_c):
       env = pex_run_kwargs.pop('env', os.environ).copy()
       pex.run(env=env, **pex_run_kwargs)


### PR DESCRIPTION
### Problem

In the context of #7596, pants tasks will be executed outside of the main thread. This means that tasks like `python-repl` cannot override signal handling ([code](https://github.com/pantsbuild/pants/blob/039051735542d29ae02f4faa09c0c51c47292bf0/src/python/pants/backend/python/tasks/python_repl.py#L60)), because this can only be done from the main thread.

### Solution

Create an atomic variable, `SignalHandler._ignore_sigint`, that gates SIGINT handling. Create a global context manager inside `ExceptionSink` that toggles this for a certain time if needed.

### Result

Any thread can pause the handling of SIGINT in a controlled way.
`python-repl` no longer installs signal handlers, but rather it toggles the handling of the signal.

### Caveat

We may want to gate all signals individually, but the semantics of SIGINT are usually different enough from SIGTERM and SIGKILL that I think it's okay to only gate the first one.