### PR TITLE
better error messaging for binaries not found during pants bootstrapping

### DIFF
--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -67,3 +67,13 @@ function git_merge_base() {
   git rev-parse --symbolic-full-name --abbrev-ref HEAD@{upstream} 2>/dev/null || echo 'master'
 
 }
+
+function validate_executable() {
+  local -r exe_name="$1"
+  if ! hash "$exe_name"; then
+    die "$(cat <<EOF
+Executable ${exe_name} must be discoverable on the PATH for pants to bootstrap itself in this repo.
+Exiting.
+EOF)"
+  fi
+}

--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -70,7 +70,9 @@ function git_merge_base() {
 
 function validate_executable() {
   local -r exe_name="$1"
-  if ! hash "$exe_name"; then
+  # `command -v` is the POSIX way to check for a command's existence -- see
+  # https://stackoverflow.com/a/677212/2518889.
+  if ! command -v "$exe_name" &>/dev/null; then
     die "$(cat <<EOF
 Executable ${exe_name} must be discoverable on the PATH for pants to bootstrap itself in this repo.
 Exiting.

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -34,19 +34,22 @@ function create_venv() {
 }
 
 function ensure_gcc() {
-  GCC_VERSION=$(gcc -v 2>&1)
-  if (( $? != 0 )); then
+  if ! gcc -v &>/dev/null; then
+    # The output was swallowed last time to avoid output in the success case, so we repeat the
+    # command's output again to stderr if it fails.
+    gcc -v >&2
     die "$(cat << MESSAGE
 ERROR: unable to execute 'gcc'. Please verify that your compiler is installed, in your
        \$PATH and functional.
 
 Hint: on Mac OS X, you may need to accept the XCode EULA: 'sudo xcodebuild -license accept'.
+Alternatively, if gcc was not found at all, you may need to run 'sudo xcode-select --install'.
 MESSAGE
 )"
   fi
   # Prevent bootstrapping failure due to unrecognized flag:
   # https://github.com/pantsbuild/pants/issues/78
-  if [[ "$GCC_VERSION" == *503.0.38* ]]; then
+  if [[ "$(gcc -v 2>&1)" == *503.0.38* ]]; then
     # Required for clang version 503.0.38
     export ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future
   fi
@@ -86,4 +89,3 @@ function activate_pants_venv() {
     activate_venv || die "Failed to activate venv."
   fi
 }
-

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -34,13 +34,15 @@ function create_venv() {
 }
 
 function ensure_gcc() {
-  if ! gcc -v &>/dev/null; then
+  if ! GCC_VERSION="$(gcc -v 2>&1)"; then
     # The output was swallowed last time to avoid output in the success case, so we repeat the
     # command's output again to stderr if it fails.
-    gcc -v >&2
     die "$(cat << MESSAGE
+Output was:
+${GCC_VERSION}
+
 ERROR: unable to execute 'gcc'. Please verify that your compiler is installed, in your
-       \$PATH and functional.
+\$PATH and functional.
 
 Hint: on Mac OS X, you may need to accept the XCode EULA: 'sudo xcodebuild -license accept'.
 Alternatively, if gcc was not found at all, you may need to run 'sudo xcode-select --install'.
@@ -49,7 +51,7 @@ MESSAGE
   fi
   # Prevent bootstrapping failure due to unrecognized flag:
   # https://github.com/pantsbuild/pants/issues/78
-  if [[ "$(gcc -v 2>&1)" == *503.0.38* ]]; then
+  if [[ "$GCC_VERSION" == *503.0.38* ]]; then
     # Required for clang version 503.0.38
     export ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future
   fi

--- a/pants
+++ b/pants
@@ -48,8 +48,13 @@ fi
 # Otherwise, run directly from sources, bootstrapping if needed.
 
 # Exposes:
+# + ensure_gcc: Attempt to invoke gcc to ensure one exists on the PATH.
 # + activate_pants_venv: Activate a virtualenv for pants requirements, creating it if needed.
 source ${HERE}/build-support/pants_venv
+# gcc is only necessary for compiling 3rdparty python requirements that pants itself depends on (not
+# for rust compilation), but
+# we validate it here in order to fail early.
+ensure_gcc
 
 # Exposes:
 # + bootstrap_native_code: Builds target-specific native engine binaries.

--- a/pants
+++ b/pants
@@ -57,6 +57,7 @@ source ${HERE}/build-support/bin/native/bootstrap_code.sh
 
 # Default to using Python 3 if not otherwise specified.
 export PY="${PY:-python3}"
+validate_executable "$PY"
 
 # Set interpreter constraints to exactly match the interpreter used for the venv, if not already set.
 # Note that $PY only impacts which virtualenv we use for the parent Pants process; we must also set

--- a/tests/python/pants_test/repo_scripts/BUILD
+++ b/tests/python/pants_test/repo_scripts/BUILD
@@ -1,13 +1,36 @@
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+python_library(
+  name='repo-script-test-base',
+  dependencies=[
+    'src/python/pants/util:process_handler',
+    'src/python/pants/util:strutil',
+    'tests/python/pants_test:test_base',
+    'tests/python/pants_test/testutils:git_util',
+  ],
+)
+
 python_tests(
-  name = 'git_hooks',
-  dependencies = [
+  name='git-hooks',
+  sources=['test_git_hooks.py'],
+  dependencies=[
+    ':repo-script-test-base',
     '3rdparty/python:future',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-    'src/python/pants/util:process_handler',
     'tests/python/pants_test/testutils:git_util',
-  ]
+  ],
+)
+
+python_tests(
+  name='pants-bootstrap',
+  sources=['test_pants_bootstrap.py'],
+  dependencies=[
+    ':repo-script-test-base',
+    '3rdparty/python:ansicolors',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:strutil',
+  ],
 )

--- a/tests/python/pants_test/repo_scripts/repo_script_test_base.py
+++ b/tests/python/pants_test/repo_scripts/repo_script_test_base.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from pants.util.process_handler import subprocess
+from pants.util.strutil import ensure_binary
+from pants_test.test_base import TestBase
+from pants_test.testutils.git_util import get_repo_root
+
+
+class RepoScriptTestBase(TestBase):
+
+  def setUp(self):
+    self.pants_repo_root = get_repo_root()
+
+  def _assert_subprocess_error(self, worktree, cmd, expected_output, **kwargs):
+    with self.assertRaises(subprocess.CalledProcessError) as cm:
+      subprocess.check_output(cmd, cwd=worktree, stderr=subprocess.STDOUT, **kwargs)
+    # Checks for an exact match of the combined stdout and stderr.
+    self.assertEqual(expected_output, cm.exception.output.decode('utf-8'))
+
+  def _assert_subprocess_error_excerpt(self, worktree, cmd, expected_excerpt, **kwargs):
+    with self.assertRaises(subprocess.CalledProcessError) as cm:
+      subprocess.check_output(cmd, cwd=worktree, stderr=subprocess.STDOUT, **kwargs)
+    # NB: checks for a string contained in the combined stdout and stderr, not an exact match!
+    self.assertIn(expected_excerpt, cm.exception.output.decode('utf-8'))
+
+  def _assert_subprocess_success(self, worktree, cmd, **kwargs):
+    self.assertEqual(0, subprocess.check_call(cmd, cwd=worktree, **kwargs))
+
+  def _assert_subprocess_success_with_output(self, worktree, cmd, full_expected_output):
+    output = subprocess.check_output(cmd, cwd=worktree)
+    self.assertEqual(full_expected_output, output.decode('utf-8'))
+
+  def _assert_subprocess_error_with_input(self, worktree, cmd, stdin_payload, expected_excerpt):
+    proc = subprocess.Popen(
+      cmd,
+      cwd=worktree,
+      stdin=subprocess.PIPE,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE,
+    )
+    (stdout_data, stderr_data) = proc.communicate(input=ensure_binary(stdin_payload))
+    # Attempting to call '{}\n{}'.format(...) on bytes in python 3 gives you the string:
+    #   "b'<the first string>'\nb'<the second string>'"
+    # So we explicitly decode both stdout and stderr here.
+    stdout_data = stdout_data.decode('utf-8')
+    stderr_data = stderr_data.decode('utf-8')
+    self.assertNotEqual(0, proc.returncode)
+    all_output = '{}\n{}'.format(stdout_data, stderr_data)
+    self.assertIn(expected_excerpt, all_output)

--- a/tests/python/pants_test/repo_scripts/test_pants_bootstrap.py
+++ b/tests/python/pants_test/repo_scripts/test_pants_bootstrap.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+from textwrap import dedent
+
+from colors import red
+
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import chmod_plus_x, safe_file_dump
+from pants.util.strutil import create_path_env_var
+from pants_test.repo_scripts.repo_script_test_base import RepoScriptTestBase
+
+
+class PantsBootstrapTest(RepoScriptTestBase):
+
+  def test_invalid_py_env_var(self):
+    self._assert_subprocess_error(
+      self.pants_repo_root,
+      ['./pants'],
+      env={'PY': 'this-is-not-a-real-python-executable'},
+      expected_output='\n{}\n'.format(red(dedent("""\
+        Executable this-is-not-a-real-python-executable must be discoverable on the PATH for pants to bootstrap itself in this repo.
+        Exiting."""))))
+
+  def test_invalid_gcc(self):
+    with temporary_dir() as tmp_gcc_bin_dir:
+      dummy_gcc_script = os.path.join(tmp_gcc_bin_dir, 'gcc')
+      safe_file_dump(dummy_gcc_script, mode='w', payload=dedent("""\
+        #!/usr/bin/env bash
+
+        echo 'failure' >&2
+        exit 1
+        """))
+      chmod_plus_x(dummy_gcc_script)
+      # import pdb; pdb.set_trace()
+      self._assert_subprocess_error_excerpt(
+        self.pants_repo_root,
+        ["./pants"],
+        env={'PATH': create_path_env_var([tmp_gcc_bin_dir], env=os.environ, prepend=True)},
+        expected_excerpt=dedent("""\
+          Output was:
+          failure
+
+          ERROR: unable to execute 'gcc'. Please verify that your compiler is installed, in your
+          $PATH and functional.
+          """))


### PR DESCRIPTION
### Problem

@dotordogh was having issues with pants self-bootstrapping in this repo. She was able to overcome this, but the process could have been made easier if we had couple explicit checks for necessary binaries we invoke in bootstrap scripts.

### Solution

- Add a check for the `$PY` python binary.
- Add a check for `gcc -v` failing, since @dotordogh noticed the output here implied that some weird logic was happening with the existing code in `ensure_gcc` when `set -x` was turned on:
```bash
+ GCC_VERSION='xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun'
```

### Result

The pants bootstrap process in this repo should be less confusing for first-time contributors!