### PR TITLE
Improve error message when no valid Python interpreter can be resolved

### DIFF
--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -9,6 +9,7 @@ import os
 import shutil
 from builtins import str
 from collections import defaultdict
+from textwrap import dedent
 
 from pex.interpreter import PythonInterpreter
 
@@ -91,10 +92,15 @@ class PythonInterpreterCache(Subsystem):
       unique_compatibilities = {tuple(c) for c in tgts_by_compatibilities.keys()}
       unique_compatibilities_strs = [','.join(x) for x in unique_compatibilities if x]
       tgts_by_compatibilities_strs = [t[0].address.spec for t in tgts_by_compatibilities.values()]
-      raise self.UnsatisfiableInterpreterConstraintsError(
-        'Unable to detect a suitable interpreter for compatibilities: {} '
-        '(Conflicting targets: {})'.format(' && '.join(sorted(unique_compatibilities_strs)),
-                                           ', '.join(tgts_by_compatibilities_strs)))
+      raise self.UnsatisfiableInterpreterConstraintsError(dedent("""\
+        Unable to detect a suitable interpreter for compatibilities: {} (Conflicting targets: {})
+
+        To fix this, either modify your Python interpreter constraints by following
+        https://www.pantsbuild.org/python_readme.html#configure-the-python-version or install the
+        targeted interpreter on your system.""".format(
+          ' && '.join(sorted(unique_compatibilities_strs)),
+          ', '.join(tgts_by_compatibilities_strs)
+        )))
     # Return the lowest compatible interpreter.
     return min(allowed_interpreters)
 

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 # TODO: Move under subsystems/ .
 class PythonInterpreterCache(Subsystem):
-  """Finds python interpreters on the local system."""
+  """Finds Python interpreters on the local system."""
   options_scope = 'python-interpreter-cache'
 
   @classmethod
@@ -35,7 +35,7 @@ class PythonInterpreterCache(Subsystem):
     return super(PythonInterpreterCache, cls).subsystem_dependencies() + (PythonSetup,)
 
   class UnsatisfiableInterpreterConstraintsError(TaskError):
-    """Indicates a python interpreter matching given constraints could not be located."""
+    """Indicates a Python interpreter matching given constraints could not be located."""
 
   @staticmethod
   def _matches(interpreter, filters=()):
@@ -89,17 +89,28 @@ class PythonInterpreterCache(Subsystem):
 
     if not allowed_interpreters:
       # Create a helpful error message.
+      all_interpreter_version_strings = sorted({
+        interpreter.version_string
+        # NB: self.setup() requires filters to be passed, or else it will use the global interpreter
+        # constraints. We allow any interpreter other than CPython 3.0-3.3, which is known to choke
+        # with Pants.
+        for interpreter in self.setup(filters=("CPython<3", "CPython>=3.3", "PyPy"))
+      })
       unique_compatibilities = {tuple(c) for c in tgts_by_compatibilities.keys()}
       unique_compatibilities_strs = [','.join(x) for x in unique_compatibilities if x]
       tgts_by_compatibilities_strs = [t[0].address.spec for t in tgts_by_compatibilities.values()]
       raise self.UnsatisfiableInterpreterConstraintsError(dedent("""\
         Unable to detect a suitable interpreter for compatibilities: {} (Conflicting targets: {})
 
-        To fix this, either modify your Python interpreter constraints by following
-        https://www.pantsbuild.org/python_readme.html#configure-the-python-version or install the
-        targeted interpreter on your system.""".format(
+        Pants detected these interpreter versions on your system: {}
+
+        Possible ways to fix this:
+        * Modify your Python interpreter constraints by following https://www.pantsbuild.org/python_readme.html#configure-the-python-version.
+        * Ensure the targeted Python version is installed and discoverable.
+        * Modify Pants' interpreter search paths via --pants-setup-interpreter-search-paths.""".format(
           ' && '.join(sorted(unique_compatibilities_strs)),
-          ', '.join(tgts_by_compatibilities_strs)
+          ', '.join(tgts_by_compatibilities_strs),
+          ', '.join(all_interpreter_version_strings)
         )))
     # Return the lowest compatible interpreter.
     return min(allowed_interpreters)


### PR DESCRIPTION
### Problem
Currently, when a valid interpreter cannot be found, such as by running `PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==3.9.*']" ./pants test tests/python/pants_test/util:strutil`, we will print something like this:

```
FAILURE: Unable to detect a suitable interpreter for compatibilities: CPython==3.9.* (Conflicting targets: tests/python/pants_test/util:strutil)
```

A user reported that they were very confused by this message. It seems the main issue was not explaining *what to do* to fix it, which led to them searching through GitHub and getting confused with our Python 3 migration efforts (e.g. `pants_runtime_python_version`) vs. setting constraints for your own code.

The other motivating factor is our setup repo failing to find a Python 3.6+ interpreter, despite us knowing for a fact that it is installed and on the PATH. https://travis-ci.org/pantsbuild/setup/jobs/524685486#L355. Here, it would be extremely helpful if we knew what Pants _is_ resolving.

### Solution
Improve the message to do two things:
* Provide several suggestions to fix the issue. We do not settle on one, because any of these 3 suggestions may be relevant.
* Print all the interpreters that _are_ discovered by Pants.

### Result
Now running `PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==3.9.*']" ./pants test tests/python/pants_test/util:strutil` results in this more helpful message:

```
FAILURE: Unable to detect a suitable interpreter for compatibilities: CPython==3.9.* (Conflicting targets: tests/python/pants_test/util:strutil)

Pants detected these interpreter versions on your system: CPython-2.7.10, CPython-2.7.15, CPython-3.6.8, CPython-3.7.1, CPython-3.7.3

Possible ways to fix this:
* Modify your Python interpreter constraints by following https://www.pantsbuild.org/python_readme.html#configure-the-python-version.
* Ensure the targeted Python version is installed and discoverable.
* Modify Pants' interpreter search paths via --pants-setup-interpreter-search-paths.
```