### PR TITLE
Add testing for improved error message from #7628 when no valid interpreter can be resolved

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -96,7 +96,7 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
     self.assertIn("Conflicting targets: {}".format(binary_target), pants_run.stdout_data)
     # NB: we expect the error message to print *all* interpreters resolved by Pants. However,
     # to simplify the tests and for hermicity, here we only test that the current interpreter
-    # gets printed as a prxoy for the overall behavior.
+    # gets printed as a proxy for the overall behavior.
     self.assertIn(
       PythonInterpreter.get().version_string,
       pants_run.stdout_data,

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -94,6 +94,9 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
       "Did not output requested compatibiility."
     )
     self.assertIn("Conflicting targets: {}".format(binary_target), pants_run.stdout_data)
+    # NB: we expect the error message to print *all* interpreters resolved by Pants. However,
+    # to simplify the tests and for hermicity, here we only test that the current interpreter
+    # gets printed as a prxoy for the overall behavior.
     self.assertIn(
       PythonInterpreter.get().version_string,
       pants_run.stdout_data,

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -32,10 +32,7 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
 
   def _build_pex(self, binary_target, config=None, args=None, version=PY_27):
     # By default, Avoid some known-to-choke-on interpreters.
-    if version == PY_3:
-      constraint = '["CPython>=3.6,<4"]'
-    else:
-      constraint = '["CPython>=2.7,<3"]'
+    constraint = '["CPython>=3.6,<4"]' if version == PY_3 else '["CPython>=2.7,<3"]'
     args = list(args) if args is not None else [
           '--python-setup-interpreter-constraints={}'.format(constraint)
         ]

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -83,10 +83,25 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
       }
     binary_target = '{}:echo_interpreter_version'.format(self.testproject)
     pants_run = self._build_pex(binary_target, config=config, args=[])
-    self.assert_failure(pants_run,
-                        'Unexpected successful build of {binary}.'.format(binary=binary_target))
-    self.assertIn('Unable to detect a suitable interpreter for compatibilities',
-                  pants_run.stdout_data)
+    self.assert_failure(
+      pants_run,
+      'Unexpected successful build of {binary}.'.format(binary=binary_target)
+    )
+    self.assertIn(
+      "Unable to detect a suitable interpreter for compatibilities",
+      pants_run.stdout_data
+    )
+    self.assertIn(
+      "CPython<2.7",
+      pants_run.stdout_data,
+      "Did not output requested compatibiility."
+    )
+    self.assertIn("Conflicting targets: {}".format(binary_target), pants_run.stdout_data)
+    self.assertIn(
+      PythonInterpreter.get().version_string,
+      pants_run.stdout_data,
+      "Did not output interpreters discoved by Pants."
+    )
 
   @skip_unless_python3_present
   def test_select_3(self):

--- a/tests/python/pants_test/backend/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/backend/python/test_interpreter_cache.py
@@ -29,10 +29,9 @@ class TestInterpreterCache(TestBase):
 
     E.g. 'CPython==2.7.5' becomes 'CPython==99.7.5'
     """
-    return (
-      str(requirement).replace('==3', '==99')
-      if PY3
-      else str(requirement).replace('==2.', '==99')
+    requirement_major_version = '3' if PY3 else '2'
+    return str(requirement).replace(
+      '=={}'.format(requirement_major_version), '==99'
     )
 
   def setUp(self):

--- a/tests/python/pants_test/backend/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/backend/python/test_interpreter_cache.py
@@ -29,10 +29,11 @@ class TestInterpreterCache(TestBase):
 
     E.g. 'CPython==2.7.5' becomes 'CPython==99.7.5'
     """
-    if PY3:
-      return str(requirement).replace('==3', '==99')
-    else:
-      return str(requirement).replace('==2.', '==99')
+    return (
+      str(requirement).replace('==3', '==99')
+      if PY3
+      else str(requirement).replace('==2.', '==99')
+    )
 
   def setUp(self):
     super(TestInterpreterCache, self).setUp()


### PR DESCRIPTION
While we currently do check that the branch for no valid interpreter being detected works, the check is not very comprehensive. 

In https://github.com/pantsbuild/pants/pull/7628, we made the logged error message even more complex, so it becomes even more important to check that we are logging the error message correctly.