### PR TITLE
Modernize `check_pants_pex_abi.py` script to Python 3

### DIFF
--- a/build-support/bin/check_pants_pex_abi.py
+++ b/build-support/bin/check_pants_pex_abi.py
@@ -1,16 +1,13 @@
-#!/usr/bin/env python2.7
-# coding=utf-8
+#!/usr/bin/env python3
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 # Check that the ./pants.pex was built using the passed abi specification.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import argparse
 import json
-import os.path
 import zipfile
+from pathlib import Path
 
 
 RED = "\033[31m"
@@ -18,8 +15,8 @@ BLUE = "\033[34m"
 RESET = "\033[0m"
 
 
-def main():
-  if not os.path.isfile("pants.pex"):
+def main() -> None:
+  if not Path("pants.pex").is_file:
     die("pants.pex not found! Ensure you are in the repository root, then run " \
         "'./build-support/bin/ci.sh -b' to bootstrap pants.pex with Python 3 or " \
         "'./build-support/bin/ci.sh -2b' to bootstrap pants.pex with Python 2.")
@@ -39,7 +36,7 @@ def main():
           .format(', '.join(sorted(parsed_abis))))
 
 
-def create_parser():
+def create_parser() -> argparse.ArgumentParser:
   parser = argparse.ArgumentParser(
     description="Check that ./pants.pex was built using the passed abi specification."
   )
@@ -47,7 +44,7 @@ def create_parser():
   return parser
 
 
-def parse_abi_from_filename(filename):
+def parse_abi_from_filename(filename: str) -> str:
   """This parses out the abi from a wheel filename.
 
   For example, `configparser-3.5.0-py2-abi3-any.whl` would return `abi3`.
@@ -55,12 +52,12 @@ def parse_abi_from_filename(filename):
   return filename.split("-")[-2]
 
 
-def success(message):
-  print("{}{}{}".format(BLUE, message, RESET))
+def success(message: str) -> None:
+  print(f"{BLUE}{message}{RESET}")
 
 
-def die(message):
-  raise SystemExit("{}{}{}".format(RED, message, RESET))
+def die(message: str) -> None:
+  raise SystemExit(f"{RED}{message}{RESET}")
 
 
 if __name__ == "__main__":

--- a/build-support/bin/check_pants_pex_abi.py
+++ b/build-support/bin/check_pants_pex_abi.py
@@ -23,7 +23,7 @@ def main() -> None:
   expected_abis = frozenset(create_parser().parse_args().abis)
   with zipfile.ZipFile("pants.pex", "r") as pex:
     with pex.open("PEX-INFO", "r") as pex_info:
-      pex_info_content = str(pex_info.readline())
+      pex_info_content = pex_info.readline().decode()
   parsed_abis = frozenset(
     parse_abi_from_filename(filename)
     for filename in json.loads(pex_info_content)["distributions"].keys()


### PR DESCRIPTION
Because we're guaranteed to have Py3 on all wheel building shards, we can refactor this script to use modern Python 3 for improved code and to prepare for removing Python 2 from CI.

Makes these refactors:
* Use type hints to allow scanning function signatures more easily.
* Use f-strings, but only where more readable.
* Remove unnecessary `__future__` import.
* Remove unnecessary file encoding header, since Python 3 assumes source files are UTF-8.
* Use modern `pathlib` library for object oriented interface (see [PEP 428](https://www.python.org/dev/peps/pep-0428/#why-an-object-oriented-api))