### PR TITLE
Prepare release 1.16.0.dev3 - fix notes.

### DIFF
--- a/src/python/pants/notes/master.rst
+++ b/src/python/pants/notes/master.rst
@@ -25,6 +25,9 @@ Bugfixes
 Refactoring, Improvements, and Tooling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Modernize `check_pants_pex_abi.py` script to Python 3 (#7631)
+  `PR #7631 <https://github.com/pantsbuild/pants/pull/7631>`_
+
 * unify precedence logic for options which may be overridden on targets (#7594)
   `PR #7594 <https://github.com/pantsbuild/pants/pull/7594>`_
 


### PR DESCRIPTION
A commit was merged into master between the commit
at which the release was cut, and the one that merged
the release notes. This change adds that commit to
the notes, so we can include it in the release.
