### PR TITLE
add suffix and Levenshtein matching for invalid option names

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -26,6 +26,7 @@ pyopenssl==17.3.0
 pystache==0.5.3
 pytest-cov>=2.5,<2.6
 pytest>=3.4,<4.0
+python-Levenshtein==0.12.0
 pywatchman==1.4.1
 PyYAML==5.1
 py_zipkin==0.17.0

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -6,6 +6,7 @@ python_library(
     'src/python/pants/util:collections_abc_backport',
     '3rdparty/python:ansicolors',
     '3rdparty/python:future',
+    '3rdparty/python:python-Levenshtein',
     '3rdparty/python:PyYAML',
     '3rdparty/python:setuptools',
     '3rdparty/python/twitter/commons:twitter.common.collections',

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -126,7 +126,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   'from the start of the warning string, and will always be case-insensitive. '
                   'See the `warnings` module documentation for more background on these are used.')
     register('--option-name-check-distance', advanced=True, type=int, default=2,
-             help='The maximum levenshtein distance to use when offering auggestions for invalid '
+             help='The maximum Levenshtein distance to use when offering suggestions for invalid '
                   'option names.')
 
     register('--pants-version', advanced=True, default=pants_version(),

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -125,6 +125,9 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   '["DEPRECATED: scope some_scope will be removed"]. The regexps will be matched '
                   'from the start of the warning string, and will always be case-insensitive. '
                   'See the `warnings` module documentation for more background on these are used.')
+    register('--option-name-check-distance', advanced=True, type=int, default=2,
+             help='The maximum levenshtein distance to use when offering auggestions for invalid '
+                  'option names.')
 
     register('--pants-version', advanced=True, default=pants_version(),
              help='Use this pants version. Note Pants code only uses this to verify that you are '

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -12,6 +12,7 @@ import traceback
 from builtins import next, object, open, str
 from collections import defaultdict
 
+import Levenshtein
 import six
 import yaml
 
@@ -29,6 +30,7 @@ from pants.option.errors import (BooleanOptionNameWithNo, FrozenRegistration, Im
 from pants.option.option_util import is_dict_option, is_list_option
 from pants.option.ranked_value import RankedValue
 from pants.option.scope import ScopeInfo
+from pants.util.objects import SubclassesOf, datatype
 
 
 class Parser(object):
@@ -115,37 +117,79 @@ class Parser(object):
   def scope(self):
     return self._scope
 
+  @property
+  def known_args(self):
+    return self._known_args
+
   def walk(self, callback):
     """Invoke callback on this parser and its descendants, in depth-first order."""
     callback(self)
     for child in self._child_parsers:
       child.walk(callback)
 
-  def _create_flag_value_map(self, flags):
-    """Returns a map of flag -> list of values, based on the given flag strings.
+  class ParseArgsRequest(datatype([
+      ('flag_value_map', SubclassesOf(dict)),
+      'namespace',
+      'get_all_scoped_flag_names',
+      ('levenshtein_max_distance', int),
+  ])):
 
-    None signals no value given (e.g., -x, --foo).
-    The value is a list because the user may specify the same flag multiple times, and that's
-    sometimes OK (e.g., when appending to list-valued options).
+    @staticmethod
+    def _create_flag_value_map(flags):
+      """Returns a map of flag -> list of values, based on the given flag strings.
+
+      None signals no value given (e.g., -x, --foo).
+      The value is a list because the user may specify the same flag multiple times, and that's
+      sometimes OK (e.g., when appending to list-valued options).
+      """
+      flag_value_map = defaultdict(list)
+      for flag in flags:
+        key, has_equals_sign, flag_val = flag.partition('=')
+        if not has_equals_sign:
+          if not flag.startswith('--'):  # '-xfoo' style.
+            key = flag[0:2]
+            flag_val = flag[2:]
+          if not flag_val:
+            # Either a short option with no value or a long option with no equals sign.
+            # Important so we can distinguish between no value ('--foo') and setting to an empty
+            # string ('--foo='), for options with an implicit_value.
+            flag_val = None
+        flag_value_map[key].append(flag_val)
+      return flag_value_map
+
+    def __new__(cls, flags_in_scope, namespace,
+                get_all_scoped_flag_names,
+                levenshtein_max_distance):
+      """
+      :param Iterable flags_in_scope: Iterable of arg strings to parse into flag values.
+      :param namespace: The object to register the flag values on
+      :param function get_all_scoped_flag_names: A 0-argument function which returns an iterable of
+                                                 all registered option names in all their scopes. This
+                                                 is used to create an error message with suggestions
+                                                 when raising a `ParseError`.
+      :param int levenshtein_max_distance: The maximum Levenshtein edit distance between option names
+                                           to determine similarly named options when an option name
+                                           hasn't been registered.
+      """
+      flag_value_map = cls._create_flag_value_map(flags_in_scope)
+      return super(Parser.ParseArgsRequest, cls).__new__(cls, flag_value_map, namespace,
+                                                         get_all_scoped_flag_names,
+                                                         levenshtein_max_distance)
+
+  def parse_args(self, parse_args_request):
+    """Set values for this parser's options on the namespace object.
+
+    :param Parser.ParseArgsRequest parse_args_request: parameters for parsing this parser's
+                                                       arguments.
+    :returns: The `parse_args_request.namespace` object that the option values are being registered
+              on.
+    :raises: :class:`ParseError` if any flags weren't recognized.
     """
-    flag_value_map = defaultdict(list)
-    for flag in flags:
-      key, has_equals_sign, flag_val = flag.partition('=')
-      if not has_equals_sign:
-        if not flag.startswith('--'):  # '-xfoo' style.
-          key = flag[0:2]
-          flag_val = flag[2:]
-        if not flag_val:
-          # Either a short option with no value or a long option with no equals sign.
-          # Important so we can distinguish between no value ('--foo') and setting to an empty
-          # string ('--foo='), for options with an implicit_value.
-          flag_val = None
-      flag_value_map[key].append(flag_val)
-    return flag_value_map
 
-  def parse_args(self, flags, namespace):
-    """Set values for this parser's options on the namespace object."""
-    flag_value_map = self._create_flag_value_map(flags)
+    flag_value_map = parse_args_request.flag_value_map
+    namespace = parse_args_request.namespace
+    get_all_scoped_flag_names = parse_args_request.get_all_scoped_flag_names
+    levenshtein_max_distance = parse_args_request.levenshtein_max_distance
 
     mutex_map = defaultdict(list)
     for args, kwargs in self._unnormalized_option_registrations_iter():
@@ -221,12 +265,63 @@ class Parser(object):
 
       setattr(namespace, dest, val)
 
-    # See if there are any unconsumed flags remaining.
+    # See if there are any unconsumed flags remaining, and if so, raise a ParseError.
     if flag_value_map:
-      raise ParseError('Unrecognized command line flags on {}: {}'.format(
-        self._scope_str(), ', '.join(flag_value_map.keys())))
+      self._raise_error_for_invalid_flag_names(
+        flag_value_map,
+        all_scoped_flag_names=list(get_all_scoped_flag_names()),
+        levenshtein_max_distance=levenshtein_max_distance)
 
     return namespace
+
+  def _raise_error_for_invalid_flag_names(self, flag_value_map, all_scoped_flag_names,
+                                          levenshtein_max_distance):
+    """Identify similar option names to unconsumed flags and raise a ParseError with those names."""
+    matching_flags = {}
+    for flag_name in flag_value_map.keys():
+      # We will be matching option names without their leading hyphens, in order to capture both
+      # short and long-form options.
+      flag_minus_leading_dashes = re.sub(r'^-+', '', flag_name)
+      scoped_name = (
+        '{}-{}'.format(self.scope, flag_minus_leading_dashes)
+        if self.scope != GLOBAL_SCOPE
+        else flag_minus_leading_dashes)
+      suffix_matching_option_names = []
+      levenshtein_matching_option_names = defaultdict(list)
+      for other_name in all_scoped_flag_names:
+        other_name_no_dashes = re.sub(r'^-+', '', other_name)
+        # If the invalid option on the command line is the ending of another option, display
+        # that. This can occur when an option is used without the appropriate prefix scope.
+        if other_name_no_dashes.endswith(scoped_name):
+          suffix_matching_option_names.append(other_name)
+        else:
+          # If an option name is similar to the one entered, according to
+          # --option-name-check-distance, display that. This covers misspellings!
+          levenshtein_distance = Levenshtein.distance(scoped_name, other_name_no_dashes)
+          if levenshtein_distance <= levenshtein_max_distance:
+            levenshtein_matching_option_names[levenshtein_distance].append(other_name)
+      # If any option name's suffix matched the invalid flag, put those first. Then, display the
+      # option names matching via edit distance in a deterministic way.
+      all_matching_scoped_option_names = suffix_matching_option_names + [
+        flag
+        for distance in sorted(levenshtein_matching_option_names.keys())
+        for flag in sorted(levenshtein_matching_option_names[distance])
+      ]
+      if all_matching_scoped_option_names:
+        matching_flags[flag_name] = all_matching_scoped_option_names
+
+    if matching_flags:
+      suggestions_message = '\n{}'.format('\n'.join(
+        '{}: [{}]'.format(flag_name, ', '.join(matches))
+        for flag_name, matches in matching_flags.items()
+      ))
+    else:
+      suggestions_message = ' <none>'
+    raise ParseError(
+      'Unrecognized command line flags on {scope}: {flags}. Suggestions:{suggestions}'
+      .format(scope=self._scope_str(),
+              flags=', '.join(flag_value_map.keys()),
+              suggestions=suggestions_message))
 
   def option_registrations_iter(self):
     """Returns an iterator over the normalized registration arguments of each option in this parser.

--- a/src/python/pants/option/parser_hierarchy.py
+++ b/src/python/pants/option/parser_hierarchy.py
@@ -36,7 +36,6 @@ def all_enclosing_scopes(scope, allow_global=True):
 
   _validate_full_scope(scope)
 
-  # TODO: validate scopes here and/or in `enclosing_scope()` instead of assuming correctness.
   def scope_within_range(tentative_scope):
     if tentative_scope is None:
       return False

--- a/tests/python/pants_test/option/test_options_integration.py
+++ b/tests/python/pants_test/option/test_options_integration.py
@@ -233,38 +233,6 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
       self.assertIn("ERROR] Invalid option 'bad_option' under [test.junit]", pants_run.stderr_data)
       self.assertIn("ERROR] Invalid scope [invalid_scope]", pants_run.stderr_data)
 
-  def test_invalid_command_line_option_shows_suggestions_in_error(self):
-    pants_run = self.run_pants([
-      # A nonexistent short-form option -- other short-form options should be displayed.
-      '-vd',
-      # A misspelling of `--level=debug` should show the correct option name.
-      '--lebel=debug',
-      # An option name without the correct prefix scope should match all options of the same name.
-      '--interpreter-search-paths=[]',
-      # A dummy goal to ensure options are parsed.
-      'goals',
-    ])
-    self.assert_failure(pants_run)
-    self.assertIn(dedent("""
-      Exception message: Unrecognized command line flags on global scope: -v, --lebel, --interpreter-search-paths. Suggestions:
-      -v: [--v1, --v2, -d, -e, -k, -l, -q, -t, -x]
-      --lebel: [--level]
-      --interpreter-search-paths: [--python-setup-interpreter-search-paths]
-      """),
-                  pants_run.stderr_data)
-
-    # Verify that misspelling searches work for options in non-global scopes.
-    pants_run = self.run_pants([
-      '--python-setup-interpreter-search-path=[]',
-      'goals',
-    ])
-    self.assert_failure(pants_run)
-    self.assertIn(dedent("""
-      Exception message: Unrecognized command line flags on scope 'python-setup': --interpreter-search-path. Suggestions:
-      --interpreter-search-path: [--python-setup-interpreter-search-paths]
-      """),
-                  pants_run.stderr_data)
-
   def test_command_line_option_unused_by_goals(self):
     self.assert_success(self.run_pants(['filter', '--bundle-jvm-archive=zip']))
     self.assert_failure(self.run_pants(['filter', '--jvm-invalid=zip']))


### PR DESCRIPTION
### Problem

When typing out a pants command line, a user may wish to use many options in many different scopes, which may take a lot of typing. If any of those options are misspelled, Pants currently doesn't display any help to the user helping them to figure it out, e.g.:

```
> ./pants --python-setup-interpreter-search-path="['/usr/bin']" options
timestamp: 2019-04-28T23:44:14.453055
Exception caught: (pants.option.errors.ParseError)
  ...
  File "/Users/dmcclanahan/workspace/source-v2/.pex/install/pantsbuild.pants-1.15.0rc0+git5c01b701-cp27-cp27m-macosx_10_11_x86_64.whl.850db4d17434427af3fd197127b57022c1d69259/pantsbuild.pants-1.15.0rc0+git5c01b701-cp27-cp27m-macosx_10_11_x86_64.whl/pants/option/parser.py", line 225, in parse_args
    self._scope_str(), ', '.join(flag_value_map.keys())))

Exception message: Unrecognized command line flags on scope 'python-setup': --interpreter-search-path
```

### Solution

- When unregistered options are found, fuzzy match them against a list of all registered options in all their scopes.
  - Add suffix matching to suggest containing scopes for options incorrectly provided in the global scope.
  - Add similarity matching via Levenshtein edit distance for misspelled options (configurable with the `--option-name-check-distance` global bootstrap option).

### Result

```
> ./pants --python-setup-interpreter-search-path="['/usr/bin']" options
Exception caught: (pants.option.errors.ParseError)
  ...
  File "/Users/dmcclanahan/tools/pants/src/python/pants/option/parser.py", line 324, in _raise_error_for_invalid_flag_names
    suggestions=suggestions_message))

Exception message: Unrecognized command line flags on scope 'python-setup': --interpreter-search-path. Suggestions:
--interpreter-search-path: [--python-setup-interpreter-search-paths]
```

Incorrectly-typed option names become less of a problem for new users!