### PR TITLE
Remote Execution allows extra platform properties to be set

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -778,6 +778,7 @@ class Native(Singleton):
         execution_options.remote_store_chunk_bytes,
         execution_options.remote_store_chunk_upload_timeout_seconds,
         execution_options.remote_store_rpc_retries,
+        self.context.utf8_buf_buf(execution_options.remote_execution_extra_platform_properties),
         execution_options.process_execution_parallelism,
         execution_options.process_execution_cleanup_local_dirs,
       )

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -42,6 +42,7 @@ class ExecutionOptions(datatype([
   'remote_instance_name',
   'remote_ca_certs_path',
   'remote_oauth_bearer_token_path',
+  'remote_execution_extra_platform_properties',
 ])):
   """A collection of all options related to (remote) execution of processes.
 
@@ -64,6 +65,7 @@ class ExecutionOptions(datatype([
       remote_instance_name=bootstrap_options.remote_instance_name,
       remote_ca_certs_path=bootstrap_options.remote_ca_certs_path,
       remote_oauth_bearer_token_path=bootstrap_options.remote_oauth_bearer_token_path,
+      remote_execution_extra_platform_properties=bootstrap_options.remote_execution_extra_platform_properties,
     )
 
 
@@ -80,6 +82,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_instance_name=None,
     remote_ca_certs_path=None,
     remote_oauth_bearer_token_path=None,
+    remote_execution_extra_platform_properties=[],
   )
 
 
@@ -369,6 +372,11 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help='Path to a file containing an oauth token to use for grpc connections to '
                   '--remote-execution-server and --remote-store-server. If not specified, no '
                   'authorization will be performed.')
+    register('--remote-execution-extra-platform-properties', advanced=True,
+             help='Platform properties to set on remote execution requests. '
+                  'Format: property=value. Multiple values should be specified as multiple '
+                  'occurrences of this flag. Pants itself may add additional platform properties.',
+                   type=list, default=[])
 
     # This should eventually deprecate the RunTracker worker count, which is used for legacy cache
     # lookups via CacheSetup in TaskBase.

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -28,6 +28,7 @@ use process_execution::{self, BoundedCommandRunner, CommandRunner};
 use rand::seq::SliceRandom;
 use reqwest;
 use resettable::Resettable;
+use std::collections::btree_map::BTreeMap;
 
 ///
 /// The core context shared (via Arc) between the Scheduler and the Context objects of
@@ -70,6 +71,7 @@ impl Core {
     remote_store_chunk_bytes: usize,
     remote_store_chunk_upload_timeout: Duration,
     remote_store_rpc_retries: usize,
+    remote_execution_extra_platform_properties: BTreeMap<String, String>,
     process_execution_parallelism: usize,
     process_execution_cleanup_local_dirs: bool,
   ) -> Core {
@@ -139,6 +141,7 @@ impl Core {
           remote_instance_name.clone(),
           root_ca_certs.clone(),
           oauth_bearer_token.clone(),
+          remote_execution_extra_platform_properties.clone(),
           // Allow for some overhead for bookkeeping threads (if any).
           process_execution_parallelism + 2,
           store.clone(),


### PR DESCRIPTION
Google's Remote Build Execution service now requires setting a platform property to specify in which docker
container you want to run actions.