### PR TITLE
Short-circuit primitive encoding on CoercingEncoder

### DIFF
--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -65,8 +65,14 @@ class CoercingEncoder(json.JSONEncoder):
     else:
       return self.encode(key_obj)
 
+  def _is_primitive(self, o):
+    if PY3:
+      return isinstance(o, (type(None), bool, int, list, str))
+    else:
+      return isinstance(o, (type(None), bool, int, list, str, unicode, basestring))
+
   def default(self, o):
-    if isinstance(o, (type(None), bool, int, list, str, unicode, basestring)):
+    if self._is_primitive(o):
       # isinstance() checks are expensive, particularly isinstance(o, Mapping):
       # https://stackoverflow.com/questions/42378726/why-is-checking-isinstancesomething-mapping-so-slow
       # This means that, if we let primitives fall through, we incur a performance hit, since

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -9,7 +9,7 @@ import json
 import logging
 from builtins import bytes, object, open, str
 
-from future.utils import PY3
+from future.utils import PY3, binary_type, text_type
 from twitter.common.collections import OrderedSet
 
 from pants.util.collections_abc_backport import Iterable, Mapping, OrderedDict, Set
@@ -67,8 +67,7 @@ class CoercingEncoder(json.JSONEncoder):
       return self.encode(key_obj)
 
   def _is_primitive(self, o):
-      return (isinstance(o, (type(None), bool, int, list, str, bytes)) if PY3 else
-              isinstance(o, (type(None), bool, int, list, str, unicode, basestring)))
+    return isinstance(o, (type(None), bool, int, list, text_type, binary_type)
 
   def default(self, o):
     if self._is_primitive(o):

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -16,6 +16,7 @@ from pants.util.collections_abc_backport import Iterable, Mapping, OrderedDict, 
 from pants.util.objects import DatatypeMixin
 from pants.util.strutil import ensure_binary
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -66,14 +67,12 @@ class CoercingEncoder(json.JSONEncoder):
       return self.encode(key_obj)
 
   def _is_primitive(self, o):
-    if PY3:
-      return isinstance(o, (type(None), bool, int, list, str))
-    else:
-      return isinstance(o, (type(None), bool, int, list, str, unicode, basestring))
+      return (isinstance(o, (type(None), bool, int, list, str, bytes)) if PY3 else
+              isinstance(o, (type(None), bool, int, list, str, unicode, basestring)))
 
   def default(self, o):
     if self._is_primitive(o):
-      # isinstance() checks are expensive, particularly isinstance(o, Mapping):
+      # isinstance() checks are expensive, particularly for abstract base classes such as Mapping:
       # https://stackoverflow.com/questions/42378726/why-is-checking-isinstancesomething-mapping-so-slow
       # This means that, if we let primitives fall through, we incur a performance hit, since
       # we call this function very often.
@@ -117,7 +116,7 @@ class CoercingEncoder(json.JSONEncoder):
       logger.debug("Our custom Encoder is trying to hash a primitive type, but has gone through"
                    "checking every other data type before. These checks are expensive,"
                    "so you should consider adding the type of your primitive {} to the top"
-                   "of this function".format(type(o)))
+                   "of this function (CoercingEncoder.default)".format(type(o)))
     return o
 
   def encode(self, o):

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -66,11 +66,11 @@ class CoercingEncoder(json.JSONEncoder):
     else:
       return self.encode(key_obj)
 
-  def _is_primitive(self, o):
-    return isinstance(o, (type(None), bool, int, list, text_type, binary_type)
+  def _is_natively_encodable(self, o):
+    return isinstance(o, (type(None), bool, int, list, text_type, binary_type))
 
   def default(self, o):
-    if self._is_primitive(o):
+    if self._is_natively_encodable(o):
       # isinstance() checks are expensive, particularly for abstract base classes such as Mapping:
       # https://stackoverflow.com/questions/42378726/why-is-checking-isinstancesomething-mapping-so-slow
       # This means that, if we let primitives fall through, we incur a performance hit, since

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -73,8 +73,9 @@ class CoercingEncoder(json.JSONEncoder):
     if self._is_natively_encodable(o):
       # isinstance() checks are expensive, particularly for abstract base classes such as Mapping:
       # https://stackoverflow.com/questions/42378726/why-is-checking-isinstancesomething-mapping-so-slow
-      # This means that, if we let primitives fall through, we incur a performance hit, since
+      # This means that, if we let natively encodable types all through, we incur a performance hit, since
       # we call this function very often.
+      # TODO(#7658) Figure out why we call this function so often.
       return o
     if isinstance(o, Mapping):
       # Preserve order to avoid collisions for OrderedDict inputs to json.dumps(). We don't do this
@@ -94,7 +95,7 @@ class CoercingEncoder(json.JSONEncoder):
       return OrderedDict(
         (self._maybe_encode_dict_key(k), self.default(v))
         for k, v in ordered_kv_pairs)
-    elif isinstance(o, Set):
+    if isinstance(o, Set):
       # We disallow OrderedSet (although it is not a stdlib collection) for the same reasons as
       # OrderedDict above.
       if isinstance(o, OrderedSet):
@@ -102,20 +103,19 @@ class CoercingEncoder(json.JSONEncoder):
                         .format(cls=type(self).__name__, val=o))
       # Set order is arbitrary in python 3.6 and 3.7, so we need to keep this sorted() call.
       return sorted(self.default(i) for i in o)
-    elif isinstance(o, DatatypeMixin):
+    if isinstance(o, DatatypeMixin):
       # datatype objects will intentionally raise in the __iter__ method, but the Iterable abstract
       # base class will match any class with any superclass that has the attribute __iter__ in the
       # __dict__ (see https://docs.python.org/2/library/abc.html), so we need to check for it
       # specially here.
       # TODO: determine if the __repr__ should be some abstractmethod on DatatypeMixin!
       return self.default(repr(o))
-    elif isinstance(o, Iterable) and not isinstance(o, (bytes, list, str)):
+    if isinstance(o, Iterable) and not isinstance(o, (bytes, list, str)):
       return list(self.default(i) for i in o)
-    else:
-      logger.debug("Our custom Encoder is trying to hash a primitive type, but has gone through"
-                   "checking every other data type before. These checks are expensive,"
-                   "so you should consider adding the type of your primitive {} to the top"
-                   "of this function (CoercingEncoder.default)".format(type(o)))
+    logger.debug("Our custom json encoder {} is trying to hash a primitive type, but has gone through"
+                 "checking every other registered type class before. These checks are expensive,"
+                 "so you should consider registering the type {} within"
+                 "this function ({}.default)".format(type(self).__name__, type(o), type(self).__name__))
     return o
 
   def encode(self, o):


### PR DESCRIPTION
### Problem

`CoercingEncoder.encode()` is called many times when fingerprinting options. There is a significant overhead to the `isinstance()` calls in python [reference](https://stackoverflow.com/questions/42378726/why-is-checking-isinstancesomething-mapping-so-slow). This means that, when `datatype`s recursively encode themselves after #7304, they do twice the checks that they already did, causing a several-second regression in large targets (from 56s to 59s, without pantsd).

### Solution

Short-circuit primitives to avoid some of those checks.

There is probably more reordering of branches to be done, but I don't know enough about the callers of that function to reorder safely, since the if-else branches return early and thus the cases might not be a real partition of the set of possible inputs.

### Result

The noop compile times of that large target are back to 56s.

### Acknowledgements

@ity and @stuhood for finding the regressing commit, and @cosmicexplorer and @illicitonion for helping find the root cause.