### PR TITLE
Apply timeouts to pex resolves

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_repos.py
+++ b/src/python/pants/backend/python/subsystems/python_repos.py
@@ -16,6 +16,8 @@ from pants.util.memo import memoized_method
 logger = logging.getLogger(__name__)
 
 
+# TODO: These methods of RequestsContext are monkey-patched out to work around
+# https://github.com/pantsbuild/pex/issues/26: we should upstream a fix for this.
 _REQUESTS_TIMEOUTS = (15, 30)
 
 

--- a/src/python/pants/backend/python/subsystems/python_repos.py
+++ b/src/python/pants/backend/python/subsystems/python_repos.py
@@ -4,10 +4,57 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
+
 from pex.fetcher import Fetcher, PyPIFetcher
-from pex.http import Context
+from pex.http import RequestsContext, StreamFilelike, requests
 
 from pants.subsystem.subsystem import Subsystem
+from pants.util.memo import memoized_method
+
+
+logger = logging.getLogger(__name__)
+
+
+_REQUESTS_TIMEOUTS = (15, 30)
+
+
+def _open_monkey(self, link):
+  # requests does not support file:// -- so we must short-circuit manually
+  if link.local:
+    return open(link.local_path, 'rb')  # noqa: T802
+  for attempt in range(self._max_retries + 1):
+    try:
+      return StreamFilelike(self._session.get(
+          link.url, verify=self._verify, stream=True, headers={'User-Agent': self.USER_AGENT},
+          timeout=_REQUESTS_TIMEOUTS),
+          link)
+    except requests.exceptions.ReadTimeout:
+      # Connect timeouts are handled by the HTTPAdapter, unfortunately read timeouts are not
+      # so we'll retry them ourselves.
+      logger.log('Read timeout trying to fetch %s, retrying. %d retries remain.' % (
+          link.url,
+          self._max_retries - attempt))
+    except requests.exceptions.RequestException as e:
+      raise self.Error(e)
+
+  raise self.Error(
+      requests.packages.urllib3.exceptions.MaxRetryError(
+          None,
+          link,
+          'Exceeded max retries of %d' % self._max_retries))
+
+
+def _resolve_monkey(self, link):
+  return link.wrap(self._session.head(
+      link.url, verify=self._verify, allow_redirects=True,
+      headers={'User-Agent': self.USER_AGENT},
+      timeout=_REQUESTS_TIMEOUTS,
+  ).url)
+
+
+RequestsContext.open = _open_monkey
+RequestsContext.resolve = _resolve_monkey
 
 
 class PythonRepos(Subsystem):
@@ -30,12 +77,14 @@ class PythonRepos(Subsystem):
   def indexes(self):
     return self.get_options().indexes
 
+  @memoized_method
   def get_fetchers(self):
     fetchers = []
     fetchers.extend(Fetcher([url]) for url in self.repos)
     fetchers.extend(PyPIFetcher(url) for url in self.indexes)
     return fetchers
 
+  @memoized_method
   def get_network_context(self):
     # TODO(wickman): Add retry, conn_timeout, threads, etc configuration here.
-    return Context.get()
+    return RequestsContext()

--- a/src/python/pants/releases/packages.py
+++ b/src/python/pants/releases/packages.py
@@ -194,9 +194,9 @@ def build_and_print_packages(version, py2=False):
     packages_by_flags[package.bdist_wheel_flags].append(package)
 
   for (flags, packages) in packages_by_flags.items():
-    args = ("./pants", "-q", "setup-py", "--run=bdist_wheel {}".format(" ".join(flags))) + tuple(package.target for package in packages)
+    args = ("./pants", "setup-py", "--run=bdist_wheel {}".format(" ".join(flags))) + tuple(package.target for package in packages)
     try:
-      subprocess.check_call(args)
+      subprocess.check_call(args, stdout=sys.stderr)
       for package in packages:
         print(package.name)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
### Problem

Either pypi or travis are currently intensely flaky with regard to the opening of https connections to pypi, with the result that the wheel-builder shards in master have a near-zero success rate due to the number of resolves they attempt during wheel testing.

This flakiness is significantly exacerbated by the fact that, when used with `requests`, `pex` does not set a connect/read timeout for http connections: the result is that many attempts to connect were hanging indefinitely at:
```
06:42:14 [DEBUG] urllib3.connectionpool:pid=3921: Starting new HTTPS connection (1): pypi.org:443
```

### Solution

1. Monkey-patch the methods of `RequestsContext` that should specify timeouts, and specify them.
2. Guarantee that we use `RequestsContext`, rather than whatever `Context.get` might choose.
3. Memoize `Context` creation on `PythonRepos`, which allows the connection pool to be reused across multiple resolves.

### Result

Connections will time out and retry:
```
06:42:14 [DEBUG] urllib3.connectionpool:pid=3921: Starting new HTTPS connection (1): pypi.org:443
06:42:29 [DEBUG] urllib3.util.retry:pid=3921: Incremented Retry for (url='/simple/pantsbuild-pants-contrib-awslambda-python/'): Retry(total=4, connect=None, read=None, redirect=None, status=None)
06:42:29 [WARN] Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='pypi.org', port=443): Read timed out. (read timeout=15)",)': /simple/pantsbuild-pants-contrib-awslambda-python/
06:42:29 [DEBUG] urllib3.connectionpool:pid=3921: Starting new HTTPS connection (2): pypi.org:443
06:42:29 [DEBUG] urllib3.connectionpool:pid=3921: https://pypi.org:443 "HEAD /simple/pantsbuild-pants-contrib-awslambda-python/ HTTP/1.1" 200 0
```

I'll look into upstreaming this as a fix for http://github.com/pantsbuild/pex/issues/26 tomorrow, but assuming it goes green, it would be good to land it temporarily to fix the breakage in master.