### PR TITLE
Use @union to make the v2 test runner generic

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -164,7 +164,6 @@ function execute_packaged_pants_with_internal_backends() {
     --no-verify-config \
     --pythonpath="['pants-plugins/src/python']" \
     --backend-packages="[\
-        'pants.rules.core',\
         'pants.backend.codegen',\
         'pants.backend.docgen',\
         'pants.backend.graph_info',\

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -25,8 +25,7 @@ from pants.build_graph.remote_sources import RemoteSources
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
-from pants.engine.legacy.structs import (BundleAdaptor, BundlesField, HydrateableField,
-                                         SourcesField, TargetAdaptor)
+from pants.engine.legacy.structs import BundleAdaptor, BundlesField, HydrateableField, SourcesField
 from pants.engine.mapper import AddressMapper
 from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct
@@ -505,8 +504,8 @@ def hydrate_target(hydrated_struct):
   for field in hydrated_fields:
     kwargs[field.name] = field.value
   yield HydratedTarget(target_adaptor.address,
-                        TargetAdaptor(**kwargs),
-                        tuple(target_adaptor.dependencies))
+                       type(target_adaptor)(**kwargs),
+                       tuple(target_adaptor.dependencies))
 
 
 def _eager_fileset_with_spec(spec_path, filespec, snapshot, include_dirs=False):

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -20,7 +20,7 @@ from pants.engine.struct import Struct, StructWithDeps
 from pants.source import wrapped_globs
 from pants.util.collections_abc_backport import MutableSequence, MutableSet
 from pants.util.contextutil import exception_logging
-from pants.util.meta import AbstractClass
+from pants.util.meta import AbstractClass, classproperty
 from pants.util.objects import Exactly, SubclassesOf, datatype
 
 
@@ -103,12 +103,12 @@ class TargetAdaptor(StructWithDeps):
         self.validate_sources,
       ),)
 
-  @property
-  def default_sources_globs(self):
+  @classproperty
+  def default_sources_globs(cls):
     return None
 
-  @property
-  def default_sources_exclude_globs(self):
+  @classproperty
+  def default_sources_exclude_globs(cls):
     return None
 
   def validate_sources(self, sources):
@@ -250,6 +250,12 @@ class AppAdaptor(TargetAdaptor):
                         path_globs_list)
 
 
+class JvmAppAdaptor(AppAdaptor): pass
+
+
+class PythonAppAdaptor(AppAdaptor): pass
+
+
 class RemoteSourcesAdaptor(TargetAdaptor):
   def __init__(self, dest=None, **kwargs):
     """
@@ -289,12 +295,7 @@ class PythonBinaryAdaptor(PythonTargetAdaptor):
       )
 
 
-class PythonTestsAdaptor(PythonTargetAdaptor):
-  python_test_globs = ('test_*.py', '*_test.py')
-
-  @property
-  def default_sources_globs(self):
-    return self.python_test_globs
+class PythonTestsAdaptor(PythonTargetAdaptor): pass
 
 
 class PantsPluginAdaptor(PythonTargetAdaptor):

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -126,17 +126,13 @@ class TargetAdaptor(StructWithDeps):
     pass
 
 
-class Field(object):
+@union
+class HydrateableField(object):
   """A marker for Target(Adaptor) fields for which the engine might perform extra construction."""
 
 
-@union
-class HydrateableField(object): pass
-
-
 class SourcesField(
-  datatype(['address', 'arg', 'filespecs', 'base_globs', 'path_globs', 'validate_fn']),
-  Field
+  datatype(['address', 'arg', 'filespecs', 'base_globs', 'path_globs', 'validate_fn'])
 ):
   """Represents the `sources` argument for a particular Target.
 
@@ -188,7 +184,7 @@ class PageAdaptor(TargetAdaptor):
       )
 
 
-class BundlesField(datatype(['address', 'bundles', 'filespecs_list', 'path_globs_list']), Field):
+class BundlesField(datatype(['address', 'bundles', 'filespecs_list', 'path_globs_list'])):
   """Represents the `bundles` argument, each of which has a PathGlobs to represent its `fileset`."""
 
   def __hash__(self):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -202,10 +202,9 @@ class Scheduler(object):
       self._native.lib.tasks_add_get(self._tasks, self._to_type(product), self._to_type(subject))
 
     for the_get in rule.input_gets:
-      union_members = union_rules.get(the_get.subject_declared_type, None)
-      if union_members:
+      if getattr(the_get.subject_declared_type, '_is_union', False):
         # If the registered subject type is a union, add Get edges to all registered union members.
-        for union_member in union_members:
+        for union_member in union_rules.get(the_get.subject_declared_type, []):
           add_get_edge(the_get.product, union_member)
       else:
         # Otherwise, the Get subject is a "concrete" type, so add a single Get edge.

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -30,8 +30,8 @@ from pants.engine.legacy.graph import (LegacyBuildGraph, TransitiveHydratedTarge
                                        create_legacy_graph_tasks)
 from pants.engine.legacy.options_parsing import create_options_parsing_rules
 from pants.engine.legacy.parser import LegacyPythonCallbacksParser
-from pants.engine.legacy.structs import (AppAdaptor, JvmBinaryAdaptor, PageAdaptor,
-                                         PantsPluginAdaptor, PythonBinaryAdaptor,
+from pants.engine.legacy.structs import (JvmAppAdaptor, JvmBinaryAdaptor, PageAdaptor,
+                                         PantsPluginAdaptor, PythonAppAdaptor, PythonBinaryAdaptor,
                                          PythonTargetAdaptor, PythonTestsAdaptor,
                                          RemoteSourcesAdaptor, TargetAdaptor)
 from pants.engine.legacy.structs import rules as structs_rules
@@ -47,6 +47,47 @@ from pants.util.objects import datatype
 
 
 logger = logging.getLogger(__name__)
+
+
+def _tuplify(v):
+  if v is None:
+    return None
+  if isinstance(v, tuple):
+    return v
+  if isinstance(v, (list, set)):
+    return tuple(v)
+  return (v,)
+
+
+def _compute_default_sources_globs(base_class, target_type):
+  """Look up the default source globs for the type, and return as a tuple of (globs, excludes)."""
+  if not target_type.supports_default_sources() or target_type.default_sources_globs is None:
+    return (None, None)
+
+  globs = _tuplify(target_type.default_sources_globs)
+  excludes = _tuplify(target_type.default_sources_exclude_globs)
+
+  return (globs, excludes)
+
+
+def _apply_default_sources_globs(base_class, target_type):
+  """Mutates the given TargetAdaptor subclass to apply default sources from the given legacy target type."""
+  globs, excludes = _compute_default_sources_globs(base_class, target_type)
+  base_class.default_sources_globs = globs
+  base_class.default_sources_exclude_globs = excludes
+
+
+# TODO: These calls mutate the adaptor classes for some known library types to copy over
+# their default source globs while preserving their concrete types. As with the alias replacement
+# below, this is a delaying tactic to avoid elevating the TargetAdaptor API.
+_apply_default_sources_globs(JvmAppAdaptor, JvmApp)
+_apply_default_sources_globs(PythonAppAdaptor, PythonApp)
+_apply_default_sources_globs(JvmBinaryAdaptor, JvmBinary)
+_apply_default_sources_globs(PageAdaptor, Page)
+_apply_default_sources_globs(PythonBinaryAdaptor, PythonBinary)
+_apply_default_sources_globs(PythonTargetAdaptor, PythonLibrary)
+_apply_default_sources_globs(PythonTestsAdaptor, PythonTests)
+_apply_default_sources_globs(RemoteSourcesAdaptor, RemoteSources)
 
 
 def _legacy_symbol_table(build_file_aliases):
@@ -79,15 +120,14 @@ def _legacy_symbol_table(build_file_aliases):
   # API until after https://github.com/pantsbuild/pants/issues/3560 has been completed.
   # These should likely move onto Target subclasses as the engine gets deeper into beta
   # territory.
-  table['python_library'] = _make_target_adaptor(PythonTargetAdaptor, PythonLibrary)
-
-  table['jvm_app'] = _make_target_adaptor(AppAdaptor, JvmApp)
-  table['jvm_binary'] = _make_target_adaptor(JvmBinaryAdaptor, JvmBinary)
-  table['python_app'] = _make_target_adaptor(AppAdaptor, PythonApp)
-  table['python_tests'] = _make_target_adaptor(PythonTestsAdaptor, PythonTests)
-  table['python_binary'] = _make_target_adaptor(PythonBinaryAdaptor, PythonBinary)
-  table['remote_sources'] = _make_target_adaptor(RemoteSourcesAdaptor, RemoteSources)
-  table['page'] = _make_target_adaptor(PageAdaptor, Page)
+  table['python_library'] = PythonTargetAdaptor
+  table['jvm_app'] = JvmAppAdaptor
+  table['jvm_binary'] = JvmBinaryAdaptor
+  table['python_app'] = PythonAppAdaptor
+  table['python_tests'] = PythonTestsAdaptor
+  table['python_binary'] = PythonBinaryAdaptor
+  table['remote_sources'] = RemoteSourcesAdaptor
+  table['page'] = PageAdaptor
 
   # Note that these don't call _make_target_adaptor because we don't have a handy reference to the
   # types being constructed. They don't have any default_sources behavior, so this should be ok,
@@ -100,39 +140,16 @@ def _legacy_symbol_table(build_file_aliases):
 
 
 def _make_target_adaptor(base_class, target_type):
-  """Look up the default source globs for the type, and apply them to parsing through the engine."""
-  if not target_type.supports_default_sources() or target_type.default_sources_globs is None:
+  """Create an adaptor subclass for the given TargetAdaptor base class and legacy target type."""
+  globs, excludes = _compute_default_sources_globs(base_class, target_type)
+  if globs is None:
     return base_class
 
-  globs = _tuplify(target_type.default_sources_globs)
-  excludes = _tuplify(target_type.default_sources_exclude_globs)
-
   class GlobsHandlingTargetAdaptor(base_class):
-    @property
-    def default_sources_globs(self):
-      if globs is None:
-        return super(GlobsHandlingTargetAdaptor, self).default_sources_globs
-      else:
-        return globs
-
-    @property
-    def default_sources_exclude_globs(self):
-      if excludes is None:
-        return super(GlobsHandlingTargetAdaptor, self).default_sources_exclude_globs
-      else:
-        return excludes
+    default_sources_globs = globs
+    default_sources_exclude_globs = excludes
 
   return GlobsHandlingTargetAdaptor
-
-
-def _tuplify(v):
-  if v is None:
-    return None
-  if isinstance(v, tuple):
-    return v
-  if isinstance(v, (list, set)):
-    return tuple(v)
-  return (v,)
 
 
 class LegacyGraphScheduler(datatype(['scheduler', 'build_file_aliases', 'goal_map'])):

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -10,7 +10,6 @@ from builtins import object
 from pants.backend.docgen.targets.doc import Page
 from pants.backend.jvm.targets.jvm_app import JvmApp
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
-from pants.backend.python.rules import python_test_runner
 from pants.backend.python.targets.python_app import PythonApp
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
@@ -372,8 +371,6 @@ class EngineInitializer(object):
       create_graph_rules(address_mapper) +
       create_options_parsing_rules() +
       structs_rules() +
-      # TODO: This should happen automatically, but most tests (e.g. tests/python/pants_test/auth) fail if it's not here:
-      python_test_runner.rules() +
       rules
     )
 

--- a/src/python/pants/init/extension_loader.py
+++ b/src/python/pants/init/extension_loader.py
@@ -107,7 +107,11 @@ def load_build_configuration_from_source(build_configuration, backends=None):
   # pants.build_graph and pants.core_task must always be loaded, and before any other backends.
   # TODO: Consider replacing the "backend" nomenclature here. pants.build_graph and
   # pants.core_tasks aren't really backends.
-  backend_packages = OrderedSet(['pants.build_graph', 'pants.core_tasks'] + (backends or []))
+  backend_packages = OrderedSet([
+      'pants.build_graph',
+      'pants.core_tasks',
+      'pants.rules.core',
+    ] + (backends or []))
   for backend_package in backend_packages:
     load_backend(build_configuration, backend_package)
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -177,8 +177,6 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                       'pants.backend.python',
                       'pants.backend.jvm',
                       'pants.backend.native',
-                      # TODO: Move into the graph_info backend.
-                      'pants.rules.core',
                       'pants.backend.codegen.antlr.java',
                       'pants.backend.codegen.antlr.python',
                       'pants.backend.codegen.jaxb',

--- a/src/python/pants/rules/core/core_test_model.py
+++ b/src/python/pants/rules/core/core_test_model.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from future.utils import text_type
 
+from pants.engine.rules import union
 from pants.util.objects import datatype, enum
 
 
@@ -18,6 +19,14 @@ class TestResult(datatype([
   ('stdout', text_type),
   ('stderr', text_type),
 ])):
+
+  # Prevent this class from being detected by pytest as a test class.
+  __test__ = False
+
+
+@union
+class TestTarget(object):
+  """A union for registration of a testable target type."""
 
   # Prevent this class from being detected by pytest as a test class.
   __test__ = False

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 
-from pants.backend.python.rules.python_test_runner import PyTestResult
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
@@ -15,7 +14,7 @@ from pants.engine.goal import Goal
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.rules import console_rule, rule
 from pants.engine.selectors import Get
-from pants.rules.core.core_test_model import Status, TestResult
+from pants.rules.core.core_test_model import Status, TestResult, TestTarget
 
 
 # TODO(#6004): use proper Logging singleton, rather than static logger.
@@ -68,22 +67,18 @@ def fast_test(console, addresses):
 
 @rule(TestResult, [HydratedTarget])
 def coordinator_of_tests(target):
-  # This should do an instance match, or canonicalise the adaptor type, or something
-  #if isinstance(target.adaptor, PythonTestsAdaptor):
-  # See https://github.com/pantsbuild/pants/issues/4535
-  if target.adaptor.type_alias == 'python_tests':
-    # TODO(#6004): when streaming to live TTY, rely on V2 UI for this information. When not a
-    # live TTY, periodically dump heavy hitters to stderr. See
-    # https://github.com/pantsbuild/pants/issues/6004#issuecomment-492699898.
-    logger.info("Starting tests: {}".format(target.address.reference()))
-    result = yield Get(PyTestResult, HydratedTarget, target)
-    logger.info("Tests {}: {}".format(
-      "succeeded" if result.status == Status.SUCCESS else "failed",
-      target.address.reference(),
-    ))
-    yield TestResult(status=result.status, stdout=result.stdout, stderr=result.stderr)
-  else:
-    raise Exception("Didn't know how to run tests for type {}".format(target.adaptor.type_alias))
+  # TODO(#6004): when streaming to live TTY, rely on V2 UI for this information. When not a
+  # live TTY, periodically dump heavy hitters to stderr. See
+  # https://github.com/pantsbuild/pants/issues/6004#issuecomment-492699898.
+  logger.info("Starting tests: {}".format(target.address.reference()))
+  # NB: This has the effect of "casting" a TargetAdaptor to a member of the TestTarget union. If the
+  # TargetAdaptor is not a member of the union, it will fail at runtime with a useful error message.
+  result = yield Get(TestResult, TestTarget, target.adaptor)
+  logger.info("Tests {}: {}".format(
+    "succeeded" if result.status == Status.SUCCESS else "failed",
+    target.address.reference(),
+  ))
+  yield result
 
 
 def rules():


### PR DESCRIPTION
### Problem

Fixing #4535 moved us closer to supporting a `Target` API for v2, but did not begin to use `@union` and `UnionRule` to make the v2 test `@console_rule` generic.

### Solution

Add `@union TestTarget`, and consume it in the v2 `test` `@console_rule`. The result is that a language implementer that wants to add support for testing a target type `MyTestTarget` can declare a `UnionRule(TestTarget, MyTestTarget)` in their registered rules, which would in turn require a declared `@rule` to produce a `TestResult` for `MyTestTarget`.

In order to use `PythonTestAdaptor` as a member of the `TestTarget` union, the bottom commit refactors the `SymbolTable` manipulation that we do to preserve the concrete `TargetAdaptor` classes.

### Result

Although we're not quite ready to "bless" `TargetAdaptor` by requiring it in the `SymbolTable` or coupling it to the v1 `Target` class, this change represents an incremental step in the direction of using (a likely renamed) `TargetAdaptor` incarnation as the v2 Target class.