### PR TITLE
convert options scope to text_type() when matching invalid options

### DIFF
--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -418,7 +418,10 @@ class Options(object):
       scope = parser.scope
       known_args = parser.known_args
       for arg in known_args:
-        scoped_flag = self._ScopedFlagNameForFuzzyMatching(scope=scope, arg=arg)
+        scoped_flag = self._ScopedFlagNameForFuzzyMatching(
+          scope=text_type(scope),
+          arg=text_type(arg),
+        )
         all_scoped_flag_names.append(scoped_flag)
     self.walk_parsers(register_all_scoped_names)
     return sorted(all_scoped_flag_names, key=lambda flag_info: flag_info.scoped_arg)


### PR DESCRIPTION
### Problem

When using Python 2.7, users may not have `from __future__ import unicode_literals` or similar in their python sources, so their literal strings may end up being bytes, rather than unicode. However, our matching for invalid command-line options assumes they are already unicode, and errors out if not. This isn't necessary.

### Solution

- Wrap fields of `_ScopedFlagNameForFuzzyMatching` in `text_type()`.

### Result

Fixes breakage downstream. Tests weren't added since we are dropping py2 support very soon.