### PR TITLE
allow configuration of the subsystems to initialize in a test

### DIFF
--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -38,6 +38,7 @@ class PythonBinary(PythonTarget):
 
     @classmethod
     def register_options(cls, register):
+      super(PythonBinary.Defaults, cls).register_options(register)
       register('--pex-emit-warnings', advanced=True, type=bool, default=True, fingerprint=True,
                help='Whether built pex binaries should emit pex warnings at runtime by default. '
                     'Can be over-ridden by specifying the `emit_warnings` parameter of individual '

--- a/tests/python/pants_test/backend/python/targets/test_python_binary.py
+++ b/tests/python/pants_test/backend/python/targets/test_python_binary.py
@@ -18,7 +18,7 @@ class PythonBinaryTest(TestBase):
       },
     )
 
-  target_class_for_subsystems = PythonBinary
+  subsystems = PythonBinary.subsystems()
 
   def test_python_binary(self):
     # Set up and run

--- a/tests/python/pants_test/backend/python/targets/test_python_binary.py
+++ b/tests/python/pants_test/backend/python/targets/test_python_binary.py
@@ -18,6 +18,8 @@ class PythonBinaryTest(TestBase):
       },
     )
 
+  target_class_for_subsystems = PythonBinary
+
   def test_python_binary(self):
     # Set up and run
     self.create_file('some/path/to/python/path/to/py.py')

--- a/tests/python/pants_test/backend/python/targets/test_python_binary.py
+++ b/tests/python/pants_test/backend/python/targets/test_python_binary.py
@@ -1,0 +1,30 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from pants.backend.python.targets.python_binary import PythonBinary
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants_test.test_base import TestBase
+
+
+class PythonBinaryTest(TestBase):
+  @classmethod
+  def alias_groups(cls):
+    return BuildFileAliases(
+      targets={
+        'python_binary': PythonBinary,
+      },
+    )
+
+  def test_python_binary(self):
+    # Set up and run
+    self.create_file('some/path/to/python/path/to/py.py')
+    self.add_to_build_file(
+      'some/path/to/python',
+      'python_binary(name = "binary", source = "path/to/py.py")\n',
+    )
+    target = self.target('some/path/to/python:binary')
+    # Verify
+    self.assertTrue(isinstance(target, PythonBinary))

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -517,18 +517,20 @@ class TestBase(unittest.TestCase, AbstractClass):
     Subsystem.reset()
 
   @classproperty
-  def target_class_for_subsystems(cls):
-    """The Target subclass to call .subsystems() on.
+  def subsystems(cls):
+    """Initialize these subsystems when running your test.
 
     If your test instantiates a target type that depends on any subsystems, those subsystems need to
-    be initialized in your test. If you only have one target type with subsystems to initialize, you
-    can override this property with your target type to have its subsystems initialized.
+    be initialized in your test. You can override this property to return the necessary subsystem
+    classes.
+
+    :rtype: list of type objects, all subclasses of Subsystem
     """
-    return Target
+    return Target.subsystems()
 
   def _init_target_subsystem(self):
     if not self._inited_target:
-      subsystem_util.init_subsystems(self.target_class_for_subsystems.subsystems())
+      subsystem_util.init_subsystems(self.subsystems)
       self._inited_target = True
 
   def target(self, spec):

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -518,6 +518,12 @@ class TestBase(unittest.TestCase, AbstractClass):
 
   @classproperty
   def target_class_for_subsystems(cls):
+    """The Target subclass to call .subsystems() on.
+
+    If your test instantiates a target type that depends on any subsystems, those subsystems need to
+    be initialized in your test. If you only have one target type with subsystems to initialize, you
+    can override this property with your target type to have its subsystems initialized.
+    """
     return Target
 
   def _init_target_subsystem(self):

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -40,7 +40,7 @@ from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import (recursive_dirname, relative_symlink, safe_file_dump, safe_mkdir,
                                 safe_mkdtemp, safe_open, safe_rmtree)
 from pants.util.memo import memoized_method
-from pants.util.meta import AbstractClass
+from pants.util.meta import AbstractClass, classproperty
 from pants_test.base.context_utils import create_context_from_options
 from pants_test.engine.util import init_native
 from pants_test.option.util.fakes import create_options_for_optionables
@@ -516,9 +516,13 @@ class TestBase(unittest.TestCase, AbstractClass):
     super(TestBase, self).tearDown()
     Subsystem.reset()
 
+  @classproperty
+  def target_class_for_subsystems(cls):
+    return Target
+
   def _init_target_subsystem(self):
     if not self._inited_target:
-      subsystem_util.init_subsystems(Target.subsystems())
+      subsystem_util.init_subsystems(self.target_class_for_subsystems.subsystems())
       self._inited_target = True
 
   def target(self, spec):


### PR DESCRIPTION
### Problem

Some target types, such as `PythonBinary`, depend on subsystems which they access during initialization. To test instantiation of these targets, their subsystems need to be initialized. We already do this with the subsystems for the `Target` base class -- this just exposes that to test classes.

### Solution

- Introduce the `TestBase.subsystems` classproperty.
- Add testing demonstrating its use.

### Result

Tests which instantiate targets that require subsystems to be initialized can declare that with a `classproperty`.