### PR TITLE
Fix for reference cycle from Target to BuildGraph

### DIFF
--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/meta_rename.py
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/meta_rename.py
@@ -48,9 +48,8 @@ class MetaRename(Task):
 
   def update_dependee_references(self):
     dependee_targets = self.dependency_graph()[
-      # TODO: Target() expects build_graph to be an instance of BuildGraph, not a list.
       # TODO: The **{} seems unnecessary.
-      Target(name=self._from_address.target_name, address=self._from_address, build_graph=[], **{})
+      Target(name=self._from_address.target_name, address=self._from_address, build_graph=self.context.build_graph, **{})
     ]
 
     logging.disable(logging.WARNING)

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import os
+import weakref
 from builtins import object, str
 from hashlib import sha1
 
@@ -325,7 +326,7 @@ class Target(AbstractTarget):
     self.payload.freeze()
     self.name = name
     self.address = address
-    self._build_graph = build_graph
+    self._build_graph = weakref.proxy(build_graph)
     self._type_alias = type_alias
     self._tags = set(tags or []).union(self.TagAssignments.tags_for(address.spec))
     self.description = description

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -403,7 +403,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
   def test_pantsd_memory_usage(self):
     """Validates that after N runs, memory usage has increased by no more than X percent."""
     number_of_runs = 10
-    max_memory_increase_fraction = 0.60 # TODO https://github.com/pantsbuild/pants/issues/7647
+    max_memory_increase_fraction = 0.40 # TODO https://github.com/pantsbuild/pants/issues/7647
     with self.pantsd_successful_run_context() as (pantsd_run, checker, workdir, config):
       cmd = ['filter', 'testprojects::']
       self.assert_success(pantsd_run(cmd))


### PR DESCRIPTION
### Problem

As described in #5668

### Solution

Use weakref to remove the BuildGraph reference from Target.
