### PR TITLE
Use global instance of PythonSetup for resolve requirements task base

### DIFF
--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -37,8 +37,8 @@ class ResolveRequirementsTaskBase(Task):
   def subsystem_dependencies(cls):
     return super(ResolveRequirementsTaskBase, cls).subsystem_dependencies() + (
       PexBuilderWrapper.Factory,
+      PythonSetup,
       PythonNativeCode.scoped(cls),
-      PythonSetup.scoped(cls),
     )
 
   @memoized_property

--- a/tests/python/pants_test/backend/python/tasks/test_python_repl_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_repl_integration.py
@@ -14,8 +14,8 @@ class PythonReplIntegrationTest(PantsRunIntegrationTest):
   def test_run_repl(self):
     # Run a repl on a library target. Avoid some known-to-choke-on interpreters.
     command = ['repl',
-               'testprojects/src/python/interpreter_selection:echo_interpreter_version_lib',
                '--python-setup-interpreter-constraints=CPython>=2.7,<3',
+               'testprojects/src/python/interpreter_selection:echo_interpreter_version_lib',
                '--quiet']
     program = 'from interpreter_selection.echo_interpreter_version import say_hello; say_hello()'
     pants_run = self.run_pants(command=command, stdin_data=program)
@@ -26,8 +26,8 @@ class PythonReplIntegrationTest(PantsRunIntegrationTest):
   def test_run_repl_with_2(self):
     # Run a Python 2 repl on a Python 2/3 library target.
     command = ['repl',
-               'testprojects/src/python/interpreter_selection:echo_interpreter_version_lib',
                '--python-setup-interpreter-constraints=["CPython<3"]',
+               'testprojects/src/python/interpreter_selection:echo_interpreter_version_lib',
                '--quiet']
     program = 'from interpreter_selection.echo_interpreter_version import say_hello; say_hello()'
     pants_run = self.run_pants(command=command, stdin_data=program)
@@ -37,8 +37,8 @@ class PythonReplIntegrationTest(PantsRunIntegrationTest):
   def test_run_repl_with_3(self):
     # Run a Python 3 repl on a Python 2/3 library target. Avoid some known-to-choke-on interpreters.
     command = ['repl',
-               'testprojects/src/python/interpreter_selection:echo_interpreter_version_lib',
                '--python-setup-interpreter-constraints=["CPython>=3.3"]',
+               'testprojects/src/python/interpreter_selection:echo_interpreter_version_lib',
                '--quiet']
     program = 'from interpreter_selection.echo_interpreter_version import say_hello; say_hello()'
     pants_run = self.run_pants(command=command, stdin_data=program)


### PR DESCRIPTION
Fix for https://github.com/pantsbuild/pants/issues/7625. The resolve requirements task base module was using a scoped instance of PythonSetup, breaking the `./pants repl --python-setup-interpreter-constraints=<constraints> <target>` usage pattern.

### Solution

Use the global instance of PythonSetup so we can still use global options that cut across all interpreter selection-related mechanisms.

### Result

Users that set non-scoped options on PythonSetup are once again able to apply them globally across tasks that use PythonSetup. 