### PR TITLE
Refactor v2 TestResult model to use enum

### DIFF
--- a/src/python/pants/rules/core/core_test_model.py
+++ b/src/python/pants/rules/core/core_test_model.py
@@ -6,19 +6,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from future.utils import text_type
 
-from pants.util.objects import datatype
+from pants.util.objects import datatype, enum
 
 
-class Status(object):
-  SUCCESS = 'SUCCESS'
-  FAILURE = 'FAILURE'
+class Status(enum(['SUCCESS', 'FAILURE'])): pass
 
 
 class TestResult(datatype([
-  # One of the Status pseudo-enum values capturing whether the run was successful.
-  ('status', text_type),
+  ('status', Status),
   # The stdout of the test runner (which may or may not include actual testcase output).
   ('stdout', text_type)
 ])):
+
   # Prevent this class from being detected by pytest as a test class.
   __test__ = False

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -40,7 +40,7 @@ def fast_test(console, addresses):
     console.write_stdout('\n')
 
   for address, test_result in zip(addresses, test_results):
-    console.print_stdout('{0:80}.....{1:>10}'.format(address.reference(), test_result.status))
+    console.print_stdout('{0:80}.....{1:>10}'.format(address.reference(), test_result.status.value))
 
   if did_any_fail:
     console.print_stderr('Tests failed')


### PR DESCRIPTION
Now that we have an implementation for enums, we should not be using this pseudo-enum implementation because it makes the engine type checking less stringent than desired. That is, before any `text_type` would work for `Status`, whereas now only accepted enum values work.