### PR TITLE
WIP: In target adaptors, populate attributes with a None value

### DIFF
--- a/src/python/pants/engine/struct.py
+++ b/src/python/pants/engine/struct.py
@@ -199,8 +199,7 @@ class Struct(Serializable, SerializableFactory, Validatable):
       return self
 
     # Filter out the attributes that we will consume below for inheritance.
-    attributes = {k: v for k, v in self._asdict().items()
-                  if k not in self._INHERITANCE_FIELDS and v is not None}
+    attributes = {k: v for k, v in self._asdict().items() if k not in self._INHERITANCE_FIELDS}
 
     if self.extends:
       for k, v in self._extract_inheritable_attributes(self.extends).items():


### PR DESCRIPTION
### Problem
Certain attributes default to `None`, such as `PythonTarget`'s `compatibility` defaulting to `None`:

https://github.com/pantsbuild/pants/blob/3742edb4040967899c404b43570caa721bb3bd95/src/python/pants/backend/python/targets/python_target.py#L27-L32

In the case of target adaptors, such as a `PythonTarget`, if the BUILD entry does not provide an explicit value for a field like `compatibility`, then the target adaptor will simply not have that attribute defined, as opposed to having it with `None` as a value. 

This became an issue when working on https://github.com/pantsbuild/pants/pull/7679. There, we are trying to call `PythonSetup.compatibility_or_constraints(hydrated_target.adaptor)`. This function expects the passed object to have `.compatibility` defined, or else it will raise an `AttributeError`. However, the value does not need to have a non-None value; in fact, a value of `None` is meaningful and means that the global constraints should be used. So, if we were to filter out the hydrated targets to only call the function on targets with `.compatibility` set to non-None, then we would never be considering the global interpreter constraints.

### Solution
First, we must modify the engine initializer to identify and populate attributes that are not defined in the BUILD entry but who have a `None` value in the corresponding target class. TODO.

Second, we must modify the `create()` function to not filter out attributes with `None`.