### PR TITLE
deprecate ExecutablePexTool

### DIFF
--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -270,4 +270,4 @@ def deprecated_module(removal_version, hint_message=None):
 
   Arguments are as for deprecated(), above.
   """
-  warn_or_error(removal_version, 'module', hint_message)
+  warn_or_error(removal_version, 'module', hint_message, stacklevel=4)

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -270,4 +270,7 @@ def deprecated_module(removal_version, hint_message=None):
 
   Arguments are as for deprecated(), above.
   """
+  # stacklevel=4 ensures we don't show the of code invoking deprecated_module(), but rather the line
+  # of code which *imports* the deprecated module, which is more useful for debugging how to remove
+  # uses of the deprecated module.
   warn_or_error(removal_version, 'module', hint_message, stacklevel=4)

--- a/src/python/pants/binaries/executable_pex_tool.py
+++ b/src/python/pants/binaries/executable_pex_tool.py
@@ -9,8 +9,12 @@ from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 
 from pants.backend.python.subsystems.pex_build_util import PexBuilderWrapper
+from pants.base.deprecated import deprecated_module
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import is_executable, safe_concurrent_creation
+
+
+deprecated_module('1.19.0.dev0', 'Use PythonToolBase and PythonToolPrepBase instead!')
 
 
 class ExecutablePexTool(Subsystem):


### PR DESCRIPTION
### Problem

`ExecutablePexTool` was created to simplify the process of PEX creation before we had `PythonToolBase` and `PythonToolPrepBase`, which are used e.g. to invoke Conan. There's no need for this module taking up space in `pants.binaries` anymore.

### Solution

- Merge the body of `ExecutablePexTool` into `BuildSetupRequiresPex`.
- Deprecate `pants.binaries.executable_pex_tool`.