### PR TITLE
Ensure NailgunStreamWriter obtains a socket lock prior to writing into the socket

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -216,9 +216,8 @@ class DaemonPantsRunner(object):
         with open('/dev/null', 'rb') as fh:
           yield fh.fileno()
 
-    # TODO https://github.com/pantsbuild/pants/issues/7653
     with maybe_handle_stdin(handle_stdin) as stdin_fd,\
-      NailgunStreamWriter.open_multi(maybe_shutdown_socket.socket, types, ttys) as ((stdout_fd, stderr_fd), writer),\
+      NailgunStreamWriter.open_multi(maybe_shutdown_socket, types, ttys) as ((stdout_fd, stderr_fd), writer),\
       stdio_as(stdout_fd=stdout_fd, stderr_fd=stderr_fd, stdin_fd=stdin_fd):
       # N.B. This will be passed to and called by the `DaemonExiter` prior to sending an
       # exit chunk, to avoid any socket shutdown vs write races.


### PR DESCRIPTION
### Problem

As described in #7653 
> NailgunStreamWriter probably shouldn't grab the socket without a lock
>
> Within DaemonPantsRunner#_pipe_stdio(..) -
> NailgunStreamWriter.open_multi(maybe_shutdown_socket.socket, types, ttys)

### Solution

NailgunStreamWriter obtains a socket lock prior to writing into the socket