### PR TITLE
Allow V2 console rules to use colors

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -214,7 +214,10 @@ python_library(
 
 python_library(
   name='console',
-  sources=['console.py']
+  sources=['console.py'],
+  dependencies=[
+    '3rdparty/python:ansicolors',
+  ],
 )
 
 resources(

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -6,11 +6,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 
+from colors import blue, green, red
+
 
 class Console(object):
-  def __init__(self, stdout=None, stderr=None):
+  def __init__(self, stdout=None, stderr=None, use_colors=True):
     self._stdout = stdout or sys.stdout
     self._stderr = stderr or sys.stderr
+    self._use_colors = use_colors
 
   @property
   def stdout(self):
@@ -35,3 +38,16 @@ class Console(object):
   def flush(self):
     self.stdout.flush()
     self.stderr.flush()
+
+  def _safe_color(self, text, color):
+    """We should only output color when the global flag --colors is enabled."""
+    return color(text) if self._use_colors else text
+
+  def blue(self, text):
+    return self._safe_color(text, blue)
+
+  def green(self, text):
+    return self._safe_color(text, green)
+
+  def red(self, text):
+    return self._safe_color(text, red)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -180,7 +180,9 @@ class LegacyGraphSession(datatype(['scheduler_session', 'build_file_aliases', 'g
     :returns: An exit code.
     """
     subject = target_roots.specs
-    console = Console()
+    console = Console(
+      use_colors=options_bootstrapper.bootstrap_options.for_global_scope().colors
+    )
     for goal in goals:
       goal_product = self.goal_map[goal]
       params = Params(subject, options_bootstrapper, console)

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -43,7 +43,7 @@ def fast_test(console, addresses):
     console.print_stdout('{0:80}.....{1:>10}'.format(address.reference(), test_result.status.value))
 
   if did_any_fail:
-    console.print_stderr('Tests failed')
+    console.print_stderr(console.red('Tests failed'))
     exit_code = PANTS_FAILED_EXIT_CODE
   else:
     exit_code = PANTS_SUCCEEDED_EXIT_CODE

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -5,6 +5,7 @@ python_library(
   name = 'util',
   sources = ['util.py'],
   dependencies = [
+    '3rdparty/python:ansicolors',
     '3rdparty/python:future',
     'src/python/pants/binaries',
     'src/python/pants/engine:addressable',

--- a/tests/python/pants_test/engine/util.py
+++ b/tests/python/pants_test/engine/util.py
@@ -165,7 +165,6 @@ class MockConsole(object):
     print(payload, file=self.stderr)
 
   def _safe_color(self, text, color):
-    """We should only output color when the global flag --colors is enabled."""
     return color(text) if self._use_colors else text
 
   def blue(self, text):

--- a/tests/python/pants_test/engine/util.py
+++ b/tests/python/pants_test/engine/util.py
@@ -10,6 +10,8 @@ from builtins import str
 from io import StringIO
 from types import GeneratorType
 
+from colors import blue, green, red
+
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.engine.addressable import addressable_list
 from pants.engine.native import Native
@@ -145,9 +147,10 @@ def remove_locations_from_traceback(trace):
 class MockConsole(object):
   """An implementation of pants.engine.console.Console which captures output."""
 
-  def __init__(self):
+  def __init__(self, use_colors=True):
     self.stdout = StringIO()
     self.stderr = StringIO()
+    self._use_colors = use_colors
 
   def write_stdout(self, payload):
     self.stdout.write(payload)
@@ -160,3 +163,16 @@ class MockConsole(object):
 
   def print_stderr(self, payload):
     print(payload, file=self.stderr)
+
+  def _safe_color(self, text, color):
+    """We should only output color when the global flag --colors is enabled."""
+    return color(text) if self._use_colors else text
+
+  def blue(self, text):
+    return self._safe_color(text, blue)
+
+  def green(self, text):
+    return self._safe_color(text, green)
+
+  def red(self, text):
+    return self._safe_color(text, red)


### PR DESCRIPTION
### Problem
To improve the UX of V2 rules, there are certain times that we would like to use colors in the output, just as we do in V1.

However, we also need some way to respect the global flag `--no-colors` / `--colors`.

### Solution
Add safe color methods to the `Console` and `MockConsole` classes. These take a parameter for whether colors may be used, which in the former case get initialized by the global options.

Console rule users would then use colors like this: `console.write_stdout(console.green("Pretty colors!"))`.

#### Alternative API considered: stripping output
Instead of defining color methods on the `Console` class, we could have left the callers to use the `colors` library normally, then changed `Console.write_stderr()` et al. to call `colors.strip_colors()` on the payload.

This reduces the risk of people in the current approach accidentally directly using `colors` rather than the console methods. It also allows us to keep the definition of `Console` a bit smaller.

However, the idea of first adding color codes then intentionally stripping them away is awkward and it was decided that this was not worth it.

### Result
Colors can now be safely used in V2, which unblocks https://github.com/pantsbuild/pants/pull/7676.

The v2 test rule was also updated to print in red "Tests failed" upon any failures.

<img width="830" alt="Screen Shot 2019-05-09 at 8 53 41 AM" src="https://user-images.githubusercontent.com/14852634/57467745-f45cc900-7237-11e9-8bcb-6a7cf3c5ebc0.png">
