### PR TITLE
Refactor `PythonSetup.interpreter_or_constraints()` to take a `compatibility` value rather than a `PythonTarget`

### DIFF
--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -71,7 +71,7 @@ class PythonInterpreterCache(Subsystem):
 
     for target in targets:
       if isinstance(target, PythonTarget):
-        c = self.python_setup.compatibility_or_constraints(target)
+        c = self.python_setup.compatibility_or_constraints(target.compatibility)
         tgts_by_compatibilities[c].append(target)
         filters.update(c)
     return tgts_by_compatibilities, filters

--- a/src/python/pants/backend/python/subsystems/pex_build_util.py
+++ b/src/python/pants/backend/python/subsystems/pex_build_util.py
@@ -360,8 +360,10 @@ class PexBuilderWrapper(object):
     # TODO this would be a great place to validate the constraints and present a good error message
     # if they are incompatible because all the sources of the constraints are available.
     # See: https://github.com/pantsbuild/pex/blob/584b6e367939d24bc28aa9fa36eb911c8297dac8/pex/interpreter_constraints.py
-    constraint_tuples = {self._python_setup_subsystem.compatibility_or_constraints(tgt)
-                         for tgt in constraint_tgts}
+    constraint_tuples = {
+      self._python_setup_subsystem.compatibility_or_constraints(tgt.compatibility)
+      for tgt in constraint_tgts
+    }
     for constraint_tuple in constraint_tuples:
       for constraint in constraint_tuple:
         self.add_interpreter_constraint(constraint)

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -122,14 +122,16 @@ class PythonSetup(Subsystem):
   def scratch_dir(self):
     return os.path.join(self.get_options().pants_workdir, *self.options_scope.split('.'))
 
-  def compatibility_or_constraints(self, target):
+  def compatibility_or_constraints(self, compatibility):
     """
-    Return either the compatibility of the given target, or the interpreter constraints.
-    If interpreter constraints are supplied by the CLI flag, return those only.
+    Return either the given compatibility, or the interpreter constraints. If interpreter
+    constraints are supplied by the CLI flag, return those only.
+
+    :param compatibility: Optional[List[str]], e.g. None or ['CPython>3'].
     """
     if self.get_options().is_flagged('interpreter_constraints'):
       return tuple(self.interpreter_constraints)
-    return tuple(target.compatibility or self.interpreter_constraints)
+    return tuple(compatibility or self.interpreter_constraints)
 
   @classmethod
   def expand_interpreter_search_paths(cls, interpreter_search_paths, pyenv_root_func=None):

--- a/src/python/pants/backend/python/tasks/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks/python_execution_task_base.py
@@ -139,7 +139,7 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
         else:
           constraints = {
             constraint for rt in relevant_targets if is_python_target(rt)
-            for constraint in PythonSetup.global_instance().compatibility_or_constraints(rt)
+            for constraint in PythonSetup.global_instance().compatibility_or_constraints(rt.compatibility)
           }
           self.context.log.debug('target set {} has constraints: {}'
                                  .format(relevant_targets, constraints))

--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -29,7 +29,9 @@ class PythonInterpreterFingerprintStrategy(DefaultFingerprintHashingMixin, Finge
   def compute_fingerprint(self, python_target):
     # Consider the target's compatibility requirements, and if those are missing then fall back
     # to the global interpreter constraints. Only these two values can affect the selected interpreter.
-    hash_elements_for_target = sorted(self.python_setup.compatibility_or_constraints(python_target))
+    hash_elements_for_target = sorted(
+      self.python_setup.compatibility_or_constraints(python_target.compatibility)
+    )
     if not hash_elements_for_target:
       return None
     hasher = hashlib.sha1()

--- a/src/python/pants/backend/python/tasks/unpack_wheels.py
+++ b/src/python/pants/backend/python/tasks/unpack_wheels.py
@@ -69,7 +69,7 @@ class UnpackWheels(UnpackRemoteSourcesBase):
 
   @memoized_method
   def _compatible_interpreter(self, unpacked_whls):
-    constraints = PythonSetup.global_instance().compatibility_or_constraints(unpacked_whls)
+    constraints = PythonSetup.global_instance().compatibility_or_constraints(unpacked_whls.compatibility)
     allowable_interpreters = PythonInterpreterCache.global_instance().setup(filters=constraints)
     return min(allowable_interpreters)
 


### PR DESCRIPTION
### Problem
Our V2 Target API is not fully implemented, including that we do not populate in target adaptors attributes with a default value of `None` (https://github.com/pantsbuild/pants/pull/7680). This limitation resulted in https://github.com/pantsbuild/pants/pull/7679/files#diff-04a0048c70898e46a42c73225c47b906R58 having to monkey patch the `.compatibility` field for the target adaptors to get `PythonSetup.interpreter_or_constraints()` to not raise an `AttributeError`.

While the underlying issue could be resolved with changing the V2 Target API, we can work around this by changing `PythonSetup.interpreter_or_constraints()` to no longer require a `Target` but rather just its `.compatibility` field.

### Solution
Change `PythonSetup.interpreter_or_constraints()` to have a more direct API of expecting the `compatibility` field itself.

#### Not using a deprecation
Neither this function nor its class `PythonSetup` have a public API. Per our deprecation policy, and confirmed via Slack, it was decided that we do not need a deprecation cycle for this change.

### Result
https://github.com/pantsbuild/pants/pull/7680 is unblocked.

Regardless of V2, this is also arguably a better API to only request as a parameter the field we actually need. For example, this makes testing easier because we no longer would need to create a fake `PythonTarget`.