### PR TITLE
Fix dependency cycle with cache folder

### DIFF
--- a/src/python/pants/cache/BUILD
+++ b/src/python/pants/cache/BUILD
@@ -2,18 +2,80 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
+  name='artifact',
+  source='artifact.py',
   dependencies = [
-    'src/python/pants/util:collections_abc_backport',
-    '3rdparty/python:future',
-    '3rdparty/python:requests',
-    '3rdparty/python:pyopenssl',
-    '3rdparty/python:six',
-    'src/python/pants/base:deprecated',
-    'src/python/pants/base:validation',
-    'src/python/pants/engine:native',
-    'src/python/pants/option',
-    'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+  ]
+)
+
+python_library(
+  name='artifact_cache',
+  source='artifact_cache.py',
+  dependencies = [
+    '3rdparty/python:future',
+  ]
+)
+
+python_library(
+  name='cache_setup',
+  source='cache_setup.py',
+  dependencies = [
+    '3rdparty/python:future',
+    'src/python/pants/base:build_environment',
+    'src/python/pants/subsystem',
+    'src/python/pants/util:memo',
+    ':artifact',
+    ':artifact_cache',
+    ':local_artifact_cache',
+    ':pinger',
+    ':resolver',
+    ':restful_artifact_cache',
+  ]
+)
+
+python_library(
+  name='local_artifact_cache',
+  source='local_artifact_cache.py',
+  dependencies = [
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    ':artifact',
+    ':artifact_cache',
+  ]
+)
+
+python_library(
+  name='pinger',
+  source='pinger.py',
+  dependencies = [
+    '3rdparty/python:future',
+    '3rdparty/python:requests',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
+    ':artifact_cache',
+  ]
+)
+
+python_library(
+  name='resolver',
+  source='resolver.py',
+  dependencies = [
+    '3rdparty/python:future',
+    '3rdparty/python:requests',
+    'src/python/pants/base:validation',
+    'src/python/pants/util:meta',
+  ]
+)
+
+python_library(
+  name='restful_artifact_cache',
+  source='restful_artifact_cache.py',
+  dependencies = [
+    '3rdparty/python:future',
+    '3rdparty/python:requests',
+    ':artifact_cache',
   ]
 )

--- a/src/python/pants/cache/BUILD
+++ b/src/python/pants/cache/BUILD
@@ -3,17 +3,15 @@
 
 python_library(
   dependencies = [
-    'src/python/pants/util:collections_abc_backport',
     '3rdparty/python:future',
     '3rdparty/python:requests',
-    '3rdparty/python:pyopenssl',
-    '3rdparty/python:six',
-    'src/python/pants/base:deprecated',
+    'src/python/pants/base:build_environment',
     'src/python/pants/base:validation',
-    'src/python/pants/engine:native',
-    'src/python/pants/option',
     'src/python/pants/subsystem',
+    'src/python/pants/util:collections_abc_backport',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
+    'src/python/pants/util:meta',
   ]
 )

--- a/src/python/pants/cache/BUILD
+++ b/src/python/pants/cache/BUILD
@@ -2,80 +2,18 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='artifact',
-  source='artifact.py',
   dependencies = [
-    'src/python/pants/util:contextutil',
-    'src/python/pants/util:dirutil',
-  ]
-)
-
-python_library(
-  name='artifact_cache',
-  source='artifact_cache.py',
-  dependencies = [
-    '3rdparty/python:future',
-  ]
-)
-
-python_library(
-  name='cache_setup',
-  source='cache_setup.py',
-  dependencies = [
-    '3rdparty/python:future',
-    'src/python/pants/base:build_environment',
-    'src/python/pants/subsystem',
-    'src/python/pants/util:memo',
-    ':artifact',
-    ':artifact_cache',
-    ':local_artifact_cache',
-    ':pinger',
-    ':resolver',
-    ':restful_artifact_cache',
-  ]
-)
-
-python_library(
-  name='local_artifact_cache',
-  source='local_artifact_cache.py',
-  dependencies = [
-    'src/python/pants/util:contextutil',
-    'src/python/pants/util:dirutil',
-    ':artifact',
-    ':artifact_cache',
-  ]
-)
-
-python_library(
-  name='pinger',
-  source='pinger.py',
-  dependencies = [
+    'src/python/pants/util:collections_abc_backport',
     '3rdparty/python:future',
     '3rdparty/python:requests',
-    'src/python/pants/util:contextutil',
-    'src/python/pants/util:dirutil',
-    'src/python/pants/util:memo',
-    ':artifact_cache',
-  ]
-)
-
-python_library(
-  name='resolver',
-  source='resolver.py',
-  dependencies = [
-    '3rdparty/python:future',
-    '3rdparty/python:requests',
+    '3rdparty/python:pyopenssl',
+    '3rdparty/python:six',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:validation',
-    'src/python/pants/util:meta',
-  ]
-)
-
-python_library(
-  name='restful_artifact_cache',
-  source='restful_artifact_cache.py',
-  dependencies = [
-    '3rdparty/python:future',
-    '3rdparty/python:requests',
-    ':artifact_cache',
+    'src/python/pants/engine:native',
+    'src/python/pants/option',
+    'src/python/pants/subsystem',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
   ]
 )

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -64,8 +64,11 @@ python_library(
   name='goal',
   sources=['goal.py'],
   dependencies=[
+    'src/python/pants/cache:cache_setup',
     'src/python/pants/option',
+    'src/python/pants/util:memo',
     'src/python/pants/util:meta',
+    'src/python/pants/util:objects',
   ]
 )
 

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -64,7 +64,7 @@ python_library(
   name='goal',
   sources=['goal.py'],
   dependencies=[
-    'src/python/pants/cache:cache_setup',
+    'src/python/pants/cache',
     'src/python/pants/option',
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',


### PR DESCRIPTION
### Problem
There were two issues causing an import of `subsystem_util.global_subsystem_instance()` to fail:

1) `engine/goal.py` did not properly declare its dependency on `cache`
2) `cache/` had a declared dependency on `engine:native`, even though it was never used.

### Solution
Update both `engine/goal.py`'s and `cache/`'s BUILD to reflect all the actual dependencies used, as several were missing and several unused.

### Result
The offending import now works properly.