### PR TITLE
[WIP] add `prepend_to_pythonpath=True` workaround for some 3rdparty python packages

### DIFF
--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import hashlib
 import os
-from builtins import open
+from builtins import object, open
 
 from future.utils import PY3
 from pex.executor import Executor
@@ -19,6 +19,32 @@ from pants.base.fingerprint_strategy import DefaultFingerprintHashingMixin, Fing
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.task.task import Task
 from pants.util.dirutil import safe_mkdir_for
+
+
+class SelectInterpreterClientMixin(object):
+  """Helper methods for python tasks which require a specific interpreter to run.
+
+  pex may change its interface and deprecate methods of resolving interpreters. This mixin allows
+  individual python tasks to avoid the details of how to invoke pex with exactly the interpreter
+  they've selected.
+  """
+
+  def get_selected_interpreter(self):
+    return self.context.products.get_data(PythonInterpreter)
+
+  def env_for_pinning_runtime_interpreter_for_pex(self):
+    """Return an environment for invoking a pex which ensures the use of the selected interpreter.
+
+    When creating the merged pytest pex, we already have an interpreter, and we only invoke that pex
+    within a pants run, so we can be sure the selected interpreter will be available. Constraining
+    the interpreter search path at pex runtime ensures that any resolved requirements will be
+    compatible with the interpreter being used to invoke the merged pytest pex.
+    """
+    chosen_interpreter_binary_path = self.get_selected_interpreter().binary
+    return {
+      'PEX_PYTHON': chosen_interpreter_binary_path,
+      'PEX_PYTHON_PATH': chosen_interpreter_binary_path,
+    }
 
 
 class PythonInterpreterFingerprintStrategy(DefaultFingerprintHashingMixin, FingerprintStrategy):

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -612,14 +612,13 @@ class PantsRunIntegrationTest(unittest.TestCase):
     """Wrapper around run_pants method.
 
     :param args: command line arguments used to run pants
-    :param kwargs: handles 1 key
-      success - indicate whether to expect pants run to succeed or fail.
+    :param bool success: indicate whether to expect pants run to succeed or fail.
+    :param kwargs: forwarded to self.run_pants().
     :return: a PantsResult object
     """
-    success = kwargs.get('success', True)
-    cmd = []
-    cmd.extend(list(args))
-    pants_run = self.run_pants(cmd)
+    success = kwargs.pop('success', True)
+    cmd = list(args)
+    pants_run = self.run_pants(cmd, **kwargs)
     if success:
       self.assert_success(pants_run)
     else:


### PR DESCRIPTION
*WIP because it may be rendered irrelevant depending upon an upstream pex fix, see pantsbuild/pex#729*

### Problem

Some 3rdparty python packages will fail at import time with a `pkg_resources.DistributionNotFound` due to containing the following snippet in some `__init__.py`, e.g. (for `google-cloud-bigquery` at https://github.com/googleapis/google-cloud-python/blob/3791847bc647b5fe415768459d3d0a4764e006f0/bigquery/google/cloud/bigquery/__init__.py#L31-L33):
```python
from pkg_resources import get_distribution
__version__ = get_distribution("google-cloud-bigquery").version # this fails
```

Separately, some of those same packages (`google-cloud-bigquery`) also seem to trigger a bug in resolving requirements for `./pants run`, causing interpreter selection to fail. This was fixed for python tests in #7563, so this PR simply extends that fix.

### Solution

*commits are independently reviewable*

- Add a `prepend_to_pythonpath=False` kwarg to `python_requirement_library()` targets.
  - In `PythonRun` and `PytestRun`, the requirements from these targets are placed into a pex which is before others on the `PEX_PATH` when running a test or executing a binary.
  - This allows packages using this idiom of querying `get_distribution()` to succeed at import time.
- Create `SelectInterpreterClientMixin` to abstract the process of pinning the python interpreter used at task runtime, and extend it to `PythonRun`.

### Result

Certain packages such as `google-cloud-bigquery` can now be resolved, albeit with an undocumented kwarg.