### PR TITLE
Improve error handling on pantsd launch failures

### DIFF
--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -449,7 +449,6 @@ class PantsDaemon(FingerprintedProcessManager):
     # Pass all of sys.argv so that we can proxy arg flags e.g. `-ldebug`.
     cmd = [sys.executable] + sys.argv
     self._logger.debug('cmd is: PANTS_ENTRYPOINT={} {}'.format(entry_point, ' '.join(cmd)))
-    # TODO: Improve error handling on launch failures.
     os.spawnve(os.P_NOWAIT, sys.executable, cmd, env=exec_env)
 
   def needs_launch(self):


### PR DESCRIPTION
### Problem

As described in #6901

> If one calls ./pants --enable-daemon ... for the first time before the daemon is initialised, and the child process (the one started by the call to os.spawnve@src/python/pants/pantsd/pants_daemon.py:389) crashes, there will be no stack trace shown.
>
> There is a TODO in that same file, just opening the issue to keep track of those efforts and possibly do something about it.


### Solution

Catch the connection timeout exception from pantsd client to pantsd server and assert the daemon is not alive 