### PR TITLE
Support running Kythe on recent JVMs.

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -28,16 +28,16 @@ jar_library(name = 'scrooge-linter',
             ])
 
 # Google doesn't publish Kythe jars (yet?).  So we publish them to a custom repo
-# (https://github.com/benjyw/binhost) for now.  See build-support/ivy/ivysettings.xml
+# (https://github.com/toolchainlabs/binhost) for now.  See build-support/ivy/ivysettings.xml
 # for more info.
 jar_library(
   name='kythe-java-extractor',
-  jars = [jar(org='kythe', name='javac_extractor', rev='v0.0.26.5-snowchain037-82964297aef')]
+  jars = [jar(org='kythe', name='javac_extractor', rev='v0.0.30-toolchain001-26a6b03b-000')]
 )
 
 jar_library(
   name='kythe-java-indexer',
-  jars = [jar(org='kythe', name='java_indexer', rev='v0.0.26.5-snowchain037-82964297aef')]
+  jars = [jar(org='kythe', name='java_indexer', rev='v0.0.30-toolchain001-26a6b03b-000')]
 )
 
 # Runtime dependencies for the Avro Java generated code.

--- a/BUILD.tools
+++ b/BUILD.tools
@@ -40,6 +40,13 @@ jar_library(
   jars = [jar(org='kythe', name='java_indexer', rev='v0.0.30-toolchain001-26a6b03b-000')]
 )
 
+# Running Kythe on JDK8 requires a standalone javac 9 on the bootclasspath.
+# This jar is published to the same custom rpeo as the Kythe jars.
+jar_library(
+  name='javac9',
+  jars = [jar(org='java', name='javac', rev='9+181-r4173-1')]
+)
+
 # Runtime dependencies for the Avro Java generated code.
 avro_rev = '1.8.2'
 jar_library(

--- a/build-support/ivy/ivysettings.xml
+++ b/build-support/ivy/ivysettings.xml
@@ -35,8 +35,8 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
       </filesystem>
 
       <!-- Custom repo for Kythe jars, as Google don't currently publish them anywhere. -->
-      <url name="benjyw/binhost">
-        <artifact pattern="https://github.com/benjyw/binhost/raw/master/${kythe.artifact}" />
+      <url name="toolchainlabs/binhost">
+        <artifact pattern="https://github.com/toolchainlabs/binhost/raw/master/${kythe.artifact}" />
       </url>
     </chain>
   </resolvers>

--- a/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/BUILD
+++ b/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/BUILD
@@ -8,6 +8,7 @@ python_library(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin',
     'src/python/pants/base:exceptions',
+    'src/python/pants/base:revision',
     'src/python/pants/build_graph',
     'src/python/pants/java/jar',
   ]

--- a/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/extract_java.py
+++ b/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/extract_java.py
@@ -33,8 +33,7 @@ class ExtractJava(JvmToolTaskMixin):
 
   @classmethod
   def product_types(cls):
-    # TODO: Support indexpack files?
-    return ['kindex_files']
+    return ['kzip_files']
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -88,10 +87,10 @@ class ExtractJava(JvmToolTaskMixin):
     for vt in invalidation_check.all_vts:
       created_files = os.listdir(vt.results_dir)
       if len(created_files) != 1:
-        raise TaskError('Expected a single .kindex file in {}. Got: {}.'.format(
+        raise TaskError('Expected a single .kzip file in {}. Got: {}.'.format(
           vt.results_dir, ', '.join(created_files) if created_files else 'none'))
-      kindex_files = self.context.products.get_data('kindex_files', dict)
-      kindex_files[vt.target] = os.path.join(vt.results_dir, created_files[0])
+      kzip_files = self.context.products.get_data('kzip_files', dict)
+      kzip_files[vt.target] = os.path.join(vt.results_dir, created_files[0])
 
   @staticmethod
   def _get_javac_args_from_zinc_args(zinc_args):

--- a/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/index_java.py
+++ b/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/index_java.py
@@ -42,7 +42,7 @@ class IndexJava(NailgunTask):
   @classmethod
   def prepare(cls, options, round_manager):
     super(IndexJava, cls).prepare(options, round_manager)
-    round_manager.require_data('kindex_files')
+    round_manager.require_data('kzip_files')
 
   @classmethod
   def register_options(cls, register):
@@ -83,10 +83,10 @@ class IndexJava(NailgunTask):
 
   def _index(self, vt, indexer_cp, jvm_options):
     self.context.log.info('Kythe indexing {}'.format(vt.target.address.spec))
-    kindex_file = self.context.products.get_data('kindex_files').get(vt.target)
-    if not kindex_file:
-      raise TaskError('No .kindex file found for {}'.format(vt.target.address.spec))
-    args = [kindex_file, '--emit_jvm', 'semantic', '--out', self._entries_file(vt)]
+    kzip_file = self.context.products.get_data('kzip_files').get(vt.target)
+    if not kzip_file:
+      raise TaskError('No .kzip file found for {}'.format(vt.target.address.spec))
+    args = [kzip_file, '--emit_jvm', 'semantic', '--out', self._entries_file(vt)]
     result = self.runjava(classpath=indexer_cp, main=self._KYTHE_JAVA_INDEXER_MAIN,
                           jvm_options=jvm_options,
                           args=args, workunit_name='kythe-index',

--- a/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/test_index_java_integration.py
+++ b/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/test_index_java_integration.py
@@ -15,19 +15,19 @@ class TestIndexJavaIntegration(PantsRunIntegrationTest):
     # Very simple test that we can run the extractor and indexer on some
     # fairly trivial code without crashing, and that we produce something.
     args = ['index', 'examples/src/java/org/pantsbuild/example/hello::']
-    with self.temporary_workdir() as workdir:
+    with self.temporary_workdir(cleanup=False) as workdir:
       pants_run = self.run_pants_with_workdir(args, workdir)
       self.assert_success(pants_run)
       for tgt in ['examples.src.java.org.pantsbuild.example.hello.greet.greet',
                   'examples.src.java.org.pantsbuild.example.hello.main.main-bin',
                   'examples.src.java.org.pantsbuild.example.hello.simple.simple']:
-        kindex_glob = os.path.join(
-          workdir, 'index/kythe-java-extract/current/{}/current/*.kindex'.format(tgt))
-        kindex_files = glob.glob(kindex_glob)
-        self.assertEqual(1, len(kindex_files))
-        kindex_file = kindex_files[0]
-        self.assertTrue(os.path.isfile(kindex_file))
-        self.assertGreater(os.path.getsize(kindex_file), 200)  # Make sure it's not trivial.
+        kzip_glob = os.path.join(
+          workdir, 'index/kythe-java-extract/current/{}/current/*.kzip'.format(tgt))
+        kzip_files = glob.glob(kzip_glob)
+        self.assertEqual(1, len(kzip_files))
+        kzip_file = kzip_files[0]
+        self.assertTrue(os.path.isfile(kzip_file))
+        self.assertGreater(os.path.getsize(kzip_file), 200)  # Make sure it's not trivial.
 
         entries_path = os.path.join(
           workdir, 'index/kythe-java-index/current/{}/current/index.entries'.format(tgt))


### PR DESCRIPTION
Kythe was stuck requiring JDK8 for a long time.
It now supports up to at least JDK11. This change 
upgrades to a recent version, and special-cases
some bootclasspath magic required only on JDK8.
