### PR TITLE
Ensure pantsd invalidates any files update under PANTS_SRCPATH

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -69,6 +69,11 @@ backend_packages: +[
     "pants.contrib.thrifty",
   ]
 
+# The pants script in this repo consumes these files to run pants
+pantsd_invalidation_globs: +[
+    "src/python/**/*.py",
+  ]
+
 # Path patterns to ignore for filesystem operations on top of the builtin patterns.
 pants_ignore: +[
     # venv directories under build-support.


### PR DESCRIPTION
### Problem

pants script consumes those files under PANTS_SRCPATH (src/python directory). But pantsd does not invalidate those files (pantsd does not shutdown) when any of those files gets updated.  

### Solution

Add pantsd_invalidation_globs option, which includes PANTS_SRCPATH, into pants.ini file