### PR TITLE
Refactor `check_banned_imports.py` to allow Python 3 files to import `subprocess`

### DIFF
--- a/build-support/bin/check_banned_imports.py
+++ b/build-support/bin/check_banned_imports.py
@@ -15,10 +15,10 @@ def main() -> None:
   )
   rust_files = find_files("src/rust/engine", extension=".rs")
 
-  python2_files = filter_files(python_files, snippet_regex=r"^from __future__ import")
+  python2_compatible_files = filter_files(python_files, snippet_regex=r"^from __future__ import")
 
   check_banned_import(
-    python2_files,
+    python2_compatible_files,
     bad_import_regex=r"^import subprocess$",
     correct_import_message="`from pants.util.process_handler import subprocess`"
   )
@@ -43,6 +43,7 @@ def find_files(*directories: str, extension: str) -> List[str]:
 
 
 def filter_files(files: List[str], *, snippet_regex: str) -> List[str]:
+  """Only return files that contain the snippet_regex."""
   regex = re.compile(snippet_regex)
   result: List[str] = []
   for fp in files:

--- a/build-support/bin/check_banned_imports.py
+++ b/build-support/bin/check_banned_imports.py
@@ -15,8 +15,9 @@ def main() -> None:
   )
   rust_files = find_files("src/rust/engine", extension=".rs")
 
-  check_banned_import(
+  check_banned_import_if_snippet_present(
     python_files,
+    snippet_regex=r"^from __future__ import",
     bad_import_regex=r"^import subprocess$",
     correct_import_message="`from pants.util.process_handler import subprocess`"
   )
@@ -52,6 +53,20 @@ def check_banned_import(files: List[str], *, bad_import_regex: str, correct_impo
     die(
       f"Found forbidden imports matching `{bad_import_regex}`. Instead, you should use "
       f"{correct_import_message}. Bad files:\n{bad_files_str}")
+
+
+def check_banned_import_if_snippet_present(
+  files: List[str], *, snippet_regex: str, bad_import_regex: str, correct_import_message: str
+) -> None:
+  regex = re.compile(snippet_regex)
+  filtered_files: List[str] = []
+  for fp in files:
+    with open(fp, 'r') as f:
+      if any(re.search(regex, line) for line in f.readlines()):
+        filtered_files.append(fp)
+  check_banned_import(
+    filtered_files, bad_import_regex=bad_import_regex, correct_import_message=correct_import_message
+  )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Problem
Once we drop Python 2, we will start directly importing the stdlib module for `subprocess` and will stop using `subprocess32` and `pants.util.process_handler.subprocess`. However, our `check_banned_imports.py` would not allow this to happen. 

At the same time, we would like to keep checking that our Python 2 files are valid, so we don't want to remove the check outright.

### Solution
Extract out a `filter_files()` function that will remove any files without the given snippet. This allows us to identify and save in memory all of our Python 2 files, then to call `check_banned_import` on only those files.

We check for the presence of `from __future__` imports, which are only used in our codebase for Python 2 compatibility.

### Result
We can now import `subprocess` in Python 3-only files.

There is a 1-second slowdown in the performance of that script. After we finish dropping Python 2, we could reclaim this second by removing both the filter to get Python 2 only files and removing the `subprocess` check entirely.