### PR TITLE
Rerun cbindgen on changes to src

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -591,6 +591,7 @@ dependencies = [
  "tokio 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "ui 0.0.1",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -20,6 +20,7 @@ crate-type = ["cdylib"]
 build_utils = { path = "build_utils" }
 cbindgen = "0.6.7"
 cc = "1.0"
+walkdir = "2"
 
 [workspace]
 # These are the packages which are built/tested when the --all flag is passed to cargo.


### PR DESCRIPTION
Currently, if you only modify a signature in src, and don't otherwise
happen to modify native.py, we won't rerun cbindgen, and you'll get an
error that the Python and Rust code had different expectations.