### PR TITLE
Add support in `check_header.py` for Python 3-style headers

### DIFF
--- a/build-support/bin/check_header.py
+++ b/build-support/bin/check_header.py
@@ -71,9 +71,12 @@ def create_parser() -> argparse.ArgumentParser:
 
 def check_header(filename: str, *, is_newly_created: bool = False) -> None:
   """Raises `HeaderCheckFailure` if the header doesn't match."""
+  expected_num_py2_lines = 6
+  expected_num_py3_lines = 3
   try:
     with open(filename, 'r') as f:
-      first_lines = [f.readline() for _ in range(0, 7)]
+      # We grab an extra line in case there is a shebang.
+      first_lines = [f.readline() for _ in range(0, expected_num_py2_lines + 1)]
   except IOError as e:
     raise HeaderCheckFailure(f"{filename}: error while reading input ({e})")
   # If a shebang line is included, remove it. Otherwise, we will have conservatively grabbed
@@ -81,11 +84,11 @@ def check_header(filename: str, *, is_newly_created: bool = False) -> None:
   first_lines.pop(0 if first_lines[0].startswith("#!") else - 1)
   # Check that the first lines even exists. Note that first_lines will always have an entry
   # for each line, even if the file is completely empty.
-  if len([line for line in first_lines if line]) < 3:
+  if len([line for line in first_lines if line]) < expected_num_py3_lines:
     raise HeaderCheckFailure(f"{filename}: missing the expected header")
   is_py3_file = all("from __future__" not in line for line in first_lines)
   if is_py3_file:
-    first_lines = first_lines[:3]
+    first_lines = first_lines[:expected_num_py3_lines]
   # Check copyright year. If it's a new file, it should be the current year. Else, it should
   # be within the current century.
   copyright_line_index = 0 if is_py3_file else 1

--- a/build-support/bin/check_header.py
+++ b/build-support/bin/check_header.py
@@ -112,7 +112,7 @@ def check_header_present(filename: str, lines: List[str]) -> None:
 
 def check_copyright_year(filename: str, *, copyright_line: str, is_newly_created: bool) -> None:
   """Check that copyright is current year if for a new file, else that it's within
-  the current centuury."""
+  the current century."""
   year = copyright_line[12:16]
   if is_newly_created and year != _current_year:
     raise HeaderCheckFailure(f'{filename}: copyright year must be {_current_year} (was {year})')

--- a/tests/python/pants_test/repo_scripts/test_git_hooks.py
+++ b/tests/python/pants_test/repo_scripts/test_git_hooks.py
@@ -127,11 +127,8 @@ subdir/__init__.py
 
       # Check that a file with a typo in the header fails
       safe_file_dump(new_py_path, dedent("""\
-        # coding=utf-8
         # Copyright {} Pants project contributors (see CONTRIBUTORS.md).
         # Licensed under the MIT License, Version 3.3 (see LICENSE).
-
-        from __future__ import absolute_import, division, print_function, unicode_literals
 
         """.format(cur_year))
       )
@@ -142,11 +139,8 @@ subdir/__init__.py
 
       # Check that a file without a valid copyright year fails.
       safe_file_dump(new_py_path, dedent("""\
-        # coding=utf-8
         # Copyright YYYY Pants project contributors (see CONTRIBUTORS.md).
         # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
-        from __future__ import absolute_import, division, print_function, unicode_literals
 
         """)
       )
@@ -161,11 +155,8 @@ subdir/__init__.py
       # Check that a newly added file must have the current year.
       last_year = str(cur_year_num - 1)
       safe_file_dump(new_py_path, dedent("""\
-        # coding=utf-8
         # Copyright {} Pants project contributors (see CONTRIBUTORS.md).
         # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
-        from __future__ import absolute_import, division, print_function, unicode_literals
 
         """.format(last_year))
       )
@@ -174,6 +165,18 @@ subdir/__init__.py
         added_files=[rel_new_py_path],
         expected_excerpt="subdir/file.py: copyright year must be {} (was {})".format(cur_year, last_year)
       )
+
+      # Check that we also support Python 2-style headers.
+      safe_file_dump(new_py_path, dedent("""\
+        # coding=utf-8
+        # Copyright {} Pants project contributors (see CONTRIBUTORS.md).
+        # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+        from __future__ import absolute_import, division, print_function, unicode_literals
+
+        """.format(cur_year))
+      )
+      self._assert_subprocess_success(worktree, [header_check_script, 'subdir'])
 
       # Check that a file isn't checked against the current year if it is not passed as an
       # arg to the script.


### PR DESCRIPTION
### Problem
Once we drop Python 2, we can simplify our headers to no longer use `from __future__ import` and `# coding=utf-8`, as both are repetitive and add unnecessary code.

Still, we (at least temporarily) want to support the Python 2 style as well.

### Solution
Allow `check_header.py` to accept either style.