### PR TITLE
Apply more shellcheck fixes to build-support scripts

### DIFF
--- a/build-support/bin/check_rust_formatting.sh
+++ b/build-support/bin/check_rust_formatting.sh
@@ -9,7 +9,7 @@ function usage() {
   echo " -h    print out this help message"
   echo " -f    instead of erroring on files with bad formatting, fix those files"
 
-  if [[ -n "$@" ]]; then
+  if [[ -n "$*" ]]; then
     echo
     echo "$@"
   fi

--- a/build-support/bin/ci-failure.sh
+++ b/build-support/bin/ci-failure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 if [[ "$(uname)" == "Darwin" ]]; then
-  if (( $(ls -1 /cores | wc -l) > 0 )); then
+  if (( $(find /cores -maxdepth 1 ! -name "$(basename /cores)" | wc -l) > 0 )); then
     echo >&2 "Core files detected; trying to get backtraces"
     sudo pip install six
     for core in /cores/*; do

--- a/build-support/bin/get_ci_bootstrapped_pants_pex.sh
+++ b/build-support/bin/get_ci_bootstrapped_pants_pex.sh
@@ -18,7 +18,7 @@ NUM_VERSIONS=$(aws --no-sign-request --region us-east-1 s3api list-object-versio
 
 # Now fetch the pre-bootstrapped pex, so that the ./pants wrapper script can use it
 # instead of running from sources (and re-bootstrapping).
-aws --no-sign-request --region us-east-1 s3 cp ${BOOTSTRAPPED_PEX_URL} ./pants.pex
+aws --no-sign-request --region us-east-1 s3 cp "${BOOTSTRAPPED_PEX_URL}" ./pants.pex
 chmod 755 ./pants.pex
 
 # Pants code executing under test expects native_engine.so to be present as a resource

--- a/build-support/bin/native/bootstrap_rust.sh
+++ b/build-support/bin/native/bootstrap_rust.sh
@@ -19,7 +19,6 @@ function cargo_bin() {
   "${RUSTUP}" which cargo
 }
 
-
 function bootstrap_rust() {
   RUST_TOOLCHAIN="$(cat "${REPO_ROOT}/rust-toolchain")"
   RUST_COMPONENTS=(

--- a/build-support/bin/native/bootstrap_rust.sh
+++ b/build-support/bin/native/bootstrap_rust.sh
@@ -19,8 +19,9 @@ function cargo_bin() {
   "${RUSTUP}" which cargo
 }
 
+
 function bootstrap_rust() {
-  RUST_TOOLCHAIN="$(cat ${REPO_ROOT}/rust-toolchain)"
+  RUST_TOOLCHAIN="$(cat "${REPO_ROOT}/rust-toolchain")"
   RUST_COMPONENTS=(
     "rustfmt-preview"
     "rust-src"
@@ -47,8 +48,8 @@ function bootstrap_rust() {
     # If rustup was already bootstrapped against a different toolchain in the past, freshen it and
     # ensure the toolchain and components we need are installed.
     "${RUSTUP}" self update
-    "${RUSTUP}" toolchain install ${RUST_TOOLCHAIN}
-    "${RUSTUP}" component add --toolchain ${RUST_TOOLCHAIN} ${RUST_COMPONENTS[@]} >&2
+    "${RUSTUP}" toolchain install "${RUST_TOOLCHAIN}"
+    "${RUSTUP}" component add --toolchain "${RUST_TOOLCHAIN}" "${RUST_COMPONENTS[@]}" >&2
 
     symlink_target="$(python -c 'import os, sys; print(os.path.relpath(*sys.argv[1:]))' "$(RUSTUP_TOOLCHAIN="${RUST_TOOLCHAIN}" cargo_bin)" "${rust_toolchain_root}")"
     ln -fs "${symlink_target}" "${rust_toolchain_root}/${cargo_versioned}"
@@ -62,14 +63,14 @@ function bootstrap_rust() {
   local -r symlink_farm_root="${REPO_ROOT}/build-support/bin/native"
   if [[ ! -x "${symlink_farm_root}/.${cargo_versioned}" ]]; then
     (
-      cd "${symlink_farm_root}"
+      cd "${symlink_farm_root}" || exit 1
 
       # Kill potentially stale symlinks generated from an older or newer rust toolchain.
       git clean -fdx .
 
       ln -fs "rust_toolchain.sh" rustup
       local -r cargo_bin_dir="$(dirname "$(cargo_bin)")"
-      find "${cargo_bin_dir}" -type f | while read executable; do
+      find "${cargo_bin_dir}" -type f | while read -r executable; do
         if [[ -x "${executable}" ]]; then
           ln -fs "rust_toolchain.sh" "$(basename "${executable}")"
         fi

--- a/build-support/bin/native/cargo.sh
+++ b/build-support/bin/native/cargo.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd ../../.. && pwd -P)
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd -P)
 
 export PY=${PY:-python}
 
@@ -10,6 +10,7 @@ export PY=${PY:-python}
 # + CARGO_HOME: The CARGO_HOME of the Pants-controlled rust toolchain.
 # Exposes:
 # + bootstrap_rust: Bootstraps a Pants-controlled rust toolchain and associated extras.
+# shellcheck source=build-support/bin/native/bootstrap_rust.sh
 source "${REPO_ROOT}/build-support/bin/native/bootstrap_rust.sh"
 
 bootstrap_rust >&2
@@ -25,7 +26,8 @@ goroot="$("${download_binary}" "go" "1.7.3" "go.tar.gz")/go"
 protoc="$("${download_binary}" "protobuf" "3.4.1" "protoc")"
 
 export GOROOT="${goroot}"
-export PATH="${cmakeroot}/bin:${goroot}/bin:${CARGO_HOME}/bin:$(dirname "${protoc}"):${PATH}"
+PATH="${cmakeroot}/bin:${goroot}/bin:${CARGO_HOME}/bin:$(dirname "${protoc}"):${PATH}"
+export PATH
 export PROTOC="${protoc}"
 
 cargo_bin="${CARGO_HOME}/bin/cargo"

--- a/build-support/bin/native/rust_toolchain.sh
+++ b/build-support/bin/native/rust_toolchain.sh
@@ -8,9 +8,10 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd -P)"
 # + CARGO_HOME: The CARGO_HOME of the Pants-controlled rust toolchain.
 # Exposes:
 # + bootstrap_rust: Bootstraps a Pants-controlled rust toolchain and associated extras.
+# shellcheck source=build-support/bin/native/bootstrap_rust.sh
 source "${REPO_ROOT}/build-support/bin/native/bootstrap_rust.sh"
 
-if [ ! -h $0 ]; then
+if [ ! -h "$0" ]; then
   cat << EOF
 This script should be executed via a symbolic link matching the name
 of the \$CARGO_HOME binary to run.

--- a/build-support/bin/publish_docs.sh
+++ b/build-support/bin/publish_docs.sh
@@ -85,8 +85,8 @@ set +x
 if [[ -z "${local_dir}" ]]; then
   do_open "${REPO_ROOT}/dist/docsite/index.html"
 else
-  find "${REPO_ROOT}/dist/docsite" -mindepth 1 -maxdepth 1 \
-    -exec -I '{}' cp -r '{}' "${local_dir}" +
+  find "${REPO_ROOT}/dist/docsite" -mindepth 1 -maxdepth 1 -print0 \
+    | xargs -0 -I '{}' cp -r '{}' "${local_dir}"
   do_open "${local_dir}/index.html"
 fi
 

--- a/build-support/bin/publish_docs.sh
+++ b/build-support/bin/publish_docs.sh
@@ -12,6 +12,7 @@ VIEW_PUBLISH_URL="${VIEW_PUBLISH_URL:-${PANTS_SITE_URL}}"
 
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd "$(git rev-parse --show-toplevel)" && pwd)
 
+# shellcheck source=build-support/common.sh
 source "${REPO_ROOT}/build-support/common.sh"
 
 PANTS_EXE="${REPO_ROOT}/pants"
@@ -85,7 +86,7 @@ if [[ -z "${local_dir}" ]]; then
   do_open "${REPO_ROOT}/dist/docsite/index.html"
 else
   find "${REPO_ROOT}/dist/docsite" -mindepth 1 -maxdepth 1 \
-    | xargs -I '{}' cp -r '{}' "${local_dir}"
+    -exec -I '{}' cp -r '{}' "${local_dir}" +
   do_open "${local_dir}/index.html"
 fi
 

--- a/build-support/bin/release-changelog-helper.sh
+++ b/build-support/bin/release-changelog-helper.sh
@@ -75,7 +75,7 @@ do
 
   urls=()
   urls=(
-    ${urls}
+    "${urls[@]}"
     $(
       git log -1 --oneline "${sha}" | \
         grep -Eo "\(#[0-9]+\)" | \
@@ -83,7 +83,7 @@ do
     )
   )
   urls=(
-    ${urls}
+    "${urls[@]}"
     $(
       git log -1 "${sha}" --format="format:%b" | \
         grep -E "https?://" | \

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -324,6 +324,7 @@ function install_and_test_packages() {
   for package in "${packages[@]}"
   do
     start_travis_section "${package}" "Installing and testing package ${package}-${VERSION}"
+    # shellcheck disable=SC2086
     eval pkg_${package##*\.}_install_test "${PIP_ARGS[@]}" || \
       die "Failed to install and test package ${package}-${VERSION}!"
     end_travis_section
@@ -443,7 +444,7 @@ function reversion_whls() {
   local dest_dir=$2
   local output_version=$3
 
-  for whl in $(ls -1 "${src_dir}"/*.whl); do
+  for whl in "${src_dir}"/*.whl; do
     run_local_pants -q run src/python/pants/releases:reversion -- \
       --glob='pants/VERSION' \
       "${whl}" "${dest_dir}" "${output_version}" \

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -87,7 +87,7 @@ function run_pex() {
     PEX_VERSION="$(requirement pex | sed -e "s|pex==||")"
 
     pexdir="$(mktemp -d -t build_pex.XXXXX)"
-    trap "rm -rf ${pexdir}" EXIT
+    trap 'rm -rf "${pexdir}"' EXIT
 
     pex="${pexdir}/pex"
 
@@ -314,7 +314,7 @@ function install_and_test_packages() {
   # Avoid caching plugin installs.
   PANTS_PLUGIN_CACHE_DIR=$(mktemp -d -t plugins_cache.XXXXX)
   export PANTS_PLUGIN_CACHE_DIR
-  trap "rm -rf ${PANTS_PLUGIN_CACHE_DIR}" EXIT
+  trap 'rm -rf "${PANTS_PLUGIN_CACHE_DIR}"' EXIT
 
   packages=(
     $(run_packages_script list | grep '.' | awk '{print $1}')
@@ -456,7 +456,7 @@ readonly BINARY_BASE_URL=https://binaries.pantsbuild.org
 function list_prebuilt_wheels() {
   # List prebuilt wheels as tab-separated tuples of filename and URL-encoded name.
   wheel_listing="$(mktemp -t pants.wheels.XXXXX)"
-  trap "rm -f ${wheel_listing}" RETURN
+  trap 'rm -f ${wheel_listing}"' RETURN
 
   for wheels_path in "${DEPLOY_PANTS_WHEELS_PATH}" "${DEPLOY_3RDPARTY_WHEELS_PATH}"; do
     curl -sSL "${BINARY_BASE_URL}/?prefix=${wheels_path}" > "${wheel_listing}"
@@ -508,7 +508,7 @@ function fetch_and_check_prebuilt_wheels() {
   if [[ -z "${check_dir}" ]]
   then
     check_dir=$(mktemp -d -t pants.wheel_check.XXXXX)
-    trap "rm -rf ${check_dir}" RETURN
+    trap 'rm -rf "${check_dir}"' RETURN
   fi
 
   banner "Checking prebuilt wheels for ${PANTS_UNSTABLE_VERSION}"

--- a/build-support/bin/shellcheck.py
+++ b/build-support/bin/shellcheck.py
@@ -22,18 +22,17 @@ def ensure_shellcheck_installed() -> None:
 
 
 def run_shellcheck() -> None:
-  targets = glob("./build-support/bin/*.sh") + glob("./build-support/bin/native/*.sh") + [
+  targets = set(glob("./**/*.sh", recursive=True)) | {
     "./pants",
     "./pants2",
-    "./build-support/common.sh",
-    "./build-support/pants-intellij.sh",
     "./build-support/pants_venv",
     "./build-support/virtualenv",
     "./build-support/githooks/pre-commit",
     "./build-support/githooks/prepare-commit-msg",
-    "./build-support/python/clean.sh",
-  ]
-  command = ["shellcheck", "--shell=bash", "--external-sources"] + targets
+  }
+  targets -= set(glob("./build-support/bin/native/src/**/*.sh", recursive=True))
+  targets -= set(glob("./build-support/virtualenv.dist/**/*.sh", recursive=True))
+  command = ["shellcheck", "--shell=bash", "--external-sources"] + sorted(targets)
   try:
     subprocess.run(command, check=True)
   except subprocess.CalledProcessError:

--- a/build-support/bin/shellcheck.py
+++ b/build-support/bin/shellcheck.py
@@ -22,11 +22,11 @@ def ensure_shellcheck_installed() -> None:
 
 
 def run_shellcheck() -> None:
-  targets = glob("./build-support/bin/**/*.sh", recursive=True) + [
+  targets = glob("./build-support/bin/*.sh") + glob("./build-support/bin/native/*.sh") + [
     "./pants",
     "./pants2",
     "./build-support/common.sh",
-    "./build-support/pants_intellij.sh",
+    "./build-support/pants-intellij.sh",
     "./build-support/pants_venv",
     "./build-support/virtualenv",
     "./build-support/githooks/pre-commit",

--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -9,7 +9,8 @@ source build-support/common.sh
 # running in the git root, as it looks for a .git directory relative to the working directory.
 # Explicitly absolute-ify the $GIT_DIR variable so that this doesn't happen.
 if [[ -n "${GIT_DIR}" && "${GIT_DIR}" != /* ]]; then
-  export GIR_DIR="$(pwd)/${GIT_DIR}"
+  GIT_DIR="$(pwd)/${GIT_DIR}"
+  export GIT_DIR
 fi
 
 DIRS_TO_CHECK=(
@@ -44,19 +45,21 @@ echo "* Checking headers"
 echo "* Checking for banned imports"
 ./build-support/bin/check_banned_imports.py
 
-echo "* Checking for bad shell patterns" && ./build-support/bin/check_shell.sh || exit 1
+echo "* Checking for bad shell patterns"
+./build-support/bin/check_shell.sh || exit 1
 
 # When travis builds a tag, it does so in a shallow clone without master fetched, which
 # fails in pants changed.
 if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
-  echo "* Checking imports" && ./build-support/bin/isort.sh || \
-    die "To fix import sort order, run \`\"$(pwd)/build-support/bin/isort.sh\" -f\`"
+  echo "* Checking imports"
+  ./build-support/bin/isort.sh || die "To fix import sort order, run \`\"$(pwd)/build-support/bin/isort.sh\" -f\`"
 
   # TODO(CMLivingston) Make lint use `-q` option again after addressing proper workunit labeling:
   # https://github.com/pantsbuild/pants/issues/6633
   # TODO: add a test case for this while including a pexrc file, as python checkstyle currently fails
   # quite often with a pexrc available.
-  echo "* Checking lint" && ./pants --exclude-target-regexp='testprojects/.*' --changed-parent="${MERGE_BASE}" lint || exit 1
+  echo "* Checking lint"
+  ./pants --exclude-target-regexp='testprojects/.*' --changed-parent="${MERGE_BASE}" lint || exit 1
 
   echo "* Checking types (for build-support)"
   # NB: This task requires Python 3, so we must temporarily override any intepreter constraints
@@ -65,22 +68,25 @@ if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
   PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']" ./pants mypy 'build-support::' || exit 1
 
   if git diff "${MERGE_BASE}" --name-only | grep '\.rs$' > /dev/null; then
-    echo "* Checking formatting of rust files" && ./build-support/bin/check_rust_formatting.sh || exit 1
+    echo "* Checking formatting of rust files"
+    ./build-support/bin/check_rust_formatting.sh || exit 1
     # Clippy happens on a different Travis CI shard because of separate caching concerns.
     # The TRAVIS env var is documented here:
     #   https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
     if [[ "${TRAVIS}" != "true" ]]; then
-      echo "* Running cargo clippy" && ./build-support/bin/check_clippy.sh || exit 1
+      echo "* Running cargo clippy"
+      ./build-support/bin/check_clippy.sh || exit 1
     fi
-    echo "* Checking rust target headers" && build-support/bin/check_rust_target_headers.sh || exit 1
+    echo "* Checking rust target headers"
+    build-support/bin/check_rust_target_headers.sh || exit 1
   fi
 
   if git diff "${MERGE_BASE}" --name-only | grep build-support/travis > /dev/null; then
-    echo "* Checking .travis.yml generation" && \
-    actual_travis_yml=$(<.travis.yml) && \
-    expected_travis_yml=$(./pants --quiet run build-support/travis:generate_travis_yml) && \
+    echo "* Checking .travis.yml generation"
+    actual_travis_yml=$(<.travis.yml)
+    expected_travis_yml=$(./pants --quiet run build-support/travis:generate_travis_yml)
     [ "${expected_travis_yml}" == "${actual_travis_yml}" ] || \
-    die "Travis config generator changed but .travis.yml file not regenerated. See top of that file for instructions."
+      die "Travis config generator changed but .travis.yml file not regenerated. See top of that file for instructions."
   fi
 else
   echo "* Skipping import/lint checks in partial working copy."

--- a/build-support/githooks/prepare-commit-msg
+++ b/build-support/githooks/prepare-commit-msg
@@ -6,7 +6,7 @@ COMMIT_MSG_SRC=$2
 NUM_NON_MD_FILES=$(git status -s --porcelain | grep -cv ".\md$")
 
 # The msg source will be "commit" if we were called with --amend.
-if [ "${COMMIT_MSG_SRC}" != "commit" ] && [ "${NUM_NON_MD_FILES}" == "0" ]; then
+if [ "${COMMIT_MSG_SRC}" != "commit" ] && [ "${NUM_NON_MD_FILES}" -eq 0 ]; then
 cat <<EOF >> "${COMMIT_MSG_FILEPATH}"
 
 # Delete this line to force a full CI run for documentation-only changes.

--- a/build-support/githooks/prepare-commit-msg
+++ b/build-support/githooks/prepare-commit-msg
@@ -3,8 +3,7 @@
 COMMIT_MSG_FILEPATH=$1
 COMMIT_MSG_SRC=$2
 
-# Note that xargs with no args just returns the string with surrounding whitespace trimmed.
-NUM_NON_MD_FILES=$(git status -s --porcelain | grep -v ".\md$" | wc -l | xargs)
+NUM_NON_MD_FILES=$(git status -s --porcelain | grep -cv ".\md$")
 
 # The msg source will be "commit" if we were called with --amend.
 if [ "${COMMIT_MSG_SRC}" != "commit" ] && [ "${NUM_NON_MD_FILES}" == "0" ]; then

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -39,8 +39,7 @@ function create_venv() {
 }
 
 function ensure_gcc() {
-  GCC_VERSION=$(gcc -v 2>&1)
-  if (( $? != 0 )); then
+  if ! GCC_VERSION="$(gcc -v 2>&1)"; then
     die "$(cat << MESSAGE
 ERROR: unable to execute 'gcc'. Please verify that your compiler is installed, in your
        \$PATH and functional.

--- a/pants
+++ b/pants
@@ -67,6 +67,7 @@ export PY="${PY:-python3}"
 # Pants will try to use Python 2 for subprocesses. Without setting minor version constraints, when using Python 3
 # we could end up using a different Python minor version for subprocesses than we do for Pants.
 py_major_minor_patch=$(${PY} -c 'import sys; print(".".join(map(str, sys.version_info[0:3])))')
+# shellcheck disable=SC2016
 export PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="${PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS:-['CPython==${py_major_minor_patch}']}"
 
 PANTS_EXE="${HERE}/src/python/pants/bin/pants_loader.py"
@@ -74,7 +75,7 @@ PANTS_EXE="${HERE}/src/python/pants/bin/pants_loader.py"
 if [[ -n "${WRAPPER_REQUIREMENTS}" ]]; then
   REQUIREMENTS=(
     $(echo "${WRAPPER_REQUIREMENTS}" | tr : ' ')
-    ${REQUIREMENTS[@]}
+    "${REQUIREMENTS[@]}"
   )
 fi
 
@@ -84,10 +85,10 @@ PANTS_SRCPATH=(
 if [[ -n "${WRAPPER_SRCPATH}" ]]; then
   PANTS_SRCPATH=(
     $(echo "${WRAPPER_SRCPATH}" | tr : ' ')
-    ${PANTS_SRCPATH[@]}
+    "${PANTS_SRCPATH[@]}"
   )
 fi
-PANTS_SRCPATH="$(echo ${PANTS_SRCPATH[@]} | tr ' ' :)"
+PANTS_SRCPATH="$(echo "${PANTS_SRCPATH[@]}" | tr ' ' :)"
 
 function exec_pants_bare() {
   # Redirect activation and native bootstrap to ensure that they don't interfere with stdout.


### PR DESCRIPTION
Applies more fixes from the `shellcheck.py` script introduced in https://github.com/pantsbuild/pants/pull/7698.

There are still a few more failures, which are left for a final PR that will fix those issues and enforce shellcheck in `githooks/pre-commit`.