### PR TITLE
Properly resolve transitive dependencies in V2 Pytest runner

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -71,7 +71,6 @@ def run_python_test(transitive_hydrated_target, pytest, python_setup, source_roo
 
   all_targets = resolve_all_transitive_hydrated_targets(transitive_hydrated_target)
 
-
   # Produce a pex containing pytest and all transitive 3rdparty requirements.
   all_requirements = []
   for maybe_python_req_lib in all_targets:

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -45,6 +45,8 @@ def parse_interpreter_constraints(python_setup, python_target_adaptors):
   return constraints_args
 
 
+# TODO(7726): replace this function with a proper API to get the `closure` for a
+# TransitiveHydratedTarget.
 def resolve_all_transitive_hydrated_targets(initial_transitive_hydrated_target):
   all_targets = set()
   def recursively_add_transitive_deps(transitive_hydrated_target):

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -17,7 +17,8 @@ from pants.engine.fs import (Digest, DirectoryWithPrefixToStrip, FilesContent, M
                              Snapshot, UrlToFetch)
 from pants.engine.isolated_process import (ExecuteProcessRequest, ExecuteProcessResult,
                                            FallibleExecuteProcessResult)
-from pants.engine.legacy.graph import TransitiveHydratedTarget
+from pants.engine.legacy.graph import (BuildFileAddresses, TransitiveHydratedTarget,
+                                       TransitiveHydratedTargets)
 from pants.engine.rules import optionable_rule, rule
 from pants.engine.selectors import Get
 from pants.rules.core.core_test_model import Status, TestResult
@@ -45,19 +46,6 @@ def parse_interpreter_constraints(python_setup, python_target_adaptors):
   return constraints_args
 
 
-# TODO(7726): replace this function with a proper API to get the `closure` for a
-# TransitiveHydratedTarget.
-def resolve_all_transitive_hydrated_targets(initial_transitive_hydrated_target):
-  all_targets = set()
-  def recursively_add_transitive_deps(transitive_hydrated_target):
-    all_targets.add(transitive_hydrated_target.root)
-    for dep in transitive_hydrated_target.dependencies:
-      recursively_add_transitive_deps(dep)
-
-  recursively_add_transitive_deps(initial_transitive_hydrated_target)
-  return all_targets
-
-
 # TODO: Support deps
 # TODO: Support resources
 # TODO(7697): Use a dedicated rule for removing the source root prefix, so that this rule
@@ -71,7 +59,12 @@ def run_python_test(transitive_hydrated_target, pytest, python_setup, source_roo
   digest = Digest('61bb79384db0da8c844678440bd368bcbfac17bbdb865721ad3f9cb0ab29b629', 1826945)
   pex_snapshot = yield Get(Snapshot, UrlToFetch(url, digest))
 
-  all_targets = resolve_all_transitive_hydrated_targets(transitive_hydrated_target)
+  # TODO(7726): replace this with a proper API to get the `closure` for a
+  # TransitiveHydratedTarget.
+  transitive_hydrated_targets = yield Get(
+    TransitiveHydratedTargets, BuildFileAddresses((target_root.address,))
+  )
+  all_targets = transitive_hydrated_targets.closure
 
   # Produce a pex containing pytest and all transitive 3rdparty requirements.
   all_requirements = []

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -58,7 +58,14 @@ def run_python_test(transitive_hydrated_target, pytest, python_setup, source_roo
   digest = Digest('61bb79384db0da8c844678440bd368bcbfac17bbdb865721ad3f9cb0ab29b629', 1826945)
   pex_snapshot = yield Get(Snapshot, UrlToFetch(url, digest))
 
-  all_targets = [target_root] + [dep.root for dep in transitive_hydrated_target.dependencies]
+  all_targets = set()
+  def add_transitive_deps(hydrated_target):
+    all_targets.add(hydrated_target.root)
+    for dep in hydrated_target.dependencies:
+      add_transitive_deps(dep)
+
+  add_transitive_deps(transitive_hydrated_target)
+
 
   # Produce a pex containing pytest and all transitive 3rdparty requirements.
   all_requirements = []

--- a/testprojects/tests/python/pants/dummies/BUILD
+++ b/testprojects/tests/python/pants/dummies/BUILD
@@ -36,3 +36,19 @@ python_tests(
     '3rdparty/python:future',
   ],
 )
+
+python_library(
+  name = 'transitive_dep',
+  source = 'example_transitive_source.py',
+  dependencies = [
+    ':example_lib',
+  ],
+)
+
+python_tests(
+  name = 'target_with_transitive_dep',
+  sources = ['test_with_transitive_dep.py'],
+  dependencies = [
+    ':transitive_dep',
+  ],
+)

--- a/testprojects/tests/python/pants/dummies/example_transitive_source.py
+++ b/testprojects/tests/python/pants/dummies/example_transitive_source.py
@@ -1,0 +1,5 @@
+from pants.dummies.example_source import add_two
+
+
+def add_four(x):
+  return add_two(x) + 2

--- a/testprojects/tests/python/pants/dummies/test_with_transitive_dep.py
+++ b/testprojects/tests/python/pants/dummies/test_with_transitive_dep.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+
+from pants.dummies.example_transitive_source import add_four
+
+
+def test_external_method():
+  assert add_four(2) == 6

--- a/tests/python/pants_test/rules/test_test_integration.py
+++ b/tests/python/pants_test/rules/test_test_integration.py
@@ -181,6 +181,29 @@ class TestIntegrationTest(PantsRunIntegrationTest):
         """)
     )
 
+  def test_transitive_dep(self):
+    pants_run = self.run_passing_pants_test([
+      'testprojects/tests/python/pants/dummies:target_with_transitive_dep',
+    ])
+    self.assert_fuzzy_string_match(
+      pants_run.stdout_data,
+      dedent("""\
+        testprojects/tests/python/pants/dummies:target_with_transitive_dep stdout:
+        ============================= test session starts ==============================
+        platform SOME_TEXT
+        rootdir: SOME_TEXT
+        plugins: SOME_TEXT
+        collected 1 item
+
+        pants/dummies/test_with_transitive_dep.py .                              [100%]
+
+        =========================== 1 passed in SOME_TEXT ===========================
+
+
+        testprojects/tests/python/pants/dummies:target_with_transitive_dep              .....   SUCCESS
+        """)
+    )
+
   def test_mixed_python_tests(self):
     pants_run = self.run_failing_pants_test([
       'testprojects/tests/python/pants/dummies:failing_target',


### PR DESCRIPTION
### Problem
`./pants --no-v1 --v2 test tests/python/pants_test/util:dirutil` would fail to pass because the snapshot would not include the file `strutil.py` so the import would fail.

This is the result of transitive dependencies not being properly resolved. `test_dirutil.py` does not directly depend on `strutil.py`; instead, `test_dirutil.py` depends on `dirutil.py`, which itself depends on `strutil.py`. We were not recursively grabbing the 3rd party requirements and source files for transitive dependencies.

### Solution
`TransitiveHydratedTarget` already resolves all transitive dependencies for us. We simply must use those results differently to fix this issue.

Specifically, we can convert the `TransitiveHydratedTarget` into `TransitiveHydratedTargets`, which then allows us to access the `closure` property to get all the `HydratedTargets` in a de-duplicated and flattened data structure.

### Result
`./pants --no-v1 --v2 test tests/python/pants_test/util:dirutil` now works, along with the majority of the `util` unit tests.