### PR TITLE
[v2] Pipe LineOriented through the Console

### DIFF
--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -29,11 +29,11 @@ class Console(object):
   def write_stderr(self, payload):
     self.stderr.write(payload)
 
-  def print_stdout(self, payload):
-    print(payload, file=self.stdout)
+  def print_stdout(self, payload, end='\n'):
+    print(payload, file=self.stdout, end=end)
 
-  def print_stderr(self, payload):
-    print(payload, file=self.stderr)
+  def print_stderr(self, payload, end='\n'):
+    print(payload, file=self.stderr, end=end)
 
   def flush(self):
     self.stdout.flush()

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -135,17 +135,17 @@ class LineOriented(object):
     output_file = line_oriented_options.values.output_file
     sep = line_oriented_options.values.sep.encode('utf-8').decode('unicode_escape')
 
-    stdout, stderr = console.stdout, console.stderr
     if output_file:
-      stdout = open(output_file, 'w')
+      stdout_file = open(output_file, 'w')
+      print_stdout = lambda msg: print(msg, file=stdout_file, end=sep)
+    else:
+      print_stdout = lambda msg: console.print_stdout(msg, end=sep)
+
+    print_stderr = lambda msg: console.print_stderr(msg)
 
     try:
-      print_stdout = lambda msg: print(msg, file=stdout, end=sep)
-      print_stderr = lambda msg: print(msg, file=stderr)
       yield print_stdout, print_stderr
     finally:
       if output_file:
-        stdout.close()
-      else:
-        stdout.flush()
-      stderr.flush()
+        stdout_file.close()
+      console.flush()


### PR DESCRIPTION
### Problem

`LineOriented` is a nice utility to mix options with the console, but unfortunately it writes directly to `std{out,err}` after grabbing them from the `Console`. Ideally, we would like all output to go through the `Console` class, to make things like the UI easier to develop.

### Solution

- Enhance `print_std{out,err}` in `Console` to accept a separator.
- Refactor `LineOriented` a bit to only write to raw files when we are not writing to stdout.

### Result

There should be no visible change in behavior.