### PR TITLE
Fixes for pants release 1.17.0.dev0

### DIFF
--- a/src/python/pants/ABOUT.rst
+++ b/src/python/pants/ABOUT.rst
@@ -1,4 +1,4 @@
 Pants is an Apache2 licensed build tool written in Python.
 
-The latest documentation can be found `here <http://pantsbuild.org/>`_.
+The latest documentation can be found at `pantsbuild <http://pantsbuild.org/>`_.
 

--- a/src/python/pants/notes/master.rst
+++ b/src/python/pants/notes/master.rst
@@ -20,11 +20,9 @@ Refactoring, Improvements, and Tooling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Setup MyPy config and enforce types for build-support scripts (#7704)
-  `Issue #6742 <https://github.com/pantsbuild/pants/issues/6742>`_
   `PR #7704 <https://github.com/pantsbuild/pants/pull/7704>`_
 
 * Add builtin Rust rule to strip prefixes from directories for source root support (#7699)
-  `Issue #7697 <https://github.com/pantsbuild/pants/issues/7697>`_
   `PR #7699 <https://github.com/pantsbuild/pants/pull/7699>`_
 
 * Refactor and modernize `check_header.py` to use Python 3 (#7635)

--- a/src/python/pants/notes/master.rst
+++ b/src/python/pants/notes/master.rst
@@ -20,9 +20,11 @@ Refactoring, Improvements, and Tooling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Setup MyPy config and enforce types for build-support scripts (#7704)
+  `Issue #6742 <https://github.com/pantsbuild/pants/issues/6742>`_
   `PR #7704 <https://github.com/pantsbuild/pants/pull/7704>`_
 
 * Add builtin Rust rule to strip prefixes from directories for source root support (#7699)
+  `Issue #7697 <https://github.com/pantsbuild/pants/issues/7697>`_
   `PR #7699 <https://github.com/pantsbuild/pants/pull/7699>`_
 
 * Refactor and modernize `check_header.py` to use Python 3 (#7635)
@@ -1277,7 +1279,7 @@ Refactoring, Improvements, and Tooling
 * Allow Pants to run with Python 3 via `./pants3` script (#6959)
   `PR #6959 <https://github.com/pantsbuild/pants/pull/6959>`_
 
-* Properly render \n in exceptions with Py3 (#7073)
+* Properly render newline in exceptions with Py3 (#7073)
   `PR #7073 <https://github.com/pantsbuild/pants/pull/7073>`_
 
 * use the asttokens 3rdparty lib to make @rule parsing errors very smooth (#7023)


### PR DESCRIPTION
### Problem

error in uploading to pypi:
```
$twine check dist/deploy/wheels/pantsbuild.pants/9464d7e2ba0bb520d77e96f543c04b461ca977ac/1.17.0.dev0/pantsbuild.pants.contrib.avro-1.17.0.dev0-py27.py36.py37-none-any.whl
Checking distribution dist/deploy/wheels/pantsbuild.pants/9464d7e2ba0bb520d77e96f543c04b461ca977ac/1.17.0.dev0/pantsbuild.pants.contrib.avro-1.17.0.dev0-py27.py36.py37-none-any.whl: warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
Failed
The project's long_description has invalid markup which will not be rendered on PyPI. The following syntax errors were detected:
line 1287: Warning: Bullet list ends without a blank line; unexpected unindent.
```

### Solution

Confirmed that it passes `twine check`
```
$ twine check dist/deploy/wheels/pantsbuild.pants/e0aec1480f1282f0c28a353f6c9caa565b77863d/1.17.0.dev0+gite0aec148/pantsbuild.pants.contrib.avro-1.17.0.dev0+gite0aec148-py27.py36.py37-none-any.whl
Checking distribution dist/deploy/wheels/pantsbuild.pants/e0aec1480f1282f0c28a353f6c9caa565b77863d/1.17.0.dev0+gite0aec148/pantsbuild.pants.contrib.avro-1.17.0.dev0+gite0aec148-py27.py36.py37-none-any.whl: warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
Passed
```