### PR TITLE
Add logging for V2 test scheduler as temporary workaround until V2 UI is finished

### DIFF
--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -72,12 +72,12 @@ def coordinator_of_tests(target):
   #if isinstance(target.adaptor, PythonTestsAdaptor):
   # See https://github.com/pantsbuild/pants/issues/4535
   if target.adaptor.type_alias == 'python_tests':
-    logger.info("Starting test for {}...".format(target.address.reference()))
+    logger.info("Starting tests for {}...".format(target.address.reference()))
     result = yield Get(PyTestResult, HydratedTarget, target)
-    logger.info("Result of test for {}: {}".format(
+    logger.info("Tests {}: {}".format(
+      "succeeded" if result.status == Status.SUCCESS else "failed",
       target.address.reference(),
-      "success" if result.status == Status.SUCCESS else "failure")
-    )
+    ))
     yield TestResult(status=result.status, stdout=result.stdout, stderr=result.stderr)
   else:
     raise Exception("Didn't know how to run tests for type {}".format(target.adaptor.type_alias))

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -72,7 +72,7 @@ def coordinator_of_tests(target):
   #if isinstance(target.adaptor, PythonTestsAdaptor):
   # See https://github.com/pantsbuild/pants/issues/4535
   if target.adaptor.type_alias == 'python_tests':
-    logger.info("Starting tests for {}...".format(target.address.reference()))
+    logger.info("Starting tests: {}".format(target.address.reference()))
     result = yield Get(PyTestResult, HydratedTarget, target)
     logger.info("Tests {}: {}".format(
       "succeeded" if result.status == Status.SUCCESS else "failed",

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -72,6 +72,9 @@ def coordinator_of_tests(target):
   #if isinstance(target.adaptor, PythonTestsAdaptor):
   # See https://github.com/pantsbuild/pants/issues/4535
   if target.adaptor.type_alias == 'python_tests':
+    # TODO(#6004): when streaming to live TTY, rely on V2 UI for this information. When not a
+    # live TTY, periodically dump heavy hitters to stderr. See
+    # https://github.com/pantsbuild/pants/issues/6004#issuecomment-492699898.
     logger.info("Starting tests: {}".format(target.address.reference()))
     result = yield Get(PyTestResult, HydratedTarget, target)
     logger.info("Tests {}: {}".format(

--- a/tests/python/pants_test/rules/test_test.py
+++ b/tests/python/pants_test/rules/test_test.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
 from builtins import str
 from textwrap import dedent
 
@@ -104,17 +105,17 @@ class TestTest(TestBase, SchedulerTestBase, AbstractClass):
 
   def test_coordinator_python_test(self):
     target_adaptor = PythonTestsAdaptor(type_alias='python_tests')
-
-    result = run_rule(coordinator_of_tests, HydratedTarget(Address.parse("some/target"), target_adaptor, ()), {
-      (PyTestResult, HydratedTarget): lambda _: PyTestResult(status=Status.FAILURE, stdout='foo', stderr=''),
-    })
+    with self.captured_logging(logging.INFO):
+      result = run_rule(coordinator_of_tests, HydratedTarget(Address.parse("some/target"), target_adaptor, ()), {
+        (PyTestResult, HydratedTarget): lambda _: PyTestResult(status=Status.FAILURE, stdout='foo', stderr=''),
+      })
 
     self.assertEqual(result, TestResult(status=Status.FAILURE, stdout='foo', stderr=''))
 
   def test_coordinator_unknown_test(self):
     target_adaptor = PythonTestsAdaptor(type_alias='unknown_tests')
 
-    with self.assertRaises(Exception) as cm:
+    with self.captured_logging(logging.INFO), self.assertRaises(Exception) as cm:
       run_rule(coordinator_of_tests, HydratedTarget(Address.parse("some/target"), target_adaptor, ()), {
         (PyTestResult, HydratedTarget): lambda _: PyTestResult(status=Status.FAILURE, stdout='foo', stderr=''),
       })

--- a/tests/python/pants_test/rules/test_test_integration.py
+++ b/tests/python/pants_test/rules/test_test_integration.py
@@ -11,7 +11,14 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 class TestIntegrationTest(PantsRunIntegrationTest):
 
-  def run_pants(self, args):
+  def run_pants(self, trailing_args):
+    args = [
+      '--no-v1',
+      '--v2',
+      '--no-colors',
+      '--level=warn',
+      'test',
+    ] + trailing_args
     # Set TERM=dumb to stop pytest from trying to be clever and wrap lines which may interfere with
     # our golden data.
     return super(TestIntegrationTest, self).run_pants(args, extra_env={'TERM': 'dumb'})
@@ -33,26 +40,12 @@ class TestIntegrationTest(PantsRunIntegrationTest):
         self.assertTrue(got_line.endswith(want_parts[1]), 'Line {} Want "{}" to end with "{}"'.format(line_number, got_line, want_parts[1]))
 
   def run_passing_pants_test(self, trailing_args):
-    args = [
-      '--no-v1',
-      '--v2',
-      '--no-colors',
-      'test',
-    ] + trailing_args
-
-    pants_run = self.run_pants(args)
+    pants_run = self.run_pants(trailing_args)
     self.assert_success(pants_run)
     return pants_run
 
   def run_failing_pants_test(self, trailing_args):
-    args = [
-      '--no-v1',
-      '--v2',
-      '--no-colors',
-      'test',
-    ] + trailing_args
-
-    pants_run = self.run_pants(args)
+    pants_run = self.run_pants(trailing_args)
     self.assert_failure(pants_run)
     self.assertEqual('Tests failed\n', pants_run.stderr_data)
 


### PR DESCRIPTION
We want to add logging to `./pants test` when using V2 both as a matter of UI and to avoid Travis timeouts of not receiving input for 10+ minutes.

Eventually, we should be doing this via a `Logging` singleton, similar to the `Console` singleton, per https://github.com/pantsbuild/pants/issues/6004. This acts as a temporary workaround in the meantime.

### Result
```
$ ./pants --no-v1 --v2 test tests/python/pants_test/util:strutil tests/python/pants_test/util:dirutil tests/python/pants_test/util:contextutil tests/python/pants_test/util:tarutil tests/python/pants_test/util:argutil tests/python/pants_test/util:collections
18:53:47 [INFO] Starting tests: tests/python/pants_test/util:strutil
18:53:47 [INFO] Starting tests: tests/python/pants_test/util:dirutil
18:53:47 [INFO] Starting tests: tests/python/pants_test/util:argutil
18:53:47 [INFO] Starting tests: tests/python/pants_test/util:contextutil
18:53:47 [INFO] Starting tests: tests/python/pants_test/util:tarutil
18:53:47 [INFO] Starting tests: tests/python/pants_test/util:collections
18:53:57 [INFO] Tests succeeded: tests/python/pants_test/util:argutil
18:53:59 [INFO] Tests succeeded: tests/python/pants_test/util:collections
18:53:59 [INFO] Tests succeeded: tests/python/pants_test/util:strutil
18:53:59 [INFO] Tests succeeded: tests/python/pants_test/util:tarutil
18:54:00 [INFO] Tests failed: tests/python/pants_test/util:contextutil
18:54:03 [INFO] Tests failed: tests/python/pants_test/util:dirutil
tests/python/pants_test/util:strutil stdout:
============================= test session starts ==============================
platform darwin -- Python 3.6.8, pytest-3.6.4, py-1.8.0, pluggy-0.7.1
rootdir: /Users/eric/DocsLocal/code/projects/pants/.pants.d/process-executionTYuLur, inifile:
plugins: timeout-1.2.1, cov-2.4.0
collected 5 items

pants_test/util/test_strutil.py .....                                    [100%]

=========================== 5 passed in 0.07 seconds ===========================

tests/python/pants_test/util:dirutil stdout:
...
```