### PR TITLE
Rename V2's `MergedDirectories` to `DirectoriesToMerge`

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -13,7 +13,7 @@ from future.utils import text_type
 from pants.backend.python.subsystems.pex_build_util import identify_missing_init_files
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.python_setup import PythonSetup
-from pants.engine.fs import (Digest, DirectoryWithPrefixToStrip, FilesContent, DirectoriesToMerge,
+from pants.engine.fs import (Digest, DirectoriesToMerge, DirectoryWithPrefixToStrip, FilesContent,
                              Snapshot, UrlToFetch)
 from pants.engine.isolated_process import (ExecuteProcessRequest, ExecuteProcessResult,
                                            FallibleExecuteProcessResult)

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -13,7 +13,7 @@ from future.utils import text_type
 from pants.backend.python.subsystems.pex_build_util import identify_missing_init_files
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.python_setup import PythonSetup
-from pants.engine.fs import (Digest, DirectoryWithPrefixToStrip, FilesContent, MergedDirectories,
+from pants.engine.fs import (Digest, DirectoryWithPrefixToStrip, FilesContent, DirectoriesToMerge,
                              Snapshot, UrlToFetch)
 from pants.engine.isolated_process import (ExecuteProcessRequest, ExecuteProcessResult,
                                            FallibleExecuteProcessResult)
@@ -128,10 +128,10 @@ def run_python_test(transitive_hydrated_target, pytest, python_setup, source_roo
   ]
 
   sources_digest = yield Get(
-    Digest, MergedDirectories(directories=tuple(all_sources_digests)),
+    Digest, DirectoriesToMerge(directories=tuple(all_sources_digests)),
   )
 
-  # TODO(7716): add a builtin rule to go from MergedDirectories->Snapshot or Digest->Snapshot.
+  # TODO(7716): add a builtin rule to go from DirectoriesToMerge->Snapshot or Digest->Snapshot.
   # TODO(7715): generalize the injection of __init__.py files.
   # TODO(7718): add a builtin rule for FilesContent->Snapshot.
   file_contents = yield Get(FilesContent, Digest, sources_digest)
@@ -152,8 +152,8 @@ def run_python_test(transitive_hydrated_target, pytest, python_setup, source_roo
 
   merged_input_files = yield Get(
     Digest,
-    MergedDirectories,
-    MergedDirectories(directories=tuple(all_input_digests)),
+    DirectoriesToMerge,
+    DirectoriesToMerge(directories=tuple(all_input_digests)),
   )
 
   request = ExecuteProcessRequest(

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -144,7 +144,7 @@ class Snapshot(datatype([('directory_digest', Digest), ('files', tuple), ('dirs'
     return self == EMPTY_SNAPSHOT
 
 
-class MergedDirectories(datatype([('directories', tuple)])):
+class DirectoriesToMerge(datatype([('directories', tuple)])):
   pass
 
 
@@ -184,7 +184,7 @@ def create_fs_rules():
   """Creates rules that consume the intrinsic filesystem types."""
   return [
     RootRule(Digest),
-    RootRule(MergedDirectories),
+    RootRule(DirectoriesToMerge),
     RootRule(PathGlobs),
     RootRule(DirectoryWithPrefixToStrip),
     RootRule(UrlToFetch),

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -18,7 +18,7 @@ from pants.base.exiter import PANTS_FAILED_EXIT_CODE
 from pants.base.project_tree import Dir, File, Link
 from pants.build_graph.address import Address
 from pants.engine.fs import (Digest, DirectoryToMaterialize, DirectoryWithPrefixToStrip,
-                             FileContent, FilesContent, MergedDirectories, PathGlobs,
+                             FileContent, FilesContent, DirectoriesToMerge, PathGlobs,
                              PathGlobsAndRoot, Snapshot, UrlToFetch)
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.engine.native import Function, TypeId
@@ -112,7 +112,7 @@ class Scheduler(object):
       type_path_globs=PathGlobs,
       type_directory_digest=Digest,
       type_snapshot=Snapshot,
-      type_merge_snapshots_request=MergedDirectories,
+      type_merge_snapshots_request=DirectoriesToMerge,
       type_directory_with_prefix_to_strip=DirectoryWithPrefixToStrip,
       type_files_content=FilesContent,
       type_dir=Dir,

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -17,8 +17,8 @@ from types import GeneratorType
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE
 from pants.base.project_tree import Dir, File, Link
 from pants.build_graph.address import Address
-from pants.engine.fs import (Digest, DirectoryToMaterialize, DirectoryWithPrefixToStrip,
-                             FileContent, FilesContent, DirectoriesToMerge, PathGlobs,
+from pants.engine.fs import (Digest, DirectoriesToMerge, DirectoryToMaterialize,
+                             DirectoryWithPrefixToStrip, FileContent, FilesContent, PathGlobs,
                              PathGlobsAndRoot, Snapshot, UrlToFetch)
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.engine.native import Function, TypeId

--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -301,14 +301,14 @@ impl Snapshot {
 
         // Group and recurse for DirectoryNodes.
         let sorted_child_directories = {
-          let mut merged_directories = Iterator::flatten(
+          let mut directories_to_merge = Iterator::flatten(
             directories
               .iter_mut()
               .map(|directory| directory.take_directories().into_iter()),
           )
           .collect::<Vec<_>>();
-          merged_directories.sort_by(|a, b| a.name.cmp(&b.name));
-          merged_directories
+          directories_to_merge.sort_by(|a, b| a.name.cmp(&b.name));
+          directories_to_merge
         };
         let store2 = store.clone();
         join_all(

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -232,7 +232,7 @@ pub extern "C" fn scheduler_create(
     path_globs: type_path_globs,
     directory_digest: type_directory_digest,
     snapshot: type_snapshot,
-    merged_directories: type_merge_directories_request,
+    directories_to_merge: type_merge_directories_request,
     directory_with_prefix_to_strip: type_directory_with_prefix_to_strip,
     files_content: type_files_content,
     dir: type_dir,

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -185,10 +185,10 @@ impl WrappedNode for Select {
         }
         &rule_graph::Rule::Intrinsic(Intrinsic { product, input })
           if product == context.core.types.directory_digest
-            && input == context.core.types.merged_directories =>
+            && input == context.core.types.directories_to_merge =>
         {
           let request =
-            self.select_product(&context, context.core.types.merged_directories, "intrinsic");
+            self.select_product(&context, context.core.types.directories_to_merge, "intrinsic");
           let core = context.core.clone();
           request
             .and_then(move |request| {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -187,8 +187,11 @@ impl WrappedNode for Select {
           if product == context.core.types.directory_digest
             && input == context.core.types.directories_to_merge =>
         {
-          let request =
-            self.select_product(&context, context.core.types.directories_to_merge, "intrinsic");
+          let request = self.select_product(
+            &context,
+            context.core.types.directories_to_merge,
+            "intrinsic",
+          );
           let core = context.core.clone();
           request
             .and_then(move |request| {

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -83,7 +83,7 @@ impl Tasks {
       },
       Intrinsic {
         product: types.directory_digest,
-        input: types.merged_directories,
+        input: types.directories_to_merge,
       },
       Intrinsic {
         product: types.directory_digest,

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -10,7 +10,7 @@ pub struct Types {
   pub path_globs: TypeId,
   pub directory_digest: TypeId,
   pub snapshot: TypeId,
-  pub merged_directories: TypeId,
+  pub directories_to_merge: TypeId,
   pub directory_with_prefix_to_strip: TypeId,
   pub files_content: TypeId,
   pub dir: TypeId,

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -13,9 +13,9 @@ from contextlib import contextmanager
 
 from future.utils import PY2, text_type
 
-from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, Digest, DirectoryToMaterialize,
-                             DirectoryWithPrefixToStrip, FilesContent, DirectoriesToMerge, PathGlobs,
-                             PathGlobsAndRoot, Snapshot, UrlToFetch, create_fs_rules)
+from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, Digest, DirectoriesToMerge,
+                             DirectoryToMaterialize, DirectoryWithPrefixToStrip, FilesContent,
+                             PathGlobs, PathGlobsAndRoot, Snapshot, UrlToFetch, create_fs_rules)
 from pants.engine.scheduler import ExecutionError
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.util.collections import assert_single_element

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 from future.utils import PY2, text_type
 
 from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, Digest, DirectoryToMaterialize,
-                             DirectoryWithPrefixToStrip, FilesContent, MergedDirectories, PathGlobs,
+                             DirectoryWithPrefixToStrip, FilesContent, DirectoriesToMerge, PathGlobs,
                              PathGlobsAndRoot, Snapshot, UrlToFetch, create_fs_rules)
 from pants.engine.scheduler import ExecutionError
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -334,13 +334,13 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
 
       empty_merged = self.scheduler.product_request(
         Digest,
-        [MergedDirectories((empty_snapshot.directory_digest,))],
+        [DirectoriesToMerge((empty_snapshot.directory_digest,))],
       )[0]
       self.assertEqual(empty_snapshot.directory_digest, empty_merged)
 
       roland_merged = self.scheduler.product_request(
         Digest,
-        [MergedDirectories((roland_snapshot.directory_digest, empty_snapshot.directory_digest))],
+        [DirectoriesToMerge((roland_snapshot.directory_digest, empty_snapshot.directory_digest))],
       )[0]
       self.assertEqual(
         roland_snapshot.directory_digest,
@@ -349,7 +349,7 @@ class FSTest(TestBase, SchedulerTestBase, AbstractClass):
 
       both_merged = self.scheduler.product_request(
         Digest,
-        [MergedDirectories((roland_snapshot.directory_digest, susannah_snapshot.directory_digest))],
+        [DirectoriesToMerge((roland_snapshot.directory_digest, susannah_snapshot.directory_digest))],
       )[0]
 
       self.assertEqual(both_snapshot.directory_digest, both_merged)


### PR DESCRIPTION
`MergedDirectories` is a confusing name because it suggests that the directories are already merged (i.e. the output), whereas really this is the type of the directories that _will_ be merged (i.e. the input).

Refer to https://github.com/pantsbuild/pants/pull/7699#discussion_r283065942.