### PR TITLE
bump pex version to 1.6.7

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -17,7 +17,7 @@ more-itertools<6.0.0 ; python_version<'3'
 packaging==16.8
 parameterized==0.6.1
 pathspec==0.5.9
-pex==1.6.6
+pex==1.6.7
 psutil==5.4.8
 pycodestyle==2.4.0
 pyflakes==2.0.0


### PR DESCRIPTION
### Problem

Pex 1.6.7 fixes pantsbuild/pex#729 along with several other issues (yay!).

### Solution

- Upgrade the pex version to 1.6.7.

### Result

pantsbuild/pex#729 is fixed, which allows us to remove a ton of code in #7695 working around that pex issue.