### PR TITLE
Turn on reproducible PEX builds, e.g. for `./pants binary` command

### DIFF
--- a/src/python/pants/backend/python/subsystems/pex_build_util.py
+++ b/src/python/pants/backend/python/subsystems/pex_build_util.py
@@ -347,7 +347,7 @@ class PexBuilderWrapper(object):
 
   def build(self, safe_path):
     self.freeze()
-    self._builder.build(safe_path)
+    self._builder.build(safe_path, bytecode_compile=False, deterministic_timestamp=True)
 
   def set_shebang(self, shebang):
     self._builder.set_shebang(shebang)


### PR DESCRIPTION
Pex 1.6.7 added support for reproducible Pex builds (https://github.com/pantsbuild/pex/issues/716), meaning that the output of `pex -o 1.pex` will be byte for byte identical to `pex -o 2.pex`. This specifically means that the PEX will use a deterministic timestamp of January 1, 1980 and that the built PEX will not include `.pyc`, which is inherently non-reproducible.

In Pex 1.7.0, Pex will default to this reproducible behavior. Originally we were going to wait for that to land to avoid making any changes to Pex. However, a [user has a strong desire](https://github.com/pantsbuild/pex/pull/718#issuecomment-492345360) for reproducible PEX builds so we are turning on the behavior earlier.

Note that we do not introduce any flags to turn off reproducible builds, because we expect that all users will want this behavior. If we get feedback that users do not, e.g. that they want to include `.pyc` files, then we will add options to turn this behavior off.