### PR TITLE
Rsc compile task fixes

### DIFF
--- a/src/python/pants/backend/jvm/targets/scala_library.py
+++ b/src/python/pants/backend/jvm/targets/scala_library.py
@@ -77,9 +77,11 @@ class ScalaLibrary(ExportableJvmLibrary):
 
   @property
   def java_sources(self):
+    targets = []
     for spec in self.payload.java_sources:
       address = Address.parse(spec, relative_to=self.address.spec_path)
       target = self._build_graph.get_target(address)
       if target is None:
         raise TargetDefinitionException(self, 'No such java target: {}'.format(spec))
-      yield target
+      targets.append(target)
+    return targets

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -760,20 +760,11 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         return True
       if target in invalid_target_set:
         invalid_dependencies.add(target)
-        return self._on_invalid_compile_dependency(target, compile_target, compile_contexts)
+        return False
       return True
 
     compile_target.walk(work, predicate)
     return invalid_dependencies
-
-  def _on_invalid_compile_dependency(self, dep, compile_target, compile_contexts):
-    """Decide whether to continue searching for invalid targets to use in the execution graph.
-
-    By default, don't recurse because once we have an invalid dependency, we can rely on its
-    dependencies having been compiled already.
-
-    Override to adjust this behavior."""
-    return False
 
   def _create_context_jar(self, compile_context):
     """Jar up the compile_context to its output jar location.

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
@@ -75,13 +75,9 @@ class RscCompileTest(TaskTestBase):
 
       dependee_graph = self.construct_dependee_graph_str(jobs, task)
       print(dependee_graph)
-      # TODO: remove the dep for zinc_against_rsc from rsc and fix these tests!!!
       self.assertEqual(dedent("""
-                     rsc(java/classpath:java_lib) -> {
-                       zinc_against_rsc(java/classpath:java_lib)
-                     }
-                     zinc_against_rsc(java/classpath:java_lib) -> {}
-                     zinc(scala/classpath:scala_lib) -> {}""").strip(),
+                     zinc[zinc-java](java/classpath:java_lib) -> {}
+                     zinc[zinc-only](scala/classpath:scala_lib) -> {}""").strip(),
         dependee_graph)
 
   def test_no_dependencies_between_scala_and_java_targets(self):
@@ -116,11 +112,9 @@ class RscCompileTest(TaskTestBase):
       dependee_graph = self.construct_dependee_graph_str(jobs, task)
       print(dependee_graph)
       self.assertEqual(dedent("""
-                     zinc(java/classpath:java_lib) -> {}
-                     rsc(scala/classpath:scala_lib) -> {
-                       zinc_against_rsc(scala/classpath:scala_lib)
-                     }
-                     zinc_against_rsc(scala/classpath:scala_lib) -> {}""").strip(),
+                     zinc[zinc-java](java/classpath:java_lib) -> {}
+                     rsc(scala/classpath:scala_lib) -> {}
+                     zinc[rsc-and-zinc](scala/classpath:scala_lib) -> {}""").strip(),
         dependee_graph)
 
   def test_default_workflow_of_zinc_only_zincs_scala(self):
@@ -149,12 +143,12 @@ class RscCompileTest(TaskTestBase):
       dependee_graph = self.construct_dependee_graph_str(jobs, task)
       print(dependee_graph)
       self.assertEqual(dedent("""
-                    zinc(scala/classpath:scala_lib) -> {}""").strip(),
+                    zinc[zinc-only](scala/classpath:scala_lib) -> {}""").strip(),
         dependee_graph)
 
   def test_rsc_dep_for_scala_java_and_test_targets(self):
     self.set_options(workflow=RankedValue(
-      value=RscCompile.JvmCompileWorkflowType.rsc_then_zinc,
+      value=RscCompile.JvmCompileWorkflowType.rsc_and_zinc,
       rank=RankedValue.CONFIG,
     ))
     self.init_dependencies_for_scala_libraries()
@@ -201,23 +195,19 @@ class RscCompileTest(TaskTestBase):
       dependee_graph = self.construct_dependee_graph_str(jobs, task)
 
       self.assertEqual(dedent("""
-                     zinc(java/classpath:java_lib) -> {}
+                     zinc[zinc-java](java/classpath:java_lib) -> {}
                      rsc(scala/classpath:scala_lib) -> {
-                       zinc_against_rsc(scala/classpath:scala_lib)
+                       zinc[zinc-only](scala/classpath:scala_test)
                      }
-                     zinc_against_rsc(scala/classpath:scala_lib) -> {
-                       zinc(scala/classpath:scala_test)
-                     }
+                     zinc[rsc-and-zinc](scala/classpath:scala_lib) -> {}
                      rsc(scala/classpath:scala_dep) -> {
                        rsc(scala/classpath:scala_lib),
-                       zinc_against_rsc(scala/classpath:scala_lib),
-                       zinc_against_rsc(scala/classpath:scala_dep)
+                       zinc[rsc-and-zinc](scala/classpath:scala_lib)
                      }
-                     zinc_against_rsc(scala/classpath:scala_dep) -> {
-                       zinc(java/classpath:java_lib),
-                       zinc(scala/classpath:scala_test)
+                     zinc[rsc-and-zinc](scala/classpath:scala_dep) -> {
+                       zinc[zinc-java](java/classpath:java_lib)
                      }
-                     zinc(scala/classpath:scala_test) -> {}""").strip(),
+                     zinc[zinc-only](scala/classpath:scala_test) -> {}""").strip(),
         dependee_graph)
 
   def test_scala_lib_with_java_sources_not_passed_to_rsc(self):
@@ -261,9 +251,9 @@ class RscCompileTest(TaskTestBase):
       dependee_graph = self.construct_dependee_graph_str(jobs, task)
 
       self.assertEqual(dedent("""
-                     zinc(java/classpath:java_lib) -> {}
-                     zinc(scala/classpath:scala_with_direct_java_sources) -> {}
-                     zinc(scala/classpath:scala_with_indirect_java_sources) -> {}""").strip(),
+                     zinc[zinc-java](java/classpath:java_lib) -> {}
+                     zinc[zinc-java](scala/classpath:scala_with_direct_java_sources) -> {}
+                     zinc[zinc-java](scala/classpath:scala_with_indirect_java_sources) -> {}""").strip(),
         dependee_graph)
 
   def test_desandbox_fn(self):


### PR DESCRIPTION
### Problem

The `RscCompile` task is supposed to start running the zinc compile of a target once the rsc compiles of of all the target's dependencies are complete -- this is what allows for the massive parallelism from rsc in the first place. However, currently, the execution graph has the zinc compile of a target depending on the zinc compiles of all its dependencies, failing to use the rsc output at all.

This issue covered up a separate issue, because `javac` still can't actually use rsc output yet, and that should have caused failures, but since the zinc compiles were all scheduled after other zinc compiles, the rsc output was never being used.

These issues were fixed in #7227, but the implementation there was deemed too complex and parts were reverted without enough discussion when the "mixed compile" changes landed in master.

### Solution

- Fix execution graph dependency breakages.
- Rename `rsc-then-zinc` to `rsc-and-zinc`, since they're supposed to happen in parallel.
- Default the `--workflow` option to `rsc-and-zinc`.
- Change the display of each job in the debug output displaying the dynamic execution graph (e.g. `zinc[zinc-only]`, `zinc[zinc-java]`, and `zinc[rsc-and-zinc]`).

### Result

Some bugs are fixed!