### PR TITLE
Confluence publishing uses correct text types

### DIFF
--- a/contrib/confluence/src/python/pants/contrib/confluence/tasks/BUILD
+++ b/contrib/confluence/src/python/pants/contrib/confluence/tasks/BUILD
@@ -4,6 +4,7 @@
 
 python_library(
   dependencies = [
+    '3rdparty/python:future',
     'contrib/confluence/src/python/pants/contrib/confluence/util',
     'src/python/pants/backend/docgen/targets',
     'src/python/pants/backend/docgen/tasks',

--- a/contrib/confluence/src/python/pants/contrib/confluence/tasks/BUILD
+++ b/contrib/confluence/src/python/pants/contrib/confluence/tasks/BUILD
@@ -4,7 +4,6 @@
 
 python_library(
   dependencies = [
-    '3rdparty/python:future',
     'contrib/confluence/src/python/pants/contrib/confluence/util',
     'src/python/pants/backend/docgen/targets',
     'src/python/pants/backend/docgen/tasks',

--- a/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
+++ b/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import textwrap
 
-from future.utils import text_type
-
 from pants.backend.docgen.targets.doc import Page
 from pants.backend.docgen.tasks.markdown_to_html import MarkdownToHtml
 from pants.base.exceptions import TaskError
@@ -46,11 +44,11 @@ class ConfluencePublish(Task):
   def __init__(self, *args, **kwargs):
     super(ConfluencePublish, self).__init__(*args, **kwargs)
     
-    self.url = text_type(self.get_options().url)
+    self.url = str(self.get_options().url)
     self.force = self.get_options().force
     self.open = self.get_options().open
     self._wiki = None
-    self.user = text_type(self.get_options().user)
+    self.user = str(self.get_options().user)
   
   def wiki(self):
     raise NotImplementedError('Subclasses must provide the wiki target they are associated with')

--- a/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
+++ b/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import textwrap
 
+from future.utils import text_type
+
 from pants.backend.docgen.targets.doc import Page
 from pants.backend.docgen.tasks.markdown_to_html import MarkdownToHtml
 from pants.base.exceptions import TaskError
@@ -44,11 +46,11 @@ class ConfluencePublish(Task):
   def __init__(self, *args, **kwargs):
     super(ConfluencePublish, self).__init__(*args, **kwargs)
     
-    self.url = self.get_options().url
+    self.url = text_type(self.get_options().url)
     self.force = self.get_options().force
     self.open = self.get_options().open
     self._wiki = None
-    self.user = self.get_options().user
+    self.user = text_type(self.get_options().user)
   
   def wiki(self):
     raise NotImplementedError('Subclasses must provide the wiki target they are associated with')


### PR DESCRIPTION
Without this change, actually publishing to Confluence fails with encoding errors.

Specifically:
user needs converting because xmlrpclib hard-codes what kinds it can encode, and doesn't count future's newstr.
url needs converting because it's detected as a newbytes which has its `encode` disabled. Maybe this should instead be calling `binary_type(...).encode("utf-8")`?