### PR TITLE
Fix using sets with V2 `Struct` causing unhashable TypeError

### DIFF
--- a/src/python/pants/engine/struct.py
+++ b/src/python/pants/engine/struct.py
@@ -261,6 +261,8 @@ class Struct(Serializable, SerializableFactory, Validatable):
         return tuple(sorted((k, hashable(v)) for k, v in value.items()))
       elif isinstance(value, list):
         return tuple(hashable(v) for v in value)
+      elif isinstance(value, set):
+        return tuple(sorted(hashable(v) for v in value))
       else:
         return value
     return tuple(sorted((k, hashable(v)) for k, v in self._kwargs.items()


### PR DESCRIPTION
### Problem
When running our whole unit test suite with V2, we encounter a `TypeError` that sets are not hashable. This happens because one of the tests includes the value `'tags': {'platform_specific_behavior'}`, which gets stored in its `Struct`.

### Solution
Teach `Struct` how to safely hash `set`. We must first sort the `set` because `set`s have non-deterministic ordering.
