### PR TITLE
Handle empty test targets for `junit_xml_dir`.

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -652,13 +652,13 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
   def _expose_results(self, invalid_tgts, workdirs):
     external_junit_xml_dir = self.get_options().junit_xml_dir
     if external_junit_xml_dir:
-      # Either we just ran pytest for a set of invalid targets and generated a junit xml file
-      # specific to that (sub)set or else we hit the cache for the whole partition and skipped
-      # running pytest, simply retrieving the partition's full junit xml file.
       junitxml_path = workdirs.junitxml_path(*invalid_tgts)
-
-      safe_mkdir(external_junit_xml_dir)
-      shutil.copy2(junitxml_path, external_junit_xml_dir)
+      if os.path.exists(junitxml_path):
+        # Either we just ran pytest for a set of invalid targets and generated a junit xml file
+        # specific to that (sub)set or else we hit the cache for the whole partition and skipped
+        # running pytest, simply retrieving the partition's full junit xml file.
+        safe_mkdir(external_junit_xml_dir)
+        shutil.copy2(junitxml_path, external_junit_xml_dir)
 
     if self.get_options().coverage:
       coverage_output_dir = self.get_options().coverage_output_dir

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -652,12 +652,13 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
   def _expose_results(self, invalid_tgts, workdirs):
     external_junit_xml_dir = self.get_options().junit_xml_dir
     if external_junit_xml_dir:
+      safe_mkdir(external_junit_xml_dir)
+
       junitxml_path = workdirs.junitxml_path(*invalid_tgts)
       if os.path.exists(junitxml_path):
         # Either we just ran pytest for a set of invalid targets and generated a junit xml file
         # specific to that (sub)set or else we hit the cache for the whole partition and skipped
         # running pytest, simply retrieving the partition's full junit xml file.
-        safe_mkdir(external_junit_xml_dir)
         shutil.copy2(junitxml_path, external_junit_xml_dir)
 
     if self.get_options().coverage:

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -111,6 +111,7 @@ python_tests(
   dependencies = [
     '3rdparty/python:coverage',
     '3rdparty/python:future',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/backend/python/tasks',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
@@ -118,7 +119,6 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:py2_compat',
-    'src/python/pants/util:process_handler',
     'tests/python/pants_test:task_test_base',
     'tests/python/pants_test/subsystem:subsystem_utils',
     ':python_task_test_base',

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -851,14 +851,14 @@ python_tests(
     with temporary_dir() as dist:
       junit_xml_dir = os.path.join(dist, 'test-results')
       self.run_tests(targets, junit_xml_dir=junit_xml_dir)
-      yield junit_xml_dir
+      assert os.path.exists(junit_xml_dir)
+      yield os.listdir(junit_xml_dir)
 
   def test_junit_xml_dir(self):
-    with self.run_with_junit_xml_dir([self.green]) as junit_xml_dir:
-      assert os.path.exists(junit_xml_dir)
-      assert ['TEST-{}.xml'.format(self.green.id)] == os.listdir(junit_xml_dir)
+    with self.run_with_junit_xml_dir([self.green]) as junit_xml_files:
+      assert ['TEST-{}.xml'.format(self.green.id)] == junit_xml_files
 
   def test_issue_7749(self):
     empty_test_target = self.make_target(spec='empty', target_type=PythonTests)
-    with self.run_with_junit_xml_dir([empty_test_target]) as junit_xml_dir:
-      assert not os.path.exists(junit_xml_dir)
+    with self.run_with_junit_xml_dir([empty_test_target]) as junit_xml_files:
+      assert [] == junit_xml_files


### PR DESCRIPTION
Allow for test targets that contain no tests and thus output no junit
xml file. Add basic testing for the empty and non-empty cases.

Fixes #7749
