### PR TITLE
Don't require `ack`, `grep` can do the job.

### DIFF
--- a/build-support/bin/check_shell.sh
+++ b/build-support/bin/check_shell.sh
@@ -16,7 +16,10 @@ if [[ -n "${bad_output}" ]]; then
   exit_code=1
 fi
 
-bad_output="$(find ./* -name '*.sh' -print0 | xargs -0 ack -l 'curl (?!--fail)' | grep -v build-support/bin/check_shell.sh || :)"
+bad_output="$(find ./* -name '*.sh' -print0 \
+  | xargs -0 grep -H 'curl '| grep -v 'curl --fail' | cut -d: -f1 \
+  | grep -v build-support/bin/check_shell.sh \
+  || :)"
 if [[ -n "${bad_output}" ]]; then
   echo >&2 "Found bash files with curl not followed by --fail."
   echo >&2 "This is bad because 404s and such will end up with error pages in the output files."

--- a/build-support/bin/check_shell.sh
+++ b/build-support/bin/check_shell.sh
@@ -20,6 +20,7 @@ bad_output="$(find ./* -name '*.sh' -print0 \
   | xargs -0 grep -H 'curl '| grep -v 'curl --fail' | cut -d: -f1 \
   | grep -v build-support/bin/check_shell.sh \
   || :)"
+
 if [[ -n "${bad_output}" ]]; then
   echo >&2 "Found bash files with curl not followed by --fail."
   echo >&2 "This is bad because 404s and such will end up with error pages in the output files."


### PR DESCRIPTION
I don't have ack installed and hit an error in shell checks. Since we
already use grep, stick with it at the cost of a tiny bit more
verbosity.