### PR TITLE
Align mypy interpreter constraint with reality.

### DIFF
--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/test_mypy_integration.py
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/test_mypy_integration.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants_test.backend.python.interpreter_selection_utils import PY_3, has_python_version
+from pants_test.backend.python.interpreter_selection_utils import has_python_version
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -16,13 +16,14 @@ class MypyIntegrationTest(PantsRunIntegrationTest):
       '--',
       '--follow-imports=silent'
     ]
-    if has_python_version(PY_3):
-      # Python 3.x is available. Test that we see an error in this integration test.
+
+    if any((has_python_version('3.{}'.format(v)) for v in (5, 6, 7, 8))):
+      # Python 3.5+ is available. Test that we see an error in this integration test.
       with self.pants_results(cmd) as pants_run:
         self.assert_success(pants_run)
     else:
-      # Python 3.x was not found. Test whether mypy task fails for that reason.
+      # Python 3.5+ was not found. Test whether mypy task fails for that reason.
       with self.pants_results(cmd) as pants_run:
         self.assert_failure(pants_run)
-        self.assertIn('Unable to find a Python 3.x interpreter (required for mypy)',
+        self.assertIn('Unable to find a Python >=3.5 interpreter (required for mypy)',
                       pants_run.stdout_data)

--- a/tests/python/pants_test/backend/python/interpreter_selection_utils.py
+++ b/tests/python/pants_test/backend/python/interpreter_selection_utils.py
@@ -15,20 +15,8 @@ from pants.util.process_handler import subprocess
 PY_2 = '2'
 PY_3 = '3'
 
-PY_26 = '2.6'
 PY_27 = '2.7'
-PY_34 = '3.4'
-PY_35 = '3.5'
 PY_36 = '3.6'
-PY_37 = '3.7'
-PY_38 = '3.8'
-
-
-def find_all_pythons_present(*versions):
-  """Return sorted list of all Python versions present on the system."""
-  if not versions:
-    versions = {PY_26, PY_27, PY_34, PY_35, PY_36, PY_37, PY_38}
-  return sorted(version for version in versions if has_python_version(version))
 
 
 def has_python_version(version):
@@ -56,16 +44,6 @@ def python_interpreter_path(version):
     return os.path.realpath(py_path)
   except (subprocess.CalledProcessError, FileNotFoundError):
     return None
-
-
-def skip_unless_any_pythons_present(*versions):
-  """A decorator that only runs the decorated test method if any of the specified pythons are present.
-
-  :param string *versions: Python version strings, such as 2.7, 3.
-  """
-  if any(v for v in versions if has_python_version(v)):
-    return skipIf(False, 'At least one of the expected python versions found.')
-  return skipIf(True, 'Could not find at least one of the required pythons from {} on the system. Skipping.'.format(versions))
 
 
 def skip_unless_all_pythons_present(*versions):


### PR DESCRIPTION
The mypy tool actually requires python 3.5+. On a machine with 3.4 and
3.x higher the minimum interpreter selection scheme would pick 3.4 and
fail.

Fixup interpreter constraints to avoid this erroneous error and correct
the corresponding test. Cleanup dead code in
interpreter_selection_utils.py along the way.
