### PR TITLE
add hacky options to ZincCompile to use a provided native-image binary

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -289,6 +289,8 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     super(JvmCompile, self).__init__(*args, **kwargs)
     self._targets_to_compile_settings = None
 
+    # TODO: self._jvm_options doesn't seem to record changes from `--<scope>-jvm-options` on the
+    # command line (but this might work in pants.ini?)!
     # JVM options for running the compiler.
     self._jvm_options = self.get_options().jvm_options
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -517,6 +517,7 @@ class BaseZincCompile(JvmCompile):
       )),
       '-Dscala.usejavacp=true',
       '-cp', zinc_relpath,
+      '-java-home', '.jdk',
     ] + zinc_args
     # TODO(#6071): Our ExecuteProcessRequest expects a specific string type for arguments,
     # which py2 doesn't default to. This can be removed when we drop python 2.
@@ -527,12 +528,7 @@ class BaseZincCompile(JvmCompile):
       input_files=merged_input_digest,
       output_directories=(classes_dir,),
       description="zinc compile for {}".format(ctx.target.address.spec),
-      env={
-        'PATH': '/Users/dmcclanahan/Downloads/graalvm-ce-19.0.0/Contents/Home/bin',
-      },
-      # TODO: These should always be unicodes
-      # Since this is always hermetic, we need to use `underlying_dist`
-      jdk_home=text_type('/Users/dmcclanahan/Downloads/graalvm-ce-19.0.0/Contents/Home'),
+      jdk_home=self._zinc.underlying_dist.home,
     )
     res = self.context.execute_process_synchronously_or_raise(
       req, self.name(), [WorkUnitLabel.COMPILER])


### PR DESCRIPTION
### Problem

We would like to run a `native-image` of the pants zinc wrapper (a la #7506), with the same arguments, and determine if it works correctly. We would also like to benchmark it.

### Solution

- Add `--native-image-location`/etc options to `ZincCompile` for necessary resources for invoking zinc via native-image.
- Add a check for these new options, and when `--execution-strategy=subprocess` is provided, invoke zinc using a native image instead!

### Result

We can run zinc via a native image! Right now, we are just testing invoking it as a local subprocess, not hermetically -- that's next. Later, we will get back to #6893 and others where we build the native image on demand, but for now we will plan to use these options to work around deeper support.