### PR TITLE
Hash an entire json input in one call.

### DIFF
--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -135,7 +135,7 @@ def json_hash(obj, digest=None, encoder=None):
   :API: public
   """
   json_str = json.dumps(obj, ensure_ascii=True, allow_nan=False, sort_keys=True, cls=encoder)
-  return hash_all(json_str, digest=digest)
+  return hash_all([json_str], digest=digest)
 
 
 # TODO(#6513): something like python 3's @lru_cache decorator could be useful here!


### PR DESCRIPTION
### Problem

`hash_all` takes a list of strings, but was being passed a string. And thanks to python's venerable implicit conversion from string to list of (single character) strings, that ... "worked".

### Solution

Pass a list of strings.

### Result

Surprisingly little performance difference (less than 2% in this usecase), but a better example to follow in future.