### PR TITLE
Skip broken `CTypesIntegrationTest` methods.

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -7,7 +7,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import glob
 import os
 import re
+import sys
 from functools import wraps
+from unittest import skipIf
 from zipfile import ZipFile
 
 from pants.backend.native.config.environment import Platform
@@ -33,6 +35,10 @@ def _toolchain_variants(func):
   return wrapper
 
 
+_IS_OSX = sys.platform.startswith('darwin')
+_PYTHON_MAJOR_MINOR = sys.version_info[:2]
+
+
 class CTypesIntegrationTest(PantsRunIntegrationTest):
 
   @classmethod
@@ -56,6 +62,8 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     'testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags:bin'
   )
 
+  @skipIf(_IS_OSX and _PYTHON_MAJOR_MINOR == (2, 7),
+          reason='Broken as described in https://github.com/pantsbuild/pants/issues/7763.')
   @_toolchain_variants
   def test_ctypes_binary_creation(self, toolchain_variant):
     """Create a python_binary() with all native toolchain variants, and test the result."""
@@ -177,6 +185,8 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       self.assert_success(pants_run_interop)
       self.assertEqual('x=3, f(x)=299\n', pants_run_interop.stdout_data)
 
+  @skipIf(_IS_OSX and _PYTHON_MAJOR_MINOR == (3, 7),
+          reason='Broken as described in https://github.com/pantsbuild/pants/issues/7762.')
   @_toolchain_variants
   def test_ctypes_third_party_integration(self, toolchain_variant):
     pants_binary = self.run_pants(['binary', self._binary_target_with_third_party], config={

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -35,7 +35,7 @@ def _toolchain_variants(func):
   return wrapper
 
 
-_IS_OSX = sys.platform.startswith('darwin')
+_IS_OSX = Platform.current == Platform.darwin
 _PYTHON_MAJOR_MINOR = sys.version_info[:2]
 
 


### PR DESCRIPTION
There were two OSX-specific breaks detected by nightly CRON; this
change skips them for the respective appropriate python interpreters.

Fixes to un-skip tracked in #7762 and #7763.