### PR TITLE
Extract RuleGraph into a separate crate

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -577,7 +577,6 @@ dependencies = [
  "graph 0.0.1",
  "hashing 0.0.1",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
@@ -587,6 +586,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "resettable 0.0.1",
+ "rule_graph 0.0.1",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar_api 0.0.1",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2025,6 +2025,13 @@ dependencies = [
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rule_graph"
+version = "0.0.1"
+dependencies = [
+ "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2030,9 +2030,6 @@ dependencies = [
 [[package]]
 name = "rule_graph"
 version = "0.0.1"
-dependencies = [
- "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "rustc-demangle"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -40,6 +40,7 @@ members = [
   "process_execution",
   "process_executor",
   "resettable",
+  "rule_graph",
   "serverset",
   "tar_api",
   "testutil",
@@ -68,6 +69,7 @@ default-members = [
   "process_execution",
   "process_executor",
   "resettable",
+  "rule_graph",
   "serverset",
   "tar_api",
   "testutil",
@@ -87,7 +89,6 @@ futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b
 graph = { path = "graph" }
 hashing = { path = "hashing" }
 indexmap = "1.0.2"
-itertools = "0.7.2"
 lazy_static = "1"
 log = "0.4"
 logging = { path = "logging" }
@@ -97,6 +98,7 @@ process_execution = { path = "process_execution" }
 rand = "0.6"
 reqwest = { version = "0.9.10", default_features = false, features = ["rustls-tls"] }
 resettable = { path = "resettable" }
+rule_graph = { path = "rule_graph" }
 smallvec = "0.6"
 tokio = "0.1"
 tempfile = "3"

--- a/src/rust/engine/rule_graph/Cargo.toml
+++ b/src/rust/engine/rule_graph/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+version = "0.0.1"
+edition = "2018"
+name = "rule_graph"
+authors = [ "Pants Build <pantsbuild@gmail.com>" ]
+publish = false
+
+[dependencies]
+itertools = "0.7.2"

--- a/src/rust/engine/rule_graph/Cargo.toml
+++ b/src/rust/engine/rule_graph/Cargo.toml
@@ -4,6 +4,3 @@ edition = "2018"
 name = "rule_graph"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
-
-[dependencies]
-itertools = "0.7.2"

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -1053,3 +1053,93 @@ impl<R: Rule> Default for RuleEdges<R> {
     }
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::RuleGraph;
+  use std::fmt;
+
+  #[test]
+  fn create_and_validate_valid() {
+    let rules = vec![("a", vec![Rule("a_from_b", vec![DependencyKey("b", None)])])]
+      .into_iter()
+      .collect();
+    let roots = vec!["b"];
+    let graph = RuleGraph::new(&rules, roots);
+
+    graph.validate().unwrap();
+  }
+
+  #[test]
+  fn create_and_validate_no_root() {
+    let rules = vec![("a", vec![Rule("a_from_b", vec![DependencyKey("b", None)])])]
+      .into_iter()
+      .collect();
+    let roots = vec![];
+    let graph = RuleGraph::new(&rules, roots);
+
+    assert!(graph
+      .validate()
+      .err()
+      .unwrap()
+      .contains("No rule was available to compute DependencyKey(\"b\", None)."));
+  }
+
+  impl super::TypeId for &'static str {
+    fn display<I>(type_ids: I) -> String
+    where
+      I: Iterator<Item = Self>,
+    {
+      type_ids.collect::<Vec<_>>().join("+")
+    }
+  }
+
+  // A name and vec of DependencyKeys. Abbreviated for simpler construction and matching.
+  #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+  struct Rule(&'static str, Vec<DependencyKey>);
+
+  impl super::Rule for Rule {
+    type TypeId = &'static str;
+    type DependencyKey = DependencyKey;
+
+    fn dependency_keys(&self) -> Vec<Self::DependencyKey> {
+      self.1.clone()
+    }
+
+    fn require_reachable(&self) -> bool {
+      true
+    }
+  }
+
+  impl fmt::Display for Rule {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+      write!(f, "{:?}", self)
+    }
+  }
+
+  // A product and a param. Abbreviated for simpler construction and matching.
+  #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+  struct DependencyKey(&'static str, Option<&'static str>);
+
+  impl super::DependencyKey for DependencyKey {
+    type TypeId = &'static str;
+
+    fn new_root(product: Self::TypeId) -> Self {
+      DependencyKey(product, None)
+    }
+
+    fn product(&self) -> Self::TypeId {
+      self.0
+    }
+
+    fn provided_param(&self) -> Option<Self::TypeId> {
+      self.1
+    }
+  }
+
+  impl fmt::Display for DependencyKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+      write!(f, "{:?}", self)
+    }
+  }
+}

--- a/src/rust/engine/rule_graph/src/rules.rs
+++ b/src/rust/engine/rule_graph/src/rules.rs
@@ -1,0 +1,49 @@
+// Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::fmt::{Debug, Display};
+use std::hash::Hash;
+
+pub trait TypeId: Clone + Copy + Debug + Display + Hash + Eq + Ord + Sized + 'static {
+  ///
+  /// Render a string for a collection of TypeIds.
+  ///
+  fn display<I>(type_ids: I) -> String
+  where
+    I: Iterator<Item = Self>;
+}
+
+pub trait DependencyKey: Clone + Copy + Debug + Display + Hash + Eq + Sized + 'static {
+  type TypeId: TypeId;
+
+  ///
+  /// Generate a DependencyKey for a dependency at the "root" of the RuleGraph, which represents an
+  /// entrypoint into the set of installed Rules.
+  ///
+  fn new_root(product: Self::TypeId) -> Self;
+
+  ///
+  /// Returns the product (output) type for this dependency.
+  ///
+  fn product(&self) -> Self::TypeId;
+
+  ///
+  /// Returns the Param (input) type for this dependency, if it provides one.
+  ///
+  fn provided_param(&self) -> Option<Self::TypeId>;
+}
+
+pub trait Rule: Clone + Debug + Display + Hash + Eq + Sized + 'static {
+  type TypeId: TypeId;
+  type DependencyKey: DependencyKey<TypeId = Self::TypeId>;
+
+  ///
+  /// Return keys for the dependencies of this Rule.
+  ///
+  fn dependency_keys(&self) -> Vec<Self::DependencyKey>;
+
+  ///
+  /// True if this rule implementation should be required to be reachable in the RuleGraph.
+  ///
+  fn require_reachable(&self) -> bool;
+}

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -15,8 +15,7 @@ use futures::Future;
 use crate::core::{Failure, TypeId};
 use crate::handles::maybe_drop_handles;
 use crate::nodes::{NodeKey, WrappedNode};
-use crate::rule_graph::RuleGraph;
-use crate::tasks::Tasks;
+use crate::tasks::{Rule, Tasks};
 use crate::types::Types;
 use boxfuture::{BoxFuture, Boxable};
 use core::clone::Clone;
@@ -28,6 +27,7 @@ use process_execution::{self, BoundedCommandRunner, CommandRunner};
 use rand::seq::SliceRandom;
 use reqwest;
 use resettable::Resettable;
+use rule_graph::RuleGraph;
 use std::collections::btree_map::BTreeMap;
 
 ///
@@ -41,7 +41,7 @@ use std::collections::btree_map::BTreeMap;
 pub struct Core {
   pub graph: Graph<NodeKey>,
   pub tasks: Tasks,
-  pub rule_graph: RuleGraph,
+  pub rule_graph: RuleGraph<Rule>,
   pub types: Types,
   runtime: Resettable<Arc<RwLock<Runtime>>>,
   pub futures_timer_thread: Resettable<futures_timer::HelperThread>,

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -160,7 +160,7 @@ impl Core {
       (store, command_runner, http_client)
     });
 
-    let rule_graph = RuleGraph::new(&tasks, root_subject_types);
+    let rule_graph = RuleGraph::new(tasks.as_map(), root_subject_types);
 
     Core {
       graph: Graph::new(),

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -10,6 +10,7 @@ use std::{fmt, hash};
 use crate::externs;
 use crate::handles::Handle;
 
+use rule_graph;
 use smallvec::{smallvec, SmallVec};
 
 pub type FNV = hash::BuildHasherDefault<FnvHasher>;
@@ -128,13 +129,15 @@ impl TypeId {
       write!(f, "{}", externs::type_to_str(self))
     }
   }
+}
 
+impl rule_graph::TypeId for TypeId {
   ///
   /// Render a string for a collection of TypeIds.
   ///
-  pub fn display<T>(type_ids: T) -> String
+  fn display<I>(type_ids: I) -> String
   where
-    T: Iterator<Item = TypeId>,
+    I: Iterator<Item = TypeId>,
   {
     Params::display(type_ids)
   }

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -89,7 +89,12 @@ impl Params {
   ///
   /// Given a set of either param type or param value strings: sort, join, and render as one string.
   ///
-  pub fn display(mut params: Vec<String>) -> String {
+  pub fn display<T>(params: T) -> String
+  where
+    T: Iterator,
+    T::Item: fmt::Display,
+  {
+    let mut params: Vec<_> = params.map(|p| format!("{}", p)).collect();
     match params.len() {
       0 => "()".to_string(),
       1 => params.pop().unwrap(),
@@ -103,11 +108,7 @@ impl Params {
 
 impl fmt::Display for Params {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(
-      f,
-      "{}",
-      Self::display(self.0.iter().map(|k| format!("{}", k)).collect())
-    )
+    write!(f, "{}", Self::display(self.0.iter()))
   }
 }
 
@@ -126,6 +127,16 @@ impl TypeId {
     } else {
       write!(f, "{}", externs::type_to_str(self))
     }
+  }
+
+  ///
+  /// Render a string for a collection of TypeIds.
+  ///
+  pub fn display<T>(type_ids: T) -> String
+  where
+    T: Iterator<Item = TypeId>,
+  {
+    Params::display(type_ids)
   }
 }
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -855,12 +855,12 @@ pub extern "C" fn override_thread_logging_destination(destination: Destination) 
 }
 
 fn graph_full(scheduler: &Scheduler, subject_types: Vec<TypeId>) -> RuleGraph {
-  let graph_maker = GraphMaker::new(&scheduler.core.tasks, subject_types);
+  let graph_maker = GraphMaker::new(scheduler.core.tasks.as_map(), subject_types);
   graph_maker.full_graph()
 }
 
 fn graph_sub(scheduler: &Scheduler, subject_type: TypeId, product_type: TypeId) -> RuleGraph {
-  let graph_maker = GraphMaker::new(&scheduler.core.tasks, vec![subject_type]);
+  let graph_maker = GraphMaker::new(scheduler.core.tasks.as_map(), vec![subject_type]);
   graph_maker.sub_graph(subject_type, product_type)
 }
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -37,7 +37,6 @@ mod externs;
 mod handles;
 mod interning;
 mod nodes;
-mod rule_graph;
 mod scheduler;
 mod selectors;
 mod tasks;
@@ -73,15 +72,15 @@ use crate::externs::{
   StoreUtf8Extern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
 };
 use crate::handles::Handle;
-use crate::rule_graph::{GraphMaker, RuleGraph};
 use crate::scheduler::{ExecutionRequest, RootResult, Scheduler, Session};
-use crate::tasks::Tasks;
+use crate::tasks::{Rule, Tasks};
 use crate::types::Types;
 use futures::Future;
 use hashing::Digest;
 use log::{error, Log};
 use logging::logger::LOGGER;
 use logging::{Destination, Logger};
+use rule_graph::{GraphMaker, RuleGraph};
 
 // TODO: Consider renaming and making generic for collections of PyResults.
 #[repr(C)]
@@ -854,17 +853,17 @@ pub extern "C" fn override_thread_logging_destination(destination: Destination) 
   logging::set_destination(destination);
 }
 
-fn graph_full(scheduler: &Scheduler, subject_types: Vec<TypeId>) -> RuleGraph {
+fn graph_full(scheduler: &Scheduler, subject_types: Vec<TypeId>) -> RuleGraph<Rule> {
   let graph_maker = GraphMaker::new(scheduler.core.tasks.as_map(), subject_types);
   graph_maker.full_graph()
 }
 
-fn graph_sub(scheduler: &Scheduler, subject_type: TypeId, product_type: TypeId) -> RuleGraph {
+fn graph_sub(scheduler: &Scheduler, subject_type: TypeId, product_type: TypeId) -> RuleGraph<Rule> {
   let graph_maker = GraphMaker::new(scheduler.core.tasks.as_map(), vec![subject_type]);
   graph_maker.sub_graph(subject_type, product_type)
 }
 
-fn write_to_file(path: &Path, graph: &RuleGraph) -> io::Result<()> {
+fn write_to_file(path: &Path, graph: &RuleGraph<Rule>) -> io::Result<()> {
   let file = File::create(path)?;
   let mut f = io::BufWriter::new(file);
   graph.visualize(&mut f)

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -112,10 +112,10 @@ impl Select {
   }
 
   pub fn new_from_edges(params: Params, product: TypeId, edges: &rule_graph::RuleEdges) -> Select {
-    let select_key = rule_graph::SelectKey::JustSelect(selectors::Select::new(product));
+    let dependency_key = selectors::DependencyKey::JustSelect(selectors::Select::new(product));
     // TODO: Is it worth propagating an error here?
     let entry = edges
-      .entry_for(&select_key)
+      .entry_for(&dependency_key)
       .unwrap_or_else(|| panic!("{:?} did not declare a dependency on {:?}", edges, product))
       .clone();
     Select::new(params, product, entry)
@@ -845,7 +845,7 @@ impl Task {
         let context = context.clone();
         let params = params.clone();
         let entry = entry.clone();
-        let select_key = rule_graph::SelectKey::JustGet(selectors::Get {
+        let dependency_key = selectors::DependencyKey::JustGet(selectors::Get {
           product: get.product,
           subject: *get.subject.type_id(),
         });
@@ -855,10 +855,10 @@ impl Task {
           .edges_for_inner(&entry)
           .ok_or_else(|| throw(&format!("no edges for task {:?} exist!", entry)))
           .and_then(|edges| {
-            edges.entry_for(&select_key).cloned().ok_or_else(|| {
+            edges.entry_for(&dependency_key).cloned().ok_or_else(|| {
               throw(&format!(
                 "{:?} did not declare a dependency on {:?}",
-                entry, select_key
+                entry, dependency_key
               ))
             })
           });

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -152,13 +152,13 @@ impl WrappedNode for Select {
       &rule_graph::Entry::WithDeps(rule_graph::EntryWithDeps::Inner(ref inner)) => match inner
         .rule()
       {
-        &rule_graph::Rule::Task(ref task) => context.get(Task {
+        &tasks::Rule::Task(ref task) => context.get(Task {
           params: self.params.clone(),
           product: self.product,
           task: task.clone(),
           entry: Arc::new(self.entry.clone()),
         }),
-        &rule_graph::Rule::Intrinsic(Intrinsic { product, input })
+        &tasks::Rule::Intrinsic(Intrinsic { product, input })
           if product == context.core.types.snapshot && input == context.core.types.path_globs =>
         {
           let context = context.clone();
@@ -169,7 +169,7 @@ impl WrappedNode for Select {
             .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
             .to_boxed()
         }
-        &rule_graph::Rule::Intrinsic(Intrinsic { product, input })
+        &tasks::Rule::Intrinsic(Intrinsic { product, input })
           if product == context.core.types.snapshot && input == context.core.types.url_to_fetch =>
         {
           let context = context.clone();
@@ -180,7 +180,7 @@ impl WrappedNode for Select {
             .map(move |snapshot| Snapshot::store_snapshot(&core, &snapshot))
             .to_boxed()
         }
-        &rule_graph::Rule::Intrinsic(Intrinsic { product, input })
+        &tasks::Rule::Intrinsic(Intrinsic { product, input })
           if product == context.core.types.directory_digest
             && input == context.core.types.directories_to_merge =>
         {
@@ -204,7 +204,7 @@ impl WrappedNode for Select {
             })
             .to_boxed()
         }
-        &rule_graph::Rule::Intrinsic(Intrinsic { product, input })
+        &tasks::Rule::Intrinsic(Intrinsic { product, input })
           if product == context.core.types.snapshot
             && input == context.core.types.directory_digest =>
         {
@@ -221,7 +221,7 @@ impl WrappedNode for Select {
             .to_boxed()
         }
 
-        &rule_graph::Rule::Intrinsic(Intrinsic { product, input })
+        &tasks::Rule::Intrinsic(Intrinsic { product, input })
           if product == context.core.types.directory_digest
             && input == context.core.types.directory_with_prefix_to_strip =>
         {
@@ -248,7 +248,7 @@ impl WrappedNode for Select {
             })
             .to_boxed()
         }
-        &rule_graph::Rule::Intrinsic(Intrinsic { product, input })
+        &tasks::Rule::Intrinsic(Intrinsic { product, input })
           if product == context.core.types.files_content
             && input == context.core.types.directory_digest =>
         {
@@ -268,7 +268,7 @@ impl WrappedNode for Select {
             })
             .to_boxed()
         }
-        &rule_graph::Rule::Intrinsic(Intrinsic { product, input })
+        &tasks::Rule::Intrinsic(Intrinsic { product, input })
           if product == context.core.types.process_result
             && input == context.core.types.process_request =>
         {
@@ -294,7 +294,7 @@ impl WrappedNode for Select {
             })
             .to_boxed()
         }
-        &rule_graph::Rule::Intrinsic(i) => panic!("Unrecognized intrinsic: {:?}", i),
+        &tasks::Rule::Intrinsic(i) => panic!("Unrecognized intrinsic: {:?}", i),
       },
       &rule_graph::Entry::Param(type_id) => {
         if let Some(key) = self.params.find(type_id) {

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -6,7 +6,7 @@ use std::io;
 
 use itertools::Itertools;
 
-use crate::core::{Params, TypeId};
+use crate::core::TypeId;
 use crate::selectors::DependencyKey;
 use crate::tasks::Rule;
 
@@ -724,11 +724,7 @@ pub struct RuleGraph {
 }
 
 pub fn params_str(params: &ParamTypes) -> String {
-  let param_names = params
-    .iter()
-    .map(|type_id| format!("{}", *type_id))
-    .collect::<Vec<_>>();
-  Params::display(param_names)
+  TypeId::display(params.iter().cloned())
 }
 
 ///

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -13,7 +13,6 @@ use futures::future::{self, Future};
 use crate::context::{Context, Core};
 use crate::core::{Failure, Params, TypeId, Value};
 use crate::nodes::{NodeKey, Select, Tracer, Visualizer};
-use crate::selectors;
 use graph::{EntryId, Graph, InvalidationResult, NodeContext};
 use indexmap::IndexMap;
 use log::{debug, info, warn};
@@ -113,7 +112,7 @@ impl Scheduler {
     let edges = self
       .core
       .rule_graph
-      .find_root_edges(params.type_ids(), &selectors::Select::new(product))?;
+      .find_root_edges(params.type_ids(), product)?;
     request
       .roots
       .push(Select::new_from_edges(params, product, &edges));

--- a/src/rust/engine/src/selectors.rs
+++ b/src/rust/engine/src/selectors.rs
@@ -32,3 +32,55 @@ impl fmt::Debug for Select {
     write!(f, "Select {{ product: {} }}", self.product,)
   }
 }
+
+///
+/// A key for the dependencies used from a rule.
+///
+#[derive(Eq, Hash, PartialEq, Clone, Debug)]
+pub enum DependencyKey {
+  // A Get for a particular product/subject pair.
+  JustGet(Get),
+  // A bare select with no projection.
+  JustSelect(Select),
+}
+
+impl DependencyKey {
+  ///
+  /// Generates a DependencyKey for a "root" dependency.
+  ///
+  /// TODO: Currently this uses 'Select', but when https://github.com/pantsbuild/pants/issues/7490
+  /// is implemented, it should probably use `Get`.
+  ///
+  pub fn new_root(product: TypeId) -> DependencyKey {
+    DependencyKey::JustSelect(Select::new(product))
+  }
+
+  ///
+  /// Returns the product (output) type for this dependency.
+  ///
+  pub fn product(&self) -> TypeId {
+    match self {
+      DependencyKey::JustGet(ref g) => g.product,
+      DependencyKey::JustSelect(ref s) => s.product,
+    }
+  }
+
+  ///
+  /// Returns the Param (input) type for this dependency, if it provides one.
+  ///
+  pub fn provided_param(&self) -> Option<TypeId> {
+    match self {
+      DependencyKey::JustGet(ref g) => Some(g.subject),
+      DependencyKey::JustSelect(_) => None,
+    }
+  }
+}
+
+impl fmt::Display for DependencyKey {
+  fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    match self {
+      DependencyKey::JustSelect(s) => write!(f, "{}", s.product),
+      DependencyKey::JustGet(g) => write!(f, "{}", g),
+    }
+  }
+}

--- a/src/rust/engine/src/selectors.rs
+++ b/src/rust/engine/src/selectors.rs
@@ -10,6 +10,12 @@ pub struct Get {
   pub subject: TypeId,
 }
 
+impl fmt::Display for Get {
+  fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    write!(f, "Get({}, {})", self.product, self.subject)
+  }
+}
+
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub struct Select {
   pub product: TypeId,

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -5,8 +5,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 use crate::core::{Function, TypeId};
-use crate::rule_graph::SelectKey;
-use crate::selectors::{Get, Select};
+use crate::selectors::{DependencyKey, Get, Select};
 use crate::types::Types;
 
 #[derive(Eq, Hash, PartialEq, Clone, Debug)]
@@ -18,7 +17,7 @@ pub enum Rule {
 }
 
 impl Rule {
-  pub fn dependency_keys(&self) -> Vec<SelectKey> {
+  pub fn dependency_keys(&self) -> Vec<DependencyKey> {
     match self {
       &Rule::Task(Task {
         ref clause,
@@ -26,11 +25,11 @@ impl Rule {
         ..
       }) => clause
         .iter()
-        .map(|s| SelectKey::JustSelect(s.clone()))
-        .chain(gets.iter().map(|g| SelectKey::JustGet(*g)))
+        .map(|s| DependencyKey::JustSelect(s.clone()))
+        .chain(gets.iter().map(|g| DependencyKey::JustGet(*g)))
         .collect(),
       &Rule::Intrinsic(Intrinsic { ref input, .. }) => {
-        vec![SelectKey::JustSelect(Select::new(*input))]
+        vec![DependencyKey::JustSelect(Select::new(*input))]
       }
     }
   }

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -1,11 +1,86 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::fmt;
 
-use crate::core::{Function, TypeId, FNV};
+use crate::core::{Function, TypeId};
+use crate::rule_graph::SelectKey;
 use crate::selectors::{Get, Select};
 use crate::types::Types;
+
+#[derive(Eq, Hash, PartialEq, Clone, Debug)]
+pub enum Rule {
+  // Intrinsic rules are implemented in rust.
+  Intrinsic(Intrinsic),
+  // Task rules are implemented in python.
+  Task(Task),
+}
+
+impl Rule {
+  pub fn dependency_keys(&self) -> Vec<SelectKey> {
+    match self {
+      &Rule::Task(Task {
+        ref clause,
+        ref gets,
+        ..
+      }) => clause
+        .iter()
+        .map(|s| SelectKey::JustSelect(s.clone()))
+        .chain(gets.iter().map(|g| SelectKey::JustGet(*g)))
+        .collect(),
+      &Rule::Intrinsic(Intrinsic { ref input, .. }) => {
+        vec![SelectKey::JustSelect(Select::new(*input))]
+      }
+    }
+  }
+
+  pub fn require_reachable(&self) -> bool {
+    match self {
+      &Rule::Task(_) => true,
+      &Rule::Intrinsic(_) => false,
+    }
+  }
+}
+
+impl fmt::Display for Rule {
+  fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    match self {
+      &Rule::Task(ref task) => {
+        let product = format!("{}", task.product);
+        let mut clause_portion = task
+          .clause
+          .iter()
+          .map(|c| c.product.to_string())
+          .collect::<Vec<_>>()
+          .join(", ");
+        clause_portion = format!("[{}]", clause_portion);
+        let mut get_portion = task
+          .gets
+          .iter()
+          .map(::std::string::ToString::to_string)
+          .collect::<Vec<_>>()
+          .join(", ");
+        get_portion = if task.gets.is_empty() {
+          "".to_string()
+        } else {
+          format!("[{}], ", get_portion)
+        };
+
+        write!(
+          f,
+          "({}, {}, {}{})",
+          product, clause_portion, get_portion, task.func,
+        )
+      }
+      &Rule::Intrinsic(ref intrinsic) => write!(
+        f,
+        "({}, [{}], <intrinsic>)",
+        intrinsic.product, intrinsic.input,
+      ),
+    }
+  }
+}
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Task {
@@ -21,14 +96,14 @@ pub struct Task {
 ///
 #[derive(Clone, Debug)]
 pub struct Tasks {
-  // output product type -> Intrinsic providing it
-  intrinsics: HashMap<TypeId, Vec<Intrinsic>, FNV>,
-  // output product type -> list of tasks providing it
-  tasks: HashMap<TypeId, Vec<Task>, FNV>,
+  // output product type -> list of rules providing it
+  rules: HashMap<TypeId, Vec<Rule>>,
   // Used during the construction of the tasks map.
   preparing: Option<Task>,
 }
 
+///
+/// A collection of Rules (TODO: rename to Rules).
 ///
 /// Defines a stateful lifecycle for defining tasks via the C api. Call in order:
 ///   1. task_begin() - once per task
@@ -40,31 +115,13 @@ pub struct Tasks {
 impl Tasks {
   pub fn new() -> Tasks {
     Tasks {
-      intrinsics: HashMap::default(),
-      tasks: HashMap::default(),
+      rules: HashMap::default(),
       preparing: None,
     }
   }
 
-  pub fn all_product_types(&self) -> HashSet<TypeId> {
-    self
-      .tasks
-      .keys()
-      .chain(self.intrinsics.keys())
-      .cloned()
-      .collect::<HashSet<_>>()
-  }
-
-  pub fn all_tasks(&self) -> Vec<&Task> {
-    self.tasks.values().flat_map(|tasks| tasks).collect()
-  }
-
-  pub fn gen_intrinsic(&self, product: TypeId) -> Option<&Vec<Intrinsic>> {
-    self.intrinsics.get(&product)
-  }
-
-  pub fn gen_tasks(&self, product: TypeId) -> Option<&Vec<Task>> {
-    self.tasks.get(&product)
+  pub fn as_map(&self) -> &HashMap<TypeId, Vec<Rule>> {
+    &self.rules
   }
 
   pub fn intrinsics_set(&mut self, types: &Types) {
@@ -99,13 +156,8 @@ impl Tasks {
       },
     ];
 
-    self.intrinsics = vec![].into_iter().collect();
     for intrinsic in intrinsics {
-      self
-        .intrinsics
-        .entry(intrinsic.product)
-        .or_insert_with(Vec::new)
-        .push(intrinsic)
+      self.insert_rule(intrinsic.product, Rule::Intrinsic(intrinsic))
     }
   }
 
@@ -149,22 +201,24 @@ impl Tasks {
   }
 
   pub fn task_end(&mut self) {
-    // Move the task from `preparing` to the Tasks map
-    let mut task = self
+    // Move the task from `preparing` to the Rules map
+    let task = self
       .preparing
       .take()
       .expect("Must `begin()` a task creation before ending it!");
-    let tasks = self.tasks.entry(task.product).or_insert_with(Vec::new);
+    self.insert_rule(task.product, Rule::Task(task))
+  }
+
+  fn insert_rule(&mut self, product: TypeId, rule: Rule) {
+    let rules = self.rules.entry(product).or_insert_with(Vec::new);
     assert!(
-      !tasks.contains(&task),
+      !rules.contains(&rule),
       "{:?} was double-registered for {:?}: {:?}",
-      task,
-      task.product,
-      tasks,
+      rule,
+      product,
+      rules,
     );
-    task.clause.shrink_to_fit();
-    task.gets.shrink_to_fit();
-    tasks.push(task);
+    rules.push(rule);
   }
 }
 

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -215,7 +215,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     with self.assertRaises(Exception) as cm:
       list(scheduler.product_request(A, subjects=[(B())]))
 
-    self.assert_equal_with_printing('No installed @rules can satisfy Select(A) for input Params(B).', str(cm.exception))
+    self.assert_equal_with_printing('No installed @rules can compute A for input Params(B).', str(cm.exception))
 
   def test_non_existing_root_fails_differently(self):
     rules = [

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -178,7 +178,7 @@ class SchedulerTest(TestBase):
     self.assertEquals(result_str, consumes_a_and_b(a, b))
 
     # But not a subset.
-    expected_msg = ("No installed @rules can satisfy Select({}) for input Params(A)"
+    expected_msg = ("No installed @rules can compute {} for input Params(A)"
                     .format(str.__name__))
     with self.assertRaisesRegexp(Exception, re.escape(expected_msg)):
       self.scheduler.product_request(str, [Params(a)])
@@ -261,7 +261,7 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
         TypeError: For datatype object CollectionType(items=[1, 2, 3]) (type 'CollectionType'): in field 'items': unhashable type: 'list'
         """), exc_str, "exc_str was: {}".format(exc_str))
 
-    resulting_engine_error = "Exception: No installed @rules can satisfy Select(C) for input Params(Any).\n\n\n"
+    resulting_engine_error = "Exception: No installed @rules can compute C for input Params(Any).\n\n\n"
 
     # Test that the error contains the full traceback from within the CFFI context as well
     # (mentioning which specific extern method ended up raising the exception).


### PR DESCRIPTION
### Problem

The `RuleGraph` is relatively intertwined with the rest of the engine and has dependencies on the python code and the externs. This makes it more challenging to test, and its interface less clear. 

### Solution

Extract implementations of `Rule` and `DependencyKey` from the `RuleGraph`, then move `RuleGraph` to its own crate and parameterize it on a `R: Rule` type.

### Result

Adding tests for #7710 should be more straightforward.