### PR TITLE
OSX ignore serverset::tests::reattempts_unhealthy.

### DIFF
--- a/src/rust/engine/serverset/src/lib.rs
+++ b/src/rust/engine/serverset/src/lib.rs
@@ -365,6 +365,8 @@ mod tests {
   }
 
   #[test]
+  // TODO: un-ignore on OSX: https://github.com/pantsbuild/pants/issues/7756
+  #[cfg_attr(target_os = "macos", ignore)]
   fn reattempts_unhealthy() {
     let s = Serverset::new(
       vec!["good", "bad"],


### PR DESCRIPTION
The test is currently flaky on OSX as tracked by #7756.
