### PR TITLE
Only python_binary's constraint should be included in a built pex

### DIFF
--- a/testprojects/src/python/interpreter_selection/BUILD
+++ b/testprojects/src/python/interpreter_selection/BUILD
@@ -41,7 +41,7 @@ python_binary(
 
 # Note: Used by tests, but also useful for manual testing.
 python_binary(
-  name = 'deliberately_conficting_compatibility',
+  name = 'deliberately_conflicting_compatibility',
   dependencies = [
     ':echo_interpreter_version_lib',
   ],

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -72,7 +72,7 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
 
   def test_cli_option_wins_compatibility_conflict(self):
     # Tests that targets with compatibility conflicts collide.
-    binary_target = '{}:deliberately_conficting_compatibility'.format(self.testproject)
+    binary_target = '{}:deliberately_conflicting_compatibility'.format(self.testproject)
     pants_run = self._build_pex(binary_target)
     self.assert_success(pants_run, 'Failed to build {binary}.'.format(binary=binary_target))
 

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -14,6 +14,7 @@ from pants.util.contextutil import temporary_dir
 from pants.util.process_handler import subprocess
 from pants_test.backend.python.interpreter_selection_utils import (PY_3, PY_27,
                                                                    skip_unless_python3_present,
+                                                                   skip_unless_python27_and_python3_present,
                                                                    skip_unless_python27_present)
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -53,15 +54,20 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
 
       # Run the built pex.
       exe = os.path.join(distdir, binary_name + '.pex')
-      proc = subprocess.Popen([exe], stdout=subprocess.PIPE)
-      (stdout_data, _) = proc.communicate()
-      return stdout_data.decode('utf-8')
+      return self._popen_stdout(exe)
+
+  def _popen_stdout(self, exe):
+    proc = subprocess.Popen([exe], stdout=subprocess.PIPE)
+    (stdout_data, _) = proc.communicate()
+    return stdout_data.decode('utf-8')
 
   def _test_version(self, version):
-    echo = self._echo_version(version)
-    v = echo.split('.')  # E.g., 2.7.13.
+    self._assert_version_matches(self._echo_version(version), version)
+
+  def _assert_version_matches(self, actual, expected):
+    v = actual.strip().split('.')  # E.g., 2.7.13.
     self.assertTrue(len(v) > 2, 'Not a valid version string: {}'.format(v))
-    expected_components = version.split('.')
+    expected_components = expected.split('.')
     self.assertEqual(expected_components, v[:len(expected_components)])
 
   def test_cli_option_wins_compatibility_conflict(self):
@@ -102,6 +108,32 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
       pants_run.stdout_data,
       "Did not output interpreters discoved by Pants."
     )
+
+  @skip_unless_python27_and_python3_present
+  def test_binary_uses_own_compatibility(self):
+    """Tests that a binary target uses its own compatiblity, rather than including that of its
+    transitive dependencies.
+    """
+    # This target depends on a 2.7 minimum library, but does not declare its own compatibility.
+    # By specifying a version on the CLI, we ensure that the binary target will use that, and then
+    # test that it ends up with the version we request (and not the lower version specified on its
+    # dependency).
+    with temporary_dir() as distdir:
+      config = {
+        'GLOBAL': {
+          'pants_distdir': distdir
+        }
+      }
+      args = [
+          '--python-setup-interpreter-constraints=["CPython>=3.6,<4"]',
+        ]
+      binary_name = 'echo_interpreter_version'
+      binary_target = '{}:{}'.format(self.testproject, binary_name)
+      pants_run = self._build_pex(binary_target, config=config, args=args)
+      self.assert_success(pants_run, 'Failed to build {binary}.'.format(binary=binary_target))
+
+      actual = self._popen_stdout(os.path.join(distdir, binary_name + '.pex'))
+      self._assert_version_matches(actual, '3')
 
   @skip_unless_python3_present
   def test_select_3(self):


### PR DESCRIPTION
### Problem

See the problem described in #7775.

### Solution

Compute and validate the transitive constraints, but only include the `python_binary`'s constraint in the built pex.

### Result

Fixes #7775, but leaves a TODO about supporting building a binary for an interpreter for which we do not have a valid interpreter.