### PR TITLE
Only log to stderr in pants runs

### DIFF
--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -62,7 +62,7 @@ class PailgunHandler(PailgunHandlerBase):
       Native().override_thread_logging_destination_to_just_stderr()
       yield
     finally:
-      Native.override_thread_logging_destination_to_just_pantsd()
+      Native().override_thread_logging_destination_to_just_pantsd()
 
   def _run_pants(self, sock, arguments, environment):
     """Execute a given run with a pants runner."""

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -56,7 +56,13 @@ class PailgunHandler(PailgunHandlerBase):
 
   def _run_pants(self, sock, arguments, environment):
     """Execute a given run with a pants runner."""
+    # For the pants run, we want to log to stderr.
+    # TODO Might be worth to make contextmanagers for this?
+    Native().override_thread_logging_destination_to_just_stderr()
+
     self.server.runner_factory(sock, arguments, environment).run()
+
+    Native().override_thread_logging_destination_to_just_pantsd()
 
   def handle(self):
     """Request handler for a single Pailgun request."""
@@ -181,7 +187,7 @@ class PailgunServer(ThreadingMixIn, TCPServer):
   def process_request_thread(self, request, client_address):
     """Override of ThreadingMixIn.process_request_thread() that delegates to the request handler."""
     # Instantiate the request handler.
-    Native().override_thread_logging_destination_to_just_stderr()
+    Native().override_thread_logging_destination_to_just_pantsd()
     handler = self.RequestHandlerClass(request, client_address, self)
     try:
       # Attempt to handle a request with the handler.


### PR DESCRIPTION
### Problem

There were some instances of logging that happened before we start  the pants run but once we have created a pailgun thread to answer the request (#7777). Those need to go to the pantsd log.

### Result

```
13:21:48 [INFO] handling pailgun request: `./pants --enable-pantsd list src/scala::`
``` 
and 
```
13:21:49 [INFO] pailgun request completed: `./pants --enable-pantsd list src/scala::`
```
are now back.

Fixes #7777