### PR TITLE
Deflake serverset test

### DIFF
--- a/src/rust/engine/serverset/src/lib.rs
+++ b/src/rust/engine/serverset/src/lib.rs
@@ -479,11 +479,13 @@ mod tests {
 
     let start = std::time::Instant::now();
     let mut should_break = false;
+    let mut did_get_at_least_one_good = false;
     while !should_break {
       s.next()
         .map(|(server, token)| {
           if start.elapsed() < duration - buffer {
             assert_eq!("good", server);
+            did_get_at_least_one_good = true;
           } else {
             should_break = true;
           }
@@ -492,6 +494,8 @@ mod tests {
         .wait()
         .unwrap();
     }
+
+    assert!(did_get_at_least_one_good);
 
     std::thread::sleep(buffer * 2);
   }

--- a/src/rust/engine/serverset/src/lib.rs
+++ b/src/rust/engine/serverset/src/lib.rs
@@ -365,8 +365,6 @@ mod tests {
   }
 
   #[test]
-  // TODO: un-ignore on OSX: https://github.com/pantsbuild/pants/issues/7756
-  #[cfg_attr(target_os = "macos", ignore)]
   fn reattempts_unhealthy() {
     let s = Serverset::new(
       vec!["good", "bad"],
@@ -480,10 +478,15 @@ mod tests {
     let buffer = Duration::from_millis(1);
 
     let start = std::time::Instant::now();
-    while start.elapsed() < duration - buffer {
+    let mut should_break = false;
+    while !should_break {
       s.next()
         .map(|(server, token)| {
-          assert_eq!("good", server);
+          if start.elapsed() < duration - buffer {
+            assert_eq!("good", server);
+          } else {
+            should_break = true;
+          }
           s.report_health(token, Health::Healthy);
         })
         .wait()


### PR DESCRIPTION
This code is time-sensitive, so pull the timeout check into around the
assert, rather than around the loop.

Fixes #7756