### PR TITLE
Force sequential runs under pantsd

### DIFF
--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -141,6 +141,7 @@ class RemotePantsRunner(object):
     ng_env = NailgunProtocol.isatty_to_env(self._stdin, self._stdout, self._stderr)
     modified_env = combined_dict(self._env, ng_env)
     modified_env['PANTSD_RUNTRACKER_CLIENT_START_TIME'] = str(self._start_time)
+    modified_env['PANTSD_REQUEST_TIMEOUT_LIMIT'] = str(self._bootstrap_options.for_global_scope().pantsd_timeout_when_multiple_invocations)
 
     assert isinstance(port, int), 'port {} is not an integer!'.format(port)
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -273,6 +273,16 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
       help='Create a new pantsd server, and use it, and shut it down immediately after. '
            'If pantsd is already running, it will shut it down and spawn a new instance (Beta)')
 
+    # NB: We really don't want this option to invalidate the daemon, because different clients might have
+    # different needs. For instance, an IDE might have a very long timeout because it only wants to refresh
+    # a project in the background, while a user might want a shorter timeout for interactivity.
+    register('--pantsd-timeout-when-multiple-invocations', advanced=True, type=float, default=60.0, daemon=False,
+             help='The maximum amount of time to wait for the invocation to start until '
+                  'raising a timeout exception. '
+                  'Because pantsd currently does not support parallel runs, '
+                  'any prior running Pants command must be finished for the current one to start. '
+                  'To never timeout, use the value -1.')
+
     # These facilitate configuring the native engine.
     register('--native-engine-visualize-to', advanced=True, default=None, type=dir_option, daemon=False,
              help='A directory to write execution and rule graphs to as `dot` files. The contents '

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -62,7 +62,11 @@ class PailgunHandler(PailgunHandlerBase):
 
   def _run_pants(self, sock, arguments, environment):
     """Execute a given run with a pants runner."""
+    # For the pants run, we want to log to stderr.
+    # TODO Might be worth to make contextmanagers for this?
+    Native().override_thread_logging_destination_to_just_stderr()
     self.server.runner_factory(sock, arguments, environment).run()
+    Native().override_thread_logging_destination_to_just_pantsd()
 
   def handle(self):
     """Request handler for a single Pailgun request."""

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -225,7 +225,7 @@ class PantsDaemon(FingerprintedProcessManager):
         (bootstrap_options.pantsd_pailgun_host, bootstrap_options.pantsd_pailgun_port),
         DaemonPantsRunner,
         scheduler_service,
-        should_shutdown_after_run
+        should_shutdown_after_run,
       )
 
       store_gc_service = StoreGCService(legacy_graph_scheduler.scheduler)

--- a/tests/python/pants_test/pantsd/test_pailgun_server.py
+++ b/tests/python/pants_test/pantsd/test_pailgun_server.py
@@ -173,7 +173,8 @@ class TestPailgunServer(unittest.TestCase):
       thread.start()
 
     for thread in threads:
-      thread.join()
+      # If this fails because it times out, it's definitely a legitimate error.
+      thread.join(10)
 
     for thread in threads:
       self.assertFalse(thread.is_alive())

--- a/tests/python/pants_test/pantsd/test_pailgun_server.py
+++ b/tests/python/pants_test/pantsd/test_pailgun_server.py
@@ -177,7 +177,7 @@ class TestPailgunServer(unittest.TestCase):
                               args = (mock_request, ('1.2.3.4', port)),
                               name="MockThread-{}".format(port))
 
-    threads = [create_request_thread(33330 + i) for i in range(0, self.threads_to_start)]
+    threads = [create_request_thread(0) for _ in range(0, self.threads_to_start)]
     for thread in threads:
       thread.start()
       self.assertTrue(self.thread_errors.empty(), "There were some errors in the threads:\n {}".format(self.thread_errors))

--- a/tests/python/pants_test/pantsd/test_pailgun_server.py
+++ b/tests/python/pants_test/pantsd/test_pailgun_server.py
@@ -104,7 +104,7 @@ class TestPailgunServer(unittest.TestCase):
       if self.threads_running == self.threads_to_start:
         self.threads_running_cond.notify_all()
       else:
-        while not self.threads_running == self.threads_to_start:
+        while self.threads_running != self.threads_to_start:
           self.threads_running_cond.wait()
 
 
@@ -119,7 +119,7 @@ class TestPailgunServer(unittest.TestCase):
       if self.threads_running == 0:
         self.threads_running_cond.notify_all()
       else:
-        while not self.threads_running == 0:
+        while self.threads_running != 0:
           self.threads_running_cond.wait()
 
       threaded_assert_equal(self.threads_running, 0, "handle_thread_finished exited when there still were threads running.")
@@ -185,10 +185,6 @@ class TestPailgunServer(unittest.TestCase):
     for thread in threads:
       # If this fails because it times out, it's definitely a legitimate error.
       thread.join(10)
-      self.assertTrue(self.thread_errors.empty(), "There were some errors in the threads:\n {}".format(self.thread_errors))
-
-    for thread in threads:
-      self.assertFalse(thread.is_alive())
       self.assertTrue(self.thread_errors.empty(), "There were some errors in the threads:\n {}".format(self.thread_errors))
 
 


### PR DESCRIPTION
## Problem

It's not currently safe to have multiple parallel pants runs with the daemon enabled.
However, this was not enforced (context: #7751).

## Solution

- Implement a lock in `PailgunServer`, so that each request thread waits to acquire it (in `PailgunServer.process_request_thread`).
- Implement an option that is passed via the environment, to each request, to communicate how long should a request wait for the lock before timing out.

## Result

In the cases where a single pants run is running at a time, the UX is unchanged.
When a request is run, we have three cases:
- If we specify a positive timeout (or if we leave it by default), and the request finishes before we time out, the request waits for a bit and then runs:
```
$ ./pants --enable-pantsd --pantsd-run-start-timeout=20 list src/scala::
Another pants run was found, starting waiting for up to 20.0s for it to finish
Waiting for request to finish (1.0s total)...
Waiting for request to finish (2.0s total)...
Waiting for request to finish (3.0s total)...
Waiting for request to finish (4.0s total)...
Waiting for request to finish (5.0s total)...
Waiting for request to finish (6.0s total)...
Waiting for request to finish (7.0s total)...
Waiting for request to finish (8.0s total)...
Waiting for request to finish (9.0s total)...
src/scala/org/pantsbuild/zinc/cache:cache
src/scala/org/pantsbuild/zinc/analysis:analysis
src/scala/org/pantsbuild/zinc/options:options
src/scala/org/pantsbuild/zinc/compiler:compiler
src/scala/org/pantsbuild/zinc/extractor:extractor
src/scala/org/pantsbuild/zinc/scalautil:scalautil
src/scala/org/pantsbuild/zinc/bootstrapper:bootstrapper
src/scala/org/pantsbuild/zinc/util:util
```

- If we specify a timeout and hit it, the run will fail with a useful error:
```
$ ./pants --enable-pantsd --pantsd-run-start-timeout="0" list ::
Another pants run was found, starting waiting for up to 0.0s for it to finish
Traceback (most recent call last):
  File "/Users/bescobar/workspace/otherpants/src/python/pants/pantsd/pailgun_server.py", line 259, in process_request_thread
    with self.ensure_request_is_exclusive(environment, request):
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/contextlib.py", line 112, in __enter__
    return next(self.gen)
  File "/Users/bescobar/workspace/otherpants/src/python/pants/pantsd/pailgun_server.py", line 246, in ensure_request_is_exclusive
    raise ExclusiveRequestTimeout("Timed out while waiting for another pants run to finish")
pants.pantsd.pailgun_server.ExclusiveRequestTimeout: Timed out while waiting for another pants run to finish
```

- If we specify a **negative** timeout, the request will block _potentially_ forever:
```
$ ./pants --enable-pantsd --pantsd-run-start-timeout=-1 list src/scala::
Another pants run was found, starting waiting forever for it to finish
Waiting for request to finish (1.0s total)...
Waiting for request to finish (2.0s total)...
Waiting for request to finish (3.0s total)...
Waiting for request to finish (4.0s total)...
Waiting for request to finish (5.0s total)...
Waiting for request to finish (6.0s total)...
Waiting for request to finish (7.0s total)...
Waiting for request to finish (8.0s total)...
Waiting for request to finish (9.0s total)...
Waiting for request to finish (10.0s total)...
Waiting for request to finish (11.0s total)...
src/scala/org/pantsbuild/zinc/extractor:extractor
src/scala/org/pantsbuild/zinc/compiler:compiler
src/scala/org/pantsbuild/zinc/analysis:analysis
src/scala/org/pantsbuild/zinc/bootstrapper:bootstrapper
src/scala/org/pantsbuild/zinc/options:options
src/scala/org/pantsbuild/zinc/util:util
src/scala/org/pantsbuild/zinc/scalautil:scalautil
src/scala/org/pantsbuild/zinc/cache:cache
```
**All of the new output is to stderr**

Fixes #7751.
Commits should _mostly_ make sense independently.