### PR TITLE
Have the daemon wait until we stop writing to the socket.

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -234,7 +234,7 @@ class DaemonPantsRunner(object):
           time.sleep(.001)  # HACK: Sleep 1ms in the main thread to free the GIL.
           stdout_pipe.stop_writing()
           stderr_pipe.stop_writing()
-          writer.join()
+          writer.join(timeout=60)
           if writer.isAlive():
             raise NailgunStreamWriterError("pantsd timed out while waiting for the stdout/err to finish writing to the socket.")
       yield finalizer

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -173,6 +173,10 @@ class NailgunStreamStdinReader(_StoppableDaemonThread):
         pass
 
 
+class NailgunStreamWriterError(Exception):
+  pass
+
+
 class NailgunStreamWriter(_StoppableDaemonThread):
   """Reads input from an input fd and writes Nailgun chunks on a socket.
 
@@ -205,6 +209,73 @@ class NailgunStreamWriter(_StoppableDaemonThread):
   def _assert_aligned(self, *iterables):
     assert len({len(i) for i in iterables}) == 1, 'inputs are not aligned'
 
+  def _handle_closed_input_stream(self, fileno):
+    # We've reached EOF.
+    try:
+      if self._chunk_eof_type is not None:
+        NailgunProtocol.write_chunk(self._socket, self._chunk_eof_type)
+    finally:
+      try:
+        os.close(fileno)
+      finally:
+        self.stop_reading_from_fd(fileno)
+
+  def stop_reading_from_fd(self, fileno):
+    self._in_fds.remove(fileno)
+
+  def run(self):
+    while self._in_fds and not self.is_stopped:
+      readable, _, errored = select.select(self._in_fds, [], self._in_fds, self._select_timeout)
+      self.do_run(readable, errored)
+
+  def do_run(self, readable, errored):
+    """Represents one iteration of the infinite reading cycle. Subclasses should override this."""
+    if readable:
+      for fileno in readable:
+        data = os.read(fileno, self._buf_size)
+        if not data:
+          self._handle_closed_input_stream(fileno)
+        else:
+          NailgunProtocol.write_chunk(
+            self._socket,
+            self._fileno_chunk_type_map[fileno],
+            data
+          )
+
+    if errored:
+      for fileno in errored:
+        self.stop_reading_from_fd(fileno)
+
+
+class PipedNailgunStreamWriter(NailgunStreamWriter):
+  """
+  Represents a NailgunStreamWriter that reads from a pipe.
+  """
+
+  def __init__(self, pipes, socket, chunk_type, *args, **kwargs):
+    self._pipes = pipes
+    in_fds = tuple(pipe.read_fd for pipe in pipes)
+    super(PipedNailgunStreamWriter, self).__init__(in_fds, socket, chunk_type, *args, **kwargs)
+
+  def do_run(self, readables, errored):
+    """
+    Overrides the superclass.
+
+    Wraps the running logic of the parent class to handle pipes that have been closed on the write end.
+    If no file descriptors are readable (i.e. there is no more to read from any pipe for now),
+    it will check each of its pipes. If a pipe is not writable, it will interpret that the writer class
+    does not want to write any more, and so it will remove that pipe from the available pipes to read from.
+    When there are no more pipes to read from, it will stop.
+    """
+    super(PipedNailgunStreamWriter, self).do_run(readables, errored)
+    if not readables:
+      for pipe in self._pipes:
+        if not pipe.is_writable():
+          self.stop_reading_from_fd(pipe.read_fd)
+          self._pipes.remove(pipe)
+    if not self._pipes:
+      self.stop()
+
   @classmethod
   @contextmanager
   def open(cls, sock, chunk_type, isatty, chunk_eof_type=None, buf_size=None, select_timeout=None):
@@ -231,8 +302,8 @@ class NailgunStreamWriter(_StoppableDaemonThread):
         # Allocate one pipe pair per chunk type provided.
         (stack.enter_context(Pipe.self_closing(isatty)) for isatty in isattys)
       )
-      writer = NailgunStreamWriter(
-        tuple(pipe.read_fd for pipe in pipes),
+      writer = PipedNailgunStreamWriter(
+        pipes,
         sock,
         chunk_types,
         chunk_eof_type,
@@ -241,31 +312,3 @@ class NailgunStreamWriter(_StoppableDaemonThread):
       )
       with writer.running():
         yield pipes, writer
-
-  def run(self):
-    while self._in_fds and not self.is_stopped:
-      readable, _, errored = select.select(self._in_fds, [], self._in_fds, self._select_timeout)
-
-      if readable:
-        for fileno in readable:
-          data = os.read(fileno, self._buf_size)
-          if not data:
-            # We've reached EOF.
-            try:
-              if self._chunk_eof_type is not None:
-                NailgunProtocol.write_chunk(self._socket, self._chunk_eof_type)
-            finally:
-              try:
-                os.close(fileno)
-              finally:
-                self._in_fds.remove(fileno)
-          else:
-            NailgunProtocol.write_chunk(
-              self._socket,
-              self._fileno_chunk_type_map[fileno],
-              data
-            )
-
-      if errored:
-        for fileno in errored:
-          self._in_fds.remove(fileno)

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -116,6 +116,7 @@ python_library(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:future',
     ':collections_abc_backport',
+    ':strutil',
     ':memo',
     ':meta',
   ],

--- a/tests/python/pants_test/java/test_nailgun_io.py
+++ b/tests/python/pants_test/java/test_nailgun_io.py
@@ -105,5 +105,4 @@ class TestPipedNailgunStreamWriter(unittest.TestCase):
 
     self.assertFalse(writer.is_alive())
 
-    self.assertEqual(mock_read.call_count, len(test_data))
     mock_writer.assert_has_calls([mock.call(mock.ANY, ChunkType.STDOUT, b'A')] * (len(test_data) - 1))

--- a/tests/python/pants_test/java/test_nailgun_io.py
+++ b/tests/python/pants_test/java/test_nailgun_io.py
@@ -79,7 +79,7 @@ class TestNailgunStreamWriter(unittest.TestCase):
 
 
 class TestPipedNailgunStreamWriter(unittest.TestCase):
-  def setUp(self) -> None:
+  def setUp(self):
     self.mock_socket = mock.Mock()
 
   @mock.patch('os.read')

--- a/tests/python/pants_test/java/test_nailgun_io.py
+++ b/tests/python/pants_test/java/test_nailgun_io.py
@@ -87,7 +87,7 @@ class TestPipedNailgunStreamWriter(unittest.TestCase):
   @mock.patch.object(NailgunProtocol, 'write_chunk')
   def test_auto_shutdown_on_write_end_closed(self, mock_writer, mock_select, mock_read):
     pipe = Pipe.create(False)
-    test_data = [b"A"] * 100000 + [b'']
+    test_data = [b"A"] * 1000 + [b'']
     mock_read.side_effect = test_data
     mock_select.side_effect = [([pipe.read_fd], [], [])] * len(test_data)
 
@@ -102,7 +102,6 @@ class TestPipedNailgunStreamWriter(unittest.TestCase):
     with writer.running():
       pipe.stop_writing()
       writer.join(1)
-
-    self.assertFalse(writer.is_alive())
+      self.assertFalse(writer.is_alive())
 
     mock_writer.assert_has_calls([mock.call(mock.ANY, ChunkType.STDOUT, b'A')] * (len(test_data) - 1))


### PR DESCRIPTION
## Problem

As described in #7465, when we pipe the output of a pants run with pantsd into anything, it may truncate output.
The root cause:
- `NailgunStreamWriter` runs in another thread, and is periodically reading from `std{out,err}` and writing it in the Nailgun socket. Among other uses, we create one of these whenever we need to redirect stdout/err from pants into the client.
- In the current implementation of pantsd, this happens in DaemonPantsRunner, whenever we call to `nailgunned_stdio` and either stdout, err or in are not TTYs (there's more nuance, but it's not relevant). We create pipes and give the writing end to the `DaemonPantsRunner`, while the `NailgunStreamWriter` listens to the reading end for output. The `DaemonPantsRunner` then redirects `sys.stdout/err` (and some other stuff) to the reading ends of those pipes, through `stdio_as`. This happens in two places:
  - When we warm up the v2 product graph, where things like v2 list are computed.
  - When we actually execute the pants run under pantsd.
- When the daemon is finished with `nailgunned_stdio`, it stops the `NailgunStreamWriter` thread that is transmitting output to the client through the socket, and then it joins  until it's done.
**- The issue:** When the daemon `stop()`s the thread, this stops reading immediately, even if it hasn't finished transmitting every chunk to the client. Therefore, there is a race condition between `NailgunStreamWriter` trying to send all the chunk through the socket and `DaemonPantsRunner` trying to close it. This can be checked by inserting a `time.sleep(0.1)` [here](https://github.com/pantsbuild/pants/blob/3c17cd2b54b468590ddf8f486f37652ed0db6afc/src/python/pants/java/nailgun_io.py#L201), which will make the issue repro consistently.

## Solution

Depends on #7740, and includes commits from that.

**The only commit worth reviewing is b9d0c95**

The `DaemonPantsRunner` must no longer `stop()` the thread, but rather mark the pipes that are is stdout/err as "I'm not going to write to this anymore, please close yourself when you're done reading from this".

We create the class `PipedNailgunStreamWriter`, wich is aware that it's reading end belongs to a pipe. Whenever we don't have anything to read, we check if the write end of the pipe is closed. If so, we stop trying to read from that pipe. When no pipes are left, we close ourselves.

## Result

Hopefully, `./pants --enable-pantsd list :: | wc -l` should give consistent output, and #7465 should be resolved.