### PR TITLE
Upgrade all pytest deps to pinned latests.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -4,7 +4,7 @@ beautifulsoup4>=4.6.0,<4.7
 cffi==1.11.5
 configparser==3.7.1 ; python_version<'3'
 contextlib2==0.5.5
-coverage>=4.5,<4.6
+coverage==4.5.3
 docutils==0.14
 fasteners==0.14.1
 faulthandler==2.6 ; python_version<'3'
@@ -12,8 +12,6 @@ future==0.17.1
 futures==3.0.5 ; python_version<'3'
 Markdown==2.1.1
 mock==2.0.0
-# TODO(6282): once we can upgrade Pytest to 4.2.1+, we can remove the more-itertools requirement
-more-itertools<6.0.0 ; python_version<'3'
 packaging==16.8
 parameterized==0.6.1
 pathspec==0.5.9
@@ -24,8 +22,7 @@ pyflakes==2.0.0
 Pygments==2.3.1
 pyopenssl==17.3.0
 pystache==0.5.3
-pytest-cov>=2.5,<2.6
-pytest>=3.4,<4.0
+pytest==4.5.0
 python-Levenshtein==0.12.0
 pywatchman==1.4.1
 PyYAML==5.1

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -13,14 +13,13 @@ class PyTest(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(PyTest, cls).register_options(register)
-    # TODO: This is currently bounded below `3.7` due to #6282.
-    register('--requirements', advanced=True, default='pytest>=3.0.7,<3.7',
+    register('--requirements', advanced=True, default='pytest==4.5.0',
              help='Requirements string for the pytest library.')
-    register('--timeout-requirements', advanced=True, default='pytest-timeout>=1.2,<1.3',
+    register('--timeout-requirements', advanced=True, default='pytest-timeout==1.3.3',
              help='Requirements string for the pytest-timeout library.')
-    register('--cov-requirements', advanced=True, default='pytest-cov>=2.4,<2.5',
+    register('--cov-requirements', advanced=True, default='pytest-cov==2.7.1',
              help='Requirements string for the pytest-cov library.')
-    register('--unittest2-requirements', advanced=True, default='unittest2>=0.6.0,<=1.9.0',
+    register('--unittest2-requirements', advanced=True, default='unittest2==1.1.0',
              help='Requirements string for the unittest2 library, which some python versions '
                   'may need.')
 
@@ -30,9 +29,7 @@ class PyTest(Subsystem):
     Make sure the requirements are satisfied in any environment used for running tests.
     """
     opts = self.get_options()
-    # TODO(6282): once we can upgrade Pytest to 4.2.1+, we can remove the more-itertools requirement
     return (
-      "more-itertools<6.0.0 ; python_version<'3'",
       opts.requirements,
       opts.timeout_requirements,
       opts.cov_requirements,


### PR DESCRIPTION
This undoes the workarounds introduced for #6282.

Fixes #6282
