### PR TITLE
Simplify pytest configuration.

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest/plugin.py
+++ b/src/python/pants/backend/python/tasks/pytest/plugin.py
@@ -73,11 +73,6 @@ class ShardingPlugin(object):
 
 def pytest_addoption(parser):
   group = parser.getgroup('pants', 'Pants testing support')
-  group.addoption('--pants-rootdir-comm-path',
-                  dest='rootdir_comm_path',
-                  action='store',
-                  metavar='PATH',
-                  help='Path to a file to write the pytest rootdir to.')
   group.addoption('--pants-sources-map-path',
                   dest='sources_map_path',
                   action='store',
@@ -105,9 +100,6 @@ def pytest_configure(config):
     return
 
   rootdir = str(config.rootdir)
-  rootdir_comm_path = config.getoption('rootdir_comm_path')
-  with open(rootdir_comm_path, 'w') as fp:
-    fp.write(rootdir)
 
   sources_map_path = config.getoption('sources_map_path')
   with open(sources_map_path) as fp:

--- a/src/python/pants/backend/python/tasks/pytest_prep.py
+++ b/src/python/pants/backend/python/tasks/pytest_prep.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
 from builtins import object
 
 import pkg_resources
@@ -72,14 +71,6 @@ class PytestPrep(PythonExecutionTaskBase):
       """
       return self._interpreter
 
-    @property
-    def config_path(self):
-      """Return the absolute path of the `pytest.ini` config file in this pytest binary.
-
-      :rtype: str
-      """
-      return os.path.join(self._pex.path(), 'pytest.ini')
-
   @classmethod
   def implementation_version(cls):
     return super(PytestPrep, cls).implementation_version() + [('PytestPrep', 2)]
@@ -98,7 +89,6 @@ class PytestPrep(PythonExecutionTaskBase):
                          content=pkg_resources.resource_string(__name__, resource_relpath))
 
   def extra_files(self):
-    yield self.ExtraFile.empty('pytest.ini')
     yield self._module_resource(self.PytestBinary.pytest_plugin_module, 'pytest/plugin.py')
     yield self._module_resource(self.PytestBinary.coverage_plugin_module, 'coverage/plugin.py')
 


### PR DESCRIPTION
+ Use `--rootdir` to set the rootdir ahead of time and use the buildroot
  for sensible RHS paths in `-v` output (previously we only had sensible
  LHS paths via the `NodeRenamerPlugin`). This option was introduced
  relatively recently in 3.5.0:
    https://docs.pytest.org/en/latest/changelog.html#pytest-3-5-0-2018-03-21
    https://github.com/pytest-dev/pytest/issues/1642
+ Control the `.pytest_cachedir` location with `-o` and move it into the
  task workdir (defaults to the `--rootdir` otherwise).
+ Simplify `pytest.ini` nullification by pointing to os.devnull instead
  of embedding an empty `pytest.ini` in the pytest pex.