### PR TITLE
Fix `create_subprocess_encoding_environment` rule.

### DIFF
--- a/src/python/pants/backend/python/subsystems/subprocess_environment.py
+++ b/src/python/pants/backend/python/subsystems/subprocess_environment.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 
+from future.utils import text_type
+
 from pants.engine.rules import optionable_rule, rule
 from pants.subsystem.subsystem import Subsystem
 from pants.util.objects import datatype, string_optional
@@ -44,9 +46,12 @@ class SubprocessEncodingEnvironment(datatype([
 
 @rule(SubprocessEncodingEnvironment, [SubprocessEnvironment])
 def create_subprocess_encoding_environment(subprocess_environment):
+  def ensure_string_optional(value):
+    return text_type(value) if value is not None else None
+
   return SubprocessEncodingEnvironment(
-    lang=subprocess_environment.get_options().lang,
-    lc_all=subprocess_environment.get_options().lc_all,
+    lang=ensure_string_optional(subprocess_environment.get_options().lang),
+    lc_all=ensure_string_optional(subprocess_environment.get_options().lc_all),
   )
 
 


### PR DESCRIPTION
This was not converting option values to the right type for python2.7
which led to the following in nightly CRON:
```
field 'lang' was invalid: value 'en_US.UTF-8' (with type 'newstr') must satisfy this type constraint: Exactly(unicode or NoneType).
field 'lc_all' was invalid: value 'en_US.UTF-8' (with type 'newstr') must satisfy this type constraint: Exactly(unicode or NoneType).)
            Traceback (most recent call last):
              File "/home/travis/.pex/code/4e00e9f8a6de2adf6740aaa38ad0c944fd32aa86/pants/engine/native.py", line 276, in call
                val = func(*args)
              File "/home/travis/.pex/code/4e00e9f8a6de2adf6740aaa38ad0c944fd32aa86/pants/backend/python/subsystems/subprocess_environment.py", line 49, in create_subprocess_encoding_environment
                lc_all=subprocess_environment.get_options().lc_all,
              File "/home/travis/.pex/code/4e00e9f8a6de2adf6740aaa38ad0c944fd32aa86/pants/util/objects.py", line 128, in __new__
                '\n'.join(type_failure_msgs)))
            TypedDatatypeInstanceConstructionError: type check error in class SubprocessEncodingEnvironment: 2 errors type checking constructor arguments:
            field 'lang' was invalid: value 'en_US.UTF-8' (with type 'newstr') must satisfy this type constraint: Exactly(unicode or NoneType).
            field 'lc_all' was invalid: value 'en_US.UTF-8' (with type 'newstr') must satisfy this type constraint: Exactly(unicode or NoneType).
```
