### PR TITLE
Hermetic zinc runs with a native-image

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -22,14 +22,17 @@ from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.backend.jvm.tasks.nailgun_task import NailgunTaskBase
 from pants.base.build_environment import get_buildroot
 from pants.base.workunit import WorkUnitLabel
+from pants.binaries.binary_tool import NativeTool
 from pants.engine.fs import DirectoryToMaterialize, PathGlobs, PathGlobsAndRoot
 from pants.engine.isolated_process import ExecuteProcessRequest
 from pants.java.distribution.distribution import Distribution
 from pants.java.jar.jar_dependency import JarDependency
-from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import fast_relpath, safe_delete, safe_mkdir
 from pants.util.fileutil import safe_hardlink_or_copy
 from pants.util.memo import memoized_method, memoized_property
+
+
+_ZINC_COMPILER_VERSION = '0.0.9'
 
 
 class Zinc(object):
@@ -46,8 +49,26 @@ class Zinc(object):
 
   _lock = Lock()
 
-  class Factory(Subsystem, JvmToolMixin):
+  # This is both a NativeTool (for the graal native image of zinc), _and_ a Subsystem by its own
+  # right. We're not allowed to explicitly inherit from both because of MRO.
+  class Factory(JvmToolMixin, NativeTool):
     options_scope = 'zinc'
+
+    # version and allow_version_override need to be set like this so that Zinc can act as a
+    # NativeTool.
+    # NativeTool requires that there is an options scope with at least one option registered on the
+    # class.
+    # Because we don't want to allow version overrides, and instead want to pin the Zinc
+    # native-image version to be the same as the Zinc version we use everywhere else, we either need
+    # to put the NativeTool on an existing options scope (this one makes sense!), or we'd need to
+    # make an options scope with a dummy option just for the ZincNativeImage NativeTool.
+    # Because the native image's version is tightly coupled to this class, and zinc is the options
+    # scope we'd want to pick for it, we just put these details here.
+
+    allow_version_override = False
+
+    def version(self, context=None):
+      return _ZINC_COMPILER_VERSION
 
     @classmethod
     def subsystem_dependencies(cls):
@@ -85,7 +106,7 @@ class Zinc(object):
       cls.register_jvm_tool(register,
                             Zinc.ZINC_COMPILER_TOOL_NAME,
                             classpath=[
-                              JarDependency('org.pantsbuild', 'zinc-compiler_2.11', '0.0.9'),
+                              JarDependency('org.pantsbuild', 'zinc-compiler_2.11', _ZINC_COMPILER_VERSION),
                             ],
                             main=Zinc.ZINC_COMPILE_MAIN,
                             custom_rules=shader_rules)
@@ -195,6 +216,10 @@ class Zinc(object):
     :rtype: list of str
     """
     return self._zinc_factory._zinc(self._products)
+
+  @memoized_method
+  def native_image(self, context):
+    return self._zinc_factory.hackily_snapshot(context)
 
   @memoized_property
   def dist(self):

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -79,6 +79,8 @@ class Zinc(object):
     @classmethod
     def register_options(cls, register):
       super(Zinc.Factory, cls).register_options(register)
+      register('--native-image', fingerprint=True, type=bool,
+        help='Use a pre-compiled native-image for zinc. Requires running in hermetic mode')
 
       zinc_rev = '1.0.3'
 
@@ -216,6 +218,10 @@ class Zinc(object):
     :rtype: list of str
     """
     return self._zinc_factory._zinc(self._products)
+
+  @property
+  def use_native_image(self):
+    return self._zinc_factory.get_options().native_image
 
   @memoized_method
   def native_image(self, context):

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -53,22 +53,7 @@ class Zinc(object):
   # right. We're not allowed to explicitly inherit from both because of MRO.
   class Factory(JvmToolMixin, NativeTool):
     options_scope = 'zinc'
-
-    # version and allow_version_override need to be set like this so that Zinc can act as a
-    # NativeTool.
-    # NativeTool requires that there is an options scope with at least one option registered on the
-    # class.
-    # Because we don't want to allow version overrides, and instead want to pin the Zinc
-    # native-image version to be the same as the Zinc version we use everywhere else, we either need
-    # to put the NativeTool on an existing options scope (this one makes sense!), or we'd need to
-    # make an options scope with a dummy option just for the ZincNativeImage NativeTool.
-    # Because the native image's version is tightly coupled to this class, and zinc is the options
-    # scope we'd want to pick for it, we just put these details here.
-
-    allow_version_override = False
-
-    def version(self, context=None):
-      return _ZINC_COMPILER_VERSION
+    default_version = _ZINC_COMPILER_VERSION
 
     @classmethod
     def subsystem_dependencies(cls):

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -53,7 +53,10 @@ class Zinc(object):
   # right. We're not allowed to explicitly inherit from both because of MRO.
   class Factory(JvmToolMixin, NativeTool):
     options_scope = 'zinc'
+
+    # NB: These two properties are consumed by the NativeTool mixin.
     default_version = _ZINC_COMPILER_VERSION
+    name = 'zinc-pants-native-image'
 
     @classmethod
     def subsystem_dependencies(cls):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -36,7 +36,7 @@ from pants.util.contextutil import open_zip
 from pants.util.dirutil import fast_relpath, safe_open
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.meta import classproperty
-from pants.util.strutil import ensure_text, safe_shlex_join
+from pants.util.strutil import ensure_text
 
 
 # Well known metadata file required to register scalac plugins with nsc.
@@ -392,23 +392,10 @@ class BaseZincCompile(JvmCompile):
         fp.write(arg)
         fp.write('\n')
 
-    def compile_hermetic():
-      if jvm_options:
-        raise ValueError(
-          "zinc_compile got non-empty jvm_options when running with a graal native-image, but this "
-          "is unsupported. jvm_options received: {}".format(safe_shlex_join(jvm_options))
-        )
-      return self._compile_hermetic(
-        ctx,
-        classes_dir,
-        zinc_args,
-        compiler_bridge_classpath_entry,
-        dependency_classpath,
-        scalac_classpath_entries,
-      )
-
     return self.execution_strategy_enum.resolve_for_enum_variant({
-      self.HERMETIC: compile_hermetic,
+      self.HERMETIC: lambda: self._compile_hermetic(
+        jvm_options, ctx, classes_dir, zinc_args, compiler_bridge_classpath_entry,
+        dependency_classpath, scalac_classpath_entries),
       self.SUBPROCESS: lambda: self._compile_nonhermetic(jvm_options, zinc_args),
       self.NAILGUN: lambda: self._compile_nonhermetic(jvm_options, zinc_args),
     })()
@@ -427,7 +414,7 @@ class BaseZincCompile(JvmCompile):
     if exit_code != 0:
       raise self.ZincCompileError('Zinc compile failed.', exit_code=exit_code)
 
-  def _compile_hermetic(self, ctx, classes_dir, zinc_args,
+  def _compile_hermetic(self, jvm_options, ctx, classes_dir, zinc_args,
                         compiler_bridge_classpath_entry, dependency_classpath,
                         scalac_classpath_entries):
     zinc_relpath = fast_relpath(self._zinc.zinc, get_buildroot())
@@ -453,20 +440,30 @@ class BaseZincCompile(JvmCompile):
       classpath_entry.directory_digest for classpath_entry in scalac_classpath_entries
     )
 
-    native_image_path, native_image_snapshot = self._zinc.native_image(self.context)
+    if self._zinc.use_native_image:
+      native_image_path, native_image_snapshot = self._zinc.native_image(self.context)
+      additional_snapshots = (native_image_snapshot.directory_digest,)
+      image_specific_argv =  [
+        native_image_path,
+        '-java-home', '.jdk',
+      ]
+    else:
+      additional_snapshots = ()
+      image_specific_argv =  ['.jdk/bin/java'] + jvm_options + [
+        '-cp', zinc_relpath,
+        Zinc.ZINC_COMPILE_MAIN
+      ]
 
     # TODO: Extract something common from Executor._create_command to make the command line
     # TODO: Lean on distribution for the bin/java appending here
     merged_input_digest = self.context._scheduler.merge_directories(
       tuple(s.directory_digest for s in snapshots) +
       directory_digests +
-      (native_image_snapshot.directory_digest,)
+      additional_snapshots
     )
-    argv = [
-      native_image_path,
-      '-cp', zinc_relpath,
-      '-java-home', '.jdk',
-    ] + zinc_args
+
+
+    argv = image_specific_argv + zinc_args
     # TODO(#6071): Our ExecuteProcessRequest expects a specific string type for arguments,
     # which py2 doesn't default to. This can be removed when we drop python 2.
     argv = [text_type(arg) for arg in argv]

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -182,6 +182,17 @@ class BinaryToolBase(Subsystem):
     binary_request = self._make_binary_request(version)
     return self._binary_util.select(binary_request)
 
+  def hackily_snapshot(self, context):
+    bootstrapdir = self.get_options().pants_bootstrapdir
+    relpath = os.path.relpath(self.select(context), bootstrapdir)
+    snapshot = context._scheduler.capture_snapshots((
+      PathGlobsAndRoot(
+        PathGlobs((relpath,)),
+        text_type(bootstrapdir),
+      ),
+    ))[0]
+    return (relpath, snapshot)
+
 
 class NativeTool(BinaryToolBase):
   """A base class for native-code tools.
@@ -197,17 +208,6 @@ class Script(BinaryToolBase):
   :API: public
   """
   platform_dependent = False
-
-  def hackily_snapshot(self, context):
-    bootstrapdir = self.get_options().pants_bootstrapdir
-    script_relpath = os.path.relpath(self.select(context), bootstrapdir)
-    snapshot = context._scheduler.capture_snapshots((
-      PathGlobsAndRoot(
-        PathGlobs((script_relpath,)),
-        text_type(bootstrapdir),
-      ),
-    ))[0]
-    return (script_relpath, snapshot)
 
 
 class XZ(NativeTool):

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -50,8 +50,6 @@ class BinaryToolBase(Subsystem):
   # Subclasses may set this to provide extra register() kwargs for the --version option.
   extra_version_option_kwargs = None
 
-  allow_version_override = True
-
   @classmethod
   def subsystem_dependencies(cls):
     sub_deps = super(BinaryToolBase, cls).subsystem_dependencies() + (BinaryUtil.Factory,)
@@ -101,22 +99,21 @@ class BinaryToolBase(Subsystem):
   def register_options(cls, register):
     super(BinaryToolBase, cls).register_options(register)
 
-    if cls.allow_version_override:
-      version_registration_kwargs = {
-        'type': str,
-        'default': cls.default_version,
-      }
-      if cls.extra_version_option_kwargs:
-        version_registration_kwargs.update(cls.extra_version_option_kwargs)
-      version_registration_kwargs['help'] = (
-        version_registration_kwargs.get('help') or
-        'Version of the {} {} to use'.format(cls._get_name(),
-                                             'binary' if cls.platform_dependent else 'script')
-      )
-      # The default for fingerprint in register() is False, but we want to default to True.
-      if 'fingerprint' not in version_registration_kwargs:
-        version_registration_kwargs['fingerprint'] = True
-      register('--version', **version_registration_kwargs)
+    version_registration_kwargs = {
+      'type': str,
+      'default': cls.default_version,
+    }
+    if cls.extra_version_option_kwargs:
+      version_registration_kwargs.update(cls.extra_version_option_kwargs)
+    version_registration_kwargs['help'] = (
+      version_registration_kwargs.get('help') or
+      'Version of the {} {} to use'.format(cls._get_name(),
+                                           'binary' if cls.platform_dependent else 'script')
+    )
+    # The default for fingerprint in register() is False, but we want to default to True.
+    if 'fingerprint' not in version_registration_kwargs:
+      version_registration_kwargs['fingerprint'] = True
+    register('--version', **version_registration_kwargs)
 
   @memoized_method
   def select(self, context=None):

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -50,6 +50,8 @@ class BinaryToolBase(Subsystem):
   # Subclasses may set this to provide extra register() kwargs for the --version option.
   extra_version_option_kwargs = None
 
+  allow_version_override = True
+
   @classmethod
   def subsystem_dependencies(cls):
     sub_deps = super(BinaryToolBase, cls).subsystem_dependencies() + (BinaryUtil.Factory,)
@@ -99,21 +101,22 @@ class BinaryToolBase(Subsystem):
   def register_options(cls, register):
     super(BinaryToolBase, cls).register_options(register)
 
-    version_registration_kwargs = {
-      'type': str,
-      'default': cls.default_version,
-    }
-    if cls.extra_version_option_kwargs:
-      version_registration_kwargs.update(cls.extra_version_option_kwargs)
-    version_registration_kwargs['help'] = (
-      version_registration_kwargs.get('help') or
-      'Version of the {} {} to use'.format(cls._get_name(),
-                                           'binary' if cls.platform_dependent else 'script')
-    )
-    # The default for fingerprint in register() is False, but we want to default to True.
-    if 'fingerprint' not in version_registration_kwargs:
-      version_registration_kwargs['fingerprint'] = True
-    register('--version', **version_registration_kwargs)
+    if cls.allow_version_override:
+      version_registration_kwargs = {
+        'type': str,
+        'default': cls.default_version,
+      }
+      if cls.extra_version_option_kwargs:
+        version_registration_kwargs.update(cls.extra_version_option_kwargs)
+      version_registration_kwargs['help'] = (
+        version_registration_kwargs.get('help') or
+        'Version of the {} {} to use'.format(cls._get_name(),
+                                             'binary' if cls.platform_dependent else 'script')
+      )
+      # The default for fingerprint in register() is False, but we want to default to True.
+      if 'fingerprint' not in version_registration_kwargs:
+        version_registration_kwargs['fingerprint'] = True
+      register('--version', **version_registration_kwargs)
 
   @memoized_method
   def select(self, context=None):


### PR DESCRIPTION
This will not work with remoting across platforms yet.
This will depend on a native image being uploaded to binaries.pantsbuild.org

Some pieces of this are a little ugly, but the options system kind of forces them to be. I don't want to do a significant restructure of BinaryUtil because #7790 would probably replace it anyway...

Commits are separately useful.