### PR TITLE
Fix doc bug for `--fast` in testrunner_task_mixin

### DIFF
--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -408,7 +408,7 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
     # https://github.com/pantsbuild/pants/issues/5073
 
     register('--fast', type=bool, default=True, fingerprint=True,
-             help='Run all tests in a single pytest invocation. If turned off, each test target '
+             help='Run all tests in a single invocation. If turned off, each test target '
                   'will run in its own pytest invocation, which will be slower, but isolates '
                   'tests from process-wide state created by tests in other targets.')
     register('--chroot', advanced=True, fingerprint=True, type=bool, default=False,

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -409,7 +409,7 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
 
     register('--fast', type=bool, default=True, fingerprint=True,
              help='Run all tests in a single invocation. If turned off, each test target '
-                'will run in its own invocation, which will be slower, but isolates '
+                  'will run in its own invocation, which will be slower, but isolates '
                   'tests from process-wide state created by tests in other targets.')
     register('--chroot', advanced=True, fingerprint=True, type=bool, default=False,
              help='Run tests in a chroot. Any loose files tests depend on via `{}` dependencies '

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -94,7 +94,7 @@ class TestResult(object):
 class TestRunnerTaskMixin(object):
   """A mixin to combine with test runner tasks.
 
-  The intent is to migrate logic over time out of JUnitRun and PytestRun, so the functionality
+  The intent is to migrate logic over time out of JUnitRun and pytestRun, so the functionality
   expressed can support both languages, and any additional languages that are added to pants.
   """
 
@@ -409,7 +409,7 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
 
     register('--fast', type=bool, default=True, fingerprint=True,
              help='Run all tests in a single invocation. If turned off, each test target '
-                  'will run in its own pytest invocation, which will be slower, but isolates '
+                'will run in its own invocation, which will be slower, but isolates '
                   'tests from process-wide state created by tests in other targets.')
     register('--chroot', advanced=True, fingerprint=True, type=bool, default=False,
              help='Run tests in a chroot. Any loose files tests depend on via `{}` dependencies '

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -94,7 +94,7 @@ class TestResult(object):
 class TestRunnerTaskMixin(object):
   """A mixin to combine with test runner tasks.
 
-  The intent is to migrate logic over time out of JUnitRun and pytestRun, so the functionality
+  The intent is to migrate logic over time out of JUnitRun and PytestRun, so the functionality
   expressed can support both languages, and any additional languages that are added to pants.
   """
 


### PR DESCRIPTION

### Problem
JUnit (and other test runners) claims to use PyTest.

### Solution

Don't claim to use python.

### Result

Humans get less confused.