### PR TITLE
Write output from JUnit ConsoleRunner when process is terminated

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
@@ -453,8 +453,9 @@ class AntJunitXmlReportListener extends RunListener {
     if (suite != null) {
       suite.incrementSkipped();
       // Ignored tests don't have testStarted and testFinished callbacks so call finish here.
-      if (!suite.wasStarted()) suite.tests++;
       suite.finished();
+      // finished() counts only started tests, so count ignored tests here so the totals are correct
+      if (!suite.wasStarted()) suite.tests++;
     }
 
     TestCase testCase = getTestCaseFor(description);

--- a/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
@@ -424,6 +424,7 @@ class AntJunitXmlReportListener extends RunListener {
         if (suite != null) {
           suite.testCases.clear();
           suite.testCases.add(testCase);
+          suite.tests = 1;
           suite.finished();
         }
       } else {
@@ -452,6 +453,7 @@ class AntJunitXmlReportListener extends RunListener {
     if (suite != null) {
       suite.incrementSkipped();
       // Ignored tests don't have testStarted and testFinished callbacks so call finish here.
+      if (!suite.wasStarted()) suite.tests++;
       suite.finished();
     }
 

--- a/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
@@ -13,8 +13,6 @@ import java.io.File;
 import java.io.FilterWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -305,9 +303,9 @@ class AntJunitXmlReportListener extends RunListener {
     }
 
     public void finished() {
-      tests++;
       if (startNs != 0) {
         time = convertTimeSpanNs(System.nanoTime() - startNs);
+        tests++;
       } else {
         time = "0";
       }
@@ -489,6 +487,7 @@ class AntJunitXmlReportListener extends RunListener {
   public void testRunFinished(Result result) throws java.lang.Exception {
     for (TestSuite suite : suites.values()) {
       if (suite.wasStarted() && suite.testClass != null) {
+        streamSource.close(suite.testClass); // may not be closed if we're abnormally terminating
         suite.setOut(new String(streamSource.readOut(suite.testClass), Charsets.UTF_8));
         suite.setErr(new String(streamSource.readErr(suite.testClass), Charsets.UTF_8));
       }

--- a/src/java/org/pantsbuild/tools/junit/impl/ShutdownListener.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ShutdownListener.java
@@ -16,11 +16,11 @@ import org.junit.runner.notification.RunListener;
 public class ShutdownListener extends RunListener {
   private final Result result = new Result();
   private final RunListener resultListener = result.createListener();
+  // holds running tests: Descriptions are added on testStarted and removed on testFinished
   private ConcurrentHashMap.KeySetView<Description, Boolean> currentDescriptions =
     ConcurrentHashMap.newKeySet();
   private RunListener underlying;
-  private static Throwable abnormalExit =
-    new UnknownError("Abnormal VM exit - test crashed. The test run may have timed out.");
+
 
   public ShutdownListener(RunListener underlying) {
     this.underlying = underlying;
@@ -40,7 +40,8 @@ public class ShutdownListener extends RunListener {
   }
 
   private void completeTestWithFailure(Description description) {
-    Failure shutdownFailure = new Failure(description, abnormalExit);
+    Failure shutdownFailure = new Failure(description,
+      new UnknownError("Abnormal VM exit - test crashed. The test run may have timed out."));
 
     try {
       // Mark this test as completed with a failure (finish its lifecycle)

--- a/src/java/org/pantsbuild/tools/junit/impl/ShutdownListener.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ShutdownListener.java
@@ -3,71 +3,88 @@
 
 package org.pantsbuild.tools.junit.impl;
 
-import java.io.PrintStream;
+import java.util.concurrent.ConcurrentHashMap;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 
 /**
- * A listener that keeps track of the current test state with its own result class so it can print
+ * A listener that keeps track of the current test state with its own result class so it can record
  * the state of tests being run if there is unexpected exit during the tests.
  */
-public class ShutdownListener extends ConsoleListener {
+public class ShutdownListener extends RunListener {
   private final Result result = new Result();
   private final RunListener resultListener = result.createListener();
-  private Description currentTestDescription;
+  private ConcurrentHashMap.KeySetView<Description, Boolean> currentDescriptions =
+    ConcurrentHashMap.newKeySet();
+  private RunListener underlying;
+  private static Throwable abnormalExit =
+    new UnknownError("Abnormal VM exit - test crashed. The test run may have timed out.");
 
-  public ShutdownListener(PrintStream out) {
-    super(out);
+  public ShutdownListener(RunListener underlying) {
+    this.underlying = underlying;
   }
 
   public void unexpectedShutdown() {
-    if (currentTestDescription != null) {
-      Failure shutdownFailure = new Failure(currentTestDescription,
-          new UnknownError("Abnormal VM exit - test crashed."));
-      testFailure(shutdownFailure);
+    for(Description description : currentDescriptions) {
+      completeTestWithFailure(description);
     }
 
-    // Log the test summary to the Console
-    super.testRunFinished(result);
+    try {
+      resultListener.testRunFinished(result);
+      underlying.testRunFinished(result);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void completeTestWithFailure(Description description) {
+    Failure shutdownFailure = new Failure(description, abnormalExit);
+
+    try {
+      // Mark this test as completed with a failure (finish its lifecycle)
+      resultListener.testFailure(shutdownFailure);
+      resultListener.testFinished(description);
+      underlying.testFailure(shutdownFailure);
+      underlying.testFinished(description);
+    } catch (Exception ignored){}
   }
 
   @Override
   public void testRunStarted(Description description) throws Exception {
-    this.currentTestDescription = description;
     resultListener.testRunStarted(description);
   }
 
   @Override
-  public void testRunFinished(Result result) {
-    try {
-      resultListener.testRunFinished(result);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+  public void testStarted(Description description) throws Exception {
+    currentDescriptions.add(description);
+    resultListener.testStarted(description);
+  }
+
+  @Override
+  public void testAssumptionFailure(Failure failure) {
+    resultListener.testAssumptionFailure(failure);
+  }
+
+  @Override
+  public void testRunFinished(Result result) throws Exception {
+    resultListener.testRunFinished(result);
   }
 
   @Override
   public void testFinished(Description description) throws Exception {
+    currentDescriptions.remove(description);
     resultListener.testFinished(description);
   }
 
   @Override
-  public void testFailure(Failure failure) {
-    try {
-      resultListener.testFailure(failure);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+  public void testFailure(Failure failure) throws Exception {
+    resultListener.testFailure(failure);
   }
 
   @Override
-  public void testIgnored(Description description) {
-    try {
-      resultListener.testIgnored(description);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+  public void testIgnored(Description description) throws Exception {
+    resultListener.testIgnored(description);
   }
 }

--- a/src/java/org/pantsbuild/tools/junit/impl/StreamSource.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/StreamSource.java
@@ -27,4 +27,12 @@ interface StreamSource {
    * @throws IOException If there is a problem retrieving the output.
    */
   byte[] readErr(Class<?> testClass) throws IOException;
+
+  /**
+   * Releases the output stream resources for the test class run.
+   *
+   * @param testClass The test class to close the captured output for.
+   * @throws IOException If there is a problem closing the stream.
+   */
+  void close(Class<?> testClass) throws IOException;
 }

--- a/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
@@ -7,6 +7,7 @@ import com.google.common.base.Charsets;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -26,6 +27,7 @@ import org.pantsbuild.tools.junit.lib.ParallelMethodsDefaultParallelTest1;
 import org.pantsbuild.tools.junit.lib.ParallelTest1;
 import org.pantsbuild.tools.junit.lib.SerialTest1;
 import org.pantsbuild.tools.junit.lib.TestRegistry;
+import org.pantsbuild.tools.junit.lib.XmlOutputOnShutdownTest;
 
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -186,6 +188,36 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestBase {
     assertThat(output, containsString("test41"));
     assertThat(output, containsString("start test42"));
     assertThat(output, containsString("end test42"));
+  }
+
+  @Test
+  public void testXmlOutputOnShutdown() throws Exception {
+    String outdir = temporary.newFolder("testOutputDir").getAbsolutePath();
+    ConsoleRunnerImpl runner =
+      prepareConsoleRunner("XmlOutputOnShutdownTest -xmlreport -outdir " + outdir);
+
+    Thread runningTests = new Thread(){
+      @Override public void run() {
+        runner.run();
+      }
+    };
+
+    XmlOutputOnShutdownTest.setUpLatch();
+    runningTests.start();
+    XmlOutputOnShutdownTest.testStarted.await(2, TimeUnit.SECONDS);
+    runner.runShutdownHooks();
+
+    String testsCalled = TestRegistry.getCalledTests();
+    assertThat(testsCalled, containsString("hangs"));
+
+    String testClassName = XmlOutputOnShutdownTest.class.getCanonicalName();
+    String xmlOutput = FileUtils.readFileToString(
+        new File(outdir, "TEST-" + testClassName + ".xml"), Charsets.UTF_8);
+    assertThat(xmlOutput, containsString("errors=\"1\""));
+    assertThat(xmlOutput, containsString("tests=\"1\""));
+    assertThat(xmlOutput, containsString("The test run may have timed out."));
+
+    runningTests.interrupt();
   }
 
   @Test

--- a/tests/java/org/pantsbuild/tools/junit/lib/ConsoleRunnerTestBase.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/ConsoleRunnerTestBase.java
@@ -99,6 +99,13 @@ public abstract class ConsoleRunnerTestBase {
    * test runner.
    */
   protected void invokeConsoleRunner(String argsString) {
+    prepareConsoleRunner(argsString).run();
+  }
+
+  /**
+   * As invokeConsoleRunner, but returns a ConsoleRunnerImpl ready for calling run() on.
+   */
+  protected ConsoleRunnerImpl prepareConsoleRunner(String argsString) {
     List<String> testArgs = new ArrayList<String>();
     for (String arg : Splitter.on(" ").split(argsString)) {
       // Prepend the package name to tests to allow shorthand command line invocation
@@ -123,9 +130,9 @@ public abstract class ConsoleRunnerTestBase {
     if (!testArgs.contains(USE_EXPERIMENTAL_RUNNER_FLAG) && parameters.useExperimentalRunner) {
       testArgs.add(USE_EXPERIMENTAL_RUNNER_FLAG);
     }
-    System.out.println("Invoking ConsoleRunnerImpl.main(\""
+    System.out.println("Invoking ConsoleRunnerImpl.mainImpl(\""
         + Joiner.on(' ').join(testArgs) + "\")");
 
-    ConsoleRunnerImpl.main(testArgs.toArray(new String[testArgs.size()]));
+    return ConsoleRunnerImpl.mainImpl(testArgs.toArray(new String[testArgs.size()]));
   }
 }

--- a/tests/java/org/pantsbuild/tools/junit/lib/XmlOutputOnShutdownTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/XmlOutputOnShutdownTest.java
@@ -1,0 +1,36 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+package org.pantsbuild.tools.junit.lib;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+/**
+ * This test is intentionally under a java_library() BUILD target so it will not be run
+ * on its own. It is run by the ConsoleRunnerTest suite to test ConsoleRunnerImpl.
+ * <p>
+ * This test is intended to show that XML test output will be written to disk even when
+ * the JUnit process is terminated (usually due to a Pants default test timeout).
+ * It registers itself, releases a static lock the caller is awaiting, then blocks itself.
+ * This allows the actual test to control this test's progression and make assertions about
+ * output written from the test runner.
+ * </p>
+ */
+public class XmlOutputOnShutdownTest {
+  private static CountDownLatch never = new CountDownLatch(1);
+  public static CountDownLatch testStarted;
+
+  public static void setUpLatch() {
+    testStarted = new CountDownLatch(1);
+  }
+
+  @Test
+  public void hangs() throws InterruptedException {
+    TestRegistry.registerTestCall("hangs");
+    testStarted.countDown();
+    // testXmlOutputOnShutdown interrupts this thread, so ignore that eventuality
+    never.await(2, TimeUnit.SECONDS);
+  }
+}


### PR DESCRIPTION
### Problem

Pants enforces test timeouts for JVM JUnit tests by terminating the JVM process (usually sending SIGINT). When this happens today, test output is not consistently written out. In particular, XML output from AntJunitXmlReportListener will not be written.

Unfortunately, this means test tooling that relies on this XML cannot accurately report test results when the global timeout (usually set with --test-junit-timeout-default) is reached.

### Solution

Add a JVM shutdown hook to write out test results on JVM termination.

### Result

JUnit test results are available even when Pants times out on a given test run.

### Notes

This branch also makes the following changes in support of this:
* Adds close() to the StreamSource interface to ensure we can close output streams before using their values, and uses it
* Modifies ConsoleRunnerImpl to improve testability (as might be expected, it's tricky to test behavior triggered on SIGINT)
* Generalizes and simplifies ShutdownListener so that it:
  - Supports parallel test execution
  - Tracks result state across the entire lifecycle
  - Delegates its work instead of extending ConsoleListener
* Adjusts the counting of tests in AntJunitXmlReportListener to be accurate in the face of abnormal termination
