### PR TITLE
Add scalastyle to the v2 unit test blacklist

### DIFF
--- a/build-support/unit_test_v2_blacklist.txt
+++ b/build-support/unit_test_v2_blacklist.txt
@@ -5,5 +5,6 @@ tests/python/pants_test/backend/jvm/tasks:consolidate_classpath
 tests/python/pants_test/backend/jvm/tasks:coursier_resolve
 tests/python/pants_test/backend/jvm/tasks:ivy_utils
 tests/python/pants_test/backend/jvm/tasks:scalafmt
+tests/python/pants_test/backend/jvm/tasks:scalastyle
 tests/python/pants_test/backend/python/tasks:pytest_run
 tests/python/pants_test/cache:artifact_cache


### PR DESCRIPTION
### Problem

I don't repro a failure locally, but this one has failed in two PRs recently. I'm guessing that there is a concurrency issue with creating lots of nailgun servers at once (I think that the hermetic API does not defend against, unfortunately).

### Solution

Blacklist to run under v1 (ie, without concurrency).