### PR TITLE
Always use the global interpreter for PythonExecutionTaskBase.

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_prep.py
+++ b/src/python/pants/backend/python/tasks/pytest_prep.py
@@ -100,7 +100,7 @@ class PytestPrep(PythonExecutionTaskBase):
       return
     pex_info = PexInfo.default()
     pex_info.entry_point = 'pytest'
-    pytest_binary = self.create_pex(pex_info, pin_selected_interpreter=True)
+    pytest_binary = self.create_pex(pex_info)
     interpreter = self.context.products.get_data(PythonInterpreter)
     self.context.products.register_data(self.PytestBinary,
                                         self.PytestBinary(interpreter, pytest_binary))

--- a/src/python/pants/backend/python/tasks/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks/python_execution_task_base.py
@@ -11,7 +11,6 @@ from future.utils import binary_type, text_type
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 
-from pants.backend.python.subsystems.pex_build_util import is_python_target
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_distribution import PythonDistribution
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
@@ -83,12 +82,12 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
     """
     return ()
 
-  # TODO: remove `pin_selected_interpreter` arg and constrain all resulting pexes to a single ==
-  # interpreter constraint for the globally selected interpreter! This also requries porting
-  # `PythonRun` to set 'PEX_PYTHON_PATH' and 'PEX_PYTHON' when invoking the resulting pex, see
-  # https://github.com/pantsbuild/pants/pull/7563.
-  def create_pex(self, pex_info=None, pin_selected_interpreter=False):
+  def create_pex(self, pex_info=None):
     """Returns a wrapped pex that "merges" other pexes produced in previous tasks via PEX_PATH.
+
+    This method always creates a PEX to run locally on the current platform and selected
+    interpreter: to create a pex that is distributable to other environments, use the pex_build_util
+    Subsystem.
 
     The returned pex will have the pexes from the ResolveRequirements and GatherSources tasks mixed
     into it via PEX_PATH. Any 3rdparty requirements declared with self.extra_requirements() will
@@ -96,9 +95,6 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
 
     :param pex_info: An optional PexInfo instance to provide to self.merged_pex().
     :type pex_info: :class:`pex.pex_info.PexInfo`, or None
-    :param bool pin_selected_interpreter: If True, the produced pex will have a single ==
-                                          interpreter constraint applied to it, for the global
-                                          interpreter selected by the SelectInterpreter
     task. Otherwise, all of the interpreter constraints from all python targets will applied.
     :rtype: :class:`pex.pex.PEX`
     """
@@ -134,16 +130,8 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
           # in the target set's dependency closure.
           pexes = [extra_requirements_pex] + pexes
 
-        if pin_selected_interpreter:
-          constraints = {str(interpreter.identity.requirement)}
-        else:
-          constraints = {
-            constraint for rt in relevant_targets if is_python_target(rt)
-            for constraint in PythonSetup.global_instance().compatibility_or_constraints(rt.compatibility)
-          }
-          self.context.log.debug('target set {} has constraints: {}'
-                                 .format(relevant_targets, constraints))
-
+        # NB: See docstring. We always use the previous selected interpreter.
+        constraints = {str(interpreter.identity.requirement)}
 
         with self.merged_pex(path, pex_info, interpreter, pexes, constraints) as builder:
           for extra_file in self.extra_files():

--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -56,6 +56,7 @@ class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
 
   def _run_repl(self, pex, **pex_run_kwargs):
     env = pex_run_kwargs.pop('env', os.environ).copy()
+    env.update(self.ensure_interpreter_search_path_env())
     pex.run(env=env, **pex_run_kwargs)
 
   # N.B. **pex_run_kwargs is used by tests only.

--- a/src/python/pants/backend/python/tasks/python_run.py
+++ b/src/python/pants/backend/python/tasks/python_run.py
@@ -40,12 +40,15 @@ class PythonRun(PythonExecutionTaskBase):
         args.extend(safe_shlex_split(arg))
       args += self.get_passthru_args()
 
+      env = os.environ.copy()
+      env.update(self.ensure_interpreter_search_path_env())
+
       self.context.release_lock()
       cmdline = ' '.join(pex.cmdline(args))
       with self.context.new_workunit(name='run',
                                      cmd=cmdline,
                                      labels=[WorkUnitLabel.TOOL, WorkUnitLabel.RUN]):
-        po = pex.run(blocking=False, args=args, env=os.environ.copy())
+        po = pex.run(blocking=False, args=args, env=env)
         try:
           result = po.wait()
           if result != 0:

--- a/testprojects/src/python/interpreter_selection/python_3_selection_testing/BUILD
+++ b/testprojects/src/python/interpreter_selection/python_3_selection_testing/BUILD
@@ -21,7 +21,10 @@ python_binary(
   source='main_py3.py',
   compatibility=['CPython>3'],
   dependencies=[
-    ':lib_py3'
+    # We depend on libraries with both narrow and wide ranges in order to confirm that the narrower
+    # range is the one selected.
+    ':lib_py3',
+    ':lib_py23',
   ]
 )
 
@@ -47,7 +50,10 @@ python_binary(
   source='main_py2.py',
   compatibility=['CPython>2.7.6,<3'],
   dependencies=[
-    ':lib_py2'
+    # We depend on libraries with both narrow and wide ranges in order to confirm that the narrower
+    # range is the one selected.
+    ':lib_py2',
+    ':lib_py23',
   ]
 )
 

--- a/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
@@ -143,14 +143,14 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
           config=pants_ini_config
         )
         self.assert_success(pants_run_27)
-        self.assertIn(py27_path, pants_run_27.stdout_data)
+        self.assertIn('I am a python 2 library method.', pants_run_27.stdout_data)
         pants_run_3 = self.run_pants(
           command=['run', '{}:main_py3'.format(os.path.join(self.testproject,
                                                             'python_3_selection_testing'))],
           config=pants_ini_config
         )
         self.assert_success(pants_run_3)
-        self.assertIn(py3_path, pants_run_3.stdout_data)
+        self.assertIn('I am a python 3 library method.', pants_run_3.stdout_data)
 
   @skip_unless_python27_and_python3_present
   def test_pants_binary_interpreter_selection_with_pexrc(self):


### PR DESCRIPTION
### Problem

The problems observed in #7775 and #7563 had a third (and hopefully final: I'll audit before we land this) buddy in the `PythonRun` case.

The tests in https://github.com/pantsbuild/pants/blob/817f7f6aedad8143fe7b2cf86559019254230da4/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py#L134-L184 attempt to cover this case, but they were not using mixed contexts (contexts containing `(2-or-3, 3-only)` and `(2-only, 2-or-3)` constraints). 

### Solution

Similar to #7775 and #7563, do not include transitive constraints when `./pants run`ing a binary. Clarify the documentation of `PythonExecutionTaskBase`. Expand coverage of the mixed context case in existing tests.

### Result

The tests linked above fail before this change for `PythonRun`, and succeed afterward.