### PR TITLE
Add generic --passthrough-args support.

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -118,7 +118,8 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
     #   https://github.com/pantsbuild/pants/issues/7802
     register('--options', type=list, fingerprint=True,
              removal_version='1.19.0.dev2',
-             removal_hint='Use the `--passthrough-args` option instead.',
+             removal_hint='Use the `--passthrough-args` option instead. You my need to remove'
+                          'some argument quoting when converting.',
              help='Pass these options to pytest. You can also use pass-through args.')
 
     register('--coverage', fingerprint=True,

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -113,8 +113,14 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
                   "emitted to that file (prefix). Note that tests may run in a different cwd, so "
                   "it's best to use an absolute path to make it easy to find the subprocess "
                   "profiles later.")
+
+    # TODO(John Sirois): Remove this option. The cleanup work is tracked in:
+    #   https://github.com/pantsbuild/pants/issues/7802
     register('--options', type=list, fingerprint=True,
+             removal_version='1.19.0.dev2',
+             removal_hint='Use the `--passthrough-args` option instead.',
              help='Pass these options to pytest. You can also use pass-through args.')
+
     register('--coverage', fingerprint=True,
              help='Emit coverage information for specified packages or directories (absolute or '
                   'relative to the build root).  The special value "auto" indicates that Pants '

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -31,7 +31,6 @@ from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 from pants.util.dirutil import safe_mkdir, safe_rm_oldest_items_in_dir
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.meta import AbstractClass, classproperty
-from pants.util.strutil import safe_shlex_split
 
 
 class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
@@ -214,8 +213,7 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
       raise TaskError('{} Does not support passthru args.'.format(self.stable_name()))
 
     passthru_args = []
-    for arg in self.get_options().get('passthrough_args', default=()):
-      passthru_args.extend(safe_shlex_split(arg))
+    passthru_args.extend(self.get_options().get('passthrough_args', default=()))
     passthru_args.extend(self.context.options.passthru_args_for_scope(self.options_scope))
     return passthru_args
 

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -31,6 +31,7 @@ from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 from pants.util.dirutil import safe_mkdir, safe_rm_oldest_items_in_dir
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.meta import AbstractClass, classproperty
+from pants.util.strutil import safe_shlex_split
 
 
 class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
@@ -121,6 +122,18 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     return False
 
   @classmethod
+  def register_options(cls, register):
+    super(TaskBase, cls).register_options(register)
+    if cls.supports_passthru_args():
+      register('--passthrough-args',
+               type=list,
+               advanced=True,
+               fingerprint=True,
+               help='Pass these options as pass-through args; ie: as if by appending '
+                    '`-- <passthrough arg> ...` to the command line. Any passthrough args actually'
+                    'supplied on the command line will be used as well.')
+
+  @classmethod
   def _scoped_options(cls, options):
     return options[cls.options_scope]
 
@@ -198,9 +211,13 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     :API: public
     """
     if not self.supports_passthru_args():
-      raise TaskError('{0} Does not support passthru args.'.format(self.stable_name()))
-    else:
-      return self.context.options.passthru_args_for_scope(self.options_scope)
+      raise TaskError('{} Does not support passthru args.'.format(self.stable_name()))
+
+    passthru_args = []
+    for arg in self.get_options().get('passthrough_args', default=()):
+      passthru_args.extend(safe_shlex_split(arg))
+    passthru_args.extend(self.context.options.passthru_args_for_scope(self.options_scope))
+    return passthru_args
 
   @property
   def skip_execution(self):
@@ -255,7 +272,7 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
 
     if not self.target_filtering_enabled:
       return initial_targets
-    else: 
+    else:
       return self._filter_targets(initial_targets)
 
   def _filter_targets(self, targets):

--- a/tests/python/pants_test/task/test_task.py
+++ b/tests/python/pants_test/task/test_task.py
@@ -549,20 +549,20 @@ files(
     versioned_fake = self._synth_fp(_impls=[('asdf', 0)])
     base_version_other_fake = self._synth_fp(
       cls=OtherFakeTask,
-       _impls=[('asdf', 0)],
+      _impls=[('asdf', 0)],
       _other_impls=[],
     )
     self.assertNotEqual(base_version_other_fake, versioned_fake)
     extended_version_other_fake = self._synth_fp(
       cls=OtherFakeTask,
-       _impls=[('asdf', 0)],
+      _impls=[('asdf', 0)],
       _other_impls=[('xxx', 0)],
     )
     self.assertNotEqual(extended_version_other_fake, base_version_other_fake)
 
     extended_version_copy = self._synth_fp(
       cls=OtherFakeTask,
-       _impls=[('asdf', 1)],
+      _impls=[('asdf', 1)],
       _other_impls=[('xxx', 0)],
     )
     self.assertNotEqual(extended_version_copy, extended_version_other_fake)
@@ -638,11 +638,9 @@ files(
                               passthrough_args=['a', 'b'],
                               passthrough_args_option=['c', 'd'])
 
-  def test_passthru_args_option_shlexed(self):
-    self.assert_passthru_args(expected=['c', 'd e'], passthrough_args_option=['c "d e"'])
-
-  def test_passthru_args_not_shlexed(self):
+  def test_passthru_args_option_shlex_ignored(self):
     self.assert_passthru_args(expected=['a b'], passthrough_args=['a b'])
+    self.assert_passthru_args(expected=['c "d e"'], passthrough_args_option=['c "d e"'])
 
   def test_fingerprint_passthru_args(self):
     """Passthrough arguments should affect fingerprints iff the task

--- a/tests/python/pants_test/task/test_task.py
+++ b/tests/python/pants_test/task/test_task.py
@@ -614,6 +614,36 @@ files(
     task_opt_true_fp = self._synth_fp(cls=AnotherFakeTask, options_fingerprintable=cur_option_spec)
     self.assertNotEqual(task_opt_true_fp, task_opt_false_fp)
 
+  def assert_passthru_args(self, expected=None, passthrough_args=(), passthrough_args_option=()):
+    aft_type = self.synthesize_task_subtype(AnotherFakeTask, 'aft')
+    context = self.context(
+      for_task_types=[aft_type],
+      options={aft_type.options_scope: {'passthrough_args': passthrough_args_option}},
+      passthru_args=passthrough_args
+    )
+    aft = aft_type(context=context, workdir=self.test_workdir)
+    self.assertEqual(expected, aft.get_passthru_args())
+
+  def test_passthru_args_empty(self):
+    self.assert_passthru_args(expected=[])
+
+  def test_passthru_args_non_empty(self):
+    self.assert_passthru_args(expected=['a', 'b'], passthrough_args=['a', 'b'])
+
+  def test_passthru_args_option(self):
+    self.assert_passthru_args(expected=['c', 'd'], passthrough_args_option=['c', 'd'])
+
+  def test_passthru_args_mixed(self):
+    self.assert_passthru_args(expected=['c', 'd', 'a', 'b'],
+                              passthrough_args=['a', 'b'],
+                              passthrough_args_option=['c', 'd'])
+
+  def test_passthru_args_option_shlexed(self):
+    self.assert_passthru_args(expected=['c', 'd e'], passthrough_args_option=['c "d e"'])
+
+  def test_passthru_args_not_shlexed(self):
+    self.assert_passthru_args(expected=['a b'], passthrough_args=['a b'])
+
   def test_fingerprint_passthru_args(self):
     """Passthrough arguments should affect fingerprints iff the task
     supports passthrough args."""
@@ -660,5 +690,5 @@ files(
   def test_target_filtering_enabled(self):
     self.assertNotIn(TargetFilter.scoped(DummyTask),
                      DummyTask.subsystem_dependencies())
-    self.assertIn(TargetFilter.scoped(TaskWithTargetFiltering), 
+    self.assertIn(TargetFilter.scoped(TaskWithTargetFiltering),
                   TaskWithTargetFiltering.subsystem_dependencies())


### PR DESCRIPTION
Now any task that `supports_passthru_args()` also automatically
registers a `--passthrough-args` option to allow setting fixed
passthrough args via environment variable or config file.
