### PR TITLE
Upgrade isort and add/fix support for skip config.

### DIFF
--- a/src/python/pants/backend/python/subsystems/isort.py
+++ b/src/python/pants/backend/python/subsystems/isort.py
@@ -9,5 +9,5 @@ from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 
 class Isort(PythonToolBase):
   options_scope = 'isort'
-  default_requirements = ['isort==4.3.4', 'setuptools']
+  default_requirements = ['isort==4.3.20', 'setuptools']
   default_entry_point = 'isort.main'

--- a/src/python/pants/backend/python/tasks/isort_run.py
+++ b/src/python/pants/backend/python/tasks/isort_run.py
@@ -52,7 +52,7 @@ class IsortRun(FmtTaskMixin, Task):
         return
 
       isort = self.context.products.get_data(IsortPrep.tool_instance_cls)
-      args = self.get_passthru_args() + sources
+      args = self.get_passthru_args() + ['--filter-files'] + sources
 
       # NB: We execute isort out of process to avoid unwanted side-effects from importing it:
       #   https://github.com/timothycrosley/isort/issues/456

--- a/tests/python/pants_test/backend/python/tasks/test_isort_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_isort_run.py
@@ -142,3 +142,17 @@ class PythonIsortTest(PythonTaskTestBase):
     with open(path, 'r') as f:
       self.assertEqual(self.BAD_IMPORT_ORDER, f.read(),
                        '{} should not be sorted, but is.'.format(path))
+
+  def test_skip_config(self):
+    self.create_file('src/python/a/.isort.cfg', mode='a', contents='skip=a_1.py')
+    isort_task = self._create_task(target_roots=[self.a_library])
+    isort_task.execute()
+    self.assertNotSorted(os.path.join(self.build_root, 'src/python/a/a_1.py'))
+    self.assertSortedWithConfigA(os.path.join(self.build_root, 'src/python/a/a_2.py'))
+
+  def test_skip_glob_config(self):
+    self.create_file('src/python/a/.isort.cfg', mode='a', contents='skip_glob=src/python/a/*2.py')
+    isort_task = self._create_task(target_roots=[self.a_library])
+    isort_task.execute()
+    self.assertSortedWithConfigA(os.path.join(self.build_root, 'src/python/a/a_1.py'))
+    self.assertNotSorted(os.path.join(self.build_root, 'src/python/a/a_2.py'))


### PR DESCRIPTION
We upgrade isort to pick up support for `skip_glob` and fix skipping for
both `skip` and `skip_glob` directives by passing `--filter-files` to
inform isort to honor any skip configuration even when we pass all file
names to sort explicitly.