### PR TITLE
Make futures_helper_thread not Resettable

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1483,7 +1483,7 @@ mod tests {
       BTreeMap::new(),
       1,
       store,
-      timer_thread.clone(),
+      timer_thread,
     );
     let result = runtime
       .block_on(cmd_runner.run(echo_roland_request()))
@@ -1854,7 +1854,7 @@ mod tests {
       BTreeMap::new(),
       1,
       store,
-      timer_thread.clone(),
+      timer_thread,
     );
 
     let result = runtime
@@ -1951,7 +1951,7 @@ mod tests {
       BTreeMap::new(),
       1,
       store,
-      timer_thread.clone(),
+      timer_thread,
     )
     .run(cat_roland_request())
     .wait();
@@ -2020,7 +2020,7 @@ mod tests {
       BTreeMap::new(),
       1,
       store,
-      timer_thread.clone(),
+      timer_thread,
     );
 
     let error = runtime
@@ -2629,7 +2629,7 @@ mod tests {
       BTreeMap::new(),
       1,
       store,
-      timer_thread.clone(),
+      timer_thread,
     )
   }
 

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -39,6 +39,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::iter::Iterator;
 use std::path::PathBuf;
 use std::process::exit;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// A binary which takes args of format:
@@ -211,7 +212,7 @@ fn main() {
     .value_of("local-store-path")
     .map(PathBuf::from)
     .unwrap_or_else(fs::Store::default_path);
-  let timer_thread = resettable::Resettable::new(|| futures_timer::HelperThread::new().unwrap());
+  let timer_thread = Arc::new(futures_timer::HelperThread::new().unwrap());
   let server_arg = args.value_of("server");
   let remote_instance_arg = args.value_of("remote-instance-name").map(str::to_owned);
   let output_files = if let Some(values) = args.values_of("output-file-path") {
@@ -254,7 +255,7 @@ fn main() {
         // TODO: Take a command line arg.
         fs::BackoffConfig::new(Duration::from_secs(1), 1.2, Duration::from_secs(20)).unwrap(),
         3,
-        timer_thread.with(futures_timer::HelperThread::handle),
+        timer_thread.handle(),
       )
     }
     (None, None) => fs::Store::local_only(local_store_path),
@@ -308,7 +309,7 @@ fn main() {
         platform_properties,
         1,
         store.clone(),
-        timer_thread,
+        timer_thread.clone(),
       )) as Box<dyn process_execution::CommandRunner>
     }
     None => Box::new(process_execution::local::CommandRunner::new(

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -143,7 +143,7 @@ impl Core {
           // Allow for some overhead for bookkeeping threads (if any).
           process_execution_parallelism + 2,
           store.clone(),
-          futures_timer_thread2.clone(), // TODO remove once the store and http are not resettables
+          futures_timer_thread2.clone(), // TODO remove clone once the store and http are not resettables
         )),
         None => Box::new(process_execution::local::CommandRunner::new(
           store.clone(),

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -44,7 +44,7 @@ pub struct Core {
   pub rule_graph: RuleGraph<Rule>,
   pub types: Types,
   runtime: Resettable<Arc<RwLock<Runtime>>>,
-  pub futures_timer_thread: Resettable<futures_timer::HelperThread>,
+  pub futures_timer_thread: Arc<futures_timer::HelperThread>,
   store_and_command_runner_and_http_client:
     Resettable<(Store, BoundedCommandRunner, reqwest::r#async::Client)>,
   pub vfs: PosixFS,
@@ -103,7 +103,7 @@ impl Core {
       None
     };
 
-    let futures_timer_thread = Resettable::new(|| futures_timer::HelperThread::new().unwrap());
+    let futures_timer_thread = Arc::new(futures_timer::HelperThread::new().unwrap());
     let futures_timer_thread2 = futures_timer_thread.clone();
     let store_and_command_runner_and_http_client = Resettable::new(move || {
       let local_store_dir = local_store_dir.clone();
@@ -126,7 +126,7 @@ impl Core {
               fs::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10))
                 .unwrap(),
               remote_store_rpc_retries,
-              futures_timer_thread2.with(futures_timer::HelperThread::handle),
+              futures_timer_thread2.handle(),
             )
           }
         })
@@ -143,7 +143,7 @@ impl Core {
           // Allow for some overhead for bookkeeping threads (if any).
           process_execution_parallelism + 2,
           store.clone(),
-          futures_timer_thread2.clone(),
+          futures_timer_thread2.clone(), // TODO remove once the store and http are not resettables
         )),
         None => Box::new(process_execution::local::CommandRunner::new(
           store.clone(),
@@ -196,12 +196,10 @@ impl Core {
       debug!("Waiting to enter fork_context...");
       thread::sleep(Duration::from_millis(10));
     }
-    let t = self.futures_timer_thread.with_reset(|| {
-      self.runtime.with_reset(|| {
-        self
-          .graph
-          .with_exclusive(|| self.store_and_command_runner_and_http_client.with_reset(f))
-      })
+    let t = self.runtime.with_reset(|| {
+      self
+        .graph
+        .with_exclusive(|| self.store_and_command_runner_and_http_client.with_reset(f))
     });
     self
       .graph


### PR DESCRIPTION
### Problem

After removing forking, a bunch of code is leftover that has to be removed, for a slight perf improvement.

Related issues: #7670 

### Solution

This PR removes one of the uses of `Resettable`, as a step towards removing `fork_context`