### PR TITLE
Add name to threads created by WorkerPool

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
@@ -118,7 +118,8 @@ class ThriftLinter(LintTaskMixin, NailgunTask):
       with self.context.new_workunit('parallel-thrift-linter') as workunit:
         worker_pool = WorkerPool(workunit.parent,
                                  self.context.run_tracker,
-                                 self.get_options().worker_count)
+                                 self.get_options().worker_count,
+                                 workunit.name)
 
         scrooge_linter_classpath = self.tool_classpath('scrooge-linter')
         results = []

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -424,7 +424,8 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
       # workunit is on the bottom of the page rather than possibly in the middle.
       worker_pool = WorkerPool(workunit.parent,
                                self.context.run_tracker,
-                               self._worker_count)
+                               self._worker_count,
+                               workunit.name)
 
     # Prepare the output directory for each invalid target, and confirm that analysis is valid.
     for target in invalid_targets:

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -568,7 +568,8 @@ class RunTracker(Subsystem):
     if self._background_worker_pool is None:  # Initialize lazily.
       self._background_worker_pool = WorkerPool(parent_workunit=self.get_background_root_workunit(),
                                                 run_tracker=self,
-                                                num_workers=self._num_background_workers)
+                                                num_workers=self._num_background_workers,
+                                                thread_name_prefix="background")
     return self._background_worker_pool
 
   def shutdown_worker_pool(self):

--- a/tests/python/pants_test/base/test_worker_pool.py
+++ b/tests/python/pants_test/base/test_worker_pool.py
@@ -28,7 +28,7 @@ class WorkerPoolTest(unittest.TestCase):
     condition.acquire()
     with self.assertRaises(KeyboardInterrupt):
       with temporary_dir() as rundir:
-        pool = WorkerPool(WorkUnit(rundir, None, "work"), FakeRunTracker(), 1)
+        pool = WorkerPool(WorkUnit(rundir, None, "work"), FakeRunTracker(), 1, "test")
         try:
           pool.submit_async_work(Work(keyboard_interrupt_raiser, [()]))
           condition.wait(2)


### PR DESCRIPTION
### Problem
When debugging pants with an issue related to multithreading there wasn't enough info about threads created by WorkerPool and the workunit that started the WorkerPool. 

### Solution
When a new thread in the WorkerPool is created the thread receives a name by its parent workunit name. 