### PR TITLE
Replace futures-timer with tokio_timer

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -172,7 +172,6 @@ dependencies = [
  "fs 0.0.1",
  "fuse 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "hashing 0.0.1",
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -719,7 +718,6 @@ dependencies = [
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
  "hashing 0.0.1",
@@ -765,7 +763,6 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "hashing 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
@@ -2195,8 +2192,9 @@ version = "0.0.1"
 dependencies = [
  "boxfuture 0.0.1",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -572,7 +572,6 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "graph 0.0.1",
  "hashing 0.0.1",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -816,14 +815,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "futures-timer"
-version = "0.1.1"
-source = "git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0#0b747e565309a58537807ab43c674d8951f9e5a0"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1647,7 +1638,6 @@ dependencies = [
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
  "hashing 0.0.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1661,6 +1651,7 @@ dependencies = [
  "tokio 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1671,7 +1662,6 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "hashing 0.0.1",
  "process_execution 0.0.1",
  "resettable 0.0.1",
@@ -3104,7 +3094,6 @@ dependencies = [
 "checksum fuse 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80e57070510966bfef93662a81cb8aa2b1c7db0964354fa9921434f04b9e8660"
 "checksum futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "a2037ec1c6c1c4f79557762eab1f7eae1f64f6cb418ace90fae88f0942b60139"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-"checksum futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)" = "<none>"
 "checksum fwdansi 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "34dd4c507af68d37ffef962063dfa1944ce0dd4d5b82043dbab1dabe088610c3"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -84,8 +84,6 @@ bytes = "0.4.5"
 fnv = "1.0.5"
 fs = { path = "fs" }
 futures = "0.1.27"
-# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
-futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 graph = { path = "graph" }
 hashing = { path = "hashing" }
 indexmap = "1.0.2"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -12,8 +12,6 @@ bytes = "0.4.5"
 digest = "0.8"
 dirs = "1"
 futures = "^0.1.16"
-# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
-futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 glob = "0.2.11"
 grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../hashing" }

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -14,8 +14,6 @@ errno = "0.2.3"
 fs = { path = ".." }
 fuse = "0.3.1"
 futures = "^0.1.16"
-# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
-futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 hashing = { path = "../../hashing" }
 libc = "0.2.39"
 log = "0.4.1"

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -34,8 +34,6 @@ use errno;
 use fs;
 use fuse;
 
-use futures_timer;
-
 use libc;
 
 use serverset;
@@ -704,7 +702,6 @@ fn main() {
       )
       .expect("Error making BackoffConfig"),
       1,
-      futures_timer::TimerHandle::default(),
     ),
     None => fs::Store::local_only(&store_path),
   }

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -12,8 +12,6 @@ clap = "2"
 env_logger = "0.5.4"
 fs = { path = ".." }
 futures = "^0.1.16"
-# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
-futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 hashing = { path = "../../hashing" }
 parking_lot = "0.6"
 protobuf = { version = "2.0.6", features = ["with-bytes"] }

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -30,7 +30,6 @@ use clap;
 use env_logger;
 use fs;
 use futures;
-use futures_timer;
 
 use rand;
 
@@ -313,7 +312,6 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
               std::time::Duration::from_secs(20),
             )?,
             value_t!(top_match.value_of("rpc-attempts"), usize).expect("Bad rpc-attempts flag"),
-            futures_timer::TimerHandle::default(),
           ),
           true,
         )

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -106,7 +106,6 @@ impl Store {
     upload_timeout: Duration,
     backoff_config: BackoffConfig,
     rpc_retries: usize,
-    futures_timer_thread: futures_timer::TimerHandle,
   ) -> Result<Store, String> {
     Ok(Store {
       local: local::ByteStore::new(path)?,
@@ -120,7 +119,6 @@ impl Store {
         upload_timeout,
         backoff_config,
         rpc_retries,
-        futures_timer_thread,
       )?),
     })
   }
@@ -1696,7 +1694,6 @@ mod remote {
       upload_timeout: Duration,
       backoff_config: BackoffConfig,
       rpc_retries: usize,
-      futures_timer_thread: futures_timer::TimerHandle,
     ) -> Result<ByteStore, String> {
       let env = Arc::new(grpcio::Environment::new(thread_count));
 
@@ -1715,7 +1712,7 @@ mod remote {
         })
         .collect();
 
-      let serverset = Serverset::new(channels, backoff_config, futures_timer_thread)?;
+      let serverset = Serverset::new(channels, backoff_config)?;
 
       Ok(ByteStore {
         instance_name,
@@ -1996,7 +1993,6 @@ mod remote {
     use super::super::EntryType;
     use super::ByteStore;
     use bytes::Bytes;
-    use futures_timer::TimerHandle;
     use hashing::Digest;
     use mock::StubCAS;
     use serverset::BackoffConfig;
@@ -2153,7 +2149,6 @@ mod remote {
         Duration::from_secs(5),
         BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
         1,
-        TimerHandle::default(),
       )
       .unwrap();
 
@@ -2229,7 +2224,6 @@ mod remote {
         Duration::from_secs(1),
         BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
         1,
-        TimerHandle::default(),
       )
       .unwrap();
       let error = block_on(store.store_bytes(TestData::roland().bytes())).expect_err("Want error");
@@ -2303,7 +2297,6 @@ mod remote {
         Duration::from_secs(1),
         BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
         1,
-        TimerHandle::default(),
       )
       .unwrap();
 
@@ -2332,7 +2325,6 @@ mod remote {
         Duration::from_secs(1),
         BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
         1,
-        TimerHandle::default(),
       )
       .unwrap()
     }
@@ -2366,7 +2358,6 @@ mod tests {
   use bytes::Bytes;
   use digest::{Digest as DigestTrait, FixedOutput};
   use futures::Future;
-  use futures_timer::TimerHandle;
   use hashing::{Digest, Fingerprint};
   use mock::StubCAS;
   use protobuf::Message;
@@ -2456,7 +2447,6 @@ mod tests {
       Duration::from_secs(1),
       BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
-      TimerHandle::default(),
     )
     .unwrap()
   }
@@ -3125,7 +3115,6 @@ mod tests {
       Duration::from_secs(1),
       BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
-      TimerHandle::default(),
     )
     .unwrap();
 
@@ -3152,7 +3141,6 @@ mod tests {
       Duration::from_secs(1),
       BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
-      TimerHandle::default(),
     )
     .unwrap();
 
@@ -3190,7 +3178,6 @@ mod tests {
       Duration::from_secs(1),
       BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
-      TimerHandle::default(),
     )
     .unwrap();
 
@@ -3217,7 +3204,6 @@ mod tests {
       Duration::from_secs(1),
       BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
-      TimerHandle::default(),
     )
     .unwrap();
 

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -20,11 +20,10 @@ protobuf = { version = "2.0.6", features = ["with-bytes"] }
 resettable = { path = "../resettable" }
 sha2 = "0.8"
 tempfile = "3"
-# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
-futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 time = "0.1.40"
 tokio-codec = "0.1"
 tokio-process = "0.2.1"
+tokio-timer = "0.2"
 
 [dev-dependencies]
 mock = { path = "../testutil/mock" }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1470,7 +1470,6 @@ mod tests {
       Duration::from_secs(1),
       fs::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
-      timer_thread.handle(),
     )
     .expect("Failed to make store");
 
@@ -1836,7 +1835,6 @@ mod tests {
       Duration::from_secs(1),
       fs::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
-      timer_thread.handle(),
     )
     .expect("Failed to make store");
     runtime
@@ -1934,7 +1932,6 @@ mod tests {
       Duration::from_secs(1),
       fs::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
-      timer_thread.handle(),
     )
     .expect("Failed to make store");
     store
@@ -2006,7 +2003,6 @@ mod tests {
       Duration::from_secs(1),
       fs::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
-      timer_thread.handle(),
     )
     .expect("Failed to make store");
 
@@ -2616,7 +2612,6 @@ mod tests {
       Duration::from_secs(1),
       fs::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
-      timer_thread.handle(),
     )
     .expect("Failed to make store");
 

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -10,13 +10,13 @@ use bytes::Bytes;
 use digest::{Digest as DigestTrait, FixedOutput};
 use fs::{self, File, PathStat, Store};
 use futures::{future, Future, Stream};
-use futures_timer::Delay;
 use grpcio;
 use hashing::{Digest, Fingerprint};
 use log::{debug, trace, warn};
 use protobuf::{self, Message, ProtobufEnum};
 use sha2::Sha256;
 use time;
+use tokio_timer::Delay;
 
 use super::{ExecuteProcessRequest, ExecutionStats, FallibleExecuteProcessResult};
 use std;
@@ -45,7 +45,6 @@ pub struct CommandRunner {
   execution_client: Arc<bazel_protos::remote_execution_grpc::ExecutionClient>,
   operations_client: Arc<bazel_protos::operations_grpc::OperationsClient>,
   store: Store,
-  futures_timer_thread: Arc<futures_timer::HelperThread>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -153,7 +152,6 @@ impl super::CommandRunner for CommandRunner {
         let command_runner3 = self.clone();
         let execute_request = Arc::new(execute_request);
         let execute_request2 = execute_request.clone();
-        let futures_timer_thread = self.futures_timer_thread.clone();
 
         let store2 = store.clone();
         let mut history = ExecutionHistory::default();
@@ -188,7 +186,6 @@ impl super::CommandRunner for CommandRunner {
                 let operations_client = operations_client.clone();
                 let command_runner2 = command_runner2.clone();
                 let command_runner3 = command_runner3.clone();
-                let futures_timer_thread = futures_timer_thread.clone();
                 let f = command_runner2.extract_execute_response(operation, &mut history);
                 f.map(future::Loop::Break).or_else(move |value| {
                   match value {
@@ -246,32 +243,32 @@ impl super::CommandRunner for CommandRunner {
                         .to_boxed()
                       } else {
                         // maybe the delay here should be the min of remaining time and the backoff period
-                        Delay::new_handle(
-                          Instant::now() + Duration::from_millis(backoff_period),
-                          futures_timer_thread.handle(),
-                        )
-                        .map_err(move |e| {
-                          format!(
-                            "Future-Delay errored at operation result polling for {}, {}: {}",
-                            operation_name, description, e
-                          )
-                        })
-                        .and_then(move |_| {
-                          future::done(
-                            operations_client
-                              .get_operation_opt(&operation_request, command_runner3.call_option())
-                              .or_else(move |err| {
-                                rpcerror_recover_cancelled(operation_request.take_name(), err)
-                              })
-                              .map(OperationOrStatus::Operation)
-                              .map_err(rpcerror_to_string),
-                          )
-                          .map(move |operation| {
-                            future::Loop::Continue((history, operation, iter_num + 1))
+                        Delay::new(Instant::now() + Duration::from_millis(backoff_period))
+                          .map_err(move |e| {
+                            format!(
+                              "Future-Delay errored at operation result polling for {}, {}: {}",
+                              operation_name, description, e
+                            )
+                          })
+                          .and_then(move |_| {
+                            future::done(
+                              operations_client
+                                .get_operation_opt(
+                                  &operation_request,
+                                  command_runner3.call_option(),
+                                )
+                                .or_else(move |err| {
+                                  rpcerror_recover_cancelled(operation_request.take_name(), err)
+                                })
+                                .map(OperationOrStatus::Operation)
+                                .map_err(rpcerror_to_string),
+                            )
+                            .map(move |operation| {
+                              future::Loop::Continue((history, operation, iter_num + 1))
+                            })
+                            .to_boxed()
                           })
                           .to_boxed()
-                        })
-                        .to_boxed()
                       }
                     }
                   }
@@ -312,7 +309,6 @@ impl CommandRunner {
     platform_properties: BTreeMap<String, String>,
     thread_count: usize,
     store: Store,
-    futures_timer_thread: Arc<futures_timer::HelperThread>,
   ) -> CommandRunner {
     let env = Arc::new(grpcio::Environment::new(thread_count));
     let channel = {
@@ -343,7 +339,6 @@ impl CommandRunner {
       execution_client,
       operations_client,
       store,
-      futures_timer_thread,
     }
   }
 
@@ -926,7 +921,6 @@ mod tests {
   use std::iter::{self, FromIterator};
   use std::ops::Sub;
   use std::path::PathBuf;
-  use std::sync::Arc;
   use std::time::Duration;
 
   #[derive(Debug, PartialEq)]
@@ -1458,7 +1452,6 @@ mod tests {
     let store_dir_path = store_dir.path();
 
     let cas = mock::StubCAS::empty();
-    let timer_thread = timer_thread();
     let store = fs::Store::with_remote(
       &store_dir_path,
       &[cas.address()],
@@ -1482,7 +1475,6 @@ mod tests {
       BTreeMap::new(),
       1,
       store,
-      timer_thread,
     );
     let result = runtime
       .block_on(cmd_runner.run(echo_roland_request()))
@@ -1823,7 +1815,6 @@ mod tests {
     let cas = mock::StubCAS::builder()
       .directory(&TestDirectory::containing_roland())
       .build();
-    let timer_thread = timer_thread();
     let store = fs::Store::with_remote(
       store_dir,
       &[cas.address()],
@@ -1852,7 +1843,6 @@ mod tests {
       BTreeMap::new(),
       1,
       store,
-      timer_thread,
     );
 
     let result = runtime
@@ -1920,7 +1910,6 @@ mod tests {
     let cas = mock::StubCAS::builder()
       .directory(&TestDirectory::containing_roland())
       .build();
-    let timer_thread = timer_thread();
     let store = fs::Store::with_remote(
       store_dir,
       &[cas.address()],
@@ -1948,7 +1937,6 @@ mod tests {
       BTreeMap::new(),
       1,
       store,
-      timer_thread,
     )
     .run(cat_roland_request())
     .wait();
@@ -1991,7 +1979,6 @@ mod tests {
       .file(&TestData::roland())
       .directory(&TestDirectory::containing_roland())
       .build();
-    let timer_thread = timer_thread();
     let store = fs::Store::with_remote(
       store_dir,
       &[cas.address()],
@@ -2016,7 +2003,6 @@ mod tests {
       BTreeMap::new(),
       1,
       store,
-      timer_thread,
     );
 
     let error = runtime
@@ -2600,7 +2586,6 @@ mod tests {
 
   fn create_command_runner(address: String, cas: &mock::StubCAS) -> CommandRunner {
     let store_dir = TempDir::new().unwrap();
-    let timer_thread = timer_thread();
     let store = fs::Store::with_remote(
       store_dir,
       &[cas.address()],
@@ -2615,21 +2600,7 @@ mod tests {
     )
     .expect("Failed to make store");
 
-    CommandRunner::new(
-      &address,
-      None,
-      None,
-      None,
-      None,
-      BTreeMap::new(),
-      1,
-      store,
-      timer_thread,
-    )
-  }
-
-  fn timer_thread() -> Arc<futures_timer::HelperThread> {
-    Arc::new(futures_timer::HelperThread::new().unwrap())
+    CommandRunner::new(&address, None, None, None, None, BTreeMap::new(), 1, store)
   }
 
   fn extract_execute_response(

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -9,8 +9,6 @@ publish = false
 clap = "2"
 env_logger = "0.5.4"
 fs = { path = "../fs" }
-# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
-futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 hashing = { path = "../hashing" }
 futures = "^0.1.16"
 process_execution = { path = "../process_execution" }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -39,7 +39,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::iter::Iterator;
 use std::path::PathBuf;
 use std::process::exit;
-use std::sync::Arc;
 use std::time::Duration;
 
 /// A binary which takes args of format:
@@ -212,7 +211,6 @@ fn main() {
     .value_of("local-store-path")
     .map(PathBuf::from)
     .unwrap_or_else(fs::Store::default_path);
-  let timer_thread = Arc::new(futures_timer::HelperThread::new().unwrap());
   let server_arg = args.value_of("server");
   let remote_instance_arg = args.value_of("remote-instance-name").map(str::to_owned);
   let output_files = if let Some(values) = args.values_of("output-file-path") {
@@ -308,7 +306,6 @@ fn main() {
         platform_properties,
         1,
         store.clone(),
-        timer_thread.clone(),
       )) as Box<dyn process_execution::CommandRunner>
     }
     None => Box::new(process_execution::local::CommandRunner::new(

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -255,7 +255,6 @@ fn main() {
         // TODO: Take a command line arg.
         fs::BackoffConfig::new(Duration::from_secs(1), 1.2, Duration::from_secs(20)).unwrap(),
         3,
-        timer_thread.handle(),
       )
     }
     (None, None) => fs::Store::local_only(local_store_path),

--- a/src/rust/engine/serverset/Cargo.toml
+++ b/src/rust/engine/serverset/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 [dependencies]
 boxfuture = { path = "../boxfuture" }
 futures = "^0.1.16"
-# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
-futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 parking_lot = "0.6"
+tokio-timer = "0.2"
+
+[dev-dependencies]
+tokio = "0.1"

--- a/src/rust/engine/serverset/src/lib.rs
+++ b/src/rust/engine/serverset/src/lib.rs
@@ -27,15 +27,14 @@
 #![allow(clippy::mutex_atomic)]
 
 use futures;
-use futures_timer;
 
 use boxfuture::{BoxFuture, Boxable};
 use futures::Future;
-use futures_timer::Delay;
 use parking_lot::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio_timer::Delay;
 
 mod retry;
 pub use crate::retry::Retry;
@@ -79,8 +78,6 @@ struct Inner<T> {
   pub(crate) next: AtomicUsize,
 
   backoff_config: BackoffConfig,
-
-  timer_handle: futures_timer::TimerHandle,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -182,11 +179,7 @@ impl BackoffConfig {
 }
 
 impl<T: Clone + Send + Sync + 'static> Serverset<T> {
-  pub fn new(
-    servers: Vec<T>,
-    backoff_config: BackoffConfig,
-    timer_handle: futures_timer::TimerHandle,
-  ) -> Result<Self, String> {
+  pub fn new(servers: Vec<T>, backoff_config: BackoffConfig) -> Result<Self, String> {
     if servers.is_empty() {
       return Err("Must supply some servers".to_owned());
     }
@@ -202,7 +195,6 @@ impl<T: Clone + Send + Sync + 'static> Serverset<T> {
           .collect(),
         next: AtomicUsize::new(0),
         backoff_config,
-        timer_handle,
       }),
     })
   }
@@ -258,7 +250,7 @@ impl<T: Clone + Send + Sync + 'static> Serverset<T> {
     let (index, instant) = earliest_future.unwrap();
     let server = self.inner.servers[index].server.clone();
     // Note that Delay::new_at(time in the past) gets immediately scheduled.
-    Delay::new_handle(instant, self.inner.timer_handle.clone())
+    Delay::new(instant)
       .map_err(|err| format!("Error delaying for serverset: {}", err))
       .map(move |()| (server, HealthReportToken { index }))
       .to_boxed()
@@ -298,7 +290,6 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Serverset<T> {
 mod tests {
   use super::{BackoffConfig, Health, Serverset};
   use futures::{self, Future};
-  use futures_timer::TimerHandle;
   use parking_lot::Mutex;
   use std;
   use std::collections::HashSet;
@@ -313,35 +304,26 @@ mod tests {
   #[test]
   fn no_servers_is_error() {
     let servers: Vec<String> = vec![];
-    Serverset::new(servers, backoff_config(), TimerHandle::default())
-      .expect_err("Want error constructing with no servers");
+    Serverset::new(servers, backoff_config()).expect_err("Want error constructing with no servers");
   }
 
   #[test]
   fn round_robins() {
-    let s = Serverset::new(
-      vec!["good", "bad"],
-      backoff_config(),
-      TimerHandle::default(),
-    )
-    .unwrap();
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let s = Serverset::new(vec!["good", "bad"], backoff_config()).unwrap();
 
-    expect_both(&s, 2);
+    expect_both(&mut rt, &s, 2);
   }
 
   #[test]
   fn handles_overflow_internally() {
-    let s = Serverset::new(
-      vec!["good", "bad"],
-      backoff_config(),
-      TimerHandle::default(),
-    )
-    .unwrap();
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let s = Serverset::new(vec!["good", "bad"], backoff_config()).unwrap();
     s.inner.next.store(std::usize::MAX, Ordering::SeqCst);
 
     // 3 because we may skip some values if the number of servers isn't a factor of
     // std::usize::MAX, so we make sure to go around them all again after overflowing.
-    expect_both(&s, 3)
+    expect_both(&mut rt, &s, 3)
   }
 
   fn unwrap<T: std::fmt::Debug>(wrapped: Arc<Mutex<T>>) -> T {
@@ -352,150 +334,157 @@ mod tests {
 
   #[test]
   fn skips_unhealthy() {
-    let s = Serverset::new(
-      vec!["good", "bad"],
-      backoff_config(),
-      TimerHandle::default(),
-    )
-    .unwrap();
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let s = Serverset::new(vec!["good", "bad"], backoff_config()).unwrap();
 
-    mark_bad_as_bad(&s, Health::Unhealthy);
+    mark_bad_as_bad(&mut rt, &s, Health::Unhealthy);
 
-    expect_only_good(&s, Duration::from_millis(10));
+    expect_only_good(&mut rt, &s, Duration::from_millis(10));
   }
 
   #[test]
   fn reattempts_unhealthy() {
-    let s = Serverset::new(
-      vec!["good", "bad"],
-      backoff_config(),
-      TimerHandle::default(),
-    )
-    .unwrap();
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let s = Serverset::new(vec!["good", "bad"], backoff_config()).unwrap();
 
-    mark_bad_as_bad(&s, Health::Unhealthy);
+    mark_bad_as_bad(&mut rt, &s, Health::Unhealthy);
 
-    expect_only_good(&s, Duration::from_millis(10));
+    expect_only_good(&mut rt, &s, Duration::from_millis(10));
 
-    expect_both(&s, 2);
+    expect_both(&mut rt, &s, 2);
   }
 
   #[test]
   fn backoff_when_unhealthy() {
-    let s = Serverset::new(
-      vec!["good", "bad"],
-      backoff_config(),
-      TimerHandle::default(),
-    )
-    .unwrap();
+    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let s = Serverset::new(vec!["good", "bad"], backoff_config()).unwrap();
 
-    mark_bad_as_bad(&s, Health::Unhealthy);
+    mark_bad_as_bad(&mut rt, &s, Health::Unhealthy);
 
-    expect_only_good(&s, Duration::from_millis(10));
+    expect_only_good(&mut rt, &s, Duration::from_millis(10));
 
-    mark_bad_as_bad(&s, Health::Unhealthy);
+    mark_bad_as_bad(&mut rt, &s, Health::Unhealthy);
 
-    expect_only_good(&s, Duration::from_millis(20));
+    expect_only_good(&mut rt, &s, Duration::from_millis(20));
 
-    mark_bad_as_bad(&s, Health::Unhealthy);
+    mark_bad_as_bad(&mut rt, &s, Health::Unhealthy);
 
-    expect_only_good(&s, Duration::from_millis(40));
+    expect_only_good(&mut rt, &s, Duration::from_millis(40));
 
-    mark_bad_as_bad(&s, Health::Healthy);
+    mark_bad_as_bad(&mut rt, &s, Health::Healthy);
 
-    expect_only_good(&s, Duration::from_millis(20));
+    expect_only_good(&mut rt, &s, Duration::from_millis(20));
 
-    mark_bad_as_bad(&s, Health::Healthy);
+    mark_bad_as_bad(&mut rt, &s, Health::Healthy);
 
-    expect_only_good(&s, Duration::from_millis(10));
+    expect_only_good(&mut rt, &s, Duration::from_millis(10));
 
-    mark_bad_as_bad(&s, Health::Healthy);
+    mark_bad_as_bad(&mut rt, &s, Health::Healthy);
 
-    expect_both(&s, 2);
+    expect_both(&mut rt, &s, 2);
   }
 
   #[test]
   fn waits_if_all_unhealthy() {
     let backoff_config = backoff_config();
-    let s = Serverset::new(vec!["good", "bad"], backoff_config, TimerHandle::default()).unwrap();
+    let s = Serverset::new(vec!["good", "bad"], backoff_config).unwrap();
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
 
     for _ in 0..2 {
-      s.next()
-        .map(|(_server, token)| s.report_health(token, Health::Unhealthy))
-        .wait()
+      let s = s.clone();
+      runtime
+        .block_on(
+          s.next()
+            .map(move |(_server, token)| s.report_health(token, Health::Unhealthy)),
+        )
         .unwrap();
     }
 
     let start = std::time::Instant::now();
 
-    s.next().wait().unwrap();
+    runtime.block_on(s.next()).unwrap();
 
     assert!(start.elapsed() > Duration::from_millis(10))
   }
 
-  fn expect_both(s: &Serverset<&'static str>, repetitions: usize) {
+  fn expect_both(
+    runtime: &mut tokio::runtime::Runtime,
+    s: &Serverset<&'static str>,
+    repetitions: usize,
+  ) {
     let visited = Arc::new(Mutex::new(HashSet::new()));
 
-    futures::future::join_all(
-      (0..repetitions)
-        .into_iter()
-        .map(|_| {
-          let saw = visited.clone();
-          let s = s.clone();
-          s.next().map(move |(server, token)| {
-            saw.lock().insert(server);
-            s.report_health(token, Health::Healthy)
+    runtime
+      .block_on(futures::future::join_all(
+        (0..repetitions)
+          .into_iter()
+          .map(|_| {
+            let saw = visited.clone();
+            let s = s.clone();
+            s.next().map(move |(server, token)| {
+              saw.lock().insert(server);
+              s.report_health(token, Health::Healthy)
+            })
           })
-        })
-        .collect::<Vec<_>>(),
-    )
-    .wait()
-    .unwrap();
+          .collect::<Vec<_>>(),
+      ))
+      .unwrap();
 
     let expect: HashSet<_> = vec!["good", "bad"].into_iter().collect();
     assert_eq!(unwrap(visited), expect);
   }
 
-  fn mark_bad_as_bad(s: &Serverset<&'static str>, health: Health) {
-    let mut mark_bad_as_baded_bad = false;
+  fn mark_bad_as_bad(
+    runtime: &mut tokio::runtime::Runtime,
+    s: &Serverset<&'static str>,
+    health: Health,
+  ) {
+    let mark_bad_as_baded_bad = Arc::new(Mutex::new(false));
     for _ in 0..2 {
-      s.next()
-        .map(|(server, token)| {
+      let s = s.clone();
+      let mark_bad_as_baded_bad = mark_bad_as_baded_bad.clone();
+      runtime
+        .block_on(s.next().map(move |(server, token)| {
           if server == "bad" {
-            mark_bad_as_baded_bad = true;
+            *mark_bad_as_baded_bad.lock() = true;
             s.report_health(token, health);
           } else {
             s.report_health(token, Health::Healthy);
           }
-        })
-        .wait()
+        }))
         .unwrap();
     }
-    assert!(mark_bad_as_baded_bad);
+    assert!(*mark_bad_as_baded_bad.lock());
   }
 
-  fn expect_only_good(s: &Serverset<&'static str>, duration: Duration) {
+  fn expect_only_good(
+    runtime: &mut tokio::runtime::Runtime,
+    s: &Serverset<&'static str>,
+    duration: Duration,
+  ) {
     let buffer = Duration::from_millis(1);
 
     let start = std::time::Instant::now();
-    let mut should_break = false;
-    let mut did_get_at_least_one_good = false;
-    while !should_break {
-      s.next()
-        .map(|(server, token)| {
+    let should_break = Arc::new(Mutex::new(false));
+    let did_get_at_least_one_good = Arc::new(Mutex::new(false));
+    while !*should_break.lock() {
+      let s = s.clone();
+      let should_break = should_break.clone();
+      let did_get_at_least_one_good = did_get_at_least_one_good.clone();
+      runtime
+        .block_on(s.next().map(move |(server, token)| {
           if start.elapsed() < duration - buffer {
             assert_eq!("good", server);
-            did_get_at_least_one_good = true;
+            *did_get_at_least_one_good.lock() = true;
           } else {
-            should_break = true;
+            *should_break.lock() = true;
           }
           s.report_health(token, Health::Healthy);
-        })
-        .wait()
+        }))
         .unwrap();
     }
 
-    assert!(did_get_at_least_one_good);
+    assert!(*did_get_at_least_one_good.lock());
 
     std::thread::sleep(buffer * 2);
   }

--- a/src/rust/engine/serverset/src/lib.rs
+++ b/src/rust/engine/serverset/src/lib.rs
@@ -404,7 +404,9 @@ mod tests {
 
     runtime.block_on(s.next()).unwrap();
 
-    assert!(start.elapsed() > Duration::from_millis(10))
+    // The serverset is configured to block for 10ms; make sure we waited for at least 9ms for
+    // stability.
+    assert!(start.elapsed() > Duration::from_millis(9))
   }
 
   fn expect_both(

--- a/src/rust/engine/serverset/src/retry.rs
+++ b/src/rust/engine/serverset/src/retry.rs
@@ -51,24 +51,21 @@ impl<T: Clone + Send + Sync + 'static> Retry<T> {
 #[cfg(test)]
 mod tests {
   use crate::{BackoffConfig, Retry, Serverset};
-  use futures::Future;
-  use futures_timer::TimerHandle;
   use std::time::Duration;
 
   #[test]
   fn retries() {
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
     let s = Serverset::new(
       vec![Ok("good"), Err("bad".to_owned()), Ok("enough")],
       BackoffConfig::new(Duration::from_millis(10), 2.0, Duration::from_millis(100)).unwrap(),
-      TimerHandle::default(),
     )
     .unwrap();
     let mut v = vec![];
     for _ in 0..3 {
       v.push(
-        Retry(s.clone())
-          .all_errors_immediately(|v| v, 1)
-          .wait()
+        runtime
+          .block_on(Retry(s.clone()).all_errors_immediately(|v| v, 1))
           .unwrap(),
       );
     }
@@ -77,17 +74,15 @@ mod tests {
 
   #[test]
   fn gives_up_on_enough_bad() {
+    let mut runtime = tokio::runtime::Runtime::new().unwrap();
     let s = Serverset::new(
       vec![Err("bad".to_owned())],
       BackoffConfig::new(Duration::from_millis(1), 1.0, Duration::from_millis(1)).unwrap(),
-      TimerHandle::default(),
     )
     .unwrap();
     assert_eq!(
       Err(format!("Failed after 5 retries; last failure: bad")),
-      Retry(s)
-        .all_errors_immediately(|v: Result<u8, _>| v, 5)
-        .wait()
+      runtime.block_on(Retry(s).all_errors_immediately(|v: Result<u8, _>| v, 5))
     );
   }
 }

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -126,7 +126,6 @@ impl Core {
               fs::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10))
                 .unwrap(),
               remote_store_rpc_retries,
-              futures_timer_thread2.handle(),
             )
           }
         })

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -44,7 +44,6 @@ pub struct Core {
   pub rule_graph: RuleGraph<Rule>,
   pub types: Types,
   runtime: Resettable<Arc<RwLock<Runtime>>>,
-  pub futures_timer_thread: Arc<futures_timer::HelperThread>,
   store_and_command_runner_and_http_client:
     Resettable<(Store, BoundedCommandRunner, reqwest::r#async::Client)>,
   pub vfs: PosixFS,
@@ -103,8 +102,6 @@ impl Core {
       None
     };
 
-    let futures_timer_thread = Arc::new(futures_timer::HelperThread::new().unwrap());
-    let futures_timer_thread2 = futures_timer_thread.clone();
     let store_and_command_runner_and_http_client = Resettable::new(move || {
       let local_store_dir = local_store_dir.clone();
       let store = safe_create_dir_all_ioerror(&local_store_dir)
@@ -142,7 +139,6 @@ impl Core {
           // Allow for some overhead for bookkeeping threads (if any).
           process_execution_parallelism + 2,
           store.clone(),
-          futures_timer_thread2.clone(), // TODO remove clone once the store and http are not resettables
         )),
         None => Box::new(process_execution::local::CommandRunner::new(
           store.clone(),
@@ -167,7 +163,6 @@ impl Core {
       rule_graph: rule_graph,
       types: types,
       runtime: runtime,
-      futures_timer_thread: futures_timer_thread,
       store_and_command_runner_and_http_client: store_and_command_runner_and_http_client,
       // TODO: Errors in initialization should definitely be exposed as python
       // exceptions, rather than as panics.


### PR DESCRIPTION
We now run all our futures on tokio runtimes, so we can do this.

This removes a dep, and in particular, a dep which we had to fork from upstream.

It also means we have one fewer background thread running.