### PR TITLE
Change into repo dir when running cargo

### DIFF
--- a/build-support/bin/native/bootstrap_code.sh
+++ b/build-support/bin/native/bootstrap_code.sh
@@ -62,6 +62,10 @@ function _build_native_code() {
   # Builds the native code, and echos the path of the built binary.
 
   (
+    # Change into $REPO_ROOT in a subshell. This is necessary so that we're in a child of a
+    # directory containing the rust-toolchain file, so that rustup knows which version of rust we
+    # should be using.
+    cd "${REPO_ROOT}"
     "${REPO_ROOT}/build-support/bin/native/cargo" build ${MODE_FLAG} \
       --manifest-path "${NATIVE_ROOT}/Cargo.toml" -p engine
   ) || die


### PR DESCRIPTION
This means the rust-toolchain file is correctly detected when running outside of the pants checkout.

This was accidentally removed in #7798