### PR TITLE
Avoid redundant work while hackily_snapshot()ing.

### DIFF
--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -53,7 +53,7 @@ class BinaryToolBase(Subsystem):
 
   def __init__(self, *args, **kwargs):
     super(BinaryToolBase, self).__init__(*args, **kwargs)
-    self._snapshot_lock = threading.RLock()
+    self._snapshot_lock = threading.Lock()
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/tests/python/pants_test/binaries/test_binary_tool.py
+++ b/tests/python/pants_test/binaries/test_binary_tool.py
@@ -4,12 +4,15 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import os
 from builtins import str
 
 from pants.binaries.binary_tool import BinaryToolBase
 from pants.binaries.binary_util import (BinaryToolFetcher, BinaryToolUrlGenerator, BinaryUtil,
                                         HostPlatform)
 from pants.option.scope import GLOBAL_SCOPE
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import safe_file_dump
 from pants_test.test_base import TestBase
 
 
@@ -144,3 +147,24 @@ class BinaryToolBaseTest(TestBase):
     self.assertIn(
       "Failed to fetch binary from https://custom-url.example.org/files/custom_urls_tool-v2.3-zzz-alternate:",
       err_msg)
+
+  def test_hackily_snapshot(self):
+    with temporary_dir() as temp_dir:
+      safe_file_dump(
+          os.path.join(temp_dir, 'bin', DefaultVersion.name, DefaultVersion.default_version, DefaultVersion.name),
+          'content!',
+        )
+      context = self.context(
+        for_subsystems=[DefaultVersion],
+        options={
+          GLOBAL_SCOPE: {
+            'binaries_baseurls': ['file:///{}'.format(temp_dir)],
+          },
+        })
+      self.maxDiff = None
+      default_version_tool = DefaultVersion.global_instance()
+      _, snapshot = default_version_tool.hackily_snapshot(context)
+      self.assertEqual(
+          '51a98706ab7458069aabe01856cb352ca97686e3edd3bf9ebd3205c2b38b2974',
+          snapshot.directory_digest.fingerprint
+        )

--- a/tests/python/pants_test/binaries/test_binary_tool.py
+++ b/tests/python/pants_test/binaries/test_binary_tool.py
@@ -85,6 +85,7 @@ class BinaryToolBaseTest(TestBase):
       options={
         GLOBAL_SCOPE: {
           'binaries_baseurls': ['https://binaries.example.org'],
+          'pants_bootstrapdir': str(temporary_dir()),
         },
         'another-tool': {
           'version': '0.0.2',


### PR DESCRIPTION
### Problem

In runs with high degrees of concurrency, we end up seeing many simultaneous instances of tools being fetched and snapshotted.

### Solution

Enforce a single fetch+snapshot attempt per tool. As mentioned in the comment, this is a temporary solution until #7790 migrates this into the engine itself.