### PR TITLE
Bump CI unit test timeout for fewer flaky runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -947,7 +947,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=linuxunittests.py27
       script:
-        - travis_wait 50 ./build-support/bin/ci.sh -2lp
+        - travis_wait 60 ./build-support/bin/ci.sh -2lp
 
     - <<: *py36_linux_test_config
       name: "Unit tests (Py3.6 PEX)"
@@ -955,7 +955,7 @@ matrix:
         - *py36_linux_test_config_env
         - CACHE_NAME=linuxunittests.py36
       script:
-        - travis_wait 50 ./build-support/bin/ci.sh -lp
+        - travis_wait 60 ./build-support/bin/ci.sh -lp
 
     - <<: *py37_linux_test_config
       name: "Unit tests (Py3.7 PEX)"
@@ -963,7 +963,7 @@ matrix:
         - *py37_linux_test_config_env
         - CACHE_NAME=linuxunittests.py37
       script:
-        - travis_wait 50 ./build-support/bin/ci.sh -7lp
+        - travis_wait 60 ./build-support/bin/ci.sh -7lp
 
     - <<: *py27_linux_build_wheels_ucs2
     - <<: *py27_linux_build_wheels_ucs4

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -890,7 +890,7 @@ matrix:
         - *py27_linux_test_config_env
         - CACHE_NAME=linuxunittests.py27
       script:
-        - travis_wait 50 ./build-support/bin/ci.sh -2lp
+        - travis_wait 60 ./build-support/bin/ci.sh -2lp
 
     - <<: *py36_linux_test_config
       name: "Unit tests (Py3.6 PEX)"
@@ -898,7 +898,7 @@ matrix:
         - *py36_linux_test_config_env
         - CACHE_NAME=linuxunittests.py36
       script:
-        - travis_wait 50 ./build-support/bin/ci.sh -lp
+        - travis_wait 60 ./build-support/bin/ci.sh -lp
 
     - <<: *py37_linux_test_config
       name: "Unit tests (Py3.7 PEX)"
@@ -906,7 +906,7 @@ matrix:
         - *py37_linux_test_config_env
         - CACHE_NAME=linuxunittests.py37
       script:
-        - travis_wait 50 ./build-support/bin/ci.sh -7lp
+        - travis_wait 60 ./build-support/bin/ci.sh -7lp
 
     - <<: *py27_linux_build_wheels_ucs2
     - <<: *py27_linux_build_wheels_ucs4


### PR DESCRIPTION
When using V2, unit tests take too long to run so we have to use `travis_wait`. We set the wait time too short, and have a few times had timeouts.

Note that a better solution would be to figure out why V2 is slower in the first place via https://github.com/pantsbuild/pants/issues/7795, followed by implementing local caching via https://github.com/pantsbuild/pants/issues/6898. 
