### PR TITLE
Use zinc to create the context jar for zinc and rsc

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -32,7 +32,9 @@ from pants.util.fileutil import safe_hardlink_or_copy
 from pants.util.memo import memoized_method, memoized_property
 
 
-_ZINC_COMPILER_VERSION = '0.0.9'
+# TODO: To use this with the nailgun strategy, will need a publish of `rsc_2.12`: this will
+# block landing this.
+_ZINC_COMPILER_VERSION = '0.0.11'
 
 
 class Zinc(object):
@@ -87,7 +89,7 @@ class Zinc(object):
       cls.register_jvm_tool(register,
                             Zinc.ZINC_BOOTSTRAPPER_TOOL_NAME,
                             classpath=[
-                              JarDependency('org.pantsbuild', 'zinc-bootstrapper_2.11', '0.0.4'),
+                              JarDependency('org.pantsbuild', 'zinc-bootstrapper_2.12', '0.0.11'),
                             ],
                             main=Zinc.ZINC_BOOTSTRAPER_MAIN,
                             custom_rules=shader_rules,
@@ -96,7 +98,7 @@ class Zinc(object):
       cls.register_jvm_tool(register,
                             Zinc.ZINC_COMPILER_TOOL_NAME,
                             classpath=[
-                              JarDependency('org.pantsbuild', 'zinc-compiler_2.11', _ZINC_COMPILER_VERSION),
+                              JarDependency('org.pantsbuild', 'zinc-compiler_2.12', _ZINC_COMPILER_VERSION),
                             ],
                             main=Zinc.ZINC_COMPILE_MAIN,
                             custom_rules=shader_rules)
@@ -127,7 +129,7 @@ class Zinc(object):
       cls.register_jvm_tool(register,
                             Zinc.ZINC_EXTRACTOR_TOOL_NAME,
                             classpath=[
-                              JarDependency('org.pantsbuild', 'zinc-extractor_2.11', '0.0.6')
+                              JarDependency('org.pantsbuild', 'zinc-extractor_2.12', '0.0.11')
                             ])
 
       # Register scalac for fixed versions of Scala, 2.10, 2.11 and 2.12.

--- a/src/python/pants/backend/jvm/tasks/analysis_extraction.py
+++ b/src/python/pants/backend/jvm/tasks/analysis_extraction.py
@@ -140,12 +140,16 @@ class AnalysisExtraction(NailgunTask):
     if classes_by_source is not None:
       buildroot = get_buildroot()
       for abs_src, classes in summary_json['products'].items():
-        source = os.path.relpath(abs_src, buildroot)
+        source = os.path.relpath(os.path.normpath(abs_src), buildroot)
+        classes = [os.path.normpath(c) for c in classes]
         classes_by_source[source].add_abs_paths(target_cp_entry, classes)
 
     # Register classfile product dependencies (if requested).
     if product_deps_by_src is not None:
-      product_deps_by_src[target] = summary_json['dependencies']
+      product_deps_by_src[target] = {
+          os.path.normpath(src): [os.path.normpath(dep) for dep in deps]
+          for src, deps in summary_json['dependencies'].items()
+        }
 
   def _parse_summary_json(self, summary_json_file):
     with open(summary_json_file, 'r') as f:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -13,8 +13,6 @@ from future.utils import text_type
 from pants.backend.jvm import argfile
 from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
-from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
-from pants.backend.jvm.targets.javac_plugin import JavacPlugin
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.jvm_compile.jvm_compile import JvmCompile
 from pants.base.exceptions import TaskError
@@ -22,16 +20,9 @@ from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.engine.fs import DirectoryToMaterialize
 from pants.engine.isolated_process import ExecuteProcessRequest
 from pants.java.distribution.distribution import DistributionLocator
-from pants.util.dirutil import safe_open
 from pants.util.meta import classproperty
 from pants.util.process_handler import subprocess
 
-
-# Well known metadata file to register javac plugins.
-_JAVAC_PLUGIN_INFO_FILE = 'META-INF/services/com.sun.source.util.Plugin'
-
-# Well known metadata file to register annotation processors with a java 1.6+ compiler.
-_PROCESSOR_INFO_FILE = 'META-INF/services/javax.annotation.processing.Processor'
 
 logger = logging.getLogger(__name__)
 
@@ -41,12 +32,6 @@ class JavacCompile(JvmCompile):
 
   _name = 'java'
   compiler_name = 'javac'
-
-  @staticmethod
-  def _write_javac_plugin_info(resources_dir, javac_plugin_target):
-    javac_plugin_info_file = os.path.join(resources_dir, _JAVAC_PLUGIN_INFO_FILE)
-    with safe_open(javac_plugin_info_file, 'w') as f:
-      f.write(javac_plugin_target.classname)
 
   @classmethod
   def get_args_default(cls, bootstrap_option_values):
@@ -100,20 +85,6 @@ class JavacCompile(JvmCompile):
     # Note that if this classpath is empty then Javac will automatically use the javac from
     # the JDK it was invoked with.
     return Java.global_javac_classpath(self.context.products)
-
-  def write_extra_resources(self, compile_context):
-    """Override write_extra_resources to produce plugin and annotation processor files."""
-    target = compile_context.target
-    if isinstance(target, JavacPlugin):
-      self._write_javac_plugin_info(compile_context.classes_dir.path, target)
-    elif isinstance(target, AnnotationProcessor) and target.processors:
-      processor_info_file = os.path.join(compile_context.classes_dir.path, _PROCESSOR_INFO_FILE)
-      self._write_processor_info(processor_info_file, target.processors)
-
-  def _write_processor_info(self, processor_info_file, processors):
-    with safe_open(processor_info_file, 'w') as f:
-      for processor in processors:
-        f.write('{}\n'.format(processor.strip()))
 
   def compile(self, ctx, args, dependency_classpath, upstream_analysis,
               settings, compiler_option_sets, zinc_file_manager,
@@ -197,6 +168,9 @@ class JavacCompile(JvmCompile):
           workunit.set_outcome(WorkUnit.FAILURE if return_code else WorkUnit.SUCCESS)
           if return_code:
             raise TaskError('javac exited with return code {rc}'.format(rc=return_code))
+        self.context._scheduler.materialize_directories((
+          DirectoryToMaterialize(text_type(ctx.classes_dir.path), self.extra_resources_digest(ctx)),
+        ))
 
   @classmethod
   def _javac_plugin_args(cls, javac_plugin_map):
@@ -241,7 +215,11 @@ class JavacCompile(JvmCompile):
     )
 
     # Dump the output to the .pants.d directory where it's expected by downstream tasks.
+    merged_directories = self.context._scheduler.merge_directories([
+        exec_result.output_directory_digest,
+        self.extra_resources_digest(ctx),
+      ])
     classes_directory = ctx.classes_dir.path
     self.context._scheduler.materialize_directories((
-      DirectoryToMaterialize(text_type(classes_directory), exec_result.output_directory_digest),
+      DirectoryToMaterialize(text_type(classes_directory), merged_directories),
     ))

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -414,8 +414,6 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
           False,
           'rsc'
         )
-        # Write any additional resources for this target to the target workdir.
-        self.write_extra_resources(ctx)
 
       # Update the products with the latest classes.
       self.register_extra_products_from_contexts([ctx.target], compile_contexts)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -180,8 +180,8 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       classpath=[
         JarDependency(
           org='com.twitter',
-          name='rsc_2.11',
-          rev='0.0.0-734-e57e96eb',
+          name='rsc_2.12',
+          rev='0.0.0-768-7357aa0a',
         ),
       ],
       custom_rules=[

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -14,14 +14,12 @@ from collections import defaultdict
 from contextlib import closing
 from xml.etree import ElementTree
 
-from future.utils import PY2, PY3, text_type
+from future.utils import PY2, text_type
 
 from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.subsystems.zinc import Zinc
-from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
-from pants.backend.jvm.targets.javac_plugin import JavacPlugin
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.targets.scalac_plugin import ScalacPlugin
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
@@ -33,7 +31,7 @@ from pants.base.workunit import WorkUnitLabel
 from pants.engine.fs import DirectoryToMaterialize
 from pants.engine.isolated_process import ExecuteProcessRequest
 from pants.util.contextutil import open_zip
-from pants.util.dirutil import fast_relpath, safe_open
+from pants.util.dirutil import fast_relpath
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.meta import classproperty
 from pants.util.strutil import ensure_text, safe_shlex_join
@@ -41,12 +39,6 @@ from pants.util.strutil import ensure_text, safe_shlex_join
 
 # Well known metadata file required to register scalac plugins with nsc.
 _SCALAC_PLUGIN_INFO_FILE = 'scalac-plugin.xml'
-
-# Well known metadata file to register javac plugins.
-_JAVAC_PLUGIN_INFO_FILE = 'META-INF/services/com.sun.source.util.Plugin'
-
-# Well known metadata file to register annotation processors with a java 1.6+ compiler.
-_PROCESSOR_INFO_FILE = 'META-INF/services/javax.annotation.processing.Processor'
 
 
 logger = logging.getLogger(__name__)
@@ -56,24 +48,6 @@ class BaseZincCompile(JvmCompile):
   """An abstract base class for zinc compilation tasks."""
 
   _name = 'zinc'
-
-  @staticmethod
-  def _write_scalac_plugin_info(resources_dir, scalac_plugin_target):
-    scalac_plugin_info_file = os.path.join(resources_dir, _SCALAC_PLUGIN_INFO_FILE)
-    with safe_open(scalac_plugin_info_file, 'w') as f:
-      f.write(textwrap.dedent("""
-        <plugin>
-          <name>{}</name>
-          <classname>{}</classname>
-        </plugin>
-      """.format(scalac_plugin_target.plugin, scalac_plugin_target.classname)).strip())
-
-  @staticmethod
-  def _write_javac_plugin_info(resources_dir, javac_plugin_target):
-    javac_plugin_info_file = os.path.join(resources_dir, _JAVAC_PLUGIN_INFO_FILE)
-    with safe_open(javac_plugin_info_file, 'w') as f:
-      classname = javac_plugin_target.classname if PY3 else javac_plugin_target.classname.decode('utf-8')
-      f.write(classname)
 
   @staticmethod
   def validate_arguments(log, whitelisted_args, args):
@@ -263,6 +237,21 @@ class BaseZincCompile(JvmCompile):
     if self.context.products.is_required_data('zinc_args'):
       self.context.products.safe_create_data('zinc_args', lambda: defaultdict(list))
 
+  def extra_resources(self, compile_context):
+    """Override `extra_resources` to additionally include scalac_plugin info."""
+    result = super(BaseZincCompile, self).extra_resources(compile_context)
+    target = compile_context.target
+
+    if isinstance(target, ScalacPlugin):
+      result[_SCALAC_PLUGIN_INFO_FILE] = textwrap.dedent("""
+          <plugin>
+            <name>{}</name>
+            <classname>{}</classname>
+          </plugin>
+        """.format(target.plugin, target.classname))
+
+    return result
+
   def javac_classpath(self):
     # Note that if this classpath is empty then Zinc will automatically use the javac from
     # the JDK it was invoked with.
@@ -272,22 +261,6 @@ class BaseZincCompile(JvmCompile):
     """Returns classpath entries for the scalac classpath."""
     return ScalaPlatform.global_instance().compiler_classpath_entries(
       self.context.products, self.context._scheduler)
-
-  def write_extra_resources(self, compile_context):
-    """Override write_extra_resources to produce plugin and annotation processor files."""
-    target = compile_context.target
-    if isinstance(target, ScalacPlugin):
-      self._write_scalac_plugin_info(compile_context.classes_dir.path, target)
-    elif isinstance(target, JavacPlugin):
-      self._write_javac_plugin_info(compile_context.classes_dir.path, target)
-    elif isinstance(target, AnnotationProcessor) and target.processors:
-      processor_info_file = os.path.join(compile_context.classes_dir.path, _PROCESSOR_INFO_FILE)
-      self._write_processor_info(processor_info_file, target.processors)
-
-  def _write_processor_info(self, processor_info_file, processors):
-    with safe_open(processor_info_file, 'w') as f:
-      for processor in processors:
-        f.write('{}\n'.format(processor.strip()))
 
   def compile(self, ctx, args, dependency_classpath, upstream_analysis,
               settings, compiler_option_sets, zinc_file_manager,
@@ -397,14 +370,14 @@ class BaseZincCompile(JvmCompile):
       self.HERMETIC: lambda: self._compile_hermetic(
         jvm_options, ctx, classes_dir, zinc_args, compiler_bridge_classpath_entry,
         dependency_classpath, scalac_classpath_entries),
-      self.SUBPROCESS: lambda: self._compile_nonhermetic(jvm_options, zinc_args),
-      self.NAILGUN: lambda: self._compile_nonhermetic(jvm_options, zinc_args),
+      self.SUBPROCESS: lambda: self._compile_nonhermetic(jvm_options, ctx, classes_dir, zinc_args),
+      self.NAILGUN: lambda: self._compile_nonhermetic(jvm_options, ctx, classes_dir, zinc_args),
     })()
 
   class ZincCompileError(TaskError):
     """An exception type specifically to signal a failed zinc execution."""
 
-  def _compile_nonhermetic(self, jvm_options, zinc_args):
+  def _compile_nonhermetic(self, jvm_options, ctx, classes_directory, zinc_args):
     exit_code = self.runjava(classpath=self.get_zinc_compiler_classpath(),
                              main=Zinc.ZINC_COMPILE_MAIN,
                              jvm_options=jvm_options,
@@ -414,6 +387,9 @@ class BaseZincCompile(JvmCompile):
                              dist=self._zinc.dist)
     if exit_code != 0:
       raise self.ZincCompileError('Zinc compile failed.', exit_code=exit_code)
+    self.context._scheduler.materialize_directories((
+      DirectoryToMaterialize(text_type(classes_directory), self.extra_resources_digest(ctx)),
+    ))
 
   def _compile_hermetic(self, jvm_options, ctx, classes_dir, zinc_args,
                         compiler_bridge_classpath_entry, dependency_classpath,
@@ -466,18 +442,19 @@ class BaseZincCompile(JvmCompile):
         '-Dscala.usejavacp=true',
       ]
     else:
+      # TODO: Extract something common from Executor._create_command to make the command line
+      # TODO: Lean on distribution for the bin/java appending here
       additional_snapshots = ()
       image_specific_argv =  ['.jdk/bin/java'] + jvm_options + [
         '-cp', zinc_relpath,
         Zinc.ZINC_COMPILE_MAIN
       ]
 
-    # TODO: Extract something common from Executor._create_command to make the command line
-    # TODO: Lean on distribution for the bin/java appending here
     merged_input_digest = self.context._scheduler.merge_directories(
       tuple(s.directory_digest for s in snapshots) +
       directory_digests +
-      additional_snapshots
+      additional_snapshots +
+      (self.extra_resources_digest(ctx),)
     )
 
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -41,7 +41,7 @@ python_tests(
     ':base_compile_integration_test',
   ],
   tags={'integration'},
-  timeout=240,
+  timeout=360,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -52,7 +52,7 @@ python_tests(
     'tests/python/pants_test/backend/jvm/tasks:missing_jvm_check',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
   ],
-  timeout = 240,
+  timeout = 360,
   tags = {'integration'},
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -431,60 +431,34 @@ class ZincCompileIntegrationTest(BaseCompileIT):
             path = os.path.join(compile_dir, path_suffix)
             self.assertTrue(os.path.exists(path), "Want path {} to exist".format(path))
 
-  def test_hermetic_binary_with_3rdparty_dependencies_ivy(self):
-    config = {
-      'resolve.ivy': {'capture_snapshots': True},
-      'compile.zinc': {
-        'execution_strategy': 'hermetic',
-        'use_classpath_jars': False,
-        'incremental': False,
-      },
-      'resolver': {
-        'resolver': 'ivy',
-      }
-    }
+  def test_hermetic_binary_with_3rdparty_dependencies(self):
+    for resolver in ('ivy', 'coursier'):
+      for use_classpath_jars in (False, True):
+        config = {
+          'resolve.ivy': {'capture_snapshots': True},
+          'resolve.coursier': {'capture_snapshots': True},
+          'compile.zinc': {
+            'execution_strategy': 'hermetic',
+            'use_classpath_jars': use_classpath_jars,
+            'incremental': False,
+          },
+          'resolver': {
+            'resolver': resolver,
+          }
+        }
 
-    with self.temporary_workdir() as workdir:
-      with self.temporary_file_content("readme.txt", b"yo"):
-        pants_run = self.run_pants_with_workdir(
-          [
-            'run',
-            'testprojects/src/java/org/pantsbuild/testproject/cwdexample',
-          ],
-          workdir,
-          config,
-        )
-        self.assert_success(pants_run)
-        self.assertIn(
-          'Found readme.txt',
-          pants_run.stdout_data,
-        )
-
-  def test_hermetic_binary_with_3rdparty_dependencies_coursier(self):
-    config = {
-      'resolve.coursier': {'capture_snapshots': True},
-      'compile.zinc': {
-        'execution_strategy': 'hermetic',
-        'use_classpath_jars': False,
-        'incremental': False,
-      },
-      'resolver': {
-        'resolver': 'coursier',
-      }
-    }
-
-    with self.temporary_workdir() as workdir:
-      with self.temporary_file_content("readme.txt", b"yo"):
-        pants_run = self.run_pants_with_workdir(
-          [
-            'run',
-            'testprojects/src/java/org/pantsbuild/testproject/cwdexample',
-          ],
-          workdir,
-          config,
-        )
-        self.assert_success(pants_run)
-        self.assertIn(
-          'Found readme.txt',
-          pants_run.stdout_data,
-        )
+        with self.temporary_workdir() as workdir:
+          with self.temporary_file_content("readme.txt", b"yo"):
+            pants_run = self.run_pants_with_workdir(
+              [
+                'run',
+                'testprojects/src/java/org/pantsbuild/testproject/cwdexample',
+              ],
+              workdir,
+              config,
+            )
+            self.assert_success(pants_run)
+            self.assertIn(
+              'Found readme.txt',
+              pants_run.stdout_data,
+            )


### PR DESCRIPTION
### Problem

We are not currently using `zinc`'s `-jar` option to jar our outputs, which means that in order to use the `--use-classpath-jars` option (without adding a wrapper script) we would need to capture a snapshot of loose output class files, download it, zip it, and then re-upload... which would mostly defeat the purpose of that option. 

### Solution

After fixing a minor issue with `zinc` (#7834), use its `-jar` option to produce the context jar. `javac_compile` continues to use the existing python codepath for this.

In order to continue to inject resources created for annotation processors and compiler plugins, even when the compiler is itself producing the output jar, we now provide the extra_resources as a `Digest` that a compiler should mix in.

### Result

`--use-classpath-jars` can be used with `hermetic` `zinc` and `rsc`.