### PR TITLE
Sort entries in output zinc jars

### DIFF
--- a/src/scala/org/pantsbuild/zinc/compiler/OutputUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/OutputUtils.scala
@@ -43,14 +43,14 @@ object OutputUtils {
   }
 
   /**
-   * Create a JAR of of filePaths provided.
+   * Create a JAR from the file and directory paths provided.
    *
-   * @param filePaths set of all paths to be added to the JAR
+   * @param paths set of all paths to be added to the JAR
    * @param outputJarPath Absolute Path to the output JAR being created
    * @param jarEntryTime time to be set for each JAR entry
    */
   def createJar(
-    base: String, filePaths: mutable.TreeSet[Path], outputJarPath: Path, jarEntryTime: Long) {
+    base: String, paths: mutable.TreeSet[Path], outputJarPath: Path, jarEntryTime: Long) {
 
     val target = new JarOutputStream(Files.newOutputStream(outputJarPath))
 
@@ -72,8 +72,12 @@ object OutputUtils {
       target.closeEntry()
     }
 
-    for (filePath <- filePaths) {
-      addToJar(filePath, relativize(base, filePath))
+    for (
+      path <- paths;
+      relativePath = relativize(base, path)
+      if relativePath.nonEmpty
+    ) {
+      addToJar(path, relativePath)
     }
     target.close()
   }

--- a/src/scala/org/pantsbuild/zinc/compiler/OutputUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/OutputUtils.scala
@@ -19,16 +19,12 @@ object OutputUtils {
    * @param dir File handle containing the contents to sort
    * @return sorted set of all paths within the `dir`
    */
-  def sort(dir:File): mutable.TreeSet[Path] = {
+  def sort(dir: File): mutable.TreeSet[Path] = {
     val sorted = new mutable.TreeSet[Path]()
 
     val fileSortVisitor = new SimpleFileVisitor[Path]() {
       override def preVisitDirectory(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
-        if (!path.endsWith("/")) {
-          sorted.add(Paths.get(path.toString, "/"))
-        } else {
-          sorted.add(path)
-        }
+        sorted.add(path)
         FileVisitResult.CONTINUE
       }
 
@@ -66,19 +62,19 @@ object OutputUtils {
       jarEntry
     }
 
-    def addToJar(source: Path, entryName: String): FileVisitResult = {
+    def addToJar(source: Path, entryName: String) {
       if (source.toFile.isDirectory) {
-        target.putNextEntry(jarEntry(entryName))
+        target.putNextEntry(jarEntry(if (entryName.endsWith("/")) entryName else entryName + '/'))
       } else {
         target.putNextEntry(jarEntry(entryName))
         Files.copy(source, target)
       }
       target.closeEntry()
-      FileVisitResult.CONTINUE
     }
 
-    val pathToName = filePaths.zipWithIndex.map{case(k, v) => (k, relativize(base, k))}.toMap
-    pathToName.map(e => addToJar(e._1, e._2))
+    for (filePath <- filePaths) {
+      addToJar(filePath, relativize(base, filePath))
+    }
     target.close()
   }
 


### PR DESCRIPTION
### Problem

The jars produced by the `zinc` `-jar` flag were not ending up sorted due to conversion to a `Map` before writing. Additionally, they contained a duplicate entry (that `findbugs` would choke on) as an artifact of how relativization was happening.

### Solution

Preserve the sorted order that is created by the `TreeSet` that we collect entries into, and do not create an entry for the "root" directory of the inputs.

### Result

Pants is able to consume the `-jar` option successfully in #7833.