### PR TITLE
Always capture and cache Digests in coursier and ivy

### DIFF
--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -78,31 +78,31 @@ class Digest(datatype([('fingerprint', text_type), ('serialized_bytes_length', i
   """
 
   @classmethod
-  def _path(cls, directory):
-    return '{}.digest'.format(directory.rstrip(os.sep))
+  def _path(cls, digested_path):
+    return '{}.digest'.format(digested_path.rstrip(os.sep))
 
   @classmethod
-  def clear(cls, directory):
-    """Clear any existing Digest file adjacent to the given directory."""
-    safe_delete(cls._path(directory))
+  def clear(cls, digested_path):
+    """Clear any existing Digest file adjacent to the given digested_path."""
+    safe_delete(cls._path(digested_path))
 
   @classmethod
-  def load(cls, directory):
-    """Load a Digest from a `.digest` file adjacent to the given directory.
+  def load(cls, digested_path):
+    """Load a Digest from a `.digest` file adjacent to the given digested_path.
 
     :return: A Digest, or None if the Digest did not exist.
     """
-    read_file = maybe_read_file(cls._path(directory))
+    read_file = maybe_read_file(cls._path(digested_path))
     if read_file:
       fingerprint, length = read_file.split(':')
       return Digest(fingerprint, int(length))
     else:
       return None
 
-  def dump(self, directory):
-    """Dump this Digest object adjacent to the given directory."""
+  def dump(self, digested_path):
+    """Dump this Digest object adjacent to the given digested_path."""
     payload = '{}:{}'.format(self.fingerprint, self.serialized_bytes_length)
-    safe_file_dump(self._path(directory), payload=payload)
+    safe_file_dump(self._path(digested_path), payload=payload)
 
   def __repr__(self):
     return '''Digest(fingerprint={}, serialized_bytes_length={})'''.format(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -431,29 +431,6 @@ class ZincCompileIntegrationTest(BaseCompileIT):
             path = os.path.join(compile_dir, path_suffix)
             self.assertTrue(os.path.exists(path), "Want path {} to exist".format(path))
 
-  def test_hermetic_binary_with_capturing_off(self):
-    capture_snapshots = False
-    config = {
-      'resolve.ivy': {'capture_snapshots': capture_snapshots},
-      'resolve.coursier': {'capture_snapshots': capture_snapshots},
-      'compile.zinc': {
-        'execution_strategy': 'hermetic',
-        'use_classpath_jars': False,
-        'incremental': False,
-      },
-    }
-    with self.temporary_workdir() as workdir:
-      with self.temporary_file_content("readme.txt", b"yo"):
-        pants_run = self.run_pants_with_workdir(
-          [
-            'run',
-            'testprojects/src/java/org/pantsbuild/testproject/cwdexample',
-          ],
-          workdir,
-          config,
-        )
-        self.assert_failure(pants_run)
-
   def test_hermetic_binary_with_3rdparty_dependencies_ivy(self):
     config = {
       'resolve.ivy': {'capture_snapshots': True},


### PR DESCRIPTION
### Problem

Capturing digests for `coursier` and `ivy` artifacts is currently optional, presumably due to the performance impact of not being cached run over run.

### Solution

#7241 added support for stashing `Digest`s next to digested files, and support for providing a `Digest` hint that will skip snapshotting if the `Digest` is already stored. We use that support here to always-snapshot 3rdparty inputs (and to skip re-snapshotting if a `Digest` was stashed).

### Result

One fewer option, and slightly better performance when re-running.