### PR TITLE
add java_sources to scala_library() snapshot

### DIFF
--- a/src/python/pants/backend/jvm/targets/scala_library.py
+++ b/src/python/pants/backend/jvm/targets/scala_library.py
@@ -11,7 +11,6 @@ from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 from pants.build_graph.address import Address
-from pants.engine.fs import Snapshot
 
 
 class ScalaLibrary(ExportableJvmLibrary):
@@ -86,30 +85,3 @@ class ScalaLibrary(ExportableJvmLibrary):
         raise TargetDefinitionException(self, 'No such java target: {}'.format(spec))
       targets.append(target)
     return targets
-
-  def sources_snapshot(self, scheduler=None):
-    scala_sources = super(ScalaLibrary, self).sources_snapshot(scheduler=scheduler)
-    all_java_sources = [
-      java_target.sources_snapshot(scheduler=scheduler)
-      for java_target in self.java_sources
-    ]
-    all_merged_sources_digest = scheduler.merge_directories(tuple([
-      scala_sources.directory_digest,
-    ] + [
-      java_sources_snapshot.directory_digest
-      for java_sources_snapshot in all_java_sources
-    ]))
-    # TODO: make this .files/.dirs merging process into a helper method in the Scheduler(Session)?!
-    return Snapshot(
-      directory_digest=all_merged_sources_digest,
-      files=tuple([
-        scala_sources.files
-      ] + [
-        j.files for j in all_java_sources
-      ]),
-      dirs=tuple([
-        scala_sources.dirs
-      ] + [
-        j.dirs for j in all_java_sources
-      ]),
-    )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -86,3 +86,9 @@ class RscCompileIntegration(BaseCompileIT):
     self.do_command(
       'compile', 'testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive:java-in-different-package',
       config=config)
+
+  @_for_all_supported_execution_environments
+  def test_java_sources(self, config):
+    self.do_command(
+      'compile', 'testprojects/src/scala/org/pantsbuild/testproject/javasources',
+      config=config)


### PR DESCRIPTION
### Problem

Zinc or rsc compiles with `--execution-strategy=hermetic` will fail on `scala_library()` targets with `java_sources`, because those sources aren't added into the source snapshot, and zinc fails with an opaque error:
```
[error] IO error while decoding /Users/dmcclanahan/tools/pants/.pants.d/tmp/tmpfv8ds506.pants.d/process-executionUP7R5m/testprojects/src/java/org/pantsbuild/testproject/javasources/JavaSource.java with UTF-8: /Users/dmcclanahan/tools/pants/.pants.d/tmp/tmpfv8ds506.pants.d/process-executionUP7R5m/testprojects/src/java/org/pantsbuild/testproject/javasources/JavaSource.java (No such file or directory)
[error] Please try specifying another one using the -encoding option
```

### Solution

- Add the sources from `java_sources` targets into the `sources_snapshot()` for a `scala_library()` target.

### Result

`java_sources` works with hermetic compiles!