### PR TITLE
Fix .pyc files being included to partially get reproducible PEX builds

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -157,7 +157,7 @@ class PythonEval(LintTaskMixin, ResolveRequirementsTaskBase):
           pex_info.entry_point = self._EXEC_NAME
           pex_info.pex_path = ':'.join(pex.path() for pex in (reqs_pex, srcs_pex) if pex)
           builder = PEXBuilder(safe_path, interpreter, pex_info=pex_info)
-          builder.freeze()
+          builder.freeze(bytecode_compile=False)
 
       pex = PEX(exec_pex_path, interpreter)
 

--- a/src/python/pants/backend/python/subsystems/pex_build_util.py
+++ b/src/python/pants/backend/python/subsystems/pex_build_util.py
@@ -342,7 +342,7 @@ class PexBuilderWrapper(object):
         dist = self._distributions.get('setuptools')
         if not dist:
           self.add_resolved_requirements([self._setuptools_requirement])
-      self._builder.freeze()
+      self._builder.freeze(bytecode_compile=False)
       self._frozen = True
 
   def set_entry_point(self, entry_point):

--- a/src/python/pants/backend/python/tasks/pytest_prep.py
+++ b/src/python/pants/backend/python/tasks/pytest_prep.py
@@ -51,7 +51,7 @@ class PytestPrep(PythonExecutionTaskBase):
       pex_path = pex.path()
       pex_info = PexInfo.from_pex(pex_path)
       pex_info.merge_pex_path(pex_path)  # We're now on the sys.path twice.
-      PEXBuilder(pex_path, interpreter=interpreter, pex_info=pex_info).freeze()
+      PEXBuilder(pex_path, interpreter=interpreter, pex_info=pex_info).freeze(bytecode_compile=False)
       self._pex = PEX(pex=pex_path, interpreter=interpreter)
       self._interpreter = interpreter
 

--- a/src/python/pants/backend/python/tasks/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks/python_execution_task_base.py
@@ -165,6 +165,6 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
         with self.merged_pex(path, pex_info, interpreter, pexes, constraints) as builder:
           for extra_file in self.extra_files():
             extra_file.add_to(builder)
-          builder.freeze()
+          builder.freeze(bytecode_compile=False)
 
     return PEX(path, interpreter)

--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -141,4 +141,4 @@ class ResolveRequirementsTaskBase(Task):
   def merge_pexes(cls, path, pex_info, interpreter, pexes, interpeter_constraints=None):
     """Generates a merged pex at path."""
     with cls.merged_pex(path, pex_info, interpreter, pexes, interpeter_constraints) as builder:
-      builder.freeze()
+      builder.freeze(bytecode_compile=False)

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -464,7 +464,7 @@ class SetupPy(Task):
           """).strip().format(declares_namespace_package_code=declares_namespace_package_code))
           fp.close()
           builder.set_executable(filename=fp.name, env_filename='main.py')
-          builder.freeze()
+          builder.freeze(bytecode_compile=False)
     return PEX(pex=chroot, interpreter=interpreter)
 
   def filter_namespace_packages(self, root_target, inits):

--- a/testprojects/src/python/unicode/compilation_failure/BUILD
+++ b/testprojects/src/python/unicode/compilation_failure/BUILD
@@ -1,1 +1,3 @@
-python_library()
+python_binary(
+  source = 'main.py'
+)

--- a/testprojects/src/python/unicode/compilation_failure/main.py
+++ b/testprojects/src/python/unicode/compilation_failure/main.py
@@ -1,4 +1,6 @@
-# This file is expected to fail to "compile", and raise a unicode error while doing so.
+# This file is expected to fail to "compile" when run via `./pants run` due to a SyntaxError.
 # Because the error itself contains unicode, it can exercise that error handling codepaths
 # are unicode aware.
-import sys¡
+
+if __name__ == '__main__':
+  import sys¡

--- a/tests/python/pants_test/base/test_exiter_integration.py
+++ b/tests/python/pants_test/base/test_exiter_integration.py
@@ -13,8 +13,7 @@ class ExiterIntegrationTest(PantsRunIntegrationTest):
   @ensure_daemon
   def test_unicode_containing_exception(self):
     """Test whether we can run a single target without special flags."""
-    pants_run = self.run_pants(['test', 'testprojects/src/python/unicode/compilation_failure'])
+    pants_run = self.run_pants(['run', 'testprojects/src/python/unicode/compilation_failure'])
     self.assert_failure(pants_run)
 
-    self.assertIn('during bytecode compilation', pants_run.stderr_data)
     self.assertIn('import sys¡', pants_run.stderr_data)


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/7734 partially turned on reproducible PEX builds, but did not properly update every call site to avoid including `.pyc` files.

As decided there, we do not (at the moment) provide an opt-out to still include `.pyc` files at the expense of reproducible PEXes, because we deem this to be a sensible default.

Fixes part of https://github.com/pantsbuild/pants/issues/7808.