### PR TITLE
No longer default to saving non-deterministic run information to PEX in `./pants binary`

### DIFF
--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -32,6 +32,15 @@ class PythonBinaryCreate(Task):
   """Create an executable .pex file."""
 
   @classmethod
+  def register_options(cls, register):
+    super(PythonBinaryCreate, cls).register_options(register)
+    register('--include-run-information', type=bool, default=False,
+             help="Include run information in the PEX's PEX-INFO for information like the timestamp the PEX was "
+                  "created and the command line used to create it. This information may be helpful to you, but means "
+                  "that the generated PEX will not be reproducible; that is, future runs of `./pants binary` will not "
+                  "create the same byte-for-byte identical .pex files.")
+
+  @classmethod
   def subsystem_dependencies(cls):
     return super(PythonBinaryCreate, cls).subsystem_dependencies() + (
       PexBuilderWrapper.Factory,
@@ -125,9 +134,10 @@ class PythonBinaryCreate(Task):
     interpreter = self.context.products.get_data(PythonInterpreter)
     with temporary_dir() as tmpdir:
       # Create the pex_info for the binary.
-      run_info_dict = self.context.run_tracker.run_info.get_as_dict()
       build_properties = PexInfo.make_build_properties()
-      build_properties.update(run_info_dict)
+      if self.get_options().include_run_information:
+        run_info_dict = self.context.run_tracker.run_info.get_as_dict()
+        build_properties.update(run_info_dict)
       pex_info = binary_tgt.pexinfo.copy()
       pex_info.build_properties = build_properties
 


### PR DESCRIPTION
### Problem
With `./pants binary`, from the start we have injected our own information into `build_properties` to include the run information, which includes things like the `timestamp` and `report_url`.

For example, a `PEX-INFO` would include these build properties:
 
```python
"build_properties": {"branch": "no-pyc", "buildroot": "/Users/eric/DocsLocal/code/projects/pants", "class": "CPython", "cmd_line": "pants --cache-ignore binary build-support/bin:shellcheck", "datetime": "Monday Jun 03, 2019 12:27:55", "default_report": "/Users/eric/DocsLocal/code/projects/pants/.pants.d/reports/pants_run_2019_06_03_12_27_55_249_2fd25ab784514e618dc2f05af46dd824/html/build.html", "id": "pants_run_2019_06_03_12_27_55_249_2fd25ab784514e618dc2f05af46dd824", "machine": "Erics-MacBook-Pro.local", "path": "/Users/eric/DocsLocal/code/projects/pants", "pex_version": "1.6.7", "platform": "macosx_10_14_x86_64", "report_url": "http://localhost:49468/run/pants_run_2019_06_03_12_27_55_249_2fd25ab784514e618dc2f05af46dd824", "revision": "4948b9f87d4cf3856c89e3b456da3ce22c8c93f7", "timestamp": "1559590075.249843", "user": "eric", "version": "1.17.0rc0"}
```

Not only are most of these irrelevant when shipping a PEX, but they also cause any PEX created via `./pants binary` to never be able to be reproducible, meaning that https://github.com/pantsbuild/pants/pull/7734 and https://github.com/pantsbuild/pants/pull/7841 will not fully fix reproducible builds (https://github.com/pantsbuild/pants/issues/7808).

### Solution
Default to not including this run information, as it is generally not relevant to built PEXes and we do not anticipate the average user exploding the `.pex` file to inspect this data.

However, we do introduce a new option `--binary-py-include-run-information` that allows the original behavior. Because we have included this information in `PEX-INFO` from the start, some users may have come to depend on it and should have the option to keep the behavior.

### Result
With https://github.com/pantsbuild/pants/pull/7841 also included, two built PEXes will be byte-for-byte identical, e.g.

```bash
$ ./pants --cache-ignore binary build-support/bin:shellcheck; mv dist/shellcheck.pex 1.pex
$ ./pants --cache-ignore binary build-support/bin:shellcheck; mv dist/shellcheck.pex 2.pex
$ cmp 1.pex 2.pex
```

[`--cache-ignore` is used to ensure here that a new PEX is being generated each time, rather than relying on the prior cached result.]

The `PEX-INFO` will now only include this much saner set of values for `build_properties`:

```python
 "build_properties": {"class": "CPython", "pex_version": "1.6.7", "platform": "macosx_10_14_x86_64", "version": [3, 6, 8]}
```