### PR TITLE
Fix remoting of V2 Python test runnner not being able to discover the Python interpreter

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import sys
 from builtins import str
 
 from future.utils import text_type
@@ -74,8 +73,13 @@ def run_python_test(test_target, pytest, python_setup, source_root_config, pex_b
   # Sort all user requirement strings to increase the chance of cache hits across invocations.
   all_requirements = sorted(all_target_requirements + list(pytest.get_requirement_strings()))
 
-  # TODO(#7061): This str() can be removed after we drop py2!
-  python_binary = text_type(sys.executable)
+  # NB: we use the generic bin name `python`, rather than something hardcoded like
+  # `sys.executable`, to ensure that the python_binary may be discovered both locally and in remote
+  # execution. This is only used to run the downloaded PEX tool; it is not necessarily the
+  # interpreter that PEX will use to execute the generated .pex files.
+  # Because PEX works with Python 2.7 and 3.4+, we do not need to worry about `python` pointing to
+  # a specific interpreter version.
+  python_binary = "python"
   interpreter_constraint_args = parse_interpreter_constraints(
     python_setup, python_target_adaptors=all_targets
   )

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -73,7 +73,7 @@ def run_python_test(test_target, pytest, python_setup, source_root_config, pex_b
   # Sort all user requirement strings to increase the chance of cache hits across invocations.
   all_requirements = sorted(all_target_requirements + list(pytest.get_requirement_strings()))
 
-  # NB: we use the generic bin name `python`, rather than something hardcoded like
+  # NB: we use the hardcoded and generic bin name `python`, rather than something dynamic like
   # `sys.executable`, to ensure that the python_binary may be discovered both locally and in remote
   # execution. This is only used to run the downloaded PEX tool; it is not necessarily the
   # interpreter that PEX will use to execute the generated .pex files.


### PR DESCRIPTION
### Problem
Separately from the interpreter PEX uses to run Pytest and to resolve requirements, we must also have an interpreter to run PEX itself. This might be the same interpreter used by Pytest, but need not be, so long as it is Python 2.7 or 3.4+.

Currently, we use `sys.executable` to determine this interpreter. This works when running locally, but fails when remoting because `sys.executable` is an absolute path, such as `'/Users/eric/DocsLocal/code/projects/pants/build-support/pants_dev_deps.py36.venv/bin/python'`.

### Solution
Use a generic `python` bin name.

### Result
Local execution still works as expected, including choosing a Python 2 vs. Python 3 interpreter via `--python-setup-interpreter-constraints`.

While remoting still fails due to other issues, this issue no longer causes an error.