### PR TITLE
Split up contrib tests into shards in CI for fewer delays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1658,39 +1658,71 @@ matrix:
     - <<: *osx_rust_tests
 
     - <<: *py27_linux_test_config
-      name: "Python contrib tests (Py2.7 PEX)"
-      stage: *test
+      name: "Python contrib tests - shard 0 (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=linuxcontribtests.py27
+        - CACHE_NAME=contrib.py27.shard0
       script:
-        - ./build-support/bin/ci.sh -2n
+        - ./build-support/bin/ci.sh -2n -y 0/2
+
+    - <<: *py27_linux_test_config
+      name: "Python contrib tests - shard 1 (Py2.7 PEX)"
+      env:
+        - *py27_linux_test_config_env
+        - CACHE_NAME=contrib.py27.shard1
+      script:
+        - ./build-support/bin/ci.sh -2n -y 1/2
 
     - <<: *py36_linux_test_config
-      name: "Python contrib tests (Py3.6 PEX)"
+      name: "Python contrib tests - shard 0 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
-        - CACHE_NAME=linuxcontribtests.py36
+        - CACHE_NAME=contrib.py36.shard0
       script:
-        - ./build-support/bin/ci.sh -n
+        - ./build-support/bin/ci.sh -n -y 0/2
 
     - <<: *py36_linux_test_config
-      name: "Python contrib tests with Pantsd (Py3.6 PEX)"
-      stage: *test_cron
+      name: "Python contrib tests - shard 1 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - CACHE_NAME=contrib.py36.shard1
+      script:
+        - ./build-support/bin/ci.sh -n -y 1/2
+
+    - <<: *py36_linux_test_config
+      name: "Python contrib tests with Pantsd - shard 0 (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - *run_tests_under_pantsd
-        - CACHE_NAME=linuxcontribtests.py36
+        - CACHE_NAME=contrib.py36.pantsd.shard0
       script:
-        - ./build-support/bin/ci.sh -n
+        - ./build-support/bin/ci.sh -n -y 0/2
+
+    - <<: *py36_linux_test_config
+      name: "Python contrib tests with Pantsd - shard 1 (Py3.6 PEX)"
+      env:
+        - *py36_linux_test_config_env
+        - *run_tests_under_pantsd
+        - CACHE_NAME=contrib.py36.pantsd.shard1
+      script:
+        - ./build-support/bin/ci.sh -n -y 1/2
 
     - <<: *py37_linux_test_config
-      name: "Python contrib tests (Py3.7 PEX)"
+      name: "Python contrib tests - shard 0 (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
-        - CACHE_NAME=linuxcontribtests.py37
+        - CACHE_NAME=contrib.py37.shard0
       script:
-        - ./build-support/bin/ci.sh -7n
+        - ./build-support/bin/ci.sh -7n -y 0/2
+
+    - <<: *py37_linux_test_config
+      name: "Python contrib tests - shard 1 (Py3.7 PEX)"
+      env:
+        - *py37_linux_test_config_env
+        - CACHE_NAME=contrib.py37.shard1
+      script:
+        - ./build-support/bin/ci.sh -7n -y 1/2
+
 
     - <<: *py27_osx_10_12_sanity_check
     - <<: *py36_osx_10_12_sanity_check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1659,6 +1659,7 @@ matrix:
 
     - <<: *py27_linux_test_config
       name: "Python contrib tests - shard 0 (Py2.7 PEX)"
+      stage: *test
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=contrib.py27.shard0
@@ -1667,6 +1668,7 @@ matrix:
 
     - <<: *py27_linux_test_config
       name: "Python contrib tests - shard 1 (Py2.7 PEX)"
+      stage: *test
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=contrib.py27.shard1
@@ -1691,6 +1693,7 @@ matrix:
 
     - <<: *py36_linux_test_config
       name: "Python contrib tests with Pantsd - shard 0 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_linux_test_config_env
         - *run_tests_under_pantsd
@@ -1700,6 +1703,7 @@ matrix:
 
     - <<: *py36_linux_test_config
       name: "Python contrib tests with Pantsd - shard 1 (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_linux_test_config_env
         - *run_tests_under_pantsd

--- a/build-support/travis/generate_travis_yml.py
+++ b/build-support/travis/generate_travis_yml.py
@@ -9,6 +9,7 @@ import pystache
 
 
 num_integration_shards = 20
+num_contrib_shards = 2
 
 
 HEADER = """
@@ -37,6 +38,8 @@ def generate_travis_yml():
     'header': HEADER,
     'integration_shards': range(0, num_integration_shards),
     'integration_shards_length': num_integration_shards,
+    'contrib_shards': range(0, num_contrib_shards),
+    'contrib_shards_length': num_contrib_shards,
   }
   renderer = pystache.Renderer(partials={
     'before_install_linux': before_install_linux,

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -965,6 +965,7 @@ matrix:
 {{#contrib_shards}}
     - <<: *py27_linux_test_config
       name: "Python contrib tests - shard {{.}} (Py2.7 PEX)"
+      stage: *test
       env:
         - *py27_linux_test_config_env
         - CACHE_NAME=contrib.py27.shard{{.}}
@@ -985,6 +986,7 @@ matrix:
 {{#contrib_shards}}
     - <<: *py36_linux_test_config
       name: "Python contrib tests with Pantsd - shard {{.}} (Py3.6 PEX)"
+      stage: *test_cron
       env:
         - *py36_linux_test_config_env
         - *run_tests_under_pantsd

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -962,40 +962,47 @@ matrix:
     - <<: *linux_rust_tests
     - <<: *osx_rust_tests
 
+{{#contrib_shards}}
     - <<: *py27_linux_test_config
-      name: "Python contrib tests (Py2.7 PEX)"
-      stage: *test
+      name: "Python contrib tests - shard {{.}} (Py2.7 PEX)"
       env:
         - *py27_linux_test_config_env
-        - CACHE_NAME=linuxcontribtests.py27
+        - CACHE_NAME=contrib.py27.shard{{.}}
       script:
-        - ./build-support/bin/ci.sh -2n
+        - ./build-support/bin/ci.sh -2n -y {{.}}/{{contrib_shards_length}}
 
+{{/contrib_shards}}
+{{#contrib_shards}}
     - <<: *py36_linux_test_config
-      name: "Python contrib tests (Py3.6 PEX)"
+      name: "Python contrib tests - shard {{.}} (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
-        - CACHE_NAME=linuxcontribtests.py36
+        - CACHE_NAME=contrib.py36.shard{{.}}
       script:
-        - ./build-support/bin/ci.sh -n
+        - ./build-support/bin/ci.sh -n -y {{.}}/{{contrib_shards_length}}
 
+{{/contrib_shards}}
+{{#contrib_shards}}
     - <<: *py36_linux_test_config
-      name: "Python contrib tests with Pantsd (Py3.6 PEX)"
-      stage: *test_cron
+      name: "Python contrib tests with Pantsd - shard {{.}} (Py3.6 PEX)"
       env:
         - *py36_linux_test_config_env
         - *run_tests_under_pantsd
-        - CACHE_NAME=linuxcontribtests.py36
+        - CACHE_NAME=contrib.py36.pantsd.shard{{.}}
       script:
-        - ./build-support/bin/ci.sh -n
+        - ./build-support/bin/ci.sh -n -y {{.}}/{{contrib_shards_length}}
 
+{{/contrib_shards}}
+{{#contrib_shards}}
     - <<: *py37_linux_test_config
-      name: "Python contrib tests (Py3.7 PEX)"
+      name: "Python contrib tests - shard {{.}} (Py3.7 PEX)"
       env:
         - *py37_linux_test_config_env
-        - CACHE_NAME=linuxcontribtests.py37
+        - CACHE_NAME=contrib.py37.shard{{.}}
       script:
-        - ./build-support/bin/ci.sh -7n
+        - ./build-support/bin/ci.sh -7n -y {{.}}/{{contrib_shards_length}}
+
+{{/contrib_shards}}
 
     - <<: *py27_osx_10_12_sanity_check
     - <<: *py36_osx_10_12_sanity_check


### PR DESCRIPTION
### Problem
The contrib shards consistently are the blocker for CI runs because they appear near the end of the shards.

### Solution
Add a new shard for each permutation of the contrib tests, so that it no longer takes 40 minutes for the job to finish.

#### Alternative solution: remove dedicated contrib shards
A better solution would be just to consume unit and integration tests into the normal tests, as attempted in https://github.com/pantsbuild/pants/pull/7709. However, this approach failed because of failures from not originally using `--chroot` for contrib tests and starting to with that change.

In the meantime, this is a decent workaround.

### Result
Before, CI took about 37 - 40 minutes for each contrib shard (2 of them).

Now, it takes about 23 - 30 minutes for each contrib shard (4 of them).

This means that the wall time is improved by ~10 minutes, at the expense of ~20 more total minutes.