### PR TITLE
Move V2 test runner integration test into proper location of `backend/python` folder

### DIFF
--- a/tests/python/pants_test/backend/python/rules/BUILD
+++ b/tests/python/pants_test/backend/python/rules/BUILD
@@ -3,7 +3,7 @@
 
 python_tests(
   name='inject_init',
-  sources=['test_inject_init.py'],
+  source='test_inject_init.py',
   dependencies=[
     'src/python/pants/backend/python/rules',
     'src/python/pants/engine:fs',
@@ -15,11 +15,20 @@ python_tests(
 
 python_tests(
   name='python_test_runner',
-  sources=['test_python_test_runner.py'],
+  source='test_python_test_runner.py',
   dependencies=[
     'src/python/pants/backend/python/rules',
     'src/python/pants/backend/python/subsystems',
     'src/python/pants/engine/legacy:structs',
     'tests/python/pants_test/subsystem:subsystem_utils',
   ]
+)
+
+python_tests(
+  name='python_test_runner_integration',
+  source='test_python_test_runner_integration.py',
+  dependencies=[
+    'tests/python/pants_test:int-test',
+  ],
+  tags={'integration'},
 )

--- a/tests/python/pants_test/backend/python/rules/test_python_test_runner_integration.py
+++ b/tests/python/pants_test/backend/python/rules/test_python_test_runner_integration.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
-class TestIntegrationTest(PantsRunIntegrationTest):
+class TestPythonTestRunnerIntegration(PantsRunIntegrationTest):
 
   def run_pants(self, trailing_args):
     args = [
@@ -21,13 +21,17 @@ class TestIntegrationTest(PantsRunIntegrationTest):
     ] + trailing_args
     # Set TERM=dumb to stop pytest from trying to be clever and wrap lines which may interfere with
     # our golden data.
-    return super(TestIntegrationTest, self).run_pants(args, extra_env={'TERM': 'dumb'})
+    return super(TestPythonTestRunnerIntegration, self).run_pants(args, extra_env={'TERM': 'dumb'})
 
   # TODO: Modify flags (or pytest) so that output is hermetic and deterministic, and doesn't require fuzzy matching
   def assert_fuzzy_string_match(self, got, want):
     want_lines = want.split('\n')
     got_lines = got.split('\n')
-    self.assertEqual(len(want_lines), len(got_lines), 'Wrong number of lines comparing:\nWANT:\n{}\nGOT:\n{}'.format(want, got))
+    self.assertEqual(
+      len(want_lines),
+      len(got_lines),
+      'Wrong number of lines comparing:\nWANT:\n{}\nGOT:\n{}'.format(want, got)
+    )
 
     for line_number, (want_line, got_line) in enumerate(zip(want_lines, got_lines)):
       want_parts = want_line.split('SOME_TEXT')
@@ -48,10 +52,9 @@ class TestIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(trailing_args)
     self.assert_failure(pants_run)
     self.assertEqual('Tests failed\n', pants_run.stderr_data)
-
     return pants_run
 
-  def test_passing_python_test(self):
+  def test_passing_test(self):
     pants_run = self.run_passing_pants_test([
       'testprojects/tests/python/pants/dummies:passing_target',
     ])
@@ -74,7 +77,7 @@ class TestIntegrationTest(PantsRunIntegrationTest):
         """),
     )
 
-  def test_failing_python_test(self):
+  def test_failing_test(self):
     pants_run = self.run_failing_pants_test([
       'testprojects/tests/python/pants/dummies:failing_target',
     ])
@@ -102,6 +105,50 @@ class TestIntegrationTest(PantsRunIntegrationTest):
 
 
         testprojects/tests/python/pants/dummies:failing_target                          .....   FAILURE
+        """),
+    )
+
+  def test_mixed_tests(self):
+    pants_run = self.run_failing_pants_test([
+      'testprojects/tests/python/pants/dummies:failing_target',
+      'testprojects/tests/python/pants/dummies:passing_target',
+    ])
+    self.assert_fuzzy_string_match(
+      pants_run.stdout_data,
+      dedent("""\
+        testprojects/tests/python/pants/dummies:failing_target stdout:
+        ============================= test session starts ==============================
+        platform SOME_TEXT
+        rootdir: SOME_TEXT
+        plugins: SOME_TEXT
+        collected 1 item
+
+        pants/dummies/test_fail.py F                                             [100%]
+
+        =================================== FAILURES ===================================
+        __________________________________ test_fail ___________________________________
+
+            def test_fail():
+        >     assert False
+        E     assert False
+
+        pants/dummies/test_fail.py:2: AssertionError
+        =========================== 1 failed in SOME_TEXT ===========================
+
+        testprojects/tests/python/pants/dummies:passing_target stdout:
+        ============================= test session starts ==============================
+        platform SOME_TEXT
+        rootdir: SOME_TEXT
+        plugins: SOME_TEXT
+        collected 1 item
+
+        pants/dummies/test_pass.py .                                             [100%]
+
+        =========================== 1 passed in SOME_TEXT ===========================
+
+
+        testprojects/tests/python/pants/dummies:failing_target                          .....   FAILURE
+        testprojects/tests/python/pants/dummies:passing_target                          .....   SUCCESS
         """),
     )
 
@@ -195,48 +242,4 @@ class TestIntegrationTest(PantsRunIntegrationTest):
 
         testprojects/tests/python/pants/dummies:target_with_transitive_dep              .....   SUCCESS
         """)
-    )
-
-  def test_mixed_python_tests(self):
-    pants_run = self.run_failing_pants_test([
-      'testprojects/tests/python/pants/dummies:failing_target',
-      'testprojects/tests/python/pants/dummies:passing_target',
-    ])
-    self.assert_fuzzy_string_match(
-      pants_run.stdout_data,
-      dedent("""\
-        testprojects/tests/python/pants/dummies:failing_target stdout:
-        ============================= test session starts ==============================
-        platform SOME_TEXT
-        rootdir: SOME_TEXT
-        plugins: SOME_TEXT
-        collected 1 item
-
-        pants/dummies/test_fail.py F                                             [100%]
-
-        =================================== FAILURES ===================================
-        __________________________________ test_fail ___________________________________
-
-            def test_fail():
-        >     assert False
-        E     assert False
-
-        pants/dummies/test_fail.py:2: AssertionError
-        =========================== 1 failed in SOME_TEXT ===========================
-
-        testprojects/tests/python/pants/dummies:passing_target stdout:
-        ============================= test session starts ==============================
-        platform SOME_TEXT
-        rootdir: SOME_TEXT
-        plugins: SOME_TEXT
-        collected 1 item
-
-        pants/dummies/test_pass.py .                                             [100%]
-
-        =========================== 1 passed in SOME_TEXT ===========================
-
-
-        testprojects/tests/python/pants/dummies:failing_target                          .....   FAILURE
-        testprojects/tests/python/pants/dummies:passing_target                          .....   SUCCESS
-        """),
     )

--- a/tests/python/pants_test/rules/BUILD
+++ b/tests/python/pants_test/rules/BUILD
@@ -1,26 +1,38 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-INTEGRATION_SOURCES = globs('*_integration.py')
 
 python_tests(
-  sources=globs('*.py', exclude=[INTEGRATION_SOURCES]),
+  name='filedeps',
+  source='test_filedeps.py',
   dependencies=[
-    '3rdparty/python:future',
     '3rdparty/python:mock',
-    'src/python/pants/backend/python/rules',
-    'src/python/pants/util:objects',
+    'src/python/pants/build_graph',
+    'src/python/pants/engine/legacy:graph',
+    'src/python/pants/rules/core',
     'tests/python/pants_test:test_base',
-    'tests/python/pants_test/engine:scheduler_test_base',
-    'tests/python/pants_test/engine/examples:scheduler_inputs',
+    'tests/python/pants_test/engine:util',
   ]
 )
 
 python_tests(
-  name='integration',
-  sources=INTEGRATION_SOURCES,
+  name='filedeps_integration',
+  source='test_filedeps_integration.py',
   dependencies=[
     'tests/python/pants_test:int-test',
   ],
   tags={'integration'},
+)
+
+python_tests(
+  name='test',
+  source='test_test.py',
+  dependencies=[
+    'src/python/pants/build_graph',
+    'src/python/pants/engine/legacy:graph',
+    'src/python/pants/engine/legacy:structs',
+    'src/python/pants/rules/core',
+    'tests/python/pants_test:test_base',
+    'tests/python/pants_test/engine:util',
+  ]
 )


### PR DESCRIPTION
`test_test_integration.py` was really an integration test for the V2 Pytest runner, not for the generic V2 test runner. For example, these tests would not make sense in the context of running Java tests. Related code should live near each other to make things more discoverable.

Also, this changes the `BUILD` for `pants_test/rules` to create an entry for each test file and to properly include each test's dependencies, which were quite out of date. Having a target per test file makes it easier to keep dependencies up to date and makes it easier to run a specific test suite.

This is prework for https://github.com/pantsbuild/pants/pull/7846.