### PR TITLE
Re-instate PosixFS Threadpool

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -729,6 +729,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb 0.8.0 (git+https://github.com/pantsbuild/lmdb-rs.git?rev=06bdfbfc6348f6804127176e561843f214fc17f8)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logging 0.0.1",
  "mock 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -739,8 +739,6 @@ dependencies = [
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "tokio 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1660,7 +1658,6 @@ dependencies = [
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -182,7 +182,6 @@ dependencies = [
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -719,6 +718,7 @@ dependencies = [
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
@@ -741,7 +741,6 @@ dependencies = [
  "tokio 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -172,6 +172,7 @@ dependencies = [
  "fs 0.0.1",
  "fuse 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "hashing 0.0.1",
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -572,6 +573,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "graph 0.0.1",
  "hashing 0.0.1",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,6 +719,7 @@ dependencies = [
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
  "hashing 0.0.1",
@@ -762,6 +765,7 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "hashing 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
@@ -815,6 +819,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-timer"
+version = "0.1.1"
+source = "git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0#0b747e565309a58537807ab43c674d8951f9e5a0"
+dependencies = [
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1638,6 +1650,7 @@ dependencies = [
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
  "hashing 0.0.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1651,7 +1664,6 @@ dependencies = [
  "tokio 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1661,6 +1673,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
+ "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "hashing 0.0.1",
  "process_execution 0.0.1",
  "resettable 0.0.1",
@@ -2182,9 +2195,8 @@ version = "0.0.1"
 dependencies = [
  "boxfuture 0.0.1",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3094,6 +3106,7 @@ dependencies = [
 "checksum fuse 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80e57070510966bfef93662a81cb8aa2b1c7db0964354fa9921434f04b9e8660"
 "checksum futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "a2037ec1c6c1c4f79557762eab1f7eae1f64f6cb418ace90fae88f0942b60139"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+"checksum futures-timer 0.1.1 (git+https://github.com/pantsbuild/futures-timer?rev=0b747e565309a58537807ab43c674d8951f9e5a0)" = "<none>"
 "checksum fwdansi 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "34dd4c507af68d37ffef962063dfa1944ce0dd4d5b82043dbab1dabe088610c3"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -84,6 +84,8 @@ bytes = "0.4.5"
 fnv = "1.0.5"
 fs = { path = "fs" }
 futures = "0.1.27"
+# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
+futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 graph = { path = "graph" }
 hashing = { path = "hashing" }
 indexmap = "1.0.2"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -24,6 +24,7 @@ itertools = "0.7.2"
 lazy_static = "1"
 lmdb = { git = "https://github.com/pantsbuild/lmdb-rs.git", rev = "06bdfbfc6348f6804127176e561843f214fc17f8" }
 log = "0.4"
+logging = { path = "../logging" }
 parking_lot = "0.6"
 protobuf = { version = "2.0.6", features = ["with-bytes"] }
 serverset = { path = "../serverset" }

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -12,6 +12,7 @@ bytes = "0.4.5"
 digest = "0.8"
 dirs = "1"
 futures = "^0.1.16"
+futures-cpupool = "0.1"
 # TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
 futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 glob = "0.2.11"
@@ -32,7 +33,6 @@ serde_derive = "1.0"
 tempfile = "3"
 tokio-codec = "0.1"
 tokio-fs = "0.1.6"
-tokio-threadpool = "0.1.12"
 uuid = { version = "0.7.1", features = ["v4"] }
 
 [dev-dependencies]

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -12,6 +12,8 @@ bytes = "0.4.5"
 digest = "0.8"
 dirs = "1"
 futures = "^0.1.16"
+# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
+futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 glob = "0.2.11"
 grpcio = { git = "https://github.com/pantsbuild/grpc-rs.git", rev = "4dfafe9355dc996d7d0702e7386a6fedcd9734c0", default_features = false, features = ["protobuf-codec", "secure"] }
 hashing = { path = "../hashing" }

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -31,8 +31,6 @@ sha2 = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 tempfile = "3"
-tokio-codec = "0.1"
-tokio-fs = "0.1.6"
 uuid = { version = "0.7.1", features = ["v4"] }
 
 [dev-dependencies]

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -23,7 +23,6 @@ parking_lot = "0.6"
 protobuf = { version = "2.0.6", features = ["with-bytes"] }
 serverset = { path = "../../serverset" }
 time = "0.1.39"
-tokio = "0.1"
 
 [dev-dependencies]
 bytes = "0.4.5"

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -14,6 +14,8 @@ errno = "0.2.3"
 fs = { path = ".." }
 fuse = "0.3.1"
 futures = "^0.1.16"
+# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
+futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 hashing = { path = "../../hashing" }
 libc = "0.2.39"
 log = "0.4.1"

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -34,6 +34,8 @@ use errno;
 use fs;
 use fuse;
 
+use futures_timer;
+
 use libc;
 
 use serverset;
@@ -702,6 +704,7 @@ fn main() {
       )
       .expect("Error making BackoffConfig"),
       1,
+      futures_timer::TimerHandle::default(),
     ),
     None => fs::Store::local_only(&store_path),
   }

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -12,6 +12,8 @@ clap = "2"
 env_logger = "0.5.4"
 fs = { path = ".." }
 futures = "^0.1.16"
+# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
+futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 hashing = { path = "../../hashing" }
 parking_lot = "0.6"
 protobuf = { version = "2.0.6", features = ["with-bytes"] }

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -30,6 +30,7 @@ use clap;
 use env_logger;
 use fs;
 use futures;
+use futures_timer;
 
 use rand;
 
@@ -312,6 +313,7 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
               std::time::Duration::from_secs(20),
             )?,
             value_t!(top_match.value_of("rpc-attempts"), usize).expect("Bad rpc-attempts flag"),
+            futures_timer::TimerHandle::default(),
           ),
           true,
         )

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -290,7 +290,7 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
         (
           Store::with_remote(
             &store_dir,
-            pool,
+            pool.clone(),
             &cas_addresses,
             top_match
               .value_of("remote-instance-name")
@@ -320,7 +320,7 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           true,
         )
       }
-      None => (Store::local_only(&store_dir, pool), false),
+      None => (Store::local_only(&store_dir, pool.clone()), false),
     };
     let store = store_result.map_err(|e| {
       format!(
@@ -361,9 +361,10 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
               .map_err(|e| format!("Error canonicalizing path {:?}: {:?}", path, e))?
               .parent()
               .ok_or_else(|| format!("File being saved must have parent but {:?} did not", path))?,
+            pool,
           );
-          let file = runtime
-            .block_on(posix_fs.stat(PathBuf::from(path.file_name().unwrap())))
+          let file = posix_fs
+            .stat(PathBuf::from(path.file_name().unwrap()))
             .unwrap();
           match file {
             fs::Stat::File(f) => {
@@ -414,7 +415,7 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           })
       }
       ("save", Some(args)) => {
-        let posix_fs = Arc::new(make_posix_fs(args.value_of("root").unwrap()));
+        let posix_fs = Arc::new(make_posix_fs(args.value_of("root").unwrap(), pool));
         let store_copy = store.clone();
         let digest = runtime.block_on(
           posix_fs
@@ -602,8 +603,8 @@ fn expand_files_helper(
     .to_boxed()
 }
 
-fn make_posix_fs<P: AsRef<Path>>(root: P) -> fs::PosixFS {
-  fs::PosixFS::new(&root, &[]).unwrap()
+fn make_posix_fs<P: AsRef<Path>>(root: P, pool: Arc<ResettablePool>) -> fs::PosixFS {
+  fs::PosixFS::new(&root, pool, &[]).unwrap()
 }
 
 fn ensure_uploaded_to_remote(

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -39,7 +39,7 @@ use serde_json;
 use boxfuture::{try_future, BoxFuture, Boxable};
 use bytes::Bytes;
 use clap::{value_t, App, Arg, SubCommand};
-use fs::{GlobMatching, Snapshot, Store, StoreFileByDigest, UploadSummary};
+use fs::{GlobMatching, ResettablePool, Snapshot, Store, StoreFileByDigest, UploadSummary};
 use futures::future::Future;
 use hashing::{Digest, Fingerprint};
 use parking_lot::Mutex;
@@ -257,6 +257,7 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
     .value_of("local-store-path")
     .map(PathBuf::from)
     .unwrap_or_else(Store::default_path);
+  let pool = Arc::new(ResettablePool::new("fsutil-pool-".to_string()));
   let mut runtime = tokio::runtime::Runtime::new().unwrap();
   let (store, store_has_remote) = {
     let (store_result, store_has_remote) = match top_match.values_of("server-address") {
@@ -289,6 +290,7 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
         (
           Store::with_remote(
             &store_dir,
+            pool,
             &cas_addresses,
             top_match
               .value_of("remote-instance-name")
@@ -318,7 +320,7 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           true,
         )
       }
-      None => (Store::local_only(&store_dir), false),
+      None => (Store::local_only(&store_dir, pool), false),
     };
     let store = store_result.map_err(|e| {
       format!(

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -34,6 +34,8 @@ pub use crate::snapshot::{
 };
 mod store;
 pub use crate::store::{ShrinkBehavior, Store, UploadSummary, DEFAULT_LOCAL_STORE_GC_TARGET_BYTES};
+mod pool;
+pub use crate::pool::ResettablePool;
 
 pub use serverset::BackoffConfig;
 

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -41,7 +41,7 @@ pub use serverset::BackoffConfig;
 
 use std::cmp::min;
 use std::ffi::OsStr;
-use std::io;
+use std::io::{self, Read};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -51,7 +51,6 @@ use ::ignore::gitignore::{Gitignore, GitignoreBuilder};
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
 use futures::future::{self, Future};
-use futures::Stream;
 use glob::{MatchOptions, Pattern};
 use lazy_static::lazy_static;
 
@@ -558,11 +557,16 @@ pub struct GlobWithSource {
 #[derive(Clone)]
 pub struct PosixFS {
   root: Dir,
+  pool: Arc<ResettablePool>,
   ignore: Arc<GitignoreStyleExcludes>,
 }
 
 impl PosixFS {
-  pub fn new<P: AsRef<Path>>(root: P, ignore_patterns: &[String]) -> Result<PosixFS, String> {
+  pub fn new<P: AsRef<Path>>(
+    root: P,
+    pool: Arc<ResettablePool>,
+    ignore_patterns: &[String],
+  ) -> Result<PosixFS, String> {
     let root: &Path = root.as_ref();
     let canonical_root = root
       .canonicalize()
@@ -588,78 +592,100 @@ impl PosixFS {
     })?;
     Ok(PosixFS {
       root: canonical_root,
+      pool: pool,
       ignore: ignore,
     })
   }
 
-  pub fn scandir(
-    &self,
-    dir_relative_to_root: Dir,
-  ) -> impl Future<Item = DirectoryListing, Error = io::Error> {
+  fn scandir_sync(&self, dir_relative_to_root: &Dir) -> Result<Vec<Stat>, io::Error> {
     let dir_abs = self.root.0.join(&dir_relative_to_root.0);
-    let posix_fs = self.clone();
-    let ignore = self.ignore.clone();
-    tokio_fs::read_dir(dir_abs.clone())
-      .and_then(move |readdir| {
-        readdir
-          .and_then(move |dir_entry| {
-            let dir_relative_to_root = dir_relative_to_root.clone();
-            posix_fs.stat(dir_relative_to_root.0.join(dir_entry.file_name()))
-          })
-          .filter(move |s| !ignore.is_ignored(s))
-          .collect()
+    let mut stats: Vec<Stat> = dir_abs
+      .read_dir()?
+      .map(|readdir| {
+        let dir_entry = readdir?;
+        let get_metadata = || std::fs::metadata(dir_abs.join(dir_entry.file_name()));
+        PosixFS::stat_internal(
+          dir_relative_to_root.0.join(dir_entry.file_name()),
+          dir_entry.file_type()?,
+          &dir_abs,
+          get_metadata,
+        )
       })
-      .map(|mut stats| {
-        stats.sort_by(|s1, s2| s1.path().cmp(s2.path()));
-        DirectoryListing(stats)
+      .filter(|s| match s {
+        Ok(ref s) =>
+        // It would be nice to be able to ignore paths before stat'ing them, but in order to apply
+        // git-style ignore patterns, we need to know whether a path represents a directory.
+        {
+          !self.ignore.is_ignored(s)
+        }
+        Err(_) => true,
       })
+      .collect::<Result<Vec<_>, io::Error>>()?;
+    stats.sort_by(|s1, s2| s1.path().cmp(s2.path()));
+    Ok(stats)
   }
 
   pub fn is_ignored(&self, stat: &Stat) -> bool {
     self.ignore.is_ignored(stat)
   }
 
-  pub fn read_file(&self, file: &File) -> impl Future<Item = FileContent, Error = io::Error> {
+  pub fn read_file(&self, file: &File) -> BoxFuture<FileContent, io::Error> {
     let path = file.path.clone();
     let path_abs = self.root.0.join(&file.path);
-    tokio_fs::File::open(path_abs)
-      .and_then(|file| tokio_codec::FramedRead::new(file, tokio_codec::BytesCodec::new()).concat2())
-      .map(|content| FileContent {
-        path,
-        content: content.freeze(),
+    self
+      .pool
+      .spawn_fn(move || {
+        std::fs::File::open(&path_abs).and_then(|mut f| {
+          let mut content = Vec::new();
+          f.read_to_end(&mut content)?;
+          Ok(FileContent {
+            path: path,
+            content: Bytes::from(content),
+          })
+        })
       })
+      .to_boxed()
   }
 
-  pub fn read_link(&self, link: &Link) -> impl Future<Item = PathBuf, Error = io::Error> {
+  pub fn read_link(&self, link: &Link) -> BoxFuture<PathBuf, io::Error> {
     let link_parent = link.0.parent().map(Path::to_owned);
     let link_abs = self.root.0.join(link.0.as_path()).to_owned();
-    tokio_fs::read_link(link_abs.clone()).and_then(move |path_buf| {
-      if path_buf.is_absolute() {
-        Err(io::Error::new(
-          io::ErrorKind::InvalidData,
-          format!("Absolute symlink: {:?}", link_abs),
-        ))
-      } else {
-        link_parent
-          .map(|parent| parent.join(path_buf))
-          .ok_or_else(|| {
-            io::Error::new(
+    self
+      .pool
+      .spawn_fn(move || {
+        link_abs.read_link().and_then(|path_buf| {
+          if path_buf.is_absolute() {
+            Err(io::Error::new(
               io::ErrorKind::InvalidData,
-              format!("Symlink without a parent?: {:?}", link_abs),
-            )
-          })
-      }
-    })
+              format!("Absolute symlink: {:?}", link_abs),
+            ))
+          } else {
+            link_parent
+              .map(|parent| parent.join(path_buf))
+              .ok_or_else(|| {
+                io::Error::new(
+                  io::ErrorKind::InvalidData,
+                  format!("Symlink without a parent?: {:?}", link_abs),
+                )
+              })
+          }
+        })
+      })
+      .to_boxed()
   }
 
   ///
   /// Makes a Stat for path_for_stat relative to absolute_path_to_root.
   ///
-  fn stat_internal(
+  fn stat_internal<F>(
     path_for_stat: PathBuf,
+    file_type: std::fs::FileType,
     absolute_path_to_root: &Path,
-    metadata: &std::fs::Metadata,
-  ) -> Result<Stat, io::Error> {
+    get_metadata: F,
+  ) -> Result<Stat, io::Error>
+  where
+    F: FnOnce() -> Result<fs::Metadata, io::Error>,
+  {
     if !path_for_stat.is_relative() {
       return Err(io::Error::new(
         io::ErrorKind::InvalidInput,
@@ -679,17 +705,16 @@ impl PosixFS {
         ),
       ));
     }
-    let file_type = metadata.file_type();
-    if file_type.is_symlink() {
-      Ok(Stat::Link(Link(path_for_stat)))
+    if file_type.is_dir() {
+      Ok(Stat::Dir(Dir(path_for_stat)))
     } else if file_type.is_file() {
-      let is_executable = metadata.permissions().mode() & 0o100 == 0o100;
+      let is_executable = get_metadata()?.permissions().mode() & 0o100 == 0o100;
       Ok(Stat::File(File {
         path: path_for_stat,
         is_executable: is_executable,
       }))
-    } else if file_type.is_dir() {
-      Ok(Stat::Dir(Dir(path_for_stat)))
+    } else if file_type.is_symlink() {
+      Ok(Stat::Link(Link(path_for_stat)))
     } else {
       Err(io::Error::new(
         io::ErrorKind::InvalidData,
@@ -701,20 +726,33 @@ impl PosixFS {
     }
   }
 
-  pub fn stat(&self, relative_path: PathBuf) -> impl Future<Item = Stat, Error = io::Error> {
-    let root = self.root.0.clone();
-    tokio_fs::symlink_metadata(self.root.0.join(&relative_path))
-      .and_then(move |metadata| PosixFS::stat_internal(relative_path, &root, &metadata))
+  pub fn stat(&self, relative_path: PathBuf) -> Result<Stat, io::Error> {
+    PosixFS::stat_path(relative_path, &self.root.0)
+  }
+
+  fn stat_path(relative_path: PathBuf, root: &Path) -> Result<Stat, io::Error> {
+    let metadata = fs::symlink_metadata(root.join(&relative_path))?;
+    PosixFS::stat_internal(relative_path, metadata.file_type(), &root, || Ok(metadata))
+  }
+
+  pub fn scandir(&self, dir: &Dir) -> BoxFuture<DirectoryListing, io::Error> {
+    let dir = dir.to_owned();
+    let fs: PosixFS = self.clone();
+    self
+      .pool
+      .spawn_fn(move || fs.scandir_sync(&dir))
+      .map(DirectoryListing)
+      .to_boxed()
   }
 }
 
 impl VFS<io::Error> for Arc<PosixFS> {
   fn read_link(&self, link: &Link) -> BoxFuture<PathBuf, io::Error> {
-    PosixFS::read_link(self, link).to_boxed()
+    PosixFS::read_link(self, link)
   }
 
   fn scandir(&self, dir: Dir) -> BoxFuture<Arc<DirectoryListing>, io::Error> {
-    PosixFS::scandir(self, dir).map(Arc::new).to_boxed()
+    PosixFS::scandir(self, &dir).map(Arc::new).to_boxed()
   }
 
   fn is_ignored(&self, stat: &Stat) -> bool {
@@ -736,9 +774,11 @@ impl PathStatGetter<io::Error> for Arc<PosixFS> {
       paths
         .into_iter()
         .map(|path| {
+          let root = self.root.0.clone();
           let fs = self.clone();
           self
-            .stat(path)
+            .pool
+            .spawn_fn(move || PosixFS::stat_path(path, &root))
             .then(|stat_result| match stat_result {
               Ok(v) => Ok(Some(v)),
               Err(err) => match err.kind() {
@@ -832,7 +872,7 @@ mod posixfs_test {
 
   use super::{
     Dir, DirectoryListing, File, GlobExpansionConjunction, GlobMatching, Link, PathGlobs, PathStat,
-    PathStatGetter, PosixFS, Stat, StrictGlobMatching, VFS,
+    PathStatGetter, PosixFS, ResettablePool, Stat, StrictGlobMatching, VFS,
   };
   use boxfuture::{BoxFuture, Boxable};
   use futures::future::{self, Future};
@@ -867,12 +907,12 @@ mod posixfs_test {
       0o600,
     );
     let fs = new_posixfs(&dir.path());
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
-    let file_content = rt
-      .block_on(fs.read_file(&File {
+    let file_content = fs
+      .read_file(&File {
         path: path.clone(),
         is_executable: false,
-      }))
+      })
+      .wait()
       .unwrap();
     assert_eq!(file_content.path, path);
     assert_eq!(file_content.content, content);
@@ -896,9 +936,8 @@ mod posixfs_test {
     let posix_fs = new_posixfs(&dir.path());
     let path = PathBuf::from("photograph_marmosets");
     make_file(&dir.path().join(&path), &[], 0o700);
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
     assert_eq!(
-      runtime.block_on(posix_fs.stat(path.clone())).unwrap(),
+      posix_fs.stat(path.clone()).unwrap(),
       super::Stat::File(File {
         path: path,
         is_executable: true,
@@ -912,9 +951,8 @@ mod posixfs_test {
     let posix_fs = new_posixfs(&dir.path());
     let path = PathBuf::from("marmosets");
     make_file(&dir.path().join(&path), &[], 0o600);
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
     assert_eq!(
-      runtime.block_on(posix_fs.stat(path.clone())).unwrap(),
+      posix_fs.stat(path.clone()).unwrap(),
       super::Stat::File(File {
         path: path,
         is_executable: false,
@@ -928,9 +966,8 @@ mod posixfs_test {
     let posix_fs = new_posixfs(&dir.path());
     let path = PathBuf::from("enclosure");
     std::fs::create_dir(dir.path().join(&path)).unwrap();
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
     assert_eq!(
-      runtime.block_on(posix_fs.stat(path.clone())).unwrap(),
+      posix_fs.stat(path.clone()).unwrap(),
       super::Stat::Dir(Dir(path))
     )
   }
@@ -944,18 +981,16 @@ mod posixfs_test {
 
     let link_path = PathBuf::from("remarkably_similar_marmoset");
     std::os::unix::fs::symlink(&dir.path().join(path), dir.path().join(&link_path)).unwrap();
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
     assert_eq!(
-      runtime.block_on(posix_fs.stat(link_path.clone())).unwrap(),
+      posix_fs.stat(link_path.clone()).unwrap(),
       super::Stat::Link(Link(link_path))
     )
   }
 
   #[test]
   fn stat_other() {
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
-    runtime
-      .block_on(new_posixfs("/dev").stat(PathBuf::from("null")))
+    new_posixfs("/dev")
+      .stat(PathBuf::from("null"))
       .expect_err("Want error");
   }
 
@@ -963,9 +998,8 @@ mod posixfs_test {
   fn stat_missing() {
     let dir = tempfile::TempDir::new().unwrap();
     let posix_fs = new_posixfs(&dir.path());
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
-    runtime
-      .block_on(posix_fs.stat(PathBuf::from("no_marmosets")))
+    posix_fs
+      .stat(PathBuf::from("no_marmosets"))
       .expect_err("Want error");
   }
 
@@ -975,9 +1009,8 @@ mod posixfs_test {
     let posix_fs = new_posixfs(&dir.path());
     let path = PathBuf::from("empty_enclosure");
     std::fs::create_dir(dir.path().join(&path)).unwrap();
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
     assert_eq!(
-      runtime.block_on(posix_fs.scandir(Dir(path))).unwrap(),
+      posix_fs.scandir(&Dir(path)).wait().unwrap(),
       DirectoryListing(vec![])
     );
   }
@@ -1012,10 +1045,8 @@ mod posixfs_test {
       0o600,
     );
 
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
-
     assert_eq!(
-      runtime.block_on(posix_fs.scandir(Dir(path))).unwrap(),
+      posix_fs.scandir(&Dir(path)).wait().unwrap(),
       DirectoryListing(vec![
         Stat::File(File {
           path: a_marmoset,
@@ -1040,7 +1071,7 @@ mod posixfs_test {
     let dir = tempfile::TempDir::new().unwrap();
     let posix_fs = new_posixfs(&dir.path());
     posix_fs
-      .scandir(Dir(PathBuf::from("no_marmosets_here")))
+      .scandir(&Dir(PathBuf::from("no_marmosets_here")))
       .wait()
       .expect_err("Want error");
   }
@@ -1072,9 +1103,8 @@ mod posixfs_test {
     std::os::unix::fs::symlink("doesnotexist", &root_path.join("symlink_to_nothing")).unwrap();
 
     let posix_fs = Arc::new(new_posixfs(&root_path));
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
-    let path_stats = runtime
-      .block_on(posix_fs.path_stats(vec![
+    let path_stats = posix_fs
+      .path_stats(vec![
         PathBuf::from("executable_file"),
         PathBuf::from("regular_file"),
         PathBuf::from("dir"),
@@ -1083,7 +1113,8 @@ mod posixfs_test {
         PathBuf::from("dir_symlink"),
         PathBuf::from("symlink_to_nothing"),
         PathBuf::from("doesnotexist"),
-      ]))
+      ])
+      .wait()
       .unwrap();
     let v: Vec<Option<PathStat>> = vec![
       Some(PathStat::file(
@@ -1159,10 +1190,7 @@ mod posixfs_test {
 
   fn assert_only_file_is_executable(path: &Path, want_is_executable: bool) {
     let fs = new_posixfs(path);
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
-    let stats = runtime
-      .block_on(fs.scandir(Dir(PathBuf::from("."))))
-      .unwrap();
+    let stats = fs.scandir(&Dir(PathBuf::from("."))).wait().unwrap();
     assert_eq!(stats.0.len(), 1);
     match stats.0.get(0).unwrap() {
       &super::Stat::File(File {
@@ -1173,7 +1201,12 @@ mod posixfs_test {
   }
 
   fn new_posixfs<P: AsRef<Path>>(dir: P) -> PosixFS {
-    PosixFS::new(dir.as_ref(), &[]).unwrap()
+    PosixFS::new(
+      dir.as_ref(),
+      Arc::new(ResettablePool::new("test-pool-".to_string())),
+      &[],
+    )
+    .unwrap()
   }
 
   ///

--- a/src/rust/engine/fs/src/pool.rs
+++ b/src/rust/engine/fs/src/pool.rs
@@ -1,0 +1,68 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use futures::future::IntoFuture;
+use futures_cpupool::{self, CpuFuture, CpuPool};
+use parking_lot::RwLock;
+
+///
+/// A wrapper around a CpuPool, to add the ability to drop the pool before forking,
+/// and then lazily re-initialize it in a new process.
+///
+/// When a process forks, the kernel clones only the thread that called fork: all other
+/// threads are effectively destroyed. If a CpuPool has live threads during a fork, it
+/// will not be able to perform any work or be dropped cleanly (it will hang instead).
+/// It's thus necessary to drop the pool before forking, and to re-create it after forking.
+///
+pub struct ResettablePool {
+  name_prefix: String,
+  pool: RwLock<Option<CpuPool>>,
+}
+
+impl ResettablePool {
+  pub fn new(name_prefix: String) -> ResettablePool {
+    ResettablePool {
+      name_prefix: name_prefix.clone(),
+      pool: RwLock::new(Some(Self::new_pool(name_prefix))),
+    }
+  }
+
+  fn new_pool(name_prefix: String) -> CpuPool {
+    futures_cpupool::Builder::new()
+      .name_prefix(name_prefix)
+      .create()
+  }
+
+  ///
+  /// Delegates to `CpuPool::spawn_fn`, and shares its signature.
+  /// http://alexcrichton.com/futures-rs/futures_cpupool/struct.CpuPool.html#method.spawn_fn
+  ///
+  pub fn spawn_fn<F, R>(&self, f: F) -> CpuFuture<R::Item, R::Error>
+  where
+    F: FnOnce() -> R + Send + 'static,
+    R: IntoFuture + 'static,
+    R::Future: Send + 'static,
+    R::Item: Send + 'static,
+    R::Error: Send + 'static,
+  {
+    let pool_opt = self.pool.read();
+    let pool = pool_opt
+      .as_ref()
+      .unwrap_or_else(|| panic!("A CpuPool cannot be used inside the fork context."));
+    pool.spawn_fn(f)
+  }
+
+  ///
+  /// Run a function while the pool is shut down, and restore the pool after it completes.
+  ///
+  pub fn with_shutdown<F, T>(&self, f: F) -> T
+  where
+    F: FnOnce() -> T,
+  {
+    let mut pool = self.pool.write();
+    *pool = None;
+    let t = f();
+    *pool = Some(Self::new_pool(self.name_prefix.clone()));
+    t
+  }
+}

--- a/src/rust/engine/fs/src/pool.rs
+++ b/src/rust/engine/fs/src/pool.rs
@@ -49,7 +49,11 @@ impl ResettablePool {
     let pool = pool_opt
       .as_ref()
       .unwrap_or_else(|| panic!("A CpuPool cannot be used inside the fork context."));
-    pool.spawn_fn(f)
+    let logging_destination = logging::get_destination();
+    pool.spawn_fn(move || {
+      logging::set_destination(logging_destination);
+      f()
+    })
   }
 
   ///

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -106,6 +106,7 @@ impl Store {
     upload_timeout: Duration,
     backoff_config: BackoffConfig,
     rpc_retries: usize,
+    futures_timer_thread: futures_timer::TimerHandle,
   ) -> Result<Store, String> {
     Ok(Store {
       local: local::ByteStore::new(path)?,
@@ -119,6 +120,7 @@ impl Store {
         upload_timeout,
         backoff_config,
         rpc_retries,
+        futures_timer_thread,
       )?),
     })
   }
@@ -1694,6 +1696,7 @@ mod remote {
       upload_timeout: Duration,
       backoff_config: BackoffConfig,
       rpc_retries: usize,
+      futures_timer_thread: futures_timer::TimerHandle,
     ) -> Result<ByteStore, String> {
       let env = Arc::new(grpcio::Environment::new(thread_count));
 
@@ -1712,7 +1715,7 @@ mod remote {
         })
         .collect();
 
-      let serverset = Serverset::new(channels, backoff_config)?;
+      let serverset = Serverset::new(channels, backoff_config, futures_timer_thread)?;
 
       Ok(ByteStore {
         instance_name,
@@ -1993,6 +1996,7 @@ mod remote {
     use super::super::EntryType;
     use super::ByteStore;
     use bytes::Bytes;
+    use futures_timer::TimerHandle;
     use hashing::Digest;
     use mock::StubCAS;
     use serverset::BackoffConfig;
@@ -2149,6 +2153,7 @@ mod remote {
         Duration::from_secs(5),
         BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
         1,
+        TimerHandle::default(),
       )
       .unwrap();
 
@@ -2224,6 +2229,7 @@ mod remote {
         Duration::from_secs(1),
         BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
         1,
+        TimerHandle::default(),
       )
       .unwrap();
       let error = block_on(store.store_bytes(TestData::roland().bytes())).expect_err("Want error");
@@ -2297,6 +2303,7 @@ mod remote {
         Duration::from_secs(1),
         BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
         1,
+        TimerHandle::default(),
       )
       .unwrap();
 
@@ -2325,6 +2332,7 @@ mod remote {
         Duration::from_secs(1),
         BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
         1,
+        TimerHandle::default(),
       )
       .unwrap()
     }
@@ -2358,6 +2366,7 @@ mod tests {
   use bytes::Bytes;
   use digest::{Digest as DigestTrait, FixedOutput};
   use futures::Future;
+  use futures_timer::TimerHandle;
   use hashing::{Digest, Fingerprint};
   use mock::StubCAS;
   use protobuf::Message;
@@ -2447,6 +2456,7 @@ mod tests {
       Duration::from_secs(1),
       BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
+      TimerHandle::default(),
     )
     .unwrap()
   }
@@ -3115,6 +3125,7 @@ mod tests {
       Duration::from_secs(1),
       BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
+      TimerHandle::default(),
     )
     .unwrap();
 
@@ -3141,6 +3152,7 @@ mod tests {
       Duration::from_secs(1),
       BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
+      TimerHandle::default(),
     )
     .unwrap();
 
@@ -3178,6 +3190,7 @@ mod tests {
       Duration::from_secs(1),
       BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
+      TimerHandle::default(),
     )
     .unwrap();
 
@@ -3204,6 +3217,7 @@ mod tests {
       Duration::from_secs(1),
       BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
+      TimerHandle::default(),
     )
     .unwrap();
 

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -20,10 +20,11 @@ protobuf = { version = "2.0.6", features = ["with-bytes"] }
 resettable = { path = "../resettable" }
 sha2 = "0.8"
 tempfile = "3"
+# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
+futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 time = "0.1.40"
 tokio-codec = "0.1"
 tokio-process = "0.2.1"
-tokio-timer = "0.2"
 
 [dev-dependencies]
 mock = { path = "../testutil/mock" }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -30,4 +30,3 @@ tokio-process = "0.2.1"
 mock = { path = "../testutil/mock" }
 tempfile = "3"
 testutil = { path = "../testutil" }
-tokio = "0.1"

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -335,6 +335,7 @@ mod tests {
   use std::env;
   use std::os::unix::fs::PermissionsExt;
   use std::path::{Path, PathBuf};
+  use std::sync::Arc;
   use std::time::Duration;
   use tempfile::TempDir;
   use testutil::data::{TestData, TestDirectory};
@@ -892,7 +893,8 @@ mod tests {
     cleanup: bool,
   ) -> Result<FallibleExecuteProcessResult, String> {
     let store_dir = TempDir::new().unwrap();
-    let store = fs::Store::local_only(store_dir.path()).unwrap();
+    let pool = Arc::new(fs::ResettablePool::new("test-pool-".to_owned()));
+    let store = fs::Store::local_only(store_dir.path(), pool).unwrap();
     let runner = super::CommandRunner {
       store: store,
       work_dir: dir,

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -23,14 +23,21 @@ use bytes::{Bytes, BytesMut};
 
 pub struct CommandRunner {
   store: fs::Store,
+  fs_pool: Arc<fs::ResettablePool>,
   work_dir: PathBuf,
   cleanup_local_dirs: bool,
 }
 
 impl CommandRunner {
-  pub fn new(store: fs::Store, work_dir: PathBuf, cleanup_local_dirs: bool) -> CommandRunner {
+  pub fn new(
+    store: fs::Store,
+    fs_pool: Arc<fs::ResettablePool>,
+    work_dir: PathBuf,
+    cleanup_local_dirs: bool,
+  ) -> CommandRunner {
     CommandRunner {
       store,
+      fs_pool,
       work_dir,
       cleanup_local_dirs,
     }
@@ -216,6 +223,7 @@ impl super::CommandRunner for CommandRunner {
     let workdir_path2 = workdir_path.clone();
     let workdir_path3 = workdir_path.clone();
     let store = self.store.clone();
+    let fs_pool = self.fs_pool.clone();
 
     let env = req.env;
     let output_file_paths = req.output_files;
@@ -276,7 +284,7 @@ impl super::CommandRunner for CommandRunner {
           future::ok(fs::Snapshot::empty()).to_boxed()
         } else {
           // Use no ignore patterns, because we are looking for explicitly listed paths.
-          future::done(fs::PosixFS::new(workdir_path2, &[]))
+          future::done(fs::PosixFS::new(workdir_path2, fs_pool, &[]))
             .map_err(|err| {
               format!(
                 "Error making posix_fs to fetch local process execution output files: {}",
@@ -330,6 +338,7 @@ mod tests {
   use super::super::CommandRunner as CommandRunnerTrait;
   use super::{ExecuteProcessRequest, FallibleExecuteProcessResult};
   use fs;
+  use futures::Future;
   use std;
   use std::collections::{BTreeMap, BTreeSet};
   use std::env;
@@ -894,15 +903,14 @@ mod tests {
   ) -> Result<FallibleExecuteProcessResult, String> {
     let store_dir = TempDir::new().unwrap();
     let pool = Arc::new(fs::ResettablePool::new("test-pool-".to_owned()));
-    let store = fs::Store::local_only(store_dir.path(), pool).unwrap();
+    let store = fs::Store::local_only(store_dir.path(), pool.clone()).unwrap();
     let runner = super::CommandRunner {
       store: store,
+      fs_pool: pool,
       work_dir: dir,
       cleanup_local_dirs: cleanup,
     };
-    tokio::runtime::Runtime::new()
-      .unwrap()
-      .block_on(runner.run(req))
+    runner.run(req).wait()
   }
 
   fn find_bash() -> String {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -10,13 +10,13 @@ use bytes::Bytes;
 use digest::{Digest as DigestTrait, FixedOutput};
 use fs::{self, File, PathStat, Store};
 use futures::{future, Future, Stream};
+use futures_timer::Delay;
 use grpcio;
 use hashing::{Digest, Fingerprint};
 use log::{debug, trace, warn};
 use protobuf::{self, Message, ProtobufEnum};
 use sha2::Sha256;
 use time;
-use tokio_timer::Delay;
 
 use super::{ExecuteProcessRequest, ExecutionStats, FallibleExecuteProcessResult};
 use std;
@@ -45,6 +45,7 @@ pub struct CommandRunner {
   execution_client: Arc<bazel_protos::remote_execution_grpc::ExecutionClient>,
   operations_client: Arc<bazel_protos::operations_grpc::OperationsClient>,
   store: Store,
+  futures_timer_thread: Arc<futures_timer::HelperThread>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -152,6 +153,7 @@ impl super::CommandRunner for CommandRunner {
         let command_runner3 = self.clone();
         let execute_request = Arc::new(execute_request);
         let execute_request2 = execute_request.clone();
+        let futures_timer_thread = self.futures_timer_thread.clone();
 
         let store2 = store.clone();
         let mut history = ExecutionHistory::default();
@@ -186,6 +188,7 @@ impl super::CommandRunner for CommandRunner {
                 let operations_client = operations_client.clone();
                 let command_runner2 = command_runner2.clone();
                 let command_runner3 = command_runner3.clone();
+                let futures_timer_thread = futures_timer_thread.clone();
                 let f = command_runner2.extract_execute_response(operation, &mut history);
                 f.map(future::Loop::Break).or_else(move |value| {
                   match value {
@@ -243,32 +246,32 @@ impl super::CommandRunner for CommandRunner {
                         .to_boxed()
                       } else {
                         // maybe the delay here should be the min of remaining time and the backoff period
-                        Delay::new(Instant::now() + Duration::from_millis(backoff_period))
-                          .map_err(move |e| {
-                            format!(
-                              "Future-Delay errored at operation result polling for {}, {}: {}",
-                              operation_name, description, e
-                            )
-                          })
-                          .and_then(move |_| {
-                            future::done(
-                              operations_client
-                                .get_operation_opt(
-                                  &operation_request,
-                                  command_runner3.call_option(),
-                                )
-                                .or_else(move |err| {
-                                  rpcerror_recover_cancelled(operation_request.take_name(), err)
-                                })
-                                .map(OperationOrStatus::Operation)
-                                .map_err(rpcerror_to_string),
-                            )
-                            .map(move |operation| {
-                              future::Loop::Continue((history, operation, iter_num + 1))
-                            })
-                            .to_boxed()
+                        Delay::new_handle(
+                          Instant::now() + Duration::from_millis(backoff_period),
+                          futures_timer_thread.handle(),
+                        )
+                        .map_err(move |e| {
+                          format!(
+                            "Future-Delay errored at operation result polling for {}, {}: {}",
+                            operation_name, description, e
+                          )
+                        })
+                        .and_then(move |_| {
+                          future::done(
+                            operations_client
+                              .get_operation_opt(&operation_request, command_runner3.call_option())
+                              .or_else(move |err| {
+                                rpcerror_recover_cancelled(operation_request.take_name(), err)
+                              })
+                              .map(OperationOrStatus::Operation)
+                              .map_err(rpcerror_to_string),
+                          )
+                          .map(move |operation| {
+                            future::Loop::Continue((history, operation, iter_num + 1))
                           })
                           .to_boxed()
+                        })
+                        .to_boxed()
                       }
                     }
                   }
@@ -309,6 +312,7 @@ impl CommandRunner {
     platform_properties: BTreeMap<String, String>,
     thread_count: usize,
     store: Store,
+    futures_timer_thread: Arc<futures_timer::HelperThread>,
   ) -> CommandRunner {
     let env = Arc::new(grpcio::Environment::new(thread_count));
     let channel = {
@@ -339,6 +343,7 @@ impl CommandRunner {
       execution_client,
       operations_client,
       store,
+      futures_timer_thread,
     }
   }
 
@@ -921,6 +926,7 @@ mod tests {
   use std::iter::{self, FromIterator};
   use std::ops::Sub;
   use std::path::PathBuf;
+  use std::sync::Arc;
   use std::time::Duration;
 
   #[derive(Debug, PartialEq)]
@@ -1452,6 +1458,7 @@ mod tests {
     let store_dir_path = store_dir.path();
 
     let cas = mock::StubCAS::empty();
+    let timer_thread = timer_thread();
     let store = fs::Store::with_remote(
       &store_dir_path,
       &[cas.address()],
@@ -1463,6 +1470,7 @@ mod tests {
       Duration::from_secs(1),
       fs::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
+      timer_thread.handle(),
     )
     .expect("Failed to make store");
 
@@ -1475,6 +1483,7 @@ mod tests {
       BTreeMap::new(),
       1,
       store,
+      timer_thread,
     );
     let result = runtime
       .block_on(cmd_runner.run(echo_roland_request()))
@@ -1815,6 +1824,7 @@ mod tests {
     let cas = mock::StubCAS::builder()
       .directory(&TestDirectory::containing_roland())
       .build();
+    let timer_thread = timer_thread();
     let store = fs::Store::with_remote(
       store_dir,
       &[cas.address()],
@@ -1826,6 +1836,7 @@ mod tests {
       Duration::from_secs(1),
       fs::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
+      timer_thread.handle(),
     )
     .expect("Failed to make store");
     runtime
@@ -1843,6 +1854,7 @@ mod tests {
       BTreeMap::new(),
       1,
       store,
+      timer_thread,
     );
 
     let result = runtime
@@ -1910,6 +1922,7 @@ mod tests {
     let cas = mock::StubCAS::builder()
       .directory(&TestDirectory::containing_roland())
       .build();
+    let timer_thread = timer_thread();
     let store = fs::Store::with_remote(
       store_dir,
       &[cas.address()],
@@ -1921,6 +1934,7 @@ mod tests {
       Duration::from_secs(1),
       fs::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
+      timer_thread.handle(),
     )
     .expect("Failed to make store");
     store
@@ -1937,6 +1951,7 @@ mod tests {
       BTreeMap::new(),
       1,
       store,
+      timer_thread,
     )
     .run(cat_roland_request())
     .wait();
@@ -1979,6 +1994,7 @@ mod tests {
       .file(&TestData::roland())
       .directory(&TestDirectory::containing_roland())
       .build();
+    let timer_thread = timer_thread();
     let store = fs::Store::with_remote(
       store_dir,
       &[cas.address()],
@@ -1990,6 +2006,7 @@ mod tests {
       Duration::from_secs(1),
       fs::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
+      timer_thread.handle(),
     )
     .expect("Failed to make store");
 
@@ -2003,6 +2020,7 @@ mod tests {
       BTreeMap::new(),
       1,
       store,
+      timer_thread,
     );
 
     let error = runtime
@@ -2586,6 +2604,7 @@ mod tests {
 
   fn create_command_runner(address: String, cas: &mock::StubCAS) -> CommandRunner {
     let store_dir = TempDir::new().unwrap();
+    let timer_thread = timer_thread();
     let store = fs::Store::with_remote(
       store_dir,
       &[cas.address()],
@@ -2597,10 +2616,25 @@ mod tests {
       Duration::from_secs(1),
       fs::BackoffConfig::new(Duration::from_millis(10), 1.0, Duration::from_millis(10)).unwrap(),
       1,
+      timer_thread.handle(),
     )
     .expect("Failed to make store");
 
-    CommandRunner::new(&address, None, None, None, None, BTreeMap::new(), 1, store)
+    CommandRunner::new(
+      &address,
+      None,
+      None,
+      None,
+      None,
+      BTreeMap::new(),
+      1,
+      store,
+      timer_thread,
+    )
+  }
+
+  fn timer_thread() -> Arc<futures_timer::HelperThread> {
+    Arc::new(futures_timer::HelperThread::new().unwrap())
   }
 
   fn extract_execute_response(

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -9,6 +9,8 @@ publish = false
 clap = "2"
 env_logger = "0.5.4"
 fs = { path = "../fs" }
+# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
+futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 hashing = { path = "../hashing" }
 process_execution = { path = "../process_execution" }
 resettable = { path = "../resettable" }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -246,7 +246,7 @@ fn main() {
 
       fs::Store::with_remote(
         local_store_path,
-        pool,
+        pool.clone(),
         &[cas_server.to_owned()],
         remote_instance_arg.clone(),
         &root_ca_certs,
@@ -316,6 +316,7 @@ fn main() {
     }
     None => Box::new(process_execution::local::CommandRunner::new(
       store.clone(),
+      pool,
       work_dir,
       true,
     )) as Box<dyn process_execution::CommandRunner>,

--- a/src/rust/engine/serverset/Cargo.toml
+++ b/src/rust/engine/serverset/Cargo.toml
@@ -8,8 +8,6 @@ publish = false
 [dependencies]
 boxfuture = { path = "../boxfuture" }
 futures = "^0.1.16"
+# TODO: Switch to a release once https://github.com/alexcrichton/futures-timer/pull/11 and https://github.com/alexcrichton/futures-timer/pull/12 merge
+futures-timer = { git = "https://github.com/pantsbuild/futures-timer", rev = "0b747e565309a58537807ab43c674d8951f9e5a0" }
 parking_lot = "0.6"
-tokio-timer = "0.2"
-
-[dev-dependencies]
-tokio = "0.1"

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -715,25 +715,25 @@ pub extern "C" fn capture_snapshots(
 
   with_scheduler(scheduler_ptr, |scheduler| {
     let core = scheduler.core.clone();
-    core.block_on(
-      futures::future::join_all(
-        path_globs_and_roots
-          .into_iter()
-          .map(|(path_globs, root, digest_hint)| {
-            let core = core.clone();
-            fs::Snapshot::capture_snapshot_from_arbitrary_root(
-              core.store(),
-              root,
-              path_globs,
-              digest_hint,
-            )
-            .map(move |snapshot| nodes::Snapshot::store_snapshot(&core, &snapshot))
-          })
-          .collect::<Vec<_>>(),
-      )
-      .map(|values| externs::store_tuple(&values)),
+    futures::future::join_all(
+      path_globs_and_roots
+        .into_iter()
+        .map(|(path_globs, root, digest_hint)| {
+          let core = core.clone();
+          fs::Snapshot::capture_snapshot_from_arbitrary_root(
+            core.store(),
+            core.fs_pool.clone(),
+            root,
+            path_globs,
+            digest_hint,
+          )
+          .map(move |snapshot| nodes::Snapshot::store_snapshot(&core, &snapshot))
+        })
+        .collect::<Vec<_>>(),
     )
   })
+  .map(|values| externs::store_tuple(&values))
+  .wait()
   .into()
 }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -506,7 +506,7 @@ impl WrappedNode for Scandir {
     context
       .core
       .vfs
-      .scandir(self.0)
+      .scandir(&self.0)
       .then(move |listing_res| match listing_res {
         Ok(listing) => Ok(Arc::new(listing)),
         Err(e) => Err(throw(&format!("Failed to scandir for {:?}: {:?}", dir, e))),


### PR DESCRIPTION
Removing this threadpool introduced a significant performance regression to the `export` goal, for as-yet undiagnosed reasons.

This is a dirty revert of #7822, #7688, and #7685, and adding a tiny commit on top to support thread-local logging.

I will hopefully investigate and re-land fixing up the regression at some point.