### PR TITLE
Create a separate crate for workunit_store

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -593,6 +593,7 @@ dependencies = [
  "ui 0.0.1",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "workunit_store 0.0.1",
 ]
 
 [[package]]
@@ -3010,6 +3011,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "workunit_store"
+version = "0.0.1"
+dependencies = [
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -46,7 +46,8 @@ members = [
   "testutil",
   "testutil/mock",
   "testutil/local_cas",
-  "ui"
+  "ui",
+  "workunit_store"
 ]
 
 # These are the packages which are built/tested when no special selector flags are passed to cargo.
@@ -75,7 +76,8 @@ default-members = [
   "testutil",
   "testutil/mock",
   "testutil/local_cas",
-  "ui"
+  "ui",
+  "workunit_store"
 ]
 
 [dependencies]
@@ -105,6 +107,7 @@ tempfile = "3"
 ui = { path = "ui" }
 url = "1.7.1"
 tar_api = { path = "tar_api" }
+workunit_store = { path = "workunit_store" }
 
 [patch.crates-io]
 # TODO: Remove patch when we can upgrade to an official released version of protobuf with a fix.

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -51,8 +51,6 @@ use log;
 
 use tar_api;
 
-use workunit_store;
-
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::ffi::CStr;
@@ -77,13 +75,13 @@ use crate::handles::Handle;
 use crate::scheduler::{ExecutionRequest, RootResult, Scheduler, Session};
 use crate::tasks::{Rule, Tasks};
 use crate::types::Types;
-use crate::workunit_store::WorkUnitStore;
 use futures::Future;
 use hashing::Digest;
 use log::{error, Log};
 use logging::logger::LOGGER;
 use logging::{Destination, Logger};
 use rule_graph::{GraphMaker, RuleGraph};
+use workunit_store::WorkUnitStore;
 
 // TODO: Consider renaming and making generic for collections of PyResults.
 #[repr(C)]

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -51,6 +51,8 @@ use log;
 
 use tar_api;
 
+use workunit_store;
+
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::ffi::CStr;
@@ -75,6 +77,7 @@ use crate::handles::Handle;
 use crate::scheduler::{ExecutionRequest, RootResult, Scheduler, Session};
 use crate::tasks::{Rule, Tasks};
 use crate::types::Types;
+use crate::workunit_store::WorkUnitStore;
 use futures::Future;
 use hashing::Digest;
 use log::{error, Log};

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -19,7 +19,6 @@ use crate::core::{throw, Failure, Key, Params, TypeId, Value};
 use crate::externs;
 use crate::selectors;
 use crate::tasks::{self, Intrinsic, Rule};
-use crate::workunit_store::{WorkUnit, WorkUnitStore};
 use boxfuture::{try_future, BoxFuture, Boxable};
 use bytes::{self, BufMut};
 use fs::{
@@ -33,6 +32,7 @@ use rule_graph;
 use graph::{Entry, Node, NodeError, NodeTracer, NodeVisualizer};
 use rand::thread_rng;
 use rand::Rng;
+use workunit_store::{WorkUnit, WorkUnitStore};
 
 pub type NodeFuture<T> = BoxFuture<T, Failure>;
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -19,6 +19,7 @@ use crate::core::{throw, Failure, Key, Params, TypeId, Value};
 use crate::externs;
 use crate::selectors;
 use crate::tasks::{self, Intrinsic, Rule};
+use crate::workunit_store::{WorkUnit, WorkUnitStore};
 use boxfuture::{try_future, BoxFuture, Boxable};
 use bytes::{self, BufMut};
 use fs::{
@@ -29,7 +30,6 @@ use hashing;
 use process_execution::{self, CommandRunner};
 use rule_graph;
 
-use crate::scheduler::WorkUnit;
 use graph::{Entry, Node, NodeError, NodeTracer, NodeVisualizer};
 use rand::thread_rng;
 use rand::Rng;

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -13,12 +13,12 @@ use futures::future::{self, Future};
 use crate::context::{Context, Core};
 use crate::core::{Failure, Params, TypeId, Value};
 use crate::nodes::{NodeKey, Select, Tracer, Visualizer};
-use crate::workunit_store::{WorkUnit, WorkUnitStore};
 use graph::{EntryId, Graph, InvalidationResult, NodeContext};
 use indexmap::IndexMap;
 use log::{debug, info, warn};
 use parking_lot::Mutex;
 use ui::EngineDisplay;
+use workunit_store::{WorkUnit, WorkUnitStore};
 
 ///
 /// A Session represents a related series of requests (generally: one run of the pants CLI) on an

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+version = "0.0.1"
+edition = "2018"
+name = "workunit_store"
+authors = [ "Pants Build <pantsbuild@gmail.com>" ]
+publish = false
+
+[dependencies]
+parking_lot = "0.6"

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -4,22 +4,22 @@
 #![deny(warnings)]
 // Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
 #![deny(
-clippy::all,
-clippy::default_trait_access,
-clippy::expl_impl_clone_on_copy,
-clippy::if_not_else,
-clippy::needless_continue,
-clippy::single_match_else,
-clippy::unseparated_literal_suffix,
-clippy::used_underscore_binding
+  clippy::all,
+  clippy::default_trait_access,
+  clippy::expl_impl_clone_on_copy,
+  clippy::if_not_else,
+  clippy::needless_continue,
+  clippy::single_match_else,
+  clippy::unseparated_literal_suffix,
+  clippy::used_underscore_binding
 )]
 // It is often more clear to show that nothing is being moved.
 #![allow(clippy::match_ref_pats)]
 // Subjective style.
 #![allow(
-clippy::len_without_is_empty,
-clippy::redundant_field_names,
-clippy::too_many_arguments
+  clippy::len_without_is_empty,
+  clippy::redundant_field_names,
+  clippy::too_many_arguments
 )]
 // Default isn't as big a deal as people seem to think it is.
 #![allow(clippy::new_without_default, clippy::new_ret_no_self)]

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -1,0 +1,14 @@
+use parking_lot::Mutex;
+
+pub struct WorkUnit {
+    pub name: String,
+    pub start_timestamp: f64,
+    pub end_timestamp: f64,
+    pub span_id: String,
+}
+
+pub trait WorkUnitStore {
+    fn should_record_zipkin_spans(&self) -> bool;
+    fn get_workunits(&self) -> &Mutex<Vec<WorkUnit>>;
+    fn add_workunit(&self, workunit: WorkUnit);
+}

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -1,14 +1,14 @@
 use parking_lot::Mutex;
 
 pub struct WorkUnit {
-    pub name: String,
-    pub start_timestamp: f64,
-    pub end_timestamp: f64,
-    pub span_id: String,
+  pub name: String,
+  pub start_timestamp: f64,
+  pub end_timestamp: f64,
+  pub span_id: String,
 }
 
 pub trait WorkUnitStore {
-    fn should_record_zipkin_spans(&self) -> bool;
-    fn get_workunits(&self) -> &Mutex<Vec<WorkUnit>>;
-    fn add_workunit(&self, workunit: WorkUnit);
+  fn should_record_zipkin_spans(&self) -> bool;
+  fn get_workunits(&self) -> &Mutex<Vec<WorkUnit>>;
+  fn add_workunit(&self, workunit: WorkUnit);
 }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -1,3 +1,31 @@
+// Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+#![deny(warnings)]
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![deny(
+clippy::all,
+clippy::default_trait_access,
+clippy::expl_impl_clone_on_copy,
+clippy::if_not_else,
+clippy::needless_continue,
+clippy::single_match_else,
+clippy::unseparated_literal_suffix,
+clippy::used_underscore_binding
+)]
+// It is often more clear to show that nothing is being moved.
+#![allow(clippy::match_ref_pats)]
+// Subjective style.
+#![allow(
+clippy::len_without_is_empty,
+clippy::redundant_field_names,
+clippy::too_many_arguments
+)]
+// Default isn't as big a deal as people seem to think it is.
+#![allow(clippy::new_without_default, clippy::new_ret_no_self)]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![allow(clippy::mutex_atomic)]
+
 use parking_lot::Mutex;
 
 pub struct WorkUnit {


### PR DESCRIPTION
We are decoupling `Session` from `WorkUnit` related structure.

 - Create workunit_store crate
 - Extract WorkUnit and WorkUnitStore traits from `Session`
 - Implement `WorkUnitStore` trait for `Session`