### PR TITLE
Remove an old redundant .isort.cfg.

### DIFF
--- a/contrib/scrooge/.isort.cfg
+++ b/contrib/scrooge/.isort.cfg
@@ -1,9 +1,0 @@
-# See the menu of settings available here:
-#   https://github.com/timothycrosley/isort/wiki/isort-Settings
-
-[settings]
-line_length=100
-indent=2
-lines_after_imports=2
-known_first_party=pants.contrib.scrooge
-default_section=THIRDPARTY


### PR DESCRIPTION
This came up in discussion surrounding #7857.
