### PR TITLE
possibly fix nondeterministic cache insertion error in rsc compile

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -113,7 +113,7 @@ class RscCompileContext(CompileContext):
     # compile, failing to find this directory. Since rsc doesn't output to the classes dir, this
     # shouldn't matter, but this line avoids that failure. Intended to fix
     #     https://github.com/pantsbuild/pants/issues/7856.
-    safe_mkdir(self.classes_dir)
+    safe_mkdir(self.classes_dir.path)
 
 
 class RscCompile(ZincCompile, MirroredTargetOptionMixin):
@@ -561,7 +561,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       rsc_cc=RscCompileContext(
         target=target,
         analysis_file=None,
-        classes_dir=None,
+        classes_dir=ClasspathEntry(os.path.join(zinc_dir, 'classes'), None),
         jar_file=None,
         zinc_args_file=None,
         rsc_jar_file=os.path.join(rsc_dir, 'm.jar'),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -103,12 +103,17 @@ class RscCompileContext(CompileContext):
                sources,
                workflow):
     super(RscCompileContext, self).__init__(target, analysis_file, classes_dir, jar_file,
-                                               log_dir, zinc_args_file, sources)
+                                            log_dir, zinc_args_file, sources)
     self.workflow = workflow
     self.rsc_jar_file = rsc_jar_file
 
   def ensure_output_dirs_exist(self):
     safe_mkdir(os.path.dirname(self.rsc_jar_file))
+    # NB: The background cache insert workunit will nondeterministically fail after a successful rsc
+    # compile, failing to find this directory. Since rsc doesn't output to the classes dir, this
+    # shouldn't matter, but this line avoids that failure. Intended to fix
+    #     https://github.com/pantsbuild/pants/issues/7856.
+    safe_mkdir(self.classes_dir)
 
 
 class RscCompile(ZincCompile, MirroredTargetOptionMixin):


### PR DESCRIPTION
### Problem

Intended to fix #7856.

### Solution

Ensure that the zinc classes dir is created when we make the rsc jar output directory.

### Result

The rsc compile integration tests should stop flaking!