### PR TITLE
add extra rsc args and print its output upon success

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -787,6 +787,9 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
 
   def _record_target_stats(self, target, classpath_len, sources_len, compiletime, is_incremental,
     stats_key):
+    # TODO: classpath_len doesn't *really* capture what we're looking for -- the cumulative size of
+    # classpath files might be, though. Capturing the digest of the input classpath might give us
+    # that, though (as well as the source files?).
     def record(k, v):
       self.context.run_tracker.report_target_info(self.options_scope, target, [stats_key, k], v)
     record('time', compiletime)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -169,6 +169,9 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       default=cls.JvmCompileWorkflowType.rsc_and_zinc, metavar='<workflow>',
       help='The workflow to use to compile JVM targets.')
 
+    register('--extra-rsc-args', type=list, default=[],
+             help='Extra arguments to pass to the rsc invocation.')
+
     cls.register_jvm_tool(
       register,
       'rsc',
@@ -378,7 +381,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
           args = [
                    '-cp', os.pathsep.join(classpath_entry_paths),
                    '-d', rsc_jar_file_relative_path,
-                 ] + target_sources
+                 ] + self.get_options().extra_rsc_args + target_sources
 
           self.write_argsfile(ctx, args)
 
@@ -618,7 +621,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     res = self.context.execute_process_synchronously_without_raising(
       epr,
       self.name(),
-      [WorkUnitLabel.TOOL])
+      [WorkUnitLabel.COMPILER])
 
     if res.exit_code != 0:
       raise TaskError(res.stderr, exit_code=res.exit_code)
@@ -645,7 +648,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       jvm_options=self.get_options().jvm_options,
       args=['@{}'.format(ctx.args_file)],
       workunit_name=tool_name,
-      workunit_labels=[WorkUnitLabel.TOOL],
+      workunit_labels=[WorkUnitLabel.COMPILER],
       dist=distribution
     )
     if result != 0:


### PR DESCRIPTION
### Problem

While we can currently pass zinc extra arguments with `--args` and passthrough args, there's no equivalent for arguments to rsc. Additionally, rsc's output is hidden unless it fails.

### Solution

- Add `--extra-rsc-args` option (named to avoid clashing with any other options).
- Convert the rsc invocation to use `WorkUnitLabel.COMPILER` in order to view its output upon success (allowing rsc to e.g. print timings).

### Result

Rsc args can be added by setting an option, without pants changes!