### PR TITLE
Fix `py-thrift-namespace-clash-check` type issue when logging with `--no-strict` mode

### DIFF
--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import re
-from builtins import zip
+from builtins import str, zip
 
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.base.exceptions import TaskError

--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -101,7 +101,7 @@ and/or files which need to be edited will be dumped to: {}
       if self.get_options().strict:
         raise error
       else:
-        self.context.log.warn(error)
+        self.context.log.warn(str(error))
     return py_namespaces_by_target
 
   class ClashingNamespaceError(TaskError): pass
@@ -136,7 +136,7 @@ Errors:
       if self.get_options().strict:
         raise error
       else:
-        self.context.log.warn(error)
+        self.context.log.warn(str(error))
     return namespaces_by_files
 
   def execute(self):

--- a/src/python/pants/reporting/report.py
+++ b/src/python/pants/reporting/report.py
@@ -100,7 +100,8 @@ class Report(object):
   def log(self, workunit, level, *msg_elements):
     """Log a message.
 
-    Each element of msg_elements is either a message string or a (message, detail) pair.
+    Each element of msg_elements is either a message or a (message, detail) pair, i.e. of type
+    Union[str, Tuple[str, str]].
     """
     with self._lock:
       for reporter in self._reporters.values():

--- a/src/python/pants/reporting/report.py
+++ b/src/python/pants/reporting/report.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import threading
 import time
-from builtins import object, str
+from builtins import bytes, object, str
 
 
 class ReportingError(Exception):
@@ -101,12 +101,14 @@ class Report(object):
     """Log a message.
 
     Each element of msg_elements is either a message or a (message, detail) pair, i.e. of type
-    Union[str, Tuple[str, str]].
+    Union[str, bytes, Tuple[str, str]].
     """
     # TODO(6742): Once we have enough MyPy coverage, we can rely on MyPy to catch any issues for us,
     # rather than this runtime check.
-    assert all(isinstance(element, (str, tuple)) for element in msg_elements), \
-      "At least one logged message element is not of type Union[str, Tuple[str, str]]:\n {}".format(msg_elements)
+    # TODO(6071): No longer allow bytes once Py2 is removed.
+    assert all(isinstance(element, (str, bytes, tuple)) for element in msg_elements), \
+      "At least one logged message element is not of type " \
+      "Union[str, bytes, Tuple[str, str]]:\n {}".format(msg_elements)
     with self._lock:
       for reporter in self._reporters.values():
         reporter.handle_log(workunit, level, *msg_elements)

--- a/src/python/pants/reporting/report.py
+++ b/src/python/pants/reporting/report.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import threading
 import time
-from builtins import object
+from builtins import object, str
 
 
 class ReportingError(Exception):

--- a/src/python/pants/reporting/report.py
+++ b/src/python/pants/reporting/report.py
@@ -103,6 +103,10 @@ class Report(object):
     Each element of msg_elements is either a message or a (message, detail) pair, i.e. of type
     Union[str, Tuple[str, str]].
     """
+    # TODO(6742): Once we have enough MyPy coverage, we can rely on MyPy to catch any issues for us,
+    # rather than this runtime check.
+    assert all(isinstance(element, (str, tuple)) for element in msg_elements), \
+      "At least one logged message element is not of type Union[str, Tuple[str, str]]:\n {}".format(msg_elements)
     with self._lock:
       for reporter in self._reporters.values():
         reporter.handle_log(workunit, level, *msg_elements)


### PR DESCRIPTION
### Problem
When running `py-thrift-namespace-clash-check` in Twitter's sandbox with `--no-strict` mode, Pants crashed with the exception:

```
zip_longest argument #1 must support iteration
```

This is because we were trying to log a `NamespaceExtractionError`, and `log()` only understands `Union[str, Tuple[str, str]]`.

### Solution
Fix the issue by using `str()` to get the underlying message.

Also add an assertion to make sure that we don't introduce this issue again. Once we have MyPy set up, we can remove this assertion.