### PR TITLE
Stabilize all tests of NailgunTask subclasses.

### DIFF
--- a/tests/python/pants_test/backend/codegen/wire/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/wire/java/BUILD
@@ -8,15 +8,15 @@ python_tests(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:parameterized',
     'src/python/pants/backend/codegen/wire/java',
-    'src/python/pants/java/jar',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:revision',
     'src/python/pants/base:validation',
     'src/python/pants/build_graph',
+    'src/python/pants/java/jar',
     'src/python/pants/util:contextutil',
+    'tests/python/pants_test/jvm:nailgun_task_test_base',
     'tests/python/pants_test:test_base',
-    'tests/python/pants_test:task_test_base',
   ]
 )
 

--- a/tests/python/pants_test/backend/codegen/wire/java/test_wire_gen.py
+++ b/tests/python/pants_test/backend/codegen/wire/java/test_wire_gen.py
@@ -12,10 +12,10 @@ from pants.backend.codegen.wire.java.wire_gen import WireGen
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.build_graph.register import build_file_aliases as register_core
 from pants.java.jar.jar_dependency import JarDependency
-from pants_test.task_test_base import TaskTestBase
+from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 
 
-class WireGenTest(TaskTestBase):
+class WireGenTest(NailgunTaskTestBase):
 
   # A bogus target workdir.
   TARGET_WORKDIR = ".pants.d/bogus/workdir"

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -213,14 +213,14 @@ python_tests(
   name = 'detect_duplicates',
   sources = ['test_detect_duplicates.py'],
   dependencies = [
-    'src/python/pants/java/jar',
-    'src/python/pants/backend/jvm/targets:jvm',
+    ':jvm_binary_task_test_base',
     'src/python/pants/backend/jvm/targets:java',
+    'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:detect_duplicates',
     'src/python/pants/base:exceptions',
+    'src/python/pants/java/jar',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-    'tests/python/pants_test/jvm:jvm_task_test_base',
   ],
 )
 
@@ -262,21 +262,21 @@ python_tests(
   name = 'ivy_resolve',
   sources = ['test_ivy_resolve.py'],
   dependencies = [
-    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    'src/python/pants/backend/jvm:ivy_utils',
-    'src/python/pants/java/jar',
+    '3rdparty/python:future',
     'src/python/pants/backend/jvm/subsystems:jar_dependency_management',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:ivy_resolve',
     'src/python/pants/backend/jvm/tasks:ivy_task_mixin',
+    'src/python/pants/backend/jvm:ivy_utils',
+    'src/python/pants/java/jar',
     'src/python/pants/task',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
+    'tests/python/pants_test/jvm:nailgun_task_test_base',
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test:test_base',
-    'tests/python/pants_test:task_test_base',
   ]
 )
 
@@ -286,21 +286,21 @@ python_tests(
     'test_coursier_resolve.py',
   ],
   dependencies = [
-    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:future',
     '3rdparty/python:mock',
-    'src/python/pants/backend/jvm:ivy_utils',
-    'src/python/pants/java/jar',
     'src/python/pants/backend/jvm/subsystems:jar_dependency_management',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:coursier_resolve',
+    'src/python/pants/backend/jvm:ivy_utils',
+    'src/python/pants/java/jar',
     'src/python/pants/task',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
+    'tests/python/pants_test/jvm:nailgun_task_test_base',
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test:test_base',
-    'tests/python/pants_test:task_test_base',
   ]
 )
 
@@ -379,7 +379,7 @@ python_tests(
     'src/python/pants/scm:scm',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-    'tests/python/pants_test:task_test_base',
+    'tests/python/pants_test/jvm:nailgun_task_test_base',
     'tests/python/pants_test/testutils:mock_logger',
   ],
 )
@@ -481,7 +481,7 @@ python_library(
   dependencies = [
     'src/python/pants/backend/jvm/tasks:classpath_products',
     'src/python/pants/java/jar',
-    'tests/python/pants_test/jvm:jvm_tool_task_test_base',
+    'tests/python/pants_test/jvm:nailgun_task_test_base',
   ]
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_binary_task_test_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_binary_task_test_base.py
@@ -8,10 +8,10 @@ import os
 
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.java.jar.jar_dependency_utils import M2Coordinate, ResolvedJar
-from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
+from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 
 
-class JvmBinaryTaskTestBase(JvmToolTaskTestBase):
+class JvmBinaryTaskTestBase(NailgunTaskTestBase):
   """
   :API: public
   """

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -17,9 +17,9 @@ python_tests(
   name = 'jvm_compile',
   sources = ['test_jvm_compile.py'],
   dependencies = [
-    'src/python/pants/backend/jvm/tasks:classpath_products',
     'src/python/pants/backend/jvm/tasks/jvm_compile',
-    'tests/python/pants_test:task_test_base',
+    'src/python/pants/backend/jvm/tasks:classpath_products',
+    'tests/python/pants_test/jvm:nailgun_task_test_base',
   ],
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -77,8 +77,8 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/java/distribution',
+    'tests/python/pants_test/jvm:nailgun_task_test_base',
     'tests/python/pants_test/subsystem:subsystem_utils',
-    'tests/python/pants_test:task_test_base',
   ],
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
@@ -19,11 +19,11 @@ from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method
 from pants.util.osutil import get_os_name, normalize_os_name
 from pants_test.java.distribution.test_distribution import EXE, distribution
+from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 from pants_test.subsystem.subsystem_util import init_subsystem
-from pants_test.task_test_base import TaskTestBase
 
 
-class JavaCompileSettingsPartitioningTest(TaskTestBase):
+class JavaCompileSettingsPartitioningTest(NailgunTaskTestBase):
 
   @classmethod
   def task_type(cls):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -17,9 +17,9 @@ python_tests(
   name = 'rsc_compile',
   sources = ['test_rsc_compile.py'],
   dependencies = [
-    'src/python/pants/backend/jvm/tasks:classpath_products',
     'src/python/pants/backend/jvm/tasks/jvm_compile',
     'src/python/pants/backend/jvm/tasks/jvm_compile/rsc',
-    'tests/python/pants_test:task_test_base',
+    'src/python/pants/backend/jvm/tasks:classpath_products',
+    'tests/python/pants_test/jvm:nailgun_task_test_base',
   ],
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
@@ -19,8 +19,8 @@ from pants.backend.jvm.tasks.jvm_compile.rsc.rsc_compile import RscCompile, _cre
 from pants.java.jar.jar_dependency import JarDependency
 from pants.option.ranked_value import RankedValue
 from pants.util.contextutil import temporary_dir
+from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 from pants_test.subsystem.subsystem_util import init_subsystem
-from pants_test.task_test_base import TaskTestBase
 
 
 class LightWeightVTS(object):
@@ -36,7 +36,7 @@ class LightWeightVTS(object):
     pass
 
 
-class RscCompileTest(TaskTestBase):
+class RscCompileTest(NailgunTaskTestBase):
   DEFAULT_CONF = 'default'
 
   @classmethod

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_compile.py
@@ -13,14 +13,14 @@ from pants.backend.jvm.tasks.jvm_compile.jvm_compile import JvmCompile
 from pants.backend.jvm.tasks.jvm_compile.zinc.zinc_compile import BaseZincCompile
 from pants.backend.jvm.tasks.nailgun_task import NailgunTaskBase
 from pants.base.build_environment import get_buildroot
-from pants_test.task_test_base import TaskTestBase
+from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 
 
 class DummyJvmCompile(JvmCompile):
   pass
 
 
-class JvmCompileTest(TaskTestBase):
+class JvmCompileTest(NailgunTaskTestBase):
   DEFAULT_CONF = 'default'
 
   @classmethod
@@ -50,7 +50,7 @@ class JvmCompileTest(TaskTestBase):
       resulting_classpath.get_for_target(target))
 
 
-class BaseZincCompileJDKTest(TaskTestBase):
+class BaseZincCompileJDKTest(NailgunTaskTestBase):
   DEFAULT_CONF = 'default'
   old_cwd = os.getcwd()
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -22,7 +22,6 @@ from pants.backend.jvm.targets.managed_jar_dependencies import ManagedJarDepende
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.coursier_resolve import (CoursierResolve,
                                                       CoursierResolveFingerprintStrategy)
-from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
 from pants.java import util
 from pants.java.jar.exclude import Exclude
@@ -30,12 +29,12 @@ from pants.java.jar.jar_dependency import JarDependency
 from pants.task.task import Task
 from pants.util.contextutil import temporary_dir, temporary_file_path
 from pants.util.dirutil import safe_rmtree
-from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
+from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 from pants_test.subsystem.subsystem_util import init_subsystem
 from pants_test.task_test_base import TaskTestBase
 
 
-class CoursierResolveTest(JvmToolTaskTestBase):
+class CoursierResolveTest(NailgunTaskTestBase):
   """Tests for the class CoursierResolve."""
 
   @classmethod
@@ -44,7 +43,6 @@ class CoursierResolveTest(JvmToolTaskTestBase):
 
   def setUp(self):
     super(CoursierResolveTest, self).setUp()
-    self.set_options(execution_strategy=NailgunTask.ExecutionStrategy.subprocess)
     self.set_options_for_scope('cache.{}'.format(self.options_scope),
                                read_from=None,
                                write_to=None)
@@ -69,22 +67,22 @@ class CoursierResolveTest(JvmToolTaskTestBase):
     compile_classpath = self.resolve([jar_lib, scala_lib])
     self.assertEqual(1, len(compile_classpath.get_for_target(jar_lib)))
     self.assertEqual(0, len(compile_classpath.get_for_target(scala_lib)))
-    
+
   def test_resolve_with_remote_url(self):
     dep_with_url = JarDependency('a', 'b', 'c',
                                  url='http://central.maven.org/maven2/junit/junit/4.12/junit-4.12.jar')
     dep_with_url_lib = self.make_target('//:a', JarLibrary, jars=[dep_with_url])
-    
+
     compile_classpath = self.resolve([dep_with_url_lib])
     # Get paths on compile classpath and assert that it starts with '.../coursier/cache/relative'
     paths = [tup[1] for tup in compile_classpath.get_for_target(dep_with_url_lib)]
     self.assertTrue(any(self._cache_dir_regex('relative').search(path) for path in paths), str(paths))
-  
+
   def test_resolve_with_local_url(self):
     with temporary_file_path(suffix='.jar') as url:
       dep_with_url = JarDependency('commons-lang', 'commons-lang', '2.5', url='file://' + url)
       dep_with_url_lib = self.make_target('//:a', JarLibrary, jars=[dep_with_url])
-      
+
       compile_classpath = self.resolve([dep_with_url_lib])
       # Get paths on compile classpath and assert that it starts with '.../coursier/cache/absolute'
       paths = [tup[1] for tup in compile_classpath.get_for_target(dep_with_url_lib)]

--- a/tests/python/pants_test/backend/jvm/tasks/test_detect_duplicates.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_detect_duplicates.py
@@ -15,10 +15,10 @@ from pants.java.jar.jar_dependency import JarDependency
 from pants.java.jar.jar_dependency_utils import M2Coordinate, ResolvedJar
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import safe_mkdir, safe_mkdir_for, touch
-from pants_test.jvm.jvm_task_test_base import JvmTaskTestBase
+from pants_test.backend.jvm.tasks.jvm_binary_task_test_base import JvmBinaryTaskTestBase
 
 
-class DuplicateDetectorTest(JvmTaskTestBase):
+class DuplicateDetectorTest(JvmBinaryTaskTestBase):
 
   @classmethod
   def task_type(cls):

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_imports.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_imports.py
@@ -12,7 +12,6 @@ from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
 from pants.backend.jvm.tasks.ivy_imports import IvyImports
 from pants.backend.jvm.tasks.jar_import_products import JarImportProducts
-from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.java.jar.jar_dependency import JarDependency
 from pants.java.jar.jar_dependency_utils import M2Coordinate
 from pants.util.contextutil import open_zip, temporary_dir
@@ -53,7 +52,6 @@ class IvyImportsTest(NailgunTaskTestBase):
                                     libraries=[jar_library.address.spec],
                                     include_patterns=['a/b/c/*.proto'])
 
-      self.set_options(execution_strategy=NailgunTask.ExecutionStrategy.subprocess)
       ivy_imports_task = self.execute(self.context(target_roots=[foo_target]))
 
       # Make sure the product is properly populated

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
@@ -21,14 +21,13 @@ from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.targets.managed_jar_dependencies import ManagedJarDependencies
 from pants.backend.jvm.tasks.ivy_resolve import IvyResolve
 from pants.backend.jvm.tasks.ivy_task_mixin import IvyResolveFingerprintStrategy
-from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.java.jar.exclude import Exclude
 from pants.java.jar.jar_dependency import JarDependency
 from pants.task.task import Task
 from pants.util.contextutil import temporary_dir, temporary_file_path
 from pants.util.dirutil import safe_delete
-from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
+from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 from pants_test.subsystem.subsystem_util import init_subsystem
 from pants_test.task_test_base import TaskTestBase, ensure_cached
 
@@ -37,7 +36,7 @@ def strip_workdir(dir, classpath):
   return [(conf, path[len(dir):]) for conf, path in classpath]
 
 
-class IvyResolveTest(JvmToolTaskTestBase):
+class IvyResolveTest(NailgunTaskTestBase):
   """Tests for the class IvyResolve."""
 
   @classmethod
@@ -46,7 +45,6 @@ class IvyResolveTest(JvmToolTaskTestBase):
 
   def setUp(self):
     super(IvyResolveTest, self).setUp()
-    self.set_options(execution_strategy=NailgunTask.ExecutionStrategy.subprocess)
     self.set_options_for_scope('cache.{}'.format(self.options_scope),
                                read_from=None,
                                write_to=None)

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
@@ -20,7 +20,6 @@ from pants.backend.jvm.ivy_utils import (FrozenResolution, IvyFetchStep, IvyInfo
 from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.jvm.subsystems.jar_dependency_management import JarDependencyManagement
 from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.build_environment import get_buildroot
 from pants.build_graph.register import build_file_aliases as register_core
 from pants.ivy.ivy_subsystem import IvySubsystem
@@ -401,8 +400,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
 
   def test_missing_ivy_report(self):
     self.set_options_for_scope(IvySubsystem.options_scope,
-                               cache_dir='DOES_NOT_EXIST',
-                               execution_strategy=NailgunTask.ExecutionStrategy.subprocess)
+                               cache_dir='DOES_NOT_EXIST')
 
     with self.assertRaises(IvyUtils.IvyResolveReportError):
       IvyUtils.parse_xml_report('default', IvyUtils.xml_report_path('INVALID_CACHE_DIR',

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
@@ -22,10 +22,10 @@ from pants.build_graph.target import Target
 from pants.scm.scm import Scm
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_walk
-from pants_test.task_test_base import TaskTestBase
+from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 
 
-class JarPublishTest(TaskTestBase):
+class JarPublishTest(NailgunTaskTestBase):
 
   @classmethod
   def task_type(cls):
@@ -293,7 +293,7 @@ class FailNTimesTest(unittest.TestCase):
     foo.bar()
 
 
-class JarPublishAuthTest(TaskTestBase):
+class JarPublishAuthTest(NailgunTaskTestBase):
   """Tests for backend jvm JarPublish class"""
 
   def _default_jvm_opts(self):

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_task.py
@@ -59,7 +59,6 @@ class JarTaskTest(BaseJarTaskTest):
   MAX_SUBPROC_ARGS = 50
 
   class TestJarTask(JarTask):
-
     def execute(self):
       pass
 
@@ -234,7 +233,6 @@ class JarTaskTest(BaseJarTaskTest):
 class JarBuilderTest(BaseJarTaskTest):
 
   class TestJarBuilderTask(JarBuilderTask):
-
     def execute(self):
       pass
 

--- a/tests/python/pants_test/java/BUILD
+++ b/tests/python/pants_test/java/BUILD
@@ -81,9 +81,9 @@ python_tests(
   name = 'test_runjava',
   sources = ['test_runjava_synthetic_classpath.py'],
   dependencies = [
+    'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/java:util',
     'src/python/pants/util:dirutil',
-    'tests/python/pants_test/jvm:jvm_tool_task_test_base',
-    'src/python/pants/backend/jvm/tasks:nailgun_task',
+    'tests/python/pants_test/jvm:nailgun_task_test_base',
   ]
 )

--- a/tests/python/pants_test/java/test_runjava_synthetic_classpath.py
+++ b/tests/python/pants_test/java/test_runjava_synthetic_classpath.py
@@ -12,7 +12,7 @@ from pants.java import util
 from pants.net.http.fetcher import Fetcher
 from pants.util.contextutil import temporary_file
 from pants.util.dirutil import safe_concurrent_rename
-from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
+from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 
 
 class DummyRunJavaTask(NailgunTask):
@@ -20,14 +20,10 @@ class DummyRunJavaTask(NailgunTask):
     pass
 
 
-class SyntheticClasspathTest(JvmToolTaskTestBase):
+class SyntheticClasspathTest(NailgunTaskTestBase):
   @classmethod
   def task_type(cls):
     return DummyRunJavaTask
-
-  def setUp(self):
-    super(SyntheticClasspathTest, self).setUp()
-    self.set_options(execution_strategy=NailgunTask.ExecutionStrategy.subprocess)
 
   def test_execute_java_no_error_weird_path(self):
     """

--- a/tests/python/pants_test/jvm/BUILD
+++ b/tests/python/pants_test/jvm/BUILD
@@ -25,14 +25,15 @@ python_library(
   sources=['jvm_tool_task_test_base.py'],
   dependencies=[
     ':jvm_task_test_base',
-    'src/python/pants/java/jar',
     'src/python/pants/backend/jvm/subsystems:jvm_tool_mixin',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/backend/jvm/tasks:bootstrap_jvm_tools',
+    'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/base:build_environment',
     'src/python/pants/build_graph',
     'src/python/pants/ivy',
+    'src/python/pants/java/jar',
   ]
 )
 

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -10,6 +10,7 @@ import shutil
 from pants.backend.jvm.register import build_file_aliases
 from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.backend.jvm.tasks.bootstrap_jvm_tools import BootstrapJvmTools
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.build_environment import get_pants_cachedir
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
@@ -60,7 +61,9 @@ class JvmToolTaskTestBase(JvmTaskTestBase):
     # TODO: We really need a straightforward way for pants's own tests to get to the enclosing
     # pants instance's options values.
     artifact_caches = [os.path.join(get_pants_cachedir(), 'artifact_cache')]
-    self.set_options_for_scope(bootstrap_scope, jvm_options=['-Xmx128m'])
+    self.set_options_for_scope(bootstrap_scope,
+                               execution_strategy=NailgunTask.ExecutionStrategy.subprocess,
+                               jvm_options=['-Xmx128m'])
     self.set_options_for_scope('cache.{}'.format(bootstrap_scope),
                                read_from=artifact_caches,
                                write_to=artifact_caches)

--- a/tests/python/pants_test/jvm/nailgun_task_test_base.py
+++ b/tests/python/pants_test/jvm/nailgun_task_test_base.py
@@ -4,12 +4,17 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from pants.backend.jvm.tasks.nailgun_task import NailgunProcessGroup, NailgunTask
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
 
 
 class NailgunTaskTestBase(JvmToolTaskTestBase):
-  """Prepares an ephemeral test build root that supports nailgun tasks.
+  """Ensures `NailgunTask` tests use subprocess mode to stably test the task under test.
+
+  For subclasses of NailgunTask the nailgun behavior is irrelevant to the code under test and can
+  cause problems in CI environments. As such, disabling nailgunning ensures the test focus is where
+  it needs to be to test the unit.
+
   :API: public
   """
 
@@ -18,12 +23,4 @@ class NailgunTaskTestBase(JvmToolTaskTestBase):
     :API: public
     """
     super(NailgunTaskTestBase, self).setUp()
-    self.set_options(execution_strategy=NailgunTask.ExecutionStrategy.nailgun)
-
-  def tearDown(self):
-    """
-    :API: public
-    """
-    super(NailgunTaskTestBase, self).tearDown()
-    # Kill any nailguns launched in our ephemeral build root.
-    NailgunProcessGroup(metadata_base_dir=self.subprocess_dir).killall()
+    self.set_options(execution_strategy=NailgunTask.ExecutionStrategy.subprocess)


### PR DESCRIPTION
Since there is no need to re-test nailgun behavior for each
`NailgunTask` subclass, turn off nailgunning in unit tests. Previously
we did this piecemeal and left out the `JarTask` test for one. This led
to problems in CI under the v2 runner's highly parallel regime.

Fixes #7865
