### PR TITLE
Use argfile support in zinc and rsc

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -32,7 +32,7 @@ from pants.util.fileutil import safe_hardlink_or_copy
 from pants.util.memo import memoized_method, memoized_property
 
 
-_ZINC_COMPILER_VERSION = '0.0.12'
+_ZINC_COMPILER_VERSION = '0.0.13'
 
 
 class Zinc(object):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/compile_context.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/compile_context.py
@@ -19,13 +19,13 @@ class CompileContext(object):
   """
 
   def __init__(self, target, analysis_file, classes_dir, jar_file,
-               log_dir, zinc_args_file, sources):
+               log_dir, args_file, sources):
     self.target = target
     self.analysis_file = analysis_file
     self.classes_dir = classes_dir
     self.jar_file = jar_file
     self.log_dir = log_dir
-    self.zinc_args_file = zinc_args_file
+    self.args_file = args_file
     self.sources = sources
 
   @contextmanager


### PR DESCRIPTION
### Problem

In hermetic and subprocess environments, large targets can fail with "argument list too long" errors. As of #6803, `zinc` supports `@argfile`s, and `rsc` has supported them for a while. 

### Solution

Use `@argfile` support in all environments (to minimize variability).

### Result

subprocess and hermetic modes scale to larger contexts. 