### PR TITLE
fs_util directory materialize prints timing information to stderr

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
  "lmdb 0.8.0 (git+https://github.com/pantsbuild/lmdb-rs.git?rev=06bdfbfc6348f6804127176e561843f214fc17f8)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
+ "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
@@ -1268,6 +1269,11 @@ dependencies = [
  "simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ui 0.0.1",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "matches"
@@ -3152,6 +3158,7 @@ dependencies = [
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -35,6 +35,7 @@ tempfile = "3"
 uuid = { version = "0.7.1", features = ["v4"] }
 
 [dev-dependencies]
+maplit = "*"
 mock = { path = "../testutil/mock" }
 testutil = { path = "../testutil" }
 tokio = "0.1"

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -179,7 +179,7 @@ impl BuildResultFS {
         }))
       }
       Vacant(entry) => match self.store.load_file_bytes_with(digest, |_| ()).wait() {
-        Ok(Some(())) => {
+        Ok(Some(((), _metadata))) => {
           let executable_inode = self.next_inode;
           self.next_inode += 1;
           let non_executable_inode = self.next_inode;
@@ -308,7 +308,7 @@ impl BuildResultFS {
           let maybe_directory = self.store.load_directory(digest).wait();
 
           match maybe_directory {
-            Ok(Some(directory)) => {
+            Ok(Some((directory, _metadata))) => {
               let mut entries = vec![
                 ReaddirEntry {
                   inode: inode,
@@ -441,7 +441,7 @@ impl fuse::Filesystem for BuildResultFS {
                 error!("Error reading directory {:?}: {}", parent_digest, err);
                 libc::EINVAL
               })?
-              .and_then(|directory| self.node_for_digest(&directory, filename))
+              .and_then(|(directory, _metadata)| self.node_for_digest(&directory, filename))
               .ok_or(libc::ENOENT)
           })
           .and_then(|node| match node {

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -408,6 +408,9 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
         let digest = Digest(fingerprint, size_bytes);
         runtime
           .block_on(store.materialize_directory(destination, digest))
+          .map(|metadata| {
+            eprintln!("{}", serde_json::to_string_pretty(&metadata).unwrap());
+          })
           .map_err(|err| {
             if err.contains("not found") {
               ExitError(err, ExitCode::NotFound)

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -345,12 +345,14 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           let write_result = runtime.block_on(
             store.load_file_bytes_with(digest, |bytes| io::stdout().write_all(&bytes).unwrap()),
           )?;
-          write_result.ok_or_else(|| {
-            ExitError(
-              format!("File with digest {:?} not found", digest),
-              ExitCode::NotFound,
-            )
-          })
+          write_result
+            .ok_or_else(|| {
+              ExitError(
+                format!("File with digest {:?} not found", digest),
+                ExitCode::NotFound,
+              )
+            })
+            .map(|((), _metadata)| ())
         }
         ("save", Some(args)) => {
           let path = PathBuf::from(args.value_of("path").unwrap());
@@ -457,27 +459,27 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           .parse::<usize>()
           .expect("size_bytes must be a non-negative number");
         let digest = Digest(fingerprint, size_bytes);
-        let proto_bytes =
-          match args.value_of("output-format").unwrap() {
-            "binary" => runtime
-              .block_on(store.load_directory(digest))
-              .map(|maybe_d| maybe_d.map(|d| d.write_to_bytes().unwrap())),
-            "text" => runtime
-              .block_on(store.load_directory(digest))
-              .map(|maybe_p| maybe_p.map(|p| format!("{:?}\n", p).as_bytes().to_vec())),
-            "recursive-file-list" => runtime
-              .block_on(expand_files(store, digest))
-              .map(|maybe_v| {
-                maybe_v
-                  .map(|v| {
-                    v.into_iter()
-                      .map(|(name, _digest)| format!("{}\n", name))
-                      .collect::<Vec<String>>()
-                      .join("")
-                  })
-                  .map(String::into_bytes)
-              }),
-            "recursive-file-list-with-digests" => runtime
+        let proto_bytes = match args.value_of("output-format").unwrap() {
+          "binary" => runtime
+            .block_on(store.load_directory(digest))
+            .map(|maybe_d| maybe_d.map(|(d, _metadata)| d.write_to_bytes().unwrap())),
+          "text" => runtime
+            .block_on(store.load_directory(digest))
+            .map(|maybe_p| maybe_p.map(|(p, _metadata)| format!("{:?}\n", p).as_bytes().to_vec())),
+          "recursive-file-list" => runtime
+            .block_on(expand_files(store, digest))
+            .map(|maybe_v| {
+              maybe_v
+                .map(|v| {
+                  v.into_iter()
+                    .map(|(name, _digest)| format!("{}\n", name))
+                    .collect::<Vec<String>>()
+                    .join("")
+                })
+                .map(String::into_bytes)
+            }),
+          "recursive-file-list-with-digests" => {
+            runtime
               .block_on(expand_files(store, digest))
               .map(|maybe_v| {
                 maybe_v
@@ -488,12 +490,13 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
                       .join("")
                   })
                   .map(String::into_bytes)
-              }),
-            format => Err(format!(
-              "Unexpected value of --output-format arg: {}",
-              format
-            )),
-          }?;
+              })
+          }
+          format => Err(format!(
+            "Unexpected value of --output-format arg: {}",
+            format
+          )),
+        }?;
         match proto_bytes {
           Some(bytes) => {
             io::stdout().write_all(&bytes).unwrap();
@@ -517,7 +520,7 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
       let digest = Digest(fingerprint, size_bytes);
       let v = match runtime.block_on(store.load_file_bytes_with(digest, |bytes| bytes))? {
         None => runtime.block_on(store.load_directory(digest).map(|maybe_dir| {
-          maybe_dir.map(|dir| {
+          maybe_dir.map(|(dir, _metadata)| {
             Bytes::from(
               dir
                 .write_to_bytes()
@@ -525,7 +528,7 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
             )
           })
         }))?,
-        some => some,
+        Some((bytes, _metadata)) => Some(bytes),
       };
       match v {
         Some(bytes) => {
@@ -572,7 +575,7 @@ fn expand_files_helper(
   store
     .load_directory(digest)
     .and_then(|maybe_dir| match maybe_dir {
-      Some(dir) => {
+      Some((dir, _metadata)) => {
         {
           let mut files_unlocked = files.lock();
           for file in dir.get_files() {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -865,6 +865,14 @@ fn safe_create_dir_all(path: &Path) -> Result<(), String> {
     .map_err(|e| format!("Failed to create dir {:?} due to {:?}", path, e))
 }
 
+fn safe_create_dir(path: &Path) -> Result<(), String> {
+  match fs::create_dir(path) {
+    Ok(()) => Ok(()),
+    Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+    Err(err) => Err(format!("{}", err)),
+  }
+}
+
 #[cfg(test)]
 mod posixfs_test {
   use tempfile;

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -3981,6 +3981,8 @@ mod tests {
 
     let local = LoadMetadata {
       source: Source::Local,
+      duration: None,
+      start: None,
     };
 
     let want = DirectoryMaterializeMetadata {
@@ -4036,34 +4038,28 @@ mod tests {
       .wait()
       .unwrap();
 
-    let local = LoadMetadata {
-      source: Source::Local,
-    };
-
-    let remote = LoadMetadata {
-      source: Source::Remote,
-    };
-
-    let want = DirectoryMaterializeMetadata {
-      metadata: local.clone(),
-      child_directories: btreemap! {
-        "pets".to_owned() => DirectoryMaterializeMetadata {
-          metadata: remote.clone(),
-          child_directories: btreemap!{
-            "cats".to_owned() => DirectoryMaterializeMetadata {
-              metadata: local.clone(),
-              child_directories: btreemap!{},
-              child_files: btreemap!{
-                "roland".to_owned() => local.clone(),
-              }
-            }
-          },
-          child_files: btreemap!{},
-        }
-      },
-      child_files: btreemap! {},
-    };
-
-    assert_eq!(want, metadata);
+    assert_eq!(
+      Source::Remote,
+      metadata
+        .child_directories
+        .get("pets")
+        .unwrap()
+        .metadata
+        .source
+    );
+    assert_eq!(
+      Source::Local,
+      metadata
+        .child_directories
+        .get("pets")
+        .unwrap()
+        .child_directories
+        .get("cats")
+        .unwrap()
+        .child_files
+        .get("roland")
+        .unwrap()
+        .source
+    );
   }
 }

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -95,6 +95,7 @@ impl DirectoryMaterializeMetadataBuilder {
   }
 }
 
+#[allow(clippy::type_complexity)]
 #[derive(Debug)]
 enum RootOrParentMetadataBuilder {
   Root(Arc<Mutex<Option<DirectoryMaterializeMetadataBuilder>>>),
@@ -350,7 +351,7 @@ impl Store {
 
                         // Sadly not quite stable in std yet.
                         fn as_secs_f64(d: std::time::Duration) -> f64 {
-                          (d.as_nanos() as f64) / (1_000_000_000 as f64)
+                          (d.as_nanos() as f64) / (1_000_000_000_f64)
                         }
 
                         Ok(Some((

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -237,7 +237,7 @@ impl super::CommandRunner for CommandRunner {
     self
       .store
       .materialize_directory(workdir_path.clone(), req.input_files)
-      .and_then(move |()| {
+      .and_then(move |_metadata| {
         maybe_jdk_home.map_or(Ok(()), |jdk_home| {
           symlink(jdk_home, workdir_path3.clone().join(".jdk"))
             .map_err(|err| format!("Error making symlink for local execution: {:?}", err))

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -566,6 +566,7 @@ impl CommandRunner {
             ))
           })
         })
+        .map(|(bytes, _metadata)| bytes)
         .to_boxed()
     } else {
       let stdout_raw = Bytes::from(execute_response.get_result().get_stdout_raw());
@@ -607,6 +608,7 @@ impl CommandRunner {
             ))
           })
         })
+        .map(|(bytes, _metadata)| bytes)
         .to_boxed()
     } else {
       let stderr_raw = Bytes::from(execute_response.get_result().get_stderr_raw());
@@ -1506,15 +1508,19 @@ mod tests {
         local_store
           .load_file_bytes_with(test_stdout.digest(), |v| v)
           .wait()
-          .unwrap(),
-        Some(test_stdout.bytes())
+          .unwrap()
+          .unwrap()
+          .0,
+        test_stdout.bytes()
       );
       assert_eq!(
         local_store
           .load_file_bytes_with(test_stderr.digest(), |v| v)
           .wait()
-          .unwrap(),
-        Some(test_stderr.bytes())
+          .unwrap()
+          .unwrap()
+          .0,
+        test_stderr.bytes()
       );
     }
   }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -666,7 +666,7 @@ impl DownloadedFile {
       .load_file_bytes_with(digest, |_| ())
       .and_then(move |maybe_bytes| {
         maybe_bytes
-          .map(|()| future::ok(()).to_boxed())
+          .map(|((), _metadata)| future::ok(()).to_boxed())
           .unwrap_or_else(|| DownloadedFile::download(core.clone(), url, file_name.clone(), digest))
           .and_then(move |()| {
             DownloadedFile::snapshot_of_one_file(core.store(), PathBuf::from(file_name), digest)

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -183,6 +183,20 @@ impl TestDirectory {
 
   // Directory structure:
   //
+  // /pets/cats/roland
+  pub fn double_nested() -> TestDirectory {
+    let mut directory = bazel_protos::remote_execution::Directory::new();
+    directory.mut_directories().push({
+      let mut subdir = bazel_protos::remote_execution::DirectoryNode::new();
+      subdir.set_name("pets".to_string());
+      subdir.set_digest((&TestDirectory::nested().digest()).into());
+      subdir
+    });
+    TestDirectory { directory }
+  }
+
+  // Directory structure:
+  //
   // /dnalor
   pub fn containing_dnalor() -> TestDirectory {
     let mut directory = bazel_protos::remote_execution::Directory::new();


### PR DESCRIPTION
This helps in profiling why materializes are slow.

It's pretty verbose, and we may want to tone it down and/or clean it up at some point, but it will be useful in the short term as-is.

Commits are separately useful.

Example out:
```
     Running `target/debug/fs_util --local-store-path=/Users/dwagnerhall/tmp/store '--server-address=localhost:61578' directory materialize 1a8f4cf3f956be34c154961f24f7a4a1349e08087cf1a374d2f33a1d450556c5 322 /Users/dwagnerhall/tmp/mat`
{
  "metadata": {
    "source": "Remote",
    "start": 1559934853.5456588,
    "duration": 0.004036486
  },
  "child_directories": {
    ".dwhtemp": {
      "metadata": {
        "source": "Remote",
        "start": 1559934853.5497978,
        "duration": 0.002109302
      },
      "child_directories": {
        ".pants.d": {
          "metadata": {
            "source": "Remote",
            "start": 1559934853.5519328,
            "duration": 0.001037263
          },
          "child_directories": {
            "bootstrap": {
              "metadata": {
                "source": "Remote",
                "start": 1559934853.552997,
                "duration": 0.000746087
              },
              "child_directories": {
                "bootstrap-jvm-tools": {
                  "metadata": {
                    "source": "Remote",
                    "start": 1559934853.553777,
                    "duration": 0.001177418
                  },
                  "child_directories": {
                    "7c0a62077e8f": {
                      "metadata": {
                        "source": "Remote",
                        "start": 1559934853.554987,
                        "duration": 0.001259715
                      },
                      "child_directories": {
                        "ivy": {
                          "metadata": {
                            "source": "Remote",
                            "start": 1559934853.556273,
                            "duration": 0.000833806
                          },
                          "child_directories": {
                            "jars": {
                              "metadata": {
                                "source": "Remote",
                                "start": 1559934853.557133,
                                "duration": 0.048746768
                              },
                              "child_directories": {
                                "org.scala-lang": {
                                  "metadata": {
                                    "source": "Remote",
                                    "start": 1559934853.605939,
                                    "duration": 0.006758074
                                  },
                                  "child_directories": {
                                    "scala-compiler": {
                                      "metadata": {
                                        "source": "Remote",
                                        "start": 1559934853.612747,
                                        "duration": 0.006060426
                                      },
                                      "child_directories": {
                                        "jars": {
                                          "metadata": {
                                            "source": "Remote",
                                            "start": 1559934853.618859,
                                            "duration": 0.004744778
                                          },
                                          "child_directories": {},
                                          "child_files": {
                                            "scala-compiler-2.12.8.jar": {
                                              "source": "Remote",
                                              "start": 1559934853.6236281,
                                              "duration": 3.773785812
                                            }
                                          }
                                        }
                                      },
                                      "child_files": {}
                                    },
                                    "scala-library": {
                                      "metadata": {
                                        "source": "Remote",
                                        "start": 1559934853.612777,
                                        "duration": 0.00613949
                                      },
                                      "child_directories": {
                                        "jars": {
                                          "metadata": {
                                            "source": "Remote",
                                            "start": 1559934853.61895,
                                            "duration": 0.00472107
                                          },
                                          "child_directories": {},
                                          "child_files": {
                                            "scala-library-2.12.8.jar": {
                                              "source": "Remote",
                                              "start": 1559934853.623691,
                                              "duration": 2.316036718
                                            }
                                          }
                                        }
                                      },
                                      "child_files": {}
                                    },
                                    "scala-reflect": {
                                      "metadata": {
                                        "source": "Remote",
                                        "start": 1559934853.6128,
                                        "duration": 0.006192942
                                      },
                                      "child_directories": {
                                        "jars": {
                                          "metadata": {
                                            "source": "Remote",
                                            "start": 1559934853.619021,
                                            "duration": 0.004708559
                                          },
                                          "child_directories": {},
                                          "child_files": {
                                            "scala-reflect-2.12.8.jar": {
                                              "source": "Remote",
                                              "start": 1559934853.623749,
                                              "duration": 1.713186374
                                            }
                                          }
                                        }
                                      },
                                      "child_files": {}
                                    }
                                  },
                                  "child_files": {}
                                },
                                "org.scala-lang.modules": {
                                  "metadata": {
                                    "source": "Remote",
                                    "start": 1559934853.605967,
                                    "duration": 0.007205637
                                  },
                                  "child_directories": {
                                    "scala-xml_2.12": {
                                      "metadata": {
                                        "source": "Remote",
                                        "start": 1559934853.613205,
                                        "duration": 0.007158205
                                      },
                                      "child_directories": {
                                        "jars": {
                                          "metadata": {
                                            "source": "Remote",
                                            "start": 1559934853.6204002,
                                            "duration": 0.003387392
                                          },
                                          "child_directories": {},
                                          "child_files": {
                                            "scala-xml_2.12-1.0.6.jar": {
                                              "source": "Remote",
                                              "start": 1559934853.623807,
                                              "duration": 0.350211899
                                            }
                                          }
                                        }
                                      },
                                      "child_files": {}
                                    }
                                  },
                                  "child_files": {}
                                },
                                "org.scala-sbt": {
                                  "metadata": {
                                    "source": "Remote",
                                    "start": 1559934853.605983,
                                    "duration": 0.007262791
                                  },
                                  "child_directories": {
                                    "compiler-bridge_2.12": {
                                      "metadata": {
                                        "source": "Remote",
                                        "start": 1559934853.6132731,
                                        "duration": 0.007174929
                                      },
                                      "child_directories": {
                                        "jars": {
                                          "metadata": {
                                            "source": "Remote",
                                            "start": 1559934853.620477,
                                            "duration": 0.003367212
                                          },
                                          "child_directories": {},
                                          "child_files": {
                                            "compiler-bridge_2.12-1.0.3-sources.jar": {
                                              "source": "Remote",
                                              "start": 1559934853.623863,
                                              "duration": 0.066368064
                                            }
                                          }
                                        }
                                      },
                                      "child_files": {}
                                    }
                                  },
                                  "child_files": {}
                                }
                              },
                              "child_files": {}
                            }
                          },
                          "child_files": {}
                        }
                      },
                      "child_files": {}
                    },
                    "tool_cache": {
                      "metadata": {
                        "source": "Remote",
                        "start": 1559934853.5550132,
                        "duration": 0.001296908
                      },
                      "child_directories": {
                        "shaded_jars": {
                          "metadata": {
                            "source": "Remote",
                            "start": 1559934853.556333,
                            "duration": 0.001213698
                          },
                          "child_directories": {},
                          "child_files": {
                            "no.such.main.Main-a6da447d452f0635bafcd343f20afa7f91023dcf-ShadedToolFingerprintStrategy_a729bb28c531.jar": {
                              "source": "Remote",
                              "start": 1559934853.557566,
                              "duration": 0.120638968
                            },
                            "org.pantsbuild.zinc.compiler.Main-bf0e3110c2a2760b34ea8d6f99fae361680a5768-ShadedToolFingerprintStrategy_a729bb28c531.jar": {
                              "source": "Remote",
                              "start": 1559934853.557586,
                              "duration": 8.41385437
                            }
                          }
                        }
                      },
                      "child_files": {}
                    }
                  },
                  "child_files": {}
                }
              },
              "child_files": {}
            },
            "compile": {
              "metadata": {
                "source": "Remote",
                "start": 1559934853.5530229,
                "duration": 0.001142287
              },
              "child_directories": {
                "rsc": {
                  "metadata": {
                    "source": "Remote",
                    "start": 1559934853.554202,
                    "duration": 0.000842591
                  },
                  "child_directories": {
                    "b296c10728f0": {
                      "metadata": {
                        "source": "Remote",
                        "start": 1559934853.555068,
                        "duration": 0.001593522
                      },
                      "child_directories": {
                        "examples.src.java.org.pantsbuild.example.hello.greet.greet": {
                          "metadata": {
                            "source": "Remote",
                            "start": 1559934853.55669,
                            "duration": 0.00137371
                          },
                          "child_directories": {
                            "current": {
                              "metadata": {
                                "source": "Remote",
                                "start": 1559934853.558096,
                                "duration": 0.048273058
                              },
                              "child_directories": {
                                "zinc": {
                                  "metadata": {
                                    "source": "Remote",
                                    "start": 1559934853.606396,
                                    "duration": 0.007034734
                                  },
                                  "child_directories": {
                                    "backup": {
                                      "metadata": {
                                        "source": "Local",
                                        "start": null,
                                        "duration": null
                                      },
                                      "child_directories": {},
                                      "child_files": {}
                                    },
                                    "classes": {
                                      "metadata": {
                                        "source": "Remote",
                                        "start": 1559934853.6135209,
                                        "duration": 0.006264819
                                      },
                                      "child_directories": {
                                        "org": {
                                          "metadata": {
                                            "source": "Remote",
                                            "start": 1559934853.619821,
                                            "duration": 0.004119666
                                          },
                                          "child_directories": {
                                            "pantsbuild": {
                                              "metadata": {
                                                "source": "Remote",
                                                "start": 1559934853.623971,
                                                "duration": 0.035485796
                                              },
                                              "child_directories": {
                                                "example": {
                                                  "metadata": {
                                                    "source": "Remote",
                                                    "start": 1559934853.65952,
                                                    "duration": 0.006255534
                                                  },
                                                  "child_directories": {
                                                    "hello": {
                                                      "metadata": {
                                                        "source": "Remote",
                                                        "start": 1559934853.665832,
                                                        "duration": 0.003876938
                                                      },
                                                      "child_directories": {
                                                        "greet": {
                                                          "metadata": {
                                                            "source": "Remote",
                                                            "start": 1559934853.669744,
                                                            "duration": 0.005551092
                                                          },
                                                          "child_directories": {},
                                                          "child_files": {
                                                            "Greeting.class": {
                                                              "source": "Remote",
                                                              "start": 1559934853.675318,
                                                              "duration": 0.009592613
                                                            }
                                                          }
                                                        }
                                                      },
                                                      "child_files": {}
                                                    }
                                                  },
                                                  "child_files": {}
                                                }
                                              },
                                              "child_files": {}
                                            }
                                          },
                                          "child_files": {}
                                        }
                                      },
                                      "child_files": {}
                                    }
                                  },
                                  "child_files": {
                                    "z.analysis": {
                                      "source": "Remote",
                                      "start": 1559934853.6134558,
                                      "duration": 0.007170911
                                    },
                                    "z.jar": {
                                      "source": "Remote",
                                      "start": 1559934853.613479,
                                      "duration": 0.007162416
                                    }
                                  }
                                }
                              },
                              "child_files": {}
                            }
                          },
                          "child_files": {}
                        }
                      },
                      "child_files": {}
                    }
                  },
                  "child_files": {}
                }
              },
              "child_files": {}
            },
            "zinc": {
              "metadata": {
                "source": "Remote",
                "start": 1559934853.553045,
                "duration": 0.001197541
              },
              "child_directories": {
                "compiler-bridge": {
                  "metadata": {
                    "source": "Remote",
                    "start": 1559934853.554268,
                    "duration": 0.001514048
                  },
                  "child_directories": {
                    "c4fc6a00dfe9": {
                      "metadata": {
                        "source": "Remote",
                        "start": 1559934853.55581,
                        "duration": 0.001168222
                      },
                      "child_directories": {},
                      "child_files": {
                        "scala-compiler-bridge.jar": {
                          "source": "Remote",
                          "start": 1559934853.556997,
                          "duration": 0.165911773
                        }
                      }
                    }
                  },
                  "child_files": {}
                }
              },
              "child_files": {}
            }
          },
          "child_files": {}
        }
      },
      "child_files": {}
    },
    "examples": {
      "metadata": {
        "source": "Remote",
        "start": 1559934853.549819,
        "duration": 0.001927327
      },
      "child_directories": {
        "src": {
          "metadata": {
            "source": "Remote",
            "start": 1559934853.5518138,
            "duration": 0.001063936
          },
          "child_directories": {
            "java": {
              "metadata": {
                "source": "Remote",
                "start": 1559934853.55291,
                "duration": 0.001953766
              },
              "child_directories": {
                "org": {
                  "metadata": {
                    "source": "Remote",
                    "start": 1559934853.5548952,
                    "duration": 0.000957071
                  },
                  "child_directories": {
                    "pantsbuild": {
                      "metadata": {
                        "source": "Remote",
                        "start": 1559934853.555876,
                        "duration": 0.001509457
                      },
                      "child_directories": {
                        "example": {
                          "metadata": {
                            "source": "Remote",
                            "start": 1559934853.557411,
                            "duration": 0.049043837
                          },
                          "child_directories": {
                            "hello": {
                              "metadata": {
                                "source": "Remote",
                                "start": 1559934853.606484,
                                "duration": 0.007556386
                              },
                              "child_directories": {
                                "greet": {
                                  "metadata": {
                                    "source": "Remote",
                                    "start": 1559934853.614073,
                                    "duration": 0.006755243
                                  },
                                  "child_directories": {},
                                  "child_files": {
                                    "Greeting.java": {
                                      "source": "Remote",
                                      "start": 1559934853.620852,
                                      "duration": 0.004520117
                                    }
                                  }
                                }
                              },
                              "child_files": {}
                            }
                          },
                          "child_files": {}
                        }
                      },
                      "child_files": {}
                    }
                  },
                  "child_files": {}
                }
              },
              "child_files": {}
            }
          },
          "child_files": {}
        }
      },
      "child_files": {}
    }
  },
  "child_files": {
    "cmd": {
      "source": "Remote",
      "start": 1559934853.54974,
      "duration": 0.002127099
    },
    "roland": {
      "source": "Remote",
      "start": 1559934853.549769,
      "duration": 0.002111813
    }
  }
}
```