### PR TITLE
NailgunTasks execute java with consistent cwd.

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -142,13 +142,15 @@ class ScalaPlatform(JvmToolMixin, ZincLanguageMixin, InjectablesMixin, Subsystem
     classpath = self.tool_classpath_from_products(products,
                                                   self.versioned_tool_name(tool, self.version),
                                                   scope=self.options_scope)
-    classpath = tuple(fast_relpath(c, get_buildroot()) for c in classpath)
-
-    return self._memoized_scalac_classpath(classpath, scheduler)
+    return self._memoized_scalac_classpath(tuple(classpath), scheduler)
 
   @memoized_method
   def _memoized_scalac_classpath(self, scala_path, scheduler):
-    snapshots = scheduler.capture_snapshots(tuple(PathGlobsAndRoot(PathGlobs([path]), get_buildroot()) for path in scala_path))
+    buildroot = get_buildroot()
+    path_globs_and_roots = tuple(PathGlobsAndRoot(PathGlobs([fast_relpath(path, buildroot)]),
+                                                  buildroot)
+                                 for path in scala_path)
+    snapshots = scheduler.capture_snapshots(path_globs_and_roots)
     return [ClasspathEntry(path, snapshot) for path, snapshot in list(zip(scala_path, snapshots))]
 
   def compiler_classpath_entries(self, products, scheduler):

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -562,6 +562,7 @@ python_library(
   dependencies = [
     ':jvm_tool_task_mixin',
     'src/python/pants/java/jar',
+    'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/java/distribution:distribution',
     'src/python/pants/java:executor',

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
+from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.java import util
 from pants.java.executor import SubprocessExecutor
@@ -112,6 +113,7 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
                                main=main,
                                jvm_options=jvm_options,
                                args=args,
+                               cwd=get_buildroot(),
                                executor=executor,
                                workunit_factory=self.context.new_workunit,
                                workunit_name=workunit_name,

--- a/src/python/pants/java/executor.py
+++ b/src/python/pants/java/executor.py
@@ -14,9 +14,7 @@ from contextlib import contextmanager
 from six import string_types
 from twitter.common.collections import maybe_list
 
-from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import environment_as
-from pants.util.dirutil import relativize_paths
 from pants.util.meta import AbstractClass
 from pants.util.process_handler import subprocess
 
@@ -31,13 +29,13 @@ class Executor(AbstractClass):
   """
 
   @staticmethod
-  def _scrub_args(classpath, main, jvm_options, args, cwd):
+  def _scrub_args(classpath, main, jvm_options, args):
     classpath = maybe_list(classpath)
     if not isinstance(main, string_types) or not main:
       raise ValueError('A non-empty main classname is required, given: {}'.format(main))
     jvm_options = maybe_list(jvm_options or ())
     args = maybe_list(args or ())
-    return classpath, main, jvm_options, args, cwd
+    return classpath, main, jvm_options, args
 
   class Error(Exception):
     """Indicates an error launching a java program.
@@ -109,9 +107,10 @@ class Executor(AbstractClass):
     """Returns the `Distribution` this executor runs via."""
     return self._distribution
 
-  def runner(self, classpath, main, jvm_options=None, args=None, cwd=None):
+  def runner(self, classpath, main, jvm_options=None, args=None):
     """Returns an `Executor.Runner` for the given java command."""
-    return self._runner(*self._scrub_args(classpath, main, jvm_options, args, cwd=cwd))
+    classpath, main, jvm_options, args = self._scrub_args(classpath, main, jvm_options, args)
+    return self._runner(classpath, main, jvm_options, args)
 
   def execute(self, classpath, main, jvm_options=None, args=None, stdout=None, stderr=None,
       cwd=None):
@@ -126,19 +125,16 @@ class Executor(AbstractClass):
     Returns the exit code of the java program.
     Raises Executor.Error if there was a problem launching java itself.
     """
-    runner = self.runner(classpath=classpath, main=main, jvm_options=jvm_options, args=args,
-                         cwd=cwd)
-    return runner.run(stdout=stdout, stderr=stderr)
+    runner = self.runner(classpath=classpath, main=main, jvm_options=jvm_options, args=args)
+    return runner.run(stdout=stdout, stderr=stderr, cwd=cwd)
 
   @abstractmethod
-  def _runner(self, classpath, main, jvm_options, args, cwd=None):
+  def _runner(self, classpath, main, jvm_options, args):
     """Subclasses should return a `Runner` that can execute the given java main."""
 
-  def _create_command(self, classpath, main, jvm_options, args, cwd=None):
+  def _create_command(self, classpath, main, jvm_options, args):
     cmd = [self._distribution.java]
     cmd.extend(jvm_options)
-    if cwd:
-      classpath = relativize_paths(classpath, cwd)
     cmd.extend(['-cp', os.pathsep.join(classpath), main])
     cmd.extend(args)
     return cmd
@@ -151,8 +147,8 @@ class CommandLineGrabber(Executor):
     super(CommandLineGrabber, self).__init__(distribution=distribution)
     self._command = None  # Initialized when we run something.
 
-  def _runner(self, classpath, main, jvm_options, args, cwd=None):
-    self._command = self._create_command(classpath, main, jvm_options, args, cwd=cwd)
+  def _runner(self, classpath, main, jvm_options, args):
+    self._command = self._create_command(classpath, main, jvm_options, args)
 
     class Runner(self.Runner):
       @property
@@ -163,10 +159,10 @@ class CommandLineGrabber(Executor):
       def command(_):
         return list(self._command)
 
-      def run(_, stdout=None, stderr=None, stdin=None):
+      def run(_, stdout=None, stderr=None, stdin=None, cwd=None):
         return 0
 
-      def spawn(_, stdout=None, stderr=None, stdin=None):
+      def spawn(_, stdout=None, stderr=None, stdin=None, cwd=None):
         return None
 
     return Runner()
@@ -205,14 +201,8 @@ class SubprocessExecutor(Executor):
     with environment_as(**cls._SCRUBBED_ENV):
       yield
 
-  def __init__(self, distribution):
-    super(SubprocessExecutor, self).__init__(distribution=distribution)
-    self._buildroot = get_buildroot()
-    self._process = None
-
-  def _runner(self, classpath, main, jvm_options, args, cwd=None):
-    cwd = cwd or os.getcwd()
-    command = self._create_command(classpath, main, jvm_options, args, cwd=cwd)
+  def _runner(self, classpath, main, jvm_options, args):
+    command = self._create_command(classpath, main, jvm_options, args)
 
     class Runner(self.Runner):
       @property
@@ -223,11 +213,11 @@ class SubprocessExecutor(Executor):
       def command(_):
         return list(command)
 
-      def spawn(_, stdout=None, stderr=None, stdin=None):
-        return self._spawn(command, cwd, stdout=stdout, stderr=stderr, stdin=stdin)
+      def spawn(_, stdout=None, stderr=None, stdin=None, cwd=None):
+        return self._spawn(command, cwd=cwd, stdout=stdout, stderr=stderr, stdin=stdin)
 
-      def run(_, stdout=None, stderr=None, stdin=None):
-        return self._spawn(command, cwd, stdout=stdout, stderr=stderr, stdin=stdin).wait()
+      def run(_, stdout=None, stderr=None, stdin=None, cwd=None):
+        return self._spawn(command, cwd=cwd, stdout=stdout, stderr=stderr, stdin=stdin).wait()
 
     return Runner()
 
@@ -240,11 +230,13 @@ class SubprocessExecutor(Executor):
 
     :raises: :class:`Executor.Error` if there is a problem spawning the subprocess.
     """
-    cwd = cwd or os.getcwd()
-    cmd = self._create_command(*self._scrub_args(classpath, main, jvm_options, args, cwd=cwd))
-    return self._spawn(cmd, cwd, **subprocess_args)
+    classpath, main, jvm_options, args = self._scrub_args(classpath, main, jvm_options, args)
+    cmd = self._create_command(classpath, main, jvm_options, args)
+    return self._spawn(cmd, cwd=cwd, **subprocess_args)
 
-  def _spawn(self, cmd, cwd, stdout=None, stderr=None, stdin=None, **subprocess_args):
+  def _spawn(self, cmd, cwd=None, stdout=None, stderr=None, stdin=None, **subprocess_args):
+    cwd = cwd or os.getcwd()
+
     # NB: Only stdout and stderr have non-None defaults: callers that want to capture
     # stdin should pass it explicitly.
     stdout = stdout or sys.stdout

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -227,7 +227,7 @@ class NailgunClient(object):
   DEFAULT_NG_PORT = 2113
 
   def __init__(self, host=DEFAULT_NG_HOST, port=DEFAULT_NG_PORT, ins=sys.stdin, out=None, err=None,
-               workdir=None, exit_on_broken_pipe=False, metadata_base_dir=None):
+               exit_on_broken_pipe=False, metadata_base_dir=None):
     """Creates a nailgun client that can be used to issue zero or more nailgun commands.
 
     :param string host: the nailgun server to contact (defaults to '127.0.0.1')
@@ -237,7 +237,6 @@ class NailgunClient(object):
                      in which case no input is read
     :param file out: a stream to write command standard output to (defaults to stdout)
     :param file err: a stream to write command standard error to (defaults to stderr)
-    :param string workdir: the default working directory for all nailgun commands (defaults to CWD)
     :param bool exit_on_broken_pipe: whether or not to exit when `Broken Pipe` errors are
                                      encountered
     :param string metadata_base_dir: If a PID and PGRP are received from the server (only for
@@ -252,7 +251,6 @@ class NailgunClient(object):
     self._stdin = ins
     self._stdout = out or (sys.stdout.buffer if PY3 else sys.stdout)
     self._stderr = err or (sys.stderr.buffer if PY3 else sys.stderr)
-    self._workdir = workdir or os.path.abspath(os.path.curdir)
     self._exit_on_broken_pipe = exit_on_broken_pipe
     self._metadata_base_dir = metadata_base_dir
     # Mutable session state.
@@ -339,7 +337,7 @@ class NailgunClient(object):
     """
     environment = dict(**environment)
     environment.update(self.ENV_DEFAULTS)
-    cwd = cwd or self._workdir
+    cwd = cwd or os.getcwd()
 
     sock = self.try_connect()
 
@@ -370,6 +368,4 @@ class NailgunClient(object):
       self._session = None
 
   def __repr__(self):
-    return 'NailgunClient(host={!r}, port={!r}, workdir={!r})'.format(self._host,
-                                                                      self._port,
-                                                                      self._workdir)
+    return 'NailgunClient(host={!r}, port={!r})'.format(self._host, self._port)

--- a/src/python/pants/java/util.py
+++ b/src/python/pants/java/util.py
@@ -23,9 +23,8 @@ from pants.util.process_handler import ProcessHandler, SubprocessProcessHandler
 logger = logging.getLogger(__name__)
 
 
-def _get_runner(classpath, main, jvm_options, args, executor,
-               cwd, distribution,
-               create_synthetic_jar, synthetic_jar_dir):
+def _get_runner(classpath, main, jvm_options, args, executor, distribution, create_synthetic_jar,
+                synthetic_jar_dir):
   """Gets the java runner for execute_java and execute_java_async."""
 
   executor = executor or SubprocessExecutor(distribution)
@@ -35,7 +34,7 @@ def _get_runner(classpath, main, jvm_options, args, executor,
     safe_cp = safe_classpath(classpath, synthetic_jar_dir)
     logger.debug('Bundling classpath {} into {}'.format(':'.join(classpath), safe_cp))
 
-  return executor.runner(safe_cp, main, args=args, jvm_options=jvm_options, cwd=cwd)
+  return executor.runner(safe_cp, main, args=args, jvm_options=jvm_options)
 
 
 def execute_java(classpath, main, jvm_options=None, args=None, executor=None,
@@ -68,7 +67,7 @@ def execute_java(classpath, main, jvm_options=None, args=None, executor=None,
   Raises `pants.java.Executor.Error` if there was a problem launching java itself.
   """
 
-  runner = _get_runner(classpath, main, jvm_options, args, executor, cwd, distribution,
+  runner = _get_runner(classpath, main, jvm_options, args, executor, distribution,
                        create_synthetic_jar, synthetic_jar_dir)
   workunit_name = workunit_name or main
 
@@ -77,7 +76,8 @@ def execute_java(classpath, main, jvm_options=None, args=None, executor=None,
                         workunit_name=workunit_name,
                         workunit_labels=workunit_labels,
                         workunit_log_config=workunit_log_config,
-                        stdin=stdin)
+                        stdin=stdin,
+                        cwd=cwd)
 
 
 def execute_java_async(classpath, main, jvm_options=None, args=None, executor=None,
@@ -109,7 +109,7 @@ def execute_java_async(classpath, main, jvm_options=None, args=None, executor=No
   Raises `pants.java.Executor.Error` if there was a problem launching java itself.
   """
 
-  runner = _get_runner(classpath, main, jvm_options, args, executor, cwd, distribution,
+  runner = _get_runner(classpath, main, jvm_options, args, executor, distribution,
                        create_synthetic_jar, synthetic_jar_dir)
   workunit_name = workunit_name or main
 
@@ -117,11 +117,23 @@ def execute_java_async(classpath, main, jvm_options=None, args=None, executor=No
                               workunit_factory=workunit_factory,
                               workunit_name=workunit_name,
                               workunit_labels=workunit_labels,
-                              workunit_log_config=workunit_log_config)
+                              workunit_log_config=workunit_log_config,
+                              cwd=cwd)
+
+
+def _create_workunit_generator(runner, workunit_factory, workunit_name, workunit_labels=None,
+                               workunit_log_config=None):
+
+  is_nailgun = isinstance(runner.executor, NailgunExecutor)
+  execution_mode_label = WorkUnitLabel.NAILGUN if is_nailgun else WorkUnitLabel.JVM
+  workunit_labels = [WorkUnitLabel.TOOL, execution_mode_label] + (workunit_labels or [])
+
+  return workunit_factory(name=workunit_name, labels=workunit_labels, cmd=runner.cmd,
+                          log_config=workunit_log_config)
 
 
 def execute_runner(runner, workunit_factory=None, workunit_name=None, workunit_labels=None,
-                   workunit_log_config=None, stdin=None):
+                   workunit_log_config=None, stdin=None, cwd=None):
   """Executes the given java runner.
 
   If `workunit_factory` is supplied, does so in the context of a workunit.
@@ -133,6 +145,7 @@ def execute_runner(runner, workunit_factory=None, workunit_name=None, workunit_l
   :param WorkUnit.LogConfig workunit_log_config: an optional tuple of task options affecting reporting
   :param file stdin: The stdin handle to use: by default None, meaning that stdin will
     not be propagated into the process.
+  :param string cwd: optionally set the working directory
 
   Returns the exit code of the java runner.
   Raises `pants.java.Executor.Error` if there was a problem launching java itself.
@@ -142,24 +155,20 @@ def execute_runner(runner, workunit_factory=None, workunit_name=None, workunit_l
                      'given {} of type {}'.format(runner, type(runner)))
 
   if workunit_factory is None:
-    return runner.run(stdin=stdin)
+    return runner.run(stdin=stdin, cwd=cwd)
   else:
-    workunit_labels = [
-        WorkUnitLabel.TOOL,
-        WorkUnitLabel.NAILGUN if isinstance(runner.executor, NailgunExecutor) else WorkUnitLabel.JVM
-    ] + (workunit_labels or [])
-
-    with workunit_factory(name=workunit_name, labels=workunit_labels,
-                          cmd=runner.cmd, log_config=workunit_log_config) as workunit:
+    with _create_workunit_generator(runner, workunit_factory, workunit_name, workunit_labels,
+                                    workunit_log_config) as workunit:
       ret = runner.run(stdout=workunit.output('stdout'),
                        stderr=workunit.output('stderr'),
-                       stdin=stdin)
+                       stdin=stdin,
+                       cwd=cwd)
       workunit.set_outcome(WorkUnit.FAILURE if ret else WorkUnit.SUCCESS)
       return ret
 
 
 def execute_runner_async(runner, workunit_factory=None, workunit_name=None, workunit_labels=None,
-                         workunit_log_config=None):
+                         workunit_log_config=None, cwd=None):
   """Executes the given java runner asynchronously.
 
   We can't use 'with' here because the workunit_generator's __exit__ function
@@ -189,15 +198,12 @@ def execute_runner_async(runner, workunit_factory=None, workunit_name=None, work
   if workunit_factory is None:
     return SubprocessProcessHandler(runner.spawn())
   else:
-    workunit_labels = [
-                        WorkUnitLabel.TOOL,
-                        WorkUnitLabel.NAILGUN if isinstance(runner.executor, NailgunExecutor) else WorkUnitLabel.JVM
-                      ] + (workunit_labels or [])
-
-    workunit_generator = workunit_factory(name=workunit_name, labels=workunit_labels,
-                                cmd=runner.cmd, log_config=workunit_log_config)
+    workunit_generator = _create_workunit_generator(runner, workunit_factory, workunit_name,
+                                                    workunit_labels, workunit_log_config)
     workunit = workunit_generator.__enter__()
-    process = runner.spawn(stdout=workunit.output('stdout'), stderr=workunit.output('stderr'))
+    process = runner.spawn(stdout=workunit.output('stdout'),
+                           stderr=workunit.output('stderr'),
+                           cwd=cwd)
 
     class WorkUnitProcessHandler(ProcessHandler):
       def wait(_, timeout=None):

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -815,3 +815,18 @@ python_tests(
   ],
   tags = {'integration'},
 )
+
+python_tests(
+  name = 'nailgun_task',
+  sources = ['test_nailgun_task.py'],
+  dependencies = [
+    'src/python/pants/backend/jvm/tasks:nailgun_task',
+    'src/python/pants/base:build_environment',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/java:nailgun_executor',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:process_handler',
+    'tests/python/pants_test/jvm:jvm_tool_task_test_base',
+  ],
+)

--- a/tests/python/pants_test/backend/jvm/tasks/test_nailgun_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_nailgun_task.py
@@ -1,0 +1,104 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+from textwrap import dedent
+
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
+from pants.base.build_environment import get_buildroot
+from pants.base.exceptions import TaskError
+from pants.java.nailgun_executor import NailgunProcessGroup
+from pants.util.contextutil import pushd, temporary_dir
+from pants.util.dirutil import safe_mkdir
+from pants.util.process_handler import subprocess
+from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
+
+
+class NailgunTaskTest(JvmToolTaskTestBase):
+
+  class DetermineJavaCwd(NailgunTask):
+    def execute(self):
+      cwd_code = os.path.join(self.workdir, 'Cwd.java')
+      with open(cwd_code, 'w') as fp:
+        fp.write(dedent("""
+        import java.io.IOException;
+        import java.nio.charset.Charset;
+        import java.nio.file.Files;
+        import java.nio.file.Paths;
+        import java.util.Arrays;
+        
+        import com.martiansoftware.nailgun.NGContext;
+        
+        public class Cwd {
+          public static void nailMain(NGContext context) throws IOException {
+            String comm_file = context.getArgs()[0];
+            String cwd = context.getWorkingDirectory();
+            communicate(comm_file, cwd, "nailMain");
+          }
+          
+          public static void main(String[] args) throws IOException {
+            String comm_file = args[0];
+            String cwd = System.getProperty("user.dir");
+            communicate(comm_file, cwd, "main"); 
+          }
+          
+          private static void communicate(String comm_file, String cwd, String source)
+              throws IOException {
+
+            Files.write(Paths.get(comm_file), Arrays.asList(source, cwd), Charset.forName("UTF-8"));
+          }
+        }
+        """))
+
+      javac = self.dist.binary('javac')
+      nailgun_cp = self.tool_classpath('nailgun-server')
+
+      classes_dir = os.path.join(self.workdir, 'classes')
+      safe_mkdir(classes_dir)
+
+      subprocess.check_call([
+        javac,
+        '-cp', os.pathsep.join(nailgun_cp),
+        '-d', classes_dir,
+        '-Werror',
+        cwd_code
+      ])
+
+      comm_file = os.path.join(self.workdir, 'comm_file')
+      with temporary_dir() as python_cwd:
+        with pushd(python_cwd):
+          exit_code = self.runjava(nailgun_cp + [classes_dir], 'Cwd', args=[comm_file])
+          if exit_code != 0:
+            raise TaskError(exit_code=exit_code)
+
+          with open(comm_file, 'rb') as fp:
+            source, java_cwd = fp.read().strip().decode('utf-8').splitlines()
+            return source, java_cwd, python_cwd
+
+  @classmethod
+  def task_type(cls):
+    return cls.DetermineJavaCwd
+
+  def assert_cwd_is_buildroot(self, expected_source):
+    task = self.prepare_execute(self.context())
+    source, java_cwd, python_cwd = task.execute()
+
+    self.assertEqual(source, expected_source)
+
+    buildroot = os.path.realpath(get_buildroot())
+    self.assertEqual(buildroot, os.path.realpath(java_cwd))
+    self.assertNotEqual(buildroot, os.path.realpath(python_cwd))
+
+  def test_execution_strategy_nailgun(self):
+    self.set_options(execution_strategy=NailgunTask.ExecutionStrategy.nailgun)
+    self.addCleanup(lambda: NailgunProcessGroup(metadata_base_dir=self.subprocess_dir).killall())
+
+    self.assert_cwd_is_buildroot(expected_source='nailMain')
+
+  def test_execution_strategy_subprocess(self):
+    self.set_options(execution_strategy=NailgunTask.ExecutionStrategy.subprocess)
+
+    self.assert_cwd_is_buildroot(expected_source='main')

--- a/tests/python/pants_test/java/test_executor.py
+++ b/tests/python/pants_test/java/test_executor.py
@@ -57,23 +57,6 @@ class SubprocessExecutorTest(unittest.TestCase):
   def test_scrubbed_java_tool_options(self):
     self.do_test_jre_env_var('JAVA_TOOL_OPTIONS', '-Xmx1g')
 
-  def do_test_executor_classpath_relativize(self, executor):
-    """Test that 'executor' relativizes the classpath."""
-    here = os.path.abspath(".")
-    runner = executor.runner([here], "bogus")
-    self.assertFalse(here in runner.cmd)
-    parts = runner.cmd.split(" ")
-    found = False
-    for i, part in enumerate(parts):
-      if part == "-cp":
-        self.assertTrue(os.path.abspath(parts[i + 1]) == here)
-        found = True
-    self.assertTrue(found)
-
-  def test_subprocess_classpath_relativize(self):
-    with self.jre("FOO") as jre:
-      self.do_test_executor_classpath_relativize(SubprocessExecutor(Distribution(bin_path=jre)))
-
   def test_fails_with_bad_distribution(self):
 
     class DefinitelyNotADistribution(object):

--- a/tests/python/pants_test/java/test_util.py
+++ b/tests/python/pants_test/java/test_util.py
@@ -45,14 +45,14 @@ class ExecuteJavaTest(unittest.TestCase):
       mock_safe_classpath.side_effect = fake_safe_classpath
       yield mock_safe_classpath
 
-    self.runner.run.assert_called_once_with(stdin=None)
+    self.runner.run.assert_called_once_with(stdin=None, cwd=None)
     if create_synthetic_jar:
       self.executor.runner.assert_called_once_with(self.SAFE_CLASSPATH, self.TEST_MAIN,
-                                                    args=None, jvm_options=None, cwd=None)
+                                                   args=None, jvm_options=None)
       mock_safe_classpath.assert_called_once_with(self.TEST_CLASSPATH, self.SYNTHETIC_JAR_DIR)
     else:
       self.executor.runner.assert_called_once_with(self.TEST_CLASSPATH, self.TEST_MAIN,
-                                                    args=None, jvm_options=None, cwd=None)
+                                                   args=None, jvm_options=None)
       mock_safe_classpath.assert_not_called()
 
   def test_execute_java_no_error(self):
@@ -61,8 +61,8 @@ class ExecuteJavaTest(unittest.TestCase):
     """
     with self.mock_safe_classpath_helper():
       self.assertEqual(0, execute_java(self.TEST_CLASSPATH, self.TEST_MAIN,
-                                        executor=self.executor,
-                                        synthetic_jar_dir=self.SYNTHETIC_JAR_DIR))
+                                       executor=self.executor,
+                                       synthetic_jar_dir=self.SYNTHETIC_JAR_DIR))
 
   def test_execute_java_executor_error(self):
     """
@@ -81,8 +81,8 @@ class ExecuteJavaTest(unittest.TestCase):
     """
     with self.mock_safe_classpath_helper(create_synthetic_jar=False):
       self.assertEqual(0, execute_java(self.TEST_CLASSPATH, self.TEST_MAIN,
-                                        executor=self.executor,
-                                        create_synthetic_jar=False))
+                                       executor=self.executor,
+                                       create_synthetic_jar=False))
 
 
 def fake_safe_classpath(classpath, synthetic_jar_dir):


### PR DESCRIPTION
Previously, nailgun-mode executions would run with the cwd set to the
buildroot but subprocess mode executions would inherit cwd. These
usually aligned since pants is run from the buildroot, but could
misalign in tests where a test buildroot is propped up.

Ensure cwd is always explicitly the buildroot for NailgunTasks and fix
executor cwd plumbing to effect this with a test added that proves this
all works.

Additionally, fix ScalaPlatform classpaths, which had been relativized
to the buildroot to support snapshotting. Maintain the snapshot relative
paths, but leave the in-memory classpath un-altered and populated with
absolute paths like all other runtime classpaths.

Prep work for #7866.