### PR TITLE
Generate rsc execution test matrix

### DIFF
--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -7,6 +7,7 @@ python_tests(
   dependencies=[
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
+    'tests/python/pants_test:test_base',
   ],
   timeout = 600,
   tags = {'integration'},

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -5,17 +5,27 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from functools import wraps
 
 from pants.backend.jvm.subsystems.resolve_subsystem import JvmResolveSubsystem
 from pants.backend.jvm.tasks.jvm_compile.rsc.rsc_compile import RscCompile
 from pants.util.contextutil import temporary_dir
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
+from pants_test.test_base import TestGenerator
 
 
 def _for_all_supported_execution_environments(func):
-  @wraps(func)
-  def wrapper_self(*args, **kwargs):
+  func._with_run_config = True
+  return func
+
+
+class RscCompileIntegration(BaseCompileIT, TestGenerator):
+
+  @classmethod
+  def generate_tests(cls):
+    tests_with_generated_config = {
+      name: func for name, func in cls.__dict__.items() if getattr(func, '_with_run_config', False)
+    }
+
     for worker_count in [1, 2]:
       for resolver in JvmResolveSubsystem.CHOICES:
         for execution_strategy in RscCompile.ExecutionStrategy.all_variants:
@@ -52,14 +62,14 @@ def _for_all_supported_execution_environments(func):
               'hermetic': populate_necessary_hermetic_options,
             })()
 
-            func(*args, config=config, **kwargs)
-  return wrapper_self
-
-
-class RscCompileIntegration(BaseCompileIT):
+            for name, test in tests_with_generated_config.items():
+              cls.add_test(
+                'test_{}_resolver_{}_strategy_{}_worker_{}'
+                .format(name, resolver, execution_strategy.value, worker_count),
+                lambda this: test(this, config=config.copy()))
 
   @_for_all_supported_execution_environments
-  def test_basic_binary(self, config):
+  def basic_binary(self, config):
     with self.do_command_yielding_workdir(
         'compile', 'testprojects/src/scala/org/pantsbuild/testproject/mutual:bin',
         config=config) as pants_run:
@@ -75,20 +85,23 @@ class RscCompileIntegration(BaseCompileIT):
       self.assertIsFile(rsc_header_jar)
 
   @_for_all_supported_execution_environments
-  def test_executing_multi_target_binary(self, config):
+  def executing_multi_target_binary(self, config):
     pants_run = self.do_command(
       'run', 'examples/src/scala/org/pantsbuild/example/hello/exe',
       config=config)
     self.assertIn('Hello, Resource World!', pants_run.stdout_data)
 
   @_for_all_supported_execution_environments
-  def test_java_with_transitive_exported_scala_dep(self, config):
+  def java_with_transitive_exported_scala_dep(self, config):
     self.do_command(
       'compile', 'testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive:java-in-different-package',
       config=config)
 
   @_for_all_supported_execution_environments
-  def test_java_sources(self, config):
+  def java_sources(self, config):
     self.do_command(
       'compile', 'testprojects/src/scala/org/pantsbuild/testproject/javasources',
       config=config)
+
+
+RscCompileIntegration.generate_tests()


### PR DESCRIPTION
### Problem

The rsc compile integration tests take a while to run, since each test runs a single target with every supported execution environment. This is fine, but makes each test take a while to run, and is harder for us to automatically shard.

### Solution

- Use `TestGenerator` to generate tests instead of doing a for loop inside a single test!

### Result

The rsc compile integration tests should be easier to shard and easier to view the output of!