### PR TITLE
Fix `DistributionLocator` dependency declarations.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -486,8 +486,10 @@ python_library(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:build_environment',
     'src/python/pants/build_graph',
+    'src/python/pants/java/distribution',
     'src/python/pants/task',
     'src/python/pants/util:fileutil',
+    'src/python/pants/util:memo',
   ]
 )
 

--- a/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
+++ b/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
@@ -10,7 +10,6 @@ import os
 
 from pants.base.build_environment import get_buildroot, get_pants_cachedir
 from pants.base.workunit import WorkUnit, WorkUnitLabel
-from pants.java.distribution.distribution import DistributionLocator
 from pants.net.http.fetcher import Fetcher
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import safe_concurrent_creation
@@ -61,10 +60,6 @@ class CoursierSubsystem(Subsystem):
              help='Version paired with --bootstrap-jar-url, in order to invalidate and fetch the new version.')
     register('--bootstrap-fetch-timeout-secs', type=int, advanced=True, default=10,
              help='Timeout the fetch if the connection is idle for longer than this value.')
-
-  @classmethod
-  def subsystem_dependencies(cls):
-    return super(CoursierSubsystem, cls).subsystem_dependencies() + (DistributionLocator,)
 
   def bootstrap_coursier(self, workunit_factory):
 

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -57,7 +57,11 @@ class CoursierMixin(JvmResolverBase):
 
   @classmethod
   def subsystem_dependencies(cls):
-    return super(CoursierMixin, cls).subsystem_dependencies() + (JarDependencyManagement, CoursierSubsystem)
+    return super(CoursierMixin, cls).subsystem_dependencies() + (
+      CoursierSubsystem,
+      DistributionLocator,
+      JarDependencyManagement
+    )
 
   @classmethod
   def register_options(cls, register):
@@ -382,7 +386,7 @@ class CoursierMixin(JvmResolverBase):
       if j.get_url():
         jar_url = j.get_url()
         module += ',url={}'.format(parse.quote_plus(jar_url))
-        
+
       if j.intransitive:
         cmd_args.append('--intransitive')
 
@@ -646,7 +650,7 @@ class CoursierMixin(JvmResolverBase):
   def _get_path_to_jar(cls, coursier_cache_path, pants_jar_path_base, jar_path):
     """
     Create the path to the jar that will live in .pants.d
-    
+
     :param coursier_cache_path: coursier cache location
     :param pants_jar_path_base: location under pants workdir to store the hardlink to the coursier cache
     :param jar_path: path of the jar
@@ -686,7 +690,7 @@ class CoursierResolve(CoursierMixin, NailgunTask):
   @classmethod
   def implementation_version(cls):
     return super(CoursierResolve, cls).implementation_version() + [('CoursierResolve', 2)]
-  
+
   def execute(self):
     """Resolves the specified confs for the configured targets and returns an iterator over
     tuples of (conf, jar path).

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -28,7 +28,6 @@ from pants.base.exceptions import TargetDefinitionException, TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target
 from pants.build_graph.target_scopes import Scopes
-from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
 from pants.java.junit.junit_xml_parser import RegistryOfTests, Test, parse_failed_targets
 from pants.process.lock import OwnerPrintingInterProcessFileLock
@@ -107,7 +106,7 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
 
   @classmethod
   def subsystem_dependencies(cls):
-    return super(JUnitRun, cls).subsystem_dependencies() + (CodeCoverage, DistributionLocator, JUnit)
+    return super(JUnitRun, cls).subsystem_dependencies() + (CodeCoverage, JUnit)
 
   @classmethod
   def prepare(cls, options, round_manager):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -365,6 +365,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
   @memoized_property
   def _missing_deps_finder(self):
     dep_analyzer = JvmDependencyAnalyzer(get_buildroot(),
+                                         self._get_jvm_distribution(),
                                          self.context.products.get_data('runtime_classpath'))
     return MissingDependencyFinder(dep_analyzer, CompileErrorExtractor(
       self.get_options().class_not_found_error_patterns))

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_analyzer.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_analyzer.py
@@ -16,7 +16,6 @@ from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.build_graph.aliased_target import AliasTarget
 from pants.build_graph.build_graph import sort_targets
 from pants.build_graph.target import Target
-from pants.java.distribution.distribution import DistributionLocator
 from pants.util.memo import memoized_method, memoized_property
 
 
@@ -27,8 +26,9 @@ class JvmDependencyAnalyzer(object):
   determining which targets correspond to the actual source dependencies of any given target.
   """
 
-  def __init__(self, buildroot, runtime_classpath):
+  def __init__(self, buildroot, distribution, runtime_classpath):
     self.buildroot = buildroot
+    self.distribution = distribution
     self.runtime_classpath = runtime_classpath
 
   @memoized_method
@@ -122,7 +122,7 @@ class JvmDependencyAnalyzer(object):
 
   def _find_all_bootstrap_jars(self):
     def get_path(key):
-      return DistributionLocator.cached().system_properties.get(key, '').split(':')
+      return self.distribution.system_properties.get(key, '').split(':')
 
     def find_jars_in_dirs(dirs):
       ret = []

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_check.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_check.py
@@ -53,7 +53,10 @@ class JvmDependencyCheck(Task):
 
   @classmethod
   def subsystem_dependencies(cls):
-    return super(JvmDependencyCheck, cls).subsystem_dependencies() + (DependencyContext,)
+    return super(JvmDependencyCheck, cls).subsystem_dependencies() + (
+      DependencyContext,
+      DistributionLocator
+    )
 
   @staticmethod
   def _skip(options):
@@ -86,8 +89,13 @@ class JvmDependencyCheck(Task):
     return True
 
   @memoized_property
+  def _distribution(self):
+    return DistributionLocator.cached()
+
+  @memoized_property
   def _analyzer(self):
     return JvmDependencyAnalyzer(get_buildroot(),
+                                 self._distribution,
                                  self.context.products.get_data('runtime_classpath'))
 
   def execute(self):
@@ -180,7 +188,7 @@ class JvmDependencyCheck(Task):
       # We don't require explicit deps on the java runtime, so we shouldn't consider that
       # a missing dep.
       return (dep not in analyzer.bootstrap_jar_classfiles
-              and not dep.startswith(DistributionLocator.cached().real_home))
+              and not dep.startswith(self._distribution.real_home))
 
     def target_or_java_dep_in_targets(target, targets):
       # We want to check if the target is in the targets collection

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -19,6 +19,7 @@ from pants.build_graph.aliased_target import AliasTarget
 from pants.build_graph.resources import Resources
 from pants.build_graph.target import Target
 from pants.build_graph.target_scopes import Scopes
+from pants.java.distribution.distribution import DistributionLocator
 from pants.task.task import Task
 from pants.util.fileutil import create_size_estimators
 
@@ -65,6 +66,10 @@ class JvmDependencyUsage(Task):
                   'Useful for computing analysis for a lot of targets, but '
                   'result can differ from direct execution because cached information '
                   'doesn\'t depend on 3rdparty libraries versions.')
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(JvmDependencyUsage, cls).subsystem_dependencies() + (DistributionLocator,)
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -159,7 +164,9 @@ class JvmDependencyUsage(Task):
     `classes_by_source`, `runtime_classpath`, `product_deps_by_src` parameters and
     stores the result to the build cache.
     """
-    analyzer = JvmDependencyAnalyzer(get_buildroot(), runtime_classpath)
+    analyzer = JvmDependencyAnalyzer(get_buildroot(),
+                                     DistributionLocator.cached(),
+                                     runtime_classpath)
     targets = self.context.targets()
     targets_by_file = analyzer.targets_by_file(targets)
     transitive_deps_by_target = analyzer.compute_transitive_deps_by_target(targets)

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -22,6 +22,7 @@ from pants.build_graph.target_scopes import Scopes
 from pants.java.distribution.distribution import DistributionLocator
 from pants.task.task import Task
 from pants.util.fileutil import create_size_estimators
+from pants.util.memo import memoized_property
 
 
 class JvmDependencyUsage(Task):
@@ -147,37 +148,30 @@ class JvmDependencyUsage(Task):
         target_to_vts[vts.target] = vts
 
       if not self.get_options().use_cached:
-        node_creator = self.calculating_node_creator(
-          self.context.products.get_data('classes_by_source'),
-          self.context.products.get_data('runtime_classpath'),
-          self.context.products.get_data('product_deps_by_src'),
-          target_to_vts)
+        node_creator = self.calculating_node_creator(target_to_vts)
       else:
         node_creator = self.cached_node_creator(target_to_vts)
 
       return DependencyUsageGraph(self.create_dep_usage_nodes(targets, node_creator),
                                   self.size_estimators[self.get_options().size_estimator])
 
-  def calculating_node_creator(self, classes_by_source, runtime_classpath, product_deps_by_src,
-                               target_to_vts):
+  @memoized_property
+  def _analyzer(self):
+    return JvmDependencyAnalyzer(get_buildroot(),
+                                 DistributionLocator.cached(),
+                                 self.context.products.get_data('runtime_classpath'))
+
+  def calculating_node_creator(self, target_to_vts):
     """Strategy directly computes dependency graph node based on
     `classes_by_source`, `runtime_classpath`, `product_deps_by_src` parameters and
     stores the result to the build cache.
     """
-    analyzer = JvmDependencyAnalyzer(get_buildroot(),
-                                     DistributionLocator.cached(),
-                                     runtime_classpath)
     targets = self.context.targets()
-    targets_by_file = analyzer.targets_by_file(targets)
-    transitive_deps_by_target = analyzer.compute_transitive_deps_by_target(targets)
+    targets_by_file = self._analyzer.targets_by_file(targets)
+    transitive_deps_by_target = self._analyzer.compute_transitive_deps_by_target(targets)
     def creator(target):
       transitive_deps = set(transitive_deps_by_target.get(target))
-      node = self.create_dep_usage_node(target,
-                                        analyzer,
-                                        product_deps_by_src,
-                                        classes_by_source,
-                                        targets_by_file,
-                                        transitive_deps)
+      node = self.create_dep_usage_node(target, targets_by_file, transitive_deps)
       vt = target_to_vts[target]
       mode = 'w' if PY3 else 'wb'
       with open(self.nodes_json(vt.results_dir), mode=mode) as fp:
@@ -195,8 +189,10 @@ class JvmDependencyUsage(Task):
       if vt.valid and os.path.exists(self.nodes_json(vt.results_dir)):
         try:
           with open(self.nodes_json(vt.results_dir), 'r') as fp:
-            return Node.from_cacheable_dict(json.load(fp),
-                                            lambda spec: next(self.context.resolve(spec).__iter__()))
+            return Node.from_cacheable_dict(
+              json.load(fp),
+              lambda spec: next(self.context.resolve(spec).__iter__())
+            )
         except Exception:
           self.context.log.warn("Can't deserialize json for target {}".format(target))
           return Node(target.concrete_derived_from)
@@ -232,18 +228,13 @@ class JvmDependencyUsage(Task):
   def cache_target_dirs(self):
     return True
 
-  def create_dep_usage_node(self,
-                            target,
-                            analyzer,
-                            product_deps_by_src,
-                            classes_by_source,
-                            targets_by_file,
-                            transitive_deps):
-    declared_deps_with_aliases = set(analyzer.resolve_aliases(target))
-    eligible_unused_deps = {d for d, _ in analyzer.resolve_aliases(target, scope=Scopes.DEFAULT)}
+  def create_dep_usage_node(self, target, targets_by_file, transitive_deps):
+    declared_deps_with_aliases = set(self._analyzer.resolve_aliases(target))
+    eligible_unused_deps = {d for d, _ in self._analyzer.resolve_aliases(target,
+                                                                         scope=Scopes.DEFAULT)}
     concrete_target = target.concrete_derived_from
     declared_deps = [resolved for resolved, _ in declared_deps_with_aliases]
-    products_total = analyzer.count_products(target)
+    products_total = self._analyzer.count_products(target)
     node = Node(concrete_target)
     node.add_derivation(target, products_total)
 
@@ -263,6 +254,7 @@ class JvmDependencyUsage(Task):
 
     # Record the used products and undeclared Edges for this target. Note that some of
     # these may be self edges, which are considered later.
+    product_deps_by_src = self.context.products.get_data('product_deps_by_src')
     target_product_deps_by_src = product_deps_by_src.get(target, {})
     for product_deps in target_product_deps_by_src.values():
       for product_dep in product_deps:

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -501,11 +501,9 @@ python_tests(
   name = 'jvm_dependency_usage',
   sources = ['test_jvm_dependency_usage.py'],
   dependencies = [
+    'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/tasks:classpath_products',
     'src/python/pants/backend/jvm/tasks:jvm_dependency_usage',
-    'src/python/pants/base:payload',
-    'src/python/pants/base:payload_field',
-    'src/python/pants/goal:products',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:task_test_base',
   ]

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
@@ -8,7 +8,6 @@ import os
 
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
-from pants.backend.jvm.tasks.jvm_dependency_analyzer import JvmDependencyAnalyzer
 from pants.backend.jvm.tasks.jvm_dependency_usage import DependencyUsageGraph, JvmDependencyUsage
 from pants.util.dirutil import safe_mkdir, touch
 from pants_test.task_test_base import TaskTestBase, ensure_cached
@@ -159,21 +158,12 @@ class TestJvmDependencyUsage(TaskTestBase):
     self.assertTrue(graph._nodes[t4].dep_edges[t3].is_declared)
 
   def create_graph(self, task, targets):
-    classes_by_source = task.context.products.get_data('classes_by_source')
-    runtime_classpath = task.context.products.get_data('runtime_classpath')
-    product_deps_by_src = task.context.products.get_data('product_deps_by_src')
-    analyzer = JvmDependencyAnalyzer('', runtime_classpath)
-    targets_by_file = analyzer.targets_by_file(targets)
-    transitive_deps_by_target = analyzer.compute_transitive_deps_by_target(targets)
+    targets_by_file = task._analyzer.targets_by_file(targets)
+    transitive_deps_by_target = task._analyzer.compute_transitive_deps_by_target(targets)
 
     def node_creator(target):
       transitive_deps = set(transitive_deps_by_target.get(target))
-      return task.create_dep_usage_node(target,
-                                        analyzer,
-                                        product_deps_by_src,
-                                        classes_by_source,
-                                        targets_by_file,
-                                        transitive_deps)
+      return task.create_dep_usage_node(target, targets_by_file, transitive_deps)
 
     return DependencyUsageGraph(task.create_dep_usage_nodes(targets, node_creator),
                                 task.size_estimators[task.get_options().size_estimator])


### PR DESCRIPTION
This fixes all usages of `DistributionLocator` to declare a subsystem
dependency and removes all unused dependency declarations save for
those in the `Ivy` family where the tangles run deep.

Discovered working #7872.