### PR TITLE
Fix workunit tool_output directory filenames

### DIFF
--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -6,6 +6,7 @@ import re
 import time
 import uuid
 from collections import namedtuple
+from hashlib import sha1
 
 from pants.util.dirutil import safe_mkdir_for
 from pants.util.memo import memoized_method
@@ -189,11 +190,16 @@ class WorkUnit:
       raise Exception('Invalid output name: {}'.format(name))
     if name not in self._outputs:
       workunit_name = re.sub(r'\W', '_', self.name)
-      path = os.path.join(self.run_info_dir,
-                          'tool_outputs', '{workunit_name}-{id}.{output_name}'
-                          .format(workunit_name=workunit_name,
-                                  id=self.id,
-                                  output_name=name))
+      workunit_slug = '{workunit_name}-{id}.{output_name}'.format(
+          workunit_name=workunit_name,
+          id=self.id,
+          output_name=name
+        )
+      path = os.path.join(
+          self.run_info_dir,
+          'tool_outputs',
+          sha1(workunit_slug.encode('UTF-8')).hexdigest()
+        )
       safe_mkdir_for(path)
       self._outputs[name] = FileBackedRWBuf(path)
       self._output_paths[name] = path

--- a/tests/python/pants_test/goal/data/register.py
+++ b/tests/python/pants_test/goal/data/register.py
@@ -15,11 +15,13 @@ class TestWorkUnitTask(NailgunTask):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
+    register('--name', default='dummy')
     register('--success', default=False, type=bool)
 
   def execute(self):
     result = WorkUnit.SUCCESS if self.get_options().success else WorkUnit.FAILURE
 
     # This creates workunit and marks it as failure.
-    with self.context.new_workunit('dummy') as workunit:
+    with self.context.new_workunit(self.get_options().name) as workunit:
+      workunit.output("stdout").write("Hello! I'm {}.".format(self.get_options().name).encode("UTF-8"))
       workunit.set_outcome(result)

--- a/tests/python/pants_test/goal/test_run_tracker_integration.py
+++ b/tests/python/pants_test/goal/test_run_tracker_integration.py
@@ -53,23 +53,27 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
         self.assertIn('pantsd_stats', stats_json)
         self.assertIn('workunits', stats_json)
 
-  def test_workunit_failure(self):
-    pants_run = self.run_pants([
+  def _dummy_task_args(self):
+    return [
       '--pythonpath={}'.format(os.path.join(os.getcwd(), 'tests', 'python')),
       '--backend-packages={}'.format('pants_test.goal.data'),
       'run-dummy-workunit',
-      '--no-success'
-    ])
+    ]
+
+  def test_workunit_failure(self):
+    pants_run = self.run_pants(self._dummy_task_args() + ['--no-success'])
     # Make sure the task actually happens and of no exception.
     self.assertIn('[run-dummy-workunit]', pants_run.stdout_data)
     self.assertNotIn('Exception', pants_run.stderr_data)
     self.assert_failure(pants_run)
 
   def test_workunit_success(self):
-    pants_run = self.run_pants([
-      '--pythonpath={}'.format(os.path.join(os.getcwd(), 'tests', 'python')),
-      '--backend-packages={}'.format('pants_test.goal.data'),
-      'run-dummy-workunit',
-      '--success'
-    ])
+    pants_run = self.run_pants(self._dummy_task_args() + ['--success'])
+    self.assert_success(pants_run)
+
+  def test_workunit_long_name(self):
+    pants_run = self.run_pants(self._dummy_task_args() + [
+        '--success',
+        '--name={}'.format('ohno!' * 500),
+      ])
     self.assert_success(pants_run)


### PR DESCRIPTION
### Problem

Workunits with very long names and outputs (to `stdout`/`stderr`/etc) hit a filename length limit.

### Solution

Hash the workunit "slug" when writing the outputs.

### Result

Longer workunit names are supported.