### PR TITLE
Fix Junit runner failing when `--extra-jvm-options` provided

### DIFF
--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -389,8 +389,8 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
       lambda tgt: tgt.concurrency,
       lambda tgt: tgt.threads)
 
-    # N.B. Python 3 does not allow comparisons between None and other types like str. Several
-    # of the properties, which act as dictionary keys, may have None values, whereras another
+    # NB: Python 3 does not allow comparisons between None and other types like str. Several
+    # of the properties, which act as dictionary keys, may have None values, whereas another
     # may have a non-None value for the same property, so comparison when sorting would fail.
     # We provide this custom key function to avoid such invalid comparisons, while still
     # allowing us to use None to represent non-present properties.
@@ -399,8 +399,8 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
       return (
         workdir or '',
         platform,
-        extra_jvm_options or [],
-        extra_env_vars or {},
+        extra_jvm_options,  # Will always be a tuple.
+        extra_env_vars,  # Will always be a tuple.
         concurrency or "",
         threads or 0)
 


### PR DESCRIPTION
### Problem
In Python 3, you cannot compare unlike types like `list` and `tuple`, whereas Python 2 allowed this. https://github.com/pantsbuild/pants/pull/7067 mostly fixed this, but got the types wrong for `extra_jvm_options` and `extra_env_vars`.

This was detected when running Twitter code with Pants using Python 3, which resulted in the exception:

```python
Exception message: '<' not supported between instances of 'tuple' and 'list'
```

We did not encounter this error earlier because we never encountered the edge case of one target specifying `extra_jvm_options` and the other not specifying it, which would result in comparing a tuple to a list.

### Solution
For these two fields, there is no `None` value ever. The values are always tuples, just sometimes empty tuples. So, we can remove the fallback value.

### Result
The Twitter test now succeeds.