### PR TITLE
Fix Nailgun failure when the port is not specified

### DIFF
--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -143,7 +143,8 @@ class RemotePantsRunner(object):
     modified_env['PANTSD_RUNTRACKER_CLIENT_START_TIME'] = str(self._start_time)
     modified_env['PANTSD_REQUEST_TIMEOUT_LIMIT'] = str(self._bootstrap_options.for_global_scope().pantsd_timeout_when_multiple_invocations)
 
-    assert isinstance(port, int), 'port {} is not an integer!'.format(port)
+    assert isinstance(port, int), \
+      'port {} is not an integer! It has type {}.'.format(port, type(port))
 
     # Instantiate a NailgunClient.
     client = NailgunClient(port=port,

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -290,7 +290,9 @@ class NailgunClient(object):
     :returns: a connected `socket.socket`.
     :raises: `NailgunClient.NailgunConnectionError` on failure to connect.
     """
-    sock = RecvBufferedSocket(socket.socket(socket.AF_INET, socket.SOCK_STREAM))
+    sock = RecvBufferedSocket(
+      sock=socket.socket(family=socket.AF_INET, type=socket.SOCK_STREAM)
+    )
     try:
       sock.connect(self._address)
     except (socket.error, socket.gaierror) as e:

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -226,7 +226,7 @@ class NailgunClient(object):
   DEFAULT_NG_HOST = '127.0.0.1'
   DEFAULT_NG_PORT = 2113
 
-  def __init__(self, host=DEFAULT_NG_HOST, port=DEFAULT_NG_PORT, ins=sys.stdin, out=None, err=None,
+  def __init__(self, host=None, port=None, ins=sys.stdin, out=None, err=None,
                exit_on_broken_pipe=False, metadata_base_dir=None):
     """Creates a nailgun client that can be used to issue zero or more nailgun commands.
 
@@ -244,9 +244,9 @@ class NailgunClient(object):
                                      written under this directory. For non-pailgun connections this
                                      may be None.
     """
-    self._host = host
-    self._port = port
-    self._address = (host, port)
+    self._host = host or self.DEFAULT_NG_HOST
+    self._port = port or self.DEFAULT_NG_PORT
+    self._address = (self._host, self._port)
     self._address_string = ':'.join(str(i) for i in self._address)
     self._stdin = ins
     self._stdout = out or (sys.stdout.buffer if PY3 else sys.stdout)

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -188,7 +188,7 @@ class NailgunExecutor(Executor, FingerprintedProcessManager):
         return self._spawn_nailgun_server(new_fingerprint, jvm_options, classpath, stdout, stderr,
                                           stdin)
 
-    return self._create_ngclient(self.socket, stdout, stderr, stdin)
+    return self._create_ngclient(port=self.socket, stdout=stdout, stderr=stderr, stdin=stdin)
 
   class InitialNailgunConnectTimedOut(Exception):
     _msg_fmt = """Failed to read nailgun output after {timeout} seconds!
@@ -228,7 +228,10 @@ Stderr:
           accumulated_stdout += line
 
   def _create_ngclient(self, port, stdout, stderr, stdin):
-    return NailgunClient(port=port, ins=stdin, out=stdout, err=stderr)
+    kwargs = {"ins": stdin, "out": stdout, "err": stderr}
+    if port is not None:
+      kwargs["port"] = port
+    return NailgunClient(**kwargs)
 
   def ensure_connectable(self, nailgun):
     """Ensures that a nailgun client is connectable or raises NailgunError."""
@@ -274,7 +277,7 @@ Stderr:
     logger.debug('Spawned nailgun server {i} with fingerprint={f}, pid={pid} port={port}'
                  .format(i=self._identity, f=fingerprint, pid=self.pid, port=self.socket))
 
-    client = self._create_ngclient(self.socket, stdout, stderr, stdin)
+    client = self._create_ngclient(port=self.socket, stdout=stdout, stderr=stderr, stdin=stdin)
     self.ensure_connectable(client)
 
     return client

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -228,10 +228,7 @@ Stderr:
           accumulated_stdout += line
 
   def _create_ngclient(self, port, stdout, stderr, stdin):
-    kwargs = {"ins": stdin, "out": stdout, "err": stderr}
-    if port is not None:
-      kwargs["port"] = port
-    return NailgunClient(**kwargs)
+    return NailgunClient(port=port, ins=stdin, out=stdout, err=stderr)
 
   def ensure_connectable(self, nailgun):
     """Ensures that a nailgun client is connectable or raises NailgunError."""


### PR DESCRIPTION
Downstream Twitter tests were failing to compile certain targets with the error message:

```
zinc[zinc-java](path/to/target:target) failed: an integer is required (got type NoneType)
```

This happens when `ProcessManager.socket` returns `None`, which is an expected return value:

https://github.com/pantsbuild/pants/blob/e727747e036584301fb4dac5203597fd1066d6f7/src/python/pants/pantsd/process_manager.py#L306-L309

This ends up resulting in the nailgun code trying to use `None` for the `port`, which is invalid and causes the error.

Instead, we use Pants' idiom of setting the default to `None` and in the body of the constructor then defaulting to the actual default value we care about.