### PR TITLE
Use Selectors module for more robust and efficient syscalls

### DIFF
--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -57,6 +57,7 @@ python_library(
   dependencies = [
     ':executor',
     ':nailgun_client',
+    '3rdparty/python:future',
     '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -212,8 +212,6 @@ Stderr:
     accumulated_stdout = ''
 
     def calculate_remaining_time():
-      # TODO: share the decreasing timeout logic here with NailgunProtocol.iter_chunks() by adding
-      # a method to pants.util.contextutil!
       return time.time() - (start_time + timeout)
 
     def possibly_raise_timeout(remaining_time):

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -226,7 +226,10 @@ Stderr:
         )
 
     if PY3:
-      with selectors.DefaultSelector() as selector, \
+      # NB: We use PollSelector, rather than the more efficient DefaultSelector, because
+      # DefaultSelector results in using the epoll() syscall on Linux, which does not work with
+      # regular text files like ng_stdout. See https://stackoverflow.com/a/8645770.
+      with selectors.PollSelector() as selector, \
         safe_open(self._ng_stdout, 'r') as ng_stdout:
         selector.register(ng_stdout, selectors.EVENT_READ)
         while 1:

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -8,7 +8,6 @@ import hashlib
 import logging
 import os
 import re
-import select
 import threading
 import time
 from contextlib import closing
@@ -22,6 +21,12 @@ from pants.java.nailgun_client import NailgunClient
 from pants.pantsd.process_manager import FingerprintedProcessManager, ProcessGroup
 from pants.util.dirutil import read_file, safe_file_dump, safe_open
 from pants.util.memo import memoized_classproperty
+
+
+if PY3:
+  import selectors
+else:
+  import select
 
 
 logger = logging.getLogger(__name__)
@@ -203,29 +208,51 @@ Stderr:
 
   def _await_socket(self, timeout):
     """Blocks for the nailgun subprocess to bind and emit a listening port in the nailgun stdout."""
-    with safe_open(self._ng_stdout, 'r') as ng_stdout:
-      start_time = time.time()
-      accumulated_stdout = ''
-      while 1:
-        # TODO: share the decreasing timeout logic here with NailgunProtocol.iter_chunks() by adding
-        # a method to pants.util.contextutil!
-        remaining_time = time.time() - (start_time + timeout)
-        if remaining_time > 0:
-          stderr = read_file(self._ng_stderr, binary_mode=True)
-          raise self.InitialNailgunConnectTimedOut(
-            timeout=timeout,
-            stdout=accumulated_stdout,
-            stderr=stderr,
-          )
+    start_time = time.time()
+    accumulated_stdout = ''
 
-        readable, _, _ = select.select([ng_stdout], [], [], (-1 * remaining_time))
-        if readable:
-          line = ng_stdout.readline()                          # TODO: address deadlock risk here.
-          try:
-            return self._NG_PORT_REGEX.match(line).group(1)
-          except AttributeError:
-            pass
-          accumulated_stdout += line
+    def calculate_remaining_time():
+      # TODO: share the decreasing timeout logic here with NailgunProtocol.iter_chunks() by adding
+      # a method to pants.util.contextutil!
+      return time.time() - (start_time + timeout)
+
+    def possibly_raise_timeout(remaining_time):
+      if remaining_time > 0:
+        stderr = read_file(self._ng_stderr, binary_mode=True)
+        raise self.InitialNailgunConnectTimedOut(
+          timeout=timeout,
+          stdout=accumulated_stdout,
+          stderr=stderr,
+        )
+
+    if PY3:
+      with selectors.DefaultSelector() as selector, \
+        safe_open(self._ng_stdout, 'r') as ng_stdout:
+        selector.register(ng_stdout, selectors.EVENT_READ)
+        while 1:
+          remaining_time = calculate_remaining_time()
+          possibly_raise_timeout(remaining_time)
+          events = selector.select(timeout=-1 * remaining_time)
+          if events:
+            line = ng_stdout.readline()  # TODO: address deadlock risk here.
+            try:
+              return self._NG_PORT_REGEX.match(line).group(1)
+            except AttributeError:
+              pass
+            accumulated_stdout += line
+    else:
+      with safe_open(self._ng_stdout, 'r') as ng_stdout:
+        while 1:
+          remaining_time = calculate_remaining_time()
+          possibly_raise_timeout(remaining_time)
+          readable, _, _ = select.select([ng_stdout], [], [], (-1 * remaining_time))
+          if readable:
+            line = ng_stdout.readline()  # TODO: address deadlock risk here.
+            try:
+              return self._NG_PORT_REGEX.match(line).group(1)
+            except AttributeError:
+              pass
+            accumulated_stdout += line
 
   def _create_ngclient(self, port, stdout, stderr, stdin):
     return NailgunClient(port=port, ins=stdin, out=stdout, err=stderr)

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -225,6 +225,11 @@ class NailgunStreamWriter(_StoppableDaemonThread):
 
   def run(self):
     while self._in_fds and not self.is_stopped:
+      # NB: For now, we stick with select.select, rather than the better abstracted and more robust
+      # selectors.DefaultSelector. We do this because we currently check for errored_fds, and this
+      # cannot be easily recreated with selectors (https://stackoverflow.com/a/49563017). See
+      # https://github.com/pantsbuild/pants/issues/7880 for why we might want to revisit this code
+      # to instead use selectors.
       readable_fds, _, errored_fds = select.select(self._in_fds, [], self._in_fds, self._select_timeout)
       self.do_run(readable_fds, errored_fds)
 

--- a/src/python/pants/pantsd/BUILD
+++ b/src/python/pants/pantsd/BUILD
@@ -18,6 +18,7 @@ python_library(
   name = 'pailgun_server',
   sources = ['pailgun_server.py'],
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python:six',
     'src/python/pants/java:nailgun_protocol',
     'src/python/pants/util:contextutil',

--- a/src/python/pants/pantsd/BUILD
+++ b/src/python/pants/pantsd/BUILD
@@ -18,7 +18,6 @@ python_library(
   name = 'pailgun_server',
   sources = ['pailgun_server.py'],
   dependencies = [
-    '3rdparty/python:future',
     '3rdparty/python:six',
     'src/python/pants/java:nailgun_protocol',
     'src/python/pants/util:contextutil',

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -230,9 +230,9 @@ class PailgunServer(ThreadingMixIn, TCPServer):
     elif self.timeout is not None:
       timeout = min(timeout, self.timeout)
     if PY3:
-      selector = selectors.DefaultSelector()
-      selector.register(self, selectors.EVENT_READ)
-      events = selector.select(timeout=timeout)
+      with selectors.DefaultSelector() as selector:
+        selector.register(self, selectors.EVENT_READ)
+        events = selector.select(timeout=timeout)
       if not events:
         self.handle_timeout()
         return

--- a/src/python/pants/util/socket.py
+++ b/src/python/pants/util/socket.py
@@ -80,9 +80,9 @@ class RecvBufferedSocket(object):
 
     if len(self._buffer) < bufsize:
       if PY3:
-        selector = selectors.DefaultSelector()
-        selector.register(self._socket, selectors.EVENT_READ)
-        events = selector.select(timeout=self._select_timeout)
+        with selectors.DefaultSelector() as selector:
+          selector.register(self._socket, selectors.EVENT_READ)
+          events = selector.select(timeout=self._select_timeout)
         if events:
           read_and_add_to_buffer()
       else:

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -155,6 +155,7 @@ python_tests(
   sources = ['test_socket.py'],
   coverage = ['pants.util.socket'],
   dependencies = [
+    '3rdparty/python:future',
     '3rdparty/python:mock',
     'src/python/pants/util:socket',
   ]

--- a/tests/python/pants_test/util/test_socket.py
+++ b/tests/python/pants_test/util/test_socket.py
@@ -11,20 +11,38 @@ import unittest
 import mock
 from future.utils import PY3
 
-from pants.util.socket import RecvBufferedSocket
-
-
-if PY3:
-  import selectors
+from pants.util.socket import RecvBufferedSocket, is_readable
 
 
 PATCH_OPTS = dict(autospec=True, spec_set=True)
 
 
+class TestSocketUtils(unittest.TestCase):
+
+  @mock.patch('selectors.DefaultSelector' if PY3 else 'select.select', **PATCH_OPTS)
+  def test_is_readable(self, mock_selector):
+    mock_fileobj = mock.Mock()
+    if PY3:
+      mock_selector = mock_selector.return_value.__enter__.return_value
+      mock_selector.register = mock.Mock()
+      # NB: the return value should actually be List[Tuple[SelectorKey, Events]], but our code only
+      # cares that _some_ event happened so we choose a simpler mock here. See
+      # https://docs.python.org/3/library/selectors.html#selectors.BaseSelector.select.
+      mock_selector.select = mock.Mock(return_value=[(1, "")])
+    else:
+      mock_selector.return_value = ([1], [], [])
+    self.assertTrue(is_readable(mock_fileobj, timeout=0.1))
+    if PY3:
+      mock_selector.select = mock.Mock(return_value=[])
+    else:
+      mock_selector.return_value = ([], [], [])
+    self.assertFalse(is_readable(mock_fileobj, timeout=0.1))
+
+
 class TestRecvBufferedSocket(unittest.TestCase):
   def setUp(self):
     self.chunk_size = 512
-    self.mock_socket = mock.Mock(fileno=lambda: 1)
+    self.mock_socket = mock.Mock()
     self.client_sock, self.server_sock = socket.socketpair()
     self.buf_sock = RecvBufferedSocket(self.client_sock, chunk_size=self.chunk_size)
     self.mocked_buf_sock = RecvBufferedSocket(self.mock_socket, chunk_size=self.chunk_size)
@@ -52,12 +70,12 @@ class TestRecvBufferedSocket(unittest.TestCase):
   @mock.patch('selectors.DefaultSelector' if PY3 else 'select.select', **PATCH_OPTS)
   def test_recv_check_calls(self, mock_selector):
     if PY3:
-      # NB: We use PollSelector because Linux's epoll() does not work with mock objects.
-      mock_selector.register = selectors.PollSelector.register
+      mock_selector = mock_selector.return_value.__enter__.return_value
+      mock_selector.register = mock.Mock()
       # NB: the return value should actually be List[Tuple[SelectorKey, Events]], but our code only
       # cares that _some_ event happened so we choose a simpler mock here. See
       # https://docs.python.org/3/library/selectors.html#selectors.BaseSelector.select.
-      mock_selector.select = mock.Mock(return_value=[(1, b"")])
+      mock_selector.select = mock.Mock(return_value=[(1, "")])
     else:
       mock_selector.return_value = ([1], [], [])
 

--- a/tests/python/pants_test/util/test_socket.py
+++ b/tests/python/pants_test/util/test_socket.py
@@ -9,6 +9,7 @@ import socket
 import unittest
 
 import mock
+from future.utils import PY3
 
 from pants.util.socket import RecvBufferedSocket
 
@@ -19,7 +20,7 @@ PATCH_OPTS = dict(autospec=True, spec_set=True)
 class TestRecvBufferedSocket(unittest.TestCase):
   def setUp(self):
     self.chunk_size = 512
-    self.mock_socket = mock.Mock()
+    self.mock_socket = mock.Mock(fileno=lambda: 1)
     self.client_sock, self.server_sock = socket.socketpair()
     self.buf_sock = RecvBufferedSocket(self.client_sock, chunk_size=self.chunk_size)
     self.mocked_buf_sock = RecvBufferedSocket(self.mock_socket, chunk_size=self.chunk_size)
@@ -44,9 +45,13 @@ class TestRecvBufferedSocket(unittest.TestCase):
     self.server_sock.sendall(b'A' * double_chunk)
     self.assertEqual(self.buf_sock.recv(double_chunk), b'A' * double_chunk)
 
-  @mock.patch('pants.util.socket.select.select', **PATCH_OPTS)
+  @mock.patch('selectors.DefaultSelector.select' if PY3 else 'select.select', **PATCH_OPTS)
   def test_recv_check_calls(self, mock_select):
-    mock_select.return_value = ([1], [], [])
+    # NB: this is not quite the expected return value for `DefaultSelector.select`, which expects
+    # List[Tuple[SelectorKey, Events]]. Our code only cares that _some_ event happened, though,
+    # so we choose a far simpler mock for the sake of this test. See
+    # https://docs.python.org/3/library/selectors.html#selectors.BaseSelector.select.
+    mock_select.return_value = [(1, b"")] if PY3 else ([1], [], [])
     self.mock_socket.recv.side_effect = [b'A' * self.chunk_size, b'B' * self.chunk_size]
 
     self.assertEqual(self.mocked_buf_sock.recv(128), b'A' * 128)


### PR DESCRIPTION
### Problem
Twitter was running into the error `filedescriptor out of range in select()` when compiling a large number of targets, per https://github.com/pantsbuild/pants/issues/7880.

In the process, we found that it is more efficient and robust to use the more modern syscalls of `epoll()`, `devpoll()`, and `kqueue()` than `select()`. Python 3.4 introduced the Selectors module to choose the best syscall available for us.

This will close https://github.com/pantsbuild/pants/issues/7880.

### Solution
For Python 3 code, use the new selectors library. Python 2 code stays the same as before, since the library does not exist for it and we are soon going to drop Python 2.
