### PR TITLE
Disable pantsd in inner runs.

### DIFF
--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -80,6 +80,11 @@ class PailgunHandler(PailgunHandlerBase):
     self.logger.info('handling pailgun request: `{}`'.format(' '.join(arguments)))
     self.logger.debug('pailgun request environment: %s', environment)
 
+    # We don't support parallel runs in pantsd, and therefore if this pailgun request
+    # triggers any pants command, we want it to not use pantsd at all.
+    # See https://github.com/pantsbuild/pants/issues/7881 for context.
+    environment["PANTS_ENABLE_PANTSD"] = "False"
+
     # Execute the requested command with optional daemon-side profiling.
     with maybe_profiled(environment.get('PANTSD_PROFILE')):
       self._run_pants(self.request, arguments, environment)

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -83,7 +83,7 @@ class PailgunHandler(PailgunHandlerBase):
     # We don't support parallel runs in pantsd, and therefore if this pailgun request
     # triggers any pants command, we want it to not use pantsd at all.
     # See https://github.com/pantsbuild/pants/issues/7881 for context.
-    environment["PANTS_ENABLE_PANTSD"] = "False"
+    environment["PANTS_CONCURRENT"] = "True"
 
     # Execute the requested command with optional daemon-side profiling.
     with maybe_profiled(environment.get('PANTSD_PROFILE')):

--- a/testprojects/src/python/nested_runs/BUILD
+++ b/testprojects/src/python/nested_runs/BUILD
@@ -1,5 +1,6 @@
 python_binary(
   name="nested_runs",
-  source="run_pants_with_pantsd.py"
+  source="run_pants_with_pantsd.py",
+  compatibility=['CPython>=3.6,<4']
 )
 

--- a/testprojects/src/python/nested_runs/BUILD
+++ b/testprojects/src/python/nested_runs/BUILD
@@ -1,0 +1,5 @@
+python_binary(
+  name="nested_runs",
+  source="run_pants_with_pantsd.py"
+)
+

--- a/testprojects/src/python/nested_runs/run_pants_with_pantsd.py
+++ b/testprojects/src/python/nested_runs/run_pants_with_pantsd.py
@@ -1,0 +1,18 @@
+import os
+import subprocess
+import sys
+
+
+def main():
+  workdir = sys.argv[1]
+  config = os.path.join(workdir, 'pants.ini')
+
+  cmd = './pants --no-pantsrc --pants-config-files={config} --print-exception-stacktrace=True --pants-workdir={workdir} goals'.format(
+    config=config,
+    workdir=workdir,
+  )
+  print(cmd)
+  subprocess.run(cmd, shell=True, check=True)
+
+if __name__ == '__main__':
+  main()

--- a/testprojects/src/python/nested_runs/run_pants_with_pantsd.py
+++ b/testprojects/src/python/nested_runs/run_pants_with_pantsd.py
@@ -1,18 +1,23 @@
-import os
+import pathlib
 import subprocess
 import sys
 
 
 def main():
   workdir = sys.argv[1]
-  config = os.path.join(workdir, 'pants.ini')
+  config = pathlib.Path(workdir) / 'pants.ini'
 
-  cmd = './pants --no-pantsrc --pants-config-files={config} --print-exception-stacktrace=True --pants-workdir={workdir} goals'.format(
-    config=config,
-    workdir=workdir,
-  )
-  print(cmd)
-  subprocess.run(cmd, shell=True, check=True)
+  cmd = [
+    './pants',
+    '--no-pantsrc',
+    f'--pants-config-files={config}',
+    '--print-exception-stacktrace=True',
+    f'--pants-workdir={workdir}',
+    'goals'
+  ]
+  print(f'Running pants with command {cmd}')
+  subprocess.run(cmd, check=True)
+
 
 if __name__ == '__main__':
   main()

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -772,13 +772,14 @@ Interrupted by user over pailgun client!
         result.stderr_data,
       )
 
-  # Regression test for issue https://github.com/pantsbuild/pants/issues/7881
-  # When a run under pantsd calls pants with pantsd inside it, the inner run will time out
-  # waiting for the outer run to end.
   def test_inner_runs_dont_deadlock(self):
     """
     Create a pantsd run that calls testprojects/src/python/nested_runs with the appropriate
     bootstrap options to avoid restarting pantsd.
+
+    Regression test for issue https://github.com/pantsbuild/pants/issues/7881
+    When a run under pantsd calls pants with pantsd inside it, the inner run will time out
+    waiting for the outer run to end.
 
     NB: testprojects/src/python/nested_runs assumes that the pants.ini file is in ${workdir}/pants.ini
     """
@@ -790,6 +791,5 @@ Interrupted by user over pailgun client!
     with self.pantsd_successful_run_context(extra_config=config) as (pantsd_run, checker, workdir, _):
       result = pantsd_run(['run', 'testprojects/src/python/nested_runs', '--', workdir], expected_runs=2)
       checker.assert_started()
-      self.assertNotIn("Another pants invocation is running", result.stderr_data)
       self.assert_success(result)
->>>>>>> Add failing test
+      self.assertNotIn("Another pants invocation is running", result.stderr_data)

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -771,3 +771,25 @@ Interrupted by user over pailgun client!
         'pants.bin.daemon_pants_runner._PantsRunFinishedWithFailureException: Terminated with 1',
         result.stderr_data,
       )
+
+  # Regression test for issue https://github.com/pantsbuild/pants/issues/7881
+  # When a run under pantsd calls pants with pantsd inside it, the inner run will time out
+  # waiting for the outer run to end.
+  def test_inner_runs_dont_deadlock(self):
+    """
+    Create a pantsd run that calls testprojects/src/python/nested_runs with the appropriate
+    bootstrap options to avoid restarting pantsd.
+
+    NB: testprojects/src/python/nested_runs assumes that the pants.ini file is in ${workdir}/pants.ini
+    """
+    config = {
+      'GLOBAL': {
+        'pantsd_timeout_when_multiple_invocations': 1,
+      }
+    }
+    with self.pantsd_successful_run_context(extra_config=config) as (pantsd_run, checker, workdir, _):
+      result = pantsd_run(['run', 'testprojects/src/python/nested_runs', '--', workdir], expected_runs=2)
+      checker.assert_started()
+      self.assertNotIn("Another pants invocation is running", result.stderr_data)
+      self.assert_success(result)
+>>>>>>> Add failing test


### PR DESCRIPTION
### Problem

When a pants run under pantsd calls pants, it will also enable pantsd in the inner run. Since we don't allow parallel runs under pantsd, the inner run will block waiting for the outer run to complete, eventually timing out and crashing the whole run.
See #7881 for context.
The only real instance we've seen of this was entirely accidental.

### Solution

Explicitly disable pantsd through an environment variable whenever we are serving a pailgun request.

### Result

Inner runs under pantsd have the daemon turned off by default.
Fixes #7881 , Depends on #7890

Commits should be independently reviewable.