### PR TITLE
Set up `type_checked` tag for internal type hint migration

### DIFF
--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -5,6 +5,7 @@ python_library(
   name = 'common',
   sources = 'common.py',
   compatibility = ['CPython>=3.6'],
+  tags = {'type_checked'},
 )
 
 python_binary(
@@ -14,6 +15,7 @@ python_binary(
     ':common',
   ],
   compatibility = ['CPython>=3.6'],
+  tags = {'type_checked'},
 )
 
 python_binary(
@@ -23,6 +25,7 @@ python_binary(
     ':common',
   ],
   compatibility = ['CPython>=3.6'],
+  tags = {'type_checked'},
 )
 
 python_binary(
@@ -32,6 +35,7 @@ python_binary(
     ':common',
   ],
   compatibility = ['CPython>=3.6'],
+  tags = {'type_checked'},
 )
 
 python_binary(
@@ -41,6 +45,14 @@ python_binary(
     ':common',
   ],
   compatibility = ['CPython>=3.6'],
+  tags = {'type_checked'},
+)
+
+python_binary(
+  name = 'mypy',
+  sources = 'mypy.py',
+  compatibility = ['CPython>=3.6'],
+  tags = {'type_checked'},
 )
 
 python_binary(
@@ -50,4 +62,5 @@ python_binary(
     ':common',
   ],
   compatibility = ['CPython>=3.6'],
+  tags = {'type_checked'},
 )

--- a/build-support/bin/mypy.py
+++ b/build-support/bin/mypy.py
@@ -6,15 +6,7 @@ import subprocess
 
 
 def main() -> None:
-  subprocess.run([
-    "./pants",
-    "--tag=+type_checked",
-    "mypy",
-    "src/python/pants::",
-    "tests/python/pants_test::",
-    "contrib::",
-    "build-support/bin::",
-  ], check=True)
+  subprocess.run(["./pants", "--tag=+type_checked", "mypy", "::"], check=True)
 
 
 if __name__ == '__main__':

--- a/build-support/bin/mypy.py
+++ b/build-support/bin/mypy.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import subprocess
+
+
+def main() -> None:
+  subprocess.run([
+    "./pants",
+    "--tag=+type_checked",
+    "mypy",
+    "src/python/pants::",
+    "tests/python/pants_test::",
+    "contrib::",
+    "build-support/bin::",
+  ], check=True)
+
+
+if __name__ == '__main__':
+  main()

--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -62,11 +62,11 @@ if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
   echo "* Checking lint"
   ./pants --exclude-target-regexp='testprojects/.*' --changed-parent="${MERGE_BASE}" lint || exit 1
 
-  echo "* Checking types (for build-support)"
+  echo "* Checking types for targets marked \`type_checked\`"
   # NB: This task requires Python 3, so we must temporarily override any intepreter constraints
   # set by ci.py, specifically it setting constraints to Python 2, because those constraints may
   # cause a select-interpreter failure.
-  PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']" ./pants mypy 'build-support::' || exit 1
+  PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython>=3.6']" ./build-support/bin/mypy.py || exit 1
 
   if git diff "${MERGE_BASE}" --name-only | grep '\.rs$' > /dev/null; then
     echo "* Checking formatting of rust files"


### PR DESCRIPTION
### Problem
Per https://github.com/pantsbuild/pants/issues/6742, we will be _incrementally_ adding type hints to Pants.

We need some way to mark to our CI that the target should be checked against, to make sure that any gains we make in type hints are actually enforced.

### Solution
Introduce a new tag `type_checked`, which indicates to our CI that `./pants mypy` should be ran against that target.

Also introduce a helper script `build-support/bin/mypy.py` that runs `./pants mypy` over _all_ eligible targets in Pants. To run over a select few targets, users should instead simply run `./pants mypy path/to:target`.

#### Alternative solution considered: centralized whitelist file
It was decided that a decentralized system will work better in this particular case, for some of these reasons:

1) There's a convention for keeping it decentralized: the `integration` tag.
2) `BUILD` files are more accessible to modify, e.g. being closer to the source.
3) We want to type check the entire codebase eventually. One centralized file would risk becoming too large and difficult to maintain.
