### PR TITLE
Suppress git stderr when checking for existence of repo

### DIFF
--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -72,8 +72,11 @@ class Git(Scm):
   def _invoke(cls, cmd, stderr=None):
     """Invoke the given command, and return a tuple of process and raw binary output.
 
-    stderr flows to wherever its currently mapped for the parent process - generally to
-    the terminal where the user can see the error.
+    If stderr is defined as None, it will flow to wherever it is currently mapped
+    for the parent process, generally to the terminal where the user can see the error
+    (cf. https://docs.python.org/3.7/library/subprocess.html#subprocess.Popen ). In
+    some cases we want to treat it specially, which is why it is exposed
+    in the signature of _invoke.
 
     :param list cmd: The command in the form of a list of strings
     :returns: The completed process object and its standard output.

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -47,9 +47,9 @@ class Git(Scm):
     try:
       if subdir:
         with pushd(subdir):
-          process, out = cls._invoke(cmd)
+          process, out = cls._invoke(cmd, stderr=subproces.DEVNULL)
       else:
-        process, out = cls._invoke(cmd)
+        process, out = cls._invoke(cmd, stderr=subprocess.DEVNULL)
       cls._check_result(cmd, process.returncode, raise_type=Scm.ScmException)
     except Scm.ScmException:
       return None
@@ -69,7 +69,7 @@ class Git(Scm):
     return cls(binary=binary, worktree=dest)
 
   @classmethod
-  def _invoke(cls, cmd):
+  def _invoke(cls, cmd, stderr=None):
     """Invoke the given command, and return a tuple of process and raw binary output.
 
     stderr flows to wherever its currently mapped for the parent process - generally to
@@ -80,7 +80,7 @@ class Git(Scm):
     :raises: Scm.LocalException if there was a problem exec'ing the command at all.
     """
     try:
-      process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+      process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=stderr)
     except OSError as e:
       # Binary DNE or is not executable
       raise cls.LocalException('Failed to execute command {}: {}'.format(' '.join(cmd), e))

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -47,7 +47,7 @@ class Git(Scm):
     try:
       if subdir:
         with pushd(subdir):
-          process, out = cls._invoke(cmd, stderr=subproces.DEVNULL)
+          process, out = cls._invoke(cmd, stderr=subprocess.DEVNULL)
       else:
         process, out = cls._invoke(cmd, stderr=subprocess.DEVNULL)
       cls._check_result(cmd, process.returncode, raise_type=Scm.ScmException)


### PR DESCRIPTION
When we shell out to `git rev-parse` in `detect_worktree` to check for
the existence of a git repository, we should be suppressing the stderr
output to avoid printing the confusing git error message `fatal: not a
git repository (or any of the parent directories): .git` in the case
where pants happens not to be invoked inside a git repo.
