### PR TITLE
Fix macOS Rust tests shard failing to Brew install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -680,6 +680,9 @@ osx_rust_tests: &osx_rust_tests
       casks:
       - openssl
       - osxfuse
+      # We must update or else Homebrew will complain it is too outdated
+      # (See https://travis-ci.org/pantsbuild/pants/jobs/546948768#L278).
+      update: true
   before_install:
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
   env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -672,18 +672,18 @@ linux_rust_tests: &linux_rust_tests
 osx_rust_tests: &osx_rust_tests
   <<: *base_rust_tests
   name: "Rust tests - OSX (No PEX)"
-  stage: *bootstrap
   os: osx
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3
   addons:
     homebrew:
-      casks:
-      - openssl
-      - osxfuse
-      # We must update or else Homebrew will complain it is too outdated
+      # We must update or else Brew will complain that it is too outdated
       # (See https://travis-ci.org/pantsbuild/pants/jobs/546948768#L278).
       update: true
+      packages:
+        - openssl
+      casks:
+        - osxfuse
   before_install:
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
   env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -672,6 +672,7 @@ linux_rust_tests: &linux_rust_tests
 osx_rust_tests: &osx_rust_tests
   <<: *base_rust_tests
   name: "Rust tests - OSX (No PEX)"
+  stage: *bootstrap
   os: osx
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -623,12 +623,13 @@ osx_rust_tests: &osx_rust_tests
   osx_image: xcode8.3
   addons:
     homebrew:
-      casks:
-      - openssl
-      - osxfuse
-      # We must update or else Homebrew will complain it is too outdated
+      # We must update or else Brew will complain that it is too outdated
       # (See https://travis-ci.org/pantsbuild/pants/jobs/546948768#L278).
       update: true
+      packages:
+        - openssl
+      casks:
+        - osxfuse
   before_install:
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
   env:

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -625,6 +625,9 @@ osx_rust_tests: &osx_rust_tests
       casks:
       - openssl
       - osxfuse
+      # We must update or else Homebrew will complain it is too outdated
+      # (See https://travis-ci.org/pantsbuild/pants/jobs/546948768#L278).
+      update: true
   before_install:
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"
   env:

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -617,7 +617,6 @@ linux_rust_tests: &linux_rust_tests
 osx_rust_tests: &osx_rust_tests
   <<: *base_rust_tests
   name: "Rust tests - OSX (No PEX)"
-  stage: *bootstrap
   os: osx
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -617,6 +617,7 @@ linux_rust_tests: &linux_rust_tests
 osx_rust_tests: &osx_rust_tests
   <<: *base_rust_tests
   name: "Rust tests - OSX (No PEX)"
+  stage: *bootstrap
   os: osx
   # Fuse actually works on this image. It hangs on many others.
   osx_image: xcode8.3


### PR DESCRIPTION
Homebrew recently stopped installing Fuse, complaining that it is too out-of-date. See https://travis-ci.org/pantsbuild/pants/jobs/546948768#L278.

Per the [Brew plugin docs](https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos), we add `update: true`.

Also, `opennssl` was failing to install because it's a package, not a cask.