### PR TITLE
Add remote workunits for Zipkin trace

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -626,6 +626,7 @@ dependencies = [
  "store 0.1.0",
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "ui 0.0.1",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
@@ -646,6 +647,7 @@ dependencies = [
  "rule_graph 0.0.1",
  "store 0.1.0",
  "tar_api 0.0.1",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
@@ -1722,6 +1724,7 @@ dependencies = [
  "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
  "hashing 0.0.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1734,6 +1737,7 @@ dependencies = [
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "workunit_store 0.0.1",
 ]
 
 [[package]]
@@ -1747,6 +1751,7 @@ dependencies = [
  "store 0.1.0",
  "task_executor 0.0.1",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "workunit_store 0.0.1",
 ]
 
 [[package]]
@@ -3202,7 +3207,10 @@ dependencies = [
 name = "workunit_store"
 version = "0.0.1"
 dependencies = [
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -97,6 +97,7 @@ rule_graph = { path = "rule_graph" }
 smallvec = "0.6"
 store = { path = "fs/store" }
 tempfile = "3"
+time = "0.1.40"
 ui = { path = "ui" }
 url = "1.7.1"
 task_executor = { path = "task_executor" }

--- a/src/rust/engine/engine_cffi/Cargo.toml
+++ b/src/rust/engine/engine_cffi/Cargo.toml
@@ -17,6 +17,7 @@ logging = { path = "../logging" }
 rule_graph = { path = "../rule_graph" }
 store = { path = "../fs/store" }
 tar_api = { path = "../tar_api" }
+time = "0.1.40"
 workunit_store = { path = "../workunit_store" }
 
 [build-dependencies]

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -26,8 +26,10 @@ time = "0.1.40"
 tokio-codec = "0.1"
 tokio-process = "0.2.1"
 tokio-timer = "0.2"
+workunit_store = { path = "../workunit_store" }
 
 [dev-dependencies]
+maplit = "1.0.1"
 mock = { path = "../testutil/mock" }
 tempfile = "3"
 testutil = { path = "../testutil" }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -21,6 +21,7 @@ use tokio_process::CommandExt;
 use super::{ExecuteProcessRequest, FallibleExecuteProcessResult};
 
 use bytes::{Bytes, BytesMut};
+use workunit_store::WorkUnitStore;
 
 pub struct CommandRunner {
   store: Store,
@@ -212,7 +213,13 @@ impl super::CommandRunner for CommandRunner {
   ///
   /// Runs a command on this machine in the passed working directory.
   ///
-  fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<FallibleExecuteProcessResult, String> {
+  /// TODO: start to create workunits for local process execution
+  ///
+  fn run(
+    &self,
+    req: ExecuteProcessRequest,
+    _workunit_store: WorkUnitStore,
+  ) -> BoxFuture<FallibleExecuteProcessResult, String> {
     let workdir = try_future!(tempfile::Builder::new()
       .prefix("process-execution")
       .tempdir_in(&self.work_dir)
@@ -348,6 +355,7 @@ mod tests {
   use testutil::data::{TestData, TestDirectory};
   use testutil::path::find_bash;
   use testutil::{as_bytes, owned_string_vec};
+  use workunit_store::WorkUnitStore;
 
   #[test]
   #[cfg(unix)]
@@ -905,6 +913,6 @@ mod tests {
       work_dir: dir,
       cleanup_local_dirs: cleanup,
     };
-    executor.block_on(runner.run(req))
+    executor.block_on(runner.run(req, WorkUnitStore::new()))
   }
 }

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -13,3 +13,4 @@ process_execution = { path = "../process_execution" }
 store = { path = "../fs/store" }
 task_executor = { path = "../task_executor" }
 tokio = "0.1"
+workunit_store = { path = "../workunit_store"}

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -40,6 +40,7 @@ use std::process::exit;
 use std::time::Duration;
 use store::{BackoffConfig, Store};
 use tokio::runtime::Runtime;
+use workunit_store::WorkUnitStore;
 
 /// A binary which takes args of format:
 ///  process_executor --env=FOO=bar --env=SOME=value --input-digest=abc123 --input-digest-length=80
@@ -321,7 +322,7 @@ fn main() {
   let mut runtime = Runtime::new().unwrap();
 
   let result = runtime
-    .block_on(runner.run(request))
+    .block_on(runner.run(request, WorkUnitStore::new()))
     .expect("Error executing");
 
   if let Some(output) = args.value_of("materialize-output-to").map(PathBuf::from) {

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -6,4 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
+futures = "0.1.27"
 parking_lot = "0.6"
+rand = "0.6"
+time = "0.1.40"


### PR DESCRIPTION
### Problem
As the purpose of the remoting is to make pants runs faster (for compile) it is very important to understand its performance. One of the nice ways is Zipkin tracing.

### Solution
The result of the remote execution contains timings of different stages of the remote process that are used to create workunits to Zipkin trace.

The last part of this PR is to add a test(unitest and/or integration test).
