### PR TITLE
Use Docker to build Python 3.7 PEX in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -924,6 +924,7 @@ matrix:
     - <<: *py36_linux_build_engine
       stage: *bootstrap_cron
     - <<: *py37_linux_build_engine
+      stage: *bootstrap
 
     - <<: *py27_osx_build_engine
     - <<: *py27_osx_build_engine

--- a/.travis.yml
+++ b/.travis.yml
@@ -351,7 +351,8 @@ base_linux_build_engine: &base_linux_build_engine
   script:
     - >
       docker build
-      --rm -t ${docker_image_name}
+      --rm -t "${docker_image_name}"
+      --build-arg "BASE_IMAGE=pantsbuild/centos${docker_centos_version:-6}:latest"
       --build-arg "TRAVIS_USER=$(id -un)"
       --build-arg "TRAVIS_UID=$(id -u)"
       --build-arg "TRAVIS_GROUP=$(id -gn)"
@@ -387,20 +388,16 @@ py36_linux_build_engine: &py36_linux_build_engine
     - CACHE_NAME=linuxpexbuild.py36
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
 
-# NB: we do not use Docker for Py37 because Centos6 has too outdated of OpenSSL.
-# See https://github.com/pantsbuild/pants/issues/7421. We will want to change this
-# shard back to Docker once we have a Centos7 base image.
 py37_linux_build_engine: &py37_linux_build_engine
   <<: *py37_linux_config
-  <<: *native_engine_cache_config
-  stage: *bootstrap_cron
+  <<: *base_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py3.7 PEX)"
   env:
+    - docker_centos_version=7
+    - docker_image_name=travis_ci
+    - docker_run_command="./build-support/bin/ci.py --bootstrap --python-version 3.7"
     - CACHE_NAME=linuxpexbuild.py37
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
-  script:
-    - ./build-support/bin/ci.py --bootstrap --python-version 3.7
-    - *aws_deploy_pants_pex
 
 base_osx_build_engine: &base_osx_build_engine
   <<: *native_engine_cache_config
@@ -540,7 +537,8 @@ base_linux_build_wheels: &base_linux_build_wheels
   script:
     - >
       docker build
-      --rm -t ${docker_image_name}
+      --rm -t "${docker_image_name}"
+      --build-arg "BASE_IMAGE=pantsbuild/centos${docker_centos_version:-6}:latest"
       --build-arg "TRAVIS_USER=$(id -un)"
       --build-arg "TRAVIS_UID=$(id -u)"
       --build-arg "TRAVIS_GROUP=$(id -gn)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -391,6 +391,7 @@ py36_linux_build_engine: &py36_linux_build_engine
 py37_linux_build_engine: &py37_linux_build_engine
   <<: *py37_linux_config
   <<: *base_linux_build_engine
+  stage: *bootstrap_cron
   name: "Build Linux native engine and pants.pex (Py3.7 PEX)"
   env:
     - docker_centos_version=7

--- a/.travis.yml
+++ b/.travis.yml
@@ -924,7 +924,6 @@ matrix:
     - <<: *py36_linux_build_engine
       stage: *bootstrap_cron
     - <<: *py37_linux_build_engine
-      stage: *bootstrap
 
     - <<: *py27_osx_build_engine
     - <<: *py27_osx_build_engine

--- a/build-support/docker/travis_ci_py27_ucs2/Dockerfile
+++ b/build-support/docker/travis_ci_py27_ucs2/Dockerfile
@@ -8,7 +8,8 @@
 # with by resulting in two Python 2.7 installs: system vs. pyenv.
 
 # Use our custom Centos6 image for binary compatibility with old linux distros.
-FROM pantsbuild/centos6:latest
+ARG BASE_IMAGE=pantsbuild/centos6:latest
+FROM ${BASE_IMAGE}
 
 # Note we use 2.7.15, rather than 2.7.13, as the centos6 image already comes with 2.7.13
 # installed, which uses UCS4 instead of UCS2. This allows us to disambiguate which Python 2

--- a/build-support/travis/docker_build_image.mustache
+++ b/build-support/travis/docker_build_image.mustache
@@ -1,5 +1,6 @@
 docker build
---rm -t ${docker_image_name}
+--rm -t "${docker_image_name}"
+--build-arg "BASE_IMAGE=pantsbuild/centos${docker_centos_version:-6}:latest"
 --build-arg "TRAVIS_USER=$(id -un)"
 --build-arg "TRAVIS_UID=$(id -u)"
 --build-arg "TRAVIS_GROUP=$(id -gn)"

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -865,6 +865,7 @@ matrix:
     - <<: *py36_linux_build_engine
       stage: *bootstrap_cron
     - <<: *py37_linux_build_engine
+      stage: *bootstrap
 
     - <<: *py27_osx_build_engine
     - <<: *py27_osx_build_engine

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -346,6 +346,7 @@ py36_linux_build_engine: &py36_linux_build_engine
 py37_linux_build_engine: &py37_linux_build_engine
   <<: *py37_linux_config
   <<: *base_linux_build_engine
+  stage: *bootstrap_cron
   name: "Build Linux native engine and pants.pex (Py3.7 PEX)"
   env:
     - docker_centos_version=7

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -343,20 +343,16 @@ py36_linux_build_engine: &py36_linux_build_engine
     - CACHE_NAME=linuxpexbuild.py36
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
 
-# NB: we do not use Docker for Py37 because Centos6 has too outdated of OpenSSL.
-# See https://github.com/pantsbuild/pants/issues/7421. We will want to change this
-# shard back to Docker once we have a Centos7 base image.
 py37_linux_build_engine: &py37_linux_build_engine
   <<: *py37_linux_config
-  <<: *native_engine_cache_config
-  stage: *bootstrap_cron
+  <<: *base_linux_build_engine
   name: "Build Linux native engine and pants.pex (Py3.7 PEX)"
   env:
+    - docker_centos_version=7
+    - docker_image_name=travis_ci
+    - docker_run_command="./build-support/bin/ci.py --bootstrap --python-version 3.7"
     - CACHE_NAME=linuxpexbuild.py37
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
-  script:
-    - ./build-support/bin/ci.py --bootstrap --python-version 3.7
-    - *aws_deploy_pants_pex
 
 base_osx_build_engine: &base_osx_build_engine
   <<: *native_engine_cache_config

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -865,7 +865,6 @@ matrix:
     - <<: *py36_linux_build_engine
       stage: *bootstrap_cron
     - <<: *py37_linux_build_engine
-      stage: *bootstrap
 
     - <<: *py27_osx_build_engine
     - <<: *py27_osx_build_engine


### PR DESCRIPTION
Will close https://github.com/pantsbuild/pants/issues/7421.

We could not use Docker to build the Python 3.7 PEX because we only had a Centos6 image. Now that we have a Centos7 image thanks to https://github.com/pantsbuild/pants/pull/7892, we can use Docker for this shard, as verified by https://travis-ci.org/pantsbuild/pants/jobs/547836170.

This will unblock building Python 3.7 wheels, which will allow releasing a PEX that works with Python 3.7.