### PR TITLE
Move PATH testutils to testutil crate

### DIFF
--- a/src/rust/engine/testutil/src/file.rs
+++ b/src/rust/engine/testutil/src/file.rs
@@ -29,9 +29,6 @@ pub fn contents(path: &Path) -> bytes::Bytes {
 
 pub fn is_executable(path: &Path) -> bool {
   std::fs::metadata(path)
-    .expect("Getting file metadata")
-    .permissions()
-    .mode()
-    & 0o100
-    == 0o100
+    .map(|meta| meta.permissions().mode() & 0o100 == 0o100)
+    .unwrap_or(false)
 }

--- a/src/rust/engine/testutil/src/lib.rs
+++ b/src/rust/engine/testutil/src/lib.rs
@@ -33,6 +33,7 @@ use std::path::Path;
 
 pub mod data;
 pub mod file;
+pub mod path;
 
 pub fn owned_string_vec(args: &[&str]) -> Vec<String> {
   args.iter().map(<&str>::to_string).collect()

--- a/src/rust/engine/testutil/src/path.rs
+++ b/src/rust/engine/testutil/src/path.rs
@@ -1,0 +1,22 @@
+use std::env;
+use std::path::PathBuf;
+
+pub fn find_bash() -> String {
+  which("bash")
+    .expect("No bash on PATH")
+    .to_str()
+    .expect("Path to bash not unicode")
+    .to_owned()
+}
+
+pub fn which(executable: &str) -> Option<PathBuf> {
+  if let Some(paths) = env::var_os("PATH") {
+    for path in env::split_paths(&paths) {
+      let executable_path = path.join(executable);
+      if executable_path.exists() && crate::file::is_executable(&executable_path) {
+        return Some(executable_path);
+      }
+    }
+  }
+  None
+}


### PR DESCRIPTION
I'm about to use these from another module.

Also, unify on one `is_executable` implementation.