### PR TITLE
Bump default Mypy version from 0.670 to 0.710

### DIFF
--- a/build-support/mypy/mypy.ini
+++ b/build-support/mypy/mypy.ini
@@ -30,7 +30,7 @@ disallow_subclassing_any = False
 
 # Strictness
 implicit_reexport = False
-strict_equality = False
+strict_equality = True
 
 # Warnings
 warn_unused_ignores = True

--- a/build-support/mypy/mypy.ini
+++ b/build-support/mypy/mypy.ini
@@ -7,6 +7,8 @@
 # because our codebase has so little type coverage. As we add more types, these options should be
 # re-evaluated and made more strict where possible.
 
+new_semantic_analyzer = True
+
 # Optionals
 no_implicit_optional = True
 
@@ -27,6 +29,7 @@ disallow_any_generics = False
 disallow_subclassing_any = False
 
 # Strictness
+implicit_reexport = False
 strict_equality = False
 
 # Warnings

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -37,7 +37,7 @@ class MypyTask(ResolveRequirementsTaskBase):
 
   @classmethod
   def register_options(cls, register):
-    register('--mypy-version', default='0.670', help='The version of mypy to use.')
+    register('--mypy-version', default='0.710', help='The version of mypy to use.')
     register('--config-file', default=None,
              help='Path mypy configuration file, relative to buildroot.')
 

--- a/pants.ini
+++ b/pants.ini
@@ -300,7 +300,6 @@ skip: True
 skip: True
 
 [mypy]
-mypy_version: 0.701
 config_file: build-support/mypy/mypy.ini
 
 [scala]


### PR DESCRIPTION
Some major highlights:
* New semantic analyzer, which will soon allow recursive types
* Python 3.8 support
* Up to 4x faster via Mypyc
* `--strict-equality` check

See these changelogs:
- 0.700: https://mypy-lang.blogspot.com/2019/04/mypy-0700-released-up-to-4x-faster.html
- 0.710: https://mypy-lang.blogspot.com/2019/06/mypy-0710-released-new-semantic-analyzer.html