### PR TITLE
improve the messaging around the --concurrent global option

### DIFF
--- a/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
+++ b/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
@@ -1,6 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pants.base.exiter import PANTS_NONSTANDARD_TESTING_EXIT_CODE
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal
@@ -17,7 +18,7 @@ class ListAndDieForTesting(Goal):
 def fast_list_and_die_for_testing(console, addresses):
   for address in addresses.dependencies:
     console.print_stdout(address.spec)
-  yield ListAndDieForTesting(exit_code=42)
+  yield ListAndDieForTesting(exit_code=PANTS_NONSTANDARD_TESTING_EXIT_CODE)
 
 
 def rules():

--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -18,6 +18,11 @@ logger = logging.getLogger(__name__)
 PANTS_SUCCEEDED_EXIT_CODE = 0
 PANTS_FAILED_EXIT_CODE = 1
 
+# A return code for when pants is invoked via an integration test and it needs to be checked that
+# pants returns the correct exit code.
+# TODO: Randomize this -- the result just needs to be an int!
+PANTS_NONSTANDARD_TESTING_EXIT_CODE = 10
+
 # TODO: This is returned by the exit code of the pantsd nailgun connection if a client is already
 # connected and --concurrent is *disabled*. This number is chosen to be a large enough number that
 # we hopefully don't have too many collisions with real errors. There could be a better method of

--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -18,6 +18,12 @@ logger = logging.getLogger(__name__)
 PANTS_SUCCEEDED_EXIT_CODE = 0
 PANTS_FAILED_EXIT_CODE = 1
 
+# TODO: This is returned by the exit code of the pantsd nailgun connection if a client is already
+# connected and --allow-pantsd-concurrent-runs is *disabled*. This number is chosen to be a large
+# enough number that we hopefully don't have too many collisions with real errors. There could be a
+# better method of IPC used for this case.
+PANTSD_NO_CONCURRENT_RUN_EXIT_CODE = 42
+
 
 class Exiter:
   """A class that provides standard runtime exit behavior.

--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -21,7 +21,7 @@ PANTS_FAILED_EXIT_CODE = 1
 # TODO: This is returned by the exit code of the pantsd nailgun connection if a client is already
 # connected and --concurrent is *disabled*. This number is chosen to be a large enough number that
 # we hopefully don't have too many collisions with real errors. There could be a better method of
-# IPC used than exit codes for this case.
+# IPC used than exit codes for this case (see #7948).
 # TODO: Randomize this -- the result just needs to be an int!
 PANTSD_NO_CONCURRENT_RUN_EXIT_CODE = 42
 

--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -19,9 +19,10 @@ PANTS_SUCCEEDED_EXIT_CODE = 0
 PANTS_FAILED_EXIT_CODE = 1
 
 # TODO: This is returned by the exit code of the pantsd nailgun connection if a client is already
-# connected and --allow-pantsd-concurrent-runs is *disabled*. This number is chosen to be a large
-# enough number that we hopefully don't have too many collisions with real errors. There could be a
-# better method of IPC used for this case.
+# connected and --concurrent is *disabled*. This number is chosen to be a large enough number that
+# we hopefully don't have too many collisions with real errors. There could be a better method of
+# IPC used than exit codes for this case.
+# TODO: Randomize this -- the result just needs to be an int!
 PANTSD_NO_CONCURRENT_RUN_EXIT_CODE = 42
 
 

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -72,7 +72,7 @@ class PantsRunner:
       try:
         return RemotePantsRunner(self._exiter, self._args, self._env, options_bootstrapper).run()
       except RemotePantsRunner.Fallback as e:
-        logger.warn('caught client exception: {!r}, falling back to non-daemon mode'.format(e))
+        logger.warning('caught client exception: {!r}, falling back to non-daemon mode'.format(e))
 
     # N.B. Inlining this import speeds up the python thin client run by about 100ms.
     from pants.bin.local_pants_runner import LocalPantsRunner

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -143,7 +143,7 @@ class RemotePantsRunner:
     modified_env = combined_dict(self._env, ng_env)
     modified_env['PANTSD_RUNTRACKER_CLIENT_START_TIME'] = str(self._start_time)
     modified_env['PANTSD_REQUEST_TIMEOUT_LIMIT'] = str(self._bootstrap_options.for_global_scope().pantsd_timeout_when_multiple_invocations)
-    modified_env['PANTSD_ALLOW_CONCURRENT_RUNS'] = str(self._bootstrap_options.for_global_scope().allow_pantsd_concurrent_runs)
+    modified_env['PANTSD_ALLOW_CONCURRENT_RUNS'] = str(self._bootstrap_options.for_global_scope().concurrent)
 
     assert isinstance(port, int), \
       'port {} is not an integer! It has type {}.'.format(port, type(port))

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -141,6 +141,7 @@ class RemotePantsRunner:
     # Merge the nailgun TTY capability environment variables with the passed environment dict.
     ng_env = NailgunProtocol.isatty_to_env(self._stdin, self._stdout, self._stderr)
     modified_env = combined_dict(self._env, ng_env)
+    # TODO: remove these repeated literal strings across the codebase (see #7948)!
     modified_env['PANTSD_RUNTRACKER_CLIENT_START_TIME'] = str(self._start_time)
     modified_env['PANTSD_REQUEST_TIMEOUT_LIMIT'] = str(self._bootstrap_options.for_global_scope().pantsd_timeout_when_multiple_invocations)
     modified_env['PANTSD_ALLOW_CONCURRENT_RUNS'] = str(self._bootstrap_options.for_global_scope().concurrent)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -261,6 +261,10 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     # without resorting to heavier options parsing.
     register('--enable-pantsd', advanced=True, type=bool, default=False,
              help='Enables use of the pants daemon (and implicitly, the v2 engine). (Beta)')
+    register('--allow-pantsd-concurrent-runs', type=bool, default=False,
+             help='Enables multiple parallel runs using pantsd. Without this enabled, pants will '
+                  'start up all concurrent invocations (e.g. in other terminals) without pantsd. '
+                  'Enabling this option requires parallel pants invocations to block on the first.')
 
     # Whether or not to make necessary arrangements to have concurrent runs in pants.
     # In practice, this means that if this is set, a run will not even try to use pantsd.

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -261,16 +261,14 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     # without resorting to heavier options parsing.
     register('--enable-pantsd', advanced=True, type=bool, default=False,
              help='Enables use of the pants daemon (and implicitly, the v2 engine). (Beta)')
-    register('--allow-pantsd-concurrent-runs', type=bool, default=False,
-             help='Enables multiple parallel runs using pantsd. Without this enabled, pants will '
-                  'start up all concurrent invocations (e.g. in other terminals) without pantsd. '
-                  'Enabling this option requires parallel pants invocations to block on the first.')
 
     # Whether or not to make necessary arrangements to have concurrent runs in pants.
     # In practice, this means that if this is set, a run will not even try to use pantsd.
     # NB: Eventually, we would like to deprecate this flag in favor of making pantsd runs parallelizable.
     register('--concurrent', advanced=True, type=bool, default=False, daemon=False,
-             help='Enable concurrent runs of pants.')
+             help='Enable concurrent runs of pants. Without this enabled, pants will '
+                  'start up all concurrent invocations (e.g. in other terminals) without pantsd. '
+                  'Enabling this option requires parallel pants invocations to block on the first.')
 
     # Shutdown pantsd after the current run.
     # This needs to be accessed at the same time as enable_pantsd,

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -256,6 +256,7 @@ class PailgunServer(ThreadingMixIn, TCPServer):
     """
     # TODO add `did_poll` to pantsd metrics
 
+    # TODO: remove these repeated literal strings across the codebase (see #7948)!
     timeout = float(environment['PANTSD_REQUEST_TIMEOUT_LIMIT'])
     no_concurrent = environment['PANTSD_ALLOW_CONCURRENT_RUNS'] == 'False'
 

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -106,8 +106,7 @@ class ExclusiveRequestTimeout(Exception):
 
 
 class ImmediateTimeout(Exception):
-  """Represents an early exit for the attempted pailgun connection when
-     --allow-pantsd-concurrent-runs is set."""
+  """Represents an early exit for the attempted pailgun connection when --concurrent is set."""
 
 
 class PailgunHandleRequestLock(object):
@@ -282,14 +281,14 @@ class PailgunServer(ThreadingMixIn, TCPServer):
     else:
       if no_concurrent:
         self._send_stderr(request, "Another pants invocation is running with pantsd enabled.")
-        raise ImmediateTimeout("Exiting quickly with pantsd concurrent runs disabled.")
+        raise ImmediateTimeout("Exiting quickly with concurrent runs disabled.")
       # We have to wait for another request to finish being handled.
       self._send_stderr(request, "Another pants invocation is running with pantsd enabled. "
                                  "Will wait {} for it to finish before giving up.\n".format(
                                    "forever" if self._should_poll_forever(timeout)
                                    else "up to {} seconds".format(timeout)))
       self._send_stderr(request, "If you don't want to wait for the first run to finish, please "
-                                 "press Ctrl-C and run this command with PANTS_ALLOW_PANTSD_CONCURRENT_RUNS=True "
+                                 "press Ctrl-C and run this command with PANTS_CONCURRENT=True "
                                  "in the environment.")
       while not self.free_to_handle_request_lock.acquire(timeout=user_notification_interval):
         time_polled += user_notification_interval

--- a/tests/python/pants_test/engine/test_scheduler_integration.py
+++ b/tests/python/pants_test/engine/test_scheduler_integration.py
@@ -3,6 +3,7 @@
 
 import os
 
+from pants.base.exiter import PANTS_NONSTANDARD_TESTING_EXIT_CODE
 from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
 
@@ -33,4 +34,4 @@ class SchedulerIntegrationTest(PantsRunIntegrationTest):
     pants_result = self.run_pants(args)
     self.assert_failure(pants_result)
     self.assertEqual(pants_result.stdout_data, 'examples/src/scala/org/pantsbuild/example/hello/welcome:welcome\n')
-    self.assertEqual(pants_result.returncode, 42)
+    self.assertEqual(pants_result.returncode, PANTS_NONSTANDARD_TESTING_EXIT_CODE)


### PR DESCRIPTION
### Problem

When multiple pantsd runs are active at once, pants will block up to a timeout on the other runs for the active run to complete. Many pants workflows (including `repl`) rely on being able to have multiple pants invocations active at once, and the current messaging doesn't make it clear how to override that.

### Solution

- Describe how to use the `PANTS_CONCURRENT=True` flag to allow multiple parallel pants runs.

### Result

Users are less confused by pantsd fork removal!