### PR TITLE
Report zipkin spans regardless of goal version.

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -183,7 +183,7 @@ class LocalPantsRunner(object):
     )
 
   def __init__(self, build_root, exiter, options, options_bootstrapper, build_config, target_roots,
-               graph_session, scheduler, is_daemon, profile_path):
+               graph_session, scheduler_session, is_daemon, profile_path):
     """
     :param string build_root: The build root for this run.
     :param Exiter exiter: The Exiter instance to use for this run.
@@ -202,7 +202,7 @@ class LocalPantsRunner(object):
     self._build_config = build_config
     self._target_roots = target_roots
     self._graph_session = graph_session
-    self._scheduler = scheduler
+    self._scheduler_session = scheduler_session
     self._is_daemon = is_daemon
     self._profile_path = profile_path
 
@@ -288,9 +288,9 @@ class LocalPantsRunner(object):
     return max_code
 
   def _update_stats(self):
-    metrics = self._scheduler.metrics()
+    metrics = self._scheduler_session.metrics()
     self._run_tracker.pantsd_stats.set_scheduler_metrics(metrics)
-    engine_workunits = self._scheduler.engine_workunits(metrics)
+    engine_workunits = self._scheduler_session.engine_workunits(metrics)
     if engine_workunits:
       self._run_tracker.report.bulk_record_workunits(engine_workunits)
 

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -156,11 +156,6 @@ class Context(object):
     """A contextmanager that sets metrics in the context of a (v1) engine execution."""
     self._set_target_root_count_in_runtracker()
     yield
-    metrics = self._scheduler.metrics()
-    self.run_tracker.pantsd_stats.set_scheduler_metrics(metrics)
-    engine_workunits = self._scheduler.engine_workunits(metrics)
-    if engine_workunits:
-      self.run_tracker.report.bulk_record_workunits(engine_workunits)
     self._set_affected_target_count_in_runtracker()
 
   def _set_target_root_count_in_runtracker(self):

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -257,6 +257,31 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
         v2_span_name_part, trace
         ))
 
+  def test_zipkin_reports_for_pure_v2_goals(self):
+    ZipkinHandler = zipkin_handler()
+    with http_server(ZipkinHandler) as port:
+      endpoint = "http://localhost:{}".format(port)
+      command = [
+        '--v1',
+        '--v2',
+        '--reporting-zipkin-endpoint={}'.format(endpoint),
+        '--reporting-zipkin-trace-v2',
+        'list',
+        '3rdparty:'
+      ]
+
+      pants_run = self.run_pants(command)
+      self.assert_success(pants_run)
+
+      trace = assert_single_element(ZipkinHandler.traces.values())
+
+      v2_span_name_part = "Scandir"
+      self.assertTrue(any(v2_span_name_part in span['name'] for span in trace),
+        "There is no span that contains '{}' in it's name. The trace:{}".format(
+        v2_span_name_part, trace
+        ))
+
+
   def test_zipkin_reporter_multi_threads(self):
     ZipkinHandler = zipkin_handler()
     with http_server(ZipkinHandler) as port:

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -262,7 +262,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
     with http_server(ZipkinHandler) as port:
       endpoint = "http://localhost:{}".format(port)
       command = [
-        '--v1',
+        '--no-v1',
         '--v2',
         '--reporting-zipkin-endpoint={}'.format(endpoint),
         '--reporting-zipkin-trace-v2',
@@ -280,7 +280,6 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
         "There is no span that contains '{}' in it's name. The trace:{}".format(
         v2_span_name_part, trace
         ))
-
 
   def test_zipkin_reporter_multi_threads(self):
     ZipkinHandler = zipkin_handler()


### PR DESCRIPTION
### Problem
fixes pantsbuild/pants#7386

Goals which use the v2 engine were not exporting zipkin spans because the code doing the exporting was inside the context of the legacy graph, which isn't used during v2 engine goal execution.

### Solution
Moved the zipkin bulk export code to the local pants runner so that it gets called regardless of which engine is run.

### Result

Users can now see spans / timings from engine workunits displayed through zipkin dash for both v1 and v2 goals.