### PR TITLE
Add --post-compile-merge-dir option in zinc

### DIFF
--- a/src/scala/org/pantsbuild/zinc/compiler/BUILD
+++ b/src/scala/org/pantsbuild/zinc/compiler/BUILD
@@ -25,3 +25,9 @@ scala_library(
   strict_deps=True,
   platform='java8',
 )
+
+jvm_binary(
+  name = 'bin',
+  dependencies = [':compiler'],
+  main = 'org.pantsbuild.zinc.compiler.Main'
+)

--- a/src/scala/org/pantsbuild/zinc/compiler/BUILD
+++ b/src/scala/org/pantsbuild/zinc/compiler/BUILD
@@ -25,9 +25,3 @@ scala_library(
   strict_deps=True,
   platform='java8',
 )
-
-jvm_binary(
-  name = 'bin',
-  dependencies = [':compiler'],
-  main = 'org.pantsbuild.zinc.compiler.Main'
-)

--- a/src/scala/org/pantsbuild/zinc/compiler/Main.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Main.scala
@@ -10,6 +10,7 @@ import scala.collection.JavaConverters._
 
 import sbt.internal.inc.IncrementalCompilerImpl
 import sbt.internal.util.{ ConsoleLogger, ConsoleOut }
+import sbt.io.IO
 import sbt.util.Level
 import xsbti.CompileFailed
 
@@ -159,6 +160,11 @@ object Main {
     try {
       // Run the compile.
       val result = new IncrementalCompilerImpl().compile(inputs, log)
+
+      // post compile merge dir
+      if (settings.postCompileMergeDir.isDefined) {
+        IO.copyDirectory(new File(settings.postCompileMergeDir.get.toURI), new File(settings.classesDirectory.toURI))
+      }
 
       // Store the output if the result changed.
       if (result.hasModified) {

--- a/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
@@ -28,7 +28,7 @@ case class Settings(
   _sources: Seq[File]               = Seq.empty,
   classpath: Seq[File]              = Seq.empty,
   _classesDirectory: Option[File]   = None,
-  _postCompileMergeDir: Option[File]   = None,
+  _postCompileMergeDir: Option[File] = None,
   outputJar: Option[File]           = None,
   scala: ScalaLocation              = ScalaLocation(),
   scalacOptions: Seq[String]        = Seq.empty,

--- a/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
@@ -287,7 +287,7 @@ object Settings {
 
     opt[File]("post-compile-merge-dir")
       .action((x, c) => c.copy(_postCompileMergeDir = Some(x)))
-      .text("Dir to merge with compile outputs after compilation")
+      .text("Directory to merge with compile outputs after compilation")
 
     opt[File]("class-destination")
       .abbr("d")

--- a/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
@@ -28,6 +28,7 @@ case class Settings(
   _sources: Seq[File]               = Seq.empty,
   classpath: Seq[File]              = Seq.empty,
   _classesDirectory: Option[File]   = None,
+  _postCompileMergeDir: Option[File]   = None,
   outputJar: Option[File]           = None,
   scala: ScalaLocation              = ScalaLocation(),
   scalacOptions: Seq[String]        = Seq.empty,
@@ -46,6 +47,8 @@ case class Settings(
 
   lazy val classesDirectory: File =
     normalise(_classesDirectory.getOrElse(defaultClassesDirectory()))
+
+  lazy val postCompileMergeDir: Option[File] = _postCompileMergeDir.map(normalise)
 
   lazy val incOptions: IncOptions = {
     _incOptions.copy(
@@ -281,6 +284,10 @@ object Settings {
       .abbr("cp")
       .action((x, c) => c.copy(classpath = x))
       .text("Specify the classpath")
+
+    opt[File]("post-compile-merge-dir")
+      .action((x, c) => c.copy(_postCompileMergeDir = Some(x)))
+      .text("Dir to merge with compile outputs after compilation")
 
     opt[File]("class-destination")
       .abbr("d")


### PR DESCRIPTION
Prerequisite for #7869, so resources like
```
META-INF/services/
META-INF/services/javax.annotation.processing.Processor
```
in the z.jar can be added by zinc wrapper instead of post processing by Pants.