### PR TITLE
Fix #7895 breaking CI for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,10 @@ env:
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
     - PATH="${PYENV_ROOT}/shims:${PATH}"
     - AWS_CLI_ROOT="${HOME}/.aws_cli"
-    - AWS_ACCESS_KEY_ID=AKIAV6A6G7RQWPRUWIXR
+    # NB: We use this verbose name so that AWS does not pick up the env var $AWS_ACCESS_KEY_ID on
+    # pull request builds. We only want this value to be populated on branch builds. Users of this
+    # env var (e.g. `deploy_to_s3.py`) are expected to re-export the env var as $AWS_ACCESS_KEY_ID.
+    - AWS_ACCESS_KEY_ID__TO_BE_REEXPORTED_ON_DEPLOYS=AKIAV6A6G7RQWPRUWIXR
     # This stores the encrypted AWS secret access key with the env var AWS_SECRET_ACCESS_KEY.
     # Travis converts it back into its original decrypted value when ran in CI, per
     # https://docs.travis-ci.com/user/environment-variables#defining-encrypted-variables-in-travisyml.

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ env:
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
     - PATH="${PYENV_ROOT}/shims:${PATH}"
     - AWS_CLI_ROOT="${HOME}/.aws_cli"
+    - AWS_ACCESS_KEY_ID=AKIAV6A6G7RQWPRUWIXR
+    # This stores the encrypted AWS secret access key with the env var AWS_SECRET_ACCESS_KEY.
+    # Travis converts it back into its original decrypted value when ran in CI, per
+    # https://docs.travis-ci.com/user/environment-variables#defining-encrypted-variables-in-travisyml.
+    - secure: hFVAQGLVkexzTd3f9NF+JoG1dE+CPICKqOcdvQYv8+YB2rwwqu0/J6MnqKUZSmec4AM4ZvyPUBIHnSw8aMJysYs+GZ6iG/8ZRRmdbmo2WBPbSZ+ThRZxx/F6AjmovUmf8Zt366ZAZXpc9NHKREkTUGl6UL7FFe9+ouVnb90asdw=
 
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
@@ -1913,12 +1918,6 @@ deploy:
   script: ./build-support/bin/deploy_to_s3.py
   # Otherwise travis will stash dist/deploy and the deploy will fail.
   skip_cleanup: true
-  env:
-    - AWS_ACCESS_KEY_ID=AKIAV6A6G7RQWPRUWIXR
-    # This stores the encrypted env var AWS_SECRET_ACCESS_KEY. Travis converts it back into its
-    # original decrypted value when ran in CI, per
-    # https://docs.travis-ci.com/user/environment-variables#defining-encrypted-variables-in-travisyml.
-    - secure: hFVAQGLVkexzTd3f9NF+JoG1dE+CPICKqOcdvQYv8+YB2rwwqu0/J6MnqKUZSmec4AM4ZvyPUBIHnSw8aMJysYs+GZ6iG/8ZRRmdbmo2WBPbSZ+ThRZxx/F6AjmovUmf8Zt366ZAZXpc9NHKREkTUGl6UL7FFe9+ouVnb90asdw=
   on:
     condition: $PREPARE_DEPLOY = 1
     # NB: We mainly want deploys for `master` commits; but we also need new binaries for stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,6 @@ env:
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
     - PATH="${PYENV_ROOT}/shims:${PATH}"
     - AWS_CLI_ROOT="${HOME}/.aws_cli"
-    - AWS_ACCESS_KEY_ID=AKIAV6A6G7RQWPRUWIXR
-    # This stores the encrypted AWS secret access key with the env var AWS_SECRET_ACCESS_KEY.
-    # Travis converts it back into its original decrypted value when ran in CI, per
-    # https://docs.travis-ci.com/user/environment-variables#defining-encrypted-variables-in-travisyml.
-    - secure: hFVAQGLVkexzTd3f9NF+JoG1dE+CPICKqOcdvQYv8+YB2rwwqu0/J6MnqKUZSmec4AM4ZvyPUBIHnSw8aMJysYs+GZ6iG/8ZRRmdbmo2WBPbSZ+ThRZxx/F6AjmovUmf8Zt366ZAZXpc9NHKREkTUGl6UL7FFe9+ouVnb90asdw=
 
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
@@ -1918,6 +1913,12 @@ deploy:
   script: ./build-support/bin/deploy_to_s3.py
   # Otherwise travis will stash dist/deploy and the deploy will fail.
   skip_cleanup: true
+  env:
+    - AWS_ACCESS_KEY_ID=AKIAV6A6G7RQWPRUWIXR
+    # This stores the encrypted env var AWS_SECRET_ACCESS_KEY. Travis converts it back into its
+    # original decrypted value when ran in CI, per
+    # https://docs.travis-ci.com/user/environment-variables#defining-encrypted-variables-in-travisyml.
+    - secure: hFVAQGLVkexzTd3f9NF+JoG1dE+CPICKqOcdvQYv8+YB2rwwqu0/J6MnqKUZSmec4AM4ZvyPUBIHnSw8aMJysYs+GZ6iG/8ZRRmdbmo2WBPbSZ+ThRZxx/F6AjmovUmf8Zt366ZAZXpc9NHKREkTUGl6UL7FFe9+ouVnb90asdw=
   on:
     condition: $PREPARE_DEPLOY = 1
     # NB: We mainly want deploys for `master` commits; but we also need new binaries for stable

--- a/build-support/bin/deploy_to_s3.py
+++ b/build-support/bin/deploy_to_s3.py
@@ -26,7 +26,7 @@ def setup_authentication() -> None:
   if access_key_id not in os.environ or secret_access_key not in os.environ:
     die(f"Caller of the script must set both {access_key_id} and {secret_access_key}.")
   # Properly export the value so that AWS picks it up.
-  os.environ["AWS_ACESS_KEY_ID"] = os.environ[access_key_id]
+  os.environ["AWS_ACCESS_KEY_ID"] = os.environ[access_key_id]
 
 
 def deploy() -> None:

--- a/build-support/bin/deploy_to_s3.py
+++ b/build-support/bin/deploy_to_s3.py
@@ -12,7 +12,7 @@ from common import die
 def main() -> None:
   if shutil.which("aws") is None:
     install_aws_cli()
-  check_authentication_setup()
+  setup_authentication()
   deploy()
 
 
@@ -20,11 +20,13 @@ def install_aws_cli() -> None:
   subprocess.run(["./build-support/bin/install_aws_cli_for_ci.sh"], check=True)
 
 
-def check_authentication_setup() -> None:
-  access_key_id = "AWS_ACCESS_KEY_ID"
+def setup_authentication() -> None:
+  access_key_id = "AWS_ACCESS_KEY_ID__TO_BE_REEXPORTED_ON_DEPLOYS"
   secret_access_key = "AWS_SECRET_ACCESS_KEY"
   if access_key_id not in os.environ or secret_access_key not in os.environ:
     die(f"Caller of the script must set both {access_key_id} and {secret_access_key}.")
+  # Properly export the value so that AWS picks it up.
+  os.environ["AWS_ACESS_KEY_ID"] = os.environ[access_key_id]
 
 
 def deploy() -> None:

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -24,7 +24,10 @@ env:
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
     - PATH="${PYENV_ROOT}/shims:${PATH}"
     - AWS_CLI_ROOT="${HOME}/.aws_cli"
-    - AWS_ACCESS_KEY_ID=AKIAV6A6G7RQWPRUWIXR
+    # NB: We use this verbose name so that AWS does not pick up the env var $AWS_ACCESS_KEY_ID on
+    # pull request builds. We only want this value to be populated on branch builds. Users of this
+    # env var (e.g. `deploy_to_s3.py`) are expected to re-export the env var as $AWS_ACCESS_KEY_ID.
+    - AWS_ACCESS_KEY_ID__TO_BE_REEXPORTED_ON_DEPLOYS=AKIAV6A6G7RQWPRUWIXR
     # This stores the encrypted AWS secret access key with the env var AWS_SECRET_ACCESS_KEY.
     # Travis converts it back into its original decrypted value when ran in CI, per
     # https://docs.travis-ci.com/user/environment-variables#defining-encrypted-variables-in-travisyml.

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -24,11 +24,6 @@ env:
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
     - PATH="${PYENV_ROOT}/shims:${PATH}"
     - AWS_CLI_ROOT="${HOME}/.aws_cli"
-    - AWS_ACCESS_KEY_ID=AKIAV6A6G7RQWPRUWIXR
-    # This stores the encrypted AWS secret access key with the env var AWS_SECRET_ACCESS_KEY.
-    # Travis converts it back into its original decrypted value when ran in CI, per
-    # https://docs.travis-ci.com/user/environment-variables#defining-encrypted-variables-in-travisyml.
-    - secure: hFVAQGLVkexzTd3f9NF+JoG1dE+CPICKqOcdvQYv8+YB2rwwqu0/J6MnqKUZSmec4AM4ZvyPUBIHnSw8aMJysYs+GZ6iG/8ZRRmdbmo2WBPbSZ+ThRZxx/F6AjmovUmf8Zt366ZAZXpc9NHKREkTUGl6UL7FFe9+ouVnb90asdw=
 
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
@@ -1031,6 +1026,12 @@ deploy:
   script: ./build-support/bin/deploy_to_s3.py
   # Otherwise travis will stash dist/deploy and the deploy will fail.
   skip_cleanup: true
+  env:
+    - AWS_ACCESS_KEY_ID=AKIAV6A6G7RQWPRUWIXR
+    # This stores the encrypted env var AWS_SECRET_ACCESS_KEY. Travis converts it back into its
+    # original decrypted value when ran in CI, per
+    # https://docs.travis-ci.com/user/environment-variables#defining-encrypted-variables-in-travisyml.
+    - secure: hFVAQGLVkexzTd3f9NF+JoG1dE+CPICKqOcdvQYv8+YB2rwwqu0/J6MnqKUZSmec4AM4ZvyPUBIHnSw8aMJysYs+GZ6iG/8ZRRmdbmo2WBPbSZ+ThRZxx/F6AjmovUmf8Zt366ZAZXpc9NHKREkTUGl6UL7FFe9+ouVnb90asdw=
   on:
     condition: $PREPARE_DEPLOY = 1
     # NB: We mainly want deploys for `master` commits; but we also need new binaries for stable

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -24,6 +24,11 @@ env:
     - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
     - PATH="${PYENV_ROOT}/shims:${PATH}"
     - AWS_CLI_ROOT="${HOME}/.aws_cli"
+    - AWS_ACCESS_KEY_ID=AKIAV6A6G7RQWPRUWIXR
+    # This stores the encrypted AWS secret access key with the env var AWS_SECRET_ACCESS_KEY.
+    # Travis converts it back into its original decrypted value when ran in CI, per
+    # https://docs.travis-ci.com/user/environment-variables#defining-encrypted-variables-in-travisyml.
+    - secure: hFVAQGLVkexzTd3f9NF+JoG1dE+CPICKqOcdvQYv8+YB2rwwqu0/J6MnqKUZSmec4AM4ZvyPUBIHnSw8aMJysYs+GZ6iG/8ZRRmdbmo2WBPbSZ+ThRZxx/F6AjmovUmf8Zt366ZAZXpc9NHKREkTUGl6UL7FFe9+ouVnb90asdw=
 
 # Stages are documented here: https://docs.travis-ci.com/user/build-stages
 stages:
@@ -1026,12 +1031,6 @@ deploy:
   script: ./build-support/bin/deploy_to_s3.py
   # Otherwise travis will stash dist/deploy and the deploy will fail.
   skip_cleanup: true
-  env:
-    - AWS_ACCESS_KEY_ID=AKIAV6A6G7RQWPRUWIXR
-    # This stores the encrypted env var AWS_SECRET_ACCESS_KEY. Travis converts it back into its
-    # original decrypted value when ran in CI, per
-    # https://docs.travis-ci.com/user/environment-variables#defining-encrypted-variables-in-travisyml.
-    - secure: hFVAQGLVkexzTd3f9NF+JoG1dE+CPICKqOcdvQYv8+YB2rwwqu0/J6MnqKUZSmec4AM4ZvyPUBIHnSw8aMJysYs+GZ6iG/8ZRRmdbmo2WBPbSZ+ThRZxx/F6AjmovUmf8Zt366ZAZXpc9NHKREkTUGl6UL7FFe9+ouVnb90asdw=
   on:
     condition: $PREPARE_DEPLOY = 1
     # NB: We mainly want deploys for `master` commits; but we also need new binaries for stable


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/7895 works for branch builds, but not pull request builds due to the error `Partial credentials found in env, missing: AWS_SECRET_ACCESS_KEY`.

This would happen because we always would define `AWS_SECRET_ACCESS_KEY`, but the value `AWS_SECRET_ACCESS_KEY` would only be defined on branch builds because it's encrypted.

Instead, we should only define `AWS_SECRET_ACCESS_KEY` if we're on a branch build.