### PR TITLE
Add option to safe_rmtree to follow symlinks

### DIFF
--- a/src/python/pants/core_tasks/clean.py
+++ b/src/python/pants/core_tasks/clean.py
@@ -26,7 +26,6 @@ class Clean(Task):
     register('--recursive', type=bool, default=True,
             help='Allows clean-all to walk symlinks, if any.')
 
-
   def execute(self):
     pants_wd = self.get_options().pants_workdir
     pants_trash = os.path.join(pants_wd, "trash")

--- a/src/python/pants/core_tasks/clean.py
+++ b/src/python/pants/core_tasks/clean.py
@@ -6,7 +6,7 @@ import os
 
 from pants.task.task import Task
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_concurrent_rename, safe_rmtree
+from pants.util.dirutil import safe_concurrent_rename, safe_rmtree_recursive
 
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ class Clean(Task):
         pid = os.fork()
         if pid == 0:
           try:
-            safe_rmtree(pants_trash)
+            safe_rmtree_recursive(pants_trash)
           except (IOError, OSError):
             logger.warning("Async clean-all failed. Please try again.")
           finally:
@@ -53,4 +53,4 @@ class Clean(Task):
       else:
         # Recursively removes pants cache; user waits patiently.
         logger.info('For async removal, run `./pants clean-all --async`')
-        safe_rmtree(pants_trash)
+        safe_rmtree_recursive(pants_trash)

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -300,6 +300,7 @@ def register_rmtree(directory, cleaner=_mkdtemp_atexit_cleaner):
 def append_os_sep(directory):
   return os.path.join(directory, directory + os.sep)
 
+
 def safe_rmtree(directory, recursive=False):
   """Delete a directory if it's present. If it's not present, no-op.
   :param directory: path to a directory or a symlink

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -320,10 +320,8 @@ def safe_rmtree_recursive(directory):
   :API: public
   """
   if os.path.islink(directory):
-    safe_delete(directory)
-  else:
     directory = os.path.join(directory, os.sep)
-    shutil.rmtree(directory, ignore_errors=True)
+  shutil.rmtree(directory, ignore_errors=True)
 
 
 def safe_open(filename, *args, **kwargs):

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -310,6 +310,7 @@ def safe_rmtree(directory):
   else:
     shutil.rmtree(directory, ignore_errors=True)
 
+
 def safe_rmtree_recursive(directory):
   """Delete a directory if it's present. If it's not present, no-op.
 

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -310,6 +310,20 @@ def safe_rmtree(directory):
   else:
     shutil.rmtree(directory, ignore_errors=True)
 
+def safe_rmtree_recursive(directory):
+  """Delete a directory if it's present. If it's not present, no-op.
+
+  Note that if the directory argument is a symlink, it will follow the symlink and delete
+  everything inside.
+
+  :API: public
+  """
+  if os.path.islink(directory):
+    safe_delete(directory)
+  else:
+    directory = os.path.join(directory, os.sep)
+    shutil.rmtree(directory, ignore_errors=True)
+
 
 def safe_open(filename, *args, **kwargs):
   """Open a file safely, ensuring that its directory exists.

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -16,8 +16,7 @@ from pants.util.dirutil import (ExistingDirError, ExistingFileError, _mkdtemp_un
                                 get_basedir, longest_dir_prefix, mergetree, read_file,
                                 relative_symlink, relativize_paths, rm_rf, safe_concurrent_creation,
                                 safe_file_dump, safe_mkdir, safe_mkdtemp, safe_open,
-                                safe_rm_oldest_items_in_dir, safe_rmtree, safe_rmtree_recursive,
-                                touch)
+                                safe_rm_oldest_items_in_dir, safe_rmtree, touch)
 from pants.util.objects import datatype
 
 
@@ -505,9 +504,9 @@ class DirutilTest(unittest.TestCase):
       os.symlink(real, link)
       self.assertTrue(os.path.exists(real))
       self.assertTrue(os.path.exists(link))
-      safe_rmtree_recursive(link)
-      self.assertFalse(os.path.exists(real))
+      safe_rmtree(link, recursive=True)
       self.assertFalse(os.path.exists(link))
+      self.assertFalse(os.path.exists(real))
 
 
 class AbsoluteSymlinkTest(unittest.TestCase):

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -16,7 +16,8 @@ from pants.util.dirutil import (ExistingDirError, ExistingFileError, _mkdtemp_un
                                 get_basedir, longest_dir_prefix, mergetree, read_file,
                                 relative_symlink, relativize_paths, rm_rf, safe_concurrent_creation,
                                 safe_file_dump, safe_mkdir, safe_mkdtemp, safe_open,
-                                safe_rm_oldest_items_in_dir, safe_rmtree, touch)
+                                safe_rm_oldest_items_in_dir, safe_rmtree, safe_rmtree_recursive,
+                                touch)
 from pants.util.objects import datatype
 
 
@@ -494,6 +495,18 @@ class DirutilTest(unittest.TestCase):
       self.assertTrue(os.path.exists(link))
       safe_rmtree(link)
       self.assertTrue(os.path.exists(real))
+      self.assertFalse(os.path.exists(link))
+
+  def test_safe_rmtree_recursive_link(self):
+    with temporary_dir() as td:
+      real = os.path.join(td, 'real')
+      link = os.path.join(td, 'link')
+      os.mkdir(real)
+      os.symlink(real, link)
+      self.assertTrue(os.path.exists(real))
+      self.assertTrue(os.path.exists(link))
+      safe_rmtree_recursive(link)
+      self.assertFalse(os.path.exists(real))
       self.assertFalse(os.path.exists(link))
 
 


### PR DESCRIPTION
### Problem

currently, running clean will not remove .pants.d if it is a symlink due to the limitation of shutil.rmtree api.

### Solution

Add a trailing "/" to the directory being passed into a separate function that can walk the symlink. An improved version of this would be implementing #7957 

### Result

delete them all! 