### PR TITLE
Modernize `abc` stdlib usage.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/targets/go_target.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_target.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-from abc import abstractproperty
+from abc import abstractmethod
 
 from pants.build_graph.target import Target
 
@@ -54,7 +54,8 @@ class GoTarget(Target):
       raise ValueError('Absolute package paths are not allowed. Given: {!r}'.format(package_path))
     return '' if not package_path or package_path == os.curdir else package_path.lstrip('/')
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def import_path(self):
     """Returns the import path string that should be used to import this target's package.
 

--- a/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 from textwrap import dedent
 
 from pants.build_graph.address_lookup_error import AddressLookupError
@@ -26,7 +26,8 @@ class GoLocalSourceTestBase(ABC):
     # Force setup of SourceRootConfig subsystem, as go targets do computation on source roots.
     self.context()
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def target_type(self):
     """Subclasses should return a GoLocalSource target subclass."""
 

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/googlejavaformat.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from abc import abstractproperty
+from abc import abstractmethod
 
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
 from pants.base.exceptions import TaskError
@@ -44,7 +44,8 @@ class GoogleJavaFormatBase(RewriteBase):
                         workunit_name='google-java-format',
                         jvm_options=self.get_options().jvm_options)
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def additional_args(self):
     """List of additional args to supply on the tool command-line."""
 

--- a/src/python/pants/backend/jvm/targets/jarable.py
+++ b/src/python/pants/backend/jvm/targets/jarable.py
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 
 from pants.java.jar.jar_dependency import JarDependency
 
@@ -12,7 +12,8 @@ class Jarable(ABC):
   :API: public
   """
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def identifier(self):
     """Subclasses should return a stable unique identifier for the jarable target."""
 

--- a/src/python/pants/backend/jvm/tasks/rewrite_base.py
+++ b/src/python/pants/backend/jvm/tasks/rewrite_base.py
@@ -3,7 +3,7 @@
 
 import os
 import shutil
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.build_environment import get_buildroot
@@ -101,7 +101,8 @@ class RewriteBase(NailgunTask, metaclass=ABCMeta):
     Returns the UNIX return code of the tool.
     """
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def sideeffecting(self):
     """True if this command has sideeffects: ie, mutates the working copy."""
 

--- a/src/python/pants/backend/jvm/tasks/scalafix.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-from abc import abstractproperty
+from abc import abstractmethod
 
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
 from pants.base.exceptions import TaskError
@@ -83,7 +83,8 @@ class ScalaFix(RewriteBase):
                         args=args,
                         workunit_name='scalafix')
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def additional_args(self):
     """Additional arguments to the Scalafix command."""
 

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -1,7 +1,7 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from abc import abstractproperty
+from abc import abstractmethod
 
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
 from pants.base.exceptions import TaskError
@@ -58,7 +58,8 @@ class ScalaFmt(RewriteBase):
                         workunit_name='scalafmt',
                         jvm_options=self.get_options().jvm_options)
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def additional_args(self):
     """Returns the arguments used to run Scalafmt command.
 

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -19,11 +19,10 @@ class Platform(enum(all_normalized_os_names())):
     return cls(get_normalized_os_name())
 
 
-def _list_field(func):
+class _list_field(property):
   """A decorator for methods corresponding to list-valued fields of an `ExtensibleAlgebraic`."""
-  wrapped = abstractmethod(func)
-  wrapped._field_type = 'list'
-  return property(wrapped)
+  __isabstractmethod__ = True
+  _field_type = 'list'
 
 
 def _algebraic_data(metaclass):

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 
 from pants.engine.rules import rule
 from pants.util.memo import memoized_classproperty
@@ -20,13 +20,10 @@ class Platform(enum(all_normalized_os_names())):
 
 
 def _list_field(func):
-  """A decorator for methods corresponding to list-valued fields of an `ExtensibleAlgebraic`.
-
-  The result is also wrapped in `abstractproperty`.
-  """
-  wrapped = abstractproperty(func)
+  """A decorator for methods corresponding to list-valued fields of an `ExtensibleAlgebraic`."""
+  wrapped = abstractmethod(func)
   wrapped._field_type = 'list'
-  return wrapped
+  return property(wrapped)
 
 
 def _algebraic_data(metaclass):
@@ -129,7 +126,8 @@ class _Executable(_ExtensibleAlgebraic):
     :rtype: list of str
     """
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def exe_filename(self):
     """The "entry point" -- which file to invoke when PATH is set to `path_entries()`.
 

--- a/src/python/pants/base/build_file_target_factory.py
+++ b/src/python/pants/base/build_file_target_factory.py
@@ -1,13 +1,14 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 
 
 class BuildFileTargetFactory(ABC):
   """An object that can hydrate target types from BUILD files."""
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def target_types(self):
     """The set of target types this factory can produce.
 

--- a/src/python/pants/base/project_tree.py
+++ b/src/python/pants/base/project_tree.py
@@ -3,7 +3,7 @@
 
 import logging
 import os
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 
 from pathspec.pathspec import PathSpec
 from pathspec.patterns.gitwildmatch import GitWildMatchPattern
@@ -200,7 +200,8 @@ class Stat(ABC):
   instantiate Stat instances.
   """
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def path(self):
     """:returns: The string path for this Stat."""
 

--- a/src/python/pants/build_graph/mirrored_target_option_mixin.py
+++ b/src/python/pants/build_graph/mirrored_target_option_mixin.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 
 from future.utils import text_type
 
@@ -74,7 +74,8 @@ class MirroredTargetOptionMixin(ABC):
   3. Otherwise, return the option value from the environment, config, or hardcoded default.
   """
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def mirrored_target_option_actions(self):
     """Subclasses should override and return a dict of (subsystem option name) -> selector function.
 

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -3,7 +3,7 @@
 
 import logging
 import os.path
-from abc import ABCMeta, abstractproperty
+from abc import ABCMeta, abstractmethod
 from builtins import object, str
 
 from six import string_types
@@ -331,11 +331,13 @@ class BaseGlobs(Locatable, metaclass=ABCMeta):
       excluded_patterns.extend(exclude_filespecs.get('globs', []))
     return {'globs': excluded_patterns}
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def path_globs_kwarg(self):
     """The name of the `PathGlobs` parameter corresponding to this BaseGlobs instance."""
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def legacy_globs_class(self):
     """The corresponding `wrapped_globs` class for this BaseGlobs."""
 

--- a/src/python/pants/engine/objects.py
+++ b/src/python/pants/engine/objects.py
@@ -3,7 +3,7 @@
 
 import inspect
 import sys
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from builtins import object
 from collections import namedtuple
 
@@ -21,7 +21,8 @@ class SerializationError(Exception):
 class Resolvable(ABC):
   """Represents a resolvable object."""
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def address(self):
     """Return the opaque address descriptor that this resolvable resolves."""
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -6,7 +6,7 @@ import inspect
 import itertools
 import logging
 import sys
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 
 import asttokens
 from twitter.common.collections import OrderedSet
@@ -324,11 +324,13 @@ class Rule(ABC):
   as factories for constructing the nodes within the graph.
   """
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def output_type(self):
     """An output `type` for the rule."""
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def dependency_rules(self):
     """A tuple of @rules that are known to be necessary to run this rule.
 
@@ -336,7 +338,8 @@ class Rule(ABC):
     form a loosely coupled RuleGraph: this facility exists only to assist with boilerplate removal.
     """
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def dependency_optionables(self):
     """A tuple of Optionable classes that are known to be necessary to run this rule."""
     return ()

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -6,7 +6,7 @@ import logging
 import os
 import pkgutil
 import plistlib
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 from builtins import object, open, str
 from collections import namedtuple
 from contextlib import contextmanager
@@ -301,7 +301,8 @@ class _DistributionEnvironment(ABC):
       """
       return cls(home_path=None, bin_path=bin_path)
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def jvm_locations(self):
     """Return the jvm locations discovered in this environment.
 

--- a/src/python/pants/java/executor.py
+++ b/src/python/pants/java/executor.py
@@ -4,7 +4,7 @@
 import logging
 import os
 import sys
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from builtins import object
 from contextlib import contextmanager
 
@@ -45,7 +45,8 @@ class Executor(ABC):
   class Runner(object):
     """A re-usable executor that can run a configured java command line."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def executor(self):
       """Returns the executor this runner uses to run itself."""
       raise NotImplementedError
@@ -55,7 +56,8 @@ class Executor(ABC):
       """Returns a string representation of the command that will be run."""
       return ' '.join(self.command)
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def command(self):
       """Returns a copy of the command line that will be run as a list of command line tokens."""
       raise NotImplementedError

--- a/src/python/pants/net/http/fetcher.py
+++ b/src/python/pants/net/http/fetcher.py
@@ -7,7 +7,7 @@ import re
 import sys
 import tempfile
 import time
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from builtins import object, open, str
 from contextlib import closing, contextmanager
 
@@ -209,14 +209,16 @@ class Fetcher(object):
   class _Response(ABC):
     """Abstracts a fetch response."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def status_code(self):
       """The HTTP status code for the fetch.
 
       :rtype: int
       """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def size(self):
       """The size of the fetched file in bytes if known; otherwise, `None`.
 

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -3,7 +3,7 @@
 
 import functools
 import re
-from abc import ABC, ABCMeta, abstractproperty
+from abc import ABC, ABCMeta, abstractmethod
 from builtins import str
 
 from pants.engine.selectors import Get
@@ -25,11 +25,13 @@ class OptionableFactory(ABC):
   loosely defined by `_construct_optionable` and `OptionableFactory.signature`.
   """
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def optionable_cls(self):
     """The Optionable class that is constructed by this OptionableFactory."""
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def options_scope(self):
     """The scope from which the ScopedOptions for the target Optionable will be parsed."""
 

--- a/src/python/pants/scm/scm.py
+++ b/src/python/pants/scm/scm.py
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 
 
 class Scm(ABC):
@@ -28,32 +28,37 @@ class Scm(ABC):
     :API: public
     """
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def current_rev_identifier(self):
     """Identifier for the tip/head of the current branch eg. "HEAD" in git.
 
     :API: public
     """
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def commit_id(self):
     """Returns the id of the current commit.
 
     :API: public
     """
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def server_url(self):
     """Returns the url of the (default) remote server."""
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def tag_name(self):
     """Returns the name of the current tag if any.
 
     :API: public
     """
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def branch_name(self):
     """Returns the name of the current branch if any.
 
@@ -67,7 +72,8 @@ class Scm(ABC):
     :API: public
     """
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def worktree(self):
     """Returns the worktree for the SCM.
 

--- a/src/python/pants/source/wrapped_globs.py
+++ b/src/python/pants/source/wrapped_globs.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from builtins import open
 from hashlib import sha1
 
@@ -56,11 +56,13 @@ class FilesetWithSpec(ABC):
       for exclude_filespec in exclude:
         self._validate_globs_in_filespec(exclude_filespec, rel_root)
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def files(self):
     """Return the concrete set of files matched by this FilesetWithSpec, relative to `self.rel_root`."""
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def files_hash(self):
     """Return a unique hash for this set of files."""
 
@@ -151,11 +153,13 @@ class LazyFilesetWithSpec(FilesetWithSpec):
 class FilesetRelPathWrapper(ABC):
   KNOWN_PARAMETERS = frozenset({'exclude', 'follow_links'})
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def wrapped_fn(cls):
     """The wrapped file calculation function."""
 
-  @abstractproperty
+  @property
+  @abstractmethod
   def validate_files(cls):
     """True to validate the existence of files returned by wrapped_fn."""
 

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from abc import abstractproperty
 from builtins import object
 
 
@@ -32,7 +31,7 @@ class ClassPropertyDescriptor(object):
       objtype = type(obj)
       # Get the callable field for this object, which may be a property.
     callable_field = self.fget.__get__(obj, objtype)
-    if isinstance(self.fget.__func__, abstractproperty):
+    if getattr(self.fget.__func__, '__isabstractmethod__', False):
       field_name = self.fget.__func__.fget.__name__
       raise TypeError("""\
 The classproperty '{func_name}' in type '{type_name}' was an abstractproperty, meaning that type \
@@ -104,7 +103,4 @@ def staticproperty(func):
 # TODO: look into merging this with `enum` and `ChoicesMixin`, which describe a fixed set of
 # singletons, to decouple the enum interface from the implementation as a `datatype`.
 # Extend Singleton and your class becomes a singleton, each construction returns the same instance.
-try:  # Python3
-  Singleton = SingletonMetaclass(u'Singleton', (object,), {})
-except TypeError:  # Python2
-  Singleton = SingletonMetaclass(b'Singleton', (object,), {})
+Singleton = SingletonMetaclass('Singleton', (object,), {})

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import re
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from builtins import zip
 
 from future.utils import binary_type, text_type
@@ -247,7 +247,7 @@ class ChoicesMixin(ABC):
   """A mixin which declares that the type has a fixed set of possible instances."""
 
   @classproperty
-  @abstractproperty
+  @abstractmethod
   def all_variants(cls):
     """Return an iterable containing a de-duplicated list of all possible instances of this type."""
 

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from builtins import object
 
 from pants.util.meta import Singleton, classproperty, staticproperty
@@ -11,7 +11,8 @@ from pants_test.test_base import TestBase
 class AbstractClassTest(TestBase):
   def test_abstract_property(self):
     class AbstractProperty(ABC):
-      @abstractproperty
+      @property
+      @abstractmethod
       def property(self):
         pass
 
@@ -212,7 +213,8 @@ class ClassPropertyTest(TestBase):
   def test_abstract_classproperty(self):
     class Abstract(ABC):
       @classproperty
-      @abstractproperty
+      @property
+      @abstractmethod
       def f(cls):
         pass
 


### PR DESCRIPTION
Eliminate use of the `deprecated abc.abstractproperty`. See:
  https://docs.python.org/3/library/abc.html#abc.abstractproperty

While in meta.py also simplify the `Singleton` baseclass.
