### PR TITLE
Fix the wheel count check for pex building

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -513,8 +513,8 @@ function fetch_and_check_prebuilt_wheels() {
       fi
     done
 
-    # N.B. For platform-specific wheels, we expect 6 wheels: {linux,osx} * {cp27m,cp27mu,abi3}.
-    if [ "${cross_platform}" != "true" ] && [ ${#packages[@]} -ne 6 ]; then
+    # N.B. For platform-specific wheels, we expect 2 wheels: {linux,osx} * {abi3,}.
+    if [ "${cross_platform}" != "true" ] && [ ${#packages[@]} -ne 2 ]; then
       missing+=("${PACKAGE} (expected whls for each platform: had only ${packages[@]})")
       continue
     fi


### PR DESCRIPTION
### Problem

#7888 fixed most of the locations that were expecting particular whl counts, but missed one.

### Solution

Fix the last whl count check.

### Result

Confirmed that `build-support/bin/release.sh -p` works.