### PR TITLE
Fix notes for 1.16.0rc6 to prepare to release it.

### DIFF
--- a/src/python/pants/notes/1.16.x.rst
+++ b/src/python/pants/notes/1.16.x.rst
@@ -2,7 +2,7 @@
 ======================
 This document describes releases leading up to the ``1.16.x`` ``stable`` series.
 
-1.16.0rc6 (6/05/2019)
+1.16.0rc6 (6/22/2019)
 ---------------------
 
 Bugfixes
@@ -13,6 +13,9 @@ Bugfixes
 
 * Fix rsc compile transitive dep bug introduced in #7742 (#7825)
   `PR #7825 <https://github.com/pantsbuild/pants/pull/7825>`_
+
+* Fix `py-thrift-namespace-clash-check` type issue when logging with `--no-strict` mode (#7864)
+  `PR #7864 <https://github.com/pantsbuild/pants/pull/7864>`_
 
 Refactoring, Improvements, and Tooling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
`1.16.0rc6` was previously prepared, but not released.