### PR TITLE
Add `--concurrent` flag, which overrides `--enable-pantsd`

### DIFF
--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -46,6 +46,12 @@ class PantsRunner(object):
     init_rust_logger(levelname, global_bootstrap_options.log_show_rust_3rdparty)
     setup_logging_to_stderr(logging.getLogger(None), levelname)
 
+  def _should_run_with_pantsd(self, global_bootstrap_options):
+    # If we want concurrent pants runs, we can't have pantsd enabled.
+    return global_bootstrap_options.enable_pantsd and \
+           not self.will_terminate_pantsd() and \
+           not global_bootstrap_options.concurrent
+
   def run(self):
     # Register our exiter at the beginning of the run() method so that any code in this process from
     # this point onwards will use that exiter in the case of a fatal error.
@@ -66,7 +72,7 @@ class PantsRunner(object):
       warnings.filterwarnings(action='ignore', message=message_regexp)
 
     # TODO https://github.com/pantsbuild/pants/issues/7205
-    if global_bootstrap_options.enable_pantsd and not self.will_terminate_pantsd():
+    if self._should_run_with_pantsd(global_bootstrap_options):
       try:
         return RemotePantsRunner(self._exiter, self._args, self._env, options_bootstrapper).run()
       except RemotePantsRunner.Fallback as e:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -266,6 +266,12 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--enable-pantsd', advanced=True, type=bool, default=False,
              help='Enables use of the pants daemon (and implicitly, the v2 engine). (Beta)')
 
+    # Whether or not to make necessary arrangements to have concurrent runs in pants.
+    # In practice, this means that if this is set, a run will not even try to use pantsd.
+    # NB: Eventually, we would like to deprecate this flag in favor of making pantsd runs parallelizable.
+    register('--concurrent', advanced=True, type=bool, default=False, daemon=False,
+             help='Enable concurrent runs of pants.')
+
     # Shutdown pantsd after the current run.
     # This needs to be accessed at the same time as enable_pantsd,
     # so we register it at bootstrap time.

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -689,3 +689,16 @@ Interrupted by user over pailgun client!
         with open(os.path.join(directory, 'BUILD'), 'w') as f:
           f.write(template.format(a_deps='', b_deps='dependencies = [":A"],'))
         list_and_verify()
+
+  def test_concurrent_overrides_pantsd(self):
+    """
+    Tests that the --concurrent flag overrides the --enable-pantsd flag,
+    because we don't allow concurrent runs under pantsd.
+    """
+    config = {'GLOBAL': {'concurrent': True, 'enable_pantsd': True}}
+    with self.temporary_workdir() as workdir:
+      pants_run = self.run_pants_with_workdir(['goals'], workdir=workdir, config=config)
+      self.assert_success(pants_run)
+      # TODO migrate to pathlib when we cut 1.18.x
+      pantsd_log_location = os.path.join(workdir, 'pantsd', 'pantsd.log')
+      self.assertFalse(os.path.exists(pantsd_log_location))


### PR DESCRIPTION
### Problem

We want for users to be able to run concurrent pants runs. This, essentially, means turning off pantsd. This PR implements that flag, and just doesn't even try to use pantsd if `--concurrent` is set.

Some more context: https://github.com/pantsbuild/pants/pull/7913#issuecomment-504523310

Feel free to push stuff on top of this.
