### PR TITLE
Add conftest.py to the python_tests default sources.

### DIFF
--- a/src/python/pants/backend/python/targets/python_tests.py
+++ b/src/python/pants/backend/python/targets/python_tests.py
@@ -12,8 +12,8 @@ class PythonTests(PythonTarget):
   :API: public
   """
 
-  # These are the patterns matched by pytest's test discovery.
-  default_sources_globs = ('test_*.py', '*_test.py')
+  # These are the patterns matched by pytest's test discovery, plus pytest's config hook file.
+  default_sources_globs = ('test_*.py', '*_test.py', 'conftest.py')
 
   @classmethod
   def alias(cls):

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -116,7 +116,7 @@ class PytestTestConftest(PytestTestBase):
     def pytest_configure(config):
       INDEX.update((app, len(app)) for app in APPS)
     """))
-    self.add_to_build_file('src/python/base', target='python_library()\n')
+    self.add_to_build_file('src/python/base', target='python_library(sources=globs("*.py"))\n')
 
     self.create_file('src/python/base/app/__init__.py')
     self.create_file('src/python/base/app/conftest.py', contents=dedent("""


### PR DESCRIPTION
This is the standard pytest configuration hook, so it basically never belongs in library targets, always in test targets.