### PR TITLE
Remove unittest.mock backport

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -10,7 +10,6 @@ faulthandler==2.6 ; python_version<'3'
 future==0.17.1
 futures==3.0.5 ; python_version<'3'
 Markdown==2.1.1
-mock==2.0.0
 # TODO(6282): once we can upgrade Pytest to 4.2.1+, we can remove the more-itertools requirement
 more-itertools<6.0.0 ; python_version<'3'
 packaging==16.8

--- a/contrib/node/tests/python/pants_test/contrib/node/subsystems/BUILD
+++ b/contrib/node/tests/python/pants_test/contrib/node/subsystems/BUILD
@@ -16,7 +16,6 @@ python_tests(
   name='package_managers',
   sources=['test_package_managers.py'],
   dependencies=[
-    '3rdparty/python:mock',
     'contrib/node/src/python/pants/contrib/node/subsystems',
   ]
 )

--- a/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_package_managers.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_package_managers.py
@@ -2,8 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import unittest
-
-import mock
+import unittest.mock
 
 from pants.contrib.node.subsystems.package_managers import (PackageInstallationTypeOption,
                                                             PackageInstallationVersionOption,
@@ -15,7 +14,7 @@ def fake_install():
   return 'fake_install_dir'
 
 
-@mock.patch('pants.contrib.node.subsystems.package_managers.command_gen')
+@unittest.mock.patch('pants.contrib.node.subsystems.package_managers.command_gen')
 class TestYarnpkg(unittest.TestCase):
 
   def setUp(self):
@@ -101,7 +100,7 @@ class TestYarnpkg(unittest.TestCase):
       mock_command_gen.reset_mock()
 
 
-@mock.patch('pants.contrib.node.subsystems.package_managers.command_gen')
+@unittest.mock.patch('pants.contrib.node.subsystems.package_managers.command_gen')
 class TestNpm(unittest.TestCase):
 
   def setUp(self):

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
@@ -99,7 +99,6 @@ python_tests(
   name='node_resolve',
   sources=['test_node_resolve.py'],
   dependencies=[
-    '3rdparty/python:mock',
     'contrib/node/src/python/pants/contrib/node/targets:node_module',
     'contrib/node/src/python/pants/contrib/node/targets:node_preinstalled_module',
     'contrib/node/src/python/pants/contrib/node/targets:node_remote_module',
@@ -138,7 +137,6 @@ python_tests(
   sources=['test_node_resolve_src_deps.py'],
   dependencies=[
     '3rdparty/python:future',
-    '3rdparty/python:mock',
     'contrib/node/src/python/pants/contrib/node/targets:node_module',
     'contrib/node/src/python/pants/contrib/node/targets:node_preinstalled_module',
     'contrib/node/src/python/pants/contrib/node/targets:node_remote_module',

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve.py
@@ -3,9 +3,9 @@
 
 import json
 import os
+import unittest.mock
 from textwrap import dedent
 
-import mock
 from pants.base.exceptions import TaskError
 from pants.build_graph.target import Target
 from pants_test.task_test_base import TaskTestBase
@@ -291,7 +291,7 @@ class NodeResolveTest(TaskTestBase):
     task = self.create_task(context)
 
     package_manager_obj = task.get_package_manager(target=target)
-    with mock.patch.object(package_manager_obj, 'run_command') as exec_call:
+    with unittest.mock.patch.object(package_manager_obj, 'run_command') as exec_call:
       exec_call.return_value.run.return_value.wait.return_value = 0
       task.execute()
       exec_call.assert_called_once_with(

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
@@ -15,7 +15,6 @@ python_tests(
   name='scrooge_gen',
   sources=['test_scrooge_gen.py'],
   dependencies=[
-    '3rdparty/python:mock',
     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:scrooge_gen',
     'src/python/pants/backend/codegen/thrift/java',
     'src/python/pants/backend/jvm/targets:java',
@@ -50,7 +49,6 @@ python_tests(
   name='thrift_linter',
   sources=['test_thrift_linter.py'],
   dependencies=[
-    '3rdparty/python:mock',
     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:thrift_linter',
     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:thrift_util',
     'src/python/pants/backend/codegen/thrift/java',

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -3,8 +3,8 @@
 
 import os
 from textwrap import dedent
+from unittest.mock import MagicMock
 
-from mock import MagicMock
 from pants.backend.codegen.thrift.java.java_thrift_library import JavaThriftLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
@@ -1,7 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
+
 from pants.backend.codegen.thrift.java.java_thrift_library import JavaThriftLibrary
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.build_file_aliases import BuildFileAliases

--- a/tests/python/pants_test/backend/docgen/tasks/BUILD
+++ b/tests/python/pants_test/backend/docgen/tasks/BUILD
@@ -7,7 +7,6 @@ python_tests(
   sources = ['test_markdown_to_html.py'],
   dependencies = [
     '3rdparty/python:beautifulsoup4',
-    '3rdparty/python:mock',
     'src/python/pants/backend/docgen/targets',
     'src/python/pants/backend/docgen/tasks',
     'src/python/pants/base:exceptions',

--- a/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
+++ b/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
@@ -3,10 +3,10 @@
 
 import os
 import unittest
+import unittest.mock
 from textwrap import dedent
 
 import bs4
-import mock
 
 from pants.backend.docgen.register import build_file_aliases
 from pants.backend.docgen.tasks import markdown_to_html_utils
@@ -144,7 +144,7 @@ class MarkdownToHtmlTest(TaskTestBase):
     self.set_options(ignore_failure=True)
     bad_rst = self.target(':bad_rst')
     context = self.context(target_roots=[bad_rst])
-    context.log.warn = mock.Mock()
+    context.log.warn = unittest.mock.Mock()
     task = self.create_task(context)
     task.execute()
 

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -283,7 +283,6 @@ python_tests(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:future',
-    '3rdparty/python:mock',
     'src/python/pants/backend/jvm/subsystems:jar_dependency_management',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
@@ -362,7 +361,6 @@ python_tests(
   name = 'jar_publish',
   sources = ['test_jar_publish.py'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jar_publish',
@@ -409,7 +407,6 @@ python_tests(
   name = 'junit_run',
   sources = ['test_junit_run.py'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/backend/jvm/subsystems:junit',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/tasks:junit_run',

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -4,9 +4,9 @@
 import os
 import re
 from contextlib import contextmanager
+from unittest.mock import MagicMock
 
 from future.utils import PY3
-from mock import MagicMock
 from psutil.tests import safe_rmpath
 
 from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
@@ -3,8 +3,7 @@
 
 import os
 import unittest
-
-from mock import Mock
+from unittest.mock import Mock
 
 from pants.backend.jvm.artifact import Artifact
 from pants.backend.jvm.repository import Repository

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -224,7 +224,6 @@ python_tests(
   name = 'select_interpreter',
   sources = ['test_select_interpreter.py'],
   dependencies = [
-    '3rdparty/python:mock',
     '3rdparty/python:pex',
     'src/python/pants/backend/python:interpreter_cache',
     'src/python/pants/backend/python/subsystems',
@@ -240,7 +239,6 @@ python_tests(
   name = 'setup_py',
   sources = ['test_setup_py.py'],
   dependencies = [
-    '3rdparty/python:mock',
     '3rdparty/python:pex',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',

--- a/tests/python/pants_test/backend/python/tasks/native/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/native/BUILD
@@ -8,7 +8,6 @@ python_tests(
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     '3rdparty/python:coverage',
     '3rdparty/python:future',
-    '3rdparty/python:mock',
     '3rdparty/python:pex',
     'src/python/pants/backend/native',
     'src/python/pants/backend/python/subsystems',

--- a/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
+++ b/tests/python/pants_test/backend/python/tasks/test_select_interpreter.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import unittest.mock
 from textwrap import dedent
 
-import mock
 from pex.interpreter import PythonInterpreter
 
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
@@ -81,7 +81,7 @@ class SelectInterpreterTest(TaskTestBase):
 
     task = self.create_task(context)
     if should_invalidate is not None:
-      task._select_interpreter = mock.MagicMock(wraps=task._select_interpreter)
+      task._select_interpreter = unittest.mock.MagicMock(wraps=task._select_interpreter)
 
     task.execute()
 

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -5,8 +5,8 @@ import os
 from collections import OrderedDict
 from contextlib import contextmanager
 from textwrap import dedent
+from unittest.mock import Mock
 
-from mock import Mock
 from twitter.common.collections import OrderedSet
 from twitter.common.dirutil.chroot import Chroot
 

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -61,7 +61,6 @@ python_tests(
   name = 'deprecated',
   sources = ['test_deprecated.py'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/base:deprecated',
     'src/python/pants/util:collections',
     'src/python/pants:version',
@@ -197,7 +196,6 @@ python_tests(
   name = 'exception_sink',
   sources = ['test_exception_sink.py'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/base:exception_sink',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
@@ -213,7 +211,6 @@ python_tests(
   sources = ['test_exception_sink_integration.py'],
   dependencies = [
     '3rdparty/python:future',
-    '3rdparty/python:mock',
     'src/python/pants/base:exception_sink',
     'src/python/pants/util:osutil',
     'tests/python/pants_test:int-test',

--- a/tests/python/pants_test/base/test_deprecated.py
+++ b/tests/python/pants_test/base/test_deprecated.py
@@ -1,10 +1,10 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import unittest.mock
 import warnings
 from contextlib import contextmanager
 
-import mock
 from packaging.version import Version
 
 from pants.base.deprecated import (BadDecoratorNestingError, BadSemanticVersionError,
@@ -153,7 +153,7 @@ class DeprecatedTest(TestBase):
       def test_func1a():
         pass
 
-  @mock.patch('pants.base.deprecated.PANTS_SEMVER', Version(_FAKE_CUR_VERSION))
+  @unittest.mock.patch('pants.base.deprecated.PANTS_SEMVER', Version(_FAKE_CUR_VERSION))
   def test_removal_version_same(self):
     with self.assertRaises(CodeRemovedError):
       warn_or_error(_FAKE_CUR_VERSION, 'dummy description')
@@ -193,7 +193,7 @@ class DeprecatedTest(TestBase):
                     deprecated_entity_description='dummy',
                     deprecation_start_version='1.0.0.dev0')
 
-  @mock.patch('pants.base.deprecated.PANTS_SEMVER', Version(_FAKE_CUR_VERSION))
+  @unittest.mock.patch('pants.base.deprecated.PANTS_SEMVER', Version(_FAKE_CUR_VERSION))
   def test_deprecation_start_period(self):
     with self.assertRaises(CodeRemovedError):
       warn_or_error(removal_version=_FAKE_CUR_VERSION,

--- a/tests/python/pants_test/base/test_exception_sink.py
+++ b/tests/python/pants_test/base/test_exception_sink.py
@@ -4,8 +4,7 @@
 import logging
 import os
 import re
-
-import mock
+import unittest.mock
 
 from pants.base.exception_sink import ExceptionSink
 from pants.util.contextutil import temporary_dir
@@ -68,7 +67,7 @@ class TestExceptionSink(TestBase):
       # Check that tmpdir exists, and log an exception into that directory.
       sink.reset_log_location(tmpdir)
 
-      with mock.patch('setproctitle.getproctitle', autospec=True, spec_set=True) \
+      with unittest.mock.patch('setproctitle.getproctitle', autospec=True, spec_set=True) \
            as getproctitle_mock:
         getproctitle_mock.return_value = fake_process_title
         sink.log_exception(msg)
@@ -105,7 +104,7 @@ pid: {pid}
     with self.captured_logging(level=logging.ERROR) as captured:
       with temporary_dir() as tmpdir:
         sink.reset_log_location(tmpdir)
-        with mock.patch.object(sink, '_try_write_with_flush', autospec=sink) as mock_write:
+        with unittest.mock.patch.object(sink, '_try_write_with_flush', autospec=sink) as mock_write:
           mock_write.side_effect = ExceptionSink.ExceptionSinkError('fake write failure')
           sink.log_exception('XXX')
     errors = list(captured.errors())

--- a/tests/python/pants_test/binaries/BUILD
+++ b/tests/python/pants_test/binaries/BUILD
@@ -4,7 +4,6 @@
 python_tests(
   sources=globs('test_*.py', exclude=[globs('*_integration.py')]),
   dependencies=[
-    '3rdparty/python:mock',
     'src/python/pants/binaries',
     'src/python/pants/net',
     'src/python/pants/option',

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -4,8 +4,8 @@
 import glob
 import logging
 import os
+import unittest.mock
 
-import mock
 from future.utils import PY2
 
 from pants.binaries.binary_util import (BinaryRequest, BinaryToolFetcher, BinaryToolUrlGenerator,
@@ -95,7 +95,7 @@ class BinaryUtilTest(TestBase):
       return result_file.read()
 
   def test_timeout(self):
-    fetcher = mock.create_autospec(Fetcher, spec_set=True)
+    fetcher = unittest.mock.create_autospec(Fetcher, spec_set=True)
     timeout_value = 42
     binary_util = self._gen_binary_util(baseurls=['http://binaries.example.com'],
                                         timeout_secs=timeout_value,
@@ -105,8 +105,8 @@ class BinaryUtilTest(TestBase):
     fetch_path = binary_util.select_script(supportdir='a-binary', version='v1.2', name='a-binary')
     logger.debug("fetch_path: {}".format(fetch_path))
     fetcher.download.assert_called_once_with('http://binaries.example.com/a-binary/v1.2/a-binary',
-                                             listener=mock.ANY,
-                                             path_or_fd=mock.ANY,
+                                             listener=unittest.mock.ANY,
+                                             path_or_fd=unittest.mock.ANY,
                                              timeout_secs=timeout_value)
 
   def test_no_base_urls_error(self):

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -112,7 +112,6 @@ python_tests(
   sources = ['test_target.py'],
   dependencies = [
     '3rdparty/python:future',
-    '3rdparty/python:mock',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:fingerprint_strategy',
     'src/python/pants/base:payload',

--- a/tests/python/pants_test/build_graph/test_target.py
+++ b/tests/python/pants_test/build_graph/test_target.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
+import unittest.mock
 from hashlib import sha1
 
-import mock
 from future.utils import PY3
 
 from pants.base.exceptions import TargetDefinitionException
@@ -290,7 +290,7 @@ class TargetTest(TestBase):
 
   def test_strict_dependencies(self):
     self._generate_strict_dependencies()
-    dep_context = mock.Mock()
+    dep_context = unittest.mock.Mock()
     dep_context.types_with_closure = ()
     dep_context.codegen_types = ()
     dep_context.alias_types = (Target,)

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -29,7 +29,6 @@ python_tests(
   name = 'cache_setup',
   sources = ['test_cache_setup.py'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/cache',
     'src/python/pants/option',
     'src/python/pants/subsystem',
@@ -79,7 +78,6 @@ python_tests(
   sources = ['test_pinger.py'],
   dependencies = [
     '3rdparty/python:future',
-    '3rdparty/python:mock',
     '3rdparty/python:responses',
     'src/python/pants/cache',
     'tests/python/pants_test:test_base',
@@ -91,7 +89,6 @@ python_tests(
   name = 'resolver',
   sources = ['test_resolver.py'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/cache',
     'tests/python/pants_test/subsystem:subsystem_utils',
   ]

--- a/tests/python/pants_test/cache/test_cache_setup.py
+++ b/tests/python/pants_test/cache/test_cache_setup.py
@@ -2,8 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-
-from mock import Mock
+from unittest.mock import Mock
 
 from pants.cache.cache_setup import (CacheFactory, CacheSetup, CacheSpec, CacheSpecFormatError,
                                      EmptyCacheSpecError, InvalidCacheSpecError,

--- a/tests/python/pants_test/cache/test_pinger.py
+++ b/tests/python/pants_test/cache/test_pinger.py
@@ -1,9 +1,9 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import unittest.mock
 from contextlib import contextmanager
 
-import mock
 import requests
 import responses
 from future.moves.urllib.parse import urlparse
@@ -45,7 +45,7 @@ class TestPinger(TestBase):
 
   @contextmanager
   def pinger(self, timeout, urls, tries=2):
-    with mock.patch('pants.cache.pinger.Timer.elapsed', new_callable=mock.PropertyMock) as elapsed:
+    with unittest.mock.patch('pants.cache.pinger.Timer.elapsed', new_callable=unittest.mock.PropertyMock) as elapsed:
       times = []
       for url in urls:
         for _ in range(tries):

--- a/tests/python/pants_test/cache/test_resolver.py
+++ b/tests/python/pants_test/cache/test_resolver.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import unittest
+from unittest.mock import Mock, patch
 
 import requests
-from mock import Mock, patch
 
 from pants.cache.resolver import Resolver, ResponseParser, RESTfulResolver
 

--- a/tests/python/pants_test/core_tasks/BUILD
+++ b/tests/python/pants_test/core_tasks/BUILD
@@ -6,7 +6,6 @@ python_tests(
   sources=['test_bash_completion.py'],
   coverage=['pants.core_tasks.bash_completion'],
   dependencies=[
-    '3rdparty/python:mock',
     'src/python/pants/core_tasks',
     'tests/python/pants_test:task_test_base',
   ]

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -111,7 +111,6 @@ python_tests(
 python_tests(
   sources=['test_engine.py'],
   dependencies=[
-    '3rdparty/python:mock',
     ':scheduler_test_base',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',
@@ -192,7 +191,6 @@ python_tests(
   sources=['test_scheduler.py'],
   coverage=['pants.engine.nodes', 'pants.engine.scheduler'],
   dependencies=[
-    '3rdparty/python:mock',
     ':util',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -5,7 +5,6 @@ python_tests(
   name = 'address_mapper',
   sources = ['test_address_mapper.py'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/base:specs',
     'src/python/pants/bin',
     'src/python/pants/build_graph',
@@ -117,7 +116,6 @@ python_tests(
   name = 'graph',
   sources = ['test_graph.py'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/bin',
     'src/python/pants/build_graph',
     'src/python/pants/engine/legacy:graph',
@@ -155,7 +153,6 @@ python_tests(
   name = 'options_parsing',
   sources = ['test_options_parsing.py'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/bin',
     'src/python/pants/build_graph',
     'src/python/pants/init',

--- a/tests/python/pants_test/engine/legacy/test_address_mapper.py
+++ b/tests/python/pants_test/engine/legacy/test_address_mapper.py
@@ -2,8 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-
-import mock
+import unittest.mock
 
 from pants.base.specs import SiblingAddresses, SingleAddress
 from pants.build_graph.address import Address, BuildFileAddress
@@ -82,7 +81,7 @@ class LegacyAddressMapperTest(TestBase):
     self.assertEqual(build_files, set())
 
   def test_is_declaring_file(self):
-    scheduler = mock.Mock()
+    scheduler = unittest.mock.Mock()
     mapper = LegacyAddressMapper(scheduler, '')
     self.assertTrue(mapper.is_declaring_file(Address('path', 'name'), 'path/BUILD'))
     self.assertTrue(mapper.is_declaring_file(Address('path', 'name'), 'path/BUILD.suffix'))

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -3,10 +3,9 @@
 
 import re
 import sys
+import unittest.mock
 from contextlib import contextmanager
 from textwrap import dedent
-
-import mock
 
 from pants.engine.native import Native
 from pants.engine.rules import RootRule, UnionRule, rule, union
@@ -284,9 +283,9 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
     # Test that CFFI extern method errors result in an ExecutionError, even if .execution_request()
     # succeeds.
     with self.assertRaises(ExecutionError) as cm:
-      with mock.patch.object(SchedulerSession, 'execution_request',
+      with unittest.mock.patch.object(SchedulerSession, 'execution_request',
                              **PATCH_OPTS) as mock_exe_request:
-        with mock.patch.object(Native, 'cffi_extern_method_runtime_exceptions',
+        with unittest.mock.patch.object(Native, 'cffi_extern_method_runtime_exceptions',
                                **PATCH_OPTS) as mock_cffi_exceptions:
           mock_exe_request.return_value = None
           mock_cffi_exceptions.return_value = [create_cffi_exception()]
@@ -300,7 +299,7 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
     # are no CFFI extern methods.
     class TestError(Exception): pass
     with self.assertRaisesWithMessage(TestError, 'non-CFFI error'):
-      with mock.patch.object(SchedulerSession, 'execution_request',
+      with unittest.mock.patch.object(SchedulerSession, 'execution_request',
                              **PATCH_OPTS) as mock_exe_request:
         mock_exe_request.side_effect = TestError('non-CFFI error')
         self.scheduler.product_request(C, [Params(CollectionType([1, 2, 3]))])

--- a/tests/python/pants_test/help/BUILD
+++ b/tests/python/pants_test/help/BUILD
@@ -26,7 +26,6 @@ python_tests(
   sources=['test_help_info_extracter.py'],
   coverage=['pants.help.help_info_extracter'],
   dependencies=[
-    '3rdparty/python:mock',
     'src/python/pants/help',
     'src/python/pants/option',
   ]

--- a/tests/python/pants_test/init/BUILD
+++ b/tests/python/pants_test/init/BUILD
@@ -5,7 +5,6 @@
 python_tests(
   sources=rglobs('*.py'),
   dependencies = [
-    '3rdparty/python:mock',
     '3rdparty/python:parameterized',
     '3rdparty/python:pex',
     '3rdparty/python:setuptools',

--- a/tests/python/pants_test/java/BUILD
+++ b/tests/python/pants_test/java/BUILD
@@ -18,7 +18,6 @@ python_tests(
   sources = ['test_nailgun_client.py'],
   coverage = ['pants.java.nailgun_client'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/java:nailgun_client',
   ]
 )
@@ -28,7 +27,6 @@ python_tests(
   sources = ['test_nailgun_executor.py'],
   coverage = ['pants.java.nailgun_executor'],
   dependencies = [
-    '3rdparty/python:mock',
     '3rdparty/python:psutil',
     'src/python/pants/java:nailgun_executor',
     'tests/python/pants_test:test_base'
@@ -40,7 +38,6 @@ python_tests(
   sources = ['test_nailgun_io.py'],
   coverage = ['pants.java.nailgun_io'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/java:nailgun_io',
   ]
 )
@@ -50,7 +47,6 @@ python_tests(
   sources = ['test_nailgun_protocol.py'],
   coverage = ['pants.java.nailgun_protocol'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/java:nailgun_protocol',
   ]
 )
@@ -59,7 +55,6 @@ python_tests(
   name = 'util',
   sources = ['test_util.py'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/java:util',
     'src/python/pants/util:dirutil',
   ]

--- a/tests/python/pants_test/java/test_nailgun_client.py
+++ b/tests/python/pants_test/java/test_nailgun_client.py
@@ -4,8 +4,7 @@
 import signal
 import socket
 import unittest
-
-import mock
+import unittest.mock
 
 from pants.java.nailgun_client import NailgunClient, NailgunClientSession
 from pants.java.nailgun_io import NailgunStreamWriter
@@ -50,7 +49,7 @@ class TestNailgunClientSession(unittest.TestCase):
       err_file=self.fake_stderr
     )
 
-    self.mock_stdin_reader = mock.create_autospec(NailgunStreamWriter, spec_set=True)
+    self.mock_stdin_reader = unittest.mock.create_autospec(NailgunStreamWriter, spec_set=True)
     self.mock_stdin_reader.is_alive.side_effect = [False, True]
     self.nailgun_client_session._input_writer = self.mock_stdin_reader
 
@@ -70,7 +69,7 @@ class TestNailgunClientSession(unittest.TestCase):
     self.nailgun_client_session._maybe_start_input_writer()
     self.nailgun_client_session._maybe_stop_input_writer()
 
-  @mock.patch('psutil.Process', **PATCH_OPTS)
+  @unittest.mock.patch('psutil.Process', **PATCH_OPTS)
   def test_process_session(self, mock_psutil_process):
     mock_psutil_process.cmdline.return_value = ['mock', 'process']
     NailgunProtocol.write_chunk(self.server_sock, ChunkType.PID, b'31337')
@@ -88,7 +87,7 @@ class TestNailgunClientSession(unittest.TestCase):
     self.mock_stdin_reader.stop.assert_called_once_with()
     self.assertEqual(self.nailgun_client_session.remote_pid, 31337)
 
-  @mock.patch('psutil.Process', **PATCH_OPTS)
+  @unittest.mock.patch('psutil.Process', **PATCH_OPTS)
   def test_process_session_bad_chunk(self, mock_psutil_process):
     mock_psutil_process.cmdline.return_value = ['mock', 'process']
     NailgunProtocol.write_chunk(self.server_sock, ChunkType.PID, b'31337')
@@ -101,7 +100,7 @@ class TestNailgunClientSession(unittest.TestCase):
     self.mock_stdin_reader.start.assert_called_once_with()
     self.mock_stdin_reader.stop.assert_called_once_with()
 
-  @mock.patch.object(NailgunClientSession, '_process_session', **PATCH_OPTS)
+  @unittest.mock.patch.object(NailgunClientSession, '_process_session', **PATCH_OPTS)
   def test_execute(self, mock_process_session):
     mock_process_session.return_value = self.TEST_PAYLOAD
     out = self.nailgun_client_session.execute(
@@ -118,9 +117,9 @@ class TestNailgunClient(unittest.TestCase):
   def setUp(self):
     self.nailgun_client = NailgunClient()
 
-  @mock.patch('pants.java.nailgun_client.RecvBufferedSocket', **PATCH_OPTS)
+  @unittest.mock.patch('pants.java.nailgun_client.RecvBufferedSocket', **PATCH_OPTS)
   def test_try_connect(self, mock_socket_cls):
-    mock_socket = mock.Mock()
+    mock_socket = unittest.mock.Mock()
     mock_socket_cls.return_value = mock_socket
 
     self.assertEqual(self.nailgun_client.try_connect(), mock_socket)
@@ -130,24 +129,24 @@ class TestNailgunClient(unittest.TestCase):
       (NailgunClient.DEFAULT_NG_HOST, NailgunClient.DEFAULT_NG_PORT)
     )
 
-  @mock.patch('pants.java.nailgun_client.RecvBufferedSocket', **PATCH_OPTS)
+  @unittest.mock.patch('pants.java.nailgun_client.RecvBufferedSocket', **PATCH_OPTS)
   def test_try_connect_socket_error(self, mock_socket_cls):
-    mock_socket = mock.Mock()
+    mock_socket = unittest.mock.Mock()
     mock_socket.connect.side_effect = socket.error()
     mock_socket_cls.return_value = mock_socket
 
     with self.assertRaises(NailgunClient.NailgunConnectionError):
       self.nailgun_client.try_connect()
 
-  @mock.patch.object(NailgunClient, 'try_connect', **PATCH_OPTS)
-  @mock.patch('pants.java.nailgun_client.NailgunClientSession', **PATCH_OPTS)
+  @unittest.mock.patch.object(NailgunClient, 'try_connect', **PATCH_OPTS)
+  @unittest.mock.patch('pants.java.nailgun_client.NailgunClientSession', **PATCH_OPTS)
   def test_execute(self, mock_session, mock_try_connect):
     self.nailgun_client.execute('test')
     self.assertEqual(mock_try_connect.call_count, 1)
     self.assertEqual(mock_session.call_count, 1)
 
-  @mock.patch.object(NailgunClient, 'try_connect', **PATCH_OPTS)
-  @mock.patch('pants.java.nailgun_client.NailgunClientSession', **PATCH_OPTS)
+  @unittest.mock.patch.object(NailgunClient, 'try_connect', **PATCH_OPTS)
+  @unittest.mock.patch('pants.java.nailgun_client.NailgunClientSession', **PATCH_OPTS)
   def test_execute_propagates_connection_error_on_connect(self, mock_session, mock_try_connect):
     mock_try_connect.side_effect = NailgunClient.NailgunConnectionError(
       '127.0.0.1:31337',
@@ -159,16 +158,16 @@ class TestNailgunClient(unittest.TestCase):
     with self.assertRaises(NailgunClient.NailgunConnectionError):
       self.nailgun_client.execute('test')
 
-  @mock.patch.object(NailgunClient, 'try_connect', **PATCH_OPTS)
-  @mock.patch('pants.java.nailgun_client.NailgunClientSession', **PATCH_OPTS)
+  @unittest.mock.patch.object(NailgunClient, 'try_connect', **PATCH_OPTS)
+  @unittest.mock.patch('pants.java.nailgun_client.NailgunClientSession', **PATCH_OPTS)
   def test_execute_socketerror_on_execute(self, mock_session, mock_try_connect):
     mock_session.return_value.execute.side_effect = socket.error('oops')
 
     with self.assertRaises(NailgunClient.NailgunError):
       self.nailgun_client.execute('test')
 
-  @mock.patch.object(NailgunClient, 'try_connect', **PATCH_OPTS)
-  @mock.patch('pants.java.nailgun_client.NailgunClientSession', **PATCH_OPTS)
+  @unittest.mock.patch.object(NailgunClient, 'try_connect', **PATCH_OPTS)
+  @unittest.mock.patch('pants.java.nailgun_client.NailgunClientSession', **PATCH_OPTS)
   def test_execute_protocolerror_on_execute(self, mock_session, mock_try_connect):
     mock_session.return_value.ProtocolError = NailgunProtocol.ProtocolError
     mock_session.return_value.execute.side_effect = NailgunProtocol.ProtocolError('oops')
@@ -179,31 +178,31 @@ class TestNailgunClient(unittest.TestCase):
   def test_repr(self):
     self.assertIsNotNone(repr(self.nailgun_client))
 
-  @mock.patch('os.kill', **PATCH_OPTS)
+  @unittest.mock.patch('os.kill', **PATCH_OPTS)
   def test_send_control_c(self, mock_kill):
     self.nailgun_client._maybe_last_pid = lambda: 31337
     self.nailgun_client._maybe_last_pgrp = lambda: -31336
     self.nailgun_client.maybe_send_signal(signal.SIGINT)
     mock_kill.assert_has_calls([
       # The pid is killed first, then the pgrp, if include_pgrp=True.
-      mock.call(31337, signal.SIGINT),
-      mock.call(-31336, signal.SIGINT),
+      unittest.mock.call(31337, signal.SIGINT),
+      unittest.mock.call(-31336, signal.SIGINT),
     ])
 
-  @mock.patch('os.kill', **PATCH_OPTS)
+  @unittest.mock.patch('os.kill', **PATCH_OPTS)
   def test_send_signal_no_pgrp(self, mock_kill):
     self.nailgun_client._maybe_last_pid = lambda: 111111
     self.nailgun_client.maybe_send_signal(signal.SIGINT, include_pgrp=False)
     mock_kill.assert_called_once_with(111111, signal.SIGINT)
 
-  @mock.patch('os.kill', **PATCH_OPTS)
+  @unittest.mock.patch('os.kill', **PATCH_OPTS)
   def test_send_control_c_noop_none(self, mock_kill):
     self.nailgun_client._session = None
     self.nailgun_client.maybe_send_signal(signal.SIGINT)
     mock_kill.assert_not_called()
 
-  @mock.patch('os.kill', **PATCH_OPTS)
+  @unittest.mock.patch('os.kill', **PATCH_OPTS)
   def test_send_control_c_noop_nopid(self, mock_kill):
-    self.nailgun_client._session = mock.Mock(remote_pid=None, remote_pgrp=None)
+    self.nailgun_client._session = unittest.mock.Mock(remote_pid=None, remote_pgrp=None)
     self.nailgun_client.maybe_send_signal(signal.SIGINT)
     mock_kill.assert_not_called()

--- a/tests/python/pants_test/java/test_nailgun_executor.py
+++ b/tests/python/pants_test/java/test_nailgun_executor.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import unittest.mock
 from contextlib import contextmanager
 
-import mock
 import psutil
 
 from pants.java.nailgun_executor import NailgunExecutor
@@ -15,7 +15,7 @@ PATCH_OPTS = dict(autospec=True, spec_set=True)
 
 
 def fake_process(**kwargs):
-  proc = mock.create_autospec(psutil.Process, spec_set=True)
+  proc = unittest.mock.create_autospec(psutil.Process, spec_set=True)
   [setattr(getattr(proc, k), 'return_value', v) for k, v in kwargs.items()]
   return proc
 
@@ -50,11 +50,11 @@ class NailgunExecutorTest(TestBase):
     self.executor = NailgunExecutor(identity='test',
                                     workdir='/__non_existent_dir',
                                     nailgun_classpath=[],
-                                    distribution=mock.Mock(),
+                                    distribution=unittest.mock.Mock(),
                                     metadata_base_dir=self.subprocess_dir)
 
   def test_is_alive_override(self):
-    with mock.patch.object(NailgunExecutor, '_as_process', **PATCH_OPTS) as mock_as_process:
+    with unittest.mock.patch.object(NailgunExecutor, '_as_process', **PATCH_OPTS) as mock_as_process:
       mock_as_process.return_value = fake_process(
         name='java',
         pid=3,
@@ -65,7 +65,7 @@ class NailgunExecutorTest(TestBase):
       mock_as_process.assert_called_with(self.executor)
 
   def test_is_alive_override_not_my_process(self):
-    with mock.patch.object(NailgunExecutor, '_as_process', **PATCH_OPTS) as mock_as_process:
+    with unittest.mock.patch.object(NailgunExecutor, '_as_process', **PATCH_OPTS) as mock_as_process:
       mock_as_process.return_value = fake_process(
         name='java',
         pid=3,
@@ -77,8 +77,8 @@ class NailgunExecutorTest(TestBase):
 
   def test_connect_timeout(self):
     with rw_pipes() as (stdout_read, _),\
-         mock.patch('pants.java.nailgun_executor.safe_open') as mock_open,\
-         mock.patch('pants.java.nailgun_executor.read_file') as mock_read_file:
+         unittest.mock.patch('pants.java.nailgun_executor.safe_open') as mock_open,\
+         unittest.mock.patch('pants.java.nailgun_executor.read_file') as mock_read_file:
       mock_open.return_value = stdout_read
       mock_read_file.return_value = 'err'
       # The stdout write pipe has no input and hasn't been closed, so the select.select() should

--- a/tests/python/pants_test/java/test_nailgun_io.py
+++ b/tests/python/pants_test/java/test_nailgun_io.py
@@ -5,8 +5,7 @@ import inspect
 import io
 import time
 import unittest
-
-import mock
+import unittest.mock
 
 from pants.java.nailgun_io import NailgunStreamWriter, Pipe, PipedNailgunStreamWriter
 from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
@@ -18,7 +17,7 @@ PATCH_OPTS = dict(autospec=True, spec_set=True)
 class TestNailgunStreamWriter(unittest.TestCase):
   def setUp(self):
     self.in_fd = -1
-    self.mock_socket = mock.Mock()
+    self.mock_socket = unittest.mock.Mock()
     self.writer = NailgunStreamWriter(
       (self.in_fd,),
       self.mock_socket,
@@ -35,16 +34,16 @@ class TestNailgunStreamWriter(unittest.TestCase):
   def test_startable(self):
     self.assertTrue(inspect.ismethod(self.writer.start))
 
-  @mock.patch('select.select')
+  @unittest.mock.patch('select.select')
   def test_run_stop_on_error(self, mock_select):
     mock_select.return_value = ([], [], [self.in_fd])
     self.writer.run()
     self.assertFalse(self.writer.is_alive())
     self.assertEqual(mock_select.call_count, 1)
 
-  @mock.patch('os.read')
-  @mock.patch('select.select')
-  @mock.patch.object(NailgunProtocol, 'write_chunk')
+  @unittest.mock.patch('os.read')
+  @unittest.mock.patch('select.select')
+  @unittest.mock.patch.object(NailgunProtocol, 'write_chunk')
   def test_run_read_write(self, mock_writer, mock_select, mock_read):
     mock_select.side_effect = [
       ([self.in_fd], [], []),
@@ -70,18 +69,18 @@ class TestNailgunStreamWriter(unittest.TestCase):
     self.assertEqual(mock_read.call_count, 2)
 
     mock_writer.assert_has_calls([
-      mock.call(mock.ANY, ChunkType.STDIN, b'A' * 300),
-      mock.call(mock.ANY, ChunkType.STDIN_EOF)
+      unittest.mock.call(unittest.mock.ANY, ChunkType.STDIN, b'A' * 300),
+      unittest.mock.call(unittest.mock.ANY, ChunkType.STDIN_EOF)
     ])
 
 
 class TestPipedNailgunStreamWriter(unittest.TestCase):
   def setUp(self):
-    self.mock_socket = mock.Mock()
+    self.mock_socket = unittest.mock.Mock()
 
-  @mock.patch('os.read')
-  @mock.patch('select.select')
-  @mock.patch.object(NailgunProtocol, 'write_chunk')
+  @unittest.mock.patch('os.read')
+  @unittest.mock.patch('select.select')
+  @unittest.mock.patch.object(NailgunProtocol, 'write_chunk')
   def test_auto_shutdown_on_write_end_closed(self, mock_writer, mock_select, mock_read):
     pipe = Pipe.create(False)
     test_data = [b"A"] * 1000 + [b'']
@@ -101,4 +100,4 @@ class TestPipedNailgunStreamWriter(unittest.TestCase):
       writer.join(1)
       self.assertFalse(writer.is_alive())
 
-    mock_writer.assert_has_calls([mock.call(mock.ANY, ChunkType.STDOUT, b'A')] * (len(test_data) - 1))
+    mock_writer.assert_has_calls([unittest.mock.call(unittest.mock.ANY, ChunkType.STDOUT, b'A')] * (len(test_data) - 1))

--- a/tests/python/pants_test/java/test_nailgun_protocol.py
+++ b/tests/python/pants_test/java/test_nailgun_protocol.py
@@ -3,8 +3,7 @@
 
 import socket
 import unittest
-
-import mock
+import unittest.mock
 
 from pants.java.nailgun_protocol import ChunkType, MaybeShutdownSocket, NailgunProtocol
 
@@ -66,7 +65,7 @@ class TestNailgunProtocol(unittest.TestCase):
 
   def test_read_until(self):
     recv_chunks = [b'1', b'234', b'56', b'789', b'0']
-    mock_socket = mock.Mock()
+    mock_socket = unittest.mock.Mock()
     mock_socket.recv.side_effect = recv_chunks
     self.assertEqual(NailgunProtocol._read_until(mock_socket, 10), b'1234567890')
     self.assertEqual(mock_socket.recv.call_count, len(recv_chunks))
@@ -230,14 +229,14 @@ class TestNailgunProtocol(unittest.TestCase):
     )
 
   def _make_mock_stream(self, isatty, fileno):
-    mock_stream = mock.Mock()
+    mock_stream = unittest.mock.Mock()
     mock_stream.isatty.return_value = isatty
     mock_stream.fileno.return_value = fileno
     return mock_stream
 
   _fake_ttyname = '/this/is/not/a/real/tty'
 
-  @mock.patch('os.ttyname', autospec=True, spec_set=True)
+  @unittest.mock.patch('os.ttyname', autospec=True, spec_set=True)
   def test_isatty_to_env_with_mock_tty(self, mock_ttyname):
     mock_ttyname.return_value = self._fake_ttyname
     mock_stdin = self._make_mock_stream(True, 0)

--- a/tests/python/pants_test/java/test_util.py
+++ b/tests/python/pants_test/java/test_util.py
@@ -4,8 +4,7 @@
 import os
 import unittest
 from contextlib import contextmanager
-
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from pants.java.executor import Executor
 from pants.java.jar.manifest import Manifest

--- a/tests/python/pants_test/net/http/BUILD
+++ b/tests/python/pants_test/net/http/BUILD
@@ -3,7 +3,6 @@
 
 python_tests(
   dependencies = [
-    '3rdparty/python:mock',
     '3rdparty/python:requests',
     '3rdparty/python:pyopenssl',
     'src/python/pants/net',

--- a/tests/python/pants_test/option/BUILD
+++ b/tests/python/pants_test/option/BUILD
@@ -5,7 +5,6 @@ python_tests(
   name='testing',
   sources=globs('*.py', exclude=[globs('*_integration.py')]),
   dependencies=[
-    '3rdparty/python:mock',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:deprecated',
     'src/python/pants/option',

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -5,10 +5,10 @@ import io
 import json
 import os
 import shlex
+import unittest.mock
 from contextlib import contextmanager
 from textwrap import dedent
 
-import mock
 import yaml
 from future.utils import text_type
 from packaging.version import Version
@@ -923,7 +923,7 @@ class OptionsTest(TestBase):
       self.assertEqual('stale_and_crufty', options.for_scope('stale').crufty)
       self.assertOptionWarning(w, 'crufty')
 
-  @mock.patch('pants.base.deprecated.PANTS_SEMVER', Version(_FAKE_CUR_VERSION))
+  @unittest.mock.patch('pants.base.deprecated.PANTS_SEMVER', Version(_FAKE_CUR_VERSION))
   def test_delayed_deprecated_option(self):
     with self.warnings_catcher() as w:
       delayed_deprecation_option_value = (

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -4,7 +4,6 @@
 target(
   name = 'test_deps',
   dependencies = [
-    '3rdparty/python:mock',
     'tests/python/pants_test:test_base'
   ]
 )

--- a/tests/python/pants_test/pantsd/service/test_fs_event_service.py
+++ b/tests/python/pants_test/pantsd/service/test_fs_event_service.py
@@ -1,9 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import unittest.mock
 from contextlib import contextmanager
-
-import mock
 
 from pants.pantsd.service.fs_event_service import FSEventService
 from pants.pantsd.watchman import Watchman
@@ -19,7 +18,7 @@ class TestFSEventService(TestBase):
 
   def setUp(self):
     super().setUp()
-    self.mock_watchman = mock.create_autospec(Watchman, spec_set=True)
+    self.mock_watchman = unittest.mock.create_autospec(Watchman, spec_set=True)
     self.service = FSEventService(self.mock_watchman, self.BUILD_ROOT)
     self.service.setup(None)
     self.service.register_all_files_handler(lambda x: True, name='test')
@@ -45,7 +44,7 @@ class TestFSEventService(TestBase):
 
   @contextmanager
   def mocked_run(self, asserts=True):
-    self.service.fire_callback = mock.Mock()
+    self.service.fire_callback = unittest.mock.Mock()
     yield self.service.fire_callback
     if asserts:
       self.mock_watchman.watch_project.assert_called_once_with(self.BUILD_ROOT)
@@ -59,7 +58,7 @@ class TestFSEventService(TestBase):
     with self.mocked_run() as mock_callback:
       self.mock_watchman.subscribed.return_value = self.FAKE_EVENT_STREAM
       self.service.run()
-      mock_callback.assert_has_calls([mock.call(*self.FAKE_EVENT), mock.call(*self.FAKE_EVENT)],
+      mock_callback.assert_has_calls([unittest.mock.call(*self.FAKE_EVENT), unittest.mock.call(*self.FAKE_EVENT)],
                                      any_order=True)
 
   def test_run_failed_callback(self):
@@ -67,7 +66,7 @@ class TestFSEventService(TestBase):
       self.mock_watchman.subscribed.return_value = self.FAKE_EVENT_STREAM
       mock_callback.side_effect = [False, True]
       self.service.run()
-      mock_callback.assert_has_calls([mock.call(*self.FAKE_EVENT), mock.call(*self.FAKE_EVENT)],
+      mock_callback.assert_has_calls([unittest.mock.call(*self.FAKE_EVENT), unittest.mock.call(*self.FAKE_EVENT)],
                                      any_order=True)
 
   def test_run_breaks_on_kill_switch(self):

--- a/tests/python/pants_test/pantsd/service/test_pailgun_service.py
+++ b/tests/python/pants_test/pantsd/service/test_pailgun_service.py
@@ -2,8 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import unittest
-
-import mock
+import unittest.mock
 
 from pants.pantsd.service.pailgun_service import PailgunService
 
@@ -17,23 +16,23 @@ class FakePailgun:
 
 class TestPailgunService(unittest.TestCase):
   def setUp(self):
-    self.mock_exiter_class = mock.Mock(side_effect=Exception('should not be called'))
-    self.mock_runner_class = mock.Mock(side_effect=Exception('should not be called'))
-    self.mock_scheduler_service = mock.Mock(side_effect=Exception('should not be called'))
-    self.mock_target_roots_calculator = mock.Mock(side_effect=Exception('should not be called'))
+    self.mock_exiter_class = unittest.mock.Mock(side_effect=Exception('should not be called'))
+    self.mock_runner_class = unittest.mock.Mock(side_effect=Exception('should not be called'))
+    self.mock_scheduler_service = unittest.mock.Mock(side_effect=Exception('should not be called'))
+    self.mock_target_roots_calculator = unittest.mock.Mock(side_effect=Exception('should not be called'))
     self.service = PailgunService(bind_addr=(None, None),
                                   runner_class=self.mock_runner_class,
                                   scheduler_service=self.mock_scheduler_service,
                                   shutdown_after_run=False)
 
-  @mock.patch.object(PailgunService, '_setup_pailgun', **PATCH_OPTS)
+  @unittest.mock.patch.object(PailgunService, '_setup_pailgun', **PATCH_OPTS)
   def test_pailgun_property_values(self, mock_setup):
     fake_pailgun = FakePailgun()
     mock_setup.return_value = fake_pailgun
     self.assertIs(self.service.pailgun, fake_pailgun)
     self.assertEqual(self.service.pailgun_port, 33333)
 
-  @mock.patch.object(PailgunService, 'terminate', **PATCH_OPTS)
+  @unittest.mock.patch.object(PailgunService, 'terminate', **PATCH_OPTS)
   def test_pailgun_service_closes_when_callback_is_called(self, mock_setup):
     fake_pailgun = FakePailgun()
     mock_setup.return_value = fake_pailgun

--- a/tests/python/pants_test/pantsd/test_pants_daemon.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon.py
@@ -3,8 +3,7 @@
 
 import logging
 import sys
-
-import mock
+import unittest.mock
 
 from pants.pantsd.pants_daemon import PantsDaemon, _LoggerStream
 from pants.pantsd.service.pants_service import PantsService, PantsServices
@@ -20,28 +19,28 @@ class LoggerStreamTest(TestBase):
   TEST_LOG_LEVEL = logging.INFO
 
   def test_write(self):
-    mock_logger = mock.Mock()
+    mock_logger = unittest.mock.Mock()
     _LoggerStream(mock_logger, self.TEST_LOG_LEVEL, None).write('testing 1 2 3')
     mock_logger.log.assert_called_once_with(self.TEST_LOG_LEVEL, 'testing 1 2 3')
 
   def test_write_multiline(self):
-    mock_logger = mock.Mock()
+    mock_logger = unittest.mock.Mock()
     _LoggerStream(mock_logger, self.TEST_LOG_LEVEL, None).write('testing\n1\n2\n3\n\n')
     mock_logger.log.assert_has_calls([
-      mock.call(self.TEST_LOG_LEVEL, 'testing'),
-      mock.call(self.TEST_LOG_LEVEL, '1'),
-      mock.call(self.TEST_LOG_LEVEL, '2'),
-      mock.call(self.TEST_LOG_LEVEL, '3')
+      unittest.mock.call(self.TEST_LOG_LEVEL, 'testing'),
+      unittest.mock.call(self.TEST_LOG_LEVEL, '1'),
+      unittest.mock.call(self.TEST_LOG_LEVEL, '2'),
+      unittest.mock.call(self.TEST_LOG_LEVEL, '3')
     ])
 
   def test_flush(self):
-    _LoggerStream(mock.Mock(), self.TEST_LOG_LEVEL, None).flush()
+    _LoggerStream(unittest.mock.Mock(), self.TEST_LOG_LEVEL, None).flush()
 
 
 class PantsDaemonTest(TestBase):
   def setUp(self):
     super().setUp()
-    mock_options = mock.Mock()
+    mock_options = unittest.mock.Mock()
     mock_options.pants_subprocessdir = 'non_existent_dir'
     self.pantsd = PantsDaemon(None,
                               'test_buildroot',
@@ -50,22 +49,22 @@ class PantsDaemonTest(TestBase):
                               PantsServices(),
                               '/tmp/pants_test_metadata_dir',
                               mock_options)
-    self.mock_killswitch = mock.Mock()
+    self.mock_killswitch = unittest.mock.Mock()
     self.pantsd._kill_switch = self.mock_killswitch
-    self.mock_service = mock.create_autospec(PantsService, spec_set=True)
+    self.mock_service = unittest.mock.create_autospec(PantsService, spec_set=True)
 
-  @mock.patch('os.close', **PATCH_OPTS)
+  @unittest.mock.patch('os.close', **PATCH_OPTS)
   def test_close_stdio(self, mock_close):
     with stdio_as(-1, -1, -1):
       handles = (sys.stdin, sys.stdout, sys.stderr)
       fds = [h.fileno() for h in handles]
       self.pantsd._close_stdio()
-      mock_close.assert_has_calls(mock.call(x) for x in fds)
+      mock_close.assert_has_calls(unittest.mock.call(x) for x in fds)
       for handle in handles:
         self.assertTrue(handle.closed, '{} was not closed'.format(handle))
 
   def test_shutdown(self):
-    mock_thread = mock.Mock()
+    mock_thread = unittest.mock.Mock()
     mock_service_thread_map = {self.mock_service: mock_thread}
 
     self.pantsd.shutdown(mock_service_thread_map)
@@ -77,8 +76,8 @@ class PantsDaemonTest(TestBase):
   def test_run_services_no_services(self):
     self.pantsd._run_services(PantsServices())
 
-  @mock.patch('threading.Thread', **PATCH_OPTS)
-  @mock.patch.object(PantsDaemon, 'shutdown', spec_set=True)
+  @unittest.mock.patch('threading.Thread', **PATCH_OPTS)
+  @unittest.mock.patch.object(PantsDaemon, 'shutdown', spec_set=True)
   def test_run_services_startupfailure(self, mock_shutdown, mock_thread):
     mock_thread.return_value.start.side_effect = RuntimeError('oops!')
 
@@ -87,10 +86,10 @@ class PantsDaemonTest(TestBase):
 
     self.assertGreater(mock_shutdown.call_count, 0)
 
-  @mock.patch('threading.Thread', **PATCH_OPTS)
-  @mock.patch.object(PantsDaemon, 'shutdown', spec_set=True)
-  @mock.patch.object(PantsDaemon, 'options_fingerprint', spec_set=True,
-                     new_callable=mock.PropertyMock)
+  @unittest.mock.patch('threading.Thread', **PATCH_OPTS)
+  @unittest.mock.patch.object(PantsDaemon, 'shutdown', spec_set=True)
+  @unittest.mock.patch.object(PantsDaemon, 'options_fingerprint', spec_set=True,
+                     new_callable=unittest.mock.PropertyMock)
   def test_run_services_runtimefailure(self, mock_fp, mock_shutdown, mock_thread):
     self.mock_killswitch.is_set.side_effect = [False, False, True]
     mock_thread.return_value.is_alive.side_effect = [True, False]

--- a/tests/python/pants_test/pantsd/test_watchman.py
+++ b/tests/python/pants_test/pantsd/test_watchman.py
@@ -4,9 +4,9 @@
 import json
 import os
 import sys
+import unittest.mock
 from contextlib import contextmanager
 
-import mock
 import pywatchman
 
 from pants.pantsd.watchman import Watchman
@@ -19,11 +19,11 @@ class TestWatchman(TestBase):
   BUILD_ROOT = '/path/to/a/fake/build_root'
   WATCHMAN_PATH = '/path/to/a/fake/watchman'
   TEST_DIR = '/path/to/a/fake/test'
-  HANDLERS = [Watchman.EventHandler('test', {}, mock.Mock())]
+  HANDLERS = [Watchman.EventHandler('test', {}, unittest.mock.Mock())]
 
   def setUp(self):
     super().setUp()
-    with mock.patch.object(Watchman, '_is_valid_executable', **self.PATCH_OPTS) as mock_is_valid:
+    with unittest.mock.patch.object(Watchman, '_is_valid_executable', **self.PATCH_OPTS) as mock_is_valid:
       mock_is_valid.return_value = True
       self.watchman = Watchman('/fake/path/to/watchman', self.subprocess_dir)
 
@@ -55,8 +55,8 @@ class TestWatchman(TestBase):
 
   def test_maybe_init_metadata(self):
     # TODO(#7106): is this the right path to patch?
-    with mock.patch('pants.pantsd.watchman.safe_mkdir', **self.PATCH_OPTS) as mock_mkdir, \
-         mock.patch('pants.pantsd.watchman.safe_file_dump', **self.PATCH_OPTS) as mock_file_dump:
+    with unittest.mock.patch('pants.pantsd.watchman.safe_mkdir', **self.PATCH_OPTS) as mock_mkdir, \
+         unittest.mock.patch('pants.pantsd.watchman.safe_file_dump', **self.PATCH_OPTS) as mock_file_dump:
       self.watchman._maybe_init_metadata()
 
       mock_mkdir.assert_called_once_with(self._watchman_dir)
@@ -97,10 +97,10 @@ class TestWatchman(TestBase):
       self.watchman._parse_pid_from_output(output)
 
   def test_launch(self):
-    with mock.patch.object(Watchman, '_maybe_init_metadata') as mock_initmeta, \
-         mock.patch.object(Watchman, 'get_subprocess_output') as mock_getsubout, \
-         mock.patch.object(Watchman, 'write_pid') as mock_writepid, \
-         mock.patch.object(Watchman, 'write_socket') as mock_writesock:
+    with unittest.mock.patch.object(Watchman, '_maybe_init_metadata') as mock_initmeta, \
+         unittest.mock.patch.object(Watchman, 'get_subprocess_output') as mock_getsubout, \
+         unittest.mock.patch.object(Watchman, 'write_pid') as mock_writepid, \
+         unittest.mock.patch.object(Watchman, 'write_socket') as mock_writesock:
       mock_getsubout.return_value = json.dumps(dict(pid='3'))
       self.watchman.launch()
       assert mock_getsubout.called
@@ -109,13 +109,13 @@ class TestWatchman(TestBase):
       mock_writesock.assert_called_once_with(self.watchman._sock_file)
 
   def test_watch_project(self):
-    self.watchman._watchman_client = mock.create_autospec(StreamableWatchmanClient, spec_set=True)
+    self.watchman._watchman_client = unittest.mock.create_autospec(StreamableWatchmanClient, spec_set=True)
     self.watchman.watch_project(self.TEST_DIR)
     self.watchman._watchman_client.query.assert_called_once_with('watch-project', self.TEST_DIR)
 
   @contextmanager
   def setup_subscribed(self, iterable):
-    mock_client = mock.create_autospec(StreamableWatchmanClient, spec_set=True)
+    mock_client = unittest.mock.create_autospec(StreamableWatchmanClient, spec_set=True)
     mock_client.stream_query.return_value = iter(iterable)
     self.watchman._watchman_client = mock_client
     yield mock_client

--- a/tests/python/pants_test/pantsd/test_watchman_client.py
+++ b/tests/python/pants_test/pantsd/test_watchman_client.py
@@ -1,9 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import unittest.mock
 from contextlib import contextmanager
-
-import mock
 
 from pants.pantsd.watchman_client import StreamableWatchmanClient
 from pants_test.test_base import TestBase
@@ -16,9 +15,9 @@ class TestWatchmanClient(TestBase):
 
   @contextmanager
   def setup_stream_query(self):
-    with mock.patch.object(StreamableWatchmanClient, '_connect') as mock_connect, \
-         mock.patch.object(StreamableWatchmanClient, 'sendConn') as mock_sendconn, \
-         mock.patch.object(StreamableWatchmanClient, 'recvConn') as mock_recvconn:
+    with unittest.mock.patch.object(StreamableWatchmanClient, '_connect') as mock_connect, \
+         unittest.mock.patch.object(StreamableWatchmanClient, 'sendConn') as mock_sendconn, \
+         unittest.mock.patch.object(StreamableWatchmanClient, 'recvConn') as mock_recvconn:
       yield mock_connect, mock_sendconn, mock_recvconn
 
   def test_stream_query(self):

--- a/tests/python/pants_test/pantsd/test_watchman_launcher.py
+++ b/tests/python/pants_test/pantsd/test_watchman_launcher.py
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import mock
+import unittest.mock
 
 from pants.pantsd.watchman import Watchman
 from pants.pantsd.watchman_launcher import WatchmanLauncher
@@ -14,7 +14,7 @@ class TestWatchmanLauncher(TestBase):
     return WatchmanLauncher.create(bootstrap_options)
 
   def create_mock_watchman(self, is_alive):
-    mock_watchman = mock.create_autospec(Watchman, spec_set=False)
+    mock_watchman = unittest.mock.create_autospec(Watchman, spec_set=False)
     mock_watchman.ExecutionError = Watchman.ExecutionError
     mock_watchman.is_alive.return_value = is_alive
     return mock_watchman

--- a/tests/python/pants_test/process/BUILD
+++ b/tests/python/pants_test/process/BUILD
@@ -3,7 +3,6 @@
 
 python_tests(
   dependencies = [
-    '3rdparty/python:mock',
     '3rdparty/python:six',
     'src/python/pants/process',
     'tests/python/pants_test:test_base',

--- a/tests/python/pants_test/process/test_xargs.py
+++ b/tests/python/pants_test/process/test_xargs.py
@@ -4,15 +4,14 @@
 import errno
 import os
 import unittest
-
-import mock
+import unittest.mock
 
 from pants.process.xargs import Xargs
 
 
 class XargsTest(unittest.TestCase):
   def setUp(self):
-    self.call = mock.Mock()
+    self.call = unittest.mock.Mock()
     self.xargs = Xargs(self.call)
 
   def test_execute_nosplit_success(self):
@@ -46,9 +45,9 @@ class XargsTest(unittest.TestCase):
 
     self.assertEqual(0, self.xargs.execute(['one', 'two', 'three', 'four']))
 
-    self.assertEqual([mock.call(['one', 'two', 'three', 'four']),
-                      mock.call(['one', 'two']),
-                      mock.call(['three', 'four'])],
+    self.assertEqual([unittest.mock.call(['one', 'two', 'three', 'four']),
+                      unittest.mock.call(['one', 'two']),
+                      unittest.mock.call(['three', 'four'])],
                      self.call.mock_calls)
 
   def test_execute_uneven(self):
@@ -57,10 +56,10 @@ class XargsTest(unittest.TestCase):
     self.assertEqual(0, self.xargs.execute(['one', 'two', 'three']))
 
     self.assertEqual(3, self.call.call_count)
-    self.assertEqual(mock.call(['one', 'two', 'three']),
+    self.assertEqual(unittest.mock.call(['one', 'two', 'three']),
                      self.call.mock_calls[0])
 
-    self.assertEqual(sorted((mock.call(['one']), mock.call(['two', 'three']))),
+    self.assertEqual(sorted((unittest.mock.call(['one']), unittest.mock.call(['two', 'three']))),
                      sorted(self.call.mock_calls[1:]))
 
   def test_execute_split_multirecurse(self):
@@ -68,11 +67,11 @@ class XargsTest(unittest.TestCase):
 
     self.assertEqual(0, self.xargs.execute(['one', 'two', 'three', 'four']))
 
-    self.assertEqual([mock.call(['one', 'two', 'three', 'four']),
-                      mock.call(['one', 'two']),
-                      mock.call(['one']),
-                      mock.call(['two']),
-                      mock.call(['three', 'four'])],
+    self.assertEqual([unittest.mock.call(['one', 'two', 'three', 'four']),
+                      unittest.mock.call(['one', 'two']),
+                      unittest.mock.call(['one']),
+                      unittest.mock.call(['two']),
+                      unittest.mock.call(['three', 'four'])],
                      self.call.mock_calls)
 
   def test_execute_split_fail_fast(self):
@@ -80,8 +79,8 @@ class XargsTest(unittest.TestCase):
 
     self.assertEqual(42, self.xargs.execute(['one', 'two', 'three', 'four']))
 
-    self.assertEqual([mock.call(['one', 'two', 'three', 'four']),
-                      mock.call(['one', 'two'])],
+    self.assertEqual([unittest.mock.call(['one', 'two', 'three', 'four']),
+                      unittest.mock.call(['one', 'two'])],
                      self.call.mock_calls)
 
   def test_execute_split_fail_slow(self):
@@ -89,7 +88,7 @@ class XargsTest(unittest.TestCase):
 
     self.assertEqual(42, self.xargs.execute(['one', 'two', 'three', 'four']))
 
-    self.assertEqual([mock.call(['one', 'two', 'three', 'four']),
-                      mock.call(['one', 'two']),
-                      mock.call(['three', 'four'])],
+    self.assertEqual([unittest.mock.call(['one', 'two', 'three', 'four']),
+                      unittest.mock.call(['one', 'two']),
+                      unittest.mock.call(['three', 'four'])],
                      self.call.mock_calls)

--- a/tests/python/pants_test/rules/BUILD
+++ b/tests/python/pants_test/rules/BUILD
@@ -6,7 +6,6 @@ python_tests(
   name='filedeps',
   source='test_filedeps.py',
   dependencies=[
-    '3rdparty/python:mock',
     'src/python/pants/build_graph',
     'src/python/pants/engine/legacy:graph',
     'src/python/pants/rules/core',

--- a/tests/python/pants_test/rules/test_filedeps.py
+++ b/tests/python/pants_test/rules/test_filedeps.py
@@ -3,8 +3,8 @@
 
 import unittest
 from textwrap import dedent
+from unittest.mock import Mock
 
-from mock import Mock
 from pex.orderedset import OrderedSet
 
 from pants.build_graph.address import Address, BuildFileAddress

--- a/tests/python/pants_test/task/BUILD
+++ b/tests/python/pants_test/task/BUILD
@@ -50,7 +50,6 @@ python_tests(
   sources=['test_scm_publish_mixin.py'],
   coverage=['pants.task.scm_publish_mixin'],
   dependencies=[
-    '3rdparty/python:mock',
     'src/python/pants/task',
   ]
 )
@@ -73,7 +72,6 @@ python_tests(
   name='testrunner_task_mixin',
   sources=['test_testrunner_task_mixin.py'],
   dependencies=[
-    '3rdparty/python:mock',
     'src/python/pants/task',
     'src/python/pants/util:process_handler',
     'tests/python/pants_test:task_test_base',

--- a/tests/python/pants_test/task/test_scm_publish_mixin.py
+++ b/tests/python/pants_test/task/test_scm_publish_mixin.py
@@ -2,8 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import unittest
-
-import mock
+import unittest.mock
 
 from pants.task.scm_publish_mixin import Namedver, ScmPublishMixin
 
@@ -13,8 +12,8 @@ class ScmPublishMixinTest(unittest.TestCase):
     def __init__(self, restrict_push_branches=None, restrict_push_urls=None, scm_available=True):
       self._restrict_push_branches = restrict_push_branches
       self._restrict_push_urls = restrict_push_urls
-      self._scm = mock.Mock() if scm_available else None
-      self._log = mock.MagicMock()
+      self._scm = unittest.mock.Mock() if scm_available else None
+      self._log = unittest.mock.MagicMock()
 
     @property
     def restrict_push_branches(self):
@@ -48,8 +47,8 @@ class ScmPublishMixinTest(unittest.TestCase):
   def test_check_clean_master_dry_run_bad_remote(self):
     scm_publish = self.ScmPublish(restrict_push_urls=['amy'])
     # Property mocks must be installed on the type instead of on the instance, see:
-    #   http://www.voidspace.org.uk/python/mock/mock.html#mock.PropertyMock
-    type(scm_publish.scm).server_url = mock.PropertyMock(side_effect=AssertionError)
+    #   https://docs.python.org/3/library/unittest.mock.html#unittest.mock.PropertyMock
+    type(scm_publish.scm).server_url = unittest.mock.PropertyMock(side_effect=AssertionError)
     scm_publish.check_clean_master(commit=False)
 
   def test_check_clean_master_dry_run_unclean(self):

--- a/tests/python/pants_test/task/test_testrunner_task_mixin.py
+++ b/tests/python/pants_test/task/test_testrunner_task_mixin.py
@@ -5,9 +5,8 @@ import collections
 import os
 from contextlib import contextmanager
 from unittest import TestCase
+from unittest.mock import Mock, patch
 from xml.etree.ElementTree import ParseError
-
-from mock import Mock, patch
 
 from pants.base.exceptions import ErrorWhileTesting
 from pants.task.task import TaskBase

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -25,7 +25,6 @@ python_tests(
   coverage = ['pants.util.contextutil'],
   dependencies = [
     '3rdparty/python:future',
-    '3rdparty/python:mock',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:process_handler',
   ]
@@ -36,7 +35,6 @@ python_tests(
   sources = ['test_dirutil.py'],
   coverage = ['pants.util.dirutil'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:objects',
@@ -56,7 +54,6 @@ python_tests(
   name = 'fileutil',
   sources = ['test_fileutil.py'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:fileutil',
   ]
@@ -93,7 +90,6 @@ python_tests(
   sources = ['test_netrc.py'],
   dependencies = [
     '3rdparty/python:future',
-    '3rdparty/python:mock',
     'src/python/pants/util:netrc',
   ]
 )
@@ -131,7 +127,6 @@ python_tests(
   name = 'retry',
   sources = ['test_retry.py'],
   dependencies = [
-    '3rdparty/python:mock',
     'src/python/pants/util:retry',
   ]
 )
@@ -151,7 +146,6 @@ python_tests(
   coverage = ['pants.util.socket'],
   dependencies = [
     '3rdparty/python:future',
-    '3rdparty/python:mock',
     'src/python/pants/util:socket',
   ]
 )

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -7,11 +7,11 @@ import shutil
 import signal
 import sys
 import unittest
+import unittest.mock
 import uuid
 import zipfile
 from contextlib import contextmanager
 
-import mock
 from future.utils import PY3
 
 from pants.util.contextutil import (InvalidZipPath, Timer, environment_as, exception_logging,
@@ -290,7 +290,7 @@ class ContextutilTest(unittest.TestCase):
   def test_signal_handler_as(self):
     mock_initial_handler = 1
     mock_new_handler = 2
-    with mock.patch('signal.signal', **PATCH_OPTS) as mock_signal:
+    with unittest.mock.patch('signal.signal', **PATCH_OPTS) as mock_signal:
       mock_signal.return_value = mock_initial_handler
       try:
         with signal_handler_as(signal.SIGUSR2, mock_new_handler):
@@ -299,8 +299,8 @@ class ContextutilTest(unittest.TestCase):
         pass
     self.assertEqual(mock_signal.call_count, 2)
     mock_signal.assert_has_calls([
-      mock.call(signal.SIGUSR2, mock_new_handler),
-      mock.call(signal.SIGUSR2, mock_initial_handler)
+      unittest.mock.call(signal.SIGUSR2, mock_new_handler),
+      unittest.mock.call(signal.SIGUSR2, mock_initial_handler)
     ])
 
   def test_permissions(self):
@@ -311,7 +311,7 @@ class ContextutilTest(unittest.TestCase):
       self.assertEqual(0o644, os.stat(path)[0] & 0o777)
 
   def test_exception_logging(self):
-    fake_logger = mock.Mock()
+    fake_logger = unittest.mock.Mock()
 
     with self.assertRaises(AssertionError):
       with exception_logging(fake_logger, 'error!'):

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -5,9 +5,8 @@ import errno
 import os
 import time
 import unittest
+import unittest.mock
 from contextlib import contextmanager
-
-import mock
 
 from pants.util import dirutil
 from pants.util.contextutil import pushd, temporary_dir
@@ -21,7 +20,7 @@ from pants.util.objects import datatype
 
 
 def strict_patch(target, **kwargs):
-  return mock.patch(target, autospec=True, spec_set=True, **kwargs)
+  return unittest.mock.patch(target, autospec=True, spec_set=True, **kwargs)
 
 
 class DirutilTest(unittest.TestCase):
@@ -107,8 +106,8 @@ class DirutilTest(unittest.TestCase):
 
     atexit_register.assert_called_once_with(faux_cleaner)
     self.assertTrue(os_getpid.called)
-    self.assertEqual([mock.call(dir='1'), mock.call(dir='2')], tempfile_mkdtemp.mock_calls)
-    self.assertEqual(sorted([mock.call(DIR1), mock.call(DIR2)]), sorted(dirutil_safe_rmtree.mock_calls))
+    self.assertEqual([unittest.mock.call(dir='1'), unittest.mock.call(dir='2')], tempfile_mkdtemp.mock_calls)
+    self.assertEqual(sorted([unittest.mock.call(DIR1), unittest.mock.call(DIR2)]), sorted(dirutil_safe_rmtree.mock_calls))
 
   def test_safe_walk(self):
     """Test that directory names are correctly represented as unicode strings"""
@@ -376,7 +375,7 @@ class DirutilTest(unittest.TestCase):
 
   def test_rm_rf_permission_error_raises(self, file_name='./perm_guarded_file'):
     with temporary_dir() as td, pushd(td), \
-         mock.patch('pants.util.dirutil.shutil.rmtree') as mock_rmtree, \
+         unittest.mock.patch('pants.util.dirutil.shutil.rmtree') as mock_rmtree, \
          self.assertRaises(OSError):
       mock_rmtree.side_effect = OSError(errno.EACCES, os.strerror(errno.EACCES))
       touch(file_name)
@@ -384,7 +383,7 @@ class DirutilTest(unittest.TestCase):
 
   def test_rm_rf_no_such_file_not_an_error(self, file_name='./vanishing_file'):
     with temporary_dir() as td, pushd(td), \
-         mock.patch('pants.util.dirutil.shutil.rmtree') as mock_rmtree:
+         unittest.mock.patch('pants.util.dirutil.shutil.rmtree') as mock_rmtree:
       mock_rmtree.side_effect = OSError(errno.ENOENT, os.strerror(errno.ENOENT))
       touch(file_name)
       rm_rf(file_name)

--- a/tests/python/pants_test/util/test_fileutil.py
+++ b/tests/python/pants_test/util/test_fileutil.py
@@ -6,8 +6,7 @@ import os
 import random
 import stat
 import unittest
-
-from mock import mock
+import unittest.mock
 
 from pants.util.contextutil import temporary_dir, temporary_file, temporary_file_path
 from pants.util.fileutil import (atomic_copy, create_size_estimators, safe_hardlink_or_copy,
@@ -70,7 +69,7 @@ class FileutilTest(unittest.TestCase):
     content = b'hello'
 
     # Mock os.link to throw an CROSS-DEVICE error
-    with mock.patch('os.link') as os_mock:
+    with unittest.mock.patch('os.link') as os_mock:
       err = OSError()
       err.errno = errno.EXDEV
       os_mock.side_effect = err

--- a/tests/python/pants_test/util/test_netrc.py
+++ b/tests/python/pants_test/util/test_netrc.py
@@ -4,9 +4,9 @@
 import re
 import unittest
 from contextlib import contextmanager
+from unittest.mock import MagicMock, mock_open, patch
 
 from future.utils import PY3
-from mock import MagicMock, mock_open, patch
 
 from pants.util.netrc import Netrc
 

--- a/tests/python/pants_test/util/test_retry.py
+++ b/tests/python/pants_test/util/test_retry.py
@@ -2,16 +2,15 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import unittest
-
-import mock
+import unittest.mock
 
 from pants.util.retry import retry_on_exception
 
 
 class RetryTest(unittest.TestCase):
-  @mock.patch('time.sleep', autospec=True, spec_set=True)
+  @unittest.mock.patch('time.sleep', autospec=True, spec_set=True)
   def test_retry_on_exception(self, mock_sleep):
-    broken_func = mock.Mock()
+    broken_func = unittest.mock.Mock()
     broken_func.side_effect = OSError('broken')
 
     with self.assertRaises(OSError):
@@ -20,24 +19,24 @@ class RetryTest(unittest.TestCase):
     self.assertEqual(broken_func.call_count, 3)
 
   def test_retry_on_exception_immediate_success(self):
-    working_func = mock.Mock()
+    working_func = unittest.mock.Mock()
     working_func.return_value = 'works'
 
     self.assertEqual(retry_on_exception(working_func, 3, (OSError,)), 'works')
     self.assertEqual(working_func.call_count, 1)
 
-  @mock.patch('time.sleep', autospec=True, spec_set=True)
+  @unittest.mock.patch('time.sleep', autospec=True, spec_set=True)
   def test_retry_on_exception_eventual_success(self, mock_sleep):
-    broken_func = mock.Mock()
+    broken_func = unittest.mock.Mock()
     broken_func.side_effect = [OSError('broken'), OSError('broken'), 'works now']
 
     retry_on_exception(broken_func, 3, (OSError,))
 
     self.assertEqual(broken_func.call_count, 3)
 
-  @mock.patch('time.sleep', autospec=True, spec_set=True)
+  @unittest.mock.patch('time.sleep', autospec=True, spec_set=True)
   def test_retry_on_exception_not_caught(self, mock_sleep):
-    broken_func = mock.Mock()
+    broken_func = unittest.mock.Mock()
     broken_func.side_effect = OSError('broken')
 
     with self.assertRaises(OSError):
@@ -45,16 +44,16 @@ class RetryTest(unittest.TestCase):
 
     self.assertEqual(broken_func.call_count, 1)
 
-  @mock.patch('time.sleep', autospec=True, spec_set=True)
+  @unittest.mock.patch('time.sleep', autospec=True, spec_set=True)
   def test_retry_default_backoff(self, mock_sleep):
-    broken_func = mock.Mock()
+    broken_func = unittest.mock.Mock()
     broken_func.side_effect = OSError('broken')
 
     with self.assertRaises(OSError):
       retry_on_exception(broken_func, 4, (OSError,))
 
     mock_sleep.assert_has_calls((
-      mock.call(0),
-      mock.call(0),
-      mock.call(0)
+      unittest.mock.call(0),
+      unittest.mock.call(0),
+      unittest.mock.call(0)
     ))

--- a/tests/python/pants_test/util/test_socket.py
+++ b/tests/python/pants_test/util/test_socket.py
@@ -4,8 +4,8 @@
 import inspect
 import socket
 import unittest
+import unittest.mock
 
-import mock
 from future.utils import PY3
 
 from pants.util.socket import RecvBufferedSocket, is_readable
@@ -16,21 +16,21 @@ PATCH_OPTS = dict(autospec=True, spec_set=True)
 
 class TestSocketUtils(unittest.TestCase):
 
-  @mock.patch('selectors.DefaultSelector' if PY3 else 'select.select', **PATCH_OPTS)
+  @unittest.mock.patch('selectors.DefaultSelector' if PY3 else 'select.select', **PATCH_OPTS)
   def test_is_readable(self, mock_selector):
-    mock_fileobj = mock.Mock()
+    mock_fileobj = unittest.mock.Mock()
     if PY3:
       mock_selector = mock_selector.return_value.__enter__.return_value
-      mock_selector.register = mock.Mock()
+      mock_selector.register = unittest.mock.Mock()
       # NB: the return value should actually be List[Tuple[SelectorKey, Events]], but our code only
       # cares that _some_ event happened so we choose a simpler mock here. See
       # https://docs.python.org/3/library/selectors.html#selectors.BaseSelector.select.
-      mock_selector.select = mock.Mock(return_value=[(1, "")])
+      mock_selector.select = unittest.mock.Mock(return_value=[(1, "")])
     else:
       mock_selector.return_value = ([1], [], [])
     self.assertTrue(is_readable(mock_fileobj, timeout=0.1))
     if PY3:
-      mock_selector.select = mock.Mock(return_value=[])
+      mock_selector.select = unittest.mock.Mock(return_value=[])
     else:
       mock_selector.return_value = ([], [], [])
     self.assertFalse(is_readable(mock_fileobj, timeout=0.1))
@@ -39,7 +39,7 @@ class TestSocketUtils(unittest.TestCase):
 class TestRecvBufferedSocket(unittest.TestCase):
   def setUp(self):
     self.chunk_size = 512
-    self.mock_socket = mock.Mock()
+    self.mock_socket = unittest.mock.Mock()
     self.client_sock, self.server_sock = socket.socketpair()
     self.buf_sock = RecvBufferedSocket(self.client_sock, chunk_size=self.chunk_size)
     self.mocked_buf_sock = RecvBufferedSocket(self.mock_socket, chunk_size=self.chunk_size)
@@ -64,15 +64,15 @@ class TestRecvBufferedSocket(unittest.TestCase):
     self.server_sock.sendall(b'A' * double_chunk)
     self.assertEqual(self.buf_sock.recv(double_chunk), b'A' * double_chunk)
 
-  @mock.patch('selectors.DefaultSelector' if PY3 else 'select.select', **PATCH_OPTS)
+  @unittest.mock.patch('selectors.DefaultSelector' if PY3 else 'select.select', **PATCH_OPTS)
   def test_recv_check_calls(self, mock_selector):
     if PY3:
       mock_selector = mock_selector.return_value.__enter__.return_value
-      mock_selector.register = mock.Mock()
+      mock_selector.register = unittest.mock.Mock()
       # NB: the return value should actually be List[Tuple[SelectorKey, Events]], but our code only
       # cares that _some_ event happened so we choose a simpler mock here. See
       # https://docs.python.org/3/library/selectors.html#selectors.BaseSelector.select.
-      mock_selector.select = mock.Mock(return_value=[(1, "")])
+      mock_selector.select = unittest.mock.Mock(return_value=[(1, "")])
     else:
       mock_selector.return_value = ([1], [], [])
 


### PR DESCRIPTION
`mock` became part of the stdlib in Python 3.