### PR TITLE
Blacklist failing tests as a result of #7952

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
+++ b/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
@@ -89,4 +89,7 @@ class CoursierSubsystem(Subsystem):
           else:
             workunit.set_outcome(WorkUnit.SUCCESS)
 
+    import subprocess
+    sha = subprocess.check_output(['sha1sum', bootstrap_jar_path]).decode('utf-8')
+    logger.info("coursier sha1sum: {}".format(sha))
     return bootstrap_jar_path

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -30,6 +30,14 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/src/java/org/pantsbuild/testproject/thriftdeptest',
       # TODO(Eric Ayers): I don't understand why this fails
       'testprojects/src/java/org/pantsbuild/testproject/jvmprepcommand:compile-prep-command',
+      # TODO(#7952): Fails to execute Coursier
+      'testprojects/src/java/org/pantsbuild/testproject/aliases:main',
+      'testprojects/src/java/org/pantsbuild/testproject/aliases:intransitive-dependency',
+      # NB: These fail to bootstrap in their integration test shard, not compiling per se.
+      'testprojects/tests/scala/org/pantsbuild/testproject/exports:TC',
+      'testprojects/tests/scala/org/pantsbuild/testproject/exports:TD',
+      'testprojects/tests/scala/org/pantsbuild/testproject/non_exports:A',
+      'testprojects/tests/scala/org/pantsbuild/testproject/non_exports:B',
       # TODO(#7903): failing to find -ltensorflow_framework
       'examples/src/python/example/tensorflow_custom_op:tensorflow-zero-out-op',
       'examples/src/python/example/tensorflow_custom_op:tensorflow-zero-out-op-wrapper',


### PR DESCRIPTION
### Problem

A failing shard is consistently blocking merging PRs. Details here: #7952 
The failure seems related to having the wrong version of coursier: https://gist.github.com/blorente/d2d37b5432ffa8c355f1d6577cd2510f

### Solution

Blacklist the failing targets.

### Result

PRs that rebase on top of this should hopefully not fail in shard 14 of the integration tests.