### PR TITLE
Upgrade to pex 1.6.8.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -13,7 +13,7 @@ more-itertools<6.0.0 ; python_version<'3'
 packaging==16.8
 parameterized==0.6.1
 pathspec==0.5.9
-pex==1.6.7
+pex==1.6.8
 psutil==5.4.8
 pycodestyle==2.4.0
 pyflakes==2.0.0

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -68,14 +68,7 @@ function run_pex() {
     pex="${pexdir}/pex"
 
     curl --fail -sSL "${PEX_DOWNLOAD_PREFIX}/v${PEX_VERSION}/pex" > "${pex}"
-    # We use `PEX_PYTHON_PATH="${PY}" "${PY}" "${pex}"` instead of either of:
-    # 1. PEX_PYTHON_PATH="${PY}" "${pex}"
-    # 2. "${PY}" "${pex}"
-    # This works around Pex re-exec-ing when it need not and subsequently losing constraints when
-    # it need not. The fixes for these are tracked in:
-    #   1. https://github.com/pantsbuild/pex/issues/709
-    #   2. https://github.com/pantsbuild/pex/issues/710
-    PEX_PYTHON_PATH="${PY}" "${PY}" "${pex}" "$@"
+    "${PY}" "${pex}" "$@"
   )
 }
 

--- a/src/python/pants/backend/python/rules/resolve_requirements.py
+++ b/src/python/pants/backend/python/rules/resolve_requirements.py
@@ -34,8 +34,8 @@ def resolve_requirements(request, python_setup, pex_build_environment):
   interpreter constraints."""
 
   # TODO: Inject versions and digests here through some option, rather than hard-coding it.
-  url = 'https://github.com/pantsbuild/pex/releases/download/v1.6.6/pex'
-  digest = Digest('61bb79384db0da8c844678440bd368bcbfac17bbdb865721ad3f9cb0ab29b629', 1826945)
+  url = 'https://github.com/pantsbuild/pex/releases/download/v1.6.8/pex'
+  digest = Digest('2ca320aede7e7bbcb907af54c9de832707a1df965fb5a0d560f2df29ba8a2f3d', 1866441)
   pex_snapshot = yield Get(Snapshot, UrlToFetch(url, digest))
 
   interpreter_search_paths = text_type(create_path_env_var(python_setup.interpreter_search_paths))

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -22,21 +22,14 @@ class PythonSetup(Subsystem):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    register('--interpreter-constraints', advanced=True, default=['CPython>=2.7,<3', 'CPython>=3.6,<4'], type=list,
-             metavar='<requirement>', fingerprint=True,
+    register('--interpreter-constraints', advanced=True, fingerprint=True, type=list,
+             default=['CPython>=2.7,<3', 'CPython>=3.6,<4'],
+             metavar='<requirement>',
              help="Constrain the selected Python interpreter.  Specify with requirement syntax, "
                   "e.g. 'CPython>=2.7,<3' (A CPython interpreter with version >=2.7 AND version <3)"
                   "or 'PyPy' (A pypy interpreter of any version). Multiple constraint strings will "
                   "be ORed together. These constraints are applied in addition to any "
                   "compatibilities required by the relevant targets.")
-    register('--setuptools-version', advanced=True, default='40.4.3',
-             help='The setuptools version for this python environment.',
-             removal_version='1.17.0.dev2',
-             removal_hint='This option is now unused and can be removed from pants configuration.')
-    register('--wheel-version', advanced=True, default='0.31.1',
-             help='The wheel version for this python environment.',
-             removal_version='1.17.0.dev2',
-             removal_hint='This option is now unused and can be removed from pants configuration.')
     register('--platforms', advanced=True, type=list, metavar='<platform>', default=['current'],
              fingerprint=True,
              help='A list of platforms to be supported by this python environment. Each platform'

--- a/src/python/pants/backend/python/tasks/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks/python_execution_task_base.py
@@ -23,24 +23,21 @@ from pants.util.objects import datatype
 def ensure_interpreter_search_path_env(interpreter):
   """Produces an environment dict that ensures that the given interpreter is discovered at runtime.
 
-  At build time, a pex contains constraints on which interpreter version ranges are legal, but
-  at runtime it will apply those constraints to the current (PEX_PYTHON_)PATH to locate a
-  relevant interpreter.
+  At pex build time, if any interpreter constraints are specified (e.g.: 'CPython>=2.7,<3'), they
+  are added to the resulting pex binary's metadata. At runtime, pex will apply those constraints to
+  locate a relevant interpreter on the `PATH`. If `PEX_PYTHON_PATH` is set in the environment, it
+  will be used instead of a `PATH` search. Unlike a typical `PATH`, `PEX_PYTHON_PATH` can contain a
+  mix of files and directories. We exploit this to set up a singluar `PEX_PYTHON_PATH` pointing
+  directly at the given `interpreter` (which should match the constraints that were provided at
+  build time).
 
-  This environment is for use at runtime to ensure that a particular interpreter (which should
-  match the constraints that were provided at build time) is locatable. PEX no longer allows
-  for forcing use of a particular interpreter (the PEX_PYTHON_PATH is additive), so use
-  of this method does not guarantee that the given interpreter is used: rather, that it is
-  definitely considered for use.
-
-  Subclasses of PythonExecutionTaskBase can use `self.ensure_interpreter_search_path_env`
-  to get the relevant interpreter, but this method is exposed as static for cases where
-  the building of the pex is separated from the execution of the pex.
+  Subclasses of PythonExecutionTaskBase can use `self.ensure_interpreter_search_path_env` to get the
+  relevant interpreter, but this method is exposed as static for cases where the building of the pex
+  is separated from the execution of the pex.
   """
   chosen_interpreter_binary_path = interpreter.binary
   return {
     'PEX_IGNORE_RCFILES': '1',
-    'PEX_PYTHON': chosen_interpreter_binary_path,
     'PEX_PYTHON_PATH': chosen_interpreter_binary_path,
   }
 

--- a/tests/python/pants_test/engine/legacy/test_options_parsing.py
+++ b/tests/python/pants_test/engine/legacy/test_options_parsing.py
@@ -39,7 +39,7 @@ class TestEngineOptionsParsing(TestBase):
     self.assertEqual(global_options.options.enable_pantsd, True)
     self.assertEqual(global_options.options.binaries_baseurls, ['https://bins.com'])
 
-    self.assertEqual(python_setup_options.options.wheel_version, '0.31.1')
+    self.assertEqual(python_setup_options.options.platforms, ['current'])
 
   def test_options_parse_memoization(self):
     # Confirm that re-executing with a new-but-identical Options object results in memoization.


### PR DESCRIPTION
This picks up fixes to `PEX_PYTHON` and `PEX_PYTHON_PATH` handling and
allows us to simplify pex execution slightly.
