### PR TITLE
Remove Python 2 select.select() code

### DIFF
--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -159,9 +159,6 @@ python_binary(
 python_library(
   name = 'socket',
   sources = ['socket.py'],
-  dependencies = [
-    '3rdparty/python:future',
-  ]
 )
 
 python_library(

--- a/tests/python/pants_test/java/test_nailgun_executor.py
+++ b/tests/python/pants_test/java/test_nailgun_executor.py
@@ -81,7 +81,7 @@ class NailgunExecutorTest(TestBase):
          unittest.mock.patch('pants.java.nailgun_executor.read_file') as mock_read_file:
       mock_open.return_value = stdout_read
       mock_read_file.return_value = 'err'
-      # The stdout write pipe has no input and hasn't been closed, so the select.select() should
+      # The stdout write pipe has no input and hasn't been closed, so the selector.select() should
       # time out regardless of the timemout argument, and raise.
       with self.assertRaisesWithMessage(NailgunExecutor.InitialNailgunConnectTimedOut, """\
 Failed to read nailgun output after 0.0001 seconds!

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -145,7 +145,6 @@ python_tests(
   sources = ['test_socket.py'],
   coverage = ['pants.util.socket'],
   dependencies = [
-    '3rdparty/python:future',
     'src/python/pants/util:socket',
   ]
 )

--- a/tests/python/pants_test/util/test_socket.py
+++ b/tests/python/pants_test/util/test_socket.py
@@ -6,8 +6,6 @@ import socket
 import unittest
 import unittest.mock
 
-from future.utils import PY3
-
 from pants.util.socket import RecvBufferedSocket, is_readable
 
 
@@ -16,23 +14,17 @@ PATCH_OPTS = dict(autospec=True, spec_set=True)
 
 class TestSocketUtils(unittest.TestCase):
 
-  @unittest.mock.patch('selectors.DefaultSelector' if PY3 else 'select.select', **PATCH_OPTS)
+  @unittest.mock.patch('selectors.DefaultSelector', **PATCH_OPTS)
   def test_is_readable(self, mock_selector):
     mock_fileobj = unittest.mock.Mock()
-    if PY3:
-      mock_selector = mock_selector.return_value.__enter__.return_value
-      mock_selector.register = unittest.mock.Mock()
-      # NB: the return value should actually be List[Tuple[SelectorKey, Events]], but our code only
-      # cares that _some_ event happened so we choose a simpler mock here. See
-      # https://docs.python.org/3/library/selectors.html#selectors.BaseSelector.select.
-      mock_selector.select = unittest.mock.Mock(return_value=[(1, "")])
-    else:
-      mock_selector.return_value = ([1], [], [])
+    mock_selector = mock_selector.return_value.__enter__.return_value
+    mock_selector.register = unittest.mock.Mock()
+    # NB: the return value should actually be List[Tuple[SelectorKey, Events]], but our code only
+    # cares that _some_ event happened so we choose a simpler mock here. See
+    # https://docs.python.org/3/library/selectors.html#selectors.BaseSelector.select.
+    mock_selector.select = unittest.mock.Mock(return_value=[(1, "")])
     self.assertTrue(is_readable(mock_fileobj, timeout=0.1))
-    if PY3:
-      mock_selector.select = unittest.mock.Mock(return_value=[])
-    else:
-      mock_selector.return_value = ([], [], [])
+    mock_selector.select = unittest.mock.Mock(return_value=[])
     self.assertFalse(is_readable(mock_fileobj, timeout=0.1))
 
 
@@ -64,17 +56,14 @@ class TestRecvBufferedSocket(unittest.TestCase):
     self.server_sock.sendall(b'A' * double_chunk)
     self.assertEqual(self.buf_sock.recv(double_chunk), b'A' * double_chunk)
 
-  @unittest.mock.patch('selectors.DefaultSelector' if PY3 else 'select.select', **PATCH_OPTS)
+  @unittest.mock.patch('selectors.DefaultSelector', **PATCH_OPTS)
   def test_recv_check_calls(self, mock_selector):
-    if PY3:
-      mock_selector = mock_selector.return_value.__enter__.return_value
-      mock_selector.register = unittest.mock.Mock()
-      # NB: the return value should actually be List[Tuple[SelectorKey, Events]], but our code only
-      # cares that _some_ event happened so we choose a simpler mock here. See
-      # https://docs.python.org/3/library/selectors.html#selectors.BaseSelector.select.
-      mock_selector.select = unittest.mock.Mock(return_value=[(1, "")])
-    else:
-      mock_selector.return_value = ([1], [], [])
+    mock_selector = mock_selector.return_value.__enter__.return_value
+    mock_selector.register = unittest.mock.Mock()
+    # NB: the return value should actually be List[Tuple[SelectorKey, Events]], but our code only
+    # cares that _some_ event happened so we choose a simpler mock here. See
+    # https://docs.python.org/3/library/selectors.html#selectors.BaseSelector.select.
+    mock_selector.select = unittest.mock.Mock(return_value=[(1, "")])
 
     self.mock_socket.recv.side_effect = [b'A' * self.chunk_size, b'B' * self.chunk_size]
 


### PR DESCRIPTION
In https://github.com/pantsbuild/pants/pull/7882, we started using the much more efficient `selectors` module with Python 3 instead of `select.select()`. We may now remove the Python 2 code that was still using the original `select.select()`.