### PR TITLE
Remove Python 2 `hashlib.hexdigest()` decoding

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_binary_fingerprint_strategy.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_binary_fingerprint_strategy.py
@@ -3,7 +3,6 @@
 
 import hashlib
 
-from future.utils import PY3
 from pants.base.fingerprint_strategy import FingerprintStrategy
 
 from pants.contrib.go.targets.go_binary import GoBinary
@@ -30,7 +29,7 @@ class GoBinaryFingerprintStrategy(FingerprintStrategy):
     hasher = hashlib.sha1()
     hasher.update(fp.encode('utf-8'))
     hasher.update(str(self._get_build_flags_func(target)).encode('utf-8'))
-    return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+    return hasher.hexdigest()
 
   def __hash__(self):
     return hash((type(self), self._get_build_flags_func))

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_resolve.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_resolve.py
@@ -4,7 +4,6 @@
 import os
 from hashlib import sha1
 
-from future.utils import PY3
 from pants.base.build_environment import get_buildroot
 from pants.base.fingerprint_strategy import DefaultFingerprintHashingMixin, FingerprintStrategy
 from pants.base.workunit import WorkUnitLabel
@@ -45,7 +44,7 @@ class NodeResolveFingerprintStrategy(DefaultFingerprintHashingMixin, Fingerprint
           with open(absolute_lockfile_path, 'r') as lockfile:
             contents = lockfile.read().encode('utf-8')
             hasher.update(contents)
-      return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+      return hasher.hexdigest()
     return None
 
 

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
@@ -56,7 +56,6 @@ python_library(
   name='java_thrift_library_fingerprint_strategy',
   sources=['java_thrift_library_fingerprint_strategy.py'],
   dependencies=[
-    '3rdparty/python:future',
     'src/python/pants/backend/codegen/thrift/java',
     'src/python/pants/base:fingerprint_strategy',
   ],

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/java_thrift_library_fingerprint_strategy.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/java_thrift_library_fingerprint_strategy.py
@@ -3,7 +3,6 @@
 
 import hashlib
 
-from future.utils import PY3
 from pants.backend.codegen.thrift.java.java_thrift_library import JavaThriftLibrary
 from pants.base.fingerprint_strategy import FingerprintStrategy
 
@@ -40,7 +39,7 @@ class JavaThriftLibraryFingerprintStrategy(FingerprintStrategy):
     if target.include_paths:
       hasher.update(str(target.include_paths).encode('utf-8'))
 
-    return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+    return hasher.hexdigest()
 
   def __hash__(self):
     return hash((type(self), self._thrift_defaults))

--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -5,7 +5,6 @@ python_library(
   name = 'dependency_context',
   sources = ['dependency_context.py'],
   dependencies = [
-    '3rdparty/python:future',
     ':java',
     ':scala_platform',
     'src/python/pants/backend/codegen/thrift/java',

--- a/src/python/pants/backend/jvm/subsystems/dependency_context.py
+++ b/src/python/pants/backend/jvm/subsystems/dependency_context.py
@@ -3,8 +3,6 @@
 
 import hashlib
 
-from future.utils import PY3
-
 from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
@@ -98,7 +96,7 @@ class ResolvedJarAwareFingerprintStrategy(FingerprintStrategy):
         [target])
       for _, entry in classpath_entries:
         hasher.update(str(entry.coordinate).encode('utf-8'))
-    return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+    return hasher.hexdigest()
 
   def direct(self, target):
     return self._dep_context.defaulted_property(target, 'strict_deps')

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -5,7 +5,7 @@ import re
 from abc import ABCMeta
 from hashlib import sha1
 
-from future.utils import PY3, string_types
+from future.utils import string_types
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.exceptions import TargetDefinitionException
@@ -238,7 +238,7 @@ class JarRules(FingerprintedMixin):
     hasher.update(self.payload.fingerprint().encode('utf-8'))
     for rule in self.rules:
       hasher.update(rule.fingerprint().encode('utf-8'))
-    return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+    return hasher.hexdigest()
 
   @property
   def value(self):

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -101,7 +101,6 @@ python_library(
   name = 'bootstrap_jvm_tools',
   sources = ['bootstrap_jvm_tools.py'],
   dependencies = [
-    '3rdparty/python:future',
     ':ivy_task_mixin',
     ':jar_task',
     'src/python/pants/backend/jvm/subsystems:jvm_tool_mixin',
@@ -242,7 +241,6 @@ python_library(
   name = 'ivy_task_mixin',
   sources = ['ivy_task_mixin.py'],
   dependencies = [
-    '3rdparty/python:future',
     'src/python/pants/backend/jvm/subsystems:jar_dependency_management',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:classpath_products',
@@ -480,7 +478,6 @@ python_library(
   name = 'jvm_platform_analysis',
   sources = ['jvm_platform_analysis.py'],
   dependencies = [
-    '3rdparty/python:future',
     '3rdparty/python:ansicolors',
     'src/python/pants/base:exceptions',
     'src/python/pants/backend/jvm/targets:jvm',
@@ -718,7 +715,6 @@ python_library(
   name = 'unpack_jars',
   sources = ['unpack_jars.py'],
   dependencies = [
-    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jar_import_products',

--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -9,8 +9,6 @@ import threading
 from collections import defaultdict
 from textwrap import dedent
 
-from future.utils import PY3
-
 from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.backend.jvm.subsystems.resolve_subsystem import JvmResolveSubsystem
 from pants.backend.jvm.subsystems.shader import Shader
@@ -55,7 +53,7 @@ class ShadedToolFingerprintStrategy(IvyResolveFingerprintStrategy):
       for rule in self._custom_rules:
         hasher.update(rule.render().encode('utf-8'))
 
-    return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+    return hasher.hexdigest()
 
   def _tuple(self):
     # NB: this tuple's slots - used for `==/hash()` - must be kept in agreement with the hashed

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -744,7 +744,7 @@ class CoursierResolveFingerprintStrategy(FingerprintStrategy):
     # Just in case so we do not collide with ivy cache
     hasher.update(b'coursier')
 
-    return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+    return hasher.hexdigest()
 
   def __hash__(self):
     return hash((type(self), '-'.join(self._confs)))

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -5,8 +5,6 @@ import hashlib
 import logging
 import os
 
-from future.utils import PY3
-
 from pants.backend.jvm.ivy_utils import NO_RESOLVE_RUN_RESULT, IvyFetchStep, IvyResolveStep
 from pants.backend.jvm.subsystems.jar_dependency_management import JarDependencyManagement
 from pants.backend.jvm.targets.jar_library import JarLibrary
@@ -56,7 +54,7 @@ class IvyResolveFingerprintStrategy(FingerprintStrategy):
     for element in hash_elements_for_target:
       hasher.update(element.encode('utf-8'))
 
-    return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+    return hasher.hexdigest()
 
   def __hash__(self):
     return hash((type(self), '-'.join(self._confs)))

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -890,7 +890,7 @@ class JarPublish(TransitiveOptionRegistrar, HasTransitiveOptionMixin, ScmPublish
       fingerprint = fingerprint_internal(internal_target)
       sha.update(fingerprint.encode('utf-8'))
 
-    return sha.hexdigest() if PY3 else sha.hexdigest().decode('utf-8')
+    return sha.hexdigest()
 
   def changelog(self, target, sha):
     # Filter synthetic files.

--- a/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
@@ -6,7 +6,6 @@ from collections import defaultdict, namedtuple
 from hashlib import sha1
 
 from colors import red
-from future.utils import PY3
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.exceptions import TaskError
@@ -135,7 +134,7 @@ class JvmPlatformValidate(JvmPlatformAnalysisMixin, Task):
       hasher = sha1()
       if hasattr(target, 'platform'):
         hasher.update(str(tuple(target.platform)).encode('utf-8'))
-      return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+      return hasher.hexdigest()
 
     def __eq__(self, other):
       return type(self) == type(other)

--- a/src/python/pants/backend/jvm/tasks/unpack_jars.py
+++ b/src/python/pants/backend/jvm/tasks/unpack_jars.py
@@ -3,8 +3,6 @@
 
 from hashlib import sha1
 
-from future.utils import PY3
-
 from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
 from pants.backend.jvm.tasks.jar_import_products import JarImportProducts
 from pants.base.fingerprint_strategy import DefaultFingerprintHashingMixin, FingerprintStrategy
@@ -24,7 +22,7 @@ class UnpackJarsFingerprintStrategy(DefaultFingerprintHashingMixin, FingerprintS
       for cache_key in sorted(jar.cache_key() for jar in target.all_imported_jar_deps):
         hasher.update(cache_key.encode('utf-8'))
       hasher.update(target.payload.fingerprint().encode('utf-8'))
-      return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+      return hasher.hexdigest()
     return None
 
 

--- a/src/python/pants/backend/native/targets/BUILD
+++ b/src/python/pants/backend/native/targets/BUILD
@@ -4,7 +4,6 @@
 
 python_library(
   dependencies=[
-    '3rdparty/python:future',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:payload',

--- a/src/python/pants/backend/native/targets/native_artifact.py
+++ b/src/python/pants/backend/native/targets/native_artifact.py
@@ -3,8 +3,6 @@
 
 from hashlib import sha1
 
-from future.utils import PY3
-
 from pants.base.payload_field import PayloadField
 from pants.util.objects import datatype
 
@@ -28,4 +26,4 @@ class NativeArtifact(datatype(['lib_name']), PayloadField):
     # TODO: This fingerprint computation boilerplate is error-prone and could probably be
     # streamlined, for simple payload fields.
     hasher = sha1(self.lib_name.encode('utf-8'))
-    return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+    return hasher.hexdigest()

--- a/src/python/pants/backend/python/tasks/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks/select_interpreter.py
@@ -4,7 +4,6 @@
 import hashlib
 import os
 
-from future.utils import PY3
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 
@@ -33,7 +32,7 @@ class PythonInterpreterFingerprintStrategy(DefaultFingerprintHashingMixin, Finge
     hasher = hashlib.sha1()
     for element in hash_elements_for_target:
       hasher.update(element.encode('utf-8'))
-    return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+    return hasher.hexdigest()
 
 
 class SelectInterpreter(Task):

--- a/src/python/pants/backend/python/tasks/unpack_wheels.py
+++ b/src/python/pants/backend/python/tasks/unpack_wheels.py
@@ -4,7 +4,6 @@
 import os
 from hashlib import sha1
 
-from future.utils import PY3
 from pex.pex_builder import PEXBuilder
 
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
@@ -32,7 +31,7 @@ class UnpackWheelsFingerprintStrategy(DefaultFingerprintHashingMixin, Fingerprin
       for cache_key in sorted(req.cache_key() for req in target.all_imported_requirements):
         hasher.update(cache_key.encode('utf-8'))
       hasher.update(target.payload.fingerprint().encode('utf-8'))
-      return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+      return hasher.hexdigest()
     return None
 
 

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -128,16 +128,12 @@ python_library(
 python_library(
   name = 'payload',
   sources = ['payload.py'],
-  dependencies = [
-    '3rdparty/python:future',
-  ]
 )
 
 python_library(
   name = 'payload_field',
   sources = ['payload_field.py'],
   dependencies = [
-    '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':deprecated',
     ':hash_utils',

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -7,7 +7,7 @@ import logging
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping, Set
 
-from future.utils import PY3, binary_type, text_type
+from future.utils import binary_type, text_type
 from twitter.common.collections import OrderedSet
 
 from pants.util.objects import DatatypeMixin
@@ -26,7 +26,7 @@ def hash_all(strs, digest=None):
   for s in strs:
     s = ensure_binary(s)
     digest.update(s)
-  return digest.hexdigest() if PY3 else digest.hexdigest().decode('utf-8')
+  return digest.hexdigest()
 
 
 def hash_file(path, digest=None):
@@ -40,7 +40,7 @@ def hash_file(path, digest=None):
     while s:
       digest.update(s)
       s = fd.read(8192)
-  return digest.hexdigest() if PY3 else digest.hexdigest().decode('utf-8')
+  return digest.hexdigest()
 
 
 class CoercingEncoder(json.JSONEncoder):

--- a/src/python/pants/base/payload.py
+++ b/src/python/pants/base/payload.py
@@ -3,8 +3,6 @@
 
 from hashlib import sha1
 
-from future.utils import PY3
-
 from pants.util.strutil import ensure_binary
 
 
@@ -127,7 +125,7 @@ class Payload:
     if empty_hash:
       return None
     else:
-      return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+      return hasher.hexdigest()
 
   def mark_dirty(self):
     """Invalidates memoized fingerprints for this payload.

--- a/src/python/pants/base/payload_field.py
+++ b/src/python/pants/base/payload_field.py
@@ -4,7 +4,6 @@
 from abc import ABC, abstractmethod
 from hashlib import sha1
 
-from future.utils import PY3
 from twitter.common.collections import OrderedSet
 
 from pants.base.hash_utils import stable_json_sha1
@@ -17,7 +16,7 @@ def combine_hashes(hashes):
   for h in sorted(hashes):
     h = ensure_binary(h)
     hasher.update(h)
-  return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+  return hasher.hexdigest()
 
 
 class PayloadField(ABC):

--- a/src/python/pants/build_graph/intermediate_target_factory.py
+++ b/src/python/pants/build_graph/intermediate_target_factory.py
@@ -4,7 +4,7 @@
 from abc import ABC
 from hashlib import sha1
 
-from future.utils import PY3, string_types
+from future.utils import string_types
 
 from pants.base.exceptions import TargetDefinitionException
 from pants.build_graph.address import Address
@@ -14,7 +14,7 @@ def hash_target(address, suffix):
   hasher = sha1()
   hasher.update(address.encode('utf-8'))
   hasher.update(suffix.encode('utf-8'))
-  return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+  return hasher.hexdigest()
 
 
 class IntermediateTargetFactoryBase(ABC):

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -10,7 +10,7 @@ import threading
 import time
 from contextlib import closing
 
-from future.utils import PY3, string_types
+from future.utils import string_types
 from twitter.common.collections import maybe_list
 
 from pants.base.build_environment import get_buildroot
@@ -126,7 +126,7 @@ class NailgunExecutor(Executor, FingerprintedProcessManager):
     encoded_java_version = repr(java_version).encode('utf-8')
     for item in (encoded_jvm_options, encoded_classpath, encoded_java_version):
       digest.update(str(item).encode('utf-8'))
-    return digest.hexdigest() if PY3 else digest.hexdigest().decode('utf-8')
+    return digest.hexdigest()
 
   def _runner(self, classpath, main, jvm_options, args):
     """Runner factory. Called via Executor.execute()."""

--- a/src/python/pants/source/payload_fields.py
+++ b/src/python/pants/source/payload_fields.py
@@ -3,8 +3,6 @@
 
 from hashlib import sha1
 
-from future.utils import PY3
-
 from pants.base.payload_field import PayloadField
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.source.filespec import matches_filespec
@@ -84,4 +82,4 @@ class SourcesField(PayloadField):
     hasher = sha1()
     hasher.update(self.rel_path.encode('utf-8'))
     hasher.update(self.sources.files_hash)
-    return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+    return hasher.hexdigest()

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -8,8 +8,6 @@ from contextlib import contextmanager
 from hashlib import sha1
 from itertools import repeat
 
-from future.utils import PY3
-
 from pants.base.exceptions import TaskError
 from pants.base.worker_pool import Work
 from pants.build_graph.target_filter_subsystem import TargetFilter
@@ -315,7 +313,7 @@ class TaskBase(SubsystemClientMixin, Optionable, metaclass=ABCMeta):
       include_passthru=self.supports_passthru_args(),
     )
     options_hasher.update(options_fp.encode('utf-8'))
-    return options_hasher.hexdigest() if PY3 else options_hasher.hexdigest().decode('utf-8')
+    return options_hasher.hexdigest()
 
   @memoized_property
   def fingerprint(self):
@@ -333,7 +331,7 @@ class TaskBase(SubsystemClientMixin, Optionable, metaclass=ABCMeta):
     hasher.update(self.implementation_version_str().encode('utf-8'))
     for dep in self.subsystem_closure_iter():
       hasher.update(self._options_fingerprint(dep.options_scope).encode('utf-8'))
-    return hasher.hexdigest() if PY3 else hasher.hexdigest().decode('utf-8')
+    return hasher.hexdigest()
 
   def artifact_cache_reads_enabled(self):
     return self._cache_factory.read_cache_available()

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -20,15 +20,11 @@ python_library(
 python_library(
   name = 'collections',
   sources = ['collections.py'],
-  dependencies = [
-  ]
 )
 
 python_library(
   name = 'debug',
   sources = ['debug.py'],
-  dependencies = [
-  ],
 )
 
 python_library(
@@ -84,15 +80,11 @@ python_library(
 python_library(
   name = 'meta',
   sources = ['meta.py'],
-  dependencies = [
-  ]
 )
 
 python_library(
   name = 'netrc',
   sources = ['netrc.py'],
-  dependencies = [
-  ]
 )
 
 python_library(
@@ -126,8 +118,6 @@ python_library(
 python_library(
   name = 'retry',
   sources = ['retry.py'],
-  dependencies = [
-  ]
 )
 
 python_library(


### PR DESCRIPTION
In Python 2, `hashlib.hexdigest()` returned a byte string, but unicode in Py3. We adopted an idiom to always return unicode, which we can now remove.