### PR TITLE
Simplify tests to no longer check for `u""` character or `unicode` type

### DIFF
--- a/pants-plugins/tests/python/internal_backend_test/sitegen/BUILD
+++ b/pants-plugins/tests/python/internal_backend_test/sitegen/BUILD
@@ -4,7 +4,6 @@
 python_tests(
   sources=['test_sitegen.py'],
   dependencies=[
-    '3rdparty/python:future',
     'pants-plugins/3rdparty/python:beautifulsoup4',
     'pants-plugins/src/python/internal_backend/sitegen/tasks:sitegen',
   ],

--- a/pants-plugins/tests/python/internal_backend_test/sitegen/test_sitegen.py
+++ b/pants-plugins/tests/python/internal_backend_test/sitegen/test_sitegen.py
@@ -5,7 +5,6 @@ import json
 import unittest
 
 import bs4
-from future.utils import PY3
 
 from internal_backend.sitegen.tasks import sitegen
 
@@ -203,12 +202,10 @@ class AllTheThingsTestCase(unittest.TestCase):
                                    """)
     self.assertIn("DEPTH=1 LINK=None HEADING=non_collapse", rendered)
     escaped_single_quote = '&#x27;'
-    # Py2 and Py3 order the elements differently and Py3 doesn't render 'u' in unicode literals. Both are valid.
-    rendered_expected = ("DEPTH=1 LINK=[{{{q}link{q}: {q}subdir/page2.html{q}, {q}text{q}: {q}Page 2: Electric Boogaloo{q}, {q}here{q}: False}}, "
-                         "{{{q}link{q}: {q}index.html{q}, {q}text{q}: {q}Pants Build System{q}, {q}here{q}: True}}] HEADING=collapse".format(q=escaped_single_quote)
-                         if PY3 else
-                         "DEPTH=1 LINK=[{{{q}text{q}: u{q}Page 2: Electric Boogaloo{q}, {q}link{q}: u{q}subdir/page2.html{q}, {q}here{q}: False}}, "
-                         "{{{q}text{q}: u{q}Pants Build System{q}, {q}link{q}: u{q}index.html{q}, {q}here{q}: True}}] HEADING=collapse".format(q=escaped_single_quote))
+    rendered_expected = (
+      "DEPTH=1 LINK=[{{{q}link{q}: {q}subdir/page2.html{q}, {q}text{q}: {q}Page 2: Electric Boogaloo{q}, {q}here{q}: False}}, "
+      "{{{q}link{q}: {q}index.html{q}, {q}text{q}: {q}Pants Build System{q}, {q}here{q}: True}}] HEADING=collapse".format(q=escaped_single_quote)
+    )
     self.assertIn(rendered_expected, rendered)
 
   def test_transform_fixes_up_internal_links(self):

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -282,7 +282,6 @@ python_tests(
   ],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python:future',
     'src/python/pants/backend/jvm/subsystems:jar_dependency_management',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -6,7 +6,6 @@ import re
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
-from future.utils import PY3
 from psutil.tests import safe_rmpath
 
 from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
@@ -133,8 +132,8 @@ class CoursierResolveTest(NailgunTaskTestBase):
       self.resolve([lib])
     self.assertEqual(
       "Undefined revs for jars unsupported by Coursier. "
-      "\"jar(org={unicode_literal}'com.google.guava', name={unicode_literal}'guava', "
-      "rev=None, classifier=None, ext={unicode_literal}'jar')\"".format(unicode_literal='' if PY3 else 'u'),
+      "\"jar(org='com.google.guava', name='guava', "
+      "rev=None, classifier=None, ext='jar')\"",
       str(cm.exception))
 
   def test_resolve_multiple_artifacts(self):

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -6,8 +6,6 @@ import logging
 import os
 import unittest.mock
 
-from future.utils import PY2
-
 from pants.binaries.binary_util import (BinaryRequest, BinaryToolFetcher, BinaryToolUrlGenerator,
                                         BinaryUtil, select)
 from pants.net.http.fetcher import Fetcher
@@ -249,9 +247,9 @@ class BinaryUtilTest(TestBase):
       "Error resolving binary request BinaryRequest(supportdir=mysupportdir, version=myversion, "
       "name=myname, platform_dependent=True, external_url_generator=None, archiver=None): "
       "Pants could not resolve binaries for the current host. Update --binaries-path-by-id to "
-      "find binaries for the current host platform ({unicode_literal}\'linux\', "
-      "{unicode_literal}\'quantum_computer\').\\n--binaries-path-by-id was:"
-    ).format(unicode_literal='u' if PY2 else '')
+      "find binaries for the current host platform (\'linux\', "
+      "\'quantum_computer\').\\n--binaries-path-by-id was:"
+    )
     self.assertIn(expected_msg, the_raised_exception_message)
 
   def test_select_script_missing_arch(self):
@@ -270,9 +268,9 @@ class BinaryUtilTest(TestBase):
       # platform_dependent=False when doing select_script()
       "name=myname, platform_dependent=False, external_url_generator=None, archiver=None): Pants "
       "could not resolve binaries for the current host. Update --binaries-path-by-id to find "
-      "binaries for the current host platform ({unicode_literal}\'linux\', "
-      "{unicode_literal}\'quantum_computer\').\\n--binaries-path-by-id was:"
-    ).format(unicode_literal='u' if PY2 else '')
+      "binaries for the current host platform (\'linux\', "
+      "\'quantum_computer\').\\n--binaries-path-by-id was:"
+    )
     self.assertIn(expected_msg, the_raised_exception_message)
 
   def test_select_binary_base_path_override(self):

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -111,7 +111,6 @@ python_tests(
   name = 'target',
   sources = ['test_target.py'],
   dependencies = [
-    '3rdparty/python:future',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:fingerprint_strategy',
     'src/python/pants/base:payload',

--- a/tests/python/pants_test/build_graph/test_target.py
+++ b/tests/python/pants_test/build_graph/test_target.py
@@ -5,8 +5,6 @@ import os.path
 import unittest.mock
 from hashlib import sha1
 
-from future.utils import PY3
-
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
 from pants.base.payload import Payload
@@ -153,17 +151,16 @@ class TargetTest(TestBase):
     # No key_arg.
     with self.assertRaises(TargetDefinitionException) as cm:
       target.create_sources_field(sources='a-string', sources_rel_path='')
-    self.assertIn("Expected a glob, an address or a list, but was {}"
-                  .format('<class \'str\'>' if PY3 else '<type \'unicode\'>'),
-                  str(cm.exception))
+    self.assertIn("Expected a glob, an address or a list, but was <class 'str'>", str(cm.exception))
 
     # With key_arg.
     with self.assertRaises(TargetDefinitionException) as cm:
       target.create_sources_field(sources='a-string', sources_rel_path='', key_arg='my_cool_field')
-    self.assertIn("Expected 'my_cool_field' to be a glob, an address or a list, but was {}"
-                  .format('<class \'str\'>' if PY3 else '<type \'unicode\'>'),
-                  str(cm.exception))
-    #could also test address case, but looks like nothing really uses it.
+    self.assertIn(
+      "Expected 'my_cool_field' to be a glob, an address or a list, but was <class 'str'>",
+      str(cm.exception)
+    )
+    # could also test address case, but looks like nothing really uses it.
 
   def test_max_recursion(self):
     target_a = self.make_target('a', Target)

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -129,7 +129,6 @@ python_tests(
   name='graph_integration',
   sources=['test_graph_integration.py'],
   dependencies=[
-    '3rdparty/python:future',
     'src/python/pants/build_graph',
     'src/python/pants/engine/legacy:graph',
     'src/python/pants/option',

--- a/tests/python/pants_test/engine/legacy/test_graph_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_graph_integration.py
@@ -4,8 +4,6 @@
 import os
 import unittest
 
-from future.utils import PY2
-
 from pants.option.scope import GLOBAL_SCOPE_CONFIG_SECTION
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -69,12 +67,12 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
   _ERR_TARGETS = {
     'testprojects/src/python/sources:some-missing-some-not': [
       "globs('*.txt', '*.rs')",
-      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/python/sources/*.txt\', {unicode_literal}\'testprojects/src/python/sources/*.rs\'), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))".format(unicode_literal='u' if PY2 else ''),
+      "Snapshot(PathGlobs(include=(\'testprojects/src/python/sources/*.txt\', \'testprojects/src/python/sources/*.rs\'), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))",
       "Globs did not match. Excludes were: []. Unmatched globs were: [\"testprojects/src/python/sources/*.rs\"].",
     ],
     'testprojects/src/python/sources:missing-sources': [
       "*.scala",
-      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/python/sources/*.scala\',), exclude=({unicode_literal}\'testprojects/src/python/sources/*Test.scala\', {unicode_literal}\'testprojects/src/python/sources/*Spec.scala\'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=any_match)))".format(unicode_literal='u' if PY2 else ''),
+      "Snapshot(PathGlobs(include=(\'testprojects/src/python/sources/*.scala\',), exclude=(\'testprojects/src/python/sources/*Test.scala\', \'testprojects/src/python/sources/*Spec.scala\'), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=any_match)))",
       "Globs did not match. Excludes were: [\"testprojects/src/python/sources/*Test.scala\", \"testprojects/src/python/sources/*Spec.scala\"]. Unmatched globs were: [\"testprojects/src/python/sources/*.scala\"].",
     ],
     'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-bundle-fileset': [
@@ -83,7 +81,7 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       "Globs('*.aaaa')",
       "ZGlobs('**/*.abab')",
       "['file1.aaaa', 'file2.aaaa']",
-      "Snapshot(PathGlobs(include=({unicode_literal}\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))".format(unicode_literal='u' if PY2 else ''),
+      "Snapshot(PathGlobs(include=(\'testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\',), exclude=(), glob_match_error_behavior<Exactly(GlobMatchErrorBehavior)>=GlobMatchErrorBehavior(value=error), conjunction<Exactly(GlobExpansionConjunction)>=GlobExpansionConjunction(value=all_match)))",
       "Globs did not match. Excludes were: []. Unmatched globs were: [\"testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa\"].",
     ]
   }

--- a/tests/python/pants_test/engine/legacy/test_structs.py
+++ b/tests/python/pants_test/engine/legacy/test_structs.py
@@ -3,8 +3,6 @@
 
 import unittest
 
-from future.utils import PY3
-
 from pants.engine.legacy.structs import Files
 
 
@@ -19,5 +17,5 @@ class StructTest(unittest.TestCase):
   def test_excludes_of_wrong_type(self):
     with self.assertRaises(ValueError) as cm:
       Files(exclude='*.md', spec_path='')
-    self.assertEqual('Excludes of type `{}` are not supported: got "*.md"'.format('str' if PY3 else 'unicode'),
+    self.assertEqual('Excludes of type `str` are not supported: got "*.md"',
                      str(cm.exception))

--- a/tests/python/pants_test/engine/test_objects.py
+++ b/tests/python/pants_test/engine/test_objects.py
@@ -3,7 +3,7 @@
 
 import re
 
-from future.utils import PY3, text_type
+from future.utils import text_type
 
 from pants.engine.objects import Collection
 from pants.util.objects import TypeCheckError
@@ -16,17 +16,18 @@ class CollectionTest(TestBase):
 
   def test_element_typechecking(self):
     IntColl = Collection.of(int)
-    with self.assertRaisesRegexp(TypeCheckError, re.escape("""\
-field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'hello']: value {u}'hello' (with type '{string_type}') must satisfy this type constraint: Exactly(int)."""
-                                                           .format(u='' if PY3 else 'u',
-                                                                   string_type='str' if PY3 else 'unicode'))):
+    with self.assertRaisesRegexp(TypeCheckError, re.escape(
+      "field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) "
+      "matching iterable object [3, 'hello']: value 'hello' (with type 'str') must satisfy this "
+      "type constraint: Exactly(int).")):
       IntColl([3, "hello"])
 
     IntOrStringColl = Collection.of(int, text_type)
     self.assertEqual([3, "hello"], [x for x in IntOrStringColl([3, "hello"])])
-    with self.assertRaisesRegexp(TypeCheckError, re.escape("""\
-field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int or {string_type})) matching iterable object [()]: value () (with type 'tuple') must satisfy this type constraint: Exactly(int or {string_type})."""
-                                                           .format(string_type='str' if PY3 else 'unicode'))):
+    with self.assertRaisesRegexp(TypeCheckError, re.escape(
+      "field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int or "
+      "str)) matching iterable object [()]: value () (with type 'tuple') must satisfy this type "
+      "constraint: Exactly(int or str).""")):
       IntOrStringColl([()])
 
   def test_collection_bool(self):

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -40,7 +40,7 @@ python_tests(
   sources = ['test_execution_graph.py'],
   dependencies = [
     'src/python/pants/backend/jvm/tasks/jvm_compile:execution_graph',
-    ]
+  ]
 )
 
 python_tests(

--- a/tests/python/pants_test/tasks/test_execution_graph.py
+++ b/tests/python/pants_test/tasks/test_execution_graph.py
@@ -5,8 +5,6 @@ import re
 import unittest
 from collections import defaultdict
 
-from future.utils import PY3
-
 from pants.backend.jvm.tasks.jvm_compile.execution_graph import (ExecutionFailure, ExecutionGraph,
                                                                  Job, JobExistsError,
                                                                  NoRootJobError, UnknownJobError)
@@ -199,7 +197,7 @@ class ExecutionGraphTest(unittest.TestCase):
       ExecutionGraph([self.job("A", passing_fn, []),
                       self.job("B", passing_fn, ["Z"])], False)
 
-    self.assertEqual("Unexecutable graph: Undefined dependencies " + ("'Z'" if PY3 else "u'Z'"),
+    self.assertEqual("Unexecutable graph: Undefined dependencies 'Z'",
                      str(cm.exception))
 
   def test_on_success_callback_raises_error(self):
@@ -223,7 +221,7 @@ class ExecutionGraphTest(unittest.TestCase):
       ExecutionGraph([self.job("Same", passing_fn, []),
                       self.job("Same", passing_fn, [])], False)
 
-    self.assertEqual("Unexecutable graph: Job already scheduled " + ("'Same'" if PY3 else "u'Same'"),
+    self.assertEqual("Unexecutable graph: Job already scheduled 'Same'",
                      str(cm.exception))
 
   def test_priorities_for_chain_of_jobs(self):

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 from collections import OrderedDict
 from textwrap import dedent
 
-from future.utils import PY2, PY3, text_type
+from future.utils import text_type
 
 from pants.util.objects import (EnumVariantSelectionError, Exactly, HashableTypedCollection,
                                 SubclassesOf, SuperclassesOf, TypeCheckError, TypeConstraintError,
@@ -214,12 +214,9 @@ class TypedCollectionTest(TypeConstraintTestBase):
 
     with self.assertRaisesWithMessage(TypeCheckError, dedent("""\
         type check error in class StringCollectionField: 1 error type checking constructor arguments:
-        field 'hello_strings' was invalid: in wrapped constraint TypedCollection(Exactly({string_type})): value {u}'xxx' (with type '{input_string_type}') must satisfy this type constraint: SubclassesOf(Iterable).
+        field 'hello_strings' was invalid: in wrapped constraint TypedCollection(Exactly(str)): value 'xxx' (with type 'str') must satisfy this type constraint: SubclassesOf(Iterable).
         Note that objects matching {exclude_constraint} are not considered iterable.""")
-                                      .format(string_type=text_type.__name__,
-                                              u='u' if PY2 else '',
-                                              input_string_type=type('xxx').__name__,
-                                              exclude_constraint=_string_type_constraint)):
+                                      .format(exclude_constraint=_string_type_constraint)):
       StringCollectionField(hello_strings='xxx')
 
   def test_hashable_collection(self):
@@ -394,9 +391,7 @@ class DatatypeTest(TestBase):
   def test_invalid_field_name(self):
     with self.assertRaisesWithMessage(
         ValueError,
-        "Type names and field names must be valid identifiers: '0isntanallowedfirstchar'"
-        if PY3 else
-        "Type names and field names cannot start with a number: '0isntanallowedfirstchar'"):
+        "Type names and field names must be valid identifiers: '0isntanallowedfirstchar'"):
       datatype(['0isntanallowedfirstchar'])
     with self.assertRaisesWithMessage(
         ValueError,
@@ -423,19 +418,14 @@ class DatatypeTest(TestBase):
 
   def test_double_passed_arg(self):
     bar = datatype(['val', 'zal'])
-    with self.assertRaisesWithMessageContaining(
-        TypeError,
-        "__new__() got multiple values for {kw}argument 'val'"
-        .format(kw='' if PY3 else 'keyword ')):
+    with self.assertRaisesWithMessageContaining(TypeError, "__new__() got multiple values for argument 'val'"):
       bar(1, val=1)
 
   def test_too_many_args(self):
     bar = datatype(['val', 'zal'])
     with self.assertRaisesWithMessageContaining(
         TypeError,
-        '__new__() takes 3 positional arguments but 4 were given'
-        if PY3 else
-        '__new__() takes exactly 3 arguments (4 given)'):
+        '__new__() takes 3 positional arguments but 4 were given'):
       bar(1, 1, 1)
 
   def test_unexpect_kwarg(self):
@@ -454,44 +444,24 @@ class TypedDatatypeTest(TestBase):
 
     # If the type_name can't be converted into a suitable identifier, throw a
     # ValueError.
-    expected_msg = (
-      "Type names and field names must be valid identifiers: \"<class 'int'>\""
-      if PY3 else
-      "Type names and field names can only contain alphanumeric characters and underscores: \"<type 'int'>\""
-    )
+    expected_msg = "Type names and field names must be valid identifiers: \"<class 'int'>\""
     with self.assertRaisesWithMessage(ValueError, expected_msg):
       class NonStrType(datatype([int])): pass
 
     # This raises a TypeError because it doesn't provide a required argument.
-    expected_msg = (
-      "datatype() missing 1 required positional argument: 'field_decls'"
-      if PY3 else
-      "datatype() takes at least 1 argument (0 given)"
-    )
+    expected_msg = "datatype() missing 1 required positional argument: 'field_decls'"
     with self.assertRaisesWithMessage(TypeError, expected_msg):
       class NoFields(datatype()): pass
 
-    expected_msg = (
-      "Type names and field names must be valid identifiers: \"<class 'str'>\""
-      if PY3 else
-      "Type names and field names can only contain alphanumeric characters and underscores: \"<type 'unicode'>\""
-    )
+    expected_msg = "Type names and field names must be valid identifiers: \"<class 'str'>\""
     with self.assertRaisesWithMessage(ValueError, expected_msg):
       class JustTypeField(datatype([text_type])): pass
 
-    expected_msg = (
-      "Type names and field names must be valid identifiers: '3'"
-      if PY3 else
-      "Type names and field names cannot start with a number: '3'"
-    )
+    expected_msg = "Type names and field names must be valid identifiers: '3'"
     with self.assertRaisesWithMessage(ValueError, expected_msg):
       class NonStringField(datatype([3])): pass
 
-    expected_msg = (
-      "Type names and field names must be valid identifiers: '32'"
-      if PY3 else
-      "Type names and field names cannot start with a number: '32'"
-    )
+    expected_msg = "Type names and field names must be valid identifiers: '32'"
     with self.assertRaisesWithMessage(ValueError, expected_msg):
       class NonStringTypeField(datatype([(32, int)])): pass
 
@@ -527,19 +497,8 @@ class TypedDatatypeTest(TestBase):
     some_object = WithExplicitTypeConstraint(text_type('asdf'), 45)
     self.assertEqual(some_object.a_string, 'asdf')
     self.assertEqual(some_object.an_int, 45)
-    def compare_repr(include_unicode = False):
-      expected_msg = "WithExplicitTypeConstraint(a_string={unicode_literal}'asdf', an_int=45)"\
-        .format(unicode_literal='u' if include_unicode else '')
-      self.assertEqual(repr(some_object), expected_msg)
-    def compare_str(unicode_type_name):
-      expected_msg = "WithExplicitTypeConstraint(a_string<Exactly({})>=asdf, an_int<Exactly(int)>=45)".format(unicode_type_name)
-      self.assertEqual(str(some_object), expected_msg)
-    if PY2:
-      compare_str('unicode')
-      compare_repr(include_unicode=True)
-    else:
-      compare_str('str')
-      compare_repr()
+    self.assertEqual(str(some_object), "WithExplicitTypeConstraint(a_string<Exactly(str)>=asdf, an_int<Exactly(int)>=45)")
+    self.assertEqual(repr(some_object), "WithExplicitTypeConstraint(a_string='asdf', an_int=45)")
 
     some_nonneg_int = NonNegativeInt(an_int=3)
     self.assertEqual(3, some_nonneg_int.an_int)
@@ -558,19 +517,8 @@ class TypedDatatypeTest(TestBase):
 
     mixed_type_obj = MixedTyping(value=3, name=text_type('asdf'))
     self.assertEqual(3, mixed_type_obj.value)
-    def compare_repr(include_unicode = False):
-      expected_msg = "MixedTyping(value=3, name={unicode_literal}'asdf')" \
-        .format(unicode_literal='u' if include_unicode else '')
-      self.assertEqual(repr(mixed_type_obj), expected_msg)
-    def compare_str(unicode_type_name):
-      expected_msg = "MixedTyping(value=3, name<Exactly({})>=asdf)".format(unicode_type_name)
-      self.assertEqual(str(mixed_type_obj), expected_msg)
-    if PY2:
-      compare_str('unicode')
-      compare_repr(include_unicode=True)
-    else:
-      compare_str('str')
-      compare_repr()
+    self.assertEqual(repr(mixed_type_obj), "MixedTyping(value=3, name='asdf')")
+    self.assertEqual(str(mixed_type_obj), "MixedTyping(value=3, name<Exactly(str)>=asdf)")
 
     subclass_constraint_obj = WithSubclassTypeConstraint(SomeDatatypeClass())
     self.assertEqual('asdf', subclass_constraint_obj.some_value.something())
@@ -581,20 +529,9 @@ class TypedDatatypeTest(TestBase):
       "WithSubclassTypeConstraint(some_value<SubclassesOf(SomeBaseClass)>=SomeDatatypeClass())")
 
   def test_mixin_type_construction(self):
-    obj_with_mixin = TypedWithMixin(text_type(' asdf '))
-    def compare_repr(include_unicode = False):
-      expected_msg = "TypedWithMixin(val={unicode_literal}' asdf ')" \
-        .format(unicode_literal='u' if include_unicode else '')
-      self.assertEqual(repr(obj_with_mixin), expected_msg)
-    def compare_str(unicode_type_name):
-      expected_msg = "TypedWithMixin(val<Exactly({})>= asdf )".format(unicode_type_name)
-      self.assertEqual(str(obj_with_mixin), expected_msg)
-    if PY2:
-      compare_str('unicode')
-      compare_repr(include_unicode=True)
-    else:
-      compare_str('str')
-      compare_repr()
+    obj_with_mixin = TypedWithMixin(' asdf ')
+    self.assertEqual(repr(obj_with_mixin), "TypedWithMixin(val=' asdf ')")
+    self.assertEqual(str(obj_with_mixin), "TypedWithMixin(val<Exactly(str)>= asdf )")
     self.assertEqual(obj_with_mixin.as_str(), ' asdf ')
     self.assertEqual(obj_with_mixin.stripped(), 'asdf')
 
@@ -612,22 +549,12 @@ class TypedDatatypeTest(TestBase):
       SomeTypedDatatype(something=3)
 
     # not providing all the fields
-    expected_msg_ending = (
-      "__new__() missing 1 required positional argument: 'val'"
-      if PY3 else
-      "__new__() takes exactly 2 arguments (1 given)"
-    )
-    expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: {}".format(expected_msg_ending)
+    expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: __new__() missing 1 required positional argument: 'val'"
     with self.assertRaisesWithMessage(TypeError, expected_msg):
       SomeTypedDatatype()
 
     # unrecognized fields
-    expected_msg_ending = (
-      "__new__() takes 2 positional arguments but 3 were given"
-      if PY3 else
-      "__new__() takes exactly 2 arguments (3 given)"
-    )
-    expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: {}".format(expected_msg_ending)
+    expected_msg = "type check error in class SomeTypedDatatype: error in namedtuple() base constructor: __new__() takes 2 positional arguments but 3 were given"
     with self.assertRaisesWithMessage(TypeError, expected_msg):
       SomeTypedDatatype(3, 4)
 
@@ -646,11 +573,6 @@ field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type
   def test_type_check_errors(self):
     self.maxDiff = None
 
-    def format_string_type_check_message(format_string):
-      return format_string.format(
-        str_type='unicode' if PY2 else 'str',
-        u='u' if PY2 else '')
-
     # single type checking failure
     expected_msg = (
       """type check error in class SomeTypedDatatype: 1 error type checking constructor arguments:
@@ -659,23 +581,23 @@ field 'val' was invalid: value [] (with type 'list') must satisfy this type cons
       SomeTypedDatatype([])
 
     # type checking failure with multiple arguments (one is correct)
-    expected_msg = format_string_type_check_message(
+    expected_msg = (
       """type check error in class AnotherTypedDatatype: 1 error type checking constructor arguments:
-field 'elements' was invalid: value {u}'should be list' (with type '{str_type}') must satisfy this type constraint: Exactly(list).""")
+field 'elements' was invalid: value 'should be list' (with type 'str') must satisfy this type constraint: Exactly(list).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       AnotherTypedDatatype(text_type('correct'), text_type('should be list'))
 
     # type checking failure on both arguments
-    expected_msg = format_string_type_check_message(
+    expected_msg = (
         """type check error in class AnotherTypedDatatype: 2 errors type checking constructor arguments:
-field 'string' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly({str_type}).
-field 'elements' was invalid: value {u}'should be list' (with type '{str_type}') must satisfy this type constraint: Exactly(list).""")
+field 'string' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(str).
+field 'elements' was invalid: value 'should be list' (with type 'str') must satisfy this type constraint: Exactly(list).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       AnotherTypedDatatype(3, text_type('should be list'))
 
-    expected_msg = format_string_type_check_message(
+    expected_msg = (
         """type check error in class NonNegativeInt: 1 error type checking constructor arguments:
-field 'an_int' was invalid: value {u}'asdf' (with type '{str_type}') must satisfy this type constraint: Exactly(int).""")
+field 'an_int' was invalid: value 'asdf' (with type 'str') must satisfy this type constraint: Exactly(int).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       NonNegativeInt(text_type('asdf'))
 
@@ -696,9 +618,9 @@ Note that objects matching {} are not considered iterable.""".format(_string_typ
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       WithCollectionTypeConstraint(3)
 
-    expected_msg = format_string_type_check_message("""\
+    expected_msg = ("""\
 type check error in class WithCollectionTypeConstraint: 1 error type checking constructor arguments:
-field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, {u}'asdf']: value {u}'asdf' (with type '{str_type}') must satisfy this type constraint: Exactly(int).""")
+field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) matching iterable object [3, 'asdf']: value 'asdf' (with type 'str') must satisfy this type constraint: Exactly(int).""")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       WithCollectionTypeConstraint([3, "asdf"])
 
@@ -764,9 +686,8 @@ field 'elements' was invalid: value 3 (with type 'int') must satisfy this type c
     class StrEnum(enum(['a'])): pass
     enum_instance = StrEnum('a')
     expected_msg = (
-      "type check error in class StrEnum: when comparing StrEnum(value={u}'a') against {u}'a' with type '{string_type}': "
-      "enum equality is only defined for instances of the same enum class!"
-      .format(u='u' if PY2 else '', string_type='unicode' if PY2 else 'str'))
+      "type check error in class StrEnum: when comparing StrEnum(value='a') against 'a' with type 'str': "
+      "enum equality is only defined for instances of the same enum class!")
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       enum_instance == 'a'
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):


### PR DESCRIPTION
When ran with Python 2, Pants would include an `u""` character in front of certain strings. This is no longer a concern thanks to only running via Python 3.