### PR TITLE
Revert "Workaround Travis timeout for OSX platforms test"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -602,7 +602,7 @@ py36_osx_platform_tests: &py36_osx_platform_tests
     - *py36_osx_test_config_env
     - CACHE_NAME=macosplatformtests.py36
   script:
-    - travis_wait 50 ./build-support/bin/ci.py --platform-specific-tests
+    - ./build-support/bin/ci.py --platform-specific-tests
 
 py37_osx_platform_tests: &py37_osx_platform_tests
   <<: *py37_osx_test_config
@@ -611,7 +611,7 @@ py37_osx_platform_tests: &py37_osx_platform_tests
     - *py37_osx_test_config_env
     - CACHE_NAME=macosplatformtests.py37
   script:
-    - travis_wait 50 ./build-support/bin/ci.py --platform-specific-tests --python-version 3.7
+    - ./build-support/bin/ci.py --platform-specific-tests --python-version 3.7
 
 # -------------------------------------------------------------------------
 # JVM tests

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -549,7 +549,7 @@ py36_osx_platform_tests: &py36_osx_platform_tests
     - *py36_osx_test_config_env
     - CACHE_NAME=macosplatformtests.py36
   script:
-    - travis_wait 50 ./build-support/bin/ci.py --platform-specific-tests
+    - ./build-support/bin/ci.py --platform-specific-tests
 
 py37_osx_platform_tests: &py37_osx_platform_tests
   <<: *py37_osx_test_config
@@ -558,7 +558,7 @@ py37_osx_platform_tests: &py37_osx_platform_tests
     - *py37_osx_test_config_env
     - CACHE_NAME=macosplatformtests.py37
   script:
-    - travis_wait 50 ./build-support/bin/ci.py --platform-specific-tests --python-version 3.7
+    - ./build-support/bin/ci.py --platform-specific-tests --python-version 3.7
 
 # -------------------------------------------------------------------------
 # JVM tests


### PR DESCRIPTION
Reverts pantsbuild/pants#7919, because rather than just taking a long time, the test seems to actually hang.