### PR TITLE
Remove text_type and binary_type wrappers

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -3,7 +3,6 @@
 
 from contextlib import contextmanager
 
-from future.utils import text_type
 from pants.base.build_environment import get_buildroot
 from pants.base.workunit import WorkUnitLabel
 from pants.task.testrunner_task_mixin import PartitionedTestRunnerTaskMixin, TestResult
@@ -52,8 +51,8 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
     self.ensure_workspace(target)
 
   class _GoTestTargetInfo(datatype([
-      ('import_path', text_type),
-      ('gopath', text_type),
+      ('import_path', str),
+      ('gopath', str),
   ])): pass
 
   def _generate_args_for_targets(self, targets):
@@ -62,8 +61,7 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
     reconstructed for spawning test commands regardless of how the targets are partitioned.
     """
     return {
-      t: self._GoTestTargetInfo(import_path=text_type(t.import_path),
-                                gopath=text_type(self.get_gopath(t)))
+      t: self._GoTestTargetInfo(import_path=t.import_path, gopath=self.get_gopath(t))
       for t in targets
     }
 

--- a/src/python/pants/backend/graph_info/tasks/cloc.py
+++ b/src/python/pants/backend/graph_info/tasks/cloc.py
@@ -3,8 +3,6 @@
 
 import os
 
-from future.utils import text_type
-
 from pants.backend.graph_info.subsystems.cloc_binary import ClocBinary
 from pants.base.workunit import WorkUnitLabel
 from pants.engine.fs import FilesContent, PathGlobs, PathGlobsAndRoot
@@ -48,7 +46,7 @@ class CountLinesOfCode(ConsoleTask):
       list_file_snapshot = self.context._scheduler.capture_snapshots((
         PathGlobsAndRoot(
           PathGlobs(('input_files_list',)),
-          text_type(tmpdir),
+          tmpdir,
         ),
       ))[0]
 

--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -131,7 +131,6 @@ python_library(
   name = 'zinc',
   sources = ['zinc.py'],
   dependencies = [
-    '3rdparty/python:future',
     ':dependency_context',
     ':jvm_tool_mixin',
     ':shader',

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -5,8 +5,6 @@ import os
 from hashlib import sha1
 from threading import Lock
 
-from future.utils import text_type
-
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext
 from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
@@ -323,7 +321,7 @@ class Zinc:
     ]
     input_jar_snapshots = context._scheduler.capture_snapshots((PathGlobsAndRoot(
       PathGlobs(tuple([bootstrapper] + bootstrapper_args[1::2])),
-      text_type(get_buildroot()),
+      get_buildroot(),
     ),))
     argv = tuple(['.jdk/bin/java'] +
                  ['-cp', bootstrapper, Zinc.ZINC_BOOTSTRAPER_MAIN] +
@@ -377,7 +375,7 @@ class Zinc:
     else:
       bridge_jar_snapshot = context._scheduler.capture_snapshots((PathGlobsAndRoot(
         PathGlobs((self._relative_to_buildroot(bridge_jar),)),
-        text_type(get_buildroot())
+        get_buildroot()
       ),))[0]
       bridge_jar_digest = bridge_jar_snapshot.directory_digest
       return ClasspathEntry(bridge_jar, bridge_jar_digest)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/BUILD
@@ -4,7 +4,6 @@
 python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python:future',
     'src/python/pants/backend/jvm/subsystems:java',
     'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/backend/jvm/subsystems:shader',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -5,8 +5,6 @@ import logging
 import os
 import subprocess
 
-from future.utils import text_type
-
 from pants.backend.jvm import argfile
 from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
@@ -173,7 +171,7 @@ class JavacCompile(JvmCompile):
             raise TaskError('javac exited with return code {rc}'.format(rc=return_code))
         self.context._scheduler.materialize_directories((
           DirectoryToMaterialize(
-            text_type(ctx.classes_dir.path),
+            ctx.classes_dir.path,
             self.post_compile_extra_resources_digest(ctx, prepend_post_merge_relative_path=False)),
         ))
 
@@ -215,12 +213,8 @@ class JavacCompile(JvmCompile):
       for f in input_snapshot.files if f.endswith('.java')
     )
 
-    # TODO(#6071): Our ExecuteProcessRequest expects a specific string type for arguments,
-    # which py2 doesn't default to. This can be removed when we drop python 2.
-    argv = [text_type(arg) for arg in cmd]
-
     exec_process_request = ExecuteProcessRequest(
-      argv=tuple(argv),
+      argv=tuple(cmd),
       input_files=input_snapshot.directory_digest,
       output_files=output_files,
       description='Compiling {} with javac'.format(ctx.target.address.spec),
@@ -238,5 +232,5 @@ class JavacCompile(JvmCompile):
       ])
     classes_directory = ctx.classes_dir.path
     self.context._scheduler.materialize_directories((
-      DirectoryToMaterialize(text_type(classes_directory), merged_directories),
+      DirectoryToMaterialize(classes_directory, merged_directories),
     ))

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -5,7 +5,7 @@ import functools
 import os
 from multiprocessing import cpu_count
 
-from future.utils import PY2, PY3, text_type
+from future.utils import PY2, PY3
 from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext
@@ -902,7 +902,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
       libs_unrooted = [self._unroot_lib_path(l) for l in libs_abs]
       path_globs = PathGlobsAndRoot(
         PathGlobs(tuple(libs_unrooted)),
-        text_type(self._underlying.home))
+        self._underlying.home)
       return (libs_unrooted, path_globs)
 
     @property

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 
-from future.utils import PY3, text_type
+from future.utils import PY3
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext  # noqa
 from pants.backend.jvm.subsystems.rsc import Rsc
@@ -571,13 +571,10 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       additional_snapshots = [native_image_snapshot]
       initial_args = [native_image_path]
     else:
-      # TODO(#6071): Our ExecuteProcessRequest expects a specific string type for arguments,
-      # which py2 doesn't default to. This can be removed when we drop python 2.
-      str_jvm_options = [text_type(opt) for opt in self.get_options().jvm_options]
       additional_snapshots = []
       initial_args = [
         distribution.java,
-      ] + str_jvm_options + [
+      ] + self.get_options().jvm_options + [
         '-cp', os.pathsep.join(tool_classpath),
         main,
       ]
@@ -596,7 +593,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     if pathglobs:
       root = PathGlobsAndRoot(
         PathGlobs(tuple(pathglobs)),
-        text_type(get_buildroot()))
+        get_buildroot())
       # dont capture snapshot, if pathglobs is empty
       path_globs_input_digest = self.context._scheduler.capture_snapshots((root,))[0].directory_digest
 
@@ -616,7 +613,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       # TODO: These should always be unicodes
       # Since this is always hermetic, we need to use `underlying.home` because
       # ExecuteProcessRequest requires an existing, local jdk location.
-      jdk_home=text_type(distribution.underlying_home),
+      jdk_home=distribution.underlying_home,
     )
     res = self.context.execute_process_synchronously_without_raising(
       epr,
@@ -635,7 +632,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     self.context._scheduler.materialize_directories((
       DirectoryToMaterialize(
         # NB the first element here is the root to materialize into, not the dir to snapshot
-        text_type(get_buildroot()),
+        get_buildroot(),
         res.output_directory_digest),
     ))
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/BUILD
@@ -4,7 +4,6 @@
 python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python:future',
     'src/python/pants/backend/jvm/subsystems:java',
     'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/backend/jvm/subsystems:scala_platform',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_analysis.py
@@ -2,8 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from future.utils import text_type
-
 from pants.backend.jvm.tasks.jvm_compile.analysis import Analysis
 from pants.backend.jvm.zinc.zinc_analysis import ZincAnalysis as UnderlyingAnalysis
 
@@ -43,6 +41,3 @@ class ZincAnalysis(Analysis):
 
   def __str__(self):
     return str(self.underlying_analysis)
-
-  def __unicode__(self):
-    return text_type(self.underlying_analysis)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -10,8 +10,6 @@ from collections import defaultdict
 from contextlib import closing
 from xml.etree import ElementTree
 
-from future.utils import text_type
-
 from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
@@ -456,9 +454,6 @@ class BaseZincCompile(JvmCompile):
       ])
 
     argv = image_specific_argv + ['@{}'.format(argfile_snapshot.files[0])]
-    # TODO(#6071): Our ExecuteProcessRequest expects a specific string type for arguments,
-    # which py2 doesn't default to. This can be removed when we drop python 2.
-    argv = [text_type(arg) for arg in argv]
 
     merged_input_digest = self.context._scheduler.merge_directories(
       tuple(s.directory_digest for s in snapshots) +

--- a/src/python/pants/backend/native/targets/external_native_library.py
+++ b/src/python/pants/backend/native/targets/external_native_library.py
@@ -3,8 +3,6 @@
 
 import re
 
-from future.utils import text_type
-
 from pants.base.hash_utils import stable_json_sha1
 from pants.base.payload import Payload
 from pants.base.payload_field import PayloadField
@@ -22,9 +20,9 @@ class ConanRequirementSetField(tuple, PayloadField):
 
 
 class ConanRequirement(datatype([
-    ('pkg_spec', text_type),
-    ('include_relpath', text_type),
-    ('lib_relpath', text_type),
+    ('pkg_spec', str),
+    ('include_relpath', str),
+    ('lib_relpath', str),
     ('lib_names', tuple),
 ])):
   """A specification for a conan package to be resolved against a remote repository.
@@ -54,9 +52,9 @@ class ConanRequirement(datatype([
     """
     return super().__new__(
       cls,
-      text_type(pkg_spec),
-      include_relpath=text_type(include_relpath or 'include'),
-      lib_relpath=text_type(lib_relpath or 'lib'),
+      pkg_spec,
+      include_relpath=include_relpath or 'include',
+      lib_relpath=lib_relpath or 'lib',
       lib_names=tuple(lib_names or ()))
 
   def parse_conan_stdout_for_pkg_sha(self, stdout):

--- a/src/python/pants/backend/project_info/rules/source_file_validator.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator.py
@@ -4,8 +4,6 @@
 import itertools
 import re
 
-from future.utils import text_type
-
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.engine.console import Console
 from pants.engine.fs import Digest, FilesContent
@@ -83,7 +81,7 @@ class SourceFileValidation(Subsystem):
 
 
 class RegexMatchResult(datatype([
-  ('path', text_type), ('matching', tuple), ('nonmatching', tuple)
+  ('path', str), ('matching', tuple), ('nonmatching', tuple)
 ])):
   """The result of running regex matches on a source file."""
 

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -1,9 +1,6 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
-from future.utils import text_type
-
 from pants.backend.python.rules.inject_init import InjectedInitDigest
 from pants.backend.python.rules.resolve_requirements import (ResolvedRequirementsPex,
                                                              ResolveRequirementsRequest)
@@ -58,9 +55,8 @@ def run_python_test(test_target, pytest, python_setup, source_root_config, subpr
   resolved_requirements_pex = yield Get(
     ResolvedRequirementsPex, ResolveRequirementsRequest(
       output_filename=output_pytest_requirements_pex_filename,
-      # TODO(#7061): This text_type() wrapping can be removed after we drop py2!
-      requirements=tuple(sorted(text_type(requirement) for requirement in all_requirements)),
-      interpreter_constraints=tuple(sorted(text_type(constraint) for constraint in interpreter_constraints)),
+      requirements=tuple(sorted(all_requirements)),
+      interpreter_constraints=tuple(sorted(interpreter_constraints)),
       entry_point="pytest:main",
     )
   )
@@ -106,7 +102,7 @@ def run_python_test(test_target, pytest, python_setup, source_root_config, subpr
     DirectoriesToMerge(directories=tuple(all_input_digests)),
   )
 
-  interpreter_search_paths = text_type(create_path_env_var(python_setup.interpreter_search_paths))
+  interpreter_search_paths = create_path_env_var(python_setup.interpreter_search_paths)
   pex_exe_env = {'PATH': interpreter_search_paths}
   # TODO(#6071): merge the two dicts via ** unpacking once we drop Py2.
   pex_exe_env.update(subprocess_encoding_environment.invocation_environment_dict)

--- a/src/python/pants/backend/python/rules/resolve_requirements.py
+++ b/src/python/pants/backend/python/rules/resolve_requirements.py
@@ -1,8 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from future.utils import text_type
-
 from pants.backend.python.subsystems.python_native_code import PexBuildEnvironment, PythonNativeCode
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.engine.fs import Digest, Snapshot, UrlToFetch
@@ -38,7 +36,7 @@ def resolve_requirements(request, python_setup, pex_build_environment):
   digest = Digest('61bb79384db0da8c844678440bd368bcbfac17bbdb865721ad3f9cb0ab29b629', 1826945)
   pex_snapshot = yield Get(Snapshot, UrlToFetch(url, digest))
 
-  interpreter_search_paths = text_type(create_path_env_var(python_setup.interpreter_search_paths))
+  interpreter_search_paths = create_path_env_var(python_setup.interpreter_search_paths)
   env = {"PATH": interpreter_search_paths}
   # TODO(#6071): merge the two dicts via ** unpacking once we drop Py2.
   env.update(pex_build_environment.invocation_environment_dict)

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -5,8 +5,6 @@ import logging
 import os
 from textwrap import dedent
 
-from future.utils import text_type
-
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.python.python_requirement import PythonRequirement
@@ -160,9 +158,8 @@ class PexBuildEnvironment(datatype([
 @rule(PexBuildEnvironment, [PythonNativeCode])
 def create_pex_native_build_environment(python_native_code):
   return PexBuildEnvironment(
-    # TODO(#6071): drop the text_type wrapping.
-    cpp_flags=[text_type(v) for v in python_native_code.get_options().cpp_flags],
-    ld_flags=[text_type(v) for v in python_native_code.get_options().ld_flags],
+    cpp_flags=python_native_code.get_options().cpp_flags,
+    ld_flags=python_native_code.get_options().ld_flags,
   )
 
 

--- a/src/python/pants/backend/python/subsystems/subprocess_environment.py
+++ b/src/python/pants/backend/python/subsystems/subprocess_environment.py
@@ -3,8 +3,6 @@
 
 import os
 
-from future.utils import text_type
-
 from pants.engine.rules import optionable_rule, rule
 from pants.subsystem.subsystem import Subsystem
 from pants.util.objects import datatype, string_optional
@@ -43,12 +41,9 @@ class SubprocessEncodingEnvironment(datatype([
 
 @rule(SubprocessEncodingEnvironment, [SubprocessEnvironment])
 def create_subprocess_encoding_environment(subprocess_environment):
-  def ensure_string_optional(value):
-    return text_type(value) if value is not None else None
-
   return SubprocessEncodingEnvironment(
-    lang=ensure_string_optional(subprocess_environment.get_options().lang),
-    lc_all=ensure_string_optional(subprocess_environment.get_options().lc_all),
+    lang=subprocess_environment.get_options().lang,
+    lc_all=subprocess_environment.get_options().lc_all,
   )
 
 

--- a/src/python/pants/backend/python/tasks/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks/python_execution_task_base.py
@@ -3,7 +3,6 @@
 
 import os
 
-from future.utils import binary_type, text_type
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 
@@ -67,7 +66,7 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
     """
     return ()
 
-  class ExtraFile(datatype([('path', text_type), ('content', binary_type)])):
+  class ExtraFile(datatype([('path', str), ('content', bytes)])):
     """Models an extra file to place in a PEX."""
 
     @classmethod

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -103,7 +103,6 @@ python_library(
   name = 'hash_utils',
   sources = ['hash_utils.py'],
   dependencies = [
-    '3rdparty/python:future',
     ':deprecated',
     'src/python/pants/util:objects',
   ]
@@ -114,15 +113,12 @@ python_library(
   sources = ['mustache.py'],
   dependencies = [
     '3rdparty/python:pystache',
-    '3rdparty/python:six',
   ]
 )
 
 python_library(
   name = 'parse_context',
   sources = ['parse_context.py'],
-  dependencies = [
-  ]
 )
 
 python_library(

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -7,7 +7,6 @@ import logging
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping, Set
 
-from future.utils import binary_type, text_type
 from twitter.common.collections import OrderedSet
 
 from pants.util.objects import DatatypeMixin
@@ -64,7 +63,7 @@ class CoercingEncoder(json.JSONEncoder):
       return self.encode(key_obj)
 
   def _is_natively_encodable(self, o):
-    return isinstance(o, (type(None), bool, int, list, text_type, binary_type))
+    return isinstance(o, (type(None), bool, int, list, str, bytes))
 
   def default(self, o):
     if self._is_natively_encodable(o):

--- a/src/python/pants/base/mustache.py
+++ b/src/python/pants/base/mustache.py
@@ -5,7 +5,6 @@ import os
 import pkgutil
 
 import pystache
-import six
 
 
 class MustacheRenderer:
@@ -37,7 +36,6 @@ class MustacheRenderer:
 
   @staticmethod
   def parse_template(template_text):
-    template_text = six.text_type(template_text)
     template = pystache.parse(template_text)
     return template
 

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -5,8 +5,6 @@ import logging
 import os
 import threading
 
-from future.utils import text_type
-
 from pants.binaries.binary_util import BinaryRequest, BinaryUtil
 from pants.engine.fs import PathGlobs, PathGlobsAndRoot
 from pants.fs.archive import XZCompressedTarArchiver, create_archiver
@@ -187,7 +185,7 @@ class BinaryToolBase(Subsystem):
     snapshot = context._scheduler.capture_snapshots((
       PathGlobsAndRoot(
         PathGlobs((relpath,)),
-        text_type(bootstrapdir),
+        bootstrapdir,
       ),
     ))[0]
     return (relpath, snapshot)

--- a/src/python/pants/build_graph/mirrored_target_option_mixin.py
+++ b/src/python/pants/build_graph/mirrored_target_option_mixin.py
@@ -3,15 +3,13 @@
 
 from abc import ABC, abstractmethod
 
-from future.utils import text_type
-
 from pants.util.memo import memoized_property
 from pants.util.objects import datatype
 
 
 class MirroredTargetOptionDeclaration(datatype([
     'options',
-    ('option_name', text_type),
+    ('option_name', str),
     'accessor',
 ])):
   """An interface for operations to perform on an option which may also be set on a target."""

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -46,7 +46,6 @@ python_library(
   sources=['fs.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python:future',
     ':objects',
     ':rules',
     ':selectors',

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -3,8 +3,6 @@
 
 import os
 
-from future.utils import binary_type, text_type
-
 from pants.engine.objects import Collection
 from pants.engine.rules import RootRule
 from pants.option.custom_types import GlobExpansionConjunction
@@ -13,7 +11,7 @@ from pants.util.dirutil import maybe_read_file, safe_delete, safe_file_dump
 from pants.util.objects import Exactly, datatype
 
 
-class FileContent(datatype([('path', text_type), ('content', binary_type)])):
+class FileContent(datatype([('path', str), ('content', bytes)])):
   """The content of a file."""
 
   def __repr__(self):
@@ -56,7 +54,7 @@ class PathGlobs(datatype([
       conjunction=(conjunction or GlobExpansionConjunction.any_match))
 
 
-class Digest(datatype([('fingerprint', text_type), ('serialized_bytes_length', int)])):
+class Digest(datatype([('fingerprint', str), ('serialized_bytes_length', int)])):
   """A Digest is a content-digest fingerprint, and a length of underlying content.
 
   These are used both to reference digests of strings/bytes/content, and as an opaque handle to a
@@ -113,7 +111,7 @@ class Digest(datatype([('fingerprint', text_type), ('serialized_bytes_length', i
 
 class PathGlobsAndRoot(datatype([
     ('path_globs', PathGlobs),
-    ('root', text_type),
+    ('root', str),
     ('digest_hint', Exactly(Digest, type(None))),
 ])):
   """A set of PathGlobs to capture relative to some root (which may exist outside of the buildroot).
@@ -145,16 +143,16 @@ class DirectoriesToMerge(datatype([('directories', tuple)])):
   pass
 
 
-class DirectoryWithPrefixToStrip(datatype([('directory_digest', Digest), ('prefix', text_type)])):
+class DirectoryWithPrefixToStrip(datatype([('directory_digest', Digest), ('prefix', str)])):
   pass
 
 
-class DirectoryToMaterialize(datatype([('path', text_type), ('directory_digest', Digest)])):
+class DirectoryToMaterialize(datatype([('path', str), ('directory_digest', Digest)])):
   """A request to materialize the contents of a directory digest at the provided path."""
   pass
 
 
-class UrlToFetch(datatype([('url', text_type), ('digest', Digest)])):
+class UrlToFetch(datatype([('url', str), ('digest', Digest)])):
   pass
 
 
@@ -166,7 +164,7 @@ _EMPTY_FINGERPRINT = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b78
 
 
 EMPTY_DIRECTORY_DIGEST = Digest(
-  fingerprint=text_type(_EMPTY_FINGERPRINT),
+  fingerprint=_EMPTY_FINGERPRINT,
   serialized_bytes_length=0
 )
 

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -3,8 +3,6 @@
 
 import logging
 
-from future.utils import binary_type
-
 from pants.engine.fs import Digest
 from pants.engine.rules import RootRule, rule
 from pants.util.objects import Exactly, datatype, hashable_string_list, string_optional, string_type
@@ -62,8 +60,8 @@ class ExecuteProcessRequest(datatype([
     )
 
 
-class ExecuteProcessResult(datatype([('stdout', binary_type),
-                                     ('stderr', binary_type),
+class ExecuteProcessResult(datatype([('stdout', bytes),
+                                     ('stderr', bytes),
                                      ('output_directory_digest', Digest)
                                      ])):
   """Result of successfully executing a process.
@@ -71,8 +69,8 @@ class ExecuteProcessResult(datatype([('stdout', binary_type),
   Requesting one of these will raise an exception if the exit code is non-zero."""
 
 
-class FallibleExecuteProcessResult(datatype([('stdout', binary_type),
-                                             ('stderr', binary_type),
+class FallibleExecuteProcessResult(datatype([('stdout', bytes),
+                                             ('stderr', bytes),
                                              ('exit_code', int),
                                              ('output_directory_digest', Digest)
                                              ])):

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -12,7 +12,7 @@ from contextlib import closing
 
 import cffi
 import pkg_resources
-from future.utils import PY2, binary_type, text_type
+from future.utils import PY2
 from twitter.common.collections.orderedset import OrderedSet
 
 from pants.engine.selectors import Get
@@ -321,7 +321,7 @@ class _FFISpecification(object):
   def extern_type_to_str(self, context_handle, type_id):
     """Given a TypeId, write type.__name__ and return it."""
     c = self._ffi.from_handle(context_handle)
-    return c.utf8_buf(text_type(c.from_id(type_id.tup_0).__name__))
+    return c.utf8_buf(str(c.from_id(type_id.tup_0).__name__))
 
   @_extern_decl('Buffer', ['ExternContext*', 'Handle*'])
   def extern_val_to_str(self, context_handle, val):
@@ -329,7 +329,7 @@ class _FFISpecification(object):
     c = self._ffi.from_handle(context_handle)
     v = c.from_value(val[0])
     # Consistently use the empty string to indicate None.
-    v_str = '' if v is None else text_type(v)
+    v_str = '' if v is None else str(v)
     return c.utf8_buf(v_str)
 
   @_extern_decl('Handle', ['ExternContext*', 'Handle**', 'uint64_t'])
@@ -363,7 +363,7 @@ class _FFISpecification(object):
   def extern_store_bytes(self, context_handle, bytes_ptr, bytes_len):
     """Given a context and raw bytes, return a new Handle to represent the content."""
     c = self._ffi.from_handle(context_handle)
-    return c.to_value(binary_type(self._ffi.buffer(bytes_ptr, bytes_len)))
+    return c.to_value(bytes(self._ffi.buffer(bytes_ptr, bytes_len)))
 
   @_extern_decl('Handle', ['ExternContext*', 'uint8_t*', 'uint64_t'])
   def extern_store_utf8(self, context_handle, utf8_ptr, utf8_len):
@@ -803,8 +803,8 @@ class Native(Singleton):
         ti(type_process_result),
         ti(type_generator),
         ti(type_url_to_fetch),
-        ti(text_type),
-        ti(binary_type),
+        ti(str),
+        ti(bytes),
         # Project tree.
         self.context.utf8_buf(build_root),
         self.context.utf8_buf(work_dir),

--- a/src/python/pants/engine/struct.py
+++ b/src/python/pants/engine/struct.py
@@ -4,8 +4,6 @@
 
 from collections.abc import MutableMapping, MutableSequence
 
-from future.utils import binary_type, text_type
-
 from pants.engine.addressable import addressable, addressable_list
 from pants.engine.objects import Serializable, SerializableFactory, Validatable, ValidationError
 from pants.util.objects import SubclassesOf, SuperclassesOf
@@ -13,10 +11,10 @@ from pants.util.objects import SubclassesOf, SuperclassesOf
 
 def _normalize_utf8_keys(kwargs):
   """When kwargs are passed literally in a source file, their keys are ascii: normalize."""
-  if any(type(key) is binary_type for key in kwargs.keys()):
+  if any(type(key) is bytes for key in kwargs.keys()):
     # This is to preserve the original dict type for kwargs.
     dict_type = type(kwargs)
-    return dict_type([(text_type(k), v) for k, v in kwargs.items()])
+    return dict_type([(str(k), v) for k, v in kwargs.items()])
   return kwargs
 
 

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 from collections import namedtuple
 from contextlib import contextmanager
 
-from future.utils import PY3, text_type
+from future.utils import PY3
 from six import string_types
 
 from pants.base.revision import Revision
@@ -149,7 +149,7 @@ class Distribution:
         if self._is_executable(os.path.join(jdk_dir, 'bin', 'javac')):
           home = jdk_dir
       self._home = home
-    return text_type(self._home)
+    return self._home
 
   @property
   def real_home(self):

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -5,8 +5,6 @@ import copy
 import re
 import sys
 
-from future.utils import text_type
-
 from pants.base.deprecated import warn_or_error
 from pants.option.arg_splitter import GLOBAL_SCOPE, ArgSplitter
 from pants.option.global_options import GlobalOptionsRegistrar
@@ -368,10 +366,10 @@ class Options:
           )
 
   class _ScopedFlagNameForFuzzyMatching(datatype([
-      ('scope', text_type),
-      ('arg', text_type),
-      ('normalized_arg', text_type),
-      ('scoped_arg', text_type),
+      ('scope', str),
+      ('arg', str),
+      ('normalized_arg', str),
+      ('scoped_arg', str),
   ])):
     """Specify how a registered option would look like on the command line.
 
@@ -415,8 +413,8 @@ class Options:
       known_args = parser.known_args
       for arg in known_args:
         scoped_flag = self._ScopedFlagNameForFuzzyMatching(
-          scope=text_type(scope),
-          arg=text_type(arg),
+          scope=scope,
+          arg=arg,
         )
         all_scoped_flag_names.append(scoped_flag)
     self.walk_parsers(register_all_scoped_names)

--- a/src/python/pants/pantsd/BUILD
+++ b/src/python/pants/pantsd/BUILD
@@ -56,7 +56,6 @@ python_library(
   name = 'pants_daemon',
   sources = ['pants_daemon.py'],
   dependencies = [
-    '3rdparty/python:future',
     '3rdparty/python:setproctitle',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exception_sink',

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -7,7 +7,6 @@ import sys
 import threading
 from contextlib import contextmanager
 
-from future.utils import text_type
 from setproctitle import setproctitle as set_process_title
 
 from pants.base.build_environment import get_buildroot
@@ -100,7 +99,7 @@ class PantsDaemon(FingerprintedProcessManager):
   class RuntimeFailure(Exception):
     """Represents a pantsd failure at runtime, usually from an underlying service failure."""
 
-  class Handle(datatype([('pid', int), ('port', int), ('metadata_base_dir', text_type)])):
+  class Handle(datatype([('pid', int), ('port', int), ('metadata_base_dir', str)])):
     """A handle to a "probably running" pantsd instance.
 
     We attempt to verify that the pantsd instance is still running when we create a Handle, but
@@ -127,7 +126,7 @@ class PantsDaemon(FingerprintedProcessManager):
           return PantsDaemon.Handle(
               stub_pantsd.await_pid(10),
               stub_pantsd.read_named_socket('pailgun', int),
-              text_type(stub_pantsd._metadata_base_dir),
+              stub_pantsd._metadata_base_dir,
           )
 
     @classmethod
@@ -484,7 +483,7 @@ class PantsDaemon(FingerprintedProcessManager):
     listening_port = self.read_named_socket('pailgun', int)
     self._logger.debug('pantsd is running at pid {}, pailgun port is {}'
                        .format(self.pid, listening_port))
-    return self.Handle(pantsd_pid, listening_port, text_type(self._metadata_base_dir))
+    return self.Handle(pantsd_pid, listening_port, self._metadata_base_dir)
 
   def terminate(self, include_watchman=True):
     """Terminates pantsd and watchman.

--- a/src/python/pants/rules/core/core_test_model.py
+++ b/src/python/pants/rules/core/core_test_model.py
@@ -1,8 +1,6 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from future.utils import text_type
-
 from pants.engine.rules import union
 from pants.util.objects import datatype, enum
 
@@ -13,8 +11,8 @@ class Status(enum(['SUCCESS', 'FAILURE'])): pass
 class TestResult(datatype([
   ('status', Status),
   # The stdout of the test runner (which may or may not include actual testcase output).
-  ('stdout', text_type),
-  ('stderr', text_type),
+  ('stdout', str),
+  ('stderr', str),
 ])):
 
   # Prevent this class from being detected by pytest as a test class.

--- a/src/python/pants/task/simple_codegen_task.py
+++ b/src/python/pants/task/simple_codegen_task.py
@@ -6,7 +6,6 @@ import os
 from abc import abstractmethod
 from collections import OrderedDict
 
-from future.utils import text_type
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot
@@ -286,7 +285,7 @@ class SimpleCodegenTask(Task):
       to_capture.append(
         PathGlobsAndRoot(
           PathGlobs(buildroot_relative_globs, buildroot_relative_excludes),
-          text_type(get_buildroot()),
+          get_buildroot(),
           # The digest is stored adjacent to the hash-versioned `vt.current_results_dir`.
           Digest.load(vt.current_results_dir),
         )

--- a/src/python/pants/task/unpack_remote_sources_base.py
+++ b/src/python/pants/task/unpack_remote_sources_base.py
@@ -6,7 +6,6 @@ import os
 import re
 from abc import ABCMeta, abstractmethod
 
-from future.utils import text_type
 from twitter.common.dirutil.fileset import fnmatch_translate_extended
 
 from pants.base.build_environment import get_buildroot
@@ -19,13 +18,10 @@ from pants.util.objects import datatype
 logger = logging.getLogger(__name__)
 
 
-class UnpackedArchives(datatype([('found_files', tuple), ('rel_unpack_dir', text_type)])):
+class UnpackedArchives(datatype([('found_files', tuple), ('rel_unpack_dir', str)])):
 
   def __new__(cls, found_files, rel_unpack_dir):
-    return super().__new__(
-      cls,
-      tuple(found_files),
-      text_type(rel_unpack_dir))
+    return super().__new__(cls, tuple(found_files), rel_unpack_dir)
 
 
 class UnpackRemoteSourcesBase(Task, metaclass=ABCMeta):

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -92,7 +92,6 @@ python_library(
   sources = ['objects.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python:future',
     ':strutil',
     ':memo',
     ':meta',

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -6,7 +6,6 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict, namedtuple
 from collections.abc import Iterable
 
-from future.utils import binary_type, text_type
 from twitter.common.collections import OrderedSet
 
 from pants.util.memo import memoized_classproperty
@@ -537,7 +536,9 @@ class SubclassesOf(TypeOnlyConstraint):
     return issubclass(obj_type, self._types)
 
 
-_string_type_constraint = SubclassesOf(binary_type, text_type)
+# TODO(#6071): We should in general not allow bytes _and_ str. The whole point of Py3 was to decide
+# for each case which to use, not to support both.
+_string_type_constraint = SubclassesOf(bytes, str)
 
 
 class TypedCollection(TypeConstraint):
@@ -627,9 +628,9 @@ class HashableTypedCollection(TypedCollection):
   iterable_constraint = hashable_collection_constraint
 
 
-string_type = Exactly(text_type)
+string_type = Exactly(str)
 string_list = TypedCollection(string_type)
-string_optional = Exactly(text_type, type(None))
+string_optional = Exactly(str, type(None))
 
 
 hashable_string_list = HashableTypedCollection(string_type)

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -66,7 +66,6 @@ python_tests(
   sources=['test_fs.py'],
   dependencies=[
     ':scheduler_test_base',
-    '3rdparty/python:future',
     'src/python/pants/engine:fs',
     'src/python/pants/engine:nodes',
     'tests/python/pants_test:test_base',
@@ -78,7 +77,6 @@ python_tests(
   name='isolated_process',
   sources=['test_isolated_process.py'],
   dependencies=[
-    '3rdparty/python:future',
     'src/python/pants/engine:fs',
     'src/python/pants/engine:isolated_process',
     'src/python/pants/engine:rules',

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -10,8 +10,6 @@ from abc import ABCMeta
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler
 
-from future.utils import text_type
-
 from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, Digest, DirectoriesToMerge,
                              DirectoryToMaterialize, DirectoryWithPrefixToStrip, FilesContent,
                              PathGlobs, PathGlobsAndRoot, Snapshot, UrlToFetch, create_fs_rules)
@@ -226,9 +224,9 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         f.write("European Burmese")
       scheduler = self.mk_scheduler(rules=create_fs_rules())
       globs = PathGlobs(("*",), ())
-      snapshot = scheduler.capture_snapshots((PathGlobsAndRoot(globs, text_type(temp_dir)),))[0]
+      snapshot = scheduler.capture_snapshots((PathGlobsAndRoot(globs, temp_dir),))[0]
       self.assert_snapshot_equals(snapshot, ["roland"], Digest(
-        text_type("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16"),
+        "63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16",
         80
       ))
 
@@ -240,17 +238,17 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         f.write("I don't know")
       scheduler = self.mk_scheduler(rules=create_fs_rules())
       snapshots = scheduler.capture_snapshots((
-        PathGlobsAndRoot(PathGlobs(("roland",), ()), text_type(temp_dir)),
-        PathGlobsAndRoot(PathGlobs(("susannah",), ()), text_type(temp_dir)),
-        PathGlobsAndRoot(PathGlobs(("doesnotexist",), ()), text_type(temp_dir)),
+        PathGlobsAndRoot(PathGlobs(("roland",), ()), temp_dir),
+        PathGlobsAndRoot(PathGlobs(("susannah",), ()), temp_dir),
+        PathGlobsAndRoot(PathGlobs(("doesnotexist",), ()), temp_dir),
       ))
       self.assertEqual(3, len(snapshots))
       self.assert_snapshot_equals(snapshots[0], ["roland"], Digest(
-        text_type("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16"),
+        "63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16",
         80
       ))
       self.assert_snapshot_equals(snapshots[1], ["susannah"], Digest(
-        text_type("d3539cfc21eb4bab328ca9173144a8e932c515b1b9e26695454eeedbc5a95f6f"),
+        "d3539cfc21eb4bab328ca9173144a8e932c515b1b9e26695454eeedbc5a95f6f",
         82
       ))
       self.assert_snapshot_equals(snapshots[2], [], EMPTY_DIRECTORY_DIGEST)
@@ -260,7 +258,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
       scheduler = self.mk_scheduler(rules=create_fs_rules())
       globs = PathGlobs(("*",), ())
       with self.assertRaises(Exception) as cm:
-        scheduler.capture_snapshots((PathGlobsAndRoot(globs, text_type(os.path.join(temp_dir, "doesnotexist"))),))
+        scheduler.capture_snapshots((PathGlobsAndRoot(globs, os.path.join(temp_dir, "doesnotexist")),))
       self.assertIn("doesnotexist", str(cm.exception))
 
   def assert_snapshot_equals(self, snapshot, files, directory_digest):
@@ -280,10 +278,10 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         f.write("Not sure actually")
       (empty_snapshot, roland_snapshot, susannah_snapshot, both_snapshot) = (
         self.scheduler.capture_snapshots((
-          PathGlobsAndRoot(PathGlobs(("doesnotmatch",), ()), text_type(temp_dir)),
-          PathGlobsAndRoot(PathGlobs(("roland",), ()), text_type(temp_dir)),
-          PathGlobsAndRoot(PathGlobs(("susannah",), ()), text_type(temp_dir)),
-          PathGlobsAndRoot(PathGlobs(("*",), ()), text_type(temp_dir)),
+          PathGlobsAndRoot(PathGlobs(("doesnotmatch",), ()), temp_dir),
+          PathGlobsAndRoot(PathGlobs(("roland",), ()), temp_dir),
+          PathGlobsAndRoot(PathGlobs(("susannah",), ()), temp_dir),
+          PathGlobsAndRoot(PathGlobs(("*",), ()), temp_dir),
         ))
       )
 
@@ -317,10 +315,10 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         f.write("Not sure actually")
       (empty_snapshot, roland_snapshot, susannah_snapshot, both_snapshot) = (
         self.scheduler.capture_snapshots((
-          PathGlobsAndRoot(PathGlobs(("doesnotmatch",), ()), text_type(temp_dir)),
-          PathGlobsAndRoot(PathGlobs(("roland",), ()), text_type(temp_dir)),
-          PathGlobsAndRoot(PathGlobs(("susannah",), ()), text_type(temp_dir)),
-          PathGlobsAndRoot(PathGlobs(("*",), ()), text_type(temp_dir)),
+          PathGlobsAndRoot(PathGlobs(("doesnotmatch",), ()), temp_dir),
+          PathGlobsAndRoot(PathGlobs(("roland",), ()), temp_dir),
+          PathGlobsAndRoot(PathGlobs(("susannah",), ()), temp_dir),
+          PathGlobsAndRoot(PathGlobs(("*",), ()), temp_dir),
         ))
       )
 
@@ -354,10 +352,10 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
     with temporary_dir() as temp_dir:
       dir_path = os.path.join(temp_dir, "containing_roland")
       digest = Digest(
-        text_type("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16"),
+        "63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16",
         80
       )
-      self.scheduler.materialize_directories((DirectoryToMaterialize(text_type(dir_path), digest),))
+      self.scheduler.materialize_directories((DirectoryToMaterialize(dir_path, digest),))
 
       created_file = os.path.join(dir_path, "roland")
       with open(created_file, 'r') as f:
@@ -397,8 +395,8 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
       )
 
       snapshot, snapshot_with_extra_files = self.scheduler.capture_snapshots((
-        PathGlobsAndRoot(PathGlobs(("characters/dark_tower/*",)), text_type(temp_dir)),
-        PathGlobsAndRoot(PathGlobs(("**",)), text_type(temp_dir)),
+        PathGlobsAndRoot(PathGlobs(("characters/dark_tower/*",)), temp_dir),
+        PathGlobsAndRoot(PathGlobs(("**",)), temp_dir),
       ))
       # Check that we got the full snapshots that we expect
       self.assertEquals(snapshot.files, relevant_files)
@@ -407,14 +405,14 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
       # Strip empty prefix:
       zero_prefix_stripped_digest = assert_single_element(self.scheduler.product_request(
         Digest,
-        [DirectoryWithPrefixToStrip(snapshot.directory_digest, text_type(""))],
+        [DirectoryWithPrefixToStrip(snapshot.directory_digest, "")],
       ))
       self.assertEquals(snapshot.directory_digest, zero_prefix_stripped_digest)
 
       # Strip a non-empty prefix shared by all files:
       stripped_digest = assert_single_element(self.scheduler.product_request(
         Digest,
-        [DirectoryWithPrefixToStrip(snapshot.directory_digest, text_type("characters/dark_tower"))],
+        [DirectoryWithPrefixToStrip(snapshot.directory_digest, "characters/dark_tower")],
       ))
       self.assertEquals(
         stripped_digest,
@@ -424,7 +422,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         )
       )
       expected_snapshot = assert_single_element(self.scheduler.capture_snapshots((
-        PathGlobsAndRoot(PathGlobs(("*",)), text_type(tower_dir)),
+        PathGlobsAndRoot(PathGlobs(("*",)), tower_dir),
       )))
       self.assertEquals(expected_snapshot.files, ('roland', 'susannah'))
       self.assertEquals(stripped_digest, expected_snapshot.directory_digest)
@@ -433,7 +431,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
       with self.assertRaisesWithMessageContaining(Exception, "Cannot strip prefix characters/dark_tower from root directory Digest(Fingerprint<28c47f77867f0c8d577d2ada2f06b03fc8e5ef2d780e8942713b26c5e3f434b8>, 243) - root directory contained non-matching directory named: books and file named: index"):
         self.scheduler.product_request(
           Digest,
-          [DirectoryWithPrefixToStrip(snapshot_with_extra_files.directory_digest, text_type("characters/dark_tower"))]
+          [DirectoryWithPrefixToStrip(snapshot_with_extra_files.directory_digest, "characters/dark_tower")]
         )
 
   def test_lift_directory_digest_to_snapshot(self):
@@ -450,7 +448,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
     text = b"European Burmese"
     hasher = hashlib.sha256()
     hasher.update(text)
-    digest = Digest(fingerprint=text_type(hasher.hexdigest()), serialized_bytes_length=len(text))
+    digest = Digest(fingerprint=hasher.hexdigest(), serialized_bytes_length=len(text))
 
     with self.assertRaisesWithMessageContaining(ExecutionError, "unknown directory"):
       self.scheduler.product_request(Snapshot, [digest])
@@ -505,9 +503,9 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
       with open(os.path.join(temp_dir, "roland"), "w") as f:
         f.write("European Burmese")
       globs = PathGlobs(("*",), ())
-      snapshot = self.scheduler.capture_snapshots((PathGlobsAndRoot(globs, text_type(temp_dir)),))[0]
+      snapshot = self.scheduler.capture_snapshots((PathGlobsAndRoot(globs, temp_dir),))[0]
 
-      expected_digest = Digest(text_type("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16"), 80)
+      expected_digest = Digest("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16", 80)
       self.assert_snapshot_equals(snapshot, ["roland"], expected_digest)
     return expected_digest
 
@@ -519,7 +517,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         url = UrlToFetch("http://localhost:{}/CNAME".format(port), self.pantsbuild_digest)
         snapshot, = self.scheduler.product_request(Snapshot, subjects=[url])
         self.assert_snapshot_equals(snapshot, ["CNAME"], Digest(
-          text_type("16ba2118adbe5b53270008790e245bbf7088033389461b08640a4092f7f647cf"),
+          "16ba2118adbe5b53270008790e245bbf7088033389461b08640a4092f7f647cf",
           81
         ))
 
@@ -554,7 +552,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
       ))
       snapshot, = self.scheduler.product_request(Snapshot, subjects=[url])
       self.assert_snapshot_equals(snapshot, ["CNAME"], Digest(
-        text_type("16ba2118adbe5b53270008790e245bbf7088033389461b08640a4092f7f647cf"),
+        "16ba2118adbe5b53270008790e245bbf7088033389461b08640a4092f7f647cf",
         81
       ))
 
@@ -572,7 +570,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
         )
         snapshot, = self.scheduler.product_request(Snapshot, subjects=[url])
         self.assert_snapshot_equals(snapshot, ["roland"], Digest(
-          text_type("9341f76bef74170bedffe51e4f2e233f61786b7752d21c2339f8ee6070eba819"),
+          "9341f76bef74170bedffe51e4f2e233f61786b7752d21c2339f8ee6070eba819",
           82
         ))
 

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -4,8 +4,6 @@
 import os
 import unittest
 
-from future.utils import text_type
-
 from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, Digest, FileContent, FilesContent, PathGlobs,
                              Snapshot)
 from pants.engine.isolated_process import (ExecuteProcessRequest, ExecuteProcessResult,
@@ -18,13 +16,13 @@ from pants.util.objects import TypeCheckError, datatype
 from pants_test.test_base import TestBase
 
 
-class Concatted(datatype([('value', text_type)])): pass
+class Concatted(datatype([('value', str)])): pass
 
 
-class BinaryLocation(datatype([('bin_path', text_type)])):
+class BinaryLocation(datatype([('bin_path', str)])):
 
   def __new__(cls, bin_path):
-    this_object = super().__new__(cls, text_type(bin_path))
+    this_object = super().__new__(cls, bin_path)
 
     bin_path = this_object.bin_path
 
@@ -97,7 +95,7 @@ class JavacVersionExecutionRequest(datatype([('binary_location', BinaryLocation)
     return (self.bin_path, '-version',)
 
 
-class JavacVersionOutput(datatype([('value', text_type)])): pass
+class JavacVersionOutput(datatype([('value', str)])): pass
 
 
 @rule(JavacVersionOutput, [JavacVersionExecutionRequest])
@@ -110,7 +108,7 @@ def get_javac_version_output(javac_version_command):
   javac_version_proc_result = yield Get(
     ExecuteProcessResult, ExecuteProcessRequest, javac_version_proc_req)
 
-  yield JavacVersionOutput(text_type(javac_version_proc_result.stderr))
+  yield JavacVersionOutput(javac_version_proc_result.stderr)
 
 
 class JavacSources(datatype([('java_files', tuple)])):
@@ -138,8 +136,8 @@ class JavacCompileRequest(datatype([
 
 
 class JavacCompileResult(datatype([
-  ('stdout', text_type),
-  ('stderr', text_type),
+  ('stdout', str),
+  ('stderr', str),
   ('directory_digest', Digest),
 ])): pass
 
@@ -166,12 +164,9 @@ def javac_compile_process_result(javac_compile_req):
   )
   javac_proc_result = yield Get(ExecuteProcessResult, ExecuteProcessRequest, process_request)
 
-  stdout = javac_proc_result.stdout
-  stderr = javac_proc_result.stderr
-
   yield JavacCompileResult(
-    text_type(stdout),
-    text_type(stderr),
+    javac_proc_result.stdout,
+    javac_proc_result.stderr,
     javac_proc_result.output_directory_digest,
   )
 
@@ -301,7 +296,7 @@ class IsolatedProcessTest(TestBase, unittest.TestCase):
     self.assertEqual(
       execute_process_result.output_directory_digest,
       Digest(
-        fingerprint=text_type("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16"),
+        fingerprint="63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16",
         serialized_bytes_length=80,
       )
     )

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -108,7 +108,7 @@ def get_javac_version_output(javac_version_command):
   javac_version_proc_result = yield Get(
     ExecuteProcessResult, ExecuteProcessRequest, javac_version_proc_req)
 
-  yield JavacVersionOutput(javac_version_proc_result.stderr)
+  yield JavacVersionOutput(javac_version_proc_result.stderr.decode())
 
 
 class JavacSources(datatype([('java_files', tuple)])):
@@ -165,8 +165,8 @@ def javac_compile_process_result(javac_compile_req):
   javac_proc_result = yield Get(ExecuteProcessResult, ExecuteProcessRequest, process_request)
 
   yield JavacCompileResult(
-    javac_proc_result.stdout,
-    javac_proc_result.stderr,
+    javac_proc_result.stdout.decode(),
+    javac_proc_result.stderr.decode(),
     javac_proc_result.output_directory_digest,
   )
 

--- a/tests/python/pants_test/engine/test_objects.py
+++ b/tests/python/pants_test/engine/test_objects.py
@@ -3,8 +3,6 @@
 
 import re
 
-from future.utils import text_type
-
 from pants.engine.objects import Collection
 from pants.util.objects import TypeCheckError
 from pants_test.test_base import TestBase
@@ -22,7 +20,7 @@ class CollectionTest(TestBase):
       "type constraint: Exactly(int).")):
       IntColl([3, "hello"])
 
-    IntOrStringColl = Collection.of(int, text_type)
+    IntOrStringColl = Collection.of(int, str)
     self.assertEqual([3, "hello"], [x for x in IntOrStringColl([3, "hello"])])
     with self.assertRaisesRegexp(TypeCheckError, re.escape(
       "field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int or "

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -851,8 +851,8 @@ class OptionsTest(TestBase):
     single_warning = assert_single_element(w)
     self.assertEqual(single_warning.category, DeprecationWarning)
     warning_message = single_warning.message
-    self.assertIn("will be removed in version", warning_message)
-    self.assertIn(option_string, warning_message)
+    self.assertIn("will be removed in version", str(warning_message))
+    self.assertIn(option_string, str(warning_message))
 
   def test_deprecated_options_flag(self):
     with self.warnings_catcher() as w:

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -10,7 +10,6 @@ from contextlib import contextmanager
 from textwrap import dedent
 
 import yaml
-from future.utils import text_type
 from packaging.version import Version
 
 from pants.base.deprecated import CodeRemovedError
@@ -852,8 +851,8 @@ class OptionsTest(TestBase):
     single_warning = assert_single_element(w)
     self.assertEqual(single_warning.category, DeprecationWarning)
     warning_message = single_warning.message
-    self.assertIn("will be removed in version", text_type(warning_message))
-    self.assertIn(option_string, text_type(warning_message))
+    self.assertIn("will be removed in version", warning_message)
+    self.assertIn(option_string, warning_message)
 
   def test_deprecated_options_flag(self):
     with self.warnings_catcher() as w:

--- a/tests/python/pants_test/source/test_payload_fields.py
+++ b/tests/python/pants_test/source/test_payload_fields.py
@@ -1,8 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from future.utils import text_type
-
 from pants.engine.fs import Digest, Snapshot
 from pants.source.payload_fields import SourcesField
 from pants.source.wrapped_globs import Globs, LazyFilesetWithSpec
@@ -79,7 +77,7 @@ class PayloadTest(TestBase):
     self.assertEqual(['foo/foo/a.txt'], list(sf.relative_to_buildroot()))
 
     digest = '56001a7e48555f156420099a99da60a7a83acc90853046709341bf9f00a6f944'
-    want_snapshot = Snapshot(Digest(text_type(digest), 77), ('foo/foo/a.txt',), ())
+    want_snapshot = Snapshot(Digest(digest, 77), ('foo/foo/a.txt',), ())
 
     # We explicitly pass a None scheduler because we expect no scheduler lookups to be required
     # in order to get a Snapshot.

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -721,7 +721,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
     single_warning = assert_single_element(w)
     self.assertEqual(single_warning.category, category)
     warning_message = single_warning.message
-    self.assertEqual(warning_text, warning_message)
+    self.assertEqual(warning_text, str(warning_message))
 
   def retrieve_single_product_at_target_base(self, product_mapping, target):
     mapping_for_target = product_mapping.get(target)

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from tempfile import mkdtemp
 from textwrap import dedent
 
-from future.utils import PY2, text_type
+from future.utils import PY2
 
 from pants.base.build_root import BuildRoot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
@@ -670,7 +670,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
       for file_name, content in files.items():
         safe_file_dump(os.path.join(temp_dir, file_name), content)
       return self.scheduler.capture_snapshots((
-        PathGlobsAndRoot(PathGlobs(('**',)), text_type(temp_dir)),
+        PathGlobsAndRoot(PathGlobs(('**',)), temp_dir),
       ))[0]
 
   class LoggingRecorder:
@@ -721,7 +721,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
     single_warning = assert_single_element(w)
     self.assertEqual(single_warning.category, category)
     warning_message = single_warning.message
-    self.assertEqual(warning_text, text_type(warning_message))
+    self.assertEqual(warning_text, warning_message)
 
   def retrieve_single_product_at_target_base(self, product_mapping, target):
     mapping_for_target = product_mapping.get(target)

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -98,7 +98,6 @@ python_tests(
   sources = ['test_objects.py'],
   coverage = ['pants.util.objects'],
   dependencies = [
-    '3rdparty/python:future',
     'src/python/pants/util:objects',
     'tests/python/pants_test:test_base',
   ]


### PR DESCRIPTION
We can now safely use `str` and `bytes` everywhere.