### PR TITLE
Fix `cargo.sh` to use Python 3

### DIFF
--- a/build-support/bin/native/cargo.sh
+++ b/build-support/bin/native/cargo.sh
@@ -4,7 +4,7 @@ set -e
 
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd -P)
 
-export PY=${PY:-python}
+export PY=${PY:-python3}
 
 # Exports:
 # + CARGO_HOME: The CARGO_HOME of the Pants-controlled rust toolchain.


### PR DESCRIPTION
On many systems `python` resolves to `python2.7`. We cannot run Pants with Python 2.7 anymore, so this results in a confusing error where the Rust linters try to bootstrap Pants with Python 2 on macOS.