### PR TITLE
fix grpc threadpool size

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1477,7 +1477,6 @@ mod tests {
       None,
       None,
       BTreeMap::new(),
-      1,
       store,
     );
     let result = runtime
@@ -1849,7 +1848,6 @@ mod tests {
       None,
       None,
       BTreeMap::new(),
-      1,
       store,
     );
 
@@ -1943,7 +1941,6 @@ mod tests {
       None,
       None,
       BTreeMap::new(),
-      1,
       store,
     )
     .run(cat_roland_request())
@@ -2009,7 +2006,6 @@ mod tests {
       None,
       None,
       BTreeMap::new(),
-      1,
       store,
     );
 
@@ -2628,7 +2624,7 @@ mod tests {
     )
     .expect("Failed to make store");
 
-    CommandRunner::new(&address, None, None, None, None, BTreeMap::new(), 1, store)
+    CommandRunner::new(&address, None, None, None, None, BTreeMap::new(), store)
   }
 
   fn extract_execute_response(

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -308,10 +308,9 @@ impl CommandRunner {
     root_ca_certs: Option<Vec<u8>>,
     oauth_bearer_token: Option<String>,
     platform_properties: BTreeMap<String, String>,
-    thread_count: usize,
     store: Store,
   ) -> CommandRunner {
-    let env = Arc::new(grpcio::Environment::new(thread_count));
+    let env = Arc::new(grpcio::EnvBuilder::new().build());
     let channel = {
       let builder = grpcio::ChannelBuilder::new(env.clone());
       if let Some(root_ca_certs) = root_ca_certs {

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -304,7 +304,6 @@ fn main() {
         root_ca_certs,
         oauth_bearer_token,
         platform_properties,
-        1,
         store.clone(),
       )) as Box<dyn process_execution::CommandRunner>
     }

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -136,10 +136,6 @@ impl Core {
           root_ca_certs.clone(),
           oauth_bearer_token.clone(),
           remote_execution_extra_platform_properties.clone(),
-          // This param sets the grpc thread pool size. We use the local_execution_parallelism,
-          // because it is likely to be related to the processor count on this platform, via the option default.
-          // Allow for some overhead for bookkeeping threads (if any).
-          process_execution_remote_parallelism + 2,
           store.clone(),
         )),
         process_execution_remote_parallelism,


### PR DESCRIPTION
### Problem
The number of grpc completion queues on the host is tied to the requested remote concurrency. The remote concurrency numbers are likely to be much larger than the available cores on the host machine creating thread management overhead on the host.

### Solution

Use the built in GRPC EnvBuilder class which picks a sensible number of completion queue / threads based on the host proc count.
### Result

The user wont have to worry about strange side effects on the host when increasing remote concurrency.