### PR TITLE
Fix gocheckstyle decoding error

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
@@ -35,7 +35,7 @@ class GoFmtTaskBase(GoWorkspaceTask):
       if sources:
         args = [os.path.join(self.go_dist.goroot, 'bin', 'gofmt')] + flags + list(sources)
         try:
-          output = subprocess.check_output(args).decode('utf-8')
+          output = subprocess.check_output(args).decode()
         except subprocess.CalledProcessError as e:
           raise TaskError('{} failed with exit code {}'.format(' '.join(args), e.returncode),
                           exit_code=e.returncode)

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
@@ -35,7 +35,7 @@ class GoFmtTaskBase(GoWorkspaceTask):
       if sources:
         args = [os.path.join(self.go_dist.goroot, 'bin', 'gofmt')] + flags + list(sources)
         try:
-          output = subprocess.check_output(args)
+          output = subprocess.check_output(args).decode('utf-8')
         except subprocess.CalledProcessError as e:
           raise TaskError('{} failed with exit code {}'.format(' '.join(args), e.returncode),
                           exit_code=e.returncode)


### PR DESCRIPTION
### Problem

A breaking go style change would the trigger the following error.
```
14:16:23 00:04     [checkstyle]
14:16:24 00:05     [gocheckstyle]
14:16:24 00:05       [cache] 
                   No cached artifacts for 1 target.
                   Invalidated 1 target.
               Waiting for background workers to finish.
14:16:24 00:05   [complete]
               FAILURE
timestamp: 2019-06-28T14:16:24.669268
Exception caught: (builtins.ValueError)
  File "/Users/user/.cache/pants/pex/bin/pants.pex/1.17.0rc1-git8634422c-md5212b5eea/pants-1.17.0rc1-git8634422c-md5212b5eea.pex/.bootstrap/pex/pex.py", line 352, in execute
    exit_code = self._wrap_coverage(self._wrap_profiling, self._execute)
  File "/Users/user/.cache/pants/pex/bin/pants.pex/1.17.0rc1-git8634422c-md5212b5eea/pants-1.17.0rc1-git8634422c-md5212b5eea.pex/.bootstrap/pex/pex.py", line 284, in _wrap_coverage
    return runner(*args)
  File "/Users/user/.cache/pants/pex/bin/pants.pex/1.17.0rc1-git8634422c-md5212b5eea/pants-1.17.0rc1-git8634422c-md5212b5eea.pex/.bootstrap/pex/pex.py", line 315, in _wrap_profiling
    return runner(*args)
  File "/Users/user/.cache/pants/pex/bin/pants.pex/1.17.0rc1-git8634422c-md5212b5eea/pants-1.17.0rc1-git8634422c-md5212b5eea.pex/.bootstrap/pex/pex.py", line 397, in _execute
    return self.execute_entry(self._pex_info.entry_point)
  File "/Users/user/.cache/pants/pex/bin/pants.pex/1.17.0rc1-git8634422c-md5212b5eea/pants-1.17.0rc1-git8634422c-md5212b5eea.pex/.bootstrap/pex/pex.py", line 495, in execute_entry
    return runner(entry_point)
  File "/Users/user/.cache/pants/pex/bin/pants.pex/1.17.0rc1-git8634422c-md5212b5eea/pants-1.17.0rc1-git8634422c-md5212b5eea.pex/.bootstrap/pex/pex.py", line 510, in execute_pkg_resources
    return runner()
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/bin/pants_loader.py", line 85, in main
    PantsLoader.run()
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/bin/pants_loader.py", line 81, in run
    cls.load_and_execute(entrypoint)
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/bin/pants_loader.py", line 74, in load_and_execute
    entrypoint_main()
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/bin/pants_exe.py", line 39, in main
    PantsRunner(exiter, start_time=start_time).run()
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/bin/pants_runner.py", line 94, in run
    return runner.run()
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/bin/local_pants_runner.py", line 231, in run
    self._run()
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/bin/local_pants_runner.py", line 292, in _run
    goal_runner_result = self._maybe_run_v1()
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/bin/local_pants_runner.py", line 259, in _maybe_run_v1
    return goal_runner_factory.create().run()
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/bin/goal_runner.py", line 209, in run
    return self._run_goals()
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/bin/goal_runner.py", line 180, in _run_goals
    result = self._execute_engine()
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/bin/goal_runner.py", line 168, in _execute_engine
    result = engine.execute(self._context, self._goals)
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/engine/legacy_engine.py", line 26, in execute
    self.attempt(context, goals)
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/engine/round_engine.py", line 234, in attempt
    goal_executor.attempt(explain)
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/engine/round_engine.py", line 50, in attempt
    task.execute()
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants.contrib.go-1.17.0rc1+git8634422c-py27.py36.py37-none-any.whl.8169f259f1a1e6655207f97b4886b3fc710b20e8/pantsbuild.pants.contrib.go-1.17.0rc1+git8634422c-py27.py36.py37-none-any.whl/pants/contrib/go/tasks/go_checkstyle.py", line 19, in execute
    self.context.log.error(output)
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/goal/run_tracker.py", line 720, in error
    self._run_tracker.log(Report.ERROR, *msg_elements)
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/goal/run_tracker.py", line 352, in log
    self.report.log(self._threadlocal.current_workunit, level, *msg_elements)
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/reporting/report.py", line 114, in log
    reporter.handle_log(workunit, level, *msg_elements)
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/reporting/reporter.py", line 62, in handle_log
    self.do_handle_log(workunit, level, *msg_elements)
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/reporting/html_reporter.py", line 343, in do_handle_log
    message = self._render_message(*msg_elements)
  File "/Users/user/workspace/source/.pex/install/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl.d2d7ed027503d1a4f1d2454e6b8b7adc975b9e73/pantsbuild.pants-1.17.0rc1+git8634422c-cp36-abi3-macosx_10_11_x86_64.whl/pants/reporting/html_reporter.py", line 387, in _render_message
    (text, detail, detail_id, detail_initially_visible) = (x or y for x, y in zip_longest(element, default_values))
```