### PR TITLE
No longer use `string_types`

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/targets/node_module.py
+++ b/contrib/node/src/python/pants/contrib/node/targets/node_module.py
@@ -6,7 +6,6 @@ import logging
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
-from six import string_types
 
 from pants.contrib.node.targets.node_package import NodePackage
 
@@ -44,7 +43,7 @@ class NodeModule(NodePackage):
                             and the value will be the local file name per package.json rules.
     :type bin_executables: `dict`, where key is bin name and value is a local file path to an executable
                            E.G. { 'app': './cli.js', 'runner': './scripts/run.sh' }
-                           `string`, file path and package name as  the default bin name
+                           `str`, file path and package name as  the default bin name
                            E.G. './cli.js' would be interpreted as { 'app': './cli.js' }
     :param node_scope: Groups related packages together by adding a scope. The `@`
       symbol is typically used for specifying scope in the package name in `package.json`.
@@ -60,7 +59,7 @@ class NodeModule(NodePackage):
     # of pre-existing package.json files as node_module targets will require this.
 
     bin_executables = bin_executables or {}
-    if not (isinstance(bin_executables, dict) or isinstance(bin_executables, string_types)):
+    if not (isinstance(bin_executables, dict) or isinstance(bin_executables, str)):
       raise TargetDefinitionException(
         self,
         'expected a `dict` or `str` object for bin_executables, instead found a {}'
@@ -94,8 +93,8 @@ class NodeModule(NodePackage):
 
     :rtype: dict
     """
-    if isinstance(self.payload.bin_executables, string_types):
+    if isinstance(self.payload.bin_executables, str):
       # In this case, the package_name is the bin name
-      return { self.package_name: self.payload.bin_executables }
+      return {self.package_name: self.payload.bin_executables}
 
     return self.payload.bin_executables

--- a/src/python/pants/backend/jvm/BUILD
+++ b/src/python/pants/backend/jvm/BUILD
@@ -14,7 +14,6 @@ python_library(
   name='artifact',
   sources=['artifact.py'],
   dependencies=[
-    '3rdparty/python:six',
     ':repository',
     'src/python/pants/base:hash_utils',
     'src/python/pants/base:payload_field',
@@ -89,7 +88,6 @@ python_library(
   name='ossrh_publication_metadata',
   sources=['ossrh_publication_metadata.py'],
   dependencies=[
-    '3rdparty/python:future',
     ':artifact',
     'src/python/pants/base:validation',
   ],

--- a/src/python/pants/backend/jvm/artifact.py
+++ b/src/python/pants/backend/jvm/artifact.py
@@ -26,9 +26,9 @@ class Artifact(PayloadField):
     :param publication_metadata: Optional extra publication metadata required by the ``repo``.
     """
     if not isinstance(org, str):
-      raise ValueError("org must be str but was {}".format(org))
+      raise ValueError(f"org must be `str` but was {org} with type {type(org)}")
     if not isinstance(name, str):
-      raise ValueError("name must be str but was {}".format(name))
+      raise ValueError(f"name must be str but was {name} with type {type(name)}")
     if not isinstance(repo, Repository):
       raise ValueError("repo must be an instance of Repository")
 

--- a/src/python/pants/backend/jvm/artifact.py
+++ b/src/python/pants/backend/jvm/artifact.py
@@ -1,8 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from six import string_types
-
 from pants.backend.jvm.repository import Repository
 from pants.base.hash_utils import stable_json_sha1
 from pants.base.payload_field import PayloadField
@@ -27,10 +25,10 @@ class Artifact(PayloadField):
     :param repo: The ``repo`` this artifact is published to.
     :param publication_metadata: Optional extra publication metadata required by the ``repo``.
     """
-    if not isinstance(org, string_types):
-      raise ValueError("org must be {} but was {}".format(string_types, org))
-    if not isinstance(name, string_types):
-      raise ValueError("name must be {} but was {}".format(string_types, name))
+    if not isinstance(org, str):
+      raise ValueError("org must be str but was {}".format(org))
+    if not isinstance(name, str):
+      raise ValueError("name must be str but was {}".format(name))
     if not isinstance(repo, Repository):
       raise ValueError("repo must be an instance of Repository")
 

--- a/src/python/pants/backend/jvm/ossrh_publication_metadata.py
+++ b/src/python/pants/backend/jvm/ossrh_publication_metadata.py
@@ -1,16 +1,13 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
-from future.utils import string_types
-
 from pants.backend.jvm.artifact import PublicationMetadata
 from pants.base.validation import assert_list
 
 
 def _validate_maybe_string(name, item):
-  if item and not isinstance(item, string_types):
-    raise ValueError('{} was expected to be of type {} but given {}'.format(name, type(item), item))
+  if item and not isinstance(item, str):
+    raise ValueError('{} was expected to be of type str but given {}'.format(name, type(item)))
   return item
 
 

--- a/src/python/pants/backend/jvm/ossrh_publication_metadata.py
+++ b/src/python/pants/backend/jvm/ossrh_publication_metadata.py
@@ -7,7 +7,7 @@ from pants.base.validation import assert_list
 
 def _validate_maybe_string(name, item):
   if item and not isinstance(item, str):
-    raise ValueError('{} was expected to be of type str but given {}'.format(name, type(item)))
+    raise ValueError(f"{name} was expected to be of type str but given {type(item)}")
   return item
 
 

--- a/src/python/pants/backend/jvm/targets/java_agent.py
+++ b/src/python/pants/backend/jvm/targets/java_agent.py
@@ -1,8 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from future.utils import string_types
-
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.base.exceptions import TargetDefinitionException
 
@@ -44,11 +42,11 @@ class JavaAgent(JavaLibrary):
     if not (premain or agent_class):
       raise TargetDefinitionException(self, "Must have at least one of 'premain' or 'agent_class' "
                                             "defined.")
-    if premain and not isinstance(premain, string_types):
+    if premain and not isinstance(premain, str):
       raise TargetDefinitionException(self, 'The premain must be a fully qualified class name, '
                                             'given {} of type {}'.format(premain, type(premain)))
 
-    if agent_class and not isinstance(agent_class, string_types):
+    if agent_class and not isinstance(agent_class, str):
       raise TargetDefinitionException(self,
                                       'The agent_class must be a fully qualified class name, given '
                                       '{} of type {}'.format(agent_class, type(agent_class)))

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -19,8 +19,7 @@ class JarRule(FingerprintedMixin, metaclass=ABCMeta):
   def __init__(self, apply_pattern, payload=None):
     self.payload = payload or Payload()
     if not isinstance(apply_pattern, str):
-      raise ValueError('The supplied apply_pattern is not a str, given: {}'
-                       .format(apply_pattern))
+      raise ValueError(f"The supplied apply_pattern is not a str, given: {apply_pattern}")
     try:
       self._apply_pattern = re.compile(apply_pattern)
     except re.error as e:

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -5,8 +5,6 @@ import re
 from abc import ABCMeta
 from hashlib import sha1
 
-from future.utils import string_types
-
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
@@ -20,8 +18,8 @@ class JarRule(FingerprintedMixin, metaclass=ABCMeta):
 
   def __init__(self, apply_pattern, payload=None):
     self.payload = payload or Payload()
-    if not isinstance(apply_pattern, string_types):
-      raise ValueError('The supplied apply_pattern is not a string, given: {}'
+    if not isinstance(apply_pattern, str):
+      raise ValueError('The supplied apply_pattern is not a str, given: {}'
                        .format(apply_pattern))
     try:
       self._apply_pattern = re.compile(apply_pattern)
@@ -63,7 +61,7 @@ class Duplicate(JarRule):
 
       :param string path: The path of the duplicate entry.
       """
-      assert path and isinstance(path, string_types), 'A non-empty path must be supplied.'
+      assert path and isinstance(path, str), 'A non-empty path must be supplied.'
       super(Duplicate.Error, self).__init__('Duplicate entry encountered for path {}'.format(path))
       self._path = path
 
@@ -262,7 +260,7 @@ class ManifestEntries(FingerprintedMixin):
       if not isinstance(entries, dict):
         raise self.ExpectedDictionaryError("entries must be a dictionary of strings.")
       for key in entries.keys():
-        if not isinstance(key, string_types):
+        if not isinstance(key, str):
           raise self.ExpectedDictionaryError(
             "entries must be dictionary of strings, got key {} type {}"
             .format(key, type(key).__name__))
@@ -337,7 +335,7 @@ class JvmBinary(JvmTarget):
       binary. Example: ['-Dexample.property=1', '-DMyFlag', '-Xmx4G'] If unspecified, no extra jvm options will be added.
     """
     self.address = address  # Set in case a TargetDefinitionException is thrown early
-    if main and not isinstance(main, string_types):
+    if main and not isinstance(main, str):
       raise TargetDefinitionException(self, 'main must be a fully qualified classname')
     if deploy_jar_rules and not isinstance(deploy_jar_rules, JarRules):
       raise TargetDefinitionException(self,

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -579,9 +579,6 @@ python_library(
 python_library(
   name = 'properties',
   sources = ['properties.py'],
-  dependencies = [
-    '3rdparty/python:six',
-  ],
 )
 
 python_library(

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -7,7 +7,7 @@ import tempfile
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
-from future.utils import iteritems, string_types
+from future.utils import iteritems
 from twitter.common.collections import maybe_list
 
 from pants.backend.jvm.argfile import safe_args
@@ -139,7 +139,7 @@ class Jar:
 
     :param string main: a fully qualified class name
     """
-    if not main or not isinstance(main, string_types):
+    if not main or not isinstance(main, str):
       raise ValueError('The main entry must be a non-empty string')
     self._main = main
 
@@ -164,10 +164,10 @@ class Jar:
     :param string src: the path to the pre-existing source file or directory
     :param string dest: the path the source file or directory should have in this jar
     """
-    if not src or not isinstance(src, string_types):
+    if not src or not isinstance(src, str):
       raise ValueError('The src path must be a non-empty string, got {} of type {}.'.format(
         src, type(src)))
-    if dest and not isinstance(dest, string_types):
+    if dest and not isinstance(dest, str):
       raise ValueError('The dest entry path must be a non-empty string, got {} of type {}.'.format(
         dest, type(dest)))
     if not os.path.isdir(src) and not dest:
@@ -181,7 +181,7 @@ class Jar:
     :param string path: the path to write the contents to in this jar
     :param string contents: the raw byte contents of the file to write to ``path``
     """
-    if not path or not isinstance(path, string_types):
+    if not path or not isinstance(path, str):
       raise ValueError('The path must be a non-empty string')
 
     if contents is None or not isinstance(contents, bytes):
@@ -201,7 +201,7 @@ class Jar:
 
     :param string jar: the path to the pre-existing jar to graft into this jar
     """
-    if not jar or not isinstance(jar, string_types):
+    if not jar or not isinstance(jar, str):
       raise ValueError('The jar path must be a non-empty string')
 
     self._jars.append(jar)

--- a/src/python/pants/backend/jvm/tasks/properties.py
+++ b/src/python/pants/backend/jvm/tasks/properties.py
@@ -33,7 +33,7 @@ class Properties:
     elif isinstance(data, str):
       contents = data
     else:
-      raise TypeError('Can only process data from a str or a readable object, given: %s' % data)
+      raise TypeError(f"Can only process data from a str or a readable object, given: {data}")
 
     return Properties._parse(contents.splitlines())
 

--- a/src/python/pants/backend/jvm/tasks/properties.py
+++ b/src/python/pants/backend/jvm/tasks/properties.py
@@ -4,8 +4,6 @@
 import re
 from collections import OrderedDict
 
-import six
-
 
 class Properties:
   """A Python reader for java.util.Properties formatted data.
@@ -25,17 +23,17 @@ class Properties:
 
     :API: public
 
-    :param (string | open stream) data: An open stream or a string.
+    :param (str | open stream) data: An open stream or a string.
     :returns: A dict of parsed property data.
     :rtype: dict
     """
 
     if hasattr(data, 'read') and callable(data.read):
       contents = data.read()
-    elif isinstance(data, six.string_types):
+    elif isinstance(data, str):
       contents = data
     else:
-      raise TypeError('Can only process data from a string or a readable object, given: %s' % data)
+      raise TypeError('Can only process data from a str or a readable object, given: %s' % data)
 
     return Properties._parse(contents.splitlines())
 
@@ -107,7 +105,7 @@ class Properties:
 
     if hasattr(output, 'write') and callable(output.write):
       write(output)
-    elif isinstance(output, six.string_types):
+    elif isinstance(output, str):
       with open(output, 'w+') as out:
         write(out)
     else:

--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -3,7 +3,6 @@
 
 import os
 
-from future.utils import string_types
 from pex.pex_info import PexInfo
 from twitter.common.collections import maybe_list
 
@@ -111,8 +110,8 @@ class PythonBinary(PythonTarget):
       raise TargetDefinitionException(self,
           'A python binary target must specify either a single source or entry_point.')
 
-    if not isinstance(platforms, (list, tuple)) and not isinstance(platforms, string_types):
-      raise TargetDefinitionException(self, 'platforms must be a list, tuple or string.')
+    if not isinstance(platforms, (list, tuple)) and not isinstance(platforms, str):
+      raise TargetDefinitionException(self, 'platforms must be a list, tuple or str.')
 
     if sources and sources.files and entry_point:
       entry_point_module = entry_point.split(':', 1)[0]

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -55,7 +55,6 @@ python_library(
   name = 'deprecated',
   sources = ['deprecated.py'],
   dependencies = [
-    '3rdparty/python:six',
     ':revision',
     'src/python/pants:version',
     'src/python/pants/util:memo',

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -203,7 +203,6 @@ python_library(
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
-    '3rdparty/python:six',
   ],
 )
 

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -7,7 +7,6 @@ import warnings
 from contextlib import contextmanager
 from functools import wraps
 
-import six
 from future.utils import PY2
 from packaging.version import InvalidVersion, Version
 
@@ -68,7 +67,7 @@ def validate_deprecation_semver(version_string, version_description):
   """
   if version_string is None:
     raise MissingSemanticVersionError('The {} must be provided.'.format(version_description))
-  if not isinstance(version_string, six.string_types):
+  if not isinstance(version_string, str):
     raise BadSemanticVersionError('The {} must be a version string.'.format(version_description))
   try:
     # NB: packaging will see versions like 1.a.0 as 1a0, and are "valid"

--- a/src/python/pants/base/validation.py
+++ b/src/python/pants/base/validation.py
@@ -1,12 +1,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from six import string_types
 from twitter.common.collections import OrderedSet
 from twitter.common.dirutil.fileset import Fileset
 
 
-def assert_list(obj, expected_type=string_types, can_be_none=True, default=(), key_arg=None,
+def assert_list(obj, expected_type=str, can_be_none=True, default=(), key_arg=None,
     allowable=(list, Fileset, OrderedSet, set, tuple), raise_type=ValueError):
   """
   This function is used to ensure that parameters set by users in BUILD files are of acceptable types.

--- a/src/python/pants/build_graph/app_base.py
+++ b/src/python/pants/build_graph/app_base.py
@@ -5,7 +5,6 @@ import os
 from collections import OrderedDict, namedtuple
 from hashlib import sha1
 
-import six
 from twitter.common.dirutil import Fileset
 
 from pants.base.build_environment import get_buildroot
@@ -150,7 +149,7 @@ class Bundle:
     # A fileset is either a glob, a string or a list of strings.
     if isinstance(fileset, FilesetWithSpec):
       pass
-    elif isinstance(fileset, six.string_types):
+    elif isinstance(fileset, str):
       fileset = [fileset]
     else:
       fileset = assert_list(fileset, key_arg='fileset')

--- a/src/python/pants/build_graph/build_file_aliases.py
+++ b/src/python/pants/build_graph/build_file_aliases.py
@@ -5,8 +5,6 @@ import inspect
 from abc import abstractmethod
 from collections import defaultdict
 
-import six
-
 from pants.base.build_file_target_factory import BuildFileTargetFactory
 from pants.build_graph.target import Target
 from pants.util.memo import memoized_property
@@ -107,7 +105,7 @@ class BuildFileAliases:
 
   @classmethod
   def _validate_alias(cls, category, alias, obj):
-    if not isinstance(alias, six.string_types):
+    if not isinstance(alias, str):
       raise TypeError('Aliases must be strings, given {category} entry {alias!r} of type {typ} as '
                       'the alias of {obj}'
                       .format(category=category, alias=alias, typ=type(alias).__name__, obj=obj))

--- a/src/python/pants/build_graph/import_remote_sources_mixin.py
+++ b/src/python/pants/build_graph/import_remote_sources_mixin.py
@@ -3,8 +3,6 @@
 
 from abc import ABCMeta, abstractmethod
 
-from future.utils import string_types
-
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.target import Target
 from pants.util.memo import memoized_property
@@ -70,7 +68,7 @@ class ImportRemoteSourcesMixin(Target, metaclass=ABCMeta):
 
     specs = []
     for item in target_representation.get(field, ()):
-      if not isinstance(item, string_types):
+      if not isinstance(item, str):
         raise cls.ExpectedAddressError(
           'expected imports to contain string addresses, got {obj} (type: {found_class}) instead.'
           .format(obj=item, found_class=type(item).__name__)

--- a/src/python/pants/build_graph/intermediate_target_factory.py
+++ b/src/python/pants/build_graph/intermediate_target_factory.py
@@ -4,8 +4,6 @@
 from abc import ABC
 from hashlib import sha1
 
-from future.utils import string_types
-
 from pants.base.exceptions import TargetDefinitionException
 from pants.build_graph.address import Address
 
@@ -37,8 +35,8 @@ class IntermediateTargetFactoryBase(ABC):
     :param string suffix: A string used as a suffix of the intermediate target name.
     :returns: The address of a synthetic intermediary target.
     """
-    if not isinstance(address, string_types):
-      raise self.ExpectedAddressError("Expected string address argument, got type {type}"
+    if not isinstance(address, str):
+      raise self.ExpectedAddressError("Expected str address argument, got type {type}"
                                       .format(type=type(address)))
 
     address = Address.parse(address, self._parse_context.rel_path)

--- a/src/python/pants/build_graph/intermediate_target_factory.py
+++ b/src/python/pants/build_graph/intermediate_target_factory.py
@@ -36,9 +36,7 @@ class IntermediateTargetFactoryBase(ABC):
     :returns: The address of a synthetic intermediary target.
     """
     if not isinstance(address, str):
-      raise self.ExpectedAddressError("Expected str address argument, got type {type}"
-                                      .format(type=type(address)))
-
+      raise self.ExpectedAddressError(f"Expected str address argument, got type {type(address)}")
     address = Address.parse(address, self._parse_context.rel_path)
     # NB(gmalmquist): Ideally there should be a way to indicate that these targets are synthetic
     # and shouldn't show up in `./pants list` etc, because we really don't want people to write

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -6,7 +6,6 @@ import os
 import weakref
 from hashlib import sha1
 
-from six import string_types
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot
@@ -371,7 +370,7 @@ class Target(AbstractTarget):
     """
     return self._tags
 
-  def assert_list(self, putative_list, expected_type=string_types, key_arg=None):
+  def assert_list(self, putative_list, expected_type=str, key_arg=None):
     """
     :API: public
     """

--- a/src/python/pants/build_graph/target_addressable.py
+++ b/src/python/pants/build_graph/target_addressable.py
@@ -3,8 +3,6 @@
 
 import logging
 
-from six import string_types
-
 from pants.base.exceptions import TargetDefinitionException
 from pants.build_graph.addressable import Addressable
 
@@ -57,7 +55,7 @@ class TargetAddressable(Addressable):
       raise TargetDefinitionException(target=self, msg=msg)
 
     for dep_spec in self.dependency_specs:
-      if not isinstance(dep_spec, string_types):
+      if not isinstance(dep_spec, str):
         msg = ('dependencies passed to Target constructors must be strings.  {dep_spec} is not'
                ' a string.  Target type was: {target_type}.'
                .format(target_type=self.addressed_type, dep_spec=dep_spec))

--- a/src/python/pants/build_graph/target_scopes.py
+++ b/src/python/pants/build_graph/target_scopes.py
@@ -1,9 +1,6 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
-from future.utils import string_types
-
 from pants.build_graph.intermediate_target_factory import IntermediateTargetFactoryBase
 
 
@@ -24,7 +21,7 @@ class Scope(frozenset):
     """
     if not scope:
       return ('default',)
-    if isinstance(scope, string_types):
+    if isinstance(scope, str):
       scope = scope.split(' ')
     scope = {str(s).lower() for s in scope if s}
     return scope or ('default',)

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -72,7 +72,6 @@ python_library(
   sources=['build_files.py'],
   dependencies=[
     '3rdparty/python:future',
-    '3rdparty/python:six',
     ':addressable',
     ':fs',
     ':mapper',

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -5,8 +5,6 @@ import inspect
 from collections.abc import MutableMapping, MutableSequence
 from functools import update_wrapper
 
-from future.utils import string_types
-
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.objects import Collection, Resolvable, Serializable
 from pants.util.objects import TypeConstraintError
@@ -150,7 +148,7 @@ class AddressableDescriptor:
     if value is None:
       return None
 
-    if isinstance(value, (string_types, Address, Resolvable)):
+    if isinstance(value, (str, Address, Resolvable)):
       return value
 
     # Support untyped dicts that we deserialize on-demand here into the required type.

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -5,7 +5,6 @@ import logging
 from collections.abc import MutableMapping, MutableSequence
 from os.path import dirname, join
 
-import six
 from future.utils import raise_from
 from twitter.common.collections import OrderedSet
 
@@ -92,7 +91,7 @@ def hydrate_struct(address_mapper, address):
 
   inline_dependencies = []
   def maybe_append(outer_key, value):
-    if isinstance(value, six.string_types):
+    if isinstance(value, str):
       if outer_key != 'dependencies':
         inline_dependencies.append(Address.parse(value,
                                           relative_to=address.spec_path,
@@ -121,7 +120,7 @@ def hydrate_struct(address_mapper, address):
   dependencies = [d.value for d in hydrated_inline_dependencies]
 
   def maybe_consume(outer_key, value):
-    if isinstance(value, six.string_types):
+    if isinstance(value, str):
       if outer_key == 'dependencies':
         # Don't recurse into the dependencies field of a Struct, since those will be explicitly
         # requested by tasks. But do ensure that their addresses are absolute, since we're

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -49,8 +49,8 @@ class TargetAdaptor(StructWithDeps):
       if not isinstance(source, str):
         raise Target.IllegalArgument(
           self.address.spec,
-          'source must be a str containing a path relative to the target, but got {} of type {}'
-            .format(source, type(source))
+          f"source must be a str containing a path relative to the target, but got {source} of "
+          f"type {type(source)}"
         )
       sources = [source]
 

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -6,8 +6,6 @@ import os.path
 from abc import ABCMeta, abstractmethod
 from collections.abc import MutableSequence, MutableSet
 
-from six import string_types
-
 from pants.build_graph.target import Target
 from pants.engine.addressable import addressable_list
 from pants.engine.fs import GlobExpansionConjunction, PathGlobs
@@ -48,10 +46,10 @@ class TargetAdaptor(StructWithDeps):
       )
 
     if source is not None:
-      if not isinstance(source, string_types):
+      if not isinstance(source, str):
         raise Target.IllegalArgument(
           self.address.spec,
-          'source must be a string containing a path relative to the target, but got {} of type {}'
+          'source must be a str containing a path relative to the target, but got {} of type {}'
             .format(source, type(source))
         )
       sources = [source]
@@ -253,7 +251,7 @@ class RemoteSourcesAdaptor(TargetAdaptor):
     """
     :param dest: A target constructor.
     """
-    if not isinstance(dest, string_types):
+    if not isinstance(dest, str):
       dest = dest._type_alias
     super().__init__(dest=dest, **kwargs)
 
@@ -308,17 +306,17 @@ class BaseGlobs(Locatable, metaclass=ABCMeta):
       return Files(spec_path=spec_path)
     elif isinstance(sources, BaseGlobs):
       return sources
-    elif isinstance(sources, string_types):
+    elif isinstance(sources, str):
       return Files(sources, spec_path=spec_path)
     elif isinstance(sources, (MutableSet, MutableSequence, tuple)) and \
-         all(isinstance(s, string_types) for s in sources):
+         all(isinstance(s, str) for s in sources):
       return Files(*sources, spec_path=spec_path)
     else:
       raise ValueError('Expected either a glob or list of literal sources: got: {}'.format(sources))
 
   @staticmethod
   def _filespec_for_exclude(raw_exclude, spec_path):
-    if isinstance(raw_exclude, string_types):
+    if isinstance(raw_exclude, str):
       raise ValueError('Excludes of type `{}` are not supported: got "{}"'
                        .format(type(raw_exclude).__name__, raw_exclude))
 

--- a/src/python/pants/ivy/BUILD
+++ b/src/python/pants/ivy/BUILD
@@ -4,7 +4,6 @@
 python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python:six',
     'src/python/pants/base:build_environment',
     'src/python/pants/java/distribution',
     'src/python/pants/java:executor',

--- a/src/python/pants/ivy/ivy.py
+++ b/src/python/pants/ivy/ivy.py
@@ -4,7 +4,6 @@
 import os.path
 from contextlib import contextmanager
 
-from six import string_types
 from twitter.common.collections import maybe_list
 
 from pants.java import util
@@ -33,12 +32,12 @@ class Ivy:
     """
     self._classpath = maybe_list(classpath)
     self._ivy_settings = ivy_settings
-    if self._ivy_settings and not isinstance(self._ivy_settings, string_types):
+    if self._ivy_settings and not isinstance(self._ivy_settings, str):
       raise ValueError('ivy_settings must be a string, given {} of type {}'.format(
                          self._ivy_settings, type(self._ivy_settings)))
 
     self._ivy_resolution_cache_dir = ivy_resolution_cache_dir
-    if not isinstance(self._ivy_resolution_cache_dir, string_types):
+    if not isinstance(self._ivy_resolution_cache_dir, str):
       raise ValueError('ivy_resolution_cache_dir must be a string, given {} of type {}'.format(
                          self._ivy_resolution_cache_dir, type(self._ivy_resolution_cache_dir)))
 

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -6,7 +6,6 @@ python_library(
   sources = ['executor.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python:six',
     'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
@@ -50,8 +49,6 @@ python_library(
   dependencies = [
     ':executor',
     ':nailgun_client',
-    '3rdparty/python:future',
-    '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
     'src/python/pants/pantsd:process_manager',

--- a/src/python/pants/java/distribution/BUILD
+++ b/src/python/pants/java/distribution/BUILD
@@ -5,7 +5,6 @@ python_library(
   sources=[ 'distribution.py' ],
   dependencies=[
     '3rdparty/python:future',
-    '3rdparty/python:six',
     ':resources',
     'src/python/pants/base:revision',
     'src/python/pants/java:util',

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -12,7 +12,6 @@ from collections import namedtuple
 from contextlib import contextmanager
 
 from future.utils import PY3
-from six import string_types
 
 from pants.base.revision import Revision
 from pants.java.util import execute_java, execute_java_async
@@ -34,7 +33,7 @@ def _parse_java_version(name, version):
   # We also accommodate specification versions, which just have major and minor
   # components; eg: `1.8`.  These are useful when specifying constraints a distribution must
   # satisfy; eg: to pick any 1.8 java distribution: '1.8' <= version <= '1.8.99'
-  if isinstance(version, string_types):
+  if isinstance(version, str):
     version = Revision.lenient(version)
   if version and not isinstance(version, Revision):
     raise ValueError('{} must be a string or a Revision object, given: {}'.format(name, version))

--- a/src/python/pants/java/executor.py
+++ b/src/python/pants/java/executor.py
@@ -8,7 +8,6 @@ import sys
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
-from six import string_types
 from twitter.common.collections import maybe_list
 
 from pants.util.contextutil import environment_as
@@ -26,7 +25,7 @@ class Executor(ABC):
   @staticmethod
   def _scrub_args(classpath, main, jvm_options, args):
     classpath = maybe_list(classpath)
-    if not isinstance(main, string_types) or not main:
+    if not isinstance(main, str) or not main:
       raise ValueError('A non-empty main classname is required, given: {}'.format(main))
     jvm_options = maybe_list(jvm_options or ())
     args = maybe_list(args or ())

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -10,7 +10,6 @@ import threading
 import time
 from contextlib import closing
 
-from future.utils import string_types
 from twitter.common.collections import maybe_list
 
 from pants.base.build_environment import get_buildroot
@@ -87,7 +86,7 @@ class NailgunExecutor(Executor, FingerprintedProcessManager):
                                          process_name=self._PROCESS_NAME,
                                          metadata_base_dir=metadata_base_dir)
 
-    if not isinstance(workdir, string_types):
+    if not isinstance(workdir, str):
       raise ValueError('Workdir must be a path string, not: {workdir}'.format(workdir=workdir))
 
     self._identity = identity

--- a/src/python/pants/net/http/fetcher.py
+++ b/src/python/pants/net/http/fetcher.py
@@ -366,7 +366,7 @@ class Fetcher:
     """
     @contextmanager
     def download_fp(_path_or_fd):
-      if _path_or_fd and not isinstance(_path_or_fd, six.string_types):
+      if _path_or_fd and not isinstance(_path_or_fd, str):
         yield _path_or_fd, _path_or_fd.name
       else:
         if not _path_or_fd:

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -10,7 +10,6 @@ from abc import ABC
 from contextlib import contextmanager
 from hashlib import sha1
 
-import six
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot, get_pants_cachedir, get_pants_configdir
@@ -123,7 +122,7 @@ class Config(ABC):
 
     return configparser.ConfigParser(all_seed_values)
 
-  def get(self, section, option, type_=six.string_types, default=None):
+  def get(self, section, option, type_=str, default=None):
     """Retrieves option from the specified section (or 'DEFAULT') and attempts to parse it as type.
 
     If the specified section does not exist or is missing a definition for the option, the value is
@@ -137,10 +136,7 @@ class Config(ABC):
       return default
 
     raw_value = self.get_value(section, option)
-    # We jump through some hoops here to deal with the fact that `six.string_types` is a tuple of
-    # types.
-    if (type_ == six.string_types or
-        (isinstance(type_, type) and issubclass(type_, six.string_types))):
+    if type_ == str:
       return raw_value
 
     key = '{}.{}'.format(section, option)

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -136,7 +136,7 @@ class Config(ABC):
       return default
 
     raw_value = self.get_value(section, option)
-    if type_ == str:
+    if type_ == str or issubclass(type_, str):
       return raw_value
 
     key = '{}.{}'.format(section, option)

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -9,7 +9,6 @@ import traceback
 from collections import defaultdict
 
 import Levenshtein
-import six
 import yaml
 
 from pants.base.deprecated import validate_deprecation_semver, warn_or_error
@@ -54,7 +53,7 @@ class Parser:
 
   @staticmethod
   def _ensure_bool(s):
-    if isinstance(s, six.string_types):
+    if isinstance(s, str):
       if s.lower() == 'true':
         return True
       elif s.lower() == 'false':

--- a/src/python/pants/reporting/BUILD
+++ b/src/python/pants/reporting/BUILD
@@ -6,7 +6,6 @@ python_library(
   dependencies=[
     '3rdparty/python:ansicolors',
     '3rdparty/python:pystache',
-    '3rdparty/python:six',
     '3rdparty/python:py-zipkin',
     '3rdparty/python:requests',
     ':report',

--- a/src/python/pants/reporting/html_reporter.py
+++ b/src/python/pants/reporting/html_reporter.py
@@ -10,8 +10,6 @@ from collections import defaultdict, namedtuple
 from itertools import zip_longest
 from textwrap import dedent
 
-from six import string_types
-
 from pants.base.build_environment import get_buildroot
 from pants.base.mustache import MustacheRenderer
 from pants.base.workunit import WorkUnit, WorkUnitLabel
@@ -279,7 +277,7 @@ class HtmlReporter(Reporter):
     # Update the artifact cache stats.
     def render_cache_stats(artifact_cache_stats):
       def fix_detail_id(e, _id):
-        return e if isinstance(e, string_types) else e + (_id, )
+        return e if isinstance(e, str) else e + (_id, )
 
       msg_elements = []
       for cache_name, stat in artifact_cache_stats.stats_per_cache.items():
@@ -377,7 +375,7 @@ class HtmlReporter(Reporter):
       # preserved through refreshes. For example, when looking at the artifact cache stats,
       # if "hits" are open and "misses" are closed, we want to remember that even after
       # the cache stats are updated and the message re-rendered.
-      if isinstance(element, string_types):
+      if isinstance(element, str):
         element = [element]
 
       # zip_longest assumes None for missing values, so this generator will pick the default for those.

--- a/src/python/pants/reporting/json_reporter.py
+++ b/src/python/pants/reporting/json_reporter.py
@@ -4,8 +4,6 @@
 from collections import defaultdict, namedtuple
 from itertools import zip_longest
 
-from six import string_types
-
 from pants.reporting.reporter import Reporter
 
 
@@ -98,7 +96,7 @@ class JsonReporter(Reporter):
 
   def _render_messages(self, *msg_elements):
     def _message_details(element):
-      if isinstance(element, string_types):
+      if isinstance(element, str):
         element = [element]
 
       text, detail = (x or y for x, y in zip_longest(element, ('', None)))

--- a/src/python/pants/reporting/plaintext_reporter.py
+++ b/src/python/pants/reporting/plaintext_reporter.py
@@ -3,7 +3,6 @@
 
 from collections import namedtuple
 
-import six
 from colors import cyan, green, red, yellow
 
 from pants.base.workunit import WorkUnit, WorkUnitLabel
@@ -163,7 +162,7 @@ class PlainTextReporter(PlainTextReporterBase):
 
     # If the element is a (msg, detail) pair, we ignore the detail. There's no
     # useful way to display it on the console.
-    elements = [e if isinstance(e, six.string_types) else e[0] for e in msg_elements]
+    elements = [e if isinstance(e, str) else e[0] for e in msg_elements]
     msg = '\n' + ''.join(elements)
     if self.use_color_for_workunit(workunit, self.settings.color):
       msg = self._COLOR_BY_LEVEL.get(level, lambda x: x)(msg)

--- a/src/python/pants/reporting/quiet_reporter.py
+++ b/src/python/pants/reporting/quiet_reporter.py
@@ -5,7 +5,6 @@ import sys
 from collections import namedtuple
 
 from colors import red
-from six import string_types
 
 from pants.reporting.plaintext_reporter_base import PlainTextReporterBase
 from pants.reporting.report import Report
@@ -36,7 +35,7 @@ class QuietReporter(PlainTextReporterBase):
     """Implementation of Reporter callback."""
     # If the element is a (msg, detail) pair, we ignore the detail. There's no
     # useful way to display it on the console.
-    elements = [e if isinstance(e, string_types) else e[0] for e in msg_elements]
+    elements = [e if isinstance(e, str) else e[0] for e in msg_elements]
     msg = '\n' + ''.join(elements)
     if self.settings.color:
       msg = red(msg)

--- a/src/python/pants/source/BUILD
+++ b/src/python/pants/source/BUILD
@@ -4,7 +4,6 @@
 python_library(
   sources = globs('*.py', exclude=[globs('payload_fields.py')]),
   dependencies=[
-    '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:payload_field',

--- a/src/python/pants/source/wrapped_globs.py
+++ b/src/python/pants/source/wrapped_globs.py
@@ -5,7 +5,6 @@ import os
 from abc import ABC, abstractmethod
 from hashlib import sha1
 
-from six import string_types
 from twitter.common.dirutil.fileset import Fileset
 
 from pants.base.build_environment import get_buildroot
@@ -180,7 +179,7 @@ class FilesetRelPathWrapper(ABC):
                     NB: this argument is contained within **kwargs!
     """
     for pattern in patterns:
-      if not isinstance(pattern, string_types):
+      if not isinstance(pattern, str):
         raise ValueError("Expected string patterns for {}: got {}".format(cls.__name__, patterns))
 
     raw_exclude = kwargs.pop('exclude', [])
@@ -233,13 +232,13 @@ class FilesetRelPathWrapper(ABC):
 
   @staticmethod
   def process_raw_exclude(raw_exclude):
-    if isinstance(raw_exclude, string_types):
+    if isinstance(raw_exclude, str):
       raise ValueError("Expected exclude parameter to be a list of globs, lists, or strings,"
                        " but was a string: {}".format(raw_exclude))
 
     # You can't subtract raw strings from globs
     def ensure_string_wrapped_in_list(element):
-      if isinstance(element, string_types):
+      if isinstance(element, str):
         return [element]
       else:
         return element

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -48,9 +48,6 @@ python_library(
 python_library(
   name = 'eval',
   sources = ['eval.py'],
-  dependencies = [
-    '3rdparty/python:future',
-  ]
 )
 
 python_library(

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -11,7 +11,6 @@ python_library(
   sources = ['contextutil.py'],
   dependencies = [
     '3rdparty/python:ansicolors',
-    '3rdparty/python:future',
     ':dirutil',
     ':tarutil',
   ],

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -16,7 +16,6 @@ from queue import Queue
 from socketserver import TCPServer
 
 from colors import green
-from future.utils import string_types
 
 from pants.util.dirutil import safe_delete
 from pants.util.tarutil import TarFile
@@ -291,9 +290,7 @@ def open_tar(path_or_file, *args, **kwargs):
 
     If path_or_file is a file, caller must close it separately.
   """
-  (path, fileobj) = ((path_or_file, None) if isinstance(path_or_file, string_types)
-                     else (None, path_or_file))  # TODO(#6071): stop using six.string_types
-                                                 # This should only accept python3 `str`, not byte strings.
+  (path, fileobj) = (path_or_file, None) if isinstance(path_or_file, str) else (None, path_or_file)
   with closing(TarFile.open(path, *args, fileobj=fileobj, **kwargs)) as tar:
     yield tar
 

--- a/src/python/pants/util/eval.py
+++ b/src/python/pants/util/eval.py
@@ -3,8 +3,6 @@
 
 from textwrap import dedent
 
-from future.utils import string_types
-
 
 def parse_expression(val, acceptable_types, name=None, raise_type=ValueError):
   """Attempts to parse the given `val` as a python expression of the specified `acceptable_types`.
@@ -22,8 +20,8 @@ def parse_expression(val, acceptable_types, name=None, raise_type=ValueError):
   def format_type(typ):
     return typ.__name__
 
-  if not isinstance(val, string_types):
-    raise raise_type('The raw `val` is not a string.  Given {} of type {}.'
+  if not isinstance(val, str):
+    raise raise_type('The raw `val` is not a str.  Given {} of type {}.'
                      .format(val, format_type(type(val))))
 
   def get_name():

--- a/src/python/pants/util/eval.py
+++ b/src/python/pants/util/eval.py
@@ -21,8 +21,7 @@ def parse_expression(val, acceptable_types, name=None, raise_type=ValueError):
     return typ.__name__
 
   if not isinstance(val, str):
-    raise raise_type('The raw `val` is not a str.  Given {} of type {}.'
-                     .format(val, format_type(type(val))))
+    raise raise_type(f"The raw `val` is not a str.  Given {val} of type {format_type(type(val))}.")
 
   def get_name():
     return repr(name) if name else 'value'

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -384,7 +384,7 @@ def enum(all_values):
   # Python requires creating an explicit closure to save the value on each loop iteration.
   accessor_generator = lambda case: lambda cls: cls(case)
   for case in all_values_realized:
-    if _string_type_constraint.satisfied_by(case):
+    if SubclassesOf(str).satisfied_by(case):
       accessor = classproperty(accessor_generator(case))
       attr_name = re.sub(r'-', '_', case)
       setattr(ChoiceDatatype, attr_name, accessor)
@@ -536,11 +536,6 @@ class SubclassesOf(TypeOnlyConstraint):
     return issubclass(obj_type, self._types)
 
 
-# TODO(#6071): We should in general not allow bytes _and_ str. The whole point of Py3 was to decide
-# for each case which to use, not to support both.
-_string_type_constraint = SubclassesOf(bytes, str)
-
-
 class TypedCollection(TypeConstraint):
   """A `TypeConstraint` which accepts a TypeOnlyConstraint and validates a collection."""
 
@@ -557,12 +552,12 @@ class TypedCollection(TypeConstraint):
   def exclude_iterable_constraint(cls):
     """Define what collection inputs are *not* accepted by this type constraint.
 
-    Strings in Python are considered iterables of substrings, but we only want to allow explicit
-    collection types.
+    Strings (unicode and byte) in Python are considered iterables of substrings, but we only want
+    to allow explicit collection types.
 
     :rtype: TypeConstraint
     """
-    return _string_type_constraint
+    return SubclassesOf(str, bytes)
 
   def __init__(self, constraint):
     """Create a `TypeConstraint` which validates each member of a collection with `constraint`.

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
@@ -122,7 +122,7 @@ class JvmBinaryTest(TestBase):
       'jvm_binary(name = "foo", main = "com.example.Foo", source = ["foo.py"])',
     )
     with self.assertRaisesRegexp(AddressLookupError,
-                                 r'Invalid target.*foo.*source must be a string'):
+                                 r'Invalid target.*foo.*source must be a str'):
       self.target(':foo')
 
   def test_bad_sources_declaration(self):

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
@@ -23,9 +23,9 @@ class JarRulesTest(unittest.TestCase):
     self.assertEqual('Skip(apply_pattern=foo)', repr(skip_rule))
 
   def test_invalid_apply_pattern(self):
-    with self.assertRaisesRegexp(ValueError, r'The supplied apply_pattern is not a string'):
+    with self.assertRaisesRegexp(ValueError, r'The supplied apply_pattern is not a str'):
       Skip(None)
-    with self.assertRaisesRegexp(ValueError, r'The supplied apply_pattern is not a string'):
+    with self.assertRaisesRegexp(ValueError, r'The supplied apply_pattern is not a str'):
       Duplicate(None, Duplicate.SKIP)
     with self.assertRaisesRegexp(ValueError, r'The supplied apply_pattern: \) is not a valid'):
       Skip(r')')

--- a/tests/python/pants_test/engine/examples/BUILD
+++ b/tests/python/pants_test/engine/examples/BUILD
@@ -10,7 +10,6 @@ python_library(
   name='parsers',
   sources=['parsers.py'],
   dependencies=[
-    '3rdparty/python:six',
     'src/python/pants/build_graph',
     'src/python/pants/engine:objects',
     'src/python/pants/engine:parser',

--- a/tests/python/pants_test/engine/examples/parsers.py
+++ b/tests/python/pants_test/engine/examples/parsers.py
@@ -8,8 +8,6 @@ import threading
 from json.decoder import JSONDecoder
 from json.encoder import JSONEncoder
 
-import six
-
 from pants.build_graph.address import Address
 from pants.engine.objects import Resolvable, Serializable
 from pants.engine.parser import ParseError, Parser
@@ -40,7 +38,7 @@ class JsonParser(Parser):
     self.symbol_table = symbol_table
 
   def _as_type(self, type_or_name):
-    return _import(type_or_name) if isinstance(type_or_name, six.string_types) else type_or_name
+    return _import(type_or_name) if isinstance(type_or_name, str) else type_or_name
 
   @staticmethod
   def _object_decoder(obj, symbol_table):

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -43,7 +43,6 @@ python_tests(
   name = 'eval',
   sources = ['test_eval.py'],
   dependencies = [
-    '3rdparty/python:future',
     'src/python/pants/util:eval',
   ]
 )

--- a/tests/python/pants_test/util/test_eval.py
+++ b/tests/python/pants_test/util/test_eval.py
@@ -3,15 +3,13 @@
 
 import unittest
 
-from future.utils import string_types
-
 from pants.util.eval import parse_expression
 
 
 class ParseLiteralTest(unittest.TestCase):
 
   def test_success_simple(self):
-    literal = parse_expression("'42'", acceptable_types=string_types)
+    literal = parse_expression("'42'", acceptable_types=str)
     self.assertEqual('42', literal)
 
   def test_success_mixed(self):

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -9,8 +9,8 @@ from textwrap import dedent
 
 from pants.util.objects import (EnumVariantSelectionError, Exactly, HashableTypedCollection,
                                 SubclassesOf, SuperclassesOf, TypeCheckError, TypeConstraintError,
-                                TypedCollection, TypedDatatypeInstanceConstructionError,
-                                _string_type_constraint, datatype, enum)
+                                TypedCollection, TypedDatatypeInstanceConstructionError, datatype,
+                                enum)
 from pants_test.test_base import TestBase
 
 
@@ -198,7 +198,7 @@ class TypedCollectionTest(TypeConstraintTestBase):
     with self.assertRaisesWithMessage(TypeConstraintError, dedent("""\
         in wrapped constraint TypedCollection(Exactly(A or B)): value A() (with type 'A') must satisfy this type constraint: SubclassesOf(Iterable).
         Note that objects matching {} are not considered iterable.""")
-                                      .format(_string_type_constraint)):
+                                      .format(TypedCollection.exclude_iterable_constraint)):
       collection_exactly_a_or_b.validate_satisfied_by(self.A())
     with self.assertRaisesWithMessage(TypeConstraintError, dedent("""\
         in wrapped constraint TypedCollection(Exactly(A or B)) matching iterable object [C()]: value C() (with type 'C') must satisfy this type constraint: Exactly(A or B).""")):
@@ -214,7 +214,7 @@ class TypedCollectionTest(TypeConstraintTestBase):
         type check error in class StringCollectionField: 1 error type checking constructor arguments:
         field 'hello_strings' was invalid: in wrapped constraint TypedCollection(Exactly(str)): value 'xxx' (with type 'str') must satisfy this type constraint: SubclassesOf(Iterable).
         Note that objects matching {exclude_constraint} are not considered iterable.""")
-                                      .format(exclude_constraint=_string_type_constraint)):
+                                      .format(exclude_constraint=TypedCollection.exclude_iterable_constraint)):
       StringCollectionField(hello_strings='xxx')
 
   def test_hashable_collection(self):
@@ -612,7 +612,7 @@ field 'some_value' was invalid: value 3 (with type 'int') must satisfy this type
     expected_msg = """\
 type check error in class WithCollectionTypeConstraint: 1 error type checking constructor arguments:
 field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)): value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(Iterable).
-Note that objects matching {} are not considered iterable.""".format(_string_type_constraint)
+Note that objects matching {} are not considered iterable.""".format(TypedCollection.exclude_iterable_constraint)
     with self.assertRaisesWithMessage(TypeCheckError, expected_msg):
       WithCollectionTypeConstraint(3)
 


### PR DESCRIPTION
`string_types`, which is the same as `Tuple[bytes, str]`, is a vestige of Python 2's loose mixing of unicode and byte strings. Python 3 intentionally makes you choose which you want to use, which we should be doing too for more sane code.

While this technically violates the deprecation policy for some APIs, this coincides with the even larger breaking change of no longer supporting Python 2. It is almost guaranteed that users who extend Pants will already need to make changes, so it is helpful to land this API change at the same time that people are modernizing their `pants-plugins`. 

Further, several of the below instances do not make sense to support bytes—they would crash were someone to pass bytes and it is solely happenstance that no one has reported trying. We had only kept the support for bytes due to Python 2's frequent use of byte strings.

