### PR TITLE
Use dedicated requirements.txt for `contrib.python.checks.checker`

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -15,8 +15,6 @@ parameterized==0.6.1
 pathspec==0.5.9
 pex==1.6.7
 psutil==5.4.8
-pycodestyle==2.4.0
-pyflakes==2.0.0
 Pygments==2.3.1
 pyopenssl==17.3.0
 pystache==0.5.3

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -120,6 +120,7 @@ function pkg_testinfra_install_test() {
 REQUIREMENTS_3RDPARTY_FILES=(
   "3rdparty/python/requirements.txt"
   "3rdparty/python/twitter/commons/requirements.txt"
+  "contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty/requirements.txt"
 )
 
 # When we do (dry-run) testing, we need to run the packaged pants.

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -11,6 +11,7 @@ REQUIREMENTS=(
   "${REPO_ROOT}/3rdparty/python/requirements.txt"
   "${REPO_ROOT}/3rdparty/python/twitter/commons/requirements.txt"
   "${REPO_ROOT}/pants-plugins/3rdparty/python/requirements.txt"
+  "${REPO_ROOT}/contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty/requirements.txt"
 )
 
 venv_dir_prefix="${REPO_ROOT}/build-support/pants_dev_deps"

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_requirements()

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty/requirements.txt
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty/requirements.txt
@@ -1,0 +1,6 @@
+# NB: See https://github.com/pantsbuild/pants/issues/7158 before introducing additional
+# dependencies here.
+
+six>=1.9.0,<2
+pycodestyle==2.4.0
+pyflakes==2.0.0

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/BUILD
@@ -15,11 +15,10 @@ python_library(
     }
   ),
   dependencies=[
-    # NB: See https://github.com/pantsbuild/pants/issues/7158 before introducing additional
-    # dependencies here.
-    '3rdparty/python:pycodestyle',
-    '3rdparty/python:pyflakes',
-    '3rdparty/python:six',
+    # NB: Dependencies should only come from this directory's own 3rdparty folder.
+    'contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty:pycodestyle',
+    'contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty:pyflakes',
+    'contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty:six',
   ]
 )
 


### PR DESCRIPTION
### Problem
`contrib.python.checks.checker` must keep support for Python 2, e.g. using `six`, which we will soon drop from the rest of the codebase.

Likewise, the module uses `pycodestyle` and `pyflakes`, neither of which are used anywhere else in the project.

We would like a way to provide requirements for specifically this module and to not pollute the rest of the project in doing so.

### Solution
Introduce a dedicated `3rdparty/requirements.txt` for the module, per https://www.pantsbuild.org/3rdparty_py.html#3rdpartypython.

We also indicate `pants_venv` should install these dependencies locally and `release.sh` should build 3rd party wheels for this so that the released PEX continues to work for the contrib package.