### PR TITLE
Add __init__.py to directories created by grpcio

### DIFF
--- a/src/python/pants/backend/codegen/grpcio/python/BUILD
+++ b/src/python/pants/backend/codegen/grpcio/python/BUILD
@@ -14,6 +14,8 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
     'src/python/pants/task',
   ],
 )

--- a/src/python/pants/backend/codegen/grpcio/python/BUILD
+++ b/src/python/pants/backend/codegen/grpcio/python/BUILD
@@ -14,7 +14,6 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
-    'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
     'src/python/pants/task',
   ],

--- a/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
+++ b/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
@@ -48,7 +48,9 @@ class GrpcioRun(SimpleCodegenTask):
         raise TaskError('{} ... exited non-zero ({}).'.format(cmdline, exit_code),
                         exit_code=exit_code)
       # Create __init__.py in each subdirectory of the target directory so that setup_py recognizes
-      # them as modules.
+      # them as modules.  Note that we do not use pex_build_util.py's identify_missing_init_files()
+      # because it expects a set of all the filenames and we do not want to precompute that, as we
+      # only have the root directory name at this point.
       for root, dirs, _ in safe_walk(target_workdir):
         for dirname in dirs:
           (Path(root) / dirname / '__init__.py').touch()

--- a/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
+++ b/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
@@ -50,13 +50,9 @@ class GrpcioRun(SimpleCodegenTask):
                         exit_code=exit_code)
       # Create __init__.py in each subdirectory of the target
       # directory so that setup_py recognizes them as modules.
-      def iter_module_dirs():
-        yield target_workdir
-        for root, dirs, _ in safe_walk(target_workdir):
-          for dirname in dirs:
-            yield os.path.join(root, dirname)
-      for module_dir in iter_module_dirs():
-        Path(os.path.join(module_dir, '__init__.py')).touch()
+      for root, dirs, _ in safe_walk(target_workdir):
+        for dirname in dirs:
+          Path(os.path.join(root, dirname, '__init__.py')).touch()
       logging.info("Grpcio finished code generation into: [{}]".format(target_workdir))
 
   def build_args(self, target, target_workdir):

--- a/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
+++ b/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
@@ -13,8 +13,8 @@ from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.task.simple_codegen_task import SimpleCodegenTask
 from pants.util.contextutil import pushd
-from pants.util.memo import memoized_property
 from pants.util.dirutil import safe_walk
+from pants.util.memo import memoized_property
 
 
 class GrpcioRun(SimpleCodegenTask):

--- a/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
+++ b/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
@@ -49,10 +49,10 @@ class GrpcioRun(SimpleCodegenTask):
                         exit_code=exit_code)
       # Create __init__.py in each subdirectory of the target directory so that setup_py recognizes
       # them as modules.
-      target_workdir_obj = Path(target_workdir)
-      sources = [str(p.relative_to(target_workdir)) for p in target_workdir_obj.rglob("*.py")]
+      target_workdir_path = Path(target_workdir)
+      sources = [str(p.relative_to(target_workdir_path)) for p in target_workdir_path.rglob("*.py")]
       for missing_init in identify_missing_init_files(sources):
-        (target_workdir_obj / missing_init).touch()
+        (target_workdir_path / missing_init).touch()
       logging.info("Grpcio finished code generation into: [{}]".format(target_workdir))
 
   def build_args(self, target, target_workdir):

--- a/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
+++ b/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
@@ -4,6 +4,7 @@
 import functools
 import logging
 import os
+from pathlib import Path
 
 from pants.backend.codegen.grpcio.python.grpcio_prep import GrpcioPrep
 from pants.backend.codegen.grpcio.python.python_grpcio_library import PythonGrpcioLibrary
@@ -55,8 +56,7 @@ class GrpcioRun(SimpleCodegenTask):
           for dirname in dirs:
             yield os.path.join(root, dirname)
       for module_dir in iter_module_dirs():
-        with open(os.path.join(module_dir, '__init__.py'), 'a'):
-          pass
+        Path(os.path.join(module_dir, '__init__.py')).touch()
       logging.info("Grpcio finished code generation into: [{}]".format(target_workdir))
 
   def build_args(self, target, target_workdir):

--- a/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
+++ b/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
@@ -3,7 +3,6 @@
 
 import functools
 import logging
-import os
 from pathlib import Path
 
 from pants.backend.codegen.grpcio.python.grpcio_prep import GrpcioPrep
@@ -48,11 +47,11 @@ class GrpcioRun(SimpleCodegenTask):
       if exit_code != 0:
         raise TaskError('{} ... exited non-zero ({}).'.format(cmdline, exit_code),
                         exit_code=exit_code)
-      # Create __init__.py in each subdirectory of the target
-      # directory so that setup_py recognizes them as modules.
+      # Create __init__.py in each subdirectory of the target directory so that setup_py recognizes
+      # them as modules.
       for root, dirs, _ in safe_walk(target_workdir):
         for dirname in dirs:
-          Path(os.path.join(root, dirname, '__init__.py')).touch()
+          (Path(root) / dirname / '__init__.py').touch()
       logging.info("Grpcio finished code generation into: [{}]".format(target_workdir))
 
   def build_args(self, target, target_workdir):

--- a/tests/python/pants_test/backend/codegen/grpcio/test_multiple_grpcio_gen.py
+++ b/tests/python/pants_test/backend/codegen/grpcio/test_multiple_grpcio_gen.py
@@ -55,14 +55,12 @@ class GrpcioGenTest(GrpcioTestBase):
     # then
     self.assertIsNotNone(synthetic_target)
     self.assertEqual(2, len(synthetic_target))
-    self.assertEqual({'__init__.py',
-                      'com/__init__.py',
+    self.assertEqual({'com/__init__.py',
                       'com/foo/__init__.py',
                       'com/foo/foo_example_pb2_grpc.py',
                       'com/foo/foo_example_pb2.py'},
                      set(synthetic_target[0].sources_relative_to_source_root()))
-    self.assertEqual({'__init__.py',
-                      'com/__init__.py',
+    self.assertEqual({'com/__init__.py',
                       'com/bar/__init__.py',
                       'com/bar/bar_example_pb2_grpc.py',
                       'com/bar/bar_example_pb2.py'},

--- a/tests/python/pants_test/backend/codegen/grpcio/test_multiple_grpcio_gen.py
+++ b/tests/python/pants_test/backend/codegen/grpcio/test_multiple_grpcio_gen.py
@@ -55,9 +55,15 @@ class GrpcioGenTest(GrpcioTestBase):
     # then
     self.assertIsNotNone(synthetic_target)
     self.assertEqual(2, len(synthetic_target))
-    self.assertEqual({'com/foo/foo_example_pb2_grpc.py',
+    self.assertEqual({'__init__.py',
+                      'com/__init__.py',
+                      'com/foo/__init__.py',
+                      'com/foo/foo_example_pb2_grpc.py',
                       'com/foo/foo_example_pb2.py'},
                      set(synthetic_target[0].sources_relative_to_source_root()))
-    self.assertEqual({'com/bar/bar_example_pb2_grpc.py',
+    self.assertEqual({'__init__.py',
+                      'com/__init__.py',
+                      'com/bar/__init__.py',
+                      'com/bar/bar_example_pb2_grpc.py',
                       'com/bar/bar_example_pb2.py'},
                      set(synthetic_target[1].sources_relative_to_source_root()))

--- a/tests/python/pants_test/backend/codegen/grpcio/test_single_grpcio_gen.py
+++ b/tests/python/pants_test/backend/codegen/grpcio/test_single_grpcio_gen.py
@@ -34,8 +34,7 @@ class GrpcioMultipleGenTest(GrpcioTestBase):
 
     # then
     self.assertEqual(1, len(synthetic_target))
-    self.assertEqual({'__init__.py',
-                      'com/__init__.py',
+    self.assertEqual({'com/__init__.py',
                       'com/example/__init__.py',
                       'com/example/example_pb2_grpc.py',
                       'com/example/example_pb2.py'},

--- a/tests/python/pants_test/backend/codegen/grpcio/test_single_grpcio_gen.py
+++ b/tests/python/pants_test/backend/codegen/grpcio/test_single_grpcio_gen.py
@@ -34,6 +34,9 @@ class GrpcioMultipleGenTest(GrpcioTestBase):
 
     # then
     self.assertEqual(1, len(synthetic_target))
-    self.assertEqual({'com/example/example_pb2_grpc.py',
+    self.assertEqual({'__init__.py',
+                      'com/__init__.py',
+                      'com/example/__init__.py',
+                      'com/example/example_pb2_grpc.py',
                       'com/example/example_pb2.py'},
                      set(synthetic_target[0].sources_relative_to_source_root()))


### PR DESCRIPTION
### Problem

When trying to create a dist tarball from `python_grpcio_library` using `provides=setup_py`, the `find-namespace-packages` step fails with the following errors:

    $ ./pants setup-py ...
    [...]
    ..._pb2.py is source but does not belong to a package.
    ..._pb2_grpc.py is source but does not belong to a package.

That happens because the `find_packages()` method in `setup_py.py` ignores subdirectories that do not contain `__init__.py`.

### Solution

This commit adds an empty `__init__.py` file to each directory created by grpcio.

### Result

A package with gRPC interfaces is properly created.