### PR TITLE
Remove `six` library

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -29,6 +29,5 @@ responses==0.10.4
 scandir==1.2
 setproctitle==1.1.10
 setuptools==40.6.3
-six>=1.9.0,<2
 wheel==0.31.1
 www-authenticate==0.9.2

--- a/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/BUILD
@@ -28,7 +28,6 @@ python_library(
   sources=['node_preinstalled_module_resolver.py'],
   dependencies=[
     ':node_resolver_base',
-    '3rdparty/python:six',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/fs',

--- a/src/python/pants/backend/jvm/BUILD
+++ b/src/python/pants/backend/jvm/BUILD
@@ -45,7 +45,6 @@ python_library(
   sources=['ivy_utils.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python:six',
     ':ivy_utils_resources',
     'src/python/pants/backend/jvm/subsystems:jar_dependency_management',
     'src/python/pants/backend/jvm/targets:jvm',

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -11,7 +11,6 @@ from abc import abstractmethod
 from collections import OrderedDict, defaultdict, namedtuple
 from functools import total_ordering
 
-import six
 from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
@@ -848,7 +847,7 @@ class IvyUtils:
         hardlink_map[path] = path
 
     # Create hardlinks for paths in the ivy cache dir.
-    for path, hardlink in six.iteritems(hardlink_map):
+    for path, hardlink in hardlink_map.items():
       if path == hardlink:
         # Skip paths that aren't going to be hardlinked.
         continue

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -343,7 +343,6 @@ python_library(
   dependencies = [
     '3rdparty/python:future',
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python:six',
     ':classpath_util',
     ':nailgun_task',
     'src/python/pants/backend/jvm:argfile',

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -5,7 +5,6 @@ import json
 import os
 from collections import defaultdict
 
-import six
 from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
@@ -336,7 +335,7 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
       default_interpreter = min(python_interpreter_targets_mapping.keys())
 
       interpreters_info = {}
-      for interpreter, targets in six.iteritems(python_interpreter_targets_mapping):
+      for interpreter, targets in python_interpreter_targets_mapping.items():
         req_libs = [target for target in Target.closure_for_targets(targets)
                     if has_python_requirements(target)]
         chroot = self.resolve_requirements(interpreter, req_libs)

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -19,7 +19,6 @@ python_library(
   dependencies = [
     '3rdparty/python:pathspec',
     '3rdparty/python:scandir',
-    '3rdparty/python:six',
     ':build_environment',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',

--- a/src/python/pants/build_graph/BUILD
+++ b/src/python/pants/build_graph/BUILD
@@ -5,7 +5,6 @@
 python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python:six',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file',
     'src/python/pants/base:build_file_target_factory',

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -136,7 +136,6 @@ python_library(
   name='parser',
   sources=['parser.py'],
   dependencies=[
-    '3rdparty/python:six',
     ':addressable',
     ':objects',
     'src/python/pants/build_graph',
@@ -164,7 +163,6 @@ python_library(
   sources=['selectors.py'],
   dependencies=[
     '3rdparty/python:future',
-    '3rdparty/python:six',
     'src/python/pants/util:objects',
   ]
 )

--- a/src/python/pants/engine/legacy/BUILD
+++ b/src/python/pants/engine/legacy/BUILD
@@ -21,7 +21,6 @@ python_library(
   name='parser',
   sources=['parser.py'],
   dependencies=[
-    '3rdparty/python:six',
     ':structs',
     'src/python/pants/base:build_file_target_factory',
     'src/python/pants/base:parse_context',

--- a/src/python/pants/goal/products.py
+++ b/src/python/pants/goal/products.py
@@ -4,7 +4,6 @@
 import os
 from collections import defaultdict
 
-import six
 from twitter.common.collections import OrderedSet
 
 from pants.util.collections import factory_dict
@@ -333,7 +332,7 @@ class Products:
 
         :API: public
       """
-      return six.iteritems(self.by_target)
+      return self.by_target.items()
 
     def keys_for(self, basedir, product):
       """Returns the set of keys the given mapped product is registered under.

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -37,7 +37,6 @@ python_library(
   name = 'nailgun_protocol',
   sources = ['nailgun_protocol.py'],
   dependencies = [
-    '3rdparty/python:six',
     'src/python/pants/util:objects',
     'src/python/pants/util:osutil',
   ]

--- a/src/python/pants/java/jar/BUILD
+++ b/src/python/pants/java/jar/BUILD
@@ -3,7 +3,6 @@
 
 python_library(
   dependencies = [
-    '3rdparty/python:six',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:hash_utils',
     'src/python/pants/base:payload_field',

--- a/src/python/pants/net/BUILD
+++ b/src/python/pants/net/BUILD
@@ -6,7 +6,6 @@ python_library(
   dependencies = [
     '3rdparty/python:requests',
     '3rdparty/python:pyopenssl',
-    '3rdparty/python:six',
     'src/python/pants/util:dirutil',
   ],
 )

--- a/src/python/pants/net/http/fetcher.py
+++ b/src/python/pants/net/http/fetcher.py
@@ -11,7 +11,6 @@ from abc import ABC, abstractmethod
 from contextlib import closing, contextmanager
 
 import requests
-import six
 
 from pants.util.dirutil import safe_open
 from pants.util.strutil import strip_prefix
@@ -38,7 +37,7 @@ class Fetcher:
 
     def __init__(self, value=None, response_code=None):
       super(Fetcher.PermanentError, self).__init__(value)
-      if response_code and not isinstance(response_code, six.integer_types):
+      if response_code and not isinstance(response_code, int):
         raise ValueError('response_code must be an integer, got {}'.format(response_code))
       self._response_code = response_code
 
@@ -152,7 +151,7 @@ class Fetcher:
       :type stream: :class:`io.RawIOBase`
       """
       self._width = width or 50
-      if not isinstance(self._width, six.integer_types):
+      if not isinstance(self._width, int):
         raise ValueError('The width must be an integer, given {}'.format(self._width))
       self._chunk_size_bytes = chunk_size_bytes or 10 * 1024
       self._stream = stream or sys.stderr.buffer

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -115,9 +115,6 @@ python_library(
 python_library(
   name = 'rwbuf',
   sources = ['rwbuf.py'],
-  dependencies = [
-    '3rdparty/python:six',
-  ]
 )
 
 python_library(
@@ -149,9 +146,6 @@ python_library(
 python_library(
   name = 'tarutil',
   sources = ['tarutil.py'],
-  dependencies = [
-    '3rdparty/python:six',
-  ],
 )
 
 python_library(

--- a/tests/python/pants_test/process/BUILD
+++ b/tests/python/pants_test/process/BUILD
@@ -3,7 +3,6 @@
 
 python_tests(
   dependencies = [
-    '3rdparty/python:six',
     'src/python/pants/process',
     'tests/python/pants_test:test_base',
     'tests/python/pants_test/subsystem:subsystem_utils',


### PR DESCRIPTION
However, `contrib.python.checks.checker` does still need `six`, which was setup in https://github.com/pantsbuild/pants/pull/7982 to be isolated from this change.