### PR TITLE
Set up pants.remote.ini for remoting Python unit tests

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -83,17 +83,6 @@ pants_ignore: +[
     '/build-support/bin/native/src',
   ]
 
-remote_execution_server: remotebuildexecution.googleapis.com
-remote_store_server: remotebuildexecution.googleapis.com
-# This file might not exist on your machine. If this default fails, run `find /usr -name '*.pem'`
-# and override this value via the env var PANTS_REMOTE_CA_CERTS_PATH.
-remote_ca_certs_path: /usr/local/etc/openssl/cert.pem
-remote_instance_name: projects/pants-remoting-beta/instances/default_instance
-remote_execution_extra_platform_properties: [
-    # This allows network requests, e.g. to resolve dependencies with Pex.
-    "dockerNetwork=standard",
-    "container-image=docker://marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:da0f21c71abce3bbb92c3a0c44c3737f007a82b60f8bd2930abc55fe64fc2729",
-  ]
 
 [cache]
 # Caching is on globally by default, but we disable it here for development purposes.
@@ -399,26 +388,9 @@ verify_commit: False
 
 
 [python-setup]
-interpreter_search_paths: [
-     '<PEXRC>',
-     '<PATH>'
-     # TODO(#7735): We need to add this entry for remoting to be able to discover a valid
-     # interpreter, because <PATH> will refer to the host PATH and not the remote value. This value
-     # was found by inspecting the docker image for remoting.
-     "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/python3.6/bin:/usr/local/go/bin",
-  ]
 interpreter_constraints: ["CPython>=3.6,<4"]
 interpreter_cache_dir: %(pants_bootstrapdir)s/python_cache/interpreters
 resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
-
-
-[python-native-code]
-# TODO(#7735): These two lines are necessary to get remoting working, but it will likely cause
-# failures when running locally on macOS. What we really want is some way to say that when remoting
-# on Linux, set these values to none; when running locally on macOS, use the default env var values.
-# REMOTING: uncomment these two lines when remoting tests.
-# ld_flags: []
-# cpp_flags: []
 
 
 [test.pytest]

--- a/pants.ini
+++ b/pants.ini
@@ -83,6 +83,17 @@ pants_ignore: +[
     '/build-support/bin/native/src',
   ]
 
+remote_execution_server: remotebuildexecution.googleapis.com
+remote_store_server: remotebuildexecution.googleapis.com
+# This file might not exist on your machine. If this default fails, run `find /usr -name '*.pem'`
+# and override this value via the env var PANTS_REMOTE_CA_CERTS_PATH.
+remote_ca_certs_path: /usr/local/etc/openssl/cert.pem
+remote_instance_name: projects/pants-remoting-beta/instances/default_instance
+remote_execution_extra_platform_properties: [
+    # This allows network requests, e.g. to resolve dependencies with Pex.
+    "dockerNetwork=standard",
+    "container-image=docker://marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:da0f21c71abce3bbb92c3a0c44c3737f007a82b60f8bd2930abc55fe64fc2729",
+  ]
 
 [cache]
 # Caching is on globally by default, but we disable it here for development purposes.
@@ -388,9 +399,26 @@ verify_commit: False
 
 
 [python-setup]
+interpreter_search_paths: [
+     '<PEXRC>',
+     '<PATH>'
+     # TODO(#7735): We need to add this entry for remoting to be able to discover a valid
+     # interpreter, because <PATH> will refer to the host PATH and not the remote value. This value
+     # was found by inspecting the docker image for remoting.
+     "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/python3.6/bin:/usr/local/go/bin",
+  ]
 interpreter_constraints: ["CPython>=3.6,<4"]
 interpreter_cache_dir: %(pants_bootstrapdir)s/python_cache/interpreters
 resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
+
+
+[python-native-code]
+# TODO(#7735): These two lines are necessary to get remoting working, but it will likely cause
+# failures when running locally on macOS. What we really want is some way to say that when remoting
+# on Linux, set these values to none; when running locally on macOS, use the default env var values.
+# REMOTING: uncomment these two lines when remoting tests.
+# ld_flags: []
+# cpp_flags: []
 
 
 [test.pytest]

--- a/pants.remote.ini
+++ b/pants.remote.ini
@@ -1,8 +1,9 @@
-# For goals that you'd like to remote, point to this config file and provide the oauth token like
-# this:
+# For goals that you'd like to remote, first install the Google cloud CLI and then log in to an
+# an account authorized to run the Pants project (you may need to ask a Pants committer for
+# to authorize your account). Then, point to this config file and provide the oauth token like this:
 #
 #  $ ./pants --pants-config-files=pants.remote.ini
-#     --remote-oauth-bearer-token-path=<path to file>
+#     --remote-oauth-bearer-token-path=<(gcloud auth application-default print-access-token | perl -p -e 'chomp if eof')
 #     --no-v1 --v2 test tests/python/pants_test/util:strutil
 #
 # Remoting does not work for every goal, so you should not permanently point to this ini file, e.g.

--- a/pants.remote.ini
+++ b/pants.remote.ini
@@ -1,0 +1,39 @@
+# For goals that you'd like to remote, point to this config file and provide the oauth token like
+# this:
+#
+#  $ ./pants --pants-config-files=pants.remote.ini
+#     --remote-oauth-bearer-token-path=<path to file>
+#     --no-v1 --v2 test tests/python/pants_test/util:strutil
+#
+# Remoting does not work for every goal, so you should not permanently point to this ini file, e.g.
+# via an env var; only point to it when you want to remote a specific invocation.
+
+[DEFAULT]
+remote_execution: True
+remote_execution_server: remotebuildexecution.googleapis.com
+remote_store_server: remotebuildexecution.googleapis.com
+# This file might not exist on your machine. If this default fails, run `find /usr -name '*.pem'`
+# and override this value via the env var PANTS_REMOTE_CA_CERTS_PATH.
+remote_ca_certs_path: /usr/local/etc/openssl/cert.pem
+remote_instance_name: projects/pants-remoting-beta/instances/default_instance
+remote_execution_extra_platform_properties: [
+    # This allows network requests, e.g. to resolve dependencies with Pex.
+    "dockerNetwork=standard",
+    "container-image=docker://marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:da0f21c71abce3bbb92c3a0c44c3737f007a82b60f8bd2930abc55fe64fc2729",
+  ]
+
+
+[python-setup]
+interpreter_search_paths: [
+     '<PEXRC>',
+     '<PATH>'
+     # TODO(#7735): We need to add this entry for remoting to be able to discover a valid
+     # interpreter, because <PATH> will refer to the host PATH and not the remote value. This value
+     # was found by inspecting the docker image for remoting.
+     "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/python3.6/bin:/usr/local/go/bin",
+  ]
+
+
+[python-native-code]
+ld_flags: []
+cpp_flags: []


### PR DESCRIPTION
Per https://github.com/pantsbuild/pants/issues/7649, we are working to remote unit tests in CI.

This implements step #2, which allows us to run unit tests locally (several, but not all tests). Here, we set up `pants.remote.ini` so that users only must point to it and provide the authentication token.