### PR TITLE
Add `--[no-]remote-execution` flag

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -809,6 +809,7 @@ class Native(Singleton):
         self.context.utf8_buf_buf(ignore_patterns),
         self.to_ids_buf(root_subject_types),
         # Remote execution config.
+        execution_options.enable_remoting,
         self.context.utf8_buf_buf(execution_options.remote_store_server),
         # We can't currently pass Options to the rust side, so we pass empty strings for None.
         self.context.utf8_buf(execution_options.remote_execution_server or ""),

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -809,7 +809,7 @@ class Native(Singleton):
         self.context.utf8_buf_buf(ignore_patterns),
         self.to_ids_buf(root_subject_types),
         # Remote execution config.
-        execution_options.enable_remoting,
+        execution_options.remote_execution,
         self.context.utf8_buf_buf(execution_options.remote_store_server),
         # We can't currently pass Options to the rust side, so we pass empty strings for None.
         self.context.utf8_buf(execution_options.remote_execution_server or ""),

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -74,10 +74,6 @@ class Scheduler:
     :type include_trace_on_error: bool
     :param validate: True to assert that the ruleset is valid.
     """
-
-    if execution_options.remote_execution_server and not execution_options.remote_store_server:
-      raise ValueError("Cannot set remote execution server without setting remote store server")
-
     self._native = native
     self.include_trace_on_error = include_trace_on_error
     self._visualize_to_dir = visualize_to_dir

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -26,6 +26,7 @@ class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'])):
 
 
 class ExecutionOptions(datatype([
+  'enable_remoting',
   'remote_store_server',
   'remote_store_thread_count',
   'remote_execution_server',
@@ -50,6 +51,7 @@ class ExecutionOptions(datatype([
   @classmethod
   def from_bootstrap_options(cls, bootstrap_options):
     return cls(
+      enable_remoting=bootstrap_options.enable_remoting,
       remote_store_server=bootstrap_options.remote_store_server,
       remote_execution_server=bootstrap_options.remote_execution_server,
       remote_store_thread_count=bootstrap_options.remote_store_thread_count,
@@ -68,6 +70,7 @@ class ExecutionOptions(datatype([
 
 
 DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
+    enable_remoting=False,
     remote_store_server=[],
     remote_store_thread_count=1,
     remote_execution_server=None,
@@ -355,6 +358,10 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              # This default is also hard-coded into the engine's rust code in
              # fs::Store::default_path
              default=os.path.expanduser('~/.cache/pants/lmdb_store'))
+
+    register('--enable-remoting', advanced=True, type=bool,
+             default=DEFAULT_EXECUTION_OPTIONS.enable_remoting,
+             help="Enables remote workers for increased parallelism. (Alpha)")
     register('--remote-store-server', advanced=True, type=list, default=[],
              help='host:port of grpc server to use as remote execution file store.')
     register('--remote-store-thread-count', type=int, advanced=True,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -26,7 +26,7 @@ class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'])):
 
 
 class ExecutionOptions(datatype([
-  'enable_remoting',
+  'remote_execution',
   'remote_store_server',
   'remote_store_thread_count',
   'remote_execution_server',
@@ -51,7 +51,7 @@ class ExecutionOptions(datatype([
   @classmethod
   def from_bootstrap_options(cls, bootstrap_options):
     return cls(
-      enable_remoting=bootstrap_options.enable_remoting,
+      remote_execution=bootstrap_options.remote_execution,
       remote_store_server=bootstrap_options.remote_store_server,
       remote_execution_server=bootstrap_options.remote_execution_server,
       remote_store_thread_count=bootstrap_options.remote_store_thread_count,
@@ -70,7 +70,7 @@ class ExecutionOptions(datatype([
 
 
 DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
-    enable_remoting=False,
+    remote_execution=False,
     remote_store_server=[],
     remote_store_thread_count=1,
     remote_execution_server=None,
@@ -359,8 +359,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              # fs::Store::default_path
              default=os.path.expanduser('~/.cache/pants/lmdb_store'))
 
-    register('--enable-remoting', advanced=True, type=bool,
-             default=DEFAULT_EXECUTION_OPTIONS.enable_remoting,
+    register('--remote-execution', advanced=True, type=bool,
+             default=DEFAULT_EXECUTION_OPTIONS.remote_execution,
              help="Enables remote workers for increased parallelism. (Alpha)")
     register('--remote-store-server', advanced=True, type=list, default=[],
              help='host:port of grpc server to use as remote execution file store.')
@@ -488,8 +488,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     if opts.v2_ui and not opts.v2:
       raise OptionsError('The `--v2-ui` option requires `--v2` to be enabled together.')
 
-    if opts.enable_remoting and not opts.remote_execution_server:
-      raise OptionsError("The `--enable-remoting` option requires also setting "
+    if opts.remote_execution and not opts.remote_execution_server:
+      raise OptionsError("The `--remote-execution` option requires also setting "
                          "`--remote-execution-server` to work properly.")
 
     if opts.remote_execution_server and not opts.remote_store_server:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -480,10 +480,18 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     Raises pants.option.errors.OptionsError on validation failure.
     """
     if opts.loop and (not opts.v2 or opts.v1):
-      raise OptionsError('The --loop option only works with @console_rules, and thus requires '
+      raise OptionsError('The `--loop` option only works with @console_rules, and thus requires '
                          '`--v2 --no-v1` to function as expected.')
     if opts.loop and not opts.enable_pantsd:
-      raise OptionsError('The --loop option requires `--enable-pantsd`, in order to watch files.')
+      raise OptionsError('The `--loop` option requires `--enable-pantsd`, in order to watch files.')
 
     if opts.v2_ui and not opts.v2:
-      raise OptionsError('The --v2-ui option requires --v2 to be enabled together.')
+      raise OptionsError('The `--v2-ui` option requires `--v2` to be enabled together.')
+
+    if opts.enable_remoting and not opts.remote_execution_server:
+      raise OptionsError("The `--enable-remoting` option requires also setting "
+                         "`--remote-execution-server` to work properly.")
+
+    if opts.remote_execution_server and not opts.remote_store_server:
+      raise OptionsError("The `--remote-execution-server` option requires also setting "
+                         "`--remote-store-server`. Often these have the same value.")

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -59,7 +59,7 @@ impl Core {
     ignore_patterns: &[String],
     work_dir: PathBuf,
     local_store_dir: PathBuf,
-    enable_remoting: bool,
+    remote_execution: bool,
     remote_store_servers: Vec<String>,
     remote_execution_server: Option<String>,
     remote_execution_process_cache_namespace: Option<String>,
@@ -129,7 +129,7 @@ impl Core {
       .unwrap_or_else(|e| panic!("Could not initialize Store: {:?}", e));
 
     let command_runner = match &remote_execution_server {
-      Some(ref address) if enable_remoting => BoundedCommandRunner::new(
+      Some(ref address) if remote_execution => BoundedCommandRunner::new(
         Box::new(process_execution::remote::CommandRunner::new(
           address,
           remote_execution_process_cache_namespace.clone(),

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -59,6 +59,7 @@ impl Core {
     ignore_patterns: &[String],
     work_dir: PathBuf,
     local_store_dir: PathBuf,
+    enable_remoting: bool,
     remote_store_servers: Vec<String>,
     remote_execution_server: Option<String>,
     remote_execution_process_cache_namespace: Option<String>,
@@ -128,7 +129,7 @@ impl Core {
       .unwrap_or_else(|e| panic!("Could not initialize Store: {:?}", e));
 
     let command_runner = match &remote_execution_server {
-      Some(ref address) => BoundedCommandRunner::new(
+      Some(ref address) if enable_remoting => BoundedCommandRunner::new(
         Box::new(process_execution::remote::CommandRunner::new(
           address,
           remote_execution_process_cache_namespace.clone(),
@@ -140,7 +141,7 @@ impl Core {
         )),
         process_execution_remote_parallelism,
       ),
-      None => BoundedCommandRunner::new(
+      _ => BoundedCommandRunner::new(
         Box::new(process_execution::local::CommandRunner::new(
           store.clone(),
           work_dir.clone(),

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -299,7 +299,7 @@ pub extern "C" fn scheduler_create(
     &ignore_patterns,
     PathBuf::from(work_dir_buf.to_os_string()),
     PathBuf::from(local_store_dir_buf.to_os_string()),
-    remote_execution as bool,
+    remote_execution,
     remote_store_servers_vec,
     if remote_execution_server_string.is_empty() {
       None
@@ -325,7 +325,7 @@ pub extern "C" fn scheduler_create(
     remote_execution_extra_platform_properties_map,
     process_execution_local_parallelism as usize,
     process_execution_remote_parallelism as usize,
-    process_execution_cleanup_local_dirs as bool,
+    process_execution_cleanup_local_dirs,
   ))))
 }
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -203,7 +203,7 @@ pub extern "C" fn scheduler_create(
   local_store_dir_buf: Buffer,
   ignore_patterns_buf: BufferBuffer,
   root_type_ids: TypeIdBuffer,
-  enable_remoting: bool,
+  remote_execution: bool,
   remote_store_servers_buf: BufferBuffer,
   remote_execution_server: Buffer,
   remote_execution_process_cache_namespace: Buffer,
@@ -299,7 +299,7 @@ pub extern "C" fn scheduler_create(
     &ignore_patterns,
     PathBuf::from(work_dir_buf.to_os_string()),
     PathBuf::from(local_store_dir_buf.to_os_string()),
-    enable_remoting as bool,
+    remote_execution as bool,
     remote_store_servers_vec,
     if remote_execution_server_string.is_empty() {
       None

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -203,6 +203,7 @@ pub extern "C" fn scheduler_create(
   local_store_dir_buf: Buffer,
   ignore_patterns_buf: BufferBuffer,
   root_type_ids: TypeIdBuffer,
+  enable_remoting: bool,
   remote_store_servers_buf: BufferBuffer,
   remote_execution_server: Buffer,
   remote_execution_process_cache_namespace: Buffer,
@@ -298,6 +299,7 @@ pub extern "C" fn scheduler_create(
     &ignore_patterns,
     PathBuf::from(work_dir_buf.to_os_string()),
     PathBuf::from(local_store_dir_buf.to_os_string()),
+    enable_remoting as bool,
     remote_store_servers_vec,
     if remote_execution_server_string.is_empty() {
       None

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -23,4 +23,4 @@ class OptionsInitializerTest(unittest.TestCase):
     build_config = BuildConfigInitializer.get(ob)
     with self.assertRaises(OptionsError) as exc:
       OptionsInitializer.create(ob, build_config)
-    self.assertIn('loop option only works with', str(exc.exception))
+    self.assertIn('The `--loop` option only works with', str(exc.exception))


### PR DESCRIPTION
### Problem
We want to allow users to permanently configure all remoting options in their `pants.ini`, without that config triggering Pants always using remoting. Tangibly, we are trying to land https://github.com/pantsbuild/pants/pull/7990 to setup our own usage and can't get green CI because Pants is trying to remote things it shouldn't.

Instead, users should be able to turn on remoting at the per-invocation level, just like we have `--enable-pantsd`. 

### Solution
Introduce `--[no-]remote-execution`. For now, this defaults to `False` as this is an alpha feature and it does not work without other remoting config.

### Result
Users can have all their remoting config setup and still be able to entirely run locally. Also now more explicit when you are and are not remoting.