### PR TITLE
Properly manage the lifetime of Exiters in Daemon Runs

### DIFF
--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -178,10 +178,10 @@ class ExceptionSink:
   class AccessGlobalExiterMixin:
     @property
     def _exiter(self) -> Exiter:
-      return ExceptionSink._get_global_exiter()
+      return ExceptionSink.get_global_exiter()
 
   @classmethod
-  def _get_global_exiter(cls) -> Exiter:
+  def get_global_exiter(cls) -> Exiter:
     return cls._exiter
 
   @classmethod
@@ -190,13 +190,13 @@ class ExceptionSink:
     previous_exiter = cls._exiter
     new_exiter = new_exiter_fun(previous_exiter)
     try:
-      cls.reset_exiter(new_exiter)
+      cls._reset_exiter(new_exiter)
       yield
     finally:
-      cls.reset_exiter(previous_exiter)
+      cls._reset_exiter(previous_exiter)
 
   @classmethod
-  def reset_exiter(cls, exiter: Exiter) -> None:
+  def _reset_exiter(cls, exiter: Exiter) -> None:
     """
     Class state:
     - Overwrites `cls._exiter`.
@@ -506,7 +506,7 @@ Signal {signum} ({signame}) was raised. Exiting with failure.{formatted_tracebac
 # Set the initial log location, for fatal errors during import time.
 ExceptionSink.reset_log_location(os.path.join(os.getcwd(), '.pants.d'))
 # Sets except hook for exceptions at import time.
-ExceptionSink.reset_exiter(Exiter(exiter=sys.exit))
+ExceptionSink._reset_exiter(Exiter(exiter=sys.exit))
 # Sets a SIGUSR2 handler.
 ExceptionSink.reset_interactive_output_stream(sys.stderr.buffer)
 # Sets a handler that logs nonfatal signals to the exception sink before exiting.

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -199,6 +199,7 @@ class ExceptionSink:
     - Overwrites sys.excepthook.
     """
     assert(isinstance(exiter, Exiter))
+    logger.debug(f"overriding the global exiter with {exiter} (from {cls._exiter})")
     # NB: mutate the class variables! This is done before mutating the exception hook, because the
     # uncaught exception handler uses cls._exiter to exit.
     cls._exiter = exiter

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -189,11 +189,12 @@ class ExceptionSink:
   def exiter_as(cls, new_exiter_fun: Callable[[Exiter], Exiter]) -> None:
     previous_exiter = cls._exiter
     new_exiter = new_exiter_fun(previous_exiter)
-    try:
-      cls._reset_exiter(new_exiter)
-      yield
-    finally:
-      cls._reset_exiter(previous_exiter)
+    # NB: We don't want to try/finally here, because we want exceptions to propagate
+    # with the most recent exiter installed in sys.excepthook.
+    # If we wrap this in a try:finally, exceptions will be caught and exiters unset.
+    cls._reset_exiter(new_exiter)
+    yield
+    cls._reset_exiter(previous_exiter)
 
   @classmethod
   def _reset_exiter(cls, exiter: Exiter) -> None:

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -175,8 +175,13 @@ class ExceptionSink:
     cls._pid_specific_error_fileobj = pid_specific_error_stream
     cls._shared_error_fileobj = shared_error_stream
 
+  class AccessGlobalExiterMixin:
+    @property
+    def _exiter(self) -> Exiter:
+      return ExceptionSink._get_global_exiter()
+
   @classmethod
-  def get_global_exiter(cls) -> Exiter:
+  def _get_global_exiter(cls) -> Exiter:
     return cls._exiter
 
   @classmethod

--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 PANTS_SUCCEEDED_EXIT_CODE = 0
 PANTS_FAILED_EXIT_CODE = 1
 
+ExitCode = int
+
 
 class Exiter:
   """A class that provides standard runtime exit behavior.

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -29,10 +29,7 @@ class PantsRunFailCheckerExiter(Exiter):
 
 
 class DaemonExiter(Exiter):
-  """An Exiter that emits unhandled tracebacks and exit codes via the Nailgun protocol.
-
-  TODO: https://github.com/pantsbuild/pants/pull/7606
-  """
+  """An Exiter that emits unhandled tracebacks and exit codes via the Nailgun protocol."""
 
   @classmethod
   @contextmanager
@@ -41,10 +38,7 @@ class DaemonExiter(Exiter):
       yield
 
   def __init__(self, maybe_shutdown_socket, finalizer, previous_exiter):
-    # N.B. Assuming a fork()'d child, cause os._exit to be called here to avoid the routine
-    # sys.exit behavior.
-    # TODO: The behavior we're avoiding with the use of os._exit should be described and tested.
-    super().__init__(exiter=os._exit)
+    super().__init__(exiter=previous_exiter)
     self._maybe_shutdown_socket = maybe_shutdown_socket
     self._finalizer = finalizer
 

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -103,7 +103,7 @@ class _PantsRunFinishedWithFailureException(Exception):
     return self._exit_code
 
 
-class DaemonPantsRunner:
+class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
   """A daemonizing PantsRunner that speaks the nailgun protocol to a remote client.
 
   N.B. this class is primarily used by the PailgunService in pantsd.
@@ -141,10 +141,6 @@ class DaemonPantsRunner:
     self._scheduler_service = scheduler_service
 
     self.exit_code = exit_code
-
-  @property
-  def _exiter(self) -> Exiter:
-    return ExceptionSink.get_global_exiter()
 
   # TODO: this should probably no longer be necesary, remove.
   def _make_identity(self):

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -6,7 +6,6 @@ import os
 import sys
 import termios
 import time
-import logging
 from contextlib import contextmanager
 
 from pants.base.exception_sink import ExceptionSink
@@ -265,17 +264,17 @@ class DaemonPantsRunner:
         clean_global_runtime_state(reset_subsystem=True)
 
         # Otherwise, conduct a normal run.
-        runner = LocalPantsRunner.create(
-          PantsRunFailCheckerExiter(),
-          self._args,
-          self._env,
-          target_roots,
-          graph_helper,
-          options_bootstrapper,
-        )
-        runner.set_start_time(self._maybe_get_client_start_time_from_env(self._env))
+        with ExceptionSink.exiter_as(PantsRunFailCheckerExiter):
+          runner = LocalPantsRunner.create(
+            self._args,
+            self._env,
+            target_roots,
+            graph_helper,
+            options_bootstrapper,
+          )
+          runner.set_start_time(self._maybe_get_client_start_time_from_env(self._env))
 
-        runner.run()
+          runner.run()
       except KeyboardInterrupt:
         self._exiter.exit_and_fail('Interrupted by user.\n')
       except _PantsRunFinishedWithFailureException as e:

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -259,7 +259,7 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         clean_global_runtime_state(reset_subsystem=True)
 
         # Otherwise, conduct a normal run.
-        with ExceptionSink.exiter_as(lambda _: PantsRunFailCheckerExiter()):
+        with ExceptionSink.exiter_as_until_exception(lambda _: PantsRunFailCheckerExiter()):
           runner = LocalPantsRunner.create(
             self._args,
             self._env,

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -259,7 +259,7 @@ class DaemonPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
         clean_global_runtime_state(reset_subsystem=True)
 
         # Otherwise, conduct a normal run.
-        with ExceptionSink.exiter_as(PantsRunFailCheckerExiter):
+        with ExceptionSink.exiter_as(lambda _: PantsRunFailCheckerExiter()):
           runner = LocalPantsRunner.create(
             self._args,
             self._env,

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -81,7 +81,7 @@ class LocalExiter(Exiter):
     super().exit(result=result, msg=msg, *args, **kwargs)
 
 
-class LocalPantsRunner:
+class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
   """Handles a single pants invocation running in the process-local context."""
 
   @staticmethod
@@ -229,10 +229,6 @@ class LocalPantsRunner:
     with LocalExiter.wrap_global_exiter(self._run_tracker, self._repro), \
          maybe_profiled(self._profile_path):
       self._run()
-
-  @property
-  def _exiter(self):
-    return ExceptionSink.get_global_exiter()
 
   def _maybe_handle_help(self):
     """Handle requests for `help` information."""

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -5,7 +5,6 @@ import os
 import time
 
 from pants.base.exception_sink import ExceptionSink
-from pants.base.exiter import Exiter
 from pants.bin.pants_runner import PantsRunner
 from pants.util.contextutil import maybe_profiled
 
@@ -28,12 +27,8 @@ def test_env():
 def main():
   start_time = time.time()
 
-  # NB: This is the root exiter, so we don't need a contextmanager for this.
-  exiter = Exiter()
-  ExceptionSink.reset_exiter(exiter)
-
   with maybe_profiled(os.environ.get('PANTSC_PROFILE')):
     try:
       PantsRunner(start_time=start_time).run()
     except KeyboardInterrupt as e:
-      exiter.exit_and_fail('Interrupted by user:\n{}'.format(e))
+      ExceptionSink.get_global_exiter().exit_and_fail('Interrupted by user:\n{}'.format(e))

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -28,11 +28,12 @@ def test_env():
 def main():
   start_time = time.time()
 
+  # NB: This is the root exiter, so we don't need a contextmanager for this.
   exiter = Exiter()
   ExceptionSink.reset_exiter(exiter)
 
   with maybe_profiled(os.environ.get('PANTSC_PROFILE')):
     try:
-      PantsRunner(exiter, start_time=start_time).run()
+      PantsRunner(start_time=start_time).run()
     except KeyboardInterrupt as e:
       exiter.exit_and_fail('Interrupted by user:\n{}'.format(e))

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -79,7 +79,6 @@ class PantsRunner:
       logger.debug("Pantsd terminating goal detected: {}".format(self._args))
 
     runner = LocalPantsRunner.create(
-        self._exiter,
         self._args,
         self._env,
         options_bootstrapper=options_bootstrapper

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -15,7 +15,7 @@ from pants.option.options_bootstrapper import OptionsBootstrapper
 logger = logging.getLogger(__name__)
 
 
-class PantsRunner:
+class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
   """A higher-level runner that delegates runs to either a LocalPantsRunner or RemotePantsRunner."""
 
   def __init__(self, args=None, env=None, start_time=None):
@@ -34,10 +34,6 @@ class PantsRunner:
 
   def will_terminate_pantsd(self):
     return not frozenset(self._args).isdisjoint(self._DAEMON_KILLING_GOALS)
-
-  @property
-  def _exiter(self):
-    return ExceptionSink.get_global_exiter()
 
   def _enable_rust_logging(self, global_bootstrap_options):
     levelname = global_bootstrap_options.level.upper()

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -18,13 +18,11 @@ logger = logging.getLogger(__name__)
 class PantsRunner:
   """A higher-level runner that delegates runs to either a LocalPantsRunner or RemotePantsRunner."""
 
-  def __init__(self, exiter, args=None, env=None, start_time=None):
+  def __init__(self, args=None, env=None, start_time=None):
     """
-    :param Exiter exiter: The Exiter instance to use for this run.
     :param list args: The arguments (sys.argv) for this run. (Optional, default: sys.argv)
     :param dict env: The environment for this run. (Optional, default: os.environ)
     """
-    self._exiter = exiter
     self._args = args or sys.argv
     self._env = env or os.environ
     self._start_time = start_time
@@ -36,6 +34,10 @@ class PantsRunner:
 
   def will_terminate_pantsd(self):
     return not frozenset(self._args).isdisjoint(self._DAEMON_KILLING_GOALS)
+
+  @property
+  def _exiter(self):
+    return ExceptionSink.get_global_exiter()
 
   def _enable_rust_logging(self, global_bootstrap_options):
     levelname = global_bootstrap_options.level.upper()
@@ -49,10 +51,6 @@ class PantsRunner:
            not global_bootstrap_options.concurrent
 
   def run(self):
-    # Register our exiter at the beginning of the run() method so that any code in this process from
-    # this point onwards will use that exiter in the case of a fatal error.
-    ExceptionSink.reset_exiter(self._exiter)
-
     options_bootstrapper = OptionsBootstrapper.create(env=self._env, args=self._args)
     bootstrap_options = options_bootstrapper.bootstrap_options
     global_bootstrap_options = bootstrap_options.for_global_scope()

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -406,11 +406,10 @@ class PantsDaemon(FingerprintedProcessManager):
   def run_sync(self):
     """Synchronously run pantsd."""
     # Switch log output to the daemon's log stream from here forward.
+    # Also, register an exiter using os._exit to ensure we only close stdio streams once.
     self._close_stdio()
-    with self._pantsd_logging() as (log_stream, log_filename):
-
-      # Register an exiter using os._exit to ensure we only close stdio streams once.
-      ExceptionSink.reset_exiter(Exiter(exiter=os._exit))
+    with self._pantsd_logging() as (log_stream, log_filename), \
+         ExceptionSink.exiter_as(lambda _: Exiter(exiter=os._exit)):
 
       # We don't have any stdio streams to log to anymore, so we log to a file.
       # We don't override the faulthandler destination because the stream we get will proxy things

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/tasks/lifecycle_stub_task.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/tasks/lifecycle_stub_task.py
@@ -38,7 +38,7 @@ class LifecycleStubTask(Task):
     exit_msg = self._lifecycle_stubs.add_exiter_message
     if exit_msg:
       new_exiter = MessagingExiter(exit_msg)
-      ExceptionSink.reset_exiter(new_exiter)
+      ExceptionSink._reset_exiter(new_exiter)
 
     output_file = self._lifecycle_stubs.new_interactive_stream_output_file
     if output_file:

--- a/testprojects/src/python/bad_requirements/BUILD
+++ b/testprojects/src/python/bad_requirements/BUILD
@@ -1,0 +1,12 @@
+python_requirement_library(
+  name='badreq',
+  requirements=[
+    python_requirement('badreq==99.99.99')
+  ]
+)
+
+python_binary(
+  name='use_badreq',
+  dependencies=[':badreq'],
+  entry_point='bad_requirements.use_badreq',
+)

--- a/testprojects/src/python/bad_requirements/use_badreq.py
+++ b/testprojects/src/python/bad_requirements/use_badreq.py
@@ -1,0 +1,10 @@
+# coding=utf-8
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import sys
+
+
+if __name__ == "__main__":
+  print("Shouldn't have reached this point. This should have crashed when resolving badreq")
+  sys.exit(1)

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -62,6 +62,8 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/tests/python/pants/dummies:failing_target',
       'testprojects/tests/scala/org/pantsbuild/testproject/non_exports:C',
       'testprojects/src/scala/org/pantsbuild/testproject/exclude_direct_dep',
+      'testprojects/src/python/bad_requirements:badreq',
+      'testprojects/src/python/bad_requirements:use_badreq',
       'testprojects/tests/python/pants/timeout:terminates_self',
       # These don't pass without special config.
       'testprojects/tests/java/org/pantsbuild/testproject/depman:new-tests',


### PR DESCRIPTION
### Problem

There is a bug where, once the `LocalPantsRunner` has reset the global exiter to its own `LocalExiter`, it won't un-set it ever, and therefore unhandled exceptions will use that exiter to exit.
 
This has caused issues, around [this line](https://github.com/pantsbuild/pants/compare/master...blorente:blorente/fix-exiters-and-exceptions?expand=1#diff-40fe9ee4d7b0c13c2386990d899deab2L307), because the LocalPantsRunner reset the global exiter and the DaemonPantsRunner didn't reset it.

There is a regression test to demonstrate this issue.

### Solution

- Following the discussion on #7606, implement a contextmanager that temporarily overrides the global exiter.
- Remove the concept of "my exiter", and make classes (`LocalPantsRunner`, `DaemonPantsRunner`, `PantsRunner` and `PantsDaemon`) use the global exiter.

### Result
The regression test passes, and `_log_unhandled_exceptions_and_exit` works as expected in `DaemonPantsRunner`.
