### PR TITLE
Fix bug background workunits were printed in UI

### DIFF
--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -246,6 +246,18 @@ class WorkUnit:
       ret = ret.parent
     return ret
 
+  def is_background(self, background_root_workunit):
+    """
+    :API: public
+    """
+    ret = self
+    while ret is not None:
+      if ret is background_root_workunit:
+        return True
+      ret = ret.parent
+    return False
+
+
   def ancestors(self):
     """Returns a list consisting of this workunit and those enclosing it, up to the root.
 

--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -247,14 +247,17 @@ class WorkUnit:
     return ret
 
   def is_background(self, background_root_workunit):
-    """
+    """ Returns True if this workunit is a background root workunit or its successor.
+
+    :param WorkUnit background_root_workunit: parent of all background workunits.
+
     :API: public
     """
-    ret = self
-    while ret is not None:
-      if ret is background_root_workunit:
+    curr_workunit = self
+    while curr_workunit is not None:
+      if curr_workunit is background_root_workunit:
         return True
-      ret = ret.parent
+      curr_workunit = curr_workunit.parent
     return False
 
 

--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -260,7 +260,6 @@ class WorkUnit:
       curr_workunit = curr_workunit.parent
     return False
 
-
   def ancestors(self):
     """Returns a list consisting of this workunit and those enclosing it, up to the root.
 

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -180,9 +180,9 @@ class RunTracker(Subsystem):
     """
     self._threadlocal.current_workunit = parent_workunit
 
-  def is_under_main_root(self, workunit):
-    """Is the workunit running under the main thread's root."""
-    return workunit.root() == self._main_root_workunit
+  def is_under_background_root(self, workunit):
+    """Is the workunit running under the background thread's root."""
+    return workunit.is_background(self._background_root_workunit)
 
   def is_main_root_workunit(self, workunit):
     return workunit is self._main_root_workunit

--- a/src/python/pants/reporting/html_reporter.py
+++ b/src/python/pants/reporting/html_reporter.py
@@ -223,7 +223,7 @@ class HtmlReporter(Reporter):
     timing = '{:.3f}'.format(duration)
     unaccounted_time = ''
     # Background work may be idle a lot, no point in reporting that as unaccounted.
-    if self.is_under_main_root(workunit):
+    if not self.is_under_background_root(workunit):
       unaccounted_time_secs = workunit.unaccounted_time()
       if unaccounted_time_secs >= 1 and unaccounted_time_secs > 0.05 * duration:
         unaccounted_time = '{:.3f}'.format(unaccounted_time_secs)

--- a/src/python/pants/reporting/plaintext_reporter.py
+++ b/src/python/pants/reporting/plaintext_reporter.py
@@ -122,7 +122,7 @@ class PlainTextReporter(PlainTextReporterBase):
 
   def start_workunit(self, workunit):
     """Implementation of Reporter callback."""
-    if not self.is_under_main_root(workunit):
+    if self.is_under_background_root(workunit):
       return
 
     label_format = self._get_label_format(workunit)
@@ -143,7 +143,7 @@ class PlainTextReporter(PlainTextReporterBase):
 
   def end_workunit(self, workunit):
     """Implementation of Reporter callback."""
-    if not self.is_under_main_root(workunit):
+    if self.is_under_background_root(workunit):
       return
 
     if workunit.outcome() != WorkUnit.SUCCESS and not self._show_output(workunit):
@@ -157,7 +157,7 @@ class PlainTextReporter(PlainTextReporterBase):
 
   def do_handle_log(self, workunit, level, *msg_elements):
     """Implementation of Reporter callback."""
-    if not self.is_under_main_root(workunit):
+    if self.is_under_background_root(workunit):
       return
 
     # If the element is a (msg, detail) pair, we ignore the detail. There's no
@@ -172,7 +172,7 @@ class PlainTextReporter(PlainTextReporterBase):
 
   def handle_output(self, workunit, label, s):
     """Implementation of Reporter callback."""
-    if not self.is_under_main_root(workunit):
+    if self.is_under_background_root(workunit):
       return
     tool_output_format = self._get_tool_output_format(workunit)
     if tool_output_format == ToolOutputFormat.INDENT:

--- a/src/python/pants/reporting/reporter.py
+++ b/src/python/pants/reporting/reporter.py
@@ -75,9 +75,9 @@ class Reporter:
     """
     pass
 
-  def is_under_main_root(self, workunit):
+  def is_under_background_root(self, workunit):
     """Is the workunit running under the main thread's root."""
-    return self.run_tracker.is_under_main_root(workunit)
+    return self.run_tracker.is_under_background_root(workunit)
 
   def level_for_workunit(self, workunit, default_level):
     if workunit.log_config and workunit.log_config.level:

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -137,6 +137,16 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
       # zinc's label should be suppressed
       self.assertNotIn('[zinc]', line)
 
+  def test_suppress_background_workunits_output(self):
+    command = ['compile',
+      'examples/src/java/org/pantsbuild/example/hello::']
+    pants_run = self.run_pants(command)
+    self.assert_success(pants_run)
+    # background workunit label should be suppressed
+    self.assertNotIn('[background]', pants_run.stdout_data)
+    # labels of children of the background workunit should be suppressed
+    self.assertNotIn('[workdir_build_cleanup]', pants_run.stdout_data)
+
   def test_invalid_config(self):
     command = ['compile',
                'examples/src/java/org/pantsbuild/example/hello::',


### PR DESCRIPTION
### Problem
Background workunits were present in UI output. The reason is that background root workunit start to have a parent - main thread root.

### Solution
Print workunit label in UI only if it is not under the background root workunit.
