### PR TITLE
Add type checking to several `util` files

### DIFF
--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -4,6 +4,7 @@
 python_library(
   name = 'argutil',
   sources = ['argutil.py'],
+  tags={'type_checked'},
 )
 
 python_library(

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -33,6 +33,7 @@ python_library(
   dependencies = [
     ':osutil',
   ],
+  tags={'type_checked'},
 )
 
 python_library(

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -134,6 +134,7 @@ python_library(
 python_library(
   name = 'strutil',
   sources = ['strutil.py'],
+  tags={'type_checked'},
 )
 
 python_library(

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -94,6 +94,7 @@ python_library(
 python_library(
   name = 'osutil',
   sources = ['osutil.py'],
+  tags={'type_checked'},
 )
 
 python_library(

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -4,7 +4,7 @@
 python_library(
   name = 'argutil',
   sources = ['argutil.py'],
-  tags={'type_checked'},
+  tags = {'type_checked'},
 )
 
 python_library(
@@ -33,7 +33,7 @@ python_library(
   dependencies = [
     ':osutil',
   ],
-  tags={'type_checked'},
+  tags = {'type_checked'},
 )
 
 python_library(
@@ -95,7 +95,7 @@ python_library(
 python_library(
   name = 'osutil',
   sources = ['osutil.py'],
-  tags={'type_checked'},
+  tags = {'type_checked'},
 )
 
 python_library(
@@ -137,7 +137,7 @@ python_library(
 python_library(
   name = 'strutil',
   sources = ['strutil.py'],
-  tags={'type_checked'},
+  tags = {'type_checked'},
 )
 
 python_library(

--- a/src/python/pants/util/argutil.py
+++ b/src/python/pants/util/argutil.py
@@ -1,16 +1,18 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import List, Optional
 
-def ensure_arg(args, arg, param=None):
+
+def ensure_arg(args: List[str], arg: str, param: Optional[str] = None) -> List[str]:
   """Make sure the arg is present in the list of args.
 
   If arg is not present, adds the arg and the optional param.
   If present and param != None, sets the parameter following the arg to param.
 
-  :param list args: strings representing an argument list.
-  :param string arg: argument to make sure is present in the list.
-  :param string param: parameter to add or update after arg in the list.
+  :param args: strings representing an argument list.
+  :param arg: argument to make sure is present in the list.
+  :param param: parameter to add or update after arg in the list.
   :return: possibly modified list of args.
   """
   for idx, found_arg in enumerate(args):
@@ -25,14 +27,14 @@ def ensure_arg(args, arg, param=None):
   return args
 
 
-def remove_arg(args, arg, has_param=False):
+def remove_arg(args: List[str], arg: str, has_param: bool = False) -> List[str]:
   """Removes the first instance of the specified arg from the list of args.
 
   If the arg is present and has_param is set, also removes the parameter that follows
   the arg.
-  :param list args: strings representing an argument list.
-  :param staring arg: argument to remove from the list.
-  :param bool has_param: if true, also remove the parameter that follows arg in the list.
+  :param args: strings representing an argument list.
+  :param arg: argument to remove from the list.
+  :param has_param: if true, also remove the parameter that follows arg in the list.
   :return: possibly modified list of args.
   """
   for idx, found_arg in enumerate(args):

--- a/src/python/pants/util/desktop.py
+++ b/src/python/pants/util/desktop.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import subprocess
+from typing import Sequence
 
 from pants.util.osutil import get_os_name
 
@@ -10,11 +11,11 @@ class OpenError(Exception):
   """Indicates an error opening a file in a desktop application."""
 
 
-def _mac_open(files):
+def _mac_open(files: Sequence[str]) -> None:
   subprocess.call(['open'] + list(files))
 
 
-def _linux_open(files):
+def _linux_open(files: Sequence[str]) -> None:
   cmd = "xdg-open"
   if not _cmd_exists(cmd):
     raise OpenError("The program '{}' isn't in your PATH. Please install and re-run this "
@@ -24,9 +25,10 @@ def _linux_open(files):
 
 
 # From: http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python
-def _cmd_exists(cmd):
-  return subprocess.call(["/usr/bin/which", cmd], shell=False, stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE) == 0
+def _cmd_exists(cmd: str) -> bool:
+  return subprocess.call(
+    ["/usr/bin/which", cmd], shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+  ) == 0
 
 
 _OPENER_BY_OS = {
@@ -35,7 +37,7 @@ _OPENER_BY_OS = {
 }
 
 
-def ui_open(*files):
+def ui_open(*files: str) -> None:
   """Attempts to open the given files using the preferred desktop viewer or editor.
 
   :raises :class:`OpenError`: if there is a problem opening any of the files.

--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -4,7 +4,9 @@
 import errno
 import logging
 import os
+import posix
 from functools import reduce
+from typing import Dict, List, Optional, Set, Tuple
 
 
 logger = logging.getLogger(__name__)
@@ -18,7 +20,7 @@ OS_ALIASES = {
 Pid = int
 
 
-def get_os_name(uname_result=None):
+def get_os_name(uname_result: Optional[posix.uname_result] = None) -> str:
   """
   :API: public
   """
@@ -27,7 +29,7 @@ def get_os_name(uname_result=None):
   return uname_result[0].lower()
 
 
-def normalize_os_name(os_name):
+def normalize_os_name(os_name: str) -> str:
   """
   :API: public
   """
@@ -40,15 +42,15 @@ def normalize_os_name(os_name):
   return os_name
 
 
-def get_normalized_os_name():
+def get_normalized_os_name() -> str:
   return normalize_os_name(get_os_name())
 
 
-def all_normalized_os_names():
+def all_normalized_os_names() -> List[str]:
   return list(OS_ALIASES.keys())
 
 
-def known_os_names():
+def known_os_names() -> Set[str]:
   return reduce(set.union, OS_ALIASES.values())
 
 
@@ -61,7 +63,7 @@ def known_os_names():
 #     [ESRCH]            No process or process group can be found corresponding to that specified by pid.
 #
 #     [ESRCH]            The process id was given as 0, but the sending process does not have a process group.
-def safe_kill(pid, signum):
+def safe_kill(pid: Pid, signum: int) -> None:
   """Kill a process with the specified signal, catching nonfatal errors."""
   assert(isinstance(pid, Pid))
   assert(isinstance(signum, int))
@@ -97,8 +99,10 @@ SUPPORTED_PLATFORM_NORMALIZED_NAMES = {
 }
 
 
-def get_closest_mac_host_platform_pair(darwin_version_upper_bound,
-                                       platform_name_map=SUPPORTED_PLATFORM_NORMALIZED_NAMES):
+def get_closest_mac_host_platform_pair(
+  darwin_version_upper_bound: str,
+  platform_name_map: Dict[Tuple[str, str], Tuple[str, str]] = SUPPORTED_PLATFORM_NORMALIZED_NAMES
+) -> Tuple[Optional[str], Optional[str]]:
   """Return the (host, platform) pair for the highest known darwin version less than the bound."""
   darwin_versions = [int(x[1]) for x in platform_name_map if x[0] == 'darwin']
   bounded_darwin_versions = [v for v in darwin_versions if v <= int(darwin_version_upper_bound)]

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -3,9 +3,10 @@
 
 import re
 import shlex
+from typing import Any, Dict, List, Optional, Union
 
 
-def ensure_binary(text_or_binary):
+def ensure_binary(text_or_binary: Union[bytes, str]) -> bytes:
   if isinstance(text_or_binary, bytes):
     return text_or_binary
   elif isinstance(text_or_binary, str):
@@ -14,7 +15,7 @@ def ensure_binary(text_or_binary):
     raise TypeError('Argument is neither text nor binary type.({})'.format(type(text_or_binary)))
 
 
-def ensure_text(text_or_binary):
+def ensure_text(text_or_binary: Union[bytes, str]) -> str:
   if isinstance(text_or_binary, bytes):
     return text_or_binary.decode()
   elif isinstance(text_or_binary, str):
@@ -23,11 +24,11 @@ def ensure_text(text_or_binary):
     raise TypeError('Argument is neither text nor binary type ({})'.format(type(text_or_binary)))
 
 
-def is_text_or_binary(obj):
+def is_text_or_binary(obj: Any) -> bool:
   return isinstance(obj, (str, bytes))
 
 
-def safe_shlex_split(text_or_binary):
+def safe_shlex_split(text_or_binary: Union[bytes, str]) -> List[str]:
   """Split a string using shell-like syntax.
 
   Safe even on python versions whose shlex.split() method doesn't accept unicode.
@@ -41,7 +42,7 @@ def safe_shlex_split(text_or_binary):
 _shell_unsafe_chars_pattern = re.compile(r'[^\w@%+=:,./-]').search
 
 
-def shell_quote(s):
+def shell_quote(s: str) -> str:
   """Return a shell-escaped version of the string *s*."""
   if not s:
     return "''"
@@ -53,7 +54,7 @@ def shell_quote(s):
   return "'" + s.replace("'", "'\"'\"'") + "'"
 
 
-def safe_shlex_join(arg_list):
+def safe_shlex_join(arg_list: List[str]) -> str:
   """Join a list of strings into a shlex-able string.
 
   Shell-quotes each argument with `shell_quote()`.
@@ -61,14 +62,20 @@ def safe_shlex_join(arg_list):
   return ' '.join(shell_quote(arg) for arg in arg_list)
 
 
-def create_path_env_var(new_entries, env=None, env_var='PATH', delimiter=':', prepend=False):
+def create_path_env_var(
+  new_entries: List[str],
+  env: Optional[Dict[str, str]] = None,
+  env_var: str = 'PATH',
+  delimiter: str = ':',
+  prepend: bool = False
+):
   """Join path entries, combining with an environment variable if specified."""
   if env is None:
     env = {}
 
   prev_path = env.get(env_var, None)
   if prev_path is None:
-    path_dirs = list()
+    path_dirs: List[str] = []
   else:
     path_dirs = list(prev_path.split(delimiter))
 
@@ -82,21 +89,20 @@ def create_path_env_var(new_entries, env=None, env_var='PATH', delimiter=':', pr
   return delimiter.join(path_dirs)
 
 
-def camelcase(string):
+def camelcase(string: str) -> str:
   """Convert snake casing (containing - or _ characters) to camel casing."""
   return ''.join(word.capitalize() for word in re.split('[-_]', string))
 
 
-def pluralize(count, item_type):
+def pluralize(count: int, item_type: str) -> str:
   """Pluralizes the item_type if the count does not equal one.
 
   For example `pluralize(1, 'apple')` returns '1 apple',
   while `pluralize(0, 'apple') returns '0 apples'.
 
   :return The count and inflected item_type together as a string
-  :rtype string
   """
-  def pluralize_string(x):
+  def pluralize_string(x: str) -> str:
     if x.endswith('s'):
       return x + 'es'
     else:
@@ -106,17 +112,16 @@ def pluralize(count, item_type):
   return text
 
 
-def strip_prefix(string, prefix):
+def strip_prefix(string: str, prefix: str) -> str:
   """Returns a copy of the string from which the multi-character prefix has been stripped.
 
   Use strip_prefix() instead of lstrip() to remove a substring (instead of individual characters)
   from the beginning of a string, if the substring is present.  lstrip() does not match substrings
   but rather treats a substring argument as a set of characters.
 
-  :param str string: The string from which to strip the specified prefix.
-  :param str prefix: The substring to strip from the left of string, if present.
+  :param string: The string from which to strip the specified prefix.
+  :param prefix: The substring to strip from the left of string, if present.
   :return: The string with prefix stripped from the left, if present.
-  :rtype: string
   """
   if string.startswith(prefix):
     return string[len(prefix):]

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -148,7 +148,8 @@ python_tests(
   sources = ['test_strutil.py'],
   dependencies = [
     'src/python/pants/util:strutil',
-  ]
+  ],
+  tags={'type_checked'},
 )
 
 python_tests(

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -8,7 +8,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:argutil',
   ],
-  tags={'type_checked'},
+  tags = {'type_checked'},
 )
 
 python_tests(
@@ -150,7 +150,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:strutil',
   ],
-  tags={'type_checked'},
+  tags = {'type_checked'},
 )
 
 python_tests(

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -8,6 +8,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:argutil',
   ],
+  tags={'type_checked'},
 )
 
 python_tests(

--- a/tests/python/pants_test/util/test_argutil.py
+++ b/tests/python/pants_test/util/test_argutil.py
@@ -8,7 +8,7 @@ from pants.util.argutil import ensure_arg, remove_arg
 
 class ArgutilTest(unittest.TestCase):
 
-  def test_ensure_arg(self):
+  def test_ensure_arg(self) -> None:
     self.assertEqual(['foo'], ensure_arg([], 'foo'))
     self.assertEqual(['foo'], ensure_arg(['foo'], 'foo'))
     self.assertEqual(['bar', 'foo'], ensure_arg(['bar'], 'foo'))
@@ -19,7 +19,7 @@ class ArgutilTest(unittest.TestCase):
     self.assertEqual(['foo', 'baz'], ensure_arg(['foo', 'bar'], 'foo', param='baz'))
     self.assertEqual(['qux', 'foo', 'baz', 'foobar'], ensure_arg(['qux', 'foo', 'bar', 'foobar'], 'foo', param='baz'))
 
-  def test_remove_arg(self):
+  def test_remove_arg(self) -> None:
     self.assertEqual([], remove_arg([], 'foo'))
     self.assertEqual([], remove_arg(['foo'], 'foo'))
     self.assertEqual(['bar'], remove_arg(['foo', 'bar'], 'foo'))
@@ -30,4 +30,4 @@ class ArgutilTest(unittest.TestCase):
     self.assertEqual([], remove_arg(['foo', 'bar'], 'foo', has_param=True))
     self.assertEqual(['baz'], remove_arg(['baz', 'foo', 'bar'], 'foo', has_param=True))
     self.assertEqual(['baz'], remove_arg(['foo', 'bar', 'baz'], 'foo', has_param=True))
-    self.assertEqual(['qux', 'foobar'], remove_arg(['qux', 'foo', 'bar', 'foobar'], 'foo', has_param='baz'))
+    self.assertEqual(['qux', 'foobar'], remove_arg(['qux', 'foo', 'bar', 'foobar'], 'foo', has_param=True))

--- a/tests/python/pants_test/util/test_osutil.py
+++ b/tests/python/pants_test/util/test_osutil.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
+from typing import Optional
 
 from pants.util.osutil import (OS_ALIASES, get_closest_mac_host_platform_pair, known_os_names,
                                normalize_os_name)
@@ -10,30 +11,30 @@ from pants_test.test_base import TestBase
 
 class OsutilTest(TestBase):
 
-  def test_alias_normalization(self):
+  def test_alias_normalization(self) -> None:
     for normal_os, aliases in OS_ALIASES.items():
       for alias in aliases:
         self.assertEqual(normal_os, normalize_os_name(alias))
 
-  def test_keys_in_aliases(self):
+  def test_keys_in_aliases(self) -> None:
     for key in OS_ALIASES.keys():
       self.assertIn(key, known_os_names())
 
-  def test_no_warnings_on_known_names(self):
+  def test_no_warnings_on_known_names(self) -> None:
     for name in known_os_names():
       with self.captured_logging(logging.WARNING) as captured:
         normalize_os_name(name)
         self.assertEqual(0, len(captured.warnings()),
                          'Recieved unexpected warnings: {}'.format(captured.warnings()))
 
-  def test_warnings_on_unknown_names(self):
+  def test_warnings_on_unknown_names(self) -> None:
     name = 'I really hope no one ever names an operating system with this string.'
     with self.captured_logging(logging.WARNING) as captured:
       normalize_os_name(name)
       self.assertEqual(1, len(captured.warnings()),
                        'Expected exactly one warning, but got: {}'.format(captured.warnings()))
 
-  def test_get_closest_mac_host_platform_pair(self):
+  def test_get_closest_mac_host_platform_pair(self) -> None:
     # Note the gaps in darwin versions.
     platform_name_map = {
       ('linux', 'x86_64'): ('linux', 'x86_64'),
@@ -45,7 +46,7 @@ class OsutilTest(TestBase):
       ('darwin', '17'): ('mac', '10.13'),
     }
 
-    def get_macos_version(darwin_version):
+    def get_macos_version(darwin_version: str) -> Optional[str]:
       host, version = get_closest_mac_host_platform_pair(
         darwin_version, platform_name_map=platform_name_map)
       if host is not None:

--- a/tests/python/pants_test/util/test_strutil.py
+++ b/tests/python/pants_test/util/test_strutil.py
@@ -9,7 +9,7 @@ from pants.util.strutil import camelcase, ensure_binary, ensure_text, pluralize,
 # TODO(Eric Ayers): Backfill tests for other methods in strutil.py
 class StrutilTest(unittest.TestCase):
 
-  def test_camelcase(self):
+  def test_camelcase(self) -> None:
 
     self.assertEqual('Foo', camelcase('foo'))
     self.assertEqual('Foo', camelcase('_foo'))
@@ -26,7 +26,7 @@ class StrutilTest(unittest.TestCase):
     self.assertEqual('FooBar', camelcase('foo--bar'))
     self.assertEqual('FooBar', camelcase('foo-_bar'))
 
-  def test_pluralize(self):
+  def test_pluralize(self) -> None:
     self.assertEqual('1 bat', pluralize(1, 'bat'))
     self.assertEqual('1 boss', pluralize(1, 'boss'))
     self.assertEqual('2 bats', pluralize(2, 'bat'))
@@ -34,19 +34,19 @@ class StrutilTest(unittest.TestCase):
     self.assertEqual('0 bats', pluralize(0, 'bat'))
     self.assertEqual('0 bosses', pluralize(0, 'boss'))
 
-  def test_ensure_text(self):
+  def test_ensure_text(self) -> None:
     bytes_val = bytes(bytearray([0xe5, 0xbf, 0xab]))
     self.assertEqual(u'快', ensure_text(bytes_val))
     with self.assertRaises(TypeError):
-      ensure_text(45)
+      ensure_text(45)  # type: ignore
 
-  def test_ensure_binary(self):
+  def test_ensure_binary(self) -> None:
     unicode_val = u'快'
     self.assertEqual(bytearray([0xe5, 0xbf, 0xab]), ensure_binary(unicode_val))
     with self.assertRaises(TypeError):
-      ensure_binary(45)
+      ensure_binary(45)  # type: ignore
 
-  def test_strip_prefix(self):
+  def test_strip_prefix(self) -> None:
     self.assertEqual('testString', strip_prefix('testString', '//'))
     self.assertEqual('/testString', strip_prefix('/testString', '//'))
     self.assertEqual('testString', strip_prefix('//testString', '//'))


### PR DESCRIPTION
The util code—excluding the metaprogramming files—is a good place to start adding type hints to Pants because it is composed of simple pure functions and is used widely throughout the codebase. 

This adds some initial hints to act as a demo for type hints in Pants and get us slightly closer to critical mass.