### PR TITLE
Make union error messages better

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -283,6 +283,20 @@ class _FFISpecification(object):
     type_id = c.to_id(type(obj))
     return TypeId(type_id)
 
+  @_extern_decl('Handle', ['ExternContext*', 'TypeId'])
+  def extern_get_handle_from_type_id(self, context_handle, ty):
+    c = self._ffi.from_handle(context_handle)
+    obj = c.from_id(ty.tup_0)
+    return c.to_value(obj)
+
+  @_extern_decl('bool', ['ExternContext*', 'TypeId'])
+  def extern_is_union(self, context_handle, type_id):
+    "Return whether or not a type is a member of a union"
+
+    c = self._ffi.from_handle(context_handle)
+    input_type = c.from_id(type_id.tup_0)
+    return bool(getattr(input_type, '_is_union', None))
+
   @_extern_decl('Ident', ['ExternContext*', 'Handle*'])
   def extern_identify(self, context_handle, val):
     """Return a representation of the object's identity, including a hash and TypeId.
@@ -426,6 +440,7 @@ class _FFISpecification(object):
             TypeId(c.to_id(res.product)),
             c.to_value(res.subject),
             c.identify(res.subject),
+            TypeId(c.to_id(res.subject_declared_type)),
           )
       elif type(res) in (tuple, list):
         # GetMulti.
@@ -656,6 +671,8 @@ class Native(Singleton):
                            self.ffi_lib.extern_call,
                            self.ffi_lib.extern_generator_send,
                            self.ffi_lib.extern_get_type_for,
+                           self.ffi_lib.extern_get_handle_from_type_id,
+                           self.ffi_lib.extern_is_union,
                            self.ffi_lib.extern_identify,
                            self.ffi_lib.extern_equals,
                            self.ffi_lib.extern_clone_val,

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -291,8 +291,7 @@ class _FFISpecification(object):
 
   @_extern_decl('bool', ['ExternContext*', 'TypeId'])
   def extern_is_union(self, context_handle, type_id):
-    "Return whether or not a type is a member of a union"
-
+    """Return whether or not a type is a member of a union"""
     c = self._ffi.from_handle(context_handle)
     input_type = c.from_id(type_id.tup_0)
     return bool(getattr(input_type, '_is_union', None))

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -302,6 +302,7 @@ def union(cls):
   assert isinstance(cls, type)
   return type(cls.__name__, (cls,), {
     '_is_union': True,
+    'union_description': cls.__doc__,
   })
 
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -300,9 +300,14 @@ def union(cls):
   """
   # TODO: Check that the union base type is used as a tag and nothing else (e.g. no attributes)!
   assert isinstance(cls, type)
+  if cls.__doc__:
+    union_description = cls.__doc__
+  else:
+    union_description = cls.__name__
+
   return type(cls.__name__, (cls,), {
     '_is_union': True,
-    'union_description': cls.__doc__,
+    'union_description': union_description,
   })
 
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -65,10 +65,10 @@ use crate::context::Core;
 use crate::core::{Function, Key, Params, TypeId, Value};
 use crate::externs::{
   Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionExtern, DropHandlesExtern,
-  EqualsExtern, ExternContext, Externs, GeneratorSendExtern, GetTypeForExtern, HandleBuffer,
-  IdentifyExtern, ProjectIgnoringTypeExtern, ProjectMultiExtern, PyResult, RawBuffer,
-  StoreBoolExtern, StoreBytesExtern, StoreF64Extern, StoreI64Extern, StoreTupleExtern,
-  StoreUtf8Extern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
+  EqualsExtern, ExternContext, Externs, GeneratorSendExtern, GetHandleFromTypeIdExtern,
+  GetTypeForExtern, HandleBuffer, IdentifyExtern, IsUnionExtern, ProjectIgnoringTypeExtern,
+  ProjectMultiExtern, PyResult, RawBuffer, StoreBoolExtern, StoreBytesExtern, StoreF64Extern,
+  StoreI64Extern, StoreTupleExtern, StoreUtf8Extern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern,
 };
 use crate::handles::Handle;
 use crate::scheduler::{ExecutionRequest, RootResult, Scheduler, Session};
@@ -113,6 +113,8 @@ pub extern "C" fn externs_set(
   call: CallExtern,
   generator_send: GeneratorSendExtern,
   get_type_for: GetTypeForExtern,
+  get_handle_from_type_id: GetHandleFromTypeIdExtern,
+  is_union: IsUnionExtern,
   identify: IdentifyExtern,
   equals: EqualsExtern,
   clone_val: CloneValExtern,
@@ -138,6 +140,8 @@ pub extern "C" fn externs_set(
     call,
     generator_send,
     get_type_for,
+    get_handle_from_type_id,
+    is_union,
     identify,
     equals,
     clone_val,

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -864,10 +864,21 @@ impl Task {
           .ok_or_else(|| throw(&format!("no edges for task {:?} exist!", entry)))
           .and_then(|edges| {
             edges.entry_for(&dependency_key).cloned().ok_or_else(|| {
-              throw(&format!(
-                "{:?} did not declare a dependency on {:?}",
-                entry, dependency_key
-              ))
+              let is_union = get.declared_subject.map(externs::is_union).unwrap_or(false);
+              if is_union {
+                let union_ty = get.declared_subject.unwrap();
+                let value = externs::get_value_from_type_id(union_ty);
+                let description = externs::project_str(&value, "union_description");
+                throw(&format!(
+                  "Type {} is not a member of the {} @union (\"{}\")",
+                  get.subject, union_ty, description
+                ))
+              } else {
+                throw(&format!(
+                  "{:?} did not declare a dependency on {:?}",
+                  entry, dependency_key
+                ))
+              }
             })
           });
         // The subject of the get is a new parameter that replaces an existing param of the same

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -863,25 +863,25 @@ impl Task {
           .edges_for_inner(&entry)
           .ok_or_else(|| throw(&format!("no edges for task {:?} exist!", entry)))
           .and_then(|edges| {
-            edges.entry_for(&dependency_key).cloned().ok_or_else(|| {
-              let is_union = get.declared_subject.map(externs::is_union).unwrap_or(false);
-              if is_union {
-                let union_ty = get.declared_subject.unwrap();
-                let value = externs::get_value_from_type_id(union_ty);
-                let description = externs::project_str(&value, "union_description");
-                throw(&format!(
-                  "Type {} is not a member of the {} @union (\"{}\")",
-                  get.subject.type_id(),
-                  union_ty,
-                  description
-                ))
-              } else {
-                throw(&format!(
+            edges
+              .entry_for(&dependency_key)
+              .cloned()
+              .ok_or_else(|| match get.declared_subject {
+                Some(ty) if externs::is_union(ty) => {
+                  let value = externs::get_value_from_type_id(ty);
+                  let description = externs::project_str(&value, "union_description");
+                  throw(&format!(
+                    "Type {} is not a member of the {} @union (\"{}\")",
+                    get.subject.type_id(),
+                    ty,
+                    description
+                  ))
+                }
+                _ => throw(&format!(
                   "{:?} did not declare a dependency on {:?}",
                   entry, dependency_key
-                ))
-              }
-            })
+                )),
+              })
           });
         // The subject of the get is a new parameter that replaces an existing param of the same
         // type.

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -871,7 +871,9 @@ impl Task {
                 let description = externs::project_str(&value, "union_description");
                 throw(&format!(
                   "Type {} is not a member of the {} @union (\"{}\")",
-                  get.subject, union_ty, description
+                  get.subject.type_id(),
+                  union_ty,
+                  description
                 ))
               } else {
                 throw(&format!(

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -58,7 +58,9 @@ def transitive_coroutine_rule(c):
 
 
 @union
-class UnionBase: pass
+class UnionBase:
+  """Docstring for UnionBase"""
+  pass
 
 
 class UnionWrapper:
@@ -206,7 +208,7 @@ class SchedulerTest(TestBase):
     self.assertTrue(isinstance(a, A))
     # Fails due to no union relationship from A -> UnionBase.
     expected_msg = """\
-Exception: WithDeps(Inner(InnerEntry { params: {UnionWrapper}, rule: Task(Task { product: A, clause: [Select { product: UnionWrapper }], gets: [Get { product: A, subject: UnionA }, Get { product: A, subject: UnionB }], func: a_union_test(), cacheable: true }) })) did not declare a dependency on JustGet(Get { product: A, subject: A })
+Type A is not a member of the UnionBase @union ("Docstring for UnionBase")
 """
     with self._assert_execution_error(expected_msg):
       self.scheduler.product_request(A, [Params(UnionWrapper(A()))])

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -63,6 +63,11 @@ class UnionBase:
   pass
 
 
+@union
+class NoDocstringUnion:
+  pass
+
+
 class UnionWrapper:
   def __init__(self, inner):
     self.inner = inner
@@ -95,6 +100,16 @@ def select_union_b(union_b):
 def a_union_test(union_wrapper):
   union_a = yield Get(A, UnionBase, union_wrapper.inner)
   yield union_a
+
+
+class UnionX:
+  pass
+
+
+@rule(UnionX, [UnionWrapper])
+def no_docstring_test_rule(union_wrapper):
+  union_x = yield Get(UnionX, NoDocstringUnion, union_wrapper.inner)
+  yield union_x
 
 
 class TypeCheckFailWrapper:
@@ -151,11 +166,14 @@ class SchedulerTest(TestBase):
       # B is both a RootRule and an intermediate product here.
       RootRule(B),
       RootRule(C),
+      RootRule(UnionX),
+      no_docstring_test_rule,
       consumes_a_and_b,
       transitive_b_c,
       transitive_coroutine_rule,
       RootRule(UnionWrapper),
       UnionRule(UnionBase, UnionA),
+      UnionRule(NoDocstringUnion, UnionX),
       RootRule(UnionA),
       select_union_a,
       UnionRule(union_base=UnionBase, union_member=UnionB),
@@ -212,6 +230,13 @@ Type A is not a member of the UnionBase @union ("Docstring for UnionBase")
 """
     with self._assert_execution_error(expected_msg):
       self.scheduler.product_request(A, [Params(UnionWrapper(A()))])
+
+  def test_union_rules_no_docstring(self):
+    expected_msg = """\
+Type UnionA is not a member of the NoDocstringUnion @union ("NoDocstringUnion")
+"""
+    with self._assert_execution_error(expected_msg):
+      self.scheduler.product_request(UnionX, [Params(UnionWrapper(UnionA()))])
 
 
 class SchedulerWithNestedRaiseTest(TestBase):


### PR DESCRIPTION
cf. #7819 , we should be printing out a more helpful error message in
the case that a `Get` request is unsatisfiable because of a type
mismatch involving union membership.

This commit defines two new FFI functions: one for getting a handle to
the underlying Python class representing a type, given a TypeId; and
another for checking whether or not a type is a union (by inspecting
the '_is_union' attribute). It also modifies the `Get` struct to track
the optional declared subject of a `Get` request.

Using these, if a Get request fails in `nodes.rs`, we look at that
declared subject (if it exists), and inspect the Optional type contained
within in order to see if it is a union. If so, we print a clearer error
message mentioning the name and description of the union. If not, we
fall back to the existing error message.

In order to correctly print the description of the union, we also needed
to alter the @union decorator to explicitly create an attr on
@union-decorated types called 'union_description', and search for this
attr with `project_str` in the new union error message handling code.
