### PR TITLE
Leverage Travis built-in skip support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@
 # Conditions are documented here: https://docs.travis-ci.com/user/conditions-v1
 conditions: v1
 
-if: commit_message !~ SKIP_FULL_CI
-
 # -------------------------------------------------------------------------
 # Global setup
 # -------------------------------------------------------------------------

--- a/build-support/githooks/prepare-commit-msg
+++ b/build-support/githooks/prepare-commit-msg
@@ -10,6 +10,6 @@ if [ "${COMMIT_MSG_SRC}" != "commit" ] && [ "${NUM_NON_MD_FILES}" -eq 0 ]; then
 cat <<EOF >> "${COMMIT_MSG_FILEPATH}"
 
 # Delete this line to force a full CI run for documentation-only changes.
-SKIP_FULL_CI  # Documentation-only change.
+[ci skip]  # Documentation-only change.
 EOF
 fi

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -3,8 +3,6 @@
 # Conditions are documented here: https://docs.travis-ci.com/user/conditions-v1
 conditions: v1
 
-if: commit_message !~ SKIP_FULL_CI
-
 # -------------------------------------------------------------------------
 # Global setup
 # -------------------------------------------------------------------------


### PR DESCRIPTION
We already do this for jar publishing:
https://github.com/pantsbuild/pants/blob/14e0bd6b27910310e225ff9586c2410459153fd9/pants.ini#L366-L371
