### PR TITLE
Kill all uses of t.c.collections.OrderedDict.

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -24,7 +24,6 @@ python_tests(
   sources = ['test_build_local_python_distributions.py'],
   dependencies = [
     '3rdparty/python:pex',
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/python:python_requirement',
     'src/python/pants/backend/python/targets',
     'tests/python/pants_test/backend/python/tasks/util',

--- a/tests/python/pants_test/backend/python/tasks/native/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/native/BUILD
@@ -4,10 +4,6 @@
 python_tests(
   sources=globs('test_*.py', exclude=[globs('*_integration.py')]),
   dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.dirutil',
-    '3rdparty/python:coverage',
-    '3rdparty/python:pex',
     'src/python/pants/backend/native',
     'src/python/pants/backend/python/subsystems',
     'src/python/pants/backend/python/targets',
@@ -39,7 +35,6 @@ python_tests(
   name='integration',
   sources=globs('*_integration.py'),
   dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/native',
     'src/python/pants/backend/native/targets',
     'src/python/pants/backend/python:plugin',

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from twitter.common.collections import OrderedDict
+from collections import OrderedDict
 
 from pants.backend.native.targets.native_artifact import NativeArtifact
 from pants.backend.native.targets.native_library import CLibrary, CppLibrary

--- a/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
+++ b/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import re
+from collections import OrderedDict
 
 import pex.resolver
-from twitter.common.collections import OrderedDict
 
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_distribution import PythonDistribution


### PR DESCRIPTION
We can rely on the stdlib instead now.
