### PR TITLE
Fix bad `with_traceback()` change from #7988

### DIFF
--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -134,7 +134,7 @@ class RemotePantsRunner:
         logger.fatal('')
         logger.fatal('lost active connection to pantsd!')
         traceback = sys.exc_info()[2]
-        raise self._extract_remote_exception(pantsd_handle.pid, e).with_traceback(tb=traceback)
+        raise self._extract_remote_exception(pantsd_handle.pid, e).with_traceback(traceback)
 
   def _connect_and_execute(self, pantsd_handle):
     port = pantsd_handle.port


### PR DESCRIPTION
Python does not allow keyword args for several builtins, including `with_traceback`. This was not detected as an issue in https://github.com/pantsbuild/pants/pull/7988 because the test was already flaky, and this only causes an additional error when the test flakes.