### PR TITLE
Scalafix full classpath fix

### DIFF
--- a/src/python/pants/backend/jvm/tasks/scalafix.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix.py
@@ -4,8 +4,8 @@
 import os
 from abc import abstractmethod
 
-from pants.backend.jvm.tasks.rewrite_base import RewriteBase
 from pants.backend.jvm.tasks.jvm_task import JvmTask
+from pants.backend.jvm.tasks.rewrite_base import RewriteBase
 from pants.base.exceptions import TaskError
 from pants.java.jar.jar_dependency import JarDependency
 from pants.option.custom_types import file_option

--- a/src/python/pants/backend/jvm/tasks/scalafix.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix.py
@@ -33,7 +33,7 @@ class ScalaFix(RewriteBase, JvmTask):
     cls.register_jvm_tool(register,
                           'scalafix',
                           classpath=[
-                            JarDependency(org='ch.epfl.scala', name='scalafix-cli_2.11.12', rev='0.6.0-M16'),
+                            JarDependency(org='ch.epfl.scala', name='scalafix-cli_2.12.8', rev='0.9.4'),
                           ])
     cls.register_jvm_tool(register, 'scalafix-tool-classpath', classpath=[])
 
@@ -52,9 +52,6 @@ class ScalaFix(RewriteBase, JvmTask):
     if options.semantic:
       round_manager.require_data('runtime_classpath')
 
-  def _compute_full_classpath(self, targets):
-    return self.classpath(targets)
-
   def invoke_tool(self, absolute_root, target_sources):
     args = []
     tool_classpath = self.tool_classpath('scalafix-tool-classpath')
@@ -62,7 +59,7 @@ class ScalaFix(RewriteBase, JvmTask):
       args.append('--tool-classpath={}'.format(os.pathsep.join(tool_classpath)))
     if self.get_options().semantic:
       # If semantic checks are enabled, we need the full classpath for these targets.
-      classpath = self._compute_full_classpath({target for target, _ in target_sources})
+      classpath = self.classpath({target for target, _ in target_sources})
       args.append('--sourceroot={}'.format(absolute_root))
       args.append('--classpath={}'.format(os.pathsep.join(classpath)))
     if self.get_options().configuration:

--- a/testprojects/src/scala/org/pantsbuild/testproject/rsc_compat/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/rsc_compat/BUILD
@@ -1,0 +1,20 @@
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+scala_library()
+
+jar_library(
+    name="rsc-compat",
+    jars=[jar(org='com.twitter', name='rsc-rules_2.12', rev = "0.0.0-780-e57a1c9c")]
+)
+
+SEMANTICDB_REV='4.1.1'
+jar_library(name = 'semanticdb-scalac',
+            jars = [
+              jar(org = 'org.scalameta', name = 'semanticdb-scalac_2.12.8', rev = SEMANTICDB_REV),
+            ])
+
+jar_library(name = 'semanticdb',
+  jars = [
+    scala_jar(org = 'org.scalameta', name = 'semanticdb', rev = SEMANTICDB_REV),
+  ])

--- a/testprojects/src/scala/org/pantsbuild/testproject/rsc_compat/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/rsc_compat/BUILD
@@ -5,7 +5,7 @@ scala_library()
 
 jar_library(
     name="rsc-compat",
-    jars=[jar(org='com.twitter', name='rsc-rules_2.12', rev = "0.0.0-780-e57a1c9c")]
+    jars=[scala_jar(org='com.twitter', name='rsc-rules', rev = "0.0.0-780-e57a1c9c")]
 )
 
 SEMANTICDB_REV='4.1.1'

--- a/testprojects/src/scala/org/pantsbuild/testproject/rsc_compat/RscCompat.scala
+++ b/testprojects/src/scala/org/pantsbuild/testproject/rsc_compat/RscCompat.scala
@@ -1,0 +1,15 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.rsc_compat
+
+object RscCompat {
+  
+    def x0: Int = 42
+
+    def x1: String = "42"
+    
+    class MyClass
+
+    val x2: MyClass = new MyClass
+}

--- a/testprojects/src/scala/org/pantsbuild/testproject/rsc_compat/RscCompatFixed.scala
+++ b/testprojects/src/scala/org/pantsbuild/testproject/rsc_compat/RscCompatFixed.scala
@@ -1,0 +1,15 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.rsc_compat
+
+object RscCompatFixed {
+
+  def x0: Int = 42
+
+  def x1: String = "42"
+
+  class MyClass
+
+  val x2: MyClass = new MyClass
+}

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import re
-from pants_test.pants_run_integration_test import PantsRunIntegrationTest
-from pants.java.jar.jar_dependency import JarDependency
+
 from pants.util.dirutil import read_file
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 TEST_DIR = 'testprojects/src/scala/org/pantsbuild/testproject'
@@ -42,10 +42,8 @@ class ScalaFixIntegrationTest(PantsRunIntegrationTest):
     # take a snapshot of the file which we can write out
     # after the test finishes executing.
     test_file_name = f'{TEST_DIR}/procedure_syntax/ProcedureSyntax.scala'
-    
-    contents = read_file(test_file_name)
 
-    try:
+    with self.with_overwritten_file_content(test_file_name):
       # format an incorrectly formatted file.
       target = f'{TEST_DIR}/procedure_syntax'
       fmt_result = self.run_pants(['fmt', target], options)
@@ -54,11 +52,6 @@ class ScalaFixIntegrationTest(PantsRunIntegrationTest):
       # verify that the lint check passes.
       test_fix = self.run_pants(['lint', target], options)
       self.assert_success(test_fix)
-    finally:
-      # restore the file to its original state.
-      f = open(test_file_name, 'w')
-      f.write(contents)
-      f.close()
 
   def test_rsccompat_fmt(self):
     options =  {
@@ -79,9 +72,7 @@ class ScalaFixIntegrationTest(PantsRunIntegrationTest):
     test_file_name = f'{TEST_DIR}/rsc_compat/RscCompat.scala'
     fixed_file_name = f'{TEST_DIR}/rsc_compat/RscCompatFixed.scala'
 
-    contents = read_file(test_file_name)
-
-    try:
+    with self.with_overwritten_file_content(test_file_name):
       # format an incorrectly formatted file.
       target = f'{TEST_DIR}/rsc_compat'
       fmt_result = self.run_pants(['fmt', target], options)
@@ -90,9 +81,4 @@ class ScalaFixIntegrationTest(PantsRunIntegrationTest):
       result = read_file(test_file_name)
       result = re.sub(re.escape('object RscCompat {'), 'object RscCompatFixed {', result)
       expected = read_file(fixed_file_name)
-      assert(result == expected)
-    finally:
-      # restore the file to its original state.
-      f = open(test_file_name, 'w')
-      f.write(contents)
-      f.close()
+      self.assertEqual(result, expected)


### PR DESCRIPTION
### Problem

RscCompat is a semantic Scalafix rule and thus requires the full classpath to
build up its symbol table. The current `_compute_classpath` code only includes
the classpaths of the rewritten targets, but must instead include the classpaths
of the closure.

### Solution

Use `JvmTask`'s `classpath` method to compute the full classpath.

### Result

The Scalafix task should now support semantic rules which require use of the
full symbol table, including symbols from libraries depended on by rewritten
targets.
