### PR TITLE
add PANTS_BYPASS_CBINDGEN=y override to engine build.rs

### DIFF
--- a/build-support/bin/native/bootstrap_code.sh
+++ b/build-support/bin/native/bootstrap_code.sh
@@ -69,6 +69,9 @@ function _build_native_code() {
     "${REPO_ROOT}/build-support/bin/native/cargo" build ${MODE_FLAG} \
       --manifest-path "${NATIVE_ROOT}/Cargo.toml" -p engine
   ) || die
+  if [[ -n "${PANTS_BYPASS_CBINDGEN:-}" ]]; then
+    die "Successful no-op build with PANTS_BYPASS_CBINDGEN set -- would experience runtime link errors! Exiting."
+  fi
   echo "${NATIVE_ROOT}/target/${MODE}/libengine.${LIB_EXTENSION}"
 }
 


### PR DESCRIPTION
### Problem

When there are syntax errors in rust source files that we consume for cbindgen, the error message is extremely confusing, as it comes from the cbindgen crate parsing our rust sources, instead of rustc. This is because in the current build process, we generate C headers via `cbindgen`, then compile `cffi`-generated code via the `cc` crate, and only then do we build our rust and link the cffi sources into the result.

To overcome this locally, I've been selectively commenting out the native code generation we do in `src/rust/engine/src/cffi_build.rs`, but it would be good for others to be able to understand how to overcome cbindgen parse failures.

### Solution

- Allow passing `PANTS_BYPASS_CBINDGEN=y` in the environment to do a "no-op" build that just compiles our rust sources (which produces nice rustc error messages instead of making the cbindgen crate do that).
- Ensure that the `PANTS_BYPASS_CBINDGEN=y` workaround is described in the error message upon a cbindgen failure in the `engine` crate build script.

### Result

It's possible to quickly work around the poor error messages produced from `cbindgen` while iterating on our rust code!