### PR TITLE
Don't use remote store when --no-remote-execution specified

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -361,8 +361,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
 
     register('--remote-execution', advanced=True, type=bool,
              default=DEFAULT_EXECUTION_OPTIONS.remote_execution,
-             help="Enables the remote store and remote build execution for increased "
-                  "parallelism. (Alpha)")
+             help="Enables remote workers for increased parallelism. (Alpha)")
     register('--remote-store-server', advanced=True, type=list, default=[],
              help='host:port of grpc server to use as remote execution file store.')
     register('--remote-store-thread-count', type=int, advanced=True,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -361,7 +361,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
 
     register('--remote-execution', advanced=True, type=bool,
              default=DEFAULT_EXECUTION_OPTIONS.remote_execution,
-             help="Enables remote workers for increased parallelism. (Alpha)")
+             help="Enables the remote store and remote build execution for increased "
+                  "parallelism. (Alpha)")
     register('--remote-store-server', advanced=True, type=list, default=[],
              help='host:port of grpc server to use as remote execution file store.')
     register('--remote-store-thread-count', type=int, advanced=True,

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -107,7 +107,7 @@ impl Core {
     let store = safe_create_dir_all_ioerror(&local_store_dir)
       .map_err(|e| format!("Error making directory {:?}: {:?}", local_store_dir, e))
       .and_then(|()| {
-        if remote_store_servers.is_empty() {
+        if !remote_execution || remote_store_servers.is_empty() {
           Store::local_only(local_store_dir)
         } else {
           Store::with_remote(


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/7991 added the flag `--[no-]remote-exeuction` to toggle on and off remote behavior. There, out of error, it was only used to toggle the remote execution runner, not also the remote store.

This is causing https://github.com/pantsbuild/pants/pull/7990 to continue to fail.