### PR TITLE
relativize path for scalac classpath entry

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -274,7 +274,7 @@ class BaseZincCompile(JvmCompile):
 
     # list of classpath entries
     scalac_classpath_entries = self.scalac_classpath_entries()
-    scala_path = [classpath_entry.path for classpath_entry in scalac_classpath_entries]
+    scala_path = [relative_to_exec_root(classpath_entry.path) for classpath_entry in scalac_classpath_entries]
 
     zinc_args = []
     zinc_args.extend([


### PR DESCRIPTION
### Problem

When using remote hermetic zinc (without native-image) we were encountering an error where a path was not found during remote execution. Digging into it, it was obvious that the path being sent wasnt being rewritten/relativized.

### Solution

added relativization to all classpath entries for scalac, confirmed this fixes the issue locally.
