### PR TITLE
Add utf-8 encoding to thrift-generated python files

### DIFF
--- a/src/python/pants/backend/codegen/thrift/python/apache_thrift_py_gen.py
+++ b/src/python/pants/backend/codegen/thrift/python/apache_thrift_py_gen.py
@@ -14,7 +14,8 @@ class ApacheThriftPyGen(ApacheThriftGenBase):
   gentarget_type = PythonThriftLibrary
   thrift_generator = 'py'
   default_gen_options_map = {
-    'new_style': None
+    'new_style': None,
+    'coding': 'utf-8',
   }
 
   sources_globs = ('**/*',)

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_apache_thrift_py_gen.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_apache_thrift_py_gen.py
@@ -3,6 +3,7 @@
 
 import os
 import subprocess
+from pathlib import Path
 from textwrap import dedent
 
 from pex.resolver import resolve
@@ -104,11 +105,10 @@ class ApacheThriftPyGenTest(TaskTestBase):
       sources=['one.thrift'])
 
     _, synthetic_target = self.generate_single_thrift_target(one)
-    print(os.getcwd())
-    for file in synthetic_target.sources_relative_to_buildroot():
-      if '__init__' not in file:
-        with open(os.path.join(get_buildroot(), file), 'r') as f:
-          self.assertEqual(f.readline(), "# -*- coding: utf-8 -*-\n")
+    for filepath in synthetic_target.sources_relative_to_buildroot():
+      if '__init__' not in filepath:
+        first_line = (Path(get_buildroot()) / filepath).read_text().splitlines()[0]
+        self.assertEqual(first_line, "# -*- coding: utf-8 -*-")
 
   def test_nested_namespaces(self):
     self.create_file('src/thrift/com/foo/one.thrift', contents=dedent("""


### PR DESCRIPTION
### Problem

When you have utf-8 characters in docstrings inside thrift files, these make it to the generated python sources. Those sources should be utf-8 encoded as well.

### Solution

Passed the option `py:coding=utf-8` to the thrift compiler, as per https://stackoverflow.com/questions/33887910/thrift-add-encoding-language-in-python-generated-files

### Result

We now add the "compile utf-8" header to every non-`__init__` generated file.