### PR TITLE
Extract ExecuteProcessRequestMetadata

### DIFF
--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -90,6 +90,18 @@ pub struct ExecuteProcessRequest {
 }
 
 ///
+/// Metadata surrounding an ExecuteProcessRequest which factors into its cache key when cached
+/// externally from the engine graph (e.g. when using remote execution or an external process
+/// cache).
+///
+#[derive(Clone, Debug)]
+pub struct ExecuteProcessRequestMetadata {
+  pub instance_name: Option<String>,
+  pub cache_key_gen_version: Option<String>,
+  pub platform_properties: BTreeMap<String, String>,
+}
+
+///
 /// The result of running a process.
 ///
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -33,6 +33,7 @@ use process_execution;
 
 use clap::{value_t, App, AppSettings, Arg};
 use hashing::{Digest, Fingerprint};
+use process_execution::ExecuteProcessRequestMetadata;
 use std::collections::{BTreeMap, BTreeSet};
 use std::iter::Iterator;
 use std::path::PathBuf;
@@ -303,11 +304,13 @@ fn main() {
 
       Box::new(process_execution::remote::CommandRunner::new(
         address,
-        args.value_of("cache-key-gen-version").map(str::to_owned),
-        remote_instance_arg,
+        ExecuteProcessRequestMetadata {
+          instance_name: remote_instance_arg,
+          cache_key_gen_version: args.value_of("cache-key-gen-version").map(str::to_owned),
+          platform_properties,
+        },
         root_ca_certs,
         oauth_bearer_token,
-        platform_properties,
         store.clone(),
       )) as Box<dyn process_execution::CommandRunner>
     }

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -19,7 +19,7 @@ use boxfuture::{BoxFuture, Boxable};
 use core::clone::Clone;
 use fs::{safe_create_dir_all_ioerror, PosixFS};
 use graph::{EntryId, Graph, NodeContext};
-use process_execution::{self, BoundedCommandRunner};
+use process_execution::{self, BoundedCommandRunner, ExecuteProcessRequestMetadata};
 use rand::seq::SliceRandom;
 use reqwest;
 use rule_graph::RuleGraph;
@@ -127,11 +127,13 @@ impl Core {
       Some(ref address) if remote_execution => BoundedCommandRunner::new(
         Box::new(process_execution::remote::CommandRunner::new(
           address,
-          remote_execution_process_cache_namespace.clone(),
-          remote_instance_name.clone(),
+          ExecuteProcessRequestMetadata {
+            instance_name: remote_instance_name.clone(),
+            cache_key_gen_version: remote_execution_process_cache_namespace.clone(),
+            platform_properties: remote_execution_extra_platform_properties.clone(),
+          },
           root_ca_certs.clone(),
           oauth_bearer_token.clone(),
-          remote_execution_extra_platform_properties.clone(),
           store.clone(),
         )),
         process_execution_remote_parallelism,


### PR DESCRIPTION
This will be re-used across the remote and caching CommandRunners.