### PR TITLE
Fail for missing classpath entries with hermetic execution.

### DIFF
--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
@@ -34,7 +34,7 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags={'integration'},
-  timeout=120,
+  timeout=180,
 )
 
 python_tests(

--- a/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
@@ -177,6 +177,14 @@ class JvmToolMixin:
   def tool_jar_from_products(cls, products, key, scope):
     """Get the jar for the tool previously registered under key in the given scope.
 
+    See tool_jar_entry_from_products.
+    """
+    return cls.tool_jar_entry_from_products(products, key, scope).path
+
+  @classmethod
+  def tool_jar_entry_from_products(cls, products, key, scope):
+    """Get a ClasspathEntry for the jar for the tool previously registered under key in the given scope.
+
     :param products: The products of the current pants run.
     :type products: :class:`pants.goal.products.Products`
     :param string key: The key the tool configuration was registered under.
@@ -186,16 +194,24 @@ class JvmToolMixin:
     :raises: `JvmToolMixin.InvalidToolClasspath` when the tool classpath is not composed of exactly
              one jar.
     """
-    classpath = cls.tool_classpath_from_products(products, key, scope)
+    classpath = cls.tool_classpath_entries_from_products(products, key, scope)
     if len(classpath) != 1:
       params = dict(tool=key, scope=scope, count=len(classpath), classpath='\n\t'.join(classpath))
       raise cls.InvalidToolClasspath('Expected tool {tool} in scope {scope} to resolve to one '
                                      'jar, instead found {count}:\n\t{classpath}'.format(**params))
     return classpath[0]
 
+  @classmethod
+  def tool_classpath_from_products(cls, products, key, scope):
+    """Get a classpath of paths for the tool previously registered under key in the given scope.
+
+    See tool_classpath_entries_from_products.
+    """
+    return [entry.path for entry in cls.tool_classpath_entries_from_products(products, key, scope)]
+
   @staticmethod
-  def tool_classpath_from_products(products, key, scope):
-    """Get a classpath for the tool previously registered under key in the given scope.
+  def tool_classpath_entries_from_products(products, key, scope):
+    """Get ClasspathEntries for the tool previously registered under key in the given scope.
 
     :param products: The products of the current pants run.
     :type products: :class:`pants.goal.products.Products`

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -144,28 +144,30 @@ class Zinc:
 
     @classmethod
     def _zinc(cls, products):
-      return cls.tool_jar_from_products(products, Zinc.ZINC_COMPILER_TOOL_NAME, cls.options_scope)
+      return cls.tool_jar_entry_from_products(products, Zinc.ZINC_COMPILER_TOOL_NAME, cls.options_scope)
 
     @classmethod
     def _compiler_bridge(cls, products):
-      return cls.tool_jar_from_products(products, 'compiler-bridge', cls.options_scope)
+      return cls.tool_jar_entry_from_products(products, 'compiler-bridge', cls.options_scope)
 
     @classmethod
     def _compiler_interface(cls, products):
-      return cls.tool_jar_from_products(products, 'compiler-interface', cls.options_scope)
+      return cls.tool_jar_entry_from_products(products, 'compiler-interface', cls.options_scope)
 
     @classmethod
     def _compiler_bootstrapper(cls, products):
-      return cls.tool_jar_from_products(products, Zinc.ZINC_BOOTSTRAPPER_TOOL_NAME, cls.options_scope)
+      return cls.tool_jar_entry_from_products(products, Zinc.ZINC_BOOTSTRAPPER_TOOL_NAME, cls.options_scope)
 
     # Retrieves the path of a tool's jar
     # by looking at the classpath of the registered tool with the user-specified scala version.
     def _fetch_tool_jar_from_scalac_classpath(self, products, jar_name):
       scala_version = ScalaPlatform.global_instance().version
-      classpath = self.tool_classpath_from_products(products,
-                                                    ScalaPlatform.versioned_tool_name('scalac', scala_version),
-                                                    scope=self.options_scope)
-      candidates = [jar for jar in classpath if jar_name in jar]
+      classpath = self.tool_classpath_entries_from_products(
+          products,
+          ScalaPlatform.versioned_tool_name('scalac', scala_version),
+          scope=self.options_scope
+        )
+      candidates = [jar for jar in classpath if jar_name in jar.path]
       assert(len(candidates) == 1)
       return candidates[0]
 
@@ -244,42 +246,42 @@ class Zinc:
     return self._zinc_factory.dist
 
   @memoized_property
-  def compiler_bridge(self):
-    """Return the path to the Zinc compiler-bridge jar.
+  def _compiler_bridge(self):
+    """Return a ClasspathEntry for the Zinc compiler-bridge jar.
 
-    :rtype: str
+    :rtype: ClasspathEntry
     """
     return self._zinc_factory._compiler_bridge(self._products)
 
   @memoized_property
-  def compiler_interface(self):
-    """Return the path to the Zinc compiler-interface jar.
+  def _compiler_interface(self):
+    """Return a ClasspathEntry for the Zinc compiler-interface jar.
 
-    :rtype: str
+    :rtype: ClasspathEntry
     """
     return self._zinc_factory._compiler_interface(self._products)
 
   @memoized_property
   def scala_compiler(self):
-    """Return the path to the scala compiler jar.
+    """Return a ClasspathEntry for the scala compiler jar.
 
-    :rtype: str
+    :rtype: ClasspathEntry
     """
     return self._zinc_factory._scala_compiler(self._products)
 
   @memoized_property
   def scala_library(self):
-    """Return the path to the scala library jar (runtime).
+    """Return a ClasspathEntry for the scala library jar (runtime).
 
-    :rtype: str
+    :rtype: ClasspathEntry
     """
     return self._zinc_factory._scala_library(self._products)
 
   @memoized_property
   def scala_reflect(self):
-    """Return the path to the scala library jar (runtime).
+    """Return a ClasspathEntry for the scala library jar (runtime).
 
-    :rtype: str
+    :rtype: ClasspathEntry
     """
     return self._zinc_factory._scala_reflect(self._products)
 
@@ -297,8 +299,8 @@ class Zinc:
     and the compiler bridge.
     """
     hasher = sha1()
-    for cp_entry in [self.zinc, self.compiler_interface, self.compiler_bridge]:
-      hasher.update(os.path.relpath(cp_entry, self._workdir()).encode())
+    for cp_entry in [self.zinc, self._compiler_interface, self._compiler_bridge]:
+      hasher.update(cp_entry.directory_digest.fingerprint.encode())
     key = hasher.hexdigest()[:12]
 
     return os.path.join(self._workdir(), 'zinc', 'compiler-bridge', key)
@@ -308,28 +310,37 @@ class Zinc:
     return fast_relpath(path, get_buildroot())
 
   def _run_bootstrapper(self, bridge_jar, context):
-    bootstrapper = self._relative_to_buildroot(
-      self._zinc_factory._compiler_bootstrapper(self._products),
-    )
+    bootstrapper_entry = self._zinc_factory._compiler_bootstrapper(self._products)
+    bootstrapper = self._relative_to_buildroot(bootstrapper_entry.path)
+
+    # CLI args and their associated ClasspathEntry objects.
+    bootstrap_cp_entries = (
+        ('--compiler-interface', self._compiler_interface),
+        ('--compiler-bridge-src', self._compiler_bridge),
+        ('--scala-compiler', self.scala_compiler),
+        ('--scala-library', self.scala_library),
+        ('--scala-reflect', self.scala_reflect),
+      )
+
     bootstrapper_args = [
-      '--out', self._relative_to_buildroot(bridge_jar),
-      '--compiler-interface', self._relative_to_buildroot(self.compiler_interface),
-      '--compiler-bridge-src', self._relative_to_buildroot(self.compiler_bridge),
-      '--scala-compiler', self._relative_to_buildroot(self.scala_compiler),
-      '--scala-library', self._relative_to_buildroot(self.scala_library),
-      '--scala-reflect', self._relative_to_buildroot(self.scala_reflect),
-    ]
-    input_jar_snapshots = context._scheduler.capture_snapshots((PathGlobsAndRoot(
-      PathGlobs(tuple([bootstrapper] + bootstrapper_args[1::2])),
-      get_buildroot(),
-    ),))
+        '--out', self._relative_to_buildroot(bridge_jar),
+      ]
+    for arg, cp_entry in bootstrap_cp_entries:
+      bootstrapper_args.append(arg)
+      bootstrapper_args.append(self._relative_to_buildroot(cp_entry.path))
+
+    inputs_digest = context._scheduler.merge_directories([
+        bootstrapper_entry.directory_digest
+      ] + [
+        entry.directory_digest for _, entry in bootstrap_cp_entries
+      ])
     argv = tuple(['.jdk/bin/java'] +
                  ['-cp', bootstrapper, Zinc.ZINC_BOOTSTRAPER_MAIN] +
                  bootstrapper_args
     )
     req = ExecuteProcessRequest(
       argv=argv,
-      input_files=input_jar_snapshots[0].directory_digest,
+      input_files=inputs_digest,
       output_files=(self._relative_to_buildroot(bridge_jar),),
       description='bootstrap compiler bridge.',
       # Since this is always hermetic, we need to use `underlying_dist`
@@ -381,21 +392,6 @@ class Zinc:
       return ClasspathEntry(bridge_jar, bridge_jar_digest)
 
   @memoized_method
-  def snapshot(self, scheduler):
-    buildroot = get_buildroot()
-    return scheduler.capture_snapshots((
-      PathGlobsAndRoot(
-        PathGlobs(
-          tuple(
-            fast_relpath(a, buildroot)
-              for a in (self.zinc, self.compiler_bridge, self.compiler_interface)
-          )
-        ),
-        buildroot,
-      ),
-    ))[0]
-
-  @memoized_method
   def _compiler_plugins_cp_entries(self):
     """Any additional global compiletime classpath entries for compiler plugins."""
     java_options_src = Java.global_instance()
@@ -403,10 +399,10 @@ class Zinc:
 
     def cp(instance, toolname):
       scope = instance.options_scope
-      return instance.tool_classpath_from_products(self._products, toolname, scope=scope)
+      return instance.tool_classpath_entries_from_products(self._products, toolname, scope=scope)
     classpaths = (cp(java_options_src, 'javac-plugin-dep') +
                   cp(scala_options_src, 'scalac-plugin-dep'))
-    return [(conf, ClasspathEntry(jar)) for conf in self.DEFAULT_CONFS for jar in classpaths]
+    return [(conf, jar) for conf in self.DEFAULT_CONFS for jar in classpaths]
 
   @memoized_property
   def extractor(self):

--- a/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
+++ b/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
@@ -66,5 +66,5 @@ class ConsolidateClasspath(JvmBinaryTask):
                 jar.write(entry.path)
 
             # Replace directory classpath entry with its jarpath.
-            classpath_products.remove_for_target(vt.target, [(conf, entry.path)])
+            classpath_products.remove_for_target(vt.target, [(conf, entry)])
             classpath_products.add_for_target(vt.target, [(conf, jarpath)])

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -448,8 +448,8 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         for ccs in compile_contexts.values():
           cc = self.select_runtime_context(ccs)
           for conf in self._confs:
-            classpath_product.remove_for_target(cc.target, [(conf, cc.classes_dir.path)])
-            classpath_product.add_for_target(cc.target, [(conf, cc.jar_file.path)])
+            classpath_product.remove_for_target(cc.target, [(conf, cc.classes_dir)])
+            classpath_product.add_for_target(cc.target, [(conf, cc.jar_file)])
 
   def _classpath_for_context(self, context):
     if self.get_options().use_classpath_jars:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -347,13 +347,12 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         classpath_entries = classpath_product.get_classpath_entries_for_targets(dependencies_for_target)
         for _conf, classpath_entry in classpath_entries:
           classpath_paths.append(fast_relpath(classpath_entry.path, get_buildroot()))
-          if classpath_entry.directory_digest:
-            classpath_directory_digests.append(classpath_entry.directory_digest)
-          else:
-            logger.warning(
+          if self.HERMETIC == self.execution_strategy_enum.value and not classpath_entry.directory_digest:
+            raise AssertionError(
               "ClasspathEntry {} didn't have a Digest, so won't be present for hermetic "
               "execution of rsc".format(classpath_entry)
             )
+          classpath_directory_digests.append(classpath_entry.directory_digest)
 
         ctx.ensure_output_dirs_exist()
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -223,7 +223,6 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       self.NAILGUN: lambda: self._nailgunnable_combined_classpath,
     })()
 
-  # NB: Override of ZincCompile/JvmCompile method!
   def register_extra_products_from_contexts(self, targets, compile_contexts):
     super().register_extra_products_from_contexts(targets, compile_contexts)
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -467,11 +467,17 @@ class BaseZincCompile(JvmCompile):
       (self.post_compile_extra_resources_digest(ctx), argfile_snapshot.directory_digest)
     )
 
+    # NB: We always capture the output jar, but if classpath jars are not used, we additionally
+    # capture loose classes from the workspace. This is because we need to both:
+    #   1) allow loose classes as an input to dependent compiles
+    #   2) allow jars to be materialized at the end of the run.
+    output_directories = () if self.get_options().use_classpath_jars else (classes_dir,)
+
     req = ExecuteProcessRequest(
       argv=tuple(argv),
       input_files=merged_input_digest,
-      output_files=(jar_file,) if self.get_options().use_classpath_jars else (),
-      output_directories=() if self.get_options().use_classpath_jars else (classes_dir,),
+      output_files=(jar_file,),
+      output_directories=output_directories,
       description="zinc compile for {}".format(ctx.target.address.spec),
       jdk_home=self._zinc.underlying_dist.home,
     )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -409,8 +409,8 @@ class BaseZincCompile(JvmCompile):
     )
     if len(directory_digests) != len(relevant_classpath_entries):
       for dep in relevant_classpath_entries:
-        if dep.directory_digest is None:
-          logger.warning(
+        if not dep.directory_digest:
+          raise AssertionError(
             "ClasspathEntry {} didn't have a Digest, so won't be present for hermetic "
             "execution of zinc".format(dep)
           )

--- a/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
@@ -27,6 +27,13 @@ class JvmToolTaskMixin(JvmToolMixin, TaskBase):
   def tool_jar(self, key, scope=None):
     """Get the jar for the tool previously registered under key in the given scope.
 
+    See tool_jar_entry
+    """
+    return self.tool_jar_from_products(self.context.products, key, scope=self._scope(scope))
+
+  def tool_jar_entry(self, key, scope=None):
+    """Get a ClasspathEntry for the jar for the tool previously registered under key in the given scope.
+
     :param string key: The key the tool configuration was registered under.
     :param string scope: The scope the tool configuration was registered under; the task scope by
                          default.
@@ -35,10 +42,17 @@ class JvmToolTaskMixin(JvmToolMixin, TaskBase):
     :raises: `JvmToolMixin.InvalidToolClasspath` when the tool classpath is not composed of exactly
              one jar.
     """
-    return self.tool_jar_from_products(self.context.products, key, scope=self._scope(scope))
+    return self.tool_jar_entry_from_products(self.context.products, key, scope=self._scope(scope))
 
   def tool_classpath(self, key, scope=None):
     """Get a classpath for the tool previously registered under key in the given scope.
+
+    See tool_classpath_entry.
+    """
+    return self.tool_classpath_from_products(self.context.products, key, scope=self._scope(scope))
+
+  def tool_classpath_entries(self, key, scope=None):
+    """Get ClasspathEntries for the tool previously registered under key in the given scope.
 
     :API: public
 
@@ -48,7 +62,7 @@ class JvmToolTaskMixin(JvmToolMixin, TaskBase):
     :returns: A list of paths.
     :rtype: list
     """
-    return self.tool_classpath_from_products(self.context.products, key, scope=self._scope(scope))
+    return self.tool_classpath_entries_from_products(self.context.products, key, scope=self._scope(scope))
 
   def _scope(self, scope=None):
     return scope or self.options_scope

--- a/src/python/pants/backend/jvm/tasks/resources_task.py
+++ b/src/python/pants/backend/jvm/tasks/resources_task.py
@@ -1,9 +1,14 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
 from abc import abstractmethod
 
+from pants.backend.jvm.tasks.classpath_entry import ClasspathEntry
+from pants.base.build_environment import get_buildroot
+from pants.engine.fs import Digest, PathGlobs, PathGlobsAndRoot
 from pants.task.task import Task
+from pants.util.dirutil import fast_relpath
 
 
 class ResourcesTask(Task):
@@ -49,17 +54,38 @@ class ResourcesTask(Task):
                           fingerprint_strategy=self.create_invalidation_strategy(),
                           invalidate_dependents=False,
                           topological_order=False) as invalidation:
-      for vt in invalidation.all_vts:
+      for vt in invalidation.invalid_vts:
+        # Generate resources to the chroot.
+        self.prepare_resources(vt.target, vt.results_dir)
+        processed_targets.append(vt.target)
+      for vt, digest in self._capture_resources(invalidation.all_vts):
         # Register the target's chroot in the products.
         for conf in self.get_options().confs:
-          runtime_classpath.add_for_target(vt.target, [(conf, vt.results_dir)])
-        # And if it was invalid, generate the resources to the chroot.
-        if not vt.valid:
-          self.prepare_resources(vt.target, vt.results_dir)
-          processed_targets.append(vt.target)
-          vt.update()
+          runtime_classpath.add_for_target(vt.target, [(conf, ClasspathEntry(vt.results_dir, digest))])
 
     return processed_targets
+
+  def _capture_resources(self, vts):
+    """Given a list of VersionedTargets, capture DirectoryDigests for all of them.
+
+    :returns: A list of tuples of VersionedTargets and digests for their content.
+    """
+    # Capture Snapshots for each directory, using an optional adjacent digest. Create the digest
+    # afterward if it does not exist.
+    buildroot = get_buildroot()
+    snapshots = self.context._scheduler.capture_snapshots(
+      tuple(
+        PathGlobsAndRoot(
+          PathGlobs([os.path.join(fast_relpath(vt.results_dir, buildroot), '**')]),
+          buildroot,
+          Digest.load(vt.current_results_dir),
+        ) for vt in vts
+      ))
+    result = []
+    for vt, snapshot in zip(vts, snapshots):
+      snapshot.directory_digest.dump(vt.current_results_dir)
+      result.append((vt, snapshot.directory_digest))
+    return result
 
   @abstractmethod
   def find_all_relevant_resources_targets(self):

--- a/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
@@ -45,8 +45,9 @@ class ScaladocGen(JvmdocGen):
       return None
 
     scala_platform = ScalaPlatform.global_instance()
-    tool_classpath = [cp_entry.path for cp_entry in scala_platform.compiler_classpath_entries(
-      self.context.products, self.context._scheduler)]
+    tool_classpath = [
+        cp_entry.path for cp_entry in scala_platform.compiler_classpath_entries(self.context.products)
+      ]
 
     args = ['-usejavacp',
             '-classpath', ':'.join(classpath),

--- a/src/python/pants/backend/jvm/tasks/scalastyle.py
+++ b/src/python/pants/backend/jvm/tasks/scalastyle.py
@@ -141,7 +141,7 @@ class Scalastyle(LintTaskMixin, NailgunTask):
           def to_java_boolean(x):
             return str(x).lower()
 
-          cp = ScalaPlatform.global_instance().style_classpath(self.context.products, self.context._scheduler)
+          cp = ScalaPlatform.global_instance().style_classpath(self.context.products)
           scalastyle_args = [
             '-c', scalastyle_config,
             '-v', to_java_boolean(scalastyle_verbose),

--- a/tests/python/pants_test/backend/codegen/antlr/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/antlr/java/BUILD
@@ -24,5 +24,5 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
-  timeout = 90,
+  timeout = 240,
 )

--- a/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
@@ -61,21 +61,21 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
 
   def test_working_210(self):
     with self.tmp_scalastyle_config() as scalastyle_config_option:
-      pants_run = self.pants_run(options=['--scala-version=2.10', scalastyle_config_option])
+      pants_run = self.pants_run(options=['-ldebug', '--scala-version=2.10', scalastyle_config_option])
       self.assert_success(pants_run)
-      assert re.search('bootstrap-scalastyle_2_10', pants_run.stdout_data), pants_run.stdout_data
+      assert re.search('Bootstrapping scalastyle_2_10', pants_run.stdout_data), pants_run.stdout_data
 
   def test_working_211(self):
     with self.tmp_scalastyle_config() as scalastyle_config_option:
-      pants_run = self.pants_run(options=['--scala-version=2.11', scalastyle_config_option])
+      pants_run = self.pants_run(options=['-ldebug', '--scala-version=2.11', scalastyle_config_option])
       self.assert_success(pants_run)
-      assert re.search('bootstrap-scalastyle_2_11', pants_run.stdout_data), pants_run.stdout_data
+      assert re.search('Bootstrapping scalastyle_2_11', pants_run.stdout_data), pants_run.stdout_data
 
   def test_working_212(self):
     with self.tmp_scalastyle_config() as scalastyle_config_option:
-      pants_run = self.pants_run(options=['--scala-version=2.12', scalastyle_config_option])
+      pants_run = self.pants_run(options=['-ldebug', '--scala-version=2.12', scalastyle_config_option])
       self.assert_success(pants_run)
-      assert re.search('bootstrap-scalastyle_2_12', pants_run.stdout_data), pants_run.stdout_data
+      assert re.search('Bootstrapping scalastyle_2_12', pants_run.stdout_data), pants_run.stdout_data
 
   def test_repl_working_custom_211(self):
     with self.tmp_custom_scala('custom_211_scalatools.build') as scalastyle_config_option:
@@ -100,27 +100,29 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
     with self.tmp_custom_scala('custom_211_scalatools.build') as scalastyle_config_option:
       pants_run = self.pants_run(
         options=[
+          '-ldebug',
           '--scala-version=custom',
           '--scala-suffix-version=2.11',
           scalastyle_config_option,
         ]
       )
       self.assert_success(pants_run)
-      assert not re.search('bootstrap-scalastyle_2_10', pants_run.stdout_data)
-      assert not re.search('bootstrap-scalastyle_2_11', pants_run.stdout_data)
+      assert not re.search('Bootstrapping scalastyle_2_10', pants_run.stdout_data)
+      assert not re.search('Bootstrapping scalastyle_2_11', pants_run.stdout_data)
 
   def test_working_custom_212(self):
     with self.tmp_custom_scala('custom_212_scalatools.build') as scalastyle_config_option:
       pants_run = self.pants_run(
         options=[
+          '-ldebug',
           '--scala-version=custom',
           '--scala-suffix-version=2.12',
           scalastyle_config_option,
         ]
       )
       self.assert_success(pants_run)
-      assert not re.search('bootstrap-scalastyle_2_11', pants_run.stdout_data)
-      assert not re.search('bootstrap-scalastyle_2_12', pants_run.stdout_data)
+      assert not re.search('Bootstrapping scalastyle_2_11', pants_run.stdout_data)
+      assert not re.search('Bootstrapping scalastyle_2_12', pants_run.stdout_data)
 
   def test_missing_compiler(self):
     with self.tmp_custom_scala('custom_211_missing_compiler.build') as scalastyle_config_option:

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -475,7 +475,7 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
-  timeout = 120,
+  timeout = 180,
 )
 
 python_tests(
@@ -544,6 +544,7 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
+  timeout = 90,
 )
 
 python_tests(
@@ -576,7 +577,7 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
-  timeout = 180,
+  timeout = 360,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -136,7 +136,7 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
-  timeout = 120,
+  timeout = 240,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -70,4 +70,5 @@ python_tests(
     'src/python/pants/backend/jvm/tasks/jvm_compile:missing_dependency_finder',
   ],
   tags={'integration'},
+  timeout = 240,
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -14,15 +14,6 @@ from pants_test.backend.jvm.tasks.missing_jvm_check import is_missing_jvm
 
 
 class ZincCompileIntegrationTest(BaseCompileIT):
-
-  def test_java_src_zinc_compile(self):
-    with self.do_test_compile('examples/src/java/::'):
-      # run succeeded as expected
-      pass
-    with self.do_test_compile('examples/tests/java/::'):
-      # run succeeded as expected
-      pass
-
   def test_in_process(self):
     with self.temporary_workdir() as workdir:
       with self.temporary_cachedir() as cachedir:
@@ -361,29 +352,3 @@ class ZincCompileIntegrationTest(BaseCompileIT):
           ]:
             path = os.path.join(compile_dir, path_suffix)
             self.assertTrue(os.path.exists(path), "Want path {} to exist".format(path))
-
-  def test_hermetic_binary_with_3rdparty_dependencies(self):
-    for use_classpath_jars in (False, True):
-      config = {
-        'compile.zinc': {
-          'execution_strategy': 'hermetic',
-          'use_classpath_jars': use_classpath_jars,
-          'incremental': False,
-        },
-      }
-
-      with self.temporary_workdir() as workdir:
-        with self.temporary_file_content("readme.txt", b"yo"):
-          pants_run = self.run_pants_with_workdir(
-            [
-              'run',
-              'testprojects/src/java/org/pantsbuild/testproject/cwdexample',
-            ],
-            workdir,
-            config,
-          )
-          self.assert_success(pants_run)
-          self.assertIn(
-            'Found readme.txt',
-            pants_run.stdout_data,
-          )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
@@ -8,6 +8,6 @@ python_tests(
   dependencies=[
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
   ],
-  timeout = 240,
+  timeout = 360,
   tags = {'integration'},
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/BUILD
@@ -17,7 +17,7 @@ python_tests(
     ':zinc_compile_integration_base',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
   ],
-  timeout = 240,
+  timeout = 360,
   tags = {'integration'},
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
@@ -396,3 +396,12 @@ class BaseZincCompileIntegrationTest:
                                 """))
 
       self.run_run(cachetest_spec, config, workdir)
+
+  def test_hermetic(self):
+    extra_args = [
+        '--compile-zinc-execution-strategy=hermetic',
+        '--compile-zinc-incremental=False',
+      ]
+
+    with self.do_test_compile('examples/src/scala/org/pantsbuild/example/hello/exe', extra_args=extra_args):
+      pass

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
@@ -123,7 +123,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
   def test_config_buildroot_does_not_invalidate_targets(self, cache_args):
     previous_names = set()
     for buildroot in self._temporary_buildroots(['examples']):
-      with self.temporary_workdir() as workdir:
+      with temporary_dir(root_dir=buildroot, prefix='.pants.d', suffix='.pants.d') as workdir:
         tmp = os.path.join(buildroot, 'tmp')
         os.mkdir(tmp)
         config = dedent("""

--- a/tests/python/pants_test/backend/jvm/tasks/test_resources_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_resources_task.py
@@ -55,14 +55,15 @@ class ResourcesTaskTestBase(TaskTestBase):
     classpath_products = task.context.products.get_data('runtime_classpath')
 
     expected_confs = expected_confs or ('default',)
-    products = classpath_products.get_for_target(target)
+    products = classpath_products.get_classpath_entries_for_targets([target])
     self.assertEqual(len(expected_confs), len(products))
 
     confs = []
     chroots = set()
-    for conf, chroot in products:
+    for conf, entry in products:
+      self.assertTrue(entry.directory_digest is not None)
       confs.append(conf)
-      chroots.add(chroot)
+      chroots.add(entry.path)
     self.assertEqual(sorted(expected_confs), sorted(confs))
     self.assertEqual(1, len(chroots))
     chroot = chroots.pop()

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -29,7 +29,7 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
-  timeout = 120,
+  timeout = 240,
 )
 
 python_tests(

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -103,5 +103,5 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
-  timeout = 240,
+  timeout = 360,
 )

--- a/tests/python/pants_test/core_tasks/BUILD
+++ b/tests/python/pants_test/core_tasks/BUILD
@@ -77,4 +77,5 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
+  timeout = 120,
 )

--- a/tests/python/pants_test/invalidation/BUILD
+++ b/tests/python/pants_test/invalidation/BUILD
@@ -31,5 +31,5 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
-  timeout = 120,
+  timeout = 480,
 )

--- a/tests/python/pants_test/java/BUILD
+++ b/tests/python/pants_test/java/BUILD
@@ -66,7 +66,7 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
-  timeout = 90,
+  timeout = 180,
 )
 
 python_tests(

--- a/tests/python/pants_test/targets/BUILD
+++ b/tests/python/pants_test/targets/BUILD
@@ -45,6 +45,7 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
+  timeout = 180,
 )
 
 python_tests(

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -32,7 +32,7 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
-  timeout = 240,
+  timeout = 540,
 )
 
 python_tests(


### PR DESCRIPTION
### Problem

When hermetic execution is used for `zinc` or `rsc` and `DirectoryDigests` are not available for input classpath entries, we currently trigger a warning. But this being only a warning (and not an error) definitely masks a few different potential bugs, and might allow more to slip in in the future.

### Solution

Convert the warning into an error, and fix all of the issues exposed by that change:
* In some `Task` configurations, `ResourcesTask` could run before the compilers, meaning that its resources needed to be digested. This also prepares for remote execution of tests.
* When `--no-use-classpath-jars` was in use:
  * `ClasspathEntry`s having digests was preventing them from having an equality match in order to be removed from the classpath.
  * `rsc` was universally adding the jar for a target to the classpath, even though it was empty.
  * Both the loose classpath and output jar needed to be captured in hermetic execution.
* Tools that were bootstrapped were not propagating the digests that had already been captured for them in #7835, which caused "global" scalac plugins to not have digests.

### Result

Hermetic execution has improved validation that should help to catch additional bugs in the future.