### PR TITLE
Add lmdb_store to travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,9 @@ pants_run_cache_config: &pants_run_cache_config
     directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT}
+      # We include the lmdb_store to include a local process cache, so that hopefully we don't need to re-run processes (particularly tests) which have already run.
+      # TODO(#8041): Prune this directory before storing the cache.
+      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -99,6 +99,9 @@ pants_run_cache_config: &pants_run_cache_config
     directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT}
+      # We include the lmdb_store to include a local process cache, so that hopefully we don't need to re-run processes (particularly tests) which have already run.
+      # TODO(#8041): Prune this directory before storing the cache.
+      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants


### PR DESCRIPTION
This allows local process execution to be cached across runs

See #8041 for discussion of keeping its size down.