### PR TITLE
[WIP] create VariantRule and @rule(given=[]) to enable declarative variants

### DIFF
--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -224,7 +224,17 @@ class Linker(datatype([
     'linking_library_dirs',
     'extra_args',
     'extra_object_files',
-])): pass
+])):
+
+  # TODO: encode the "readiness" to be used by a compiler in the type somehow (perhaps by using a
+  # BaseLinker and a PreparedLinker?)!
+  def prepare_for_compiler(self, compiler, platform):
+    """Return a Linker object which is intended to be compatible with the given `compiler`."""
+    return (self
+            # TODO(#6143): describe why the compiler needs to be first on the PATH!
+            .sequence(compiler, exclude_list_fields=['extra_args', 'path_entries'])
+            .prepend_field('path_entries', compiler.path_entries)
+            .copy(exe_filename=compiler.exe_filename))
 
 
 class _CompilerMixin(_Executable):

--- a/src/python/pants/backend/native/config/environment.py
+++ b/src/python/pants/backend/native/config/environment.py
@@ -4,7 +4,7 @@
 import os
 from abc import ABC, abstractmethod
 
-from pants.engine.rules import rule
+from pants.engine.rules import VariantRule, rule
 from pants.util.memo import memoized_classproperty
 from pants.util.objects import datatype, enum
 from pants.util.osutil import all_normalized_os_names, get_normalized_os_name
@@ -301,4 +301,5 @@ def platform_singleton():
 def create_native_environment_rules():
   return [
     platform_singleton,
+    VariantRule(Platform),
   ]

--- a/src/python/pants/backend/native/register.py
+++ b/src/python/pants/backend/native/register.py
@@ -6,6 +6,7 @@ from pants.backend.native.subsystems.binaries.binutils import create_binutils_ru
 from pants.backend.native.subsystems.binaries.gcc import create_gcc_rules
 from pants.backend.native.subsystems.binaries.llvm import create_llvm_rules
 from pants.backend.native.subsystems.native_build_settings import NativeBuildSettings
+from pants.backend.native.subsystems.native_build_step import rules as native_build_step_rules
 from pants.backend.native.subsystems.native_toolchain import create_native_toolchain_rules
 from pants.backend.native.subsystems.xcode_cli_tools import create_xcode_cli_tools_rules
 from pants.backend.native.targets.external_native_library import (ConanRequirement,
@@ -58,5 +59,6 @@ def rules():
     create_xcode_cli_tools_rules() +
     create_binutils_rules() +
     create_gcc_rules() +
-    create_llvm_rules()
+    create_llvm_rules() +
+    native_build_step_rules()
   )

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -4,6 +4,7 @@
 from abc import abstractmethod
 
 from pants.build_graph.mirrored_target_option_mixin import MirroredTargetOptionMixin
+from pants.engine.rules import VariantRule
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
@@ -93,3 +94,7 @@ class CppCompileSettings(CompileSettingsBase):
 # TODO: add a fatal_warnings kwarg to NativeArtifact and make a LinkSharedLibrariesSettings subclass
 # of NativeBuildStep here! The method should work even though NativeArtifact is not a
 # Target.
+def rules():
+  return [
+    VariantRule(ToolchainVariant),
+  ]

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -34,7 +34,7 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
              help='The default for the "compiler_option_sets" argument '
                   'for targets of this language.')
 
-    register('--toolchain-variant', advanced=True,
+    register('--toolchain-variant', advanced=True, fingerprint=True,
              default=ToolchainVariant.gnu, type=ToolchainVariant,
              help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
                   "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")


### PR DESCRIPTION
*Made WIP to allow public comment on the best interface for this!*

### Problem

Closes #5933. This could possibly close #7735 too.

It's not currently obvious how to make a set of v2 rules which can specialize on some condition (e.g. the host platform, the type of a request) without introducing a lot of extra intermediate types, as is currently done in `native_toolchain.py`.

### Solution

- Create `VariantRule`, which creates anonymous classes that are converted into the subjects of `UnionRule`s.
  - This is exposed by providing instances of `enum` classes to the new `given` kwarg in the `@rule` decorator.

### Result

For example, adding `given=[Platform.darwin]` to any `@rule` will ensure it only runs on osx.