### PR TITLE
Deprecate ZincCompile task in favor of RscCompile

### DIFF
--- a/contrib/scalajs/src/python/pants/contrib/scalajs/tasks/scala_js_zinc_compile.py
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/tasks/scala_js_zinc_compile.py
@@ -12,6 +12,9 @@ class ScalaJSZincCompile(BaseZincCompile):
 
   _name = 'scala-js'
   _file_suffix = '.scala'
+  # TODO: Although this task does not extend rsc, it's currently necessary to claim to in order
+  # to not be skipped by the JvmPlatform setting. When the deprecation of the concrete instance of
+  # `ZincCompile` completes, we can merge a few classes.
   compiler_name = 'rsc'
 
   scalac_plugins = ['scalajs']

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/tasks/scala_js_zinc_compile.py
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/tasks/scala_js_zinc_compile.py
@@ -12,7 +12,7 @@ class ScalaJSZincCompile(BaseZincCompile):
 
   _name = 'scala-js'
   _file_suffix = '.scala'
-  compiler_name = 'zinc'
+  compiler_name = 'rsc'
 
   scalac_plugins = ['scalajs']
 

--- a/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala
+++ b/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala
@@ -1,33 +1,35 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 package org.pantsbuild.example.hello.exe
-                              
-                              import java.io.{BufferedReader, InputStreamReader}
-                              
-                              import org.pantsbuild.example.hello
-                              import org.pantsbuild.example.hello.welcome
-                              
-                              // A simple jvm binary to illustrate Scala BUILD targets
- 
-                              object Exe {
-                                /** Test that resources are properly namespaced. */
-                                def getWorld: String = {
-                                  val is =
-                                    this.getClass.getClassLoader.getResourceAsStream(
-                                      "org/pantsbuild/example/hello/world.txt"
-                                    )
-                                  try {
-                                    new BufferedReader(new InputStreamReader(is)).readLine()
-                                  } finally {
-                                    is.close()
-                                  }
-                                }
-                              
-                                def main(args: Array[String]) {
-                                  println("Num args passed: " + args.size + ". Stand by for welcome...")
-                                  if (args.size <= 0) {
-                                    println("Hello, and welcome to " + getWorld + "!")
-                                  } else {
-                                    val w = welcome.WelcomeEverybody(args)
-                                    w.foreach(s => println(s))
-                                  }
-                                }
-                              }
+
+import java.io.{BufferedReader, InputStreamReader}
+
+import org.pantsbuild.example.hello.welcome
+
+// A simple jvm binary to illustrate Scala BUILD targets
+
+object Exe {
+  /** Test that resources are properly namespaced. */
+  def getWorld: String = {
+    val is =
+      this.getClass.getClassLoader.getResourceAsStream(
+        "org/pantsbuild/example/hello/world.txt"
+      )
+    try {
+      new BufferedReader(new InputStreamReader(is)).readLine()
+    } finally {
+      is.close()
+    }
+  }
+
+  def main(args: Array[String]) {
+    println("Num args passed: " + args.size + ". Stand by for welcome...")
+    if (args.size <= 0) {
+      println("Hello, " + getWorld + "!")
+    } else {
+      val w = welcome.WelcomeEverybody(args)
+      w.foreach(s => println(s))
+    }
+  }
+}

--- a/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala
+++ b/examples/src/scala/org/pantsbuild/example/hello/exe/Exe.scala
@@ -1,35 +1,33 @@
-// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
-// Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 package org.pantsbuild.example.hello.exe
-
-import java.io.{BufferedReader, InputStreamReader}
-
-import org.pantsbuild.example.hello.welcome
-
-// A simple jvm binary to illustrate Scala BUILD targets
-
-object Exe {
-  /** Test that resources are properly namespaced. */
-  def getWorld: String = {
-    val is =
-      this.getClass.getClassLoader.getResourceAsStream(
-        "org/pantsbuild/example/hello/world.txt"
-      )
-    try {
-      new BufferedReader(new InputStreamReader(is)).readLine()
-    } finally {
-      is.close()
-    }
-  }
-
-  def main(args: Array[String]) {
-    println("Num args passed: " + args.size + ". Stand by for welcome...")
-    if (args.size <= 0) {
-      println("Hello, " + getWorld + "!")
-    } else {
-      val w = welcome.WelcomeEverybody(args)
-      w.foreach(s => println(s))
-    }
-  }
-}
+                              
+                              import java.io.{BufferedReader, InputStreamReader}
+                              
+                              import org.pantsbuild.example.hello
+                              import org.pantsbuild.example.hello.welcome
+                              
+                              // A simple jvm binary to illustrate Scala BUILD targets
+ 
+                              object Exe {
+                                /** Test that resources are properly namespaced. */
+                                def getWorld: String = {
+                                  val is =
+                                    this.getClass.getClassLoader.getResourceAsStream(
+                                      "org/pantsbuild/example/hello/world.txt"
+                                    )
+                                  try {
+                                    new BufferedReader(new InputStreamReader(is)).readLine()
+                                  } finally {
+                                    is.close()
+                                  }
+                                }
+                              
+                                def main(args: Array[String]) {
+                                  println("Num args passed: " + args.size + ". Stand by for welcome...")
+                                  if (args.size <= 0) {
+                                    println("Hello, and welcome to " + getWorld + "!")
+                                  } else {
+                                    val w = welcome.WelcomeEverybody(args)
+                                    w.foreach(s => println(s))
+                                  }
+                                }
+                              }

--- a/pants.ini
+++ b/pants.ini
@@ -195,7 +195,7 @@ exclude_patterns: [
     'testprojects/src/java/org/pantsbuild/testproject/.*'
   ]
 
-[compile.zinc]
+[compile.rsc]
 jvm_options: [
     '-Xmx4g', '-XX:+UseConcMarkSweepGC', '-XX:ParallelGCThreads=4',
   ]

--- a/src/docs/options.md
+++ b/src/docs/options.md
@@ -22,7 +22,7 @@ each configurable component is qualified by a _scope_.
   not `./pants list.list`.
 + Options for the global instance of subsystem `subsystem` belong to the `subsystem` scope. E.g., `jvm` or `cache`.
 + Options for the instance of subsystem `subsystem` belonging to some other task or subsystem with scope `scope`
-  belong to the `subsystem.scope` scope. E.g., `cache.compile.zinc`.
+  belong to the `subsystem.scope` scope. E.g., `cache.compile.rsc`.
 
 The scope names are used to qualify the option names when setting their values, as explained in
 the remainder of this document.

--- a/src/docs/orgs.md
+++ b/src/docs/orgs.md
@@ -59,7 +59,7 @@ minimized=("$(./pants minimize ${dependees[@]})")
 # once, but that would merge all the classpaths of all the test targets together, which may cause
 # errors. See https://www.pantsbuild.org/3rdparty_jvm.html#managing-transitive-dependencies.
 # TODO(#7480): Background cache activity when running in a loop can sometimes lead to race conditions which
-# cause pants to error. This can probably be worked around with --no-cache-compile-zinc-write. See
+# cause pants to error. This can probably be worked around with --no-cache-compile-rsc-write. See
 # https://github.com/pantsbuild/pants/issues/7480.
 for target in $(cat minimized.txt); do
   ./pants test $target

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -48,7 +48,6 @@ from pants.backend.jvm.tasks.junit_run import JUnitRun
 from pants.backend.jvm.tasks.jvm_compile.javac.javac_compile import JavacCompile
 from pants.backend.jvm.tasks.jvm_compile.jvm_classpath_publisher import RuntimeClasspathPublisher
 from pants.backend.jvm.tasks.jvm_compile.rsc.rsc_compile import RscCompile
-from pants.backend.jvm.tasks.jvm_compile.zinc.zinc_compile import ZincCompile
 from pants.backend.jvm.tasks.jvm_dependency_check import JvmDependencyCheck
 from pants.backend.jvm.tasks.jvm_dependency_usage import JvmDependencyUsage
 from pants.backend.jvm.tasks.jvm_platform_analysis import JvmPlatformExplain, JvmPlatformValidate
@@ -159,7 +158,6 @@ def register_goals():
 
   # Compile
   task(name='rsc', action=RscCompile).install('compile')
-  task(name='zinc', action=ZincCompile).install('compile')
   task(name='javac', action=JavacCompile).install('compile')
 
   # Analysis extraction.

--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -56,7 +56,7 @@ class JvmPlatform(Subsystem):
              help='Compile settings that can be referred to by name in jvm_targets.')
     register('--default-platform', advanced=True, type=str, default=None, fingerprint=True,
              help='Name of the default platform to use if none are specified.')
-    register('--compiler', advanced=True, choices=cls._COMPILER_CHOICES, default='zinc', fingerprint=True,
+    register('--compiler', advanced=True, choices=cls._COMPILER_CHOICES, default='rsc', fingerprint=True,
              help='Java compiler implementation to use.')
 
   @classmethod

--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -24,7 +24,7 @@ class JvmPlatform(Subsystem):
   # strictly (eg, if Java 10 != 1.10, simply leave it out).
   SUPPORTED_CONVERSION_VERSIONS = (6, 7, 8,)
 
-  _COMPILER_CHOICES = ['zinc', 'javac', 'rsc']
+  _COMPILER_CHOICES = ['javac', 'rsc']
 
   class IllegalDefaultPlatform(TaskError):
     """The --default-platform option was set, but isn't defined in --platforms."""

--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -24,7 +24,7 @@ class JvmPlatform(Subsystem):
   # strictly (eg, if Java 10 != 1.10, simply leave it out).
   SUPPORTED_CONVERSION_VERSIONS = (6, 7, 8,)
 
-  _COMPILER_CHOICES = ['javac', 'rsc']
+  _COMPILER_CHOICES = ['zinc', 'javac', 'rsc']
 
   class IllegalDefaultPlatform(TaskError):
     """The --default-platform option was set, but isn't defined in --platforms."""

--- a/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
+++ b/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
@@ -66,5 +66,5 @@ class ConsolidateClasspath(JvmBinaryTask):
                 jar.write(entry.path)
 
             # Replace directory classpath entry with its jarpath.
-            classpath_products.remove_for_target(vt.target, [(conf, entry)])
+            classpath_products.remove_for_target(vt.target, [(conf, entry.path)])
             classpath_products.add_for_target(vt.target, [(conf, jarpath)])

--- a/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
+++ b/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
@@ -66,5 +66,5 @@ class ConsolidateClasspath(JvmBinaryTask):
                 jar.write(entry.path)
 
             # Replace directory classpath entry with its jarpath.
-            classpath_products.remove_for_target(vt.target, [(conf, entry.path)])
+            classpath_products.remove_for_target(vt.target, [(conf, entry)])
             classpath_products.add_for_target(vt.target, [(conf, jarpath)])

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -400,7 +400,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
       return
     deprecated_conditional(
       lambda:  requested_compiler == self.Compiler.ZINC,
-      removal_version='1.19.0.dev0',
+      removal_version='1.20.0.dev0',
       entity_description='Requested a deprecated compiler: [{}].'.format(requested_compiler),
       hint_message='Compiler will be defaulted to [{}].'.format(self.compiler_name))
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -9,6 +9,7 @@ import re
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext  # noqa
 from pants.backend.jvm.subsystems.rsc import Rsc
 from pants.backend.jvm.subsystems.shader import Shader
+from pants.backend.jvm.subsystems.zinc import Zinc
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.classpath_entry import ClasspathEntry
 from pants.backend.jvm.tasks.jvm_compile.compile_context import CompileContext
@@ -18,6 +19,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.mirrored_target_option_mixin import MirroredTargetOptionMixin
+from pants.cache.cache_setup import CacheSetup
 from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, DirectoryToMaterialize, PathGlobs,
                              PathGlobsAndRoot)
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
@@ -112,8 +114,13 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
   @classmethod
   def subsystem_dependencies(cls):
+    dep = CacheSetup.scoped(
+      Zinc.Factory,
+      removal_version='1.19.0.dev0',
+      removal_hint='Cache options for `zinc` should move to `rsc`.'
+    )
     return super().subsystem_dependencies() + (
-      Rsc,
+      Rsc, dep.optionable_cls
     )
 
   @memoized_property

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -107,6 +107,9 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
   _name = 'mixed' # noqa
   compiler_name = 'rsc'
 
+  deprecated_options_scope = 'compile.zinc'
+  deprecated_options_scope_removal_version = '1.19.0.dev0'
+
   @classmethod
   def subsystem_dependencies(cls):
     return super().subsystem_dependencies() + (

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -165,7 +165,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
            'specified on the cli.')
     register('--workflow', type=cls.JvmCompileWorkflowType,
       default=cls.JvmCompileWorkflowType.zinc_only, metavar='<workflow>',
-      help='The workflow to use to compile JVM targets.')
+      help='The workflow to use to compile JVM targets.', fingerprint=True)
 
     register('--extra-rsc-args', type=list, default=[],
              help='Extra arguments to pass to the rsc invocation.')
@@ -211,8 +211,8 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
   def get_zinc_compiler_classpath(self):
     return self.execution_strategy_enum.resolve_for_enum_variant({
       # NB: We must use the verbose version of super() here, possibly because of the lambda.
-      self.HERMETIC: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
-      self.SUBPROCESS: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
+      self.HERMETIC: lambda: super().get_zinc_compiler_classpath(),
+      self.SUBPROCESS: lambda: super().get_zinc_compiler_classpath(),
       self.NAILGUN: lambda: self._nailgunnable_combined_classpath,
     })()
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -110,13 +110,13 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
   compiler_name = 'rsc'
 
   deprecated_options_scope = 'compile.zinc'
-  deprecated_options_scope_removal_version = '1.19.0.dev0'
+  deprecated_options_scope_removal_version = '1.20.0.dev0'
 
   @classmethod
   def subsystem_dependencies(cls):
     dep = CacheSetup.scoped(
       Zinc.Factory,
-      removal_version='1.19.0.dev0',
+      removal_version='1.20.0.dev0',
       removal_hint='Cache options for `zinc` should move to `rsc`.'
     )
     return super().subsystem_dependencies() + (
@@ -237,8 +237,8 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       zinc_cc = merged_cc.zinc_cc
       if rsc_cc.workflow is not None:
         cp_entries = rsc_cc.workflow.resolve_for_enum_variant({
-          'zinc-only': lambda: confify([zinc_cc.jar_file]),
-          'zinc-java': lambda: confify([zinc_cc.jar_file]),
+          'zinc-only': lambda: confify([self._classpath_for_context(zinc_cc)]),
+          'zinc-java': lambda: confify([self._classpath_for_context(zinc_cc)]),
           'rsc-and-zinc': lambda: confify([rsc_cc.rsc_jar_file]),
         })()
         self.context.products.get_data('rsc_mixed_compile_classpath').add_for_target(

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -123,6 +123,10 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       Rsc, dep.optionable_cls
     )
 
+  @classmethod
+  def product_types(cls):
+    return ['runtime_classpath']
+
   @memoized_property
   def mirrored_target_option_actions(self):
     return {

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -211,8 +211,8 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
   def get_zinc_compiler_classpath(self):
     return self.execution_strategy_enum.resolve_for_enum_variant({
       # NB: We must use the verbose version of super() here, possibly because of the lambda.
-      self.HERMETIC: lambda: super().get_zinc_compiler_classpath(),
-      self.SUBPROCESS: lambda: super().get_zinc_compiler_classpath(),
+      self.HERMETIC: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
+      self.SUBPROCESS: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.NAILGUN: lambda: self._nailgunnable_combined_classpath,
     })()
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -164,7 +164,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       help='Always compile targets marked with this tag with rsc, unless the workflow is '
            'specified on the cli.')
     register('--workflow', type=cls.JvmCompileWorkflowType,
-      default=cls.JvmCompileWorkflowType.rsc_and_zinc, metavar='<workflow>',
+      default=cls.JvmCompileWorkflowType.zinc_only, metavar='<workflow>',
       help='The workflow to use to compile JVM targets.')
 
     register('--extra-rsc-args', type=list, default=[],

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -123,10 +123,6 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       Rsc, dep.optionable_cls
     )
 
-  @classmethod
-  def product_types(cls):
-    return ['runtime_classpath']
-
   @memoized_property
   def mirrored_target_option_actions(self):
     return {

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -19,7 +19,6 @@ from pants.backend.jvm.targets.scalac_plugin import ScalacPlugin
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.backend.jvm.tasks.jvm_compile.jvm_compile import JvmCompile
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import deprecated_module
 from pants.base.exceptions import TaskError
 from pants.base.hash_utils import hash_file
 from pants.base.workunit import WorkUnitLabel
@@ -628,11 +627,6 @@ class BaseZincCompile(JvmCompile):
 
 class ZincCompile(BaseZincCompile):
   """Compile Scala and Java code to classfiles using Zinc."""
-
-  deprecated_module(
-    removal_version='1.20.0.dev0',
-    hint_message="compile.zinc task is being phased out. Use compile.rsc:zinc-only option instead."
-  )
   compiler_name = 'zinc'
 
   @classmethod

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -19,7 +19,6 @@ from pants.backend.jvm.targets.scalac_plugin import ScalacPlugin
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.backend.jvm.tasks.jvm_compile.jvm_compile import JvmCompile
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import deprecated_module
 from pants.base.exceptions import TaskError
 from pants.base.hash_utils import hash_file
 from pants.base.workunit import WorkUnitLabel
@@ -629,10 +628,6 @@ class BaseZincCompile(JvmCompile):
 class ZincCompile(BaseZincCompile):
   """Compile Scala and Java code to classfiles using Zinc."""
 
-  deprecated_module(
-    removal_version='1.19.0.dev0',
-    hint_message="compile.zinc task is being phased out. Use compile.rsc:zinc-only option instead."
-  )
   compiler_name = 'zinc'
 
   @classmethod

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -19,6 +19,7 @@ from pants.backend.jvm.targets.scalac_plugin import ScalacPlugin
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.backend.jvm.tasks.jvm_compile.jvm_compile import JvmCompile
 from pants.base.build_environment import get_buildroot
+from pants.base.deprecated import deprecated_module
 from pants.base.exceptions import TaskError
 from pants.base.hash_utils import hash_file
 from pants.base.workunit import WorkUnitLabel
@@ -628,6 +629,10 @@ class BaseZincCompile(JvmCompile):
 class ZincCompile(BaseZincCompile):
   """Compile Scala and Java code to classfiles using Zinc."""
 
+  deprecated_module(
+    removal_version='1.19.0.dev0',
+    hint_message="compile.zinc task is being phased out. Use compile.rsc:zinc-only option instead."
+  )
   compiler_name = 'zinc'
 
   @classmethod

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -341,10 +341,13 @@ class BaseZincCompile(JvmCompile):
       # That classloader will first delegate to its parent classloader, which will search the
       # regular classpath.  However it's harder to guarantee that our javac will preceed any others
       # on the classpath, so it's safer to prefix it to the bootclasspath.
-      jvm_options.extend(['-Xbootclasspath/p:{}'.format(':'.join(self.javac_classpath()))])
+      # list of classpath entries
+      javac_classpath_entries = self.javac_classpath()
+      java_path = [relative_to_exec_root(classpath_entry.path) for classpath_entry in javac_classpath_entries]
+
+      jvm_options.extend(['-Xbootclasspath/p:{}'.format(':'.join(java_path))])
 
     jvm_options.extend(self._jvm_options)
-
     zinc_args.extend(ctx.sources)
 
     self.log_zinc_file(ctx.analysis_file)
@@ -630,7 +633,7 @@ class ZincCompile(BaseZincCompile):
   """Compile Scala and Java code to classfiles using Zinc."""
 
   deprecated_module(
-    removal_version='1.19.0.dev0',
+    removal_version='1.20.0.dev0',
     hint_message="compile.zinc task is being phased out. Use compile.rsc:zinc-only option instead."
   )
   compiler_name = 'zinc'

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -633,7 +633,7 @@ class ZincCompile(BaseZincCompile):
     removal_version='1.19.0.dev0',
     hint_message="compile.zinc task is being phased out. Use compile.rsc:zinc-only option instead."
   )
-  compiler_name = 'rsc'
+  compiler_name = 'zinc'
 
   @classmethod
   def product_types(cls):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -341,13 +341,10 @@ class BaseZincCompile(JvmCompile):
       # That classloader will first delegate to its parent classloader, which will search the
       # regular classpath.  However it's harder to guarantee that our javac will preceed any others
       # on the classpath, so it's safer to prefix it to the bootclasspath.
-      # list of classpath entries
-      javac_classpath_entries = self.javac_classpath()
-      java_path = [relative_to_exec_root(classpath_entry.path) for classpath_entry in javac_classpath_entries]
-
-      jvm_options.extend(['-Xbootclasspath/p:{}'.format(':'.join(java_path))])
+      jvm_options.extend(['-Xbootclasspath/p:{}'.format(':'.join(self.javac_classpath()))])
 
     jvm_options.extend(self._jvm_options)
+
     zinc_args.extend(ctx.sources)
 
     self.log_zinc_file(ctx.analysis_file)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -633,7 +633,7 @@ class ZincCompile(BaseZincCompile):
     removal_version='1.19.0.dev0',
     hint_message="compile.zinc task is being phased out. Use compile.rsc:zinc-only option instead."
   )
-  compiler_name = 'zinc'
+  compiler_name = 'rsc'
 
   @classmethod
   def product_types(cls):

--- a/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive/BUILD
@@ -23,11 +23,13 @@ scala_library(
   sources = ['Scala.scala'],
   dependencies = [':scala-2'],
   exports = [':scala-2'],
-  tags = {'use-compiler:rsc-and-zinc'},
+  # TODO: Enable this when #8109 ships
+  # tags = {'use-compiler:rsc-and-zinc'},
 )
 
 scala_library(
   name = 'scala-2',
   sources = ['Scala2.scala'],
-  tags = {'use-compiler:rsc-and-zinc'},
+  # TODO: Enable this when #8109 ships
+  # tags = {'use-compiler:rsc-and-zinc'},
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/jvm_platform_integration_mixin.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/jvm_platform_integration_mixin.py
@@ -60,7 +60,7 @@ class JvmPlatformIntegrationMixin:
     if ':' in jar_name:
       jar_name = jar_name[jar_name.find(':') + 1:]
     with temporary_dir() as cache_dir:
-      config = {'cache.compile.zinc': {'write_to': [cache_dir]}}
+      config = {'cache.compile.rsc': {'write_to': [cache_dir]}}
       with self.temporary_workdir() as workdir:
         pants_run = self.run_pants_with_workdir(
           ['binary'] + self.get_pants_compile_args()

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
@@ -38,7 +38,7 @@ class CacheCompileIntegrationTest(BaseCompileIT):
       temporary_dir(root_dir=get_buildroot()) as src_dir:
 
       config = {
-        'cache.compile.zinc': {'write_to': [cache_dir], 'read_from': [cache_dir]},
+        'cache.compile.rsc': {'write_to': [cache_dir], 'read_from': [cache_dir]},
         'compile.zinc': {'incremental_caching': True},
         'java': {'strict_deps': False},
       }
@@ -107,7 +107,7 @@ class CacheCompileIntegrationTest(BaseCompileIT):
         temporary_dir(root_dir=get_buildroot()) as src_dir:
 
       config = {
-        'cache.compile.zinc': {'write_to': [cache_dir], 'read_from': [cache_dir]},
+        'cache.compile.rsc': {'write_to': [cache_dir], 'read_from': [cache_dir]},
         'compile.zinc': {'incremental_caching': True },
       }
 
@@ -172,7 +172,7 @@ class CacheCompileIntegrationTest(BaseCompileIT):
     with temporary_dir() as cache_dir, temporary_dir(root_dir=get_buildroot()) as src_dir, \
       temporary_dir(root_dir=get_buildroot(), suffix='.pants.d') as workdir:
       config = {
-        'cache.compile.zinc': {'write_to': [cache_dir], 'read_from': [cache_dir]},
+        'cache.compile.rsc': {'write_to': [cache_dir], 'read_from': [cache_dir]},
       }
 
       dep_src_file = os.path.join(src_dir, 'org', 'pantsbuild', 'dep', 'A.scala')
@@ -261,7 +261,7 @@ class CacheCompileIntegrationTest(BaseCompileIT):
       def complete_config(config):
         # Clone the input config and add cache settings.
         cache_settings = {'write_to': [cache_dir], 'read_from': [cache_dir]}
-        return dict(list(config.items()) + [('cache.compile.zinc', cache_settings)])
+        return dict(list(config.items()) + [('cache.compile.rsc', cache_settings)])
 
       buildfile = os.path.join(src_dir, 'BUILD')
       spec = os.path.join(src_dir, ':cachetest')

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
@@ -144,7 +144,7 @@ class CacheCompileIntegrationTest(BaseCompileIT):
       # Should cause NotMain.class to be removed
       self.run_compile(cachetest_spec, config, workdir)
 
-      root = os.path.join(workdir, 'compile', 'zinc')
+      root = os.path.join(workdir, 'compile', 'rsc')
 
       task_versions = [p for p in os.listdir(root) if p != 'current']
       self.assertEqual(len(task_versions), 1, 'Expected 1 task version.')
@@ -159,7 +159,7 @@ class CacheCompileIntegrationTest(BaseCompileIT):
       self.assertIn('current', target_workdirs)
 
       def classfiles(d):
-        cd = os.path.join(target_workdir_root, d, 'classes', 'org', 'pantsbuild', 'cachetest')
+        cd = os.path.join(target_workdir_root, d, 'zinc', 'classes', 'org', 'pantsbuild', 'cachetest')
         return sorted(os.listdir(cd))
 
       # One workdir should contain NotMain, and the other should contain Main.

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
@@ -207,7 +207,7 @@ class CacheCompileIntegrationTest(BaseCompileIT):
         run_two = self.run_compile(con_spec, config, new_workdir)
         self.assertTrue(
             re.search(
-              "\[zinc\][^[]*\[cache\][^[]*Using cached artifacts for 2 targets.",
+              "Using cached artifacts for 2 targets.",
               run_two.stdout_data),
             run_two.stdout_data)
 
@@ -223,7 +223,7 @@ class CacheCompileIntegrationTest(BaseCompileIT):
         run_three = self.run_compile(con_spec, config, new_workdir)
         self.assertTrue(
             re.search(
-              r"/org/pantsbuild/consumer:consumer\)[^[]*\[compile\][^[]*\[zinc\]\W*\[info\] Compile success",
+              r"consumer[\s\S]*Compile success",
               run_three.stdout_data),
             run_three.stdout_data)
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -223,6 +223,7 @@ class JavaCompileIntegrationTest(BaseCompileIT):
         # Build again to hit the cache.
         second_run = self.run_pants_with_workdir(['clean-all', 'test', target], workdir, config)
         self.assert_success(second_run)
+        print(second_run.stdout_data)
         self.assertFalse("Compiling" in second_run.stdout_data)
 
         # Corrupt the remote artifact.

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -14,7 +14,7 @@ class JavaCompileIntegrationTest(BaseCompileIT):
 
   def test_basic_binary(self):
     with temporary_dir() as cache_dir:
-      config = {'cache.compile.zinc': {'write_to': [cache_dir]}}
+      config = {'cache.compile.rsc': {'write_to': [cache_dir]}}
 
       with self.temporary_workdir() as workdir:
         pants_run = self.run_pants_with_workdir(
@@ -26,7 +26,7 @@ class JavaCompileIntegrationTest(BaseCompileIT):
 
   def test_nocache(self):
     with temporary_dir() as cache_dir:
-      config = {'cache.compile.zinc': {'write_to': [cache_dir]}}
+      config = {'cache.compile.rsc': {'write_to': [cache_dir]}}
 
       self.assert_success(self.run_pants([
         'compile',
@@ -55,7 +55,7 @@ class JavaCompileIntegrationTest(BaseCompileIT):
     # produces two different artifacts.
 
     with temporary_dir() as cache_dir:
-      config = {'cache.compile.zinc': {'write_to': [cache_dir]}}
+      config = {'cache.compile.rsc': {'write_to': [cache_dir]}}
 
       java_6_args = self.create_platform_args(6) + [
         'compile',
@@ -94,7 +94,7 @@ class JavaCompileIntegrationTest(BaseCompileIT):
     # the artifact contains that resource mapping.
 
     with temporary_dir() as cache_dir:
-      config = {'cache.compile.zinc': {'write_to': [cache_dir]}}
+      config = {'cache.compile.rsc': {'write_to': [cache_dir]}}
 
       self.assert_success(self.run_pants([
         'compile',
@@ -163,11 +163,11 @@ class JavaCompileIntegrationTest(BaseCompileIT):
       dotted_path = path_prefix.replace(os.path.sep, '.')
 
       config = {
-          'cache.compile.zinc': {
+          'cache.compile.rsc': {
             'write_to': [cache_dir],
             'read_from': [cache_dir],
           },
-          'compile.zinc': {
+          'compile.rsc': {
             'incremental_caching': True,
           },
       }
@@ -209,7 +209,7 @@ class JavaCompileIntegrationTest(BaseCompileIT):
       with cache_server(cache_root=cachedir) as server:
         target = 'testprojects/tests/java/org/pantsbuild/testproject/matcher'
         config = {
-            'cache.compile.zinc': {
+            'cache.compile.rsc': {
               'write_to': [server.url],
               'read_from': [server.url],
             },
@@ -235,4 +235,4 @@ class JavaCompileIntegrationTest(BaseCompileIT):
 
 
 class JavaCompileIntegrationTestWithZjar(JavaCompileIntegrationTest):
-  _EXTRA_TASK_ARGS = ['--compile-zinc-use-classpath-jars']
+  _EXTRA_TASK_ARGS = ['--compile-rsc-use-classpath-jars']

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -223,7 +223,6 @@ class JavaCompileIntegrationTest(BaseCompileIT):
         # Build again to hit the cache.
         second_run = self.run_pants_with_workdir(['clean-all', 'test', target], workdir, config)
         self.assert_success(second_run)
-        print(second_run.stdout_data)
         self.assertFalse("Compiling" in second_run.stdout_data)
 
         # Corrupt the remote artifact.

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -162,7 +162,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
           config,
         )
         self.assert_failure(pants_run)
-        self.assertIn('Please use --no-compile-zinc-incremental', pants_run.stdout_data)
+        self.assertIn('Please use --no-compile-rsc-incremental', pants_run.stdout_data)
 
   def test_failed_compile_with_hermetic(self):
     with temporary_dir() as cache_dir:

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import re
 from unittest import skipIf
 
 from pants.base.build_environment import get_buildroot
@@ -187,10 +188,12 @@ class ZincCompileIntegrationTest(BaseCompileIT):
         )
         self.assert_failure(pants_run)
         self.assertIn('package System2 does not exist', pants_run.stderr_data)
-        self.assertIn(
-          'Failed jobs: compile(testprojects/src/java/org/pantsbuild/testproject/dummies:'
-          'compilation_failure_target)',
-          pants_run.stdout_data)
+        self.assertTrue(
+          re.search(
+            'Compilation failure.*testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target',
+            pants_run.stdout_data
+          )
+        )
 
   def test_failed_compile_with_subprocess(self):
     with temporary_dir() as cache_dir:

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -51,7 +51,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
         pants_run = self.run_test_compile(
           workdir, cachedir, target,
           extra_args=[
-            '--cache-compile-zinc-write-to=["{}/dummy_artifact_cache_dir"]'.format(cachedir),
+            '--cache-compile-rsc-write-to=["{}/dummy_artifact_cache_dir"]'.format(cachedir),
           ],
           clean_all=True,
         )
@@ -143,7 +143,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
   def test_failed_hermetic_incremental_compile(self):
     with temporary_dir() as cache_dir:
       config = {
-        'cache.compile.zinc': {'write_to': [cache_dir]},
+        'cache.compile.rsc': {'write_to': [cache_dir]},
         'compile.zinc': {
           'execution_strategy': 'hermetic',
           'use_classpath_jars': False,
@@ -167,7 +167,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
   def test_failed_compile_with_hermetic(self):
     with temporary_dir() as cache_dir:
       config = {
-        'cache.compile.zinc': {'write_to': [cache_dir]},
+        'cache.compile.rsc': {'write_to': [cache_dir]},
         'compile.zinc': {
           'execution_strategy': 'hermetic',
           'use_classpath_jars': False,
@@ -195,7 +195,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
   def test_failed_compile_with_subprocess(self):
     with temporary_dir() as cache_dir:
       config = {
-        'cache.compile.zinc': {'write_to': [cache_dir]},
+        'cache.compile.rsc': {'write_to': [cache_dir]},
         'compile.zinc': {
           'execution_strategy': 'subprocess',
           'use_classpath_jars': False,
@@ -224,7 +224,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
   def test_hermetic_binary_with_dependencies(self):
     with temporary_dir() as cache_dir:
       config = {
-        'cache.compile.zinc': {'write_to': [cache_dir]},
+        'cache.compile.rsc': {'write_to': [cache_dir]},
         'compile.zinc': {
           'execution_strategy': 'hermetic',
           'use_classpath_jars': False,
@@ -263,7 +263,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
     with temporary_dir() as cache_dir:
       config = {
-        'cache.compile.zinc': {'write_to': [cache_dir]},
+        'cache.compile.rsc': {'write_to': [cache_dir]},
         'compile.zinc': {
           'execution_strategy': 'hermetic',
           'use_classpath_jars': False,

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -253,7 +253,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
           pants_run.stdout_data,
         )
 
-        compile_dir = os.path.join(workdir, 'compile', 'zinc', 'current')
+        compile_dir = os.path.join(workdir, 'compile', 'rsc', 'current')
 
         for path_suffix in [
           'examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/zinc/classes/org/pantsbuild/example/hello/exe/Exe.class',
@@ -268,7 +268,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
     with temporary_dir() as cache_dir:
       config = {
-        'cache.compile.rsc': {'write_to': [cache_dir]},
+        'cache.compile.rsc': {'write_to': [cache_dir], 'read_from': [cache_dir]},
         'compile.zinc': {
           'execution_strategy': 'hermetic',
           'use_classpath_jars': False,
@@ -305,8 +305,8 @@ class ZincCompileIntegrationTest(BaseCompileIT):
           new_temp_test = '''package org.pantsbuild.example.hello.exe
                               
                               import java.io.{BufferedReader, InputStreamReader}
-                              
                               import org.pantsbuild.example.hello
+                              import org.pantsbuild.example.hello.welcome
                               
                               // A simple jvm binary to illustrate Scala BUILD targets
                               

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -219,10 +219,12 @@ class ZincCompileIntegrationTest(BaseCompileIT):
         )
         self.assert_failure(pants_run)
         self.assertIn('package System2 does not exist', pants_run.stdout_data)
-        self.assertIn(
-          'Failed jobs: compile(testprojects/src/java/org/pantsbuild/testproject/dummies:'
-          'compilation_failure_target)',
-          pants_run.stdout_data)
+        self.assertTrue(
+          re.search(
+          'Compilation failure.*testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target',
+          pants_run.stdout_data
+          )
+        )
 
   def test_hermetic_binary_with_dependencies(self):
     with temporary_dir() as cache_dir:
@@ -254,8 +256,8 @@ class ZincCompileIntegrationTest(BaseCompileIT):
         compile_dir = os.path.join(workdir, 'compile', 'zinc', 'current')
 
         for path_suffix in [
-          'examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/org/pantsbuild/example/hello/exe/Exe.class',
-          'examples.src.scala.org.pantsbuild.example.hello.welcome.welcome/current/classes/org/pantsbuild/example/hello/welcome/WelcomeEverybody.class',
+          'examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/zinc/classes/org/pantsbuild/example/hello/exe/Exe.class',
+          'examples.src.scala.org.pantsbuild.example.hello.welcome.welcome/current/zinc/classes/org/pantsbuild/example/hello/welcome/WelcomeEverybody.class',
         ]:
           path = os.path.join(compile_dir, path_suffix)
           self.assertTrue(os.path.exists(path), "Want path {} to exist".format(path))
@@ -290,22 +292,21 @@ class ZincCompileIntegrationTest(BaseCompileIT):
           pants_run.stdout_data,
         )
 
-        compile_dir = os.path.join(workdir, 'compile', 'zinc', 'current')
+        compile_dir = os.path.join(workdir, 'compile', 'rsc', 'current')
 
         for path_suffix in [
-          'examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/org/pantsbuild/example/hello/exe/Exe.class',
-          'examples.src.scala.org.pantsbuild.example.hello.welcome.welcome/current/classes/org/pantsbuild/example/hello/welcome/WelcomeEverybody.class',
+          'examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/zinc/classes/org/pantsbuild/example/hello/exe/Exe.class',
+          'examples.src.scala.org.pantsbuild.example.hello.welcome.welcome/current/zinc/classes/org/pantsbuild/example/hello/welcome/WelcomeEverybody.class',
         ]:
           path = os.path.join(compile_dir, path_suffix)
           self.assertTrue(os.path.exists(path), "Want path {} to exist".format(path))
-
         with self.with_overwritten_file_content(file_abs_path):
 
           new_temp_test = '''package org.pantsbuild.example.hello.exe
                               
                               import java.io.{BufferedReader, InputStreamReader}
                               
-                              import org.pantsbuild.example.hello.welcome
+                              import org.pantsbuild.example.hello
                               
                               // A simple jvm binary to illustrate Scala BUILD targets
                               
@@ -352,11 +353,11 @@ class ZincCompileIntegrationTest(BaseCompileIT):
             pants_run.stdout_data,
           )
 
-          compile_dir = os.path.join(workdir, 'compile', 'zinc', 'current')
+          compile_dir = os.path.join(workdir, 'compile', 'rsc', 'current')
 
           for path_suffix in [
-            'examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/org/pantsbuild/example/hello/exe/Exe.class',
-            'examples.src.scala.org.pantsbuild.example.hello.welcome.welcome/current/classes/org/pantsbuild/example/hello/welcome/WelcomeEverybody.class',
+            'examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/zinc/classes/org/pantsbuild/example/hello/exe/Exe.class',
+            'examples.src.scala.org.pantsbuild.example.hello.welcome.welcome/current/zinc/classes/org/pantsbuild/example/hello/welcome/WelcomeEverybody.class',
           ]:
             path = os.path.join(compile_dir, path_suffix)
             self.assertTrue(os.path.exists(path), "Want path {} to exist".format(path))

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
@@ -110,8 +110,7 @@ class RscCompileTest(NailgunTaskTestBase):
       print(dependee_graph)
       self.assertEqual(dedent("""
                      zinc[zinc-java](java/classpath:java_lib) <- {}
-                     rsc(scala/classpath:scala_lib) <- {}
-                     zinc[rsc-and-zinc](scala/classpath:scala_lib) <- {}""").strip(),
+                     zinc[zinc-only](scala/classpath:scala_lib) <- {}""").strip(),
         dependee_graph)
 
   def test_default_workflow_of_zinc_only_zincs_scala(self):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -31,6 +31,7 @@ class RscCompileIntegration(BaseCompileIT, AbstractTestGenerator):
               'cache.compile.rsc': {'write_to': [cache_dir]},
               'jvm-platform': {'compiler': 'rsc'},
               'compile.rsc': {
+                'workflow': 'rsc-and-zinc',
                 'execution_strategy': execution_strategy.value,
                 'worker_count': worker_count,
               },

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+import re
 import shutil
 
 from pants.base.build_environment import get_buildroot
@@ -56,9 +57,12 @@ class DepExportsIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(['compile', '--lint-scalafmt-skip',
                                 'testprojects/tests/scala/org/pantsbuild/testproject/non_exports:C'])
     self.assert_failure(pants_run)
-    self.assertIn('FAILURE: Compilation failure: Failed jobs: '
-                  'compile(testprojects/tests/scala/org/pantsbuild/testproject/non_exports:C)',
-                  pants_run.stdout_data)
+    self.assertTrue(
+      re.search(
+        'Compilation failure.*testprojects/tests/scala/org/pantsbuild/testproject/non_exports:C',
+        pants_run.stdout_data
+      )
+    )
 
 
 class DepExportsThriftTargets(PantsRunIntegrationTest):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
@@ -265,13 +265,13 @@ class BaseZincCompileIntegrationTest:
       first_run = self.run_test_compile(workdir, cachedir,
                             'testprojects/src/scala/org/pantsbuild/testproject/javasources')
 
-      self.assertIn('isolation-zinc-pool-bootstrap', first_run.stdout_data)
+      self.assertIn('isolation-mixed-pool-bootstrap', first_run.stdout_data)
 
       # Run valid compile.
       second_run = self.run_test_compile(workdir, cachedir,
                             'testprojects/src/scala/org/pantsbuild/testproject/javasources')
 
-      self.assertNotIn('isolation-zinc-pool-bootstrap', second_run.stdout_data)
+      self.assertNotIn('isolation-mixed-pool-bootstrap', second_run.stdout_data)
 
   def test_source_compat_binary_incompat_scala_change(self):
     with temporary_dir() as cache_dir, \

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
@@ -279,7 +279,7 @@ class BaseZincCompileIntegrationTest:
       temporary_dir(root_dir=get_buildroot()) as src_dir:
 
       config = {
-        'cache.compile.zinc': {'write_to': [cache_dir], 'read_from': [cache_dir]},
+        'cache.compile.rsc': {'write_to': [cache_dir], 'read_from': [cache_dir]},
       }
 
       srcfile = os.path.join(src_dir, 'org', 'pantsbuild', 'cachetest', 'A.scala')
@@ -341,7 +341,7 @@ class BaseZincCompileIntegrationTest:
       temporary_dir(root_dir=get_buildroot()) as src_dir:
 
       config = {
-        'cache.compile.zinc': {'write_to': [cache_dir], 'read_from': [cache_dir]},
+        'cache.compile.rsc': {'write_to': [cache_dir], 'read_from': [cache_dir]},
         'compile.zinc': {'incremental_caching': True },
       }
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage_integration.py
@@ -75,6 +75,6 @@ class TestJvmDependencyUsageIntegration(PantsRunIntegrationTest):
     target = 'testprojects/src/java/org/pantsbuild/testproject/unicode/main'
     with self.temporary_cachedir() as cachedir, \
       self.temporary_workdir() as workdir:
-      for compiler in ['rsc', 'zinc']:
+      for compiler in ['rsc']:
         self._run_dep_usage(workdir, target, clean_all=True, cachedir=cachedir,
           extra_args=['--no-dep-usage-jvm-summary', '--jvm-platform-compiler={}'.format(compiler)])

--- a/tests/python/pants_test/backend/python/rules/test_python_test_runner_integration.py
+++ b/tests/python/pants_test/backend/python/rules/test_python_test_runner_integration.py
@@ -48,7 +48,7 @@ class TestPythonTestRunnerIntegration(PantsRunIntegrationTest):
   def run_failing_pants_test(self, trailing_args):
     pants_run = self.run_pants(trailing_args)
     self.assert_failure(pants_run)
-    self.assertThat('Tests failed\n' in pants_run.stderr_data)
+    self.assertIn('Tests failed\n', pants_run.stderr_data)
     return pants_run
 
   def test_passing_test(self):

--- a/tests/python/pants_test/backend/python/rules/test_python_test_runner_integration.py
+++ b/tests/python/pants_test/backend/python/rules/test_python_test_runner_integration.py
@@ -48,7 +48,7 @@ class TestPythonTestRunnerIntegration(PantsRunIntegrationTest):
   def run_failing_pants_test(self, trailing_args):
     pants_run = self.run_pants(trailing_args)
     self.assert_failure(pants_run)
-    self.assertEqual('Tests failed\n', pants_run.stderr_data)
+    self.assertThat('Tests failed\n' in pants_run.stderr_data)
     return pants_run
 
   def test_passing_test(self):

--- a/tests/python/pants_test/bin/test_runner_integration.py
+++ b/tests/python/pants_test/bin/test_runner_integration.py
@@ -43,5 +43,4 @@ class RunnerIntegrationTest(PantsRunIntegrationTest):
       },
     })
     self.assert_success(non_warning_run)
-    self.assertNotIn('DEPRECATED', non_warning_run.stderr_data)
     self.assertNotIn('test warning', non_warning_run.stderr_data)

--- a/tests/python/pants_test/cache/test_cache_cleanup_integration.py
+++ b/tests/python/pants_test/cache/test_cache_cleanup_integration.py
@@ -45,7 +45,7 @@ class CacheCleanupIntegrationTest(PantsRunIntegrationTest):
     """Ensure that max-old of 1 removes all but one files"""
 
     with temporary_dir() as cache_dir:
-      config = {'cache.compile.zinc': {'write_to': [cache_dir]}}
+      config = {'cache.compile.rsc': {'write_to': [cache_dir]}}
 
       java_6_args = self._create_platform_args(6) + [
         'compile.zinc',
@@ -88,7 +88,7 @@ class CacheCleanupIntegrationTest(PantsRunIntegrationTest):
     """
 
     with temporary_dir() as cache_dir:
-      config = {'cache.compile.zinc': {'write_to': [cache_dir]}}
+      config = {'cache.compile.rsc': {'write_to': [cache_dir]}}
 
       java_6_args = self._create_platform_args(6) + [
         'compile.zinc',

--- a/tests/python/pants_test/cache/test_cache_cleanup_integration.py
+++ b/tests/python/pants_test/cache/test_cache_cleanup_integration.py
@@ -48,7 +48,7 @@ class CacheCleanupIntegrationTest(PantsRunIntegrationTest):
       config = {'cache.compile.rsc': {'write_to': [cache_dir]}}
 
       java_6_args = self._create_platform_args(6) + [
-        'compile.zinc',
+        'compile.rsc',
         'testprojects/src/java/org/pantsbuild/testproject/unicode/main',
         '--cache-max-entries-per-target=1',
       ]
@@ -64,7 +64,7 @@ class CacheCleanupIntegrationTest(PantsRunIntegrationTest):
 
       # Rerun for java 7
       java_7_args = self._create_platform_args(7) + [
-        'compile.zinc',
+        'compile.rsc',
         'testprojects/src/java/org/pantsbuild/testproject/unicode/main',
         '--cache-max-entries-per-target=1',
       ]
@@ -91,7 +91,7 @@ class CacheCleanupIntegrationTest(PantsRunIntegrationTest):
       config = {'cache.compile.rsc': {'write_to': [cache_dir]}}
 
       java_6_args = self._create_platform_args(6) + [
-        'compile.zinc',
+        'compile.rsc',
         'testprojects/src/java/org/pantsbuild/testproject/unicode/main',
         '--cache-max-entries-per-target=0',
       ]
@@ -107,7 +107,7 @@ class CacheCleanupIntegrationTest(PantsRunIntegrationTest):
 
       # Rerun for java 7
       java_7_args = self._create_platform_args(7) + [
-        'compile.zinc',
+        'compile.rsc',
         'testprojects/src/java/org/pantsbuild/testproject/unicode/main',
         '--cache-max-entries-per-target=0',
       ]
@@ -139,11 +139,10 @@ class CacheCleanupIntegrationTest(PantsRunIntegrationTest):
       # in order to avoid computing hashed task version used in workdir.
       classpath = 'dist/export-classpath/testprojects.src.java.org.pantsbuild.testproject.unicode.main.main-0.jar'
 
-      # <workdir>/compile/zinc/d4600a981d5d/testprojects.src.java.org.pantsbuild.testproject.unicode.main.main/1a317a2504f6/z.jar'
+      # <workdir>/compile/rsc/d4600a981d5d/testprojects.src.java.org.pantsbuild.testproject.unicode.main.main/1a317a2504f6/z.jar'
       jar_path_in_pantsd = os.path.realpath(classpath)
-
-      # <workdir>/compile/zinc/d4600a981d5d/testprojects.src.java.org.pantsbuild.testproject.unicode.main.main/
-      target_dir_in_pantsd = os.path.dirname(os.path.dirname(jar_path_in_pantsd))
+      # <workdir>/compile/rsc/d4600a981d5d/testprojects.src.java.org.pantsbuild.testproject.unicode.main.main/
+      target_dir_in_pantsd = os.path.dirname(os.path.dirname(os.path.dirname(jar_path_in_pantsd)))
 
       old_cache_dirnames = {
         'old_cache_test1_dir/',
@@ -165,7 +164,7 @@ class CacheCleanupIntegrationTest(PantsRunIntegrationTest):
       expected_dirs = {os.path.join(target_dir_in_pantsd, 'current/')} | old_cache_entries | new_cache_entries
 
       # stable symlink, current version directory, and synthetically created directories.
-      remaining_cache_dir_fingerprinted = self.get_cache_subdir(target_dir_in_pantsd, other_dirs=expected_dirs)
+      remaining_cache_dir_fingerprinted = self.get_cache_subdir(cache_dir=target_dir_in_pantsd, other_dirs=expected_dirs)
       fingerprinted_realdir = os.path.realpath(os.path.join(target_dir_in_pantsd, 'current'))
       self.assertEqual(
         fingerprinted_realdir,
@@ -180,7 +179,10 @@ class CacheCleanupIntegrationTest(PantsRunIntegrationTest):
       ], workdir))
 
       # stable (same as before), current, and 2 newest dirs
-      self.assertEqual(os.path.dirname(os.path.dirname(os.path.realpath(classpath))), target_dir_in_pantsd)
+      self.assertEqual(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(classpath)))),
+        target_dir_in_pantsd
+      )
       newest_expected_dirs = expected_dirs - old_cache_entries
       other_cache_dir_fingerprinted = self.get_cache_subdir(target_dir_in_pantsd, other_dirs=newest_expected_dirs)
       self.assertEqual(other_cache_dir_fingerprinted, remaining_cache_dir_fingerprinted)
@@ -197,7 +199,10 @@ class CacheCleanupIntegrationTest(PantsRunIntegrationTest):
       ], workdir))
 
       # stable, current, and 2 newest dirs
-      self.assertEqual(os.path.dirname(os.path.dirname(os.path.realpath(classpath))), target_dir_in_pantsd)
+      self.assertEqual(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(classpath)))),
+        target_dir_in_pantsd
+      )
       new_cache_dir_fingerprinted = self.get_cache_subdir(target_dir_in_pantsd, other_dirs=newest_expected_dirs)
       # subsequent run with --compile-zinc-debug-symbols will invalidate previous build thus triggering the clean up.
       self.assertNotEqual(new_cache_dir_fingerprinted, remaining_cache_dir_fingerprinted)

--- a/tests/python/pants_test/engine/legacy/test_graph_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_graph_integration.py
@@ -111,7 +111,7 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       },
     })
     self.assert_success(pants_run)
-    self.assertNotIn("WARN]", pants_run.stderr_data)
+    self.assertNotIn("Globs", pants_run.stderr_data)
 
   def test_missing_bundles_warnings(self):
     target_full = '{}:missing-bundle-fileset'.format(self._BUNDLE_TARGET_BASE)
@@ -140,7 +140,7 @@ class GraphIntegrationTest(PantsRunIntegrationTest):
       },
     })
     self.assert_success(pants_run)
-    self.assertNotIn("WARN]", pants_run.stderr_data)
+    self.assertNotIn("Globs", pants_run.stderr_data)
 
   def test_existing_directory_with_no_build_files_fails(self):
     pants_run = self.run_pants(['list', "{}::".format(self._NO_BUILD_FILE_TARGET_BASE)])

--- a/tests/python/pants_test/java/test_nailgun_integration.py
+++ b/tests/python/pants_test/java/test_nailgun_integration.py
@@ -33,7 +33,7 @@ class TestNailgunIntegration(PantsRunIntegrationTest):
               'compile.zinc': {'nailgun_timeout_seconds': '0.00002'}}
     )
     self.assert_failure(pants_run)
-    self.assertRegex(pants_run.stdout_data, """\
-compile\\(examples/src/java/org/pantsbuild/example/hello/greet:greet\\) failed: \
-Problem launching via <no nailgun connection> command org\\.pantsbuild\\.zinc\\.compiler\\.Main .*: \
-Failed to read nailgun output after 2e\-05 seconds!""")
+    self.assertRegex(
+      pants_run.stdout_data,
+      """\<no nailgun connection>.* Failed to read nailgun output"""
+    )

--- a/tests/python/pants_test/option/test_options_integration.py
+++ b/tests/python/pants_test/option/test_options_integration.py
@@ -237,7 +237,6 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     pants_run = self.run_pants(['-q', 'compile'])
     self.assert_success(pants_run)
     self.assertEqual('', pants_run.stdout_data)
-    self.assertEqual('\n', pants_run.stderr_data)
 
   def test_skip_inherited(self):
     pants_run = self.run_pants([

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -654,7 +654,7 @@ Interrupted by user over pailgun client!
     # This pair of JVM options causes the JVM to always crash, so the command will fail if the env
     # isn't stripped.
     with self.pantsd_successful_run_context(
-      extra_config={'compile.zinc': {'jvm_options': ['-Xmx1g']}},
+      extra_config={'compile.rsc': {'jvm_options': ['-Xmx1g']}},
       extra_env={'_JAVA_OPTIONS': '-Xms2g'},
     ) as (pantsd_run, checker, workdir, _):
       pantsd_run(['help'])

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -68,7 +68,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
       self.assertTrue(os.path.exists(output), msg='Missing report file {}'.format(output))
 
   INFO_LEVEL_COMPILE_MSG='Compiling 1 mixed source in 1 target (examples/src/java/org/pantsbuild/example/hello/simple:simple).'
-  DEBUG_LEVEL_COMPILE_MSG='compile(examples/src/java/org/pantsbuild/example/hello/simple:simple) finished with status Successful'
+  DEBUG_LEVEL_COMPILE_MSG='examples/src/java/org/pantsbuild/example/hello/simple:simple) finished with status Successful'
 
   def test_output_level_warn(self):
     command = ['compile',

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -21,9 +21,9 @@ _HEADER = 'invocation_id,task_name,targets_hash,target_id,cache_key_id,cache_key
 _REPORT_LOCATION = 'reports/latest/invalidation-report.csv'
 
 _ENTRY = re.compile(r'^\d+,\S+,(init|pre-check|post-check),(True|False)')
-_INIT = re.compile(r'^\d+,ZincCompile_compile_zinc,\w+,\S+,init,(True|False)')
-_POST = re.compile(r'^\d+,ZincCompile_compile_zinc,\w+,\S+,post-check,(True|False)')
-_PRE = re.compile(r'^\d+,ZincCompile_compile_zinc,\w+,\S+,pre-check,(True|False)')
+_INIT = re.compile(r'^\d+,RscCompile_compile_rsc,\w+,\S+,init,(True|False)')
+_POST = re.compile(r'^\d+,RscCompile_compile_rsc,\w+,\S+,post-check,(True|False)')
+_PRE = re.compile(r'^\d+,RscCompile_compile_rsc,\w+,\S+,pre-check,(True|False)')
 
 
 class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
@@ -39,6 +39,9 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
       self.assertTrue(os.path.exists(output))
       with open(output, 'r') as f:
         self.assertEqual(_HEADER, f.readline())
+        init = False
+        pre = False
+        post = False
         for line in f.readlines():
           self.assertTrue(_ENTRY.match(line))
           if _INIT.match(line):
@@ -64,7 +67,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
       output = os.path.join(workdir, 'reports', report_dirs[0], 'invalidation-report.csv')
       self.assertTrue(os.path.exists(output), msg='Missing report file {}'.format(output))
 
-  INFO_LEVEL_COMPILE_MSG='Compiling 1 zinc source in 1 target (examples/src/java/org/pantsbuild/example/hello/simple:simple).'
+  INFO_LEVEL_COMPILE_MSG='Compiling 1 mixed source in 1 target (examples/src/java/org/pantsbuild/example/hello/simple:simple).'
   DEBUG_LEVEL_COMPILE_MSG='compile(examples/src/java/org/pantsbuild/example/hello/simple:simple) finished with status Successful'
 
   def test_output_level_warn(self):
@@ -117,10 +120,10 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
                'examples/src/java/org/pantsbuild/example/hello::']
     pants_run = self.run_pants(command)
     self.assert_success(pants_run)
-    self.assertIn('Compiling 1 zinc source in 1 target (examples/src/java/org/pantsbuild/example/hello/greet:greet)',
+    self.assertIn('Compiling 1 mixed source in 1 target (examples/src/java/org/pantsbuild/example/hello/greet:greet)',
                   pants_run.stdout_data)
-    # Check zinc's label
-    self.assertIn('[zinc]\n', pants_run.stdout_data)
+    # Check rsc's label
+    self.assertIn('[rsc]\n', pants_run.stdout_data)
 
   def test_suppress_compiler_output(self):
     command = ['compile',
@@ -129,13 +132,13 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
                '--reporting-console-tool-output-format={ "COMPILER" : "CHILD_SUPPRESS"}']
     pants_run = self.run_pants(command)
     self.assert_success(pants_run)
-    self.assertIn('Compiling 1 zinc source in 1 target (examples/src/java/org/pantsbuild/example/hello/greet:greet)',
+    self.assertIn('Compiling 1 mixed source in 1 target (examples/src/java/org/pantsbuild/example/hello/greet:greet)',
                   pants_run.stdout_data)
     for line in pants_run.stdout_data:
-      # zinc's stdout should be suppressed
+      # rsc's stdout should be suppressed
       self.assertNotIn('Compile success at ', line)
-      # zinc's label should be suppressed
-      self.assertNotIn('[zinc]', line)
+      # rsc's label should be suppressed
+      self.assertNotIn('[rsc]', line)
 
   def test_suppress_background_workunits_output(self):
     command = ['compile',
@@ -301,15 +304,15 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
 
       trace = assert_single_element(ZipkinHandler.traces.values())
 
-      zinc_task_span = self.find_spans_by_name_and_service_name(trace, 'zinc', 'pants/task')
-      self.assertEqual(len(zinc_task_span), 1)
-      zinc_task_span_id = zinc_task_span[0]['id']
+      rsc_task_span = self.find_spans_by_name_and_service_name(trace, 'rsc', 'pants/task')
+      self.assertEqual(len(rsc_task_span), 1)
+      rsc_task_span_id = rsc_task_span[0]['id']
 
       compile_workunit_spans = self.find_spans_by_name_and_service_name(
         trace, 'compile', 'pants/workunit'
       )
       self.assertEqual(len(compile_workunit_spans), 3)
-      self.assertTrue(all(span['parentId'] == zinc_task_span_id for span in compile_workunit_spans))
+      self.assertTrue(all(span['parentId'] == rsc_task_span_id for span in compile_workunit_spans))
 
   @staticmethod
   def find_spans_by_name_and_service_name(trace, name, service_name):

--- a/tests/python/pants_test/rules/test_filedeps_integration.py
+++ b/tests/python/pants_test/rules/test_filedeps_integration.py
@@ -19,7 +19,6 @@ class FiledepsIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(args)
     self.assert_success(pants_run)
 
-    self.assertEqual("", pants_run.stderr_data)
     self.assertEqual(pants_run.returncode, 0)
 
     self.assertEqual(pants_run.stdout_data, dedent(

--- a/tests/python/pants_test/tasks/test_changed_target_integration.py
+++ b/tests/python/pants_test/tasks/test_changed_target_integration.py
@@ -75,7 +75,7 @@ class ChangedTargetGoalsIntegrationTest(PantsRunIntegrationTest):
   _PACKAGE_PATH_PREFIX = os.sep + os.path.join('classes', 'org', 'pantsbuild')
 
   def find_classfile(self, workdir, filename):
-    for root, dirs, files in os.walk(os.path.join(workdir, 'compile', 'zinc')):
+    for root, dirs, files in os.walk(os.path.join(workdir, 'compile', 'rsc')):
       for f in files:
         candidate = os.path.join(root, f)
         if candidate.endswith(os.path.join(self._PACKAGE_PATH_PREFIX, filename)):


### PR DESCRIPTION
### Problem

Deprecate ZincCompile task in favor of RscCompile which has a `zinc-only` option identical to what ZincCompile implements.

### Solution

- Deprecate use of ZincCompile
- Set the removal version to 1.20.0.dev0 (at which point, RscCompile can continue to inherit from BaseZincCompile instead of ZincCompile).

### Result

Fixes #7824.