### PR TITLE
Log messages are rendered in the v2 UI

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -629,6 +629,7 @@ dependencies = [
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "ui 0.0.1",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
 
@@ -1333,6 +1334,7 @@ dependencies = [
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ui 0.0.1",
+ "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -100,6 +100,7 @@ tempfile = "3"
 time = "0.1.40"
 ui = { path = "ui" }
 url = "1.7.1"
+uuid = { version = "0.7", features = ["v4"] }
 task_executor = { path = "task_executor" }
 workunit_store = { path = "workunit_store" }
 

--- a/src/rust/engine/logging/Cargo.toml
+++ b/src/rust/engine/logging/Cargo.toml
@@ -13,6 +13,7 @@ num_enum = "0.1.1"
 parking_lot = "0.6"
 simplelog = "0.5.3"
 ui = { path = "../ui" }
+uuid = { version = "0.7", features = ["v4"] }
 
 [build-dependencies]
 cargo = "0.34"

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -301,7 +301,7 @@ impl Scheduler {
     // Keys are positions in the display (display workers) and the values are the actual jobs to print.
     let mut tasks_to_display = IndexMap::new();
 
-    let results = match session.maybe_display() {
+    match session.maybe_display() {
       Some(display) => {
         {
           let mut display = display.lock();
@@ -321,11 +321,11 @@ impl Scheduler {
             );
           }
         };
+        LOGGER.deregister_engine_display(unique_handle);
         {
           let mut display = display.lock();
           display.finish();
         }
-        LOGGER.deregister_engine_display(unique_handle);
         results
       }
       None => loop {
@@ -333,8 +333,7 @@ impl Scheduler {
           break res;
         }
       },
-    };
-    results
+    }
   }
 
   fn display_ongoing_tasks(

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -374,14 +374,12 @@ impl Scheduler {
       let d = display.lock();
       d.worker_count()
     };
+
+    let mut d = display.lock();
     for i in tasks_to_display.len()..worker_count {
-      let mut d = display.lock();
       d.update(i.to_string(), "".to_string());
     }
-    {
-      let mut d = display.lock();
-      d.render();
-    }
+    d.render();
   }
 }
 

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -16,6 +16,7 @@ use crate::nodes::{NodeKey, Select, Tracer, Visualizer};
 use graph::{EntryId, Graph, InvalidationResult, NodeContext};
 use indexmap::IndexMap;
 use log::{debug, info, warn};
+use logging::logger::LOGGER;
 use parking_lot::Mutex;
 use ui::EngineDisplay;
 use workunit_store::WorkUnitStore;
@@ -33,7 +34,7 @@ struct InnerSession {
   // The set of roots that have been requested within this session.
   roots: Mutex<HashSet<Root>>,
   // If enabled, the display that will render the progress of the V2 engine.
-  display: Option<Mutex<EngineDisplay>>,
+  display: Option<Arc<Mutex<EngineDisplay>>>,
   // If enabled, Zipkin spans for v2 engine will be collected.
   should_record_zipkin_spans: bool,
   // A place to store info about workunits in rust part
@@ -53,7 +54,8 @@ impl Session {
     let inner_session = InnerSession {
       preceding_graph_size: scheduler.core.graph.len(),
       roots: Mutex::new(HashSet::new()),
-      display: EngineDisplay::create(ui_worker_count, should_render_ui).map(Mutex::new),
+      display: EngineDisplay::create(ui_worker_count, should_render_ui)
+        .map(|x| Arc::new(Mutex::new(x))),
       should_record_zipkin_spans: should_record_zipkin_spans,
       workunit_store: WorkUnitStore::new(),
     };
@@ -74,8 +76,8 @@ impl Session {
     self.0.preceding_graph_size
   }
 
-  pub fn display(&self) -> &Option<Mutex<EngineDisplay>> {
-    &self.0.display
+  fn maybe_display(&self) -> Option<&Arc<Mutex<EngineDisplay>>> {
+    self.0.display.as_ref()
   }
 
   pub fn should_record_zipkin_spans(&self) -> bool {
@@ -295,64 +297,92 @@ impl Scheduler {
       .map(NodeKey::from)
       .collect();
 
-    // Lock the display for the remainder of the execution, and grab a reference to it.
-    let mut maybe_display = match &session.display() {
-      &Some(ref d) => Some(d.lock()),
-      &None => None,
-    };
-
     // This map keeps the k most relevant jobs in assigned possitions.
     // Keys are positions in the display (display workers) and the values are the actual jobs to print.
     let mut tasks_to_display = IndexMap::new();
 
-    if let Some(ref mut display) = maybe_display {
-      display.start();
-    };
+    let results = match session.maybe_display() {
+      Some(display) => {
+        {
+          let mut display = display.lock();
+          display.start();
+        }
+        let unique_handle = LOGGER.register_engine_display(display.clone());
 
-    let results = loop {
-      if let Ok(res) = receiver.recv_timeout(Duration::from_millis(100)) {
-        break res;
-      } else if let Some(ref mut display) = maybe_display {
-        Scheduler::display_ongoing_tasks(&self.core.graph, &roots, display, &mut tasks_to_display);
+        let results = loop {
+          if let Ok(res) = receiver.recv_timeout(Duration::from_millis(100)) {
+            break res;
+          } else {
+            Scheduler::display_ongoing_tasks(
+              &self.core.graph,
+              &roots,
+              display,
+              &mut tasks_to_display,
+            );
+          }
+        };
+        {
+          let mut display = display.lock();
+          display.finish();
+        }
+        LOGGER.deregister_engine_display(unique_handle);
+        results
       }
+      None => loop {
+        if let Ok(res) = receiver.recv_timeout(Duration::from_millis(100)) {
+          break res;
+        }
+      },
     };
-    if let Some(ref mut display) = maybe_display {
-      display.finish();
-    };
-
     results
   }
 
   fn display_ongoing_tasks(
     graph: &Graph<NodeKey>,
     roots: &[NodeKey],
-    display: &mut EngineDisplay,
+    display: &Mutex<EngineDisplay>,
     tasks_to_display: &mut IndexMap<String, Duration>,
   ) {
     // Update the graph. To do that, we iterate over heavy hitters.
-    let heavy_hitters = graph.heavy_hitters(&roots, display.worker_count());
+
+    let worker_count = {
+      let d = display.lock();
+      d.worker_count()
+    };
+    let heavy_hitters = graph.heavy_hitters(&roots, worker_count);
+
     // Insert every one in the set of tasks to display.
     // For tasks already here, the durations are overwritten.
     tasks_to_display.extend(heavy_hitters.clone().into_iter());
+
     // And remove the tasks that no longer should be there.
     for (task, _) in tasks_to_display.clone().into_iter() {
       if !heavy_hitters.contains_key(&task) {
         tasks_to_display.swap_remove(&task);
       }
     }
-    let display_worker_count = display.worker_count();
-    let ongoing_tasks = tasks_to_display;
-    for (i, id) in ongoing_tasks.iter().enumerate() {
+
+    for (i, id) in tasks_to_display.iter().enumerate() {
       // TODO Maybe we want to print something else besides the ID here.
-      display.update(i.to_string(), format!("{:?}", id));
+      let mut d = display.lock();
+      d.update(i.to_string(), format!("{:?}", id));
     }
+
     // If the number of ongoing tasks is less than the number of workers,
     // fill the rest of the workers with empty string.
     // TODO(yic): further improve the UI. https://github.com/pantsbuild/pants/issues/6666
-    for i in ongoing_tasks.len()..display_worker_count {
-      display.update(i.to_string(), "".to_string());
+    let worker_count = {
+      let d = display.lock();
+      d.worker_count()
+    };
+    for i in tasks_to_display.len()..worker_count {
+      let mut d = display.lock();
+      d.update(i.to_string(), "".to_string());
     }
-    display.render();
+    {
+      let mut d = display.lock();
+      d.render();
+    }
   }
 }
 


### PR DESCRIPTION
### Problem
Addresses  [V2 UI] Pipe Rust `Logger` to the V2 UI #7906 

### Solution

As per the discussion on that issue, adds to the `LOGGER` singleton handles to `EngineDisplay` instances so that when a global log happens the log methods on `EngineDisplay` can also be called 