### PR TITLE
Add support for speculation as a viable command runner.

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -841,6 +841,8 @@ class Native(Singleton):
         execution_options.process_execution_local_parallelism,
         execution_options.process_execution_remote_parallelism,
         execution_options.process_execution_cleanup_local_dirs,
+        execution_options.process_execution_speculation_timeout_ms,
+        self.context.utf8_buf(execution_options.process_execution_speculation),
       )
     return self.gc(scheduler, self.lib.scheduler_destroy)
 

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -841,8 +841,9 @@ class Native(Singleton):
         execution_options.process_execution_local_parallelism,
         execution_options.process_execution_remote_parallelism,
         execution_options.process_execution_cleanup_local_dirs,
-        execution_options.process_execution_speculation_timeout_ms,
-        self.context.utf8_buf(execution_options.process_execution_speculation),
+        execution_options.process_execution_speculation_delay,
+
+        self.context.utf8_buf(execution_options.process_execution_speculation_strategy),
       )
     return self.gc(scheduler, self.lib.scheduler_destroy)
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -415,6 +415,18 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--process-execution-cleanup-local-dirs', type=bool, default=True, advanced=True,
              help='Whether or not to cleanup directories used for local process execution '
                   '(primarily useful for e.g. debugging).')
+    register('--process-execution-speculation-timeout-ms', type=int, default=100, advanced=True,
+             help='Number of milliseconds to wait before speculating a second request for a slow process. '
+                  ' see `--process-execution-speculation`')
+    register('--process-execution-speculation', choices=['remote_first', 'local_first', 'none'], default='local_first',
+             help="Speculate a second request for an underlying process if the first one does not complete within "
+                  '`--speculation-timeout-ms` milliseconds.\n'
+                  '`local_first` (default): Try to run the process locally first, '
+                  'and fall back to remote execution if available.\n'
+                  '`remote_first`: Run the process on the remote execution backend if available, '
+                  'and fall back to the local host if remote calls take longer than the speculation timeout.\n'
+                  '`none`: Do not speculate about long running processes.',
+             advanced=True)
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -36,8 +36,8 @@ class ExecutionOptions(datatype([
   'process_execution_local_parallelism',
   'process_execution_remote_parallelism',
   'process_execution_cleanup_local_dirs',
-  'process_execution_speculation_timeout_ms',
-  'process_execution_speculation',
+  'process_execution_speculation_delay',
+  'process_execution_speculation_strategy',
   'remote_execution_process_cache_namespace',
   'remote_instance_name',
   'remote_ca_certs_path',
@@ -63,8 +63,8 @@ class ExecutionOptions(datatype([
       process_execution_local_parallelism=bootstrap_options.process_execution_local_parallelism,
       process_execution_remote_parallelism=bootstrap_options.process_execution_remote_parallelism,
       process_execution_cleanup_local_dirs=bootstrap_options.process_execution_cleanup_local_dirs,
-      process_execution_speculation_timeout_ms=bootstrap_options.process_execution_speculation_timeout_ms,
-      process_execution_speculation=bootstrap_options.process_execution_speculation,
+      process_execution_speculation_delay=bootstrap_options.process_execution_speculation_delay,
+      process_execution_speculation_strategy=bootstrap_options.process_execution_speculation_strategy,
       remote_execution_process_cache_namespace=bootstrap_options.remote_execution_process_cache_namespace,
       remote_instance_name=bootstrap_options.remote_instance_name,
       remote_ca_certs_path=bootstrap_options.remote_ca_certs_path,
@@ -84,8 +84,8 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     process_execution_local_parallelism=multiprocessing.cpu_count()*2,
     process_execution_remote_parallelism=128,
     process_execution_cleanup_local_dirs=True,
-    process_execution_speculation_timeout_ms=100,
-    process_execution_speculation='local_first',
+    process_execution_speculation_delay=.1,
+    process_execution_speculation_strategy='local_first',
     remote_execution_process_cache_namespace=None,
     remote_instance_name=None,
     remote_ca_certs_path=None,
@@ -421,14 +421,14 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--process-execution-cleanup-local-dirs', type=bool, default=True, advanced=True,
              help='Whether or not to cleanup directories used for local process execution '
                   '(primarily useful for e.g. debugging).')
-    register('--process-execution-speculation-timeout-ms', type=int,
-             default=DEFAULT_EXECUTION_OPTIONS.process_execution_speculation_timeout_ms, advanced=True,
-             help='Number of milliseconds to wait before speculating a second request for a slow process. '
-                  ' see `--process-execution-speculation`')
-    register('--process-execution-speculation', choices=['remote_first', 'local_first', 'none'],
-             default=DEFAULT_EXECUTION_OPTIONS.process_execution_speculation,
+    register('--process-execution-speculation-delay', type=float,
+             default=DEFAULT_EXECUTION_OPTIONS.process_execution_speculation_delay, advanced=True,
+             help='Number of seconds to wait before speculating a second request for a slow process. '
+                  ' see `--process-execution-speculation-strategy`')
+    register('--process-execution-speculation-strategy', choices=['remote_first', 'local_first', 'none'],
+             default=DEFAULT_EXECUTION_OPTIONS.process_execution_speculation_strategy,
              help="Speculate a second request for an underlying process if the first one does not complete within "
-                  '`--speculation-timeout-ms` milliseconds.\n'
+                  '`--process-execution-speculation-delay` seconds.\n'
                   '`local_first` (default): Try to run the process locally first, '
                   'and fall back to remote execution if available.\n'
                   '`remote_first`: Run the process on the remote execution backend if available, '

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -36,6 +36,8 @@ class ExecutionOptions(datatype([
   'process_execution_local_parallelism',
   'process_execution_remote_parallelism',
   'process_execution_cleanup_local_dirs',
+  'process_execution_speculation_timeout_ms',
+  'process_execution_speculation',
   'remote_execution_process_cache_namespace',
   'remote_instance_name',
   'remote_ca_certs_path',
@@ -61,6 +63,8 @@ class ExecutionOptions(datatype([
       process_execution_local_parallelism=bootstrap_options.process_execution_local_parallelism,
       process_execution_remote_parallelism=bootstrap_options.process_execution_remote_parallelism,
       process_execution_cleanup_local_dirs=bootstrap_options.process_execution_cleanup_local_dirs,
+      process_execution_speculation_timeout_ms=bootstrap_options.process_execution_speculation_timeout_ms,
+      process_execution_speculation=bootstrap_options.process_execution_speculation,
       remote_execution_process_cache_namespace=bootstrap_options.remote_execution_process_cache_namespace,
       remote_instance_name=bootstrap_options.remote_instance_name,
       remote_ca_certs_path=bootstrap_options.remote_ca_certs_path,
@@ -80,6 +84,8 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     process_execution_local_parallelism=multiprocessing.cpu_count()*2,
     process_execution_remote_parallelism=128,
     process_execution_cleanup_local_dirs=True,
+    process_execution_speculation_timeout_ms=100,
+    process_execution_speculation='local_first',
     remote_execution_process_cache_namespace=None,
     remote_instance_name=None,
     remote_ca_certs_path=None,
@@ -415,10 +421,12 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--process-execution-cleanup-local-dirs', type=bool, default=True, advanced=True,
              help='Whether or not to cleanup directories used for local process execution '
                   '(primarily useful for e.g. debugging).')
-    register('--process-execution-speculation-timeout-ms', type=int, default=100, advanced=True,
+    register('--process-execution-speculation-timeout-ms', type=int,
+             default=DEFAULT_EXECUTION_OPTIONS.process_execution_speculation_timeout_ms, advanced=True,
              help='Number of milliseconds to wait before speculating a second request for a slow process. '
                   ' see `--process-execution-speculation`')
-    register('--process-execution-speculation', choices=['remote_first', 'local_first', 'none'], default='local_first',
+    register('--process-execution-speculation', choices=['remote_first', 'local_first', 'none'],
+             default=DEFAULT_EXECUTION_OPTIONS.process_execution_speculation,
              help="Speculate a second request for an underlying process if the first one does not complete within "
                   '`--speculation-timeout-ms` milliseconds.\n'
                   '`local_first` (default): Try to run the process locally first, '

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -202,8 +202,8 @@ pub extern "C" fn scheduler_create(
   process_execution_local_parallelism: u64,
   process_execution_remote_parallelism: u64,
   process_execution_cleanup_local_dirs: bool,
-  process_execution_speculation_timeout_ms: u64,
-  process_execution_speculation_mode_buf: Buffer,
+  process_execution_speculation_delay: f64,
+  process_execution_speculation_strategy_buf: Buffer,
 ) -> *const Scheduler {
   let root_type_ids = root_type_ids.to_vec();
   let ignore_patterns = ignore_patterns_buf
@@ -277,9 +277,9 @@ pub extern "C" fn scheduler_create(
     }
   };
 
-  let process_execution_speculation = process_execution_speculation_mode_buf
+  let process_execution_speculation_strategy = process_execution_speculation_strategy_buf
     .to_string()
-    .expect("process_execution_speculation was not valid UTF8");
+    .expect("process_execution_speculation_strategy was not valid UTF8");
 
   Box::into_raw(Box::new(Scheduler::new(Core::new(
     root_type_ids.clone(),
@@ -316,8 +316,10 @@ pub extern "C" fn scheduler_create(
     process_execution_local_parallelism as usize,
     process_execution_remote_parallelism as usize,
     process_execution_cleanup_local_dirs,
-    Duration::from_millis(process_execution_speculation_timeout_ms),
-    process_execution_speculation,
+    // convert delay from float to millisecond resolution. use from_secs_f64 when it is
+    // off nightly. https://github.com/rust-lang/rust/issues/54361
+    Duration::from_millis((process_execution_speculation_delay * 1000.0).round() as u64),
+    process_execution_speculation_strategy,
   ))))
 }
 

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -202,6 +202,8 @@ pub extern "C" fn scheduler_create(
   process_execution_local_parallelism: u64,
   process_execution_remote_parallelism: u64,
   process_execution_cleanup_local_dirs: bool,
+  process_execution_speculation_timeout_ms: u64,
+  process_execution_speculation_mode_buf: Buffer,
 ) -> *const Scheduler {
   let root_type_ids = root_type_ids.to_vec();
   let ignore_patterns = ignore_patterns_buf
@@ -275,6 +277,10 @@ pub extern "C" fn scheduler_create(
     }
   };
 
+  let process_execution_speculation = process_execution_speculation_mode_buf
+    .to_string()
+    .expect("process_execution_speculation was not valid UTF8");
+
   Box::into_raw(Box::new(Scheduler::new(Core::new(
     root_type_ids.clone(),
     tasks,
@@ -310,6 +316,8 @@ pub extern "C" fn scheduler_create(
     process_execution_local_parallelism as usize,
     process_execution_remote_parallelism as usize,
     process_execution_cleanup_local_dirs,
+    Duration::from_millis(process_execution_speculation_timeout_ms),
+    process_execution_speculation,
   ))))
 }
 

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -73,8 +73,8 @@ impl Core {
     process_execution_local_parallelism: usize,
     process_execution_remote_parallelism: usize,
     process_execution_cleanup_local_dirs: bool,
-    process_execution_speculation_timeout: Duration,
-    process_execution_speculation: String,
+    process_execution_speculation_delay: Duration,
+    process_execution_speculation_strategy: String,
   ) -> Core {
     // Randomize CAS address order to avoid thundering herds from common config.
     let mut remote_store_servers = remote_store_servers;
@@ -155,20 +155,19 @@ impl Core {
         )),
         process_execution_remote_parallelism,
       ));
-      command_runner = match process_execution_speculation.as_ref() {
+      command_runner = match process_execution_speculation_strategy.as_ref() {
         "local_first" => Box::new(SpeculatingCommandRunner::new(
           command_runner,
           remote_command_runner,
-          process_execution_speculation_timeout,
+          process_execution_speculation_delay,
         )),
         "remote_first" => Box::new(SpeculatingCommandRunner::new(
           remote_command_runner,
           command_runner,
-          process_execution_speculation_timeout,
+          process_execution_speculation_delay,
         )),
         "none" => remote_command_runner,
-        // not possible to get this branch, but when matching a reference we need a catch all.
-        _ => command_runner,
+        _ => unreachable!(),
       };
     }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -26,7 +26,7 @@ use fs::{
   PathGlobs, PathStat, StrictGlobMatching, VFS,
 };
 use hashing;
-use process_execution::{self, CommandRunner};
+use process_execution;
 use rule_graph;
 
 use graph::{Entry, Node, NodeError, NodeTracer, NodeVisualizer};


### PR DESCRIPTION
### Problem

This is a follow up to #7992 to add CLI flags for controlling usage of speculation.

### Solution

Add two new advanced cli flags under the process_execution scope: 
* `process_execution_speculation_timeout_ms` takes a timeout after which we would speculate (if enabled).
* `process_execution_speculation` is a tri-state flag, which selects the type of speculation, or disables it. This maintains the possibility of remote only execution without any speculation.

Both flags have defaults but will only have any effect if the `remote_execution` switch is flipped on.

### Result

Users have control of the speculation mode and timeout parameter.