### PR TITLE
Add provides clauses for the new zinc deps from #7506.

### DIFF
--- a/src/scala/org/pantsbuild/zinc/compiler/native-image-substitutions/BUILD
+++ b/src/scala/org/pantsbuild/zinc/compiler/native-image-substitutions/BUILD
@@ -2,6 +2,21 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 # Substitutions for classes with static methods, which aren't available in Scala.
-java_library(name='statics')
+java_library(
+  name='statics',
+  provides=artifact(
+    org='org.pantsbuild',
+    name='zinc-compiler-native-image-substitutions',
+    repo=public,
+    publication_metadata=pants_library('Native-image substitutions for Zinc.')
+  ),
+)
 
-scala_library()
+scala_library(
+  provides=scala_artifact(
+    org='org.pantsbuild',
+    name='zinc-compiler-native-image-substitutions-scala',
+    repo=public,
+    publication_metadata=pants_library('Native-image substitutions for Zinc.')
+  ),
+)


### PR DESCRIPTION
In order to publish zinc, its dependencies must name their artifacts via provides clauses.