### PR TITLE
Replace scandir dependency with stdlib version

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -25,7 +25,6 @@ PyYAML==5.1
 py_zipkin==0.18.3
 requests[security]>=2.20.1
 responses==0.10.4
-scandir==1.2
 setproctitle==1.1.10
 setuptools==40.6.3
 wheel==0.31.1

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -17,7 +17,6 @@ python_library(
   sources = ['file_system_project_tree.py', 'project_tree.py', 'project_tree_factory.py'],
   dependencies = [
     '3rdparty/python:pathspec',
-    '3rdparty/python:scandir',
     ':build_environment',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',

--- a/src/python/pants/base/file_system_project_tree.py
+++ b/src/python/pants/base/file_system_project_tree.py
@@ -8,14 +8,6 @@ from pants.base.project_tree import Dir, File, Link, ProjectTree
 from pants.util.dirutil import fast_relpath, safe_walk
 
 
-# Use the built-in version of scandir/walk if possible, otherwise
-# use the scandir module version
-try:
-  from os import scandir
-except ImportError:
-  from scandir import scandir
-
-
 class FileSystemProjectTree(ProjectTree):
   def _join(self, relpath):
     if relpath.startswith(os.sep):
@@ -33,7 +25,7 @@ class FileSystemProjectTree(ProjectTree):
       raise ValueError('scandir for non-canonical path "{}" not supported in {}.'.format(
         relpath, self))
 
-    for entry in scandir(abspath):
+    for entry in os.scandir(abspath):
       # NB: We don't use `DirEntry.stat`, as the scandir docs indicate that that always requires
       # an additional syscall on Unixes.
       entry_path = os.path.normpath(os.path.join(relpath, entry.name))


### PR DESCRIPTION
The backport wasn't being used and caused an unnecessary sdist to be installed.