### PR TITLE
Extend Google RBE Docker image to allow building sdist wheels

### DIFF
--- a/build-support/docker/remote_execution/Dockerfile
+++ b/build-support/docker/remote_execution/Dockerfile
@@ -1,0 +1,7 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+FROM gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:da0f21c71abce3bbb92c3a0c44c3737f007a82b60f8bd2930abc55fe64fc2729
+
+RUN apt-get update
+RUN apt-get install -y build-essential

--- a/build-support/docker/remote_execution/Dockerfile
+++ b/build-support/docker/remote_execution/Dockerfile
@@ -4,4 +4,30 @@
 FROM gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:da0f21c71abce3bbb92c3a0c44c3737f007a82b60f8bd2930abc55fe64fc2729
 
 RUN apt-get update
-RUN apt-get install -y build-essential
+RUN apt-get install -y \
+  build-essential \
+  zlib1g-dev \
+  libbz2-dev \
+  libreadline-dev \
+  libssl-dev \
+  libsqlite3-dev \
+  libffi-dev \
+  python-openssl
+
+# Even though the image already comes installed with Python 2.7, 3.5, and 3.6, we install our own
+# via Pyenv because we need Python 3.7 and want consistency in how we install them.
+ARG PYTHON_27_VERSION=2.7.15
+ARG PYTHON_36_VERSION=3.6.8
+ARG PYTHON_37_VERSION=3.7.3
+
+ENV PYENV_ROOT /pyenv-docker-build
+ENV PYENV_BIN "${PYENV_ROOT}/bin/pyenv"
+RUN git clone https://github.com/pyenv/pyenv ${PYENV_ROOT}
+
+RUN ${PYENV_BIN} install ${PYTHON_27_VERSION}
+RUN ${PYENV_BIN} install ${PYTHON_36_VERSION}
+RUN ${PYENV_BIN} install ${PYTHON_37_VERSION}
+
+ENV PATH "${PYENV_ROOT}/versions/${PYTHON_27_VERSION}/bin:${PATH}"
+ENV PATH "${PYENV_ROOT}/versions/${PYTHON_36_VERSION}/bin:${PATH}"
+ENV PATH "${PYENV_ROOT}/versions/${PYTHON_37_VERSION}/bin:${PATH}"


### PR DESCRIPTION
Google's Ubuntu image does not have the dependencies necessary to install `psutil`, `scandir`, `pyopenssl`, `setproctitle`, and `python-Levenshtein`, as documented in https://github.com/pantsbuild/pants/issues/8057.

Turns out, all that's necessary to fix this is installing `build-essential`. The fix was confirmed locally by building this image then running `docker run -t remote_execution sh -c 'pip3 install pex; pex setproctitle scandir psutil python-Levenshtein'`.

Will close https://github.com/pantsbuild/pants/issues/8057.