### PR TITLE
Remove tests from V2 unit test blacklist that were already passing

### DIFF
--- a/build-support/unit_test_v2_blacklist.txt
+++ b/build-support/unit_test_v2_blacklist.txt
@@ -1,9 +1,1 @@
-tests/python/pants_test/backend/codegen/antlr/java:java
-tests/python/pants_test/backend/graph_info/tasks:list_targets
-tests/python/pants_test/backend/jvm/tasks:consolidate_classpath
-tests/python/pants_test/backend/jvm/tasks:coursier_resolve
-tests/python/pants_test/backend/jvm/tasks:scalafmt
-tests/python/pants_test/backend/jvm/tasks:scalastyle
 tests/python/pants_test/backend/python/tasks:pytest_run
-tests/python/pants_test/cache:artifact_cache
-tests/python/pants_test/pantsd:pailgun_server


### PR DESCRIPTION
Several of the tests work now without any changes, very likely thanks to https://github.com/pantsbuild/pants/pull/7866. These not only pass with V2, but also pass with remote execution.