### PR TITLE
Bump virtualenv to 16.6.2 for local run script

### DIFF
--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -3,7 +3,7 @@
 
 set -e
 
-VIRTUALENV_VERSION=15.2.0
+VIRTUALENV_VERSION=16.6.2
 VIRTUALENV_PACKAGE_LOCATION=${VIRTUALENV_PACKAGE_LOCATION:-https://pypi.io/packages/source/v/virtualenv}
 
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel)


### PR DESCRIPTION
Recently, when running Pants, the below was always printed to stderr.

```
/Users/eric/DocsLocal/code/projects/pants/build-support/pants_dev_deps.py36.venv/lib/python3.6/distutils/__init__.py:4: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
```

This was fixed in virtualenv in [16.3.0](https://virtualenv.pypa.io/en/latest/changes/#id27) and [16.4.0](https://virtualenv.pypa.io/en/latest/changes/#id20)

(Note that you must `rm -rf build-support/pants_dev_deps.py{36,37}.venv` for this change to be picked up locally.)