### PR TITLE
Use our docker image from #8059 for remote execution

### DIFF
--- a/build-support/docker/remote_execution/Dockerfile
+++ b/build-support/docker/remote_execution/Dockerfile
@@ -1,6 +1,17 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+# To deploy changes to this image, you will need to be logged in the gcloud CLI locally and
+# follow this guide https://cloud.google.com/container-registry/docs/quickstart, which boils down to:
+#
+#   1. Install Docker and the gcloud CLI.
+#   2. $ gcloud auth configure-docker
+#   3. Ensure you have permissions to upload to Google Container Registry for pants-remoting-beta.
+#   4. $ docker build --tag rbe-remote-execution build-support/docker/remote_execution
+#   5. $ docker tag rbe-remote-execution gcr.io/pants-remoting-beta/rbe-remote-execution
+#   6. $ docker push gcr.io/pants-remoting-beta/rbe-remote-execution
+#   7. Update `pants.remote.ini` to use the new SHA printed to the console.
+
 FROM gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:da0f21c71abce3bbb92c3a0c44c3737f007a82b60f8bd2930abc55fe64fc2729
 
 RUN apt-get update

--- a/pants.remote.ini
+++ b/pants.remote.ini
@@ -20,18 +20,15 @@ remote_instance_name: projects/pants-remoting-beta/instances/default_instance
 remote_execution_extra_platform_properties: [
     # This allows network requests, e.g. to resolve dependencies with Pex.
     "dockerNetwork=standard",
-    "container-image=docker://marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:da0f21c71abce3bbb92c3a0c44c3737f007a82b60f8bd2930abc55fe64fc2729",
+    "container-image=docker://gcr.io/pants-remoting-beta/rbe-remote-execution@sha256:20046a8b909cbbd94f3ff33808ceeeaa489a05eea5d00ad57c378f81f21462fc",
   ]
 
 
 [python-setup]
 interpreter_search_paths: [
-     '<PEXRC>',
-     '<PATH>'
-     # TODO(#7735): We need to add this entry for remoting to be able to discover a valid
-     # interpreter, because <PATH> will refer to the host PATH and not the remote value. This value
-     # was found by inspecting the docker image for remoting.
-     "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/python3.6/bin:/usr/local/go/bin",
+     # This is the $PATH of the docker container, obtained by locally running `$ docker run --tag
+     # rbe-remote-execution sh -c 'echo $PATH'`.
+     "/pyenv-docker-build/versions/3.7.3/bin:/pyenv-docker-build/versions/3.6.8/bin:/pyenv-docker-build/versions/2.7.15/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin",
   ]
 
 


### PR DESCRIPTION
This actually fixes https://github.com/pantsbuild/pants/issues/8057 by using the image created in https://github.com/pantsbuild/pants/pull/8059.