### PR TITLE
Use platform-specific directories for virtualenvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ out/
 # remove root-level /bin, which is created by Eclipse
 /bin/
 /build-support/*.pex
-/build-support/*.venv
+/build-support/virtualenvs
 /build-support/virtualenv-*
 /build-support/virtualenv.dist/
 /build-support/phab/

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,7 @@ matrix:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
-      - build-support/pants_dev_deps.py36.venv
-      - build-support/pants_dev_deps.py37.venv
+      - build-support/virtualenvs
       - src/rust/engine/target
       timeout: 500
     dist: xenial
@@ -115,8 +114,7 @@ matrix:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
-      - build-support/pants_dev_deps.py36.venv
-      - build-support/pants_dev_deps.py37.venv
+      - build-support/virtualenvs
       - src/rust/engine/target
       timeout: 500
     dist: xenial
@@ -166,8 +164,7 @@ matrix:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
-      - build-support/pants_dev_deps.py36.venv
-      - build-support/pants_dev_deps.py37.venv
+      - build-support/virtualenvs
       - src/rust/engine/target
       timeout: 500
     env:
@@ -212,8 +209,7 @@ matrix:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
-      - build-support/pants_dev_deps.py36.venv
-      - build-support/pants_dev_deps.py37.venv
+      - build-support/virtualenvs
       - src/rust/engine/target
       timeout: 500
     env:
@@ -261,8 +257,7 @@ matrix:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
-      - build-support/pants_dev_deps.py36.venv
-      - build-support/pants_dev_deps.py37.venv
+      - build-support/virtualenvs
       - src/rust/engine/target
       timeout: 500
     dist: xenial
@@ -313,8 +308,7 @@ matrix:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
-      - build-support/pants_dev_deps.py36.venv
-      - build-support/pants_dev_deps.py37.venv
+      - build-support/virtualenvs
       - src/rust/engine/target
       timeout: 500
     env:
@@ -530,8 +524,7 @@ matrix:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
-      - build-support/pants_dev_deps.py36.venv
-      - build-support/pants_dev_deps.py37.venv
+      - build-support/virtualenvs
       - src/rust/engine/target
       timeout: 500
     dist: xenial
@@ -4207,8 +4200,7 @@ matrix:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
-      - build-support/pants_dev_deps.py36.venv
-      - build-support/pants_dev_deps.py37.venv
+      - build-support/virtualenvs
       - src/rust/engine/target
       timeout: 500
     dist: xenial
@@ -4244,8 +4236,7 @@ matrix:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
-      - build-support/pants_dev_deps.py36.venv
-      - build-support/pants_dev_deps.py37.venv
+      - build-support/virtualenvs
       - src/rust/engine/target
       timeout: 500
     env:

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -172,8 +172,7 @@ CACHE_NATIVE_ENGINE = {
     "timeout": _cache_timeout,
     "directories": _cache_common_directories + [
       '${HOME}/.cache/pants/rust/cargo',
-      'build-support/pants_dev_deps.py36.venv',
-      'build-support/pants_dev_deps.py37.venv',
+      'build-support/virtualenvs',
       'src/rust/engine/target',
     ]
   }

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -14,7 +14,7 @@ REQUIREMENTS=(
   "${REPO_ROOT}/contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty/requirements.txt"
 )
 
-venv_dir_prefix="${REPO_ROOT}/build-support/pants_dev_deps"
+venv_dir_prefix="${REPO_ROOT}/build-support/virtualenvs/$(uname)/pants_dev_deps"
 
 function venv_dir() {
   py_venv_version=$(${PY} -c 'import sys; print("".join(map(str, sys.version_info[0:2])))')

--- a/build-support/python/clean.sh
+++ b/build-support/python/clean.sh
@@ -2,8 +2,11 @@
 
 PANTS_BASE=$(dirname "$0")/../..
 rm -rf "${HOME}/.pex"
+rm -rf "${PANTS_BASE}/build-support/virtualenvs"
+rm -rf "${PANTS_BASE}/.pants.d"
+find "${PANTS_BASE}" -name '*.pyc' -print0 | xargs -0 rm -f
+
+# Legacy:
 rm -rf "${PANTS_BASE}/build-support/pants_dev_deps.venv"
 rm -rf "${PANTS_BASE}/build-support/pants_dev_deps.py{2,3}.venv"
 rm -rf "${PANTS_BASE}/build-support/pants_dev_deps.py{2,3}?.venv"
-rm -rf "${PANTS_BASE}/.pants.d"
-find "${PANTS_BASE}" -name '*.pyc' -print0 | xargs -0 rm -f

--- a/pants.ini
+++ b/pants.ini
@@ -76,7 +76,7 @@ pantsd_invalidation_globs: +[
 # Path patterns to ignore for filesystem operations on top of the builtin patterns.
 pants_ignore: +[
     # venv directories under build-support.
-    '/build-support/*.venv/',
+    '/build-support/virtualenvs/',
 
     # An absolute symlink to the Pants Rust toolchain sources.
     '/build-support/bin/native/src',

--- a/src/docs/intellij.md
+++ b/src/docs/intellij.md
@@ -45,7 +45,7 @@ SDK".
 
 This will be a "local" interpreter and you'll need to select the virtual
 environment bootstrapped above, along with choosing the Python version
-you want IntelliJ to use. For Python 3.6, in `build-support/pants_dev_deps.py36.venv`; and for Python 3.7, in `pants_dev_deps.py37.venv`.
+you want IntelliJ to use. For Python 3.6, in `build-support/virtualenvs/$(uname)/pants_dev_deps.py36.venv`; and for Python 3.7, in `pants_dev_deps.py37.venv`.
 
 ![image](images/intellij-select-venv.png)
 


### PR DESCRIPTION
This makes it easier to use docker on OSX in-place without having to
delete directories when switching between OSs.