### PR TITLE
Disable symlink checking for uncached Snapshot captures

### DIFF
--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -459,7 +459,8 @@ impl Snapshot {
   /// Note that we don't use a Graph here, and don't cache any intermediate steps, we just place
   /// the resultant Snapshot into the store and return it. This is important, because we're reading
   /// things from arbitrary filepaths which we don't want to cache in the graph, as we don't watch
-  /// them for changes.
+  /// them for changes. Because we're not caching things, we can safely configure the virtual
+  /// filesystem to be symlink-oblivious.
   ///
   /// If the `digest_hint` is given, first attempt to load the Snapshot using that Digest, and only
   /// fall back to actually walking the filesystem if we don't have it (either due to garbage
@@ -478,7 +479,12 @@ impl Snapshot {
     future::result(digest_hint.ok_or_else(|| "No digest hint provided.".to_string()))
       .and_then(move |digest| Snapshot::from_digest(store, digest))
       .or_else(|_| {
-        let posix_fs = Arc::new(try_future!(PosixFS::new(root_path, &[], executor)));
+        let posix_fs = Arc::new(try_future!(PosixFS::new_symlink_aware(
+          root_path,
+          &[],
+          executor,
+          false
+        )));
 
         posix_fs
           .expand(path_globs)

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -488,7 +488,7 @@ impl Snapshot {
 
         posix_fs
           .expand(path_globs)
-          .map_err(|err| format!("Error expanding globs: {:?}", err))
+          .map_err(|err| format!("Error expanding globs: {}", err))
           .and_then(|path_stats| {
             Snapshot::from_path_stats(
               store2.clone(),

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -4,7 +4,7 @@
 use crate::Store;
 use bazel_protos;
 use boxfuture::{try_future, BoxFuture, Boxable};
-use fs::{Dir, File, GlobMatching, PathGlobs, PathStat, PosixFS};
+use fs::{Dir, File, GlobMatching, PathGlobs, PathStat, PosixFS, SymlinkBehavior};
 use futures::future::{self, join_all};
 use futures::Future;
 use hashing::{Digest, EMPTY_DIGEST};
@@ -479,11 +479,11 @@ impl Snapshot {
     future::result(digest_hint.ok_or_else(|| "No digest hint provided.".to_string()))
       .and_then(move |digest| Snapshot::from_digest(store, digest))
       .or_else(|_| {
-        let posix_fs = Arc::new(try_future!(PosixFS::new_symlink_aware(
+        let posix_fs = Arc::new(try_future!(PosixFS::new_with_symlink_behavior(
           root_path,
           &[],
           executor,
-          false
+          SymlinkBehavior::Oblivious
         )));
 
         posix_fs

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -443,13 +443,12 @@ impl WrappedNode for ReadLink {
   type Item = LinkDest;
 
   fn run(self, context: Context) -> NodeFuture<LinkDest> {
-    let link = self.0.clone();
     context
       .core
       .vfs
       .read_link(&self.0)
       .map(LinkDest)
-      .map_err(move |e| throw(&format!("Failed to read_link for {:?}: {:?}", link, e)))
+      .map_err(|e| throw(&format!("{}", e)))
       .to_boxed()
   }
 }
@@ -470,12 +469,11 @@ impl WrappedNode for DigestFile {
   type Item = hashing::Digest;
 
   fn run(self, context: Context) -> NodeFuture<hashing::Digest> {
-    let file = self.0.clone();
     context
       .core
       .vfs
       .read_file(&self.0)
-      .map_err(move |e| throw(&format!("Error reading file {:?}: {:?}", file, e,)))
+      .map_err(|e| throw(&format!("{}", e)))
       .and_then(move |c| {
         context
           .core
@@ -504,15 +502,12 @@ impl WrappedNode for Scandir {
   type Item = Arc<DirectoryListing>;
 
   fn run(self, context: Context) -> NodeFuture<Arc<DirectoryListing>> {
-    let dir = self.0.clone();
     context
       .core
       .vfs
       .scandir(self.0)
-      .then(move |listing_res| match listing_res {
-        Ok(listing) => Ok(Arc::new(listing)),
-        Err(e) => Err(throw(&format!("Failed to scandir for {:?}: {:?}", dir, e))),
-      })
+      .map(Arc::new)
+      .map_err(|e| throw(&format!("{}", e)))
       .to_boxed()
   }
 }

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -475,7 +475,7 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
-  timeout = 180,
+  timeout = 240,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_dep_exports_integration.py
@@ -19,16 +19,6 @@ class DepExportsIntegrationTest(PantsRunIntegrationTest):
   def hermetic(cls):
     return True
 
-  def test_compilation(self):
-    for lang in self.SRC_TYPES:
-      path = os.path.join(self.SRC_PREFIX, lang, self.SRC_PACKAGE)
-      pants_run = self.run_pants(['list', '{}::'.format(path)])
-      self.assert_success(pants_run)
-      target_list = pants_run.stdout_data.strip().split('\n')
-      for target in target_list:
-        pants_run = self.run_pants(['compile', '--lint-scalafmt-skip', target])
-        self.assert_success(pants_run)
-
   def modify_exports_and_compile(self, target, modify_file):
     with self.temporary_sourcedir() as tmp_src:
       src_dir = os.path.relpath(os.path.join(tmp_src, os.path.basename(self.SRC_PACKAGE)), get_buildroot())


### PR DESCRIPTION
### Problem

As described in #7963: when we capture Snapshots synchronously via `Scheduler.capture_snapshots`, we do it without the benefit of caching or invalidation. But we still end up using a symlink-aware codepath, meaning that the restrictions we place on absolute and escaping symlinks are unnecessary. More generally, _all_ awareness of symlinks is unnecessary in that case, as the only reason we track them is to enable correct invalidation of caches.

### Solution

Add a `symlink_aware: bool` flag to `PosixFS`, and use it to prevent a consumer from observing the existence of a symlink via `scandir`. Use the flag while capturing `Snapshots` synchronously in `Scheduler.capture_snapshots`.

Additionally, make `Metadata` capture lazy in `scandir`, to avoid actually computing it for directories and links.

### Result

Fixes #7963 and unblocks #8071.