### PR TITLE
Use pants as the user-agent instead of the default (python-requests).

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -12,6 +12,7 @@ import time
 import uuid
 from collections import OrderedDict
 from contextlib import contextmanager
+from typing import Dict
 
 import requests
 
@@ -29,6 +30,7 @@ from pants.reporting.json_reporter import JsonReporter
 from pants.reporting.report import Report
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import relative_symlink, safe_file_dump
+from pants.version import VERSION
 
 
 class RunTrackerOptionEncoder(CoercingOptionEncoder):
@@ -354,6 +356,10 @@ class RunTracker(Subsystem):
     self.report.log(self._threadlocal.current_workunit, level, *msg_elements)
 
   @classmethod
+  def _get_headers(cls) -> Dict[str, str]:
+    return {'User-Agent': f"pants/v{VERSION}"}
+
+  @classmethod
   def post_stats(cls, stats_url, stats, timeout=2, auth_provider=None):
     """POST stats to the given url.
 
@@ -369,6 +375,7 @@ class RunTracker(Subsystem):
     # But this will first require changing the upload receiver at every shop that uses this.
     params = {k: cls._json_dump_options(v) for (k, v) in stats.items()}
     cookies = Cookies.global_instance()
+    headers = cls._get_headers()
     auth_provider = auth_provider or '<provider>'
 
     # We can't simply let requests handle redirects, as we only allow them for specific codes:
@@ -381,6 +388,7 @@ class RunTracker(Subsystem):
       if num_redirects_allowed < 0:
         return error('too many redirects.')
       res = requests.post(url, data=params, timeout=timeout,
+                          headers=headers,
                         cookies=cookies.get_cookie_jar(), allow_redirects=False)
       if res.status_code in {307, 308}:
         return do_post(res.headers['location'], num_redirects_allowed - 1)

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -9,6 +9,7 @@ from urllib.parse import parse_qs
 from pants.auth.cookies import Cookies
 from pants.goal.run_tracker import RunTracker
 from pants.util.contextutil import temporary_file_path
+from pants.version import VERSION
 from pants_test.test_base import TestBase
 
 
@@ -31,6 +32,7 @@ class RunTrackerTest(TestBase):
             post_data = parse_qs(handler.rfile.read(length).decode())
             decoded_post_data = {k: json.loads(v[0]) for k, v in post_data.items()}
             self.assertEqual(stats, decoded_post_data)
+            self.assertEqual(handler.headers['User-Agent'], f"pants/v{VERSION}")
             handler.send_response(200)
             handler.end_headers()
         except Exception:


### PR DESCRIPTION
### Problem

When calling the report server, pants leveraging the [python requests](https://2.python-requests.org/) is using the default user agent (for example: `"python-requests/2.22.0"`)
This is not optimal, the user-agent should more actuarially reflect the software making the HTTP call 

### Solution

Use pants as the user-agent, adding the pants version as part of the user-agent header.

### Result

` "Pants/v1.18.0rc0"`
