### PR TITLE
 Rewrite `test_git_hooks.py` to be hermetic

### DIFF
--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -1,6 +1,11 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+files(
+  name = 'bash_scripts',
+  sources = globs('*.sh'),
+)
+
 python_binary(
   name = 'check_banned_imports',
   source = 'check_banned_imports.py',
@@ -8,11 +13,6 @@ python_binary(
     ':common',
   ],
   tags = {'type_checked'},
-)
-
-files(
-  name = 'check_clippy',
-  source = 'check_clippy.sh'
 )
 
 python_binary(
@@ -24,11 +24,6 @@ python_binary(
   tags = {'type_checked'},
 )
 
-files(
-  name = 'check_packages',
-  source = 'check_packages.sh'
-)
-
 python_binary(
   name = 'check_pants_pex_abi',
   source = 'check_pants_pex_abi.py',
@@ -36,21 +31,6 @@ python_binary(
     ':common',
   ],
   tags = {'type_checked'},
-)
-
-files(
-  name = 'check_rust_formatting',
-  source = 'check_rust_formatting.sh'
-)
-
-files(
-  name = 'check_rust_target_headers',
-  source = 'check_rust_target_headers.sh'
-)
-
-files(
-  name = 'check_shell',
-  source = 'check_shell.sh'
 )
 
 python_binary(
@@ -62,20 +42,10 @@ python_binary(
   tags = {'type_checked'},
 )
 
-files(
-  name = 'ci_failure',
-  source = 'ci-failure.sh'
-)
-
 python_library(
   name = 'common',
   source = 'common.py',
   tags = {'type_checked'},
-)
-
-files(
-  name = 'contributors',
-  source = 'contributors.sh'
 )
 
 python_binary(
@@ -86,52 +56,6 @@ python_binary(
   ],
   tags = {'type_checked'},
 )
-
-files(
-  name = 'download_binary',
-  source = 'download_binary.sh'
-)
-
-files(
-  name = 'get_added_files',
-  source = 'get_added_files.sh'
-)
-
-files(
-  name = 'get_ci_bootstrapped_pants_pex',
-  source = 'get_ci_bootstrapped_pants_pex.sh'
-)
-
-files(
-  name = 'get_failing_travis_targets_for_pr',
-  source = 'get_failing_travis_targets_for_pr.sh'
-)
-
-files(
-  name = 'get_os',
-  source = 'get_os.sh'
-)
-
-files(
-  name = 'install_aws_cli_for_ci',
-  source = 'install_aws_cli_for_ci.sh'
-)
-
-files(
-  name = 'install_git_hooks',
-  source = 'install_git_hooks.sh'
-)
-
-files(
-  name = 'install_python_for_ci',
-  source = 'install_python_for_ci.sh'
-)
-
-files(
-  name = 'isort',
-  source = 'isort.sh'
-)
-
 
 python_binary(
   name = 'get_rbe_token',
@@ -147,31 +71,6 @@ python_binary(
   name = 'mypy',
   source = 'mypy.py',
   tags = {'type_checked'},
-)
-
-files(
-  name = 'pre-commit',
-  source = 'pre-commit.sh'
-)
-
-files(
-  name = 'publish_docs',
-  source = 'publish_docs.sh'
-)
-
-files(
-  name = 'release',
-  source = 'release.sh'
-)
-
-files(
-  name = 'release-changelog-helper',
-  source = 'release-changelog-helper.sh'
-)
-
-files(
-  name = 'setup',
-  source = 'setup.sh'
 )
 
 python_binary(

--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -1,56 +1,137 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(
-  name = 'common',
-  sources = 'common.py',
-  tags = {'type_checked'},
-)
-
 python_binary(
   name = 'check_banned_imports',
-  sources = 'check_banned_imports.py',
+  source = 'check_banned_imports.py',
   dependencies = [
     ':common',
   ],
   tags = {'type_checked'},
+)
+
+files(
+  name = 'check_clippy',
+  source = 'check_clippy.sh'
 )
 
 python_binary(
   name = 'check_header',
-  sources = 'check_header.py',
+  source = 'check_header.py',
   dependencies = [
     ':common',
   ],
   tags = {'type_checked'},
+)
+
+files(
+  name = 'check_packages',
+  source = 'check_packages.sh'
 )
 
 python_binary(
   name = 'check_pants_pex_abi',
-  sources = 'check_pants_pex_abi.py',
+  source = 'check_pants_pex_abi.py',
   dependencies = [
     ':common',
   ],
   tags = {'type_checked'},
+)
+
+files(
+  name = 'check_rust_formatting',
+  source = 'check_rust_formatting.sh'
+)
+
+files(
+  name = 'check_rust_target_headers',
+  source = 'check_rust_target_headers.sh'
+)
+
+files(
+  name = 'check_shell',
+  source = 'check_shell.sh'
 )
 
 python_binary(
   name = 'ci',
-  sources = 'ci.py',
+  source = 'ci.py',
   dependencies = [
     ':common',
   ],
   tags = {'type_checked'},
 )
 
+files(
+  name = 'ci_failure',
+  source = 'ci-failure.sh'
+)
+
+python_library(
+  name = 'common',
+  source = 'common.py',
+  tags = {'type_checked'},
+)
+
+files(
+  name = 'contributors',
+  source = 'contributors.sh'
+)
+
 python_binary(
   name = 'deploy_to_s3',
-  sources = 'deploy_to_s3.py',
+  source = 'deploy_to_s3.py',
   dependencies = [
     ':common',
   ],
   tags = {'type_checked'},
 )
+
+files(
+  name = 'download_binary',
+  source = 'download_binary.sh'
+)
+
+files(
+  name = 'get_added_files',
+  source = 'get_added_files.sh'
+)
+
+files(
+  name = 'get_ci_bootstrapped_pants_pex',
+  source = 'get_ci_bootstrapped_pants_pex.sh'
+)
+
+files(
+  name = 'get_failing_travis_targets_for_pr',
+  source = 'get_failing_travis_targets_for_pr.sh'
+)
+
+files(
+  name = 'get_os',
+  source = 'get_os.sh'
+)
+
+files(
+  name = 'install_aws_cli_for_ci',
+  source = 'install_aws_cli_for_ci.sh'
+)
+
+files(
+  name = 'install_git_hooks',
+  source = 'install_git_hooks.sh'
+)
+
+files(
+  name = 'install_python_for_ci',
+  source = 'install_python_for_ci.sh'
+)
+
+files(
+  name = 'isort',
+  source = 'isort.sh'
+)
+
 
 python_binary(
   name = 'get_rbe_token',
@@ -64,13 +145,38 @@ python_binary(
 
 python_binary(
   name = 'mypy',
-  sources = 'mypy.py',
+  source = 'mypy.py',
   tags = {'type_checked'},
+)
+
+files(
+  name = 'pre-commit',
+  source = 'pre-commit.sh'
+)
+
+files(
+  name = 'publish_docs',
+  source = 'publish_docs.sh'
+)
+
+files(
+  name = 'release',
+  source = 'release.sh'
+)
+
+files(
+  name = 'release-changelog-helper',
+  source = 'release-changelog-helper.sh'
+)
+
+files(
+  name = 'setup',
+  source = 'setup.sh'
 )
 
 python_binary(
   name = 'shellcheck',
-  sources = 'shellcheck.py',
+  source = 'shellcheck.py',
   dependencies = [
     ':common',
   ],

--- a/build-support/unit_test_remote_blacklist.txt
+++ b/build-support/unit_test_remote_blacklist.txt
@@ -11,4 +11,3 @@ tests/python/pants_test/ivy:bootstrapper
 tests/python/pants_test/ivy:ivy_subsystem
 tests/python/pants_test/java/distribution:distribution
 tests/python/pants_test/option:testing
-tests/python/pants_test/repo_scripts:git_hooks

--- a/tests/python/pants_test/repo_scripts/BUILD
+++ b/tests/python/pants_test/repo_scripts/BUILD
@@ -7,5 +7,8 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/testutils:git_util',
+    'build-support/bin:check_header',
+    'build-support/bin:check_packages',
+    'build-support/bin:get_added_files',
   ]
 )

--- a/tests/python/pants_test/repo_scripts/BUILD
+++ b/tests/python/pants_test/repo_scripts/BUILD
@@ -7,8 +7,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/testutils:git_util',
+    'build-support/bin:bash_scripts',
     'build-support/bin:check_header',
-    'build-support/bin:check_packages',
-    'build-support/bin:get_added_files',
   ]
 )

--- a/tests/python/pants_test/testutils/git_util.py
+++ b/tests/python/pants_test/testutils/git_util.py
@@ -26,14 +26,6 @@ def git_version() -> Revision:
   return Revision.lenient(matches.group(1))
 
 
-def get_repo_root() -> str:
-  """Return the absolute path to the root directory of the Pants git repo."""
-  repo_root: str = subprocess.run(
-    ['git', 'rev-parse', '--show-toplevel'], stdout=subprocess.PIPE, encoding="utf-8", check=True
-  ).stdout.strip()
-  return repo_root
-
-
 @contextmanager
 def initialize_repo(worktree: str, *, gitdir: Optional[str] = None) -> Iterator[Git]:
   """Initialize a git repository for the given `worktree`.

--- a/tests/python/pants_test/testutils/git_util.py
+++ b/tests/python/pants_test/testutils/git_util.py
@@ -4,6 +4,7 @@
 import re
 import subprocess
 from contextlib import contextmanager
+from typing import Iterator, Optional
 
 from pants.base.revision import Revision
 from pants.scm.git import Git
@@ -13,35 +14,39 @@ from pants.util.contextutil import environment_as, temporary_dir
 MIN_REQUIRED_GIT_VERSION = Revision.semver('1.7.10')
 
 
-def git_version():
+def git_version() -> Revision:
   """Get a Version() based on installed command-line git's version"""
-  process = subprocess.Popen(['git', '--version'], stdout=subprocess.PIPE)
-  (stdout, stderr) = process.communicate()
-  assert process.returncode == 0, "Failed to determine git version."
+  stdout = subprocess.run(
+    ['git', '--version'], stdout=subprocess.PIPE, encoding="utf-8", check=True
+  ).stdout
   # stdout is like 'git version 1.9.1.598.g9119e8b\n'  We want '1.9.1.598'
-  matches = re.search(r'\s(\d+(?:\.\d+)*)[\s\.]', stdout.decode())
+  matches = re.search(r'\s(\d+(?:\.\d+)*)[\s\.]', stdout)
+  if matches is None:
+    raise ValueError(f"Not able to parse git version from {stdout}.")
   return Revision.lenient(matches.group(1))
 
 
-def get_repo_root():
+def get_repo_root() -> str:
   """Return the absolute path to the root directory of the Pants git repo."""
-  return subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).strip().decode()
+  repo_root: str = subprocess.run(
+    ['git', 'rev-parse', '--show-toplevel'], stdout=subprocess.PIPE, encoding="utf-8", check=True
+  ).stdout.strip()
+  return repo_root
 
 
 @contextmanager
-def initialize_repo(worktree, gitdir=None):
+def initialize_repo(worktree: str, *, gitdir: Optional[str] = None) -> Iterator[Git]:
   """Initialize a git repository for the given `worktree`.
 
   NB: The given `worktree` must contain at least one file which will be committed to form an initial
   commit.
 
-  :param string worktree: The path to the git work tree.
-  :param string gitdir: An optional path to the `.git` dir to use.
+  :param worktree: The path to the git work tree.
+  :param gitdir: An optional path to the `.git` dir to use.
   :returns: A `Git` repository object that can be used to interact with the repo.
-  :rtype: :class:`pants.scm.git.Git`
   """
   @contextmanager
-  def use_gitdir():
+  def use_gitdir() -> Iterator[str]:
     if gitdir:
       yield gitdir
     else:
@@ -49,14 +54,13 @@ def initialize_repo(worktree, gitdir=None):
         yield d
 
   with use_gitdir() as git_dir, environment_as(GIT_DIR=git_dir, GIT_WORK_TREE=worktree):
-    subprocess.check_call(['git', 'init'])
-    subprocess.check_call(['git', 'config', 'user.email', 'you@example.com'])
+    subprocess.run(['git', 'init'], check=True)
+    subprocess.run(['git', 'config', 'user.email', 'you@example.com'], check=True)
     # TODO: This method inherits the global git settings, so if a developer has gpg signing on, this
     # will turn that off. We should probably just disable reading from the global config somehow:
     # https://git-scm.com/docs/git-config.
-    subprocess.check_call(['git', 'config', 'commit.gpgSign', 'false'])
-    subprocess.check_call(['git', 'config', 'user.name', 'Your Name'])
-    subprocess.check_call(['git', 'add', '.'])
-    subprocess.check_call(['git', 'commit', '-am', 'Add project files.'])
-
+    subprocess.run(['git', 'config', 'commit.gpgSign', 'false'], check=True)
+    subprocess.run(['git', 'config', 'user.name', 'Your Name'], check=True)
+    subprocess.run(['git', 'add', '.'], check=True)
+    subprocess.run(['git', 'commit', '-am', 'Add project files.'], check=True)
     yield Git(gitdir=git_dir, worktree=worktree)


### PR DESCRIPTION
This test failed when remoting because it relied on access to several scripts in `build-support/bin` that were not explicitly declared.

This is fixed by explicitly depending on the scripts. We must jump through some hoops to then copy the scripts into the temporary workdir created by the tests.