### PR TITLE
Handle blank description in _print_goals_help

### DIFF
--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -52,7 +52,8 @@ class HelpPrinter:
     for scope_info in self._options.known_scope_to_info.values():
       if scope_info.category not in (ScopeInfo.GOAL, ScopeInfo.GOAL_V1):
         continue
-      goal_descriptions[scope_info.scope] = scope_info.description
+      description = scope_info.description or "<no description>"
+      goal_descriptions[scope_info.scope] = description
     goal_descriptions.update({goal.name: goal.description_first_line
                               for goal in Goal.all()
                               if goal.description})


### PR DESCRIPTION
If there is no description for a scope_info goal, print out a message to this
effect associated with that goal rather than just a blank line.