### PR TITLE
Parse zinc args and pass scalac options into scalafix

### DIFF
--- a/src/python/pants/backend/jvm/tasks/scalafix.py
+++ b/src/python/pants/backend/jvm/tasks/scalafix.py
@@ -50,9 +50,31 @@ class ScalaFix(RewriteBase):
   @classmethod
   def prepare(cls, options, round_manager):
     super().prepare(options, round_manager)
-    # Only request a classpath if semantic checks are enabled.
+    # Only request a classpath and zinc_args if semantic checks are enabled.
     if options.semantic:
+      round_manager.require_data('zinc_args') 
       round_manager.require_data('runtime_classpath')
+ 
+  def execute(self): 
+    self.scalac_args = []
+    
+    if self.get_options().semantic:
+      targets = self.context.targets()
+      targets_to_zinc_args = self.context.products.get_data('zinc_args')
+      
+      for t in targets:
+        zinc_args = targets_to_zinc_args[t]
+        args = []
+        for arg in zinc_args:
+          arg = arg.strip()
+          if arg.startswith('-S'):
+            args.append(arg[2:])
+        # All targets will get the same scalac args
+        if not self.scalac_args and args:
+          self.scalac_args = args
+          break
+
+    super().execute()
 
   @staticmethod
   def _compute_classpath(runtime_classpath, targets):
@@ -79,6 +101,12 @@ class ScalaFix(RewriteBase):
       args.append('--rules={}'.format(self.get_options().rules))
     if self.get_options().level == 'debug':
       args.append('--verbose')
+
+    # This is how you pass a list of strings to a single arg key
+    for a in self.scalac_args:
+      args.append('--scalac-options')
+      args.append(a)
+      
     args.extend(self.additional_args or [])
 
     args.extend(source for _, source in target_sources)

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafix.py
@@ -53,6 +53,35 @@ class ScalaFixIntegrationTest(PantsRunIntegrationTest):
       test_fix = self.run_pants(['lint', target], options)
       self.assert_success(test_fix)
 
+  def test_scalafix_scalacoptions(self):
+
+    rules = {
+      'rules': 'RemoveUnused',
+      'semantic': True
+    }
+    options = {
+      'scala': {
+        'scalac_plugin_dep': f'{TEST_DIR}/rsc_compat:semanticdb-scalac',
+        'scalac_plugins': '+["semanticdb"]'
+      },
+      'compile.zinc': {'args': '+["-S-Ywarn-unused"]'},
+      'lint.scalafix': rules,
+      'fmt.scalafix': rules,
+      'lint.scalastyle': {'skip': True}
+    }
+
+    test_file_name = f'{TEST_DIR}/rsc_compat/RscCompat.scala'
+
+    with self.with_overwritten_file_content(test_file_name):
+      # format an incorrectly formatted file.
+      target = f'{TEST_DIR}/rsc_compat'
+      fmt_result = self.run_pants(['fmt', target], options)
+      self.assert_success(fmt_result)
+
+      # verify that the lint check passes.
+      test_fix = self.run_pants(['lint', target], options)
+      self.assert_success(test_fix)
+
   def test_rsccompat_fmt(self):
     options =  {
       'scala': {


### PR DESCRIPTION
### Problem

https://github.com/pantsbuild/pants/issues/7914

### Solution

Extract scalac options from zinc args, akin to `ExtractJava`,
and feed them to scalafix args.

### Result

Allows for usage of scalafix rules which require certain compiler options,
such as `RemoveUnused`, which requires a `-Ywarn-unused` option.