### PR TITLE
Record per-target compile workflow stats when using RscCompile

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -454,10 +454,19 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         # Otherwise, fail it.
         on_success=ivts.update,
         on_failure=ivts.force_invalidate)
+        
+    workflow = rsc_compile_context.workflow
+
+    # Replica of JvmCompile's _record_target_stats logic
+    self.context.run_tracker.report_target_info(
+      self.options_scope,
+      compile_target,
+      ['compile', 'workflow'],
+      workflow.value
+    )
 
     # Create the rsc job.
     # Currently, rsc only supports outlining scala.
-    workflow = rsc_compile_context.workflow
     workflow.resolve_for_enum_variant({
       'zinc-only': lambda: None,
       'zinc-java': lambda: None,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -458,12 +458,15 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     workflow = rsc_compile_context.workflow
 
     # Replica of JvmCompile's _record_target_stats logic
-    self.context.run_tracker.report_target_info(
-      self.options_scope,
-      compile_target,
-      ['compile', 'workflow'],
-      workflow.value
-    )
+    def record(k, v):
+      self.context.run_tracker.report_target_info(
+        self.options_scope,
+        compile_target,
+        ['compile', k],
+        v
+      )
+    record('workflow', workflow)
+    record('execution_strategy', self.execution_strategy_enum)
 
     # Create the rsc job.
     # Currently, rsc only supports outlining scala.

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -465,8 +465,8 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         ['compile', k],
         v
       )
-    record('workflow', workflow)
-    record('execution_strategy', self.execution_strategy_enum)
+    record('workflow', workflow.value)
+    record('execution_strategy', self.execution_strategy)
 
     # Create the rsc job.
     # Currently, rsc only supports outlining scala.


### PR DESCRIPTION
### Problem

We would like to have metrics about how much of a build uses Rsc.

### Solution

Record the compile workflow a target uses under `RscCompile`

### Result

We will have solved the problem.