### PR TITLE
use jdeps to run dep-usage task

### DIFF
--- a/src/python/pants/backend/jvm/tasks/analysis_extraction.py
+++ b/src/python/pants/backend/jvm/tasks/analysis_extraction.py
@@ -61,13 +61,23 @@ class AnalysisExtraction(NailgunTask):
   @contextmanager
   def aliased_classpaths(self, classpaths):
     """
-    Create unique names for each classpath entry as symlinks in a temporary directory.
-    returns: dict[str -> classpath entry] which maps string paths of symlinks to classpaths.
+    Create unique names for each classpath entry as symlinks in
+    a temporary directory.  returns: dict[str -> classpath entry]
+    which maps string paths of symlinks to classpaths.
+
+    ClasspathEntries generally point to a .jar of
+    the .class files generated for java_library targets.
+    These jars all have the same basename, z.jar, which
+    confuses the `jdeps` tool. Jdeps expects unique, and
+    descriptive, basenames for jars. When all basenames are
+    the same the deps collide in the jdeps output, some
+    .class files can't be found and the summary output
+    is not complete.
     """
     with temporary_dir() as tempdir:
       aliases = {}
       for i, cp in enumerate(classpaths):
-        alias = os.path.join(tempdir, f"{i}.jar" if not os.path.isdir(cp) else f"{1}")
+        alias = os.path.join(tempdir, f"{i}.jar" if not os.path.isdir(cp) else f"{i}")
         os.symlink(cp, alias)
         aliases[alias] = cp
       yield aliases
@@ -83,52 +93,51 @@ class AnalysisExtraction(NailgunTask):
     fingerprint_strategy = DependencyContext.global_instance().create_fingerprint_strategy(
         classpath_product)
 
-    targets = self.context.targets()
-    # complete classpath list
-    deps_classpaths = [
-      cp[1] for target in targets for cp in classpath_product.get_for_target(target) if cp[1]
+    # classpath fingerprint strategy only works on jvm targets.
+    targets = [target for target in self.context.targets() if classpath_product.get_for_target(target)]
+    all_classpaths = [
+      entry for target in targets for _, entry in classpath_product.get_for_target(target) if entry
     ]
-    with self.aliased_classpaths(deps_classpaths) as deps_classpath_by_alias:
-      with self.invalidated(targets,
-                            fingerprint_strategy=fingerprint_strategy,
-                            invalidate_dependents=True) as invalidation_check:
-        for vt in invalidation_check.all_vts:
-          # class paths for the target we are computing deps for
-          target_cps = [cp[1] for cp in classpath_product.get_for_target(vt.target)]
+    with self.invalidated(targets,
+                          fingerprint_strategy=fingerprint_strategy,
+                          invalidate_dependents=True) as invalidation_check:
+      for vt in invalidation_check.all_vts:
+        # class paths for the target we are computing deps for
+        target_cps = [entry for _, entry in classpath_product.get_for_target(vt.target)]
 
-          jdeps_output_json = self._jdeps_output_json(vt)
-          if not vt.valid:
-            self._run_jdeps_analysis(vt.target, target_cps, deps_classpath_by_alias, jdeps_output_json)
-          self._register_products(vt.target,
-                                  jdeps_output_json,
-                                  product_deps_by_target)
+        jdeps_output_json = self._jdeps_output_json(vt)
+        if not vt.valid:
+          self._run_jdeps_analysis(vt.target, target_cps, all_classpaths, jdeps_output_json)
+        self._register_products(vt.target,
+                                jdeps_output_json,
+                                product_deps_by_target)
 
   @memoized_property
   def _jdeps_summary_line_regex(self):
-    return re.compile(r"^\S+\s->\s(\S+)$")
+    return re.compile(r"^.+\s->\s(.+)$")
 
-  def _run_jdeps_analysis(self, target, target_cps, deps_classpath_by_alias, jdeps_output_json):
-    with open(jdeps_output_json, 'w') as f:
-      if target_cps:
-        # TODO should we find an abs path to jdeps in a better way? a jdk path?
-        cmd = [
+  def _run_jdeps_analysis(self, target, target_cps, all_classpaths, jdeps_output_json):
+    with self.aliased_classpaths(all_classpaths) as classpaths_by_alias:
+      with open(jdeps_output_json, 'w') as f:
+        if target_cps:
+          # TODO should we find an abs path to jdeps in a better way? a jdk path?
+          cmd = [
             "jdeps", "-summary",
-            '-classpath', ":".join(cp for cp in deps_classpath_by_alias.keys()),
+            '-classpath', ":".join(cp for cp in classpaths_by_alias.keys()),
           ] + target_cps
-        jdeps_output = io.StringIO(subprocess.run(cmd, stdout=subprocess.PIPE).stdout.decode('utf-8'))
-        deps_classpaths = set()
-        for line in jdeps_output:
-          match = self._jdeps_summary_line_regex.fullmatch(line.strip()).group(1)
-          deps_classpaths.add(deps_classpath_by_alias.get(match, match))
+          jdeps_output = io.StringIO(subprocess.run(cmd, stdout=subprocess.PIPE).stdout.decode('utf-8'))
+          deps_classpaths = set()
+          for line in jdeps_output:
+            match = self._jdeps_summary_line_regex.fullmatch(line.strip()).group(1)
+            deps_classpaths.add(classpaths_by_alias.get(match, match))
 
-      else:
-        deps_classpaths = []
-      json.dump(list(deps_classpaths), f)
+        else:
+          deps_classpaths = []
+        json.dump(list(deps_classpaths), f)
 
   def _register_products(self,
                          target,
                          jdeps_output_json,
                          product_deps_by_target):
-    if target not in product_deps_by_target:
-      with open(jdeps_output_json) as f:
-        product_deps_by_target[target] = json.load(f)
+    with open(jdeps_output_json) as f:
+      product_deps_by_target[target] = json.load(f)

--- a/src/python/pants/backend/jvm/tasks/analysis_extraction.py
+++ b/src/python/pants/backend/jvm/tasks/analysis_extraction.py
@@ -91,11 +91,13 @@ class AnalysisExtraction(NailgunTask):
       lambda: self.context.products.is_required_data('classes_by_source'),
       '1.20.0.dev2',
       'The `classes_by_source` product depends on internal compiler details and is no longer produced.'
+      'For similar functionality consume `product_deps_by_target`.'
     )
     deprecated_conditional(
       lambda: self.context.products.is_required_data('product_deps_by_src'),
       '1.20.0.dev2',
-      'The `classes_by_source` product depends on internal compiler details and is no longer produced.'
+      'The `product_deps_by_src` product depends on internal compiler details and is no longer produced. '
+      'For similar functionality consume `product_deps_by_target`.'
     )
 
     if not self._create_products_if_should_run():
@@ -116,7 +118,7 @@ class AnalysisExtraction(NailgunTask):
                           fingerprint_strategy=fingerprint_strategy,
                           invalidate_dependents=True) as invalidation_check:
       for vt in invalidation_check.all_vts:
-        # class paths for the artifacts created by the target we are computing deps for
+        # A list of class paths to the artifacts created by the target we are computing deps for.
         target_artifact_classpaths = [entry for _, entry in classpath_product.get_for_target(vt.target)]
 
         jdeps_output_json = self._jdeps_output_json(vt)

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_check.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_check.py
@@ -64,9 +64,8 @@ class JvmDependencyCheck(Task):
   def prepare(cls, options, round_manager):
     super().prepare(options, round_manager)
     if not cls._skip(options):
-      round_manager.require_data('product_deps_by_src')
+      round_manager.require_data('product_deps_by_target')
       round_manager.require_data('runtime_classpath')
-      round_manager.require_data('zinc_analysis')
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
@@ -102,15 +101,15 @@ class JvmDependencyCheck(Task):
     fingerprint_strategy = DependencyContext.global_instance().create_fingerprint_strategy(
         classpath_product)
 
-    targets = list(self.context.products.get_data('zinc_analysis').keys())
+    targets = self.context.targets()
 
     with self.invalidated(targets,
                           fingerprint_strategy=fingerprint_strategy,
                           invalidate_dependents=True) as invalidation_check:
       for vt in invalidation_check.invalid_vts:
-        product_deps_by_src = self.context.products.get_data('product_deps_by_src').get(vt.target)
-        if product_deps_by_src is not None:
-          self.check(vt.target, product_deps_by_src)
+        product_deps_for_target = self.context.products.get_data('product_deps_by_target').get(vt.target)
+        if product_deps_for_target is not None:
+          self.check(vt.target, product_deps_for_target)
 
   def check(self, src_tgt, actual_deps):
     """Check for missing deps.
@@ -130,8 +129,11 @@ class JvmDependencyCheck(Task):
 
       def filter_whitelisted(missing_deps):
         # Removing any targets that exist in the whitelist from the list of dependency issues.
-        return [(tgt_pair, evidence) for (tgt_pair, evidence) in missing_deps
-                            if tgt_pair[0].address not in self._target_whitelist]
+        return [
+          (tgt_pair, evidence)
+          for (tgt_pair, evidence) in missing_deps
+          if tgt_pair[0].address not in self._target_whitelist
+        ]
 
       missing_direct_tgt_deps = filter_whitelisted(missing_direct_tgt_deps)
 
@@ -139,7 +141,7 @@ class JvmDependencyCheck(Task):
         log_fn = (self.context.log.error if self._check_missing_direct_deps == 'fatal'
                   else self.context.log.warn)
         for (tgt_pair, evidence) in missing_direct_tgt_deps:
-          evidence_str = '\n'.join(['  {} uses {}'.format(shorten(e[0]), shorten(e[1]))
+          evidence_str = '\n'.join(['  {} uses {}'.format(e[0].address.spec, shorten(e[1]))
                                     for e in evidence])
           log_fn('Missing direct BUILD dependency {} -> {} because:\n{}'
                  .format(tgt_pair[0].address.spec, tgt_pair[1].address.spec, evidence_str))
@@ -180,6 +182,7 @@ class JvmDependencyCheck(Task):
     All paths in the input and output are absolute.
     """
     analyzer = self._analyzer
+
     def must_be_explicit_dep(dep):
       # We don't require explicit deps on the java runtime, so we shouldn't consider that
       # a missing dep.
@@ -204,22 +207,23 @@ class JvmDependencyCheck(Task):
     missing_direct_tgt_deps_map = defaultdict(list)  # The same, but for direct deps.
 
     targets_by_file = analyzer.targets_by_file(self.context.targets())
-    buildroot = get_buildroot()
-    abs_srcs = [os.path.join(buildroot, src) for src in src_tgt.sources_relative_to_buildroot()]
-    for src in abs_srcs:
-      for actual_dep in filter(must_be_explicit_dep, actual_deps.get(src, [])):
-        actual_dep_tgts = targets_by_file.get(actual_dep)
-        # actual_dep_tgts is usually a singleton. If it's not, we only need one of these
-        # to be in our declared deps to be OK.
-        if actual_dep_tgts is None:
-          missing_file_deps.add((src_tgt, actual_dep))
-        elif not target_or_java_dep_in_targets(src_tgt, actual_dep_tgts):
-          # Obviously intra-target deps are fine.
-          canonical_actual_dep_tgt = next(iter(actual_dep_tgts))
-          if canonical_actual_dep_tgt not in src_tgt.dependencies:
-            # The canonical dep is the only one a direct dependency makes sense on.
-            missing_direct_tgt_deps_map[(src_tgt, canonical_actual_dep_tgt)].append(
-                (src, actual_dep))
+    for actual_dep in filter(must_be_explicit_dep, actual_deps):
+      actual_dep_tgts = targets_by_file.get(actual_dep)
+      # actual_dep_tgts is usually a singleton. If it's not, we only need one of these
+      # to be in our declared deps to be OK.
+      if actual_dep_tgts is None:
+        missing_file_deps.add((src_tgt, actual_dep))
+      elif not target_or_java_dep_in_targets(src_tgt, actual_dep_tgts):
+        # Obviously intra-target deps are fine.
+        canonical_actual_dep_tgt = next(iter(actual_dep_tgts))
+        if canonical_actual_dep_tgt not in src_tgt.dependencies:
+          # The canonical dep is the only one a direct dependency makes sense on.
+          # TODO get rid of src usage here. we dont have a way to map class
+          # files back to source files when using jdeps. I think we can get away without
+          # listing the src file directly and just list the target which has the transient
+          # dep
+          missing_direct_tgt_deps_map[(src_tgt, canonical_actual_dep_tgt)].append(
+              (src_tgt, actual_dep))
 
     return (list(missing_file_deps),
             list(missing_direct_tgt_deps_map.items()))
@@ -254,6 +258,8 @@ class JvmDependencyCheck(Task):
     """
     # Flatten the product deps of this target.
     product_deps = set()
+    # TODO update actual deps will just be a list, not a dict when switching to
+    # product_deps_by_target_product.
     for dep_entries in actual_deps.values():
       product_deps.update(dep_entries)
 

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_check.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_check.py
@@ -101,7 +101,7 @@ class JvmDependencyCheck(Task):
     fingerprint_strategy = DependencyContext.global_instance().create_fingerprint_strategy(
         classpath_product)
 
-    targets = self.context.targets()
+    targets = [target for target in self.context.targets() if hasattr(target, 'strict_deps')]
 
     with self.invalidated(targets,
                           fingerprint_strategy=fingerprint_strategy,

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -70,9 +70,8 @@ class JvmDependencyUsage(Task):
   def prepare(cls, options, round_manager):
     super().prepare(options, round_manager)
     if not options.use_cached:
-      round_manager.require_data('classes_by_source')
       round_manager.require_data('runtime_classpath')
-      round_manager.require_data('product_deps_by_src')
+      round_manager.require_data('product_deps_by_target')
     else:
       # We want to have synthetic targets in build graph to deserialize nodes properly.
       round_manager.optional_data('java')
@@ -163,6 +162,7 @@ class JvmDependencyUsage(Task):
     targets = self.context.targets()
     targets_by_file = self._analyzer.targets_by_file(targets)
     transitive_deps_by_target = self._analyzer.compute_transitive_deps_by_target(targets)
+
     def creator(target):
       transitive_deps = set(transitive_deps_by_target.get(target))
       node = self.create_dep_usage_node(target, targets_by_file, transitive_deps)
@@ -247,20 +247,20 @@ class JvmDependencyUsage(Task):
 
     # Record the used products and undeclared Edges for this target. Note that some of
     # these may be self edges, which are considered later.
-    product_deps_by_src = self.context.products.get_data('product_deps_by_src')
-    target_product_deps_by_src = product_deps_by_src.get(target, {})
-    for product_deps in target_product_deps_by_src.values():
-      for product_dep in product_deps:
-        for dep_tgt in targets_by_file.get(product_dep, []):
-          derived_from = dep_tgt.concrete_derived_from
-          if not self._select(derived_from):
-            continue
-          # Create edge only for those direct or transitive dependencies in order to
-          # disqualify irrelevant targets that happen to share some file in sources,
-          # not uncommon when globs especially rglobs is used.
-          if not derived_from in transitive_deps:
-            continue
-          node.add_edge(_construct_edge(dep_tgt, products_used={product_dep}), derived_from)
+    product_deps_by_target = self.context.products.get_data('product_deps_by_target')
+    product_deps_for_target = product_deps_by_target.get(target, [])
+    # product_deps is a list of class files / jars
+    for product_dep in product_deps_for_target:
+      for dep_tgt in targets_by_file.get(product_dep, []):
+        derived_from = dep_tgt.concrete_derived_from
+        if not self._select(derived_from):
+          continue
+        # Create edge only for those direct or transitive dependencies in order to
+        # disqualify irrelevant targets that happen to share some file in sources,
+        # not uncommon when globs especially rglobs is used.
+        if derived_from not in transitive_deps:
+          continue
+        node.add_edge(_construct_edge(dep_tgt, products_used={product_dep}), derived_from)
 
     return node
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
@@ -30,8 +30,8 @@ class TestJvmDependencyUsage(TaskTestBase):
         touch(os.path.join(target_dir, classfile))
       classpath_products.add_for_target(target, [('default', target_dir)])
 
-    product_deps_by_src = context.products.get_data('product_deps_by_src', dict)
-    return self.create_task(context), product_deps_by_src
+    product_deps_by_target = context.products.get_data('product_deps_by_target', dict)
+    return self.create_task(context), product_deps_by_target
 
   def make_java_target(self, *args, **kwargs):
     assert 'target_type' not in kwargs
@@ -48,15 +48,14 @@ class TestJvmDependencyUsage(TaskTestBase):
     t2 = self.make_java_target(spec=':t2', sources=['c.java'], dependencies=[t1])
     t3 = self.make_java_target(spec=':t3', sources=['d.java', 'e.java'], dependencies=[t1])
     self.set_options(size_estimator='filecount')
-    dep_usage, product_deps_by_src = self._setup({
+    dep_usage, product_deps_by_target = self._setup({
         t1: ['a.class', 'b.class'],
         t2: ['c.class'],
         t3: ['d.class', 'e.class'],
       })
-    product_deps_by_src[t1] = {}
-    product_deps_by_src[t2] = {'c.java': ['a.class']}
-    product_deps_by_src[t3] = {'d.java': ['a.class', 'b.class'],
-                               'e.java': ['a.class', 'b.class']}
+    product_deps_by_target[t1] = []
+    product_deps_by_target[t2] = ['a.class']
+    product_deps_by_target[t3] = ['a.class', 'b.class']
 
     graph = self.create_graph(dep_usage, [t1, t2, t3])
 
@@ -83,18 +82,17 @@ class TestJvmDependencyUsage(TaskTestBase):
                                sources=['a.java', 'b.java'],
                                dependencies=[t1, t1_x, t1_y, t1_z])
     self.set_options(size_estimator='nosize')
-    dep_usage, product_deps_by_src = self._setup({
+    dep_usage, product_deps_by_target = self._setup({
         t1_x: ['x1.class'],
         t1_y: ['y1.class'],
         t1_z: ['z1.class', 'z2.class', 'z3.class'],
         t2: ['a.class', 'b.class'],
       })
-    product_deps_by_src[t1] = {}
-    product_deps_by_src[t1_x] = {}
-    product_deps_by_src[t1_y] = {}
-    product_deps_by_src[t1_z] = {}
-    product_deps_by_src[t2] = {'a.java': ['x1.class'],
-                               'b.java': ['z1.class', 'z2.class']}
+    product_deps_by_target[t1] = []
+    product_deps_by_target[t1_x] = []
+    product_deps_by_target[t1_y] = []
+    product_deps_by_target[t1_z] = []
+    product_deps_by_target[t2] = ['x1.class', 'z1.class', 'z2.class']
     graph = self.create_graph(dep_usage, [t1, t1_x, t1_y, t1_z, t2])
 
     self.assertEqual(graph._nodes[t1].products_total, 5)
@@ -110,13 +108,13 @@ class TestJvmDependencyUsage(TaskTestBase):
     nested_alias_b = self.make_target(spec=':nest_alias_b', dependencies=[alias_b])
     c = self.make_java_target(spec=':c', sources=['c.java'], dependencies=[alias_a_b, nested_alias_b])
     self.set_options(strict_deps=False)
-    dep_usage, product_deps_by_src = self._setup({
+    dep_usage, product_deps_by_target = self._setup({
       a: ['a.class'],
       b: ['b.class'],
       c: ['c.class'],
     })
 
-    product_deps_by_src[c] = {'c.java': ['a.class']}
+    product_deps_by_target[c] = ['a.class']
     graph = self.create_graph(dep_usage, [a, b, c, alias_a_b, alias_b, nested_alias_b])
     # both `:a` and `:b` are resolved from target aliases, one is used the other is not.
     self.assertTrue(graph._nodes[c].dep_edges[a].is_declared)
@@ -136,14 +134,14 @@ class TestJvmDependencyUsage(TaskTestBase):
     t3 = self.make_java_target(spec=':t3', sources=['c.java'], dependencies=[t1])
     t4 = self.make_java_target(spec=':t4', sources=['d.java'], dependencies=[t3])
     self.set_options(strict_deps=False)
-    dep_usage, product_deps_by_src = self._setup({
+    dep_usage, product_deps_by_target = self._setup({
         t1: ['a.class'],
         t2: ['a.class', 'b.class'],
         t3: ['c.class'],
         t4: ['d.class'],
     })
-    product_deps_by_src[t3] = {'c.java': ['a.class']}
-    product_deps_by_src[t4] = {'d.java': ['a.class']}
+    product_deps_by_target[t3] = ['a.class']
+    product_deps_by_target[t4] = ['a.class']
     graph = self.create_graph(dep_usage, [t1, t2, t3, t4])
 
     # Not creating edge for t2 even it provides a.class that t4 depends on.
@@ -172,11 +170,11 @@ class TestJvmDependencyUsage(TaskTestBase):
     t2 = self.make_java_target(spec=':t2', sources=['b.java'], dependencies=[t1])
     self.create_file('b.java')
     self.set_options(size_estimator='filecount')
-    dep_usage, product_deps_by_src = self._setup({
+    dep_usage, product_deps_by_target = self._setup({
         t1: ['a.class'],
         t2: ['b.class'],
       })
-    product_deps_by_src[t1] = {}
-    product_deps_by_src[t2] = {'b.java': ['a.class']}
+    product_deps_by_target[t1] = []
+    product_deps_by_target[t2] = ['a.class']
 
     dep_usage.create_dep_usage_graph([t1, t2])


### PR DESCRIPTION
### Problem
closes #7995 

The current implementation of the dep-usage goal uses analysis files which are output from zinc compiles to track dependencies between java and scala targets. We want to replace zinc with rsc eventually so we need to disconnect the dep usage and dep linting tasks from zinc output.
### Solution

We replace using zinc analysis files to track target dependencies with the the jdk tool `jdeps`. We also change the format for the product produced by the AnalysisExecution task from a nested `{target: {src_file: [dependencies]}}` to a single `{target: [dependencies]} which removes an intermediate layer of granularity, simplifying the shape of the analysis product. We do this because jdeps does not have any information about which source files compiled to which class files, and it cannot because that information is not contained in .class files.

### Result

Changes are transparent to the user with the exception of the format of one error message when the user requests pants lint with the `--jvm-dep-check-missing-direct-deps={warn,fatal}` previously the error message would reference the source file that had an implicit dependency, and what the dependency is, but now we just reference the target address which has the implicit dependency. This is still enough information to fix the linting issue, because dependencies are specified on a target level anyway.