### PR TITLE
[pantsd] Remove dead code around prefork graph warming

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -114,19 +114,19 @@ class DaemonPantsRunner:
 
 
     return cls(
-      maybe_shutdown_socket,
-      args,
-      env,
-      graph_helper,
-      target_roots,
-      services,
-      subprocess_dir,
-      options_bootstrapper,
-      exit_code
+      maybe_shutdown_socket=maybe_shutdown_socket,
+      args=args,
+      env=env,
+      # graph_helper,
+      # target_roots,
+      services=services,
+      # subprocess_dir,
+      # options_bootstrapper,
+      exit_code=0,
+      scheduler_service=scheduler_service
     )
 
-  def __init__(self, maybe_shutdown_socket, args, env, graph_helper, target_roots, services,
-               metadata_base_dir, options_bootstrapper, exit_code):
+  def __init__(self, maybe_shutdown_socket, args, env, services, exit_code, scheduler_service):
     """
     :param socket socket: A connected socket capable of speaking the nailgun protocol.
     :param list args: The arguments (i.e. sys.argv) for this run.
@@ -140,16 +140,17 @@ class DaemonPantsRunner:
     :param OptionsBootstrapper options_bootstrapper: An OptionsBootstrapper to reuse.
     """
     self._name = self._make_identity()
-    self._metadata_base_dir = metadata_base_dir
+    # self._metadata_base_dir = metadata_base_dir
     self._maybe_shutdown_socket = maybe_shutdown_socket
     self._args = args
     self._env = env
-    self._graph_helper = graph_helper
-    self._target_roots = target_roots
+    # self._graph_helper = graph_helper
+    # self._target_roots = target_roots
     self._services = services
-    self._options_bootstrapper = options_bootstrapper
+    # self._options_bootstrapper = options_bootstrapper
     self.exit_code = exit_code
     self._exiter = DaemonExiter(maybe_shutdown_socket)
+    self._scheduler_service = scheduler_service
 
   # TODO: this should probably no longer be necesary, remove.
   def _make_identity(self):
@@ -262,9 +263,9 @@ class DaemonPantsRunner:
       encapsulated_global_logger():
       try:
 
-        options, _, options_bootstrapper = LocalPantsRunner.parse_options(args, env)
-        subprocess_dir = options.for_global_scope().pants_subprocessdir
-        graph_helper, target_roots, exit_code = scheduler_service.prepare_graph(options, options_bootstrapper)
+        options, _, options_bootstrapper = LocalPantsRunner.parse_options(self._args, self._env)
+        # subprocess_dir = options.for_global_scope().pants_subprocessdir
+        graph_helper, target_roots, exit_code = self._scheduler_service.prepare_graph(options, options_bootstrapper)
         finalizer()
 
 
@@ -279,9 +280,9 @@ class DaemonPantsRunner:
           PantsRunFailCheckerExiter(),
           self._args,
           self._env,
-          self._target_roots,
-          self._graph_helper,
-          self._options_bootstrapper,
+          target_roots,
+          graph_helper,
+          options_bootstrapper,
         )
         runner.set_start_time(self._maybe_get_client_start_time_from_env(self._env))
 

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -115,9 +115,10 @@ class DaemonPantsRunner:
     try:
       # N.B. This will redirect stdio in the daemon's context to the nailgun session.
       with cls.nailgunned_stdio(maybe_shutdown_socket, env, handle_stdin=False) as finalizer:
+        print('123')
         options, _, options_bootstrapper = LocalPantsRunner.parse_options(args, env)
         subprocess_dir = options.for_global_scope().pants_subprocessdir
-        graph_helper, target_roots, exit_code = scheduler_service.prefork(options, options_bootstrapper)
+        graph_helper, target_roots, exit_code = scheduler_service.prepare_graph(options, options_bootstrapper)
         finalizer()
     except Exception:
       graph_helper = None
@@ -126,7 +127,7 @@ class DaemonPantsRunner:
       # TODO: this should no longer be necessary, remove the creation of subprocess_dir
       subprocess_dir = os.path.join(get_buildroot(), '.pids')
       exit_code = 1
-      # TODO This used to raise the _GracefulTerminationException, and maybe it should again, or notify in some way that the prefork has failed.
+      # TODO This used to raise the _GracefulTerminationException, and maybe it should again, or notify in some way that the prepare_graph has failed.
 
     return cls(
       maybe_shutdown_socket,

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -247,14 +247,6 @@ class DaemonPantsRunner:
 
   def run(self):
 
-    try:
-      # N.B. This will redirect stdio in the daemon's context to the nailgun session.
-      with cls.nailgunned_stdio(maybe_shutdown_socket, env, handle_stdin=False) as finalizer:
-
-    except Exception:
-
-
-
     # Ensure anything referencing sys.argv inherits the Pailgun'd args.
     sys.argv = self._args
 

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -253,7 +253,6 @@ class DaemonPantsRunner:
         options, _, options_bootstrapper = LocalPantsRunner.parse_options(self._args, self._env)
         graph_helper, target_roots, exit_code = self._scheduler_service.prepare_graph(options, options_bootstrapper)
         self.exit_code = exit_code
-        finalizer()
 
         # Clean global state.
         clean_global_runtime_state(reset_subsystem=True)

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -110,18 +110,11 @@ class DaemonPantsRunner:
 
   @classmethod
   def create(cls, sock, args, env, services, scheduler_service):
-    maybe_shutdown_socket = MaybeShutdownSocket(sock)
-
-
     return cls(
-      maybe_shutdown_socket=maybe_shutdown_socket,
+      maybe_shutdown_socket=MaybeShutdownSocket(sock),
       args=args,
       env=env,
-      # graph_helper,
-      # target_roots,
       services=services,
-      # subprocess_dir,
-      # options_bootstrapper,
       exit_code=0,
       scheduler_service=scheduler_service
     )
@@ -140,17 +133,14 @@ class DaemonPantsRunner:
     :param OptionsBootstrapper options_bootstrapper: An OptionsBootstrapper to reuse.
     """
     self._name = self._make_identity()
-    # self._metadata_base_dir = metadata_base_dir
     self._maybe_shutdown_socket = maybe_shutdown_socket
     self._args = args
     self._env = env
-    # self._graph_helper = graph_helper
-    # self._target_roots = target_roots
     self._services = services
-    # self._options_bootstrapper = options_bootstrapper
-    self.exit_code = exit_code
     self._exiter = DaemonExiter(maybe_shutdown_socket)
     self._scheduler_service = scheduler_service
+
+    self.exit_code = exit_code
 
   # TODO: this should probably no longer be necesary, remove.
   def _make_identity(self):
@@ -264,10 +254,8 @@ class DaemonPantsRunner:
       try:
 
         options, _, options_bootstrapper = LocalPantsRunner.parse_options(self._args, self._env)
-        # subprocess_dir = options.for_global_scope().pants_subprocessdir
         graph_helper, target_roots, exit_code = self._scheduler_service.prepare_graph(options, options_bootstrapper)
         finalizer()
-
 
         # Clean global state.
         clean_global_runtime_state(reset_subsystem=True)

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -237,7 +237,6 @@ class DaemonPantsRunner:
     return None if client_start_time is None else float(client_start_time)
 
   def run(self):
-
     # Ensure anything referencing sys.argv inherits the Pailgun'd args.
     sys.argv = self._args
 
@@ -287,8 +286,5 @@ class DaemonPantsRunner:
         # happening here, so something is probably overriding the excepthook. By catching Exception
         # and calling this method, we emulate the normal, expected sys.excepthook override.
         ExceptionSink._log_unhandled_exception_and_exit(exc=e)
-
-
-
       else:
         self._exiter.exit(self.exit_code if self.exit_code else PANTS_SUCCEEDED_EXIT_CODE)

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -8,7 +8,6 @@ import termios
 import time
 from contextlib import contextmanager
 
-from pants.base.build_environment import get_buildroot
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE, Exiter
 from pants.bin.local_pants_runner import LocalPantsRunner
@@ -251,9 +250,9 @@ class DaemonPantsRunner:
       hermetic_environment_as(**self._env), \
       encapsulated_global_logger():
       try:
-
         options, _, options_bootstrapper = LocalPantsRunner.parse_options(self._args, self._env)
         graph_helper, target_roots, exit_code = self._scheduler_service.prepare_graph(options, options_bootstrapper)
+        self.exit_code = exit_code
         finalizer()
 
         # Clean global state.

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -251,7 +251,7 @@ class DaemonPantsRunner:
       encapsulated_global_logger():
       try:
         options, _, options_bootstrapper = LocalPantsRunner.parse_options(self._args, self._env)
-        graph_helper, target_roots, exit_code = self._scheduler_service.prepare_graph(options, options_bootstrapper)
+        graph_helper, target_roots, exit_code = self._scheduler_service.prepare_v1_graph_run_v2(options, options_bootstrapper)
         self.exit_code = exit_code
 
         # Clean global state.

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -21,8 +21,7 @@ from pants.engine.fs import create_fs_rules
 from pants.engine.goal import Goal
 from pants.engine.isolated_process import create_process_rules
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
-from pants.engine.legacy.graph import (LegacyBuildGraph, TransitiveHydratedTargets,
-                                       create_legacy_graph_tasks)
+from pants.engine.legacy.graph import (LegacyBuildGraph, create_legacy_graph_tasks)
 from pants.engine.legacy.options_parsing import create_options_parsing_rules
 from pants.engine.legacy.parser import LegacyPythonCallbacksParser
 from pants.engine.legacy.structs import (JvmAppAdaptor, JvmBinaryAdaptor, PageAdaptor,

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -168,19 +168,6 @@ class LegacyGraphSession(datatype(['scheduler_session', 'build_file_aliases', 'g
       )
       self.invalid_goals = invalid_goals
 
-  def warm_product_graph(self, target_roots):
-    """Warm the scheduler's `ProductGraph` with `TransitiveHydratedTargets` products.
-
-    This method raises only fatal errors, and does not consider failed roots in the execution
-    graph: in the v1 codepath, failed roots are accounted for post-fork.
-
-    :param TargetRoots target_roots: The targets root of the request.
-    """
-    logger.debug('warming target_roots for: %r', target_roots)
-    subjects = [target_roots.specs]
-    request = self.scheduler_session.execution_request([TransitiveHydratedTargets], subjects)
-    self.scheduler_session.execute(request)
-
   def run_console_rules(self, options_bootstrapper, goals, target_roots):
     """Runs @console_rules sequentially and interactively by requesting their implicit Goal products.
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -21,7 +21,7 @@ from pants.engine.fs import create_fs_rules
 from pants.engine.goal import Goal
 from pants.engine.isolated_process import create_process_rules
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
-from pants.engine.legacy.graph import (LegacyBuildGraph, create_legacy_graph_tasks)
+from pants.engine.legacy.graph import LegacyBuildGraph, create_legacy_graph_tasks
 from pants.engine.legacy.options_parsing import create_options_parsing_rules
 from pants.engine.legacy.parser import LegacyPythonCallbacksParser
 from pants.engine.legacy.structs import (JvmAppAdaptor, JvmBinaryAdaptor, PageAdaptor,

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -297,7 +297,6 @@ class PailgunServer(ThreadingMixIn, TCPServer):
 
     try:
       with self.ensure_request_is_exclusive(environment, request):
-        self.logger.info(request)
         # Attempt to handle a request with the handler.
         handler.handle_request()
         self.request_complete_callback()

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -297,6 +297,7 @@ class PailgunServer(ThreadingMixIn, TCPServer):
 
     try:
       with self.ensure_request_is_exclusive(environment, request):
+        self.logger.info(request)
         # Attempt to handle a request with the handler.
         handler.handle_request()
         self.request_complete_callback()

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -17,8 +17,6 @@ class SchedulerService(PantsService):
   """The pantsd scheduler service.
 
   This service holds an online Scheduler instance that is primed via watchman filesystem events.
-  This provides for a quick fork of pants runs (via the pailgun) with a fully primed ProductGraph
-  in memory.
   """
 
   QUEUE_SIZE = 64
@@ -162,8 +160,11 @@ class SchedulerService(PantsService):
     """
     return self._scheduler.graph_len()
 
-  def prepare_graph(self, options, options_bootstrapper):
-    """Runs all pre-fork logic in the process context of the daemon.
+  def prepare_v1_graph_run_v2(self, options, options_bootstrapper):
+    """For v1 (and v2): computing TargetRoots for a later v1 run
+
+    For v2: running an entire v2 run
+    The exit_code in the return indicates whether any issue was encountered
 
     :returns: `(LegacyGraphSession, TargetRoots, exit_code)`
     """

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -214,9 +214,6 @@ class SchedulerService(PantsService):
 
     v1_goals, ambiguous_goals, v2_goals = options.goals_by_version
 
-    # if v1_goals or (ambiguous_goals and global_options.v1):
-    #   session.warm_product_graph(target_roots)
-
     if v2_goals or (ambiguous_goals and global_options.v2):
       goals = v2_goals + (ambiguous_goals if global_options.v2 else tuple())
 


### PR DESCRIPTION
Implementation for #8002
--------------------------

Before removing forking from pantsd (#7596 ), we needed to warm up the v2 product graph of the daemon before forking into a `pantsd-runner` process (relevant code [here](https://github.com/pantsbuild/pants/blob/master/src/python/pants/bin/daemon_pants_runner.py#L117)).

Now, however, this warming is not necessary (because we don't fork a process per run of pants anymore), so we can do some cleanup to that code:

- We can remove the concept of "warming" ([here](https://github.com/pantsbuild/pants/blob/master/src/python/pants/init/engine_initializer.py#L171-L171)), which is invoked from `scheduler_service.prefork` ([here](https://github.com/pantsbuild/pants/blob/master/src/python/pants/bin/daemon_pants_runner.py#L120)). This probably means that we can remove the entire `warm_product_graph` function.
- We can reword the code around `scheduler_service.prefork` so that it doesn't mention forking at all. It was called prefork because that's what we did before #7596, but it can be called something different now.
- We can merge the try:except block in `DaemonPantsRunner.create()` ([here](https://github.com/pantsbuild/pants/blob/244e94d40c6d0fcf695f8ecfba9c429464345d64/src/python/pants/bin/daemon_pants_runner.py#L115)) into the try:except block in `DaemonPantsRunner.run()` ([here](https://github.com/pantsbuild/pants/blob/master/src/python/pants/bin/daemon_pants_runner.py#L277)). The `run()` function aims to centralize and correctly handle all the exceptions that happen on a pants run, so the "`prefork`" logic should be integrated there as well.

This will help a lot in correctly diagnosing pantsd problems, as this split and the wrangled exception handling that happen as a result have caused numerous issues.