### PR TITLE
[pantsd] Don't ignore the first watchman event for the daemon pid

### DIFF
--- a/src/python/pants/pantsd/service/fs_event_service.py
+++ b/src/python/pants/pantsd/service/fs_event_service.py
@@ -18,6 +18,7 @@ class FSEventService(PantsService):
 
   ZERO_DEPTH = ['depth', 'eq', 0]
 
+  PANTS_ALL_FILES_SUBSCRIPTION_NAME = 'all_files'
   PANTS_PID_SUBSCRIPTION_NAME = 'pantsd_pid'
 
   def __init__(self, watchman, build_root):
@@ -31,7 +32,7 @@ class FSEventService(PantsService):
     self._build_root = os.path.realpath(build_root)
     self._handlers = {}
 
-  def register_all_files_handler(self, callback, name='all_files'):
+  def register_all_files_handler(self, callback, name):
     """Registers a subscription for all files under a given watch path.
 
     :param func callback: the callback to execute on each filesystem event

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -143,12 +143,13 @@ class SchedulerService(PantsService):
     self._logger.debug('processing {} files for subscription {} (first_event={})'
                        .format(len(files), subscription, is_initial_event))
 
-    # The first watchman event is a listing of all files - ignore it.
-    if not is_initial_event:
-      if subscription == self._fs_event_service.PANTS_PID_SUBSCRIPTION_NAME:
-        self._maybe_invalidate_scheduler_pidfile()
-      else:
-        self._handle_batch_event(files)
+    # The first watchman event for all_files is a listing of all files - ignore it.
+    if not is_initial_event and subscription == self._fs_event_service.PANTS_ALL_FILES_SUBSCRIPTION_NAME:
+      self._handle_batch_event(files)
+
+    # However, we do want to check for the initial event in the pid file creation.
+    if subscription == self._fs_event_service.PANTS_PID_SUBSCRIPTION_NAME:
+      self._maybe_invalidate_scheduler_pidfile()
 
     if not self._watchman_is_running.is_set():
       self._watchman_is_running.set()

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -67,7 +67,7 @@ class SchedulerService(PantsService):
     """Service setup."""
     super().setup(services)
     # Register filesystem event handlers on an FSEventService instance.
-    self._fs_event_service.register_all_files_handler(self._enqueue_fs_event)
+    self._fs_event_service.register_all_files_handler(self._enqueue_fs_event, self._fs_event_service.PANTS_ALL_FILES_SUBSCRIPTION_NAME)
 
     # N.B. We compute the invalidating fileset eagerly at launch with an assumption that files
     # that exist at startup are the only ones that can affect the running daemon.


### PR DESCRIPTION
### Problem

The SchedulerService checks every event that changes the pantsd pidfile, and invalidates the daemon if the pid no longer is what it should be.

However, it also ignores the first event of every subscription. This is not something we want to do for the pidfile subscription, because if the pidfile changes between the time we write it and the time we subscribe to it and receive the first event, we will only receive the first event, and will continue on without invalidating the daemon.

This has happened in the following situation:
- Two invocations of pants are triggered at the same time on a machine, both with pantsd, and pantsd was not active at the moment. Let's call them inv1 and inv2.
- Both inv1 and inv2 see that there is not pidfile, and  therefore they assume no pantsd is running, and thus start creating one each, in parallel.
- inv1 finishes creating the services first and writes its pidfile.
- inv2 finishes creating the services, and overwrites the pidfile.
- inv1 registers the watchman subscritption for the pidfile. Watchman triggers the initial event for the pidfile in inv1. Inv1 ignores it, and continues running. It will never receive any request, because its pidfile is not there, but it will not invalidate until the pidfile is changed again.

### Solution

Not ignoring the first event for the pidfile.

### Result

More robust initialization of pantsds, where in the condition described above inv1 would check the pidfile and invalidate, leaving only inv2.

Commits are independently reviewable.