### PR TITLE
Don't hard code expecting HTTP 200 as the only success response code, all 20x responses are success codes.

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -398,11 +398,13 @@ class RunTracker(Subsystem):
                         cookies=cookies.get_cookie_jar(), allow_redirects=False)
       if res.status_code in {307, 308}:
         return do_post(res.headers['location'], num_redirects_allowed - 1)
-      elif res.status_code != 200:
+      elif 300 <= res.status_code < 400 or res.status_code == 401:
         error(f'HTTP error code: {res.status_code}. Reason: {res.reason}.')
-        if 300 <= res.status_code < 400 or res.status_code == 401:
-          print(f'Use `path/to/pants login --to={auth_provider}` to authenticate '
+        print(f'Use `path/to/pants login --to={auth_provider}` to authenticate '
                 'against the stats upload service.', file=sys.stderr)
+        return False
+      elif not res.ok:
+        error(f'HTTP error code: {res.status_code}. Reason: {res.reason}.')
         return False
       return True
 


### PR DESCRIPTION
### Problem

Pants treats non-200 HTTP responses from the server as errors. 20x HTTP responses should not be considered errors.

### Solution

Use the request's library built in [response.ok](https://github.com/psf/requests/blob/589a82256759018a7e5e289302898dae32544949/requests/models.py#L693) property to determine if we got an HTTP error response or not.

### Result

HTTP 20x responses are handled is valid success responses.