### PR TITLE
Recognize multiple sentinel files for determining the build root

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,10 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+# NB: We cannot depend on `./pants`. When running tests with V1, the folder in `.pants.d` will strip
+# the prefix so `src/python/pants` -> `pants`. You cannot both have a directory named `pants` and a
+# file named `pants`, so this causes most V1 tests to fail.
+
 files(
   name = 'build_tools',
   source = 'BUILD.tools',
@@ -11,16 +15,6 @@ files(
   source = '3rdparty/BUILD',
 )
 
-# NB: Be careful when using this in tests! Some tests will use this to determine the buildroot and
-# then dynamically try to open other files relative to the buildroot, such as BUILD.tools. This
-# should not be used to dynamically import other files—those must be explicitly imported via their
-# own BUILD entries.
-files(
-  name = 'pants_script',
-  source = 'pants',
-)
-
-# Usually this must be accompanied with `pants_script` to be discovered properly.
 files(
   name = 'pants_ini',
   source = 'pants.ini'

--- a/BUILD
+++ b/BUILD
@@ -1,9 +1,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# NB: We cannot depend on `./pants`. When running tests with V1, the folder in `.pants.d` will strip
-# the prefix so `src/python/pants` -> `pants`. You cannot both have a directory named `pants` and a
-# file named `pants`, so this causes most V1 tests to fail.
+# We use this to establish the build root, rather than `./pants`, because we cannot safely use the
+# latter as the sentinel filename per https://github.com/pantsbuild/pants/pull/8105.
+files(
+  name = 'build_root',
+  source = "BUILD_ROOT",
+)
 
 files(
   name = 'build_tools',

--- a/BUILD
+++ b/BUILD
@@ -10,3 +10,12 @@ files(
   name = '3rdparty_build',
   source = '3rdparty/BUILD',
 )
+
+# NB: Be careful when using this in tests! Some tests will use this to determine the buildroot and
+# then dynamically try to open other files relative to the buildroot, such as BUILD.tools. This
+# should not be used to dynamically import other files—those must be explicitly imported via their
+# own BUILD entries.
+files(
+  name = 'pants_script',
+  source = 'pants',
+)

--- a/BUILD
+++ b/BUILD
@@ -19,3 +19,9 @@ files(
   name = 'pants_script',
   source = 'pants',
 )
+
+# Usually this must be accompanied with `pants_script` to be discovered properly.
+files(
+  name = 'pants_ini',
+  source = 'pants.ini'
+)

--- a/BUILD_ROOT
+++ b/BUILD_ROOT
@@ -1,0 +1,2 @@
+# Used for our tests to find the build root, as we cannot safely use `./pants`
+# for the sentinel filename per https://github.com/pantsbuild/pants/pull/8105.

--- a/build-support/unit_test_remote_blacklist.txt
+++ b/build-support/unit_test_remote_blacklist.txt
@@ -1,13 +1,2 @@
-tests/python/pants_test/backend/jvm/subsystems:shader
-tests/python/pants_test/backend/jvm/targets:jar_dependency
-tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:java_compile_settings_partitioning
 tests/python/pants_test/backend/jvm/tasks/jvm_compile:jvm_compile
 tests/python/pants_test/backend/native/subsystems:subsystems
-tests/python/pants_test/base:build_root
-tests/python/pants_test/build_graph:build_file_aliases
-tests/python/pants_test/init:init
-tests/python/pants_test/invalidation:build_invalidator
-tests/python/pants_test/ivy:bootstrapper
-tests/python/pants_test/ivy:ivy_subsystem
-tests/python/pants_test/java/distribution:distribution
-tests/python/pants_test/option:testing

--- a/src/docs/install.md
+++ b/src/docs/install.md
@@ -18,7 +18,7 @@ Recommended Installation
 ------------------------
 
 To set up Pants in your repo, we recommend installing our self-contained `pants` bash script
-in the root (i.e. the "buildroot") of your repo:
+in the root (i.e. the "build root") of your repo:
 
     :::bash
     curl -L -O https://pantsbuild.github.io/setup/pants && chmod +x pants
@@ -51,16 +51,12 @@ The ./pants Runner Script
 -------------------------
 
 We highly recommend invoking pants via a checked-in runner script named `pants` in the
-root of your workspace, as demonstrated above.  Pants uses the presence of such a file, in the
-current working directory or in any of its ancestors, to detect the buildroot, e.g., when
+root of your workspace, as demonstrated above. Pants uses the presence of such a file, in the
+current working directory or in any of its ancestors, to detect the build root, e.g., when
 invoked in a subdirectory.
 
-If, for whatever reason, you don't want to run pants that way, you can also just check in an
-empty file named `pants` to act as a sentinel for the buildroot.
-
-Note that you can create whatever symlinks or extra wrapper scripts you like.  There's no absolute
-requirement that pants be invoked directly via `./pants`.  All pants cares about is the existence
-of a file named `pants` in the buildroot, and that file might as well be the runner script!
+If, for whatever reason, you don't want to run Pants that way, you can also just check in an
+empty file named `BUILD_ROOT` to act as the sentinel for determining your project's build root.
 
 PEX-based Installation
 ----------------------

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -22,7 +22,7 @@ from pants.engine.fs import DirectoryToMaterialize, PathGlobs, PathGlobsAndRoot
 from pants.engine.isolated_process import ExecuteProcessRequest
 from pants.java.distribution.distribution import Distribution
 from pants.java.jar.jar_dependency import JarDependency
-from pants.util.dirutil import fast_relpath, safe_delete, safe_mkdir
+from pants.util.dirutil import fast_relpath, safe_delete, safe_mkdir, safe_mkdir_for
 from pants.util.fileutil import safe_hardlink_or_copy
 from pants.util.memo import memoized_method, memoized_property
 
@@ -230,6 +230,7 @@ class Zinc:
       # (e.g., a JDK that is no longer present), or points to the wrong JDK.
       if not jdk_home_symlink.exists() or jdk_home_symlink.resolve() != Path(underlying_dist.home):
         safe_delete(str(jdk_home_symlink))  # Safe-delete, in case it's a broken symlink.
+        safe_mkdir_for(jdk_home_symlink)
         jdk_home_symlink.symlink_to(underlying_dist.home)
 
     return Distribution(home_path=jdk_home_symlink)

--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -27,8 +27,12 @@ def get_buildroot(*, sentinel_filename: str = "pants") -> str:
   """Returns the Pants build root, calculating it if needed.
 
   :API: public
+  :param sentinel_filename: The file to look for to establish the buildroot. This is currently only
+                            used for testing purposes.
   """
-  return BuildRoot(sentinel_filename=sentinel_filename).path
+  build_root = BuildRoot()
+  build_root.sentinel_file = sentinel_filename
+  return build_root.path
 
 
 def get_pants_cachedir():

--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -53,9 +53,9 @@ def get_pants_configdir():
   return os.path.expanduser(os.path.join(config_home, 'pants'))
 
 
-def get_default_pants_config_file():
+def get_default_pants_config_file(*, buildroot_sentinel_filename: str = "pants") -> str:
   """Return the default location of the pants config file."""
-  return os.path.join(get_buildroot(), 'pants.ini')
+  return os.path.join(get_buildroot(sentinel_filename=buildroot_sentinel_filename), 'pants.ini')
 
 
 _SCM = None

--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -23,16 +23,12 @@ def pants_release():
           .format(version=pants_version()))
 
 
-def get_buildroot(*, sentinel_filename: str = "pants") -> str:
+def get_buildroot() -> str:
   """Returns the Pants build root, calculating it if needed.
 
   :API: public
-  :param sentinel_filename: The file to look for to establish the buildroot. This is currently only
-                            used for testing purposes.
   """
-  build_root = BuildRoot()
-  build_root.sentinel_file = sentinel_filename
-  return build_root.path
+  return BuildRoot().path
 
 
 def get_pants_cachedir():
@@ -53,9 +49,9 @@ def get_pants_configdir():
   return os.path.expanduser(os.path.join(config_home, 'pants'))
 
 
-def get_default_pants_config_file(*, buildroot_sentinel_filename: str = "pants") -> str:
+def get_default_pants_config_file() -> str:
   """Return the default location of the pants config file."""
-  return os.path.join(get_buildroot(sentinel_filename=buildroot_sentinel_filename), 'pants.ini')
+  return os.path.join(get_buildroot(), 'pants.ini')
 
 
 _SCM = None

--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -23,12 +23,12 @@ def pants_release():
           .format(version=pants_version()))
 
 
-def get_buildroot():
-  """Returns the pants build root, calculating it if needed.
+def get_buildroot(*, sentinel_filename: str = "pants") -> str:
+  """Returns the Pants build root, calculating it if needed.
 
   :API: public
   """
-  return BuildRoot().path
+  return BuildRoot(sentinel_filename=sentinel_filename).path
 
 
 def get_pants_cachedir():

--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -22,20 +22,20 @@ class BuildRoot(Singleton):
 
   def find_buildroot(self):
     buildroot = os.path.abspath(os.getcwd())
-    while not os.path.isfile(os.path.join(buildroot, self._sentinel_filename)):
+    while not os.path.isfile(os.path.join(buildroot, self.sentinel_file)):
       parent = os.path.dirname(buildroot)
       if buildroot != parent:
         buildroot = parent
       else:
         raise self.NotFoundError('No buildroot detected. Pants detects the buildroot by looking '
-                                 f'for a file named {self._sentinel_filename} in the cwd and its '
+                                 f'for a file named {self.sentinel_file} in the cwd and its '
                                  'ancestors. Typically this is the runner script that executes '
                                  'Pants. If you have no such script you can create an empty file '
                                  'in your buildroot.')
     return buildroot
 
-  def __init__(self, *, sentinel_filename: str = "pants"):
-    self._sentinel_filename = sentinel_filename
+  def __init__(self) -> None:
+    self._sentinel_filename = "pants"
     self._root_dir = None
 
   @property
@@ -57,6 +57,17 @@ class BuildRoot(Singleton):
     if not os.path.exists(path):
       raise ValueError(f'Build root does not exist: {root_dir}')
     self._root_dir = path
+
+  @property
+  def sentinel_file(self) -> str:
+    """File to look for in order to establish the buildroot."""
+    return self._sentinel_filename
+
+  @sentinel_file.setter
+  def sentinel_file(self, filename: str) -> None:
+    """Replaces the sentinel filename and resets the buildroot because it is no longer valid."""
+    self._sentinel_filename = filename
+    self.reset()
 
   def reset(self):
     """Clears the last calculated build root for the current workspace."""

--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -11,33 +11,31 @@ from pants.util.meta import Singleton
 class BuildRoot(Singleton):
   """Represents the global workspace build root.
 
-  By default a pants workspace is defined by a root directory where a file called 'pants' -
-  typically the pants runner script - lives.  This path can also be manipulated through
+  By default a Pants workspace is defined by a root directory where a file called 'pants' -
+  typically the Pants runner script - lives. The expected file can be changed from 'pants' to
+  something else, which is useful for testing. Likewise, this path can also be manipulated through
   this interface for re-location of the build root in tests.
-
-  TODO: If this ever causes a problem (because some subdir that people run pants in
-        legitimately contains a file called 'pants') then we can add a second check for
-        an explicit sentinel file, like 'BUILDROOT'.
   """
 
   class NotFoundError(Exception):
     """Raised when unable to find the current workspace build root."""
 
-  @classmethod
-  def find_buildroot(cls):
+  def find_buildroot(self):
     buildroot = os.path.abspath(os.getcwd())
-    while not os.path.isfile(os.path.join(buildroot, 'pants')):
+    while not os.path.isfile(os.path.join(buildroot, self._sentinel_filename)):
       parent = os.path.dirname(buildroot)
       if buildroot != parent:
         buildroot = parent
       else:
-        raise cls.NotFoundError('No buildroot detected. Pants detects the buildroot by looking '
-                                'for a file named pants in the cwd and its ancestors.  Typically '
-                                'this is the runner script that executes pants.  If you have no '
-                                'such script you can create an empty file in your buildroot.')
+        raise self.NotFoundError('No buildroot detected. Pants detects the buildroot by looking '
+                                 f'for a file named {self._sentinel_filename} in the cwd and its '
+                                 'ancestors. Typically this is the runner script that executes '
+                                 'Pants. If you have no such script you can create an empty file '
+                                 'in your buildroot.')
     return buildroot
 
-  def __init__(self):
+  def __init__(self, *, sentinel_filename: str = "pants"):
+    self._sentinel_filename = sentinel_filename
     self._root_dir = None
 
   @property

--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -57,7 +57,7 @@ class BuildRoot(Singleton):
     """Manually establishes the build root for the current workspace."""
     path = os.path.realpath(root_dir)
     if not os.path.exists(path):
-      raise ValueError('Build root does not exist: {}'.format(root_dir))
+      raise ValueError(f'Build root does not exist: {root_dir}')
     self._root_dir = path
 
   def reset(self):
@@ -65,7 +65,7 @@ class BuildRoot(Singleton):
     self._root_dir = None
 
   def __str__(self):
-    return 'BuildRoot({})'.format(self._root_dir)
+    return f'BuildRoot({self._root_dir})'
 
   @contextmanager
   def temporary(self, path):

--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -24,14 +24,15 @@ class BuildRoot(Singleton):
 
   def find_buildroot(self) -> str:
     buildroot = Path.cwd().resolve()
-    while not any((Path(buildroot) / sentinel).is_file() for sentinel in self.sentinel_files):
+    while not any((buildroot / sentinel).is_file() for sentinel in self.sentinel_files):
       if buildroot != buildroot.parent:
         buildroot = buildroot.parent
       else:
-        raise self.NotFoundError('No buildroot detected. Pants detects the buildroot by looking '
-                                 f'for at least one file from {self.sentinel_files} in the cwd and '
-                                 'its ancestors. If you have none of these files, you can create '
-                                 'an empty file in your buildroot.')
+        raise self.NotFoundError(
+          'No build root detected. Pants detects the build root by looking for at least one file '
+          f'from {self.sentinel_files} in the cwd and its ancestors. If you have none of these '
+          f'files, you can create an empty file in your build root.'
+        )
     return str(buildroot)
 
   def __init__(self) -> None:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -101,7 +101,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
   options_scope_category = ScopeInfo.GLOBAL
 
   @classmethod
-  def register_bootstrap_options(cls, register, *, buildroot_sentinel_filename: str = "pants"):
+  def register_bootstrap_options(cls, register):
     """Register bootstrap options.
 
     "Bootstrap options" are a small set of options whose values are useful when registering other
@@ -114,7 +114,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     Note that regular code can also access these options as normal global-scope options. Their
     status as "bootstrap options" is only pertinent during option registration.
     """
-    buildroot = get_buildroot(sentinel_filename=buildroot_sentinel_filename)
+    buildroot = get_buildroot()
     default_distdir_name = 'dist'
     default_distdir = os.path.join(buildroot, default_distdir_name)
     default_rel_distdir = f'/{default_distdir_name}/'
@@ -195,10 +195,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   'live outside of the dir used by `--pants-workdir` to allow for tracking '
                   'subprocesses that outlive the workdir data (e.g. `./pants server`).')
     register('--pants-config-files', advanced=True, type=list, daemon=False,
-             default=[
-               get_default_pants_config_file(buildroot_sentinel_filename=buildroot_sentinel_filename)
-             ],
-             help='Paths to Pants config files.')
+             default=[get_default_pants_config_file()], help='Paths to Pants config files.')
     # TODO: Deprecate the --pantsrc/--pantsrc-files options?  This would require being able
     # to set extra config file locations in an initial bootstrap config file.
     register('--pantsrc', advanced=True, type=bool, default=True,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -195,7 +195,10 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   'live outside of the dir used by `--pants-workdir` to allow for tracking '
                   'subprocesses that outlive the workdir data (e.g. `./pants server`).')
     register('--pants-config-files', advanced=True, type=list, daemon=False,
-             default=[get_default_pants_config_file()], help='Paths to Pants config files.')
+             default=[
+               get_default_pants_config_file(buildroot_sentinel_filename=buildroot_sentinel_filename)
+             ],
+             help='Paths to Pants config files.')
     # TODO: Deprecate the --pantsrc/--pantsrc-files options?  This would require being able
     # to set extra config file locations in an initial bootstrap config file.
     register('--pantsrc', advanced=True, type=bool, default=True,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -101,7 +101,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
   options_scope_category = ScopeInfo.GLOBAL
 
   @classmethod
-  def register_bootstrap_options(cls, register):
+  def register_bootstrap_options(cls, register, *, buildroot_sentinel_filename: str = "pants"):
     """Register bootstrap options.
 
     "Bootstrap options" are a small set of options whose values are useful when registering other
@@ -114,10 +114,10 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     Note that regular code can also access these options as normal global-scope options. Their
     status as "bootstrap options" is only pertinent during option registration.
     """
-    buildroot = get_buildroot()
+    buildroot = get_buildroot(sentinel_filename=buildroot_sentinel_filename)
     default_distdir_name = 'dist'
     default_distdir = os.path.join(buildroot, default_distdir_name)
-    default_rel_distdir = '/{}/'.format(default_distdir_name)
+    default_rel_distdir = f'/{default_distdir_name}/'
 
     register('-l', '--level', choices=['trace', 'debug', 'info', 'warn'], default='info',
              recursive=True, help='Set the logging level.')

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -15,6 +15,7 @@ python_tests(
   name = 'build_root',
   sources = ['test_build_root.py'],
   dependencies = [
+    '//:build_root',
     'src/python/pants/base:build_root',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -15,6 +15,7 @@ python_tests(
   name = 'build_root',
   sources = ['test_build_root.py'],
   dependencies = [
+    '//:pants_script',
     'src/python/pants/base:build_root',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -15,7 +15,6 @@ python_tests(
   name = 'build_root',
   sources = ['test_build_root.py'],
   dependencies = [
-    '//:pants_script',
     'src/python/pants/base:build_root',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',

--- a/tests/python/pants_test/base/test_build_root.py
+++ b/tests/python/pants_test/base/test_build_root.py
@@ -3,6 +3,7 @@
 
 import os
 import unittest
+from pathlib import Path
 
 from pants.base.build_root import BuildRoot
 from pants.util.contextutil import environment_as, pushd, temporary_dir
@@ -11,54 +12,62 @@ from pants.util.dirutil import safe_mkdir, safe_mkdtemp, safe_rmtree, touch
 
 class BuildRootTest(unittest.TestCase):
 
+  sentinel_filename = "pants.test"
+
   def setUp(self):
-    self.original_root = BuildRoot().path
-    self.new_root = os.path.realpath(safe_mkdtemp())
-    BuildRoot().reset()
+    Path(self.sentinel_filename).touch()
+    self.build_root = BuildRoot(sentinel_filename=self.sentinel_filename)
+    self.original_path = BuildRoot(sentinel_filename=self.sentinel_filename).path
+    self.new_path = os.path.realpath(safe_mkdtemp())
+    self.build_root.reset()
 
   def tearDown(self):
-    BuildRoot().reset()
-    safe_rmtree(self.new_root)
+    self.build_root.reset()
+    Path(self.sentinel_filename).unlink()
+    safe_rmtree(self.new_path)
 
   def test_via_set(self):
-    BuildRoot().path = self.new_root
-    self.assertEqual(self.new_root, BuildRoot().path)
+    self.build_root.path = self.new_path
+    self.assertEqual(self.new_path, self.build_root.path)
 
   def test_reset(self):
-    BuildRoot().path = self.new_root
-    BuildRoot().reset()
-    self.assertEqual(self.original_root, BuildRoot().path)
+    self.build_root.path = self.new_path
+    self.build_root.reset()
+    self.assertEqual(self.original_path, self.build_root.path)
 
   def test_via_pants_runner(self):
     with temporary_dir() as root:
       root = os.path.realpath(root)
-      touch(os.path.join(root, 'pants'))
+      touch(os.path.join(root, self.sentinel_filename))
       with pushd(root):
-        self.assertEqual(root, BuildRoot().path)
+        self.assertEqual(root, self.build_root.path)
 
-      BuildRoot().reset()
+      self.build_root.reset()
       child = os.path.join(root, 'one', 'two')
       safe_mkdir(child)
       with pushd(child):
-        self.assertEqual(root, BuildRoot().path)
+        self.assertEqual(root, self.build_root.path)
 
   def test_temporary(self):
-    with BuildRoot().temporary(self.new_root):
-      self.assertEqual(self.new_root, BuildRoot().path)
-    self.assertEqual(self.original_root, BuildRoot().path)
+    with self.build_root.temporary(self.new_path):
+      self.assertEqual(self.new_path, self.build_root.path)
+    self.assertEqual(self.original_path, self.build_root.path)
 
   def test_singleton(self):
-    self.assertEqual(BuildRoot().path, BuildRoot().path)
-    BuildRoot().path = self.new_root
+    self.assertEqual(
+      BuildRoot(sentinel_filename=self.sentinel_filename).path,
+      BuildRoot(sentinel_filename=self.sentinel_filename).path
+    )
+    BuildRoot().path = self.new_path
     self.assertEqual(BuildRoot().path, BuildRoot().path)
 
   def test_not_found(self):
     with temporary_dir() as root:
       root = os.path.realpath(root)
       with pushd(root):
-        self.assertRaises(BuildRoot.NotFoundError, lambda: BuildRoot().path)
+        self.assertRaises(BuildRoot.NotFoundError, lambda: self.build_root.path)
 
   def test_buildroot_override(self):
     with temporary_dir() as root:
       with environment_as(PANTS_BUILDROOT_OVERRIDE=root):
-        self.assertEqual(BuildRoot().path, root)
+        self.assertEqual(self.build_root.path, root)

--- a/tests/python/pants_test/option/util/BUILD
+++ b/tests/python/pants_test/option/util/BUILD
@@ -3,6 +3,8 @@
 
 python_library(
   dependencies=[
+    '//:pants_ini',
+    '//:pants_script',
     'src/python/pants/option',
   ],
 )

--- a/tests/python/pants_test/option/util/BUILD
+++ b/tests/python/pants_test/option/util/BUILD
@@ -3,6 +3,7 @@
 
 python_library(
   dependencies=[
+    '//:build_root',
     '//:pants_ini',
     'src/python/pants/option',
   ],

--- a/tests/python/pants_test/option/util/BUILD
+++ b/tests/python/pants_test/option/util/BUILD
@@ -4,7 +4,6 @@
 python_library(
   dependencies=[
     '//:pants_ini',
-    '//:pants_script',
     'src/python/pants/option',
   ],
 )

--- a/tests/python/pants_test/option/util/fakes.py
+++ b/tests/python/pants_test/option/util/fakes.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from collections import defaultdict
+from pathlib import Path
 
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.option_util import is_list_option
@@ -180,8 +181,15 @@ def create_options_for_optionables(optionables,
   # TODO: This sequence is a bit repetitive of the real registration sequence.
 
   # Register bootstrap options and grab their default values for use in subsequent registration.
-  GlobalOptionsRegistrar.register_bootstrap_options(register_func(GLOBAL_SCOPE))
+  # We override the default buildroot sentinel filename of "pants" and create a temporary file so
+  # that we can load up pants.ini without any issues.
+  buildroot_sentinel_filename = "pants.test"
+  Path(buildroot_sentinel_filename).touch()
+  GlobalOptionsRegistrar.register_bootstrap_options(
+    register_func(GLOBAL_SCOPE), buildroot_sentinel_filename=buildroot_sentinel_filename
+  )
   bootstrap_option_values = _FakeOptionValues(all_options[GLOBAL_SCOPE].copy())
+  Path(buildroot_sentinel_filename).unlink()
 
   # Now register the full global scope options.
   GlobalOptionsRegistrar.register_options(register_func(GLOBAL_SCOPE))

--- a/tests/python/pants_test/option/util/fakes.py
+++ b/tests/python/pants_test/option/util/fakes.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from collections import defaultdict
-from pathlib import Path
 
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.option_util import is_list_option
@@ -181,15 +180,8 @@ def create_options_for_optionables(optionables,
   # TODO: This sequence is a bit repetitive of the real registration sequence.
 
   # Register bootstrap options and grab their default values for use in subsequent registration.
-  # We override the default buildroot sentinel filename of "pants" and create a temporary file so
-  # that we can load up pants.ini without any issues.
-  buildroot_sentinel_filename = "pants.test"
-  Path(buildroot_sentinel_filename).touch()
-  GlobalOptionsRegistrar.register_bootstrap_options(
-    register_func(GLOBAL_SCOPE), buildroot_sentinel_filename=buildroot_sentinel_filename
-  )
+  GlobalOptionsRegistrar.register_bootstrap_options(register_func(GLOBAL_SCOPE))
   bootstrap_option_values = _FakeOptionValues(all_options[GLOBAL_SCOPE].copy())
-  Path(buildroot_sentinel_filename).unlink()
 
   # Now register the full global scope options.
   GlobalOptionsRegistrar.register_options(register_func(GLOBAL_SCOPE))


### PR DESCRIPTION
## Problem
We cannot have implicit runtime dependencies on files in the buildroot - they must all be declared explicitly via `BUILD` entries. https://github.com/pantsbuild/pants/pull/8066 fixed several of these issues, but not all. 

However, we cannot explicitly depend on the file `./pants` because it breaks V1 test execution. When running tests with V1, the folder in `.pants.d` will strip the prefix so `src/python/pants` -> `pants`. You cannot both have a directory named `pants` and a file named `pants`, so this causes most V1 tests to fail.

## Solution
Use multiple sentinel files to establish the buildroot, such as `BUILD_ROOT`. This allows us to safely depend on a sentinel file with very few code changes.