### PR TITLE
Loosen constraints on the jvm heap size for tests in extra_jvm_options

### DIFF
--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/Main.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/Main.java
@@ -5,6 +5,8 @@ import java.lang.management.RuntimeMXBean;
 import java.util.List;
 
 public class Main {
+    final static long oneHundredMegabytes = 1024 * 1024 * 100;
+
     private static void printProperty(String name) {
         String value = System.getProperty(name);
         System.out.println("Property " + name + " is " + value);
@@ -13,7 +15,6 @@ public class Main {
     private static void printFlag(String name) {
         RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
         List<String> arguments = runtimeMxBean.getInputArguments();
-        
         if (arguments.contains(name)) {
           System.out.println("Flag " + name + " is set");
         } else {
@@ -22,7 +23,12 @@ public class Main {
     }
 
     private static void printMaxHeapSize() {
-      System.out.println("Max Heap Size: " + Runtime.getRuntime().maxMemory());
+      Long maxMemory = Runtime.getRuntime().maxMemory();
+      if (maxMemory > oneHundredMegabytes) {
+        System.out.println("Max Heap Size is more than 100MB");
+      } else {
+        System.out.println("Max Heap Size: " + maxMemory);
+      }
     }
 
     public static void main(String args[]) {

--- a/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/Main.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options/Main.java
@@ -5,8 +5,6 @@ import java.lang.management.RuntimeMXBean;
 import java.util.List;
 
 public class Main {
-    final static long oneHundredMegabytes = 1024 * 1024 * 100;
-
     private static void printProperty(String name) {
         String value = System.getProperty(name);
         System.out.println("Property " + name + " is " + value);
@@ -23,12 +21,7 @@ public class Main {
     }
 
     private static void printMaxHeapSize() {
-      Long maxMemory = Runtime.getRuntime().maxMemory();
-      if (maxMemory > oneHundredMegabytes) {
-        System.out.println("Max Heap Size is more than 100MB");
-      } else {
-        System.out.println("Max Heap Size: " + maxMemory);
-      }
+      System.out.println("Max Heap Size: " + Runtime.getRuntime().maxMemory());
     }
 
     public static void main(String args[]) {

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
@@ -82,7 +82,7 @@ class JvmRunIntegrationTest(PantsRunIntegrationTest):
     self.assertIn("""Property property.color is null
 Property property.size is null
 Flag -DMyFlag is NOT set
-Max Heap Size: 954728448""", output)
+Max Heap Size is more than 100MB""", output)
 
     output = self.run_pants(
       ['run',
@@ -90,7 +90,7 @@ Max Heap Size: 954728448""", output)
     self.assertIn("""Property property.color is null
 Property property.size is null
 Flag -DMyFlag is NOT set
-Max Heap Size: 954728448""", output)
+Max Heap Size is more than 100MB""", output)
 
     output = self.run_pants(
       ['run',

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
@@ -71,28 +71,32 @@ class JvmRunIntegrationTest(PantsRunIntegrationTest):
     self.assertIn('Synthetic jar run is not detected', output)
 
   def test_enable_extra_jvm_options(self):
-    output = self.run_pants(
+    jvm_run_fixed_heap_size = {'jvm.run.jvm': {'options': '["-Xmx123456789"]'}}
+    def run_pants_with_heap_size(cmd):
+      return self.run_pants(cmd, config=jvm_run_fixed_heap_size)
+
+    output = run_pants_with_heap_size(
       ['run',
         'testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options:python_app']).stdout_data
     self.assertIn('Python app runs correctly', output)
 
-    output = self.run_pants(
+    output = run_pants_with_heap_size(
       ['run',
         'testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options:noopts']).stdout_data
     self.assertIn("""Property property.color is null
 Property property.size is null
 Flag -DMyFlag is NOT set
-Max Heap Size is more than 100MB""", output)
+Max Heap Size: 119013376""", output)
 
-    output = self.run_pants(
+    output = run_pants_with_heap_size(
       ['run',
         'testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options:app_noopts']).stdout_data
     self.assertIn("""Property property.color is null
 Property property.size is null
 Flag -DMyFlag is NOT set
-Max Heap Size is more than 100MB""", output)
+Max Heap Size: 119013376""", output)
 
-    output = self.run_pants(
+    output = run_pants_with_heap_size(
       ['run',
         'testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options:opts']).stdout_data
     self.assertIn("""Property property.color is orange


### PR DESCRIPTION
### Problem

We set the default heap size to 1GB, and there was a test that trusted on that being a consistent number. However, the test doesn't need that to work. It's not testing the actual default heap size, but that we can modify the heap size if we pass an option.

This was causing travis failures: https://pastebin.com/knEMAWm7

### Solution

Only output a number if the heap size is less than 100MB. We set it to be very small in the target that we are testing.

### Result

Hopefully no failures.