### PR TITLE
Balance pytest test sharding

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest/plugin.py
+++ b/src/python/pants/backend/python/tasks/pytest/plugin.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 import os
+from zlib import crc32
 
 import pytest
 
@@ -61,7 +62,7 @@ class ShardingPlugin(object):
     def is_conftest(itm):
       return itm.fspath and itm.fspath.basename == 'conftest.py'
     for i, item in enumerate(list(x for x in items if not is_conftest(x))):
-      if i % self._num_shards != self._shard:
+      if crc32(str(item.nodeid)) % self._num_shards != self._shard:
         del items[i - removed]
         removed += 1
     reporter = config.pluginmanager.getplugin('terminalreporter')

--- a/src/python/pants/backend/python/tasks/pytest/plugin.py
+++ b/src/python/pants/backend/python/tasks/pytest/plugin.py
@@ -61,6 +61,8 @@ class ShardingPlugin(object):
     removed = 0
     def is_conftest(itm):
       return itm.fspath and itm.fspath.basename == 'conftest.py'
+    # We hash-mod to assign to shards to avoid hotspots when there are fewer tests than there
+    # are shards.
     for i, item in enumerate(list(x for x in items if not is_conftest(x))):
       if crc32(str(item.nodeid)) % self._num_shards != self._shard:
         del items[i - removed]

--- a/src/python/pants/backend/python/tasks/pytest/plugin.py
+++ b/src/python/pants/backend/python/tasks/pytest/plugin.py
@@ -64,7 +64,7 @@ class ShardingPlugin(object):
     # We hash-mod to assign to shards to avoid hotspots when there are fewer tests than there
     # are shards.
     for i, item in enumerate(list(x for x in items if not is_conftest(x))):
-      if crc32(str(item.nodeid)) % self._num_shards != self._shard:
+      if crc32(str(item.nodeid).encode()) % self._num_shards != self._shard:
         del items[i - removed]
         removed += 1
     reporter = config.pluginmanager.getplugin('terminalreporter')


### PR DESCRIPTION
### Problem

The pytest test sharding plugin uses mod of test index over the number of shards to balance across shards. That works fine when there are a lot more tests than shards, which used to ~always be the case... until we turned on `--no-fast` in travis, at which point each pytest invoke would observe only the tests for a single target. This meant that in many cases there were fewer tests than shards in an invoke.

The effect was that we biased toward overloading lower shard counts (because targets with less than a dozen test methods are very common).

### Solution

Balance across shards by hashing the pytest item "nodeid" (used elsewhere in this file for item display).

### Result

Fewer straggling shards in travis.