### PR TITLE
Fix remote execution failure to compile C code

### DIFF
--- a/build-support/docker/remote_execution/Dockerfile
+++ b/build-support/docker/remote_execution/Dockerfile
@@ -17,13 +17,15 @@ FROM gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:da0f21c71abce3bbb92c
 RUN apt-get update
 RUN apt-get install -y \
   build-essential \
-  zlib1g-dev \
+  gcc-multilib \
+  g++-multilib \
   libbz2-dev \
   libreadline-dev \
   libssl-dev \
   libsqlite3-dev \
   libffi-dev \
-  python-openssl
+  python-openssl \
+  zlib1g-dev
 
 # Even though the image already comes installed with Python 2.7, 3.5, and 3.6, we install our own
 # via Pyenv because we need Python 3.7 and want consistency in how we install them.

--- a/build-support/unit_test_remote_blacklist.txt
+++ b/build-support/unit_test_remote_blacklist.txt
@@ -1,2 +1,1 @@
 tests/python/pants_test/backend/jvm/tasks/jvm_compile:jvm_compile
-tests/python/pants_test/backend/native/subsystems:subsystems

--- a/pants.remote.ini
+++ b/pants.remote.ini
@@ -20,7 +20,7 @@ remote_instance_name: projects/pants-remoting-beta/instances/default_instance
 remote_execution_extra_platform_properties: [
     # This allows network requests, e.g. to resolve dependencies with Pex.
     "dockerNetwork=standard",
-    "container-image=docker://gcr.io/pants-remoting-beta/rbe-remote-execution@sha256:20046a8b909cbbd94f3ff33808ceeeaa489a05eea5d00ad57c378f81f21462fc",
+    "container-image=docker://gcr.io/pants-remoting-beta/rbe-remote-execution@sha256:5d818cd71c9180d977e16ca7a20e90ced14211621b69fe1d6c3fc4c42c537a14",
   ]
 
 # This should correspond to the number of workers running in Google RBE. See

--- a/src/python/pants/backend/native/subsystems/libc_dev.py
+++ b/src/python/pants/backend/native/subsystems/libc_dev.py
@@ -73,10 +73,10 @@ class LibcDev(Subsystem):
 
     if not libc_crti_object_file:
       raise self.HostLibcDevResolutionError(
-        "Could not locate {fname} in library search dirs {dirs} from compiler: {compiler!r}. "
-        "You may need to install a libc dev package for the current system. "
-        "For many operating systems, this package is named 'libc-dev' or 'libc6-dev'."
-        .format(fname=self._LIBC_INIT_OBJECT_FILE, dirs=library_dirs, compiler=compiler_exe))
+        f"Could not locate {self._LIBC_INIT_OBJECT_FILE} in library search dirs {library_dirs} from "
+        f"compiler: {compiler_exe!r}. You may need to install a libc dev package for the current "
+        "system. For many operating systems, this package is named 'libc-dev' or 'libc6-dev'."
+      )
 
     return HostLibcDev(crti_object=libc_crti_object_file,
                        fingerprint=hash_file(libc_crti_object_file))
@@ -91,8 +91,9 @@ class LibcDev(Subsystem):
         return HostLibcDev(crti_object=maybe_libc_crti,
                            fingerprint=hash_file(maybe_libc_crti))
       raise self.HostLibcDevResolutionError(
-        "Could not locate {} in directory {} provided by the --libc-dir option."
-        .format(self._LIBC_INIT_OBJECT_FILE, libc_dir_option))
+        f"Could not locate {self._LIBC_INIT_OBJECT_FILE} in directory {libc_dir_option} provided "
+        "by the --libc-dir option."
+      )
 
     return self._get_host_libc_from_host_compiler()
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -156,7 +156,7 @@ class GCCInstallLocationForLLVM(datatype(['toolchain_dir'])):
   @property
   def as_clang_argv(self):
     # TODO(#6143): describe exactly what this argument does to the clang/clang++ invocation!
-    return ['--gcc-toolchain={}'.format(self.toolchain_dir)]
+    return [f'--gcc-toolchain={self.toolchain_dir}']
 
 
 @rule(GCCInstallLocationForLLVM, [GCC])

--- a/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
+++ b/src/python/pants/backend/native/subsystems/xcode_cli_tools.py
@@ -13,7 +13,7 @@ from pants.util.memo import memoized_method, memoized_property
 MIN_OSX_SUPPORTED_VERSION = '10.11'
 
 
-MIN_OSX_VERSION_ARG = '-mmacosx-version-min={}'.format(MIN_OSX_SUPPORTED_VERSION)
+MIN_OSX_VERSION_ARG = f'-mmacosx-version-min={MIN_OSX_SUPPORTED_VERSION}'
 
 
 class XCodeCLITools(Subsystem):
@@ -70,8 +70,8 @@ class XCodeCLITools(Subsystem):
              fingerprint=True, advanced=True,
              help='Locations to search for resources from the XCode CLI tools, including a '
                   'compiler, linker, header files, and some libraries. '
-                  'Under this directory should be some selection of these subdirectories: {}.'
-                  .format(cls._REQUIRED_FILES.keys()))
+                  'Under this directory should be some selection of these subdirectories: '
+                  f'{cls._REQUIRED_FILES.keys()}.')
 
   @memoized_property
   def _all_existing_install_prefixes(self):
@@ -98,18 +98,16 @@ class XCodeCLITools(Subsystem):
 
         if not found:
           raise self.XCodeToolsUnavailable(
-            "File '{fname}' in subdirectory '{subdir_name}' does not exist at any of the specified "
-            "prefixes. This file is required to build native code on this platform. You may need "
-            "to install the XCode command line developer tools from the Mac App Store.\n\n"
+            f"File '{fname}' in subdirectory '{subdir_name}' does not exist at any of the "
+            "specified prefixes. This file is required to build native code on this platform. You "
+            "may need to install the XCode command line developer tools from the Mac App Store.\n\n"
             "If the XCode tools are installed and you are still seeing this message, please file "
             "an issue at https://github.com/pantsbuild/pants/issues/new describing your "
             "OSX environment and which file could not be found.\n"
-            "The existing install prefixes were: {pfxs}. These can be extended with "
-            "--{scope}-install-prefixes."
-            .format(fname=fname,
-                    subdir_name=subdir_name,
-                    pfxs=self._all_existing_install_prefixes,
-                    scope=self.get_options_scope_equivalent_flag_component()))
+            f"The existing install prefixes were: {self._all_existing_install_prefixes}. These can "
+            f"be extended with --{self.get_options_scope_equivalent_flag_component()}-install-"
+            f"prefixes."
+          )
 
     return existing_dirs
 

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -55,7 +55,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
       [gcc.exe_filename, '--version'],
       env=gcc.invocation_environment_dict)
 
-    gcc_version_regex = re.compile('^gcc.*{}$'.format(re.escape(self.gcc_version)),
+    gcc_version_regex = re.compile(rf'^gcc.*{re.escape(self.gcc_version)}$',
                                    flags=re.MULTILINE)
     self.assertIsNotNone(gcc_version_regex.search(gcc_version_out))
 
@@ -69,7 +69,7 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
       [gpp.exe_filename, '--version'],
       env=gpp.invocation_environment_dict)
 
-    gpp_version_regex = re.compile(r'^g\+\+.*{}$'.format(re.escape(self.gcc_version)),
+    gpp_version_regex = re.compile(rf'^g\+\+.*{re.escape(self.gcc_version)}$',
                                    flags=re.MULTILINE)
     self.assertIsNotNone(gpp_version_regex.search(gpp_version_out))
 
@@ -83,13 +83,13 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
       [clang.exe_filename, '--version'],
       env=clang.invocation_environment_dict)
 
-    clang_version_regex = re.compile('^clang version {}'.format(re.escape(self.llvm_version)),
+    clang_version_regex = re.compile(rf'^clang version {re.escape(self.llvm_version)}',
                                      flags=re.MULTILINE)
     self.assertIsNotNone(clang_version_regex.search(clang_version_out))
 
   def test_clangpp_version(self):
     scheduler = self._sched()
-    clangpp_version_regex = re.compile('^clang version {}'.format(re.escape(self.llvm_version)),
+    clangpp_version_regex = re.compile(rf'^clang version {re.escape(self.llvm_version)}',
                                        flags=re.MULTILINE)
 
     llvm_cpp_toolchain = self.execute_expecting_one_result(
@@ -137,19 +137,13 @@ class TestNativeToolchain(TestBase, SchedulerTestBase):
     except subprocess.CalledProcessError as e:
       raise Exception(
         "Command failed while invoking the native toolchain "
-        "with code '{code}', cwd='{cwd}', cmd='{cmd}', env='{env}'. "
-        "Combined stdout and stderr:\n{out}"
-        .format(code=e.returncode,
-                cwd=os.getcwd(),
-                # safe_shlex_join() is just for pretty-printing.
-                cmd=safe_shlex_join(cmd),
-                env=env,
-                out=e.output),
-        e)
+        f"with code '{e.returncode}', cwd='{os.getcwd()}', cmd='{safe_shlex_join(cmd)}', "
+        f"env='{env}'. Combined stdout and stderr:\n{e.output}"
+      )
 
   def _do_compile_link(self, compiler, linker, source_file, outfile, output):
 
-    intermediate_obj_file_name = '{}.o'.format(outfile)
+    intermediate_obj_file_name = f'{outfile}.o'
     self._invoke_compiler(
       compiler,
       ['-c', source_file, '-o', intermediate_obj_file_name])


### PR DESCRIPTION
`tests/python/pants_test/backend/native/subsystems:subsystems` was failing with `sys/cdefs.h: No such file or directory`. Per https://askubuntu.com/a/590832, we can fix this by installing `g{cc,++}-multilib`.