### PR TITLE
Improve rsc deprecation warnings

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -9,6 +9,7 @@ from pants.base.revision import Revision
 from pants.java.distribution.distribution import DistributionLocator
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method, memoized_property
+from pants.util.objects import enum
 
 
 logger = logging.getLogger(__name__)
@@ -24,7 +25,7 @@ class JvmPlatform(Subsystem):
   # strictly (eg, if Java 10 != 1.10, simply leave it out).
   SUPPORTED_CONVERSION_VERSIONS = (6, 7, 8,)
 
-  _COMPILER_CHOICES = ['zinc', 'javac', 'rsc']
+  class Compiler(enum(['zinc', 'rsc', 'javac'])): pass
 
   class IllegalDefaultPlatform(TaskError):
     """The --default-platform option was set, but isn't defined in --platforms."""
@@ -56,8 +57,8 @@ class JvmPlatform(Subsystem):
              help='Compile settings that can be referred to by name in jvm_targets.')
     register('--default-platform', advanced=True, type=str, default=None, fingerprint=True,
              help='Name of the default platform to use if none are specified.')
-    register('--compiler', advanced=True, choices=cls._COMPILER_CHOICES, default='rsc', fingerprint=True,
-             help='Java compiler implementation to use.')
+    register('--compiler', advanced=True, type=cls.Compiler, default=cls.Compiler.rsc, fingerprint=True,
+             help='JVM compiler implementation to use.')
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -400,7 +400,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         lambda:  True,
         removal_version='1.20.0.dev0',
         entity_description=f'Requested a deprecated compiler: [{requested_compiler}].',
-        hint_message='Compiler will be defaulted to [{self.compiler}].')
+        hint_message=f'Compiler will be defaulted to [{self.compiler}].')
     elif requested_compiler != self.compiler:
       # If the requested compiler is not the one supported by this task, log and abort
       self.context.log.debug(f'Requested a compiler [{requested_compiler}] other than this one [{self.compiler}], skipping.')

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -9,7 +9,6 @@ import re
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext  # noqa
 from pants.backend.jvm.subsystems.rsc import Rsc
 from pants.backend.jvm.subsystems.shader import Shader
-from pants.backend.jvm.subsystems.zinc import Zinc
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.classpath_entry import ClasspathEntry
 from pants.backend.jvm.tasks.jvm_compile.compile_context import CompileContext
@@ -19,7 +18,6 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.mirrored_target_option_mixin import MirroredTargetOptionMixin
-from pants.cache.cache_setup import CacheSetup
 from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, DirectoryToMaterialize, PathGlobs,
                              PathGlobsAndRoot)
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
@@ -114,14 +112,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
   @classmethod
   def subsystem_dependencies(cls):
-    dep = CacheSetup.scoped(
-      Zinc.Factory,
-      removal_version='1.20.0.dev0',
-      removal_hint='Cache options for `zinc` should move to `rsc`.'
-    )
-    return super().subsystem_dependencies() + (
-      Rsc, dep.optionable_cls
-    )
+    return super().subsystem_dependencies() + (Rsc,)
 
   @memoized_property
   def mirrored_target_option_actions(self):

--- a/src/python/pants/subsystem/subsystem_client_mixin.py
+++ b/src/python/pants/subsystem/subsystem_client_mixin.py
@@ -73,6 +73,12 @@ class SubsystemClientMixin:
     """Iterate over the direct subsystem dependencies of this Optionable."""
     for dep in cls.subsystem_dependencies():
       if isinstance(dep, SubsystemDependency):
+        if cls.deprecated_options_scope is not None:
+          yield dep.copy(
+              scope=cls.deprecated_options_scope,
+              removal_version=cls.deprecated_options_scope_removal_version,
+              removal_hint=f'Use {dep.options_scope}',
+            )
         yield dep
       else:
         yield SubsystemDependency(dep, GLOBAL_SCOPE, removal_version=None, removal_hint=None)
@@ -153,7 +159,7 @@ class SubsystemClientMixin:
           collect_scope_infos(dep.subsystem_cls, GLOBAL_SCOPE)
           if not dep.is_global():
             collect_scope_infos(dep.subsystem_cls,
-                                scope,
+                                dep.scope or scope,
                                 removal_version=dep.removal_version,
                                 removal_hint=dep.removal_hint)
 


### PR DESCRIPTION
### Problem

Post #8047, the `--jvm-platform-compiler=zinc` setting was not triggering a deprecation warning due to enum/str comparison mixup. Additionally, the `cache.compile.zinc` scope deprecation wasn't triggering, so passing an option like `--cache-compile-zinc-ignore` would fail rather than warning.

### Solution

Generically support deprecating `subsystem_dependencies`, and fix string comparisons.

### Result

Passing `--jvm-platform-compiler=zinc` triggers a warning and does the right thing, and passing any of `--cache-compile-zinc-*` triggers warnings.