### PR TITLE
Mark `float` as natively encodable to silence hash_utils warning

### DIFF
--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -63,7 +63,7 @@ class CoercingEncoder(json.JSONEncoder):
       return self.encode(key_obj)
 
   def _is_natively_encodable(self, o):
-    return isinstance(o, (type(None), bool, int, list, str, bytes))
+    return isinstance(o, (type(None), bool, int, list, str, bytes, float))
 
   def default(self, o):
     if self._is_natively_encodable(o):


### PR DESCRIPTION
### Problem

Compiling with pants with the `-ldebug` flag used to produce a copious
amount of output with the following warning:
```
[DEBUG] pants.base.hash_utils:pid=42887: Our custom json encoder RunTrackerOptionEncoder is trying to hash a primitive type, but has gone throughchecking every other registered type class before. These checks are expensive,so you should consider registering the type <class 'float'> withinthis function (RunTrackerOptionEncoder.default)
```
### Solution

Adding the type: `float` to the list of natively encodable types fixes
the issue.

### Result

It allegedly improves performance, and it makes the output of pants in
debug mode much more pallatable.