### PR TITLE
Fix rust WorkUnit span_id bug

### DIFF
--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -67,7 +67,11 @@ impl WorkUnitStore {
 pub fn generate_random_64bit_string() -> String {
   let mut rng = thread_rng();
   let random_u64: u64 = rng.gen();
-  format!("{:16.x}", random_u64)
+  hex_16_digit_string(random_u64)
+}
+
+fn hex_16_digit_string(number: u64) -> String {
+  format!("{:016.x}", number)
 }
 
 pub fn workunits_with_constant_span_id(workunit_store: &WorkUnitStore) -> HashSet<WorkUnit> {
@@ -99,4 +103,19 @@ pub fn get_parent_id() -> Option<String> {
     let task_parent_id = task_parent_id.lock();
     (*task_parent_id).clone()
   })
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::hex_16_digit_string;
+
+  #[test]
+  fn workunit_span_id_has_16_digits_len_hex_format() {
+    let number: u64 = 1;
+    let hex_string = hex_16_digit_string(number);
+    assert_eq!(16, hex_string.len());
+    for ch in hex_string.chars() {
+      assert!(ch.is_ascii_hexdigit())
+    }
+  }
 }


### PR DESCRIPTION
### Problem
span_id for Zipkin trace should be a 64-bit size and it is represented as a 16-digit hex string.
In rust part of the code WorkUnits sometimes had the wrong format (instead of leading 0 it had leading spaces which is not a hex string char).
