### PR TITLE
remove complicated invalid dep check in rsc compile

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -6,8 +6,6 @@ import functools
 import os
 from multiprocessing import cpu_count
 
-from twitter.common.collections import OrderedSet
-
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext
 from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -462,7 +462,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         # Otherwise, fail it.
         on_success=ivts.update,
         on_failure=ivts.force_invalidate)
-        
+
     workflow = rsc_compile_context.workflow
 
     # Replica of JvmCompile's _record_target_stats logic
@@ -705,22 +705,3 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
   @memoized_method
   def _jdk_libs_abs(self, nonhermetic_dist):
     return nonhermetic_dist.find_libs(self._JDK_LIB_NAMES)
-
-  # TODO: rename this, make it public, and explain what "searching for invalid targets" refers to!
-  def _on_invalid_compile_dependency(self, dep, compile_target, contexts):
-    """Decide whether to continue searching for invalid targets to use in the execution graph.
-
-    If a necessary dep is a rsc-and-zinc dep and the root is a zinc-only one, continue to recurse
-    because otherwise we'll drop the path between Zinc compile of the zinc-only target and a Zinc
-    compile of a transitive rsc-and-zinc dependency.
-
-    This is only an issue for graphs like J -> S1 -> S2, where J is a zinc-only target,
-    S1/2 are rsc-and-zinc targets and S2 must be on the classpath to compile J successfully.
-    """
-    def dep_has_rsc_compile():
-      return contexts[dep].rsc_cc.workflow == self.JvmCompileWorkflowType.rsc_and_zinc
-    return contexts[compile_target].rsc_cc.workflow.resolve_for_enum_variant({
-      'zinc-java': dep_has_rsc_compile,
-      'zinc-only': dep_has_rsc_compile,
-      'rsc-and-zinc': lambda: False
-    })()

--- a/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive/BUILD
@@ -23,13 +23,11 @@ scala_library(
   sources = ['Scala.scala'],
   dependencies = [':scala-2'],
   exports = [':scala-2'],
-  # TODO: Enable this when #8109 ships
-  # tags = {'use-compiler:rsc-and-zinc'},
+  tags = {'use-compiler:rsc-and-zinc'},
 )
 
 scala_library(
   name = 'scala-2',
   sources = ['Scala2.scala'],
-  # TODO: Enable this when #8109 ships
-  # tags = {'use-compiler:rsc-and-zinc'},
+  tags = {'use-compiler:rsc-and-zinc'},
 )


### PR DESCRIPTION
### Problem

There are several lines of code in `RscCompile` and `JvmCompile` relating to the overridden `_on_invalid_compile_dependency()` method, with outstanding TODOs to document how they work and why they are necessary. We are actually able to remove this entirely.

This *may* address #8109 -- I haven't been able to repro the issue yet.

### Solution

- Remove `_on_invalid_compile_dependency()` and replace it with the solution described in https://github.com/pantsbuild/pants/issues/8109#issuecomment-515794859.

### Result

The rsc compile invalidation is much less confusing!