### PR TITLE
Add test to check return of hex_16_digit_string function

### DIFF
--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -116,6 +116,13 @@ mod tests {
     assert_eq!(16, hex_string.len());
     for ch in hex_string.chars() {
       assert!(ch.is_ascii_hexdigit())
-    }
+    };
+  }
+
+  #[test]
+  fn hex_16_digit_string_actually_uses_input_number() {
+    assert_eq!(hex_16_digit_string(0x_ffff_ffff_ffff_ffff), "ffffffffffffffff");
+    assert_eq!(hex_16_digit_string(0x_1), "0000000000000001");
+    assert_eq!(hex_16_digit_string(0x_0123_4567_89ab_cdef), "0123456789abcdef");
   }
 }

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -116,13 +116,19 @@ mod tests {
     assert_eq!(16, hex_string.len());
     for ch in hex_string.chars() {
       assert!(ch.is_ascii_hexdigit())
-    };
+    }
   }
 
   #[test]
   fn hex_16_digit_string_actually_uses_input_number() {
-    assert_eq!(hex_16_digit_string(0x_ffff_ffff_ffff_ffff), "ffffffffffffffff");
+    assert_eq!(
+      hex_16_digit_string(0x_ffff_ffff_ffff_ffff),
+      "ffffffffffffffff"
+    );
     assert_eq!(hex_16_digit_string(0x_1), "0000000000000001");
-    assert_eq!(hex_16_digit_string(0x_0123_4567_89ab_cdef), "0123456789abcdef");
+    assert_eq!(
+      hex_16_digit_string(0x_0123_4567_89ab_cdef),
+      "0123456789abcdef"
+    );
   }
 }


### PR DESCRIPTION
### Problem
The existing test for the `hex_16_digit_string` function checks only the format and the length. It does not check if the input value passed to the function is used. It is important because the input value is a random value, the same should be the result of  `hex_16_digit_string` function, thus it should use the input value.

### Result
A test was added that checks that the result of the `hex_16_digit_string` function is consistent with the input value.