### PR TITLE
pin tensorflow example to 1.13.1

### DIFF
--- a/examples/3rdparty/python/requirements.txt
+++ b/examples/3rdparty/python/requirements.txt
@@ -1,4 +1,4 @@
 grpcio==1.16.1
 protobuf==3.6.1
-tensorflow>=1.13,<2
+tensorflow==1.13.1
 thrift>=0.10.0


### PR DESCRIPTION
### Problem

#8099 is failing in the lint shard due to a failing link for the C++ code in the tensorflow custom operator example. This is because tensorflow 1.14 begins to use a symlink for `libtensorflow_framework.so`, pointing to another file in the same directory, and we haven't pinned the tensorflow dependency to 1.13.1.

### Solution

- Pin the tensorflow dependency to `1.13.1` until we can support 1.14.

### Result

Native compiles and linking succeed!