### PR TITLE
Disable remote execution of unit tests temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -731,7 +731,8 @@ matrix:
         - *py37_linux_test_config_env
         - CACHE_NAME=unit_tests.v2.py37
       script:
-        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2 --remote-execution-enabled --python-version 3.7
+        # TODO: Remote execution disabled (by removing `--remote-execution-enabled`) due to #8137.
+        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2 --python-version 3.7
 
     - <<: *py36_lint
     - <<: *py37_lint
@@ -745,7 +746,8 @@ matrix:
         - *py36_linux_test_config_env
         - CACHE_NAME=unit_tests.v2.py36
       script:
-        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2 --remote-execution-enabled
+        # TODO: Remote execution disabled (by removing `--remote-execution-enabled`) due to #8137.
+        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2
 
     - <<: *py36_linux_test_config
       name: "Unit tests - V1 test runner (Py3.6 PEX)"

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -678,7 +678,8 @@ matrix:
         - *py37_linux_test_config_env
         - CACHE_NAME=unit_tests.v2.py37
       script:
-        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2 --remote-execution-enabled --python-version 3.7
+        # TODO: Remote execution disabled (by removing `--remote-execution-enabled`) due to #8137.
+        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2 --python-version 3.7
 
     - <<: *py36_lint
     - <<: *py37_lint
@@ -692,7 +693,8 @@ matrix:
         - *py36_linux_test_config_env
         - CACHE_NAME=unit_tests.v2.py36
       script:
-        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2 --remote-execution-enabled
+        # TODO: Remote execution disabled (by removing `--remote-execution-enabled`) due to #8137.
+        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2
 
     - <<: *py36_linux_test_config
       name: "Unit tests - V1 test runner (Py3.6 PEX)"


### PR DESCRIPTION
### Problem

Remote execution of unit tests under v2 began failing on Thursday afternoon.

### Solution

Disable remote execution until #8137 can be resolved. 