### PR TITLE
Ensure injected `__init__.py` are world readable.

### DIFF
--- a/src/python/pants/backend/python/subsystems/BUILD
+++ b/src/python/pants/backend/python/subsystems/BUILD
@@ -2,17 +2,30 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  dependencies = [
-    '3rdparty/python:pex',
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:pex',
+    'src/python/pants/backend/native/subsystems',
+    'src/python/pants/backend/native/targets',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
-    'src/python/pants/backend/python/targets',
-    'src/python/pants/backend/native/targets',
-    'src/python/pants/backend/native/subsystems',
     'src/python/pants/build_graph',
     'src/python/pants/option',
     'src/python/pants/subsystem',
     'src/python/pants/util:memo',
+  ],
+)
+
+python_tests(
+  name='tests',
+  dependencies=[
+    '3rdparty/python:pex',
+    ':subsystems',
+    'src/python/pants/backend/python/targets',
+    'src/python/pants/build_graph',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test/subsystem',
+    'tests/python/pants_test:test_base',
   ],
 )

--- a/src/python/pants/backend/python/subsystems/pex_build_util.py
+++ b/src/python/pants/backend/python/subsystems/pex_build_util.py
@@ -313,7 +313,7 @@ class PexBuilderWrapper:
     sources = chroot.get('source') | chroot.get('resource')
     missing_init_files = identify_missing_init_files(sources)
     if missing_init_files:
-      with temporary_file() as ns_package:
+      with temporary_file(permissions=0o644) as ns_package:
         ns_package.write(b'__import__("pkg_resources").declare_namespace(__name__)')
         ns_package.flush()
         for missing_init_file in missing_init_files:

--- a/src/python/pants/backend/python/subsystems/test_pex_build_util.py
+++ b/src/python/pants/backend/python/subsystems/test_pex_build_util.py
@@ -1,0 +1,70 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import pathlib
+import stat
+
+from pex.pex_builder import PEXBuilder
+
+from pants.backend.python.subsystems.pex_build_util import PexBuilderWrapper
+from pants.backend.python.targets.python_library import PythonLibrary
+from pants.source.source_root import SourceRootConfig
+from pants.util.contextutil import open_zip, temporary_dir, temporary_file_path
+from pants_test.subsystem import subsystem_util
+from pants_test.test_base import TestBase
+
+
+class TestPexBuilderWrapper(TestBase):
+  @staticmethod
+  def assert_perms(perms, path):
+    mode = path.stat().st_mode
+    assert perms == stat.S_IMODE(mode)
+
+  @classmethod
+  def assert_dir_perms(cls, path):
+    cls.assert_perms(0o755, path)
+
+  @classmethod
+  def assert_file_perms(cls, path):
+    cls.assert_perms(0o644, path)
+
+  @staticmethod
+  def pex_builder_wrapper(**kwargs):
+    subsystem_util.init_subsystem(PexBuilderWrapper.Factory)
+    return PexBuilderWrapper.Factory.create(PEXBuilder(**kwargs))
+
+  def test(self):
+    subsystem_util.init_subsystem(SourceRootConfig)
+    self.create_file('src/python/package/module.py')
+    implicit_package_target = self.make_target(spec='src/python/package',
+                                               target_type=PythonLibrary,
+                                               sources=['module.py'])
+
+    pbw = self.pex_builder_wrapper()
+    pbw.add_sources_from(implicit_package_target)
+    with temporary_file_path() as pex:
+      pbw.build(pex)
+      with temporary_dir() as chroot, open_zip(pex) as zip:
+        zip.extractall(path=chroot)
+
+        chroot_path = pathlib.Path(chroot)
+
+        # Check the paths we know about:
+        package_path = chroot_path / 'package'
+        self.assert_dir_perms(package_path)
+
+        user_files = {package_path / f for f in ('__init__.py', 'module.py')}
+        for user_file in user_files:
+          self.assert_file_perms(user_file)
+
+        # And all other paths pex generates (__main__.py, PEX-INFO, .deps/, etc...):
+        for root, dirs, files in os.walk(chroot_path):
+          for d in dirs:
+            dir_path = pathlib.Path(root) / d
+            if dir_path != package_path:
+              self.assert_dir_perms(dir_path)
+          for f in files:
+            file_path = pathlib.Path(root) / f
+            if file_path not in user_files:
+              self.assert_file_perms(file_path)


### PR DESCRIPTION
Previously, these would default to `600` perms leading to unexpected
failures at pex runtime when the executing user was not the owner. Add a
new test to ensure we generate pexes with world readable directories and
files.