### PR TITLE
 Use more consistent time representation throughout the engine

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -381,9 +381,15 @@ class _FFISpecification(object):
     c = self._ffi.from_handle(context_handle)
     return c.to_value(self._ffi.string(utf8_ptr, utf8_len).decode())
 
+  @_extern_decl('Handle', ['ExternContext*', 'uint64_t'])
+  def extern_store_u64(self, context_handle, u64):
+    """Given a context and uint64_t, return a new Handle to represent the uint64_t."""
+    c = self._ffi.from_handle(context_handle)
+    return c.to_value(u64)
+
   @_extern_decl('Handle', ['ExternContext*', 'int64_t'])
   def extern_store_i64(self, context_handle, i64):
-    """Given a context and int32_t, return a new Handle to represent the int32_t."""
+    """Given a context and int64_t, return a new Handle to represent the int64_t."""
     c = self._ffi.from_handle(context_handle)
     return c.to_value(i64)
 
@@ -683,6 +689,7 @@ class Native(Singleton):
                            self.ffi_lib.extern_store_dict,
                            self.ffi_lib.extern_store_bytes,
                            self.ffi_lib.extern_store_utf8,
+                           self.ffi_lib.extern_store_u64,
                            self.ffi_lib.extern_store_i64,
                            self.ffi_lib.extern_store_f64,
                            self.ffi_lib.extern_store_bool,

--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -15,6 +15,8 @@ from pants.reporting.reporter import Reporter
 
 logger = logging.getLogger(__name__)
 
+NANOSECONDS_PER_SECOND = 1000000000.0
+
 
 class HTTPTransportHandler(BaseTransportHandler):
   def __init__(self, endpoint):
@@ -156,7 +158,14 @@ class ZipkinReporter(Reporter):
   def bulk_record_workunits(self, engine_workunits):
     """A collection of workunits from v2 engine part"""
     for workunit in engine_workunits:
-      duration = workunit['end_timestamp'] - workunit['start_timestamp']
+      start_timestamp = from_secs_and_nanos_to_float(
+        workunit['start_secs'],
+        workunit['start_nanos']
+      )
+      duration = from_secs_and_nanos_to_float(
+        workunit['duration_secs'],
+        workunit['duration_nanos']
+      )
 
       local_tracer = get_default_tracer()
 
@@ -176,5 +185,9 @@ class ZipkinReporter(Reporter):
         flags='0', # flags: stores flags header. Currently unused
         is_sampled=True,
       )
-      span.start_timestamp = workunit['start_timestamp']
+      span.start_timestamp = start_timestamp
       span.stop()
+
+
+def from_secs_and_nanos_to_float(secs, nanos):
+  return secs + ( nanos / NANOSECONDS_PER_SECOND )

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "serverset 0.0.1",
@@ -263,7 +263,7 @@ dependencies = [
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "libgit2-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "opener 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -291,11 +291,11 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -378,6 +378,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "concrete_time"
+version = "0.0.1"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,7 +409,7 @@ dependencies = [
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -438,7 +448,7 @@ dependencies = [
  "curl 0.4.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -608,6 +618,7 @@ version = "0.0.1"
 dependencies = [
  "boxfuture 0.0.1",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "concrete_time 0.0.1",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -615,7 +626,7 @@ dependencies = [
  "hashing 0.0.1",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
  "num_enum 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -645,12 +656,11 @@ dependencies = [
  "engine 0.0.1",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.1",
  "rule_graph 0.0.1",
  "store 0.1.0",
  "tar_api 0.0.1",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "workunit_store 0.0.1",
 ]
@@ -662,7 +672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -674,7 +684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -788,7 +798,7 @@ dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -820,7 +830,7 @@ dependencies = [
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "store 0.1.0",
  "task_executor 0.0.1",
@@ -912,7 +922,7 @@ dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "libgit2-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -925,7 +935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curl 0.4.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -942,7 +952,7 @@ dependencies = [
  "aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bstr 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -955,7 +965,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -969,7 +979,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-sys 0.2.3 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
 ]
 
@@ -1004,7 +1014,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1017,7 +1027,7 @@ dependencies = [
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_test 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1092,7 +1102,7 @@ dependencies = [
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1141,7 +1151,7 @@ dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1193,7 +1203,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1314,12 +1324,12 @@ name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1332,7 +1342,7 @@ dependencies = [
  "cargo 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_enum 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1417,7 +1427,7 @@ dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1429,7 +1439,7 @@ name = "mio-named-pipes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1722,13 +1732,14 @@ dependencies = [
  "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "concrete_time 0.0.1",
  "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.3.0 (git+https://github.com/pantsbuild/grpc-rs.git?rev=4dfafe9355dc996d7d0702e7386a6fedcd9734c0)",
  "hashing 0.0.1",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
@@ -1738,7 +1749,6 @@ dependencies = [
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1778,7 +1788,7 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1830,7 +1840,7 @@ name = "protoc"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2113,7 +2123,7 @@ dependencies = [
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2178,9 +2188,9 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2190,7 +2200,7 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sct 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2257,12 +2267,12 @@ name = "serde"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.94"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2338,7 +2348,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "lmdb 0.8.0 (git+https://github.com/pantsbuild/lmdb-rs.git?rev=06bdfbfc6348f6804127176e561843f214fc17f8)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2372,7 +2382,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2427,6 +2437,7 @@ dependencies = [
  "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "concrete_time 0.0.1",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
@@ -2436,20 +2447,19 @@ dependencies = [
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb 0.8.0 (git+https://github.com/pantsbuild/lmdb-rs.git?rev=06bdfbfc6348f6804127176e561843f214fc17f8)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serverset 0.0.1",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sharded_lmdb 0.0.1",
  "task_executor 0.0.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2724,7 +2734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2736,7 +2746,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2753,7 +2763,7 @@ dependencies = [
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2821,7 +2831,7 @@ dependencies = [
  "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2846,7 +2856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2862,7 +2872,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2905,7 +2915,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-h2 0.1.0 (git+https://github.com/pantsbuild/tower-h2?rev=44b0efb4983b769283efd5b2a3bc3decbf7c33de)",
@@ -2933,7 +2943,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-connect 0.1.0 (git+https://github.com/pantsbuild/tokio-connect?rev=f7ad1ca437973d6e24037ac6f7d5ef1013833c0b)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (git+https://github.com/pantsbuild/tower?rev=7b61c1fc1992c1df684fd3f179644ef0ca9bfa4c)",
@@ -3134,7 +3144,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3215,11 +3225,10 @@ dependencies = [
 name = "workunit_store"
 version = "0.0.1"
 dependencies = [
+ "concrete_time 0.0.1",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3358,7 +3367,7 @@ dependencies = [
 "checksum lmdb-sys 0.8.0 (git+https://github.com/pantsbuild/lmdb-rs.git?rev=06bdfbfc6348f6804127176e561843f214fc17f8)" = "<none>"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
@@ -3454,7 +3463,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5626ac617da2f2d9c48af5515a21d5a480dbd151e01bb1c355e26a3e68113"
-"checksum serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)" = "ef45eb79d6463b22f5f9e16d283798b7c0175ba6050bc25c1a946c122727fe7b"
+"checksum serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "01e69e1b8a631f245467ee275b8c757b818653c6d704cdbcaeb56b56767b529c"
 "checksum serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "190e9765dcedb56be63b6e0993a006c7e3b071a016a304736e4a315dc01fb142"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum serde_test 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)" = "6e5889093c6aa447d971c1f152c1127eb96ef0a53c4a3e3082158fe6670b28c6"

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -381,7 +381,6 @@ dependencies = [
 name = "concrete_time"
 version = "0.0.1"
 dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   ".",
   "async_semaphore",
   "boxfuture",
+  "concrete_time",
   "engine_cffi",
   "fs",
   "fs/brfs",
@@ -55,6 +56,7 @@ default-members = [
   ".",
   "async_semaphore",
   "boxfuture",
+  "concrete_time",
   "engine_cffi",
   "fs",
   "fs/fs_util",
@@ -79,6 +81,7 @@ default-members = [
 [dependencies]
 boxfuture = { path = "boxfuture" }
 bytes = "0.4.5"
+concrete_time = { path = "concrete_time" }
 fnv = "1.0.5"
 fs = { path = "fs" }
 futures = "0.1.27"

--- a/src/rust/engine/concrete_time/Cargo.toml
+++ b/src/rust/engine/concrete_time/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+version = "0.0.1"
+edition = "2018"
+authors = ["Pants Build <pantsbuild@gmail.com>"]
+name = "concrete_time"
+publish = false
+
+[dependencies]
+protobuf = { version = "2.0.6", features = ["with-bytes"] }
+serde_derive = "1.0.98"
+serde = "1.0.98"
+log = "0.4.8"
+

--- a/src/rust/engine/concrete_time/Cargo.toml
+++ b/src/rust/engine/concrete_time/Cargo.toml
@@ -9,5 +9,3 @@ publish = false
 protobuf = { version = "2.0.6", features = ["with-bytes"] }
 serde_derive = "1.0.98"
 serde = "1.0.98"
-log = "0.4.8"
-

--- a/src/rust/engine/concrete_time/src/lib.rs
+++ b/src/rust/engine/concrete_time/src/lib.rs
@@ -1,0 +1,187 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+#![deny(warnings)]
+// Enable all clippy lints except for many of the pedantic ones. It's a shame this needs to be copied and pasted across crates, but there doesn't appear to be a way to include inner attributes from a common source.
+#![deny(
+  clippy::all,
+  clippy::default_trait_access,
+  clippy::expl_impl_clone_on_copy,
+  clippy::if_not_else,
+  clippy::needless_continue,
+  clippy::single_match_else,
+  clippy::unseparated_literal_suffix,
+  clippy::used_underscore_binding
+)]
+// It is often more clear to show that nothing is being moved.
+#![allow(clippy::match_ref_pats)]
+// Subjective style.
+#![allow(
+  clippy::len_without_is_empty,
+  clippy::redundant_field_names,
+  clippy::too_many_arguments
+)]
+// Default isn't as big a deal as people seem to think it is.
+#![allow(clippy::new_without_default, clippy::new_ret_no_self)]
+// Arc<Mutex> can be more clear than needing to grok Orderings:
+#![allow(clippy::mutex_atomic)]
+
+use log::warn;
+use serde_derive::Serialize;
+
+/// A concrete data representation of a duration.
+/// Unlike std::time::Duration, it doesn't hide how the time is stored as the purpose of this
+/// `struct` is to expose it.
+///
+/// This type can be serialized with serde.
+///
+/// This type can be converted from and into a `std::time::Duration` as this should be the goto
+/// data representation for a `Duration` when one isn't concerned about serialization.
+///
+/// It can be used to represent a timestamp (as a duration since the unix epoch) or simply a
+/// duration between two arbitrary timestamps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub struct Duration {
+  /// How many seconds did this `Duration` last?
+  pub secs: u64,
+  /// How many sub-second nanoseconds did this `Duration` last?
+  pub nanos: u32,
+}
+
+impl Duration {
+  /// Construct a new duration with `secs` seconds and `nanos` nanoseconds
+  pub fn new(secs: u64, nanos: u32) -> Self {
+    Self { secs, nanos }
+  }
+}
+
+impl From<std::time::Duration> for Duration {
+  fn from(duration: std::time::Duration) -> Self {
+    Self {
+      secs: duration.as_secs(),
+      nanos: duration.subsec_nanos(),
+    }
+  }
+}
+
+impl Into<std::time::Duration> for Duration {
+  fn into(self) -> std::time::Duration {
+    std::time::Duration::new(self.secs, self.nanos)
+  }
+}
+
+/// A timespan
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub struct TimeSpan {
+  /// Duration since the UNIX_EPOCH
+  pub start: Duration,
+  /// Duration since `start`
+  pub duration: Duration,
+}
+
+impl TimeSpan {
+  fn since_epoch(time: &std::time::SystemTime) -> std::time::Duration {
+    time
+      .duration_since(std::time::UNIX_EPOCH)
+      .expect("Surely you're not before the unix epoch?")
+  }
+
+  /// Construct a TimeSpan that started at `start` and ends now.
+  pub fn since(start: &std::time::SystemTime) -> TimeSpan {
+    let start = Self::since_epoch(start);
+    let duration = Self::since_epoch(&std::time::SystemTime::now()) - start;
+    TimeSpan {
+      start: start.into(),
+      duration: duration.into(),
+    }
+  }
+
+  fn std_duration_from_protobuf_timestamp(
+    t: &protobuf::well_known_types::Timestamp,
+  ) -> std::time::Duration {
+    std::time::Duration::new(t.seconds as u64, t.nanos as u32)
+  }
+
+  /// Construct a `TimeSpan` given a start and an end `Timestamp` from protobuf
+  pub fn from_start_and_end(
+    start: &protobuf::well_known_types::Timestamp,
+    end: &protobuf::well_known_types::Timestamp,
+    time_span_description: &str,
+  ) -> Option<Self> {
+    let start = Self::std_duration_from_protobuf_timestamp(start);
+    let end = Self::std_duration_from_protobuf_timestamp(end);
+    let time_span = end.checked_sub(start).map(|duration| TimeSpan {
+      start: start.into(),
+      duration: duration.into(),
+    });
+    if time_span.is_none() {
+      warn!(
+        "Got negative {} time: {:?} - {:?}",
+        time_span_description, end, start
+      );
+    }
+    time_span
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{Duration, TimeSpan};
+  #[test]
+  fn convert_from_std_duration() {
+    let std = std::time::Duration::new(3, 141_592_653);
+    let concrete: Duration = std.into();
+    assert_eq!(std.as_secs(), concrete.secs);
+    assert_eq!(std.subsec_nanos(), concrete.nanos);
+  }
+
+  #[test]
+  fn convert_into_std_duration() {
+    let concrete = Duration::new(3, 141_592_653);
+    let std: std::time::Duration = concrete.into();
+    assert_eq!(concrete.secs, std.as_secs());
+    assert_eq!(concrete.nanos, std.subsec_nanos());
+  }
+
+  #[test]
+  fn time_span_since() {
+    let start = std::time::SystemTime::now();
+    let sleep_duration = std::time::Duration::from_millis(1);
+    std::thread::sleep(sleep_duration);
+    let span = TimeSpan::since(&start);
+    assert!(std::convert::Into::<std::time::Duration>::into(span.duration) >= sleep_duration);
+    assert_eq!(
+      start
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap(),
+      span.start.into()
+    );
+  }
+
+  fn time_span_from_start_and_duration_in_seconds(start: i64, duration: i64) -> Option<TimeSpan> {
+    use protobuf::well_known_types::Timestamp;
+    let mut start_timestamp = Timestamp::new();
+    start_timestamp.set_seconds(start);
+    let mut end_timestamp = Timestamp::new();
+    end_timestamp.set_seconds(start + duration);
+    TimeSpan::from_start_and_end(&start_timestamp, &end_timestamp, "")
+  }
+
+  #[test]
+  fn time_span_from_start_and_end_given_positive_duration() {
+    let span = time_span_from_start_and_duration_in_seconds(42, 10);
+    assert_eq!(
+      Some(TimeSpan {
+        start: Duration::new(42, 0),
+        duration: Duration::new(10, 0),
+      }),
+      span
+    );
+  }
+
+  #[test]
+  fn time_span_from_start_and_end_given_negative_duration() {
+    let span = time_span_from_start_and_duration_in_seconds(42, -10);
+    assert!(span.is_none());
+  }
+}

--- a/src/rust/engine/engine_cffi/Cargo.toml
+++ b/src/rust/engine/engine_cffi/Cargo.toml
@@ -17,7 +17,6 @@ logging = { path = "../logging" }
 rule_graph = { path = "../rule_graph" }
 store = { path = "../fs/store" }
 tar_api = { path = "../tar_api" }
-time = "0.1.40"
 workunit_store = { path = "../workunit_store" }
 
 [build-dependencies]

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 bazel_protos = { path = "../../process_execution/bazel_protos" }
 boxfuture = { path = "../../boxfuture" }
 bytes = "0.4.5"
+concrete_time = { path = "../../concrete_time" }
 digest = "0.8"
 dirs = "1"
 fs = { path = ".." }
@@ -30,7 +31,6 @@ tempfile = "3"
 tokio-threadpool = "0.1.12"
 uuid = { version = "0.7.1", features = ["v4"] }
 workunit_store = {path = "../../workunit_store" }
-time = "0.1.42"
 
 [dev-dependencies]
 maplit = "*"

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -32,6 +32,7 @@ pub use crate::snapshot::{OneOffStoreFileByDigest, Snapshot, StoreFileByDigest};
 use bazel_protos;
 use boxfuture::{try_future, BoxFuture, Boxable};
 use bytes::Bytes;
+use concrete_time::TimeSpan;
 use dirs;
 use fs::FileContent;
 use futures::{future, Future};
@@ -46,7 +47,6 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
-use time::Timespec;
 use workunit_store::WorkUnitStore;
 
 use parking_lot::Mutex;
@@ -69,53 +69,6 @@ pub struct UploadSummary {
   pub uploaded_file_bytes: usize,
   #[serde(skip)]
   pub upload_wall_time: Duration,
-}
-
-/// A timespan represented as two floating point representations of seconds
-#[derive(Copy, Clone, Debug, PartialEq, Serialize)]
-pub struct TimeSpan {
-  /// Number of seconds since the UNIX_EPOCH with precision to the nanosecond
-  pub start: f64,
-  /// Number of seconds since `start` with precision to the nanosecond
-  pub duration: f64,
-}
-
-impl TimeSpan {
-  const NANOSECS_IN_SEC: f64 = 1_000_000_000_f64;
-  // Sadly not quite stable in std yet.
-  fn duration_as_secs_f64(d: Duration) -> f64 {
-    (d.as_nanos() as f64) / (Self::NANOSECS_IN_SEC)
-  }
-
-  fn system_time_as_secs_f64(time: &SystemTime) -> f64 {
-    let since_epoch = time
-      .duration_since(std::time::UNIX_EPOCH)
-      .expect("Surely you're not before the unix epoch?");
-    Self::duration_as_secs_f64(since_epoch)
-  }
-
-  pub fn since(start: &SystemTime) -> TimeSpan {
-    let now = Self::system_time_as_secs_f64(&SystemTime::now());
-    let start = Self::system_time_as_secs_f64(start);
-    TimeSpan {
-      start,
-      duration: now - start,
-    }
-  }
-
-  fn timespec_from_f64_secs(seconds: f64) -> Timespec {
-    let secs = seconds as i64;
-    let subsec_nanos = ((seconds - secs as f64) * Self::NANOSECS_IN_SEC) as i32;
-    Timespec::new(secs, subsec_nanos)
-  }
-
-  pub fn start_timestamp(self) -> Timespec {
-    Self::timespec_from_f64_secs(self.start)
-  }
-
-  pub fn end_timestamp(self) -> Timespec {
-    Self::timespec_from_f64_secs(self.start + self.duration)
-  }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -1794,6 +1747,7 @@ mod remote {
   use bazel_protos;
   use boxfuture::{BoxFuture, Boxable};
   use bytes::{Bytes, BytesMut};
+  use concrete_time::TimeSpan;
   use digest::{Digest as DigestTrait, FixedOutput};
   use futures::{self, future, Future, IntoFuture, Sink, Stream};
   use grpcio;
@@ -2023,11 +1977,9 @@ mod remote {
           }
         })
         .then(move |future| {
-          let time_span = super::TimeSpan::since(&start_time);
           let workunit = workunit_store::WorkUnit {
             name: workunit_name.clone(),
-            start_timestamp: time_span.start_timestamp(),
-            end_timestamp: time_span.end_timestamp(),
+            time_span: TimeSpan::since(&start_time),
             span_id: workunit_store::generate_random_64bit_string(),
             parent_id: workunit_store::get_parent_id(),
           };
@@ -2104,11 +2056,9 @@ mod remote {
           }
         })
         .then(move |future| {
-          let time_span = super::TimeSpan::since(&start_time);
           let workunit = workunit_store::WorkUnit {
             name: workunit_name.clone(),
-            start_timestamp: time_span.start_timestamp(),
-            end_timestamp: time_span.end_timestamp(),
+            time_span: TimeSpan::since(&start_time),
             span_id: workunit_store::generate_random_64bit_string(),
             parent_id: workunit_store::get_parent_id(),
           };
@@ -2154,11 +2104,9 @@ mod remote {
             })
         })
         .then(move |future| {
-          let time_span = super::TimeSpan::since(&start_time);
           let workunit = workunit_store::WorkUnit {
             name: workunit_name.clone(),
-            start_timestamp: time_span.start_timestamp(),
-            end_timestamp: time_span.end_timestamp(),
+            time_span: TimeSpan::since(&start_time),
             span_id: workunit_store::generate_random_64bit_string(),
             parent_id: workunit_store::get_parent_id(),
           };

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -23,7 +23,7 @@ sharded_lmdb = {  path = "../sharded_lmdb" }
 store = { path = "../fs/store" }
 task_executor = { path = "../task_executor" }
 tempfile = "3"
-time = "0.1.40"
+concrete_time = { path = "../concrete_time" }
 tokio-codec = "0.1"
 tokio-process = "0.2.1"
 tokio-timer = "0.2"

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -115,6 +115,10 @@ pub fn store_utf8_osstr(utf8: &OsStr) -> Value {
   with_externs(|e| (e.store_utf8)(e.context, bytes.as_ptr(), bytes.len() as u64).into())
 }
 
+pub fn store_u64(val: u64) -> Value {
+  with_externs(|e| (e.store_u64)(e.context, val).into())
+}
+
 pub fn store_i64(val: i64) -> Value {
   with_externs(|e| (e.store_i64)(e.context, val).into())
 }
@@ -341,6 +345,7 @@ pub struct Externs {
   pub store_dict: StoreTupleExtern,
   pub store_bytes: StoreBytesExtern,
   pub store_utf8: StoreUtf8Extern,
+  pub store_u64: StoreU64Extern,
   pub store_i64: StoreI64Extern,
   pub store_f64: StoreF64Extern,
   pub store_bool: StoreBoolExtern,
@@ -375,6 +380,8 @@ pub type StoreTupleExtern =
 pub type StoreBytesExtern = extern "C" fn(*const ExternContext, *const u8, u64) -> Handle;
 
 pub type StoreUtf8Extern = extern "C" fn(*const ExternContext, *const u8, u64) -> Handle;
+
+pub type StoreU64Extern = extern "C" fn(*const ExternContext, u64) -> Handle;
 
 pub type StoreI64Extern = extern "C" fn(*const ExternContext, i64) -> Handle;
 

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -6,8 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
+concrete_time = { path = "../concrete_time" }
 futures = "0.1.27"
 parking_lot = "0.6"
 rand = "0.6"
-time = "0.1.40"
-serde = "1.0.98"

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -26,19 +26,18 @@
 // Arc<Mutex> can be more clear than needing to grok Orderings:
 #![allow(clippy::mutex_atomic)]
 
+use concrete_time::TimeSpan;
 use futures::task_local;
 use parking_lot::Mutex;
 use rand::thread_rng;
 use rand::Rng;
 use std::collections::HashSet;
 use std::sync::Arc;
-use time::Timespec;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct WorkUnit {
   pub name: String,
-  pub start_timestamp: Timespec,
-  pub end_timestamp: Timespec,
+  pub time_span: TimeSpan,
   pub span_id: String,
   pub parent_id: Option<String>,
 }

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -212,7 +212,7 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'platform_specific_behavior', 'integration'},
-  timeout = 360,
+  timeout = 540,
 )
 
 python_tests(


### PR DESCRIPTION
To represent timestamps and durations, we used to use a mix of various
strategies:
* `f64` representing a number of seconds
* `time::Timespec`
* `protobuf::well_known_type::Timestamp`

A span of time was sometimes represented as
* a start and an end timestamp, or
* a start and a duration

This lead to many little helper functions converting from one type of
time representation to another, which caused clutter.

There were valid reasons for alternating between different
representations. For instance, we sometimes wanted a timestamp that
could be serialized and an `f64` filled that role.
We sometimes wanted a timestamp that was more strongly typed, and a
`time::Timespec` filled that role, despite coming from a deprecated
crate.

In general, we should use `std::time` for time operations, but these
types don't lend themselves to serialization as they explicitely avoid
exposing their internals through serialization or otherwise to avoid
misleading programmers into serializing a timestamp, checking it on a
different machine with a different timezone and ending up with broken
assumptions.

Since we do want to serialize durations (since EPOCH, so a timestamp or
since another duration), create a simple struct called
`concrete_time::Duration` that can seemlessly be converted from and into
a `std::time::Duration` and that can also be serialized.

For convenience, also create a `TimeSpan` that encapsulates the idea of
starting at some point and ending at some other point. Give it
constructors that make sense given the contexts in which we populate
timespans (from protobuf and from measurements).

Also change the ffi boundary to push the float representation of time as
far as possible, to the py_zipkin interface; so the python code can more
conveniently compare timestamps for equality in tests.

Note that brfs was purposefully omitted from the homogeneisation effort
as it only used `time::Timespec` without any conversions and that is
what the `fuse` API expects.