### PR TITLE
Only add SCM info if scm is available.

### DIFF
--- a/src/python/pants/base/run_info.py
+++ b/src/python/pants/base/run_info.py
@@ -86,9 +86,8 @@ class RunInfo:
   def add_scm_info(self):
     """Adds SCM-related info."""
     scm = get_scm()
-    if scm:
-      revision = scm.commit_id
-      branch = scm.branch_name or revision
-    else:
-      revision, branch = 'none', 'none'
+    if not scm:
+      return
+    revision = scm.commit_id
+    branch = scm.branch_name or revision
     self.add_infos(('revision', revision), ('branch', branch))


### PR DESCRIPTION
### Problem

When SCM is not available (for example, building pex in a docker container where git is not installed) we still add revision & branch info to RunInfo as strings containing 'none' which I believe is bad. since it requires whoever reads this information to special case for the 'none' string.
<img width="306" alt="Screenshot 2019-08-07 12 28 19" src="https://user-images.githubusercontent.com/1268088/62651887-da9e5100-b90e-11e9-8649-95f08e3eb435.png">


### Solution

Don't include SCM info if SCM is not available.

### Result

SCM information is not included in PEX-INFO/run-info if SCM is not available.