### PR TITLE
Serverset makes connections from addresses

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2314,6 +2314,7 @@ dependencies = [
  "boxfuture 0.0.1",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "testutil 0.0.1",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -704,7 +704,7 @@ fn main() {
     Some(address) => Store::with_remote(
       runtime.clone(),
       &store_path,
-      &[address.to_owned()],
+      vec![address.to_owned()],
       args.value_of("remote-instance-name").map(str::to_owned),
       &root_ca_certs,
       oauth_bearer_token,

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -295,7 +295,7 @@ fn execute(top_match: &clap::ArgMatches<'_>) -> Result<(), ExitError> {
           Store::with_remote(
             runtime.clone(),
             &store_dir,
-            &cas_addresses,
+            cas_addresses,
             top_match
               .value_of("remote-instance-name")
               .map(str::to_owned),

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1570,7 +1570,7 @@ pub mod tests {
     let store = Store::with_remote(
       runtime.clone(),
       &store_dir_path,
-      &[cas.address()],
+      vec![cas.address()],
       None,
       &None,
       None,
@@ -1944,7 +1944,7 @@ pub mod tests {
     let store = Store::with_remote(
       runtime.clone(),
       store_dir,
-      &[cas.address()],
+      vec![cas.address()],
       None,
       &None,
       None,
@@ -2037,7 +2037,7 @@ pub mod tests {
     let store = Store::with_remote(
       task_executor::Executor::new(),
       store_dir,
-      &[cas.address()],
+      vec![cas.address()],
       None,
       &None,
       None,
@@ -2105,7 +2105,7 @@ pub mod tests {
     let store = Store::with_remote(
       runtime.clone(),
       store_dir,
-      &[cas.address()],
+      vec![cas.address()],
       None,
       &None,
       None,
@@ -2848,7 +2848,7 @@ pub mod tests {
     let store = Store::with_remote(
       task_executor::Executor::new(),
       store_dir,
-      &[cas.address()],
+      vec![cas.address()],
       None,
       &None,
       None,

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -248,7 +248,7 @@ fn main() {
       Store::with_remote(
         executor.clone(),
         local_store_path,
-        &[cas_server.to_owned()],
+        vec![cas_server.to_owned()],
         remote_instance_arg.clone(),
         &root_ca_certs,
         oauth_bearer_token,

--- a/src/rust/engine/serverset/Cargo.toml
+++ b/src/rust/engine/serverset/Cargo.toml
@@ -12,4 +12,5 @@ parking_lot = "0.6"
 tokio-timer = "0.2"
 
 [dev-dependencies]
+testutil = { path = "../testutil" }
 tokio = "0.1"

--- a/src/rust/engine/serverset/src/lib.rs
+++ b/src/rust/engine/serverset/src/lib.rs
@@ -309,7 +309,7 @@ mod tests {
   #[test]
   fn no_servers_is_error() {
     let servers: Vec<String> = vec![];
-    Serverset::new(servers, str::to_owned, backoff_config())
+    Serverset::new(servers, fake_connect, backoff_config())
       .expect_err("Want error constructing with no servers");
   }
 
@@ -318,7 +318,7 @@ mod tests {
     let mut rt = tokio::runtime::Runtime::new().unwrap();
     let s = Serverset::new(
       owned_string_vec(&["good", "bad"]),
-      str::to_owned,
+      fake_connect,
       backoff_config(),
     )
     .unwrap();
@@ -331,7 +331,7 @@ mod tests {
     let mut rt = tokio::runtime::Runtime::new().unwrap();
     let s = Serverset::new(
       owned_string_vec(&["good", "bad"]),
-      str::to_owned,
+      fake_connect,
       backoff_config(),
     )
     .unwrap();
@@ -353,7 +353,7 @@ mod tests {
     let mut rt = tokio::runtime::Runtime::new().unwrap();
     let s = Serverset::new(
       owned_string_vec(&["good", "bad"]),
-      str::to_owned,
+      fake_connect,
       backoff_config(),
     )
     .unwrap();
@@ -368,7 +368,7 @@ mod tests {
     let mut rt = tokio::runtime::Runtime::new().unwrap();
     let s = Serverset::new(
       owned_string_vec(&["good", "bad"]),
-      str::to_owned,
+      fake_connect,
       backoff_config(),
     )
     .unwrap();
@@ -385,7 +385,7 @@ mod tests {
     let mut rt = tokio::runtime::Runtime::new().unwrap();
     let s = Serverset::new(
       owned_string_vec(&["good", "bad"]),
-      str::to_owned,
+      fake_connect,
       backoff_config(),
     )
     .unwrap();
@@ -420,7 +420,7 @@ mod tests {
     let backoff_config = backoff_config();
     let s = Serverset::new(
       owned_string_vec(&["good", "bad"]),
-      str::to_owned,
+      fake_connect,
       backoff_config,
     )
     .unwrap();
@@ -517,5 +517,10 @@ mod tests {
     assert!(*did_get_at_least_one_good.lock());
 
     std::thread::sleep(buffer * 2);
+  }
+
+  /// For tests, we just use Strings as servers, as it's an easy type we can make from addresses.
+  fn fake_connect(s: &str) -> String {
+    s.to_owned()
   }
 }

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -115,7 +115,7 @@ impl Core {
           Store::with_remote(
             executor.clone(),
             local_store_dir,
-            &remote_store_servers,
+            remote_store_servers,
             remote_instance_name.clone(),
             &root_ca_certs,
             oauth_bearer_token.clone(),


### PR DESCRIPTION
Instead of being given connections.

This is the first step in a series of PRs which will allow limiting the
number of open connections.

This is a pure refactor - no behaviour is changing.