### PR TITLE
Deflake test

### DIFF
--- a/src/rust/engine/serverset/src/lib.rs
+++ b/src/rust/engine/serverset/src/lib.rs
@@ -363,6 +363,8 @@ mod tests {
 
     expect_only_good(&mut rt, &s, Duration::from_millis(10));
 
+    // mark_bad_as_bad asserts that we attempted to use the bad server as a side effect, so this
+    // checks that we did re-use the server after the lame period.
     mark_bad_as_bad(&mut rt, &s, Health::Unhealthy);
 
     expect_only_good(&mut rt, &s, Duration::from_millis(20));
@@ -370,16 +372,6 @@ mod tests {
     mark_bad_as_bad(&mut rt, &s, Health::Unhealthy);
 
     expect_only_good(&mut rt, &s, Duration::from_millis(40));
-
-    mark_bad_as_bad(&mut rt, &s, Health::Healthy);
-
-    expect_only_good(&mut rt, &s, Duration::from_millis(20));
-
-    mark_bad_as_bad(&mut rt, &s, Health::Healthy);
-
-    expect_only_good(&mut rt, &s, Duration::from_millis(10));
-
-    mark_bad_as_bad(&mut rt, &s, Health::Healthy);
 
     expect_both(&mut rt, &s, 2);
   }


### PR DESCRIPTION
The way backing in is implemented, we halve the backoff period per
successful request, rather than based on time. The `expect_only_good`
method makes an unpredictable number of requests, filling a time window
rather.

So this test would pass when the number of requests happened to align
with the time window (which appears to be common on travis's CPUs), and
fail if they got out of sync.

We currently have no tests for the actual backing in behaviour, but I
think that's mostly ok; we have tests that shows that we start using
servers again, and we can add more if we need to.

Fixes #7836