### PR TITLE
Loosen test condition

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2330,6 +2330,7 @@ version = "0.0.1"
 dependencies = [
  "boxfuture 0.0.1",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/serverset/Cargo.toml
+++ b/src/rust/engine/serverset/Cargo.toml
@@ -12,5 +12,6 @@ parking_lot = "0.6"
 tokio-timer = "0.2"
 
 [dev-dependencies]
+maplit = "1"
 testutil = { path = "../testutil" }
 tokio = "0.1"

--- a/src/rust/engine/serverset/src/retry.rs
+++ b/src/rust/engine/serverset/src/retry.rs
@@ -51,6 +51,7 @@ impl<T: Clone + Send + Sync + 'static> Retry<T> {
 #[cfg(test)]
 mod tests {
   use crate::{BackoffConfig, Retry, Serverset};
+  use maplit::hashset;
   use std::time::Duration;
   use testutil::owned_string_vec;
 
@@ -69,15 +70,15 @@ mod tests {
       BackoffConfig::new(Duration::from_millis(10), 2.0, Duration::from_millis(100)).unwrap(),
     )
     .unwrap();
-    let mut v = vec![];
+    let mut saw = hashset![];
     for _ in 0..3 {
-      v.push(
+      saw.insert(
         runtime
           .block_on(Retry(s.clone()).all_errors_immediately(|v| v, 1))
           .unwrap(),
       );
     }
-    assert_eq!(owned_string_vec(&["good", "enough", "good"]), v);
+    assert_eq!(saw, hashset!["good".to_owned(), "enough".to_owned()]);
   }
 
   #[test]


### PR DESCRIPTION
We don't actually want to guarantee from serverset that we will
_exactly_ round-robin between servers (which is a property I'm about to
remove), just that we average out to trying them at roughly equal rates.