### PR TITLE
[pantsd] Implement --daemon-max-memory-usage to limit how much memory pantsd can take

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -7,6 +7,7 @@ coverage>=4.5,<4.6
 dataclasses==0.6
 docutils==0.14
 fasteners==0.14.1
+humanfriendly==4.8
 Markdown==2.1.1
 # TODO(6282): once we can upgrade Pytest to 4.2.1+, we can remove the more-itertools requirement
 more-itertools<6.0.0 ; python_version<'3'

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -281,8 +281,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
 
     # NB: This flag doesn't intrinsically need to invalidate the daemon, because it will invalidate
     # it anyway if the memory constraint is exceeded.
-    register('--daemon-max-memory-usage', advanced=True, type=int, default=(10 * 1024 * 1024 * 1024), daemon=False,
-             help='The maximum amount of memory (in bytes) the daemon is allowed to have. '
+    register('--daemon-max-memory-usage', advanced=True, type=str, default='10GB', daemon=False,
+             help='The maximum amount of memory the daemon is allowed to have. '
                   'If the daemon goes above this memory limit, it will restart itself before running.')
 
     # These facilitate configuring the native engine.

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -279,6 +279,12 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   'any prior running Pants command must be finished for the current one to start. '
                   'To never timeout, use the value -1.')
 
+    # NB: This flag doesn't intrinsically need to invalidate the daemon, because it will invalidate
+    # it anyway if the memory constraint is exceeded.
+    register('--daemon-max-memory-usage', advanced=True, type=int, default=(10 * 1024 * 1024 * 1024), daemon=False,
+             help='The maximum amount of memory (in bytes) the daemon is allowed to have. '
+                  'If the daemon goes above this memory limit, it will restart itself before running.')
+
     # These facilitate configuring the native engine.
     register('--native-engine-visualize-to', advanced=True, default=None, type=dir_option, daemon=False,
              help='A directory to write execution and rule graphs to as `dot` files. The contents '

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -281,7 +281,9 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
 
     # NB: This flag doesn't intrinsically need to invalidate the daemon, because it will invalidate
     # it anyway if the memory constraint is exceeded.
-    register('--daemon-max-memory-usage', advanced=True, type=str, default='10GB', daemon=False,
+    # We use a very large default intentionally, because we want this to be configurable, and
+    # we don't want to break existing usages with this change.
+    register('--daemon-max-memory-usage', advanced=True, type=str, default='1TB', daemon=False,
              help='The maximum amount of memory the daemon is allowed to have. '
                   'If the daemon goes above this memory limit, it will restart itself before running.')
 

--- a/src/python/pants/pantsd/BUILD
+++ b/src/python/pants/pantsd/BUILD
@@ -55,6 +55,7 @@ python_library(
   name = 'pants_daemon',
   sources = ['pants_daemon.py'],
   dependencies = [
+    '3rdparty/python:humanfriendly',
     '3rdparty/python:setproctitle',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exception_sink',

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -7,6 +7,7 @@ import sys
 import threading
 from contextlib import contextmanager
 
+import humanfriendly
 from setproctitle import setproctitle as set_process_title
 
 from pants.base.build_environment import get_buildroot
@@ -495,11 +496,13 @@ class PantsDaemon(FingerprintedProcessManager):
 
   def _has_exceeded_memory_usage(self):
     used_memory = self.current_memory_usage()
-    max_memory = self._bootstrap_options.for_global_scope().daemon_max_memory_usage
-    exceeded = used_memory > max_memory
-    self._logger.debug(f"pantsd is using {used_memory}b of memory, max is {max_memory}b")
+    humanfriendly_max_memory = self._bootstrap_options.for_global_scope().daemon_max_memory_usage
+    parsed_max_memory = humanfriendly.parse_size(humanfriendly_max_memory)
+    exceeded = used_memory > parsed_max_memory
+    self._logger.debug(f"pantsd is using {used_memory}b of memory, max is {humanfriendly_max_memory} ({parsed_max_memory} bytes)")
     if exceeded:
-      self._logger.info(f"pantsd exceeded it's alloted memory usage! (usage={used_memory}, max={max_memory})")
+      humanfriendly_used_memory = humanfriendly.format_size(used_memory)
+      self._logger.info(f"pantsd exceeded it's alloted memory usage! usage=({humanfriendly_used_memory})={used_memory} bytes, max=({humanfriendly_used_memory})={parsed_max_memory} bytes")
 
     return exceeded
 

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -125,6 +125,7 @@ class PantsDaemon(FingerprintedProcessManager):
       stub_pantsd = cls.create(options_bootstrapper, full_init=False)
       with stub_pantsd._services.lifecycle_lock:
         if stub_pantsd.needs_restart(stub_pantsd.options_fingerprint):
+          stub_pantsd._logger.info('Starting up a fresh Pants Daemon...')
           # Once we determine we actually need to launch, recreate with full initialization.
           pantsd = cls.create(options_bootstrapper)
           return pantsd.launch()
@@ -459,19 +460,6 @@ class PantsDaemon(FingerprintedProcessManager):
     self._logger.debug('cmd is: PANTS_ENTRYPOINT={} {}'.format(entry_point, ' '.join(cmd)))
     # TODO: Improve error handling on launch failures.
     os.spawnve(os.P_NOWAIT, sys.executable, cmd, env=exec_env)
-
-  def needs_launch(self):
-    """Determines if pantsd needs to be launched.
-
-    N.B. This should always be called under care of the `lifecycle_lock`.
-
-    :returns: True if the daemon needs launching, False otherwise.
-    :rtype: bool
-    """
-    new_fingerprint = self.options_fingerprint
-    self._logger.debug('pantsd: is_alive={} new_fingerprint={} current_fingerprint={}'
-                       .format(self.is_alive(), new_fingerprint, self.fingerprint))
-    return self.needs_restart(new_fingerprint)
 
   def launch(self):
     """Launches pantsd in a subprocess.

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -512,7 +512,7 @@ class PantsDaemon(FingerprintedProcessManager):
       self._logger.debug(f"pantsd is using {humanfriendly_used_memory} ({bytes_used} bytes) of memory, max is {humanfriendly_max_memory} ({parsed_max_memory} bytes)")
       exceeded = bytes_used > parsed_max_memory
       if exceeded:
-        self._logger.info(f"pantsd exceeded it's alloted memory usage! usage=({humanfriendly_used_memory})={bytes_used} bytes, max=({humanfriendly_max_memory})={parsed_max_memory} bytes")
+        self._logger.info(f"pantsd exceeded its allotted memory usage! usage=({humanfriendly_used_memory})={bytes_used} bytes, max=({humanfriendly_max_memory})={parsed_max_memory} bytes")
 
       return exceeded
     else:

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -527,9 +527,7 @@ class PantsDaemon(FingerprintedProcessManager):
     :param option_fingerprint: A fingeprint of the global bootstrap options.
     :return: True if the daemon needs to restart.
     """
-    should_shutdown_after_run = self._bootstrap_options.for_global_scope().shutdown_pantsd_after_run
     return super().needs_restart(option_fingerprint) or \
-           (self.is_alive() and should_shutdown_after_run) or \
            self._has_exceeded_memory_usage()
 
 

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -438,6 +438,14 @@ class ProcessManager(ProcessMetadataManager):
     if purge:
       self.purge_metadata(force=True)
 
+  def current_memory_usage(self):
+    """Return the current memory usage of the pantsd process (which must be running)
+
+    :return: memory usage in bytes
+    """
+    assert self.is_alive(), f"Cannot read memory of dead process with pid {self._pid}"
+    return psutil.Process(self._pid).memory_info()[0]
+
   def daemonize(self, pre_fork_opts=None, post_fork_parent_opts=None, post_fork_child_opts=None,
                 fork_context=None, write_pid=True):
     """Perform a double-fork, execute callbacks and write the child pid file.

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -77,6 +77,7 @@ python_tests(
   name = 'pantsd_integration',
   sources = ['test_pantsd_integration.py'],
   dependencies = [
+    '3rdparty/python:humanfriendly',
     ':pantsd_integration_test_base',
     'tests/python/pants_test:int-test',
     'tests/python/pants_test/testutils:process_test_util',

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -193,7 +193,7 @@ class PantsDaemonIntegrationTestBase(PantsRunIntegrationTest):
 
   @contextmanager
   def warm_daemon(self, *, cmd: List[str] = ['filter', 'testprojects/::'], **kwargs):
-    """Starts an inocuous daemon run, and yields the checker for that run while the run is still active.
+    """Starts an innocuous daemon run, and yields the checker for that run while the run is still active.
 
     :param cmd: Command to start the daemon with.
     """

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -69,10 +69,16 @@ class PantsDaemonMonitor(ProcessManager):
     assert self.is_dead(), 'pantsd should be stopped!'
     return self._pid
 
-  def current_memory_usage(self):
+  class PantsdIsDeadException(Exception): pass
+
+  def current_memory_usage_unwrapped(self) -> int:
     """Return the memory usage, but await for metadata first."""
     self.assert_running()
-    return super().current_memory_usage()
+    usage = self.current_memory_usage()
+    if usage.is_alive:
+      return usage.bytes_used
+    else:
+      raise PantsDaemonMonitor.PantsdIsDeadException("Pantsd died unexpectedly between blocking for metadata and now.")
 
 
 class PantsDaemonIntegrationTestBase(PantsRunIntegrationTest):

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -5,6 +5,7 @@ import functools
 import os
 import time
 from contextlib import contextmanager
+from typing import List
 
 from colors import bold, cyan, magenta
 
@@ -183,3 +184,16 @@ class PantsDaemonIntegrationTestBase(PantsRunIntegrationTest):
     else:
       self.assert_failure(run)
     return run
+
+  @contextmanager
+  def warm_daemon(self, *, cmd: List[str] = ['filter', 'testprojects/::'], **kwargs):
+    """Starts an inocuous daemon run, and yields the checker for that run while the run is still active.
+
+    :param cmd: Command to start the daemon with.
+    """
+    with self.pantsd_successful_run_context(**kwargs) as (pantsd_run, checker, _, _):
+      # Assert that pantsd can complete this run successfully, and we have an active pantsd
+      pantsd_run(cmd)
+      checker.assert_running()
+
+      yield (cmd, pantsd_run, checker)

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -6,7 +6,6 @@ import os
 import time
 from contextlib import contextmanager
 
-import psutil
 from colors import bold, cyan, magenta
 
 from pants.pantsd.process_manager import ProcessManager
@@ -57,14 +56,6 @@ class PantsDaemonMonitor(ProcessManager):
     assert self._pid is not None and self.is_alive(), 'cannot assert that pantsd is running. Try calling assert_started before calling this method.'
     return self._pid
 
-  def current_memory_usage(self):
-    """Return the current memory usage of the pantsd process (which must be running)
-
-    :return: memory usage in bytes
-    """
-    self.assert_running()
-    return psutil.Process(self._pid).memory_info()[0]
-
   def assert_running(self):
     if not self._pid:
       return self.assert_started()
@@ -76,6 +67,11 @@ class PantsDaemonMonitor(ProcessManager):
     assert self._pid is not None, 'cannot assert pantsd stoppage. Try calling assert_started before calling this method.'
     assert self.is_dead(), 'pantsd should be stopped!'
     return self._pid
+
+  def current_memory_usage(self):
+    """Return the memory usage, but await for metadata first."""
+    self.assert_running()
+    return super().current_memory_usage()
 
 
 class PantsDaemonIntegrationTestBase(PantsRunIntegrationTest):

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -12,6 +12,8 @@ import time
 import unittest
 from textwrap import dedent
 
+import humanfriendly
+
 from pants.util.contextutil import environment_as, temporary_dir, temporary_file
 from pants.util.dirutil import rm_rf, safe_file_dump, safe_mkdir, safe_open, touch
 from pants_test.pants_run_integration_test import read_pantsd_log
@@ -451,7 +453,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
 
       # Pass an extra flag, to set the maximum memory used by the daemon.
       much_less_memory = int(0.1 * (checker.current_memory_usage()))
-      max_memory_config = {'GLOBAL': {'daemon_max_memory_usage': f'{much_less_memory}'}}
+      max_memory_config = {'GLOBAL': {'daemon_max_memory_usage': humanfriendly.format_size(much_less_memory)}}
 
       pantsd_run(cmd, extra_config=max_memory_config)
 

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -423,14 +423,10 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
           )
         )
 
+
   def test_max_memory_flag_does_not_invalidate_daemon_by_default(self):
     """Validates that, if we pass a value that is large enough to a running daemon, it will not restart."""
-    with self.pantsd_successful_run_context() as (pantsd_run, checker, _, _):
-      cmd = ['filter', 'testprojects/::']
-      # Assert that pantsd can complete this run successfully, and we have an active pantsd
-      pantsd_run(cmd)
-      checker.assert_running()
-
+    with self.warm_daemon() as (cmd, pantsd_run, checker):
       # Pass an extra flag, to set the maximum memory used by the daemon.
       twenty_times_the_used_memory = 20 * (checker.current_memory_usage())
       max_memory_config = {'GLOBAL': {'daemon_max_memory_usage': twenty_times_the_used_memory}}
@@ -444,12 +440,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
     Validates that, if we pass a value that is lower than the current memory usage of the daemon,
     the daemon will restart.
     """
-    with self.pantsd_successful_run_context() as (pantsd_run, checker, _, _):
-      cmd = ['filter', 'testprojects/::']
-      # Assert that pantsd can complete this run successfully, and we have an active pantsd
-      pantsd_run(cmd)
-      checker.assert_running()
-
+    with self.warm_daemon() as (cmd, pantsd_run, checker):
       # Read the pidfile, to record which daemon is running.
       # NB: The file should already exist because we ran checker.assert_running,
       # so we have a deterministic timeout of 0.

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -409,7 +409,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         self.assert_success(pantsd_run(cmd))
         checker.assert_running()
 
-      final_memory_usage = checker.current_memory_usage()
+      final_memory_usage = checker.current_memory_usage_unwrapped()
       self.assertTrue(
           initial_memory_usage <= final_memory_usage,
           "Memory usage inverted unexpectedly: {} > {}".format(
@@ -429,7 +429,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
     """Validates that, if we pass a value that is large enough to a running daemon, it will not restart."""
     with self.warm_daemon() as (cmd, pantsd_run, checker):
       # Pass an extra flag, to set the maximum memory used by the daemon.
-      twenty_times_the_used_memory = 20 * (checker.current_memory_usage())
+      twenty_times_the_used_memory = 20 * (checker.current_memory_usage_unwrapped())
       max_memory_config = {'GLOBAL': {'daemon_max_memory_usage': twenty_times_the_used_memory}}
 
       # Assert that passing this flag (with more than enough memory) doesn't restart the daemon
@@ -452,7 +452,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
       before_daemon_processes = checker.runner_process_context.current_processes()
 
       # Pass an extra flag, to set the maximum memory used by the daemon.
-      much_less_memory = int(0.1 * (checker.current_memory_usage()))
+      much_less_memory = int(0.1 * (checker.current_memory_usage_unwrapped()))
       max_memory_config = {'GLOBAL': {'daemon_max_memory_usage': humanfriendly.format_size(much_less_memory)}}
 
       pantsd_run(cmd, extra_config=max_memory_config)

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -401,10 +401,8 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
     """Validates that after N runs, memory usage has increased by no more than X percent."""
     number_of_runs = 10
     max_memory_increase_fraction = 0.40 # TODO https://github.com/pantsbuild/pants/issues/7647
-    with self.pantsd_successful_run_context() as (pantsd_run, checker, workdir, config):
-      cmd = ['filter', 'testprojects::']
-      self.assert_success(pantsd_run(cmd))
-      initial_memory_usage = checker.current_memory_usage()
+    with self.warm_daemon() as (cmd, pantsd_run, checker):
+      initial_memory_usage = checker.current_memory_usage_unwrapped()
       for _ in range(number_of_runs):
         self.assert_success(pantsd_run(cmd))
         checker.assert_running()


### PR DESCRIPTION
### Problem

There is currently no way for us to limit how big pantsd can grow. And we have seen that the daemon's memory usage might grow run after run.

### Solution

- Extract the functionality to see a process' used memory from the pantsd test harness into `ProcessManager`.
- Implement a new bootstrap flag, --daemon-max-memory-usage. This flag will be read when `PantsDaemon` is deciding whether it needs to restart. It will compare it with the memory usage reported by the facility above.

### Result

Users can specify things like `--daemon-max-memory-usage=10MB` in their command lines.

Commits are independently reviewable.
As a side effect, we add `humanfriendly==4.8` to our 3rdparty dependencies, to parse data sizes.