### PR TITLE
Restore remote execution of unit tests by fixing firewall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -731,8 +731,7 @@ matrix:
         - *py37_linux_test_config_env
         - CACHE_NAME=unit_tests.v2.py37
       script:
-        # TODO: Remote execution disabled (by removing `--remote-execution-enabled`) due to #8137.
-        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2 --python-version 3.7
+        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2 --remote-execution-enabled --python-version 3.7
 
     - <<: *py36_lint
     - <<: *py37_lint
@@ -746,8 +745,7 @@ matrix:
         - *py36_linux_test_config_env
         - CACHE_NAME=unit_tests.v2.py36
       script:
-        # TODO: Remote execution disabled (by removing `--remote-execution-enabled`) due to #8137.
-        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2
+        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2 --remote-execution-enabled
 
     - <<: *py36_linux_test_config
       name: "Unit tests - V1 test runner (Py3.6 PEX)"

--- a/build-support/travis/travis.yml.mustache
+++ b/build-support/travis/travis.yml.mustache
@@ -678,8 +678,7 @@ matrix:
         - *py37_linux_test_config_env
         - CACHE_NAME=unit_tests.v2.py37
       script:
-        # TODO: Remote execution disabled (by removing `--remote-execution-enabled`) due to #8137.
-        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2 --python-version 3.7
+        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2 --remote-execution-enabled --python-version 3.7
 
     - <<: *py36_lint
     - <<: *py37_lint
@@ -693,8 +692,7 @@ matrix:
         - *py36_linux_test_config_env
         - CACHE_NAME=unit_tests.v2.py36
       script:
-        # TODO: Remote execution disabled (by removing `--remote-execution-enabled`) due to #8137.
-        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2
+        - travis_wait 50 ./build-support/bin/ci.py --python-tests-v2 --remote-execution-enabled
 
     - <<: *py36_linux_test_config
       name: "Unit tests - V1 test runner (Py3.6 PEX)"


### PR DESCRIPTION
In https://github.com/pantsbuild/pants/pull/8138, we turned off remote execution because we mysteriously started getting 403 errors. Turns out that Travis had updated one of its IP addresses without us realizing, so the Google App Engine firewall was giving 403 errors.

This was fixed by updating the Google Cloud Console at https://console.cloud.google.com/appengine/firewall?project=pants-remoting-beta to match the list at https://docs.travis-ci.com/user/ip-addresses/.