### PR TITLE
Test that remote calls get captured in zipkin spans.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@
 .pydevproject
 .pytest_cache/
 codegen/classes/
+local_cas
+local_execution_server
 htmlcov/
 out/
 # remove root-level /bin, which is created by Eclipse

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,14 @@ env:
   global:
   - PANTS_CONFIG_FILES="${TRAVIS_BUILD_DIR}/pants.travis-ci.ini"
   - LC_ALL="en_US.UTF-8"
-  - BOOTSTRAPPED_PEX_BUCKET=ci-public.pantsbuild.org
-  - BOOTSTRAPPED_PEX_KEY_PREFIX=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}/pants.pex
-  - BOOTSTRAPPED_PEX_URL_PREFIX=s3://${BOOTSTRAPPED_PEX_BUCKET}/${BOOTSTRAPPED_PEX_KEY_PREFIX}
+  - BOOTSTRAP_BUCKET=ci-public.pantsbuild.org
+  - BOOTSTRAP_KEY_DIRECTORY=${TRAVIS_BUILD_NUMBER}/${TRAVIS_BUILD_ID}
+  - BOOTSTRAPPED_PEX_KEY_PREFIX=${BOOTSTRAP_KEY_DIRECTORY}/pants.pex
+  - BOOTSTRAPPED_PEX_URL_PREFIX=s3://${BOOTSTRAP_BUCKET}/${BOOTSTRAPPED_PEX_KEY_PREFIX}
+  - BOOTSTRAPPED_MOCK_CAS_KEY=${BOOTSTRAP_KEY_DIRECTORY}/local_cas
+  - BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY=${BOOTSTRAP_KEY_DIRECTORY}/local_execution_server
+  - BOOTSTRAPPED_MOCK_CAS_URL=s3://${BOOTSTRAP_BUCKET}/${BOOTSTRAPPED_MOCK_CAS_KEY}
+  - BOOTSTRAPPED_MOCK_EXECUTION_SERVER_URL=s3://${BOOTSTRAP_BUCKET}/${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}
   - PYENV_PY27_VERSION=2.7.15
   - PYENV_PY36_VERSION=3.6.8
   - PYENV_PY37_VERSION=3.7.2
@@ -64,6 +69,7 @@ matrix:
     dist: xenial
     env:
     - CACHE_NAME=bootstrap.linux.py36
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PREPARE_DEPLOY=1
     language: python
@@ -79,9 +85,14 @@ matrix:
       "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
     - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest sh -c "./build-support/bin/ci.py --bootstrap --python-version
-      3.6 && ./build-support/bin/release.sh -f"
+      3.6 && ./build-support/bin/ci.py --bootstrap-mock-remote && ./build-support/bin/release.sh
+      -f"
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
+      ${BOOTSTRAPPED_MOCK_CAS_URL}.${PLATFORM}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_execution_server
+      ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_URL}.${PLATFORM}
     services:
     - docker
     stage: Bootstrap Pants
@@ -120,6 +131,7 @@ matrix:
     dist: xenial
     env:
     - CACHE_NAME=bootstrap.linux.py37
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     language: python
     name: Build Linux native engine and pants.pex (Python 3.7)
@@ -134,9 +146,13 @@ matrix:
       "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
     - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest sh -c "./build-support/bin/ci.py --bootstrap --python-version
-      3.7"
+      3.7 && ./build-support/bin/ci.py --bootstrap-mock-remote"
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
+      ${BOOTSTRAPPED_MOCK_CAS_URL}.${PLATFORM}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_execution_server
+      ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_URL}.${PLATFORM}
     services:
     - docker
     stage: Bootstrap Pants (Cron)
@@ -174,6 +190,7 @@ matrix:
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
     - CACHE_NAME=bootstrap.osx.py36
+    - PLATFORM=osx
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
     - PREPARE_DEPLOY=1
     language: generic
@@ -182,9 +199,14 @@ matrix:
     osx_image: xcode8
     script:
     - ./build-support/bin/ci.py --bootstrap --python-version 3.6
+    - ./build-support/bin/ci.py --bootstrap-mock-remote
     - ./build-support/bin/release.sh -f
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
+      ${BOOTSTRAPPED_MOCK_CAS_URL}.${PLATFORM}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_execution_server
+      ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_URL}.${PLATFORM}
     stage: Bootstrap Pants
   - addons:
       brew:
@@ -219,6 +241,7 @@ matrix:
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
     - CACHE_NAME=bootstrap.osx.py37
+    - PLATFORM=osx
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
     language: generic
     name: Build OSX native engine and pants.pex (Python 3.7)
@@ -226,8 +249,13 @@ matrix:
     osx_image: xcode8
     script:
     - ./build-support/bin/ci.py --bootstrap --python-version 3.7
+    - ./build-support/bin/ci.py --bootstrap-mock-remote
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
+      ${BOOTSTRAPPED_MOCK_CAS_URL}.${PLATFORM}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_execution_server
+      ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_URL}.${PLATFORM}
     stage: Bootstrap Pants (Cron)
   - addons:
       apt:
@@ -263,6 +291,7 @@ matrix:
     dist: xenial
     env:
     - CACHE_NAME=bootstrap.linux.py36
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PREPARE_DEPLOY=1
     language: python
@@ -278,9 +307,14 @@ matrix:
       "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
     - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest sh -c "./build-support/bin/ci.py --bootstrap --python-version
-      3.6 && ./build-support/bin/release.sh -f"
+      3.6 && ./build-support/bin/ci.py --bootstrap-mock-remote && ./build-support/bin/release.sh
+      -f"
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
+      ${BOOTSTRAPPED_MOCK_CAS_URL}.${PLATFORM}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_execution_server
+      ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_URL}.${PLATFORM}
     services:
     - docker
     stage: Bootstrap Pants (Cron)
@@ -318,6 +352,7 @@ matrix:
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
     - CACHE_NAME=bootstrap.osx.py36
+    - PLATFORM=osx
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
     - PREPARE_DEPLOY=1
     language: generic
@@ -326,9 +361,14 @@ matrix:
     osx_image: xcode8
     script:
     - ./build-support/bin/ci.py --bootstrap --python-version 3.6
+    - ./build-support/bin/ci.py --bootstrap-mock-remote
     - ./build-support/bin/release.sh -f
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
+      ${BOOTSTRAPPED_MOCK_CAS_URL}.${PLATFORM}
+    - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_execution_server
+      ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_URL}.${PLATFORM}
     stage: Bootstrap Pants (Cron)
   - addons:
       apt:
@@ -358,8 +398,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -372,6 +415,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -417,8 +461,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -431,6 +478,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -475,8 +523,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -489,6 +540,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=lint.py36
@@ -532,8 +584,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -546,6 +601,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -650,8 +706,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -664,6 +723,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=unit_tests.py36
@@ -708,8 +768,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -722,6 +785,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v2.py36
@@ -765,8 +829,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     - ulimit -c unlimited
     cache:
       directories:
@@ -780,6 +847,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PREPARE_DEPLOY=1
@@ -815,15 +883,19 @@ matrix:
     before_script:
     - ulimit -c unlimited
     - ulimit -n 8192
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     env:
     - PATH="/usr/local/opt/openssl/bin:${PATH}"
     - LDFLAGS="-L/usr/local/opt/openssl/lib"
     - CPPFLAGS="-I/usr/local/opt/openssl/include"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
+    - - PLATFORM=osx
+      - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
     - PREPARE_DEPLOY=1
     - CACHE_NAME=wheels.osx.py36
     - PY=${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin/python
@@ -864,8 +936,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -878,6 +953,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_0.py36
@@ -921,8 +997,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -935,6 +1014,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_1.py36
@@ -978,8 +1058,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -992,6 +1075,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_2.py36
@@ -1035,8 +1119,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1049,6 +1136,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_3.py36
@@ -1092,8 +1180,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1106,6 +1197,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_4.py36
@@ -1149,8 +1241,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1163,6 +1258,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_5.py36
@@ -1206,8 +1302,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1220,6 +1319,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_6.py36
@@ -1263,8 +1363,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1277,6 +1380,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_7.py36
@@ -1320,8 +1424,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1334,6 +1441,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_8.py36
@@ -1377,8 +1485,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1391,6 +1502,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_9.py36
@@ -1434,8 +1546,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1448,6 +1563,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_10.py36
@@ -1491,8 +1607,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1505,6 +1624,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_11.py36
@@ -1548,8 +1668,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1562,6 +1685,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_12.py36
@@ -1605,8 +1729,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1619,6 +1746,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_0.py36.pantsd
@@ -1663,8 +1791,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1677,6 +1808,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_1.py36.pantsd
@@ -1721,8 +1853,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1735,6 +1870,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_2.py36.pantsd
@@ -1779,8 +1915,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1793,6 +1932,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_3.py36.pantsd
@@ -1837,8 +1977,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1851,6 +1994,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_4.py36.pantsd
@@ -1895,8 +2039,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1909,6 +2056,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_5.py36.pantsd
@@ -1953,8 +2101,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -1967,6 +2118,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_6.py36.pantsd
@@ -2011,8 +2163,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2025,6 +2180,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_7.py36.pantsd
@@ -2069,8 +2225,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2083,6 +2242,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_8.py36.pantsd
@@ -2127,8 +2287,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2141,6 +2304,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_9.py36.pantsd
@@ -2185,8 +2349,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2199,6 +2366,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_10.py36.pantsd
@@ -2243,8 +2411,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2257,6 +2428,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_11.py36.pantsd
@@ -2301,8 +2473,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2315,6 +2490,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v1.shard_12.py36.pantsd
@@ -2359,8 +2535,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2373,6 +2552,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -2417,8 +2597,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2431,6 +2614,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -2475,8 +2659,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2489,6 +2676,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -2533,8 +2721,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2547,6 +2738,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -2591,8 +2783,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2605,6 +2800,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -2649,8 +2845,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2663,6 +2862,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -2707,8 +2907,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2721,6 +2924,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -2765,8 +2969,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2779,6 +2986,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -2823,8 +3031,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2837,6 +3048,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -2881,8 +3093,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2895,6 +3110,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -2939,8 +3155,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -2953,6 +3172,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -2997,8 +3217,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -3011,6 +3234,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -3055,8 +3279,11 @@ matrix:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -3069,6 +3296,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
@@ -3171,15 +3399,19 @@ matrix:
     before_script:
     - ulimit -c unlimited
     - ulimit -n 8192
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     env:
     - PATH="/usr/local/opt/openssl/bin:${PATH}"
     - LDFLAGS="-L/usr/local/opt/openssl/lib"
     - CPPFLAGS="-I/usr/local/opt/openssl/include"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
+    - - PLATFORM=osx
+      - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
     - CACHE_NAME=osx_platform_tests.py36
     language: generic
     name: OSX platform-specific tests (Python 3.6)
@@ -3200,15 +3432,19 @@ matrix:
     before_script:
     - ulimit -c unlimited
     - ulimit -n 8192
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     env:
     - PATH="/usr/local/opt/openssl/bin:${PATH}"
     - LDFLAGS="-L/usr/local/opt/openssl/lib"
     - CPPFLAGS="-I/usr/local/opt/openssl/include"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
+    - - PLATFORM=osx
+      - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
     - CACHE_NAME=osx_platform_tests.py37
     language: generic
     name: OSX platform-specific tests (Python 3.7)
@@ -3229,15 +3465,19 @@ matrix:
     before_script:
     - ulimit -c unlimited
     - ulimit -n 8192
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     env:
     - PATH="/usr/local/opt/openssl/bin:${PATH}"
     - LDFLAGS="-L/usr/local/opt/openssl/lib"
     - CPPFLAGS="-I/usr/local/opt/openssl/include"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
+    - - PLATFORM=osx
+      - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
     - CACHE_NAME=osx_sanity.10_12.py36
     language: generic
     name: OSX 10.12 sanity check (Python 3.6)
@@ -3259,15 +3499,19 @@ matrix:
     before_script:
     - ulimit -c unlimited
     - ulimit -n 8192
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     env:
     - PATH="/usr/local/opt/openssl/bin:${PATH}"
     - LDFLAGS="-L/usr/local/opt/openssl/lib"
     - CPPFLAGS="-I/usr/local/opt/openssl/include"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
+    - - PLATFORM=osx
+      - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
     - CACHE_NAME=osx_sanity.10_12.py37
     language: generic
     name: OSX 10.12 sanity check (Python 3.7)
@@ -3289,15 +3533,19 @@ matrix:
     before_script:
     - ulimit -c unlimited
     - ulimit -n 8192
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     env:
     - PATH="/usr/local/opt/openssl/bin:${PATH}"
     - LDFLAGS="-L/usr/local/opt/openssl/lib"
     - CPPFLAGS="-I/usr/local/opt/openssl/include"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin:${PATH}"
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
+    - - PLATFORM=osx
+      - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.osx
     - CACHE_NAME=osx_sanity.10_13.py36
     language: generic
     name: OSX 10.13 sanity check (Python 3.6)
@@ -3319,15 +3567,19 @@ matrix:
     before_script:
     - ulimit -c unlimited
     - ulimit -n 8192
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     env:
     - PATH="/usr/local/opt/openssl/bin:${PATH}"
     - LDFLAGS="-L/usr/local/opt/openssl/lib"
     - CPPFLAGS="-I/usr/local/opt/openssl/include"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
     - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
+    - - PLATFORM=osx
+      - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
     - CACHE_NAME=osx_sanity.10_13.py37
     language: generic
     name: OSX 10.13 sanity check (Python 3.7)
@@ -3368,8 +3620,11 @@ matrix:
     - sudo chmod 666 /dev/fuse
     - sudo chown root:$USER /etc/fuse.conf
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -3382,6 +3637,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=jvm_tests.py36
@@ -3428,8 +3684,11 @@ matrix:
     - sudo chmod 666 /dev/fuse
     - sudo chown root:$USER /etc/fuse.conf
     before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_CAS_KEY}.${PLATFORM}
+      ./local_cas
+    - ./build-support/bin/get_aws_artifact.sh ${BOOTSTRAP_BUCKET} ${BOOTSTRAPPED_MOCK_EXECUTION_SERVER_KEY}.${PLATFORM}
+      ./local_execution_server
     cache:
       directories:
       - ${AWS_CLI_ROOT}
@@ -3442,6 +3701,7 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - PLATFORM=linux
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -965,8 +965,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 0/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      0/13 --python-version 3.6"
     stage: Test Pants
     sudo: required
   - addons:
@@ -1026,8 +1030,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 1/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      1/13 --python-version 3.6"
     stage: Test Pants
     sudo: required
   - addons:
@@ -1087,8 +1095,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 2/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      2/13 --python-version 3.6"
     stage: Test Pants
     sudo: required
   - addons:
@@ -1148,8 +1160,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 3/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      3/13 --python-version 3.6"
     stage: Test Pants
     sudo: required
   - addons:
@@ -1209,8 +1225,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 4/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      4/13 --python-version 3.6"
     stage: Test Pants
     sudo: required
   - addons:
@@ -1270,8 +1290,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 5/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      5/13 --python-version 3.6"
     stage: Test Pants
     sudo: required
   - addons:
@@ -1331,8 +1355,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 6/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      6/13 --python-version 3.6"
     stage: Test Pants
     sudo: required
   - addons:
@@ -1392,8 +1420,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 7/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      7/13 --python-version 3.6"
     stage: Test Pants
     sudo: required
   - addons:
@@ -1453,8 +1485,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 8/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      8/13 --python-version 3.6"
     stage: Test Pants
     sudo: required
   - addons:
@@ -1514,8 +1550,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 9/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      9/13 --python-version 3.6"
     stage: Test Pants
     sudo: required
   - addons:
@@ -1575,8 +1615,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 10/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      10/13 --python-version 3.6"
     stage: Test Pants
     sudo: required
   - addons:
@@ -1636,8 +1680,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 11/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      11/13 --python-version 3.6"
     stage: Test Pants
     sudo: required
   - addons:
@@ -1697,8 +1745,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 12/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      12/13 --python-version 3.6"
     stage: Test Pants
     sudo: required
   - addons:
@@ -1759,8 +1811,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 0/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      0/13 --python-version 3.6"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -1821,8 +1877,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 1/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      1/13 --python-version 3.6"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -1883,8 +1943,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 2/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      2/13 --python-version 3.6"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -1945,8 +2009,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 3/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      3/13 --python-version 3.6"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2007,8 +2075,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 4/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      4/13 --python-version 3.6"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2069,8 +2141,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 5/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      5/13 --python-version 3.6"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2131,8 +2207,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 6/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      6/13 --python-version 3.6"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2193,8 +2273,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 7/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      7/13 --python-version 3.6"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2255,8 +2339,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 8/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      8/13 --python-version 3.6"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2317,8 +2405,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 9/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      9/13 --python-version 3.6"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2379,8 +2471,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 10/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      10/13 --python-version 3.6"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2441,8 +2537,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 11/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      11/13 --python-version 3.6"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2503,8 +2603,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 12/13 --python-version
-      3.6
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos6:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      12/13 --python-version 3.6"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2565,8 +2669,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 0/13 --python-version
-      3.7
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      0/13 --python-version 3.7"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2627,8 +2735,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 1/13 --python-version
-      3.7
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      1/13 --python-version 3.7"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2689,8 +2801,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 2/13 --python-version
-      3.7
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      2/13 --python-version 3.7"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2751,8 +2867,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 3/13 --python-version
-      3.7
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      3/13 --python-version 3.7"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2813,8 +2933,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 4/13 --python-version
-      3.7
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      4/13 --python-version 3.7"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2875,8 +2999,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 5/13 --python-version
-      3.7
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      5/13 --python-version 3.7"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2937,8 +3065,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 6/13 --python-version
-      3.7
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      6/13 --python-version 3.7"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -2999,8 +3131,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 7/13 --python-version
-      3.7
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      7/13 --python-version 3.7"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -3061,8 +3197,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 8/13 --python-version
-      3.7
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      8/13 --python-version 3.7"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -3123,8 +3263,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 9/13 --python-version
-      3.7
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      9/13 --python-version 3.7"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -3185,8 +3329,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 10/13 --python-version
-      3.7
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      10/13 --python-version 3.7"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -3247,8 +3395,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 11/13 --python-version
-      3.7
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      11/13 --python-version 3.7"
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -3309,8 +3461,12 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 12/13 --python-version
-      3.7
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/ci.py --integration-tests-v1 --integration-shard
+      12/13 --python-version 3.7"
     stage: Test Pants (Cron)
     sudo: required
   - before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,8 +85,8 @@ matrix:
       "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
     - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest sh -c "./build-support/bin/ci.py --bootstrap --python-version
-      3.6 && ./build-support/bin/release.sh -f"
-    - ./build-support/bin/ci.py --bootstrap-mock-remote
+      3.6 && ./build-support/bin/ci.py --bootstrap-mock-remote && ./build-support/bin/release.sh
+      -f"
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
@@ -146,8 +146,7 @@ matrix:
       "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
     - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest sh -c "./build-support/bin/ci.py --bootstrap --python-version
-      3.7"
-    - ./build-support/bin/ci.py --bootstrap-mock-remote
+      3.7 && ./build-support/bin/ci.py --bootstrap-mock-remote"
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
@@ -200,8 +199,8 @@ matrix:
     osx_image: xcode8
     script:
     - ./build-support/bin/ci.py --bootstrap --python-version 3.6
-    - ./build-support/bin/release.sh -f
     - ./build-support/bin/ci.py --bootstrap-mock-remote
+    - ./build-support/bin/release.sh -f
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
@@ -308,8 +307,8 @@ matrix:
       "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
     - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest sh -c "./build-support/bin/ci.py --bootstrap --python-version
-      3.6 && ./build-support/bin/release.sh -f"
-    - ./build-support/bin/ci.py --bootstrap-mock-remote
+      3.6 && ./build-support/bin/ci.py --bootstrap-mock-remote && ./build-support/bin/release.sh
+      -f"
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
@@ -362,8 +361,8 @@ matrix:
     osx_image: xcode8
     script:
     - ./build-support/bin/ci.py --bootstrap --python-version 3.6
-    - ./build-support/bin/release.sh -f
     - ./build-support/bin/ci.py --bootstrap-mock-remote
+    - ./build-support/bin/release.sh -f
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,8 +85,8 @@ matrix:
       "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
     - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest sh -c "./build-support/bin/ci.py --bootstrap --python-version
-      3.6 && ./build-support/bin/ci.py --bootstrap-mock-remote && ./build-support/bin/release.sh
-      -f"
+      3.6 && ./build-support/bin/release.sh -f"
+    - ./build-support/bin/ci.py --bootstrap-mock-remote
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
@@ -146,7 +146,8 @@ matrix:
       "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
     - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest sh -c "./build-support/bin/ci.py --bootstrap --python-version
-      3.7 && ./build-support/bin/ci.py --bootstrap-mock-remote"
+      3.7"
+    - ./build-support/bin/ci.py --bootstrap-mock-remote
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
@@ -199,8 +200,8 @@ matrix:
     osx_image: xcode8
     script:
     - ./build-support/bin/ci.py --bootstrap --python-version 3.6
-    - ./build-support/bin/ci.py --bootstrap-mock-remote
     - ./build-support/bin/release.sh -f
+    - ./build-support/bin/ci.py --bootstrap-mock-remote
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
@@ -307,8 +308,8 @@ matrix:
       "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
     - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
       travis_ci:latest sh -c "./build-support/bin/ci.py --bootstrap --python-version
-      3.6 && ./build-support/bin/ci.py --bootstrap-mock-remote && ./build-support/bin/release.sh
-      -f"
+      3.6 && ./build-support/bin/release.sh -f"
+    - ./build-support/bin/ci.py --bootstrap-mock-remote
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas
@@ -361,8 +362,8 @@ matrix:
     osx_image: xcode8
     script:
     - ./build-support/bin/ci.py --bootstrap --python-version 3.6
-    - ./build-support/bin/ci.py --bootstrap-mock-remote
     - ./build-support/bin/release.sh -f
+    - ./build-support/bin/ci.py --bootstrap-mock-remote
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/local_cas

--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -21,6 +21,7 @@ def main() -> None:
   args = create_parser().parse_args()
   setup_environment(python_version=args.python_version)
 
+<<<<<<< HEAD
   with maybe_get_remote_execution_oauth_token_path(
     remote_execution_enabled=args.remote_execution_enabled
   ) as remote_execution_oauth_token_path:
@@ -55,6 +56,38 @@ def main() -> None:
       run_plugin_tests()
     if args.platform_specific_tests:
       run_platform_specific_tests()
+=======
+  if args.bootstrap:
+    bootstrap(clean=args.bootstrap_clean, python_version=args.python_version)
+  set_run_from_pex()
+
+  if args.bootstrap_mock_remote:
+    bootstrap_mock_remote()
+  if args.githooks:
+    run_githooks()
+  if args.sanity_checks:
+    run_sanity_checks()
+  if args.lint:
+    run_lint()
+  if args.doc_gen:
+    run_doc_gen_tests()
+  if args.clippy:
+    run_clippy()
+  if args.cargo_audit:
+    run_cargo_audit()
+  if args.unit_tests:
+    run_unit_tests(remote_execution_enabled=args.remote_execution_enabled)
+  if args.rust_tests:
+    run_rust_tests()
+  if args.jvm_tests:
+    run_jvm_tests()
+  if args.integration_tests:
+    run_integration_tests(shard=args.integration_shard)
+  if args.plugin_tests:
+    run_plugin_tests()
+  if args.platform_specific_tests:
+    run_platform_specific_tests()
+>>>>>>> Test reporting with remote execution
 
   banner("CI ENDS")
   print()
@@ -94,6 +127,10 @@ def create_parser() -> argparse.ArgumentParser:
   parser.add_argument(
     "--bootstrap-clean", action="store_true",
     help="Before bootstrapping, clean the environment so that it's like a fresh git clone."
+  )
+  parser.add_argument(
+    "--bootstrap-mock-remote", action="store_true",
+    help="Bootstrap the mock remote stack by compiling local_cas and local_execution_server."
   )
   parser.add_argument("--githooks", action="store_true", help="Run pre-commit githook.")
   parser.add_argument(
@@ -325,6 +362,32 @@ def check_pants_pex_exists() -> None:
         "AWS is properly downloading the uploaded `pants.pex`.")
 
 # -------------------------------------------------------------------------
+# Bootstrap mock remoting stack
+# -------------------------------------------------------------------------
+
+def bootstrap_mock_remote() -> None:
+  with travis_section("Bootstrap mock remoting stack", "Compiling mock remoting executables"):
+    try:
+      subprocess.run(
+        ["./build-support/bin/native/cargo.sh", "build", "--manifest-path",
+         "src/rust/engine/Cargo.toml", "--release", "--bin", "local_cas",
+         "--bin", "local_execution_server"],
+        check=True)
+      Path("./src/rust/engine/target/release/local_cas").rename("./local_cas")
+      Path("./src/rust/engine/target/release/local_execution_server").rename("./local_execution_server")
+      subprocess.run(["./local_cas", "--version"], check=True)
+      subprocess.run(["./local_execution_server", "--version"], check=True)
+    except subprocess.CalledProcessError:
+      die("Failed to compile local_cas and local_execution_server")
+
+
+def check_mock_remote_servers_exist() -> None:
+  if not Path("local_cas").is_file() or not Path("local_execution_server").is_file():
+    die("local_cas or local_execution_server not found! "
+        "Either run `./build-support/bin/ci.py --bootstrap-mock-remote` or check that "
+        "AWS is properly downloading the uploaded mock remote servers.")
+
+# -------------------------------------------------------------------------
 # Test commands
 # -------------------------------------------------------------------------
 
@@ -505,6 +568,7 @@ def run_jvm_tests() -> None:
   )
 
 
+<<<<<<< HEAD
 def run_integration_tests_v1(*, shard: Optional[str]) -> None:
   target_sets = TestTargetSets.calculate(
     test_type=TestType.integration,
@@ -549,6 +613,20 @@ def run_integration_tests_v2(*, oauth_token_path: Optional[str] = None) -> None:
       start_message="Running integration tests via V2 local strategy.",
       die_message="Integration test failure (V2 local)",
     )
+=======
+def run_integration_tests(*, shard: Optional[str]) -> None:
+  check_pants_pex_exists()
+  check_mock_remote_servers_exist()
+  all_targets = get_all_python_tests(tag="+integration")
+  command = ["./pants.pex", "test.pytest"]
+  if shard is not None:
+    command.append(f"--test-pytest-test-shard={shard}")
+  with travis_section("IntegrationTests", f"Running Pants Integration tests {shard if shard is not None else ''}"):
+    try:
+      subprocess.run(command + sorted(all_targets) + PYTEST_PASSTHRU_ARGS, check=True)
+    except subprocess.CalledProcessError:
+      die("Integration test failure.")
+>>>>>>> Test reporting with remote execution
 
 
 def run_plugin_tests() -> None:

--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -21,7 +21,6 @@ def main() -> None:
   args = create_parser().parse_args()
   setup_environment(python_version=args.python_version)
 
-<<<<<<< HEAD
   with maybe_get_remote_execution_oauth_token_path(
     remote_execution_enabled=args.remote_execution_enabled
   ) as remote_execution_oauth_token_path:
@@ -30,6 +29,8 @@ def main() -> None:
       bootstrap(clean=args.bootstrap_clean, python_version=args.python_version)
     set_run_from_pex()
 
+    if args.bootstrap_mock_remote:
+      bootstrap_mock_remote()
     if args.githooks:
       run_githooks()
     if args.sanity_checks:
@@ -56,38 +57,6 @@ def main() -> None:
       run_plugin_tests()
     if args.platform_specific_tests:
       run_platform_specific_tests()
-=======
-  if args.bootstrap:
-    bootstrap(clean=args.bootstrap_clean, python_version=args.python_version)
-  set_run_from_pex()
-
-  if args.bootstrap_mock_remote:
-    bootstrap_mock_remote()
-  if args.githooks:
-    run_githooks()
-  if args.sanity_checks:
-    run_sanity_checks()
-  if args.lint:
-    run_lint()
-  if args.doc_gen:
-    run_doc_gen_tests()
-  if args.clippy:
-    run_clippy()
-  if args.cargo_audit:
-    run_cargo_audit()
-  if args.unit_tests:
-    run_unit_tests(remote_execution_enabled=args.remote_execution_enabled)
-  if args.rust_tests:
-    run_rust_tests()
-  if args.jvm_tests:
-    run_jvm_tests()
-  if args.integration_tests:
-    run_integration_tests(shard=args.integration_shard)
-  if args.plugin_tests:
-    run_plugin_tests()
-  if args.platform_specific_tests:
-    run_platform_specific_tests()
->>>>>>> Test reporting with remote execution
 
   banner("CI ENDS")
   print()
@@ -568,8 +537,8 @@ def run_jvm_tests() -> None:
   )
 
 
-<<<<<<< HEAD
 def run_integration_tests_v1(*, shard: Optional[str]) -> None:
+  check_mock_remote_servers_exist()
   target_sets = TestTargetSets.calculate(
     test_type=TestType.integration,
     default_test_strategy=TestStrategy.v1_no_chroot,
@@ -613,20 +582,6 @@ def run_integration_tests_v2(*, oauth_token_path: Optional[str] = None) -> None:
       start_message="Running integration tests via V2 local strategy.",
       die_message="Integration test failure (V2 local)",
     )
-=======
-def run_integration_tests(*, shard: Optional[str]) -> None:
-  check_pants_pex_exists()
-  check_mock_remote_servers_exist()
-  all_targets = get_all_python_tests(tag="+integration")
-  command = ["./pants.pex", "test.pytest"]
-  if shard is not None:
-    command.append(f"--test-pytest-test-shard={shard}")
-  with travis_section("IntegrationTests", f"Running Pants Integration tests {shard if shard is not None else ''}"):
-    try:
-      subprocess.run(command + sorted(all_targets) + PYTEST_PASSTHRU_ARGS, check=True)
-    except subprocess.CalledProcessError:
-      die("Integration test failure.")
->>>>>>> Test reporting with remote execution
 
 
 def run_plugin_tests() -> None:

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -382,7 +382,7 @@ def _bootstrap_command(*, python_version: PythonVersion) -> List[str]:
   # to take advantage of the Rust code built during bootstrapping. We use the Python 3.6 shard, as
   # it runs during both daily and nightly CI. This requires setting PREPARE_DEPLOY=1.
   command = [f'./build-support/bin/ci.py --bootstrap --python-version {python_version.decimal}']
-  command.append(f'./build-support/bin/ci.py --bootstrap-mock-remote')
+  command.append('./build-support/bin/ci.py --bootstrap-mock-remote')
   if python_version.is_py36:
     command.append('./build-support/bin/release.sh -f')
   return command

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -382,13 +382,10 @@ def _bootstrap_command(*, python_version: PythonVersion) -> List[str]:
   # to take advantage of the Rust code built during bootstrapping. We use the Python 3.6 shard, as
   # it runs during both daily and nightly CI. This requires setting PREPARE_DEPLOY=1.
   command = [f'./build-support/bin/ci.py --bootstrap --python-version {python_version.decimal}']
+  command.append('./build-support/bin/ci.py --bootstrap-mock-remote')
   if python_version.is_py36:
     command.append('./build-support/bin/release.sh -f')
   return command
-
-
-def _bootstrap_remote_command() -> str:
-  return './build-support/bin/ci.py --bootstrap-mock-remote'
 
 
 def _bootstrap_env(*, python_version: PythonVersion, platform: Platform) -> List[str]:
@@ -412,7 +409,6 @@ def bootstrap_linux(python_version: PythonVersion) -> Dict:
     "script": [
       docker_build_travis_ci_image(python_version=python_version),
       docker_run_travis_ci_image(command),
-      _bootstrap_remote_command(),
       AWS_DEPLOY_PANTS_PEX_COMMAND,
       AWS_DEPLOY_MOCK_CAS,
       AWS_DEPLOY_MOCK_EXECUTION_SERVER,
@@ -432,7 +428,7 @@ def bootstrap_osx(python_version: PythonVersion) -> Dict:
     "name": f"Build OSX native engine and pants.pex (Python {python_version.decimal})",
     "after_failure": ["./build-support/bin/ci-failure.sh"],
     "stage": python_version.default_stage(is_bootstrap=True).value,
-    "script": _bootstrap_command(python_version=python_version) + [ _bootstrap_remote_command(), AWS_DEPLOY_PANTS_PEX_COMMAND, AWS_DEPLOY_MOCK_CAS, AWS_DEPLOY_MOCK_EXECUTION_SERVER]
+    "script": _bootstrap_command(python_version=python_version) + [AWS_DEPLOY_PANTS_PEX_COMMAND, AWS_DEPLOY_MOCK_CAS, AWS_DEPLOY_MOCK_EXECUTION_SERVER]
   }
   shard["env"] = shard.get("env", []) + _bootstrap_env(python_version=python_version, platform=Platform.osx)
   return shard

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -549,15 +549,16 @@ def integration_tests_v1(python_version: PythonVersion, *, use_pantsd: bool = Fa
   num_integration_shards = 13
 
   def make_shard(*, shard_num: int) -> Dict:
+    command = (
+          "./build-support/bin/ci.py --integration-tests-v1 --integration-shard "
+          f"{shard_num}/{num_integration_shards} --python-version {python_version.decimal}"
+        )
     shard = {
       **linux_shard(python_version=python_version),
       "name": f"Integration tests {'with Pantsd' if use_pantsd else ''} - V1 - shard {shard_num} (Python {python_version.decimal})",
-      "script": [
-        (
-          "./build-support/bin/ci.py --integration-tests-v1 --integration-shard "
-          f"{shard_num}/{num_integration_shards} --python-version {python_version.decimal}"
-        ),
-      ]
+      "script": [ 
+          docker_build_travis_ci_image(python_version=python_version),
+          docker_run_travis_ci_image(command) ]
     }
     shard["env"] = shard.get("env", []) + [
       f"CACHE_NAME=integration.v1.shard_{shard_num}.py{python_version.number}{'.pantsd' if use_pantsd else ''}"

--- a/build-support/bin/get_aws_artifact.sh
+++ b/build-support/bin/get_aws_artifact.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+AWS_BUCKET=$1
+AWS_KEY=$2
+FILE_NAME=$3
+
+
+AWS_URL=s3://${AWS_BUCKET}/${AWS_KEY}
+
+# Note that in the aws cli --no-sign-request allows access to public S3 buckets without
+# credentials, as long as we specify the region.
+
+# First check that there's only one version of the object on S3, to detect malicious overwrites.
+NUM_VERSIONS=$(aws --no-sign-request --region us-east-1 s3api list-object-versions \
+  --bucket "${AWS_BUCKET}" --prefix "${AWS_KEY}" --max-items 2 \
+  | jq '.Versions | length')
+[ "${NUM_VERSIONS}" == "1" ] || (echo "Error: Found ${NUM_VERSIONS} versions for ${AWS_URL}" && exit 1)
+
+# Now fetch the file
+aws --no-sign-request --region us-east-1 s3 cp "${AWS_URL}" "${FILE_NAME}"
+
+# Make it executable
+chmod 755 "${FILE_NAME}"

--- a/build-support/bin/get_ci_bootstrapped_pants_pex.sh
+++ b/build-support/bin/get_ci_bootstrapped_pants_pex.sh
@@ -5,21 +5,9 @@ set -euo pipefail
 BOOTSTRAPPED_PEX_BUCKET=$1
 BOOTSTRAPPED_PEX_KEY=$2
 
-BOOTSTRAPPED_PEX_URL=s3://${BOOTSTRAPPED_PEX_BUCKET}/${BOOTSTRAPPED_PEX_KEY}
-
-# Note that in the aws cli --no-sign-request allows access to public S3 buckets without
-# credentials, as long as we specify the region.
-
-# First check that there's only one version of the object on S3, to detect malicious overwrites.
-NUM_VERSIONS=$(aws --no-sign-request --region us-east-1 s3api list-object-versions \
-  --bucket "${BOOTSTRAPPED_PEX_BUCKET}" --prefix "${BOOTSTRAPPED_PEX_KEY}" --max-items 2 \
-  | jq '.Versions | length')
-[ "${NUM_VERSIONS}" == "1" ] || (echo "Error: Found ${NUM_VERSIONS} versions for ${BOOTSTRAPPED_PEX_URL}" && exit 1)
-
-# Now fetch the pre-bootstrapped pex, so that the ./pants wrapper script can use it
+# Fetch the pre-bootstrapped pex, so that the ./pants wrapper script can use it
 # instead of running from sources (and re-bootstrapping).
-aws --no-sign-request --region us-east-1 s3 cp "${BOOTSTRAPPED_PEX_URL}" ./pants.pex
-chmod 755 ./pants.pex
+./build-support/bin/get_aws_artifact.sh "${BOOTSTRAPPED_PEX_BUCKET}" "${BOOTSTRAPPED_PEX_KEY}" ./pants.pex
 
 # Pants code executing under test expects native_engine.so to be present as a resource
 # in the source tree. Normally it'll be there because we created it there during bootstrapping.

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -130,6 +130,11 @@ python_binary(
 )
 
 python_library(
+  name = 'reporting_util',
+  sources = ['reporting_util.py'],
+)
+
+python_library(
   name = 'socket',
   sources = ['socket.py'],
 )

--- a/src/python/pants/util/reporting_util.py
+++ b/src/python/pants/util/reporting_util.py
@@ -1,0 +1,41 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import json
+from collections import defaultdict
+from http.server import BaseHTTPRequestHandler
+
+import psutil
+
+
+def zipkin_handler():
+  class ZipkinHandler(BaseHTTPRequestHandler):
+    traces = defaultdict(list)
+
+    def do_POST(self):
+      content_length = self.headers.get('content-length')
+      json_trace = self.rfile.read(int(content_length))
+      trace = json.loads(json_trace)
+      for span in trace:
+        trace_id = span["traceId"]
+        self.__class__.traces[trace_id].append(span)
+      self.send_response(200)
+  return ZipkinHandler
+
+
+def find_child_processes_that_send_spans(pants_result_stderr):
+  child_processes = set()
+  for line in pants_result_stderr.split('\n'):
+    if "Sending spans to Zipkin server from pid:" in line:
+      i = line.rindex(':')
+      child_process_pid = line[i+1:]
+      child_processes.add(int(child_process_pid))
+  return child_processes
+
+
+def wait_spans_to_be_sent(child_processes):
+  existing_child_processes = child_processes.copy()
+  while existing_child_processes:
+    for child_pid in child_processes:
+      if child_pid in existing_child_processes and not psutil.pid_exists(child_pid):
+        existing_child_processes.remove(child_pid)

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1315,7 +1315,9 @@ version = "0.1.0"
 dependencies = [
  "bazel_protos 0.0.1",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
  "mock 0.0.1",
+ "protobuf 2.0.6 (git+https://github.com/pantsbuild/rust-protobuf?rev=171611c33ec92f07e1b7107327f6d0139a7afebf)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1051,6 +1051,13 @@ pub mod tests {
     Digest(Digest),
   }
 
+  fn make_some_execute_request(
+    req: &ExecuteProcessRequest,
+    metadata: ExecuteProcessRequestMetadata,
+  ) -> Result<Option<bazel_protos::remote_execution::ExecuteRequest>, String> {
+    Ok(Some(super::make_execute_request(req, metadata)?.2))
+  }
+
   #[test]
   fn make_execute_request() {
     let input_directory = TestDirectory::containing_roland();
@@ -1433,7 +1440,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           "wrong-command".to_string(),
-          super::make_execute_request(
+          make_some_execute_request(
             &ExecuteProcessRequest {
               argv: owned_string_vec(&["/bin/echo", "-n", "bar"]),
               env: BTreeMap::new(),
@@ -1446,8 +1453,7 @@ pub mod tests {
             },
             empty_request_metadata(),
           )
-          .unwrap()
-          .2,
+          .unwrap(),
           vec![],
         ),
         None,
@@ -1469,9 +1475,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&execute_request, empty_request_metadata())
-            .unwrap()
-            .2,
+          make_some_execute_request(&execute_request, empty_request_metadata()).unwrap(),
           vec![
             make_incomplete_operation(&op_name),
             make_successful_operation(
@@ -1571,9 +1575,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&echo_roland_request(), empty_request_metadata())
-            .unwrap()
-            .2,
+          make_some_execute_request(&echo_roland_request(), empty_request_metadata()).unwrap(),
           vec![make_successful_operation(
             &op_name.clone(),
             StdoutType::Raw(test_stdout.string()),
@@ -1666,9 +1668,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&execute_request, empty_request_metadata())
-            .unwrap()
-            .2,
+          make_some_execute_request(&execute_request, empty_request_metadata()).unwrap(),
           Vec::from_iter(
             iter::repeat(make_incomplete_operation(&op_name))
               .take(4)
@@ -1720,9 +1720,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&execute_request, empty_request_metadata())
-            .unwrap()
-            .2,
+          make_some_execute_request(&execute_request, empty_request_metadata()).unwrap(),
           vec![
             make_incomplete_operation(&op_name),
             make_delayed_incomplete_operation(&op_name, delayed_operation_time),
@@ -1753,9 +1751,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&execute_request, empty_request_metadata())
-            .unwrap()
-            .2,
+          make_some_execute_request(&execute_request, empty_request_metadata()).unwrap(),
           vec![
             make_incomplete_operation(&op_name),
             make_canceled_operation(Some(Duration::from_millis(100))),
@@ -1795,9 +1791,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&execute_request, empty_request_metadata())
-            .unwrap()
-            .2,
+          make_some_execute_request(&execute_request, empty_request_metadata()).unwrap(),
           vec![
             make_incomplete_operation(&op_name),
             MockOperation::new({
@@ -1836,9 +1830,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&execute_request, empty_request_metadata())
-            .unwrap()
-            .2,
+          make_some_execute_request(&execute_request, empty_request_metadata()).unwrap(),
           vec![MockOperation::new({
             let mut op = bazel_protos::operations::Operation::new();
             op.set_name(op_name.to_string());
@@ -1871,9 +1863,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&execute_request, empty_request_metadata())
-            .unwrap()
-            .2,
+          make_some_execute_request(&execute_request, empty_request_metadata()).unwrap(),
           vec![
             make_incomplete_operation(&op_name),
             MockOperation::new({
@@ -1909,9 +1899,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&execute_request, empty_request_metadata())
-            .unwrap()
-            .2,
+          make_some_execute_request(&execute_request, empty_request_metadata()).unwrap(),
           vec![MockOperation::new({
             let mut op = bazel_protos::operations::Operation::new();
             op.set_name(op_name.to_string());
@@ -1938,9 +1926,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&execute_request, empty_request_metadata())
-            .unwrap()
-            .2,
+          make_some_execute_request(&execute_request, empty_request_metadata()).unwrap(),
           vec![
             make_incomplete_operation(&op_name),
             MockOperation::new({
@@ -1972,9 +1958,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&cat_roland_request(), empty_request_metadata())
-            .unwrap()
-            .2,
+          make_some_execute_request(&cat_roland_request(), empty_request_metadata()).unwrap(),
           vec![
             make_incomplete_operation(&op_name),
             make_precondition_failure_operation(vec![missing_preconditionfailure_violation(
@@ -2068,9 +2052,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&cat_roland_request(), empty_request_metadata())
-            .unwrap()
-            .2,
+          make_some_execute_request(&cat_roland_request(), empty_request_metadata()).unwrap(),
           vec![
             //make_incomplete_operation(&op_name),
             MockOperation {
@@ -2148,9 +2130,7 @@ pub mod tests {
       mock::execution_server::TestServer::new(
         mock::execution_server::MockExecution::new(
           op_name.clone(),
-          super::make_execute_request(&cat_roland_request(), empty_request_metadata())
-            .unwrap()
-            .2,
+          make_some_execute_request(&cat_roland_request(), empty_request_metadata()).unwrap(),
           // We won't get as far as trying to run the operation, so don't expect any requests whose
           // responses we would need to stub.
           vec![],
@@ -2407,9 +2387,7 @@ pub mod tests {
         mock::execution_server::TestServer::new(
           mock::execution_server::MockExecution::new(
             op_name.clone(),
-            super::make_execute_request(&execute_request, empty_request_metadata())
-              .unwrap()
-              .2,
+            make_some_execute_request(&execute_request, empty_request_metadata()).unwrap(),
             vec![
               make_incomplete_operation(&op_name),
               make_successful_operation(
@@ -2448,9 +2426,7 @@ pub mod tests {
         mock::execution_server::TestServer::new(
           mock::execution_server::MockExecution::new(
             op_name.clone(),
-            super::make_execute_request(&execute_request, empty_request_metadata())
-              .unwrap()
-              .2,
+            make_some_execute_request(&execute_request, empty_request_metadata()).unwrap(),
             vec![
               make_incomplete_operation(&op_name),
               make_incomplete_operation(&op_name),

--- a/src/rust/engine/testutil/local_execution_server/Cargo.toml
+++ b/src/rust/engine/testutil/local_execution_server/Cargo.toml
@@ -10,4 +10,6 @@ bazel_protos = { path = "../../process_execution/bazel_protos" }
 mock = { path = "../mock" }
 clap = "2"
 structopt = "0.2.18"
+protobuf = { version = "2.0.6", features = ["with-bytes"] }
+hashing = { path = "../../hashing" }
 

--- a/src/rust/engine/testutil/local_execution_server/src/main.rs
+++ b/src/rust/engine/testutil/local_execution_server/src/main.rs
@@ -55,9 +55,7 @@ struct Options {
 /// upload anything, which can make up for the absence of actual work being done and uploading
 /// actual files to it in a test configuration
 fn empty_digest() -> Digest {
-  let mut digest = Digest::new();
-  digest.set_hash("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".into());
-  digest
+  (&hashing::EMPTY_DIGEST).into()
 }
 
 /// Generate the protobuf types for a list of empty files at these paths.

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -153,7 +153,7 @@ impl StubCAS {
       .register_service(
         bazel_protos::remote_execution_grpc::create_content_addressable_storage(responder.clone()),
       )
-      .bind("localhost", port)
+      .bind("0.0.0.0", port)
       .build()
       .unwrap();
     server_transport.start();

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -96,7 +96,7 @@ impl TestServer {
       .register_service(bazel_protos::operations_grpc::create_operations(
         mock_responder.clone(),
       ))
-      .bind("localhost", port.unwrap_or(0))
+      .bind("0.0.0.0", port.unwrap_or(0))
       .build()
       .unwrap();
     server_transport.start();

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -38,7 +38,7 @@ impl MockOperation {
 #[derive(Clone, Debug)]
 pub struct MockExecution {
   name: String,
-  /// If this is some, we will panic if we receive any request that doesn't match it
+  /// If this is some, we will send a failure response to any other ExecuteRequest RPC
   execute_request: Option<bazel_protos::remote_execution::ExecuteRequest>,
   operation_responses: Arc<Mutex<VecDeque<MockOperation>>>,
 }

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -12,17 +12,18 @@ python_tests(
 
 python_tests(
   name = 'reporting_integration',
-  sources = ['test_reporting_integration.py'],
+  sources = ['test_reporting_integration.py', 'test_reporting_remote_integration.py'],
   dependencies = [
     '3rdparty/python:parameterized',
     '3rdparty/python:py-zipkin',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:reporting_util',
     'tests/python/pants_test:int-test',
     'examples/src/java/org/pantsbuild/example:hello_directory',
     'examples/src/scala/org/pantsbuild/example:several_scala_targets_directory',
   ],
   tags = {'integration'},
-  timeout = 600,
+  timeout = 540,
 )
 
 python_tests(

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -1,18 +1,9 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-<<<<<<< HEAD
-import json
 import re
 import unittest
-from collections import defaultdict
-from http.server import BaseHTTPRequestHandler
 from pathlib import Path
-=======
-import os.path
-import re
-import unittest
->>>>>>> Test reporting with remote execution
 
 from parameterized import parameterized
 

--- a/tests/python/pants_test/reporting/test_reporting_remote_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_remote_integration.py
@@ -52,9 +52,6 @@ class TestReportingRemoteIntegration(PantsRunIntegrationTest, unittest.TestCase)
       yield port
 
   def test_zipkin_reporter_for_remote_execution_with_v2_engine(self):
-    # Hardcode the hash and size of the request we know our call to cloc will trigger
-    # If this changes for some reason, the local mock execution server will print out
-    # the digest of the request that was expected and this can be manually updated.
     ZipkinHandler = zipkin_handler()
     with self.run_cas_server() as cas_port, self.run_execution_server() as execution_port, http_server(ZipkinHandler) as zipkin_port, temporary_dir() as store_dir:
       zipkin_endpoint = f"http://localhost:{zipkin_port}"

--- a/tests/python/pants_test/reporting/test_reporting_remote_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_remote_integration.py
@@ -1,0 +1,117 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import re
+import subprocess
+import unittest
+from contextlib import contextmanager
+from queue import Empty, Queue
+from threading import Thread
+from typing import List
+
+from pants.util.collections import assert_single_element
+from pants.util.contextutil import http_server, temporary_dir
+from pants.util.reporting_util import (find_child_processes_that_send_spans, wait_spans_to_be_sent,
+                                       zipkin_handler)
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+def enqueue_output(out, queue):
+  for line in iter(out.readline, b''):
+    queue.put(line)
+  out.close() 
+
+
+class TestReportingRemoteIntegration(PantsRunIntegrationTest, unittest.TestCase):
+  @contextmanager
+  def run_mock_server(self, bin_name: str, arguments: List[str]):
+    """
+    Build and run a Rust mock server binary.
+    Mainly used for remoting integration tests.
+    It assumes that the server will print a line like `localhost:99999` to indicate its port.
+    :param bin_name: The name of the binary that you want to run. It must be in the main engine's workspace.
+    :param arguments: Passthrough arguments to pass to the binary.
+    """
+    args = ["./" + bin_name]
+    if len(arguments) > 0:
+      args = args + arguments
+    try:
+      print(f"Starting {bin_name}")
+      process = subprocess.Popen(args, stdin = subprocess.PIPE, stdout = subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines = True)
+      port = None
+      while port is None:
+        line = process.stdout.readline()
+        print(f"{line}")
+        match = re.search("localhost:([0-9]+)", line)
+        if match is not None:
+          port = int(match.group(1))
+      yield port
+    finally:
+      print(f"Terminating {bin_name}")
+      q = Queue()
+      t = Thread(target=enqueue_output, args=(process.stdout, q))
+      t.daemon = True # thread dies with the program
+      t.start()
+      while True:
+        try: line = q.get(timeout=.1)
+        except Empty:
+          break;
+        else:
+          print(f"{line}")
+
+      # Terminate the server process by sending it an end of line character
+      process.communicate("\n")
+
+  @contextmanager
+  def run_cas_server(self):
+    with self.run_mock_server("local_cas", []) as port:
+      yield port
+
+  @contextmanager
+  def run_execution_server(self, request_hash, request_size):
+    with self.run_mock_server("local_execution_server", ["--request_hash", request_hash, "--request_size", request_size]) as port:
+      yield port
+
+  def test_zipkin_reporter_for_remote_execution_with_v2_engine(self):
+    # Hardcode the hash and size of the request we know our call to cloc will trigger
+    # If this changes for some reason, the local mock execution server will print out
+    # the digest of the request that was expected and this can be manually updated.
+    request_hash = "4f2e901dc3f91ffe02a558a4473456e22652f88338a57df18be21ca7a57650ca"
+    request_size = "142"
+    ZipkinHandler = zipkin_handler()
+    with self.run_cas_server() as cas_port, self.run_execution_server(request_hash, request_size) as execution_port, http_server(ZipkinHandler) as zipkin_port, temporary_dir() as store_dir:
+      endpoint = "http://localhost:{}".format(zipkin_port)
+      command = [
+        'cloc',
+        'src/python/pants:version',
+        '-ldebug',
+        '--reporting-zipkin-trace-v2',
+        '--reporting-zipkin-endpoint={}'.format(endpoint),
+        '--remote-execution',
+        '--remote-execution-server=localhost:{}'.format(execution_port),
+        '--remote-store-server=localhost:{}'.format(cas_port),
+        '--cache-cloc-ignore',
+        '--local-store-dir={}'.format(store_dir)
+      ]
+
+      pants_run = self.run_pants(command)
+      self.assert_success(pants_run)
+
+      child_processes = find_child_processes_that_send_spans(pants_run.stderr_data)
+      self.assertTrue(child_processes)
+
+      wait_spans_to_be_sent(child_processes)
+
+      trace = assert_single_element(ZipkinHandler.traces.values())
+
+    remote_list_missing_digests = "list_missing_digests"
+    self.assertTrue(any(remote_list_missing_digests in span['name'] for span in trace),
+      "There is no span that contains '{}' in its name.\nCommand: {}\n The trace:{}".format(
+          remote_list_missing_digests, command, trace
+      ))
+
+    remote_store_bytes = "store_bytes"
+    self.assertTrue(any(remote_store_bytes in span['name'] for span in trace),
+      "There is no span that contains '{}' in its name. The trace:{}".format(
+      remote_store_bytes, trace
+      ))

--- a/tests/python/pants_test/reporting/test_reporting_remote_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_remote_integration.py
@@ -57,19 +57,19 @@ class TestReportingRemoteIntegration(PantsRunIntegrationTest, unittest.TestCase)
     # the digest of the request that was expected and this can be manually updated.
     ZipkinHandler = zipkin_handler()
     with self.run_cas_server() as cas_port, self.run_execution_server() as execution_port, http_server(ZipkinHandler) as zipkin_port, temporary_dir() as store_dir:
-      endpoint = "http://localhost:{}".format(zipkin_port)
+      zipkin_endpoint = f"http://localhost:{zipkin_port}"
       command = [
         'cloc',
         'src/python/pants:version',
         '-ldebug',
         '--process-execution-speculation-strategy=none',
         '--reporting-zipkin-trace-v2',
-        '--reporting-zipkin-endpoint={}'.format(endpoint),
+        f'--reporting-zipkin-endpoint={zipkin_endpoint}',
         '--remote-execution',
-        '--remote-execution-server=localhost:{}'.format(execution_port),
-        '--remote-store-server=localhost:{}'.format(cas_port),
+        f'--remote-execution-server=localhost:{execution_port}',
+        f'--remote-store-server=localhost:{cas_port}',
         '--cache-cloc-ignore',
-        '--local-store-dir={}'.format(store_dir)
+        f'--local-store-dir={store_dir}'
       ]
 
       pants_run = self.run_pants(command, extra_env={"RUST_BACKTRACE": "FULL"})

--- a/tests/python/pants_test/reporting/test_reporting_remote_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_remote_integration.py
@@ -34,7 +34,7 @@ class TestReportingRemoteIntegration(PantsRunIntegrationTest, unittest.TestCase)
       while port is None:
         line = process.stdout.readline().decode("utf-8")
         print(f"{line}")
-        match = re.search("localhost:([0-9]+)", line)
+        match = re.search("at address:.*:([0-9]+)", line)
         if match is not None:
           port = int(match.group(1))
       yield port

--- a/tests/python/pants_test/reporting/test_reporting_remote_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_remote_integration.py
@@ -5,8 +5,6 @@ import re
 import subprocess
 import unittest
 from contextlib import contextmanager
-from queue import Empty, Queue
-from threading import Thread
 from typing import List
 
 from pants.util.collections import assert_single_element
@@ -14,12 +12,6 @@ from pants.util.contextutil import http_server, temporary_dir
 from pants.util.reporting_util import (find_child_processes_that_send_spans, wait_spans_to_be_sent,
                                        zipkin_handler)
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
-
-
-def enqueue_output(out, queue):
-  for line in iter(out.readline, b''):
-    queue.put(line)
-  out.close() 
 
 
 class TestReportingRemoteIntegration(PantsRunIntegrationTest, unittest.TestCase):
@@ -35,9 +27,8 @@ class TestReportingRemoteIntegration(PantsRunIntegrationTest, unittest.TestCase)
     args = ["./" + bin_name]
     if len(arguments) > 0:
       args = args + arguments
+    process = subprocess.Popen(args, stdin = subprocess.PIPE, stdout = subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines = True)
     try:
-      print(f"Starting {bin_name}")
-      process = subprocess.Popen(args, stdin = subprocess.PIPE, stdout = subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines = True)
       port = None
       while port is None:
         line = process.stdout.readline()
@@ -47,20 +38,7 @@ class TestReportingRemoteIntegration(PantsRunIntegrationTest, unittest.TestCase)
           port = int(match.group(1))
       yield port
     finally:
-      print(f"Terminating {bin_name}")
-      q = Queue()
-      t = Thread(target=enqueue_output, args=(process.stdout, q))
-      t.daemon = True # thread dies with the program
-      t.start()
-      while True:
-        try: line = q.get(timeout=.1)
-        except Empty:
-          break;
-        else:
-          print(f"{line}")
-
-      # Terminate the server process by sending it an end of line character
-      process.communicate("\n")
+      process.terminate()
 
   @contextmanager
   def run_cas_server(self):
@@ -68,23 +46,23 @@ class TestReportingRemoteIntegration(PantsRunIntegrationTest, unittest.TestCase)
       yield port
 
   @contextmanager
-  def run_execution_server(self, request_hash, request_size):
-    with self.run_mock_server("local_execution_server", ["--request_hash", request_hash, "--request_size", request_size]) as port:
+  def run_execution_server(self):
+    # These are the output paths that the cloc command produces
+    with self.run_mock_server("local_execution_server", ["--output_paths", "report", "ignored"]) as port:
       yield port
 
   def test_zipkin_reporter_for_remote_execution_with_v2_engine(self):
     # Hardcode the hash and size of the request we know our call to cloc will trigger
     # If this changes for some reason, the local mock execution server will print out
     # the digest of the request that was expected and this can be manually updated.
-    request_hash = "4f2e901dc3f91ffe02a558a4473456e22652f88338a57df18be21ca7a57650ca"
-    request_size = "142"
     ZipkinHandler = zipkin_handler()
-    with self.run_cas_server() as cas_port, self.run_execution_server(request_hash, request_size) as execution_port, http_server(ZipkinHandler) as zipkin_port, temporary_dir() as store_dir:
+    with self.run_cas_server() as cas_port, self.run_execution_server() as execution_port, http_server(ZipkinHandler) as zipkin_port, temporary_dir() as store_dir:
       endpoint = "http://localhost:{}".format(zipkin_port)
       command = [
         'cloc',
         'src/python/pants:version',
         '-ldebug',
+        '--process-execution-speculation-strategy=none',
         '--reporting-zipkin-trace-v2',
         '--reporting-zipkin-endpoint={}'.format(endpoint),
         '--remote-execution',

--- a/tests/python/pants_test/reporting/test_reporting_remote_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_remote_integration.py
@@ -94,7 +94,7 @@ class TestReportingRemoteIntegration(PantsRunIntegrationTest, unittest.TestCase)
         '--local-store-dir={}'.format(store_dir)
       ]
 
-      pants_run = self.run_pants(command)
+      pants_run = self.run_pants(command, extra_env={"RUST_BACKTRACE": "FULL"})
       self.assert_success(pants_run)
 
       child_processes = find_child_processes_that_send_spans(pants_run.stderr_data)


### PR DESCRIPTION
Add an integration test to ensure remote calls from pants are captured
in zipkin traces.

To avoid interacting with the Network, run local/fake versions of the
three server that are needed:
* The zipkin server, which records zipkin spans,
* The cas server which simulates a content addressable storage database
  with an in-memory representation of the database,
* The execution server which simulates executing the remote operations.

To avoid hitting the cache, we run a new cas server every time we run
the test and point the local store directory to a ramdom temp directory
where we know we won't find the artifacts we are looking for.
This strategy ensures we always actually attempt to execute tasks
remotely.

We can then verify that the zipkin trace recorded in our mock zipkin
server contains the spans we expect: "last_missing_digests" and
"store_bytes".

Note that for this to work, we needed to create an executable called
local_execution_server that leverages the mock execution server library
to run an execution server on localhost that will expect exactly one
request (described through CLI arguments) and react to it with a default
operation.
It is conceivable that we want to enrich what this
local_execution_server can do in the future (such as handle multiple
requests), but only do the minimum needed at the moment. The CLI
application can always be extended later on a per-need basis.