### PR TITLE
[Open to discuss] Set verbose for release.sh

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -2,7 +2,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-set -e
+set -ex
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd "$(git rev-parse --show-toplevel)" && pwd)
 


### PR DESCRIPTION
### Problem

Internally at Twitter we use `release.sh` to generate a fat pants pex, but it failed with the following message today:
```
10:20:17 https://binaries.pantsbuild.org/wheels%2F3rdparty%2Fac31ea9373c5ebaf9d3d0a1bca1a33c4ae3b1797%2F1.20.0.dev1%2Bgitac31ea93%2Fzipp-0.5.2-py2.py3-none-any.whl:
10:20:18 
#########################                                                 35.8%
###################################################                       71.6%
######################################################################## 100.0%
10:20:18 curl: (22) The requested URL returned error: 404 Not Found
10:20:18 curl: (22) The requested URL returned error: 404 Not Found
```
so it was hard to tell what went wrong until I set the `-x`, and then it was obvious that it choked at fetching the latest version of pex.

### Solution

Add `set -x`. This goal is not just to benefit our internal process, but I feel this would be useful as well for folks doing the release especially if there's something funky happening.

