### PR TITLE
Allow for alternate yarn versions

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -144,6 +144,10 @@ class NodeDistribution(NativeTool):
     """
     yarnpkg_package_path = YarnpkgDistribution.scoped_instance(self).select()
     yarnpkg_bin_path = os.path.join(yarnpkg_package_path, 'dist', 'bin')
+    if not is_readable_dir(yarnpkg_bin_path):
+      # The binary was pulled from yarn's Github release page and not our S3,
+      # in which case it's installed under a different directory.
+      return os.path.join(yarnpkg_package_path, os.listdir(yarnpkg_package_path)[0], 'bin')
     return yarnpkg_bin_path
 
   def node_command(self, args=None, node_paths=None):

--- a/contrib/node/src/python/pants/contrib/node/subsystems/yarnpkg_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/yarnpkg_distribution.py
@@ -4,9 +4,18 @@
 import logging
 
 from pants.binaries.binary_tool import NativeTool
+from pants.binaries.binary_util import BinaryToolUrlGenerator
 
 
 logger = logging.getLogger(__name__)
+
+
+class YarnReleaseUrlGenerator(BinaryToolUrlGenerator):
+
+  _DIST_URL_FMT = 'https://github.com/yarnpkg/yarn/releases/download/{version}/yarn-{version}.tar.gz'
+
+  def generate_urls(self, version, host_platform):
+    return [self._DIST_URL_FMT.format(version=version)]
 
 
 class YarnpkgDistribution(NativeTool):
@@ -16,3 +25,6 @@ class YarnpkgDistribution(NativeTool):
   name = 'yarnpkg'
   default_version = 'v1.6.0'
   archive_type = 'tgz'
+
+  def get_external_url_generator(self):
+    return YarnReleaseUrlGenerator()


### PR DESCRIPTION
### Problem (and solution)

Same as https://github.com/pantsbuild/pants/pull/7405

[Slack thread](https://pantsbuild.slack.com/archives/C046T6T9U/p1565633047078400) that highlighted this issue.

### Result

Users can now use any supported `yarn` release.

Related `binaries` repo script for building yarn [`here`](https://github.com/pantsbuild/binaries/blob/master/build-yarnpkg.sh).

---
📝 AFAICT the `host_platform` is not necessary here (though other instances of `BinaryToolUrlGenerator` do require it).