### PR TITLE
Bump test timeout for JVM distribution test

### DIFF
--- a/tests/python/pants_test/java/distribution/BUILD
+++ b/tests/python/pants_test/java/distribution/BUILD
@@ -25,5 +25,5 @@ python_tests(
     'tests/python/pants_test/subsystem:subsystem_utils',
   ],
   tags = {'integration'},
-  timeout = 120,
+  timeout = 180,
 )


### PR DESCRIPTION
Has been observed running in 130 seconds.