### PR TITLE
fix exception handling of KeyboardInterrupt during startup

### DIFF
--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -91,3 +91,4 @@ function activate_pants_venv() {
     activate_venv || die "Failed to activate venv."
   fi
 }
+

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -91,4 +91,3 @@ function activate_pants_venv() {
     activate_venv || die "Failed to activate venv."
   fi
 }
-

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -530,4 +530,4 @@ ExceptionSink.reset_signal_handler(SignalHandler())
 # to explicitly request it. The exception log will have any stacktraces regardless so this should
 # not hamper debugging.
 ExceptionSink.reset_should_print_backtrace_to_terminal(
-  should_print_backtrace=os.environ.get('PANTS_PRINT_EXCEPTION_STACKTRACE') == 'True')
+  should_print_backtrace=os.environ.get('PANTS_PRINT_EXCEPTION_STACKTRACE', 'True') == 'True')

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -518,6 +518,8 @@ Signal {signum} ({signame}) was raised. Exiting with failure.{formatted_tracebac
 
 # Setup global state such as signal handlers and sys.excepthook with probably-safe values at module
 # import time.
+# Set the log location for writing logs before bootstrap options are parsed.
+ExceptionSink.reset_log_location(os.getcwd())
 # Sets except hook for exceptions at import time.
 ExceptionSink._reset_exiter(Exiter(exiter=sys.exit))
 # Sets a SIGUSR2 handler.

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -590,7 +590,7 @@ class Native(Singleton):
 
   class CFFIExternMethodRuntimeErrorInfo(datatype([
       ('exc_type', type),
-      ('exc_value', SubclassesOf(Exception)),
+      ('exc_value', SubclassesOf(Exception, KeyboardInterrupt)),
       'traceback',
   ])):
     """Encapsulates an exception raised when a CFFI extern is called so that it can be displayed.

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -305,6 +305,8 @@ class _FFISpecification(object):
     having to make two separate Python calls when interning a Python object in interning.rs, which
     requires both the hash and type.
     """
+    if os.environ.get('_KEYBOARDINTERRUPT_ON_IMPORT'):
+      raise KeyboardInterrupt('ctrl-c interrupted on import!')
     c = self._ffi.from_handle(context_handle)
     obj = self._ffi.from_handle(val[0])
     return c.identify(obj)

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -590,7 +590,9 @@ class Native(Singleton):
 
   class CFFIExternMethodRuntimeErrorInfo(datatype([
       ('exc_type', type),
-      ('exc_value', SubclassesOf(Exception, KeyboardInterrupt)),
+      # See https://docs.python.org/3.6/library/exceptions.html#BaseException -- this is the base
+      # exception type for all built-in exceptions, including `Exception`.
+      ('exc_value', SubclassesOf(BaseException)),
       'traceback',
   ])):
     """Encapsulates an exception raised when a CFFI extern is called so that it can be displayed.

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
@@ -1,8 +1,6 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
-
 from test_pants_plugin.pants_infra_tests import PantsInfraTests
 from test_pants_plugin.subsystems.pants_test_infra import PantsTestInfra
 from test_pants_plugin.tasks.deprecation_warning_task import DeprecationWarningTask

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
@@ -26,7 +26,3 @@ def register_goals():
 
 def global_subsystems():
   return (PantsTestInfra,)
-
-
-if os.environ.get('_KEYBOARDINTERRUPT_ON_IMPORT'):
-  raise KeyboardInterrupt('wow')

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
@@ -1,6 +1,8 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
+
 from test_pants_plugin.pants_infra_tests import PantsInfraTests
 from test_pants_plugin.subsystems.pants_test_infra import PantsTestInfra
 from test_pants_plugin.tasks.deprecation_warning_task import DeprecationWarningTask
@@ -24,3 +26,7 @@ def register_goals():
 
 def global_subsystems():
   return (PantsTestInfra,)
+
+
+if os.environ.get('_RAISE_KEYBOARDINTERRUPT_ON_IMPORT', False):
+  raise KeyboardInterrupt('ctrl-c during import!')

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/register.py
@@ -1,6 +1,8 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
+
 from test_pants_plugin.pants_infra_tests import PantsInfraTests
 from test_pants_plugin.subsystems.pants_test_infra import PantsTestInfra
 from test_pants_plugin.tasks.deprecation_warning_task import DeprecationWarningTask
@@ -24,3 +26,7 @@ def register_goals():
 
 def global_subsystems():
   return (PantsTestInfra,)
+
+
+if os.environ.get('_KEYBOARDINTERRUPT_ON_IMPORT'):
+  raise KeyboardInterrupt('wow')

--- a/tests/python/pants_test/base/test_exception_sink.py
+++ b/tests/python/pants_test/base/test_exception_sink.py
@@ -19,6 +19,10 @@ class TestExceptionSink(TestBase):
     class AnonymousSink(ExceptionSink): pass
     return AnonymousSink
 
+  def test_default_log_location(self):
+    sink = self._gen_sink_subclass()
+    self.assertEqual(os.getcwd(), sink._log_dir)
+
   def test_reset_log_location(self):
     sink = self._gen_sink_subclass()
 

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -52,15 +52,21 @@ Exception message:.* 1 Exception encountered:
           workdir=tmpdir)
         self.assert_failure(pants_run)
 
-        self.maxDiff = None
-        self.assertEqual('', pants_run.stderr_data)
+        self.assertIn(dedent("""\
+          KeyboardInterrupt: ctrl-c interrupted on import!
+
+
+          The engine execution request raised this error, which is probably due to the errors in the
+          CFFI extern methods listed above, as CFFI externs return None upon error:
+          Traceback (most recent call last):
+          """), pants_run.stderr_data)
 
         pid_specific_log_file, shared_log_file = self._get_log_file_paths(tmpdir, pants_run)
 
-        self.assertRegex(read_file(pid_specific_log_file), dedent("""\
-          wow
-          """))
-        self.assertEqual('', read_file(shared_log_file))
+        self.assertIn('KeyboardInterrupt: ctrl-c interrupted on import!',
+                      read_file(pid_specific_log_file))
+        self.assertIn('KeyboardInterrupt: ctrl-c interrupted on import!',
+                      read_file(shared_log_file))
 
   def test_logs_unhandled_exception(self):
     with temporary_dir() as tmpdir:

--- a/tests/python/pants_test/base/test_exception_sink_integration.py
+++ b/tests/python/pants_test/base/test_exception_sink_integration.py
@@ -46,14 +46,14 @@ Exception message:.* 1 Exception encountered:
 
   def test_fails_ctrl_c_during_import(self):
     with temporary_dir() as tmpdir:
-      with environment_as(_KEYBOARDINTERRUPT_ON_IMPORT='True'):
+      with environment_as(_RAISE_KEYBOARDINTERRUPT_IN_CFFI_IDENTIFY='True'):
         pants_run = self.run_pants_with_workdir(
           self._lifecycle_stub_cmdline(),
           workdir=tmpdir)
         self.assert_failure(pants_run)
 
         self.assertIn(dedent("""\
-          KeyboardInterrupt: ctrl-c interrupted on import!
+          KeyboardInterrupt: ctrl-c interrupted execution of a cffi method!
 
 
           The engine execution request raised this error, which is probably due to the errors in the
@@ -63,9 +63,9 @@ Exception message:.* 1 Exception encountered:
 
         pid_specific_log_file, shared_log_file = self._get_log_file_paths(tmpdir, pants_run)
 
-        self.assertIn('KeyboardInterrupt: ctrl-c interrupted on import!',
+        self.assertIn('KeyboardInterrupt: ctrl-c interrupted execution of a cffi method!',
                       read_file(pid_specific_log_file))
-        self.assertIn('KeyboardInterrupt: ctrl-c interrupted on import!',
+        self.assertIn('KeyboardInterrupt: ctrl-c interrupted execution of a cffi method!',
                       read_file(shared_log_file))
 
   def test_logs_unhandled_exception(self):


### PR DESCRIPTION
### Problem

If pants is hit with a <kbd>Ctrl-C</kbd> when in the engine at the right time when it starts up, it fails to handle the exception correctly, due to an incorrect `datatype()` type constraint:
```
Traceback (most recent call last):
  File "/Users/dmcclanahan/tools/pants-v3/src/python/pants/engine/native.py", line 256, in exc_handler
    error_info = native.CFFIExternMethodRuntimeErrorInfo(exc_type, exc_value, traceback)
  File "/Users/dmcclanahan/tools/pants-v3/src/python/pants/util/objects.py", line 229, in __new__
    '\n'.join(type_failure_msgs)))
pants.util.objects.TypedDatatypeInstanceConstructionError: type check error in class CFFIExternMethodRuntimeErrorInfo: 1 error type checking constructor arguments:
field 'exc_value' was invalid: value KeyboardInterrupt('User interrupted execution with control-c!') (with type 'KeyboardInterrupt') must satisfy this type constraint: SubclassesOf(Exception).
```

Additionally, when this occurs, the exception is invisible to the user, because the default behavior decided previously in `exception_sink.py` was to *avoid* printing a stacktrace if errors occurred at import time,:
```
timestamp: 2019-08-17T13:51:45.667543
Exception caught: (pants.build_graph.address_lookup_error.AddressLookupError) (backtrace omitted)
Exception message: Build graph construction failed: RuntimeError cannot use from_handle() on NULL pointer
```

Both of these have led to repeated confusion from users, especially when using pantsd.

### Solution

- Extend the type constraint to be `SubclassesOf(BaseException)`, since apparently `KeyboardInterrupt` is not an `Exception`.
- Default to printing the stacktrace for exceptions during import time instead of hiding it.

### Result

Users don't have mysterious errors when they try to quit a pants run!