### PR TITLE
Upgrade to Pex 1.6.10.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -12,7 +12,7 @@ more-itertools<6.0.0 ; python_version<'3'
 packaging==16.8
 parameterized==0.6.1
 pathspec==0.5.9
-pex==1.6.9
+pex==1.6.10
 psutil==5.4.8
 Pygments==2.3.1
 pyopenssl==17.3.0

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -14,8 +14,8 @@ class DownloadedPexBin(datatype([('executable', str), ('directory_digest', Diges
 @rule(DownloadedPexBin, [])
 def download_pex_bin():
   # TODO: Inject versions and digests here through some option, rather than hard-coding it.
-  url = 'https://github.com/pantsbuild/pex/releases/download/v1.6.8/pex'
-  digest = Digest('2ca320aede7e7bbcb907af54c9de832707a1df965fb5a0d560f2df29ba8a2f3d', 1866441)
+  url = 'https://github.com/pantsbuild/pex/releases/download/v1.6.10/pex'
+  digest = Digest('f4ac0f61f0c469537f04418e9347658340b0bce4ba61d302c5b805d194dda482', 1868106)
   snapshot = yield Get(Snapshot, UrlToFetch(url, digest))
   yield DownloadedPexBin(executable=snapshot.files[0], directory_digest=snapshot.directory_digest)
 


### PR DESCRIPTION
This pulls in a fix for the pexes Pants generates when run under CPython
3.7+ and namespace packages are involved.

See: https://github.com/pantsbuild/pex/issues/756

Before the fix both our own tool pexes and pexes we generated for end
users could fail like so:
```
$ ./pants --python-setup-interpreter-constraints="['CPython==3.7.*']" \
  test.pytest \
  --cache-ignore \
  tests/python/pants_test/backend/graph_info/tasks:cloc
...
17:16:00 00:26   [test]
...
17:16:00 00:26     [pytest]
                   Invalidated 1 target.
                   scrubbed PYTHONPATH=/home/jsirois/dev/pantsbuild/pants/src/python: from pytest environment
17:16:00 00:26       [run]
                     Traceback (most recent call last):
...
                       File "/home/jsirois/dev/pantsbuild/pants/.pants.d/test/pytest-prep/CPython-3.7.4/e307788111116c190fe04c233d334b12cdc63f77/.bootstrap/pex/pex.py", line 179, in minimum_sys_modules
                         if cls._tainted_path(module_file, site_libs):
                       File "/home/jsirois/dev/pantsbuild/pants/.pants.d/test/pytest-prep/CPython-3.7.4/e307788111116c190fe04c233d334b12cdc63f77/.bootstrap/pex/pex.py", line 157, in _tainted_path
                         paths = frozenset([path, os.path.realpath(path)])
                       File "/home/jsirois/dev/pantsbuild/jsirois-pants/build-support/pants_dev_deps.py37.venv/lib/python3.7/posixpath.py", line 394, in realpath
                         filename = os.fspath(filename)
                     TypeError: expected str, bytes or os.PathLike object, not NoneType
...
```