### PR TITLE
Minor grammatical update

### DIFF
--- a/src/docs/common_tasks/file_bundles.md
+++ b/src/docs/common_tasks/file_bundles.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-You're create a `jvm_app` target definition for [[bundling|pants('src/docs/common_tasks:bundle')]] a Scala or Java project and you want to include assets such as config files or shell scripts in the bundle.
+You have created a `jvm_app` target definition for [[bundling|pants('src/docs/common_tasks:bundle')]] a Scala or Java project and you want to include assets such as config files or shell scripts in the bundle.
 
 ## Solution
 


### PR DESCRIPTION
### Problem

>You're create a jvm_app target definition for bundling a Scala or Java project and you want to include assets such as config files or shell scripts in the bundle.

"You're create" is a contraction of "You are create", which is not proper English grammar; "You want to create" or "You have created" or "You're creating" would all work as well.
### Solution

Changed grammatical structure.

### Result

No behavioral change; this affects the docs only.