### PR TITLE
Allow jobs to run immediately when they are unblocked

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
@@ -18,7 +18,7 @@ class Job:
   keys of its dependent jobs.
   """
 
-  def __init__(self, key, fn, dependencies, size=0, on_success=None, on_failure=None):
+  def __init__(self, key, fn, dependencies, size=0, on_success=None, on_failure=None, run_immediately=False):
     """
 
     :param key: Key used to reference and look up jobs
@@ -28,13 +28,15 @@ class Job:
     :param on_success: Zero parameter callback to run if job completes successfully. Run on main
                        thread.
     :param on_failure: Zero parameter callback to run if job completes successfully. Run on main
-                       thread."""
+                       thread.
+    :param run_immediately: Boolean indicating whether or not to queue job next once unblocked."""
     self.key = key
     self.fn = fn
     self.dependencies = dependencies
     self.size = size
     self.on_success = on_success
     self.on_failure = on_failure
+    self.run_immediately = run_immediately
 
   def __call__(self):
     self.fn()
@@ -226,6 +228,13 @@ class ExecutionGraph:
         satisfied_dependees_count[dependency_key] += 1
         if satisfied_dependees_count[dependency_key] == len(self._dependees[dependency_key]):
           bfs_queue.append(dependency_key)
+    
+    max_priority = max(job_priority.values())
+    immediate_priority = max_priority + 1
+
+    for job in job_priority.viewkeys():
+      if job.run_immediately:
+        job_priority[job] = immediate_priority
 
     return job_priority
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
@@ -18,7 +18,7 @@ class Job:
   keys of its dependent jobs.
   """
 
-  def __init__(self, key, fn, dependencies, size=0, on_success=None, on_failure=None, run_immediately=False):
+  def __init__(self, key, fn, dependencies, size=0, on_success=None, on_failure=None, run_asap=False):
     """
 
     :param key: Key used to reference and look up jobs
@@ -29,14 +29,14 @@ class Job:
                        thread.
     :param on_failure: Zero parameter callback to run if job completes successfully. Run on main
                        thread.
-    :param run_immediately: Boolean indicating whether or not to queue job next once unblocked."""
+    :param run_asap: Boolean indicating whether or not to queue job immediately once unblocked."""
     self.key = key
     self.fn = fn
     self.dependencies = dependencies
     self.size = size
     self.on_success = on_success
     self.on_failure = on_failure
-    self.run_immediately = run_immediately
+    self.run_asap = run_asap
 
   def __call__(self):
     self.fn()
@@ -232,9 +232,9 @@ class ExecutionGraph:
     max_priority = max(job_priority.values())
     immediate_priority = max_priority + 1
 
-    for job in job_priority.viewkeys():
-      if job.run_immediately:
-        job_priority[job] = immediate_priority
+    for job in job_list:
+      if job.run_asap:
+        job_priority[job.key] = immediate_priority
 
     return job_priority
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -421,7 +421,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
           yield self._key_for_target_as_dep(tgt, tgt_rsc_cc.workflow)
 
     def make_rsc_job(target, dep_targets):
-      j = Job(
+      return Job(
         key=self._rsc_key_for_target(target),
         fn=functools.partial(
           # NB: This will output to the 'rsc_mixed_compile_classpath' product via
@@ -435,9 +435,6 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         dependencies=list(all_zinc_rsc_invalid_dep_keys(dep_targets)),
         size=self._size_estimator(rsc_compile_context.sources),
       )
-      print("rsc job size")
-      print(j.size)
-      return j
 
     def only_zinc_invalid_dep_keys(invalid_deps):
       for tgt in invalid_deps:
@@ -446,7 +443,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
           yield self._zinc_key_for_target(tgt, rsc_cc_tgt.workflow)
 
     def make_zinc_job(target, input_product_key, output_products, dep_keys):
-      j = Job(
+      return Job(
         key=self._zinc_key_for_target(target, rsc_compile_context.workflow),
         fn=functools.partial(
           self._default_work_for_vts,
@@ -459,9 +456,6 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         dependencies=list(dep_keys),
         size=self._size_estimator(zinc_compile_context.sources),
       )
-      print("zinc job size")
-      print(j.size)
-      return j
 
     workflow = rsc_compile_context.workflow
 
@@ -536,7 +530,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             rsc_compile_context,
           ),
           dependencies=[job.key for job in all_jobs],
-          run_immediately=True,
+          run_asap=True,
           # If compilation and analysis work succeeds, validate the vts.
           # Otherwise, fail it.
           on_success=ivts.update,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -535,8 +535,8 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             ivts,
             rsc_compile_context,
           ),
-          size=99999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
           dependencies=[job.key for job in all_jobs],
+          run_immediately=True,
           # If compilation and analysis work succeeds, validate the vts.
           # Otherwise, fail it.
           on_success=ivts.update,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -421,7 +421,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
           yield self._key_for_target_as_dep(tgt, tgt_rsc_cc.workflow)
 
     def make_rsc_job(target, dep_targets):
-      return Job(
+      j = Job(
         key=self._rsc_key_for_target(target),
         fn=functools.partial(
           # NB: This will output to the 'rsc_mixed_compile_classpath' product via
@@ -435,6 +435,9 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         dependencies=list(all_zinc_rsc_invalid_dep_keys(dep_targets)),
         size=self._size_estimator(rsc_compile_context.sources),
       )
+      print("rsc job size")
+      print(j.size)
+      return j
 
     def only_zinc_invalid_dep_keys(invalid_deps):
       for tgt in invalid_deps:
@@ -443,7 +446,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
           yield self._zinc_key_for_target(tgt, rsc_cc_tgt.workflow)
 
     def make_zinc_job(target, input_product_key, output_products, dep_keys):
-      return Job(
+      j = Job(
         key=self._zinc_key_for_target(target, rsc_compile_context.workflow),
         fn=functools.partial(
           self._default_work_for_vts,
@@ -456,6 +459,9 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         dependencies=list(dep_keys),
         size=self._size_estimator(zinc_compile_context.sources),
       )
+      print("zinc job size")
+      print(j.size)
+      return j
 
     workflow = rsc_compile_context.workflow
 
@@ -529,6 +535,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             ivts,
             rsc_compile_context,
           ),
+          size=99999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
           dependencies=[job.key for job in all_jobs],
           # If compilation and analysis work succeeds, validate the vts.
           # Otherwise, fail it.


### PR DESCRIPTION
### Problem

A previous update to RscCompile task introduced a `write_to_cache` job waiting
on both Rsc and Zinc artifacts before writing to cache (commit
26e8056b5ceb5b032861117779636172c2326649).  However, these jobs were run at the
very end of the execution graph since they had very low priority. This means
that in a distributed run, many extra cache misses are being introduced, causing
very poor performance.

### Solution

Add a `run_asap` field to `Job`s which sets their priority to maximum of the
jobs list, allowing the scheduler to start these Jobs the moment they're
unblocked.

### Result

`write_to_cache` jobs will set `run_asap=True`, causing them to be run asap.
