### PR TITLE
Support omitting the test sources themselves from coverage.

### DIFF
--- a/src/python/pants/backend/python/tasks/coverage/plugin.py
+++ b/src/python/pants/backend/python/tasks/coverage/plugin.py
@@ -60,14 +60,21 @@ class ChrootRemappingPlugin(CoveragePlugin):
     self._target_bases = set(self._src_to_target_base.values())
 
   def find_executable_files(self, top):
+    # coverage uses this to associate files with this plugin.
+    # We only want to be associated with the sources we know about.
     if top.startswith(self._src_chroot_path):
-      for root, dirs, files in os.walk(top):
-        for f in files:
-          if f.endswith('.py'):
-            yield os.path.join(root, f)
+      for dirname, _, filenames in os.walk(top):
+        reldir = os.path.relpath(dirname, self._src_chroot_path)
+        for filename in filenames:
+          if os.path.join(reldir, filename) in self._src_to_target_base:
+            yield os.path.join(dirname, filename)
 
   def file_tracer(self, filename):
-    # Don't trace third party libraries or the standard lib, just user code in the src chroot.
+    # Note that coverage will only call this on files that we yielded from find_executable_files(),
+    # so they should all pass this check anyway, but it doesn't hurt to check again.
+    # Note also that you cannot exclude .py files from tracing or reporting by returning None here.
+    # All that does is register this plugin's disinterest in the file, but coverage will still
+    # trace and report it using the standard tracer and reporter.
     if filename.startswith(self._src_chroot_path):
       src = os.path.relpath(filename, self._src_chroot_path)
       if src in self._src_to_target_base:

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -112,6 +112,13 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
              help='Emit coverage information for specified packages or directories (absolute or '
                   'relative to the build root).  The special value "auto" indicates that Pants '
                   'should attempt to deduce which packages to emit coverage for.')
+    # TODO: The default is False for backwards compatiblity. We almost certainly want to change
+    # that after a deprecation cycle.
+    register('--coverage-omit-test-sources', fingerprint=True, type=bool, default=False,
+             help='Whether to omit test source files from coverage reports.')
+    register('--coverage-reports', fingerprint=True, choices=('xml', 'html'), type=list,
+             member_type=str, default=('xml', 'html'),
+             help='Which coverage reports to emit.')
     # For a given --coverage specification (which is fingerprinted), we will always copy the
     # associated generated and cached --coverage files to this directory post any interaction with
     # the cache to retrieve the coverage files. As such, this option is not part of the fingerprint.
@@ -182,23 +189,40 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
 
   # N.B.: Extracted for tests.
   @classmethod
-  def _add_plugin_config(cls, cp, src_chroot_path, src_to_target_base):
+  def _add_plugin_config(cls, cp, src_chroot_path, srcs_to_omit, src_to_target_base):
     # We use a coverage plugin to map PEX chroot source paths back to their original repo paths for
     # report output.
     plugin_module = PytestPrep.PytestBinary.coverage_plugin_module
     cls._ensure_section(cp, 'run')
     cp.set('run', 'plugins', plugin_module)
 
+    if srcs_to_omit:
+      # It would be nice if we could use the `include` setting to specify just the
+      # files we *do* want to trace. But unfortunately that setting is ignored if `sources`
+      # are explicitly specified, which pytest-cov does. And those `sources` must be packages or
+      # directories, not individual files, so we can't use that either (in case there are
+      # tests in the same dirs as the files they test).
+      files_to_omit = [os.path.join(src_chroot_path, relpath) for relpath in sorted(srcs_to_omit)]
+      cp.set('run', 'omit', ','.join(files_to_omit))
+
+    # Fortunately we *can* use the `include` setting at report time. Any omitted files won't
+    # have any data and won't get reported anyway. But setting `include` here allows us to also
+    # exclude synthetic __init__.py files created by pex in the chroot. Reporting on those is just
+    # confusing to the user, since they don't correspond to any file in the source tree.
+    cls._ensure_section(cp, 'report')
+    files_to_report = [os.path.join(src_chroot_path, relpath) for relpath in src_to_target_base]
+    cp.set('report', 'include', ','.join(files_to_report))
+
     cp.add_section(plugin_module)
     cp.set(plugin_module, 'buildroot', get_buildroot())
     cp.set(plugin_module, 'src_chroot_path', src_chroot_path)
     cp.set(plugin_module, 'src_to_target_base', json.dumps(src_to_target_base))
 
-  def _generate_coverage_config(self, src_to_target_base):
+  def _generate_coverage_config(self, srcs_to_omit, src_to_target_base):
     cp = configparser.ConfigParser()
     cp.read_file(StringIO(self.DEFAULT_COVERAGE_CONFIG))
 
-    self._add_plugin_config(cp, self._source_chroot_path, src_to_target_base)
+    self._add_plugin_config(cp, self._source_chroot_path, srcs_to_omit, src_to_target_base)
 
     # See the debug options here: http://nedbatchelder.com/code/coverage/cmd.html#cmd-run-debug
     if self._debug:
@@ -232,8 +256,9 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
       yield
 
   @contextmanager
-  def _cov_setup(self, workdirs, coverage_morfs, src_to_target_base):
-    cp = self._generate_coverage_config(src_to_target_base=src_to_target_base)
+  def _cov_setup(self, workdirs, coverage_morfs, srcs_to_omit, src_to_target_base):
+    cp = self._generate_coverage_config(srcs_to_omit=srcs_to_omit,
+                                        src_to_target_base=src_to_target_base)
     # Note that it's important to put the tmpfile under the workdir, because pytest
     # uses all arguments that look like paths to compute its rootdir, and we want
     # it to pick the buildroot.
@@ -260,12 +285,16 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
     pex_src_root = os.path.relpath(self._source_chroot_path, get_buildroot())
 
     src_to_target_base = {}
-    for target in test_targets:
-      libs = (tgt for tgt in target.closure()
-              if tgt.has_sources('.py') and not isinstance(tgt, PythonTests))
+    srcs_to_omit = set()
+    if self.get_options().coverage_omit_test_sources:
+      for test_target in test_targets:
+        srcs_to_omit.update(test_target.sources_relative_to_source_root())
+    for test_target in test_targets:
+      libs = (tgt for tgt in test_target.closure() if tgt.has_sources('.py'))
       for lib in libs:
         for src in lib.sources_relative_to_source_root():
-          src_to_target_base[src] = lib.target_base
+          if src not in srcs_to_omit:
+            src_to_target_base[src] = lib.target_base
 
     def ensure_trailing_sep(path):
       return path if path.endswith(os.path.sep) else path + os.path.sep
@@ -275,9 +304,15 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
         if tgt.coverage:
           return tgt.coverage
         else:
-          # This makes the assumption that tests/python/<tgt> will be testing src/python/<tgt>.
-          # Note in particular that this doesn't work for pants' own tests, as those are under
-          # the top level package 'pants_tests', rather than just 'pants'.
+          # Assume that tests in some package test the sources in that package.
+          # This is the case, e.g., if tests live in the same directories as the sources
+          # they test, or if they live in a parallel package structure under a separate
+          # source root, such as tests/python/path/to/package testing src/python/path/to/package.
+
+          # Note in particular that this doesn't work for most of Pants's own tests, as those are
+          # under the top level package 'pants_tests', rather than just 'pants' (although we
+          # are moving towards having tests in the same directories as the sources they test).
+          #
           # TODO(John Sirois): consider failing fast if there is no explicit coverage scheme;
           # but also  consider supporting configuration of a global scheme whether that be parallel
           # dirs/packages or some arbitrary function that can be registered that takes a test target
@@ -323,6 +358,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
 
     with self._cov_setup(workdirs,
                          coverage_morfs=coverage_morfs,
+                         srcs_to_omit=srcs_to_omit,
                          src_to_target_base=src_to_target_base) as (args, coverage_rc):
       try:
         yield args
@@ -343,13 +379,13 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
           if not os.path.exists('.coverage'):
             self.context.log.warn('No .coverage file was found! Skipping coverage reporting.')
           else:
-            coverage_run('report', ['-i', '--rcfile', coverage_rc])
-
             coverage_workdir = workdirs.coverage_path
-            coverage_run('html', ['-i', '--rcfile', coverage_rc, '-d', coverage_workdir])
-
-            coverage_xml = os.path.join(coverage_workdir, 'coverage.xml')
-            coverage_run('xml', ['-i', '--rcfile', coverage_rc, '-o', coverage_xml])
+            coverage_reports = self.get_options().coverage_reports
+            if 'html' in coverage_reports:
+              coverage_run('html', ['-i', '--rcfile', coverage_rc, '-d', coverage_workdir])
+            if 'xml' in coverage_reports:
+              coverage_xml = os.path.join(coverage_workdir, 'coverage.xml')
+              coverage_run('xml', ['-i', '--rcfile', coverage_rc, '-o', coverage_xml])
 
   def _get_sharding_args(self):
     shard_spec = self.get_options().test_shard

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -112,10 +112,8 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
              help='Emit coverage information for specified packages or directories (absolute or '
                   'relative to the build root).  The special value "auto" indicates that Pants '
                   'should attempt to deduce which packages to emit coverage for.')
-    # TODO: The default is False for backwards compatiblity. We almost certainly want to change
-    # that after a deprecation cycle.
-    register('--coverage-omit-test-sources', fingerprint=True, type=bool, default=False,
-             help='Whether to omit test source files from coverage reports.')
+    register('--coverage-include-test-sources', fingerprint=True, type=bool,
+             help='Whether to include test source files in coverage measurement.')
     register('--coverage-reports', fingerprint=True, choices=('xml', 'html'), type=list,
              member_type=str, default=('xml', 'html'),
              help='Which coverage reports to emit.')
@@ -286,7 +284,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
 
     src_to_target_base = {}
     srcs_to_omit = set()
-    if self.get_options().coverage_omit_test_sources:
+    if not self.get_options().coverage_include_test_sources:
       for test_target in test_targets:
         srcs_to_omit.update(test_target.sources_relative_to_source_root())
     for test_target in test_targets:

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -576,9 +576,13 @@ python_tests(
                         targets,
                         failed_targets=None,
                         expect_coverage=True,
-                        covered_path=None):
+                        covered_path=None,
+                        include_test_sources=False):
     self.assertFalse(os.path.isfile(self.coverage_data_file()))
-    simple_coverage_kwargs = {'coverage': 'auto'}
+    simple_coverage_kwargs = {
+      'coverage': 'auto',
+      'coverage_include_test_sources': include_test_sources
+    }
     if failed_targets:
       context = self.run_failing_tests(targets=targets,
                                        failed_targets=failed_targets,
@@ -728,9 +732,6 @@ python_tests(
     self.assertEqual([1, 3, 5, 6, 7], all_statements)
     self.assertEqual([], not_run_statements)
 
-
-
-
   @ensure_cached(PytestRun, expected_num_artifacts=1)
   def test_coverage_auto_option_no_explicit_coverage_idiosyncratic_layout(self):
     # The all target has no coverage attribute and the code under test does not follow the
@@ -763,7 +764,8 @@ python_tests(
     test = self.target('test/python/util_tests')
     covered_path = os.path.join(self.build_root, 'src/python/util/math.py')
     all_statements, not_run_statements = self.run_coverage_auto(targets=[test],
-                                                                covered_path=covered_path)
+                                                                covered_path=covered_path,
+                                                                include_test_sources=True)
     self.assertEqual([1, 2], all_statements)
     self.assertEqual([1, 2], not_run_statements)
 


### PR DESCRIPTION
If tests are in the same packages as the libs they test then today we
will trace and report them, which is almost certainly not what the user wants.

This change optionally omits test files from tracing. 

This change also:

- Excludes synthetic `__init__.py` files created by pex in the chroot
from reporting (there is no good way to exclude them from tracing, but
since they're empty, that doesn't really matter). 

- Drops the console output, which was just long noise cluttering up output,
especially in CI.

- Allows the user to choose which of the xml and html reports they want. 

These last two points are performance gains: Generating coverage reports 
takes non-trivial time, especially on a large set of traced files, and we were
previously always generating three reports. Now we generate two by default,
and the user can choose to generate just one (or none, but that seems pretty
pointless).

This code also updates our coverage plugin to reflect the fact that plugins
cannot on their own prevent .py files from being traced or reported. If a plugin
has no interest in a file, it will still be traced and reported using default mechanisms.

Finally, we replace a reference to the deprecated name `SafeConfigParser`
with the current name `ConfigParser`.