### PR TITLE
Refactor auth logic out of RunTracker and into BasicAuth

### DIFF
--- a/src/python/pants/auth/BUILD
+++ b/src/python/pants/auth/BUILD
@@ -4,6 +4,7 @@
 
 python_library(
   dependencies = [
+    '3rdparty/python:dataclasses',
     '3rdparty/python:requests',
     '3rdparty/python:www-authenticate',
     'src/python/pants/subsystem',

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -16,7 +16,7 @@ from typing import Dict
 
 import requests
 
-from pants.auth.cookies import Cookies
+from pants.auth.basic_auth import BasicAuth
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.run_info import RunInfo
 from pants.base.worker_pool import SubprocPool, WorkerPool
@@ -77,7 +77,7 @@ class RunTracker(Subsystem):
 
   @classmethod
   def subsystem_dependencies(cls):
-    return super().subsystem_dependencies() + (Cookies,)
+    return super().subsystem_dependencies() + (BasicAuth,)
 
   @classmethod
   def register_options(cls, register):
@@ -380,9 +380,10 @@ class RunTracker(Subsystem):
     # values.  Probably better for there to be one top-level JSON value, namely json.dumps(stats).
     # But this will first require changing the upload receiver at every shop that uses this.
     params = {k: cls._json_dump_options(v) for (k, v) in stats.items()}
-    cookies = Cookies.global_instance()
+
+    auth_data = BasicAuth.global_instance().get_auth_for_provider(auth_provider)
     headers = cls._get_headers(stats_version=stats_version)
-    auth_provider = auth_provider or '<provider>'
+    headers.update(auth_data.headers)
 
     # We can't simply let requests handle redirects, as we only allow them for specific codes:
     # 307 and 308 indicate that the redirected request must use the same method, POST in this case.
@@ -394,8 +395,7 @@ class RunTracker(Subsystem):
       if num_redirects_allowed < 0:
         return error('too many redirects.')
       res = requests.post(url, data=params, timeout=timeout,
-                          headers=headers,
-                        cookies=cookies.get_cookie_jar(), allow_redirects=False)
+                          headers=headers, allow_redirects=False, **auth_data.request_args)
       if res.status_code in {307, 308}:
         return do_post(res.headers['location'], num_redirects_allowed - 1)
       elif 300 <= res.status_code < 400 or res.status_code == 401:


### PR DESCRIPTION
Planning to add more way to auth to the remote server (using an access token)
So this is a first step in refactoring the logic out of RunTrack so there is a proper abstraction here.


### Problem

Currently, there is only one way to auth with the remote server (for run tracker)
This makes scenarios where we want to send data to remote server from CI harder.

### Solution

I am working on adding support for using Bearer Token to authenticate from the server (the token can be provided via an environment variable in CI)
This is a small refactor to create a cleaner seperation of concerns so the logic in RunTracker is not aware of how it authenticates with the remote server.

### Result

This code doesn't change existing behavior (note the change in dependencies).