### PR TITLE
No longer use `travis_wait` in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -390,8 +390,8 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - travis_wait 50 ./build-support/bin/ci.py --unit-tests --remote-execution-enabled
-      --plugin-tests --python-version 3.7
+    - ./build-support/bin/ci.py --unit-tests --remote-execution-enabled --plugin-tests
+      --python-version 3.7
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -623,8 +623,8 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - travis_wait 50 ./build-support/bin/ci.py --unit-tests --remote-execution-enabled
-      --plugin-tests --python-version 3.6
+    - ./build-support/bin/ci.py --unit-tests --remote-execution-enabled --plugin-tests
+      --python-version 3.6
     stage: Test Pants
     sudo: required
   - addons:

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -453,7 +453,7 @@ def unit_tests(python_version: PythonVersion) -> Dict:
     "name": f"Unit tests (Python {python_version.decimal})",
     "script": [
       (
-        "travis_wait 50 ./build-support/bin/ci.py --unit-tests --remote-execution-enabled "
+        "./build-support/bin/ci.py --unit-tests --remote-execution-enabled "
         f"--plugin-tests --python-version {python_version.decimal}"
       )
     ],

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
@@ -16,5 +16,6 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/backend/python/tasks:python_task_test_base',
-  ]
+  ],
+  timeout=100,
 )


### PR DESCRIPTION
Now that we remote 99% of unit tests, `travis_wait` is unnecessary. CI never takes more than 20 minutes collectively. We only needed it before due to the lack of caching when using V2 locally and low levels of parallelism.