### PR TITLE
Upgraded psutil

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -12,7 +12,7 @@ packaging==16.8
 parameterized==0.6.1
 pathspec==0.5.9
 pex==1.6.10
-psutil==5.4.8
+psutil==5.6.3
 Pygments==2.3.1
 pyopenssl==17.3.0
 pystache==0.5.3


### PR DESCRIPTION
Upgraded psutil in order to avoid errors when using Python 3.7 with Pants.

### Problem

`psutil==5.4.8` causes issues when setting up Pants. Refer to [Issue 8189](https://github.com/pantsbuild/pants/issues/8189)

### Solution

Upgraded `psutil==5.6.3` seems to have resolved the issue.

### Result

Pants can now initialize when using Python 3.7