### PR TITLE
Print stderr when get_all_python_tests fails.

### DIFF
--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -196,9 +196,12 @@ def get_all_python_tests(*, tag: Optional[str] = None) -> Set[str]:
   ]
   if tag is not None:
     command.insert(1, f"--tag={tag}")
-  return set(subprocess.run(
-    command, stdout=subprocess.PIPE, encoding="utf-8", check=True
-  ).stdout.strip().split("\n"))
+  try:
+    process = subprocess.run(command, stdout=subprocess.PIPE, encoding="utf-8", check=True)
+  except CalledProcessError as error:
+    print(f"get_all_python_tests failed {error.stderr}")
+    raise
+  return set(process.stdout.strip().split("\n"))
 
 # -------------------------------------------------------------------------
 # Bootstrap pants.pex

--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -198,7 +198,7 @@ def get_all_python_tests(*, tag: Optional[str] = None) -> Set[str]:
     command.insert(1, f"--tag={tag}")
   try:
     process = subprocess.run(command, stdout=subprocess.PIPE, encoding="utf-8", check=True)
-  except CalledProcessError as error:
+  except subprocess.CalledProcessError as error:
     print(f"get_all_python_tests failed {error.stderr}")
     raise
   return set(process.stdout.strip().split("\n"))


### PR DESCRIPTION
### Problem

Error information is not logged when the tests collection function fails
See https://travis-ci.org/pantsbuild/pants/jobs/577599091#L433
<img width="968" alt="Screenshot 2019-08-28 13 48 36" src="https://user-images.githubusercontent.com/1268088/63891643-8c72ef80-c99a-11e9-92ec-1f9a251f0034.png">

### Solution

Catch the process error and print stderr

### Result

Hopefully, better understanding of why test fail