### PR TITLE
Implement cancellation for remote execution

### DIFF
--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -322,6 +322,7 @@ fn main() {
         root_ca_certs,
         oauth_bearer_token,
         store.clone(),
+        executor.clone(),
       )) as Box<dyn process_execution::CommandRunner>
     }
     None => Box::new(process_execution::local::CommandRunner::new(

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -159,6 +159,7 @@ impl Core {
           root_ca_certs.clone(),
           oauth_bearer_token.clone(),
           store.clone(),
+          executor.clone(),
         )),
         process_execution_remote_parallelism,
       ));

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -160,7 +160,7 @@ pub struct ReceivedMessage {
 pub struct MockResponder {
   mock_execution: MockExecution,
   pub received_messages: Arc<Mutex<Vec<ReceivedMessage>>>,
-  pub cancelation_req: Arc<Mutex<Vec<bazel_protos::operations::CancelOperationRequest>>>,
+  pub cancelation_requests: Arc<Mutex<Vec<bazel_protos::operations::CancelOperationRequest>>>,
 }
 
 impl MockResponder {
@@ -168,7 +168,7 @@ impl MockResponder {
     MockResponder {
       mock_execution: mock_execution,
       received_messages: Arc::new(Mutex::new(vec![])),
-      cancelation_req: Arc::new(Mutex::new(vec![])),
+      cancelation_requests: Arc::new(Mutex::new(vec![])),
     }
   }
 
@@ -335,7 +335,7 @@ impl bazel_protos::operations_grpc::Operations for MockResponder {
     sink: grpcio::UnarySink<bazel_protos::empty::Empty>,
   ) {
     self.log(req.clone());
-    self.cancelation_req.lock().push(req);
+    self.cancelation_requests.lock().push(req);
     sink.success(bazel_protos::empty::Empty::new());
   }
 }

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -160,6 +160,7 @@ pub struct ReceivedMessage {
 pub struct MockResponder {
   mock_execution: MockExecution,
   pub received_messages: Arc<Mutex<Vec<ReceivedMessage>>>,
+  pub cancelation_req: Arc<Mutex<Vec<bazel_protos::operations::CancelOperationRequest>>>,
 }
 
 impl MockResponder {
@@ -167,6 +168,7 @@ impl MockResponder {
     MockResponder {
       mock_execution: mock_execution,
       received_messages: Arc::new(Mutex::new(vec![])),
+      cancelation_req: Arc::new(Mutex::new(vec![])),
     }
   }
 
@@ -329,12 +331,11 @@ impl bazel_protos::operations_grpc::Operations for MockResponder {
   fn cancel_operation(
     &self,
     _: grpcio::RpcContext<'_>,
-    _: bazel_protos::operations::CancelOperationRequest,
+    req: bazel_protos::operations::CancelOperationRequest,
     sink: grpcio::UnarySink<bazel_protos::empty::Empty>,
   ) {
-    sink.fail(grpcio::RpcStatus::new(
-      grpcio::RpcStatusCode::Unimplemented,
-      None,
-    ));
+    self.log(req.clone());
+    self.cancelation_req.lock().push(req);
+    sink.success(bazel_protos::empty::Empty::new());
   }
 }


### PR DESCRIPTION
### Problem
The task is described in #8039

### Solution
A CancelRemoteExecutionToken is used to cancel the remote execution process.

### Result
The remote execution process is cancelled in the case of Fatal error or timeout or pants run is cancelled by the user.
