### PR TITLE
Add a header `X-B3-Flags: 1` to the request to Zipkin server 

### DIFF
--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -49,6 +49,7 @@ class AsyncHTTPTransportHandler(BaseTransportHandler):
       args = ['curl', '-v',
               '-X', 'POST',
               '-H', 'Content-Type: application/json',
+              # It is a debug flag that ensures that the trace will be retained on the server side.
               '-H', 'X-B3-Flags: 1',
               '--data', '@' + file_path_to_store_spans,
               self.endpoint]

--- a/src/python/pants/reporting/zipkin_reporter.py
+++ b/src/python/pants/reporting/zipkin_reporter.py
@@ -49,6 +49,7 @@ class AsyncHTTPTransportHandler(BaseTransportHandler):
       args = ['curl', '-v',
               '-X', 'POST',
               '-H', 'Content-Type: application/json',
+              '-H', 'X-B3-Flags: 1',
               '--data', '@' + file_path_to_store_spans,
               self.endpoint]
       file_path_to_stdout_stderr = os.path.join(self.zipkin_spans_dir,


### PR DESCRIPTION
Add a header `X-B3-Flags: 1` to the request to Zipkin server. It is a debug flag that ensures that the trace will be retained on the server side.
The decision to sample is made on the client side by setting `--reporting-zipkin-sample-rate`. 
