### PR TITLE
add --transitive flag to ConsoleTask!

### DIFF
--- a/src/python/pants/backend/graph_info/tasks/cloc.py
+++ b/src/python/pants/backend/graph_info/tasks/cloc.py
@@ -21,9 +21,6 @@ class CountLinesOfCode(ConsoleTask):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    register('--transitive', type=bool, fingerprint=True, default=True,
-             help='Operate on the transitive dependencies of the specified targets.  '
-                  'Unset to operate only on the specified targets.')
     register('--ignored', type=bool, fingerprint=True,
              help='Show information about files ignored by cloc.')
 

--- a/src/python/pants/backend/graph_info/tasks/cloc.py
+++ b/src/python/pants/backend/graph_info/tasks/cloc.py
@@ -25,9 +25,6 @@ class CountLinesOfCode(ConsoleTask):
              help='Show information about files ignored by cloc.')
 
   def console_output(self, targets):
-    if not self.get_options().transitive:
-      targets = self.context.target_roots
-
     input_snapshots = tuple(
       target.sources_snapshot(scheduler=self.context._scheduler) for target in targets
     )

--- a/src/python/pants/backend/graph_info/tasks/dependees.py
+++ b/src/python/pants/backend/graph_info/tasks/dependees.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 
 from pants.base.specs import DescendantAddresses
 from pants.task.console_task import ConsoleTask
+from pants.util.meta import classproperty
 
 
 class ReverseDepmap(ConsoleTask):
@@ -19,11 +20,18 @@ class ReverseDepmap(ConsoleTask):
     # TODO: consider refactoring out common output format methods into MultiFormatConsoleTask.
     register('--output-format', default='text', choices=['text', 'json'],
              help='Output format of results.')
+    register('--transitive', type=bool, default=False,
+             help='Whether to include only the first level of dependendees.')
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
 
     self._closed = self.get_options().closed
+
+  @classproperty
+  def _register_console_transitivity_option(cls):
+    """This class does not use the targets provided as input!"""
+    return False
 
   def console_output(self, _):
     dependees_by_target = defaultdict(set)

--- a/src/python/pants/backend/graph_info/tasks/dependees.py
+++ b/src/python/pants/backend/graph_info/tasks/dependees.py
@@ -14,8 +14,6 @@ class ReverseDepmap(ConsoleTask):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    register('--transitive', type=bool,
-             help='List transitive dependees.')
     register('--closed', type=bool,
              help='Include the input targets in the output along with the dependees.')
     # TODO: consider refactoring out common output format methods into MultiFormatConsoleTask.

--- a/src/python/pants/backend/graph_info/tasks/dependees.py
+++ b/src/python/pants/backend/graph_info/tasks/dependees.py
@@ -23,7 +23,6 @@ class ReverseDepmap(ConsoleTask):
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
 
-    self._transitive = self.get_options().transitive
     self._closed = self.get_options().closed
 
   def console_output(self, _):
@@ -68,7 +67,7 @@ class ReverseDepmap(ConsoleTask):
       for target in check:
         dependents.update(dependees_by_target[target])
       check = dependents - known_dependents
-      if not check or not self._transitive:
+      if not check or not self.act_transitively:
         return dependents - set(roots)
       known_dependents = dependents
 

--- a/src/python/pants/backend/jvm/tasks/classmap.py
+++ b/src/python/pants/backend/jvm/tasks/classmap.py
@@ -15,8 +15,6 @@ class ClassmapTask(ConsoleTask):
 
     register('--internal-only', default=False, type=bool, fingerprint=True,
              help='Specifies that only class names of internal dependencies should be included.')
-    register('--transitive', default=True, type=bool,
-             help='Outputs all targets in the build graph transitively.')
 
   def classname_for_classfile(self, target, classpath_products):
     contents = ClasspathUtil.classpath_contents((target,), classpath_products)

--- a/src/python/pants/backend/jvm/tasks/classmap.py
+++ b/src/python/pants/backend/jvm/tasks/classmap.py
@@ -24,12 +24,11 @@ class ClassmapTask(ConsoleTask):
       if classname:
         yield classname
 
-  def console_output(self, _):
+  def console_output(self, targets):
     def should_ignore(target):
       return self.get_options().internal_only and isinstance(target, JarLibrary)
 
     classpath_product = self.context.products.get_data('runtime_classpath')
-    targets = self.context.targets() if self.get_options().transitive else self.context.target_roots
     for target in targets:
       if not should_ignore(target):
         for file in self.classname_for_classfile(target, classpath_product):

--- a/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
@@ -315,7 +315,7 @@ class JvmPlatformExplain(JvmPlatformAnalysisMixin, ConsoleTask):
 
   @memoized_property
   def dependency_map(self):
-    if not self.get_options().transitive:
+    if not (self.get_options().transitive or self.get_options().list_transitive_deps):
       return self.jvm_dependency_map
     full_map = self._unfiltered_jvm_dependency_map(fully_transitive=True)
     return {target: deps for target, deps in full_map.items()

--- a/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
@@ -13,8 +13,8 @@ from pants.base.fingerprint_strategy import FingerprintStrategy
 from pants.build_graph.build_graph import CycleException, sort_targets
 from pants.task.console_task import ConsoleTask
 from pants.task.task import Task
-from pants.util.meta import classproperty
 from pants.util.memo import memoized_property
+from pants.util.meta import classproperty
 
 
 class JvmPlatformAnalysisMixin:

--- a/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
@@ -13,6 +13,7 @@ from pants.base.fingerprint_strategy import FingerprintStrategy
 from pants.build_graph.build_graph import CycleException, sort_targets
 from pants.task.console_task import ConsoleTask
 from pants.task.task import Task
+from pants.util.meta import classproperty
 from pants.util.memo import memoized_property
 
 
@@ -264,6 +265,11 @@ class JvmPlatformExplain(JvmPlatformAnalysisMixin, ConsoleTask):
   Ranges = namedtuple('ranges', ['min_allowed_version', 'max_allowed_version',
                                  'target_dependencies', 'target_dependees'])
 
+  @classproperty
+  def _register_console_transitivity_option(cls):
+    """This class registers its own --transitive option, which acts differently."""
+    return False
+
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
@@ -284,9 +290,14 @@ class JvmPlatformExplain(JvmPlatformAnalysisMixin, ConsoleTask):
     register('--filter',
              help='Limit jvm platform possibility explanation to targets whose specs match this '
                   'regex pattern.')
-    # Note: We don't use the appropriate target_restriction_mixin, because --transitive
-    # here appears to mean something slightly different than what's implied by that mixin.
+
+    # TODO: remove `_register_console_transitivity_option` from ConsoleTask when this deprecation
+    # cycle is complete!
     register('--transitive', type=bool,
+             removal_version='1.22.0.dev0',
+             removal_hint='Use --list-transitive-deps instead!',
+             help='List transitive dependencies in analysis output.')
+    register('--list-transitive-deps', type=bool,
              help='List transitive dependencies in analysis output.')
 
   def __init__(self, *args, **kwargs):

--- a/src/python/pants/backend/project_info/tasks/dependencies.py
+++ b/src/python/pants/backend/project_info/tasks/dependencies.py
@@ -34,14 +34,13 @@ class Dependencies(ConsoleTask):
 
     self.is_internal_only = self.get_options().internal_only
     self.is_external_only = self.get_options().external_only
-    self._transitive = self.get_options().transitive
     if self.is_internal_only and self.is_external_only:
       raise TaskError('At most one of --internal-only or --external-only can be selected.')
 
   def console_output(self, unused_method_argument):
     ordered_closure = OrderedSet()
     for target in self.context.target_roots:
-      if self._transitive:
+      if self.act_transitively:
         target.walk(ordered_closure.add)
       else:
         ordered_closure.update(target.dependencies)

--- a/src/python/pants/backend/project_info/tasks/dependencies.py
+++ b/src/python/pants/backend/project_info/tasks/dependencies.py
@@ -28,9 +28,6 @@ class Dependencies(ConsoleTask):
     register('--external-only', type=bool,
              help='Specifies that only external dependencies should be included in the graph '
                   'output (only external jars).')
-    register('--transitive', default=True, type=bool,
-             help='List transitive dependencies. Disable to only list dependencies defined '
-                  'in target BUILD file(s).')
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)

--- a/src/python/pants/backend/project_info/tasks/filedeps.py
+++ b/src/python/pants/backend/project_info/tasks/filedeps.py
@@ -23,15 +23,11 @@ class FileDeps(ConsoleTask):
              help='Instead of outputting filenames, output globs (ignoring excludes)')
     register('--absolute', type=bool, default=True,
              help='If True output with absolute path, else output with path relative to the build root')
-    register('--transitive', type=bool, default=True,
-             help='If True, use all targets in the build graph, else use only target roots.')
 
   def _file_path(self, path):
     return os.path.join(get_buildroot(), path) if self.get_options().absolute else path
 
   def console_output(self, targets):
-    if not self.get_options().transitive:
-      targets = self.context.target_roots
     concrete_targets = set()
     for target in targets:
       concrete_target = target.concrete_derived_from

--- a/src/python/pants/backend/project_info/tasks/filedeps.py
+++ b/src/python/pants/backend/project_info/tasks/filedeps.py
@@ -23,11 +23,15 @@ class FileDeps(ConsoleTask):
              help='Instead of outputting filenames, output globs (ignoring excludes)')
     register('--absolute', type=bool, default=True,
              help='If True output with absolute path, else output with path relative to the build root')
+    register('--transitive', type=bool, default=True,
+             help='If True, use all targets in the build graph, else use only target roots.')
 
   def _file_path(self, path):
     return os.path.join(get_buildroot(), path) if self.get_options().absolute else path
 
   def console_output(self, targets):
+    if not self.get_options().transitive:
+      targets = self.context.target_roots
     concrete_targets = set()
     for target in targets:
       concrete_target = target.concrete_derived_from

--- a/src/python/pants/task/console_task.py
+++ b/src/python/pants/task/console_task.py
@@ -9,6 +9,7 @@ from pants.base.exceptions import TaskError
 from pants.task.target_restriction_mixins import HasTransitiveOptionMixin
 from pants.task.task import QuietTaskMixin, Task
 from pants.util.dirutil import safe_open
+from pants.util.meta import classproperty
 
 
 class ConsoleTask(QuietTaskMixin, HasTransitiveOptionMixin, Task):
@@ -17,6 +18,14 @@ class ConsoleTask(QuietTaskMixin, HasTransitiveOptionMixin, Task):
   ConsoleTasks are not intended to modify build state.
   """
 
+  @classproperty
+  def _register_console_transitivity_option(cls):
+    """Some tasks register their own --transitive option, which act differently.
+
+    TODO: This method is temporary and should be removed in 1.22.0.dev0.
+    """
+    return True
+
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
@@ -24,8 +33,10 @@ class ConsoleTask(QuietTaskMixin, HasTransitiveOptionMixin, Task):
              help='String to use to separate results.')
     register('--output-file', metavar='<path>',
              help='Write the console output to this file instead.')
-    register('--transitive', type=bool, default=True,
-             help='If True, use all targets in the build graph, else use only target roots.')
+
+    if cls._register_console_transitivity_option:
+      register('--transitive', type=bool, default=True, fingerprint=True,
+               help='If True, use all targets in the build graph, else use only target roots.')
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)

--- a/tests/python/pants_test/task_test_base.py
+++ b/tests/python/pants_test/task_test_base.py
@@ -235,7 +235,8 @@ class ConsoleTaskTestBase(TaskTestBase):
     :rtype: list of strings
     """
     task = self.create_task(context)
-    return list(task.console_output(list(task.context.targets()) + list(extra_targets or ())))
+    input_targets = task.get_targets() if task.act_transitively else context.target_roots
+    return list(task.console_output(list(input_targets) + list(extra_targets or ())))
 
   def assert_entries(self, sep, *output, **kwargs):
     """Verifies the expected output text is flushed by the console task under test.


### PR DESCRIPTION
### Problem

While many `ConsoleTask`s such as `filedeps` can very reasonably act upon target roots as well as the transitive closure of their dependencies, each `ConsoleTask` that supports `--transitive` has to add it manually, and many of these tasks don't set `fingerprint=True`.

### Solution

- Add `HasTransitiveOptionMixin` and register `--transitive` in the base `ConsoleTask` class.
- Deprecate `--transitive` in the `jvm-platform-explain` task.
- Add a unit test.

### Result

Any `ConsoleTask` now has a correctly-fingerprinted `--transitive` argument for free!