### PR TITLE
allow `@rule`s to end in `yield Get(...)`

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -448,13 +448,7 @@ class _FFISpecification(object):
     c = self._ffi.from_handle(context_handle)
     response = self._ffi.new('PyGeneratorResponse*')
     try:
-      cur_val = c.from_value(arg[0])
-      try:
-        res = c.from_value(func[0]).send(cur_val)
-      except StopIteration:
-        # This occurs when a @rule body ends with a `yield Get(...)` statement (without any
-        # assignment).
-        res = cur_val
+      res = c.from_value(func[0]).send(c.from_value(arg[0]))
 
       if isinstance(res, Get):
         # Get.

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -448,7 +448,14 @@ class _FFISpecification(object):
     c = self._ffi.from_handle(context_handle)
     response = self._ffi.new('PyGeneratorResponse*')
     try:
-      res = c.from_value(func[0]).send(c.from_value(arg[0]))
+      cur_val = c.from_value(arg[0])
+      try:
+        res = c.from_value(func[0]).send(cur_val)
+      except StopIteration:
+        # This occurs when a @rule body ends with a `yield Get(...)` statement (without any
+        # assignment).
+        res = cur_val
+
       if isinstance(res, Get):
         # Get.
         response.tag = self._lib.Get

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -151,9 +151,8 @@ The rule defined by function `{func_name}` begins at:
     self.generic_visit(node)
 
   def visit_Yield(self, node):
-    if node in self._yields_in_assignments:
-      self.generic_visit(node)
-    else:
+    self.generic_visit(node)
+    if node not in self._yields_in_assignments:
       # The current yield "expr" is the child of an "Expr" "stmt".
       expr_for_yield = self._parents_table[node]
 

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -801,7 +801,11 @@ In function g: yield in @rule without assignment must come at the end of a serie
 
 A yield in an @rule without an assignment is equivalent to a return, and we
 currently require that no statements follow such a yield at the same level of nesting.
-Use `_ = yield Get(...)` if you wish to yield control to the engine and discard the result.
+Use `_ = yield Get(...)` if you wish to yield control to the engine and discard the
+result.
+
+Note that any `yield Get(...)` in an @rule without assignment is also currently not
+supported. See https://github.com/pantsbuild/pants/pull/8227 for progress.
 
 The invalid statement was:
 test_rules.py:{lineno}:{col}
@@ -814,9 +818,9 @@ test_rules.py:{rule_lineno}:{rule_col}
         # This is a yield statement without an assignment, and not at the end.
         yield Get(B, D, D())
         yield A()
-""".format(lineno=(sys._getframe().f_lineno - 22),
+""".format(lineno=(sys._getframe().f_lineno - 26),
            col=8,
-           rule_lineno=(sys._getframe().f_lineno - 27),
+           rule_lineno=(sys._getframe().f_lineno - 31),
            rule_col=6))
 
   def test_final_yield(self):
@@ -843,9 +847,9 @@ test_rules.py:{rule_lineno}:{rule_col}
     exc_msg_trimmed = re.sub(r'^.*?(test_rules\.py)', r'\1', exc_msg, flags=re.MULTILINE)
     self.assertIn('`yield Get(...)` in @rule is currently not allowed without an assignment.',
                   exc_msg_trimmed)
-    self.assertIn("""\
+    self.assertIn(f"""\
 The invalid statement was:
-test_rules.py:842:10
+test_rules.py:{sys._getframe().f_lineno - 9}:10
           yield Get(X, Y(n))
 """, exc_msg_trimmed)
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -5,7 +5,6 @@ import re
 import sys
 import unittest.mock
 from contextlib import contextmanager
-from dataclasses import dataclass
 from textwrap import dedent
 
 from pants.engine.native import Native
@@ -32,26 +31,6 @@ def fn_raises(x):
 @rule(A, [B])
 def nested_raise(x):
   fn_raises(x)
-
-
-@dataclass(frozen=True)
-class Y:
-  none_value: type(None)
-
-
-@dataclass(frozen=True)
-class X:
-  y_value: Y
-
-
-@rule(X, [type(None)])
-def final_yield(n):
-  yield Get(X, Y(n))
-
-
-@rule(X, [Y])
-def y_to_x(y):
-  return X(y)
 
 
 @rule(str, [A, B])
@@ -190,9 +169,6 @@ class SchedulerTest(TestBase):
       RootRule(UnionX),
       no_docstring_test_rule,
       consumes_a_and_b,
-      final_yield,
-      y_to_x,
-      RootRule(type(None)),
       transitive_b_c,
       transitive_coroutine_rule,
       RootRule(UnionWrapper),
@@ -205,10 +181,6 @@ class SchedulerTest(TestBase):
       select_union_b,
       a_union_test,
     ]
-
-  def test_final_yield(self):
-    x, = self.scheduler.product_request(X, [Params(None)])
-    self.assertIsNone(x.y_value.none_value)
 
   def test_use_params(self):
     # Confirm that we can pass in Params in order to provide multiple inputs to an execution.


### PR DESCRIPTION
### Problem

Previously, if a rule ended in `yield Get(A, B())`, the engine would raise an error like:
```
Exception: WithDeps(Inner(InnerEntry { params: {NoneType}, rule: Task(Task { product: A, clause: [Select { product: NoneType }], gets: [], func: final_yield(), cacheable: true }) })) did not declare a dependency on JustGet(Get { product: A, subject: B })
```

@gshuflin first discovered this issue.

### Solution

- Traverse the internal nodes of every single `yield` expression, not just assignments.
- Check for and raise an error message if a rule ends in a `yield Get()` expression.

### Result

Rules such as the following will now cause an error at `@rule` construction time:
```python
@rule(A, [C])
def f(c):
  yield Get(A, B(c))
# YieldVisitError: `yield Get(...)` in @rule is currently not allowed without an assignment.
```