### PR TITLE
cache the bootstrap python venv and rust target/ dir across pants clones

### DIFF
--- a/build-support/bin/native/bootstrap_code.sh
+++ b/build-support/bin/native/bootstrap_code.sh
@@ -76,6 +76,23 @@ function bootstrap_native_code() {
   # Bootstraps the native code only if needed.
   local native_engine_version
   native_engine_version="$(calculate_current_hash)"
+
+  local target_dir='src/rust/engine/target'
+  local cur_fingerprint_file="${target_dir}/pants-fingerprint"
+
+  # The $maybe_cached_target_dir is in a cache shared across all pants checkouts.
+  local maybe_cached_target_dir="${NATIVE_ENGINE_CACHE_DIR}/${native_engine_version}/target"
+
+  # If the current target dir is out of date, see if there is a matching entry in the shared
+  # cache. If so, delete the target dir and copy over the target dir from the shared cache.
+  if ! [[ -f "$cur_fingerprint_file" \
+          && "$(cat "$cur_fingerprint_file")" == "$native_engine_version" ]]; then
+    if [[ -d "$maybe_cached_target_dir" ]]; then
+      rm -rf "$target_dir"
+      cp -r "$maybe_cached_target_dir" "$target_dir"
+    fi
+  fi
+
   local engine_version_hdr="engine_version: ${native_engine_version}"
   local target_binary="${NATIVE_ENGINE_CACHE_DIR}/${native_engine_version}/${NATIVE_ENGINE_BINARY}"
   local target_binary_metadata="${target_binary}.metadata"
@@ -103,6 +120,13 @@ function bootstrap_native_code() {
     echo "${engine_version_hdr}" > "${metadata_file}"
     echo "repo_version: $(git describe --dirty)" >> "${metadata_file}"
     mv "${metadata_file}" "${target_binary_metadata}"
+  fi
+
+  # Write the current target dir to the shared cache.
+  echo "$native_engine_version" > "$cur_fingerprint_file"
+  if [[ ! -d "$maybe_cached_target_dir" ]]; then
+    mkdir -pv "$(dirname "$maybe_cached_target_dir")"
+    cp -r "$target_dir" "$maybe_cached_target_dir"
   fi
 
   # Establishes the native engine wheel resource only if needed.

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -57,26 +57,10 @@ MESSAGE
   fi
 }
 
-function activate_pants_venv() {
-  fingerprint=""
-  for req in "${REQUIREMENTS[@]}"; do
-    fingerprint="${fingerprint}$(fingerprint_data < "${req}")"
-  done
-  fingerprint=$(echo "${fingerprint}" | fingerprint_data)
+function _create_or_activate_venv() {
+  local fingerprint_file="$1"
 
-  # The $BOOTSTRAPPED_DIR is in a cache shared across all pants checkouts.
-  BOOTSTRAPPED_FILE="$(venv_dir)/BOOTSTRAPPED.${fingerprint}"
-  BOOTSTRAPPED_DIR="${CACHE_ROOT}/virtualenvs/$(uname)/${fingerprint}"
-
-  if [ -d "${BOOTSTRAPPED_DIR}" ]; then
-    # If this venv was found within the shared cache, but the venv dir in the current pants checkout
-    # is not up to date, delete the venv dir and copy over the venv from the shared cache.
-    if ! [[ -f "${BOOTSTRAPPED_FILE}" ]]; then
-      rm -rf "$(venv_dir)"
-      mkdir -pv "$(dirname "$(venv_dir)")"
-      cp -r "${BOOTSTRAPPED_DIR}" "$(venv_dir)"
-      touch "${BOOTSTRAPPED_FILE}"
-    fi
+  if [[ -f "$fingerprint_file" ]]; then
     activate_venv || die "Failed to activate venv."
   else
     log "Bootstrapping pants_deps with requirements:"
@@ -98,12 +82,20 @@ function activate_pants_venv() {
       pip install ${pip_extra} -r "${req}" || \
         die "Failed to install requirements from ${req}."
     done
-
-    # Write the current venv to the shared cache.
-    touch "${BOOTSTRAPPED_FILE}"
-    if [[ ! -d "${BOOTSTRAPPED_DIR}" ]]; then
-      mkdir -pv "$(dirname "${BOOTSTRAPPED_DIR}")"
-      cp -r "$(venv_dir)" "${BOOTSTRAPPED_DIR}"
-    fi
   fi
+}
+
+function activate_pants_venv() {
+  fingerprint=""
+  for req in "${REQUIREMENTS[@]}"; do
+    fingerprint="${fingerprint}$(fingerprint_data < "${req}")"
+  done
+  fingerprint=$(echo "${fingerprint}" | fingerprint_data)
+
+  # The $BOOTSTRAPPED_DIR is in a cache shared across all pants checkouts.
+  BOOTSTRAPPED_FILE="$(venv_dir)/BOOTSTRAPPED.${fingerprint}"
+  BOOTSTRAPPED_DIR="${CACHE_ROOT}/virtualenvs/$(uname)/${fingerprint}"
+
+  with_shared_cache_dir "$fingerprint" "$(venv_dir)" "$BOOTSTRAPPED_FILE" "$BOOTSTRAPPED_DIR" \
+                        _create_or_activate_venv "$BOOTSTRAPPED_FILE"
 }

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -64,9 +64,21 @@ function activate_pants_venv() {
   done
   fingerprint=$(echo "${fingerprint}" | fingerprint_data)
 
+  # The $BOOTSTRAPPED_DIR is in a cache shared across all pants checkouts.
   BOOTSTRAPPED_FILE="$(venv_dir)/BOOTSTRAPPED.${fingerprint}"
+  BOOTSTRAPPED_DIR="${CACHE_ROOT}/virtualenvs/$(uname)/${fingerprint}"
 
-  if ! [ -f "${BOOTSTRAPPED_FILE}" ]; then
+  if [ -d "${BOOTSTRAPPED_DIR}" ]; then
+    # If this venv was found within the shared cache, but the venv dir in the current pants checkout
+    # is not up to date, delete the venv dir and copy over the venv from the shared cache.
+    if ! [[ -f "${BOOTSTRAPPED_FILE}" ]]; then
+      rm -rf "$(venv_dir)"
+      mkdir -pv "$(dirname "$(venv_dir)")"
+      cp -r "${BOOTSTRAPPED_DIR}" "$(venv_dir)"
+      touch "${BOOTSTRAPPED_FILE}"
+    fi
+    activate_venv || die "Failed to activate venv."
+  else
     log "Bootstrapping pants_deps with requirements:"
     # Use -f ${REPO_ROOT}/third_party if patching in local dependencies like so
     # pip_extra="-f ${REPO_ROOT}/third_party"
@@ -86,9 +98,12 @@ function activate_pants_venv() {
       pip install ${pip_extra} -r "${req}" || \
         die "Failed to install requirements from ${req}."
     done
+
+    # Write the current venv to the shared cache.
     touch "${BOOTSTRAPPED_FILE}"
-  else
-    activate_venv || die "Failed to activate venv."
+    if [[ ! -d "${BOOTSTRAPPED_DIR}" ]]; then
+      mkdir -pv "$(dirname "${BOOTSTRAPPED_DIR}")"
+      cp -r "$(venv_dir)" "${BOOTSTRAPPED_DIR}"
+    fi
   fi
 }
-


### PR DESCRIPTION
### Problem

When creating a new `git worktree` or perhaps doing a new `git clone` to get another copy of the pants git repo on the local machine, pants has to download python and build rust anew each time for each copy of the pants repo. This increases the difficulty of creating new one-off pants clones to solve specific problems.

### Solution

- Cache the contents of `build-support/virtualenvs/` and `src/rust/engine/target/` in `~/.cache/pants` according to their calculated input fingerprints.
  - Create a method `with_shared_cache_dir()` in `common.sh` to automate that process.

### Result

Creating a new pants workspace or cloning a new pants repo doesn't require waiting to create a python venv or to build rust!