### PR TITLE
repr() exceptions when logging/stringifying them.

### DIFF
--- a/build-support/bin/check_header.py
+++ b/build-support/bin/check_header.py
@@ -93,7 +93,7 @@ def get_header_lines(file_path: Path) -> List[str]:
       # We grab an extra line in case there is a shebang.
       lines = [f.readline() for _ in range(0, EXPECTED_NUM_LINES + 1)]
   except OSError as e:
-    raise HeaderCheckFailure(f"{file_path}: error while reading input ({e})")
+    raise HeaderCheckFailure(f"{file_path}: error while reading input ({e!r})")
   # If a shebang line is included, remove it. Otherwise, we will have conservatively grabbed
   # one extra line at the end for the shebang case that is no longer necessary.
   lines.pop(0 if lines[0].startswith("#!") else - 1)

--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -74,7 +74,7 @@ def get_scm():
         logger.debug(f'Detected git repository at {worktree} on branch {git.branch_name}')
         set_scm(git)
       except git.LocalException as e:
-        logger.info(f'Failed to load git repository at {worktree}: {e}')
+        logger.info(f'Failed to load git repository at {worktree}: {e!r}')
   return _SCM
 
 

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -415,7 +415,7 @@ class RunTracker(Subsystem):
     try:
       return do_post(stats_url, num_redirects_allowed=6)
     except Exception as e:  # Broad catch - we don't want to fail the build over upload errors.
-      return error(f'Error: {e}')
+      return error(f'Error: {e!r}')
 
   @classmethod
   def _json_dump_options(cls, stats):
@@ -428,7 +428,7 @@ class RunTracker(Subsystem):
     try:
       safe_file_dump(file_name, params, mode='w')
     except Exception as e: # Broad catch - we don't want to fail in stats related failure.
-      print(f'WARNING: Failed to write stats to {file_name} due to Error: {e}',
+      print(f'WARNING: Failed to write stats to {file_name} due to Error: {e!r}',
             file=sys.stderr)
 
   def run_information(self):
@@ -632,7 +632,7 @@ class RunTracker(Subsystem):
         return value[option]
     except (Config.ConfigValidationError, AttributeError) as e:
       option_str = "" if option is None else f" option {option}"
-      raise ValueError(f"Couldn't find option scope {scope}{option_str} for recording ({e})")
+      raise ValueError(f"Couldn't find option scope {scope}{option_str} for recording ({e!r})")
 
   @classmethod
   def _create_dict_with_nested_keys_and_val(cls, keys, value):

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -87,7 +87,7 @@ class Git(Scm):
     except OSError as e:
       # Binary DNE or is not executable
       cmd_str = ' '.join(cmd)
-      raise cls.LocalException(f'Failed to execute command {cmd_str}: {e}')
+      raise cls.LocalException(f'Failed to execute command {cmd_str}: {e!r}')
     out, _ = process.communicate()
     return process, out
 

--- a/src/python/pants/util/netrc.py
+++ b/src/python/pants/util/netrc.py
@@ -44,4 +44,4 @@ class Netrc:
         if len(self._login) == 0:
           raise self.NetrcError('Found no usable authentication blocks in ~/.netrc')
       except NetrcParseError as e:
-        raise self.NetrcError(f'Problem parsing ~/.netrc: {e}')
+        raise self.NetrcError(f'Problem parsing ~/.netrc: {e!r}')

--- a/src/python/pants/util/tarutil.py
+++ b/src/python/pants/util/tarutil.py
@@ -48,12 +48,12 @@ class TarFile(tarfile.TarFile):
         tarinfo = self.tarinfo.fromtarfile(self)
       except tarfile.EOFHeaderError as e:
         if self.ignore_zeros:
-          self._dbg(2, f"0x{self.offset:X}: {e}")
+          self._dbg(2, f"0x{self.offset:X}: {e!r}")
           self.offset += tarfile.BLOCKSIZE
           continue
       except tarfile.InvalidHeaderError as e:
         if self.ignore_zeros:
-          self._dbg(2, f"0x{self.offset:X}: {e}")
+          self._dbg(2, f"0x{self.offset:X}: {e!r}")
           self.offset += tarfile.BLOCKSIZE
           continue
         # Modify here, to raise exceptions if errorlevel is bigger than 0.


### PR DESCRIPTION
### Problem

By default, python will call str() on non string arguments in f-strings, which for exception will expose the exception message and omit the exception type.
https://pantsbuild.slack.com/archives/C046T6TA4/p1557757476004900
### Solution

Use !r to get python to call repr() (instead of str()) which will result in the exception type to show up in addition to the exception message

### Result

Hopefully, this will make it easier to track down and debug errors.