### PR TITLE
Fix error when uploading stats to stats storage

### DIFF
--- a/src/python/pants/goal/pantsd_stats.py
+++ b/src/python/pants/goal/pantsd_stats.py
@@ -9,7 +9,7 @@ class PantsDaemonStats:
     self.scheduler_metrics = {}
 
   def set_scheduler_metrics(self, scheduler_metrics):
-    self.scheduler_metrics = scheduler_metrics
+    self.scheduler_metrics = {key: value for (key, value) in scheduler_metrics.items() if key != "engine_workunits"}
 
   def set_target_root_size(self, size):
     self.scheduler_metrics['target_root_size'] = size

--- a/tests/python/pants_test/backend/native/subsystems/BUILD
+++ b/tests/python/pants_test/backend/native/subsystems/BUILD
@@ -13,4 +13,5 @@ python_tests(
     'tests/python/pants_test/subsystem:subsystem_utils',
   ],
   tags={'platform_specific_behavior'},
+  timeout=120,
 )

--- a/tests/python/pants_test/goal/test_run_tracker_integration.py
+++ b/tests/python/pants_test/goal/test_run_tracker_integration.py
@@ -15,6 +15,7 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
         'test',
         '--run-tracker-stats-local-json-file={}'.format(tmpfile),
         '--run-tracker-stats-version=1',
+        '--reporting-zipkin-trace-v2',
         '--run-tracker-stats-option-scopes-to-record=["GLOBAL", "GLOBAL^v2_ui", "compile.rsc^capture_classpath"]',
         'testprojects/src/java/org/pantsbuild/testproject/unicode/main',
       ])
@@ -31,6 +32,7 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
         self.assertIn('pantsd_stats', stats_json)
         self.assertIn('recorded_options', stats_json)
         self.assertIn('GLOBAL', stats_json['recorded_options'])
+        self.assertNotIn('engine_workunits', stats_json['pantsd_stats'])
         self.assertIs(stats_json['recorded_options']['GLOBAL']['v2_ui'], False)
         self.assertEqual(stats_json['recorded_options']['GLOBAL']['level'], 'info')
         self.assertIs(stats_json['recorded_options']['GLOBAL^v2_ui'], False)
@@ -42,6 +44,7 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
         'test',
         '--run-tracker-stats-local-json-file={}'.format(tmpfile),
         '--run-tracker-stats-version=2',
+        '--reporting-zipkin-trace-v2',
         'testprojects/src/java/org/pantsbuild/testproject/unicode/main',
       ])
       self.assert_success(pants_run)
@@ -52,6 +55,7 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
         self.assertIn('run_info', stats_json)
         self.assertIn('pantsd_stats', stats_json)
         self.assertIn('workunits', stats_json)
+        self.assertNotIn('engine_workunits', stats_json['pantsd_stats'])
 
   def test_workunit_failure(self):
     pants_run = self.run_pants([


### PR DESCRIPTION
### Problem
Stats are not uploaded to stats storage because the size of the request is too big.

Workunit information from the engine is passed to python as a part of the metrics and are recorded as a part of pantsd_stats.

### Solution
Workunit info from the engine is not passed to pantsd_stats.
