### PR TITLE
Log computed information in RunTracker

### DIFF
--- a/src/python/pants/base/run_info.py
+++ b/src/python/pants/base/run_info.py
@@ -44,16 +44,17 @@ class RunInfo:
   def get_as_dict(self):
     return self._info.copy()
 
-  def add_info(self, key, val, ignore_errors=False):
+  def add_info(self, key, val, ignore_errors=False, stringify=True):
     """Adds the given info and returns a dict composed of just this added info."""
-    self.add_infos((key, val), ignore_errors=ignore_errors)
+    self.add_infos((key, val), ignore_errors=ignore_errors, stringify=stringify)
 
   def add_infos(self, *keyvals, **kwargs):
     """Adds the given info and returns a dict composed of just this added info."""
     kv_pairs = []
     for key, val in keyvals:
       key = key.strip()
-      val = str(val).strip()
+      if kwargs.get('stringify', True):
+        val = str(val).strip()
       if ':' in key:
         raise ValueError(f'info key "{key}" must not contain a colon.')
       kv_pairs.append((key, val))

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -10,7 +10,6 @@ from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE, Exiter
 from pants.base.workunit import WorkUnit
 from pants.bin.goal_runner import GoalRunner
-from pants.build_graph.address import Address
 from pants.engine.native import Native
 from pants.goal.run_tracker import RunTracker
 from pants.help.help_printer import HelpPrinter

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -227,7 +227,8 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
       spec_parser.parse_spec(spec).to_spec_string()
       for spec in self._options.target_specs
     ]
-    self._run_tracker.run_info.add_info("specs", target_specs, stringify=False)
+    # Note: This will not include values from `--owner-of` or `--changed-*` flags.
+    self._run_tracker.run_info.add_info("specs_from_command_line", target_specs, stringify=False)
 
     # Capture a repro of the 'before' state for this build, if needed.
     self._repro = Reproducer.global_instance().create_repro()

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -5,6 +5,7 @@ import logging
 from contextlib import contextmanager
 
 from pants.base.build_environment import get_buildroot
+from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE, Exiter
 from pants.base.workunit import WorkUnit
@@ -221,21 +222,17 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     self._run_start_time = start_time
     self._reporting.initialize(self._run_tracker, self._options, start_time=self._run_start_time)
 
-    target_specs = [self.normalise_spec(spec) for spec in self._options.target_specs]
+    spec_parser = CmdLineSpecParser(get_buildroot())
+    target_specs = [
+      spec_parser.parse_spec(spec).to_spec_string()
+      for spec in self._options.target_specs
+    ]
     self._run_tracker.run_info.add_info("specs", target_specs, stringify=False)
 
     # Capture a repro of the 'before' state for this build, if needed.
     self._repro = Reproducer.global_instance().create_repro()
     if self._repro:
       self._repro.capture(self._run_tracker.run_info.get_as_dict())
-
-  @staticmethod
-  def normalise_spec(spec):
-    if spec.endswith("::"):
-      if spec.startswith("//") and not spec.startswith("//:"):
-        return spec[2:]
-      return spec
-    return Address.parse(spec).spec
 
   def run(self):
     with LocalExiter.wrap_global_exiter(self._run_tracker, self._repro), \

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -112,6 +112,7 @@ class RunTracker(Subsystem):
     self._run_timestamp = time.time()
     self._cmd_line = ' '.join(['pants'] + sys.argv[1:])
     self._sorted_goal_infos = tuple()
+    self._v2_console_rule_names = tuple()
 
     # Initialized in `initialize()`.
     self.run_info_dir = None
@@ -175,6 +176,9 @@ class RunTracker(Subsystem):
 
   def set_sorted_goal_infos(self, sorted_goal_infos):
     self._sorted_goal_infos = sorted_goal_infos
+
+  def set_v2_console_rule_names(self, v2_console_rule_names):
+    self._v2_console_rule_names = v2_console_rule_names
 
   def register_thread(self, parent_workunit):
     """Register the parent workunit for all work in the calling thread.
@@ -514,6 +518,13 @@ class RunTracker(Subsystem):
 
     if self._target_to_data:
       self.run_info.add_info('target_data', self._target_to_data)
+
+    if self._sorted_goal_infos:
+      self.run_info.add_info(
+        "computed_goals",
+        self._v2_console_rule_names + tuple(goal.goal.name for goal in self._sorted_goal_infos),
+        stringify=False,
+      )
 
     self.report.close()
     self.store_stats()

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -516,15 +516,17 @@ class RunTracker(Subsystem):
       # If the goal is clean-all then the run info dir no longer exists, so ignore that error.
       self.run_info.add_info('outcome', outcome_str, ignore_errors=True)
 
-    if self._target_to_data:
-      self.run_info.add_info('target_data', self._target_to_data)
-
-    if self._sorted_goal_infos:
+    if self._sorted_goal_infos and self.run_info.get_info("computed_goals") is None:
       self.run_info.add_info(
         "computed_goals",
         self._v2_console_rule_names + tuple(goal.goal.name for goal in self._sorted_goal_infos),
         stringify=False,
+        # If the goal is clean-all then the run info dir no longer exists, so ignore that error.
+        ignore_errors=True,
       )
+
+    if self._target_to_data:
+      self.run_info.add_info('target_data', self._target_to_data)
 
     self.report.close()
     self.store_stats()

--- a/tests/python/pants_test/goal/test_run_tracker_integration.py
+++ b/tests/python/pants_test/goal/test_run_tracker_integration.py
@@ -46,7 +46,7 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
             'testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options::',
             'testprojects/src/java/org/pantsbuild/testproject/unicode/main:main',
           ],
-          stats_json['run_info']['specs'],
+          stats_json['run_info']['specs_from_command_line'],
         )
 
         self.assertIn('self_timings', stats_json)

--- a/tests/python/pants_test/goal/test_run_tracker_integration.py
+++ b/tests/python/pants_test/goal/test_run_tracker_integration.py
@@ -12,11 +12,13 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
   def test_stats_local_json_file_v1(self):
     with temporary_file_path() as tmpfile:
       pants_run = self.run_pants([
+        'list',
         'test',
         '--run-tracker-stats-local-json-file={}'.format(tmpfile),
         '--run-tracker-stats-version=1',
         '--reporting-zipkin-trace-v2',
         '--run-tracker-stats-option-scopes-to-record=["GLOBAL", "GLOBAL^v2_ui", "compile.rsc^capture_classpath"]',
+        'testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options::',
         'testprojects/src/java/org/pantsbuild/testproject/unicode/main',
       ])
       self.assert_success(pants_run)
@@ -27,6 +29,26 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
         self.assertEqual(stats_json['outcomes']['main:test'], 'SUCCESS')
         self.assertIn('artifact_cache_stats', stats_json)
         self.assertIn('run_info', stats_json)
+
+        computed_goals = stats_json['run_info']['computed_goals']
+        self.assertIsInstance(computed_goals, list)
+
+        # Explicit v1 goal on the command line:
+        self.assertIn('test', stats_json['run_info']['computed_goals'])
+        # v1 goal implied by dependencies between goals:
+        self.assertIn('compile', stats_json['run_info']['computed_goals'])
+        # Check that v2 goals are included:
+        self.assertIn('list', stats_json['run_info']['computed_goals'])
+
+        # Expanded to canonical form, but not expanded to its actual targets.
+        self.assertEquals(
+          [
+            'testprojects/src/java/org/pantsbuild/testproject/extra_jvm_options::',
+            'testprojects/src/java/org/pantsbuild/testproject/unicode/main:main',
+          ],
+          stats_json['run_info']['specs'],
+        )
+
         self.assertIn('self_timings', stats_json)
         self.assertIn('cumulative_timings', stats_json)
         self.assertIn('pantsd_stats', stats_json)


### PR DESCRIPTION
Having to parse out and guess what the specs were, or what goals were
actually run, is imprecise. Log the computed information.