### PR TITLE
Quash warnings about missing dyn in generated code

### DIFF
--- a/src/rust/engine/process_execution/bazel_protos/build.rs
+++ b/src/rust/engine/process_execution/bazel_protos/build.rs
@@ -132,7 +132,10 @@ fn disable_clippy_in_generated_code(dir: &Path) -> Result<(), String> {
       .filter(|line| !line.contains("clippy"))
       .map(str::to_owned)
       .collect();
-    let content = String::from("#![allow(clippy::all)]\n") + &lines.join("\n");
+    let content = (String::from("#![allow(clippy::all)]\n") + &lines.join("\n"))
+      // Quash warnings about missing dyn, because we can't currently update the code generator
+      // to get rid of them because we forked it upstream a while ago.
+      .replace("::std::any::Any", "dyn ::std::any::Any");
     std::fs::write(file.path(), content).map_err(|err| {
       format!(
         "Error re-writing generated protobuf at {}: {}",


### PR DESCRIPTION
At some point we'll update to a newer code generator, or we'd switch to
tower, but until then...