### PR TITLE
Add rsc_mixed_compile_classpath to RscCompile products

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -176,6 +176,10 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       ]
     )
 
+  @classmethod
+  def product_types(cls):
+    return super(RscCompile, cls).product_types() + ['rsc_mixed_compile_classpath']
+
   @memoized_property
   def _rsc(self):
     return Rsc.global_instance()


### PR DESCRIPTION
### Problem

To depend on Rsc outlines in a later task requires the
`rsc_mixed_compile_classpath` which is currently not being produced in the eyes
of the Pants scheduler

### Solution

Add `rsc_mixed_compile_classpath` to the products of RscCompile task along with
the usual ZincCompile products.

### Result

Tasks can now depend on Rsc outlines.
