### PR TITLE
Port cloc goal to v2 engine

### DIFF
--- a/src/python/pants/backend/graph_info/subsystems/cloc_binary.py
+++ b/src/python/pants/backend/graph_info/subsystems/cloc_binary.py
@@ -12,3 +12,4 @@ class ClocBinary(Script):
 
   replaces_scope = 'cloc'
   replaces_name = 'version'
+

--- a/src/python/pants/rules/core/cloc.py
+++ b/src/python/pants/rules/core/cloc.py
@@ -1,0 +1,131 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+from typing import Set
+
+from pants.base.specs import Specs
+from pants.engine.console import Console
+from pants.engine.fs import (
+  Digest,
+  DirectoriesToMerge,
+  FileContent,
+  FilesContent,
+  InputFilesContent,
+  Snapshot,
+  UrlToFetch,
+)
+from pants.engine.goal import Goal
+from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.legacy.graph import HydratedTargets, TransitiveHydratedTargets
+from pants.engine.rules import console_rule, rule
+from pants.engine.selectors import Get
+
+
+@dataclass(frozen=True)
+class DownloadedClocScript:
+  """Cloc script as downloaded from the pantsbuild binaries repo."""
+  script_path: str
+  digest: Digest
+
+
+#TODO(#7790) - We can't call this feature-complete with the v1 version of cloc
+# until we have a way to download the cloc binary without hardcoding it
+@rule
+def download_cloc_script() -> DownloadedClocScript:
+  url = "https://binaries.pantsbuild.org/bin/cloc/1.80/cloc"
+  sha_256 = "2b23012b1c3c53bd6b9dd43cd6aa75715eed4feb2cb6db56ac3fbbd2dffeac9d"
+  digest = Digest(sha_256, 546279)
+  snapshot = yield Get(Snapshot, UrlToFetch(url, digest))
+  yield DownloadedClocScript(script_path=snapshot.files[0], digest=snapshot.directory_digest)
+
+
+class CountLinesOfCode(Goal):
+  name = 'fast-cloc'
+
+  @classmethod
+  def register_options(cls, register) -> None:
+    super().register_options(register)
+    register('--transitive', type=bool, fingerprint=True, default=True,
+             help='Operate on the transitive dependencies of the specified targets.  '
+                  'Unset to operate only on the specified targets.')
+    register('--ignored', type=bool, fingerprint=True,
+             help='Show information about files ignored by cloc.')
+
+
+@console_rule
+def run_cloc(console: Console, options: CountLinesOfCode.Options, cloc_script: DownloadedClocScript, specs: Specs) -> CountLinesOfCode:
+  """Runs the cloc perl script in an isolated process"""
+
+  transitive = options.values.transitive
+  ignored = options.values.ignored
+
+  if transitive:
+    targets = yield Get(TransitiveHydratedTargets, Specs, specs)
+    all_target_adaptors = {t.adaptor for t in targets.closure}
+  else:
+    targets = yield Get(HydratedTargets, Specs, specs)
+    all_target_adaptors = {t.adaptor for t in targets}
+
+  digests_to_merge = []
+
+  source_paths: Set[str] = set()
+  for t in all_target_adaptors:
+    sources = getattr(t, 'sources', None)
+    if sources is not None:
+      digests_to_merge.append(sources.snapshot.directory_digest)
+      for f in sources.snapshot.files:
+        source_paths.add(str(f))
+
+  file_content = '\n'.join(sorted(source_paths)).encode()
+
+  input_files_filename = 'input_files.txt'
+  report_filename = 'report.txt'
+  ignore_filename = 'ignored.txt'
+
+  input_file_list = InputFilesContent(FilesContent((FileContent(path=input_files_filename, content=file_content, is_executable=False),)))
+  input_file_digest = yield Get(Digest, InputFilesContent, input_file_list)
+  cloc_script_digest = cloc_script.digest
+  digests_to_merge.extend([cloc_script_digest, input_file_digest])
+  digest = yield Get(Digest, DirectoriesToMerge(directories=tuple(digests_to_merge)))
+
+  cmd = (
+    '/usr/bin/perl',
+    cloc_script.script_path,
+    '--skip-uniqueness', # Skip the file uniqueness check.
+    f'--ignored={ignore_filename}', # Write the names and reasons of ignored files to this file.
+    f'--report-file={report_filename}', # Write the output to this file rather than stdout.
+    f'--list-file={input_files_filename}', # Read an exhaustive list of files to process from this file.
+  )
+
+  req = ExecuteProcessRequest(
+    argv=cmd,
+    input_files=digest,
+    output_files=(report_filename, ignore_filename),
+    description='cloc',
+  )
+
+  exec_result = yield Get(ExecuteProcessResult, ExecuteProcessRequest, req)
+  files_content = yield Get(FilesContent, Digest, exec_result.output_directory_digest)
+
+  file_outputs = {fc.path: fc.content.decode() for fc in files_content.dependencies}
+
+  output = file_outputs[report_filename]
+
+  for line in output.splitlines():
+    console.print_stdout(line)
+
+  if ignored:
+    console.print_stdout("\nIgnored the following files:")
+    ignored = file_outputs[ignore_filename]
+    for line in ignored.splitlines():
+      console.print_stdout(line)
+
+  yield CountLinesOfCode(exit_code=0)
+
+
+def rules():
+  return [
+      run_cloc,
+      download_cloc_script,
+    ]

--- a/src/python/pants/rules/core/register.py
+++ b/src/python/pants/rules/core/register.py
@@ -3,6 +3,7 @@
 
 from pants.rules.core import (
   binary,
+  cloc,
   filedeps,
   fmt,
   lint,
@@ -16,6 +17,7 @@ from pants.rules.core import (
 
 def rules():
   return [
+    *cloc.rules(),
     *binary.rules(),
     *fmt.rules(),
     *lint.rules(),

--- a/src/python/pants/rules/core/test_cloc.py
+++ b/src/python/pants/rules/core/test_cloc.py
@@ -1,0 +1,63 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import Sequence
+
+from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.rules.core import cloc
+from pants.testutil.console_rule_test_base import ConsoleRuleTestBase
+
+
+class ClocTest(ConsoleRuleTestBase):
+  goal_cls = cloc.CountLinesOfCode
+
+  @classmethod
+  def rules(cls):
+    return super().rules() + cloc.rules()
+
+  @classmethod
+  def alias_groups(cls):
+    return BuildFileAliases(targets={'java_library': JavaLibrary})
+
+  def assert_counts(self, result: Sequence[str], lang: str, num_files: int, blank: int, comment: int, code: int) -> None:
+    for line in result:
+      fields = line.split()
+      if len(fields) < 5 or fields[0] != lang:
+        continue
+      self.assertEqual(num_files, int(fields[1]))
+      self.assertEqual(blank, int(fields[2]))
+      self.assertEqual(comment, int(fields[3]))
+      self.assertEqual(code, int(fields[4]))
+      return
+    self.fail(f'Found no output line for {lang}')
+
+  def test_cloc(self) -> None:
+    self.create_file('src/py/foo/foo.py', '# A comment.\n\nprint("some code")\n# Another comment.')
+    self.create_file('src/py/foo/bar.py', '# A comment.\n\nprint("some more code")')
+    self.create_file('src/py/dep/dep.py', 'print("a dependency")')
+    self.create_file('src/java/foo/Foo.java', '// A comment. \n class Foo(){}\n')
+    self.create_file('src/java/foo/Bar.java', '// We do not expect this file to appear in counts.')
+
+    self.add_to_build_file('src/py/dep', 'python_library(sources=["dep.py"])')
+    self.add_to_build_file('src/py/foo', 'python_library(dependencies=["src/py/dep"], sources=["foo.py", "bar.py"])')
+    self.add_to_build_file('src/java/foo', 'java_library(sources=["Foo.java"])')
+
+    output = self.execute_rule(args=['src/py/foo', 'src/java/foo']).splitlines()
+    self.assert_counts(output, 'Python', num_files=3, blank=2, comment=3, code=3)
+    self.assert_counts(output, 'Java', num_files=1, blank=0, comment=1, code=1)
+
+    output = self.execute_rule(args=['src/py/foo', 'src/java/foo', '--fast-cloc-no-transitive']).splitlines()
+    self.assert_counts(output, 'Python', num_files=2, blank=2, comment=3, code=2)
+    self.assert_counts(output, 'Java', num_files=1, blank=0, comment=1, code=1)
+
+  def test_ignored(self) -> None:
+    self.create_file('src/py/foo/foo.py', 'print("some code")')
+    self.create_file('src/py/foo/empty.py', '')
+
+    self.add_to_build_file('src/py/foo', 'python_library(sources=["foo.py", "empty.py"])')
+
+    output = self.execute_rule(args=['src/py/foo', '--fast-cloc-ignored'])
+
+    self.assertIn("Ignored the following files:", output)
+    self.assertIn("empty.py: zero sized file", output)


### PR DESCRIPTION
### Problem

The `cloc` goal was using v1 engine abstractions rather than v2 engine abstractions

### Solution

Rewrite the goal to use the v2 engine abstractions and delete the v1 engine code. After this commit, the `ClocBinary` subclass of `BinaryToolBase` is also removed since nothing is using it anymore.

### Result

Nothing about the `cloc` goal should change from the user's perspective