### PR TITLE
 Refactor pathlib.Path usages to use multiple path segments constructor

### DIFF
--- a/build-support/bin/common.py
+++ b/build-support/bin/common.py
@@ -66,5 +66,5 @@ def travis_section(slug: str, message: str) -> Iterator[None]:
   try:
     yield
   finally:
-    travis_fold(action="end", target=travis_fold_state_path.read_text().splitlines()[0].strip())
+    travis_fold(action="end", target=travis_fold_state_path.read_text().splitlines()[0])
     travis_fold_state_path.unlink()

--- a/build-support/bin/common.py
+++ b/build-support/bin/common.py
@@ -55,27 +55,16 @@ def elapsed_time() -> Tuple[int, int]:
 
 @contextmanager
 def travis_section(slug: str, message: str) -> Iterator[None]:
-  travis_fold_state = "/tmp/.travis_fold_current"
+  travis_fold_state_path = Path("/tmp/.travis_fold_current")
 
-  def travis_fold(action: str, target: str) -> None:
+  def travis_fold(*, action: str, target: str) -> None:
     print(f"travis_fold:{action}:{target}\r{_CLEAR_LINE}", end="")
 
-  def read_travis_fold_state() -> str:
-    with open(travis_fold_state, "r") as f:
-      return f.readline()
-
-  def write_slug_to_travis_fold_state() -> None:
-    with open(travis_fold_state, "w") as f:
-      f.write(slug)
-
-  def remove_travis_fold_state() -> None:
-    Path(travis_fold_state).unlink()
-
-  travis_fold("start", slug)
-  write_slug_to_travis_fold_state()
+  travis_fold(action="start", target=slug)
+  travis_fold_state_path.write_text(slug)
   banner(message)
   try:
     yield
   finally:
-    travis_fold("end", read_travis_fold_state())
-    remove_travis_fold_state()
+    travis_fold(action="end", target=travis_fold_state_path.read_text().splitlines()[0].strip())
+    travis_fold_state_path.unlink()

--- a/pants-plugins/src/python/internal_backend/sitegen/tasks/sitegen.py
+++ b/pants-plugins/src/python/internal_backend/sitegen/tasks/sitegen.py
@@ -374,7 +374,7 @@ def render_html(dst, config, soups, precomputed, template):
 def write_en_pages(config, soups, precomputed, template):
   outdir = config['outdir']
   for dst in soups:
-    dst_path = Path(outdir) / f'{dst}.html'
+    dst_path = Path(outdir, f'{dst}.html')
     dst_path.parent.mkdir(parents=True, exist_ok=True)
     dst_path.write_text(data=render_html(dst, config, soups, precomputed, template))
 
@@ -383,7 +383,7 @@ def copy_extras(config):
   """copy over "extra" files named in config json: stylesheets, logos, ..."""
   outdir = config['outdir']
   for dst, src in config['extras'].items():
-    dst_path = Path(outdir) / dst
+    dst_path = Path(outdir, dst)
     dst_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy(src, dst_path)
 

--- a/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
+++ b/src/python/pants/backend/codegen/grpcio/python/grpcio_run.py
@@ -37,7 +37,7 @@ class GrpcioRun(SimpleCodegenTask):
 
   def execute_codegen(self, target, target_workdir):
     args = self.build_args(target, target_workdir)
-    logging.debug("Executing grpcio code generation with args: [{}]".format(args))
+    logging.debug(f"Executing grpcio code generation with args: [{args}]")
 
     with pushd(get_buildroot()):
       workunit_factory = functools.partial(self.context.new_workunit,
@@ -45,20 +45,19 @@ class GrpcioRun(SimpleCodegenTask):
                                            labels=[WorkUnitLabel.TOOL, WorkUnitLabel.LINT])
       cmdline, exit_code = self._grpcio_binary.run(workunit_factory, args)
       if exit_code != 0:
-        raise TaskError('{} ... exited non-zero ({}).'.format(cmdline, exit_code),
-                        exit_code=exit_code)
+        raise TaskError(f'{cmdline} ... exited non-zero ({exit_code}).', exit_code=exit_code)
       # Create __init__.py in each subdirectory of the target directory so that setup_py recognizes
       # them as modules.
       target_workdir_path = Path(target_workdir)
       sources = [str(p.relative_to(target_workdir_path)) for p in target_workdir_path.rglob("*.py")]
       for missing_init in identify_missing_init_files(sources):
-        (target_workdir_path / missing_init).touch()
-      logging.info("Grpcio finished code generation into: [{}]".format(target_workdir))
+        Path(target_workdir_path, missing_init).touch()
+      logging.info(f"Grpcio finished code generation into: [{target_workdir}]")
 
   def build_args(self, target, target_workdir):
-    proto_path = '--proto_path={0}'.format(target.target_base)
-    python_out = '--python_out={0}'.format(target_workdir)
-    grpc_python_out = '--grpc_python_out={0}'.format(target_workdir)
+    proto_path = f'--proto_path={target.target_base}'
+    python_out = f'--python_out={target_workdir}'
+    grpc_python_out = f'--grpc_python_out={target_workdir}'
 
     args = [python_out, grpc_python_out, proto_path]
 

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -219,8 +219,8 @@ class Zinc:
     if self._execution_strategy == NailgunTaskBase.HERMETIC:
       return underlying_dist
     # symlink .pants.d/.jdk -> /some/java/home/
-    jdk_home_symlink = (
-      Path(self._zinc_factory.get_options().pants_workdir) / '.jdk'
+    jdk_home_symlink = Path(
+      self._zinc_factory.get_options().pants_workdir, '.jdk'
     ).relative_to(get_buildroot())
 
     # Since this code can be run in multi-threading mode due to multiple

--- a/src/python/pants/backend/python/subsystems/pex_build_util.py
+++ b/src/python/pants/backend/python/subsystems/pex_build_util.py
@@ -110,7 +110,7 @@ def _create_source_dumper(builder: PEXBuilder, tgt: Target) -> Callable[[str], N
     return str(Path(relpath).relative_to(tgt.target_base))
 
   def dump_source(relpath: str) -> None:
-    source_path = str(Path(buildroot) / relpath)
+    source_path = str(Path(buildroot, relpath))
     dest_path = get_chroot_path(relpath)
     if has_resources(tgt):
       builder.add_resource(filename=source_path, env_filename=dest_path)

--- a/src/python/pants/core_tasks/generate_pants_ini.py
+++ b/src/python/pants/core_tasks/generate_pants_ini.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os.path
+from pathlib import Path
 from textwrap import dedent
 
 from pants.base.build_environment import get_default_pants_config_file
@@ -14,25 +14,26 @@ class GeneratePantsIni(ConsoleTask):
   """Generate pants.ini with sensible defaults."""
 
   def console_output(self, _targets):
-    pants_ini_path = get_default_pants_config_file()
-    pants_ini_content = dedent("""\
+    pants_ini_path = Path(get_default_pants_config_file())
+    pants_ini_content = dedent(f"""\
       [GLOBAL]
-      pants_version: {}
-      """.format(pants_version)
+      pants_version: {pants_version}
+      """
     )
 
-    if os.path.isfile(pants_ini_path):
-      raise TaskError("{} already exists. To update config values, please directly modify pants.ini. "
-                      "For example, you may want to add these entries:\n\n{}".format(pants_ini_path, pants_ini_content))
+    if pants_ini_path.exists():
+      raise TaskError(
+        f"{pants_ini_path} already exists. To update config values, please directly modify "
+        f"pants.ini. For example, you may want to add these entries:\n\n{pants_ini_content}"
+      )
 
-    yield dedent("""\
-      Adding sensible defaults to {}:
-      * Pinning `pants_version` to `{}`.
-      """.format(pants_ini_path, pants_version)
+    yield dedent(f"""\
+      Adding sensible defaults to {pants_ini_path}:
+      * Pinning `pants_version` to `{pants_version}`.
+      """
     )
 
-    with open(pants_ini_path, "w") as f:
-      f.write(pants_ini_content)
+    pants_ini_path.write_text(pants_ini_content)
 
     yield ("You may modify these values directly in the file at any time. "
            "The ./pants script will detect any changes the next time you run it.")

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_apache_thrift_py_gen.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_apache_thrift_py_gen.py
@@ -107,7 +107,7 @@ class ApacheThriftPyGenTest(TaskTestBase):
     _, synthetic_target = self.generate_single_thrift_target(one)
     for filepath in synthetic_target.sources_relative_to_buildroot():
       if '__init__' not in filepath:
-        first_line = (Path(get_buildroot()) / filepath).read_text().splitlines()[0]
+        first_line = Path(get_buildroot(), filepath).read_text().splitlines()[0]
         self.assertEqual(first_line, "# -*- coding: utf-8 -*-")
 
   def test_nested_namespaces(self):

--- a/tests/python/pants_test/build_graph/test_target.py
+++ b/tests/python/pants_test/build_graph/test_target.py
@@ -1,9 +1,9 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os.path
 import unittest.mock
 from hashlib import sha1
+from pathlib import Path
 
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
@@ -128,9 +128,9 @@ class TargetTest(TestBase):
 
   def test_target_id_long(self):
     long_path = 'dummy'
-    for i in range(1,30):
-      long_path = os.path.join(long_path, 'dummy{}'.format(i))
-    long_target = self.make_target('{}:foo'.format(long_path), Target)
+    for i in range(1, 30):
+      long_path = Path(long_path, f'dummy{i}')
+    long_target = self.make_target(f'{long_path}:foo', Target)
     long_id = long_target.id
     self.assertEqual(len(long_id), 100)
     self.assertTrue(long_id.startswith('dummy.dummy1.'))
@@ -138,9 +138,9 @@ class TargetTest(TestBase):
 
   def test_target_id_short(self):
     short_path = 'dummy'
-    for i in range(1,10):
-      short_path = os.path.join(short_path, 'dummy{}'.format(i))
-    short_target = self.make_target('{}:foo'.format(short_path), Target)
+    for i in range(1, 10):
+      short_path = Path(short_path, f'dummy{i}')
+    short_target = self.make_target(f'{short_path}:foo', Target)
     short_id = short_target.id
     self.assertEqual(short_id,
                      'dummy.dummy1.dummy2.dummy3.dummy4.dummy5.dummy6.dummy7.dummy8.dummy9.foo')
@@ -178,21 +178,21 @@ class TargetTest(TestBase):
     hasher = sha1()
     dep_hash = hasher.hexdigest()[:12]
     target_hash = target_a.invalidation_hash()
-    hash_value = '{}.{}'.format(target_hash, dep_hash)
+    hash_value = f'{target_hash}.{dep_hash}'
     self.assertEqual(hash_value, target_a.transitive_invalidation_hash())
 
     hasher = sha1()
     hasher.update(hash_value.encode())
     dep_hash = hasher.hexdigest()[:12]
     target_hash = target_b.invalidation_hash()
-    hash_value = '{}.{}'.format(target_hash, dep_hash)
+    hash_value = f'{target_hash}.{dep_hash}'
     self.assertEqual(hash_value, target_b.transitive_invalidation_hash())
 
     hasher = sha1()
     hasher.update(hash_value.encode())
     dep_hash = hasher.hexdigest()[:12]
     target_hash = target_c.invalidation_hash()
-    hash_value = '{}.{}'.format(target_hash, dep_hash)
+    hash_value = f'{target_hash}.{dep_hash}'
     self.assertEqual(hash_value, target_c.transitive_invalidation_hash())
 
     # Check direct invalidation.
@@ -205,7 +205,7 @@ class TargetTest(TestBase):
     hasher.update(target_b.invalidation_hash(fingerprint_strategy=fingerprint_strategy).encode())
     dep_hash = hasher.hexdigest()[:12]
     target_hash = target_c.invalidation_hash(fingerprint_strategy=fingerprint_strategy)
-    hash_value = '{}.{}'.format(target_hash, dep_hash)
+    hash_value = f'{target_hash}.{dep_hash}'
     self.assertEqual(hash_value, target_c.transitive_invalidation_hash(fingerprint_strategy=fingerprint_strategy))
 
   def test_has_sources(self):

--- a/tests/python/pants_test/repo_scripts/test_git_hooks.py
+++ b/tests/python/pants_test/repo_scripts/test_git_hooks.py
@@ -23,12 +23,12 @@ class PreCommitHookTest(unittest.TestCase):
     with temporary_dir() as gitdir,\
          temporary_dir() as worktree:
       # A tiny little fake git repo we will set up. initialize_repo() requires at least one file.
-      (Path(worktree) / 'README').touch()
+      Path(worktree, 'README').touch()
       # The contextmanager interface is only necessary if an explicit gitdir is not provided.
       with initialize_repo(worktree, gitdir=gitdir) as git:
         if copy_files is not None:
           for fp in copy_files:
-            new_fp = Path(worktree) / fp
+            new_fp = Path(worktree, fp)
             safe_mkdir_for(str(new_fp))
             shutil.copy(fp, new_fp)
         yield git, worktree, gitdir

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -16,7 +16,7 @@ from pants.util.contextutil import http_server
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
-_HEADER = 'invocation_id,task_name,targets_hash,target_id,cache_key_id,cache_key_hash,phase,valid\n'
+_HEADER = 'invocation_id,task_name,targets_hash,target_id,cache_key_id,cache_key_hash,phase,valid'
 _REPORT_LOCATION = 'reports/latest/invalidation-report.csv'
 
 _ENTRY = re.compile(r'^\d+,\S+,(init|pre-check|post-check),(True|False)')


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/8251#discussion_r321972453 showed that `pathlib.Path` can take multiple args in the constructor, like `os.path.join()`, for a more ergonomic API that allows us to avoid using `/` to join two Paths.

This also replaces `os.path` with `pathlib.Path` (and adds f-strings) to some files.