### PR TITLE
Add support for Python 3.7 to the released PEX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -686,6 +686,72 @@ matrix:
     stage: Test Pants
     sudo: required
   - addons:
+      apt:
+        packages:
+        - lib32stdc++6
+        - lib32z1
+        - lib32z1-dev
+        - gcc-multilib
+        - python-dev
+        - openssl
+        - libssl-dev
+        - jq
+        - unzip
+        - shellcheck
+    after_failure:
+    - ./build-support/bin/ci-failure.sh
+    before_cache:
+    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
+    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
+    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
+    - rm -rf ${HOME}/.ivy2/pants/com.example
+    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    before_install:
+    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
+    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - sudo sysctl fs.inotify.max_user_watches=524288
+    - ./build-support/bin/install_aws_cli_for_ci.sh
+    - pyenv global 2.7.15 3.6.7 3.7.1
+    before_script:
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
+      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    - ulimit -c unlimited
+    cache:
+      directories:
+      - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
+      - ${HOME}/.cache/pants/lmdb_store
+      - ${HOME}/.cache/pants/tools
+      - ${HOME}/.cache/pants/zinc
+      - ${HOME}/.ivy2/pants
+      - ${HOME}/.npm
+      timeout: 500
+    dist: xenial
+    env:
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
+    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
+    - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
+    - PREPARE_DEPLOY=1
+    - CACHE_NAME=wheels.linux.py37
+    language: python
+    name: Build Linux wheels (Python 3.7)
+    os: linux
+    python:
+    - '2.7'
+    - '3.6'
+    - '3.7'
+    script:
+    - docker build --rm -t travis_ci --build-arg "BASE_IMAGE=pantsbuild/centos7:latest"
+      --build-arg "TRAVIS_USER=$(id -un)" --build-arg "TRAVIS_UID=$(id -u)" --build-arg
+      "TRAVIS_GROUP=$(id -gn)" --build-arg "TRAVIS_GID=$(id -g)" build-support/docker/travis_ci/
+    - docker run --rm -t -v "${HOME}:/travis/home" -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
+      travis_ci:latest sh -c "./build-support/bin/check_pants_pex_abi.py abi3 cp36m
+      && RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n"
+    services:
+    - docker
+    stage: Test Pants
+    sudo: required
+  - addons:
       brew:
         packages:
         - openssl
@@ -713,6 +779,40 @@ matrix:
     - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY36_VERSION}']"
     language: generic
     name: Build OSX wheels (Python 3.6)
+    os: osx
+    osx_image: xcode8
+    script:
+    - ./build-support/bin/check_pants_pex_abi.py abi3 cp36m
+    - RUN_PANTS_FROM_PEX=1 ./build-support/bin/release.sh -n
+    stage: Test Pants
+  - addons:
+      brew:
+        packages:
+        - openssl
+    before_install:
+    - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
+      -o /usr/local/bin/jq
+    - chmod 755 /usr/local/bin/jq
+    - ./build-support/bin/install_aws_cli_for_ci.sh
+    - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY37_VERSION}"
+    before_script:
+    - ulimit -c unlimited
+    - ulimit -n 8192
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
+      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    env:
+    - PATH="/usr/local/opt/openssl/bin:${PATH}"
+    - LDFLAGS="-L/usr/local/opt/openssl/lib"
+    - CPPFLAGS="-I/usr/local/opt/openssl/include"
+    - PATH="${PYENV_ROOT}/versions/${PYENV_PY27_VERSION}/bin:${PATH}"
+    - PATH="${PYENV_ROOT}/versions/${PYENV_PY37_VERSION}/bin:${PATH}"
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.osx
+    - PREPARE_DEPLOY=1
+    - CACHE_NAME=wheels.osx.py37
+    - PY=${PYENV_ROOT}/versions/${PYENV_PY36_VERSION}/bin/python
+    - PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==${PYENV_PY36_VERSION}']"
+    language: generic
+    name: Build OSX wheels (Python 3.7)
     os: osx
     osx_image: xcode8
     script:

--- a/src/docs/howto_develop.md
+++ b/src/docs/howto_develop.md
@@ -84,10 +84,7 @@ You'll need to setup some files one-time in your own repo:
         'linux-x86_64',
         'macosx-10.4-x86_64',
       ],
-      # You may want to adjust the Python interpreter constraints. Note that Pants requires Python 3.6+.
-      # Pex currently does not support flexible interpreter constraints (tracked by
-      # https://github.com/pantsbuild/pex/issues/690), so you must choose which version to target.
-      compatibility=['CPython==3.6.*'],
+      compatibility=['CPython>=3.6,<4'],
       dependencies=[
         ':pantsbuild.pants',
         # List any other pants backend local or remote deps here, ie:


### PR DESCRIPTION
Currently, the released PEX only supports Python 3.6. This was because https://github.com/pantsbuild/pants/issues/7421, that we could not build with Docker the proper wheels for 3.7.

Now that we've had a Centos7 base image for some time, and PEX fixed upstream issues to allow for flexible binaries that work with multiple Python interpreter versions, all that we need to do to release one single flexible file is to:
1) Add wheel building shards for Py37
2) Teach `release.sh` to look for those Py37 wheels and tell Pex to allow Py37.