### PR TITLE
Run all contrib integration tests using V2 remote execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -443,7 +443,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - travis_wait 20 ./build-support/bin/ci.py --integration-tests-v2 --remote-execution-enabled
+    - travis_wait 25 ./build-support/bin/ci.py --integration-tests-v2 --remote-execution-enabled
       --python-version 3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -733,7 +733,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - travis_wait 20 ./build-support/bin/ci.py --integration-tests-v2 --remote-execution-enabled
+    - travis_wait 25 ./build-support/bin/ci.py --integration-tests-v2 --remote-execution-enabled
       --python-version 3.6
     stage: Test Pants
     sudo: required
@@ -889,7 +889,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 0/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 0/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -946,7 +946,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 1/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 1/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1003,7 +1003,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 2/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 2/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1060,7 +1060,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 3/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 3/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1117,7 +1117,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 4/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 4/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1174,7 +1174,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 5/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 5/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1231,7 +1231,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 6/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 6/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1288,7 +1288,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 7/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 7/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1345,7 +1345,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 8/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 8/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1402,7 +1402,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 9/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 9/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1459,7 +1459,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 10/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 10/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1516,7 +1516,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 11/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 11/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1573,7 +1573,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 12/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 12/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1630,7 +1630,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 13/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 13/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1687,7 +1687,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 14/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 14/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1744,178 +1744,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 15/19 --python-version
-      3.6
-    stage: Test Pants
-    sudo: required
-  - addons:
-      apt:
-        packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-        - jq
-        - unzip
-        - shellcheck
-    after_failure:
-    - ./build-support/bin/ci-failure.sh
-    before_cache:
-    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
-    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
-    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
-    - rm -rf ${HOME}/.ivy2/pants/com.example
-    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
-    before_install:
-    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - sudo sysctl fs.inotify.max_user_watches=524288
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.15 3.6.7 3.7.1
-    before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    cache:
-      directories:
-      - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
-      - ${HOME}/.cache/pants/lmdb_store
-      - ${HOME}/.cache/pants/tools
-      - ${HOME}/.cache/pants/zinc
-      - ${HOME}/.ivy2/pants
-      - ${HOME}/.npm
-      timeout: 500
-    dist: xenial
-    env:
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
-    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - CACHE_NAME=integration.v1.shard_16.py36
-    language: python
-    name: Integration tests  - V1 - shard 16 (Python 3.6)
-    os: linux
-    python:
-    - '2.7'
-    - '3.6'
-    - '3.7'
-    script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 16/19 --python-version
-      3.6
-    stage: Test Pants
-    sudo: required
-  - addons:
-      apt:
-        packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-        - jq
-        - unzip
-        - shellcheck
-    after_failure:
-    - ./build-support/bin/ci-failure.sh
-    before_cache:
-    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
-    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
-    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
-    - rm -rf ${HOME}/.ivy2/pants/com.example
-    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
-    before_install:
-    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - sudo sysctl fs.inotify.max_user_watches=524288
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.15 3.6.7 3.7.1
-    before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    cache:
-      directories:
-      - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
-      - ${HOME}/.cache/pants/lmdb_store
-      - ${HOME}/.cache/pants/tools
-      - ${HOME}/.cache/pants/zinc
-      - ${HOME}/.ivy2/pants
-      - ${HOME}/.npm
-      timeout: 500
-    dist: xenial
-    env:
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
-    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - CACHE_NAME=integration.v1.shard_17.py36
-    language: python
-    name: Integration tests  - V1 - shard 17 (Python 3.6)
-    os: linux
-    python:
-    - '2.7'
-    - '3.6'
-    - '3.7'
-    script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 17/19 --python-version
-      3.6
-    stage: Test Pants
-    sudo: required
-  - addons:
-      apt:
-        packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-        - jq
-        - unzip
-        - shellcheck
-    after_failure:
-    - ./build-support/bin/ci-failure.sh
-    before_cache:
-    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
-    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
-    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
-    - rm -rf ${HOME}/.ivy2/pants/com.example
-    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
-    before_install:
-    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - sudo sysctl fs.inotify.max_user_watches=524288
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.15 3.6.7 3.7.1
-    before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    cache:
-      directories:
-      - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
-      - ${HOME}/.cache/pants/lmdb_store
-      - ${HOME}/.cache/pants/tools
-      - ${HOME}/.cache/pants/zinc
-      - ${HOME}/.ivy2/pants
-      - ${HOME}/.npm
-      timeout: 500
-    dist: xenial
-    env:
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
-    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - CACHE_NAME=integration.v1.shard_18.py36
-    language: python
-    name: Integration tests  - V1 - shard 18 (Python 3.6)
-    os: linux
-    python:
-    - '2.7'
-    - '3.6'
-    - '3.7'
-    script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 18/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 15/16 --python-version
       3.6
     stage: Test Pants
     sudo: required
@@ -1973,7 +1802,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 0/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 0/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2031,7 +1860,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 1/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 1/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2089,7 +1918,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 2/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 2/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2147,7 +1976,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 3/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 3/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2205,7 +2034,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 4/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 4/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2263,7 +2092,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 5/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 5/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2321,7 +2150,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 6/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 6/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2379,7 +2208,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 7/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 7/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2437,7 +2266,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 8/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 8/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2495,7 +2324,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 9/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 9/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2553,7 +2382,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 10/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 10/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2611,7 +2440,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 11/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 11/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2669,7 +2498,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 12/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 12/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2727,7 +2556,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 13/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 13/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2785,7 +2614,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 14/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 14/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -2843,181 +2672,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 15/19 --python-version
-      3.6
-    stage: Test Pants (Cron)
-    sudo: required
-  - addons:
-      apt:
-        packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-        - jq
-        - unzip
-        - shellcheck
-    after_failure:
-    - ./build-support/bin/ci-failure.sh
-    before_cache:
-    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
-    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
-    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
-    - rm -rf ${HOME}/.ivy2/pants/com.example
-    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
-    before_install:
-    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - sudo sysctl fs.inotify.max_user_watches=524288
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.15 3.6.7 3.7.1
-    before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    cache:
-      directories:
-      - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
-      - ${HOME}/.cache/pants/lmdb_store
-      - ${HOME}/.cache/pants/tools
-      - ${HOME}/.cache/pants/zinc
-      - ${HOME}/.ivy2/pants
-      - ${HOME}/.npm
-      timeout: 500
-    dist: xenial
-    env:
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
-    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - CACHE_NAME=integration.v1.shard_16.py36.pantsd
-    - USE_PANTSD_FOR_INTEGRATION_TESTS="true"
-    language: python
-    name: Integration tests with Pantsd - V1 - shard 16 (Python 3.6)
-    os: linux
-    python:
-    - '2.7'
-    - '3.6'
-    - '3.7'
-    script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 16/19 --python-version
-      3.6
-    stage: Test Pants (Cron)
-    sudo: required
-  - addons:
-      apt:
-        packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-        - jq
-        - unzip
-        - shellcheck
-    after_failure:
-    - ./build-support/bin/ci-failure.sh
-    before_cache:
-    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
-    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
-    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
-    - rm -rf ${HOME}/.ivy2/pants/com.example
-    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
-    before_install:
-    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - sudo sysctl fs.inotify.max_user_watches=524288
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.15 3.6.7 3.7.1
-    before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    cache:
-      directories:
-      - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
-      - ${HOME}/.cache/pants/lmdb_store
-      - ${HOME}/.cache/pants/tools
-      - ${HOME}/.cache/pants/zinc
-      - ${HOME}/.ivy2/pants
-      - ${HOME}/.npm
-      timeout: 500
-    dist: xenial
-    env:
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
-    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - CACHE_NAME=integration.v1.shard_17.py36.pantsd
-    - USE_PANTSD_FOR_INTEGRATION_TESTS="true"
-    language: python
-    name: Integration tests with Pantsd - V1 - shard 17 (Python 3.6)
-    os: linux
-    python:
-    - '2.7'
-    - '3.6'
-    - '3.7'
-    script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 17/19 --python-version
-      3.6
-    stage: Test Pants (Cron)
-    sudo: required
-  - addons:
-      apt:
-        packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-        - jq
-        - unzip
-        - shellcheck
-    after_failure:
-    - ./build-support/bin/ci-failure.sh
-    before_cache:
-    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
-    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
-    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
-    - rm -rf ${HOME}/.ivy2/pants/com.example
-    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
-    before_install:
-    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - sudo sysctl fs.inotify.max_user_watches=524288
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.15 3.6.7 3.7.1
-    before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    cache:
-      directories:
-      - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
-      - ${HOME}/.cache/pants/lmdb_store
-      - ${HOME}/.cache/pants/tools
-      - ${HOME}/.cache/pants/zinc
-      - ${HOME}/.ivy2/pants
-      - ${HOME}/.npm
-      timeout: 500
-    dist: xenial
-    env:
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
-    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - CACHE_NAME=integration.v1.shard_18.py36.pantsd
-    - USE_PANTSD_FOR_INTEGRATION_TESTS="true"
-    language: python
-    name: Integration tests with Pantsd - V1 - shard 18 (Python 3.6)
-    os: linux
-    python:
-    - '2.7'
-    - '3.6'
-    - '3.7'
-    script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 18/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 15/16 --python-version
       3.6
     stage: Test Pants (Cron)
     sudo: required
@@ -3075,7 +2730,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 0/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 0/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3133,7 +2788,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 1/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 1/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3191,7 +2846,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 2/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 2/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3249,7 +2904,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 3/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 3/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3307,7 +2962,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 4/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 4/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3365,7 +3020,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 5/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 5/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3423,7 +3078,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 6/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 6/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3481,7 +3136,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 7/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 7/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3539,7 +3194,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 8/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 8/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3597,7 +3252,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 9/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 9/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3655,7 +3310,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 10/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 10/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3713,7 +3368,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 11/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 11/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3771,7 +3426,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 12/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 12/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3829,7 +3484,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 13/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 13/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3887,7 +3542,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 14/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 14/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required
@@ -3945,181 +3600,7 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 15/19 --python-version
-      3.7
-    stage: Test Pants (Cron)
-    sudo: required
-  - addons:
-      apt:
-        packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-        - jq
-        - unzip
-        - shellcheck
-    after_failure:
-    - ./build-support/bin/ci-failure.sh
-    before_cache:
-    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
-    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
-    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
-    - rm -rf ${HOME}/.ivy2/pants/com.example
-    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
-    before_install:
-    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - sudo sysctl fs.inotify.max_user_watches=524288
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.15 3.6.7 3.7.1
-    before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    cache:
-      directories:
-      - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
-      - ${HOME}/.cache/pants/lmdb_store
-      - ${HOME}/.cache/pants/tools
-      - ${HOME}/.cache/pants/zinc
-      - ${HOME}/.ivy2/pants
-      - ${HOME}/.npm
-      timeout: 500
-    dist: xenial
-    env:
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
-    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
-    - CACHE_NAME=integration.v1.shard_16.py37
-    language: python
-    name: Integration tests  - V1 - shard 16 (Python 3.7)
-    os: linux
-    python:
-    - '2.7'
-    - '3.6'
-    - '3.7'
-    script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 16/19 --python-version
-      3.7
-    stage: Test Pants (Cron)
-    sudo: required
-  - addons:
-      apt:
-        packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-        - jq
-        - unzip
-        - shellcheck
-    after_failure:
-    - ./build-support/bin/ci-failure.sh
-    before_cache:
-    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
-    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
-    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
-    - rm -rf ${HOME}/.ivy2/pants/com.example
-    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
-    before_install:
-    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - sudo sysctl fs.inotify.max_user_watches=524288
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.15 3.6.7 3.7.1
-    before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    cache:
-      directories:
-      - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
-      - ${HOME}/.cache/pants/lmdb_store
-      - ${HOME}/.cache/pants/tools
-      - ${HOME}/.cache/pants/zinc
-      - ${HOME}/.ivy2/pants
-      - ${HOME}/.npm
-      timeout: 500
-    dist: xenial
-    env:
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
-    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
-    - CACHE_NAME=integration.v1.shard_17.py37
-    language: python
-    name: Integration tests  - V1 - shard 17 (Python 3.7)
-    os: linux
-    python:
-    - '2.7'
-    - '3.6'
-    - '3.7'
-    script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 17/19 --python-version
-      3.7
-    stage: Test Pants (Cron)
-    sudo: required
-  - addons:
-      apt:
-        packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-        - jq
-        - unzip
-        - shellcheck
-    after_failure:
-    - ./build-support/bin/ci-failure.sh
-    before_cache:
-    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
-    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
-    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
-    - rm -rf ${HOME}/.ivy2/pants/com.example
-    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
-    before_install:
-    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - sudo sysctl fs.inotify.max_user_watches=524288
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.15 3.6.7 3.7.1
-    before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    cache:
-      directories:
-      - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
-      - ${HOME}/.cache/pants/lmdb_store
-      - ${HOME}/.cache/pants/tools
-      - ${HOME}/.cache/pants/zinc
-      - ${HOME}/.ivy2/pants
-      - ${HOME}/.npm
-      timeout: 500
-    dist: xenial
-    env:
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
-    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
-    - CACHE_NAME=integration.v1.shard_18.py37
-    language: python
-    name: Integration tests  - V1 - shard 18 (Python 3.7)
-    os: linux
-    python:
-    - '2.7'
-    - '3.6'
-    - '3.7'
-    script:
-    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 18/19 --python-version
+    - ./build-support/bin/ci.py --integration-tests-v1 --integration-shard 15/16 --python-version
       3.7
     stage: Test Pants (Cron)
     sudo: required

--- a/BUILD
+++ b/BUILD
@@ -17,8 +17,8 @@ files(
 )
 
 files(
-  name = '3rdparty_build',
-  source = '3rdparty/BUILD',
+  name = '3rdparty_directory',
+  sources = rglobs('3rdparty/*'),
 )
 
 files(

--- a/build-support/bin/bootstrap_pants_pex.sh
+++ b/build-support/bin/bootstrap_pants_pex.sh
@@ -47,8 +47,7 @@ function calculate_pants_pex_current_hash() {
      "${REPO_ROOT}/BUILD.tools" \
      "${REPO_ROOT}/BUILD_ROOT" \
      "${REPO_ROOT}/pants.ini" \
-     "${REPO_ROOT}/3rdparty/BUILD" \
-     "${REPO_ROOT}/3rdparty/python" \
+     "${REPO_ROOT}/3rdparty" \
      "${REPO_ROOT}/build-support/checkstyle" \
      "${REPO_ROOT}/build-support/eslint" \
      "${REPO_ROOT}/build-support/ivy" \

--- a/build-support/bin/bootstrap_pants_pex.sh
+++ b/build-support/bin/bootstrap_pants_pex.sh
@@ -47,6 +47,7 @@ function calculate_pants_pex_current_hash() {
      "${REPO_ROOT}/BUILD.tools" \
      "${REPO_ROOT}/BUILD_ROOT" \
      "${REPO_ROOT}/pants.ini" \
+     "${REPO_ROOT}/3rdparty/BUILD" \
      "${REPO_ROOT}/3rdparty/python" \
      "${REPO_ROOT}/build-support/checkstyle" \
      "${REPO_ROOT}/build-support/eslint" \

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -512,7 +512,7 @@ def build_wheels_osx() -> Dict:
 # -------------------------------------------------------------------------
 
 def integration_tests_v1(python_version: PythonVersion, *, use_pantsd: bool = False) -> List[Dict]:
-  num_integration_shards = 19
+  num_integration_shards = 16
 
   def make_shard(*, shard_num: int) -> Dict:
     shard = {
@@ -541,7 +541,7 @@ def integration_tests_v2(python_version: PythonVersion) -> Dict:
     "name": f"Integration tests - V2 (Python {python_version.decimal})",
     "script": [
       (
-        "travis_wait 20 ./build-support/bin/ci.py --integration-tests-v2 "
+        "travis_wait 25 ./build-support/bin/ci.py --integration-tests-v2 "
         f"--remote-execution-enabled --python-version {python_version.decimal}"
       ),
     ]

--- a/build-support/ci_lists/integration_remote_whitelist.txt
+++ b/build-support/ci_lists/integration_remote_whitelist.txt
@@ -8,6 +8,7 @@ contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks:integration
 contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks:integration
 contrib/go/tests/python/pants_test/contrib/go/subsystems:integration
 contrib/go/tests/python/pants_test/contrib/go/tasks:integration
+contrib/jax_ws/tests/python/pants_test/contrib/jax_ws/tasks:integration
 src/python/pants/help:integration
 tests/python/pants_test/base:exclude_target_regexp_integration
 tests/python/pants_test/base:exiter_integration

--- a/build-support/ci_lists/integration_remote_whitelist.txt
+++ b/build-support/ci_lists/integration_remote_whitelist.txt
@@ -17,6 +17,7 @@ contrib/node/tests/python/pants_test/contrib/node/tasks:node_repl_integration
 contrib/node/tests/python/pants_test/contrib/node/tasks:node_resolve_integration
 contrib/node/tests/python/pants_test/contrib/node/tasks:node_run_integration
 contrib/node/tests/python/pants_test/contrib/node/tasks:node_test_integration
+contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks:scalajs_repl_integratio
 src/python/pants/help:integration
 tests/python/pants_test/base:exclude_target_regexp_integration
 tests/python/pants_test/base:exiter_integration

--- a/build-support/ci_lists/integration_remote_whitelist.txt
+++ b/build-support/ci_lists/integration_remote_whitelist.txt
@@ -9,6 +9,7 @@ contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks:integration
 contrib/go/tests/python/pants_test/contrib/go/subsystems:integration
 contrib/go/tests/python/pants_test/contrib/go/tasks:integration
 contrib/jax_ws/tests/python/pants_test/contrib/jax_ws/tasks:integration
+contrib/mypy/tests/python/pants_test/contrib/mypy/tasks:mypy_integration
 src/python/pants/help:integration
 tests/python/pants_test/base:exclude_target_regexp_integration
 tests/python/pants_test/base:exiter_integration

--- a/build-support/ci_lists/integration_remote_whitelist.txt
+++ b/build-support/ci_lists/integration_remote_whitelist.txt
@@ -17,7 +17,9 @@ contrib/node/tests/python/pants_test/contrib/node/tasks:node_repl_integration
 contrib/node/tests/python/pants_test/contrib/node/tasks:node_resolve_integration
 contrib/node/tests/python/pants_test/contrib/node/tasks:node_run_integration
 contrib/node/tests/python/pants_test/contrib/node/tasks:node_test_integration
-contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks:scalajs_repl_integratio
+contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks:scalajs_repl_integration
+contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks:scrooge_gen_integration
+contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks:thrift_linter_integration
 src/python/pants/help:integration
 tests/python/pants_test/base:exclude_target_regexp_integration
 tests/python/pants_test/base:exiter_integration

--- a/build-support/ci_lists/integration_remote_whitelist.txt
+++ b/build-support/ci_lists/integration_remote_whitelist.txt
@@ -1,4 +1,6 @@
 contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python:python
+contrib/go/tests/python/pants_test/contrib/go/subsystems:integration
+contrib/go/tests/python/pants_test/contrib/go/tasks:integration
 src/python/pants/help:integration
 tests/python/pants_test/base:exclude_target_regexp_integration
 tests/python/pants_test/base:exiter_integration

--- a/build-support/ci_lists/integration_remote_whitelist.txt
+++ b/build-support/ci_lists/integration_remote_whitelist.txt
@@ -1,4 +1,5 @@
 contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python:python
+contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks:integration
 contrib/cpp/tests/python/pants_test/contrib/cpp:cpp_integration
 contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks:integration
 contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks:integration

--- a/build-support/ci_lists/integration_remote_whitelist.txt
+++ b/build-support/ci_lists/integration_remote_whitelist.txt
@@ -10,6 +10,13 @@ contrib/go/tests/python/pants_test/contrib/go/subsystems:integration
 contrib/go/tests/python/pants_test/contrib/go/tasks:integration
 contrib/jax_ws/tests/python/pants_test/contrib/jax_ws/tasks:integration
 contrib/mypy/tests/python/pants_test/contrib/mypy/tasks:mypy_integration
+contrib/node/tests/python/pants_test/contrib/node/tasks:node_bundle_integration
+contrib/node/tests/python/pants_test/contrib/node/tasks:node_install_integration
+contrib/node/tests/python/pants_test/contrib/node/tasks:node_lint_integration
+contrib/node/tests/python/pants_test/contrib/node/tasks:node_repl_integration
+contrib/node/tests/python/pants_test/contrib/node/tasks:node_resolve_integration
+contrib/node/tests/python/pants_test/contrib/node/tasks:node_run_integration
+contrib/node/tests/python/pants_test/contrib/node/tasks:node_test_integration
 src/python/pants/help:integration
 tests/python/pants_test/base:exclude_target_regexp_integration
 tests/python/pants_test/base:exiter_integration

--- a/build-support/ci_lists/integration_remote_whitelist.txt
+++ b/build-support/ci_lists/integration_remote_whitelist.txt
@@ -1,3 +1,4 @@
+contrib/avro/tests/python/pants_test/contrib/avro/tasks:avro_java_gen_integration
 contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python:python
 contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks:integration
 contrib/cpp/tests/python/pants_test/contrib/cpp:cpp_integration

--- a/build-support/ci_lists/integration_remote_whitelist.txt
+++ b/build-support/ci_lists/integration_remote_whitelist.txt
@@ -1,5 +1,7 @@
 contrib/avro/tests/python/pants_test/contrib/avro/tasks:avro_java_gen_integration
 contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python:python
+contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor:buildozer_integration
+contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor:meta_rename_integration
 contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks:integration
 contrib/cpp/tests/python/pants_test/contrib/cpp:cpp_integration
 contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks:integration

--- a/build-support/ci_lists/integration_remote_whitelist.txt
+++ b/build-support/ci_lists/integration_remote_whitelist.txt
@@ -1,5 +1,7 @@
 contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python:python
 contrib/cpp/tests/python/pants_test/contrib/cpp:cpp_integration
+contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks:integration
+contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks:integration
 contrib/go/tests/python/pants_test/contrib/go/subsystems:integration
 contrib/go/tests/python/pants_test/contrib/go/tasks:integration
 src/python/pants/help:integration

--- a/build-support/ci_lists/integration_remote_whitelist.txt
+++ b/build-support/ci_lists/integration_remote_whitelist.txt
@@ -1,4 +1,5 @@
 contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python:python
+contrib/cpp/tests/python/pants_test/contrib/cpp:cpp_integration
 contrib/go/tests/python/pants_test/contrib/go/subsystems:integration
 contrib/go/tests/python/pants_test/contrib/go/tasks:integration
 src/python/pants/help:integration

--- a/contrib/avro/BUILD
+++ b/contrib/avro/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+files(
+  name='avro_tests_directory',
+  sources=rglobs('tests/avro/*'),
+)

--- a/contrib/avro/tests/python/pants_test/contrib/avro/tasks/BUILD
+++ b/contrib/avro/tests/python/pants_test/contrib/avro/tasks/BUILD
@@ -17,6 +17,7 @@ python_tests(
   sources=['test_avro_gen_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/avro:avro_tests_directory',
   ],
   tags={'integration'},
 )

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/BUILD
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/BUILD
@@ -41,6 +41,7 @@ python_tests(
   sources=['test_meta_rename_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'testprojects/tests/java/org/pantsbuild/testproject:buildrefactor_directory',
   ],
   tags={'integration'},
 )
@@ -51,6 +52,7 @@ python_tests(
   sources=['test_buildozer_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'testprojects/tests/java/org/pantsbuild/testproject:buildrefactor_directory',
   ],
   tags={'integration'},
 )

--- a/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/BUILD
+++ b/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/BUILD
@@ -7,6 +7,7 @@ python_tests(
   sources = globs('*_integration.py'),
   dependencies=[
     'tests/python/pants_test:int-test',
+    'examples/src/java/org/pantsbuild/example:hello_directory',
   ],
   tags={'integration'},
   timeout=240,

--- a/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/test_index_java_integration.py
+++ b/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/test_index_java_integration.py
@@ -19,7 +19,7 @@ class TestIndexJavaIntegration(PantsRunIntegrationTest):
                   'examples.src.java.org.pantsbuild.example.hello.main.main-bin',
                   'examples.src.java.org.pantsbuild.example.hello.simple.simple']:
         kzip_glob = os.path.join(
-          workdir, 'index/kythe-java-extract/current/{}/current/*.kzip'.format(tgt))
+          workdir, f'index/kythe-java-extract/current/{tgt}/current/*.kzip')
         kzip_files = glob.glob(kzip_glob)
         self.assertEqual(1, len(kzip_files))
         kzip_file = kzip_files[0]
@@ -27,6 +27,6 @@ class TestIndexJavaIntegration(PantsRunIntegrationTest):
         self.assertGreater(os.path.getsize(kzip_file), 200)  # Make sure it's not trivial.
 
         entries_path = os.path.join(
-          workdir, 'index/kythe-java-index/current/{}/current/index.entries'.format(tgt))
+          workdir, f'index/kythe-java-index/current/{tgt}/current/index.entries')
         self.assertTrue(os.path.isfile(entries_path))
         self.assertGreater(os.path.getsize(entries_path), 1000)  # Make sure it's not trivial.

--- a/contrib/cpp/BUILD
+++ b/contrib/cpp/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+files(
+  name='examples_directory',
+  sources=rglobs('examples/*'),
+)

--- a/contrib/cpp/tests/python/pants_test/contrib/cpp/BUILD
+++ b/contrib/cpp/tests/python/pants_test/contrib/cpp/BUILD
@@ -23,6 +23,7 @@ python_tests(
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'contrib/cpp/src/python/pants/contrib/cpp/toolchain:toolchain',
+    'contrib/cpp:examples_directory',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
   ],

--- a/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_integration.py
+++ b/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_integration.py
@@ -19,8 +19,6 @@ def have_compiler():
 class CppIntegrationTest(PantsRunIntegrationTest):
   """Integration test for cpp which builds libraries and builds and runs binaries."""
 
-  # TODO(dhamon): Move these to the test folder and keep the example folder for more
-  # complete examples.
   TEST_SIMPLE_BINARY_TARGET = 'contrib/cpp/examples/src/cpp/example:hello_pants'
   TEST_BINARY_WITH_LIBRARY_TARGET = 'contrib/cpp/examples/src/cpp/calcsqrt'
   TEST_LIBRARY_TARGET = 'contrib/cpp/examples/src/cpp/example/hello'
@@ -65,8 +63,8 @@ class CppIntegrationTest(PantsRunIntegrationTest):
       args = [
         'clean-all',
         task,
-        "--cache-write-to=['{}']".format(cache),
-        "--cache-read-from=['{}']".format(cache),
+        f"--cache-write-to=['{cache}']",
+        f"--cache-read-from=['{cache}']",
         target,
         '-ldebug',
       ]

--- a/contrib/errorprone/BUILD
+++ b/contrib/errorprone/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+files(
+  name='java_tests_directory',
+  sources=rglobs('tests/java/*'),
+)

--- a/contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks/BUILD
+++ b/contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks/BUILD
@@ -16,6 +16,7 @@ python_tests(
   sources=['test_errorprone_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/errorprone:java_tests_directory',
   ],
   tags={'integration'},
   timeout=300,

--- a/contrib/findbugs/BUILD
+++ b/contrib/findbugs/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+files(
+  name='java_tests_directory',
+  sources=rglobs('tests/java/*'),
+)

--- a/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/BUILD
+++ b/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/BUILD
@@ -16,6 +16,7 @@ python_tests(
   sources=['test_findbugs_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/findbugs:java_tests_directory',
   ],
   tags={'integration'},
   timeout=300,

--- a/contrib/go/BUILD
+++ b/contrib/go/BUILD
@@ -5,3 +5,8 @@ page(
   name='go_readme',
   source='README.md',
 )
+
+files(
+  name='examples_directory',
+  sources=rglobs('examples/*'),
+)

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
@@ -34,6 +34,7 @@ python_tests(
   sources = globs('test_*_integration.py'),
   dependencies=[
     'contrib/go/src/python/pants/contrib/go/subsystems',
+    'contrib/go:examples_directory',
     'tests/python/pants_test:int-test',
   ],
   tags={'integration'},

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
@@ -24,6 +24,7 @@ python_tests(
   sources = globs('*_integration.py'),
   dependencies=[
     'contrib/go/src/python/pants/contrib/go/subsystems',
+    'contrib/go:examples_directory',
     'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_binary_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_binary_integration.py
@@ -13,8 +13,7 @@ class GoBinaryIntegrationTest(PantsRunIntegrationTest):
     # We assume that targeting windows is cross-compiling.
     output_file = "dist/go/bin/hello.exe"
     safe_delete(output_file)
-    args = ['binary',
-            'contrib/go/examples/src/go/hello']
+    args = ['binary', 'contrib/go/examples/src/go/hello']
     pants_run = self.run_pants(args, extra_env={"GOOS": "windows"})
     self.assert_success(pants_run)
     self.assertIn(b"for MS Windows", subprocess.check_output(["file", output_file]))

--- a/contrib/jax_ws/BUILD
+++ b/contrib/jax_ws/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+files(
+  name='wsdl_tests_directory',
+  sources=rglobs('tests/wsdl/*'),
+)

--- a/contrib/jax_ws/tests/python/pants_test/contrib/jax_ws/tasks/BUILD
+++ b/contrib/jax_ws/tests/python/pants_test/contrib/jax_ws/tasks/BUILD
@@ -16,6 +16,7 @@ python_tests(
   sources=['test_jax_ws_gen_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/jax_ws:wsdl_tests_directory',
   ],
   tags={'integration'},
   timeout=300,

--- a/contrib/mypy/BUILD
+++ b/contrib/mypy/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+files(
+  name='examples_directory',
+  sources=rglobs('examples/*'),
+)

--- a/contrib/mypy/examples/src/python/BUILD
+++ b/contrib/mypy/examples/src/python/BUILD
@@ -1,0 +1,12 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  name = 'valid',
+  source = 'valid.py'
+)
+
+python_library(
+  name = 'invalid',
+  source = 'invalid.py'
+)

--- a/contrib/mypy/examples/src/python/invalid.py
+++ b/contrib/mypy/examples/src/python/invalid.py
@@ -1,0 +1,16 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import List
+
+
+def properly_typed(x: int, y: List[str]) -> float:
+  if x > 0:
+    return 1.0
+  if y:
+    return 0.0
+  return -1.0
+
+
+returned_float = properly_typed(x="bad!", y={"should_be_a_list"})
+print(f"{returned_float.upper()}")

--- a/contrib/mypy/examples/src/python/valid.py
+++ b/contrib/mypy/examples/src/python/valid.py
@@ -1,0 +1,16 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import List
+
+
+def properly_typed(x: int, y: List[str]) -> float:
+  if x > 0:
+    return 1.0
+  if y:
+    return 0.0
+  return -1.0
+
+
+returned_float = properly_typed(x=0, y=["test"])
+print(f"{returned_float * 2.3}")

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/BUILD
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/BUILD
@@ -2,21 +2,20 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name='mypy_integration',
-  sources=['test_mypy_integration.py'],
-  dependencies=[
-    'tests/python/pants_test:int-test',
-    'tests/python/pants_test:interpreter_selection_utils',
-  ],
-  tags={'integration', 'integration_test'},
-)
-
-python_tests(
   name='mypy',
   source = 'test_mypy.py',
   dependencies=[
     'tests/python/pants_test:task_test_base',
     'contrib/mypy/src/python/pants/contrib/mypy/tasks',
   ],
-  tags = {'integration_test'},
+)
+
+python_tests(
+  name='mypy_integration',
+  sources=['test_mypy_integration.py'],
+  dependencies=[
+    'tests/python/pants_test:int-test',
+    'contrib/mypy:examples_directory',
+  ],
+  tags={'integration'},
 )

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/test_mypy_integration.py
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/test_mypy_integration.py
@@ -1,30 +1,17 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants_test.interpreter_selection_utils import has_python_version
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class MypyIntegrationTest(PantsRunIntegrationTest):
-  def test_mypy(self):
-    cmd = [
-      '--backend-packages=pants.contrib.mypy',
-      '--tag=integration_test'
-      '--lint-skip',
-      '--no-lint-mypy-skip',
-      'lint',
-      'contrib/mypy/tests/python/pants_test/contrib/mypy::',
-      '--',
-      '--follow-imports=silent'
-    ]
 
-    if any((has_python_version('3.{}'.format(v)) for v in (5, 6, 7, 8))):
-      # Python 3.5+ is available. Test that we see an error in this integration test.
-      with self.pants_results(cmd) as pants_run:
-        self.assert_success(pants_run)
-    else:
-      # Python 3.5+ was not found. Test whether mypy task fails for that reason.
-      with self.pants_results(cmd) as pants_run:
-        self.assert_failure(pants_run)
-        self.assertIn('Unable to find a Python >=3.5 interpreter (required for mypy)',
-                      pants_run.stdout_data)
+  cmdline = ['--backend-packages=pants.contrib.mypy', 'lint']
+
+  def test_valid_type_hints(self):
+    result = self.run_pants([*self.cmdline, 'contrib/mypy/examples/src/python:valid'])
+    self.assert_success(result)
+
+  def test_invalid_type_hints(self):
+    result = self.run_pants([*self.cmdline, 'contrib/mypy/examples/src/python:invalid'])
+    self.assert_failure(result)

--- a/contrib/node/BUILD
+++ b/contrib/node/BUILD
@@ -10,7 +10,7 @@ files(
   name='examples_directory',
   sources=rglobs('examples/*'),
   dependencies = [
-    '//:3rdparty_build',
+    '//:3rdparty_directory',
   ],
 )
 

--- a/contrib/node/BUILD
+++ b/contrib/node/BUILD
@@ -5,3 +5,16 @@ page(
   name='node_readme',
   source='README.md',
 )
+
+files(
+  name='examples_directory',
+  sources=rglobs('examples/*'),
+  dependencies = [
+    '//:3rdparty_build',
+  ],
+)
+
+files(
+  name='testprojects_directory',
+  sources=rglobs('testprojects/*'),
+)

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
@@ -33,6 +33,7 @@ python_tests(
   sources=['test_node_bundle_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/node:examples_directory',
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',
   ],
@@ -45,6 +46,7 @@ python_tests(
   sources=['test_node_repl_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/node:examples_directory',
   ],
   tags={'integration'},
 )
@@ -54,6 +56,8 @@ python_tests(
   sources=['test_node_resolve_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/node:examples_directory',
+    'contrib/node:testprojects_directory',
   ],
   timeout=180,
   tags={'integration'},
@@ -64,6 +68,7 @@ python_tests(
   sources=['test_node_run_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/node:examples_directory',
   ],
   timeout=180,
   tags={'integration'},
@@ -74,6 +79,7 @@ python_tests(
   sources=['test_node_test_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/node:examples_directory',
   ],
   timeout=240,
   tags={'integration'},
@@ -116,6 +122,7 @@ python_tests(
   sources=['test_node_lint_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/node:examples_directory',
   ],
   timeout=180,
   tags={'integration'},
@@ -126,6 +133,7 @@ python_tests(
   sources=['test_node_install_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/node:examples_directory',
   ],
   timeout=180,
   tags={'integration'},

--- a/contrib/scalajs/BUILD
+++ b/contrib/scalajs/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+files(
+  name='examples_directory',
+  sources=rglobs('examples/*'),
+)

--- a/contrib/scalajs/BUILD
+++ b/contrib/scalajs/BUILD
@@ -4,4 +4,7 @@
 files(
   name='examples_directory',
   sources=rglobs('examples/*'),
+  dependencies=[
+    'examples/src/scala/org/pantsbuild/example:fact_directory',
+  ],
 )

--- a/contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks/BUILD
+++ b/contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks/BUILD
@@ -6,6 +6,7 @@ python_tests(
   sources=['test_scalajs_repl_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/scalajs:examples_directory',
   ],
   tags={'integration'},
   timeout=180,

--- a/contrib/scrooge/BUILD
+++ b/contrib/scrooge/BUILD
@@ -1,0 +1,12 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+files(
+  name='scala_tests_directory',
+  sources=rglobs('tests/scala/*'),
+)
+
+files(
+  name='thrift_tests_directory',
+  sources=rglobs('tests/thrift/*'),
+)

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
@@ -32,6 +32,8 @@ python_tests(
   sources=['test_scrooge_gen_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/scrooge:scala_tests_directory',
+    'contrib/scrooge:thrift_tests_directory',
   ],
   tags={'integration'},
   timeout=180,
@@ -42,6 +44,7 @@ python_tests(
   sources=['test_thrift_linter_integration.py'],
   dependencies=[
     'tests/python/pants_test:int-test',
+    'contrib/scrooge:thrift_tests_directory',
   ],
   tags={'integration'},
   timeout=240,

--- a/examples/src/java/org/pantsbuild/example/BUILD
+++ b/examples/src/java/org/pantsbuild/example/BUILD
@@ -54,4 +54,7 @@ page(
 files(
   name = 'hello_directory',
   sources = rglobs('hello/*'),
+  dependencies = [
+    'examples/src/resources/org/pantsbuild/example:hello_directory',
+  ],
 )

--- a/examples/src/scala/org/pantsbuild/example/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/BUILD
@@ -30,6 +30,11 @@ page(
 )
 
 files(
+  name = 'fact_directory',
+  sources = rglobs('fact/*'),
+)
+
+files(
   name = 'hello_directory',
   sources = rglobs('hello/*'),
 )

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -76,6 +76,7 @@ python_binary(
     '//:build_root',
     '//:build_tools',
     '//:pants_ini',
+    '//:3rdparty_build',
     'build-support/checkstyle',
     'build-support/eslint',
     'build-support/ivy',

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -76,7 +76,7 @@ python_binary(
     '//:build_root',
     '//:build_tools',
     '//:pants_ini',
-    '//:3rdparty_build',
+    '//:3rdparty_directory',
     'build-support/checkstyle',
     'build-support/eslint',
     'build-support/ivy',

--- a/testprojects/tests/java/org/pantsbuild/testproject/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+files(
+  name='buildrefactor_directory',
+  sources=rglobs('buildrefactor/*'),
+)

--- a/tests/python/pants_test/jvm/BUILD
+++ b/tests/python/pants_test/jvm/BUILD
@@ -24,7 +24,7 @@ python_library(
   sources=['jvm_tool_task_test_base.py'],
   dependencies=[
     '//:build_tools',
-    '//:3rdparty_build',
+    '//:3rdparty_directory',
     ':jvm_task_test_base',
     'src/python/pants/backend/jvm/subsystems:jvm_tool_mixin',
     'src/python/pants/backend/jvm/targets:jvm',

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -18,7 +18,6 @@ python_tests(
     '3rdparty/python:py-zipkin',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
-    '//:3rdparty_build',
     'examples/src/java/org/pantsbuild/example:hello_directory',
     'examples/src/scala/org/pantsbuild/example:several_scala_targets_directory',
   ],


### PR DESCRIPTION
Requires redesigning the MyPy integration test. It was originally testing against itself. Now it has a proper `contrib/examples` folder like everything else.

Brings integration tests to 25% remoted (https://github.com/pantsbuild/pants/issues/8113).