### PR TITLE
Respect a target's specified timeout with V2 Pytest runner

### DIFF
--- a/contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks/BUILD
+++ b/contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks/BUILD
@@ -19,5 +19,5 @@ python_tests(
     'contrib/errorprone:java_tests_directory',
   ],
   tags={'integration'},
-  timeout=300,
+  timeout=420,
 )

--- a/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/BUILD
+++ b/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/BUILD
@@ -19,5 +19,5 @@ python_tests(
     'contrib/findbugs:java_tests_directory',
   ],
   tags={'integration'},
-  timeout=300,
+  timeout=520,
 )

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/BUILD
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/BUILD
@@ -18,4 +18,5 @@ python_tests(
     'contrib/mypy:examples_directory',
   ],
   tags={'integration'},
+  timeout = 120,
 )

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
@@ -37,7 +37,7 @@ python_tests(
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',
   ],
-  timeout=300,
+  timeout=480,
   tags={'integration'},
 )
 

--- a/contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks/BUILD
+++ b/contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks/BUILD
@@ -9,5 +9,5 @@ python_tests(
     'contrib/scalajs:examples_directory',
   ],
   tags={'integration'},
-  timeout=180,
+  timeout=270,
 )

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
@@ -36,7 +36,7 @@ python_tests(
     'contrib/scrooge:thrift_tests_directory',
   ],
   tags={'integration'},
-  timeout=180,
+  timeout=270,
 )
 
 python_tests(

--- a/pants.remote.ini
+++ b/pants.remote.ini
@@ -23,6 +23,8 @@ remote_execution_extra_platform_properties: [
     "container-image=docker://gcr.io/pants-remoting-beta/rbe-remote-execution@sha256:5d818cd71c9180d977e16ca7a20e90ced14211621b69fe1d6c3fc4c42c537a14",
   ]
 
+remote_execution_process_cache_namespace: "test4"
+
 # This should correspond to the number of workers running in Google RBE. See
 # https://console.cloud.google.com/apis/api/remotebuildexecution.googleapis.com/quotas?project=pants-remoting-beta&folder&organizationId&duration=PT6H.
 process_execution_remote_parallelism: 32

--- a/pants.remote.ini
+++ b/pants.remote.ini
@@ -23,8 +23,6 @@ remote_execution_extra_platform_properties: [
     "container-image=docker://gcr.io/pants-remoting-beta/rbe-remote-execution@sha256:5d818cd71c9180d977e16ca7a20e90ced14211621b69fe1d6c3fc4c42c537a14",
   ]
 
-remote_execution_process_cache_namespace: "test4"
-
 # This should correspond to the number of workers running in Google RBE. See
 # https://console.cloud.google.com/apis/api/remotebuildexecution.googleapis.com/quotas?project=pants-remoting-beta&folder&organizationId&duration=PT6H.
 process_execution_remote_parallelism: 32

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -94,11 +94,6 @@ def run_python_test(
   )
 
   test_target_sources_file_names = sorted(source_root_stripped_test_target_sources.snapshot.files)
-  # NB: we use the hardcoded and generic bin name `python`, rather than something dynamic like
-  # `sys.executable`, to ensure that the interpreter may be discovered both locally and in remote
-  # execution (so long as `env` is populated with a `PATH` env var and `python` is discoverable
-  # somewhere on that PATH). This is only used to run the downloaded PEX tool; it is not
-  # necessarily the interpreter that PEX will use to execute the generated .pex file.
   request = resolved_requirements_pex.create_execute_request(
     python_setup=python_setup,
     subprocess_encoding_environment=subprocess_encoding_environment,
@@ -106,6 +101,9 @@ def run_python_test(
     pex_args=test_target_sources_file_names,
     input_files=merged_input_files,
     description=f'Run Pytest for {test_target.address.reference()}',
+    # TODO(#8584): hook this up to TestRunnerTaskMixin so that we can configure the default timeout
+    #  and also use the specified max timeout time.
+    timeout_seconds=getattr(test_target, 'timeout', 60)
   )
 
   result = yield Get(FallibleExecuteProcessResult, ExecuteProcessRequest, request)

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -361,7 +361,7 @@ fn main() {
           store.clone(),
           Platform::Linux,
           executor.clone(),
-          std::time::Duration::from_secs(45),
+          std::time::Duration::from_secs(150),
           std::time::Duration::from_millis(500),
           std::time::Duration::from_secs(5),
         )

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -182,7 +182,7 @@ impl Core {
             // need to take an option all the way down here and into the remote::CommandRunner struct.
             Platform::Linux,
             executor.clone(),
-            std::time::Duration::from_secs(45),
+            std::time::Duration::from_secs(150),
             std::time::Duration::from_millis(500),
             std::time::Duration::from_secs(5),
           )?),

--- a/tests/python/pants_test/backend/codegen/protobuf/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/protobuf/java/BUILD
@@ -27,5 +27,5 @@ python_tests(
     'testprojects/src/protobuf/org/pantsbuild/testproject:import_from_buildroot_directory',
   ],
   tags = {'integration'},
-  timeout = 240,
+  timeout = 330,
 )

--- a/tests/python/pants_test/backend/jvm/subsystems/BUILD
+++ b/tests/python/pants_test/backend/jvm/subsystems/BUILD
@@ -57,7 +57,7 @@ python_tests(
     'testprojects/src/scala/org/pantsbuild/testproject:custom_scala_platform_directory',
   ],
   tags = {'integration'},
-  timeout=360,
+  timeout=500,
 )
 
 python_tests(
@@ -73,7 +73,7 @@ python_tests(
     'testprojects/3rdparty:managed_directory',
   ],
   tags = {'integration'},
-  timeout = 240,
+  timeout = 370,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -69,7 +69,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:bench_directory',
   ],
   tags = {'integration'},
-  timeout = 120,
+  timeout = 210,
 )
 
 python_tests(
@@ -84,7 +84,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:deployexcludes_directory',
     'testprojects/src/java/org/pantsbuild/testproject:manifest_directory',
   ],
-  timeout=360,
+  timeout=420,
   tags = {'integration'},
 )
 
@@ -435,7 +435,8 @@ python_tests(
     'src/python/pants/testutil/jvm:jvm_tool_task_test_base',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  timeout = 120,
 )
 
 python_tests(
@@ -514,7 +515,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
   tags = {'integration'},
-  timeout = 240,
+  timeout = 320,
 )
 
 python_tests(
@@ -539,7 +540,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
   tags = {'integration'},
-  timeout = 240,
+  timeout = 460,
 )
 
 python_tests(
@@ -586,7 +587,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:jvmprepcommand_directory',
   ],
   tags = {'integration'},
-  timeout = 90,
+  timeout = 250,
 )
 
 python_tests(
@@ -718,7 +719,7 @@ python_tests(
     'testprojects/src/scala/org/pantsbuild/testproject:procedure_syntax_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:rsc_compat_directory',
   ],
-  timeout=240,
+  timeout=340,
   tags = {'integration'},
 )
 
@@ -748,7 +749,7 @@ python_tests(
     'examples/src/scala/org/pantsbuild/example:hello_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:unicode_directory',
   ],
-  timeout=300,
+  timeout=480,
   tags = {'integration'},
 )
 
@@ -760,7 +761,7 @@ python_tests(
     'testprojects/maven_layout:provided_patching_directory',
     'testprojects/src/java/org/pantsbuild/testproject:provided_directory',
   ],
-  timeout=300,
+  timeout=720,
   tags = {'integration'},
 )
 
@@ -771,7 +772,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/java/org/pantsbuild/testproject:runtime_directory',
   ],
-  timeout=300,
+  timeout=600,
   tags = {'integration'},
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -42,7 +42,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:missingjardepswhitelist_directory',
   ],
   tags={'integration'},
-  timeout=360,
+  timeout=540,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -67,7 +67,7 @@ python_tests(
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
     'examples/src/java/org/pantsbuild/example:javac_directory',
   ],
-  timeout = 360,
+  timeout = 530,
   tags = {'integration'},
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
@@ -9,6 +9,6 @@ python_tests(
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
     'examples/src/scala/org/pantsbuild/example:scalac_directory',
   ],
-  timeout = 480,
+  timeout = 600,
   tags = {'integration'},
 )

--- a/tests/python/pants_test/backend/native/tasks/BUILD
+++ b/tests/python/pants_test/backend/native/tasks/BUILD
@@ -5,7 +5,7 @@ python_tests(
     'src/python/pants/backend/native/tasks',
   ],
   tags={'platform_specific_behavior'},
-  timeout=240,
+  timeout=280,
 )
 
 python_library(

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -91,7 +91,7 @@ python_tests(
     ':resolve_jars_test_mixin',
   ],
   tags = {'integration'},
-  timeout = 480,
+  timeout = 630,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/python/rules/BUILD
+++ b/tests/python/pants_test/backend/python/rules/BUILD
@@ -49,5 +49,6 @@ python_tests(
     'examples/src/python/example:hello_directory',
   ],
   tags={'integration'},
+  timeout = 90,
 )
 

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -31,7 +31,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:phrases_directory',
   ],
   tags = {'integration'},
-  timeout = 240,
+  timeout = 500,
 )
 
 python_tests(

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -76,6 +76,7 @@ python_tests(
     'testprojects/src/python:build_file_imports_module_directory',
   ],
   tags = {'integration'},
+  timeout = 75,
 )
 
 python_tests(

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -105,5 +105,5 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
   tags = {'integration'},
-  timeout = 480,
+  timeout = 600,
 )

--- a/tests/python/pants_test/core_tasks/BUILD
+++ b/tests/python/pants_test/core_tasks/BUILD
@@ -67,5 +67,5 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:aliases_directory'
   ],
   tags = {'integration'},
-  timeout = 120,
+  timeout = 270,
 )

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -36,7 +36,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:bundle_directory',
   ],
   tags = {'integration'},
-  timeout = 240,
+  timeout = 480,
 )
 
 python_tests(
@@ -100,7 +100,7 @@ python_tests(
     'examples/src/scala/org/pantsbuild/example:hello_directory',
   ],
   tags = {'integration'},
-  timeout = 30,
+  timeout = 40,
 )
 
 python_tests(

--- a/tests/python/pants_test/java/BUILD
+++ b/tests/python/pants_test/java/BUILD
@@ -67,7 +67,7 @@ python_tests(
     'examples/src/scala/org/pantsbuild/example:hello_directory',
   ],
   tags = {'integration'},
-  timeout = 180,
+  timeout = 270,
 )
 
 python_tests(

--- a/tests/python/pants_test/java/distribution/BUILD
+++ b/tests/python/pants_test/java/distribution/BUILD
@@ -26,5 +26,5 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:printversion_directory'
   ],
   tags = {'integration'},
-  timeout = 180,
+  timeout = 300,
 )

--- a/tests/python/pants_test/option/BUILD
+++ b/tests/python/pants_test/option/BUILD
@@ -13,7 +13,6 @@ python_tests(
     'src/python/pants/testutil/option',
     'src/python/pants/testutil:test_base',
   ],
-  timeout=30,
 )
 
 python_tests(

--- a/tests/python/pants_test/targets/BUILD
+++ b/tests/python/pants_test/targets/BUILD
@@ -46,7 +46,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:bundle_directory',
   ],
   tags = {'integration'},
-  timeout = 180,
+  timeout = 300,
 )
 
 python_tests(


### PR DESCRIPTION
We're currently using a timeout of 900 seconds (15 minutes) for each invocation of Pytest (i.e. each target). 

Instead, for parity with the V1 test runner, we should default to 60 seconds and use whatever `timeout` is specified in the `BUILD` entry if a value is provided. 

This timeout gets added to the `queue_buffer_time` we added in https://github.com/pantsbuild/pants/pull/8432, which we bump from 45 seconds to 150 seconds after testing showed multiple unit tests that take 0.1 seconds to run were still timing out.

--

Note that we must bump the timeout for several tests. This does not necessarily mean the tests take longer in V2. Rather, with V1 sharding happens at the method level, so a target with 10 tests might only run 2 of those tests per shard. Timeouts apply for each shard. When running the entire target in V1 with no shards, it would likewise timeout.