### PR TITLE
Extract generalized rule to strip source roots

### DIFF
--- a/src/python/pants/backend/python/rules/BUILD
+++ b/src/python/pants/backend/python/rules/BUILD
@@ -8,7 +8,6 @@ python_library(
     'src/python/pants/engine:rules',
     'src/python/pants/engine:selectors',
     'src/python/pants/rules/core',
-    'src/python/pants/source:source',
     'src/python/pants/util:objects',
   ],
 )

--- a/src/python/pants/rules/core/register.py
+++ b/src/python/pants/rules/core/register.py
@@ -1,8 +1,14 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.rules.core import filedeps, list_roots, list_targets, test
+from pants.rules.core import filedeps, list_roots, list_targets, strip_source_root, test
 
 
 def rules():
-  return list_roots.rules() + list_targets.rules() + filedeps.rules() + test.rules()
+  return [
+    *list_roots.rules(),
+    *list_targets.rules(),
+    *filedeps.rules(),
+    *strip_source_root.rules(),
+    *test.rules()
+  ]

--- a/src/python/pants/rules/core/strip_source_root.py
+++ b/src/python/pants/rules/core/strip_source_root.py
@@ -1,0 +1,50 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.build_graph.files import Files
+from pants.engine.fs import EMPTY_SNAPSHOT, Digest, DirectoryWithPrefixToStrip, Snapshot
+from pants.engine.legacy.structs import TargetAdaptor
+from pants.engine.rules import optionable_rule, rule
+from pants.engine.selectors import Get
+from pants.source.source_root import SourceRootConfig
+from pants.util.objects import datatype
+
+
+class SourceRootStrippedSources(datatype([('snapshot', Snapshot)])):
+  pass
+
+
+@rule(SourceRootStrippedSources, [TargetAdaptor, SourceRootConfig])
+def strip_source_root(target_adaptor, source_root_config):
+  """Relativize targets to their source root, e.g.
+  `src/python/pants/util/strutil.py` -> `pants/util/strutil.py ."""
+
+  source_roots = source_root_config.get_source_roots()
+
+  # TODO: make TargetAdaptor return a 'sources' field with an empty snapshot instead of raising to
+  # simplify the hasattr() checks here!
+  if not hasattr(target_adaptor, 'sources'):
+    yield SourceRootStrippedSources(snapshot=EMPTY_SNAPSHOT)
+
+  digest = target_adaptor.sources.snapshot.directory_digest
+  source_root = source_roots.find_by_path(target_adaptor.address.spec_path)
+
+  # Loose `Files`, as opposed to `Resources` or `Target`s, have no (implied) package
+  # structure and so we do not remove their source root like we normally do, so that filesystem
+  # APIs may still access the files. See pex_build_util.py's `_create_source_dumper`.
+  if target_adaptor.type_alias == Files.alias():
+    source_root = None
+
+  resulting_digest = yield Get(
+    Digest,
+    DirectoryWithPrefixToStrip(
+      directory_digest=digest,
+      prefix=source_root.path if source_root else ""
+    )
+  )
+  resulting_snapshot = yield Get(Snapshot, Digest, resulting_digest)
+  yield SourceRootStrippedSources(snapshot=resulting_snapshot)
+
+
+def rules():
+  return [strip_source_root, optionable_rule(SourceRootConfig)]


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/8185 introduced proper support stripping source roots for targets, but keeping the full path for loose files.

Now that we are porting the rest of the V2 pipeline, e.g. https://github.com/pantsbuild/pants/pull/8236, this functionality should be extracted out into a new rule.