### PR TITLE
Create v2 intrinsic for materializing directories

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -18,7 +18,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.mirrored_target_option_mixin import MirroredTargetOptionMixin
-from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, DirectoryToMaterialize, MaterializeDirectoriesResult, PathGlobs,
+from pants.engine.fs import (DirectoryToMaterialize, EMPTY_DIRECTORY_DIGEST, MaterializeDirectoriesResult, PathGlobs,
                              PathGlobsAndRoot)
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.java.jar.jar_dependency import JarDependency

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -668,7 +668,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
     ctx.rsc_jar_file = ClasspathEntry(ctx.rsc_jar_file.path, res.output_directory_digest)
 
-    _, = self.context._scheduler.product_request(
+    self.context._scheduler.product_request(
       MaterializeDirectoriesResult,
       DirectoryToMaterialize(
         # NB the first element here is the root to materialize into, not the dir to snapshot

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -18,7 +18,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.mirrored_target_option_mixin import MirroredTargetOptionMixin
-from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, DirectoryToMaterialize, PathGlobs,
+from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, DirectoryToMaterialize, MaterializeDirectoriesResult, PathGlobs,
                              PathGlobsAndRoot)
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.java.jar.jar_dependency import JarDependency
@@ -668,12 +668,13 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
     ctx.rsc_jar_file = ClasspathEntry(ctx.rsc_jar_file.path, res.output_directory_digest)
 
-    self.context._scheduler.materialize_directories((
+    _, = self.context._scheduler.product_request(
+      MaterializeDirectoriesResult,
       DirectoryToMaterialize(
         # NB the first element here is the root to materialize into, not the dir to snapshot
         get_buildroot(),
         res.output_directory_digest),
-    ))
+    )
 
     return res
 

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -8,7 +8,7 @@ from pants.engine.rules import RootRule
 from pants.option.custom_types import GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.util.dirutil import maybe_read_file, safe_delete, safe_file_dump
-from pants.util.objects import Exactly, datatype
+from pants.util.objects import Exactly, datatype, string_list
 
 
 class FileContent(datatype([('path', str), ('content', bytes), ('is_executable', bool)])):
@@ -163,7 +163,14 @@ class DirectoryWithPrefixToStrip(datatype([('directory_digest', Digest), ('prefi
 
 class DirectoryToMaterialize(datatype([('path', str), ('directory_digest', Digest)])):
   """A request to materialize the contents of a directory digest at the provided path."""
-  pass
+
+DirectoriesToMaterialize = Collection.of(DirectoryToMaterialize)
+
+
+class MaterializeDirectoryResult(datatype([('output_paths', string_list)])):
+  """Result of materializing a directory, contains the full output paths."""
+
+MaterializeDirectoriesResult = Collection.of(MaterializeDirectoryResult)
 
 
 class UrlToFetch(datatype([('url', str), ('digest', Digest)])):
@@ -189,6 +196,7 @@ EMPTY_SNAPSHOT = Snapshot(
 def create_fs_rules():
   """Creates rules that consume the intrinsic filesystem types."""
   return [
+    RootRule(DirectoriesToMaterialize),
     RootRule(InputFilesContent),
     RootRule(Digest),
     RootRule(DirectoriesToMerge),

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -799,6 +799,7 @@ class Native(Singleton):
     return self.gc(self.lib.session_create(scheduler, should_record_zipkin_spans, should_render_ui, ui_worker_count), self.lib.session_destroy)
 
   def new_scheduler(self,
+                    *,
                     tasks,
                     root_subject_types,
                     build_root,
@@ -810,6 +811,8 @@ class Native(Singleton):
                     construct_file_content,
                     construct_files_content,
                     construct_process_result,
+                    construct_materialize_directory_result,
+                    construct_materialize_directories_results,
                     type_address,
                     type_path_globs,
                     type_directory_digest,
@@ -824,7 +827,9 @@ class Native(Singleton):
                     type_multi_platform_process_request,
                     type_process_result,
                     type_generator,
-                    type_url_to_fetch):
+                    type_url_to_fetch,
+                    type_directories_to_materialize,
+                    type_materialize_directories_result):
     """Create and return an ExternContext and native Scheduler."""
 
     def func(fn):
@@ -841,6 +846,8 @@ class Native(Singleton):
         func(construct_file_content),
         func(construct_files_content),
         func(construct_process_result),
+        func(construct_materialize_directory_result),
+        func(construct_materialize_directories_results),
         # Types.
         ti(type_address),
         ti(type_path_globs),
@@ -857,6 +864,8 @@ class Native(Singleton):
         ti(type_process_result),
         ti(type_generator),
         ti(type_url_to_fetch),
+        ti(type_directories_to_materialize),
+        ti(type_materialize_directories_result),
         ti(str),
         ti(bytes),
         # Project tree.

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -13,9 +13,11 @@ from types import GeneratorType
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE
 from pants.base.project_tree import Dir, File, Link
 from pants.build_graph.address import Address
-from pants.engine.fs import (Digest, DirectoriesToMerge, DirectoryToMaterialize,
-                             DirectoryWithPrefixToStrip, FileContent, FilesContent,
-                             InputFilesContent, PathGlobs, PathGlobsAndRoot, Snapshot, UrlToFetch)
+from pants.engine.fs import (Digest, DirectoriesToMaterialize, DirectoriesToMerge,
+                             DirectoryToMaterialize, DirectoryWithPrefixToStrip, FileContent,
+                             FilesContent, InputFilesContent, MaterializeDirectoriesResult,
+                             MaterializeDirectoryResult, PathGlobs, PathGlobsAndRoot, Snapshot,
+                             UrlToFetch)
 from pants.engine.isolated_process import (FallibleExecuteProcessResult,
                                            MultiPlatformExecuteProcessRequest)
 from pants.engine.native import Function, TypeId
@@ -99,6 +101,8 @@ class Scheduler:
       construct_file_content=FileContent,
       construct_files_content=FilesContent,
       construct_process_result=FallibleExecuteProcessResult,
+      construct_materialize_directory_result=MaterializeDirectoryResult,
+      construct_materialize_directories_results=MaterializeDirectoriesResult,
       type_address=Address,
       type_path_globs=PathGlobs,
       type_directory_digest=Digest,
@@ -114,6 +118,8 @@ class Scheduler:
       type_process_result=FallibleExecuteProcessResult,
       type_generator=GeneratorType,
       type_url_to_fetch=UrlToFetch,
+      type_directories_to_materialize=DirectoriesToMaterialize,
+      type_materialize_directories_result=MaterializeDirectoriesResult
     )
 
     # If configured, visualize the rule graph before asserting that it is valid.

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -888,7 +888,7 @@ pub extern "C" fn materialize_directories(
     })
     .collect();
 
-  let dir_and_digests: Vec<(PathBuf, Digest)> = match directories_paths_and_digests_results {
+  let dir_and_digests = match directories_paths_and_digests_results {
     Ok(d) => d,
     Err(err) => {
       let e: Result<Value, String> = Err(err);
@@ -909,7 +909,7 @@ pub extern "C" fn materialize_directories(
           })
           .collect::<Vec<_>>(),
       )
-      .map(|_x: Vec<store::DirectoryMaterializeMetadata>| ()),
+      .map(|_| ()),
     )
   })
   .into()

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -182,6 +182,8 @@ pub extern "C" fn scheduler_create(
   construct_file_content: Function,
   construct_files_content: Function,
   construct_process_result: Function,
+  construct_materialize_directory_result: Function,
+  construct_materialize_directories_results: Function,
   type_address: TypeId,
   type_path_globs: TypeId,
   type_directory_digest: TypeId,
@@ -197,6 +199,8 @@ pub extern "C" fn scheduler_create(
   type_process_result: TypeId,
   type_generator: TypeId,
   type_url_to_fetch: TypeId,
+  type_directories_to_materialize: TypeId,
+  type_materialize_directories_result: TypeId,
   type_string: TypeId,
   type_bytes: TypeId,
   build_root_buf: Buffer,
@@ -233,6 +237,8 @@ pub extern "C" fn scheduler_create(
     construct_file_content: construct_file_content,
     construct_files_content: construct_files_content,
     construct_process_result: construct_process_result,
+    construct_materialize_directory_result,
+    construct_materialize_directories_results,
     address: type_address,
     path_globs: type_path_globs,
     directory_digest: type_directory_digest,
@@ -248,6 +254,8 @@ pub extern "C" fn scheduler_create(
     process_result: type_process_result,
     generator: type_generator,
     url_to_fetch: type_url_to_fetch,
+    directories_to_materialize: type_directories_to_materialize,
+    materialize_directories_result: type_materialize_directories_result,
     string: type_string,
     bytes: type_bytes,
   };
@@ -880,7 +888,7 @@ pub extern "C" fn materialize_directories(
     })
     .collect();
 
-  let dir_and_digests = match directories_paths_and_digests_results {
+  let dir_and_digests: Vec<(PathBuf, Digest)> = match directories_paths_and_digests_results {
     Ok(d) => d,
     Err(err) => {
       let e: Result<Value, String> = Err(err);
@@ -901,7 +909,7 @@ pub extern "C" fn materialize_directories(
           })
           .collect::<Vec<_>>(),
       )
-      .map(|_| ()),
+      .map(|_x: Vec<store::DirectoryMaterializeMetadata>| ()),
     )
   })
   .into()

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -87,6 +87,27 @@ pub struct DirectoryMaterializeMetadata {
   pub child_files: BTreeMap<String, LoadMetadata>,
 }
 
+impl DirectoryMaterializeMetadata {
+  pub fn to_path_list(&self) -> Vec<String> {
+    fn recurse(
+      outputs: &mut Vec<String>,
+      path_so_far: PathBuf,
+      current: &DirectoryMaterializeMetadata,
+    ) {
+      for (child, _) in current.child_files.iter() {
+        outputs.push(path_so_far.join(child).to_string_lossy().to_string())
+      }
+
+      for (dir, meta) in current.child_directories.iter() {
+        recurse(outputs, path_so_far.join(dir), &meta);
+      }
+    }
+    let mut output_paths: Vec<String> = vec![];
+    recurse(&mut output_paths, PathBuf::new(), self);
+    output_paths
+  }
+}
+
 #[derive(Debug)]
 struct DirectoryMaterializeMetadataBuilder {
   pub metadata: LoadMetadata,

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -162,6 +162,10 @@ impl Tasks {
         product: types.process_result,
         input: types.multi_platform_process_request,
       },
+      Intrinsic {
+        product: types.materialize_directories_result,
+        input: types.directories_to_materialize,
+      },
     ];
 
     for intrinsic in intrinsics {

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -6,6 +6,8 @@ pub struct Types {
   pub construct_file_content: Function,
   pub construct_files_content: Function,
   pub construct_process_result: Function,
+  pub construct_materialize_directory_result: Function,
+  pub construct_materialize_directories_results: Function,
   pub address: TypeId,
   pub path_globs: TypeId,
   pub directory_digest: TypeId,
@@ -21,6 +23,8 @@ pub struct Types {
   pub process_result: TypeId,
   pub generator: TypeId,
   pub url_to_fetch: TypeId,
+  pub directories_to_materialize: TypeId,
+  pub materialize_directories_result: TypeId,
   pub string: TypeId,
   pub bytes: TypeId,
 }

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -350,8 +350,8 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
     from pathlib import Path
 
     input_file = InputFilesContent((
-      FileContent(path='a.file', content=b'test'),
-      FileContent(path='subdir/b.file', content=b'some content'),
+      FileContent(path='a.file', content=b'test', is_executable=False),
+      FileContent(path='subdir/b.file', content=b'some content', is_executable=False),
     ))
 
     digest, = self.scheduler.product_request(Digest, [input_file])


### PR DESCRIPTION
### Problem

Right now we have no way for a v2 rule to safely materialize a directory except via the awkward hack of calling the `materialize_directories` FFI function.

### Solution

Create new types `MaterializeDirectoriesResult` and `MaterializeDirectoryResult` to represent the output of materializing a directory to disk, and create a rule from the existing `DirectoryToMaterialize` type to this new type that will actually perform the disk IO in the engine.