### PR TITLE
Fix support for running pants from source in other repositories

### DIFF
--- a/build-support/bin/bootstrap_pants_pex.sh
+++ b/build-support/bin/bootstrap_pants_pex.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../.. && pwd -P)"
 
+cd "$REPO_ROOT" || exit 1
+
 # This script is used to generate pants.pex and particularly to allow us to maintain multiple versions,
 # each mapped to a particular snapshot of the source code. The different versions are maintained in
 # the CACHE_ROOT, with the current one symlinked into the build root. This allows us to quickly

--- a/pants
+++ b/pants
@@ -123,7 +123,7 @@ for arg in "$@"; do
   fi
 done
 if [[ "${test_goal_used}" == 'true' && "${TRAVIS}" != 'true' ]]; then
-  ./build-support/bin/bootstrap_pants_pex.sh
+  "$HERE/build-support/bin/bootstrap_pants_pex.sh"
 fi
 
 exec_pants_bare "$@"


### PR DESCRIPTION
### Problem

The `pants` script in the pantsbuild/pants repo semi-stealthily supports running pants from source in _other_ repositories. This broke recently.

### Solution

Fix that support by using absolute paths, and `cd`-ing in the relevant spots.