### PR TITLE
Correct misleading comment in graph::Walk

### DIFF
--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -189,7 +189,9 @@ impl<N: Node> InnerGraph<N> {
   }
 
   ///
-  /// Begins a topological Walk from the given roots.
+  /// Begins a Walk from the given roots.
+  /// The Walk will iterate over all nodes that descend from the roots in the direction of
+  /// traversal but won't necessarily be in topological order.t st
   ///
   fn walk(&self, roots: VecDeque<EntryId>, direction: Direction) -> Walk<'_, N> {
     Walk {
@@ -879,8 +881,8 @@ impl<N: Node> Graph<N> {
 }
 
 ///
-/// Represents the state of a particular topological walk through a Graph. Implements Iterator and
-/// has the same lifetime as the Graph itself.
+/// Represents the state of a particular walk through a Graph. Implements Iterator and has the same
+/// lifetime as the Graph itself.
 ///
 struct Walk<'a, N: Node> {
   graph: &'a InnerGraph<N>,

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -191,7 +191,7 @@ impl<N: Node> InnerGraph<N> {
   ///
   /// Begins a Walk from the given roots.
   /// The Walk will iterate over all nodes that descend from the roots in the direction of
-  /// traversal but won't necessarily be in topological order.t st
+  /// traversal but won't necessarily be in topological order.
   ///
   fn walk(&self, roots: VecDeque<EntryId>, direction: Direction) -> Walk<'_, N> {
     Walk {


### PR DESCRIPTION
### Problem

The comment claimed the walk was topological, which lead me to try and
use it as I needed to walk the path topologically.

It actually isn't as we don't check that the neighbors have no other
dependency that is ahead of them in the topological order before adding
them to the queue.

### Solution

I went over the callers and verified that none of them relied on a
topological ordering, which means this hasn't actually manifested into a
bug (yet).

Edit the comment.

### Result

This should avoid client code having the wrong expectation and introducing
bugs.