### PR TITLE
Port 5 more integration tests to V2 remote execution

### DIFF
--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -30,7 +30,6 @@ tests/python/pants_test/engine/legacy:owners_integration
 tests/python/pants_test/goal:run_tracker_integration
 tests/python/pants_test/invalidation:strict_deps_invalidation_integration
 tests/python/pants_test/logging:test_native_engine_logging
-tests/python/pants_test/option:options_integration
 tests/python/pants_test/pantsd:pantsd_integration
 tests/python/pants_test/projects:testprojects_integration
 tests/python/pants_test/releases:releases

--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -30,7 +30,6 @@ tests/python/pants_test/engine/legacy:owners_integration
 tests/python/pants_test/goal:run_tracker_integration
 tests/python/pants_test/invalidation:strict_deps_invalidation_integration
 tests/python/pants_test/logging:test_native_engine_logging
-tests/python/pants_test/logging:test_workunit_label
 tests/python/pants_test/option:options_integration
 tests/python/pants_test/pantsd:pantsd_integration
 tests/python/pants_test/projects:testprojects_integration

--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -27,7 +27,6 @@ tests/python/pants_test/engine/legacy:dependees_integration
 tests/python/pants_test/engine/legacy:filemap_integration
 tests/python/pants_test/engine/legacy:graph_integration
 tests/python/pants_test/engine/legacy:owners_integration
-tests/python/pants_test/goal:run_tracker_integration
 tests/python/pants_test/invalidation:strict_deps_invalidation_integration
 tests/python/pants_test/logging:test_native_engine_logging
 tests/python/pants_test/pantsd:pantsd_integration

--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -31,7 +31,6 @@ tests/python/pants_test/invalidation:strict_deps_invalidation_integration
 tests/python/pants_test/logging:test_native_engine_logging
 tests/python/pants_test/pantsd:pantsd_integration
 tests/python/pants_test/projects:testprojects_integration
-tests/python/pants_test/releases:releases
 tests/python/pants_test/reporting:reporting_integration
 tests/python/pants_test/targets:jvm_app_integration
 tests/python/pants_test/tasks:bootstrap_jvm_tools_integration

--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -30,6 +30,5 @@ tests/python/pants_test/invalidation:strict_deps_invalidation_integration
 tests/python/pants_test/logging:test_native_engine_logging
 tests/python/pants_test/pantsd:pantsd_integration
 tests/python/pants_test/projects:testprojects_integration
-tests/python/pants_test/reporting:reporting_integration
 tests/python/pants_test/targets:jvm_app_integration
 tests/python/pants_test/tasks:bootstrap_jvm_tools_integration

--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -18,7 +18,6 @@ tests/python/pants_test/backend/python/tasks:pytest_run_integration
 tests/python/pants_test/backend/python/tasks:python_binary_integration
 tests/python/pants_test/backend/python/tasks:setup_py_integration
 tests/python/pants_test/backend/python:integration
-tests/python/pants_test/base:exception_sink_integration
 tests/python/pants_test/engine/legacy:build_ignore_integration
 tests/python/pants_test/engine/legacy:bundle_integration
 tests/python/pants_test/engine/legacy:changed_integration

--- a/build-support/ci_lists/integration_v2_blacklist.txt
+++ b/build-support/ci_lists/integration_v2_blacklist.txt
@@ -1,1 +1,2 @@
 tests/python/pants_test/base:exception_sink_integration
+tests/python/pants_test/reporting:reporting_integration

--- a/build-support/ci_lists/integration_v2_blacklist.txt
+++ b/build-support/ci_lists/integration_v2_blacklist.txt
@@ -1,0 +1,1 @@
+tests/python/pants_test/base:exception_sink_integration

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -67,3 +67,18 @@ This file is no longer a changelog, but remains in this location in order to avo
 older changelog links unnecessarily. Could consider removing it by 2.0.x, perhaps.
 ''',
 )
+
+# NB: This is used for the integration test `test_reversion.py`. It includes all transitive
+# dependencies to ensure that the chroot can run `src/python/pants/releases:reversion` properly.
+files(
+  name='reversion_file_with_dependencies',
+  sources=[
+    'releases/BUILD',
+    'releases/reversion.py',
+    'util/BUILD',
+    'util/contextutil.py',
+    'util/dirutil.py',
+    'util/strutil.py',
+    'util/tarutil.py',
+  ],
+)

--- a/src/python/pants/releases/BUILD
+++ b/src/python/pants/releases/BUILD
@@ -6,6 +6,7 @@ python_binary(
   source = 'reversion.py',
   dependencies = [
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
   ],
 )
 

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -41,7 +41,6 @@ python_library(
   sources = ['dirutil.py'],
   dependencies = [
     ':strutil',
-    'src/python/pants/base:deprecated',
   ],
 )
 

--- a/testprojects/src/python/BUILD
+++ b/testprojects/src/python/BUILD
@@ -22,14 +22,20 @@ files(
 )
 
 files(
-  name = 'python_distribution_directory',
-  sources = rglobs('python_distribution/*'),
+  name = 'plugins_directory',
+  sources = rglobs('plugins/*'),
 )
 
 files(
   name = 'print_env_directory',
   sources = rglobs('print_env/*'),
 )
+
+files(
+  name = 'python_distribution_directory',
+  sources = rglobs('python_distribution/*'),
+)
+
 
 files(
   name = 'python_targets_directory',

--- a/testprojects/src/python/BUILD
+++ b/testprojects/src/python/BUILD
@@ -17,6 +17,11 @@ files(
 )
 
 files(
+  name = 'coordinated_runs_directory',
+  sources = rglobs('coordinated_runs/*'),
+)
+
+files(
   name = 'interpreter_selection_directory',
   sources = rglobs('interpreter_selection/*'),
 )

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -212,6 +212,8 @@ python_tests(
     'src/python/pants/base:exception_sink',
     'src/python/pants/util:osutil',
     'tests/python/pants_test:int-test',
+    'testprojects/src/python:coordinated_runs_directory',
+    'testprojects:pants_plugins_directory',
   ],
   tags = {'platform_specific_behavior', 'integration'},
   timeout = 540,

--- a/tests/python/pants_test/goal/BUILD
+++ b/tests/python/pants_test/goal/BUILD
@@ -40,6 +40,9 @@ python_tests(
   dependencies=[
     'src/python/pants/goal:run_tracker',
     'tests/python/pants_test:int-test',
+    'tests/python/pants_test/goal/data:plugin',
+    'testprojects/src/java/org/pantsbuild/testproject:extra_jvm_options_directory',
+    'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
   tags = {'integration'},
   timeout = 180,

--- a/tests/python/pants_test/goal/data/BUILD
+++ b/tests/python/pants_test/goal/data/BUILD
@@ -1,0 +1,13 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  name = 'plugin',
+  sources = ['register.py'],
+  dependencies = [
+    'src/python/pants/backend/jvm/tasks:nailgun_task',
+    'src/python/pants/base:workunit',
+    'src/python/pants/goal:task_registrar',
+  ]
+)
+

--- a/tests/python/pants_test/goal/data/register.py
+++ b/tests/python/pants_test/goal/data/register.py
@@ -4,7 +4,6 @@
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.workunit import WorkUnit
 from pants.goal.task_registrar import TaskRegistrar as task
-from pants.task.task import Task
 
 
 def register_goals():

--- a/tests/python/pants_test/goal/test_run_tracker_integration.py
+++ b/tests/python/pants_test/goal/test_run_tracker_integration.py
@@ -2,12 +2,19 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import json
+from pathlib import Path
 
 from pants.util.contextutil import temporary_file_path
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class RunTrackerIntegrationTest(PantsRunIntegrationTest):
+
+  load_plugin_cmdline = [
+    f'--pythonpath={Path.cwd().joinpath("tests", "python")}',
+    '--backend-packages=pants_test.goal.data',
+  ]
+
   def test_stats_local_json_file_v1(self):
     with temporary_file_path() as tmpfile:
       pants_run = self.run_pants([
@@ -79,22 +86,12 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
         self.assertNotIn('engine_workunits', stats_json['pantsd_stats'])
 
   def test_workunit_failure(self):
-    pants_run = self.run_pants([
-      '--backend-packages=pants_test.logging.data',
-      '--backend-packages=pants_test.goal.data',
-      'run-dummy-workunit',
-      '--no-success'
-    ])
+    pants_run = self.run_pants([*self.load_plugin_cmdline, 'run-dummy-workunit', '--no-success'])
     # Make sure the task actually happens and of no exception.
     self.assertIn('[run-dummy-workunit]', pants_run.stdout_data)
     self.assertNotIn('Exception', pants_run.stderr_data)
     self.assert_failure(pants_run)
 
   def test_workunit_success(self):
-    pants_run = self.run_pants([
-      '--backend-packages=pants_test.logging.data',
-      '--backend-packages=pants_test.goal.data',
-      'run-dummy-workunit',
-      '--success'
-    ])
+    pants_run = self.run_pants([*self.load_plugin_cmdline, 'run-dummy-workunit', '--success'])
     self.assert_success(pants_run)

--- a/tests/python/pants_test/goal/test_run_tracker_integration.py
+++ b/tests/python/pants_test/goal/test_run_tracker_integration.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import json
-import os
 
 from pants.util.contextutil import temporary_file_path
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
@@ -81,8 +80,8 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
 
   def test_workunit_failure(self):
     pants_run = self.run_pants([
-      '--pythonpath={}'.format(os.path.join(os.getcwd(), 'tests', 'python')),
-      '--backend-packages={}'.format('pants_test.goal.data'),
+      '--backend-packages=pants_test.logging.data',
+      '--backend-packages=pants_test.goal.data',
       'run-dummy-workunit',
       '--no-success'
     ])
@@ -93,8 +92,8 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
 
   def test_workunit_success(self):
     pants_run = self.run_pants([
-      '--pythonpath={}'.format(os.path.join(os.getcwd(), 'tests', 'python')),
-      '--backend-packages={}'.format('pants_test.goal.data'),
+      '--backend-packages=pants_test.logging.data',
+      '--backend-packages=pants_test.goal.data',
       'run-dummy-workunit',
       '--success'
     ])

--- a/tests/python/pants_test/logging/BUILD
+++ b/tests/python/pants_test/logging/BUILD
@@ -21,6 +21,7 @@ python_tests(
   dependencies=[
     'src/python/pants/goal:run_tracker',
     'tests/python/pants_test:int-test',
+    'tests/python/pants_test/logging/data:plugin',
   ],
   tags = {'integration'},
 )

--- a/tests/python/pants_test/logging/data/BUILD
+++ b/tests/python/pants_test/logging/data/BUILD
@@ -1,0 +1,13 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  name = 'plugin',
+  sources = ['register.py'],
+  dependencies = [
+    'src/python/pants/backend/jvm/tasks:nailgun_task',
+    'src/python/pants/base:workunit',
+    'src/python/pants/goal:task_registrar',
+  ]
+)
+

--- a/tests/python/pants_test/logging/data/register.py
+++ b/tests/python/pants_test/logging/data/register.py
@@ -2,9 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
-from pants.base.workunit import WorkUnit, WorkUnitLabel
+from pants.base.workunit import WorkUnitLabel
 from pants.goal.task_registrar import TaskRegistrar as task
-from pants.task.task import Task
 
 
 def register_goals():
@@ -23,5 +22,7 @@ class TestWorkUnitLabelTask(NailgunTask):
     if self.get_options().ignore_label:
       labels.append(WorkUnitLabel.SUPPRESS_LABEL)
 
-    with self.context.new_workunit('dummy_workunit') as workunit:
-      self.runjava(classpath=[], main='non-existent-main-class', args=['-version'], workunit_labels=labels)
+    with self.context.new_workunit('dummy_workunit'):
+      self.runjava(
+        classpath=[], main='non-existent-main-class', args=['-version'], workunit_labels=labels
+      )

--- a/tests/python/pants_test/logging/test_workunit_label.py
+++ b/tests/python/pants_test/logging/test_workunit_label.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
+import unittest
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -15,18 +15,19 @@ class WorkUnitLabelTest(PantsRunIntegrationTest):
 
   def test_workunit_no_label_ignore(self):
     pants_run = self.run_pants([
-      '--pythonpath={}'.format(os.path.join(os.getcwd(), 'tests', 'python')),
-      '--backend-packages={}'.format('pants_test.logging.data'),
+      '--pythonpath=%(buildroot)s/tests/python',
+      '--backend-packages=pants_test.logging.data',
       'run-workunit-label-test',
     ])
 
     self.assert_failure(pants_run)
     self.assertIn("[non-existent-main-class]", pants_run.stdout_data)
 
+  @unittest.skip
   def test_workunit_label_ignore(self):
     pants_run = self.run_pants([
-      '--pythonpath={}'.format(os.path.join(os.getcwd(), 'tests', 'python')),
-      '--backend-packages={}'.format('pants_test.logging.data'),
+      '--pythonpath=%(buildroot)s/tests/python',
+      '--backend-packages=pants_test.logging.data',
       'run-workunit-label-test',
       '--ignore-label'
     ])

--- a/tests/python/pants_test/logging/test_workunit_label.py
+++ b/tests/python/pants_test/logging/test_workunit_label.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import unittest
+from pathlib import Path
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -13,23 +14,20 @@ class WorkUnitLabelTest(PantsRunIntegrationTest):
   but the point is to check whether certain label gets printed out.
   """
 
-  def test_workunit_no_label_ignore(self):
-    pants_run = self.run_pants([
-      '--pythonpath=%(buildroot)s/tests/python',
-      '--backend-packages=pants_test.logging.data',
-      'run-workunit-label-test',
-    ])
+  load_plugin_cmdline = [
+    f'--pythonpath={Path.cwd().joinpath("tests", "python")}',
+    '--backend-packages=pants_test.logging.data',
+  ]
 
+  def test_workunit_no_label_ignore(self):
+    pants_run = self.run_pants([*self.load_plugin_cmdline, 'run-workunit-label-test'])
     self.assert_failure(pants_run)
     self.assertIn("[non-existent-main-class]", pants_run.stdout_data)
 
   @unittest.skip
   def test_workunit_label_ignore(self):
-    pants_run = self.run_pants([
-      '--pythonpath=%(buildroot)s/tests/python',
-      '--backend-packages=pants_test.logging.data',
-      'run-workunit-label-test',
-      '--ignore-label'
-    ])
+    pants_run = self.run_pants(
+      [*self.load_plugin_cmdline, 'run-workunit-label-test', '--ignore-label']
+    )
     self.assert_failure(pants_run)
     self.assertNotIn("[non-existent-main-class]", pants_run.stdout_data)

--- a/tests/python/pants_test/option/BUILD
+++ b/tests/python/pants_test/option/BUILD
@@ -20,6 +20,7 @@ python_tests(
   dependencies=[
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
+    'testprojects/src/python:plugins_directory',
   ],
   tags = {'integration'},
   timeout=90,

--- a/tests/python/pants_test/releases/BUILD
+++ b/tests/python/pants_test/releases/BUILD
@@ -6,7 +6,8 @@ python_tests(
   dependencies = [
     '3rdparty/python:pex',
     '3rdparty/python:requests',
-    'tests/python/pants_test:int-test'
+    'tests/python/pants_test:int-test',
+    'src/python/pants:reversion_file_with_dependencies',
   ],
   tags = {'integration'},
 )

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -179,7 +179,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
         '-ldebug',
         '--reporting-zipkin-endpoint={}'.format(endpoint),
         'cloc',
-        'src/python/pants:version'
+        'examples/src/java/org/pantsbuild/example/hello/simple',
       ]
 
       pants_run = self.run_pants(command)
@@ -212,7 +212,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
         '--reporting-zipkin-trace-id={}'.format(trace_id),
         '--reporting-zipkin-parent-id={}'.format(parent_span_id),
         'cloc',
-        'src/python/pants:version'
+        'examples/src/java/org/pantsbuild/example/hello/simple'
       ]
 
       pants_run = self.run_pants(command)
@@ -247,7 +247,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
         '--reporting-zipkin-endpoint={}'.format(endpoint),
         '--reporting-zipkin-sample-rate=0.0',
         'cloc',
-        'src/python/pants:version'
+        'examples/src/java/org/pantsbuild/example/hello/simple'
       ]
 
       pants_run = self.run_pants(command)
@@ -268,7 +268,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
         '--reporting-zipkin-endpoint={}'.format(endpoint),
         '--reporting-zipkin-trace-v2',
         'cloc',
-        'src/python/pants:version'
+        'examples/src/java/org/pantsbuild/example/hello/simple'
       ]
 
       pants_run = self.run_pants(command)


### PR DESCRIPTION
Brings integration tests to 72.5% remoted (#8113).