### PR TITLE
Add "did you mean" functionality to runtime Param mismatches.

### DIFF
--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -854,11 +854,33 @@ impl<R: Rule> RuleGraph<R> {
 
     match subset_matches.len() {
       1 => Ok(subset_matches[0].1.clone()),
-      0 => Err(format!(
-        "No installed @rules can compute {} for input Params({}).",
-        product,
-        params_str(&params),
-      )),
+      0 => {
+        let mut suggestions: Vec<_> = self
+          .rule_dependency_edges
+          .keys()
+          .filter_map(|entry| match entry {
+            EntryWithDeps::Root(ref root_entry) if root_entry.dependency_key == dependency_key => {
+              Some(format!("Params({})", params_str(&root_entry.params)))
+            }
+            _ => None,
+          })
+          .collect();
+        let suggestions_str = if suggestions.is_empty() {
+          ".".to_string()
+        } else {
+          suggestions.sort();
+          format!(
+            ", but there were @rules that could compute it using:\n  {}",
+            suggestions.join("\n  ")
+          )
+        };
+        Err(format!(
+          "No installed @rules can compute {} for input Params({}){}",
+          product,
+          params_str(&params),
+          suggestions_str,
+        ))
+      }
       _ => {
         let match_strs = subset_matches
           .into_iter()

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -193,7 +193,7 @@ class SchedulerTest(TestBase):
     self.assertEquals(result_str, consumes_a_and_b(a, b))
 
     # But not a subset.
-    expected_msg = ("No installed @rules can compute {} for input Params(A)"
+    expected_msg = ("No installed @rules can compute {} for input Params(A), but"
                     .format(str.__name__))
     with self.assertRaisesRegexp(Exception, re.escape(expected_msg)):
       self.scheduler.product_request(str, [Params(a)])

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -283,7 +283,9 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
         TypeError: For datatype object CollectionType(items=[1, 2, 3]) (type 'CollectionType'): in field 'items': unhashable type: 'list'
         """), exc_str, "exc_str was: {}".format(exc_str))
 
-    resulting_engine_error = "Exception: No installed @rules can compute C for input Params(Any).\n\n\n"
+    resulting_engine_error = dedent("""\
+        Exception: Types that will be passed as Params at the root of a graph need to be registered via RootRule:
+          Any\n\n\n""")
 
     # Test that the error contains the full traceback from within the CFFI context as well
     # (mentioning which specific extern method ended up raising the exception).


### PR DESCRIPTION
### Problem

When a `@rule` graph has been correctly constructed, but has different requirements than you expected, it can be challenging to figure out which `Params` are necessary to make a `product_request`.

Moreover, it's not obvious that all incoming `Param` types for `product_request` must be registered via `RootRule`.

### Solution

Add "did you mean" type functionality that renders the `Params` for other `@rule` graph roots that are able to produce the type you wanted. Example:
```
Exception: No installed @rules can compute SourceRootStrippedSources for input Params((HydratedTarget+SourceRootConfig)), but there were rules that could compute it using:
  Params((Address+OptionsBootstrapper))
  Params((Address+SourceRootConfig))
```

And when an unregistered Param type is used in a `product_request`:
```
Exception: Types that will be passed as Params at the root of a graph need to be registered via RootRule:
  Any
```