### PR TITLE
Model `Platform.properties` faithfully.

### DIFF
--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -52,7 +52,6 @@ use logging::{Destination, Logger};
 use rule_graph::{GraphMaker, RuleGraph};
 use std::any::Any;
 use std::borrow::Borrow;
-use std::collections::BTreeMap;
 use std::ffi::CStr;
 use std::fs::File;
 use std::io;
@@ -267,7 +266,7 @@ pub extern "C" fn scheduler_create(
   let remote_instance_name_string = remote_instance_name
     .to_string()
     .expect("remote_instance_name was not valid UTF8");
-  let remote_execution_extra_platform_properties_map: BTreeMap<_, _> = remote_execution_extra_platform_properties_buf
+  let remote_execution_extra_platform_properties_list: Vec<_> = remote_execution_extra_platform_properties_buf
         .to_strings()
         .expect("Failed to decode remote_execution_extra_platform_properties")
         .into_iter()
@@ -277,7 +276,6 @@ pub extern "C" fn scheduler_create(
             let (value, key) = (parts.pop().unwrap().to_owned(), parts.pop().unwrap().to_owned());
             (key, value)
         }).collect();
-
   let remote_root_ca_certs_path = {
     let path = remote_root_ca_certs_path_buffer.to_os_string();
     if path.is_empty() {
@@ -330,7 +328,7 @@ pub extern "C" fn scheduler_create(
     Duration::from_secs(remote_store_chunk_upload_timeout_seconds),
     remote_store_rpc_retries as usize,
     remote_store_connection_limit as usize,
-    remote_execution_extra_platform_properties_map,
+    remote_execution_extra_platform_properties_list,
     process_execution_local_parallelism as usize,
     process_execution_remote_parallelism as usize,
     process_execution_cleanup_local_dirs,

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -243,7 +243,7 @@ mod test {
       metadata: ExecuteProcessRequestMetadata {
         instance_name: None,
         cache_key_gen_version: None,
-        platform_properties: BTreeMap::new(),
+        platform_properties: vec![],
       },
     };
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -182,7 +182,7 @@ impl From<ExecuteProcessRequest> for MultiPlatformExecuteProcessRequest {
 pub struct ExecuteProcessRequestMetadata {
   pub instance_name: Option<String>,
   pub cache_key_gen_version: Option<String>,
-  pub platform_properties: BTreeMap<String, String>,
+  pub platform_properties: Vec<(String, String)>,
 }
 
 ///

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -835,9 +835,9 @@ pub fn make_execute_request(
     // some kind of consensus across tools as to how this should work; RBE appears to work by
     // allowing you to specify a jdk-version platform property, and it will put a JDK at a
     // well-known path in the docker container you specify in which to run.
-    platform_properties.insert("JDK_SYMLINK".to_owned(), ".jdk".to_owned());
+    platform_properties.push(("JDK_SYMLINK".to_owned(), ".jdk".to_owned()));
   }
-  platform_properties.insert("target_platform".to_owned(), req.target_platform.into());
+  platform_properties.push(("target_platform".to_owned(), req.target_platform.into()));
 
   for (name, value) in platform_properties {
     command.mut_platform().mut_properties().push({
@@ -1360,7 +1360,7 @@ pub mod tests {
         ExecuteProcessRequestMetadata {
           instance_name: Some("dark-tower".to_owned()),
           cache_key_gen_version: None,
-          platform_properties: BTreeMap::new(),
+          platform_properties: vec![],
         }
       ),
       Ok((want_action, want_command, want_execute_request))
@@ -1453,7 +1453,7 @@ pub mod tests {
         ExecuteProcessRequestMetadata {
           instance_name: None,
           cache_key_gen_version: Some("meep".to_owned()),
-          platform_properties: BTreeMap::new(),
+          platform_properties: vec![],
         }
       ),
       Ok((want_action, want_command, want_execute_request))
@@ -1548,14 +1548,26 @@ pub mod tests {
     });
     want_command.mut_platform().mut_properties().push({
       let mut property = bazel_protos::remote_execution::Platform_Property::new();
-      property.set_name("JDK_SYMLINK".to_owned());
-      property.set_value(".jdk".to_owned());
+      property.set_name("Multi".to_owned());
+      property.set_value("uno".to_owned());
       property
     });
     want_command.mut_platform().mut_properties().push({
       let mut property = bazel_protos::remote_execution::Platform_Property::new();
       property.set_name("last".to_owned());
       property.set_value("bar".to_owned());
+      property
+    });
+    want_command.mut_platform().mut_properties().push({
+      let mut property = bazel_protos::remote_execution::Platform_Property::new();
+      property.set_name("Multi".to_owned());
+      property.set_value("dos".to_owned());
+      property
+    });
+    want_command.mut_platform().mut_properties().push({
+      let mut property = bazel_protos::remote_execution::Platform_Property::new();
+      property.set_name("JDK_SYMLINK".to_owned());
+      property.set_value(".jdk".to_owned());
       property
     });
     want_command.mut_platform().mut_properties().push({
@@ -1569,10 +1581,10 @@ pub mod tests {
     want_action.set_command_digest(
       (&Digest(
         Fingerprint::from_hex_string(
-          "f54a2a67d16f46c9ce8e846a4fe1cb86a16ec3f11ddfca8cbfc34ff7bac630b8",
+          "6c63c44ac364729d371931a091cc8379e32d021e06df52ab5f8461118d837e78",
         )
         .unwrap(),
-        90,
+        118,
       ))
         .into(),
     );
@@ -1582,7 +1594,7 @@ pub mod tests {
     want_execute_request.set_action_digest(
       (&Digest(
         Fingerprint::from_hex_string(
-          "be4b5057c50f3cb54b45431dcaa52588a5eb3566f63b0f28014abdb544c73b0f",
+          "5246770d23d09dc7d145e19d3a7b8233fc42316115fbc5420dfe501fb684e5e9",
         )
         .unwrap(),
         140,
@@ -1598,10 +1610,10 @@ pub mod tests {
           cache_key_gen_version: None,
           platform_properties: vec![
             ("FIRST".to_owned(), "foo".to_owned()),
-            ("last".to_owned(), "bar".to_owned())
+            ("Multi".to_owned(), "uno".to_owned()),
+            ("last".to_owned(), "bar".to_owned()),
+            ("Multi".to_owned(), "dos".to_owned()),
           ]
-          .into_iter()
-          .collect()
         },
       ),
       Ok((want_action, want_command, want_execute_request))
@@ -3372,7 +3384,7 @@ pub mod tests {
     ExecuteProcessRequestMetadata {
       instance_name: None,
       cache_key_gen_version: None,
-      platform_properties: BTreeMap::new(),
+      platform_properties: vec![],
     }
   }
 

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -36,7 +36,7 @@ use hashing::{Digest, Fingerprint};
 use process_execution::{ExecuteProcessRequestMetadata, Platform};
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
-use std::iter::Iterator;
+use std::iter::{FromIterator, Iterator};
 use std::path::PathBuf;
 use std::process::exit;
 use std::time::Duration;
@@ -215,11 +215,11 @@ fn main() {
     .collect();
   let env = args
     .values_of("env")
-    .map(btreemap_from_keyvalues)
+    .map(collection_from_keyvalues::<_, BTreeMap<_, _>>)
     .unwrap_or_default();
   let platform_properties = args
     .values_of("extra-platform-property")
-    .map(btreemap_from_keyvalues)
+    .map(collection_from_keyvalues::<_, Vec<_>>)
     .unwrap_or_default();
   let work_dir = args
     .value_of("work-dir")
@@ -361,9 +361,11 @@ fn main() {
   exit(result.exit_code);
 }
 
-fn btreemap_from_keyvalues<'a, It: Iterator<Item = &'a str>>(
-  keyvalues: It,
-) -> BTreeMap<String, String> {
+fn collection_from_keyvalues<'a, It, Col>(keyvalues: It) -> Col
+where
+  It: Iterator<Item = &'a str>,
+  Col: FromIterator<(String, String)>,
+{
   keyvalues
     .map(|kv| {
       let mut parts = kv.splitn(2, '=');

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -27,7 +27,6 @@ use rand::seq::SliceRandom;
 use reqwest;
 use rule_graph::RuleGraph;
 use sharded_lmdb::ShardedLmdb;
-use std::collections::btree_map::BTreeMap;
 use store::Store;
 
 const GIGABYTES: usize = 1024 * 1024 * 1024;
@@ -73,7 +72,7 @@ impl Core {
     remote_store_chunk_upload_timeout: Duration,
     remote_store_rpc_retries: usize,
     remote_store_connection_limit: usize,
-    remote_execution_extra_platform_properties: BTreeMap<String, String>,
+    remote_execution_extra_platform_properties: Vec<(String, String)>,
     process_execution_local_parallelism: usize,
     process_execution_remote_parallelism: usize,
     process_execution_cleanup_local_dirs: bool,


### PR DESCRIPTION
Previously we assumed the `Platform.properties` in
`remote_execution.proto` were a map, but the protocol explicitly
supports multiple values per key. Adjust our modeling and add test
coverage.

Fixes #8318
