### PR TITLE
Add project links so they show up in pypi.

### DIFF
--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -50,6 +50,11 @@ def pants_setup_py(name, description, additional_classifiers=None, **kwargs):
       description=description,
       long_description=Path('src/python/pants/ABOUT.rst').read_text() + notes,
       url='https://github.com/pantsbuild/pants',
+      project_urls={
+          'Documentation': 'https://www.pantsbuild.org/',
+          'Source': 'https://github.com/pantsbuild/pants',
+          'Tracker': 'https://github.com/pantsbuild/pants/issues',
+      },
       license='Apache License, Version 2.0',
       zip_safe=True,
       classifiers=list(classifiers),


### PR DESCRIPTION
### Problem

Links to issues tracker & docs don't show up on [pants pypi page](https://pypi.org/project/pantsbuild.pants/)


### Solution

Add [metadata to project/setup.py](https://packaging.python.org/guides/distributing-packages-using-setuptools/#project-urls) so they will show up

### Result

Issue tracker & Docs are easier to find and linked directly from pypi.