### PR TITLE
v2 rule for stripping source roots

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -7,6 +7,7 @@ from pants.backend.python.rules.inject_init import InjectedInitDigest
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
+from pants.build_graph.address import Address
 from pants.engine.fs import Digest, DirectoriesToMerge
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.engine.legacy.graph import BuildFileAddresses, HydratedTarget, TransitiveHydratedTargets
@@ -65,11 +66,9 @@ def run_python_test(test_target, pytest, python_setup, subprocess_encoding_envir
   # optimization, this ensures that any transitive sources, such as a test project file named
   # test_fail.py, do not unintentionally end up being run as tests.
 
-  hydrated_target = HydratedTarget(address="", adaptor=test_target, dependencies=())
   source_root_stripped_test_target_sources = yield Get(
-      SourceRootStrippedSources, HydratedTarget, hydrated_target
+      SourceRootStrippedSources, Address, test_target.address.to_address()
     )
-  test_target_sources_file_names = sorted(source_root_stripped_test_target_sources.snapshot.files)
 
   source_root_stripped_sources = yield [
     Get(SourceRootStrippedSources, HydratedTarget, target_adaptor)
@@ -100,6 +99,7 @@ def run_python_test(test_target, pytest, python_setup, subprocess_encoding_envir
     **subprocess_encoding_environment.invocation_environment_dict
   }
 
+  test_target_sources_file_names = sorted(source_root_stripped_test_target_sources.snapshot.files)
   # NB: we use the hardcoded and generic bin name `python`, rather than something dynamic like
   # `sys.executable`, to ensure that the interpreter may be discovered both locally and in remote
   # execution (so long as `env` is populated with a `PATH` env var and `python` is discoverable

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -1,25 +1,21 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Dict, Optional
-
 from pants.backend.python.rules.create_requirements_pex import (RequirementsPex,
                                                                 RequirementsPexRequest)
 from pants.backend.python.rules.inject_init import InjectedInitDigest
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
-from pants.build_graph.files import Files
-from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryWithPrefixToStrip
+from pants.engine.fs import Digest, DirectoriesToMerge
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
-from pants.engine.legacy.graph import BuildFileAddresses, TransitiveHydratedTargets, HydratedTarget
+from pants.engine.legacy.graph import BuildFileAddresses, HydratedTarget, TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonTestsAdaptor
 from pants.engine.rules import UnionRule, optionable_rule, rule
 from pants.engine.selectors import Get
 from pants.rules.core.core_test_model import Status, TestResult, TestTarget
-from pants.source.source_root import SourceRoot, SourceRootConfig
 from pants.rules.core.strip_source_root import SourceRootStrippedSources
-from pants.util.strutil import create_path_env_var, strip_prefix
+from pants.util.strutil import create_path_env_var
 
 
 @rule(TestResult, [PythonTestsAdaptor, PyTest, PythonSetup, SubprocessEncodingEnvironment])

--- a/src/python/pants/rules/core/register.py
+++ b/src/python/pants/rules/core/register.py
@@ -3,6 +3,7 @@
 
 from pants.rules.core import filedeps, list_roots, list_targets, strip_source_root, test
 
+
 def rules():
   return [
     *list_roots.rules(),
@@ -11,4 +12,3 @@ def rules():
     *strip_source_root.rules(),
     *test.rules()
   ]
-

--- a/src/python/pants/rules/core/register.py
+++ b/src/python/pants/rules/core/register.py
@@ -1,8 +1,14 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.rules.core import filedeps, list_roots, list_targets, test
-
+from pants.rules.core import filedeps, list_roots, list_targets, strip_source_root, test
 
 def rules():
-  return list_roots.rules() + list_targets.rules() + filedeps.rules() + test.rules()
+  return [
+    *list_roots.rules(),
+    *list_targets.rules(),
+    *filedeps.rules(),
+    *strip_source_root.rules(),
+    *test.rules()
+  ]
+

--- a/src/python/pants/rules/core/strip_source_root.py
+++ b/src/python/pants/rules/core/strip_source_root.py
@@ -1,0 +1,51 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.build_graph.files import Files
+from pants.engine.fs import EMPTY_SNAPSHOT, Digest, DirectoryWithPrefixToStrip, Snapshot
+from pants.engine.legacy.graph import HydratedTarget
+from pants.engine.rules import optionable_rule, rule
+from pants.engine.selectors import Get
+from pants.source.source_root import SourceRootConfig
+from pants.util.objects import datatype
+
+
+class SourceRootStrippedSources(datatype([('snapshot', Snapshot)])):
+  """Wrapper for a snapshot of targets whose source roots have been stripped."""
+
+@rule(SourceRootStrippedSources, [HydratedTarget, SourceRootConfig])
+def strip_source_root(hydrated_target, source_root_config):
+  """Relativize targets to their source root, e.g.
+  `src/python/pants/util/strutil.py` -> `pants/util/strutil.py ."""
+
+  target_adaptor = hydrated_target.adaptor
+  source_roots = source_root_config.get_source_roots()
+
+  # TODO: make TargetAdaptor return a 'sources' field with an empty snapshot instead of raising to
+  # simplify the hasattr() checks here!
+  if not hasattr(target_adaptor, 'sources'):
+    yield SourceRootStrippedSources(snapshot=EMPTY_SNAPSHOT)
+
+  digest = target_adaptor.sources.snapshot.directory_digest
+  source_root = source_roots.find_by_path(target_adaptor.address.spec_path)
+
+  # Loose `Files`, as opposed to `Resources` or `Target`s, have no (implied) package
+  # structure and so we do not remove their source root like we normally do, so that filesystem
+  # APIs may still access the files. See pex_build_util.py's `_create_source_dumper`.
+  if target_adaptor.type_alias == Files.alias():
+    source_root = None
+
+  resulting_digest = yield Get(
+    Digest,
+    DirectoryWithPrefixToStrip(
+      directory_digest=digest,
+      prefix=source_root.path if source_root else ""
+    )
+  )
+  resulting_snapshot = yield Get(Snapshot, Digest, resulting_digest)
+  yield SourceRootStrippedSources(snapshot=resulting_snapshot)
+
+
+def rules():
+  return [strip_source_root, optionable_rule(SourceRootConfig)]
+

--- a/src/python/pants/rules/core/strip_source_root.py
+++ b/src/python/pants/rules/core/strip_source_root.py
@@ -13,6 +13,7 @@ from pants.util.objects import datatype
 class SourceRootStrippedSources(datatype([('snapshot', Snapshot)])):
   """Wrapper for a snapshot of targets whose source roots have been stripped."""
 
+
 @rule(SourceRootStrippedSources, [HydratedTarget, SourceRootConfig])
 def strip_source_root(hydrated_target, source_root_config):
   """Relativize targets to their source root, e.g.
@@ -48,4 +49,3 @@ def strip_source_root(hydrated_target, source_root_config):
 
 def rules():
   return [strip_source_root, optionable_rule(SourceRootConfig)]
-

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -1,0 +1,40 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.engine.legacy.structs import TargetAdaptor, PythonBinaryAdaptor, PythonTestsAdaptor
+from pants.rules.core.strip_source_root import SourceRootStrippedSources, strip_source_root
+from pants.engine.rules import optionable_rule, RootRule
+from pants.engine.selectors import Get, Params
+from pants_test.test_base import TestBase
+from pants.source.source_root import SourceRootConfig
+
+from unittest.mock import Mock
+from pants.build_graph.address import Address, BuildFileAddress
+from pants.engine.legacy.graph import HydratedTarget, TransitiveHydratedTargets
+from pants_test.subsystem.subsystem_util import init_subsystem
+from pants.engine.fs import EMPTY_SNAPSHOT, Digest, DirectoryWithPrefixToStrip, Snapshot, create_fs_rules
+
+
+
+class StripSourceRootsTests(TestBase):
+  @classmethod
+  def rules(cls):
+    return super().rules() + [
+      strip_source_root,
+      optionable_rule(SourceRootConfig),
+      RootRule(SourceRootConfig),
+    ] + create_fs_rules()
+
+  def test_source_roots(self):
+
+    init_subsystem(SourceRootConfig)
+
+    adaptor = PythonTestsAdaptor(type_alias='python_tests')
+    target = HydratedTarget(Address.parse("some/target"), adaptor, ())
+
+    output = self.scheduler.product_request(SourceRootStrippedSources, [Params(target, SourceRootConfig.global_instance())])
+
+    print(f"Output: {output}")
+    self.assertEqual(1, 1)
+    self.assertEqual(output, 5)
+

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -25,14 +25,13 @@ class StripSourceRootsTests(TestBase):
   def mock_hydrated_target(self, target_address, source_filename):
     adaptor = Mock()
     adaptor.sources = Mock()
-    source_files = dict()
-    source_files[source_filename] = "print('random python')"
+    source_files = { source_filename: "print('random python')" }
     adaptor.sources.snapshot = self.make_snapshot(source_files)
     adaptor.address = Mock()
     adaptor.address.spec_path = source_filename
     return HydratedTarget(target_address, adaptor, tuple())
 
-  def test_source_roots(self):
+  def test_source_roots_python(self):
     init_subsystem(SourceRootConfig)
     target = self.mock_hydrated_target("some/target/address", 'src/python/pants/util/strutil.py')
     output = self.scheduler.product_request(SourceRootStrippedSources, [Params(target, SourceRootConfig.global_instance())])


### PR DESCRIPTION
### Problem

#8185 introduced proper support stripping source roots for targets, but keeping the full path for loose files.

### Solution
Now that we are porting the rest of the V2 pipeline, e.g. #8236, this functionality should be extracted out into a new rule.
