### PR TITLE
Introduce `hash_utils.hash_dir`.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -24,5 +24,6 @@ requests[security]>=2.20.1
 responses==0.10.4
 setproctitle==1.1.10
 setuptools==40.6.3
+typing-extensions==3.7.4
 wheel==0.31.1
 www-authenticate==0.9.2

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -98,6 +98,7 @@ python_library(
   name = 'hash_utils',
   sources = ['hash_utils.py'],
   dependencies = [
+    '3rdparty/python:typing-extensions',
     ':deprecated',
     'src/python/pants/util:objects',
   ]

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -41,54 +41,44 @@ class TestHashUtils(unittest.TestCase):
         hash_dir(Path(path))
 
   def test_hash_dir(self):
-    with temporary_dir() as root1:
-      root1_path = Path(root1)
-      with root1_path.joinpath('a').open(mode='wb') as fd:
-        fd.write(b'jake jones')
-      with root1_path.joinpath('b').open(mode='wb') as fd:
-        fd.write(b'jane george')
+    with temporary_dir() as root:
+      root1_path = Path(root)
+      root1_path.joinpath('a').write_text('jake jones')
+      root1_path.joinpath('b').write_text('jane george')
       hash1 = hash_dir(root1_path)
 
-    with temporary_dir() as root2:
-      root2_path = Path(root2)
-      with root2_path.joinpath('a').open(mode='wb') as fd:
-        fd.write(b'jake jones')
-      with root2_path.joinpath('b').open(mode='wb') as fd:
-        fd.write(b'jane george')
+    with temporary_dir() as root:
+      root2_path = Path(root)
+      root2_path.joinpath('a').write_text('jake jones')
+      root2_path.joinpath('b').write_text('jane george')
       hash2 = hash_dir(root2_path)
 
     self.assertNotEqual(root1_path, root2_path,
                         "The path of the directory being hashed should not factor into the hash.")
     self.assertEqual(hash1, hash2)
 
-    with temporary_dir() as root3:
-      root3_path = Path(root3)
-      with root3_path.joinpath('a1').open(mode='wb') as fd:
-        fd.write(b'jake jones')
-      with root3_path.joinpath('b').open(mode='wb') as fd:
-        fd.write(b'jane george')
-      hash3 = hash_dir(root3_path)
+    with temporary_dir() as root:
+      root_path = Path(root)
+      root_path.joinpath('a1').write_text('jake jones')
+      root_path.joinpath('b').write_text('jane george')
+      hash3 = hash_dir(root_path)
 
     self.assertNotEqual(hash1, hash3, "File names should be included in the hash.")
 
-    with temporary_dir() as root4:
-      root4_path = Path(root4)
-      with root4_path.joinpath('a').open(mode='wb') as fd:
-        fd.write(b'jake jones')
-      with root4_path.joinpath('b').open(mode='wb') as fd:
-        fd.write(b'jane george')
-      root4_path.joinpath("c").mkdir()
-      hash4 = hash_dir(root4_path)
+    with temporary_dir() as root:
+      root_path = Path(root)
+      root_path.joinpath('a').write_text('jake jones')
+      root_path.joinpath('b').write_text('jane george')
+      root_path.joinpath("c").mkdir()
+      hash4 = hash_dir(root_path)
 
     self.assertNotEqual(hash1, hash4, "Directory names should be included in the hash.")
 
-    with temporary_dir() as root5:
-      root5_path = Path(root5)
-      with root5_path.joinpath('a').open(mode='wb') as fd:
-        fd.write(b'jake jones II')
-      with root5_path.joinpath('b').open(mode='wb') as fd:
-        fd.write(b'jane george')
-      hash5 = hash_dir(root5_path)
+    with temporary_dir() as root:
+      root_path = Path(root)
+      root_path.joinpath('a').write_text('jake jones II')
+      root_path.joinpath('b').write_text('jane george')
+      hash5 = hash_dir(root_path)
 
     self.assertNotEqual(hash1, hash5, "File content should be included in the hash.")
 


### PR DESCRIPTION
Implement a simple stable hash for the recursive contents of a directory
for use in v1 Tasks. In v2 we have the `fs/store` crate and intrinsics
that expose its types to @rules; this just tides v1 Tasks over for cases
where we just need a hash and not a Snapshot we'll never materialize
(via `self.context._scheduler.<adhoc sync apis>`). Performance is
~identical to the `self.context._scheduler.capture_snapshots` API (a
few percent faster on average).

This change supports #8263.