### PR TITLE
Support DRY type-annotated @rules.

### DIFF
--- a/src/python/pants/backend/python/rules/create_requirements_pex.py
+++ b/src/python/pants/backend/python/rules/create_requirements_pex.py
@@ -29,8 +29,14 @@ class RequirementsPex(datatype([('directory_digest', Digest)])):
 
 # TODO: This is non-hermetic because the requirements will be resolved on the fly by
 # pex, where it should be hermetically provided in some way.
-@rule(RequirementsPex, [RequirementsPexRequest, DownloadedPexBin, PythonSetup, PexBuildEnvironment, Platform])
-def create_requirements_pex(request, pex_bin, python_setup, pex_build_environment, platform):
+@rule
+def create_requirements_pex(
+    request: RequirementsPexRequest,
+    pex_bin: DownloadedPexBin,
+    python_setup: PythonSetup,
+    pex_build_environment: PexBuildEnvironment,
+    platform: Platform
+) -> RequirementsPex:
   """Returns a PEX with the given requirements, optional entry point, and optional
   interpreter constraints."""
 

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -11,8 +11,8 @@ class DownloadedPexBin(datatype([('executable', str), ('directory_digest', Diges
   pass
 
 
-@rule(DownloadedPexBin, [])
-def download_pex_bin():
+@rule
+def download_pex_bin() -> DownloadedPexBin:
   # TODO: Inject versions and digests here through some option, rather than hard-coding it.
   url = 'https://github.com/pantsbuild/pex/releases/download/v1.6.11/pex'
   digest = Digest('7a8fdfce2de22d25ba38afaa9df0282c33dd436959b3a5c3f788ded2ccc2cae9', 1867604)

--- a/src/python/pants/backend/python/rules/inject_init.py
+++ b/src/python/pants/backend/python/rules/inject_init.py
@@ -13,8 +13,8 @@ from pants.util.objects import datatype
 class InjectedInitDigest(datatype([('directory_digest', Digest)])): pass
 
 
-@rule(InjectedInitDigest, [Snapshot])
-def inject_init(snapshot):
+@rule
+def inject_init(snapshot: Snapshot) -> InjectedInitDigest:
   """Ensure that every package has an __init__.py file in it."""
   missing_init_files = tuple(sorted(identify_missing_init_files(snapshot.files)))
   if not missing_init_files:

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -19,8 +19,6 @@ from pants.rules.core.strip_source_root import SourceRootStrippedSources
 from pants.util.strutil import create_path_env_var
 
 
-# TODO(7697): Use a dedicated rule for removing the source root prefix, so that this rule
-# does not have to depend on SourceRootConfig.
 @rule
 def run_python_test(
   test_target: PythonTestsAdaptor,

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -19,8 +19,15 @@ from pants.rules.core.strip_source_root import SourceRootStrippedSources
 from pants.util.strutil import create_path_env_var
 
 
-@rule(TestResult, [PythonTestsAdaptor, PyTest, PythonSetup, SubprocessEncodingEnvironment])
-def run_python_test(test_target, pytest, python_setup, subprocess_encoding_environment):
+# TODO(7697): Use a dedicated rule for removing the source root prefix, so that this rule
+# does not have to depend on SourceRootConfig.
+@rule
+def run_python_test(
+  test_target: PythonTestsAdaptor,
+  pytest: PyTest,
+  python_setup: PythonSetup,
+  subprocess_encoding_environment: SubprocessEncodingEnvironment
+) -> TestResult:
   """Runs pytest for one target."""
 
   # TODO(7726): replace this with a proper API to get the `closure` for a

--- a/src/python/pants/engine/README.md
+++ b/src/python/pants/engine/README.md
@@ -62,7 +62,7 @@ def int_to_str(value: int) -> str:
 Here the only requirements for the `@rule` are:
 1. The decorated function is a free, top-level function; ie: methods cannot be `@rule`s.
 2. The decorated function must be fully type annotated.
-3. As mentioned above, the types of the function `Param`s must be hashable and have useful equality.
+3. As mentioned above, the types of the function parameters must be hashable and have useful equality.
 
 When the engine encounters this `@rule` while compiling the rule graph for `str`-producing-`@rule`s,
 it will next go hunting for the dependency `@rule` that can produce an `int` using the fewest number

--- a/src/python/pants/engine/README.md
+++ b/src/python/pants/engine/README.md
@@ -3,8 +3,9 @@
 ## API
 
 The end user API for the engine is based on the registration of `@rule`s, which are functions
-or coroutines with statically declared inputs and outputs. A Pants (plugin) developer can write
-and install additional `@rule`s to extend the functionality of Pants.
+or coroutines with statically declared parameter types (also known as `Param` types) and return type
+(also known as the `Product` type). A Pants (plugin) developer can write and install additional
+`@rule`s to extend the functionality of Pants.
 
 The set of installed `@rule`s is statically checked as a closed world: this compilation step occurs
 on startup, and identifies all unreachable or unsatisfiable rules before execution begins. This
@@ -27,20 +28,20 @@ produce the requested value.
 ### Products and Params
 
 The engine executes your `@rule`s in order to (recursively) compute a `Product` of the requested
-type for a set of `Param`s. This recursive type search leads to a loosely coupled (and yet
-still statically checked) form of dependency injection.
+type for a set of `Param`s. This recursive type search leads to a loosely coupled (and yet still 
+statically checked) form of dependency injection.
 
-When an `@rule` runs, it requires a set of `Param`s that the engine has determined are needed
-to compute its transitive `@rule` dependencies. So although an `@rule` might not have a particular
+When an `@rule` runs, it requires a set of `Param`s that the engine has determined are needed to
+compute its transitive `@rule` dependencies. So although an `@rule` might not have a particular
 `Param` type in its signature, it might depend on another `@rule` that does need that `Param`, and
 would thus need that `Param` in order to run. To see which `Params` the engine needs to run each
 `@rule`, refer to the `Visualization` section below.
 
 Any hashable type with useful equality may be used as a `Param`, and additional `Params` can be
-provided to an `@rule`'s dependencies via `Get` requests (see below). Each `Param` value in a set
-of `Params` is unique by type, so if `@rules` recursively introduce a particular `Param` type,
-there will still only be one value for that type in each `@rule`, but it will change as you move
-deeper into the dependency graph.
+provided to an `@rule`'s dependencies via `Get` requests (see below). Each `Param` value in a set of
+`Params` is unique by type, so if `@rule`s recursively introduce a particular `Param` type, there
+will still only be one value for that type in each `@rule`, but it will change as you move deeper
+into the dependency graph.
 
 The return value of an `@rule` is known as a `Product`. At some level, you can think
 of `(product_type, params_set)` as a "key" that uniquely identifies a particular `Product` value
@@ -49,44 +50,44 @@ then the `@rule` will run exactly once, and the value that it produces will be a
 
 #### Example
 
-As a very simple example, you might register the following `@rule` that can compute a `String`
-Product given a single `Int` argument.
+As a very simple example, you might register the following `@rule` that can compute a `str`
+`Product` given a single `int` argument.
 
 ```python
-@rule(str, [int])
-def int_to_str(an_int):
-  return str(an_int)
+@rule
+def int_to_str(value: int) -> str:
+  return str(value)
 ```
 
-The first argument to the `@rule` decorator is the `Product` (ie, return) type for the `@rule`. The
-second argument is a list of "parameter selectors" that declare the types of the input parameters for
-the `@rule`. In this case, because the `Product` type is `str` and there is one parameter
-selector (for `int`), this `@rule` represents a conversion from `int` to `str`, with no other inputs.
+Here the only requirements for the `@rule` are:
+1. The decorated function is a free, top-level function; ie: methods cannot be `@rule`s.
+2. The decorated function must be fully type annotated.
+3. As mentioned above, the types of the function `Param`s must be hashable and have useful equality.
 
-When the engine encounters this `@rule` while compiling the rule graph for `str`-producing-`@rules`,
+When the engine encounters this `@rule` while compiling the rule graph for `str`-producing-`@rule`s,
 it will next go hunting for the dependency `@rule` that can produce an `int` using the fewest number
 of `Params`. For example, if there was an `@rule` that could produce an `int` without consuming any
-`Params` at all (ie, a singleton), then that `@rule` would always be chosen first. If all `@rules` to
-produce `int`s required at least one `Param`, then the engine would next see whether the input `Params`
-contained an `int`, or whether there were any `@rules` that required only one `Param`, then two
-`Params`, and so on.
+`Params` at all (ie, a singleton), then that `@rule` would always be chosen first. If all `@rule`s
+to produce `int`s required at least one `Param`, then the engine would next see whether the input
+`Params` contained an `int`, or whether there were any `@rule`s that required only one `Param`, then
+two `Params`, and so on.
 
-In cases where this search detects any ambiguity (generally because there are two or more `@rules` that
-can provide the same product with the same number of parameters), rule graph compilation will fail with
-a useful error message.
+In cases where this search detects any ambiguity (generally because there are two or more `@rule`s
+that can provide the same product with the same number of parameters), rule graph compilation will
+fail with a useful error message.
 
 ### Datatypes
 
-In practical use, builtin types like `str` or `int` do not provide enough information to disambiguate
-between various types of data in `@rule` signatures, so declaring small `datatype` definitions to
-provide a unique and descriptive type is highly recommended:
+In practical use, builtin types like `str` or `int` do not provide enough information to
+disambiguate between various types of data in `@rule` signatures, so declaring small `datatype` 
+definitions to provide a unique and descriptive type is highly recommended:
 
 ```python
 class FormattedInt(datatype(['content'])): pass
 
-@rule(FormattedInt, [int])
-def int_to_str(an_int):
-  return FormattedInt('{}'.format(an_int))
+@rule
+def int_to_str(value: int) -> FormattedInt:
+  return FormattedInt('{}'.format(value))
 
 # Field values can be specified with positional and/or keyword arguments in the constructor:
 x = FormattedInt('a string')
@@ -118,25 +119,26 @@ class TypedDatatype(datatype([('field_name', Exactly(str, int))])):
 Assigning a specific type to a field can be somewhat unidiomatic in Python, and may be unexpected or
 unnatural to use. However, regardless of whether the object is created directly with type-checked
 fields or whether it's produced from a set of rules by the engine's dependency injection, it is
-extremely useful to formalize the assumptions made about the value of an object into a specific type,
-even if the type just wraps a single field. The `datatype()` function makes it simple and efficient
-to apply that strategy.
+extremely useful to formalize the assumptions made about the value of an object into a specific
+type, even if the type just wraps a single field. The `datatype()` function makes it simple and
+efficient to apply that strategy.
 
 ### Gets and RootRules
 
-As demonstrated above, parameter selectors select `@rule` arguments in the context of a set of `Params`.
-But where do `Params` come from?
+As demonstrated above, parameter selectors select `@rule` arguments in the context of a set of
+`Params`. But where do `Params` come from?
 
-One source of `Params` is the root of a request, where a `Param` type that may be provided by a caller
-of the engine can be declared using a `RootRule`. Installing a `RootRule` is sometimes necessary to
-seal the rule graph in cases where a `Param` could only possibly be computed outside of the rule graph
-and then passed in.
+One source of `Params` is the root of a request, where a `Param` type that may be provided by a
+caller of the engine can be declared using a `RootRule`. Installing a `RootRule` is sometimes
+necessary to seal the rule graph in cases where a `Param` could only possibly be computed outside of
+the rule graph and then passed in.
 
 The second case for introducing new `Params` occurs within the running graph when an `@rule` needs
-to pass values to its dependencies that are necessary to compute a product. In this case, `@rule`s may
-be written as coroutines (ie, using the python `yield` statement) that yield "`Get` requests" that request
-products for other `Params`. Just like `@rule` parameter selectors, `Get` requests instantiated in the
-body of an `@rule` are statically checked to be satisfiable in the set of installed `@rule`s.
+to pass values to its dependencies that are necessary to compute a product. In this case, `@rule`s
+may be written as coroutines (ie, using the python `yield` statement) that yield "`Get` requests"
+that request products for other `Params`. Just like `@rule` parameter selectors, `Get` requests
+instantiated in the body of an `@rule` are statically checked to be satisfiable in the set of
+installed `@rule`s.
 
 #### Example
 
@@ -144,8 +146,8 @@ For example, you could declare an `@rule` that requests FileContent for each ent
 and then concatentates that content into a (datatype-wrapped) string:
 
 ```python
-@rule(ConcattedFiles, [Files])
-def concat(files):
+@rule
+def concat(files: Files) -> ConcattedFiles:
   file_content_list = yield [Get(FileContent, File(f)) for f in files]
   yield ConcattedFiles(''.join(fc.content for fc in file_content_list))
 ```
@@ -161,9 +163,9 @@ to their consumers.
 
 For example, a javac `@rule` might need to know the version of the java platform for a given
 dependent binary target, or an ivy `@rule` might need to identify a globally consistent ivy resolve
-for a test target. In both of these cases, the `@rule` requires two `Params` to be in scope. But
-due to the fact that `Params` are implicitly propagated from dependents to dependencies, it's possible
-for these `Params` to be provided much higher in the graph, without intermediate `@rules` needing to
+for a test target. In both of these cases, the `@rule` requires two `Params` to be in scope. But due
+to the fact that `Params` are implicitly propagated from dependents to dependencies, it's possible
+for these `Params` to be provided much higher in the graph, without intermediate `@rule`s needing to
 be aware of them.
 
 The result would be that any subgraph that transitively consumed a `Param` to produce Java 11 (for
@@ -182,14 +184,14 @@ To compute a value for a Node, the engine uses the `Node.run` method starting fr
 roots. If a Node needs more inputs, it requests them via `Context.get`, which will declare a
 dependency, and memoize the computation represented by the requested `Node`.
 
-This recorded `Graph` tracks all dependencies between `@rules` and builtin "intrinsic" rules that
+This recorded `Graph` tracks all dependencies between `@rule`s and builtin "intrinsic" rules that
 provide filesystem and network access. That dependency tracking allows for invalidation and dirtying
 of `Nodes` as their dependencies change.
 
 ## Registering Rules
 
-The recommended way to install `@rules` is to return them as a list from a `def rules()` definition
-in a plugin's `register.py` file. Unit tests can either invoke `@rules` with fully mocked
+The recommended way to install `@rule`s is to return them as a list from a `def rules()` definition
+in a plugin's `register.py` file. Unit tests can either invoke `@rule`s with fully mocked
 dependencies via `pants_test.engine.util.run_rule`, or extend `pants_test.test_base.TestBase` to
 construct and execute a scheduler for a given set of rules.
 
@@ -206,7 +208,7 @@ information in this document!
 ## Visualization
 
 To help visualize executions, the engine can render both the static rule graph that is compiled
-on startup, and also the content of the `Graph` that is produced while `@rules` run. This generates
+on startup, and also the content of the `Graph` that is produced while `@rule`s run. This generates
 `dot` files that can be rendered using Graphviz:
 
 ```console

--- a/src/python/pants/engine/README.md
+++ b/src/python/pants/engine/README.md
@@ -59,8 +59,8 @@ def int_to_str(value: int) -> str:
   return str(value)
 ```
 
-Here the only requirements for the `@rule` are:
-1. The decorated function is a free, top-level function; ie: methods cannot be `@rule`s.
+Here, the only requirements for the `@rule` are:
+1. The decorated function is a free, top-level function; i.e.: methods cannot be `@rule`s.
 2. The decorated function must be fully type annotated.
 3. As mentioned above, the types of the function parameters must be hashable and have useful equality.
 

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -24,8 +24,8 @@ class Test(Goal):
   name = 'test'
 
 
-@console_rule(Test, [Console, BuildFileAddresses])
-def fast_test(console, addresses):
+@console_rule
+def fast_test(console: Console, addresses: BuildFileAddresses) -> Test:
   test_results = yield [Get(TestResult, Address, address.to_address()) for address in addresses]
   did_any_fail = False
   for address, test_result in zip(addresses, test_results):

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -99,16 +99,28 @@ class RuleTypeAnnotationTest(unittest.TestCase):
       return False
     self.assertIsNotNone(dry.rule)
 
-  def test_missing_return(self):
+  def test_missing_return_annotation(self):
     with self.assertRaises(MissingReturnTypeAnnotation):
       @rule
       def dry(a: int, b: str, c: float):
         return False
 
+  def test_bad_return_annotation(self):
+    with self.assertRaises(MissingReturnTypeAnnotation):
+      @rule
+      def dry(a: int, b: str, c: float) -> 42:
+        return False
+
   def test_missing_parameter_annotation(self):
     with self.assertRaises(MissingParameterTypeAnnotation):
       @rule
-      def dry(a: int, b, c:float) -> bool:
+      def dry(a: int, b, c: float) -> bool:
+        return False
+
+  def test_bad_parameter_annotation(self):
+    with self.assertRaises(MissingParameterTypeAnnotation):
+      @rule
+      def dry(a: int, b: 42, c: float) -> bool:
         return False
 
 

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -12,7 +12,8 @@ from pants.engine.console import Console
 from pants.engine.fs import create_fs_rules
 from pants.engine.goal import Goal
 from pants.engine.mapper import AddressMapper
-from pants.engine.rules import RootRule, RuleIndex, _RuleVisitor, console_rule, rule
+from pants.engine.rules import (MissingParameterTypeAnnotation, MissingReturnTypeAnnotation,
+                                RootRule, RuleIndex, _RuleVisitor, console_rule, rule)
 from pants.engine.selectors import Get
 from pants_test.engine.examples.parsers import JsonParser
 from pants_test.engine.util import (TARGET_TABLE, assert_equal_with_printing, create_scheduler,
@@ -89,6 +90,26 @@ class RuleIndexTest(TestBase):
       "'pants_test.engine.test_rules.A'>. Rules either extend Rule or UnionRule, or "
       "are static functions decorated with @rule."""):
       RuleIndex.create([A()])
+
+
+class RuleTypeAnnotationTest(unittest.TestCase):
+  def test_nominal(self):
+    @rule
+    def dry(a: int, b: str, c: float) -> bool:
+      return False
+    self.assertIsNotNone(dry.rule)
+
+  def test_missing_return(self):
+    with self.assertRaises(MissingReturnTypeAnnotation):
+      @rule
+      def dry(a: int, b: str, c: float):
+        return False
+
+  def test_missing_parameter_annotation(self):
+    with self.assertRaises(MissingParameterTypeAnnotation):
+      @rule
+      def dry(a: int, b, c:float) -> bool:
+        return False
 
 
 class RuleGraphTest(TestBase):


### PR DESCRIPTION
This change adds support for bare `@rule` and `@console_rule` decorators that
infer types from type annotations.