### PR TITLE
Modify isort config to prepare for black formatting

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,6 +3,10 @@
 
 [settings]
 line_length=100
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=true
 indent=2
 lines_after_imports=2
 known_first_party=internal_backend,pants,pants_test

--- a/examples/src/python/example/tensorflow_custom_op/setup.py
+++ b/examples/src/python/example/tensorflow_custom_op/setup.py
@@ -1,7 +1,8 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 
 setup(
   name='tensorflow_custom_op',

--- a/pants-plugins/src/python/internal_backend/repositories/register.py
+++ b/pants-plugins/src/python/internal_backend/repositories/register.py
@@ -3,8 +3,12 @@
 
 import os
 
-from pants.backend.jvm.ossrh_publication_metadata import (Developer, License,
-                                                          OSSRHPublicationMetadata, Scm)
+from pants.backend.jvm.ossrh_publication_metadata import (
+  Developer,
+  License,
+  OSSRHPublicationMetadata,
+  Scm,
+)
 from pants.backend.jvm.repository import Repository
 from pants.build_graph.build_file_aliases import BuildFileAliases
 

--- a/src/python/pants/backend/codegen/thrift/python/register.py
+++ b/src/python/pants/backend/codegen/thrift/python/register.py
@@ -2,8 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.codegen.thrift.python.apache_thrift_py_gen import ApacheThriftPyGen
-from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
-  PyThriftNamespaceClashCheck
+from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import (
+  PyThriftNamespaceClashCheck,
+)
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -13,8 +13,10 @@ from functools import total_ordering
 
 from twitter.common.collections import OrderedSet
 
-from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
-                                                                    PinnedJarArtifactSet)
+from pants.backend.jvm.subsystems.jar_dependency_management import (
+  JarDependencyManagement,
+  PinnedJarArtifactSet,
+)
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.base.generator import Generator, TemplateData

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -2,8 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.jvm.artifact import Artifact
-from pants.backend.jvm.ossrh_publication_metadata import (Developer, License,
-                                                          OSSRHPublicationMetadata, Scm)
+from pants.backend.jvm.ossrh_publication_metadata import (
+  Developer,
+  License,
+  OSSRHPublicationMetadata,
+  Scm,
+)
 from pants.backend.jvm.repository import Repository as repo
 from pants.backend.jvm.scala_artifact import ScalaArtifact
 from pants.backend.jvm.subsystems.jar_dependency_management import JarDependencyManagementSetup
@@ -21,8 +25,10 @@ from pants.backend.jvm.targets.junit_tests import JUnitTests
 from pants.backend.jvm.targets.jvm_app import JvmApp
 from pants.backend.jvm.targets.jvm_binary import Duplicate, JarRules, JvmBinary, Skip
 from pants.backend.jvm.targets.jvm_prep_command import JvmPrepCommand
-from pants.backend.jvm.targets.managed_jar_dependencies import (ManagedJarDependencies,
-                                                                ManagedJarLibraries)
+from pants.backend.jvm.targets.managed_jar_dependencies import (
+  ManagedJarDependencies,
+  ManagedJarLibraries,
+)
 from pants.backend.jvm.targets.scala_exclude import ScalaExclude
 from pants.backend.jvm.targets.scala_jar_dependency import ScalaJarDependency
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
@@ -57,9 +63,11 @@ from pants.backend.jvm.tasks.nailgun_task import NailgunKillall
 from pants.backend.jvm.tasks.prepare_resources import PrepareResources
 from pants.backend.jvm.tasks.prepare_services import PrepareServices
 from pants.backend.jvm.tasks.provide_tools_jar import ProvideToolsJar
-from pants.backend.jvm.tasks.run_jvm_prep_command import (RunBinaryJvmPrepCommand,
-                                                          RunCompileJvmPrepCommand,
-                                                          RunTestJvmPrepCommand)
+from pants.backend.jvm.tasks.run_jvm_prep_command import (
+  RunBinaryJvmPrepCommand,
+  RunCompileJvmPrepCommand,
+  RunTestJvmPrepCommand,
+)
 from pants.backend.jvm.tasks.scala_repl import ScalaRepl
 from pants.backend.jvm.tasks.scaladoc_gen import ScaladocGen
 from pants.backend.jvm.tasks.scalafix import ScalaFixCheck, ScalaFixFix

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -8,8 +8,12 @@ from hashlib import sha1
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
-from pants.base.payload_field import (ExcludesField, FingerprintedField, FingerprintedMixin,
-                                      PrimitiveField)
+from pants.base.payload_field import (
+  ExcludesField,
+  FingerprintedField,
+  FingerprintedMixin,
+  PrimitiveField,
+)
 from pants.base.validation import assert_list
 from pants.java.jar.exclude import Exclude
 

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -9,8 +9,10 @@ from collections import defaultdict
 from urllib import parse
 
 from pants.backend.jvm.ivy_utils import IvyUtils
-from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
-                                                                    PinnedJarArtifactSet)
+from pants.backend.jvm.subsystems.jar_dependency_management import (
+  JarDependencyManagement,
+  PinnedJarArtifactSet,
+)
 from pants.backend.jvm.subsystems.resolve_subsystem import JvmResolveSubsystem
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -15,13 +15,19 @@ from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
 from pants.backend.jvm.targets.javac_plugin import JavacPlugin
 from pants.backend.jvm.targets.scalac_plugin import ScalacPlugin
 from pants.backend.jvm.tasks.classpath_products import ClasspathEntry
-from pants.backend.jvm.tasks.jvm_compile.class_not_found_error_patterns import \
-  CLASS_NOT_FOUND_ERROR_PATTERNS
+from pants.backend.jvm.tasks.jvm_compile.class_not_found_error_patterns import (
+  CLASS_NOT_FOUND_ERROR_PATTERNS,
+)
 from pants.backend.jvm.tasks.jvm_compile.compile_context import CompileContext
-from pants.backend.jvm.tasks.jvm_compile.execution_graph import (ExecutionFailure, ExecutionGraph,
-                                                                 Job)
-from pants.backend.jvm.tasks.jvm_compile.missing_dependency_finder import (CompileErrorExtractor,
-                                                                           MissingDependencyFinder)
+from pants.backend.jvm.tasks.jvm_compile.execution_graph import (
+  ExecutionFailure,
+  ExecutionGraph,
+  Job,
+)
+from pants.backend.jvm.tasks.jvm_compile.missing_dependency_finder import (
+  CompileErrorExtractor,
+  MissingDependencyFinder,
+)
 from pants.backend.jvm.tasks.jvm_dependency_analyzer import JvmDependencyAnalyzer
 from pants.backend.jvm.tasks.nailgun_task import NailgunTaskBase
 from pants.base.build_environment import get_buildroot
@@ -34,8 +40,14 @@ from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.option.ranked_value import RankedValue
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.util.contextutil import Timer, temporary_dir
-from pants.util.dirutil import (fast_relpath, read_file, safe_delete, safe_file_dump, safe_mkdir,
-                                safe_rmtree)
+from pants.util.dirutil import (
+  fast_relpath,
+  read_file,
+  safe_delete,
+  safe_file_dump,
+  safe_mkdir,
+  safe_rmtree,
+)
 from pants.util.fileutil import create_size_estimators
 from pants.util.memo import memoized_method, memoized_property
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -18,8 +18,12 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.mirrored_target_option_mixin import MirroredTargetOptionMixin
-from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, DirectoryToMaterialize, PathGlobs,
-                             PathGlobsAndRoot)
+from pants.engine.fs import (
+  EMPTY_DIRECTORY_DIGEST,
+  DirectoryToMaterialize,
+  PathGlobs,
+  PathGlobsAndRoot,
+)
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.java.jar.jar_dependency import JarDependency
 from pants.reporting.reporting_utils import items_to_report_element

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -23,8 +23,12 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.hash_utils import hash_file
 from pants.base.workunit import WorkUnitLabel
-from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, DirectoryToMaterialize, PathGlobs,
-                             PathGlobsAndRoot)
+from pants.engine.fs import (
+  EMPTY_DIRECTORY_DIGEST,
+  DirectoryToMaterialize,
+  PathGlobs,
+  PathGlobsAndRoot,
+)
 from pants.engine.isolated_process import ExecuteProcessRequest
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import fast_relpath

--- a/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
@@ -12,8 +12,10 @@ from multiprocessing.pool import ThreadPool
 from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.base.exceptions import TaskError
 from pants.build_graph.target_scopes import Scopes
-from pants.task.target_restriction_mixins import (HasSkipAndTransitiveOptionsMixin,
-                                                  SkipAndTransitiveOptionsRegistrar)
+from pants.task.target_restriction_mixins import (
+  HasSkipAndTransitiveOptionsMixin,
+  SkipAndTransitiveOptionsRegistrar,
+)
 from pants.util import desktop
 from pants.util.dirutil import safe_mkdir, safe_walk
 from pants.util.memo import memoized_property

--- a/src/python/pants/backend/native/register.py
+++ b/src/python/pants/backend/native/register.py
@@ -7,8 +7,10 @@ from pants.backend.native.subsystems.binaries.llvm import create_llvm_rules
 from pants.backend.native.subsystems.native_build_settings import NativeBuildSettings
 from pants.backend.native.subsystems.native_toolchain import create_native_toolchain_rules
 from pants.backend.native.subsystems.xcode_cli_tools import create_xcode_cli_tools_rules
-from pants.backend.native.targets.external_native_library import (ConanRequirement,
-                                                                  ExternalNativeLibrary)
+from pants.backend.native.targets.external_native_library import (
+  ConanRequirement,
+  ExternalNativeLibrary,
+)
 from pants.backend.native.targets.native_artifact import NativeArtifact
 from pants.backend.native.targets.native_library import CLibrary, CppLibrary
 from pants.backend.native.targets.packaged_native_library import PackagedNativeLibrary

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -2,8 +2,15 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from pants.backend.native.config.environment import (Assembler, CCompiler, CppCompiler,
-                                                     CppToolchain, CToolchain, Linker, Platform)
+from pants.backend.native.config.environment import (
+  Assembler,
+  CCompiler,
+  CppCompiler,
+  CppToolchain,
+  CToolchain,
+  Linker,
+  Platform,
+)
 from pants.backend.native.subsystems.binaries.binutils import Binutils
 from pants.backend.native.subsystems.binaries.gcc import GCC
 from pants.backend.native.subsystems.binaries.llvm import LLVM

--- a/src/python/pants/backend/native/tasks/native_task.py
+++ b/src/python/pants/backend/native/tasks/native_task.py
@@ -6,8 +6,10 @@ from abc import abstractmethod
 from pants.backend.native.config.environment import CppToolchain, CToolchain
 from pants.backend.native.subsystems.native_build_settings import NativeBuildSettings
 from pants.backend.native.subsystems.native_build_step import NativeBuildStep
-from pants.backend.native.subsystems.native_toolchain import (NativeToolchain,
-                                                              ToolchainVariantRequest)
+from pants.backend.native.subsystems.native_toolchain import (
+  NativeToolchain,
+  ToolchainVariantRequest,
+)
 from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.targets.packaged_native_library import PackagedNativeLibrary
 from pants.build_graph.dependency_context import DependencyContext

--- a/src/python/pants/backend/project_info/rules/source_file_validator_test.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator_test.py
@@ -4,8 +4,11 @@
 import textwrap
 import unittest
 
-from pants.backend.project_info.rules.source_file_validator import (Matcher, MultiMatcher,
-                                                                    RegexMatchResult)
+from pants.backend.project_info.rules.source_file_validator import (
+  Matcher,
+  MultiMatcher,
+  RegexMatchResult,
+)
 
 
 # Note that some parts of these tests are just exercising various capabilities of the regex engine.

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -5,13 +5,18 @@ from pants.backend.python.pants_requirement import PantsRequirement
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.python_requirements import PythonRequirements
-from pants.backend.python.rules import (create_requirements_pex, download_pex_bin, inject_init,
-                                        python_test_runner)
+from pants.backend.python.rules import (
+  create_requirements_pex,
+  download_pex_bin,
+  inject_init,
+  python_test_runner,
+)
 from pants.backend.python.subsystems.python_native_code import PythonNativeCode
 from pants.backend.python.subsystems.python_native_code import rules as python_native_code_rules
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEnvironment
-from pants.backend.python.subsystems.subprocess_environment import \
-  rules as subprocess_environment_rules
+from pants.backend.python.subsystems.subprocess_environment import (
+  rules as subprocess_environment_rules,
+)
 from pants.backend.python.targets.python_app import PythonApp
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_distribution import PythonDistribution
@@ -19,13 +24,15 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.targets.unpacked_whls import UnpackedWheels
-from pants.backend.python.tasks.build_local_python_distributions import \
-  BuildLocalPythonDistributions
+from pants.backend.python.tasks.build_local_python_distributions import (
+  BuildLocalPythonDistributions,
+)
 from pants.backend.python.tasks.gather_sources import GatherSources
 from pants.backend.python.tasks.isort_prep import IsortPrep
 from pants.backend.python.tasks.isort_run import IsortRun
-from pants.backend.python.tasks.local_python_distribution_artifact import \
-  LocalPythonDistributionArtifact
+from pants.backend.python.tasks.local_python_distribution_artifact import (
+  LocalPythonDistributionArtifact,
+)
 from pants.backend.python.tasks.pytest_prep import PytestPrep
 from pants.backend.python.tasks.pytest_run import PytestRun
 from pants.backend.python.tasks.python_binary_create import PythonBinaryCreate

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -1,8 +1,10 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.rules.create_requirements_pex import (RequirementsPex,
-                                                                RequirementsPexRequest)
+from pants.backend.python.rules.create_requirements_pex import (
+  RequirementsPex,
+  RequirementsPexRequest,
+)
 from pants.backend.python.rules.inject_init import InjectedInitDigest
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.python_setup import PythonSetup

--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -13,8 +13,10 @@ from pants.backend.native.targets.native_library import NativeLibrary
 from pants.backend.native.tasks.link_shared_libraries import SharedLibrary
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.subsystems.pex_build_util import is_local_python_dist
-from pants.backend.python.subsystems.python_native_code import (BuildSetupRequiresPex,
-                                                                PythonNativeCode)
+from pants.backend.python.subsystems.python_native_code import (
+  BuildSetupRequiresPex,
+  PythonNativeCode,
+)
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException, TaskError

--- a/src/python/pants/backend/python/tasks/coverage/plugin.py
+++ b/src/python/pants/backend/python/tasks/coverage/plugin.py
@@ -4,8 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-# NB: This file must keep Python 2 support because it is a resource that may be run with Python 2.
-
 import json
 import os
 
@@ -14,6 +12,11 @@ from coverage.config import DEFAULT_PARTIAL, DEFAULT_PARTIAL_ALWAYS
 from coverage.misc import join_regex
 from coverage.parser import PythonParser
 from coverage.python import PythonFileReporter
+
+
+# NB: This file must keep Python 2 support because it is a resource that may be run with Python 2.
+
+
 
 
 class SimpleFileTracer(FileTracer):

--- a/src/python/pants/backend/python/tasks/gather_sources.py
+++ b/src/python/pants/backend/python/tasks/gather_sources.py
@@ -8,8 +8,12 @@ from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from twitter.common.collections import OrderedSet
 
-from pants.backend.python.subsystems.pex_build_util import (PexBuilderWrapper, has_python_sources,
-                                                            has_resources, is_python_target)
+from pants.backend.python.subsystems.pex_build_util import (
+  PexBuilderWrapper,
+  has_python_sources,
+  has_resources,
+  is_python_target,
+)
 from pants.base.exceptions import TaskError
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.task.task import Task

--- a/src/python/pants/backend/python/tasks/pytest/plugin.py
+++ b/src/python/pants/backend/python/tasks/pytest/plugin.py
@@ -4,13 +4,16 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-# NB: This file must keep Python 2 support because it is a resource that may be run with Python 2.
-
 import json
 import os
 from zlib import crc32
 
 import pytest
+
+
+# NB: This file must keep Python 2 support because it is a resource that may be run with Python 2.
+
+
 
 
 class NodeRenamerPlugin(object):

--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -7,10 +7,13 @@ from pex.interpreter import PythonInterpreter
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
 
-from pants.backend.python.subsystems.pex_build_util import (PexBuilderWrapper,
-                                                            has_python_requirements,
-                                                            has_python_sources, has_resources,
-                                                            is_python_target)
+from pants.backend.python.subsystems.pex_build_util import (
+  PexBuilderWrapper,
+  has_python_requirements,
+  has_python_sources,
+  has_resources,
+  is_python_target,
+)
 from pants.backend.python.subsystems.python_native_code import PythonNativeCode
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -13,8 +13,11 @@ from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE,
 from pants.bin.local_pants_runner import LocalPantsRunner
 from pants.init.logging import encapsulated_global_logger
 from pants.init.util import clean_global_runtime_state
-from pants.java.nailgun_io import (NailgunStreamStdinReader, NailgunStreamWriterError,
-                                   PipedNailgunStreamWriter)
+from pants.java.nailgun_io import (
+  NailgunStreamStdinReader,
+  NailgunStreamWriterError,
+  PipedNailgunStreamWriter,
+)
 from pants.java.nailgun_protocol import ChunkType, MaybeShutdownSocket, NailgunProtocol
 from pants.util.contextutil import hermetic_environment_as, stdio_as
 from pants.util.socket import teardown_socket

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -24,8 +24,10 @@ from pants.util.contextutil import temporary_file
 from pants.util.dirutil import chmod_plus_x, safe_concurrent_creation, safe_open
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.objects import datatype
-from pants.util.osutil import (SUPPORTED_PLATFORM_NORMALIZED_NAMES,
-                               get_closest_mac_host_platform_pair)
+from pants.util.osutil import (
+  SUPPORTED_PLATFORM_NORMALIZED_NAMES,
+  get_closest_mac_host_platform_pair,
+)
 
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/build_graph/register.py
+++ b/src/python/pants/build_graph/register.py
@@ -7,8 +7,10 @@ from pants.base.build_environment import get_buildroot, pants_version
 from pants.build_graph.aliased_target import AliasTargetFactory
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.files import Files
-from pants.build_graph.intransitive_dependency import (IntransitiveDependencyFactory,
-                                                       ProvidedDependencyFactory)
+from pants.build_graph.intransitive_dependency import (
+  IntransitiveDependencyFactory,
+  ProvidedDependencyFactory,
+)
 from pants.build_graph.prep_command import PrepCommand
 from pants.build_graph.remote_sources import RemoteSources
 from pants.build_graph.resources import Resources

--- a/src/python/pants/cache/local_artifact_cache.py
+++ b/src/python/pants/cache/local_artifact_cache.py
@@ -8,8 +8,13 @@ from contextlib import contextmanager
 from pants.cache.artifact import TarballArtifact
 from pants.cache.artifact_cache import ArtifactCache, UnreadableArtifact
 from pants.util.contextutil import temporary_file
-from pants.util.dirutil import (safe_delete, safe_mkdir, safe_mkdir_for,
-                                safe_rm_oldest_items_in_dir, safe_rmtree)
+from pants.util.dirutil import (
+  safe_delete,
+  safe_mkdir,
+  safe_mkdir_for,
+  safe_rm_oldest_items_in_dir,
+  safe_rmtree,
+)
 
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/core_tasks/register.py
+++ b/src/python/pants/core_tasks/register.py
@@ -11,8 +11,11 @@ from pants.core_tasks.noop import NoopCompile, NoopTest
 from pants.core_tasks.pantsd_kill import PantsDaemonKill
 from pants.core_tasks.reporting_server_kill import ReportingServerKill
 from pants.core_tasks.reporting_server_run import ReportingServerRun
-from pants.core_tasks.run_prep_command import (RunBinaryPrepCommand, RunCompilePrepCommand,
-                                               RunTestPrepCommand)
+from pants.core_tasks.run_prep_command import (
+  RunBinaryPrepCommand,
+  RunCompilePrepCommand,
+  RunTestPrepCommand,
+)
 from pants.core_tasks.substitute_aliased_targets import SubstituteAliasedTargets
 from pants.core_tasks.targets_help import TargetsHelp
 from pants.goal.goal import Goal

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -6,8 +6,13 @@ import logging
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest
 from pants.engine.platform import PlatformConstraint
 from pants.engine.rules import RootRule, rule
-from pants.util.objects import (Exactly, TypedCollection, datatype, hashable_string_list,
-                                string_optional)
+from pants.util.objects import (
+  Exactly,
+  TypedCollection,
+  datatype,
+  hashable_string_list,
+  string_optional,
+)
 
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -13,11 +13,23 @@ from types import GeneratorType
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE
 from pants.base.project_tree import Dir, File, Link
 from pants.build_graph.address import Address
-from pants.engine.fs import (Digest, DirectoriesToMerge, DirectoryToMaterialize,
-                             DirectoryWithPrefixToStrip, FileContent, FilesContent,
-                             InputFilesContent, PathGlobs, PathGlobsAndRoot, Snapshot, UrlToFetch)
-from pants.engine.isolated_process import (FallibleExecuteProcessResult,
-                                           MultiPlatformExecuteProcessRequest)
+from pants.engine.fs import (
+  Digest,
+  DirectoriesToMerge,
+  DirectoryToMaterialize,
+  DirectoryWithPrefixToStrip,
+  FileContent,
+  FilesContent,
+  InputFilesContent,
+  PathGlobs,
+  PathGlobsAndRoot,
+  Snapshot,
+  UrlToFetch,
+)
+from pants.engine.isolated_process import (
+  FallibleExecuteProcessResult,
+  MultiPlatformExecuteProcessRequest,
+)
 from pants.engine.native import Function, TypeId
 from pants.engine.nodes import Return, Throw
 from pants.engine.objects import Collection

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -12,8 +12,11 @@ from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.worker_pool import SubprocPool
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.build_graph.target import Target
-from pants.engine.isolated_process import (FallibleExecuteProcessResult, ProductDescription,
-                                           fallible_to_exec_result_or_raise)
+from pants.engine.isolated_process import (
+  FallibleExecuteProcessResult,
+  ProductDescription,
+  fallible_to_exec_result_or_raise,
+)
 from pants.goal.products import Products
 from pants.goal.workspace import ScmWorkspace
 from pants.process.lock import OwnerPrintingInterProcessFileLock

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -7,8 +7,14 @@ from pants.base.build_environment import pants_release, pants_version
 from pants.goal.goal import Goal
 from pants.help.help_formatter import HelpFormatter
 from pants.help.scope_info_iterator import ScopeInfoIterator
-from pants.option.arg_splitter import (GLOBAL_SCOPE, GoalsHelp, NoGoalHelp, OptionsHelp,
-                                       UnknownGoalHelp, VersionHelp)
+from pants.option.arg_splitter import (
+  GLOBAL_SCOPE,
+  GoalsHelp,
+  NoGoalHelp,
+  OptionsHelp,
+  UnknownGoalHelp,
+  VersionHelp,
+)
 from pants.option.scope import ScopeInfo
 
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -24,10 +24,18 @@ from pants.engine.legacy.address_mapper import LegacyAddressMapper
 from pants.engine.legacy.graph import LegacyBuildGraph, create_legacy_graph_tasks
 from pants.engine.legacy.options_parsing import create_options_parsing_rules
 from pants.engine.legacy.parser import LegacyPythonCallbacksParser
-from pants.engine.legacy.structs import (JvmAppAdaptor, JvmBinaryAdaptor, PageAdaptor,
-                                         PantsPluginAdaptor, PythonAppAdaptor, PythonBinaryAdaptor,
-                                         PythonTargetAdaptor, PythonTestsAdaptor,
-                                         RemoteSourcesAdaptor, TargetAdaptor)
+from pants.engine.legacy.structs import (
+  JvmAppAdaptor,
+  JvmBinaryAdaptor,
+  PageAdaptor,
+  PantsPluginAdaptor,
+  PythonAppAdaptor,
+  PythonBinaryAdaptor,
+  PythonTargetAdaptor,
+  PythonTestsAdaptor,
+  RemoteSourcesAdaptor,
+  TargetAdaptor,
+)
 from pants.engine.legacy.structs import rules as structs_rules
 from pants.engine.mapper import AddressMapper
 from pants.engine.parser import SymbolTable
@@ -36,8 +44,11 @@ from pants.engine.rules import RootRule, rule
 from pants.engine.scheduler import Scheduler
 from pants.engine.selectors import Params
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
-from pants.option.global_options import (DEFAULT_EXECUTION_OPTIONS, ExecutionOptions,
-                                         GlobMatchErrorBehavior)
+from pants.option.global_options import (
+  DEFAULT_EXECUTION_OPTIONS,
+  ExecutionOptions,
+  GlobMatchErrorBehavior,
+)
 from pants.util.objects import datatype
 
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -5,8 +5,13 @@ import multiprocessing
 import os
 import sys
 
-from pants.base.build_environment import (get_buildroot, get_default_pants_config_file,
-                                          get_pants_cachedir, get_pants_configdir, pants_version)
+from pants.base.build_environment import (
+  get_buildroot,
+  get_default_pants_config_file,
+  get_pants_cachedir,
+  get_pants_configdir,
+  pants_version,
+)
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.custom_types import dir_option, file_option
 from pants.option.errors import OptionsError

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -6,8 +6,13 @@ from hashlib import sha1
 
 from pants.base.build_environment import get_buildroot
 from pants.base.hash_utils import CoercingEncoder, json_hash
-from pants.option.custom_types import (UnsetBool, dict_with_files_option, dir_option, file_option,
-                                       target_option)
+from pants.option.custom_types import (
+  UnsetBool,
+  dict_with_files_option,
+  dir_option,
+  file_option,
+  target_option,
+)
 
 
 class CoercingOptionEncoder(CoercingEncoder):

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -14,14 +14,32 @@ import yaml
 from pants.base.deprecated import validate_deprecation_semver, warn_or_error
 from pants.option.arg_splitter import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION
 from pants.option.config import Config
-from pants.option.custom_types import (DictValueComponent, ListValueComponent, UnsetBool,
-                                       dict_option, dir_option, file_option, list_option,
-                                       target_option)
-from pants.option.errors import (BooleanOptionNameWithNo, FrozenRegistration, ImplicitValIsNone,
-                                 InvalidKwarg, InvalidKwargNonGlobalScope, InvalidMemberType,
-                                 MemberTypeNotAllowed, NoOptionNames, OptionAlreadyRegistered,
-                                 OptionNameDash, OptionNameDoubleDash, ParseError,
-                                 RecursiveSubsystemOption, Shadowing)
+from pants.option.custom_types import (
+  DictValueComponent,
+  ListValueComponent,
+  UnsetBool,
+  dict_option,
+  dir_option,
+  file_option,
+  list_option,
+  target_option,
+)
+from pants.option.errors import (
+  BooleanOptionNameWithNo,
+  FrozenRegistration,
+  ImplicitValIsNone,
+  InvalidKwarg,
+  InvalidKwargNonGlobalScope,
+  InvalidMemberType,
+  MemberTypeNotAllowed,
+  NoOptionNames,
+  OptionAlreadyRegistered,
+  OptionNameDash,
+  OptionNameDoubleDash,
+  ParseError,
+  RecursiveSubsystemOption,
+  Shadowing,
+)
 from pants.option.option_util import is_dict_option, is_list_option
 from pants.option.ranked_value import RankedValue
 from pants.option.scope import ScopeInfo

--- a/src/python/pants/releases/packages.py
+++ b/src/python/pants/releases/packages.py
@@ -14,6 +14,7 @@ from urllib.request import Request, urlopen
 
 from bs4 import BeautifulSoup
 
+
 COLOR_BLUE = "\x1b[34m"
 COLOR_RESET = "\x1b[0m"
 

--- a/src/python/pants/task/fmt_task_mixin.py
+++ b/src/python/pants/task/fmt_task_mixin.py
@@ -1,8 +1,10 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.task.target_restriction_mixins import (HasSkipAndTransitiveGoalOptionsMixin,
-                                                  SkipAndTransitiveGoalOptionsRegistrar)
+from pants.task.target_restriction_mixins import (
+  HasSkipAndTransitiveGoalOptionsMixin,
+  SkipAndTransitiveGoalOptionsRegistrar,
+)
 
 
 class FmtTaskMixin(HasSkipAndTransitiveGoalOptionsMixin):

--- a/src/python/pants/task/lint_task_mixin.py
+++ b/src/python/pants/task/lint_task_mixin.py
@@ -1,8 +1,10 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.task.target_restriction_mixins import (HasSkipAndTransitiveGoalOptionsMixin,
-                                                  SkipAndTransitiveGoalOptionsRegistrar)
+from pants.task.target_restriction_mixins import (
+  HasSkipAndTransitiveGoalOptionsMixin,
+  SkipAndTransitiveGoalOptionsRegistrar,
+)
 
 
 class LintTaskMixin(HasSkipAndTransitiveGoalOptionsMixin):

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -13,8 +13,11 @@ from pants.base.worker_pool import Work
 from pants.build_graph.target_filter_subsystem import TargetFilter
 from pants.cache.artifact_cache import UnreadableArtifact, call_insert, call_use_cached_files
 from pants.cache.cache_setup import CacheSetup
-from pants.invalidation.build_invalidator import (BuildInvalidator, CacheKeyGenerator,
-                                                  UncacheableCacheKeyGenerator)
+from pants.invalidation.build_invalidator import (
+  BuildInvalidator,
+  CacheKeyGenerator,
+  UncacheableCacheKeyGenerator,
+)
 from pants.invalidation.cache_manager import InvalidationCacheManager, InvalidationCheck
 from pants.option.optionable import Optionable
 from pants.option.options_fingerprinter import OptionsFingerprinter

--- a/testprojects/src/python/python_distribution/ctypes/setup.py
+++ b/testprojects/src/python/python_distribution/ctypes/setup.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 
 setup(

--- a/testprojects/src/python/python_distribution/ctypes_interop/setup.py
+++ b/testprojects/src/python/python_distribution/ctypes_interop/setup.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 
 setup(

--- a/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/setup.py
+++ b/testprojects/src/python/python_distribution/ctypes_with_extra_compiler_flags/setup.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 
 setup(

--- a/testprojects/src/python/python_distribution/ctypes_with_third_party/setup.py
+++ b/testprojects/src/python/python_distribution/ctypes_with_third_party/setup.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 
 setup(

--- a/testprojects/src/python/python_distribution/hello_with_install_requires/setup.py
+++ b/testprojects/src/python/python_distribution/hello_with_install_requires/setup.py
@@ -1,7 +1,8 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 
 setup(
   name='hello_with_install_requires',

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_py_thrift_namespace_clash_check.py
@@ -2,8 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import \
-  PyThriftNamespaceClashCheck
+from pants.backend.codegen.thrift.python.py_thrift_namespace_clash_check import (
+  PyThriftNamespaceClashCheck,
+)
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.util.dirutil import read_file
 from pants_test.task_test_base import DeclarativeTaskTestMixin, TaskTestBase

--- a/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management.py
@@ -3,8 +3,10 @@
 
 import unittest
 
-from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
-                                                                    PinnedJarArtifactSet)
+from pants.backend.jvm.subsystems.jar_dependency_management import (
+  JarDependencyManagement,
+  PinnedJarArtifactSet,
+)
 from pants.java.jar.jar_dependency_utils import M2Coordinate
 from pants.subsystem.subsystem import Subsystem
 from pants_test.subsystem.subsystem_util import global_subsystem_instance

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder.py
@@ -4,11 +4,14 @@
 import random
 import unittest
 
-from pants.backend.jvm.tasks.jvm_compile.class_not_found_error_patterns import \
-  CLASS_NOT_FOUND_ERROR_PATTERNS
-from pants.backend.jvm.tasks.jvm_compile.missing_dependency_finder import (ClassNotFoundError,
-                                                                           CompileErrorExtractor,
-                                                                           StringSimilarityRanker)
+from pants.backend.jvm.tasks.jvm_compile.class_not_found_error_patterns import (
+  CLASS_NOT_FOUND_ERROR_PATTERNS,
+)
+from pants.backend.jvm.tasks.jvm_compile.missing_dependency_finder import (
+  ClassNotFoundError,
+  CompileErrorExtractor,
+  StringSimilarityRanker,
+)
 
 
 class CompileErrorExtractorTest(unittest.TestCase):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration.py
@@ -2,8 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
-from pants_test.backend.jvm.tasks.jvm_compile.zinc.zinc_compile_integration_base import \
-  BaseZincCompileIntegrationTest
+from pants_test.backend.jvm.tasks.jvm_compile.zinc.zinc_compile_integration_base import (
+  BaseZincCompileIntegrationTest,
+)
 
 
 class ZincCompileIntegration(BaseCompileIT, BaseZincCompileIntegrationTest):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration_with_zjars.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration_with_zjars.py
@@ -3,8 +3,9 @@
 
 
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
-from pants_test.backend.jvm.tasks.jvm_compile.zinc.zinc_compile_integration_base import \
-  BaseZincCompileIntegrationTest
+from pants_test.backend.jvm.tasks.jvm_compile.zinc.zinc_compile_integration_base import (
+  BaseZincCompileIntegrationTest,
+)
 
 
 class ZincCompileIntegrationWithZjars(BaseCompileIT, BaseZincCompileIntegrationTest):

--- a/tests/python/pants_test/backend/jvm/tasks/reports/test_junit_html_report.py
+++ b/tests/python/pants_test/backend/jvm/tasks/reports/test_junit_html_report.py
@@ -4,8 +4,11 @@
 import os
 from contextlib import contextmanager
 
-from pants.backend.jvm.tasks.reports.junit_html_report import (JUnitHtmlReport, ReportTestCase,
-                                                               ReportTestSuite)
+from pants.backend.jvm.tasks.reports.junit_html_report import (
+  JUnitHtmlReport,
+  ReportTestCase,
+  ReportTestSuite,
+)
 from pants.util.contextutil import temporary_dir
 from pants_test.test_base import TestBase
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
@@ -7,9 +7,12 @@ from pants.backend.jvm.artifact import Artifact
 from pants.backend.jvm.repository import Repository
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
-from pants.backend.jvm.tasks.classpath_products import (ArtifactClasspathEntry, ClasspathEntry,
-                                                        ClasspathProducts,
-                                                        MissingClasspathEntryError)
+from pants.backend.jvm.tasks.classpath_products import (
+  ArtifactClasspathEntry,
+  ClasspathEntry,
+  ClasspathProducts,
+  MissingClasspathEntryError,
+)
 from pants.base.exceptions import TaskError
 from pants.build_graph.target import Target
 from pants.java.jar.exclude import Exclude

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -6,15 +6,19 @@ import re
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
-from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
-                                                                    PinnedJarArtifactSet)
+from pants.backend.jvm.subsystems.jar_dependency_management import (
+  JarDependencyManagement,
+  PinnedJarArtifactSet,
+)
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.targets.managed_jar_dependencies import ManagedJarDependencies
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
-from pants.backend.jvm.tasks.coursier_resolve import (CoursierResolve,
-                                                      CoursierResolveFingerprintStrategy)
+from pants.backend.jvm.tasks.coursier_resolve import (
+  CoursierResolve,
+  CoursierResolveFingerprintStrategy,
+)
 from pants.base.exceptions import TaskError
 from pants.java import util
 from pants.java.jar.exclude import Exclude

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
@@ -8,8 +8,10 @@ from contextlib import contextmanager
 from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.ivy_utils import IvyInfo, IvyModule, IvyModuleRef, IvyResolveResult
-from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
-                                                                    PinnedJarArtifactSet)
+from pants.backend.jvm.subsystems.jar_dependency_management import (
+  JarDependencyManagement,
+  PinnedJarArtifactSet,
+)
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
@@ -9,9 +9,17 @@ from textwrap import dedent
 
 from twitter.common.collections import OrderedSet
 
-from pants.backend.jvm.ivy_utils import (FrozenResolution, IvyFetchStep, IvyInfo, IvyModule,
-                                         IvyModuleRef, IvyResolveMappingError, IvyResolveResult,
-                                         IvyResolveStep, IvyUtils)
+from pants.backend.jvm.ivy_utils import (
+  FrozenResolution,
+  IvyFetchStep,
+  IvyInfo,
+  IvyModule,
+  IvyModuleRef,
+  IvyResolveMappingError,
+  IvyResolveResult,
+  IvyResolveStep,
+  IvyUtils,
+)
 from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.jvm.subsystems.jar_dependency_management import JarDependencyManagement
 from pants.backend.jvm.targets.jar_library import JarLibrary

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_dependency_management_setup.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_dependency_management_setup.py
@@ -2,11 +2,15 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
-                                                                    JarDependencyManagementSetup)
+from pants.backend.jvm.subsystems.jar_dependency_management import (
+  JarDependencyManagement,
+  JarDependencyManagementSetup,
+)
 from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.backend.jvm.targets.managed_jar_dependencies import (ManagedJarDependencies,
-                                                                ManagedJarLibraries)
+from pants.backend.jvm.targets.managed_jar_dependencies import (
+  ManagedJarDependencies,
+  ManagedJarLibraries,
+)
 from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
 from pants.base.exceptions import TargetDefinitionException
 from pants.build_graph.target import Target

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -11,9 +11,13 @@ from pants.backend.native.register import rules as native_backend_rules
 from pants.backend.native.subsystems.binaries.gcc import GCC
 from pants.backend.native.subsystems.binaries.llvm import LLVM
 from pants.backend.native.subsystems.libc_dev import LibcDev
-from pants.backend.native.subsystems.native_toolchain import (GCCCppToolchain, GCCCToolchain,
-                                                              LLVMCppToolchain, LLVMCToolchain,
-                                                              NativeToolchain)
+from pants.backend.native.subsystems.native_toolchain import (
+  GCCCppToolchain,
+  GCCCToolchain,
+  LLVMCppToolchain,
+  LLVMCToolchain,
+  NativeToolchain,
+)
 from pants.engine.platform import create_platform_rules
 from pants.util.contextutil import environment_as, pushd, temporary_dir
 from pants.util.dirutil import is_executable, safe_open

--- a/tests/python/pants_test/backend/native/tasks/test_c_compile.py
+++ b/tests/python/pants_test/backend/native/tasks/test_c_compile.py
@@ -6,8 +6,10 @@ from textwrap import dedent
 from pants.backend.native.targets.native_library import CLibrary
 from pants.backend.native.tasks.c_compile import CCompile
 from pants.backend.native.tasks.native_compile import ObjectFiles
-from pants_test.backend.native.tasks.native_task_test_base import (NativeCompileTestMixin,
-                                                                   NativeTaskTestBase)
+from pants_test.backend.native.tasks.native_task_test_base import (
+  NativeCompileTestMixin,
+  NativeTaskTestBase,
+)
 
 
 class CCompileTest(NativeTaskTestBase, NativeCompileTestMixin):

--- a/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
+++ b/tests/python/pants_test/backend/native/tasks/test_cpp_compile.py
@@ -8,8 +8,10 @@ from pants.backend.native.targets.native_library import CppLibrary, NativeLibrar
 from pants.backend.native.tasks.cpp_compile import CppCompile
 from pants.backend.native.tasks.native_compile import ObjectFiles
 from pants.option.ranked_value import RankedValue
-from pants_test.backend.native.tasks.native_task_test_base import (NativeCompileTestMixin,
-                                                                   NativeTaskTestBase)
+from pants_test.backend.native.tasks.native_task_test_base import (
+  NativeCompileTestMixin,
+  NativeTaskTestBase,
+)
 
 
 class CppCompileTest(NativeTaskTestBase, NativeCompileTestMixin):

--- a/tests/python/pants_test/backend/native/tasks/test_link_shared_libraries.py
+++ b/tests/python/pants_test/backend/native/tasks/test_link_shared_libraries.py
@@ -6,8 +6,10 @@ import os
 from pants.backend.native.targets.native_artifact import NativeArtifact
 from pants.backend.native.tasks.cpp_compile import CppCompile
 from pants.backend.native.tasks.link_shared_libraries import LinkSharedLibraries
-from pants_test.backend.native.tasks.native_task_test_base import (NativeCompileTestMixin,
-                                                                   NativeTaskTestBase)
+from pants_test.backend.native.tasks.native_task_test_base import (
+  NativeCompileTestMixin,
+  NativeTaskTestBase,
+)
 
 
 class LinkSharedLibrariesTest(NativeTaskTestBase, NativeCompileTestMixin):

--- a/tests/python/pants_test/backend/python/rules/test_create_requirements_pex.py
+++ b/tests/python/pants_test/backend/python/rules/test_create_requirements_pex.py
@@ -5,15 +5,21 @@ import json
 import os.path
 import zipfile
 
-from pants.backend.python.rules.create_requirements_pex import (RequirementsPex,
-                                                                RequirementsPexRequest,
-                                                                create_requirements_pex)
+from pants.backend.python.rules.create_requirements_pex import (
+  RequirementsPex,
+  RequirementsPexRequest,
+  create_requirements_pex,
+)
 from pants.backend.python.rules.download_pex_bin import download_pex_bin
-from pants.backend.python.subsystems.python_native_code import (PythonNativeCode,
-                                                                create_pex_native_build_environment)
+from pants.backend.python.subsystems.python_native_code import (
+  PythonNativeCode,
+  create_pex_native_build_environment,
+)
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import (
-  SubprocessEnvironment, create_subprocess_encoding_environment)
+  SubprocessEnvironment,
+  create_subprocess_encoding_environment,
+)
 from pants.engine.fs import DirectoryToMaterialize
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes.py
@@ -11,8 +11,9 @@ from pants.backend.native.tasks.link_shared_libraries import LinkSharedLibraries
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_distribution import PythonDistribution
 from pants.util.meta import classproperty
-from pants_test.backend.python.tasks.util.build_local_dists_test_base import \
-  BuildLocalPythonDistributionsTestBase
+from pants_test.backend.python.tasks.util.build_local_dists_test_base import (
+  BuildLocalPythonDistributionsTestBase,
+)
 
 
 class TestBuildLocalDistsWithCtypesNativeSources(BuildLocalPythonDistributionsTestBase):

--- a/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
+++ b/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions.py
@@ -10,8 +10,9 @@ from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_distribution import PythonDistribution
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
-from pants_test.backend.python.tasks.util.build_local_dists_test_base import \
-  BuildLocalPythonDistributionsTestBase
+from pants_test.backend.python.tasks.util.build_local_dists_test_base import (
+  BuildLocalPythonDistributionsTestBase,
+)
 
 
 class TestBuildLocalPythonDistributions(BuildLocalPythonDistributionsTestBase):

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -9,9 +9,13 @@ from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 
 from pants.util.contextutil import temporary_dir
-from pants_test.interpreter_selection_utils import (PY_3, PY_27, skip_unless_python3_present,
-                                                    skip_unless_python27_and_python3_present,
-                                                    skip_unless_python27_present)
+from pants_test.interpreter_selection_utils import (
+  PY_3,
+  PY_27,
+  skip_unless_python3_present,
+  skip_unless_python27_and_python3_present,
+  skip_unless_python27_present,
+)
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -5,10 +5,14 @@ import os
 import time
 
 from pants.util.contextutil import temporary_dir
-from pants_test.interpreter_selection_utils import (PY_3, PY_27, python_interpreter_path,
-                                                    skip_unless_python3_present,
-                                                    skip_unless_python27_and_python3_present,
-                                                    skip_unless_python27_present)
+from pants_test.interpreter_selection_utils import (
+  PY_3,
+  PY_27,
+  python_interpreter_path,
+  skip_unless_python3_present,
+  skip_unless_python27_and_python3_present,
+  skip_unless_python27_present,
+)
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 from pants_test.testutils.pexrc_util import setup_pexrc_with_pex_python_path
 

--- a/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
@@ -6,10 +6,14 @@ import os
 from pex.pex_info import PexInfo
 
 from pants.util.contextutil import temporary_dir
-from pants_test.interpreter_selection_utils import (PY_3, PY_27, python_interpreter_path,
-                                                    skip_unless_python3_present,
-                                                    skip_unless_python27_and_python3_present,
-                                                    skip_unless_python27_present)
+from pants_test.interpreter_selection_utils import (
+  PY_3,
+  PY_27,
+  python_interpreter_path,
+  skip_unless_python3_present,
+  skip_unless_python27_and_python3_present,
+  skip_unless_python27_present,
+)
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
 from pants_test.testutils.pexrc_util import setup_pexrc_with_pex_python_path
 

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py_integration.py
@@ -4,8 +4,9 @@
 import re
 import tarfile
 
-from pants_test.backend.python.pants_requirement_integration_test_base import \
-  PantsRequirementIntegrationTestBase
+from pants_test.backend.python.pants_requirement_integration_test_base import (
+  PantsRequirementIntegrationTestBase,
+)
 
 
 class SetupPyIntegrationTest(PantsRequirementIntegrationTestBase):

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -8,16 +8,19 @@ from pants.backend.native.register import rules as native_backend_rules
 from pants.backend.native.subsystems.libc_dev import LibcDev
 from pants.backend.native.subsystems.native_build_step import ToolchainVariant
 from pants.backend.python.subsystems.python_repos import PythonRepos
-from pants.backend.python.tasks.build_local_python_distributions import \
-  BuildLocalPythonDistributions
+from pants.backend.python.tasks.build_local_python_distributions import (
+  BuildLocalPythonDistributions,
+)
 from pants.backend.python.tasks.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants.util.collections import assert_single_element
 from pants.util.meta import classproperty
 from pants.util.objects import enum
-from pants_test.backend.python.tasks.python_task_test_base import (PythonTaskTestBase,
-                                                                   name_and_platform,
-                                                                   normalized_current_platform)
+from pants_test.backend.python.tasks.python_task_test_base import (
+  PythonTaskTestBase,
+  name_and_platform,
+  normalized_current_platform,
+)
 from pants_test.task_test_base import DeclarativeTaskTestMixin
 
 

--- a/tests/python/pants_test/backend/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/backend/python/test_interpreter_cache.py
@@ -9,8 +9,12 @@ from pants.backend.python.interpreter_cache import PythonInterpreter, PythonInte
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_mkdir
-from pants_test.interpreter_selection_utils import (PY_27, PY_36, python_interpreter_path,
-                                                    skip_unless_python27_and_python36_present)
+from pants_test.interpreter_selection_utils import (
+  PY_27,
+  PY_36,
+  python_interpreter_path,
+  skip_unless_python27_and_python36_present,
+)
 from pants_test.test_base import TestBase
 from pants_test.testutils.pexrc_util import setup_pexrc_with_pex_python_path
 

--- a/tests/python/pants_test/backend/python/test_pants_requirement_integration.py
+++ b/tests/python/pants_test/backend/python/test_pants_requirement_integration.py
@@ -4,8 +4,9 @@
 import os
 
 from pants.base.build_environment import get_buildroot
-from pants_test.backend.python.pants_requirement_integration_test_base import \
-  PantsRequirementIntegrationTestBase
+from pants_test.backend.python.pants_requirement_integration_test_base import (
+  PantsRequirementIntegrationTestBase,
+)
 
 
 class PantsRequirementIntegrationTest(PantsRequirementIntegrationTestBase):

--- a/tests/python/pants_test/base/test_deprecated.py
+++ b/tests/python/pants_test/base/test_deprecated.py
@@ -7,11 +7,18 @@ from contextlib import contextmanager
 
 from packaging.version import Version
 
-from pants.base.deprecated import (BadDecoratorNestingError, BadSemanticVersionError,
-                                   CodeRemovedError, InvalidSemanticVersionOrderingError,
-                                   MissingSemanticVersionError, NonDevSemanticVersionError,
-                                   deprecated, deprecated_conditional, deprecated_module,
-                                   warn_or_error)
+from pants.base.deprecated import (
+  BadDecoratorNestingError,
+  BadSemanticVersionError,
+  CodeRemovedError,
+  InvalidSemanticVersionOrderingError,
+  MissingSemanticVersionError,
+  NonDevSemanticVersionError,
+  deprecated,
+  deprecated_conditional,
+  deprecated_module,
+  warn_or_error,
+)
 from pants.util.collections import assert_single_element
 from pants_test.test_base import TestBase
 

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -11,8 +11,14 @@ from pathlib import Path
 
 from twitter.common.collections import OrderedSet
 
-from pants.base.hash_utils import (CoercingEncoder, Sharder, hash_all, hash_dir, hash_file,
-                                   stable_json_sha1)
+from pants.base.hash_utils import (
+  CoercingEncoder,
+  Sharder,
+  hash_all,
+  hash_dir,
+  hash_file,
+  stable_json_sha1,
+)
 from pants.util.contextutil import temporary_dir, temporary_file, temporary_file_path
 
 

--- a/tests/python/pants_test/base/test_payload_field.py
+++ b/tests/python/pants_test/base/test_payload_field.py
@@ -4,9 +4,15 @@
 from hashlib import sha1
 
 from pants.backend.python.python_requirement import PythonRequirement
-from pants.base.payload_field import (ExcludesField, FingerprintedField, FingerprintedMixin,
-                                      JarsField, PrimitiveField, PrimitivesSetField,
-                                      PythonRequirementsField)
+from pants.base.payload_field import (
+  ExcludesField,
+  FingerprintedField,
+  FingerprintedMixin,
+  JarsField,
+  PrimitiveField,
+  PrimitivesSetField,
+  PythonRequirementsField,
+)
 from pants.java.jar.exclude import Exclude
 from pants.java.jar.jar_dependency import JarDependency
 from pants.util.strutil import ensure_binary

--- a/tests/python/pants_test/binaries/test_binary_tool.py
+++ b/tests/python/pants_test/binaries/test_binary_tool.py
@@ -4,8 +4,12 @@
 import os
 
 from pants.binaries.binary_tool import BinaryToolBase
-from pants.binaries.binary_util import (BinaryToolFetcher, BinaryToolUrlGenerator, BinaryUtil,
-                                        HostPlatform)
+from pants.binaries.binary_util import (
+  BinaryToolFetcher,
+  BinaryToolUrlGenerator,
+  BinaryUtil,
+  HostPlatform,
+)
 from pants.option.scope import GLOBAL_SCOPE
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_file_dump

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -6,8 +6,13 @@ import logging
 import os
 import unittest.mock
 
-from pants.binaries.binary_util import (BinaryRequest, BinaryToolFetcher, BinaryToolUrlGenerator,
-                                        BinaryUtil, select)
+from pants.binaries.binary_util import (
+  BinaryRequest,
+  BinaryToolFetcher,
+  BinaryToolUrlGenerator,
+  BinaryUtil,
+  select,
+)
 from pants.net.http.fetcher import Fetcher
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import environment_as, temporary_dir

--- a/tests/python/pants_test/build_graph/test_address.py
+++ b/tests/python/pants_test/build_graph/test_address.py
@@ -8,8 +8,13 @@ from contextlib import contextmanager
 from pants.base.build_file import BuildFile
 from pants.base.build_root import BuildRoot
 from pants.base.file_system_project_tree import FileSystemProjectTree
-from pants.build_graph.address import (Address, BuildFileAddress, InvalidSpecPath,
-                                       InvalidTargetName, parse_spec)
+from pants.build_graph.address import (
+  Address,
+  BuildFileAddress,
+  InvalidSpecPath,
+  InvalidTargetName,
+  parse_spec,
+)
 from pants.util.contextutil import pushd, temporary_dir
 from pants.util.dirutil import touch
 

--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -5,8 +5,11 @@ import os
 from contextlib import contextmanager
 
 from pants.cache.artifact import TarballArtifact
-from pants.cache.artifact_cache import (NonfatalArtifactCacheError, call_insert,
-                                        call_use_cached_files)
+from pants.cache.artifact_cache import (
+  NonfatalArtifactCacheError,
+  call_insert,
+  call_use_cached_files,
+)
 from pants.cache.local_artifact_cache import LocalArtifactCache, TempLocalArtifactCache
 from pants.cache.pinger import BestUrlSelector, InvalidRESTfulCacheProtoError
 from pants.cache.restful_artifact_cache import RESTfulArtifactCache

--- a/tests/python/pants_test/cache/test_cache_setup.py
+++ b/tests/python/pants_test/cache/test_cache_setup.py
@@ -4,10 +4,17 @@
 import os
 from unittest.mock import Mock
 
-from pants.cache.cache_setup import (CacheFactory, CacheSetup, CacheSpec, CacheSpecFormatError,
-                                     EmptyCacheSpecError, InvalidCacheSpecError,
-                                     LocalCacheSpecRequiredError, RemoteCacheSpecRequiredError,
-                                     TooManyCacheSpecsError)
+from pants.cache.cache_setup import (
+  CacheFactory,
+  CacheSetup,
+  CacheSpec,
+  CacheSpecFormatError,
+  EmptyCacheSpecError,
+  InvalidCacheSpecError,
+  LocalCacheSpecRequiredError,
+  RemoteCacheSpecRequiredError,
+  TooManyCacheSpecsError,
+)
 from pants.cache.local_artifact_cache import LocalArtifactCache
 from pants.cache.resolver import Resolver
 from pants.cache.restful_artifact_cache import RESTfulArtifactCache

--- a/tests/python/pants_test/engine/test_addressable.py
+++ b/tests/python/pants_test/engine/test_addressable.py
@@ -3,8 +3,13 @@
 
 import unittest
 
-from pants.engine.addressable import (MutationError, NotSerializableError, addressable,
-                                      addressable_dict, addressable_list)
+from pants.engine.addressable import (
+  MutationError,
+  NotSerializableError,
+  addressable,
+  addressable_dict,
+  addressable_list,
+)
 from pants.engine.objects import Resolvable, Serializable
 from pants.util.objects import Exactly, TypeConstraintError
 

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -9,8 +9,12 @@ from pants.base.project_tree import Dir
 from pants.base.specs import SiblingAddresses, SingleAddress, Specs
 from pants.build_graph.address import Address
 from pants.engine.addressable import addressable, addressable_dict
-from pants.engine.build_files import (ResolvedTypeMismatchError, addresses_from_address_families,
-                                      create_graph_rules, parse_address_family)
+from pants.engine.build_files import (
+  ResolvedTypeMismatchError,
+  addresses_from_address_families,
+  create_graph_rules,
+  parse_address_family,
+)
 from pants.engine.fs import Digest, FileContent, FilesContent, PathGlobs, Snapshot, create_fs_rules
 from pants.engine.legacy.structs import TargetAdaptor
 from pants.engine.mapper import AddressFamily, AddressMapper, ResolveError
@@ -19,8 +23,11 @@ from pants.engine.parser import HydratedStruct, SymbolTable
 from pants.engine.rules import rule
 from pants.engine.struct import Struct, StructWithDeps
 from pants.util.objects import Exactly
-from pants_test.engine.examples.parsers import (JsonParser, PythonAssignmentsParser,
-                                                PythonCallbacksParser)
+from pants_test.engine.examples.parsers import (
+  JsonParser,
+  PythonAssignmentsParser,
+  PythonCallbacksParser,
+)
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
 from pants_test.engine.util import Target, run_rule
 

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -10,9 +10,19 @@ from abc import ABCMeta
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler
 
-from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, Digest, DirectoriesToMerge,
-                             DirectoryToMaterialize, DirectoryWithPrefixToStrip, FilesContent,
-                             PathGlobs, PathGlobsAndRoot, Snapshot, UrlToFetch, create_fs_rules)
+from pants.engine.fs import (
+  EMPTY_DIRECTORY_DIGEST,
+  Digest,
+  DirectoriesToMerge,
+  DirectoryToMaterialize,
+  DirectoryWithPrefixToStrip,
+  FilesContent,
+  PathGlobs,
+  PathGlobsAndRoot,
+  Snapshot,
+  UrlToFetch,
+  create_fs_rules,
+)
 from pants.engine.scheduler import ExecutionError
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.util.collections import assert_single_element

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -4,10 +4,21 @@
 import os
 import unittest
 
-from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, Digest, FileContent, FilesContent,
-                             InputFilesContent, PathGlobs, Snapshot)
-from pants.engine.isolated_process import (ExecuteProcessRequest, ExecuteProcessResult,
-                                           FallibleExecuteProcessResult, ProcessExecutionFailure)
+from pants.engine.fs import (
+  EMPTY_DIRECTORY_DIGEST,
+  Digest,
+  FileContent,
+  FilesContent,
+  InputFilesContent,
+  PathGlobs,
+  Snapshot,
+)
+from pants.engine.isolated_process import (
+  ExecuteProcessRequest,
+  ExecuteProcessResult,
+  FallibleExecuteProcessResult,
+  ProcessExecutionFailure,
+)
 from pants.engine.rules import RootRule, rule
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Get

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -11,8 +11,14 @@ from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.build_files import create_graph_rules
 from pants.engine.fs import create_fs_rules
-from pants.engine.mapper import (AddressFamily, AddressMap, AddressMapper, DifferingFamiliesError,
-                                 DuplicateNameError, UnaddressableObjectError)
+from pants.engine.mapper import (
+  AddressFamily,
+  AddressMap,
+  AddressMapper,
+  DifferingFamiliesError,
+  DuplicateNameError,
+  UnaddressableObjectError,
+)
 from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct, SymbolTable
 from pants.engine.rules import rule

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -12,12 +12,23 @@ from pants.engine.console import Console
 from pants.engine.fs import create_fs_rules
 from pants.engine.goal import Goal
 from pants.engine.mapper import AddressMapper
-from pants.engine.rules import (MissingParameterTypeAnnotation, MissingReturnTypeAnnotation,
-                                RootRule, RuleIndex, _RuleVisitor, console_rule, rule)
+from pants.engine.rules import (
+  MissingParameterTypeAnnotation,
+  MissingReturnTypeAnnotation,
+  RootRule,
+  RuleIndex,
+  _RuleVisitor,
+  console_rule,
+  rule,
+)
 from pants.engine.selectors import Get
 from pants_test.engine.examples.parsers import JsonParser
-from pants_test.engine.util import (TARGET_TABLE, assert_equal_with_printing, create_scheduler,
-                                    run_rule)
+from pants_test.engine.util import (
+  TARGET_TABLE,
+  assert_equal_with_printing,
+  create_scheduler,
+  run_rule,
+)
 from pants_test.test_base import TestBase
 
 

--- a/tests/python/pants_test/help/test_build_dictionary_info_extracter.py
+++ b/tests/python/pants_test/help/test_build_dictionary_info_extracter.py
@@ -5,8 +5,11 @@ import unittest
 
 from pants.build_graph.build_file_aliases import BuildFileAliases, TargetMacro
 from pants.build_graph.target import Target
-from pants.help.build_dictionary_info_extracter import (BuildDictionaryInfoExtracter,
-                                                        BuildSymbolInfo, FunctionArg)
+from pants.help.build_dictionary_info_extracter import (
+  BuildDictionaryInfoExtracter,
+  BuildSymbolInfo,
+  FunctionArg,
+)
 from pants.util.objects import datatype
 
 

--- a/tests/python/pants_test/init/test_extension_loader.py
+++ b/tests/python/pants_test/init/test_extension_loader.py
@@ -7,8 +7,14 @@ import unittest
 import uuid
 from contextlib import contextmanager
 
-from pkg_resources import (Distribution, EmptyProvider, VersionConflict, WorkingSet, working_set,
-                           yield_lines)
+from pkg_resources import (
+  Distribution,
+  EmptyProvider,
+  VersionConflict,
+  WorkingSet,
+  working_set,
+  yield_lines,
+)
 
 from pants.base.exceptions import BuildConfigurationError
 from pants.build_graph.build_configuration import BuildConfiguration
@@ -17,8 +23,13 @@ from pants.build_graph.target import Target
 from pants.engine.rules import RootRule, rule
 from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar
-from pants.init.extension_loader import (PluginLoadOrderError, PluginNotFound, load_backend,
-                                         load_backends_and_plugins, load_plugins)
+from pants.init.extension_loader import (
+  PluginLoadOrderError,
+  PluginNotFound,
+  load_backend,
+  load_backends_and_plugins,
+  load_plugins,
+)
 from pants.subsystem.subsystem import Subsystem
 from pants.task.task import Task
 from pants.util.objects import datatype

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -18,8 +18,12 @@ from pants.init.plugin_resolver import PluginResolver
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_open, safe_rmtree, touch
-from pants_test.interpreter_selection_utils import (PY_36, PY_37, python_interpreter_path,
-                                                    skip_unless_python36_and_python37_present)
+from pants_test.interpreter_selection_utils import (
+  PY_36,
+  PY_37,
+  python_interpreter_path,
+  skip_unless_python36_and_python37_present,
+)
 
 
 req = Requirement.parse

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -10,9 +10,15 @@ from contextlib import contextmanager
 from twitter.common.collections import maybe_list
 
 from pants.base.revision import Revision
-from pants.java.distribution.distribution import (Distribution, DistributionLocator,
-                                                  _EnvVarEnvironment, _LinuxEnvironment, _Locator,
-                                                  _OSXEnvironment, _UnknownEnvironment)
+from pants.java.distribution.distribution import (
+  Distribution,
+  DistributionLocator,
+  _EnvVarEnvironment,
+  _LinuxEnvironment,
+  _Locator,
+  _OSXEnvironment,
+  _UnknownEnvironment,
+)
 from pants.util.contextutil import environment_as, temporary_dir, temporary_file
 from pants.util.dirutil import chmod_plus_x, safe_open, touch
 from pants_test.subsystem.subsystem_util import global_subsystem_instance

--- a/tests/python/pants_test/option/test_arg_splitter.py
+++ b/tests/python/pants_test/option/test_arg_splitter.py
@@ -4,8 +4,13 @@
 import shlex
 import unittest
 
-from pants.option.arg_splitter import (ArgSplitter, NoGoalHelp, OptionsHelp, UnknownGoalHelp,
-                                       VersionHelp)
+from pants.option.arg_splitter import (
+  ArgSplitter,
+  NoGoalHelp,
+  OptionsHelp,
+  UnknownGoalHelp,
+  VersionHelp,
+)
 from pants.option.scope import ScopeInfo
 
 

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -17,11 +17,21 @@ from pants.engine.fs import FileContent
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.config import Config
 from pants.option.custom_types import UnsetBool, file_option, target_option
-from pants.option.errors import (BooleanOptionNameWithNo, FrozenRegistration, ImplicitValIsNone,
-                                 InvalidKwarg, InvalidMemberType, MemberTypeNotAllowed,
-                                 NoOptionNames, OptionAlreadyRegistered, OptionNameDash,
-                                 OptionNameDoubleDash, ParseError, RecursiveSubsystemOption,
-                                 Shadowing)
+from pants.option.errors import (
+  BooleanOptionNameWithNo,
+  FrozenRegistration,
+  ImplicitValIsNone,
+  InvalidKwarg,
+  InvalidMemberType,
+  MemberTypeNotAllowed,
+  NoOptionNames,
+  OptionAlreadyRegistered,
+  OptionNameDash,
+  OptionNameDoubleDash,
+  ParseError,
+  RecursiveSubsystemOption,
+  Shadowing,
+)
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.optionable import Optionable
 from pants.option.options import Options

--- a/tests/python/pants_test/option/test_options_fingerprinter.py
+++ b/tests/python/pants_test/option/test_options_fingerprinter.py
@@ -5,8 +5,14 @@ import os
 
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
-from pants.option.custom_types import (UnsetBool, dict_option, dir_option, file_option, list_option,
-                                       target_option)
+from pants.option.custom_types import (
+  UnsetBool,
+  dict_option,
+  dir_option,
+  file_option,
+  list_option,
+  target_option,
+)
 from pants.option.options_fingerprinter import OptionsFingerprinter
 from pants.util.contextutil import temporary_dir
 from pants_test.test_base import TestBase

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -11,8 +11,12 @@ from contextlib import contextmanager
 
 import psutil
 
-from pants.pantsd.process_manager import (ProcessGroup, ProcessManager, ProcessMetadataManager,
-                                          swallow_psutil_exceptions)
+from pants.pantsd.process_manager import (
+  ProcessGroup,
+  ProcessManager,
+  ProcessMetadataManager,
+  swallow_psutil_exceptions,
+)
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_file_dump
 from pants_test.test_base import TestBase

--- a/tests/python/pants_test/source/test_source_root.py
+++ b/tests/python/pants_test/source/test_source_root.py
@@ -1,8 +1,13 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.source.source_root import (SourceRoot, SourceRootCategories, SourceRootConfig,
-                                      SourceRootFactory, SourceRootTrie)
+from pants.source.source_root import (
+  SourceRoot,
+  SourceRootCategories,
+  SourceRootConfig,
+  SourceRootFactory,
+  SourceRootTrie,
+)
 from pants_test.test_base import TestBase
 
 

--- a/tests/python/pants_test/task/echo_plugin/register.py
+++ b/tests/python/pants_test/task/echo_plugin/register.py
@@ -5,8 +5,10 @@ import os
 
 from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar as task
-from pants.task.target_restriction_mixins import (HasSkipAndTransitiveGoalOptionsMixin,
-                                                  SkipAndTransitiveGoalOptionsRegistrar)
+from pants.task.target_restriction_mixins import (
+  HasSkipAndTransitiveGoalOptionsMixin,
+  SkipAndTransitiveGoalOptionsRegistrar,
+)
 from pants.task.task import Task
 
 

--- a/tests/python/pants_test/tasks/test_execution_graph.py
+++ b/tests/python/pants_test/tasks/test_execution_graph.py
@@ -5,9 +5,14 @@ import re
 import unittest
 from collections import defaultdict
 
-from pants.backend.jvm.tasks.jvm_compile.execution_graph import (ExecutionFailure, ExecutionGraph,
-                                                                 Job, JobExistsError,
-                                                                 NoRootJobError, UnknownJobError)
+from pants.backend.jvm.tasks.jvm_compile.execution_graph import (
+  ExecutionFailure,
+  ExecutionGraph,
+  Job,
+  JobExistsError,
+  NoRootJobError,
+  UnknownJobError,
+)
 
 
 class ImmediatelyExecutingPool:

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -32,8 +32,15 @@ from pants.subsystem.subsystem import Subsystem
 from pants.task.goal_options_mixin import GoalOptionsMixin
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import (recursive_dirname, relative_symlink, safe_file_dump, safe_mkdir,
-                                safe_mkdtemp, safe_open, safe_rmtree)
+from pants.util.dirutil import (
+  recursive_dirname,
+  relative_symlink,
+  safe_file_dump,
+  safe_mkdir,
+  safe_mkdtemp,
+  safe_open,
+  safe_rmtree,
+)
 from pants.util.memo import memoized_method
 from pants.util.meta import classproperty
 from pants_test.base.context_utils import create_context_from_options

--- a/tests/python/pants_test/util/test_collections.py
+++ b/tests/python/pants_test/util/test_collections.py
@@ -3,8 +3,12 @@
 
 import unittest
 
-from pants.util.collections import (assert_single_element, combined_dict, factory_dict,
-                                    recursively_update)
+from pants.util.collections import (
+  assert_single_element,
+  combined_dict,
+  factory_dict,
+  recursively_update,
+)
 
 
 class TestCollections(unittest.TestCase):

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -13,9 +13,20 @@ import uuid
 import zipfile
 from contextlib import contextmanager
 
-from pants.util.contextutil import (InvalidZipPath, Timer, environment_as, exception_logging,
-                                    hermetic_environment_as, maybe_profiled, open_zip, pushd,
-                                    signal_handler_as, stdio_as, temporary_dir, temporary_file)
+from pants.util.contextutil import (
+  InvalidZipPath,
+  Timer,
+  environment_as,
+  exception_logging,
+  hermetic_environment_as,
+  maybe_profiled,
+  open_zip,
+  pushd,
+  signal_handler_as,
+  stdio_as,
+  temporary_dir,
+  temporary_file,
+)
 
 
 PATCH_OPTS = dict(autospec=True, spec_set=True)

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -10,12 +10,29 @@ from contextlib import contextmanager
 
 from pants.util import dirutil
 from pants.util.contextutil import pushd, temporary_dir
-from pants.util.dirutil import (ExistingDirError, ExistingFileError, _mkdtemp_unregister_cleaner,
-                                absolute_symlink, check_no_overlapping_paths, fast_relpath,
-                                get_basedir, longest_dir_prefix, mergetree, read_file,
-                                relative_symlink, relativize_paths, rm_rf, safe_concurrent_creation,
-                                safe_file_dump, safe_mkdir, safe_mkdtemp, safe_open,
-                                safe_rm_oldest_items_in_dir, safe_rmtree, touch)
+from pants.util.dirutil import (
+  ExistingDirError,
+  ExistingFileError,
+  _mkdtemp_unregister_cleaner,
+  absolute_symlink,
+  check_no_overlapping_paths,
+  fast_relpath,
+  get_basedir,
+  longest_dir_prefix,
+  mergetree,
+  read_file,
+  relative_symlink,
+  relativize_paths,
+  rm_rf,
+  safe_concurrent_creation,
+  safe_file_dump,
+  safe_mkdir,
+  safe_mkdtemp,
+  safe_open,
+  safe_rm_oldest_items_in_dir,
+  safe_rmtree,
+  touch,
+)
 from pants.util.objects import datatype
 
 

--- a/tests/python/pants_test/util/test_fileutil.py
+++ b/tests/python/pants_test/util/test_fileutil.py
@@ -9,8 +9,12 @@ import unittest
 import unittest.mock
 
 from pants.util.contextutil import temporary_dir, temporary_file, temporary_file_path
-from pants.util.fileutil import (atomic_copy, create_size_estimators, safe_hardlink_or_copy,
-                                 safe_temp_edit)
+from pants.util.fileutil import (
+  atomic_copy,
+  create_size_estimators,
+  safe_hardlink_or_copy,
+  safe_temp_edit,
+)
 
 
 class FileutilTest(unittest.TestCase):

--- a/tests/python/pants_test/util/test_memo.py
+++ b/tests/python/pants_test/util/test_memo.py
@@ -3,9 +3,17 @@
 
 import unittest
 
-from pants.util.memo import (memoized, memoized_classmethod, memoized_classproperty,
-                             memoized_method, memoized_property, memoized_staticmethod,
-                             memoized_staticproperty, per_instance, testable_memoized_property)
+from pants.util.memo import (
+  memoized,
+  memoized_classmethod,
+  memoized_classproperty,
+  memoized_method,
+  memoized_property,
+  memoized_staticmethod,
+  memoized_staticproperty,
+  per_instance,
+  testable_memoized_property,
+)
 
 
 class MemoizeTest(unittest.TestCase):

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -7,10 +7,19 @@ from abc import abstractmethod
 from collections import OrderedDict
 from textwrap import dedent
 
-from pants.util.objects import (EnumVariantSelectionError, Exactly, HashableTypedCollection,
-                                SubclassesOf, SuperclassesOf, TypeCheckError, TypeConstraintError,
-                                TypedCollection, TypedDatatypeInstanceConstructionError, datatype,
-                                enum)
+from pants.util.objects import (
+  EnumVariantSelectionError,
+  Exactly,
+  HashableTypedCollection,
+  SubclassesOf,
+  SuperclassesOf,
+  TypeCheckError,
+  TypeConstraintError,
+  TypedCollection,
+  TypedDatatypeInstanceConstructionError,
+  datatype,
+  enum,
+)
 from pants_test.test_base import TestBase
 
 

--- a/tests/python/pants_test/util/test_osutil.py
+++ b/tests/python/pants_test/util/test_osutil.py
@@ -4,8 +4,12 @@
 import logging
 from typing import Optional
 
-from pants.util.osutil import (OS_ALIASES, get_closest_mac_host_platform_pair, known_os_names,
-                               normalize_os_name)
+from pants.util.osutil import (
+  OS_ALIASES,
+  get_closest_mac_host_platform_pair,
+  known_os_names,
+  normalize_os_name,
+)
 from pants_test.test_base import TestBase
 
 


### PR DESCRIPTION
### Problem

Currently, the formatting situation in the python code is quite painful as it involves manual formatting of code.
I would like to replace our current workflow with one involving Black in a subsequent PR (see motivations for the choice over there).
Black is opinionated about code layout, so with our current settings, Black and isort would be having minor opinion differences.

### Solution

Modify the isort configuration to bend to Black's taste.

### Result

Once we run Black on the codebase with a minimal configuration, isort will be happy with the results.