### PR TITLE
Use double quoted string in __init__.py files to prepare for Black

### DIFF
--- a/build-support/bin/check_packages.sh
+++ b/build-support/bin/check_packages.sh
@@ -14,7 +14,7 @@ bad_files=()
 for package_file in ${non_empty_files}
 do
   if [[ "$(sed -E -e 's/^[[:space:]]+//' -e 's/[[:space:]]+$//' "${package_file}")" != \
-        "__import__('pkg_resources').declare_namespace(__name__)" ]]
+        '__import__("pkg_resources").declare_namespace(__name__)' ]]
   then
     bad_files+=("${package_file}")
   fi

--- a/contrib/avro/src/python/pants/__init__.py
+++ b/contrib/avro/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/avro/src/python/pants/contrib/__init__.py
+++ b/contrib/avro/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/avro/src/python/pants/contrib/avro/__init__.py
+++ b/contrib/avro/src/python/pants/contrib/avro/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/avro/src/python/pants/contrib/avro/targets/__init__.py
+++ b/contrib/avro/src/python/pants/contrib/avro/targets/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/avro/src/python/pants/contrib/avro/tasks/__init__.py
+++ b/contrib/avro/src/python/pants/contrib/avro/tasks/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/awslambda/python/src/python/pants/__init__.py
+++ b/contrib/awslambda/python/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/awslambda/python/src/python/pants/contrib/__init__.py
+++ b/contrib/awslambda/python/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/awslambda/python/tests/python/pants_test/__init__.py
+++ b/contrib/awslambda/python/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/awslambda/python/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/awslambda/python/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python/__init__.py
+++ b/contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/buildgen/src/python/pants/__init__.py
+++ b/contrib/buildgen/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/buildgen/src/python/pants/contrib/__init__.py
+++ b/contrib/buildgen/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/buildgen/src/python/pants/contrib/buildgen/__init__.py
+++ b/contrib/buildgen/src/python/pants/contrib/buildgen/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/buildgen/tests/python/pants_test/__init__.py
+++ b/contrib/buildgen/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/buildgen/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/buildgen/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/buildgen/tests/python/pants_test/contrib/buildgen/__init__.py
+++ b/contrib/buildgen/tests/python/pants_test/contrib/buildgen/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/buildrefactor/src/python/pants/__init__.py
+++ b/contrib/buildrefactor/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/buildrefactor/src/python/pants/contrib/__init__.py
+++ b/contrib/buildrefactor/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/__init__.py
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/buildrefactor/tests/python/pants_test/__init__.py
+++ b/contrib/buildrefactor/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/__init__.py
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/codeanalysis/src/python/pants/__init__.py
+++ b/contrib/codeanalysis/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/codeanalysis/src/python/pants/contrib/__init__.py
+++ b/contrib/codeanalysis/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/confluence/src/python/pants/__init__.py
+++ b/contrib/confluence/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/confluence/src/python/pants/contrib/__init__.py
+++ b/contrib/confluence/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/cpp/src/python/pants/__init__.py
+++ b/contrib/cpp/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/cpp/src/python/pants/contrib/__init__.py
+++ b/contrib/cpp/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/cpp/tests/python/pants_test/__init__.py
+++ b/contrib/cpp/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/cpp/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/cpp/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/errorprone/src/python/pants/__init__.py
+++ b/contrib/errorprone/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/errorprone/src/python/pants/contrib/__init__.py
+++ b/contrib/errorprone/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/errorprone/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/errorprone/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/errorprone/tests/python/pants_test/contrib/errorprone/__init__.py
+++ b/contrib/errorprone/tests/python/pants_test/contrib/errorprone/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/findbugs/src/python/pants/__init__.py
+++ b/contrib/findbugs/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/findbugs/src/python/pants/contrib/__init__.py
+++ b/contrib/findbugs/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/findbugs/tests/python/pants_test/__init__.py
+++ b/contrib/findbugs/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/findbugs/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/findbugs/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/go/src/python/pants/__init__.py
+++ b/contrib/go/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/go/src/python/pants/contrib/__init__.py
+++ b/contrib/go/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/go/tests/python/pants_test/__init__.py
+++ b/contrib/go/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/go/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/go/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/googlejavaformat/src/python/pants/__init__.py
+++ b/contrib/googlejavaformat/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/googlejavaformat/src/python/pants/contrib/__init__.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/jax_ws/src/python/pants/__init__.py
+++ b/contrib/jax_ws/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/jax_ws/src/python/pants/contrib/__init__.py
+++ b/contrib/jax_ws/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/jax_ws/tests/python/pants_test/__init__.py
+++ b/contrib/jax_ws/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/jax_ws/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/jax_ws/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/mypy/src/python/pants/__init__.py
+++ b/contrib/mypy/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/mypy/src/python/pants/contrib/__init__.py
+++ b/contrib/mypy/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/mypy/src/python/pants/contrib/mypy/__init__.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/__init__.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/mypy/tests/python/pants_test/__init__.py
+++ b/contrib/mypy/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/mypy/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/mypy/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/__init__.py
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/__init__.py
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/node/src/python/pants/__init__.py
+++ b/contrib/node/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/node/src/python/pants/contrib/__init__.py
+++ b/contrib/node/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/node/tests/python/pants_test/__init__.py
+++ b/contrib/node/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/node/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/node/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/python/src/python/pants/__init__.py
+++ b/contrib/python/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/python/src/python/pants/contrib/__init__.py
+++ b/contrib/python/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/python/src/python/pants/contrib/python/__init__.py
+++ b/contrib/python/src/python/pants/contrib/python/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/python/src/python/pants/contrib/python/checks/__init__.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/python/tests/python/pants_test/__init__.py
+++ b/contrib/python/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/python/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/python/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/python/tests/python/pants_test/contrib/python/__init__.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/scalajs/src/python/pants/__init__.py
+++ b/contrib/scalajs/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/scalajs/src/python/pants/contrib/__init__.py
+++ b/contrib/scalajs/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/scalajs/tests/python/pants_test/__init__.py
+++ b/contrib/scalajs/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/scalajs/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/scalajs/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/scrooge/src/python/pants/__init__.py
+++ b/contrib/scrooge/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/scrooge/src/python/pants/contrib/__init__.py
+++ b/contrib/scrooge/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/scrooge/tests/python/pants_test/__init__.py
+++ b/contrib/scrooge/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/scrooge/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/thrifty/src/python/pants/__init__.py
+++ b/contrib/thrifty/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/contrib/thrifty/src/python/pants/contrib/__init__.py
+++ b/contrib/thrifty/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/src/python/pants/__init__.py
+++ b/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/src/python/pants/backend/__init__.py
+++ b/src/python/pants/backend/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/__init__.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/tests/python/pants_test/__init__.py
+++ b/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/tests/python/pants_test/repo_scripts/test_git_hooks.py
+++ b/tests/python/pants_test/repo_scripts/test_git_hooks.py
@@ -72,7 +72,7 @@ subdir/__init__.py
       self._assert_subprocess_success(worktree, [package_check_script, 'subdir'])
 
       # Check that a valid __init__.py with `pkg_resources` setup succeeds.
-      safe_file_dump(init_py_path, "__import__('pkg_resources').declare_namespace(__name__)")
+      safe_file_dump(init_py_path, "__import__(\"pkg_resources\").declare_namespace(__name__)")
       self._assert_subprocess_success(worktree, [package_check_script, 'subdir'])
 
   # TODO: consider testing the degree to which copies (-C) and moves (-M) are detected by making


### PR DESCRIPTION
### Problem

Currently, we use a mix of single quoted strings and double quoted strings throughout our codebase.

Using Black on our code in a future PR will allow to finally get consistency for very little effort.

### Solution

Black is opinionated and prefers double quoted strings, so modify our check_packages.sh script to share that opinion.

### Result

Once we run Black on the codebase with a minimal configuration, check_packages.sh won't complain about it.