### PR TITLE
Add a minimal black configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.black]
+line-length = 100
+exclude = '''
+/(
+  | \.git
+  | \.mypy_cache
+  | dist
+  | \.pants\.d
+  | virtualenvs
+  # This file intentionally contains invalid syntax
+  # It trips black up.
+  | compilation_failure
+)/
+'''


### PR DESCRIPTION
### Problem

Rumour has it we may want to format the python code in pants with black
in the near future. With no configuration at all, Black would fail to format one specific file and would use a line length of 88 which is a bit short for our liking.

### Solution

Black is opinionated, which means that not much config is necessary.

Provide the minimum needed for pants own taste:
* line length of 100, which is consistent with previous practice (see
  pre-existing .isort.cfg for a piece of evidence backing this statement)
* exclude a few directories such as vitrualenv that really shouldn't be
  touched by Black. We also exclude "compilation_failure". This pattern
  matches a single file in our repo which trips Black up with its mix of
  invalid python syntax and use of a unicode character.

### Result

When we run Black later, through pants or manually, it should just do what we want without needing any CLI arguments.