### PR TITLE
Add black support as a v2 rule

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -36,6 +36,11 @@ files(
   source = 'pants.ini',
 )
 
+files(
+  name = 'pyproject',
+  source = 'pyproject.toml',
+)
+
 # NB: This is used for integration tests. This is generated automatically via `./pants` and
 # `build-support/bin/bootstrap_pants_pex.sh`.
 files(

--- a/examples/src/python/example/hello/greet/greet.py
+++ b/examples/src/python/example/hello/greet/greet.py
@@ -5,5 +5,5 @@ from colors import green
 
 
 def greet(greetee):
-  """Given the name, return a greeting for a person of that name."""
-  return green('Hello, {}!'.format(greetee))
+    """Given the name, return a greeting for a person of that name."""
+    return green("Hello, {}!".format(greetee))

--- a/examples/src/python/example/hello/main/main.py
+++ b/examples/src/python/example/hello/main/main.py
@@ -6,7 +6,7 @@ import sys
 from example.hello.greet.greet import greet
 
 
-if __name__ == '__main__':
-  greetees = sys.argv[1:] or ['world']
-  for greetee in greetees:
-    print(greet(greetee))
+if __name__ == "__main__":
+    greetees = sys.argv[1:] or ["world"]
+    for greetee in greetees:
+        print(greet(greetee))

--- a/pants.ini
+++ b/pants.ini
@@ -82,6 +82,8 @@ pants_ignore: +[
     '/build-support/bin/native/src',
   ]
 
+[black]
+config: pyproject.toml
 
 [cache]
 # Caching is on globally by default, but we disable it here for development purposes.

--- a/pants.ini
+++ b/pants.ini
@@ -260,6 +260,9 @@ skip: True
 # --closure option is removed. See comment in the task code for details.
 transitive: True
 
+[lint.pythonstyle]
+skip: True
+
 [lint.scalafmt]
 skip: True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.black]
+line-length = 100
+exclude = '''
+/(
+  | \.git
+  | \.mypy_cache
+  | dist
+  | \.pants\.d
+  | virtualenvs
+  # This file intentionally contains invalid syntax
+  # It trips black up.
+  | compilation_failure
+)/
+'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 line-length = 100
 exclude = '''
 /(
+  # These would already be ignored by pants, but having them here allows for manually running Black if one so whishes.
   | \.git
   | \.mypy_cache
   | dist

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -5,7 +5,13 @@ from pants.backend.python.pants_requirement import PantsRequirement
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.python_requirements import PythonRequirements
-from pants.backend.python.rules import download_pex_bin, inject_init, pex, python_test_runner
+from pants.backend.python.rules import (
+  download_pex_bin,
+  inject_init,
+  pex,
+  python_fmt,
+  python_test_runner,
+)
 from pants.backend.python.subsystems.python_native_code import PythonNativeCode
 from pants.backend.python.subsystems.python_native_code import rules as python_native_code_rules
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEnvironment
@@ -93,6 +99,7 @@ def rules():
   return (
     download_pex_bin.rules() +
     inject_init.rules() +
+    python_fmt.rules() +
     python_test_runner.rules() +
     python_native_code_rules() +
     pex.rules() +

--- a/src/python/pants/backend/python/rules/python_fmt.py
+++ b/src/python/pants/backend/python/rules/python_fmt.py
@@ -3,8 +3,9 @@
 
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Set
+from typing import Any, Set
 
 from pants.backend.python.rules.pex import CreatePex, Pex
 from pants.backend.python.subsystems.black import Black
@@ -22,14 +23,14 @@ from pants.engine.legacy.structs import (
 from pants.engine.rules import UnionRule, optionable_rule, rule
 from pants.engine.selectors import Get
 from pants.rules.core.fmt import FmtResult, FmtTarget
-from pants.util.objects import datatype
 
 
 # Note: this is a workaround until https://github.com/pantsbuild/pants/issues/8343 is addressed
 # We have to write this type which basically represents a union of all various kinds of targets
 # containing python files so we can have one single type used as an input in the run_black rule.
-class FormattablePythonTarget(datatype(['target'])):
-  pass
+@dataclass(frozen=True)
+class FormattablePythonTarget:
+    target: Any
 
 
 @rule

--- a/src/python/pants/backend/python/rules/python_fmt.py
+++ b/src/python/pants/backend/python/rules/python_fmt.py
@@ -3,6 +3,8 @@
 
 import os
 import re
+from pathlib import Path
+from typing import Set
 
 from pants.backend.python.rules.pex import CreatePex, Pex
 from pants.backend.python.subsystems.black import Black
@@ -65,14 +67,14 @@ def run_black(
   # The exclude option from Black only works on recursive invocations,
   # so call black with the directories in which the files are present
   # and passing the full file names with the include option
-  dirs = set()
+  dirs: Set[str] = set()
   for filename in target.sources.snapshot.files:
-    dirs.add(os.path.dirname(filename))
+    dirs.add(f"{Path(filename).parent}")
   pex_args= tuple(sorted(dirs))
   if config_path:
     pex_args += ("--config", config_path)
   if target.sources.snapshot.files:
-    pex_args += ("--include", "|".join(re.escape(file) for file in target.sources.snapshot.files))
+    pex_args += ("--include", "|".join(re.escape(f) for f in target.sources.snapshot.files))
 
   request = resolved_requirements_pex.create_execute_request(
     python_setup=python_setup,

--- a/src/python/pants/backend/python/rules/python_fmt.py
+++ b/src/python/pants/backend/python/rules/python_fmt.py
@@ -40,7 +40,7 @@ def run_black(
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
   ) -> FmtResult:
   config_path = black.get_options().config
-  config_snapshot = yield Get(Snapshot, PathGlobs, PathGlobs(include=(config_path,)))
+  config_snapshot = yield Get(Snapshot, PathGlobs(include=(config_path,)))
 
   resolved_requirements_pex = yield Get(
     Pex, CreatePex(
@@ -60,7 +60,6 @@ def run_black(
   ]
   merged_input_files = yield Get(
     Digest,
-    DirectoriesToMerge,
     DirectoriesToMerge(directories=tuple(all_input_digests)),
   )
 

--- a/src/python/pants/backend/python/rules/python_fmt.py
+++ b/src/python/pants/backend/python/rules/python_fmt.py
@@ -1,0 +1,132 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+
+from pants.backend.python.rules.pex import CreatePex, Pex
+from pants.backend.python.subsystems.black import Black
+from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
+from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
+from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.legacy.structs import (
+  PantsPluginAdaptor,
+  PythonAppAdaptor,
+  PythonBinaryAdaptor,
+  PythonTargetAdaptor,
+  PythonTestsAdaptor,
+)
+from pants.engine.rules import UnionRule, optionable_rule, rule
+from pants.engine.selectors import Get
+from pants.rules.core.fmt import FmtResult, FmtTarget
+from pants.util.objects import datatype
+
+
+class PythonFormatable(datatype(['target'])):
+  pass
+
+
+@rule
+def run_black(
+  target: PythonFormatable,
+  black: Black,
+  python_setup: PythonSetup,
+  subprocess_encoding_environment: SubprocessEncodingEnvironment,
+  ) -> FmtResult:
+  config_path = black.get_options().config
+  config_snapshot = yield Get(Snapshot, PathGlobs, PathGlobs(include=(config_path,)))
+
+  resolved_requirements_pex = yield Get(
+    Pex, CreatePex(
+      output_filename="black.pex",
+      requirements=tuple(black.get_requirement_specs()),
+      interpreter_constraints=(),
+      entry_point=black.get_entry_point(),
+    )
+  )
+  target = target.target
+  sources_digest = target.sources.snapshot.directory_digest
+
+  all_input_digests = [
+    sources_digest,
+    resolved_requirements_pex.directory_digest,
+    config_snapshot.directory_digest,
+  ]
+  merged_input_files = yield Get(
+    Digest,
+    DirectoriesToMerge,
+    DirectoriesToMerge(directories=tuple(all_input_digests)),
+  )
+
+  # The exclude option from Black only works on recursive invocations,
+  # so call black with the directories in which the files are present
+  # and passing the full file names with the include option
+  dirs = []
+  for filename in target.sources.snapshot.files:
+    dirs.append(os.path.dirname(filename))
+  pex_args= tuple(dirs)
+  if config_path:
+    pex_args += ("--config", config_path)
+  if target.sources.snapshot.files:
+    pex_args += ("--include",) + target.sources.snapshot.files
+
+  request = resolved_requirements_pex.create_execute_request(
+    python_setup=python_setup,
+    subprocess_encoding_environment=subprocess_encoding_environment,
+    pex_path="./black.pex",
+    pex_args=pex_args,
+    input_files=merged_input_files,
+    output_files=target.sources.snapshot.files,
+    description=f'Run Black for {target.address.reference()}',
+  )
+
+  result = yield Get(ExecuteProcessResult, ExecuteProcessRequest, request)
+
+  yield FmtResult(
+    digest=result.output_directory_digest,
+    stdout=result.stdout.decode(),
+    stderr=result.stderr.decode(),
+  )
+
+
+@rule
+def target_adaptor(target: PythonTargetAdaptor) -> PythonFormatable:
+  yield PythonFormatable(target)
+
+
+@rule
+def app_adaptor(target: PythonAppAdaptor) -> PythonFormatable:
+  yield PythonFormatable(target)
+
+
+@rule
+def binary_adaptor(target: PythonBinaryAdaptor) -> PythonFormatable:
+  yield PythonFormatable(target)
+
+
+@rule
+def tests_adaptor(target: PythonTestsAdaptor) -> PythonFormatable:
+  yield PythonFormatable(target)
+
+
+@rule
+def plugin_adaptor(target: PantsPluginAdaptor) -> PythonFormatable:
+  yield PythonFormatable(target)
+
+
+def rules():
+  return [
+    target_adaptor,
+    app_adaptor,
+    binary_adaptor,
+    tests_adaptor,
+    plugin_adaptor,
+    run_black,
+    UnionRule(FmtTarget, PythonTargetAdaptor),
+    UnionRule(FmtTarget, PythonAppAdaptor),
+    UnionRule(FmtTarget, PythonBinaryAdaptor),
+    UnionRule(FmtTarget, PythonTestsAdaptor),
+    UnionRule(FmtTarget, PantsPluginAdaptor),
+    optionable_rule(Black),
+    optionable_rule(PythonSetup),
+  ]

--- a/src/python/pants/backend/python/rules/python_fmt.py
+++ b/src/python/pants/backend/python/rules/python_fmt.py
@@ -22,6 +22,7 @@ from pants.engine.selectors import Get
 from pants.rules.core.fmt import FmtResult, FmtTarget
 from pants.util.objects import datatype
 
+
 # Note: this is a workaround until https://github.com/pantsbuild/pants/issues/8343 is addressed
 # We have to write this type which basically represents a union of all various kinds of targets
 # containing python files so we can have one single type used as an input in the run_black rule.

--- a/src/python/pants/backend/python/rules/python_fmt.py
+++ b/src/python/pants/backend/python/rules/python_fmt.py
@@ -94,27 +94,31 @@ def run_black(
     stderr=result.stderr.decode(),
   )
 
-
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
 @rule
 def target_adaptor(target: PythonTargetAdaptor) -> FormattablePythonTarget:
   yield FormattablePythonTarget(target)
 
 
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
 @rule
 def app_adaptor(target: PythonAppAdaptor) -> FormattablePythonTarget:
   yield FormattablePythonTarget(target)
 
 
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
 @rule
 def binary_adaptor(target: PythonBinaryAdaptor) -> FormattablePythonTarget:
   yield FormattablePythonTarget(target)
 
 
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
 @rule
 def tests_adaptor(target: PythonTestsAdaptor) -> FormattablePythonTarget:
   yield FormattablePythonTarget(target)
 
 
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
 @rule
 def plugin_adaptor(target: PantsPluginAdaptor) -> FormattablePythonTarget:
   yield FormattablePythonTarget(target)

--- a/src/python/pants/backend/python/rules/python_fmt.py
+++ b/src/python/pants/backend/python/rules/python_fmt.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
 import re
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/python/pants/backend/python/subsystems/black.py
+++ b/src/python/pants/backend/python/subsystems/black.py
@@ -1,0 +1,17 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.option.custom_types import file_option
+
+
+class Black(PythonToolBase):
+  options_scope = 'black'
+  default_requirements = ['black==19.3b0', 'setuptools']
+  default_entry_point = 'black:patched_main'
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register('--config', advanced=True, type=file_option, fingerprint=True,
+              help="Path to formatting tool's config file")

--- a/src/python/pants/backend/python/subsystems/black.py
+++ b/src/python/pants/backend/python/subsystems/black.py
@@ -9,6 +9,7 @@ class Black(PythonToolBase):
   options_scope = 'black'
   default_requirements = ['black==19.3b0', 'setuptools']
   default_entry_point = 'black:patched_main'
+  default_interpreter_constraints = ["CPython>=3.6"]
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -77,6 +77,7 @@ python_binary(
     '//:build_tools',
     '//:pants_ini',
     '//:3rdparty_directory',
+    '//:pyproject',
     'build-support/checkstyle',
     'build-support/eslint',
     'build-support/ivy',

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -1,0 +1,68 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+
+from pants.base.build_environment import get_buildroot
+from pants.engine.console import Console
+from pants.engine.fs import Digest, FilesContent
+from pants.engine.goal import Goal
+from pants.engine.legacy.graph import HydratedTargets
+from pants.engine.legacy.structs import (
+  PythonAppAdaptor,
+  PythonBinaryAdaptor,
+  PythonTargetAdaptor,
+  PythonTestsAdaptor,
+)
+from pants.engine.rules import console_rule, union
+from pants.engine.selectors import Get
+from pants.util.objects import datatype
+
+
+class FmtResult(datatype([
+  ('digest', Digest),
+  ('stdout', str),
+  ('stderr', str),
+])):
+
+  pass
+
+
+@union
+class FmtTarget:
+  """A union for registration of a testable target type."""
+
+
+class Fmt(Goal):
+  """Autoformat source code."""
+
+  name = 'fmt_v2'
+
+
+@console_rule
+def fmt(console: Console, targets: HydratedTargets) -> Fmt:
+  results = yield [
+          Get(FmtResult, FmtTarget, target.adaptor)
+          for target in targets
+          if isinstance(target.adaptor, (PythonAppAdaptor, PythonTargetAdaptor, PythonTestsAdaptor, PythonBinaryAdaptor)) and hasattr(target.adaptor, "sources")
+          ]
+
+  for result in results:
+    files_content = yield Get(FilesContent, Digest, result.digest)
+    for file_content in files_content:
+      with open(os.path.join(get_buildroot(), file_content.path), "wb") as f:
+        f.write(file_content.content)
+
+    console.print_stdout(result.stdout)
+    console.print_stderr(result.stderr)
+
+  # workspace.materialize_directories(tuple(digests))
+  # Since we ran an ExecuteRequest, any failure would already have interrupted our flow
+  exit_code = 0
+  yield Fmt(exit_code)
+
+
+def rules():
+  return [
+      fmt,
+    ]

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -38,7 +38,7 @@ class Fmt(Goal):
 
   # TODO: make this "fmt"
   # Blocked on https://github.com/pantsbuild/pants/issues/8351
-  name = 'fmt_v2'
+  name = 'fmt-v2'
 
 
 @console_rule

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from dataclasses import dataclass
+from pathlib import Path
 
 from pants.base.build_environment import get_buildroot
 from pants.engine.console import Console
@@ -19,13 +21,11 @@ from pants.engine.selectors import Get
 from pants.util.objects import datatype
 
 
-class FmtResult(datatype([
-  ('digest', Digest),
-  ('stdout', str),
-  ('stderr', str),
-])):
-
-  pass
+@dataclass(frozen=True)
+class FmtResult:
+  digest: Digest
+  stdout: str
+  stderr: str
 
 
 @union
@@ -61,7 +61,7 @@ def fmt(console: Console, targets: HydratedTargets) -> Fmt:
     # once that is available on master.
     # Blocked on: https://github.com/pantsbuild/pants/pull/8329
     for file_content in files_content:
-      with open(os.path.join(get_buildroot(), file_content.path), "wb") as f:
+      with Path(get_buildroot(), file_content.path).open('wb') as f:
         f.write(file_content.content)
 
     if result.stdout:
@@ -69,7 +69,6 @@ def fmt(console: Console, targets: HydratedTargets) -> Fmt:
     if result.stderr:
       console.print_stderr(result.stderr)
 
-  # workspace.materialize_directories(tuple(digests))
   # Since we ran an ExecuteRequest, any failure would already have interrupted our flow
   exit_code = 0
   yield Fmt(exit_code)

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
 from dataclasses import dataclass
 from pathlib import Path
 

--- a/src/python/pants/rules/core/register.py
+++ b/src/python/pants/rules/core/register.py
@@ -1,11 +1,12 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.rules.core import filedeps, list_roots, list_targets, strip_source_root, test
+from pants.rules.core import filedeps, fmt, list_roots, list_targets, strip_source_root, test
 
 
 def rules():
   return [
+    *fmt.rules(),
     *list_roots.rules(),
     *list_targets.rules(),
     *filedeps.rules(),

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -57,6 +57,7 @@ target(
     # on changes to those undeclared dependencies.
     'src/python/pants/bin:pants_local_binary',
     'src/rust/engine',
+    '//:pyproject',
   ],
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
@@ -95,6 +95,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
       'contrib',
       'pants-plugins',
       'src',
+      'pyproject.toml',
     ))
     with temporary_dir() as temp_root:
       temp_root = os.path.normpath(temp_root)

--- a/tests/python/pants_test/backend/python/rules/BUILD
+++ b/tests/python/pants_test/backend/python/rules/BUILD
@@ -45,11 +45,9 @@ python_tests(
   source='test_python_fmt_integration.py',
   dependencies=[
     'tests/python/pants_test:int-test',
-    '//:pyproject',
     'testprojects/src/python:unicode_directory',
     'examples/src/python/example:hello_directory',
   ],
   tags={'integration'},
-  timeout = 90,
 )
 

--- a/tests/python/pants_test/backend/python/rules/BUILD
+++ b/tests/python/pants_test/backend/python/rules/BUILD
@@ -40,3 +40,16 @@ python_tests(
   timeout = 90,
 )
 
+python_tests(
+  name='python_fmt_integration',
+  source='test_python_fmt_integration.py',
+  dependencies=[
+    'tests/python/pants_test:int-test',
+    '//:pyproject',
+    'testprojects/src/python:unicode_directory',
+    'examples/src/python/example:hello_directory',
+  ],
+  tags={'integration'},
+  timeout = 90,
+)
+

--- a/tests/python/pants_test/backend/python/rules/test_python_fmt_integration.py
+++ b/tests/python/pants_test/backend/python/rules/test_python_fmt_integration.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from os.path import relpath
+from pathlib import Path
 
 from pants.util.contextutil import temporary_file, temporary_file_path
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
@@ -70,8 +71,7 @@ class PythonFmtIntegrationTest(PantsRunIntegrationTest):
         'examples/src/python/example/hello/greet:greet'
         ]
       pants_run = self.run_pants(command=command)
-      code = open(file_name)
-      formatted = code.read();
+      formatted = Path(file_name).read_text();
       self.assertEqual("x = 42\n", formatted)
     self.assert_success(pants_run)
     self.assertIn("1 file reformatted", pants_run.stderr_data)

--- a/tests/python/pants_test/backend/python/rules/test_python_fmt_integration.py
+++ b/tests/python/pants_test/backend/python/rules/test_python_fmt_integration.py
@@ -1,0 +1,78 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from os.path import relpath
+
+from pants.util.contextutil import temporary_file, temporary_file_path
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
+
+
+class PythonFmtIntegrationTest(PantsRunIntegrationTest):
+  def test_black_one_python_source_should_leave_one_file_unchanged(self):
+    command = [
+      'fmt_v2',
+      'examples/src/python/example/hello/main:main'
+      ]
+    pants_run = self.run_pants(command=command)
+    self.assert_success(pants_run)
+    self.assertNotIn("reformatted", pants_run.stderr_data)
+    self.assertIn("1 file left unchanged", pants_run.stderr_data)
+
+
+  def test_black_two_python_sources_should_leave_two_files_unchanged(self):
+    command = [
+      'fmt_v2',
+      'examples/src/python/example/hello/greet:greet'
+      ]
+    pants_run = self.run_pants(command=command)
+    self.assert_success(pants_run)
+    self.assertNotIn("reformatted", pants_run.stderr_data)
+    self.assertIn("2 files left unchanged", pants_run.stderr_data)
+
+
+  def test_black_should_pickup_default_config(self):
+    # If the default config (pyproject.toml is picked up, the compilation_failure target will be skipped
+    command = [
+      'fmt_v2',
+      'testprojects/src/python/unicode/compilation_failure::'
+      ]
+    pants_run = self.run_pants(command=command)
+    self.assert_success(pants_run)
+    self.assertNotIn("reformatted", pants_run.stderr_data)
+    self.assertNotIn("unchanged", pants_run.stderr_data)
+    self.assertIn("Nothing to do", pants_run.stderr_data)
+
+
+  def test_black_should_pickup_non_default_config(self):
+    # If a valid toml file without a black configuration section is picked up,
+    # Black won't skip the compilation_failure and will fail
+    with temporary_file_path(root_dir=".", suffix=".toml") as empty_config:
+      command = [
+        'fmt_v2',
+        'testprojects/src/python/unicode/compilation_failure::',
+        f'--black-config={relpath(empty_config)}'
+        ]
+      pants_run = self.run_pants(command=command)
+    self.assert_failure(pants_run)
+    self.assertNotIn("reformatted", pants_run.stderr_data)
+    self.assertNotIn("unchanged", pants_run.stderr_data)
+    self.assertIn("1 file failed to reformat", pants_run.stderr_data)
+
+
+  def test_black_should_format_python_code(self):
+    # Open file in the greet target as the BUILD file globs python files from there
+    with temporary_file(root_dir="./examples/src/python/example/hello/greet/", suffix=".py") as code:
+      file_name = code.name
+      code.write(b"x     = 42")
+      code.close()
+      command = [
+        'fmt_v2',
+        'examples/src/python/example/hello/greet:greet'
+        ]
+      pants_run = self.run_pants(command=command)
+      code = open(file_name)
+      formatted = code.read();
+      self.assertEqual("x = 42\n", formatted)
+    self.assert_success(pants_run)
+    self.assertIn("1 file reformatted", pants_run.stderr_data)
+    self.assertIn("2 files left unchanged", pants_run.stderr_data)

--- a/tests/python/pants_test/backend/python/rules/test_python_fmt_integration.py
+++ b/tests/python/pants_test/backend/python/rules/test_python_fmt_integration.py
@@ -10,7 +10,7 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensur
 class PythonFmtIntegrationTest(PantsRunIntegrationTest):
   def test_black_one_python_source_should_leave_one_file_unchanged(self):
     command = [
-      'fmt_v2',
+      'fmt-v2',
       'examples/src/python/example/hello/main:main'
       ]
     pants_run = self.run_pants(command=command)
@@ -21,7 +21,7 @@ class PythonFmtIntegrationTest(PantsRunIntegrationTest):
 
   def test_black_two_python_sources_should_leave_two_files_unchanged(self):
     command = [
-      'fmt_v2',
+      'fmt-v2',
       'examples/src/python/example/hello/greet:greet'
       ]
     pants_run = self.run_pants(command=command)
@@ -33,7 +33,7 @@ class PythonFmtIntegrationTest(PantsRunIntegrationTest):
   def test_black_should_pickup_default_config(self):
     # If the default config (pyproject.toml is picked up, the compilation_failure target will be skipped
     command = [
-      'fmt_v2',
+      'fmt-v2',
       'testprojects/src/python/unicode/compilation_failure::'
       ]
     pants_run = self.run_pants(command=command)
@@ -48,7 +48,7 @@ class PythonFmtIntegrationTest(PantsRunIntegrationTest):
     # Black won't skip the compilation_failure and will fail
     with temporary_file_path(root_dir=".", suffix=".toml") as empty_config:
       command = [
-        'fmt_v2',
+        'fmt-v2',
         'testprojects/src/python/unicode/compilation_failure::',
         f'--black-config={relpath(empty_config)}'
         ]
@@ -66,7 +66,7 @@ class PythonFmtIntegrationTest(PantsRunIntegrationTest):
       code.write(b"x     = 42")
       code.close()
       command = [
-        'fmt_v2',
+        'fmt-v2',
         'examples/src/python/example/hello/greet:greet'
         ]
       pants_run = self.run_pants(command=command)

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -328,7 +328,8 @@ class PantsRunIntegrationTest(unittest.TestCase):
         ini.write(fp)
       args.append('--pants-config-files=' + ini_file_name)
 
-    Path('pyproject.toml').touch()
+    if not Path(get_buildroot()).samefile(Path(".")):
+      shutil.copy(str(Path(get_buildroot(), "pyproject.toml")), str(Path(".")))
 
     pants_script = [sys.executable, '-m', 'pants']
 

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -12,6 +12,7 @@ import unittest
 from contextlib import contextmanager
 from dataclasses import dataclass
 from operator import eq, ne
+from pathlib import Path
 from threading import Lock
 from typing import Any, List, Optional, Union
 
@@ -326,6 +327,8 @@ class PantsRunIntegrationTest(unittest.TestCase):
       with safe_open(ini_file_name, mode='w') as fp:
         ini.write(fp)
       args.append('--pants-config-files=' + ini_file_name)
+
+    Path('pyproject.toml').touch()
 
     pants_script = [sys.executable, '-m', 'pants']
 

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -12,7 +12,6 @@ import unittest
 from contextlib import contextmanager
 from dataclasses import dataclass
 from operator import eq, ne
-from pathlib import Path
 from threading import Lock
 from typing import Any, List, Optional, Union
 
@@ -328,9 +327,6 @@ class PantsRunIntegrationTest(unittest.TestCase):
         ini.write(fp)
       args.append('--pants-config-files=' + ini_file_name)
 
-    if not Path(get_buildroot()).samefile(Path(".")):
-      shutil.copy(str(Path(get_buildroot(), "pyproject.toml")), str(Path(".")))
-
     pants_script = [sys.executable, '-m', 'pants']
 
     # Permit usage of shell=True and string-based commands to allow e.g. `./pants | head`.
@@ -604,6 +600,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
                      'pants-plugins',
                      'pants.ini',
                      'pants.travis-ci.ini',
+                     'pyproject.toml',
                      'rust-toolchain',
                      'src')
     dirs_to_copy = ('3rdparty', 'contrib') + tuple(dirs_to_copy or [])

--- a/tests/python/pants_test/rules/BUILD
+++ b/tests/python/pants_test/rules/BUILD
@@ -44,10 +44,8 @@ python_tests(
   source='test_fmt_integration.py',
   dependencies=[
     'tests/python/pants_test:int-test',
-    '//:pyproject',
     'testprojects/tests/java/org/pantsbuild/testproject:dummies_directory',
   ],
   tags={'integration'},
-  timeout = 90,
 )
 

--- a/tests/python/pants_test/rules/BUILD
+++ b/tests/python/pants_test/rules/BUILD
@@ -38,3 +38,16 @@ python_tests(
     'tests/python/pants_test/engine:util',
   ]
 )
+
+python_tests(
+  name='fmt_integration',
+  source='test_fmt_integration.py',
+  dependencies=[
+    'tests/python/pants_test:int-test',
+    '//:pyproject',
+    'testprojects/tests/java/org/pantsbuild/testproject:dummies_directory',
+  ],
+  tags={'integration'},
+  timeout = 90,
+)
+

--- a/tests/python/pants_test/rules/test_fmt_integration.py
+++ b/tests/python/pants_test/rules/test_fmt_integration.py
@@ -1,0 +1,16 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class FmtIntegrationTest(PantsRunIntegrationTest):
+  def test_black_no_python_sources_should_noop(self):
+    command = [
+      'fmt_v2',
+      'testprojects/tests/java/org/pantsbuild/testproject/dummies/::'
+      ]
+    pants_run = self.run_pants(command=command)
+    self.assert_success(pants_run)
+    self.assertNotIn("reformatted", pants_run.stderr_data)
+    self.assertNotIn("unchanged", pants_run.stderr_data)

--- a/tests/python/pants_test/rules/test_fmt_integration.py
+++ b/tests/python/pants_test/rules/test_fmt_integration.py
@@ -7,7 +7,7 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 class FmtIntegrationTest(PantsRunIntegrationTest):
   def test_black_no_python_sources_should_noop(self):
     command = [
-      'fmt_v2',
+      'fmt-v2',
       'testprojects/tests/java/org/pantsbuild/testproject/dummies/::'
       ]
     pants_run = self.run_pants(command=command)

--- a/tests/python/pants_test/rules/test_fmt_integration.py
+++ b/tests/python/pants_test/rules/test_fmt_integration.py
@@ -5,7 +5,7 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class FmtIntegrationTest(PantsRunIntegrationTest):
-  def test_black_no_python_sources_should_noop(self):
+  def test_fmt_for_unsupported_target_should_noop(self):
     command = [
       'fmt-v2',
       'testprojects/tests/java/org/pantsbuild/testproject/dummies/::'


### PR DESCRIPTION
### Problem

We want to provide a way for pants to run black.

### Solution

Add a v2 rule for "fmt_v2" (temporarily, to workaround conflict with the v1 "fmt" rule).
Add a run_black rule which runs black on each target.
Register Black's config file as a configurable option.
Add a black config that works for us (line length 100 lines which is aligned with our current style,
exclude the file in "compilation_failure" as it is intentionally invalid and trips black up).

### Result

It is now possible to run `./pants fmt_v2 ::` to format all python files in the repository (or any other target, as expected).

Note that this isn't the full picture, but it is probably good enough to stand as its own PR.
Things we may want to improve in the future:
* Make it part of `./pants fmt` (and skip the python formatting by default to avoid surprising our users)
* Minimise the calls to Black by batching all the files form all targets being run and calling it only once
  This will yield speed improvement and a less verbose command line output.
* Add it as part of our pre_commit hook.
* Format our code with it.