### PR TITLE
Bump default MyPy to 0.740

### DIFF
--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -92,6 +92,9 @@ python_binary(
 python_binary(
   name = 'mypy',
   source = 'mypy.py',
+  dependencies = [
+    ':common',
+  ],
   tags = {'type_checked'},
 )
 

--- a/build-support/bin/check_packages.sh
+++ b/build-support/bin/check_packages.sh
@@ -14,7 +14,7 @@ bad_files=()
 for package_file in ${non_empty_files}
 do
   if [[ "$(sed -E -e 's/^[[:space:]]+//' -e 's/[[:space:]]+$//' "${package_file}")" != \
-        '__import__("pkg_resources").declare_namespace(__name__)' ]]
+        '__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]' ]]
   then
     bad_files+=("${package_file}")
   fi

--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -212,9 +212,9 @@ class TestStrategy(Enum):
     shard: Optional[str] = None,
     oauth_token_path: Optional[str] = None
   ) -> List[str]:
-    if self == self.v2_remote and oauth_token_path is None:  # type: ignore[comparison-overlap]
+    if self == self.v2_remote and oauth_token_path is None:  # type: ignore[comparison-overlap]  # issues with understanding `self`
       raise ValueError("Must specify oauth_token_path.")
-    result: List[str] = {
+    result = {
       self.v1_no_chroot: ["./pants.pex", "test.pytest", "--no-chroot", *sorted(targets), *PYTEST_PASSTHRU_ARGS],
       self.v1_chroot: ["./pants.pex", "test.pytest", *sorted(targets), *PYTEST_PASSTHRU_ARGS],
       self.v2_local: ["./pants.pex", "--no-v1", "--v2", "test", *sorted(targets)],
@@ -227,8 +227,8 @@ class TestStrategy(Enum):
                         "test",
                         *sorted(targets),
                       ]
-    }[self]  # type: ignore[index]
-    if shard is not None and self in [self.v1_no_chroot, self.v1_chroot]:  # type: ignore[comparison-overlap]
+    }[self]  # type: ignore[index]  # issues with understanding `self`
+    if shard is not None and self in [self.v1_no_chroot, self.v1_chroot]:  # type: ignore[comparison-overlap]  # issues with understanding `self`
       result.insert(2, f"--test-pytest-test-shard={shard}")
     return result
 

--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -212,9 +212,9 @@ class TestStrategy(Enum):
     shard: Optional[str] = None,
     oauth_token_path: Optional[str] = None
   ) -> List[str]:
-    if self == self.v2_remote and oauth_token_path is None:  # type: ignore
+    if self == self.v2_remote and oauth_token_path is None:  # type: ignore[comparison-overlap]
       raise ValueError("Must specify oauth_token_path.")
-    result: List[str] = {  # type: ignore
+    result: List[str] = {
       self.v1_no_chroot: ["./pants.pex", "test.pytest", "--no-chroot", *sorted(targets), *PYTEST_PASSTHRU_ARGS],
       self.v1_chroot: ["./pants.pex", "test.pytest", *sorted(targets), *PYTEST_PASSTHRU_ARGS],
       self.v2_local: ["./pants.pex", "--no-v1", "--v2", "test", *sorted(targets)],
@@ -227,8 +227,8 @@ class TestStrategy(Enum):
                         "test",
                         *sorted(targets),
                       ]
-    }[self]
-    if shard is not None and self in [self.v1_no_chroot, self.v1_chroot]:  # type: ignore
+    }[self]  # type: ignore[index]
+    if shard is not None and self in [self.v1_no_chroot, self.v1_chroot]:  # type: ignore[comparison-overlap]
       result.insert(2, f"--test-pytest-test-shard={shard}")
     return result
 

--- a/build-support/mypy/mypy.ini
+++ b/build-support/mypy/mypy.ini
@@ -7,8 +7,6 @@
 # because our codebase has so little type coverage. As we add more types, these options should be
 # re-evaluated and made more strict where possible.
 
-new_semantic_analyzer = True
-
 # Optionals
 no_implicit_optional = True
 
@@ -29,6 +27,8 @@ disallow_any_generics = False
 disallow_subclassing_any = False
 
 # Strictness
+allow_untyped_globals = False
+allow_redefinition = False
 implicit_reexport = False
 strict_equality = True
 
@@ -37,10 +37,16 @@ warn_unused_ignores = True
 warn_no_return = True
 warn_return_any = True
 warn_redundant_casts = True
+warn_unreachable = True
 
 # Error output
 show_column_numbers = True
+show_error_context = True
+show_error_codes = True
 show_traceback = True
+pretty = True
+color_output = True
+error_summary = True
 
 # Imports. See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports.
 ignore_missing_imports = True

--- a/contrib/avro/src/python/pants/__init__.py
+++ b/contrib/avro/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/avro/src/python/pants/contrib/__init__.py
+++ b/contrib/avro/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/avro/src/python/pants/contrib/avro/__init__.py
+++ b/contrib/avro/src/python/pants/contrib/avro/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/avro/src/python/pants/contrib/avro/targets/__init__.py
+++ b/contrib/avro/src/python/pants/contrib/avro/targets/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/avro/src/python/pants/contrib/avro/tasks/__init__.py
+++ b/contrib/avro/src/python/pants/contrib/avro/tasks/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/awslambda/python/src/python/pants/__init__.py
+++ b/contrib/awslambda/python/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/awslambda/python/src/python/pants/contrib/__init__.py
+++ b/contrib/awslambda/python/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/awslambda/python/tests/python/pants_test/__init__.py
+++ b/contrib/awslambda/python/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/awslambda/python/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/awslambda/python/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python/__init__.py
+++ b/contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/buildgen/src/python/pants/__init__.py
+++ b/contrib/buildgen/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/buildgen/src/python/pants/contrib/__init__.py
+++ b/contrib/buildgen/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/buildgen/src/python/pants/contrib/buildgen/__init__.py
+++ b/contrib/buildgen/src/python/pants/contrib/buildgen/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/buildgen/tests/python/pants_test/__init__.py
+++ b/contrib/buildgen/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/buildgen/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/buildgen/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/buildgen/tests/python/pants_test/contrib/buildgen/__init__.py
+++ b/contrib/buildgen/tests/python/pants_test/contrib/buildgen/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/buildrefactor/src/python/pants/__init__.py
+++ b/contrib/buildrefactor/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/buildrefactor/src/python/pants/contrib/__init__.py
+++ b/contrib/buildrefactor/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/__init__.py
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/buildrefactor/tests/python/pants_test/__init__.py
+++ b/contrib/buildrefactor/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/__init__.py
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/codeanalysis/src/python/pants/__init__.py
+++ b/contrib/codeanalysis/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/codeanalysis/src/python/pants/contrib/__init__.py
+++ b/contrib/codeanalysis/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/confluence/src/python/pants/__init__.py
+++ b/contrib/confluence/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/confluence/src/python/pants/contrib/__init__.py
+++ b/contrib/confluence/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/cpp/src/python/pants/__init__.py
+++ b/contrib/cpp/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/cpp/src/python/pants/contrib/__init__.py
+++ b/contrib/cpp/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/cpp/tests/python/pants_test/__init__.py
+++ b/contrib/cpp/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/cpp/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/cpp/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/errorprone/src/python/pants/__init__.py
+++ b/contrib/errorprone/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/errorprone/src/python/pants/contrib/__init__.py
+++ b/contrib/errorprone/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/errorprone/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/errorprone/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/errorprone/tests/python/pants_test/contrib/errorprone/__init__.py
+++ b/contrib/errorprone/tests/python/pants_test/contrib/errorprone/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/findbugs/src/python/pants/__init__.py
+++ b/contrib/findbugs/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/findbugs/src/python/pants/contrib/__init__.py
+++ b/contrib/findbugs/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/findbugs/tests/python/pants_test/__init__.py
+++ b/contrib/findbugs/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/findbugs/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/findbugs/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/go/src/python/pants/__init__.py
+++ b/contrib/go/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/go/src/python/pants/contrib/__init__.py
+++ b/contrib/go/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/go/tests/python/pants_test/__init__.py
+++ b/contrib/go/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/go/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/go/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/googlejavaformat/src/python/pants/__init__.py
+++ b/contrib/googlejavaformat/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/googlejavaformat/src/python/pants/contrib/__init__.py
+++ b/contrib/googlejavaformat/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/jax_ws/src/python/pants/__init__.py
+++ b/contrib/jax_ws/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/jax_ws/src/python/pants/contrib/__init__.py
+++ b/contrib/jax_ws/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/jax_ws/tests/python/pants_test/__init__.py
+++ b/contrib/jax_ws/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/jax_ws/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/jax_ws/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/mypy/src/python/pants/__init__.py
+++ b/contrib/mypy/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/mypy/src/python/pants/contrib/__init__.py
+++ b/contrib/mypy/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/mypy/src/python/pants/contrib/mypy/__init__.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/__init__.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -57,9 +57,9 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
   @classmethod
   def register_options(cls, register):
-    register('--mypy-version', default='0.720', help='The version of mypy to use.',
+    register('--mypy-version', default='0.740', help='The version of mypy to use.',
              removal_version='1.24.0.dev1', removal_hint='Use --version instead.')
-    register('--version', default='0.720', help='The version of mypy to use.')
+    register('--version', default='0.740', help='The version of mypy to use.')
     register('--include-requirements', type=bool, default=False,
              help='Whether to include the transitive requirements of targets being checked. This is'
                   'useful if those targets depend on mypy plugins or distributions that provide '

--- a/contrib/mypy/tests/python/pants_test/__init__.py
+++ b/contrib/mypy/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/mypy/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/mypy/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/__init__.py
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/__init__.py
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/node/src/python/pants/__init__.py
+++ b/contrib/node/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/node/src/python/pants/contrib/__init__.py
+++ b/contrib/node/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/node/tests/python/pants_test/__init__.py
+++ b/contrib/node/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/node/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/node/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/python/src/python/pants/__init__.py
+++ b/contrib/python/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/python/src/python/pants/contrib/__init__.py
+++ b/contrib/python/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/python/src/python/pants/contrib/python/__init__.py
+++ b/contrib/python/src/python/pants/contrib/python/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/python/src/python/pants/contrib/python/checks/__init__.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/python/tests/python/pants_test/__init__.py
+++ b/contrib/python/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/python/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/python/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/python/tests/python/pants_test/contrib/python/__init__.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/scalajs/src/python/pants/__init__.py
+++ b/contrib/scalajs/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/scalajs/src/python/pants/contrib/__init__.py
+++ b/contrib/scalajs/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/scalajs/tests/python/pants_test/__init__.py
+++ b/contrib/scalajs/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/scalajs/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/scalajs/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/scrooge/src/python/pants/__init__.py
+++ b/contrib/scrooge/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/scrooge/src/python/pants/contrib/__init__.py
+++ b/contrib/scrooge/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/scrooge/tests/python/pants_test/__init__.py
+++ b/contrib/scrooge/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/scrooge/tests/python/pants_test/contrib/__init__.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/thrifty/src/python/pants/__init__.py
+++ b/contrib/thrifty/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/contrib/thrifty/src/python/pants/contrib/__init__.py
+++ b/contrib/thrifty/src/python/pants/contrib/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/src/python/pants/__init__.py
+++ b/src/python/pants/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/src/python/pants/backend/__init__.py
+++ b/src/python/pants/backend/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/src/python/pants/backend/python/subsystems/pex_build_util.py
+++ b/src/python/pants/backend/python/subsystems/pex_build_util.py
@@ -309,7 +309,7 @@ class PexBuilderWrapper:
     missing_init_files = identify_missing_init_files(sources)
     if missing_init_files:
       with temporary_file(permissions=0o644) as ns_package:
-        ns_package.write(b'__import__("pkg_resources").declare_namespace(__name__)')
+        ns_package.write(b'__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]')
         ns_package.flush()
         for missing_init_file in missing_init_files:
           self._builder.add_source(filename=ns_package.name, env_filename=missing_init_file)

--- a/src/python/pants/binaries/executable_pex_tool.py
+++ b/src/python/pants/binaries/executable_pex_tool.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 class ExecutablePexTool(Subsystem):
 
-  entry_point = None
+  entry_point: Optional[str] = None
 
   base_requirements: List['PythonRequirement'] = []
 

--- a/src/python/pants/build_graph/aliased_target.py
+++ b/src/python/pants/build_graph/aliased_target.py
@@ -22,7 +22,7 @@ class AliasTargetMacro(TargetMacro):
     :param string target: The address of the destination target.
     """
     if name is None:
-      raise TargetDefinitionException('{}:?'.format(self._parse_context.rel_path, name),
+      raise TargetDefinitionException('{}:?'.format(self._parse_context.rel_path),
                                       'The alias() must have a name!')
     if target is None:
       raise TargetDefinitionException('{}:{}'.format(self._parse_context.rel_path, name),

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -620,7 +620,7 @@ class Target(AbstractTarget):
     # N.B. This pattern turns this method into a non-yielding generator, which is helpful for
     # subclassing.
     return
-    yield
+    yield  # type: ignore[misc]
 
   @classmethod
   def compute_dependency_specs(cls, kwargs=None, payload=None):
@@ -643,7 +643,7 @@ class Target(AbstractTarget):
     # N.B. This pattern turns this method into a non-yielding generator, which is helpful for
     # subclassing.
     return
-    yield
+    yield  # type: ignore[misc]
 
   @property
   def dependencies(self):

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -620,7 +620,7 @@ class Target(AbstractTarget):
     # N.B. This pattern turns this method into a non-yielding generator, which is helpful for
     # subclassing.
     return
-    yield  # type: ignore[misc]
+    yield  # type: ignore[misc] # MyPy doesn't understand this pattern; complains that code is unreachable
 
   @classmethod
   def compute_dependency_specs(cls, kwargs=None, payload=None):
@@ -643,7 +643,7 @@ class Target(AbstractTarget):
     # N.B. This pattern turns this method into a non-yielding generator, which is helpful for
     # subclassing.
     return
-    yield  # type: ignore[misc]
+    yield  # type: ignore[misc] # MyPy doesn't understand this pattern; complains that code is unreachable
 
   @property
   def dependencies(self):

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -189,8 +189,6 @@ class AddressableDescriptor:
         .format(self._name, instance),
         e)
 
-    return value
-
   def _resolve_value(self, instance, value):
     if not isinstance(value, Resolvable):
       # The value is concrete which means we type-checked on set so no need to do so again, its a
@@ -207,8 +205,6 @@ class AddressableDescriptor:
           "The value resolved from {} for the {} property of {} was invalid"
           .format(value.address, self._name, instance),
           e)
-
-      return resolved_value
 
 
 def _addressable_wrapper(addressable_descriptor, type_constraint):

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -13,8 +13,7 @@ from pants.util.memo import memoized_classproperty
 from pants.util.meta import classproperty
 
 
-@dataclass(frozen=True)
-# type: ignore # tracked by https://github.com/python/mypy/issues/5374, which they put as high priority.
+@dataclass(frozen=True)  # type: ignore[misc] # tracked by https://github.com/python/mypy/issues/5374, which they put as high priority.
 class Goal(metaclass=ABCMeta):
   """The named product of a `@console_rule`.
 

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -56,7 +56,7 @@ class ExecuteProcessRequest:
     self.argv = argv
     self.input_files = input_files
     self.description = description
-    self.env = tuple(item for pair in env.items() for item in pair) if env is not None else ()  # type: ignore
+    self.env = tuple(item for pair in env.items() for item in pair) if env is not None else ()  # type: ignore[assignment]
     self.output_files = output_files or ()
     self.output_directories = output_directories or ()
     self.timeout_seconds = timeout_seconds

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -56,7 +56,7 @@ class ExecuteProcessRequest:
     self.argv = argv
     self.input_files = input_files
     self.description = description
-    self.env = tuple(item for pair in env.items() for item in pair) if env is not None else ()  # type: ignore[assignment]
+    self.env = tuple(item for pair in env.items() for item in pair) if env is not None else ()  # type: ignore[assignment] # infers the expression as `object` for some reason
     self.output_files = output_files or ()
     self.output_directories = output_directories or ()
     self.timeout_seconds = timeout_seconds

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -65,7 +65,7 @@ def _get_starting_indent(source):
 
 
 def _make_rule(
-  return_type: type, parameter_types: typing.Iterable[type], cacheable: bool = True,
+  return_type: Type, parameter_types: typing.Iterable[Type], cacheable: bool = True,
   name: Optional[bool] = None
 ) -> Callable[[Callable], Callable]:
   """A @decorator that declares that a particular static function may be used as a TaskRule.
@@ -80,10 +80,7 @@ def _make_rule(
                     its inputs.
   """
 
-  # NB: the left operand is always true, according to MyPy, because we annotate `return_type` as
-  # `Type`. We keep it for now until we have higher type coverage because we should not be removing
-  # runtime checks yet.
-  is_goal_cls = isinstance(return_type, type) and issubclass(return_type, Goal)  # type: ignore[misc]
+  is_goal_cls = issubclass(return_type, Goal)
   if is_goal_cls == cacheable:
     raise TypeError(
       'An `@rule` that produces a `Goal` must be declared with @console_rule in order to signal '

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -80,7 +80,7 @@ def _make_rule(
                     its inputs.
   """
 
-  is_goal_cls = isinstance(return_type, type) and issubclass(return_type, Goal)
+  is_goal_cls = isinstance(return_type, type) and issubclass(return_type, Goal)  # type: ignore[misc]
   if is_goal_cls == cacheable:
     raise TypeError(
       'An `@rule` that produces a `Goal` must be declared with @console_rule in order to signal '
@@ -365,14 +365,14 @@ class TaskRule(Rule):
     self._output_type = output_type
     self.input_selectors = input_selectors
     self.input_gets = input_gets
-    self.func = func  # type: ignore
+    self.func = func  # type: ignore[assignment]
     self._dependency_rules = dependency_rules or ()
     self._dependency_optionables = dependency_optionables or ()
     self.cacheable = cacheable
     self.name = name
 
   def __str__(self):
-    return ('(name={}, {!r}, {}, gets={}, opts={})'
+    return ('(name={}, {}, {!r}, {}, gets={}, opts={})'
             .format(self.name or '<not defined>',
                     self.output_type.__name__,
                     self.input_selectors,

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -80,6 +80,9 @@ def _make_rule(
                     its inputs.
   """
 
+  # NB: the left operand is always true, according to MyPy, because we annotate `return_type` as
+  # `Type`. We keep it for now until we have higher type coverage because we should not be removing
+  # runtime checks yet.
   is_goal_cls = isinstance(return_type, type) and issubclass(return_type, Goal)  # type: ignore[misc]
   if is_goal_cls == cacheable:
     raise TypeError(
@@ -365,7 +368,7 @@ class TaskRule(Rule):
     self._output_type = output_type
     self.input_selectors = input_selectors
     self.input_gets = input_gets
-    self.func = func  # type: ignore[assignment]
+    self.func = func  # type: ignore[assignment] # cannot assign to a method
     self._dependency_rules = dependency_rules or ()
     self._dependency_optionables = dependency_optionables or ()
     self.cacheable = cacheable

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -171,7 +171,7 @@ class Parser:
       """
       self.flag_value_map = self._create_flag_value_map(flags_in_scope)
       self.namespace = namespace
-      self.get_all_scoped_flag_names = get_all_scoped_flag_names  # type: ignore[assignment,misc]
+      self.get_all_scoped_flag_names = get_all_scoped_flag_names  # type: ignore[assignment,misc] # cannot assign a method + MyPy says "does not accept self argument"
       self.levenshtein_max_distance = levenshtein_max_distance
 
     @staticmethod

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -171,7 +171,7 @@ class Parser:
       """
       self.flag_value_map = self._create_flag_value_map(flags_in_scope)
       self.namespace = namespace
-      self.get_all_scoped_flag_names = get_all_scoped_flag_names  # type: ignore
+      self.get_all_scoped_flag_names = get_all_scoped_flag_names  # type: ignore[assignment,misc]
       self.levenshtein_max_distance = levenshtein_max_distance
 
     @staticmethod

--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -14,14 +14,14 @@ class StreamingWorkunitHandler:
     self.scheduler = scheduler
     self.report_interval = report_interval_seconds
     self.callback = callback
-    self._thread_runner = None
+    self._thread_runner: Optional[_InnerHandler] = None
 
-  def start(self):
+  def start(self) -> None:
     if self.callback is not None:
       self._thread_runner = _InnerHandler(self.scheduler, self.callback, self.report_interval)
       self._thread_runner.start()
 
-  def end(self):
+  def end(self) -> None:
     if self._thread_runner:
       self._thread_runner.join()
 

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -84,6 +84,8 @@ class Subsystem(SubsystemClientMixin, Optionable):
     return cls._options is not None
 
   # A cache of (cls, scope) -> the instance of cls tied to that scope.
+  # NB: it would be ideal to use `_S` rather than `Subsystem`, but we can't do this because
+  # MyPy complains that `_S` would not be properly constrained.
   _scoped_instances: Dict[Tuple[Type["Subsystem"], str], "Subsystem"] = {}
 
   @classmethod
@@ -94,7 +96,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
 
     :returns: The global subsystem instance.
     """
-    return cls._instance_for_scope(cls.options_scope)  # type: ignore[arg-type]
+    return cls._instance_for_scope(cls.options_scope)  # type: ignore[arg-type]  # MyPy is treating cls.options_scope as a Callable, rather than `str`
 
   @classmethod
   def scoped_instance(cls: Type[_S], optionable: Optionable) -> _S:
@@ -105,7 +107,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
     :param optionable: An optionable type or instance to scope this subsystem under.
     :returns: The scoped subsystem instance.
     """
-    if not isinstance(optionable, Optionable) and not issubclass(optionable, Optionable):  # type: ignore[misc]
+    if not isinstance(optionable, Optionable) and not issubclass(optionable, Optionable):  # type: ignore[misc] # MyPy thinks the RHS never evaluates, but it somehow does
       raise TypeError('Can only scope an instance against an Optionable, given {} of type {}.'
                       .format(optionable, type(optionable)))
     return cls._instance_for_scope(cls.subscope(optionable.options_scope))

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -44,7 +44,7 @@ class ClassPropertyDescriptor:
       # Get the callable field for this object, which may be a property.
     callable_field = self.fget.__get__(obj, objtype)
     if getattr(self.fget.__func__, '__isabstractmethod__', False):
-      field_name = self.fget.__func__.fget.__name__  # type: ignore
+      field_name = self.fget.__func__.fget.__name__  # type: ignore[attr-defined]
       raise TypeError("""\
 The classproperty '{func_name}' in type '{type_name}' was an abstractproperty, meaning that type \
 {type_name} must override it by setting it as a variable in the class body or defining a method \
@@ -124,7 +124,7 @@ def frozen_after_init(cls: Type[T]) -> Type[T]:
 
   @wraps(prev_init)
   def new_init(self, *args: Any, **kwargs: Any) -> None:
-    prev_init(self, *args, **kwargs)  # type: ignore
+    prev_init(self, *args, **kwargs)  # type: ignore[call-arg]
     self._is_frozen = True
 
   @wraps(prev_setattr)
@@ -135,6 +135,6 @@ def frozen_after_init(cls: Type[T]) -> Type[T]:
       )
     prev_setattr(self, key, value)
 
-  cls.__init__ = new_init  # type: ignore
-  cls.__setattr__ = new_setattr  # type: ignore
+  cls.__init__ = new_init  # type: ignore[assignment]
+  cls.__setattr__ = new_setattr  # type: ignore[assignment]
   return cls

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -13,7 +13,7 @@ _PANTS_VERSION_OVERRIDE = '_PANTS_VERSION_OVERRIDE'
 
 VERSION: str = (
   os.environ.get(_PANTS_VERSION_OVERRIDE) or
-  pkgutil.get_data(__name__, 'VERSION').decode().strip()  # type: ignore
+  pkgutil.get_data(__name__, 'VERSION').decode().strip()  # type: ignore[union-attr]
 )
 
 

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -13,6 +13,7 @@ _PANTS_VERSION_OVERRIDE = '_PANTS_VERSION_OVERRIDE'
 
 VERSION: str = (
   os.environ.get(_PANTS_VERSION_OVERRIDE) or
+  # NB: We expect VERSION to always have an entry and want a runtime failure if this is false.
   pkgutil.get_data(__name__, 'VERSION').decode().strip()  # type: ignore[union-attr]
 )
 

--- a/testprojects/pants-plugins/src/python/test_pants_plugin/__init__.py
+++ b/testprojects/pants-plugins/src/python/test_pants_plugin/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/tests/python/pants_test/__init__.py
+++ b/tests/python/pants_test/__init__.py
@@ -1,1 +1,1 @@
-__import__("pkg_resources").declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -535,7 +535,7 @@ def test_detect_namespace_packages():
   assert not has_ns('')
   assert not has_ns('add(1, 2); foo(__name__); self.shoot(__name__)')
   assert not has_ns('declare_namespace(bonk)')
-  assert has_ns('__import__("pkg_resources").declare_namespace(__name__)')
+  assert has_ns('__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]')
   assert has_ns('import pkg_resources; pkg_resources.declare_namespace(__name__)')
   assert has_ns('from pkg_resources import declare_namespace; declare_namespace(__name__)')
 
@@ -555,7 +555,7 @@ class TestSetupPyFindPackages(SetupPyTestBase):
       for package in packages:
         write(package, '__init__.py', 'a = "b"; b = f"{a}"' if py3 else '')
       for package in namespace_packages:
-        write(package, '__init__.py', '__import__("pkg_resources").declare_namespace(__name__)')
+        write(package, '__init__.py', '__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]')
       for package, resource_list in resources.items():
         for resource in resource_list:
           write(package, resource, 'asdfasdf')

--- a/tests/python/pants_test/repo_scripts/test_git_hooks.py
+++ b/tests/python/pants_test/repo_scripts/test_git_hooks.py
@@ -72,7 +72,10 @@ subdir/__init__.py
       self._assert_subprocess_success(worktree, [package_check_script, 'subdir'])
 
       # Check that a valid __init__.py with `pkg_resources` setup succeeds.
-      safe_file_dump(init_py_path, "__import__(\"pkg_resources\").declare_namespace(__name__)")
+      safe_file_dump(
+        init_py_path,
+        '__import__("pkg_resources").declare_namespace(__name__)  # type: ignore[attr-defined]'
+      )
       self._assert_subprocess_success(worktree, [package_check_script, 'subdir'])
 
   # TODO: consider testing the degree to which copies (-C) and moves (-M) are detected by making

--- a/tests/python/pants_test/util/test_collections.py
+++ b/tests/python/pants_test/util/test_collections.py
@@ -127,7 +127,7 @@ class EnumTest(unittest.TestCase):
 
   def test_unrecognized_match(self) -> None:
     with self.assertRaises(UnrecognizedMatchError):
-      EnumTest.Test.pig.match({  # type: ignore
+      EnumTest.Test.pig.match({  # type: ignore[type-var]
         EnumTest.Test.dog: "woof",
         EnumTest.Test.cat: "meow",
         EnumTest.Test.pig: "oink",

--- a/tests/python/pants_test/util/test_collections.py
+++ b/tests/python/pants_test/util/test_collections.py
@@ -127,7 +127,7 @@ class EnumTest(unittest.TestCase):
 
   def test_unrecognized_match(self) -> None:
     with self.assertRaises(UnrecognizedMatchError):
-      EnumTest.Test.pig.match({  # type: ignore[type-var]
+      EnumTest.Test.pig.match({  # type: ignore[type-var] # intended to fail type check
         EnumTest.Test.dog: "woof",
         EnumTest.Test.cat: "meow",
         EnumTest.Test.pig: "oink",

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -194,17 +194,17 @@ class ContextutilTest(unittest.TestCase):
   def test_open_zipDefault(self) -> None:
     with temporary_dir() as tempdir:
       with open_zip(os.path.join(tempdir, 'test'), 'w') as zf:
-        self.assertTrue(zf._allowZip64)  # type: ignore[attr-defined]
+        self.assertTrue(zf._allowZip64)  # type: ignore[attr-defined] # intended to fail type check
 
   def test_open_zipTrue(self) -> None:
     with temporary_dir() as tempdir:
       with open_zip(os.path.join(tempdir, 'test'), 'w', allowZip64=True) as zf:
-        self.assertTrue(zf._allowZip64)  # type: ignore[attr-defined]
+        self.assertTrue(zf._allowZip64)  # type: ignore[attr-defined] # intended to fail type check
 
   def test_open_zipFalse(self) -> None:
     with temporary_dir() as tempdir:
       with open_zip(os.path.join(tempdir, 'test'), 'w', allowZip64=False) as zf:
-        self.assertFalse(zf._allowZip64)  # type: ignore[attr-defined]
+        self.assertFalse(zf._allowZip64)  # type: ignore[attr-defined] # intended to fail type check
 
   def test_open_zip_raises_exception_on_falsey_paths(self):
     falsey = (None, '', False)
@@ -322,7 +322,7 @@ class ContextutilTest(unittest.TestCase):
 
     with self.assertRaises(AssertionError):
       with exception_logging(fake_logger, 'error!'):
-        assert True is False  # type: ignore[comparison-overlap]
+        assert True is False  # type: ignore[comparison-overlap] # intended to fail type check
 
     fake_logger.exception.assert_called_once_with('error!')
 

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -194,17 +194,17 @@ class ContextutilTest(unittest.TestCase):
   def test_open_zipDefault(self) -> None:
     with temporary_dir() as tempdir:
       with open_zip(os.path.join(tempdir, 'test'), 'w') as zf:
-        self.assertTrue(zf._allowZip64)  # type: ignore
+        self.assertTrue(zf._allowZip64)  # type: ignore[attr-defined]
 
   def test_open_zipTrue(self) -> None:
     with temporary_dir() as tempdir:
       with open_zip(os.path.join(tempdir, 'test'), 'w', allowZip64=True) as zf:
-        self.assertTrue(zf._allowZip64)  # type: ignore
+        self.assertTrue(zf._allowZip64)  # type: ignore[attr-defined]
 
   def test_open_zipFalse(self) -> None:
     with temporary_dir() as tempdir:
       with open_zip(os.path.join(tempdir, 'test'), 'w', allowZip64=False) as zf:
-        self.assertFalse(zf._allowZip64)  # type: ignore
+        self.assertFalse(zf._allowZip64)  # type: ignore[attr-defined]
 
   def test_open_zip_raises_exception_on_falsey_paths(self):
     falsey = (None, '', False)
@@ -322,7 +322,7 @@ class ContextutilTest(unittest.TestCase):
 
     with self.assertRaises(AssertionError):
       with exception_logging(fake_logger, 'error!'):
-        assert True is False
+        assert True is False  # type: ignore[comparison-overlap]
 
     fake_logger.exception.assert_called_once_with('error!')
 

--- a/tests/python/pants_test/util/test_strutil.py
+++ b/tests/python/pants_test/util/test_strutil.py
@@ -38,13 +38,13 @@ class StrutilTest(unittest.TestCase):
     bytes_val = bytes(bytearray([0xe5, 0xbf, 0xab]))
     self.assertEqual(u'快', ensure_text(bytes_val))
     with self.assertRaises(TypeError):
-      ensure_text(45)  # type: ignore[arg-type]
+      ensure_text(45)  # type: ignore[arg-type] # intended to fail type check
 
   def test_ensure_binary(self) -> None:
     unicode_val = u'快'
     self.assertEqual(bytearray([0xe5, 0xbf, 0xab]), ensure_binary(unicode_val))
     with self.assertRaises(TypeError):
-      ensure_binary(45)  # type: ignore[arg-type]
+      ensure_binary(45)  # type: ignore[arg-type] # intended to fail type check
 
   def test_strip_prefix(self) -> None:
     self.assertEqual('testString', strip_prefix('testString', '//'))

--- a/tests/python/pants_test/util/test_strutil.py
+++ b/tests/python/pants_test/util/test_strutil.py
@@ -38,13 +38,13 @@ class StrutilTest(unittest.TestCase):
     bytes_val = bytes(bytearray([0xe5, 0xbf, 0xab]))
     self.assertEqual(u'快', ensure_text(bytes_val))
     with self.assertRaises(TypeError):
-      ensure_text(45)  # type: ignore
+      ensure_text(45)  # type: ignore[arg-type]
 
   def test_ensure_binary(self) -> None:
     unicode_val = u'快'
     self.assertEqual(bytearray([0xe5, 0xbf, 0xab]), ensure_binary(unicode_val))
     with self.assertRaises(TypeError):
-      ensure_binary(45)  # type: ignore
+      ensure_binary(45)  # type: ignore[arg-type]
 
   def test_strip_prefix(self) -> None:
     self.assertEqual('testString', strip_prefix('testString', '//'))


### PR DESCRIPTION
MyPy released 0.730 and 0.740, bringing these changes: https://mypy-lang.blogspot.com/2019/09/mypy-730-released.html and https://mypy-lang.blogspot.com/2019/10/mypy-0740-released.html

The main changes for the Pants project are:

- "Report undefined module attributes with --ignore-missing-imports", which means our `__init__.py`s now raise errors because of our dynamic runtime import of `pkg_utils`.
   - this requires adding `type: ignore` to all uses of `__import__("pkg_resources").declare_namespace(__name__)`
  - Alternatively, we could use `import pkg_resources; pkg_resources.declare_namespace(__name__)`, but this keeps `pkg_resources` as a registered symbol, which we want to avoid.
- `# type: ignore` can now only ignore specific error codes
- location of some errors now more precise
- type check `str.format()`
- prettier and more explicit error messages