### PR TITLE
Use the newest pyflakes for internal checker

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty/requirements.txt
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty/requirements.txt
@@ -3,4 +3,4 @@
 
 six>=1.9.0,<2
 pycodestyle==2.4.0
-pyflakes==2.0.0
+pyflakes==2.1.1


### PR DESCRIPTION
This is necessary so that we can use `typing`'s `@overload` correctly.