### PR TITLE
Replace most usages of datatype() with @dataclass

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/tasks/BUILD
@@ -6,6 +6,7 @@ python_library(
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:ansicolors',
+    '3rdparty/python:dataclasses',
     'contrib/go/src/python/pants/contrib/go/subsystems',
     'contrib/go/src/python/pants/contrib/go/targets',
     'src/python/pants/base:build_environment',

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -2,12 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from contextlib import contextmanager
+from dataclasses import dataclass
 
 from pants.base.build_environment import get_buildroot
 from pants.base.workunit import WorkUnitLabel
 from pants.task.testrunner_task_mixin import PartitionedTestRunnerTaskMixin, TestResult
 from pants.util.memo import memoized_property
-from pants.util.objects import datatype
 from pants.util.process_handler import SubprocessProcessHandler
 from pants.util.strutil import create_path_env_var, safe_shlex_join, safe_shlex_split
 
@@ -44,10 +44,10 @@ class GoTest(PartitionedTestRunnerTaskMixin, GoWorkspaceTask):
   def _validate_target(self, target):
     self.ensure_workspace(target)
 
-  class _GoTestTargetInfo(datatype([
-      ('import_path', str),
-      ('gopath', str),
-  ])): pass
+  @dataclass(frozen=True)
+  class _GoTestTargetInfo:
+    import_path: str
+    gopath: str
 
   def _generate_args_for_targets(self, targets):
     """

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -122,6 +122,7 @@ python_library(
   sources = ['bundle_create.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:dataclasses',
     ':classpath_products',
     ':jvm_binary_task',
     'src/python/pants/backend/jvm/targets:jvm',
@@ -132,7 +133,6 @@ python_library(
     'src/python/pants/fs',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:fileutil',
-    'src/python/pants/util:objects',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/bundle_create.py
+++ b/src/python/pants/backend/jvm/tasks/bundle_create.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from dataclasses import dataclass
+from typing import Any
 
 from twitter.common.collections import OrderedSet
 
@@ -15,7 +17,6 @@ from pants.build_graph.bundle_mixin import BundleMixin
 from pants.build_graph.target_scopes import Scopes
 from pants.fs import archive
 from pants.util.dirutil import safe_mkdir
-from pants.util.objects import datatype
 
 
 class BundleCreate(BundleMixin, JvmBinaryTask):
@@ -51,8 +52,16 @@ class BundleCreate(BundleMixin, JvmBinaryTask):
   def product_types(cls):
     return ['jvm_archives', 'jvm_bundles', 'deployable_archives']
 
-  class App(datatype(['address', 'binary', 'bundles', 'id', 'deployjar', 'archive', 'target'])):
+  @dataclass(frozen=True)
+  class App:
     """A uniform interface to an app."""
+    address: Any
+    binary: Any
+    bundles: Any
+    id: Any
+    deployjar: Any
+    archive: Any
+    target: Any
 
     @staticmethod
     def is_app(target):

--- a/src/python/pants/backend/jvm/tasks/coverage/BUILD
+++ b/src/python/pants/backend/jvm/tasks/coverage/BUILD
@@ -4,6 +4,7 @@
 python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:dataclasses',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/backend/jvm/subsystems:jvm_tool_mixin',
@@ -13,7 +14,6 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:meta',
-    'src/python/pants/util:objects',
     'src/python/pants/util:strutil',
   ],
 )

--- a/src/python/pants/backend/jvm/tasks/coverage/engine.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/engine.py
@@ -2,11 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
 
 from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
-from pants.util.objects import datatype
 
 
 class CoverageEngine(ABC):
@@ -26,7 +27,8 @@ class CoverageEngine(ABC):
   is instantiated and used exactly once per `JUnitRun` task execution.
   """
 
-  class RunModifications(datatype(['classpath_prepend', 'extra_jvm_options'])):
+  @dataclass(frozen=True)
+  class RunModifications:
     """Modifications that should be made to the java command where code coverage is collected.
 
     The `classpath_prepend` field should be an iterable of classpath elements to prepend to java
@@ -35,6 +37,8 @@ class CoverageEngine(ABC):
     The `extra_jvm_options` should be a list of jvm options to include when executing the java
     command.
     """
+    classpath_prepend: Any
+    extra_jvm_options: Any
 
     @classmethod
     def create(cls, classpath_prepend=None, extra_jvm_options=None):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -1,6 +1,7 @@
 python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:dataclasses',
     'src/python/pants/backend/jvm/subsystems:java',
     'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/backend/jvm/subsystems:rsc',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -5,6 +5,7 @@ import functools
 import logging
 import os
 import re
+from dataclasses import dataclass
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext  # noqa
 from pants.backend.jvm.subsystems.rsc import Rsc
@@ -31,7 +32,7 @@ from pants.util.collections import assert_single_element
 from pants.util.contextutil import Timer
 from pants.util.dirutil import fast_relpath, fast_relpath_optional, safe_mkdir
 from pants.util.memo import memoized_method, memoized_property
-from pants.util.objects import datatype, enum
+from pants.util.objects import enum
 from pants.util.strutil import safe_shlex_join
 
 
@@ -552,10 +553,10 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     all_jobs = cache_doublecheck_jobs + rsc_jobs + zinc_jobs + [write_to_cache_job]
     return (all_jobs, len(compile_jobs))
 
-  class RscZincMergedCompileContexts(datatype([
-      ('rsc_cc', RscCompileContext),
-      ('zinc_cc', CompileContext),
-  ])): pass
+  @dataclass(frozen=True)
+  class RscZincMergedCompileContexts:
+    rsc_cc: RscCompileContext
+    zinc_cc: CompileContext
 
   def select_runtime_context(self, merged_compile_context):
     return merged_compile_context.zinc_cc

--- a/src/python/pants/backend/jvm/tasks/reports/BUILD
+++ b/src/python/pants/backend/jvm/tasks/reports/BUILD
@@ -3,12 +3,12 @@
 
 python_library(
   dependencies=[
+    '3rdparty/python:dataclasses',
     'src/python/pants/backend/jvm/tasks/reports/templates',
     'src/python/pants/base:mustache',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
-    'src/python/pants/util:objects',
     'src/python/pants/util:strutil',
   ],
 )

--- a/src/python/pants/backend/jvm/tasks/reports/junit_html_report.py
+++ b/src/python/pants/backend/jvm/tasks/reports/junit_html_report.py
@@ -141,7 +141,7 @@ class ReportTestSuite:
     return d
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class ReportTestCase:
   """Data object for a JUnit test case"""
   name: Any

--- a/src/python/pants/backend/jvm/tasks/reports/junit_html_report.py
+++ b/src/python/pants/backend/jvm/tasks/reports/junit_html_report.py
@@ -8,12 +8,13 @@ import os
 import xml.etree.ElementTree as ET
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from dataclasses import dataclass
 from functools import total_ordering
+from typing import Any, Optional
 
 from pants.base.mustache import MustacheRenderer
 from pants.util.dirutil import safe_mkdir_for, safe_walk
 from pants.util.memo import memoized_property
-from pants.util.objects import datatype
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -140,11 +141,14 @@ class ReportTestSuite:
     return d
 
 
-class ReportTestCase(datatype(['name', 'time', 'failure', 'error', 'skipped'])):
+@dataclass(frozen=True)
+class ReportTestCase:
   """Data object for a JUnit test case"""
-
-  def __new__(cls, name, time, failure=None, error=None, skipped=False):
-    return super().__new__(cls, name, float(time), failure, error, skipped)
+  name: Any
+  time: float
+  failure: Optional[Any] = None
+  error: Optional[Any] = None
+  skipped: bool = False
 
   @memoized_property
   def icon_class(self):
@@ -244,7 +248,7 @@ class JUnitHtmlReport(JUnitHtmlReportInterface):
 
       testcases.append(ReportTestCase(
         testcase.attrib['name'],
-        testcase.attrib.get('time', 0),
+        float(testcase.attrib.get('time', 0)),
         failure,
         error,
         skipped

--- a/src/python/pants/backend/native/subsystems/BUILD
+++ b/src/python/pants/backend/native/subsystems/BUILD
@@ -4,6 +4,7 @@
 
 python_library(
   dependencies=[
+    '3rdparty/python:dataclasses',
     'src/python/pants/backend/native/config',
     'src/python/pants/backend/native/subsystems/binaries',
     'src/python/pants/backend/native/subsystems/utils',

--- a/src/python/pants/backend/native/targets/BUILD
+++ b/src/python/pants/backend/native/targets/BUILD
@@ -9,6 +9,7 @@ python_library(
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',
+    'src/python/pants/util:objects',
     'src/python/pants/util:memo',
   ],
 )

--- a/src/python/pants/backend/native/tasks/BUILD
+++ b/src/python/pants/backend/native/tasks/BUILD
@@ -4,6 +4,7 @@
 
 python_library(
   dependencies=[
+    '3rdparty/python:dataclasses',
     'src/python/pants/backend/native/config',
     'src/python/pants/backend/native/subsystems',
     'src/python/pants/backend/native/subsystems/packaging',

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -3,6 +3,8 @@
 
 import os
 import subprocess
+from dataclasses import dataclass
+from typing import Any, Tuple
 
 from pants.backend.native.config.environment import Linker, Platform
 from pants.backend.native.targets.native_artifact import NativeArtifact
@@ -13,21 +15,22 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.util.memo import memoized_property
-from pants.util.objects import datatype
 
 
-class SharedLibrary(datatype(['name', 'path'])): pass
+@dataclass(frozen=True)
+class SharedLibrary:
+  name: Any
+  path: Any
 
 
-class LinkSharedLibraryRequest(datatype([
-    ('linker', Linker),
-    ('object_files', tuple),
-    ('native_artifact', NativeArtifact),
-    'output_dir',
-    ('external_lib_dirs', tuple),
-    ('external_lib_names', tuple),
-])):
-  pass
+@dataclass(frozen=True)
+class LinkSharedLibraryRequest:
+  linker: Linker
+  object_files: Tuple
+  native_artifact: NativeArtifact
+  output_dir: Any
+  external_lib_dirs: Tuple
+  external_lib_names: Tuple
 
 
 class LinkSharedLibraries(NativeTask):

--- a/src/python/pants/backend/native/tasks/native_compile.py
+++ b/src/python/pants/backend/native/tasks/native_compile.py
@@ -5,6 +5,8 @@ import os
 import subprocess
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
 
 from pants.backend.native.tasks.native_task import NativeTask
 from pants.base.build_environment import get_buildroot
@@ -12,22 +14,23 @@ from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.meta import classproperty
-from pants.util.objects import datatype
 
 
-class NativeCompileRequest(datatype([
-    'compiler',
-    # TODO: add type checking for Collection.of(<type>)!
-    'include_dirs',
-    'sources',
-    'compiler_options',
-    'output_dir',
-    'header_file_extensions',
-])): pass
+@dataclass(frozen=True)
+class NativeCompileRequest:
+  compiler: Any
+  include_dirs: Any
+  sources: Any
+  compiler_options: Any
+  output_dir: Any
+  header_file_extensions: Any
 
 
 # TODO(#5950): perform all process execution in the v2 engine!
-class ObjectFiles(datatype(['root_dir', 'filenames'])):
+@dataclass(frozen=True)
+class ObjectFiles:
+  root_dir: Any
+  filenames: Any
 
   def file_paths(self):
     return [os.path.join(self.root_dir, fname) for fname in self.filenames]
@@ -88,7 +91,11 @@ class NativeCompile(NativeTask, metaclass=ABCMeta):
   def _include_dirs_for_target(self, target):
     return os.path.join(get_buildroot(), target.address.spec_path)
 
-  class NativeSourcesByType(datatype(['rel_root', 'headers', 'sources'])): pass
+  @dataclass(frozen=True)
+  class NativeSourcesByType:
+    rel_root: Any
+    headers: Any
+    sources: Any
 
   def get_sources_headers_for_target(self, target):
     """Return a list of file arguments to provide to the compiler.

--- a/src/python/pants/backend/project_info/rules/BUILD
+++ b/src/python/pants/backend/project_info/rules/BUILD
@@ -1,5 +1,6 @@
 python_library(
   dependencies=[
+    '3rdparty/python:dataclasses',
     'src/python/pants/engine:console',
     'src/python/pants/engine:fs',
     'src/python/pants/engine:objects',

--- a/src/python/pants/backend/project_info/rules/source_file_validator.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator.py
@@ -3,6 +3,8 @@
 
 import itertools
 import re
+from dataclasses import dataclass
+from typing import Tuple
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.engine.console import Console
@@ -14,7 +16,7 @@ from pants.engine.rules import console_rule, optionable_rule, rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method
-from pants.util.objects import datatype, enum
+from pants.util.objects import enum
 
 
 class DetailLevel(enum(['none', 'summary', 'nonmatching', 'all'])):
@@ -80,10 +82,12 @@ class SourceFileValidation(Subsystem):
     return MultiMatcher(self.get_options().config)
 
 
-class RegexMatchResult(datatype([
-  ('path', str), ('matching', tuple), ('nonmatching', tuple)
-])):
+@dataclass(frozen=True)
+class RegexMatchResult:
   """The result of running regex matches on a source file."""
+  path: str
+  matching: Tuple
+  nonmatching: Tuple
 
 
 RegexMatchResults = Collection.of(RegexMatchResult)

--- a/src/python/pants/backend/python/rules/BUILD
+++ b/src/python/pants/backend/python/rules/BUILD
@@ -1,5 +1,6 @@
 python_library(
   dependencies=[
+    '3rdparty/python:dataclasses',
     'src/python/pants/backend/python/subsystems',
     'src/python/pants/build_graph',
     'src/python/pants/engine/legacy:graph',
@@ -9,6 +10,5 @@ python_library(
     'src/python/pants/engine:selectors',
     'src/python/pants/rules/core',
     'src/python/pants/source:source',
-    'src/python/pants/util:objects',
   ],
 )

--- a/src/python/pants/backend/python/rules/create_requirements_pex.py
+++ b/src/python/pants/backend/python/rules/create_requirements_pex.py
@@ -1,6 +1,9 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
 from pants.backend.python.rules.download_pex_bin import DownloadedPexBin
 from pants.backend.python.rules.hermetic_pex import HermeticPex
 from pants.backend.python.subsystems.python_native_code import PexBuildEnvironment
@@ -11,20 +14,19 @@ from pants.engine.isolated_process import ExecuteProcessResult, MultiPlatformExe
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import optionable_rule, rule
 from pants.engine.selectors import Get
-from pants.util.objects import datatype, hashable_string_list, string_optional, string_type
 
 
-class RequirementsPexRequest(datatype([
-  ('output_filename', string_type),
-  ('requirements', hashable_string_list),
-  ('interpreter_constraints', hashable_string_list),
-  ('entry_point', string_optional),
-])):
-  pass
+@dataclass(frozen=True)
+class RequirementsPexRequest:
+  output_filename: str
+  requirements: Tuple[str, ...]
+  interpreter_constraints: Tuple[str, ...]
+  entry_point: Optional[str]
 
 
-class RequirementsPex(HermeticPex, datatype([('directory_digest', Digest)])):
-  pass
+@dataclass(frozen=True)
+class RequirementsPex(HermeticPex):
+  directory_digest: Digest
 
 
 # TODO: This is non-hermetic because the requirements will be resolved on the fly by

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from dataclasses import dataclass
 from typing import Any, Iterable
 
 from pants.backend.python.rules.hermetic_pex import HermeticPex
@@ -11,10 +12,12 @@ from pants.engine.fs import Digest, Snapshot, UrlToFetch
 from pants.engine.isolated_process import ExecuteProcessRequest
 from pants.engine.rules import rule
 from pants.engine.selectors import Get
-from pants.util.objects import datatype
 
 
-class DownloadedPexBin(HermeticPex, datatype([('executable', str), ('directory_digest', Digest)])):
+@dataclass(frozen=True)
+class DownloadedPexBin(HermeticPex):
+  executable: str
+  directory_digest: Digest
 
   def create_execute_request(self,
     python_setup: PythonSetup,

--- a/src/python/pants/backend/python/rules/inject_init.py
+++ b/src/python/pants/backend/python/rules/inject_init.py
@@ -1,16 +1,19 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from dataclasses import dataclass
+
 from pants.backend.python.subsystems.pex_build_util import identify_missing_init_files
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, Snapshot
 from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
 from pants.engine.rules import rule
 from pants.engine.selectors import Get
-from pants.util.objects import datatype
 
 
 # TODO(#7710): Once this gets fixed, rename this to InitInjectedDigest.
-class InjectedInitDigest(datatype([('directory_digest', Digest)])): pass
+@dataclass(frozen=True)
+class InjectedInitDigest:
+  directory_digest: Digest
 
 
 @rule

--- a/src/python/pants/backend/python/subsystems/BUILD
+++ b/src/python/pants/backend/python/subsystems/BUILD
@@ -4,6 +4,7 @@
 python_library(
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:dataclasses',
     '3rdparty/python:pex',
     'src/python/pants/backend/native/subsystems',
     'src/python/pants/backend/native/targets',

--- a/src/python/pants/backend/python/subsystems/subprocess_environment.py
+++ b/src/python/pants/backend/python/subsystems/subprocess_environment.py
@@ -2,10 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from dataclasses import dataclass
+from typing import Optional
 
 from pants.engine.rules import optionable_rule, rule
 from pants.subsystem.subsystem import Subsystem
-from pants.util.objects import datatype, string_optional
 
 
 class SubprocessEnvironment(Subsystem):
@@ -26,10 +27,10 @@ class SubprocessEnvironment(Subsystem):
              help='Override the `LC_ALL` environment variable for any forked subprocesses.')
 
 
-class SubprocessEncodingEnvironment(datatype([
-    ('lang', string_optional),
-    ('lc_all', string_optional),
-])):
+@dataclass(frozen=True)
+class SubprocessEncodingEnvironment:
+  lang: Optional[str]
+  lc_all: Optional[str]
 
   @property
   def invocation_environment_dict(self):

--- a/src/python/pants/backend/python/tasks/BUILD
+++ b/src/python/pants/backend/python/tasks/BUILD
@@ -3,6 +3,7 @@
 
 python_library(
   dependencies=[
+    '3rdparty/python:dataclasses',
     '3rdparty/python:pex',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -11,8 +11,10 @@ import traceback
 import uuid
 from collections import OrderedDict
 from contextlib import contextmanager
+from dataclasses import dataclass
 from io import StringIO
 from textwrap import dedent
+from typing import Any
 
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.gather_sources import GatherSources
@@ -29,13 +31,16 @@ from pants.task.testrunner_task_mixin import PartitionedTestRunnerTaskMixin, Tes
 from pants.util.contextutil import environment_as, pushd, temporary_dir, temporary_file
 from pants.util.dirutil import mergetree, safe_mkdir, safe_mkdir_for
 from pants.util.memo import memoized_method, memoized_property
-from pants.util.objects import datatype
 from pants.util.process_handler import SubprocessProcessHandler
 from pants.util.strutil import safe_shlex_join
 from pants.util.xml_parser import XmlParser
 
 
-class _Workdirs(datatype(['root_dir', 'partition'])):
+@dataclass(frozen=True)
+class _Workdirs:
+  root_dir: Any
+  partition: Any
+
   @classmethod
   def for_partition(cls, work_dir, partition):
     root_dir = os.path.join(work_dir, Target.maybe_readable_identify(partition))

--- a/src/python/pants/backend/python/tasks/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks/python_execution_task_base.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from dataclasses import dataclass
 from typing import Dict, Optional
 
 from pex.interpreter import PythonInterpreter
@@ -17,7 +18,6 @@ from pants.backend.python.tasks.resolve_requirements_task_base import ResolveReq
 from pants.build_graph.files import Files
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.util.contextutil import temporary_file
-from pants.util.objects import datatype
 
 
 def ensure_interpreter_search_path_env(interpreter):
@@ -64,8 +64,11 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
     """
     return ()
 
-  class ExtraFile(datatype([('path', str), ('content', bytes)])):
+  @dataclass(frozen=True)
+  class ExtraFile:
     """Models an extra file to place in a PEX."""
+    path: str
+    content: bytes
 
     @classmethod
     def empty(cls, path):

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -136,6 +136,7 @@ python_library(
   name = 'specs',
   sources = ['specs.py'],
   dependencies = [
+    '3rdparty/python:dataclasses',
     'src/python/pants/util:collections',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:objects',
@@ -172,7 +173,7 @@ python_library(
   name = 'target_roots',
   sources = ['target_roots.py'],
   dependencies = [
-    'src/python/pants/util:objects',
+    '3rdparty/python:dataclasses',
   ],
 )
 

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -4,6 +4,8 @@
 import os
 import re
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
 
 from pants.util.collections import assert_single_element
 from pants.util.dirutil import fast_relpath_optional, recursive_dirname
@@ -77,14 +79,17 @@ class Spec(ABC):
     return [os.path.join(spec_dir_path, pat) for pat in address_mapper.build_patterns]
 
 
-class SingleAddress(datatype(['directory', 'name']), Spec):
+@dataclass(frozen=True)
+class SingleAddress(Spec):
   """A Spec for a single address."""
+  directory: Any
+  name: Any
 
-  def __new__(cls, directory, name):
-    if directory is None or name is None:
-      raise ValueError('A SingleAddress must have both a directory and name. Got: '
-                       '{}:{}'.format(directory, name))
-    return super().__new__(cls, directory, name)
+  def __post_init__(self):
+    if self.directory is None or self.name is None:
+      raise ValueError(
+        f'A SingleAddress must have both a directory and name. Got: {self.directory}:{self.name}'
+      )
 
   def to_spec_string(self):
     return '{}:{}'.format(self.directory, self.name)
@@ -120,8 +125,10 @@ class SingleAddress(datatype(['directory', 'name']), Spec):
     return self.globs_in_single_dir(self.directory, address_mapper)
 
 
-class SiblingAddresses(datatype(['directory']), Spec):
+@dataclass(frozen=True)
+class SiblingAddresses(Spec):
   """A Spec representing all addresses located directly within the given directory."""
+  directory: Any
 
   def to_spec_string(self):
     return '{}:'.format(self.directory)
@@ -136,8 +143,10 @@ class SiblingAddresses(datatype(['directory']), Spec):
     return self.globs_in_single_dir(self.directory, address_mapper)
 
 
-class DescendantAddresses(datatype(['directory']), Spec):
+@dataclass(frozen=True)
+class DescendantAddresses(Spec):
   """A Spec representing all addresses located recursively under the given directory."""
+  directory: Any
 
   def to_spec_string(self):
     return '{}::'.format(self.directory)
@@ -158,8 +167,10 @@ class DescendantAddresses(datatype(['directory']), Spec):
     return [os.path.join(self.directory, '**', pat) for pat in address_mapper.build_patterns]
 
 
-class AscendantAddresses(datatype(['directory']), Spec):
+@dataclass(frozen=True)
+class AscendantAddresses(Spec):
   """A Spec representing all addresses located recursively _above_ the given directory."""
+  directory: Any
 
   def to_spec_string(self):
     return '{}^'.format(self.directory)

--- a/src/python/pants/base/target_roots.py
+++ b/src/python/pants/base/target_roots.py
@@ -1,12 +1,15 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.util.objects import datatype
+from dataclasses import dataclass
+from typing import Any
 
 
 class InvalidSpecConstraint(Exception):
   """Raised when invalid constraints are given via target specs and arguments like --changed*."""
 
 
-class TargetRoots(datatype(['specs'])):
+@dataclass(frozen=True)
+class TargetRoots:
   """Determines the target roots for a given pants run."""
+  specs: Any

--- a/src/python/pants/binaries/BUILD
+++ b/src/python/pants/binaries/BUILD
@@ -4,6 +4,7 @@
 python_library(
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:dataclasses',
     '3rdparty/python:pex',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
@@ -15,7 +16,6 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-    'src/python/pants/util:objects',
     'src/python/pants/util:osutil',
   ],
 )

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -9,7 +9,9 @@ import shutil
 import sys
 from abc import abstractmethod
 from contextlib import contextmanager
+from dataclasses import dataclass
 from functools import reduce
+from typing import Any, Optional, Tuple
 
 from twitter.common.collections import OrderedSet
 
@@ -23,7 +25,6 @@ from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import temporary_file
 from pants.util.dirutil import chmod_plus_x, safe_concurrent_creation, safe_open
 from pants.util.memo import memoized_method, memoized_property
-from pants.util.objects import datatype
 from pants.util.osutil import (
   SUPPORTED_PLATFORM_NORMALIZED_NAMES,
   get_closest_mac_host_platform_pair,
@@ -33,11 +34,14 @@ from pants.util.osutil import (
 logger = logging.getLogger(__name__)
 
 
-class HostPlatform(datatype(['os_name', 'arch_or_version'])):
+@dataclass(frozen=True)
+class HostPlatform:
   """Describes a platform to resolve binaries for. Determines the binary's location on disk.
 
   :class:`BinaryToolUrlGenerator` instances receive this to generate download urls.
   """
+  os_name: Any
+  arch_or_version: Any
 
   def binary_path_components(self):
     """These strings are used as consecutive components of the path where a binary is fetched.
@@ -111,17 +115,15 @@ class PantsHosted(BinaryToolUrlGenerator):
 # TODO: Deprecate passing in an explicit supportdir? Seems like we should be able to
 # organize our binary hosting so that it's not needed. It's also used to calculate the binary
 # download location, though.
-class BinaryRequest(datatype([
-    'supportdir',
-    'version',
-    'name',
-    'platform_dependent',
-    # NB: this can be None!
-    'external_url_generator',
-    # NB: this can be None!
-    'archiver',
-])):
+@dataclass(frozen=True)
+class BinaryRequest:
   """Describes a request for a binary to download."""
+  supportdir: Any
+  version: Any
+  name: Any
+  platform_dependent: Any
+  external_url_generator: Optional[Any]
+  archiver: Optional[Any]
 
   def _full_name(self):
     if self.archiver:
@@ -137,24 +139,21 @@ class BinaryRequest(datatype([
     return os.path.join(*binary_path_components)
 
 
-class BinaryFetchRequest(datatype(['download_path', 'urls'])):
+@dataclass(frozen=True)
+class BinaryFetchRequest:
   """Describes a request to download a file."""
+  download_path: Any
+  urls: Tuple
+
+  def __post_init__(self):
+    if not self.urls:
+      raise self.NoDownloadUrlsError(f"No urls were provided to {self.__name__}: {self!r}.")
 
   @memoized_property
   def file_name(self):
     return os.path.basename(self.download_path)
 
   class NoDownloadUrlsError(ValueError): pass
-
-  def __new__(cls, download_path, urls):
-    this_object = super().__new__(cls, download_path, tuple(urls))
-
-    if not this_object.urls:
-      raise cls.NoDownloadUrlsError(
-        "No urls were provided to {cls_name}: {obj!r}."
-        .format(cls_name=cls.__name__, obj=this_object))
-
-    return this_object
 
 
 class BinaryToolFetcher:
@@ -408,9 +407,7 @@ class BinaryUtil:
       raise self.BinaryResolutionError(
         binary_request,
         TypeError("urls must be a list: was '{}'.".format(urls)))
-    fetch_request = BinaryFetchRequest(
-      download_path=download_path,
-      urls=urls)
+    fetch_request = BinaryFetchRequest(download_path=download_path, urls=tuple(urls))
 
     logger.debug("fetch_request: {!r}".format(fetch_request))
 

--- a/src/python/pants/build_graph/BUILD
+++ b/src/python/pants/build_graph/BUILD
@@ -5,6 +5,7 @@
 python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:dataclasses',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file',
     'src/python/pants/base:build_file_target_factory',

--- a/src/python/pants/build_graph/mirrored_target_option_mixin.py
+++ b/src/python/pants/build_graph/mirrored_target_option_mixin.py
@@ -2,17 +2,18 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
 
 from pants.util.memo import memoized_property
-from pants.util.objects import datatype
 
 
-class MirroredTargetOptionDeclaration(datatype([
-    'options',
-    ('option_name', str),
-    'accessor',
-])):
+@dataclass(frozen=True)
+class MirroredTargetOptionDeclaration:
   """An interface for operations to perform on an option which may also be set on a target."""
+  options: Any
+  option_name: str
+  accessor: Any
 
   @memoized_property
   def is_flagged(self):

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -59,11 +59,11 @@ python_library(
   name='goal',
   sources=['goal.py'],
   dependencies=[
+    '3rdparty/python:dataclasses',
     'src/python/pants/cache',
     'src/python/pants/option',
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
-    'src/python/pants/util:objects',
   ]
 )
 
@@ -90,9 +90,11 @@ python_library(
   name='mapper',
   sources=['mapper.py'],
   dependencies=[
+    '3rdparty/python:dataclasses',
     ':objects',
     ':parser',
     'src/python/pants/build_graph',
+    'src/python/pants/util:objects',
     'src/python/pants/util:memo',
   ]
 )
@@ -114,12 +116,12 @@ python_library(
   sources=['nodes.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:dataclasses',
     ':addressable',
     ':fs',
     ':struct',
     'src/python/pants/base:project_tree',
     'src/python/pants/build_graph',
-    'src/python/pants/util:objects',
   ]
 )
 
@@ -136,6 +138,7 @@ python_library(
   name='parser',
   sources=['parser.py'],
   dependencies=[
+    '3rdparty/python:dataclasses',
     ':addressable',
     ':objects',
     'src/python/pants/build_graph',
@@ -181,6 +184,7 @@ python_library(
   sources=['scheduler.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:dataclasses',
     ':fs',
     ':isolated_process',
     ':native',
@@ -191,7 +195,6 @@ python_library(
     'src/python/pants/base:specs',
     'src/python/pants/build_graph',
     'src/python/pants/rules/core:core',
-    'src/python/pants/util:objects',
   ]
 )
 

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -3,6 +3,7 @@
 
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
+from dataclasses import dataclass
 
 from pants.cache.cache_setup import CacheSetup
 from pants.option.optionable import Optionable
@@ -10,10 +11,10 @@ from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 from pants.util.memo import memoized_classproperty
 from pants.util.meta import classproperty
-from pants.util.objects import datatype
 
 
-class Goal(datatype([('exit_code', int)]), metaclass=ABCMeta):
+@dataclass(frozen=True)
+class Goal(metaclass=ABCMeta):
   """The named product of a `@console_rule`.
 
   This abstract class should be subclassed and given a `Goal.name` that it will be referred to by
@@ -26,6 +27,7 @@ class Goal(datatype([('exit_code', int)]), metaclass=ABCMeta):
   Options values for a Goal can be retrived by declaring a dependency on the relevant `Goal.Options`
   class.
   """
+  exit_code: int
 
   @classproperty
   @abstractmethod

--- a/src/python/pants/engine/legacy/BUILD
+++ b/src/python/pants/engine/legacy/BUILD
@@ -35,6 +35,7 @@ python_library(
   name='options_parsing',
   sources=['options_parsing.py'],
   dependencies=[
+    '3rdparty/python:dataclasses',
     'src/python/pants/build_graph',
     'src/python/pants/engine:fs',
     'src/python/pants/engine:objects',
@@ -64,6 +65,7 @@ python_library(
   sources=['graph.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:dataclasses',
     ':address_mapper',
     ':structs',
     'src/python/pants/base:exceptions',
@@ -77,6 +79,5 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/source',
     'src/python/pants/util:dirutil',
-    'src/python/pants/util:objects',
   ],
 )

--- a/src/python/pants/engine/legacy/options_parsing.py
+++ b/src/python/pants/engine/legacy/options_parsing.py
@@ -1,16 +1,19 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from dataclasses import dataclass
+
 from pants.engine.rules import RootRule, rule
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.scope import Scope, ScopedOptions
-from pants.util.objects import datatype
 
 
-class _Options(datatype([('options', Options)])):
+@dataclass(frozen=True)
+class _Options:
   """A wrapper around bootstrapped options values: not for direct consumption."""
+  options: Options
 
 
 @rule

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -3,6 +3,8 @@
 
 import re
 from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
 
 from pants.build_graph.address import BuildFileAddress
 from pants.engine.objects import Serializable
@@ -22,7 +24,8 @@ class DuplicateNameError(MappingError):
   """Indicates more than one top-level object was found with the same name."""
 
 
-class AddressMap(datatype(['path', 'objects_by_name'])):
+@dataclass(frozen=True)
+class AddressMap:
   """Maps addressable Serializable objects from a byte source.
 
   To construct an AddressMap, use `parse`.
@@ -30,6 +33,8 @@ class AddressMap(datatype(['path', 'objects_by_name'])):
   :param path: The path to the byte source this address map's objects were pased from.
   :param objects_by_name: A dict mapping from object name to the parsed 'thin' addressable object.
   """
+  path: Any
+  objects_by_name: Any
 
   @classmethod
   def parse(cls, filepath, filecontent, parser):
@@ -71,7 +76,8 @@ class DifferingFamiliesError(MappingError):
   """Indicates an attempt was made to merge address maps from different families together."""
 
 
-class AddressFamily(datatype(['namespace', 'objects_by_name'])):
+@dataclass(frozen=True)
+class AddressFamily:
   """Represents the family of addressed objects in a namespace.
 
   To create an AddressFamily, use `create`.
@@ -83,6 +89,8 @@ class AddressFamily(datatype(['namespace', 'objects_by_name'])):
   :param namespace: The namespace path of this address family.
   :param objects_by_name: A dict mapping from object name to the parsed 'thin' addressable object.
   """
+  namespace: Any
+  objects_by_name: Any
 
   @classmethod
   def create(cls, spec_path, address_maps):

--- a/src/python/pants/engine/nodes.py
+++ b/src/python/pants/engine/nodes.py
@@ -3,8 +3,8 @@
 
 import logging
 from abc import ABC
-
-from pants.util.objects import datatype
+from dataclasses import dataclass
+from typing import Any
 
 
 logger = logging.getLogger(__name__)
@@ -35,8 +35,10 @@ class State(ABC):
     return (type(self),) + self._to_components()
 
 
-class Return(datatype(['value']), State):
+@dataclass(frozen=True)
+class Return(State):
   """Indicates that a Node successfully returned a value."""
+  value: Any
 
   @classmethod
   def _from_components(cls, components):
@@ -46,15 +48,21 @@ class Return(datatype(['value']), State):
     return (self.value,)
 
 
-class Throw(datatype(['exc']), State):
+@dataclass(frozen=True)
+class Throw(State):
   """Indicates that a Node should have been able to return a value, but failed."""
+  exc: Any
 
 
-class Runnable(datatype(['func', 'args', 'cacheable']), State):
+@dataclass(frozen=True)
+class Runnable(State):
   """Indicates that the Node is ready to run with the given closure.
 
   The return value of the Runnable will become the final state of the Node.
   """
+  func: Any
+  args: Any
+  cacheable: Any
 
   @classmethod
   def _from_components(cls, components):

--- a/src/python/pants/engine/parser.py
+++ b/src/python/pants/engine/parser.py
@@ -2,26 +2,28 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import ABC, abstractmethod
-
-from pants.util.objects import datatype
+from dataclasses import dataclass
+from typing import Any, Dict
 
 
 class ParseError(Exception):
   """Indicates an error parsing BUILD configuration."""
 
 
-class SymbolTable(datatype([
-  ('table', dict),
-])):
+@dataclass(frozen=True)
+class SymbolTable:
   """A symbol table dict mapping symbol name to implementation class."""
+  table: Dict
 
 
-class HydratedStruct(datatype(['value'])):
+@dataclass(frozen=True)
+class HydratedStruct:
   """A wrapper around a Struct subclass post hydration.
 
   This exists so that the rule graph can statically provide a struct for a target, and rules can depend on this
   without needing to depend on having a concrete instance of SymbolTable to register their input selectors.
   """
+  value: Any
 
 
 class Parser(ABC):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -7,8 +7,10 @@ import os
 import sys
 import time
 import traceback
+from dataclasses import dataclass
 from textwrap import dedent
 from types import GeneratorType
+from typing import Any
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE
 from pants.base.project_tree import Dir, File, Link
@@ -37,14 +39,14 @@ from pants.engine.rules import RuleIndex, TaskRule
 from pants.engine.selectors import Params
 from pants.util.contextutil import temporary_file_path
 from pants.util.dirutil import check_no_overlapping_paths
-from pants.util.objects import datatype
 from pants.util.strutil import pluralize
 
 
 logger = logging.getLogger(__name__)
 
 
-class ExecutionRequest(datatype(['roots', 'native'])):
+@dataclass(frozen=True)
+class ExecutionRequest:
   """Holds the roots for an execution, which might have been requested by a user.
 
   To create an ExecutionRequest, see `SchedulerSession.execution_request`.
@@ -52,6 +54,8 @@ class ExecutionRequest(datatype(['roots', 'native'])):
   :param roots: Roots for this request.
   :type roots: list of tuples of subject and product.
   """
+  roots: Any
+  native: Any
 
 
 class ExecutionError(Exception):

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -4,6 +4,7 @@
 python_library(
   dependencies=[
     ':plugins',
+    '3rdparty/python:dataclasses',
     '3rdparty/python:pex',
     '3rdparty/python:setuptools',
     '3rdparty/python:wheel',

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
+from dataclasses import dataclass
+from typing import Any
 
 from pants.backend.docgen.targets.doc import Page
 from pants.backend.jvm.targets.jvm_app import JvmApp
@@ -49,7 +51,6 @@ from pants.option.global_options import (
   ExecutionOptions,
   GlobMatchErrorBehavior,
 )
-from pants.util.objects import datatype
 
 
 logger = logging.getLogger(__name__)
@@ -158,16 +159,24 @@ def _make_target_adaptor(base_class, target_type):
   return GlobsHandlingTargetAdaptor
 
 
-class LegacyGraphScheduler(datatype(['scheduler', 'build_file_aliases', 'goal_map'])):
+@dataclass(frozen=True)
+class LegacyGraphScheduler:
   """A thin wrapper around a Scheduler configured with @rules for a symbol table."""
+  scheduler: Any
+  build_file_aliases: Any
+  goal_map: Any
 
   def new_session(self, zipkin_trace_v2, v2_ui=False):
     session = self.scheduler.new_session(zipkin_trace_v2, v2_ui)
     return LegacyGraphSession(session, self.build_file_aliases, self.goal_map)
 
 
-class LegacyGraphSession(datatype(['scheduler_session', 'build_file_aliases', 'goal_map'])):
+@dataclass(frozen=True)
+class LegacyGraphSession:
   """A thin wrapper around a SchedulerSession configured with @rules for a symbol table."""
+  scheduler_session: Any
+  build_file_aliases: Any
+  goal_map: Any
 
   class InvalidGoals(Exception):
     """Raised when invalid v2 goals are passed in a v2-only mode."""

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -39,7 +39,7 @@ python_library(
   name = 'nailgun_protocol',
   sources = ['nailgun_protocol.py'],
   dependencies = [
-    'src/python/pants/util:objects',
+    '3rdparty/python:dataclasses',
     'src/python/pants/util:osutil',
   ]
 )

--- a/src/python/pants/java/nailgun_protocol.py
+++ b/src/python/pants/java/nailgun_protocol.py
@@ -9,8 +9,8 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+from dataclasses import dataclass
 
-from pants.util.objects import datatype
 from pants.util.osutil import Pid
 
 
@@ -232,7 +232,10 @@ class NailgunProtocol:
       if timeout is not None:
         sock.settimeout(prev_timeout)
 
-  class TimeoutOptions(datatype([('start_time', float), ('interval', float)])): pass
+  @dataclass(frozen=True)
+  class TimeoutOptions:
+    start_time: float
+    interval: float
 
   class TimeoutProvider(ABC):
 

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -4,6 +4,7 @@
 python_library(
   dependencies=[
     '3rdparty/python:ansicolors',
+    '3rdparty/python:dataclasses',
     '3rdparty/python:python-Levenshtein',
     '3rdparty/python:PyYAML',
     '3rdparty/python:setuptools',

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -4,6 +4,8 @@
 import multiprocessing
 import os
 import sys
+from dataclasses import dataclass
+from typing import Any
 
 from pants.base.build_environment import (
   get_buildroot,
@@ -18,7 +20,7 @@ from pants.option.errors import OptionsError
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
-from pants.util.objects import datatype, enum
+from pants.util.objects import enum
 
 
 class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'])):
@@ -29,32 +31,32 @@ class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'])):
   """
 
 
-class ExecutionOptions(datatype([
-  'remote_execution',
-  'remote_store_server',
-  'remote_store_thread_count',
-  'remote_execution_server',
-  'remote_store_chunk_bytes',
-  'remote_store_chunk_upload_timeout_seconds',
-  'remote_store_rpc_retries',
-  'remote_store_connection_limit',
-  'process_execution_local_parallelism',
-  'process_execution_remote_parallelism',
-  'process_execution_cleanup_local_dirs',
-  'process_execution_speculation_delay',
-  'process_execution_speculation_strategy',
-  'process_execution_use_local_cache',
-  'remote_execution_process_cache_namespace',
-  'remote_instance_name',
-  'remote_ca_certs_path',
-  'remote_oauth_bearer_token_path',
-  'remote_execution_extra_platform_properties',
-])):
+@dataclass(frozen=True)
+class ExecutionOptions:
   """A collection of all options related to (remote) execution of processes.
 
   TODO: These options should move to a Subsystem once we add support for "bootstrap" Subsystems (ie,
   allowing Subsystems to be consumed before the Scheduler has been created).
   """
+  remote_execution: Any
+  remote_store_server: Any
+  remote_store_thread_count: Any
+  remote_execution_server: Any
+  remote_store_chunk_bytes: Any
+  remote_store_chunk_upload_timeout_seconds: Any
+  remote_store_rpc_retries: Any
+  remote_store_connection_limit: Any
+  process_execution_local_parallelism: Any
+  process_execution_remote_parallelism: Any
+  process_execution_cleanup_local_dirs: Any
+  process_execution_speculation_delay: Any
+  process_execution_speculation_strategy: Any
+  process_execution_use_local_cache: Any
+  remote_execution_process_cache_namespace: Any
+  remote_instance_name: Any
+  remote_ca_certs_path: Any
+  remote_oauth_bearer_token_path: Any
+  remote_execution_extra_platform_properties: Any
 
   @classmethod
   def from_bootstrap_options(cls, bootstrap_options):

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -389,7 +389,7 @@ class Options:
       else:
         dashed_scope = scope.replace('.', '-')
         scoped_arg = '--{}-{}'.format(dashed_scope, normalized_arg)
-      return super(Options._ScopedFlagNameForFuzzyMatching, cls).__new__(
+      return super().__new__(
         cls,
         scope=scope,
         arg=arg,

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -1,6 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from dataclasses import dataclass
 
 from pants.option.option_value_container import OptionValueContainer
 from pants.util.objects import datatype
@@ -54,8 +55,8 @@ class ScopeInfo(datatype([
     return getattr(self.optionable_cls, name) if self.optionable_cls else default
 
 
-class ScopedOptions(datatype([
-  ('scope', Scope),
-  ('options', OptionValueContainer),
-])):
+@dataclass(frozen=True)
+class ScopedOptions:
   """A wrapper around options selected for a particular Scope."""
+  scope: Scope
+  options: OptionValueContainer

--- a/src/python/pants/pantsd/BUILD
+++ b/src/python/pants/pantsd/BUILD
@@ -55,6 +55,7 @@ python_library(
   name = 'pants_daemon',
   sources = ['pants_daemon.py'],
   dependencies = [
+    '3rdparty/python:dataclasses',
     '3rdparty/python:setproctitle',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exception_sink',

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -6,6 +6,7 @@ import os
 import sys
 import threading
 from contextlib import contextmanager
+from dataclasses import dataclass
 
 from setproctitle import setproctitle as set_process_title
 
@@ -30,7 +31,6 @@ from pants.pantsd.watchman_launcher import WatchmanLauncher
 from pants.util.collections import combined_dict
 from pants.util.contextutil import stdio_as
 from pants.util.memo import memoized_property
-from pants.util.objects import datatype
 from pants.util.strutil import ensure_text
 
 
@@ -99,12 +99,16 @@ class PantsDaemon(FingerprintedProcessManager):
   class RuntimeFailure(Exception):
     """Represents a pantsd failure at runtime, usually from an underlying service failure."""
 
-  class Handle(datatype([('pid', int), ('port', int), ('metadata_base_dir', str)])):
+  @dataclass(frozen=True)
+  class Handle:
     """A handle to a "probably running" pantsd instance.
 
     We attempt to verify that the pantsd instance is still running when we create a Handle, but
     after it has been created it is entirely process that the pantsd instance perishes.
     """
+    pid: int
+    port: int
+    metadata_base_dir: str
 
   class Factory:
     @classmethod

--- a/src/python/pants/rules/core/BUILD
+++ b/src/python/pants/rules/core/BUILD
@@ -1,16 +1,16 @@
 python_library(
     dependencies = [
-        'src/python/pants/base:exiter',
-        'src/python/pants/build_graph',
-        'src/python/pants/engine:goal',
-        'src/python/pants/engine:rules',
-        'src/python/pants/engine:selectors',
-        'src/python/pants/engine:addressable',
-        'src/python/pants/engine:console',
-        'src/python/pants/engine/legacy:graph',
-        'src/python/pants/goal',
-        'src/python/pants/source',
-        'src/python/pants/util:objects'
+      '3rdparty/python:dataclasses',
+      'src/python/pants/base:exiter',
+      'src/python/pants/build_graph',
+      'src/python/pants/engine:goal',
+      'src/python/pants/engine:rules',
+      'src/python/pants/engine:selectors',
+      'src/python/pants/engine:addressable',
+      'src/python/pants/engine:console',
+      'src/python/pants/engine/legacy:graph',
+      'src/python/pants/goal',
+      'src/python/pants/source',
     ]
 )
 

--- a/src/python/pants/rules/core/core_test_model.py
+++ b/src/python/pants/rules/core/core_test_model.py
@@ -1,19 +1,20 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from dataclasses import dataclass
+
 from pants.engine.rules import union
-from pants.util.objects import datatype, enum
+from pants.util.objects import enum
 
 
 class Status(enum(['SUCCESS', 'FAILURE'])): pass
 
 
-class TestResult(datatype([
-  ('status', Status),
-  # The stdout of the test runner (which may or may not include actual testcase output).
-  ('stdout', str),
-  ('stderr', str),
-])):
+@dataclass(frozen=True)
+class TestResult:
+  status: Status
+  stdout: str
+  stderr: str
 
   # Prevent this class from being detected by pytest as a test class.
   __test__ = False

--- a/src/python/pants/rules/core/strip_source_root.py
+++ b/src/python/pants/rules/core/strip_source_root.py
@@ -1,17 +1,20 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from dataclasses import dataclass
+
 from pants.build_graph.files import Files
 from pants.engine.fs import EMPTY_SNAPSHOT, Digest, DirectoryWithPrefixToStrip, Snapshot
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.rules import optionable_rule, rule
 from pants.engine.selectors import Get
 from pants.source.source_root import SourceRootConfig
-from pants.util.objects import datatype
 
 
-class SourceRootStrippedSources(datatype([('snapshot', Snapshot)])):
+@dataclass(frozen=True)
+class SourceRootStrippedSources:
   """Wrapper for a snapshot of targets whose source roots have been stripped."""
+  snapshot: Snapshot
 
 
 @rule

--- a/src/python/pants/scm/subsystems/BUILD
+++ b/src/python/pants/scm/subsystems/BUILD
@@ -5,6 +5,7 @@ python_library(
   name = 'changed',
   sources = ['changed.py'],
   dependencies = [
+    '3rdparty/python:dataclasses',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/goal:workspace',

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -1,12 +1,19 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from dataclasses import dataclass
+from typing import Any
+
 from pants.subsystem.subsystem import Subsystem
-from pants.util.objects import datatype
 
 
-class ChangedRequest(datatype(['changes_since', 'diffspec', 'include_dependees', 'fast'])):
+@dataclass(frozen=True)
+class ChangedRequest:
   """Parameters required to compute a changed file/target set."""
+  changes_since: Any
+  diffspec: Any
+  include_dependees: Any
+  fast: Any
 
   @classmethod
   def from_options(cls, options):

--- a/src/python/pants/source/BUILD
+++ b/src/python/pants/source/BUILD
@@ -5,6 +5,7 @@ python_library(
   sources = globs('*.py', exclude=[globs('payload_fields.py')]),
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
+    '3rdparty/python:dataclasses',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:payload_field',
     'src/python/pants/base:project_tree',

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-from typing import Optional, Sequence, Set
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence, Set
 
 from pants.base.project_tree_factory import get_project_tree
 from pants.engine.objects import Collection
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method, memoized_property
-from pants.util.objects import datatype
 
 
 class SourceRootCategories:
@@ -19,8 +19,11 @@ class SourceRootCategories:
   ALL = [UNKNOWN, SOURCE, TEST, THIRDPARTY]
 
 
-class SourceRoot(datatype([('path', str), 'langs', ('category', str)])):
-  pass
+@dataclass(frozen=True)
+class SourceRoot:
+  path: str
+  langs: Any
+  category: str
 
 
 class AllSourceRoots(Collection.of(SourceRoot)):

--- a/src/python/pants/subsystem/BUILD
+++ b/src/python/pants/subsystem/BUILD
@@ -4,6 +4,7 @@
 python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:dataclasses',
     'src/python/pants/option',
   ],
 )

--- a/src/python/pants/subsystem/subsystem_client_mixin.py
+++ b/src/python/pants/subsystem/subsystem_client_mixin.py
@@ -2,27 +2,26 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
+from dataclasses import dataclass
+from typing import Any, Optional
+
 from twitter.common.collections import OrderedSet
 
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.optionable import OptionableFactory
 from pants.option.scope import ScopeInfo
-from pants.util.objects import datatype
 
 
 class SubsystemClientError(Exception): pass
 
 
-class SubsystemDependency(datatype([
-  'subsystem_cls',
-  'scope',
-  'removal_version',
-  'removal_hint',
-]), OptionableFactory):
+@dataclass(frozen=True)
+class SubsystemDependency(OptionableFactory):
   """Indicates intent to use an instance of `subsystem_cls` scoped to `scope`."""
-
-  def __new__(cls, subsystem_cls, scope, removal_version=None, removal_hint=None):
-    return super().__new__(cls, subsystem_cls, scope, removal_version, removal_hint)
+  subsystem_cls: Any
+  scope: Any
+  removal_version: Optional[Any] = None
+  removal_hint: Optional[Any] = None
 
   def is_global(self):
     return self.scope == GLOBAL_SCOPE

--- a/src/python/pants/task/BUILD
+++ b/src/python/pants/task/BUILD
@@ -5,6 +5,7 @@
 python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:dataclasses',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',

--- a/src/python/pants/task/unpack_remote_sources_base.py
+++ b/src/python/pants/task/unpack_remote_sources_base.py
@@ -5,6 +5,8 @@ import logging
 import os
 import re
 from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+from typing import Tuple
 
 from twitter.common.dirutil.fileset import fnmatch_translate_extended
 
@@ -12,16 +14,15 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.task.task import Task
 from pants.util.meta import classproperty
-from pants.util.objects import datatype
 
 
 logger = logging.getLogger(__name__)
 
 
-class UnpackedArchives(datatype([('found_files', tuple), ('rel_unpack_dir', str)])):
-
-  def __new__(cls, found_files, rel_unpack_dir):
-    return super().__new__(cls, tuple(found_files), rel_unpack_dir)
+@dataclass(frozen=True)
+class UnpackedArchives:
+  found_files: Tuple
+  rel_unpack_dir: str
 
 
 class UnpackRemoteSourcesBase(Task, metaclass=ABCMeta):
@@ -136,7 +137,7 @@ class UnpackRemoteSourcesBase(Task, metaclass=ABCMeta):
     found_files, rel_unpack_dir = self._traverse_unpacked_dir(unpack_dir)
     self.context.log.debug('target: {}, rel_unpack_dir: {}, found_files: {}'
                            .format(target, rel_unpack_dir, found_files))
-    self._unpacked_sources_product[target] = UnpackedArchives(found_files, rel_unpack_dir)
+    self._unpacked_sources_product[target] = UnpackedArchives(tuple(found_files), rel_unpack_dir)
 
   class MissingUnpackedDirsError(Exception):
     """Raised if a directory that is expected to be unpacked doesn't exist."""

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -39,7 +39,6 @@ python_library(
     'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-    'src/python/pants/util:objects',
     'src/python/pants/util:osutil',
     'src/python/pants/util:process_handler',
     'src/python/pants/util:strutil',

--- a/tests/python/pants_test/backend/codegen/antlr/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/antlr/java/BUILD
@@ -6,6 +6,7 @@ python_tests(
   sources = globs('*.py', exclude=[globs('*_integration.py')]),
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
+    '3rdparty/python:dataclasses',
     'src/python/pants/backend/codegen/antlr/java',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
@@ -4,7 +4,9 @@
 import os
 import re
 import time
+from dataclasses import dataclass
 from textwrap import dedent
+from typing import Any
 
 from twitter.common.dirutil.fileset import Fileset
 
@@ -13,11 +15,14 @@ from pants.backend.codegen.antlr.java.java_antlr_library import JavaAntlrLibrary
 from pants.base.exceptions import TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.util.dirutil import safe_mkdtemp
-from pants.util.objects import datatype
 from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 
 
-class DummyVersionedTarget(datatype(['target', 'results_dir'])):
+@dataclass(frozen=True)
+class DummyVersionedTarget:
+  target: Any
+  results_dir: Any
+
   @property
   def current_results_dir(self):
     return self.results_dir

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -29,7 +29,7 @@ class ExternalUrlGenerator(BinaryToolUrlGenerator):
     return ['https://www.pantsbuild.org/some-binary', 'https://www.pantsbuild.org/same-binary']
 
   # Make the __str__ deterministic, for testing exception messages.
-  def __str__(self):
+  def __repr__(self):
     return 'ExternalUrlGenerator(<example __str__()>)'
 
 
@@ -122,8 +122,8 @@ class BinaryUtilTest(TestBase):
 
     self.assertIn(BinaryUtil.NoBaseUrlsError.__name__, the_raised_exception_message)
     expected_msg = (
-      "Error resolving binary request BinaryRequest(supportdir=supportdir, version=version, "
-      "name=name, platform_dependent=False, external_url_generator=None, archiver=None): "
+      "Error resolving binary request BinaryRequest(supportdir='supportdir', version='version', "
+      "name='name', platform_dependent=False, external_url_generator=None, archiver=None): "
       "--binaries-baseurls is empty.")
     self.assertIn(expected_msg, the_raised_exception_message)
 
@@ -231,8 +231,8 @@ class BinaryUtilTest(TestBase):
 
     self.assertIn(BinaryUtil.MissingMachineInfo.__name__, the_raised_exception_message)
     expected_msg = (
-      "Error resolving binary request BinaryRequest(supportdir=supportdir, version=version, "
-      "name=name, platform_dependent=True, external_url_generator=None, archiver=None): "
+      "Error resolving binary request BinaryRequest(supportdir='supportdir', version='version', "
+      "name='name', platform_dependent=True, external_url_generator=None, archiver=None): "
       "Pants could not resolve binaries for the current host: platform 'vms' was not recognized. "
       "Recognized platforms are: [darwin, linux].")
     self.assertIn(expected_msg, the_raised_exception_message)
@@ -249,8 +249,8 @@ class BinaryUtilTest(TestBase):
 
     self.assertIn(BinaryUtil.MissingMachineInfo.__name__, the_raised_exception_message)
     expected_msg = (
-      "Error resolving binary request BinaryRequest(supportdir=mysupportdir, version=myversion, "
-      "name=myname, platform_dependent=True, external_url_generator=None, archiver=None): "
+      "Error resolving binary request BinaryRequest(supportdir='mysupportdir', version='myversion', "
+      "name='myname', platform_dependent=True, external_url_generator=None, archiver=None): "
       "Pants could not resolve binaries for the current host. Update --binaries-path-by-id to "
       "find binaries for the current host platform (\'linux\', "
       "\'quantum_computer\').\\n--binaries-path-by-id was:"
@@ -269,9 +269,9 @@ class BinaryUtilTest(TestBase):
 
     self.assertIn(BinaryUtil.MissingMachineInfo.__name__, the_raised_exception_message)
     expected_msg = (
-      "Error resolving binary request BinaryRequest(supportdir=mysupportdir, version=myversion, "
+      "Error resolving binary request BinaryRequest(supportdir='mysupportdir', version='myversion', "
       # platform_dependent=False when doing select_script()
-      "name=myname, platform_dependent=False, external_url_generator=None, archiver=None): Pants "
+      "name='myname', platform_dependent=False, external_url_generator=None, archiver=None): Pants "
       "could not resolve binaries for the current host. Update --binaries-path-by-id to find "
       "binaries for the current host platform (\'linux\', "
       "\'quantum_computer\').\\n--binaries-path-by-id was:"
@@ -308,13 +308,13 @@ class BinaryUtilTest(TestBase):
 
     self.assertIn(BinaryToolFetcher.BinaryNotFound.__name__, the_raised_exception_message)
     expected_msg = (
-      "Error resolving binary request BinaryRequest(supportdir=supportdir, version=version, "
-      "name=name, platform_dependent=False, "
+      "Error resolving binary request BinaryRequest(supportdir='supportdir', version='version', "
+      "name='name', platform_dependent=False, "
       "external_url_generator=ExternalUrlGenerator(<example __str__()>), archiver=None): "
       "Failed to fetch name binary from any source: (Failed to fetch binary from "
       "https://www.pantsbuild.org/some-binary: Fetch of https://www.pantsbuild.org/some-binary failed with "
       "status code 404, Failed to fetch binary from https://www.pantsbuild.org/same-binary: Fetch of "
-      "https://www.pantsbuild.org/same-binary failed with status code 404)'")
+      "https://www.pantsbuild.org/same-binary failed with status code 404)")
     self.assertIn(expected_msg, the_raised_exception_message)
 
   def test_disallowing_external_urls(self):
@@ -335,8 +335,8 @@ class BinaryUtilTest(TestBase):
 
     self.assertIn(BinaryUtil.NoBaseUrlsError.__name__, the_raised_exception_message)
     expected_msg = (
-      "Error resolving binary request BinaryRequest(supportdir=supportdir, version=version, "
-      "name=name, platform_dependent=False, "
+      "Error resolving binary request BinaryRequest(supportdir='supportdir', version='version', "
+      "name='name', platform_dependent=False, "
       "external_url_generator=ExternalUrlGenerator(<example __str__()>), archiver=None): "
       "--binaries-baseurls is empty.")
     self.assertIn(expected_msg, the_raised_exception_message)

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -108,6 +108,7 @@ python_tests(
 python_tests(
   sources=['test_engine.py'],
   dependencies=[
+    '3rdparty/python:dataclasses',
     ':scheduler_test_base',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',
@@ -187,6 +188,7 @@ python_tests(
   sources=['test_scheduler.py'],
   coverage=['pants.engine.nodes', 'pants.engine.scheduler'],
   dependencies=[
+    '3rdparty/python:dataclasses',
     ':util',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -193,6 +193,7 @@ python_tests(
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',
     'src/python/pants/engine:scheduler',
+    'src/python/pants/util:objects',
     'tests/python/pants_test/engine/examples:scheduler_inputs',
     'tests/python/pants_test:test_base',
   ]

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -2,12 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import unittest
+from dataclasses import dataclass
 from textwrap import dedent
 
 from pants.engine.rules import RootRule, rule
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Get
-from pants.util.objects import datatype
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
 from pants_test.engine.util import assert_equal_with_printing, remove_locations_from_traceback
 
@@ -37,7 +37,9 @@ def nested_raise(x: B) -> A:
   fn_raises(x)
 
 
-class Fib(datatype([('val', int)])): pass
+@dataclass(frozen=True)
+class Fib:
+  val: int
 
 
 @rule
@@ -48,10 +50,14 @@ def fib(n: int) -> Fib:
   yield Fib(x.val + y.val)
 
 
-class MyInt(datatype([('val', int)])): pass
+@dataclass(frozen=True)
+class MyInt:
+  val: int
 
 
-class MyFloat(datatype([('val', float)])): pass
+@dataclass(frozen=True)
+class MyFloat:
+  val: float
 
 
 @rule

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -7,12 +7,12 @@ import unittest.mock
 from contextlib import contextmanager
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Any
 
 from pants.engine.native import Native
 from pants.engine.rules import RootRule, UnionRule, rule, union
 from pants.engine.scheduler import ExecutionError, SchedulerSession
 from pants.engine.selectors import Get, Params
+from pants.util.objects import datatype
 from pants_test.engine.util import assert_equal_with_printing, remove_locations_from_traceback
 from pants_test.test_base import TestBase
 
@@ -143,9 +143,8 @@ def c_unhashable(_: TypeCheckFailWrapper) -> C:
   yield C()
 
 
-@dataclass(frozen=True)
-class CollectionType:
-  items: Any
+class CollectionType(datatype(['items'])):
+  pass
 
 
 @rule
@@ -346,8 +345,8 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
 
     trace = remove_locations_from_traceback('\n'.join(self.scheduler.trace(request)))
     assert_equal_with_printing(self, dedent('''
-                     Computing Select(<pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, A)
-                       Computing Task(nested_raise(), <pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, A, true)
+                     Computing Select(B(), A)
+                       Computing Task(nested_raise(), B(), A, true)
                          Throw(An exception for B)
                            Traceback (most recent call last):
                              File LOCATION-INFO, in call

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -5,21 +5,24 @@ import re
 import sys
 import unittest.mock
 from contextlib import contextmanager
+from dataclasses import dataclass
 from textwrap import dedent
+from typing import Any
 
 from pants.engine.native import Native
 from pants.engine.rules import RootRule, UnionRule, rule, union
 from pants.engine.scheduler import ExecutionError, SchedulerSession
 from pants.engine.selectors import Get, Params
-from pants.util.objects import datatype
 from pants_test.engine.util import assert_equal_with_printing, remove_locations_from_traceback
 from pants_test.test_base import TestBase
 
 
+@dataclass(frozen=True)
 class A:
   pass
 
 
+@dataclass(frozen=True)
 class B:
   pass
 
@@ -38,6 +41,7 @@ def consumes_a_and_b(a: A, b: B) -> str:
   return str('{} and {}'.format(a, b))
 
 
+@dataclass(frozen=True)
 class C:
   pass
 
@@ -47,8 +51,9 @@ def transitive_b_c(c: C) -> B:
   return B()
 
 
-class D(datatype([('b', B)])):
-  pass
+@dataclass(frozen=True)
+class D:
+  b: B
 
 
 @rule
@@ -138,8 +143,9 @@ def c_unhashable(_: TypeCheckFailWrapper) -> C:
   yield C()
 
 
-class CollectionType(datatype(['items'])):
-  pass
+@dataclass(frozen=True)
+class CollectionType:
+  items: Any
 
 
 @rule

--- a/tests/python/pants_test/init/BUILD
+++ b/tests/python/pants_test/init/BUILD
@@ -4,6 +4,7 @@
 
 python_tests(
   dependencies = [
+    '3rdparty/python:dataclasses',
     '3rdparty/python:parameterized',
     '3rdparty/python:pex',
     '3rdparty/python:setuptools',
@@ -20,7 +21,6 @@ python_tests(
     'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-    'src/python/pants/util:objects',
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test:interpreter_selection_utils',
     'tests/python/pants_test:test_base',

--- a/tests/python/pants_test/init/test_extension_loader.py
+++ b/tests/python/pants_test/init/test_extension_loader.py
@@ -6,6 +6,8 @@ import types
 import unittest
 import uuid
 from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
 
 from pkg_resources import (
   Distribution,
@@ -32,7 +34,6 @@ from pants.init.extension_loader import (
 )
 from pants.subsystem.subsystem import Subsystem
 from pants.task.task import Task
-from pants.util.objects import datatype
 
 
 class MockMetadata(EmptyProvider):
@@ -89,12 +90,14 @@ class DummyTask(Task):
   def execute(self): return 42
 
 
-class RootType(datatype(['value'])):
-  pass
+@dataclass(frozen=True)
+class RootType:
+  value: Any
 
 
-class WrapperType(datatype(['value'])):
-  pass
+@dataclass(frozen=True)
+class WrapperType:
+  value: Any
 
 
 @rule

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from operator import eq, ne
 from threading import Lock
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 from colors import strip_color
 
@@ -24,7 +24,6 @@ from pants.fs.archive import ZIP
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import environment_as, pushd, temporary_dir
 from pants.util.dirutil import fast_relpath, safe_mkdir, safe_mkdir_for, safe_open
-from pants.util.objects import datatype
 from pants.util.osutil import Pid
 from pants.util.process_handler import SubprocessProcessHandler
 from pants.util.strutil import ensure_binary
@@ -584,7 +583,13 @@ class PantsRunIntegrationTest(unittest.TestCase):
   @contextmanager
   def mock_buildroot(self, dirs_to_copy=None):
     """Construct a mock buildroot and return a helper object for interacting with it."""
-    class Manager(datatype(['write_file', 'pushd', 'new_buildroot'])): pass
+
+    @dataclass(frozen=True)
+    class Manager:
+      write_file: Any
+      pushd: Any
+      new_buildroot: Any
+
     # N.B. BUILD.tools, contrib, 3rdparty needs to be copied vs symlinked to avoid
     # symlink prefix check error in v1 and v2 engine.
     files_to_copy = ('BUILD.tools',)

--- a/tests/python/pants_test/task/BUILD
+++ b/tests/python/pants_test/task/BUILD
@@ -35,6 +35,7 @@ python_tests(
   name = 'simple_codegen_task',
   sources = ['test_simple_codegen_task.py'],
   dependencies = [
+    '3rdparty/python:dataclasses',
     'src/python/pants/base:payload',
     'src/python/pants/build_graph',
     'src/python/pants/task',

--- a/tests/python/pants_test/task/test_simple_codegen_task.py
+++ b/tests/python/pants_test/task/test_simple_codegen_task.py
@@ -2,7 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from dataclasses import dataclass
 from textwrap import dedent
+from typing import Any
 
 from pants.base.payload import Payload
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -10,7 +12,6 @@ from pants.build_graph.register import build_file_aliases as register_core
 from pants.build_graph.target import Target
 from pants.task.simple_codegen_task import SimpleCodegenTask
 from pants.util.dirutil import safe_mkdtemp
-from pants.util.objects import datatype
 from pants_test.task_test_base import TaskTestBase, ensure_cached
 
 
@@ -110,7 +111,11 @@ class DummyGen(SimpleCodegenTask):
     return ['copied']
 
 
-class DummyVersionedTarget(datatype(['target', 'results_dir'])):
+@dataclass(frozen=True)
+class DummyVersionedTarget:
+  target: Any
+  results_dir: Any
+
   @property
   def current_results_dir(self):
     return self.results_dir

--- a/tests/python/pants_test/testutils/BUILD
+++ b/tests/python/pants_test/testutils/BUILD
@@ -36,6 +36,7 @@ python_library(
     'process_test_util.py',
   ],
   dependencies = [
+    '3rdparty/python:dataclasses',
     '3rdparty/python:psutil',
   ],
 )

--- a/tests/python/pants_test/testutils/process_test_util.py
+++ b/tests/python/pants_test/testutils/process_test_util.py
@@ -2,10 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
 
 import psutil
-
-from pants.util.objects import datatype
 
 
 class ProcessStillRunning(AssertionError):
@@ -47,7 +47,11 @@ def no_lingering_process_by_command(name):
     )
 
 
-class TrackedProcessesContext(datatype(['name', 'before_processes'])):
+@dataclass(frozen=True)
+class TrackedProcessesContext:
+  name: Any
+  before_processes: Any
+
   def current_processes(self):
     """Returns the current set of matching processes created since the context was entered."""
     after_processes = set(_safe_iter_matching_processes(self.name))

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -34,9 +34,9 @@ python_tests(
   sources = ['test_dirutil.py'],
   coverage = ['pants.util.dirutil'],
   dependencies = [
+    '3rdparty/python:dataclasses',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-    'src/python/pants/util:objects',
   ]
 )
 

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -7,6 +7,8 @@ import time
 import unittest
 import unittest.mock
 from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
 
 from pants.util import dirutil
 from pants.util.contextutil import pushd, temporary_dir
@@ -33,7 +35,6 @@ from pants.util.dirutil import (
   safe_rmtree,
   touch,
 )
-from pants.util.objects import datatype
 
 
 def strict_patch(target, **kwargs):
@@ -155,10 +156,15 @@ class DirutilTest(unittest.TestCase):
       with temporary_dir() as dst:
         yield root, dst
 
-  class Dir(datatype(['path'])):
-    pass
+  @dataclass(frozen=True)
+  class Dir:
+    path: Any
 
-  class File(datatype(['path', 'contents'])):
+  @dataclass(frozen=True)
+  class File:
+    file: Any
+    contents: Any
+
     @classmethod
     def empty(cls, path):
       return cls(path, contents='')
@@ -168,8 +174,9 @@ class DirutilTest(unittest.TestCase):
       with open(os.path.join(root, relpath), 'r') as fp:
         return cls(relpath, fp.read())
 
-  class Symlink(datatype(['path'])):
-    pass
+  @dataclass(frozen=True)
+  class Symlink:
+    path: Any
 
   def assert_tree(self, root, *expected):
     def collect_tree():


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/8181 demonstrated that it's possible to use `@dataclass(frozen=True)` as an alternative to `datatype()`. As argued there, this brings several benefits, including aligning us more to the stdlib and allowing MyPy to understand our code for free.

This PR takes a first pass to convert >75% of `datatype` usages to `@dataclass`. It naively does this translation:

* Does not attempt to add any more type hints than were previously used.
* Leaves untouched certain `datatypes()` that inherit normal classes with class variables, which would get overridden
* Leaves untouched certain `datatypes()` with custom `__new__()` that is not easily replicated