### PR TITLE
Deprecate ivy resolve

### DIFF
--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -12,6 +12,7 @@ from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.ivy_task_mixin import IvyTaskMixin
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
+from pants.base.deprecated import deprecated, deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.java.jar.jar_dependency import JarDependency
@@ -85,6 +86,15 @@ class IvyResolve(IvyTaskMixin, NailgunTask):
     """Resolves the specified confs for the configured targets and returns an iterator over
     tuples of (conf, jar path).
     """
+
+    deprecated_conditional(
+      lambda: JvmResolveSubsystem.global_instance().get_options().resolver == 'ivy',
+      removal_version='1.27.0.dev0',
+      entity_description='Ivy Resolve',
+      hint_message='resolve.ivy as well as --resolver-resolver=ivy will be removed.'
+                   'Please use --resolver-resolver=coursier instead and refer to '
+                   'https://www.pantsbuild.org/jvm_projects.html#coursier for setup.')
+
     if JvmResolveSubsystem.global_instance().get_options().resolver != 'ivy':
       return
 


### PR DESCRIPTION
Remove at 1.27.
Publishing with ivy will remain.