### PR TITLE
add scala_platform to export output for metals!

### DIFF
--- a/src/docs/export.md
+++ b/src/docs/export.md
@@ -107,6 +107,15 @@ The following is an abbreviated export file from a command in the pants repo:
         },
         "default_interpreter": "CPython-2.7.10"
     },
+    "scala_platform": {
+        "scala_version": "2.12",
+        "compiler_classpath": [
+          "/Users/dmcclanahan/tools/pants-v4/.pants.d/bootstrap/bootstrap-jvm-tools/a0ebe8e0b001/ivy/jars/org.scala-lang/scala-compiler/jars/scala-compiler-2.12.8.jar",
+          "/Users/dmcclanahan/tools/pants-v4/.pants.d/bootstrap/bootstrap-jvm-tools/a0ebe8e0b001/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.12.8.jar",
+          "/Users/dmcclanahan/tools/pants-v4/.pants.d/bootstrap/bootstrap-jvm-tools/a0ebe8e0b001/ivy/jars/org.scala-lang/scala-reflect/jars/scala-reflect-2.12.8.jar",
+          "/Users/dmcclanahan/tools/pants-v4/.pants.d/bootstrap/bootstrap-jvm-tools/a0ebe8e0b001/ivy/jars/org.scala-lang.modules/scala-xml_2.12/jars/scala-xml_2.12-1.0.6.jar"
+        ]
+    },
     "targets": {
         "examples/tests/java/org/pantsbuild/example/usethrift:usethrift": {
             "is_code_gen": false,
@@ -167,6 +176,10 @@ The following is an abbreviated export file from a command in the pants repo:
 
 
 # Export Format Changes
+
+## 1.0.11
+
+The 'scala_platform' field is added to the top-level keys, containing the 'scala_version' string (without patch version, e.g. "2.12") and the 'compiler_classpath' jars (a list of absolute paths to jar files).
 
 ## 1.0.10
 

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -56,7 +56,7 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
   #
   # Note format changes in src/docs/export.md and update the Changelog section.
   #
-  DEFAULT_EXPORT_VERSION = '1.0.10'
+  DEFAULT_EXPORT_VERSION = '1.0.11'
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -9,6 +9,7 @@ from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.subsystems.resolve_subsystem import JvmResolveSubsystem
+from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.junit_tests import JUnitTests
 from pants.backend.jvm.targets.jvm_app import JvmApp
@@ -282,6 +283,15 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
     for target in targets:
       process_target(target)
 
+    scala_platform = ScalaPlatform.global_instance()
+    scala_platform_map = {
+      'scala_version': scala_platform.version,
+      'compiler_classpath': [
+        cp_entry.path
+        for cp_entry in scala_platform.compiler_classpath_entries(self.context.products)
+      ],
+    }
+
     jvm_platforms_map = {
       'default_platform' : JvmPlatform.global_instance().default_platform.name,
       'platforms': {
@@ -296,6 +306,7 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
       'version': self.DEFAULT_EXPORT_VERSION,
       'targets': targets_map,
       'jvm_platforms': jvm_platforms_map,
+      'scala_platform': scala_platform_map,
       # `jvm_distributions` are static distribution settings from config,
       # `preferred_jvm_distributions` are distributions that pants actually uses for the
       # given platform setting.


### PR DESCRIPTION
### Problem

We would like to support the Metals VSCode plugin -- see associated PR at scalameta/metals#935. Pants currently does not have any fields which specifically provide the scala version and the compiler jars, so that PR currently iterates over the `libraries` keys, which doesn't provide all the scala compiler jars.

### Solution

Add a `scala_platform` key to the `./pants export` output containing the `scala_version` and `compiler_classpath`:
```json
{
  ...,
  "scala_platform": {
    "scala_version": "2.12",
    "compiler_classpath": [
      "/path/to/scala-compiler-2.12.8.jar",
      "/path/to/scala-library-2.12.8.jar",
      ...
    ]
}
```

### Result

Using the branch at https://github.com/cosmicexplorer/language-server/tree/sohamr/add-pants-build-tool (which is based off of scalameta/metals#935), I have been able to show that metals can extract the `scala_platform` from the json!