### PR TITLE
Move PlatformConstraint to a param.

### DIFF
--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -51,10 +51,6 @@ def create_pex(
   """Returns a PEX with the given requirements, optional entry point, and optional
   interpreter constraints."""
 
-  # ignore none constraint if some rule pushes a constraint down as none.
-  if platform == PlatformConstraint.none:
-    platform = PlatformConstraint.local_platform
-
   interpreter_constraint_args = []
   for constraint in request.interpreter_constraints:
     interpreter_constraint_args.extend(["--interpreter-constraint", constraint])
@@ -71,6 +67,10 @@ def create_pex(
   sources_digest_as_subdir = yield Get(Digest, DirectoryWithPrefixToAdd(sources_digest, source_dir_name))
   all_inputs = (pex_bin.directory_digest, sources_digest_as_subdir,)
   merged_digest = yield Get(Digest, DirectoriesToMerge(directories=all_inputs))
+
+  # ignore none constraint if some rule pushes a constraint down as none.
+  if platform == PlatformConstraint.none:
+    platform = PlatformConstraint.local_platform
 
   # NB: PEX outputs are platform dependent so in order to get a PEX that we can use locally, without
   # cross-building, we specify that our PEX command be run on the current local platform. When we

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.rules import rule
+from pants.engine.rules import RootRule, rule
 from pants.util.memo import memoized_classproperty, memoized_property
 from pants.util.objects import enum
 from pants.util.osutil import all_normalized_os_names, get_normalized_os_name
@@ -36,4 +36,4 @@ def materialize_platform() -> Platform:
 
 
 def create_platform_rules():
-  return [materialize_platform]
+  return [materialize_platform, RootRule(PlatformConstraint)]

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -41,8 +41,6 @@ from pants.engine.legacy.structs import (
 from pants.engine.legacy.structs import rules as structs_rules
 from pants.engine.mapper import AddressMapper
 from pants.engine.parser import SymbolTable
-from pants.engine.platform import create_platform_rules
-from pants.engine.rules import RootRule, UnionMembership, rule
 from pants.engine.platform import PlatformConstraint, create_platform_rules
 from pants.engine.rules import RootRule, UnionMembership, rule
 from pants.engine.scheduler import Scheduler
@@ -205,7 +203,7 @@ class LegacyGraphSession:
     console = Console(
       use_colors=global_options.colors
     )
-    target_platform_constraint = PlatformConstraint(global_options.target_platform)
+    target_platform_constraint = PlatformConstraint.local_platform
     workspace = Workspace(self.scheduler_session)
 
     for goal in goals:

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -43,6 +43,8 @@ from pants.engine.mapper import AddressMapper
 from pants.engine.parser import SymbolTable
 from pants.engine.platform import create_platform_rules
 from pants.engine.rules import RootRule, UnionMembership, rule
+from pants.engine.platform import PlatformConstraint, create_platform_rules
+from pants.engine.rules import RootRule, UnionMembership, rule
 from pants.engine.scheduler import Scheduler
 from pants.engine.selectors import Params
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
@@ -203,7 +205,7 @@ class LegacyGraphSession:
     console = Console(
       use_colors=global_options.colors
     )
-    target_platform_constraint = global_options.target_platform
+    target_platform_constraint = PlatformConstraint(global_options.target_platform)
     workspace = Workspace(self.scheduler_session)
 
     for goal in goals:

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -199,14 +199,17 @@ class LegacyGraphSession:
     :returns: An exit code.
     """
     subject = target_roots.specs
+    global_options = options_bootstrapper.bootstrap_options.for_global_scope()
     console = Console(
-      use_colors=options_bootstrapper.bootstrap_options.for_global_scope().colors
+      use_colors=global_options.colors
     )
+    target_platform_constraint = global_options.target_platform
     workspace = Workspace(self.scheduler_session)
 
     for goal in goals:
       goal_product = self.goal_map[goal]
-      params = Params(subject, options_bootstrapper, console, workspace)
+      params = Params(subject, options_bootstrapper, console,
+                      workspace, target_platform_constraint)
       logger.debug(f'requesting {goal_product} to satisfy execution of `{goal}` goal')
       try:
         exit_code = self.scheduler_session.run_console_rule(goal_product, params)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -58,7 +58,6 @@ class ExecutionOptions:
   remote_ca_certs_path: Any
   remote_oauth_bearer_token_path: Any
   remote_execution_extra_platform_properties: Any
-  target_platform: Any
 
   @classmethod
   def from_bootstrap_options(cls, bootstrap_options):
@@ -82,7 +81,6 @@ class ExecutionOptions:
       remote_ca_certs_path=bootstrap_options.remote_ca_certs_path,
       remote_oauth_bearer_token_path=bootstrap_options.remote_oauth_bearer_token_path,
       remote_execution_extra_platform_properties=bootstrap_options.remote_execution_extra_platform_properties,
-      target_platform=bootstrap_options.target_platform,
     )
 
 
@@ -106,7 +104,6 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_ca_certs_path=None,
     remote_oauth_bearer_token_path=None,
     remote_execution_extra_platform_properties=[],
-    target_platform=get_normalized_os_name(),
   )
 
 
@@ -429,10 +426,6 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              advanced=True)
     register('--process-execution-use-local-cache', type=bool, default=True, advanced=True,
              help='Whether to keep process executions in a local cache persisted to disk.')
-
-    register('--target-platform', type=str, default=DEFAULT_EXECUTION_OPTIONS.target_platform, advanced=True,
-             help='Build binaries that are compatible, with a certain platform. Defaults is your local platform.',
-             choices=all_normalized_os_names())
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -14,6 +14,7 @@ from pants.base.build_environment import (
   get_pants_configdir,
   pants_version,
 )
+from pants.engine.platform import PlatformConstraint
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.custom_types import dir_option, file_option
 from pants.option.errors import OptionsError
@@ -57,6 +58,7 @@ class ExecutionOptions:
   remote_ca_certs_path: Any
   remote_oauth_bearer_token_path: Any
   remote_execution_extra_platform_properties: Any
+  target_platform: Any
 
   @classmethod
   def from_bootstrap_options(cls, bootstrap_options):
@@ -80,6 +82,7 @@ class ExecutionOptions:
       remote_ca_certs_path=bootstrap_options.remote_ca_certs_path,
       remote_oauth_bearer_token_path=bootstrap_options.remote_oauth_bearer_token_path,
       remote_execution_extra_platform_properties=bootstrap_options.remote_execution_extra_platform_properties,
+      target_platform=bootstrap_options.target_platform,
     )
 
 
@@ -103,6 +106,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_ca_certs_path=None,
     remote_oauth_bearer_token_path=None,
     remote_execution_extra_platform_properties=[],
+    target_platform=PlatformConstraint.local_platform,
   )
 
 
@@ -425,6 +429,10 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              advanced=True)
     register('--process-execution-use-local-cache', type=bool, default=True, advanced=True,
              help='Whether to keep process executions in a local cache persisted to disk.')
+
+    register('--target-platform', type=PlatformConstraint, default=DEFAULT_EXECUTION_OPTIONS.target_platform, advanced=True,
+             help='Build binaries that are compatible, with a certain platform. Defaults is your local platform.',
+             choices=[PlatformConstraint.linux, PlatformConstraint.darwin])
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -14,7 +14,6 @@ from pants.base.build_environment import (
   get_pants_configdir,
   pants_version,
 )
-from pants.engine.platform import PlatformConstraint
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.custom_types import dir_option, file_option
 from pants.option.errors import OptionsError
@@ -22,6 +21,7 @@ from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 from pants.util.objects import enum
+from pants.util.osutil import all_normalized_os_names, get_normalized_os_name
 
 
 class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'])):
@@ -106,7 +106,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_ca_certs_path=None,
     remote_oauth_bearer_token_path=None,
     remote_execution_extra_platform_properties=[],
-    target_platform=PlatformConstraint.local_platform,
+    target_platform=get_normalized_os_name(),
   )
 
 
@@ -430,9 +430,9 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--process-execution-use-local-cache', type=bool, default=True, advanced=True,
              help='Whether to keep process executions in a local cache persisted to disk.')
 
-    register('--target-platform', type=PlatformConstraint, default=DEFAULT_EXECUTION_OPTIONS.target_platform, advanced=True,
+    register('--target-platform', type=str, default=DEFAULT_EXECUTION_OPTIONS.target_platform, advanced=True,
              help='Build binaries that are compatible, with a certain platform. Defaults is your local platform.',
-             choices=[PlatformConstraint.linux, PlatformConstraint.darwin])
+             choices=all_normalized_os_names())
 
   @classmethod
   def register_options(cls, register):

--- a/tests/python/pants_test/backend/python/rules/BUILD
+++ b/tests/python/pants_test/backend/python/rules/BUILD
@@ -8,6 +8,7 @@ python_tests(
     'src/python/pants/backend/python/rules',
     'src/python/pants/backend/python/subsystems',
     'src/python/pants/engine:fs',
+    'src/python/pants/engine:platform',
     'src/python/pants/engine:rules',
     'src/python/pants/engine:selectors',
     'src/python/pants/util:collections',

--- a/tests/python/pants_test/backend/python/rules/test_pex.py
+++ b/tests/python/pants_test/backend/python/rules/test_pex.py
@@ -19,6 +19,7 @@ from pants.backend.python.subsystems.subprocess_environment import (
 )
 from pants.engine.fs import Digest, DirectoryToMaterialize, FileContent, InputFilesContent
 from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.platform import PlatformConstraint
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
 from pants.util.collections import assert_single_element
@@ -64,7 +65,8 @@ class TestResolveRequirements(TestBase):
         request,
         PythonSetup.global_instance(),
         SubprocessEnvironment.global_instance(),
-        PythonNativeCode.global_instance()
+        PythonNativeCode.global_instance(),
+        PlatformConstraint.local_platform,
       )])
     )
     with temporary_dir() as tmp_dir:

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -76,6 +76,7 @@ python_tests(
   name='isolated_process',
   sources=['test_isolated_process.py'],
   dependencies=[
+    '3rdparty/python:dataclasses',
     'src/python/pants/engine:fs',
     'src/python/pants/engine:isolated_process',
     'src/python/pants/engine:rules',


### PR DESCRIPTION
### Problem

Currently the target platform constraint is hardcoded to be the platform pants is executed on. Before we can build rules that cross compile targets we need to let users and rules specify the value of a target platform from the CLI and for sub-graph respectively.

### Solution

Make a CLI option called `--target-platform` whose default value is the current platform. Seed the rule graph with this value as a root at execution time.

### Result

The user can select the desired target platform for binaries and artifacts created by pants. This will only effect current and future rules which have platform dependent behavior. Cross platform rules are not effected.