### PR TITLE
Fix tensorflow==1.14 globbing with platform-specific native_lib_names

### DIFF
--- a/examples/3rdparty/python/BUILD
+++ b/examples/3rdparty/python/BUILD
@@ -13,6 +13,10 @@ remote_sources(
     lib_relpath='',
     native_lib_names = {
       'darwin': ['tensorflow_framework'],
+      # On Linux, the shared lib is literally named `libtensorflow_framework.so.1` in tensorflow
+      # 1.14. Adding a linker command line argument `-l:lib_tensorflow_framework.so.1` will tell the
+      # linker to search for and use a library literally named that filename, without any further
+      # trickery.
       'linux': [':libtensorflow_framework.so.1'],
     },
   ),

--- a/examples/3rdparty/python/BUILD
+++ b/examples/3rdparty/python/BUILD
@@ -11,7 +11,10 @@ remote_sources(
   args=dict(
     include_relpath='include',
     lib_relpath='',
-    native_lib_names=['tensorflow_framework'],
+    native_lib_names = {
+      'darwin': ['tensorflow_framework'],
+      'linux': [':libtensorflow_framework.so.1'],
+    },
   ),
 )
 
@@ -21,7 +24,8 @@ unpacked_whls(
   module_name='tensorflow',
   include_patterns=[
     'include/**/*',
-    './*.so',
+    './*.so*',
+    './*.dylib*',
   ],
   within_data_subdir='purelib/tensorflow',
 )

--- a/examples/3rdparty/python/requirements.txt
+++ b/examples/3rdparty/python/requirements.txt
@@ -1,4 +1,4 @@
 grpcio==1.16.1
 protobuf==3.6.1
-tensorflow==1.13.1
+tensorflow==1.14.0
 thrift>=0.10.0

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -3,6 +3,7 @@
 
 from abc import abstractmethod
 
+from pants.backend.native.config.environment import Platform
 from pants.build_graph.mirrored_target_option_mixin import MirroredTargetOptionMixin
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.subsystem.subsystem import Subsystem
@@ -34,9 +35,14 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
                   'for targets of this language.')
 
     register('--toolchain-variant', advanced=True,
-             default=ToolchainVariant.gnu, type=ToolchainVariant,
-             help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Currently all "
-                  "linking is done with binutils ld on Linux, and the XCode CLI Tools on MacOS.")
+             default=Platform.current.resolve_for_enum_variant({
+               'darwin': ToolchainVariant.llvm,
+               'linux': ToolchainVariant.gnu,
+             }),
+             type=ToolchainVariant,
+             help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Note that "
+                  "currently, despite the choice of toolchain, all linking is done with binutils "
+                  "ld on Linux, and the XCode CLI Tools on MacOS.")
 
   def get_compiler_option_sets_for_target(self, target):
     return self.get_scalar_mirrored_target_option('compiler_option_sets', target)

--- a/src/python/pants/backend/native/targets/packaged_native_library.py
+++ b/src/python/pants/backend/native/targets/packaged_native_library.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.base.payload import Payload
-from pants.base.payload_field import PrimitiveField, PrimitivesSetField
+from pants.base.payload_field import PrimitiveField
 from pants.build_graph.target import Target
 
 

--- a/src/python/pants/backend/native/targets/packaged_native_library.py
+++ b/src/python/pants/backend/native/targets/packaged_native_library.py
@@ -30,7 +30,9 @@ class PackagedNativeLibrary(Target):
     :param list native_lib_names: Strings containing the libraries to add to the linker command
                                   line. These libraries become `-l<name>` arguments, so they must
                                   exist and be named `lib<name>.so` (or `lib<name>.dylib` depending
-                                  on the platform) or the linker will exit with an error.
+                                  on the platform) or the linker will exit with an error. This field
+                                  may also be a dict mapping the OS name ('darwin' or 'linux') to a
+                                  list of such strings.
     """
     if not payload:
       payload = Payload()
@@ -38,7 +40,7 @@ class PackagedNativeLibrary(Target):
       'sources': self.create_sources_field(sources, address.spec_path, key_arg='sources'),
       'include_relpath': PrimitiveField(include_relpath),
       'lib_relpath': PrimitiveField(lib_relpath),
-      'native_lib_names': PrimitivesSetField(native_lib_names),
+      'native_lib_names': PrimitiveField(native_lib_names),
     })
     super().__init__(address=address, payload=payload, **kwargs)
 

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -128,7 +128,11 @@ class LinkSharedLibraries(NativeTask):
     for ext_dep in self.packaged_native_deps(vt.target):
       external_lib_dirs.append(
         os.path.join(get_buildroot(), ext_dep._sources_field.rel_path, ext_dep.lib_relpath))
-      external_lib_names.extend(ext_dep.native_lib_names)
+
+      native_lib_names = ext_dep.native_lib_names
+      if isinstance(ext_dep.native_lib_names, dict):
+        native_lib_names = self.platform.resolve_for_enum_variant(native_lib_names)
+      external_lib_names.extend(native_lib_names)
 
     link_request = LinkSharedLibraryRequest(
       linker=self.linker(vt.target),

--- a/src/python/pants/task/unpack_remote_sources_base.py
+++ b/src/python/pants/task/unpack_remote_sources_base.py
@@ -73,6 +73,16 @@ class UnpackRemoteSourcesBase(Task, metaclass=ABCMeta):
 
   @classmethod
   def compile_patterns(cls, patterns, field_name="Unknown", spec="Unknown"):
+    logger.debug(f'patterns before removing trailing stars: {patterns}')
+    # NB: `fnmatch_translate_extended()` will convert a '*' at the end into '([^/]+)' for some
+    # reason -- it should be '('[^/]*)'. This should be fixed upstream in general, but in the case
+    # where the star is at the end we can use this heuristic for now.
+    patterns.extend(
+      re.sub(r'\*$', '', p)
+      for p in patterns
+      if re.match(r'.*\*$', p)
+    )
+    logger.debug(f'patterns with any trailing stars have a version with a star removed: {patterns}')
     compiled_patterns = []
     for p in patterns:
       try:

--- a/src/python/pants/task/unpack_remote_sources_base.py
+++ b/src/python/pants/task/unpack_remote_sources_base.py
@@ -80,7 +80,7 @@ class UnpackRemoteSourcesBase(Task, metaclass=ABCMeta):
     patterns.extend(
       re.sub(r'\*$', '', p)
       for p in patterns
-      if re.match(r'.*\*$', p)
+      if isinstance(p, str) and re.match(r'.*\*$', p)
     )
     logger.debug(f'patterns with any trailing stars have a version with a star removed: {patterns}')
     compiled_patterns = []

--- a/tests/python/pants_test/task/test_unpack_remote_sources_base.py
+++ b/tests/python/pants_test/task/test_unpack_remote_sources_base.py
@@ -41,6 +41,11 @@ class UnpackRemoteSourcesTest(TestBase):
                                      include_patterns=["foo/*.java"],
                                      exclude_patterns=["foo/x*.java"]))
 
+    # Validate that trailing globs match both the empty string and non-empty strings.
+    self.assertTrue(self._run_filter("foo.so", include_patterns=["*.so"]))
+    self.assertTrue(self._run_filter("foo.so", include_patterns=["*.so*"]))
+    self.assertTrue(self._run_filter("foo.so.1", include_patterns=["*.so*"]))
+
   @unittest.expectedFailure
   def test_problematic_cases(self):
     """These should pass, but don't"""


### PR DESCRIPTION
### Problem

`tensorflow==1.14` fails in our current CI setup because they've changed the library names within the tensorflow wheel to differ across osx and linux.

### Solution

- Allow `native_lib_names` to be a dict.
- Fix issue with globbing for `remote_sources()` targets.
- Default `--native-build-step-toolchain-variant` to `llvm` on osx since we don't yet support gcc by default there.

### Result

Our tensorflow example is upgraded to 1.14!