### PR TITLE
Fix export test failure to unrevert #8370

### DIFF
--- a/src/docs/export.md
+++ b/src/docs/export.md
@@ -107,6 +107,15 @@ The following is an abbreviated export file from a command in the pants repo:
         },
         "default_interpreter": "CPython-2.7.10"
     },
+    "scala_platform": {
+        "scala_version": "2.12",
+        "compiler_classpath": [
+          "/Users/dmcclanahan/tools/pants-v4/.pants.d/bootstrap/bootstrap-jvm-tools/a0ebe8e0b001/ivy/jars/org.scala-lang/scala-compiler/jars/scala-compiler-2.12.8.jar",
+          "/Users/dmcclanahan/tools/pants-v4/.pants.d/bootstrap/bootstrap-jvm-tools/a0ebe8e0b001/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.12.8.jar",
+          "/Users/dmcclanahan/tools/pants-v4/.pants.d/bootstrap/bootstrap-jvm-tools/a0ebe8e0b001/ivy/jars/org.scala-lang/scala-reflect/jars/scala-reflect-2.12.8.jar",
+          "/Users/dmcclanahan/tools/pants-v4/.pants.d/bootstrap/bootstrap-jvm-tools/a0ebe8e0b001/ivy/jars/org.scala-lang.modules/scala-xml_2.12/jars/scala-xml_2.12-1.0.6.jar"
+        ]
+    },
     "targets": {
         "examples/tests/java/org/pantsbuild/example/usethrift:usethrift": {
             "is_code_gen": false,
@@ -167,6 +176,10 @@ The following is an abbreviated export file from a command in the pants repo:
 
 
 # Export Format Changes
+
+## 1.0.11
+
+The 'scala_platform' field is added to the top-level keys, containing the 'scala_version' string (without patch version, e.g. "2.12") and the 'compiler_classpath' jars (a list of absolute paths to jar files).
 
 ## 1.0.10
 

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -9,6 +9,7 @@ from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.subsystems.resolve_subsystem import JvmResolveSubsystem
+from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.junit_tests import JUnitTests
 from pants.backend.jvm.targets.jvm_app import JvmApp
@@ -55,7 +56,7 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
   #
   # Note format changes in src/docs/export.md and update the Changelog section.
   #
-  DEFAULT_EXPORT_VERSION = '1.0.10'
+  DEFAULT_EXPORT_VERSION = '1.0.11'
 
   @classmethod
   def subsystem_dependencies(cls):
@@ -282,6 +283,15 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
     for target in targets:
       process_target(target)
 
+    scala_platform = ScalaPlatform.global_instance()
+    scala_platform_map = {
+      'scala_version': scala_platform.version,
+      'compiler_classpath': [
+        cp_entry.path
+        for cp_entry in scala_platform.compiler_classpath_entries(self.context.products)
+      ],
+    }
+
     jvm_platforms_map = {
       'default_platform' : JvmPlatform.global_instance().default_platform.name,
       'platforms': {
@@ -296,6 +306,7 @@ class ExportTask(ResolveRequirementsTaskBase, IvyTaskMixin, CoursierMixin):
       'version': self.DEFAULT_EXPORT_VERSION,
       'targets': targets_map,
       'jvm_platforms': jvm_platforms_map,
+      'scala_platform': scala_platform_map,
       # `jvm_distributions` are static distribution settings from config,
       # `preferred_jvm_distributions` are distributions that pants actually uses for the
       # given platform setting.

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -85,6 +85,13 @@ class ExportTest(ConsoleTaskTestBase):
     )
 
     self.make_target(
+      ':scalac_2_12',
+      JarLibrary,
+      jars=[JarDependency('org.scala-lang', 'scala-compiler', '2.12.8')]
+    )
+
+
+    self.make_target(
       ':scala-reflect',
       JarLibrary,
       jars=[JarDependency('org.scala-lang', 'scala-reflect', self._scala_toolchain_version)]


### PR DESCRIPTION
#8370 was merged without passing all tests (which broke master) and was reverted in #8379. This fixes the failing test by injecting the `//:scalac_2_12` target which is necessary for the test using scala 2.12 to successfully ready the scala compiler jars.