### PR TITLE
Don't update homebrew on the OSX Rust test CI shard.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,11 +141,7 @@ matrix:
     - docker
     stage: Bootstrap Pants (Cron)
     sudo: required
-  - addons:
-      brew:
-        packages:
-        - openssl
-    after_failure:
+  - after_failure:
     - ./build-support/bin/ci-failure.sh
     before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
@@ -186,11 +182,7 @@ matrix:
     - aws --no-sign-request --region us-east-1 s3 cp ${TRAVIS_BUILD_DIR}/pants.pex
       ${BOOTSTRAPPED_PEX_URL_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
     stage: Bootstrap Pants
-  - addons:
-      brew:
-        packages:
-        - openssl
-    after_failure:
+  - after_failure:
     - ./build-support/bin/ci-failure.sh
     before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
@@ -285,11 +277,7 @@ matrix:
     - docker
     stage: Bootstrap Pants (Cron)
     sudo: required
-  - addons:
-      brew:
-        packages:
-        - openssl
-    after_failure:
+  - after_failure:
     - ./build-support/bin/ci-failure.sh
     before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
@@ -802,11 +790,7 @@ matrix:
     - docker
     stage: Test Pants
     sudo: required
-  - addons:
-      brew:
-        packages:
-        - openssl
-    before_install:
+  - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
       -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
@@ -2090,7 +2074,6 @@ matrix:
         - osxfuse
         packages:
         - openssl
-        update: true
     before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
     - find build-support -name "*.py[co]" -delete
@@ -2116,15 +2099,11 @@ matrix:
     - CACHE_NAME=rust_tests.osx
     name: Rust tests - OSX
     os: osx
-    osx_image: xcode8.3
+    osx_image: xcode11
     script:
     - ./build-support/bin/ci.py --rust-tests
     stage: Test Pants
-  - addons:
-      brew:
-        packages:
-        - openssl
-    before_install:
+  - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
       -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
@@ -2149,11 +2128,7 @@ matrix:
     script:
     - ./build-support/bin/ci.py --platform-specific-tests --python-version 3.6
     stage: Test Pants
-  - addons:
-      brew:
-        packages:
-        - openssl
-    before_install:
+  - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
       -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
@@ -2178,11 +2153,7 @@ matrix:
     script:
     - ./build-support/bin/ci.py --platform-specific-tests --python-version 3.7
     stage: Test Pants (Cron)
-  - addons:
-      brew:
-        packages:
-        - openssl
-    before_install:
+  - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
       -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
@@ -2208,11 +2179,7 @@ matrix:
     script:
     - MODE=debug ./build-support/bin/ci.py --sanity-checks --python-version 3.6
     stage: Test Pants
-  - addons:
-      brew:
-        packages:
-        - openssl
-    before_install:
+  - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
       -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
@@ -2238,11 +2205,7 @@ matrix:
     script:
     - MODE=debug ./build-support/bin/ci.py --sanity-checks --python-version 3.7
     stage: Test Pants (Cron)
-  - addons:
-      brew:
-        packages:
-        - openssl
-    before_install:
+  - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
       -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq
@@ -2268,11 +2231,7 @@ matrix:
     script:
     - MODE=debug ./build-support/bin/ci.py --sanity-checks --python-version 3.6
     stage: Test Pants
-  - addons:
-      brew:
-        packages:
-        - openssl
-    before_install:
+  - before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
       -o /usr/local/bin/jq
     - chmod 755 /usr/local/bin/jq

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -322,7 +322,6 @@ def osx_shard(
   setup = {
     "os": "osx",
     "language": "generic",
-    "addons": {"brew": {"packages": ["openssl"]}},
     "before_script": [
       "ulimit -c unlimited",
       "ulimit -n 8192",
@@ -578,14 +577,13 @@ def rust_tests_osx() -> Dict:
     "name": "Rust tests - OSX",
     "os": "osx",
     # Fuse actually works on this image. It hangs on many others.
-    "osx_image": "xcode8.3",
-    "addons": {"homebrew": {
-      # We must update or else Brew will complain that it is too outdated
-      # (See https://travis-ci.org/pantsbuild/pants/jobs/546948768#L278).
-      "update": True,
-      "packages": ["openssl"],
-      "casks": ["osxfuse"]
-    }},
+    "osx_image": "xcode11",
+    "addons": {
+      "homebrew": {
+        "packages": ["openssl"],
+        "casks": ["osxfuse"]
+      }
+    },
     "before_install": [
       './build-support/bin/install_python_for_ci.sh "${PYENV_PY27_VERSION}" "${PYENV_PY36_VERSION}"',
     ],


### PR DESCRIPTION
It cascades into a huge homebrew update of all openssl dependents on the image, 
none of which we care about.

Also removes superfluous uses of homebrew on all the other OSX shards.
Not only was homebrew not needed, but the version of it on those images was
so old that it was erroring out (fortunately this did not cause the shard to fail,
but it was evidence that we didn't really need homebrew in the first place).
