### PR TITLE
Add type hints to `collections.py` and `dirutil.py`

### DIFF
--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -41,7 +41,6 @@ python_library(
     'src/python/pants/subsystem',
     'src/python/pants/task',
     'src/python/pants/util:contextutil',
-    'src/python/pants/util:collections',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:filtering',
     'src/python/pants/util:memo',

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -11,7 +11,6 @@ from pants.console.stty_utils import STTYSettings
 from pants.java.nailgun_client import NailgunClient
 from pants.java.nailgun_protocol import NailgunProtocol
 from pants.pantsd.pants_daemon import PantsDaemon
-from pants.util.collections import combined_dict
 from pants.util.dirutil import maybe_read_file
 
 
@@ -140,9 +139,14 @@ class RemotePantsRunner:
     port = pantsd_handle.port
     # Merge the nailgun TTY capability environment variables with the passed environment dict.
     ng_env = NailgunProtocol.isatty_to_env(self._stdin, self._stdout, self._stderr)
-    modified_env = combined_dict(self._env, ng_env)
-    modified_env['PANTSD_RUNTRACKER_CLIENT_START_TIME'] = str(self._start_time)
-    modified_env['PANTSD_REQUEST_TIMEOUT_LIMIT'] = str(self._bootstrap_options.for_global_scope().pantsd_timeout_when_multiple_invocations)
+    modified_env = {
+      **self._env,
+      **ng_env,
+      "PANTSD_RUNTRACKER_CLIENT_START_TIME": str(self._start_time),
+      "PANTSD_REQUEST_TIMEOUT_LIMIT": str(
+        self._bootstrap_options.for_global_scope().pantsd_timeout_when_multiple_invocations
+      )
+    }
 
     assert isinstance(port, int), \
       'port {} is not an integer! It has type {}.'.format(port, type(port))

--- a/src/python/pants/pantsd/BUILD
+++ b/src/python/pants/pantsd/BUILD
@@ -68,7 +68,6 @@ python_library(
     'src/python/pants/pantsd/service:pailgun_service',
     'src/python/pants/pantsd/service:scheduler_service',
     'src/python/pants/pantsd/service:store_gc_service',
-    'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:memo',
     ':process_manager',

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -28,7 +28,6 @@ from pants.pantsd.service.pants_service import PantsServices
 from pants.pantsd.service.scheduler_service import SchedulerService
 from pants.pantsd.service.store_gc_service import StoreGCService
 from pants.pantsd.watchman_launcher import WatchmanLauncher
-from pants.util.collections import combined_dict
 from pants.util.contextutil import stdio_as
 from pants.util.memo import memoized_property
 from pants.util.strutil import ensure_text
@@ -431,7 +430,7 @@ class PantsDaemon(FingerprintedProcessManager):
                              # this. NB: It will scrub PYTHONPATH once started to avoid infecting
                              # its own unrelated subprocesses.
                              PYTHONPATH=os.pathsep.join(sys.path))
-    exec_env = combined_dict(os.environ, spawn_control_env)
+    exec_env = {**os.environ, **spawn_control_env}
 
     # Pass all of sys.argv so that we can proxy arg flags e.g. `-ldebug`.
     cmd = [sys.executable] + sys.argv

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -20,6 +20,7 @@ python_library(
 python_library(
   name = 'collections',
   sources = ['collections.py'],
+  tags = {'type_checked'},
 )
 
 python_library(
@@ -117,7 +118,7 @@ python_library(
   sources = ['s3_log_aggregator.py'],
   dependencies = [
     '3rdparty/python:s3logparse'
-  ]
+  ],
 )
 
 python_binary(
@@ -125,7 +126,7 @@ python_binary(
   entry_point = 'pants.util.s3_log_aggregator',
   dependencies = [
     ':s3_log_aggregator'
-  ]
+  ],
 )
 
 python_library(

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -143,6 +143,7 @@ python_library(
 python_library(
   name = 'tarutil',
   sources = ['tarutil.py'],
+  tags = {'type_checked'},
 )
 
 python_library(

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -43,6 +43,7 @@ python_library(
   dependencies = [
     ':strutil',
   ],
+  tags = {'type_checked'},
 )
 
 python_library(

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -42,6 +42,7 @@ python_library(
   sources = ['dirutil.py'],
   dependencies = [
     ':strutil',
+    '3rdparty/python:typing-extensions',
   ],
   tags = {'type_checked'},
 )

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -2,14 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import collections
-from typing import Callable, DefaultDict, Iterable, MutableMapping, Tuple, TypeVar
+from typing import Callable, DefaultDict, Iterable, MutableMapping, TypeVar
 
 
 K = TypeVar('K')
 V = TypeVar('V')
 
 
-def factory_dict(value_factory: Callable[[K], V], *args: Tuple, **kwargs) -> DefaultDict:
+def factory_dict(value_factory: Callable[[K], V], *args, **kwargs) -> DefaultDict:
   """A dict whose values are computed by `value_factory` when a `__getitem__` key is missing.
 
   Note that values retrieved by any other method will not be lazily computed; eg: via `get`.

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -2,23 +2,21 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import collections
+from typing import Callable, DefaultDict, Iterable, MutableMapping, Tuple, TypeVar
 
 
-def combined_dict(*dicts):
-  """Combine one or more dicts into a new, unified dict (dicts to the right take precedence)."""
-  return {k: v for d in dicts for k, v in d.items()}
+K = TypeVar('K')
+V = TypeVar('V')
 
 
-def factory_dict(value_factory, *args, **kwargs):
+def factory_dict(value_factory: Callable[[K], V], *args: Tuple, **kwargs) -> DefaultDict:
   """A dict whose values are computed by `value_factory` when a `__getitem__` key is missing.
 
   Note that values retrieved by any other method will not be lazily computed; eg: via `get`.
 
   :param value_factory:
-  :type value_factory: A function from dict key to value.
   :param *args: Any positional args to pass through to `dict`.
   :param **kwrags: Any kwargs to pass through to `dict`.
-  :rtype: dict
   """
   class FactoryDict(collections.defaultdict):
     @staticmethod
@@ -37,7 +35,7 @@ def factory_dict(value_factory, *args, **kwargs):
   return FactoryDict()
 
 
-def recursively_update(d, d2):
+def recursively_update(d: MutableMapping, d2: MutableMapping) -> None:
   """dict.update but which merges child dicts (dict2 takes precedence where there's conflict)."""
   for k, v in d2.items():
     if k in d:
@@ -47,7 +45,10 @@ def recursively_update(d, d2):
     d[k] = v
 
 
-def assert_single_element(iterable):
+T = TypeVar('T')
+
+
+def assert_single_element(iterable: Iterable[T]) -> T:
   """Get the single element of `iterable`, or raise an error.
 
   :raise: :class:`StopIteration` if there is no element.

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -11,11 +11,28 @@ import threading
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
+from typing import (
+  Any,
+  Callable,
+  DefaultDict,
+  FrozenSet,
+  Iterable,
+  Iterator,
+  List,
+  Optional,
+  Sequence,
+  Set,
+  Tuple,
+  Union,
+  overload,
+)
+
+from typing_extensions import Literal
 
 from pants.util.strutil import ensure_text
 
 
-def longest_dir_prefix(path, prefixes):
+def longest_dir_prefix(path: str, prefixes: Sequence[str]) -> Optional[str]:
   """Given a list of prefixes, return the one that is the longest prefix to the given path.
 
   Returns None if there are no matches.
@@ -28,7 +45,7 @@ def longest_dir_prefix(path, prefixes):
   return longest_prefix
 
 
-def fast_relpath(path, start):
+def fast_relpath(path: str, start: str) -> str:
   """A prefix-based relpath, with no normalization or support for returning `..`."""
   relpath = fast_relpath_optional(path, start)
   if relpath is None:
@@ -36,7 +53,7 @@ def fast_relpath(path, start):
   return relpath
 
 
-def fast_relpath_optional(path, start):
+def fast_relpath_optional(path: str, start: str) -> Optional[str]:
   """A prefix-based relpath, with no normalization or support for returning `..`.
 
   Returns None if `start` is not a directory-aware prefix of `path`.
@@ -54,9 +71,10 @@ def fast_relpath_optional(path, start):
     # The prefix matches, and the entries are either identical, or the suffix indicates that
     # the prefix is a directory.
     return path[pref_end+1:]
+  return None
 
 
-def safe_mkdir(directory, clean=False):
+def safe_mkdir(directory: str, clean: bool = False) -> None:
   """Ensure a directory is present.
 
   If it's not there, create it.  If it is, no-op. If clean is True, ensure the dir is empty.
@@ -72,7 +90,7 @@ def safe_mkdir(directory, clean=False):
       raise
 
 
-def safe_mkdir_for(path, clean=False):
+def safe_mkdir_for(path: str, clean: bool = False) -> None:
   """Ensure that the parent directory for a file is present.
 
   If it's not there, create it. If it is, no-op.
@@ -80,15 +98,13 @@ def safe_mkdir_for(path, clean=False):
   safe_mkdir(os.path.dirname(path), clean=clean)
 
 
-def safe_mkdir_for_all(paths):
+def safe_mkdir_for_all(paths: Sequence[str]) -> None:
   """Make directories which would contain all of the passed paths.
 
   This avoids attempting to re-make the same directories, which may be noticeably expensive if many
   paths mostly fall in the same set of directories.
-
-  :param list of str paths: The paths for which containing directories should be created.
   """
-  created_dirs = set()
+  created_dirs: Set[str] = set()
   for path in paths:
     dir_to_make = os.path.dirname(path)
     if dir_to_make not in created_dirs:
@@ -96,10 +112,9 @@ def safe_mkdir_for_all(paths):
       created_dirs.add(dir_to_make)
 
 
-# TODO(#6742): payload should be Union[str, bytes] in type hint syntax, but from
-# https://pythonhosted.org/an_example_pypi_project/sphinx.html#full-code-example it doesn't appear
-# that is possible to represent in docstring type syntax.
-def safe_file_dump(filename, payload='', mode='w', makedirs=False):
+def safe_file_dump(
+  filename: str, payload: Union[bytes, str] = '', mode: str = 'w', makedirs: bool = False
+) -> None:
   """Write a string to a file.
 
   This method is "safe" to the extent that `safe_open` is "safe". See the explanation on the method
@@ -108,11 +123,11 @@ def safe_file_dump(filename, payload='', mode='w', makedirs=False):
   When `payload` is an empty string (the default), this method can be used as a concise way to
   create an empty file along with its containing directory (or truncate it if it already exists).
 
-  :param string filename: The filename of the file to write to.
-  :param string payload: The string to write to the file.
-  :param string mode: A mode argument for the python `open` builtin which should be a write mode
-                      variant. Defaults to 'w'.
-  :param bool makedirs: Whether to make all parent directories of this file before making it.
+  :param filename: The filename of the file to write to.
+  :param payload: The string to write to the file.
+  :param mode: A mode argument for the python `open` builtin which should be a write mode variant.
+               Defaults to 'w'.
+  :param makedirs: Whether to make all parent directories of this file before making it.
   """
   if makedirs:
     os.makedirs(os.path.dirname(filename), exist_ok=True)
@@ -120,13 +135,28 @@ def safe_file_dump(filename, payload='', mode='w', makedirs=False):
     f.write(payload)
 
 
-def maybe_read_file(filename, binary_mode=False):
+@overload
+def maybe_read_file(filename: str) -> Optional[str]: ...
+
+
+@overload
+def maybe_read_file(filename: str, binary_mode: Literal[False]) -> Optional[str]: ...
+
+
+@overload
+def maybe_read_file(filename: str, binary_mode: Literal[True]) -> Optional[bytes]: ...
+
+
+@overload
+def maybe_read_file(filename: str, binary_mode: bool) -> Optional[Union[bytes, str]]: ...
+
+
+def maybe_read_file(filename: str, binary_mode: bool = False) -> Optional[Union[bytes, str]]:
   """Read and return the contents of a file in a single file.read().
 
-  :param string filename: The filename of the file to read.
-  :param bool binary_mode: Read from file as bytes or unicode.
-  :returns: The contents of the file, or opening the file fails for any reason
-  :rtype: string
+  :param filename: The filename of the file to read.
+  :param binary_mode: Read from file as bytes or unicode.
+  :returns: The contents of the file, or None if opening the file fails for any reason
   """
   try:
     return read_file(filename, binary_mode=binary_mode)
@@ -134,20 +164,36 @@ def maybe_read_file(filename, binary_mode=False):
     return None
 
 
-def read_file(filename, binary_mode=False):
+@overload
+def read_file(filename: str) -> str: ...
+
+
+@overload
+def read_file(filename: str, binary_mode: Literal[False]) -> str: ...
+
+
+@overload
+def read_file(filename: str, binary_mode: Literal[True]) -> bytes: ...
+
+
+@overload
+def read_file(filename: str, binary_mode: bool) -> Union[str, bytes]: ...
+
+
+def read_file(filename: str, binary_mode: bool = False) -> Union[bytes, str]:
   """Read and return the contents of a file in a single file.read().
 
-  :param string filename: The filename of the file to read.
-  :param bool binary_mode: Read from file as bytes or unicode.
+  :param filename: The filename of the file to read.
+  :param binary_mode: Read from file as bytes or unicode.
   :returns: The contents of the file.
-  :rtype: string
   """
   mode = 'rb' if binary_mode else 'r'
   with open(filename, mode) as f:
-    return f.read()
+    content: Union[bytes, str] = f.read()
+    return content
 
 
-def safe_walk(path, **kwargs):
+def safe_walk(path: str, **kwargs: Any) -> Iterator[Tuple[str, List[str], List[str]]]:
   """Just like os.walk, but ensures that the returned values are unicode objects.
 
     This isn't strictly safe, in that it is possible that some paths
@@ -172,7 +218,9 @@ class ExistingDirError(ValueError):
   """Indicates a copy operation would over-write a directory with a file."""
 
 
-def mergetree(src, dst, symlinks=False, ignore=None, file_filter=None):
+def mergetree(
+  src: str, dst: str, symlinks: bool = False, ignore=None, file_filter=None
+) -> None:
   """Just like `shutil.copytree`, except the `dst` dir may exist.
 
   The `src` directory will be walked and its contents copied into `dst`. If `dst` already exists the
@@ -185,7 +233,7 @@ def mergetree(src, dst, symlinks=False, ignore=None, file_filter=None):
     file_filter = lambda _: True
 
   for src_path, dirnames, filenames in safe_walk(src, topdown=True, followlinks=True):
-    ignorenames = ()
+    ignorenames: FrozenSet[str] = frozenset()
     if ignore:
       to_ignore = ignore(src_path, dirnames + filenames)
       if to_ignore:
@@ -242,32 +290,31 @@ def mergetree(src, dst, symlinks=False, ignore=None, file_filter=None):
         shutil.copy2(src_filename, dst_filename)
 
 
-_MKDTEMP_CLEANER = None
-_MKDTEMP_DIRS = defaultdict(set)
+_MkdtempCleanerType = Callable[[], None]
+_MKDTEMP_CLEANER: Optional[_MkdtempCleanerType] = None
+_MKDTEMP_DIRS: DefaultDict[int, Set[str]] = defaultdict(set)
 _MKDTEMP_LOCK = threading.RLock()
 
 
-def _mkdtemp_atexit_cleaner():
+def _mkdtemp_atexit_cleaner() -> None:
   for td in _MKDTEMP_DIRS.pop(os.getpid(), []):
     safe_rmtree(td)
 
 
-def _mkdtemp_unregister_cleaner():
+def _mkdtemp_unregister_cleaner() -> None:
   global _MKDTEMP_CLEANER
   _MKDTEMP_CLEANER = None
 
 
-def _mkdtemp_register_cleaner(cleaner):
+def _mkdtemp_register_cleaner(cleaner: _MkdtempCleanerType) -> None:
   global _MKDTEMP_CLEANER
-  if not cleaner:
-    return
   assert callable(cleaner)
   if _MKDTEMP_CLEANER is None:
     atexit.register(cleaner)
     _MKDTEMP_CLEANER = cleaner
 
 
-def safe_mkdtemp(cleaner=_mkdtemp_atexit_cleaner, **kw):
+def safe_mkdtemp(cleaner: _MkdtempCleanerType = _mkdtemp_atexit_cleaner, **kw: Any) -> str:
   """Create a temporary directory that is cleaned up on process exit.
 
   Arguments are as to tempfile.mkdtemp.
@@ -279,7 +326,7 @@ def safe_mkdtemp(cleaner=_mkdtemp_atexit_cleaner, **kw):
     return register_rmtree(tempfile.mkdtemp(**kw), cleaner=cleaner)
 
 
-def register_rmtree(directory, cleaner=_mkdtemp_atexit_cleaner):
+def register_rmtree(directory: str, cleaner: _MkdtempCleanerType = _mkdtemp_atexit_cleaner) -> str:
   """Register an existing directory to be cleaned up at process exit."""
   with _MKDTEMP_LOCK:
     _mkdtemp_register_cleaner(cleaner)
@@ -287,7 +334,7 @@ def register_rmtree(directory, cleaner=_mkdtemp_atexit_cleaner):
   return directory
 
 
-def safe_rmtree(directory):
+def safe_rmtree(directory: str) -> None:
   """Delete a directory if it's present. If it's not present, no-op.
 
   Note that if the directory argument is a symlink, only the symlink will
@@ -310,7 +357,7 @@ def safe_open(filename, *args, **kwargs):
   return open(filename, *args, **kwargs)
 
 
-def safe_delete(filename):
+def safe_delete(filename: str) -> None:
   """Delete a file safely. If it's not present, no-op."""
   try:
     os.unlink(filename)
@@ -319,7 +366,7 @@ def safe_delete(filename):
       raise
 
 
-def safe_concurrent_rename(src, dst):
+def safe_concurrent_rename(src: str, dst: str) -> None:
   """Rename src to dst, ignoring errors due to dst already existing.
 
   Useful when concurrent processes may attempt to create dst, and it doesn't matter who wins.
@@ -337,13 +384,14 @@ def safe_concurrent_rename(src, dst):
       raise
 
 
-def safe_rm_oldest_items_in_dir(root_dir, num_of_items_to_keep, excludes=frozenset()):
+def safe_rm_oldest_items_in_dir(
+  root_dir: str, num_of_items_to_keep: int, excludes: Iterable[str] = frozenset()
+) -> None:
   """
   Keep `num_of_items_to_keep` newly modified items besides `excludes` in `root_dir` then remove the rest.
   :param root_dir: the folder to examine
   :param num_of_items_to_keep: number of files/folders/symlinks to keep after the cleanup
   :param excludes: absolute paths excluded from removal (must be prefixed with `root_dir`)
-  :return: none
   """
   if os.path.isdir(root_dir):
     found_files = []
@@ -357,7 +405,7 @@ def safe_rm_oldest_items_in_dir(root_dir, num_of_items_to_keep, excludes=frozens
 
 
 @contextmanager
-def safe_concurrent_creation(target_path):
+def safe_concurrent_creation(target_path: str) -> Iterator[str]:
   """A contextmanager that yields a temporary path and renames it to a final target path when the
   contextmanager exits.
 
@@ -378,7 +426,7 @@ def safe_concurrent_creation(target_path):
       safe_concurrent_rename(tmp_path, target_path)
 
 
-def chmod_plus_x(path):
+def chmod_plus_x(path: str) -> None:
   """Equivalent of unix `chmod a+x path`"""
   path_mode = os.stat(path).st_mode
   path_mode &= int('777', 8)
@@ -391,7 +439,7 @@ def chmod_plus_x(path):
   os.chmod(path, path_mode)
 
 
-def absolute_symlink(source_path, target_path):
+def absolute_symlink(source_path: str, target_path: str) -> None:
   """Create a symlink at target pointing to source using the absolute path.
 
   :param source_path: Absolute path to source file
@@ -419,7 +467,7 @@ def absolute_symlink(source_path, target_path):
       raise
 
 
-def relative_symlink(source_path, link_path):
+def relative_symlink(source_path: str, link_path: str) -> None:
   """Create a symlink at link_path pointing to relative source
 
   :param source_path: Absolute path to source file
@@ -449,7 +497,7 @@ def relative_symlink(source_path, link_path):
       raise
 
 
-def relativize_path(path, rootdir):
+def relativize_path(path: str, rootdir: str) -> str:
   """
 
   :API: public
@@ -467,11 +515,11 @@ def relativize_path(path, rootdir):
 # prepended to most components in the classpath (some from ivy, the rest from the build),
 # in some runs the classpath gets too big and exceeds ARG_MAX.
 # We prevent this by using paths relative to the current working directory.
-def relativize_paths(paths, rootdir):
+def relativize_paths(paths: Sequence[str], rootdir: str) -> List[str]:
   return [relativize_path(path, rootdir) for path in paths]
 
 
-def touch(path, times=None):
+def touch(path: str, times: Optional[Union[int, Tuple[int, int]]] = None):
   """Equivalent of unix `touch path`.
 
     :API: public
@@ -480,19 +528,17 @@ def touch(path, times=None):
     :times Either a tuple of (atime, mtime) or else a single time to use for both.  If not
            specified both atime and mtime are updated to the current time.
   """
-  if times:
-    if len(times) > 2:
-      raise ValueError('times must either be a tuple of (atime, mtime) or else a single time value '
-                       'to use for both.')
-
-    if len(times) == 1:
-      times = (times, times)
-
+  if isinstance(times, tuple) and len(times) > 2:
+    raise ValueError(
+      "`times` must either be a tuple of (atime, mtime) or else a single time to use for both."
+    )
+  if isinstance(times, int):
+    times = (times, times)
   with safe_open(path, 'a'):
     os.utime(path, times)
 
 
-def recursive_dirname(f):
+def recursive_dirname(f: str) -> Iterator[str]:
   """Given a relative path like 'a/b/c/d', yield all ascending path components like:
 
         'a/b/c/d'
@@ -509,7 +555,7 @@ def recursive_dirname(f):
   yield ''
 
 
-def get_basedir(path):
+def get_basedir(path: str) -> str:
   """Returns the base directory of a path.
 
   Examples:
@@ -520,10 +566,10 @@ def get_basedir(path):
   return path[:path.index(os.sep)] if os.sep in path else path
 
 
-def rm_rf(name):
+def rm_rf(name: str) -> None:
   """Remove a file or a directory similarly to running `rm -rf <name>` in a UNIX shell.
 
-  :param str name: the name of the file or directory to remove.
+  :param name: the name of the file or directory to remove.
   :raises: OSError on error.
   """
   if not os.path.exists(name):
@@ -541,18 +587,13 @@ def rm_rf(name):
       raise
 
 
-def is_executable(path):
-  """Returns whether a path names an existing executable file."""
-  return os.path.isfile(path) and os.access(path, os.X_OK)
-
-
-def split_basename_and_dirname(path):
+def split_basename_and_dirname(path: str) -> Tuple[str, str]:
   if not os.path.isfile(path):
     raise ValueError("{} does not exist or is not a regular file.".format(path))
-  return (os.path.dirname(path), os.path.basename(path))
+  return os.path.dirname(path), os.path.basename(path)
 
 
-def check_no_overlapping_paths(paths):
+def check_no_overlapping_paths(paths: Sequence[str]) -> None:
   """Given a list of paths, ensure that all are unique and do not have the same prefix."""
   for path in paths:
     list_copy_without_path = list(paths)
@@ -564,12 +605,17 @@ def check_no_overlapping_paths(paths):
         raise ValueError('{} and {} have the same prefix. All paths must be unique and cannot overlap.'.format(path, p))
 
 
-def is_readable_dir(path):
+def is_executable(path: str) -> bool:
+  """Returns whether a path names an existing executable file."""
+  return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def is_readable_dir(path: str) -> bool:
   """Returns whether a path names an existing directory we can list and read files from."""
   return os.path.isdir(path) and os.access(path, os.R_OK) and os.access(path, os.X_OK)
 
 
-def is_writable_dir(path):
+def is_writable_dir(path: str) -> bool:
   """Returns whether a path names an existing directory that we can create and modify files in.
 
   We call is_readable_dir(), so this definition of "writable" is a superset of that.

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -38,7 +38,8 @@ python_tests(
     '3rdparty/python:dataclasses',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {'type_checked'},
 )
 
 python_tests(

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -17,7 +17,8 @@ python_tests(
   coverage = ['pants.util.collections'],
   dependencies = [
     'src/python/pants/util:collections',
-  ]
+  ],
+  tags = {'type_checked'},
 )
 
 python_tests(
@@ -26,7 +27,7 @@ python_tests(
   coverage = ['pants.util.contextutil'],
   dependencies = [
     'src/python/pants/util:contextutil',
-  ]
+  ],
 )
 
 python_tests(
@@ -45,7 +46,7 @@ python_tests(
   sources = ['test_eval.py'],
   dependencies = [
     'src/python/pants/util:eval',
-  ]
+  ],
 )
 
 python_tests(
@@ -54,7 +55,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:contextutil',
     'src/python/pants/util:fileutil',
-  ]
+  ],
 )
 
 python_tests(
@@ -62,7 +63,7 @@ python_tests(
   sources = ['test_filtering.py'],
   dependencies = [
     'src/python/pants/util:filtering',
-  ]
+  ],
 )
 
 python_tests(
@@ -71,7 +72,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
-  ]
+  ],
 )
 
 python_tests(
@@ -80,7 +81,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:meta',
     'tests/python/pants_test:test_base',
-  ]
+  ],
 )
 
 python_tests(
@@ -88,7 +89,7 @@ python_tests(
   sources = ['test_netrc.py'],
   dependencies = [
     'src/python/pants/util:netrc',
-  ]
+  ],
 )
 
 python_tests(
@@ -98,7 +99,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:objects',
     'tests/python/pants_test:test_base',
-  ]
+  ],
 )
 
 python_tests(
@@ -107,7 +108,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:osutil',
     'tests/python/pants_test:test_base',
-  ]
+  ],
 )
 
 python_tests(
@@ -115,7 +116,7 @@ python_tests(
   sources = ['test_process_handler.py'],
   dependencies = [
     'src/python/pants/util:process_handler',
-  ]
+  ],
 )
 
 python_tests(
@@ -123,7 +124,7 @@ python_tests(
   sources = ['test_retry.py'],
   dependencies = [
     'src/python/pants/util:retry',
-  ]
+  ],
 )
 
 python_tests(
@@ -141,7 +142,7 @@ python_tests(
   coverage = ['pants.util.socket'],
   dependencies = [
     'src/python/pants/util:socket',
-  ]
+  ],
 )
 
 python_tests(
@@ -159,7 +160,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:dirutil',
     'src/python/pants/util:tarutil',
-  ]
+  ],
 )
 
 python_library(
@@ -167,7 +168,7 @@ python_library(
   sources = ['xml_test_base.py'],
   dependencies = [
     'src/python/pants/util:contextutil',
-  ]
+  ],
 )
 
 python_tests(
@@ -176,5 +177,5 @@ python_tests(
   dependencies = [
     'src/python/pants/util:xml_parser',
     'tests/python/pants_test/util:xml_test_base',
-  ]
+  ],
 )

--- a/tests/python/pants_test/util/test_collections.py
+++ b/tests/python/pants_test/util/test_collections.py
@@ -14,7 +14,7 @@ class TestCollections(unittest.TestCase):
     def make_default_value(x: int) -> List[int]:
       return [x ** 3]
 
-    cubes = factory_dict(make_default_value, *((x, x ** 2) for x in range(3)), three=42)
+    cubes = factory_dict(make_default_value, ((x, x ** 2) for x in range(3)), three=42)
 
     # Check kwargs passed to the constructor
     self.assertEqual(42, cubes['three'])

--- a/tests/python/pants_test/util/test_collections.py
+++ b/tests/python/pants_test/util/test_collections.py
@@ -2,56 +2,84 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import unittest
+from typing import List
 
-from pants.util.collections import (
-  assert_single_element,
-  combined_dict,
-  factory_dict,
-  recursively_update,
-)
+from pants.util.collections import assert_single_element, factory_dict, recursively_update
 
 
 class TestCollections(unittest.TestCase):
-  def test_combined_dict(self):
-    self.assertEqual(
-      combined_dict(
-       {'a': 1, 'b': 1, 'c': 1},
-       {'b': 2, 'c': 2},
-       {'c': 3},
-      ),
-      {'a': 1, 'b': 2, 'c': 3}
-    )
 
-  def test_factory_dict(self):
-    cubes = factory_dict(lambda x: [x ** 3], ((x, x ** 2) for x in range(3)), three=42)
+  def test_factory_dict(self) -> None:
+
+    def make_default_value(x: int) -> List[int]:
+      return [x ** 3]
+
+    cubes = factory_dict(make_default_value, *((x, x ** 2) for x in range(3)), three=42)
+
+    # Check kwargs passed to the constructor
+    self.assertEqual(42, cubes['three'])
+
+    # Check args passed to the constructor
     self.assertEqual(0, cubes[0])
     self.assertEqual(1, cubes[1])
     self.assertEqual(4, cubes[2])
 
+    # Check value factory for missing values
     self.assertEqual([27], cubes[3])
 
+    # Check value factory only used for __getitem__, not other methods like get()
     self.assertIsNone(cubes.get(4))
-    self.assertEqual([64], cubes[4])
-
-    cubes.get(4).append(8)
-    self.assertEqual([64, 8], cubes[4])
-
-    self.assertEqual(42, cubes['three'])
-
     self.assertEqual('jake', cubes.get(5, 'jake'))
 
-  def test_recursively_update(self):
-    d = {'a': 1, 'b': {'c': 2, 'o': 'z'}, 'z': {'y': 0}}
-    recursively_update(d, {'e': 3, 'b': {'f': 4, 'o': 9}, 'g': {'h': 5}, 'z': 7})
+    # This time we access directly via __getitem__
+    self.assertEqual([64], cubes[4])
+    cubes.get(4).append(8)  # type: ignore[union-attr]
+    self.assertEqual([64, 8], cubes[4])
+
+  def test_recursively_update(self) -> None:
+    d1 = {
+      'a': 1,
+      'b': {
+        'c': 2,
+        'o': 'z',
+      },
+      'z': {
+        'y': 0,
+      }
+    }
+    d2 = {
+      'e': 3,
+      'b': {
+        'f': 4,
+        'o': 9
+      },
+      'g': {
+        'h': 5
+      },
+      'z': 7
+    }
+    recursively_update(d1, d2)
     self.assertEqual(
-      d, {'a': 1, 'b': {'c': 2, 'f': 4, 'o': 9}, 'e': 3, 'g': {'h': 5}, 'z': 7}
+      d1, {
+        'a': 1,
+        'b': {
+          'c': 2,
+          'f': 4,
+          'o': 9
+        },
+        'e': 3,
+        'g': {
+          'h': 5
+        },
+        'z': 7
+      }
     )
 
-  def test_assert_single_element(self):
+  def test_assert_single_element(self) -> None:
     single_element = [1]
     self.assertEqual(1, assert_single_element(single_element))
 
-    no_elements = []
+    no_elements: List[int] = []
     with self.assertRaises(StopIteration):
       assert_single_element(no_elements)
 


### PR DESCRIPTION
These `util/` targets are used by the vast majority of Pants targets. We need to correctly type hint them before being able to type hint anything else.