### PR TITLE
Port remaining `backend/jvm` integration tests to V1 chroot

### DIFF
--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -1,5 +1,4 @@
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:cache_compile_integration
-tests/python/pants_test/backend/jvm/tasks:jar_publish_integration
 tests/python/pants_test/backend/python/tasks/native:integration
 tests/python/pants_test/backend/python/tasks:build_local_python_distributions_integration
 tests/python/pants_test/backend/python/tasks:pytest_run_integration

--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -1,4 +1,3 @@
-tests/python/pants_test/backend/jvm/subsystems:jar_dependency_management_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:cache_compile_integration
 tests/python/pants_test/backend/jvm/tasks:checkstyle_integration
 tests/python/pants_test/backend/jvm/tasks:ivy_resolve_integration

--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -1,5 +1,4 @@
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:cache_compile_integration
-tests/python/pants_test/backend/jvm/tasks:ivy_resolve_integration
 tests/python/pants_test/backend/jvm/tasks:jar_publish_integration
 tests/python/pants_test/backend/python/tasks/native:integration
 tests/python/pants_test/backend/python/tasks:build_local_python_distributions_integration

--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -1,5 +1,4 @@
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:cache_compile_integration
-tests/python/pants_test/backend/jvm/tasks:checkstyle_integration
 tests/python/pants_test/backend/jvm/tasks:ivy_resolve_integration
 tests/python/pants_test/backend/jvm/tasks:jar_publish_integration
 tests/python/pants_test/backend/python/tasks/native:integration

--- a/build-support/ci_lists/integration_v2_blacklist.txt
+++ b/build-support/ci_lists/integration_v2_blacklist.txt
@@ -4,6 +4,7 @@ tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:zinc_compile_integrat
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc:rsc_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc:zinc_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc:zinc_compile_integration_with_zjars
+tests/python/pants_test/backend/jvm/tasks:ivy_resolve_integration
 tests/python/pants_test/backend/jvm/tasks:junit_run_integration
 tests/python/pants_test/backend/jvm/tasks:junit_tests_concurrency_integration
 tests/python/pants_test/backend/jvm/tasks:junit_tests_integration

--- a/build-support/ci_lists/integration_v2_blacklist.txt
+++ b/build-support/ci_lists/integration_v2_blacklist.txt
@@ -1,3 +1,4 @@
+tests/python/pants_test/backend/jvm/subsystems:jar_dependency_management_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:java_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:zinc_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc:rsc_compile_integration

--- a/build-support/ci_lists/integration_v2_blacklist.txt
+++ b/build-support/ci_lists/integration_v2_blacklist.txt
@@ -5,6 +5,7 @@ tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc:rsc_compile_integratio
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc:zinc_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc:zinc_compile_integration_with_zjars
 tests/python/pants_test/backend/jvm/tasks:ivy_resolve_integration
+tests/python/pants_test/backend/jvm/tasks:jar_publish_integration
 tests/python/pants_test/backend/jvm/tasks:junit_run_integration
 tests/python/pants_test/backend/jvm/tasks:junit_tests_concurrency_integration
 tests/python/pants_test/backend/jvm/tasks:junit_tests_integration

--- a/examples/src/python/example/BUILD
+++ b/examples/src/python/example/BUILD
@@ -19,3 +19,8 @@ files(
   name='hello_directory',
   sources=rglobs('hello/*'),
 )
+
+files(
+  name='pants_publish_plugin_directory',
+  sources=rglobs('pants_publish_plugin/*'),
+)

--- a/src/java/org/pantsbuild/BUILD
+++ b/src/java/org/pantsbuild/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+files(
+  name = 'junit_directory',
+  sources = rglobs('junit/*'),
+)

--- a/testprojects/src/scala/org/pantsbuild/testproject/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/BUILD
@@ -37,7 +37,7 @@ files(
   dependencies = [
     'testprojects/src/java/org/pantsbuild/testproject:javasources_directory',
     'testprojects/src/java/org/pantsbuild/testproject:publish_directory'
-  ]
+  ],
 )
 
 files(
@@ -48,6 +48,14 @@ files(
 files(
   name = 'procedure_syntax_directory',
   sources = rglobs('procedure_syntax/*'),
+)
+
+files(
+  name = 'publish_directory',
+  sources = rglobs('publish/*'),
+  dependencies = [
+    'testprojects/src/java/org/pantsbuild/testproject:publish_directory'
+  ],
 )
 
 files(

--- a/testprojects/tests/java/org/pantsbuild/testproject/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/BUILD
@@ -40,6 +40,11 @@ files(
 )
 
 files(
+  name='depman_directory',
+  sources=rglobs('depman/*'),
+)
+
+files(
   name='dummies_directory',
   sources=rglobs('dummies/*'),
 )

--- a/tests/python/pants_test/backend/jvm/subsystems/BUILD
+++ b/tests/python/pants_test/backend/jvm/subsystems/BUILD
@@ -102,7 +102,9 @@ python_tests(
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test:int-test',
     'testprojects/src/java/org/pantsbuild/testproject:depman_directory',
+    'testprojects/tests/java/org/pantsbuild/testproject:depman_directory',
+    'testprojects/3rdparty:managed_directory',
   ],
   tags = {'integration'},
-  timeout=600,
+  timeout=800,
 )

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -138,6 +138,8 @@ python_tests(
   dependencies = [
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
+    'examples/src/java/org/pantsbuild/example:hello_directory',
+    'testprojects/3rdparty:checkstyle_directory',
   ],
   tags = {'integration'},
   timeout = 240,

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -386,13 +386,17 @@ python_tests(
   name = 'jar_publish_integration',
   sources = ['test_jar_publish_integration.py'],
   dependencies = [
+    'examples/src/python/example:pants_publish_plugin_directory',
     'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:int-test',
+    'tests/python/pants_test/tasks:jar_publish_resources_directory',
+    'testprojects/src/java/org/pantsbuild/testproject:publish_directory',
+    'testprojects/src/scala/org/pantsbuild/testproject:publish_directory',
   ],
   tags = {'integration'},
-  timeout = 360,
+  timeout = 480,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -317,6 +317,8 @@ python_tests(
   name = 'ivy_resolve_integration',
   sources = ['test_ivy_resolve_integration.py'],
   dependencies = [
+    'examples/src/scala/org/pantsbuild/example:hello_directory',
+    'src/java/org/pantsbuild:junit_directory',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -13,7 +13,7 @@ python_tests(
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
   ],
   tags = {'integration'},
-  timeout=540,
+  timeout=720,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
@@ -292,13 +292,13 @@ class CacheCompileIntegrationTest(BaseCompileIT):
           zjar = os.path.join(zincpath, 'z.jar')
           self.assertTrue(os.path.exists(zjar))
           ZIP.extract(zjar, zinc_dir)
-          self.assertEqual(os.listdir(zinc_dir), ['compile_classpath'] + classfiles)
+          self.assertEqual(sorted(os.listdir(zinc_dir)), sorted(['compile_classpath', *classfiles]))
 
           rscpath = os.path.join(path, 'rsc')
           mjar = os.path.join(rscpath, 'm.jar')
           self.assertTrue(os.path.exists(mjar))
           ZIP.extract(mjar, rsc_dir)
-          self.assertEqual(os.listdir(rsc_dir), classfiles)
+          self.assertEqual(sorted(os.listdir(rsc_dir)), sorted(classfiles))
 
       ensure_classfiles("cachetestA", ["A.class"])
       ensure_classfiles("cachetestB", ["B.class"])

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve_integration.py
@@ -69,7 +69,7 @@ class IvyResolveIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants([
         'resolve',
         '--resolve-ivy-args=-blablabla',
-        'examples/src/scala::'
+        'examples/src/scala/org/pantsbuild/example/hello::'
     ])
     self.assert_failure(pants_run)
     self.assertIn('Unrecognized option: -blablabla', pants_run.stdout_data)

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -55,3 +55,8 @@ python_tests(
   ],
   tags = {'integration'},
 )
+
+files(
+  name = 'jar_publish_resources_directory',
+  sources = rglobs('jar_publish_resources/*'),
+)


### PR DESCRIPTION
This brings ITs to:

* 7% V1 no chroot (-3%)
* 12% V1 chroot (+2%)
* 81% V2 remote (+1%)

These JVM tests time out frequently when remoted, so are only ported to chroot until the V2 test runner gets timeout support.