### PR TITLE
Refactor MyPy whitelist mechanism from #8099

### DIFF
--- a/build-support/bin/mypy.py
+++ b/build-support/bin/mypy.py
@@ -8,12 +8,16 @@ import subprocess
 def main() -> None:
   subprocess.run([
     "./pants",
+    # We filter by tag to avoid irrelevant targets causing issues due to prerequisite goals against
+    # the lint goal.
+    "--tag=type_checked",
     "--backend-packages=pants.contrib.mypy",
     "lint",
     "--lint-mypy-verbose",
     "--lint-mypy-whitelist-tag-name=type_checked",
     "--lint-mypy-config-file=build-support/mypy/mypy.ini",
     "build-support::",
+    "contrib::",
     "src/python::",
     "tests/python::",
     "pants-plugins::",

--- a/build-support/bin/mypy.py
+++ b/build-support/bin/mypy.py
@@ -6,9 +6,18 @@ import subprocess
 
 
 def main() -> None:
-  subprocess.run(["./pants", "--backend-packages=pants.contrib.mypy", "--lint-mypy-verbose",
-                  "--lint-mypy-whitelist-tag-name=type_checked", "--tag=type_checked",
-                  "--lint-mypy-config-file=build-support/mypy/mypy.ini", "lint", "::"], check=True)
+  subprocess.run([
+    "./pants",
+    "--backend-packages=pants.contrib.mypy",
+    "lint",
+    "--lint-mypy-verbose",
+    "--lint-mypy-whitelist-tag-name=type_checked",
+    "--lint-mypy-config-file=build-support/mypy/mypy.ini",
+    "build-support::",
+    "src/python::",
+    "tests/python::",
+    "pants-plugins::",
+  ], check=True)
 
 
 if __name__ == '__main__':

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -104,8 +104,9 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
     formatted_targets = "\n".join(tgt.address.spec for tgt in sorted(untagged_dependencies))
     self.context.log.warn(
       f"[WARNING]: The following targets are not marked with the tag name `{tag_name}`, "
-      f"but are dependencies of targets that are type checked because they have this tag. You are "
-      f"encouraged to type check these dependencies.\n{formatted_targets}"
+      f"but are dependencies of targets that are type checked. MyPy will check these dependencies, "
+      f"inferring `Any` where possible. You are encouraged to properly type check "
+      f"these dependencies.\n{formatted_targets}"
     )
 
   def _calculate_python_sources(self, target_roots: Iterable[Target]) -> List[str]:

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/test_mypy.py
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/test_mypy.py
@@ -64,7 +64,7 @@ class MyPyWhitelistMechanismTest(TaskTestBase):
     t1 = self.make_python_target('t1')
     t2 = self.make_python_target('t2')
     captured_warnings = self.run_task_and_capture_warnings(target_roots=[t1, t2])
-    self.assert_warning(captured_warnings, expected_targets=[t1, t2])
+    self.assert_no_warning(captured_warnings)
 
   def test_whitelisted_dependency(self) -> None:
     t1 = self.make_python_target('t1', typed=True)
@@ -76,4 +76,10 @@ class MyPyWhitelistMechanismTest(TaskTestBase):
     t1 = self.make_python_target('t1')
     t2 = self.make_python_target('t2', typed=True, dependencies=[t1])
     captured_warnings = self.run_task_and_capture_warnings(target_roots=[t2])
+    self.assert_warning(captured_warnings, expected_targets=[t1])
+
+  def test_untyped_target_root_also_dependency(self) -> None:
+    t1 = self.make_python_target('t1')
+    t2 = self.make_python_target('t2', typed=True, dependencies=[t1])
+    captured_warnings = self.run_task_and_capture_warnings(target_roots=[t1, t2])
     self.assert_warning(captured_warnings, expected_targets=[t1])

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/test_mypy.py
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/test_mypy.py
@@ -1,59 +1,79 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from unittest.mock import MagicMock
+import logging
+from typing import List, Optional
 
 from pants.backend.python.targets.python_library import PythonLibrary
+from pants.build_graph.target import Target
 from pants_test.task_test_base import TaskTestBase
 
 from pants.contrib.mypy.tasks.mypy_task import MypyTask
 
 
-class MyPyTests(TaskTestBase):
+class MyPyWhitelistMechanismTest(TaskTestBase):
 
   @classmethod
   def task_type(cls):
     return MypyTask
 
-  def test_throws_no_warning_on_all_whitelisted_target_roots(self) -> None:
-    t1 = self.make_target('t1', PythonLibrary, tags=['type_checked'])
-    t2 = self.make_target('t2', PythonLibrary, tags=['type_checked'])
-    task = self.create_task(self.context(target_roots=[t1, t2]))
-    self.set_options(whitelist_tag_name='type_checked')
-    task.execute()
+  def make_python_target(
+    self, spec: str, *, typed: bool = False, dependencies: Optional[List[Target]] = None
+  ) -> Target:
+    kwargs = {}
+    if typed:
+      kwargs['tags'] = ['type_checked']
+    if dependencies:
+      kwargs['dependencies'] = dependencies
+    return self.make_target(spec, PythonLibrary, **kwargs)
 
-  def test_throws_no_warning_on_some_whitelisted_target_roots_but_all_whitelisted_in_context(self) -> None:
-    t1 = self.make_target('t1', PythonLibrary)
-    t2 = self.make_target('t2', PythonLibrary, tags=['type_checked'])
-    t3 = self.make_target('t3', PythonLibrary, tags=['type_checked'], dependencies=[t2])
-    task = self.create_task(self.context(target_roots=[t1, t3]))
-    self.set_options(whitelist_tag_name='type_checked')
-    task.execute()
+  def run_task_and_capture_warnings(
+    self, *, target_roots: List[Target], enable_whitelist: bool = True
+  ) -> List[str]:
+    self.set_options(verbose=True)
+    if enable_whitelist:
+      self.set_options(whitelist_tag_name="type_checked")
+    context = self.context(target_roots=target_roots)
+    task = self.create_task(context)
+    with self.captured_logging(level=logging.WARNING) as captured:
+      task.execute()
+    return captured.warnings()
 
-  def test_throws_warning_on_some_whitelisted_target_roots_but_all_whitelisted_in_context(self) -> None:
-    t1 = self.make_target('t1', PythonLibrary)
-    t2 = self.make_target('t2', PythonLibrary, tags=['something_else'])
-    t3 = self.make_target('t3', PythonLibrary, tags=['type_checked'], dependencies=[t2])
-    self.set_options(whitelist_tag_name='type_checked')
-    task = self.create_task(self.context(target_roots=[t1, t3]))
-    task._whitelist_warning = MagicMock()
-    task.execute()
-    task._whitelist_warning.assert_called()
+  def assert_no_warning(self, captured_warnings: List[str]) -> None:
+    self.assertFalse(captured_warnings)
 
-  def test_throws_warning_on_all_whitelisted_target_roots_but_some_whitelisted_transitive_targets(self) -> None:
-    t1 = self.make_target('t1', PythonLibrary, tags=['type_checked'])
-    t2 = self.make_target('t2', PythonLibrary, tags=['something_else'])
-    t3 = self.make_target('t3', PythonLibrary, tags=['type_checked'], dependencies=[t2])
-    t4 = self.make_target('t4', PythonLibrary, tags=['type_checked'], dependencies=[t3])
-    self.set_options(whitelist_tag_name='type_checked')
-    task = self.create_task(self.context(target_roots=[t1, t4]))
-    task._whitelist_warning = MagicMock()
-    task.execute()
-    task._whitelist_warning.assert_called()
+  def assert_warning(self, captured_warnings: List[str], *, expected_targets: List[Target]) -> None:
+    self.assertTrue(captured_warnings)
+    for tgt in expected_targets:
+      self.assertIn(tgt.address.spec, captured_warnings[0])
 
-  def test_throws_no_warning_if_no_whitelist_specified(self) -> None:
-    t1 = self.make_target('t1', PythonLibrary)
-    task = self.create_task(self.context(target_roots=[t1]))
-    task._whitelist_warning = MagicMock()
-    task.execute()
-    task._whitelist_warning.assert_not_called()
+  def test_no_whitelist(self) -> None:
+    t1 = self.make_python_target('t1')
+    captured_warnings = self.run_task_and_capture_warnings(
+      target_roots=[t1], enable_whitelist=False
+    )
+    self.assert_no_warning(captured_warnings)
+
+  def test_whitelisted_target_roots(self) -> None:
+    t1 = self.make_python_target('t1', typed=True)
+    t2 = self.make_python_target('t2', typed=True)
+    captured_warnings = self.run_task_and_capture_warnings(target_roots=[t1, t2])
+    self.assert_no_warning(captured_warnings)
+
+  def test_target_roots_not_whitelisted(self) -> None:
+    t1 = self.make_python_target('t1')
+    t2 = self.make_python_target('t2')
+    captured_warnings = self.run_task_and_capture_warnings(target_roots=[t1, t2])
+    self.assert_warning(captured_warnings, expected_targets=[t1, t2])
+
+  def test_whitelisted_dependency(self) -> None:
+    t1 = self.make_python_target('t1', typed=True)
+    t2 = self.make_python_target('t2', typed=True, dependencies=[t1])
+    captured_warnings = self.run_task_and_capture_warnings(target_roots=[t2])
+    self.assert_no_warning(captured_warnings)
+
+  def test_dependency_not_whitelisted(self) -> None:
+    t1 = self.make_python_target('t1')
+    t2 = self.make_python_target('t2', typed=True, dependencies=[t1])
+    captured_warnings = self.run_task_and_capture_warnings(target_roots=[t2])
+    self.assert_warning(captured_warnings, expected_targets=[t1])

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/test_mypy_integration.py
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/test_mypy_integration.py
@@ -10,7 +10,8 @@ class MypyIntegrationTest(PantsRunIntegrationTest):
 
   cmdline = ['--backend-packages=pants.contrib.mypy', 'lint']
 
-  def target(self, name):
+  @classmethod
+  def target(cls, name):
     return f'contrib/mypy/examples/src/python/simple:{name}'
 
   def test_valid_type_hints(self):


### PR DESCRIPTION
Refactors https://github.com/pantsbuild/pants/pull/8099.

This fixes always printing a warning no matter what about untyped targets. Now we only print this when there actually are untyped targets.