### PR TITLE
Make test discovery for `test_testprojects.py` IT more precise

### DIFF
--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -257,8 +257,8 @@ class TestTargetSets(NamedTuple):
       [
         "./pants.pex",
         f"--tag={'-' if test_type == TestType.unit else '+'}integration",
-        "--filter-type=python_tests",
         "filter",
+        "--type=python_tests",
         "src/python::",
         "tests/python::",
         "contrib::",

--- a/tests/python/pants_test/projects/BUILD
+++ b/tests/python/pants_test/projects/BUILD
@@ -10,5 +10,5 @@ python_tests(
     'tests/python/pants_test:test_base',
   ],
   tags = {'integration'},
-  timeout=950,
+  timeout=1400,
 )

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -152,7 +152,6 @@ class TestProjectsIntegrationTest(PantsRunIntegrationTest, AbstractTestGenerator
       'examples::',
       *exclude_opts
     ])
-    import pdb; pdb.set_trace()
     self.assert_success(pants_run)
     return list(sorted(pants_run.stdout_data.split()))
 

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import math
-from typing import List, Set
+from typing import List
 
 from pants.util.memo import memoized_property
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -129,14 +129,12 @@ class TestProjectsIntegrationTest(PantsRunIntegrationTest, AbstractTestGenerator
     """We don't want to run over every single target, e.g. files() are only used for us to depend
     on in ITs and it doesn't make sense to run `./pants test` against them."""
     return [
-      "target",
       # resources / loose files
       "files",
       "resources",
       "page",
       # 3rd-party dependencies
       "jar_library",
-      "managed_jar_libraries",
       "python_requirement_library",
     ]
 
@@ -154,6 +152,7 @@ class TestProjectsIntegrationTest(PantsRunIntegrationTest, AbstractTestGenerator
       'examples::',
       *exclude_opts
     ])
+    import pdb; pdb.set_trace()
     self.assert_success(pants_run)
     return list(sorted(pants_run.stdout_data.split()))
 

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -153,7 +153,6 @@ class TestProjectsIntegrationTest(PantsRunIntegrationTest, AbstractTestGenerator
       # library targets
       "python_library",
       "java_library",
-      "jar_library",
       "scala_library",
       # binary targets
       "python_binary",


### PR DESCRIPTION
### Problem
Currently, `test_testproject.py` runs `test` against everything in `testprojects::` and `examples::`, including the `files()` targets we've been adding while porting to V2. We don't want those new `files()` targets to be run here.

### Solution
We blacklist certain target types that don't make sense to test.

We also now run `./pants compile lint test` on every target. This does not make any difference now but prepares us for V2 where `./pants test` doesn't trigger prerequisite goals as it does in V1.

### Result
We no longer test targets that don't make sense, like `files()`. This prepares us for chrooting this test by allowing us to ignore targets we don't care about.