### PR TITLE
Retry certain remote execution errors

### DIFF
--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -336,6 +336,8 @@ fn main() {
         store.clone(),
         Platform::Linux,
         executor.clone(),
+        std::time::Duration::from_millis(500),
+        std::time::Duration::from_secs(5),
       )) as Box<dyn process_execution::CommandRunner>
     }
     None => Box::new(process_execution::local::CommandRunner::new(

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -164,6 +164,8 @@ impl Core {
             // need to take an option all the way down here and into the remote::CommandRunner struct.
             Platform::Linux,
             executor.clone(),
+            std::time::Duration::from_millis(500),
+            std::time::Duration::from_secs(5),
           )),
           process_execution_remote_parallelism,
         ));


### PR DESCRIPTION
We see this particular error when using Google's RBE service configured
with pre-emptable workers, which indicates that a worker was pre-empted.
In this case, we just want to try the execution again.
