### PR TITLE
remove custom NodeResolveFingerprintStrategy

### DIFF
--- a/contrib/node/examples/src/java/org/pantsbuild/testproject/jsresources/BUILD
+++ b/contrib/node/examples/src/java/org/pantsbuild/testproject/jsresources/BUILD
@@ -6,6 +6,14 @@ jvm_binary(
     'contrib/node/examples/src/node/web-component-button:web-component-button-processed',
   ]
 )
+jvm_binary(name='jsresources-unprocessed',
+  source = 'JsResourcesMain.java',
+  main = 'org.pantsbuild.testproject.jsresources.JsResourcesMain',
+  dependencies = [
+    '3rdparty:guava',
+    'contrib/node/examples/src/node/web-component-button:web-component-button',
+  ]
+)
 
 jvm_binary(name = 'jsresources-with-dependency-artifacts',
   source = 'JsResourcesMain.java',

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_resolve.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_resolve.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-from hashlib import sha1
 from typing import Dict, Optional, Type
 
 from pants.base.build_environment import get_buildroot

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_resolve.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_resolve.py
@@ -6,7 +6,6 @@ from hashlib import sha1
 from typing import Dict, Optional, Type
 
 from pants.base.build_environment import get_buildroot
-from pants.base.fingerprint_strategy import DefaultFingerprintHashingMixin, FingerprintStrategy
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.build_graph import sort_targets
 from pants.build_graph.target import Target
@@ -15,41 +14,6 @@ from pants.contrib.node.subsystems.resolvers.node_resolver_base import NodeResol
 from pants.contrib.node.targets.node_package import NodePackage
 from pants.contrib.node.tasks.node_paths import NodePaths, NodePathsLocal
 from pants.contrib.node.tasks.node_task import NodeTask
-
-
-class NodeResolveFingerprintStrategy(DefaultFingerprintHashingMixin, FingerprintStrategy):
-  """
-  Fingerprint package lockfiles (e.g. package.json, yarn.lock...),
-  so that we don't automatically run this if none of those have changed.
-
-  We read every file and add its contents to the hash.
-  """
-
-  _package_manager_lockfiles = {
-    'yarn': ['package.json', 'yarn.lock'],
-    'npm': ['package.json', 'package-lock.json', 'npm-shrinkwrap.json']
-  }
-
-  def _get_files_to_watch(self, target):
-    package_manager = target.payload.get_field_value("package_manager", '')
-    # NB: Defaults to empty list for things like scalajs ad-hoc packages.
-    lockfiles = self._package_manager_lockfiles.get(package_manager, [])
-    paths = [os.path.join(target.address.spec_path, name) for name in lockfiles]
-    return paths
-
-  def compute_fingerprint(self, target):
-    if NodeResolve.can_resolve_target(target):
-      hasher = sha1()
-      for lockfile_path in self._get_files_to_watch(target):
-        absolute_lockfile_path = os.path.join(get_buildroot(), lockfile_path)
-        # NB: It should not be up to the caching to decide what happens when a
-        # lockfile is not added in sources.
-        if os.path.exists(absolute_lockfile_path):
-          with open(absolute_lockfile_path, 'r') as lockfile:
-            contents = lockfile.read().encode()
-            hasher.update(contents)
-      return hasher.hexdigest()
-    return None
 
 
 class NodeResolve(NodeTask):
@@ -129,7 +93,6 @@ class NodeResolve(NodeTask):
       with self.invalidated(targets,
                             topological_order=True,
                             invalidate_dependents=True,
-                            fingerprint_strategy=NodeResolveFingerprintStrategy()
            ) as invalidation_check:
         with self.context.new_workunit(name='install', labels=[WorkUnitLabel.MULTITOOL]):
           for vt in invalidation_check.all_vts:

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve_integration.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve_integration.py
@@ -41,10 +41,6 @@ class NodeResolveIntegrationTest(PantsRunIntegrationTest):
     self.assert_success(pants_run)
     return pants_run
 
-  def assert_not_triggered_install(self, pants_command, workdir):
-    res = self._run_successfully(pants_command, workdir)
-    assert "yarn install" not in res.stdout_data
-
   def run_and_assert_triggered_install(self, pants_command, workdir):
     res = self._run_successfully(pants_command, workdir)
     assert "yarn install" in res.stdout_data
@@ -66,17 +62,6 @@ class NodeResolveIntegrationTest(PantsRunIntegrationTest):
         }}
       }}
       """).format(target_name=target_name))
-
-  def test_no_reinstall_with_unchanged_lockfiles(self):
-    with self.temporary_workdir() as workdir:
-      root = 'contrib/node/testprojects/lockfile-invalidation'
-      target = root + ':lockfiles'
-      index_file = os.path.join(root, 'index.js')
-      command = ['run', target]
-      self.run_and_assert_triggered_install(command, workdir)
-
-      with self.with_overwritten_file_content(index_file, temporary_content='console.log("Hello World!!")'):
-        self.assert_not_triggered_install(command, workdir)
 
   def test_changing_lockfiles_triggers_reinstall(self):
     with self.temporary_workdir() as workdir:


### PR DESCRIPTION
### Problem

From an internal customer, we found that `node_module()` targets weren't invalidating in the `NodeResolve` task when source files were changed. This meant that any changes in those source files wouldn't be seen in any downstream node tasks.

### Solution

- Remove custom `NodeResolveFingerprintStrategy` and require targets to declare the appropriate json files in their `sources` instead of checking manually.

### Result

`node_module()` targets will now get re-resolved when their source files change!