### PR TITLE
Start creating `binary` goal with support for python

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -9,6 +9,7 @@ from pants.backend.python.rules import (
   download_pex_bin,
   inject_init,
   pex,
+  python_create_binary,
   python_fmt,
   python_test_runner,
 )
@@ -101,6 +102,7 @@ def rules():
     inject_init.rules() +
     python_fmt.rules() +
     python_test_runner.rules() +
+    python_create_binary.rules() +
     python_native_code_rules() +
     pex.rules() +
     subprocess_environment_rules()

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -35,7 +35,7 @@ def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor,
     for target_adaptor in all_targets
   ]
 
-  #TODO This way of calculating the entry point works but is a bit hackish.
+  #TODO(#8420) This way of calculating the entry point works but is a bit hackish.
   entry_point = None
   if hasattr(python_binary_adaptor, 'entry_point'):
     entry_point = python_binary_adaptor.entry_point

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -1,0 +1,88 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.rules.inject_init import InjectedInitDigest
+from pants.backend.python.rules.pex import CreatePex, Pex, PexInterpreterContraints
+from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.backend.python.targets.python_binary import PythonBinary
+from pants.engine.fs import Digest, DirectoriesToMerge
+from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
+from pants.engine.legacy.graph import BuildFileAddresses, HydratedTarget, TransitiveHydratedTargets
+from pants.engine.legacy.structs import PythonBinaryAdaptor
+from pants.engine.rules import UnionRule, rule
+from pants.engine.selectors import Get
+from pants.rules.core.binary import BinaryTarget, CreatedBinary
+from pants.rules.core.strip_source_root import SourceRootStrippedSources
+
+
+@rule
+def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor,
+  python_setup: PythonSetup) -> CreatedBinary:
+  transitive_hydrated_targets = yield Get(
+    TransitiveHydratedTargets, BuildFileAddresses((python_binary_adaptor.address,))
+  )
+  all_targets = transitive_hydrated_targets.closure
+  all_target_adaptors = [t.adaptor for t in all_targets]
+
+
+  interpreter_constraints = PexInterpreterContraints.create_from_adaptors(
+    adaptors=tuple(all_targets),
+    python_setup=python_setup
+  )
+
+  source_root_stripped_sources = yield [
+    Get(SourceRootStrippedSources, HydratedTarget, target_adaptor)
+    for target_adaptor in all_targets
+  ]
+
+  #TODO This way of calculating the entry point works but is a bit hackish.
+  entry_point = None
+  if hasattr(python_binary_adaptor, 'entry_point'):
+    entry_point = python_binary_adaptor.entry_point
+  else:
+    sources_snapshot = python_binary_adaptor.sources.snapshot
+    if len(sources_snapshot.files) == 1:
+      target = transitive_hydrated_targets.roots[0]
+      output = yield Get(SourceRootStrippedSources, HydratedTarget, target)
+      root_filename = output.snapshot.files[0]
+      entry_point = PythonBinary.translate_source_path_to_py_module_specifier(root_filename)
+
+  stripped_sources_digests = [stripped_sources.snapshot.directory_digest for stripped_sources in source_root_stripped_sources]
+  sources_digest = yield Get(Digest, DirectoriesToMerge(directories=tuple(stripped_sources_digests)))
+  inits_digest = yield Get(InjectedInitDigest, Digest, sources_digest)
+  all_input_digests = [sources_digest, inits_digest.directory_digest]
+  merged_input_files = yield Get(Digest, DirectoriesToMerge, DirectoriesToMerge(directories=tuple(all_input_digests)))
+
+  #TODO This chunk of code should be made into an @rule and used both here and in
+  # python_test_runner.py.
+  # Produce a pex containing pytest and all transitive 3rdparty requirements.
+  all_target_requirements = []
+  for maybe_python_req_lib in all_target_adaptors:
+    # This is a python_requirement()-like target.
+    if hasattr(maybe_python_req_lib, 'requirement'):
+      all_target_requirements.append(str(maybe_python_req_lib.requirement))
+    # This is a python_requirement_library()-like target.
+    if hasattr(maybe_python_req_lib, 'requirements'):
+      for py_req in maybe_python_req_lib.requirements:
+        all_target_requirements.append(str(py_req.requirement))
+
+  output_filename = f"{python_binary_adaptor.address.target_name}.pex"
+
+  all_requirements = all_target_requirements
+  create_requirements_pex = CreatePex(
+    output_filename=output_filename,
+    requirements=tuple(sorted(all_requirements)),
+    interpreter_constraints=interpreter_constraints,
+    entry_point=entry_point,
+    input_files_digest=merged_input_files,
+  )
+
+  pex = yield Get(Pex, CreatePex, create_requirements_pex)
+  yield CreatedBinary(digest=pex.directory_digest)
+
+
+def rules():
+  return [
+    UnionRule(BinaryTarget, PythonBinaryAdaptor),
+    create_python_binary,
+  ]

--- a/src/python/pants/backend/python/rules/python_fmt.py
+++ b/src/python/pants/backend/python/rules/python_fmt.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Set
 
-from pants.backend.python.rules.pex import CreatePex, Pex
+from pants.backend.python.rules.pex import CreatePex, Pex, PexInterpreterContraints, PexRequirements
 from pants.backend.python.subsystems.black import Black
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
@@ -45,8 +45,8 @@ def run_black(
   resolved_requirements_pex = yield Get(
     Pex, CreatePex(
       output_filename="black.pex",
-      requirements=tuple(black.get_requirement_specs()),
-      interpreter_constraints=tuple(black.default_interpreter_constraints),
+      requirements=PexRequirements(requirements=tuple(black.get_requirement_specs())),
+      interpreter_constraints=PexInterpreterContraints(constraint_set=frozenset(black.default_interpreter_constraints)),
       entry_point=black.get_entry_point(),
     )
   )

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -32,16 +32,17 @@ def run_python_test(
     TransitiveHydratedTargets, BuildFileAddresses((test_target.address,))
   )
   all_targets = transitive_hydrated_targets.closure
+  all_target_adaptors = tuple(t.adaptor for t in all_targets)
 
   interpreter_constraints = PexInterpreterContraints.create_from_adaptors(
-    adaptors=tuple(all_targets),
+    adaptors=tuple(all_target_adaptors),
     python_setup=python_setup
   )
 
   # Produce a pex containing pytest and all transitive 3rdparty requirements.
   output_pytest_requirements_pex_filename = 'pytest-with-requirements.pex'
   requirements = PexRequirements.create_from_adaptors(
-    adaptors=all_targets,
+    adaptors=all_target_adaptors,
     additional_requirements=pytest.get_requirement_strings()
   )
 

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.python.rules.inject_init import InjectedInitDigest
-from pants.backend.python.rules.pex import CreatePex, Pex, PexInterpreterContraints
+from pants.backend.python.rules.pex import CreatePex, Pex, PexInterpreterContraints, PexRequirements
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
@@ -40,17 +40,11 @@ def run_python_test(
 
   # Produce a pex containing pytest and all transitive 3rdparty requirements.
   output_pytest_requirements_pex_filename = 'pytest-with-requirements.pex'
-  all_target_requirements = []
-  for t in all_targets:
-    maybe_python_req_lib = t.adaptor
-    # This is a python_requirement()-like target.
-    if hasattr(maybe_python_req_lib, 'requirement'):
-      all_target_requirements.append(str(maybe_python_req_lib.requirement))
-    # This is a python_requirement_library()-like target.
-    if hasattr(maybe_python_req_lib, 'requirements'):
-      for py_req in maybe_python_req_lib.requirements:
-        all_target_requirements.append(str(py_req.requirement))
-  all_requirements = all_target_requirements + list(pytest.get_requirement_strings())
+  requirements = PexRequirements.create_from_adaptors(
+    adaptors=all_targets,
+    additional_requirements=pytest.get_requirement_strings()
+  )
+
   resolved_requirements_pex = yield Get(
     Pex, CreatePex(
       output_filename=output_pytest_requirements_pex_filename,

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.python.rules.inject_init import InjectedInitDigest
-from pants.backend.python.rules.pex import CreatePex, Pex
+from pants.backend.python.rules.pex import CreatePex, Pex, PexInterpreterContraints
 from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
@@ -33,13 +33,10 @@ def run_python_test(
   )
   all_targets = transitive_hydrated_targets.closure
 
-  interpreter_constraints = {
-    constraint
-    for target_adaptor in all_targets
-    for constraint in python_setup.compatibility_or_constraints(
-      getattr(target_adaptor, 'compatibility', None)
-    )
-  }
+  interpreter_constraints = PexInterpreterContraints.create_from_adaptors(
+    adaptors=tuple(all_targets),
+    python_setup=python_setup
+  )
 
   # Produce a pex containing pytest and all transitive 3rdparty requirements.
   output_pytest_requirements_pex_filename = 'pytest-with-requirements.pex'
@@ -58,7 +55,7 @@ def run_python_test(
     Pex, CreatePex(
       output_filename=output_pytest_requirements_pex_filename,
       requirements=tuple(sorted(all_requirements)),
-      interpreter_constraints=tuple(sorted(interpreter_constraints)),
+      interpreter_constraints=interpreter_constraints,
       entry_point="pytest:main",
     )
   )

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -48,7 +48,7 @@ def run_python_test(
   resolved_requirements_pex = yield Get(
     Pex, CreatePex(
       output_filename=output_pytest_requirements_pex_filename,
-      requirements=tuple(sorted(all_requirements)),
+      requirements=requirements,
       interpreter_constraints=interpreter_constraints,
       entry_point="pytest:main",
     )

--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -116,7 +116,7 @@ class PythonBinary(PythonTarget):
     if sources and sources.files and entry_point:
       entry_point_module = entry_point.split(':', 1)[0]
       entry_source = list(self.sources_relative_to_source_root())[0]
-      source_entry_point = self._translate_to_entry_point(entry_source)
+      source_entry_point = self.translate_source_path_to_py_module_specifier(entry_source)
       if entry_point_module != source_entry_point:
         raise TargetDefinitionException(self,
             'Specified both source and entry_point but they do not agree: {} vs {}'.format(
@@ -136,7 +136,8 @@ class PythonBinary(PythonTarget):
   def indices(self):
     return self.payload.indices
 
-  def _translate_to_entry_point(self, source):
+  @classmethod
+  def translate_source_path_to_py_module_specifier(self, source: str) -> str:
     source_base, _ = os.path.splitext(source)
     return source_base.replace(os.path.sep, '.')
 
@@ -147,7 +148,7 @@ class PythonBinary(PythonTarget):
     elif self.payload.sources.source_paths:
       assert len(self.payload.sources.source_paths) == 1
       entry_source = list(self.sources_relative_to_source_root())[0]
-      return self._translate_to_entry_point(entry_source)
+      return self.translate_source_path_to_py_module_specifier(entry_source)
     else:
       return None
 

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -192,7 +192,7 @@ class Workspace:
   """Abstract handle for operations that touch the real local filesystem."""
   _scheduler: Any
 
-  def materialize_directories(self, directories_to_materialize: Tuple[DirectoryToMaterialize]) -> MaterializeDirectoriesResult:
+  def materialize_directories(self, directories_to_materialize: Tuple[DirectoryToMaterialize, ...]) -> MaterializeDirectoriesResult:
     return self._scheduler.materialize_directories(directories_to_materialize)
 
 

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -18,6 +18,7 @@ from pants.engine.selectors import Get
 
 @dataclass(frozen=True)
 class Binary(LineOriented, Goal):
+  """Create a runnable binary."""
   name = 'binary'
 
 
@@ -37,15 +38,13 @@ def create_binary(addresses: BuildFileAddresses, console: Console, workspace: Wo
   with Binary.line_oriented(options, console) as (print_stdout, print_stderr):
     print_stdout("Generating binaries in `dist/`")
     binaries = yield [Get(CreatedBinary, Address, address.to_address()) for address in addresses]
-    for binary in binaries:
-      dtm = DirectoryToMaterialize(
-        path = 'dist/',
-        directory_digest = binary.digest,
-      )
-      output = workspace.materialize_directories((dtm,))
-      for path in output.dependencies[0].output_paths:
+    dirs_to_materialize = tuple(
+      DirectoryToMaterialize(path='dist/', directory_digest=binary.digest) for binary in binaries
+    )
+    results = workspace.materialize_directories(dirs_to_materialize)
+    for result in results.dependencies:
+      for path in result.output_paths:
         print_stdout(f"Wrote {path}")
-
   yield Binary(exit_code=0)
 
 

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -1,0 +1,62 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+from typing import Any
+
+from pants.backend.python.rules.pex import Pex
+from pants.build_graph.address import Address
+from pants.engine.addressable import BuildFileAddresses
+from pants.engine.console import Console
+from pants.engine.fs import Digest, DirectoryToMaterialize, Workspace
+from pants.engine.goal import Goal, LineOriented
+from pants.engine.legacy.graph import HydratedTarget
+from pants.engine.legacy.structs import PythonBinaryAdaptor
+from pants.engine.rules import console_rule, optionable_rule, rule, union
+from pants.engine.selectors import Get
+
+
+@dataclass(frozen=True)
+class Binary(LineOriented, Goal):
+  name = 'binary'
+
+
+@union
+class BinaryTarget:
+  pass
+
+
+@union
+@dataclass(frozen=True)
+class CreatedBinary:
+  digest: Digest
+
+
+@console_rule
+def create_binary(addresses: BuildFileAddresses, console: Console, workspace: Workspace, options: Binary.Options) -> Binary:
+  with Binary.line_oriented(options, console) as (print_stdout, print_stderr):
+    print_stdout("Generating binaries in `dist/`")
+    binaries = yield [Get(CreatedBinary, Address, address.to_address()) for address in addresses]
+    for binary in binaries:
+      dtm = DirectoryToMaterialize(
+        path = 'dist/',
+        directory_digest = binary.digest,
+      )
+      output = workspace.materialize_directories((dtm,))
+      for path in output.dependencies[0].output_paths:
+        print_stdout(f"Wrote {path}")
+
+  yield Binary(exit_code=0)
+
+
+@rule
+def coordinator_of_binaries(target: HydratedTarget) -> CreatedBinary:
+  binary = yield Get(CreatedBinary, BinaryTarget, target.adaptor)
+  yield binary
+
+
+def rules():
+  return [
+    create_binary,
+    coordinator_of_binaries,
+  ]

--- a/src/python/pants/rules/core/register.py
+++ b/src/python/pants/rules/core/register.py
@@ -1,11 +1,20 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.rules.core import filedeps, fmt, list_roots, list_targets, strip_source_root, test
+from pants.rules.core import (
+  binary,
+  filedeps,
+  fmt,
+  list_roots,
+  list_targets,
+  strip_source_root,
+  test,
+)
 
 
 def rules():
   return [
+    *binary.rules(),
     *fmt.rules(),
     *list_roots.rules(),
     *list_targets.rules(),

--- a/tests/python/pants_test/backend/python/rules/test_pex.py
+++ b/tests/python/pants_test/backend/python/rules/test_pex.py
@@ -7,7 +7,7 @@ import zipfile
 from typing import Dict, List
 
 from pants.backend.python.rules.download_pex_bin import download_pex_bin
-from pants.backend.python.rules.pex import CreatePex, Pex, create_pex
+from pants.backend.python.rules.pex import CreatePex, Pex, PexInterpreterContraints, create_pex
 from pants.backend.python.subsystems.python_native_code import (
   PythonNativeCode,
   create_pex_native_build_environment,
@@ -47,7 +47,9 @@ class TestResolveRequirements(TestBase):
     super().setUp()
     init_subsystems([PythonSetup, PythonNativeCode, SubprocessEnvironment])
 
-  def create_pex_and_get_all_data(self, *, requirements=None, entry_point=None, interpreter_constraints=None,
+  def create_pex_and_get_all_data(self, *, requirements=None,
+      entry_point=None,
+      interpreter_constraints=PexInterpreterContraints(),
       input_files: Digest = None) -> (Dict, List[str]):
     def hashify_optional_collection(iterable):
       return tuple(sorted(iterable)) if iterable is not None else tuple()
@@ -55,7 +57,7 @@ class TestResolveRequirements(TestBase):
     request = CreatePex(
       output_filename="test.pex",
       requirements=hashify_optional_collection(requirements),
-      interpreter_constraints=hashify_optional_collection(interpreter_constraints),
+      interpreter_constraints=interpreter_constraints,
       entry_point=entry_point,
       input_files_digest=input_files,
     )
@@ -78,7 +80,8 @@ class TestResolveRequirements(TestBase):
     return {'pex': requirements_pex, 'info': json.loads(pex_info_content), 'files': pex_list}
 
   def create_pex_and_get_pex_info(
-    self, *, requirements=None, entry_point=None, interpreter_constraints=None,
+    self, *, requirements=None, entry_point=None,
+    interpreter_constraints=PexInterpreterContraints(),
     input_files: Digest = None) -> Dict:
     return self.create_pex_and_get_all_data(requirements=requirements, entry_point=entry_point, interpreter_constraints=interpreter_constraints,
         input_files=input_files)['info']
@@ -119,6 +122,7 @@ class TestResolveRequirements(TestBase):
     self.assertEqual(pex_info["entry_point"], entry_point)
 
   def test_interpreter_constraints(self) -> None:
-    constraints = {"CPython>=2.7,<3", "CPython>=3.6,<4"}
+    constraints = PexInterpreterContraints(
+        constraint_set=frozenset(sorted({"CPython>=2.7,<3", "CPython>=3.6,<4"})))
     pex_info = self.create_pex_and_get_pex_info(interpreter_constraints=constraints)
-    self.assertEqual(set(pex_info["interpreter_constraints"]), constraints)
+    self.assertEqual(frozenset(pex_info["interpreter_constraints"]), constraints.constraint_set)


### PR DESCRIPTION
### Problem

We need a version of the 'binary' goal that runs on the v2 engine.

### Solution

This code creates a `@console_rule` for the `binary` goal, the necessary type boilerplate, implements treating a pants-created Python PEX as a binary, and writes it to the `dist` directory. 
