### PR TITLE
Run Black as part of pre_commit hook

### DIFF
--- a/build-support/bin/black.sh
+++ b/build-support/bin/black.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}" || exit 1
+
+# shellcheck source=build-support/common.sh
+source build-support/common.sh
+
+function usage() {
+  echo "Formats python files with black through pants"
+  echo
+  echo "Usage: $0 (-h|-f)"
+  echo " -h    print out this help message"
+  echo " -f    instead of erroring on files with incorrect formatting, fix"
+  echo "       those files"
+  if (( $# > 0 )); then
+    die "$@"
+  else
+    exit 0
+  fi
+}
+
+black_args=(
+  --check
+)
+
+while getopts "hf" opt
+do
+  case ${opt} in
+    h) usage ;;
+    f) black_args=() ;;
+    *) usage "Invalid option: -${OPTARG}" ;;
+  esac
+done
+
+./pants --changed-parent="$(git_merge_base)" fmt-v2 --black-options="${black_args[*]}"

--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -65,6 +65,10 @@ if git rev-parse --verify "${MERGE_BASE}" &>/dev/null; then
   echo "* Checking types for targets marked \`type_checked\`"  
   ./build-support/bin/mypy.py || exit 1
 
+  if git diff "${MERGE_BASE}" --name-only | grep '\.py$' > /dev/null; then
+    echo "* Checking formatting of pyhon files"
+    ./build-support/bin/black.sh || die "To fix formatting, run \`build-support/bin/black.sh -f\`"
+  fi
   if git diff "${MERGE_BASE}" --name-only | grep '\.rs$' > /dev/null; then
     echo "* Checking formatting of rust files"
     ./build-support/bin/check_rust_formatting.sh || exit 1

--- a/src/python/pants/backend/python/rules/python_fmt.py
+++ b/src/python/pants/backend/python/rules/python_fmt.py
@@ -72,6 +72,9 @@ def run_black(
         pex_args += ("--config", config_path)
     if target.sources.snapshot.files:
         pex_args += ("--include", "|".join(re.escape(f) for f in target.sources.snapshot.files))
+    extra_options = black.get_options().options
+    if extra_options:
+        pex_args += (extra_options,)
 
     request = resolved_requirements_pex.create_execute_request(
         python_setup=python_setup,

--- a/src/python/pants/backend/python/subsystems/black.py
+++ b/src/python/pants/backend/python/subsystems/black.py
@@ -21,3 +21,6 @@ class Black(PythonToolBase):
             fingerprint=True,
             help="Path to formatting tool's config file",
         )
+        register(
+            "--options", advanced=True, type=str, fingerprint=True, help="Options to pass to black"
+        )


### PR DESCRIPTION
### Problem

We have recently formatted all the code with Black, but are not yet doing anything to prevent regressions.

### Solution

Add a section to the pre_commit hook that enforces any file touched by this branch to conform to black's formatting.

### Result

This should make it difficult to accidentally break the formatting.
