### PR TITLE
Add file to allow a clean looking git blame

### DIFF
--- a/.ignored_revisions
+++ b/.ignored_revisions
@@ -1,0 +1,4 @@
+# This revision reformatted all the python code with Black the first time.
+6c60cf752a6cc150620e8a2437974ae7d16917c5
+# This revision reverted the previous revision as more work and discussions were needed.
+33a6d51db91ea1fe69c39117c8878abcb824cdfb

--- a/build-support/bin/install_git_hooks.sh
+++ b/build-support/bin/install_git_hooks.sh
@@ -56,6 +56,9 @@ function ensure_hook() {
   fi
 }
 
+# Make sure users of recent git don't have their history polluted
+# by formatting changes.
+git config --local blame.ignoreRevsFile .ignored_revisions
 
 for HOOK in ${HOOK_NAMES}; do
   ensure_hook "${HOOK}"


### PR DESCRIPTION
### Problem

The commit: 6c60cf752a6cc150620e8a2437974ae7d16917c5 which automatically formats the python code, and the commit 33a6d51db91ea1fe69c39117c8878abcb824cdfb which reverts it pollute our git history.

### Solution

From git 2.23.0 on, it is possible to have git blame omit certain
revisions by default. This feature is meant to ease the pain of large
scale commits, such as automatic codebase reformattings.

Add a .ignored_revisions files to allow users of a recent git version to
benefit from a more useful `git blame`.

To opt-in, simply configure git to use the `.ignored_revisions` file by
running the following command:
```
git config --local blame.ignoreRevsFile .ignored_revisions
```

Note: this is done automatically by the `install_git_hooks` script.

Note: This will only work if you are using git 2.23 or above.

### Result

Users of a recent version of git may use git blame without suffering from the pollution caused by this wide refactoring.