### PR TITLE
PEX Interpreter constraints @rule

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -8,6 +8,7 @@ from pants.backend.python.python_requirements import PythonRequirements
 from pants.backend.python.rules import (
   download_pex_bin,
   inject_init,
+  interpreter_constraints,
   pex,
   python_fmt,
   python_test_runner,
@@ -97,11 +98,12 @@ def register_goals():
 
 def rules():
   return (
-    download_pex_bin.rules() +
-    inject_init.rules() +
-    python_fmt.rules() +
-    python_test_runner.rules() +
-    python_native_code_rules() +
-    pex.rules() +
-    subprocess_environment_rules()
+    *download_pex_bin.rules(),
+    *inject_init.rules(),
+    *interpreter_constraints.rules(),
+    *python_fmt.rules(),
+    *python_test_runner.rules(),
+    *python_native_code_rules(),
+    *pex.rules(),
+    *subprocess_environment_rules(),
   )

--- a/src/python/pants/backend/python/rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/rules/interpreter_constraints.py
@@ -1,0 +1,43 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+from typing import FrozenSet, List, Tuple
+
+from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.engine.legacy.structs import PythonTargetAdaptor
+from pants.engine.rules import RootRule, rule
+
+
+@dataclass(frozen=True)
+class BuildConstraintsForAdaptors:
+  adaptors: Tuple[PythonTargetAdaptor]
+
+
+@dataclass(frozen=True)
+class PexInterpreterContraints:
+  constraint_set: FrozenSet[str] = frozenset()
+
+  def generate_pex_arg_list(self) -> List[str]:
+    args = []
+    for constraint in self.constraint_set:
+      args.extend(["--interpreter-constraint", constraint])
+    return args
+
+
+@rule
+def handle_constraints(build_constraints_for_adaptors: BuildConstraintsForAdaptors, python_setup: PythonSetup) -> PexInterpreterContraints:
+  interpreter_constraints = frozenset(
+    [constraint
+    for target_adaptor in build_constraints_for_adaptors.adaptors
+    for constraint in python_setup.compatibility_or_constraints(
+      getattr(target_adaptor, 'compatibility', None)
+    )]
+  )
+
+  yield PexInterpreterContraints(constraint_set=interpreter_constraints)
+
+
+def rules():
+  return [handle_constraints, RootRule(BuildConstraintsForAdaptors)]
+

--- a/tests/python/pants_test/backend/python/rules/test_pex.py
+++ b/tests/python/pants_test/backend/python/rules/test_pex.py
@@ -7,6 +7,7 @@ import zipfile
 from typing import Dict, List
 
 from pants.backend.python.rules.download_pex_bin import download_pex_bin
+from pants.backend.python.rules.interpreter_constraints import PexInterpreterContraints
 from pants.backend.python.rules.pex import CreatePex, Pex, create_pex
 from pants.backend.python.subsystems.python_native_code import (
   PythonNativeCode,
@@ -47,7 +48,8 @@ class TestResolveRequirements(TestBase):
     super().setUp()
     init_subsystems([PythonSetup, PythonNativeCode, SubprocessEnvironment])
 
-  def create_pex_and_get_all_data(self, *, requirements=None, entry_point=None, interpreter_constraints=None,
+  def create_pex_and_get_all_data(self, *, requirements=None, entry_point=None,
+      interpreter_constraints=PexInterpreterContraints(),
       input_files: Digest = None) -> (Dict, List[str]):
     def hashify_optional_collection(iterable):
       return tuple(sorted(iterable)) if iterable is not None else tuple()
@@ -55,7 +57,7 @@ class TestResolveRequirements(TestBase):
     request = CreatePex(
       output_filename="test.pex",
       requirements=hashify_optional_collection(requirements),
-      interpreter_constraints=hashify_optional_collection(interpreter_constraints),
+      interpreter_constraints=interpreter_constraints,
       entry_point=entry_point,
       input_files_digest=input_files,
     )
@@ -78,7 +80,7 @@ class TestResolveRequirements(TestBase):
     return {'pex': requirements_pex, 'info': json.loads(pex_info_content), 'files': pex_list}
 
   def create_pex_and_get_pex_info(
-    self, *, requirements=None, entry_point=None, interpreter_constraints=None,
+    self, *, requirements=None, entry_point=None, interpreter_constraints=PexInterpreterContraints(),
     input_files: Digest = None) -> Dict:
     return self.create_pex_and_get_all_data(requirements=requirements, entry_point=entry_point, interpreter_constraints=interpreter_constraints,
         input_files=input_files)['info']
@@ -119,6 +121,9 @@ class TestResolveRequirements(TestBase):
     self.assertEqual(pex_info["entry_point"], entry_point)
 
   def test_interpreter_constraints(self) -> None:
-    constraints = {"CPython>=2.7,<3", "CPython>=3.6,<4"}
+    constraints = PexInterpreterContraints(
+      constraint_set=frozenset(sorted({"CPython>=2.7,<3", "CPython>=3.6,<4"}))
+    )
+
     pex_info = self.create_pex_and_get_pex_info(interpreter_constraints=constraints)
-    self.assertEqual(set(pex_info["interpreter_constraints"]), constraints)
+    self.assertEqual(set(pex_info["interpreter_constraints"]), constraints.constraint_set)


### PR DESCRIPTION
### Problem

A chunk of logic for generating the PEX constraints was being unnecessarily duplicated across the python test runner code and the (forthcoming) python binary creation code. 

### Solution

This commit isolates the logic for building the string of `--interpreter-constraint` command-line arguments to pex into a separate `@rule`. This commit is a prerequisite for forthcoming work on the v2 python binary creation rule.
