### PR TITLE
Run pants-plugin tests with V2 remote execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -372,9 +372,8 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - travis_wait 65 ./build-support/bin/ci.py --unit-tests --remote-execution-enabled
+    - travis_wait 65 ./build-support/bin/ci.py --unit-tests --plugin-tests --remote-execution-enabled
       --python-version 3.7
-    - ./build-support/bin/ci.py --plugin-tests --python-version 3.7
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -663,9 +662,8 @@ matrix:
     - '3.6'
     - '3.7'
     script:
-    - travis_wait 65 ./build-support/bin/ci.py --unit-tests --remote-execution-enabled
+    - travis_wait 65 ./build-support/bin/ci.py --unit-tests --plugin-tests --remote-execution-enabled
       --python-version 3.6
-    - ./build-support/bin/ci.py --plugin-tests --python-version 3.6
     stage: Test Pants
     sudo: required
   - addons:

--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -541,7 +541,7 @@ def run_plugin_tests(*, oauth_token_path: Optional[str] = None) -> None:
   _run_command(
     TestStrategy.v2_remote.pants_command(
       targets={"pants-plugins/src/python::", "pants-plugins/tests/python::"},
-      oauth_token_path=oauth_token_path
+      oauth_token_path=oauth_token_path,
     ),
     slug="BackendTests",
     start_message="Running internal backend Python tests",

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -456,11 +456,8 @@ def unit_tests(python_version: PythonVersion) -> Dict:
     **linux_shard(python_version=python_version),
     "name": f"Unit tests (Python {python_version.decimal})",
     "script": [
-      (
-        "travis_wait 65 ./build-support/bin/ci.py --unit-tests --remote-execution-enabled "
-        f"--python-version {python_version.decimal}"
-      ),
-      f"./build-support/bin/ci.py --plugin-tests --python-version {python_version.decimal}",
+      "travis_wait 65 ./build-support/bin/ci.py --unit-tests --plugin-tests "
+      f"--remote-execution-enabled --python-version {python_version.decimal}"
     ],
   }
   shard["env"] = shard.get("env", []) + [f"CACHE_NAME=unit_tests.py{python_version.number}"]


### PR DESCRIPTION
These worked already with V2. We simply change `ci.py` to use that setting.