### PR TITLE
Add support for running Pants with Python 3.8

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,7 +1,7 @@
 ansicolors==1.0.2
 asttokens==1.1.13
 beautifulsoup4>=4.6.0,<4.7
-cffi==1.11.5
+cffi==1.12.3
 contextlib2==0.5.5
 coverage>=4.5,<4.6
 dataclasses==0.6


### PR DESCRIPTION
Python 3.8 will be released on October 14. This ensures that Pants will work with Python 3.8, as the current version of `cffi` could not be installed with python3.8.rc0.

Because we mark the abi for `pantsbuild.pants` as `cp36.abi3`, we do not need to release a new wheel; the current wheel will work with Python 3.8.