### PR TITLE
Fix double check cache digest

### DIFF
--- a/src/python/pants/backend/jvm/tasks/classpath_entry.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_entry.py
@@ -27,7 +27,7 @@ class ClasspathEntry:
     return self._path
 
   def hydrate_missing_directory_digest(self, directory_digest):
-    assert os.path.isfile(self.path), f'Classpath entry {self} with digest to be mutated should point to an existing file!'
+    assert os.path.exists(self.path), f'Classpath entry {self} with digest to be mutated should point to an existing file or directory!'
     assert self.directory_digest is None, f'Classpath entry {self} with digest to be mutated is expected to *not* have a digest set!'
     self._directory_digest = directory_digest
 

--- a/src/python/pants/backend/jvm/tasks/classpath_entry.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_entry.py
@@ -24,6 +24,9 @@ class ClasspathEntry:
     """
     return self._path
 
+  def set_directory_digest(self, directory_digest):
+    self._directory_digest = directory_digest
+
   @property
   def directory_digest(self):
     """Returns the directory digest which contains this file. May be None.

--- a/src/python/pants/backend/jvm/tasks/classpath_entry.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_entry.py
@@ -1,6 +1,8 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
+
 
 class ClasspathEntry:
   """Represents a java classpath entry.
@@ -24,7 +26,9 @@ class ClasspathEntry:
     """
     return self._path
 
-  def set_directory_digest(self, directory_digest):
+  def hydrate_missing_directory_digest(self, directory_digest):
+    assert os.path.isfile(self.path), f'Classpath entry {self} with digest to be mutated should point to an existing file!'
+    assert self.directory_digest is None, f'Classpath entry {self} with digest to be mutated is expected to *not* have a digest set!'
     self._directory_digest = directory_digest
 
   @property

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -943,8 +943,6 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     if self.check_cache(vts):
       self.context.log.debug(f'Snapshotting results for {vts.target.address.spec}')
       classpath_entry = self._classpath_for_context(zinc_compile_context)
-      assert classpath_entry.directory_digest is None, f'Classpath entry {classpath_entry} from a double-check is expected to *not* have a digest set!'
-      assert os.path.isfile(classpath_entry.path), f'Classpath entry {classpath_entry} from a double-check should point to an existing file!'
       relpath = fast_relpath(classpath_entry.path, get_buildroot())
       classes_dir_snapshot, = self.context._scheduler.capture_snapshots([
         PathGlobsAndRoot(
@@ -952,7 +950,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
           get_buildroot(),
         ),
       ])
-      classpath_entry.set_directory_digest(classes_dir_snapshot.directory_digest)
+      classpath_entry.hydrate_missing_directory_digest(classes_dir_snapshot.directory_digest)
       # Re-validate the vts!
       vts.update()
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -941,6 +941,19 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
   def _default_double_check_cache_for_vts(self, vts):
     # Double check the cache before beginning compilation
     if self.check_cache(vts):
+      self.context.log.debug(f'Snapshotting results for {vts.target.address.spec}')
+      classpath_entry = self._classpath_for_context(zinc_compile_context)
+      assert classpath_entry.directory_digest is None, f'Classpath entry {classpath_entry} from a double-check is expected to *not* have a digest set!'
+      assert os.path.isfile(classpath_entry.path), f'Classpath entry {classpath_entry} from a double-check should point to an existing file!'
+      relpath = fast_relpath(classpath_entry.path, get_buildroot())
+      classes_dir_snapshot, = self.context._scheduler.capture_snapshots([
+        PathGlobsAndRoot(
+          PathGlobs([relpath]),
+          get_buildroot(),
+        ),
+      ])
+      classpath_entry.set_directory_digest(classes_dir_snapshot.directory_digest)
+      # Re-validate the vts!
       vts.update()
 
   def _default_work_for_vts(self, vts, ctx, input_classpath_product_key, counter, all_compile_contexts, output_classpath_product):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -940,8 +940,9 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
 
   def _default_double_check_cache_for_vts(self, vts):
     # Double check the cache before beginning compilation
-    if self.check_cache(vts):
-      vts.update()
+    # TODO: see if removing this makes the run pass!
+    # if self.check_cache(vts):
+    #   vts.update()
 
   def _default_work_for_vts(self, vts, ctx, input_classpath_product_key, counter, all_compile_contexts, output_classpath_product):
     progress_message = ctx.target.address.spec

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -941,17 +941,6 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
   def _default_double_check_cache_for_vts(self, vts):
     # Double check the cache before beginning compilation
     if self.check_cache(vts):
-      self.context.log.debug(f'Snapshotting results for {vts.target.address.spec}')
-      classpath_entry = self._classpath_for_context(zinc_compile_context)
-      relpath = fast_relpath(classpath_entry.path, get_buildroot())
-      classes_dir_snapshot, = self.context._scheduler.capture_snapshots([
-        PathGlobsAndRoot(
-          PathGlobs([relpath]),
-          get_buildroot(),
-        ),
-      ])
-      classpath_entry.hydrate_missing_directory_digest(classes_dir_snapshot.directory_digest)
-      # Re-validate the vts!
       vts.update()
 
   def _default_work_for_vts(self, vts, ctx, input_classpath_product_key, counter, all_compile_contexts, output_classpath_product):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -940,9 +940,8 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
 
   def _default_double_check_cache_for_vts(self, vts):
     # Double check the cache before beginning compilation
-    # TODO: see if removing this makes the run pass!
-    # if self.check_cache(vts):
-    #   vts.update()
+    if self.check_cache(vts):
+      vts.update()
 
   def _default_work_for_vts(self, vts, ctx, input_classpath_product_key, counter, all_compile_contexts, output_classpath_product):
     progress_message = ctx.target.address.spec

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -21,6 +21,7 @@ from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.mirrored_target_option_mixin import MirroredTargetOptionMixin
 from pants.engine.fs import (
   EMPTY_DIRECTORY_DIGEST,
+  Digest,
   DirectoryToMaterialize,
   PathGlobs,
   PathGlobsAndRoot,
@@ -741,15 +742,14 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     if self.check_cache(vts):
       self.context.log.debug(f'Snapshotting results for {vts.target.address.spec}')
       classpath_entry = self._classpath_for_context(zinc_compile_context)
-      assert classpath_entry.directory_digest is None, f'Classpath entry {classpath_entry} from a double-check is expected to *not* have a digest set!'
-      assert os.path.isfile(classpath_entry.path), f'Classpath entry {classpath_entry} from a double-check should point to an existing file!'
       relpath = fast_relpath(classpath_entry.path, get_buildroot())
       classes_dir_snapshot, = self.context._scheduler.capture_snapshots([
         PathGlobsAndRoot(
           PathGlobs([relpath]),
           get_buildroot(),
+          Digest.load(relpath),
         ),
       ])
-      classpath_entry.set_directory_digest(classes_dir_snapshot.directory_digest)
+      classpath_entry.hydrate_missing_directory_digest(classes_dir_snapshot.directory_digest)
       # Re-validate the vts!
       vts.update()

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -428,7 +428,8 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       # depends on. It depends on completion of the same dependencies as the rsc job in order to run
       # as late as possible, while still running before rsc or zinc.
       return Job(cache_doublecheck_key,
-                 functools.partial(self._double_check_cache_for_vts, ivts, zinc_compile_context),
+                 functools.partial(self._default_double_check_cache_for_vts, ivts,
+                                   zinc_compile_context),
                  dependencies=list(dep_keys))
 
     def make_rsc_job(target, dep_targets):
@@ -735,21 +736,3 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
   @memoized_method
   def _jdk_libs_abs(self, nonhermetic_dist):
     return nonhermetic_dist.find_libs(self._JDK_LIB_NAMES)
-
-  def _double_check_cache_for_vts(self, vts, zinc_compile_context):
-    # Double check the cache before beginning compilation
-    if self.check_cache(vts):
-      self.context.log.debug(f'Snapshotting results for {vts.target.address.spec}')
-      classpath_entry = self._classpath_for_context(zinc_compile_context)
-      assert classpath_entry.directory_digest is None, f'Classpath entry {classpath_entry} from a double-check is expected to *not* have a digest set!'
-      assert os.path.isfile(classpath_entry.path), f'Classpath entry {classpath_entry} from a double-check should point to an existing file!'
-      relpath = fast_relpath(classpath_entry.path, get_buildroot())
-      classes_dir_snapshot, = self.context._scheduler.capture_snapshots([
-        PathGlobsAndRoot(
-          PathGlobs([relpath]),
-          get_buildroot(),
-        ),
-      ])
-      classpath_entry.set_directory_digest(classes_dir_snapshot.directory_digest)
-      # Re-validate the vts!
-      vts.update()

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -741,8 +741,8 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     if self.check_cache(vts):
       self.context.log.debug(f'Snapshotting results for {vts.target.address.spec}')
       classpath_entry = self._classpath_for_context(zinc_compile_context)
-      assert classpath_entry.directory_digest is None, '?!?'
-      assert os.path.isfile(classpath_entry.path), '/?/'
+      assert classpath_entry.directory_digest is None, f'Classpath entry {classpath_entry} from a double-check is expected to *not* have a digest set!'
+      assert os.path.isfile(classpath_entry.path), f'Classpath entry {classpath_entry} from a double-check should point to an existing file!'
       relpath = fast_relpath(classpath_entry.path, get_buildroot())
       classes_dir_snapshot, = self.context._scheduler.capture_snapshots([
         PathGlobsAndRoot(
@@ -750,6 +750,6 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
           get_buildroot(),
         ),
       ])
-      classpath_entry.directory_digest = classes_dir_snapshot
+      classpath_entry.set_directory_digest(classes_dir_snapshot.directory_digest)
       # Re-validate the vts!
       vts.update()

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -428,7 +428,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       # depends on. It depends on completion of the same dependencies as the rsc job in order to run
       # as late as possible, while still running before rsc or zinc.
       return Job(cache_doublecheck_key,
-                 functools.partial(self._default_double_check_cache_for_vts, ivts),
+                 functools.partial(self._double_check_cache_for_vts, ivts, zinc_compile_context),
                  dependencies=list(dep_keys))
 
     def make_rsc_job(target, dep_targets):
@@ -735,3 +735,21 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
   @memoized_method
   def _jdk_libs_abs(self, nonhermetic_dist):
     return nonhermetic_dist.find_libs(self._JDK_LIB_NAMES)
+
+  def _double_check_cache_for_vts(self, vts, zinc_compile_context):
+    # Double check the cache before beginning compilation
+    if self.check_cache(vts):
+      self.context.log.debug(f'Snapshotting results for {vts.target.address.spec}')
+      classpath_entry = self._classpath_for_context(zinc_compile_context)
+      assert classpath_entry.directory_digest is None, '?!?'
+      assert os.path.isfile(classpath_entry.path), '/?/'
+      relpath = fast_relpath(classpath_entry.path, get_buildroot())
+      classes_dir_snapshot, = self.context._scheduler.capture_snapshots([
+        PathGlobsAndRoot(
+          PathGlobs([relpath]),
+          get_buildroot(),
+        ),
+      ])
+      classpath_entry.directory_digest = classes_dir_snapshot
+      # Re-validate the vts!
+      vts.update()


### PR DESCRIPTION
**Note:** this PR is explicitly being created without any test cases because we have only reproduced the issue in our internal CI, it's for the rsc compile task with `--execution-strategy=hermetic` which is explicitly experimental, and it's not clear how to make a good test for this right now. It would be good to figure out how we can maintain upstream regression testing for these kinds of issues in the future.

### Problem

Attempting to fix an issue where cache entries appear not to be read into the LMDB file store when downloaded from the remote cache on a "double check" hit during the rsc compile task. The "double check" is a separate `Job` added to the `ExecutionGraph` which explicitly checks cache entries for some target in case they had taken too long to download when determining cached targets at the beginning of the rsc compile task.

### Solution

- Explicitly synchronously snapshot the results of a double check cache hit in `rsc_compile.py`.

### Result

Pants no longer has spurious errors finding nonexistent digests when running the rsc compile task with `--execution-strategy=hermetic`!