### PR TITLE
Add nailMain to zinc bootstrapper, so that it can run under Nailgun

### DIFF
--- a/src/scala/org/pantsbuild/zinc/bootstrapper/BUILD
+++ b/src/scala/org/pantsbuild/zinc/bootstrapper/BUILD
@@ -13,9 +13,11 @@ scala_library(
     '3rdparty/jvm/org/scala-sbt:util-logging',
     '3rdparty/jvm/org/scala-sbt:io',
     '3rdparty/jvm/com/github/scopt',
+    '3rdparty/jvm/com/martiansoftware:nailgun-server',
     '3rdparty/jvm/org/pantsbuild/buck/util/zip',
     'src/scala/org/pantsbuild/zinc/options',
     'src/scala/org/pantsbuild/zinc/scalautil',
+    'src/scala/org/pantsbuild/zinc/util',
   ],
   platform='java8',
 )

--- a/src/scala/org/pantsbuild/zinc/bootstrapper/Cli.scala
+++ b/src/scala/org/pantsbuild/zinc/bootstrapper/Cli.scala
@@ -6,6 +6,7 @@
 package org.pantsbuild.zinc.bootstrapper
 
 import java.io.File
+import org.pantsbuild.zinc.util.Util
 
 case class Configuration(
   outputPath: File = new File("."),
@@ -14,7 +15,19 @@ case class Configuration(
   scalaCompiler: File = new File("."),
   scalaLibrary: File = new File("."),
   scalaReflect: File = new File(".")
-)
+) {
+  def withAbsolutePaths(relativeTo: File): Configuration = {
+    def normalise(path: File): File = Util.normalise(Some(relativeTo))(path)
+    this.copy(
+      outputPath = normalise(this.outputPath),
+      compilerInterface = normalise(this.compilerInterface),
+      compilerBridgeSource = normalise(this.compilerBridgeSource),
+      scalaCompiler = normalise(this.scalaCompiler),
+      scalaLibrary = normalise(this.scalaLibrary),
+      scalaReflect = normalise(this.scalaReflect)
+    )
+  }
+}
 
 object Cli {
   val CliParser = new scopt.OptionParser[Configuration]("scopt") {

--- a/src/scala/org/pantsbuild/zinc/bootstrapper/Main.scala
+++ b/src/scala/org/pantsbuild/zinc/bootstrapper/Main.scala
@@ -5,32 +5,54 @@
 
 package org.pantsbuild.zinc.bootstrapper
 
-import org.pantsbuild.zinc.scalautil.ScalaUtils
+import java.io.File
+
+import com.martiansoftware.nailgun.NGContext
 import sbt.internal.util.ConsoleLogger
 
+import org.pantsbuild.zinc.scalautil.ScalaUtils
+
 object Main {
+
+  def mainImpl(cliArgs: Configuration): Unit = {
+    System.out.println(cliArgs);
+    val scalaInstance = ScalaUtils
+      .scalaInstance(cliArgs.scalaCompiler,
+        Seq(cliArgs.scalaReflect),
+        cliArgs.scalaLibrary)
+
+    // As per https://github.com/pantsbuild/pants/issues/6160, this is a workaround
+    // so we can run zinc without $PATH (as needed in remoting).
+    System.setProperty("sbt.log.format", "true")
+
+    val cl = ConsoleLogger.apply()
+
+    BootstrapperUtils
+      .compilerInterface(cliArgs.outputPath,
+        cliArgs.compilerBridgeSource,
+        cliArgs.compilerInterface,
+        scalaInstance,
+        cl)
+  }
+
   def main(args: Array[String]): Unit = {
     Cli.CliParser.parse(args, Configuration()) match {
       case Some(cliArgs) => {
-        val scalaInstance = ScalaUtils
-          .scalaInstance(cliArgs.scalaCompiler,
-                         Seq(cliArgs.scalaReflect),
-                         cliArgs.scalaLibrary)
-
-        // As per https://github.com/pantsbuild/pants/issues/6160, this is a workaround
-        // so we can run zinc without $PATH (as needed in remoting).
-        System.setProperty("sbt.log.format", "true")
-
-        val cl = ConsoleLogger.apply()
-
-        BootstrapperUtils
-          .compilerInterface(cliArgs.outputPath,
-                             cliArgs.compilerBridgeSource,
-                             cliArgs.compilerInterface,
-                             scalaInstance,
-                             cl)
+        mainImpl(cliArgs)
       }
       case None => System.exit(1)
+    }
+  }
+
+  def nailMain(context: NGContext): Unit = {
+    val startTime = System.currentTimeMillis
+
+    Cli.CliParser.parse(context.getArgs, Configuration()) match {
+      case Some(settings) =>
+        mainImpl(settings.withAbsolutePaths(new File(context.getWorkingDirectory)))
+      case None => {
+        context.exit(1)
+      }
     }
   }
 }


### PR DESCRIPTION
### Problem

In the context of #8311, we want to run local, nailgunnable ExecutionProcessRequests with nailgun.
This means that the zinc bootstrapper will need to run under nailgun.

Therefore, it will have to output to an absolute path, because we want the outputs to be in the cwd of the client, not the nailgun server the bootstrapper will be running under.

### Solution

We use the same strategy as with the [Zinc compiler](https://github.com/blorente/pants/blob/e0b15b93d425b6fb556424354823bc1b0d4609a3/src/scala/org/pantsbuild/zinc/compiler/Main.scala#L178), and turn the botstrapper into a Nail (http://martiansoftware.com/nailgun/quickstart.html). We provide a new main method, `nailMain`, that will read the path of the client from the Nailgun context and normalize every configuration path.

### Result

The zinc bootstrapper can now be correctly run under Nailgun.