### PR TITLE
Don't shade the nailgun package in zinc.py

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -75,6 +75,10 @@ class Zinc:
           Shader.exclude_package('xsbti', recursive=True),
           # Unfortunately, is loaded reflectively by the compiler.
           Shader.exclude_package('org.apache.logging.log4j', recursive=True),
+          # We can't shade the Nailgun package, otherwise Nailgun won't recognize the
+          # signatures of the nailMain methods in our custom nails:
+          # http://www.martiansoftware.com/nailgun/quickstart.html#nails
+          Shader.exclude_package('com.martiansoftware.nailgun', recursive=True),
         ]
 
       cls.register_jvm_tool(register,


### PR DESCRIPTION
### Problem

Now, we are shading the nailgun packages when we do zinc compilations.
In particular, we are shading the `NGContext` class, which makes Nailgun not recognize the signatures of the `nailMain` functions in our custom JVM nails (e.g. the [zinc compiler](https://github.com/blorente/pants/blob/e0b15b93d425b6fb556424354823bc1b0d4609a3/src/scala/org/pantsbuild/zinc/compiler/Main.scala#L178): 

```
❯ javap -cp /Users/bescobar/workspace/pants/.pants.d/bootstrap/bootstrap-jvm-tools/tool_cache/shaded_jars/org.pantsbuild.zinc.compiler.Main-b17b15407be5a36a3eb91ab41d5a97dc7ee51790-ShadedToolFingerprintStrategy_c6111d2fe766.jar org.pantsbuild.zinc.compiler.Main
Compiled from "Main.scala"
public final class org.pantsbuild.zinc.compiler.Main {
  // ...
  public static void nailMain(__shaded_by_pants__.com.martiansoftware.nailgun.NGContext);
 // ...
}
```

As a result, none of our `nailMain` functions are being run under nailgun.

### Solution

Add a shader rule to exclude the Nailgun package.

### Result

`nailMain` methods in our JVM tools are correctly picked up by Nailgun now.

```
❯ javap -cp /Users/bescobar/workspace/pants/.pants.d/bootstrap/bootstrap-jvm-tools/tool_cache/shaded_jars/org.pantsbuild.zinc.compiler.Main[...].jar org.pantsbuild.zinc.compiler.Main
Compiled from "Main.scala"
public final class org.pantsbuild.zinc.compiler.Main {
  // ...
  public static void nailMain(com.martiansoftware.nailgun.NGContext);
 // ...
}
```