### PR TITLE
[junit-run] apply platform args to junit run java exec

### DIFF
--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -324,7 +324,7 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
               distribution=distribution,
               classpath=complete_classpath,
               main=JUnit.RUNNER_MAIN,
-              jvm_options=self.jvm_options + extra_jvm_options + list(target_jvm_options),
+              jvm_options=self.jvm_options + list(platform.args) + extra_jvm_options + list(target_jvm_options),
               args=args + batch_tests,
               workunit_factory=self.context.new_workunit,
               workunit_name='run',


### PR DESCRIPTION
### Problem
When a test is using a particular jvm platform, it should also use that platform's args. See #8419

### Solution

This patch changes the junit run task to include those args in the jvm_options kwarg passed to execute the test suite.

### Result

The args are now passed to Java.

### Follow on work
I think this isn't the only place with this issue. I found it in jvm run as well.