### PR TITLE
Render cyclic path in node error to avoid --print-exception-stacktrace

### DIFF
--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -48,9 +48,9 @@ pub trait NodeError: Clone + Debug + Eq + Send {
   fn invalidated() -> Self;
 
   ///
-  /// Creates an instance that represents that a Node dependency was cyclic.
+  /// Creates an instance that represents that a Node dependency was cyclic along the given path.
   ///
-  fn cyclic() -> Self;
+  fn cyclic(path: Vec<String>) -> Self;
 }
 
 ///

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -616,7 +616,7 @@ impl NodeError for TError {
     TError::Invalidated
   }
 
-  fn cyclic() -> Self {
+  fn cyclic(_path: Vec<String>) -> Self {
     TError::Cyclic
   }
 }

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -290,7 +290,7 @@ fn cyclic_dirtying() {
 
 #[test]
 fn critical_path() {
-  use super::entry::{Entry, EntryKey};
+  use super::entry::Entry;
   // First, let's describe the scenario with plain data.
   //
   // We label the nodes with static strings to help visualise the situation.
@@ -327,7 +327,7 @@ fn critical_path() {
         .unwrap(),
     )
   };
-  let node_key = |node: &str| EntryKey::Valid(tnode(node));
+  let node_key = |node: &str| tnode(node);
   let node_entry = |node: &str| Entry::new(node_key(node));
   let node_and_duration_from_entry = |entry: &super::entry::Entry<TNode>| nodes[entry.node().0];
   let node_duration =

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1294,7 +1294,12 @@ impl NodeError for Failure {
     Failure::Invalidated
   }
 
-  fn cyclic(path: Vec<String>) -> Failure {
+  fn cyclic(mut path: Vec<String>) -> Failure {
+    let path_len = path.len();
+    if path_len > 1 {
+      path[0] += " <-";
+      path[path_len - 1] += " <-"
+    }
     throw(&format!(
       "Dep graph contained a cycle:\n  {}",
       path.join("\n  ")

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1294,8 +1294,11 @@ impl NodeError for Failure {
     Failure::Invalidated
   }
 
-  fn cyclic() -> Failure {
-    throw("Dep graph contained a cycle.")
+  fn cyclic(path: Vec<String>) -> Failure {
+    throw(&format!(
+      "Dep graph contained a cycle:\n  {}",
+      path.join("\n  ")
+    ))
   }
 }
 

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -305,7 +305,7 @@ class InlinedGraphTest(GraphTestBase):
   def do_test_cycle(self, address_str):
     scheduler = self.create_json()
     parsed_address = Address.parse(address_str)
-    self.do_test_trace_message(scheduler, parsed_address, 'Dep graph contained a cycle.')
+    self.do_test_trace_message(scheduler, parsed_address, 'Dep graph contained a cycle:')
 
   def assert_throws_are_leaves(self, error_msg, throw_name):
     def indent_of(s):


### PR DESCRIPTION
### Problem

See #5739: currently, rendering a cycle in the graph requires enabling `--print-exception-stacktrace`. But `--print-exception-stacktrace` is annoying for end users.

### Solution

Use the cyclic path that @illicitonion added in #7642 to render an error directly. And in a separate commit, remove `EntryKey`, which was only used for "recording" cycles in the `Graph`... from an era where we actually looked at the complete dump of the runtime graph, I think?

### Result

`--print-exception-stacktrace` is no longer necessary to see the "path" involved in a cycle. Fixes #5739.