### PR TITLE
Replace more `datatype()` instances with `@dataclass`

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -104,11 +104,11 @@ python_library(
   name='isolated_process',
   sources=['isolated_process.py'],
   dependencies=[
+    '3rdparty/python:dataclasses',
     ':fs',
     ':rules',
     ':selectors',
     ':platform',
-    'src/python/pants/util:objects',
   ]
 )
 

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -174,6 +174,7 @@ python_library(
   name='selectors',
   sources=['selectors.py'],
   dependencies=[
+    '3rdparty/python:dataclasses',
     'src/python/pants/util:objects',
   ]
 )

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -52,7 +52,6 @@ python_library(
     ':selectors',
     'src/python/pants/base:project_tree',
     'src/python/pants/option',
-    'src/python/pants/util:objects',
   ]
 )
 

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -94,7 +94,6 @@ python_library(
     ':objects',
     ':parser',
     'src/python/pants/build_graph',
-    'src/python/pants/util:objects',
     'src/python/pants/util:memo',
   ]
 )

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -52,6 +52,7 @@ python_library(
     ':selectors',
     'src/python/pants/base:project_tree',
     'src/python/pants/option',
+    'src/python/pants/util:meta',
   ]
 )
 
@@ -95,6 +96,7 @@ python_library(
     ':parser',
     'src/python/pants/build_graph',
     'src/python/pants/util:memo',
+    'src/python/pants/util:meta',
   ]
 )
 
@@ -107,6 +109,7 @@ python_library(
     ':rules',
     ':selectors',
     ':platform',
+    'src/python/pants/util:meta',
   ]
 )
 
@@ -175,6 +178,7 @@ python_library(
   sources=['selectors.py'],
   dependencies=[
     '3rdparty/python:dataclasses',
+    'src/python/pants/util:meta',
     'src/python/pants/util:objects',
   ]
 )

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -48,8 +48,8 @@ class PathGlobs:
   NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
   be aware of any changes to this object's definition.
   """
-  include: Tuple[str]
-  exclude: Tuple[str]
+  include: Tuple[str, ...]
+  exclude: Tuple[str, ...]
   glob_match_error_behavior: GlobMatchErrorBehavior
   conjunction: GlobExpansionConjunction
 
@@ -138,8 +138,8 @@ class Snapshot:
   sandboxes.
   """
   directory_digest: Digest
-  files: Tuple[str]
-  dirs: Tuple[str]
+  files: Tuple[str, ...]
+  dirs: Tuple[str, ...]
 
   @property
   def is_empty(self):

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -26,9 +26,6 @@ class FileContent:
       self.is_executable,
     )
 
-  def __str__(self):
-    return repr(self)
-
 
 FilesContent = Collection.of(FileContent)
 

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -3,18 +3,21 @@
 
 import os
 from dataclasses import dataclass
-from typing import Any, Tuple
+from typing import Any, Iterable, Optional, Tuple
 
 from pants.engine.objects import Collection
 from pants.engine.rules import RootRule
 from pants.option.custom_types import GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.util.dirutil import maybe_read_file, safe_delete, safe_file_dump
-from pants.util.objects import Exactly, datatype, string_list
 
 
-class FileContent(datatype([('path', str), ('content', bytes), ('is_executable', bool)])):
+@dataclass(frozen=True)
+class FileContent:
   """The content of a file."""
+  path: str
+  content: bytes
+  is_executable: bool
 
   def __repr__(self):
     return 'FileContent(path={}, content=(len:{}), is_executable={})'.format(
@@ -37,12 +40,8 @@ class InputFilesContent(FilesContent):
   """
 
 
-class PathGlobs(datatype([
-    'include',
-    'exclude',
-    ('glob_match_error_behavior', GlobMatchErrorBehavior),
-    ('conjunction', GlobExpansionConjunction),
-])):
+@dataclass(unsafe_hash=True)
+class PathGlobs:
   """A wrapper around sets of filespecs to include and exclude.
 
   The syntax supported is roughly git's glob syntax.
@@ -50,27 +49,26 @@ class PathGlobs(datatype([
   NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
   be aware of any changes to this object's definition.
   """
+  include: Tuple[str]
+  exclude: Tuple[str]
+  glob_match_error_behavior: GlobMatchErrorBehavior
+  conjunction: GlobExpansionConjunction
 
-  def __new__(cls, include, exclude=(), glob_match_error_behavior=None, conjunction=None):
-    """Given various file patterns create a PathGlobs object (without using filesystem operations).
-
-    :param include: A list of filespecs to include.
-    :param exclude: A list of filespecs to exclude.
-    :param GlobMatchErrorBehavior glob_match_error_behavior: How to respond to globs matching no
-                                                             files.
-    :param GlobExpansionConjunction conjunction: Whether all globs are expected to match at least
-                                                 one file, or if any glob matching is ok.
-    :rtype: :class:`PathGlobs`
-    """
-    return super().__new__(
-      cls,
-      include=tuple(include),
-      exclude=tuple(exclude),
-      glob_match_error_behavior=(glob_match_error_behavior or GlobMatchErrorBehavior.ignore),
-      conjunction=(conjunction or GlobExpansionConjunction.any_match))
+  def __init__(
+    self,
+    include: Iterable[str],
+    exclude: Iterable[str] = (),
+    glob_match_error_behavior: GlobMatchErrorBehavior = GlobMatchErrorBehavior.ignore,
+    conjunction: GlobExpansionConjunction = GlobExpansionConjunction.any_match
+  ) -> None:
+    self.include = tuple(include)
+    self.exclude = tuple(exclude)
+    self.glob_match_error_behavior = glob_match_error_behavior
+    self.conjunction = conjunction
 
 
-class Digest(datatype([('fingerprint', str), ('serialized_bytes_length', int)])):
+@dataclass(frozen=True)
+class Digest:
   """A Digest is a content-digest fingerprint, and a length of underlying content.
 
   These are used both to reference digests of strings/bytes/content, and as an opaque handle to a
@@ -87,6 +85,8 @@ class Digest(datatype([('fingerprint', str), ('serialized_bytes_length', int)]))
   relies on the latter existing. This can be resolved when ordering is removed from Snapshots. See
   https://github.com/pantsbuild/pants/issues/5802
   """
+  fingerprint: str
+  serialized_bytes_length: int
 
   @classmethod
   def _path(cls, digested_path):
@@ -115,21 +115,9 @@ class Digest(datatype([('fingerprint', str), ('serialized_bytes_length', int)]))
     payload = '{}:{}'.format(self.fingerprint, self.serialized_bytes_length)
     safe_file_dump(self._path(digested_path), payload=payload)
 
-  def __repr__(self):
-    return '''Digest(fingerprint={}, serialized_bytes_length={})'''.format(
-      self.fingerprint,
-      self.serialized_bytes_length
-    )
 
-  def __str__(self):
-    return repr(self)
-
-
-class PathGlobsAndRoot(datatype([
-    ('path_globs', PathGlobs),
-    ('root', str),
-    ('digest_hint', Exactly(Digest, type(None))),
-])):
+@dataclass(frozen=True)
+class PathGlobsAndRoot:
   """A set of PathGlobs to capture relative to some root (which may exist outside of the buildroot).
 
   If the `digest_hint` is set, it must be the Digest that we would expect to get if we were to
@@ -137,30 +125,37 @@ class PathGlobsAndRoot(datatype([
   operations in cases where the expected Digest is known, and the content for the Digest is already
   stored.
   """
+  path_globs: PathGlobs
+  root: str
+  digest_hint: Optional[Digest] = None
 
-  def __new__(cls, path_globs, root, digest_hint=None):
-    return super().__new__(cls, path_globs, root, digest_hint)
 
-
-class Snapshot(datatype([('directory_digest', Digest), ('files', tuple), ('dirs', tuple)])):
+@dataclass(frozen=True)
+class Snapshot:
   """A Snapshot is a collection of file paths and dir paths fingerprinted by their names/content.
 
   Snapshots are used to make it easier to isolate process execution by fixing the contents
   of the files being operated on and easing their movement to and from isolated execution
   sandboxes.
   """
+  directory_digest: Digest
+  files: Tuple[str]
+  dirs: Tuple[str]
 
   @property
   def is_empty(self):
     return self == EMPTY_SNAPSHOT
 
 
-class DirectoriesToMerge(datatype([('directories', tuple)])):
-  pass
+@dataclass(frozen=True)
+class DirectoriesToMerge:
+  directories: Tuple
 
 
-class DirectoryWithPrefixToStrip(datatype([('directory_digest', Digest), ('prefix', str)])):
-  pass
+@dataclass(frozen=True)
+class DirectoryWithPrefixToStrip:
+  directory_digest: Digest
+  prefix: str
 
 
 @dataclass(frozen=True)
@@ -169,22 +164,29 @@ class DirectoryWithPrefixToAdd:
   prefix: str
 
 
-class DirectoryToMaterialize(datatype([('path', str), ('directory_digest', Digest)])):
+@dataclass(frozen=True)
+class DirectoryToMaterialize:
   """A request to materialize the contents of a directory digest at the provided path."""
+  path: str
+  directory_digest: Digest
 
 
 DirectoriesToMaterialize = Collection.of(DirectoryToMaterialize)
 
 
-class MaterializeDirectoryResult(datatype([('output_paths', string_list)])):
+@dataclass(frozen=True)
+class MaterializeDirectoryResult:
   """Result of materializing a directory, contains the full output paths."""
+  output_paths: Tuple[str, ...]
 
 
 MaterializeDirectoriesResult = Collection.of(MaterializeDirectoryResult)
 
 
-class UrlToFetch(datatype([('url', str), ('digest', Digest)])):
-  pass
+@dataclass(frozen=True)
+class UrlToFetch:
+  url: str
+  digest: Digest
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -10,6 +10,7 @@ from pants.engine.rules import RootRule
 from pants.option.custom_types import GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.util.dirutil import maybe_read_file, safe_delete, safe_file_dump
+from pants.util.meta import frozen_after_init
 
 
 @dataclass(frozen=True)
@@ -37,6 +38,7 @@ class InputFilesContent(FilesContent):
   """
 
 
+@frozen_after_init
 @dataclass(unsafe_hash=True)
 class PathGlobs:
   """A wrapper around sets of filespecs to include and exclude.

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -8,6 +8,7 @@ from typing import Dict, Optional, Tuple, Union
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest
 from pants.engine.platform import PlatformConstraint
 from pants.engine.rules import RootRule, rule
+from pants.util.meta import frozen_after_init
 
 
 logger = logging.getLogger(__name__)
@@ -20,6 +21,7 @@ class ProductDescription:
   value: str
 
 
+@frozen_after_init
 @dataclass(unsafe_hash=True)
 class ExecuteProcessRequest:
   """Request for execution with args and snapshots to extract."""
@@ -60,6 +62,7 @@ class ExecuteProcessRequest:
     self.jdk_home = jdk_home
 
 
+@frozen_after_init
 @dataclass(unsafe_hash=True)
 class MultiPlatformExecuteProcessRequest:
   # args collects a set of tuples representing platform constraints mapped to a req,

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -1,6 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import dataclasses
 import logging
 from collections import defaultdict, deque
 from contextlib import contextmanager
@@ -530,7 +531,9 @@ def hydrate_sources(
   """
   # TODO(#5864): merge the target's selection of --glob-expansion-failure (which doesn't exist yet)
   # with the global default!
-  path_globs = sources_field.path_globs.copy(glob_match_error_behavior=glob_match_error_behavior)
+  path_globs = dataclasses.replace(
+    sources_field.path_globs, glob_match_error_behavior=glob_match_error_behavior
+  )
   snapshot = yield Get(Snapshot, PathGlobs, path_globs)
   fileset_with_spec = _eager_fileset_with_spec(
     sources_field.address.spec_path,
@@ -546,7 +549,7 @@ def hydrate_bundles(
 ) -> HydratedField:
   """Given a BundlesField, request Snapshots for each of its filesets and create BundleAdaptors."""
   path_globs_with_match_errors = [
-    pg.copy(glob_match_error_behavior=glob_match_error_behavior)
+    dataclasses.replace(pg, glob_match_error_behavior=glob_match_error_behavior)
     for pg in bundles_field.path_globs_list
   ]
   snapshot_list = yield [Get(Snapshot, PathGlobs, pg) for pg in path_globs_with_match_errors]

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -10,6 +10,7 @@ from pants.build_graph.address import BuildFileAddress
 from pants.engine.objects import Serializable
 from pants.engine.parser import Parser
 from pants.util.memo import memoized_property
+from pants.util.meta import frozen_after_init
 
 
 class MappingError(Exception):
@@ -155,6 +156,7 @@ class ResolveError(MappingError):
   """Indicates an error resolving targets."""
 
 
+@frozen_after_init
 @dataclass(unsafe_hash=True)
 class AddressMapper:
   """Configuration to parse build files matching a filename pattern."""

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -6,9 +6,11 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import Any, Tuple, Type
 
+from pants.util.meta import frozen_after_init
 from pants.util.objects import TypeConstraint
 
 
+@frozen_after_init
 @dataclass(unsafe_hash=True)
 class Get:
   """Experimental synchronous generator API.
@@ -94,6 +96,7 @@ class Get:
     return cls(product_type, subject_type, None)
 
 
+@frozen_after_init
 @dataclass(unsafe_hash=True)
 class Params:
   """A set of values with distinct types.

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -103,7 +103,7 @@ class Params:
 
   Distinct types are enforced at consumption time by the rust type of the same name.
   """
-  params: Tuple[Any]
+  params: Tuple[Any, ...]
 
   def __init__(self, *args: Any) -> None:
     self.params = tuple(args)

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -14,8 +14,8 @@ python_library(
     'src/python/pants/base:hash_utils',
     'src/python/pants/engine:selectors',
     'src/python/pants/util:eval',
-    'src/python/pants/util:memo',
     'src/python/pants/util:meta',
+    'src/python/pants/util:memo',
     'src/python/pants/util:objects',
     'src/python/pants/util:strutil',
   ]

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -8,7 +8,9 @@ import itertools
 import os
 from abc import ABC
 from contextlib import contextmanager
+from dataclasses import dataclass
 from hashlib import sha1
+from typing import ClassVar, Tuple
 
 from twitter.common.collections import OrderedSet
 
@@ -23,7 +25,7 @@ class Config(ABC):
   Supports recursive variable substitution using standard python format strings. E.g.,
   %(var_name)s will be replaced with the value of var_name.
   """
-  DEFAULT_SECTION = configparser.DEFAULTSECT
+  DEFAULT_SECTION: ClassVar[str] = configparser.DEFAULTSECT
 
   class ConfigError(Exception):
     pass
@@ -181,7 +183,8 @@ class Config(ABC):
     raise NotImplementedError
 
 
-class _EmptyConfig(datatype([]), Config):
+@dataclass(frozen=True)
+class _EmptyConfig(Config):
   """A dummy config with no data at all."""
 
   def sources(self):
@@ -251,12 +254,14 @@ class _SingleFileConfig(Config):
     return hash(self.content_digest)
 
 
-class _ChainedConfig(datatype(['chained_configs']), Config):
+@dataclass(frozen=True)
+class _ChainedConfig(Config):
   """Config read from multiple sources.
 
-  :param configs: A tuple of Config instances to chain.
-                  Later instances take precedence over earlier ones.
+  :param chained_configs: A tuple of Config instances to chain. Later instances take precedence
+                          over earlier ones.
   """
+  chained_configs: Tuple[Config, ...]
 
   @property
   def _configs(self):

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -16,6 +16,7 @@ from pants.option.parser import Parser
 from pants.option.parser_hierarchy import ParserHierarchy, all_enclosing_scopes, enclosing_scope
 from pants.option.scope import ScopeInfo
 from pants.util.memo import memoized_method, memoized_property
+from pants.util.meta import frozen_after_init
 
 
 def make_flag_regex(long_name, short_name=None):
@@ -365,6 +366,7 @@ class Options:
             hint='Use scope {} instead (options: {})'.format(scope, ', '.join(explicit_keys))
           )
 
+  @frozen_after_init
   @dataclass(unsafe_hash=True)
   class _ScopedFlagNameForFuzzyMatching:
     """Specify how a registered option would look like on the command line.

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -6,6 +6,8 @@ import logging
 import os
 import stat
 import sys
+from dataclasses import dataclass
+from typing import Tuple
 
 from pants.base.build_environment import get_default_pants_config_file
 from pants.engine.fs import FileContent
@@ -16,20 +18,20 @@ from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.options import Options
 from pants.util.dirutil import read_file
 from pants.util.memo import memoized_method, memoized_property
-from pants.util.objects import SubclassesOf, datatype
 from pants.util.strutil import ensure_text
 
 
 logger = logging.getLogger(__name__)
 
 
-class OptionsBootstrapper(datatype([
-  ('env_tuples', tuple),
-  ('bootstrap_args', tuple),
-  ('args', tuple),
-  ('config', SubclassesOf(Config)),
-])):
-  """Holds the result of the first stage of options parsing, and assists with parsing full options."""
+@dataclass(frozen=True)
+class OptionsBootstrapper:
+  """Holds the result of the first stage of options parsing, and assists with parsing full
+  options."""
+  env_tuples: Tuple
+  bootstrap_args: Tuple
+  args: Tuple
+  config: Config
 
   @staticmethod
   def get_config_file_paths(env, args):

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -45,6 +45,7 @@ from pants.option.errors import (
 from pants.option.option_util import is_dict_option, is_list_option
 from pants.option.ranked_value import RankedValue
 from pants.option.scope import ScopeInfo
+from pants.util.meta import frozen_after_init
 
 
 class Parser:
@@ -141,6 +142,7 @@ class Parser:
     for child in self._child_parsers:
       child.walk(callback)
 
+  @frozen_after_init
   @dataclass(unsafe_hash=True)
   class ParseArgsRequest:
     flag_value_map: Dict

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -7,6 +7,8 @@ import os
 import re
 import traceback
 from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable
 
 import Levenshtein
 import yaml
@@ -43,7 +45,6 @@ from pants.option.errors import (
 from pants.option.option_util import is_dict_option, is_list_option
 from pants.option.ranked_value import RankedValue
 from pants.option.scope import ScopeInfo
-from pants.util.objects import SubclassesOf, datatype
 
 
 class Parser:
@@ -140,12 +141,35 @@ class Parser:
     for child in self._child_parsers:
       child.walk(callback)
 
-  class ParseArgsRequest(datatype([
-      ('flag_value_map', SubclassesOf(dict)),
-      'namespace',
-      'get_all_scoped_flag_names',
-      ('levenshtein_max_distance', int),
-  ])):
+  @dataclass(unsafe_hash=True)
+  class ParseArgsRequest:
+    flag_value_map: Dict
+    namespace: Any
+    get_all_scoped_flag_names: Callable[[], Iterable]
+    levenshtein_max_distance: int
+
+    def __init__(
+      self,
+      flags_in_scope: Iterable[str],
+      namespace,
+      get_all_scoped_flag_names: Callable[[], Iterable],
+      levenshtein_max_distance: int
+    ) -> None:
+      """
+      :param flags_in_scope: Iterable of arg strings to parse into flag values.
+      :param namespace: The object to register the flag values on
+      :param get_all_scoped_flag_names: A 0-argument function which returns an iterable of
+                                        all registered option names in all their scopes. This
+                                        is used to create an error message with suggestions
+                                        when raising a `ParseError`.
+      :param levenshtein_max_distance: The maximum Levenshtein edit distance between option names
+                                       to determine similarly named options when an option name
+                                       hasn't been registered.
+      """
+      self.flag_value_map = self._create_flag_value_map(flags_in_scope)
+      self.namespace = namespace
+      self.get_all_scoped_flag_names = get_all_scoped_flag_names
+      self.levenshtein_max_distance = levenshtein_max_distance
 
     @staticmethod
     def _create_flag_value_map(flags):
@@ -169,25 +193,6 @@ class Parser:
             flag_val = None
         flag_value_map[key].append(flag_val)
       return flag_value_map
-
-    def __new__(cls, flags_in_scope, namespace,
-                get_all_scoped_flag_names,
-                levenshtein_max_distance):
-      """
-      :param Iterable flags_in_scope: Iterable of arg strings to parse into flag values.
-      :param namespace: The object to register the flag values on
-      :param function get_all_scoped_flag_names: A 0-argument function which returns an iterable of
-                                                 all registered option names in all their scopes. This
-                                                 is used to create an error message with suggestions
-                                                 when raising a `ParseError`.
-      :param int levenshtein_max_distance: The maximum Levenshtein edit distance between option names
-                                           to determine similarly named options when an option name
-                                           hasn't been registered.
-      """
-      flag_value_map = cls._create_flag_value_map(flags_in_scope)
-      return super(Parser.ParseArgsRequest, cls).__new__(cls, flag_value_map, namespace,
-                                                         get_all_scoped_flag_names,
-                                                         levenshtein_max_distance)
 
   def parse_args(self, parse_args_request):
     """Set values for this parser's options on the namespace object.

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -2,42 +2,41 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
+from typing import Any, ClassVar, Optional
 
 from pants.option.option_value_container import OptionValueContainer
-from pants.util.objects import datatype
 
 
 GLOBAL_SCOPE = ''
 GLOBAL_SCOPE_CONFIG_SECTION = 'GLOBAL'
 
 
-class Scope(datatype([('scope', str)])):
+@dataclass(frozen=True)
+class Scope:
   """An options scope."""
+  scope: str
 
 
-class ScopeInfo(datatype([
-  'scope',
-  'category',
-  'optionable_cls',
+@dataclass(frozen=True, order=True)
+class ScopeInfo:
+  """Information about a scope."""
+  scope: Scope
+  category: Any
+  optionable_cls: Optional[Any] = None
   # A ScopeInfo may have a deprecated_scope (from its associated optionable_cls), which represents a
   # previous/deprecated name for a current/non-deprecated ScopeInfo. It may also be directly
   # deprecated via this `removal_version`, which allows for the deprecation of an entire scope,
   # including that of a SubsystemDependency (ie, deprecation of a dependency on a scoped Subsystem).
-  'removal_version',
-  'removal_hint',
-])):
-  """Information about a scope."""
+  removal_version: Optional[Any] = None
+  removal_hint: Optional[Any] = None
 
   # Symbolic constants for different categories of scope.
-  GLOBAL = 'GLOBAL'
-  GOAL = 'GOAL'
-  GOAL_V1 = 'GOAL_V1'
-  TASK = 'TASK'
-  SUBSYSTEM = 'SUBSYSTEM'
-  INTERMEDIATE = 'INTERMEDIATE'  # Scope added automatically to fill out the scope hierarchy.
-
-  def __new__(cls, scope, category, optionable_cls=None, removal_version=None, removal_hint=None):
-    return super().__new__(cls, scope, category, optionable_cls, removal_version, removal_hint)
+  GLOBAL: ClassVar[str] = 'GLOBAL'
+  GOAL: ClassVar[str] = 'GOAL'
+  GOAL_V1: ClassVar[str] = 'GOAL_V1'
+  TASK: ClassVar[str] = 'TASK'
+  SUBSYSTEM: ClassVar[str] = 'SUBSYSTEM'
+  INTERMEDIATE: ClassVar[str] = 'INTERMEDIATE'  # Scope added automatically to fill out the scope hierarchy.
 
   @property
   def description(self):

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -97,10 +97,13 @@ python_library(
   name = 'task_test_base',
   sources = ['task_test_base.py'],
   dependencies = [
+    '3rdparty/python:dataclasses',
     'src/python/pants/goal:context',
     'src/python/pants/ivy',
     'src/python/pants/task',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:memo',
+    'src/python/pants/util:meta',
     'tests/python/pants_test:test_base',
   ]
 )

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -81,6 +81,7 @@ python_tests(
     'src/python/pants/engine:isolated_process',
     'src/python/pants/engine:rules',
     'src/python/pants/engine:selectors',
+    'src/python/pants/util:contextutil',
     'tests/python/pants_test:test_base',
     'tests/python/pants_test/engine/examples:fs_test',
     'tests/python/pants_test/engine/examples:scheduler_inputs',

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -76,6 +76,7 @@ python_tests(
   name='isolated_process',
   sources=['test_isolated_process.py'],
   dependencies=[
+    '3rdparty/python:dataclasses',
     'src/python/pants/engine:fs',
     'src/python/pants/engine:isolated_process',
     'src/python/pants/engine:rules',

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -138,7 +138,7 @@ class JavacSources:
   See CatExecutionRequest and rules above for an example of using PathGlobs
   which does not introduce this additional layer of indirection.
   """
-  java_files: Tuple[str]
+  java_files: Tuple[str, ...]
 
 
 @dataclass(frozen=True)

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -25,7 +25,6 @@ from pants.engine.rules import RootRule, rule
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Get
 from pants.util.contextutil import temporary_dir
-from pants.util.objects import TypeCheckError
 from pants_test.test_base import TestBase
 
 
@@ -199,69 +198,6 @@ def create_javac_compile_rules():
 
 
 class ExecuteProcessRequestTest(unittest.TestCase):
-  def _default_args_execute_process_request(self, argv=tuple(), env=None):
-    env = env or dict()
-    return ExecuteProcessRequest(
-      argv=argv,
-      description='',
-      env=env,
-      input_files=EMPTY_DIRECTORY_DIGEST,
-      output_files=(),
-    )
-
-  def test_blows_up_on_invalid_args(self):
-    try:
-      self._default_args_execute_process_request()
-    except ValueError:
-      self.assertTrue(False, "should be able to construct without error")
-
-    with self.assertRaises(TypeCheckError):
-      self._default_args_execute_process_request(argv=1)
-    with self.assertRaises(TypeCheckError):
-      self._default_args_execute_process_request(argv='1')
-    with self.assertRaises(TypeCheckError):
-      self._default_args_execute_process_request(argv=('1',), env='foo=bar')
-
-
-    with self.assertRaisesRegexp(TypeCheckError, "env"):
-      ExecuteProcessRequest(
-        argv=('1',),
-        env=(),
-        input_files='',
-        output_files=(),
-        output_directories=(),
-        timeout_seconds=0.1,
-        description=''
-      )
-    with self.assertRaisesRegexp(TypeCheckError, "input_files"):
-      ExecuteProcessRequest(argv=('1',),
-        env=dict(),
-        input_files=3,
-        output_files=(),
-        output_directories=(),
-        timeout_seconds=0.1,
-        description=''
-      )
-    with self.assertRaisesRegexp(TypeCheckError, "output_files"):
-      ExecuteProcessRequest(
-        argv=('1',),
-        env=dict(),
-        input_files=EMPTY_DIRECTORY_DIGEST,
-        output_files=("blah"),
-        output_directories=(),
-        timeout_seconds=0.1,
-        description=''
-      )
-    with self.assertRaisesRegexp(TypeCheckError, "timeout"):
-      ExecuteProcessRequest(
-        argv=('1',),
-        env=dict(),
-        input_files=EMPTY_DIRECTORY_DIGEST,
-        output_files=("blah"),
-        output_directories=(),
-        timeout_seconds=None,
-        description=''
-      )
 
   def test_create_from_snapshot_with_env(self):
     req = ExecuteProcessRequest(


### PR DESCRIPTION
Builds off of https://github.com/pantsbuild/pants/pull/8362, this time tackling trickier instances.

This introduces a new idiom of using `@dataclass(unsafe_hash=True)`. Certain custom `__new__` implementations could not be implemented using either the normal dataclass auto-generated `__init__()` nor through `__post_init__()`. When `frozen=True`, it is impossible to implement your own `__init__()` because you cannot set attribute values. So, we cannot use `frozen=True` but still must have a hash to work with V2. `unsafe_hash=True` does this for us. We use `@frozen_after_init` from https://github.com/pantsbuild/pants/pull/8431 to ensure that we don't accidentally mutate the object after.