### PR TITLE
Type check `meta.py` and replace `Singleton` with `SingletonMetaclass`

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -9,7 +9,7 @@ python_library(
     'src/python/pants/scm',
     'src/python/pants/scm:git',
     'src/python/pants:version',
-  ]
+  ],
 )
 
 python_library(

--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -5,11 +5,11 @@ import os
 from contextlib import contextmanager
 from pathlib import Path
 
-from pants.util.meta import Singleton
+from pants.util.meta import SingletonMetaclass
 
 
 # TODO: Even this should probably just be a new-style option?
-class BuildRoot(Singleton):
+class BuildRoot(metaclass=SingletonMetaclass):
   """Represents the global workspace build root.
 
   By default a Pants workspace is defined by a root directory where one of multiple sentinel files

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -18,7 +18,7 @@ from pants.engine.selectors import Get
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import read_file, safe_mkdir, safe_mkdtemp
 from pants.util.memo import memoized_classproperty, memoized_property
-from pants.util.meta import Singleton
+from pants.util.meta import SingletonMetaclass
 from pants.util.objects import SubclassesOf, datatype
 
 
@@ -612,7 +612,7 @@ class ExternContext:
     return self._lib.val_for(key)
 
 
-class Native(Singleton):
+class Native(metaclass=SingletonMetaclass):
   """Encapsulates fetching a platform specific version of the native portion of the engine."""
 
   _errors_during_execution = None

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -79,6 +79,7 @@ python_library(
 python_library(
   name = 'meta',
   sources = ['meta.py'],
+  tags = {'type_checked'},
 )
 
 python_library(

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -3,7 +3,14 @@
 
 
 class SingletonMetaclass(type):
-  """Singleton metaclass."""
+  """When using this metaclass in your class definition, your class becomes a singleton. That is,
+  every construction returns the same instance.
+
+  Example class definition:
+
+    class Unicorn(metaclass=SingletonMetaclass):
+      pass
+  """
 
   def __call__(cls, *args, **kwargs):
     # TODO: convert this into an `@memoized_classproperty`!
@@ -96,9 +103,3 @@ def staticproperty(func):
     func = staticmethod(func)
 
   return ClassPropertyDescriptor(func, doc)
-
-
-# TODO: look into merging this with `enum` and `ChoicesMixin`, which describe a fixed set of
-# singletons, to decouple the enum interface from the implementation as a `datatype`.
-# Extend Singleton and your class becomes a singleton, each construction returns the same instance.
-Singleton = SingletonMetaclass('Singleton', (object,), {})

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -3,7 +3,7 @@
 
 from abc import ABC, abstractmethod
 
-from pants.util.meta import Singleton, classproperty, staticproperty
+from pants.util.meta import SingletonMetaclass, classproperty, staticproperty
 from pants_test.test_base import TestBase
 
 
@@ -30,7 +30,7 @@ class AbstractClassTest(TestBase):
 
 class SingletonTest(TestBase):
   def test_singleton(self):
-    class One(Singleton):
+    class One(metaclass=SingletonMetaclass):
       pass
 
     self.assertIs(One(), One())


### PR DESCRIPTION
`meta.py` is used by over 705 targets, so we must add type hints to it.

Beyond adding hints, we must remove `Singleton` to have instead people use `SingletonMetaclass`. MyPy works reasonably well with metaclasses but does much better when using the explicit `class Foo(metaclass=MyMC):` form, rather than conventional inheritance, per https://mypy.readthedocs.io/en/latest/metaclasses.html. By using the explicit metaclass form, we get MyPy to stop failing on usages of `Singleton`.

