### PR TITLE
Set internal `pants.ini` to use chroot for V1 Pytest runner

### DIFF
--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -215,8 +215,8 @@ class TestStrategy(Enum):
     if self == self.v2_remote and oauth_token_path is None:  # type: ignore
       raise ValueError("Must specify oauth_token_path.")
     result: List[str] = {  # type: ignore
-      self.v1_no_chroot: ["./pants.pex", "test", *sorted(targets), *PYTEST_PASSTHRU_ARGS],
-      self.v1_chroot: ["./pants.pex", "--test-pytest-chroot", "test", *sorted(targets), *PYTEST_PASSTHRU_ARGS],
+      self.v1_no_chroot: ["./pants.pex", "test.pytest", "--no-chroot", *sorted(targets), *PYTEST_PASSTHRU_ARGS],
+      self.v1_chroot: ["./pants.pex", "test", *sorted(targets), *PYTEST_PASSTHRU_ARGS],
       self.v2_local: ["./pants.pex", "--no-v1", "--v2", "test", *sorted(targets)],
       self.v2_remote: [
                         "./pants.pex",
@@ -232,7 +232,7 @@ class TestStrategy(Enum):
                       ],
     }[self]
     if shard is not None and self in [self.v1_no_chroot, self.v1_chroot]:  # type: ignore
-      result.insert(1, f"--test-pytest-test-shard={shard}")
+      result.insert(2, f"--test-shard={shard}")
     return result
 
 
@@ -550,14 +550,10 @@ def run_plugin_tests(*, oauth_token_path: Optional[str] = None) -> None:
 
 
 def run_platform_specific_tests() -> None:
-  targets = ["src/python/::", "tests/python::"]
+  command = TestStrategy.v1_no_chroot.pants_command(targets=["src/python/::", "tests/python::"])
+  command.insert(1, "--tag=+platform_specific_behavior")
   _run_command(
-    ["./pants.pex",
-     "--tag=+platform_specific_behavior",
-     "test",
-     *targets,
-     *PYTEST_PASSTHRU_ARGS,
-     ],
+    command,
     slug="PlatformSpecificTests",
     start_message=f"Running platform-specific tests on platform {platform.system()}",
     die_message="Pants platform-specific test failure."

--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -216,7 +216,7 @@ class TestStrategy(Enum):
       raise ValueError("Must specify oauth_token_path.")
     result: List[str] = {  # type: ignore
       self.v1_no_chroot: ["./pants.pex", "test.pytest", "--no-chroot", *sorted(targets), *PYTEST_PASSTHRU_ARGS],
-      self.v1_chroot: ["./pants.pex", "test", *sorted(targets), *PYTEST_PASSTHRU_ARGS],
+      self.v1_chroot: ["./pants.pex", "test.pytest", *sorted(targets), *PYTEST_PASSTHRU_ARGS],
       self.v2_local: ["./pants.pex", "--no-v1", "--v2", "test", *sorted(targets)],
       self.v2_remote: [
                         "./pants.pex",
@@ -232,7 +232,7 @@ class TestStrategy(Enum):
                       ],
     }[self]
     if shard is not None and self in [self.v1_no_chroot, self.v1_chroot]:  # type: ignore
-      result.insert(2, f"--test-shard={shard}")
+      result.insert(2, f"--test-pytest-test-shard={shard}")
     return result
 
 

--- a/pants.ini
+++ b/pants.ini
@@ -399,8 +399,7 @@ resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
 
 [test.pytest]
 fast: false
-# TODO(7281): turn this to true once the majority of integration tests use `--chroot`.
-chroot: false
+chroot: true
 timeouts: true
 timeout_default: 60
 


### PR DESCRIPTION
Now that the majority of ITs and unit tests work with `--test-pytest-chroot`, we set `pants.ini` so that we use this setting by default. This reduces the risk of Pants devs writing a test that does not work with chroot.