### PR TITLE
Run testprojects integration tests with V2 test runner

### DIFF
--- a/build-support/ci_lists/integration_v2_blacklist.txt
+++ b/build-support/ci_lists/integration_v2_blacklist.txt
@@ -11,6 +11,5 @@ tests/python/pants_test/backend/jvm/tasks:junit_tests_concurrency_integration
 tests/python/pants_test/backend/jvm/tasks:junit_tests_integration
 tests/python/pants_test/backend/jvm/tasks:jvm_run_integration
 tests/python/pants_test/base:exception_sink_integration
-tests/python/pants_test/projects:testprojects_integration
 tests/python/pants_test/reporting:reporting_integration
 tests/python/pants_test/tasks:bootstrap_jvm_tools_integration

--- a/examples/src/thrift/org/pantsbuild/example/BUILD
+++ b/examples/src/thrift/org/pantsbuild/example/BUILD
@@ -19,6 +19,9 @@ page(
 files(
   name = 'distance_directory',
   sources = rglobs('distance/*'),
+  dependencies = [
+    'examples/3rdparty:python_directory',
+  ],
 )
 
 files(
@@ -26,5 +29,6 @@ files(
   sources = rglobs('precipitation/*'),
   dependencies = [
     ':distance_directory',
+    'examples/3rdparty:python_directory',
   ],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/BUILD
@@ -54,6 +54,8 @@ target(
     ':typeparameters_directory',
     ':unicode_directory',
     ':utf8proto_directory',
+    # NB: See `:javasources_directory` for why this must be declared here.
+    'testprojects/src/scala/org/pantsbuild/testproject:javasources_directory',
   ],
 )
 
@@ -187,6 +189,9 @@ files(
   ],
 )
 
+# NB: This has a circular dependency on
+# 'testprojects/src/scala/org/pantsbuild/testproject:javasources_directory', which we cannot declare
+# here. Instead, we declare this in `:all_targets`.
 files(
   name = 'javasources_directory',
   sources = rglobs('javasources/*'),

--- a/testprojects/src/thrift/org/pantsbuild/BUILD
+++ b/testprojects/src/thrift/org/pantsbuild/BUILD
@@ -13,14 +13,23 @@ target(
 files(
   name='constants_only_directory',
   sources=rglobs('constants_only/*'),
+  dependencies = [
+    'examples/3rdparty:python_directory',
+  ],
 )
 
 files(
   name='testproject_directory',
   sources=rglobs('testproject/*'),
+  dependencies = [
+    'examples/3rdparty:python_directory',
+  ],
 )
 
 files(
   name='thrift_exports_directory',
   sources=rglobs('thrift_exports/*'),
+  dependencies = [
+    'examples/3rdparty:python_directory',
+  ],
 )

--- a/tests/python/pants_test/projects/BUILD
+++ b/tests/python/pants_test/projects/BUILD
@@ -1,34 +1,135 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_tests(
-  name="testprojects_integration",
-  sources=['test_testprojects_integration.py'],
-  dependencies=[
-    'examples/src/antlr/org/pantsbuild/example:all_directories',
-    'examples/src/java/org/pantsbuild/example:all_directories',
-    'examples/src/protobuf/org/pantsbuild/example:all_directories',
-    'examples/src/python/example:all_directories',
-    'examples/src/scala/org/pantsbuild/example:all_directories',
-    'examples/src/thrift/org/pantsbuild/example:all_directories',
-    'examples/src/wire/org/pantsbuild/example:all_directories',
-    'examples/tests/java/org/pantsbuild/example:all_directories',
-    'examples/tests/python/example_test:all_directories',
-    'examples/tests/scala/org/pantsbuild/example:all_directories',
-    'src/python/pants/util:contextutil',
+python_library(
+  name = "projects_test_base",
+  source = 'projects_test_base.py',
+  dependencies = [
     'tests/python/pants_test:int-test',
-    'tests/python/pants_test:test_base',
-    'testprojects/maven_layout:all_directories',
+  ],
+)
+
+python_tests(
+  name = "antlr_projects_integration",
+  source = "test_antlr_projects_integration.py",
+  dependencies = [
+    ':projects_test_base',
+    'examples/src/antlr/org/pantsbuild/example:all_directories',
     'testprojects/src/antlr/python:all_directories',
+  ],
+  tags = {'integration'},
+)
+
+python_tests(
+  name = "java_examples_integration",
+  source = "test_java_examples_integration.py",
+  dependencies = [
+    ':projects_test_base',
+    'examples/src/java/org/pantsbuild/example:all_directories',
+    'examples/tests/java/org/pantsbuild/example:all_directories',
+  ],
+  tags = {'integration'},
+  timeout = 300,
+)
+
+python_tests(
+  name = "java_testprojects_integration",
+  source = "test_java_testprojects_integration.py",
+  dependencies = [
+    ':projects_test_base',
     'testprojects/src/java/org/pantsbuild/testproject:all_directories',
-    'testprojects/src/protobuf/org/pantsbuild/testproject:all_directories',
-    'testprojects/src/python:all_directories',
-    'testprojects/src/scala/org/pantsbuild/testproject:all_directories',
-    'testprojects/src/thrift/org/pantsbuild:all_directories',
     'testprojects/tests/java/org/pantsbuild:all_directories',
+  ],
+  tags = {'integration'},
+  timeout = 300,
+)
+
+python_tests(
+  name = "maven_layout_integration",
+  source = "test_maven_layout_integration.py",
+  dependencies = [
+    ':projects_test_base',
+    'testprojects/maven_layout:all_directories',
+  ],
+  tags = {'integration'},
+)
+
+python_tests(
+  name = "protobuf_projects_integration",
+  source = "test_protobuf_projects_integration.py",
+  dependencies = [
+    ':projects_test_base',
+    'examples/src/protobuf/org/pantsbuild/example:all_directories',
+    'testprojects/src/protobuf/org/pantsbuild/testproject:all_directories',
+  ],
+  tags = {'integration'},
+)
+
+python_tests(
+  name = "thrift_projects_integration",
+  source = "test_thrift_projects_integration.py",
+  dependencies = [
+    ':projects_test_base',
+    'examples/src/thrift/org/pantsbuild/example:all_directories',
+    'testprojects/src/thrift/org/pantsbuild:all_directories',
+  ],
+  tags = {'integration'},
+)
+
+python_tests(
+  name = "wire_projects_integration",
+  source = "test_wire_projects_integration.py",
+  dependencies = [
+    ':projects_test_base',
+    'examples/src/wire/org/pantsbuild/example:all_directories',
+  ],
+  tags = {'integration'},
+)
+
+python_tests(
+  name = "python_examples_integration",
+  source = "test_python_examples_integration.py",
+  dependencies = [
+    ':projects_test_base',
+    'examples/src/python/example:all_directories',
+    'examples/tests/python/example_test:all_directories',
+  ],
+  tags = {'integration'},
+  timeout = 300,
+)
+
+python_tests(
+  name = "python_testprojects_integration",
+  source = "test_python_testprojects_integration.py",
+  dependencies = [
+    ':projects_test_base',
+    'testprojects/src/python:all_directories',
     'testprojects/tests/python:all_directories',
+  ],
+  tags = {'integration'},
+  timeout = 300,
+)
+
+python_tests(
+  name = "scala_examples_integration",
+  source = "test_scala_examples_integration.py",
+  dependencies = [
+    ':projects_test_base',
+    'examples/src/scala/org/pantsbuild/example:all_directories',
+    'examples/tests/scala/org/pantsbuild/example:all_directories',
+  ],
+  tags = {'integration'},
+  timeout = 300,
+)
+
+python_tests(
+  name = "scala_testprojects_integration",
+  source = "test_scala_testprojects_integration.py",
+  dependencies = [
+    ':projects_test_base',
+    'testprojects/src/scala/org/pantsbuild/testproject:all_directories',
     'testprojects/tests/scala/org/pantsbuild/testproject:all_directories',
   ],
   tags = {'integration'},
-  timeout=1400,
+  timeout = 300,
 )

--- a/tests/python/pants_test/projects/BUILD
+++ b/tests/python/pants_test/projects/BUILD
@@ -18,6 +18,7 @@ python_tests(
     'testprojects/src/antlr/python:all_directories',
   ],
   tags = {'integration'},
+  timeout = 200,
 )
 
 python_tests(
@@ -29,7 +30,7 @@ python_tests(
     'examples/tests/java/org/pantsbuild/example:all_directories',
   ],
   tags = {'integration'},
-  timeout = 300,
+  timeout = 360,
 )
 
 python_tests(
@@ -41,7 +42,7 @@ python_tests(
     'testprojects/tests/java/org/pantsbuild:all_directories',
   ],
   tags = {'integration'},
-  timeout = 300,
+  timeout = 400,
 )
 
 python_tests(
@@ -52,6 +53,7 @@ python_tests(
     'testprojects/maven_layout:all_directories',
   ],
   tags = {'integration'},
+  timeout - 300,
 )
 
 python_tests(
@@ -63,27 +65,7 @@ python_tests(
     'testprojects/src/protobuf/org/pantsbuild/testproject:all_directories',
   ],
   tags = {'integration'},
-)
-
-python_tests(
-  name = "thrift_projects_integration",
-  source = "test_thrift_projects_integration.py",
-  dependencies = [
-    ':projects_test_base',
-    'examples/src/thrift/org/pantsbuild/example:all_directories',
-    'testprojects/src/thrift/org/pantsbuild:all_directories',
-  ],
-  tags = {'integration'},
-)
-
-python_tests(
-  name = "wire_projects_integration",
-  source = "test_wire_projects_integration.py",
-  dependencies = [
-    ':projects_test_base',
-    'examples/src/wire/org/pantsbuild/example:all_directories',
-  ],
-  tags = {'integration'},
+  timeout = 200,
 )
 
 python_tests(
@@ -95,7 +77,6 @@ python_tests(
     'examples/tests/python/example_test:all_directories',
   ],
   tags = {'integration'},
-  timeout = 300,
 )
 
 python_tests(
@@ -107,7 +88,7 @@ python_tests(
     'testprojects/tests/python:all_directories',
   ],
   tags = {'integration'},
-  timeout = 300,
+  timeout = 120,
 )
 
 python_tests(
@@ -131,5 +112,28 @@ python_tests(
     'testprojects/tests/scala/org/pantsbuild/testproject:all_directories',
   ],
   tags = {'integration'},
+  timeout = 330,
+)
+
+python_tests(
+  name = "thrift_projects_integration",
+  source = "test_thrift_projects_integration.py",
+  dependencies = [
+    ':projects_test_base',
+    'examples/src/thrift/org/pantsbuild/example:all_directories',
+    'testprojects/src/thrift/org/pantsbuild:all_directories',
+  ],
+  tags = {'integration'},
   timeout = 300,
+)
+
+python_tests(
+  name = "wire_projects_integration",
+  source = "test_wire_projects_integration.py",
+  dependencies = [
+    ':projects_test_base',
+    'examples/src/wire/org/pantsbuild/example:all_directories',
+  ],
+  tags = {'integration'},
+  timeout = 220,
 )

--- a/tests/python/pants_test/projects/test_antlr_projects_integration.py
+++ b/tests/python/pants_test/projects/test_antlr_projects_integration.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants_test.projects.projects_test_base import ProjectsTestBase
+
+
+class TestAntlrProjectsIntegration(ProjectsTestBase):
+
+  def test_antlr_projects(self) -> None:
+    self.assert_valid_projects("examples/src/antlr::", "testprojects/src/antlr::")

--- a/tests/python/pants_test/projects/test_java_examples_integration.py
+++ b/tests/python/pants_test/projects/test_java_examples_integration.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants_test.projects.projects_test_base import ProjectsTestBase
+
+
+class TestJavaExamplesIntegration(ProjectsTestBase):
+
+  def test_java_examples(self) -> None:
+    self.assert_valid_projects("examples/src/java::", "examples/tests/java::")

--- a/tests/python/pants_test/projects/test_java_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_java_testprojects_integration.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants_test.projects.projects_test_base import ProjectsTestBase
+
+
+class TestJavaTestprojectsIntegration(ProjectsTestBase):
+
+  def test_java_testprojects(self) -> None:
+    self.assert_valid_projects("testprojects/src/java::", "testprojects/tests/java::")

--- a/tests/python/pants_test/projects/test_maven_layout_integration.py
+++ b/tests/python/pants_test/projects/test_maven_layout_integration.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants_test.projects.projects_test_base import ProjectsTestBase
+
+
+class TestMavenLayoutIntegration(ProjectsTestBase):
+
+  def test_maven_layout(self) -> None:
+    self.assert_valid_projects("testprojects/maven_layout::")

--- a/tests/python/pants_test/projects/test_protobuf_projects_integration.py
+++ b/tests/python/pants_test/projects/test_protobuf_projects_integration.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants_test.projects.projects_test_base import ProjectsTestBase
+
+
+class TestProtobufProjectsIntegration(ProjectsTestBase):
+
+  def test_protobuf_projects(self) -> None:
+    self.assert_valid_projects("examples/src/protobuf::", "testprojects/src/protobuf::")

--- a/tests/python/pants_test/projects/test_python_examples_integration.py
+++ b/tests/python/pants_test/projects/test_python_examples_integration.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants_test.projects.projects_test_base import ProjectsTestBase
+
+
+class TestPythonExamplesIntegration(ProjectsTestBase):
+
+  def test_python_examples(self) -> None:
+    self.assert_valid_projects("examples/src/python::", "examples/tests/python::")

--- a/tests/python/pants_test/projects/test_python_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_python_testprojects_integration.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants_test.projects.projects_test_base import ProjectsTestBase
+
+
+class TestPythonTestprojectsIntegration(ProjectsTestBase):
+
+  def test_python_testprojects(self) -> None:
+    self.assert_valid_projects("testprojects/src/python::", "testprojects/tests/python::")

--- a/tests/python/pants_test/projects/test_scala_examples_integration.py
+++ b/tests/python/pants_test/projects/test_scala_examples_integration.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants_test.projects.projects_test_base import ProjectsTestBase
+
+
+class TestScalaExamplesIntegration(ProjectsTestBase):
+
+  def test_scala_examples(self) -> None:
+    self.assert_valid_projects("examples/src/scala::", "examples/tests/scala::")

--- a/tests/python/pants_test/projects/test_scala_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_scala_testprojects_integration.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants_test.projects.projects_test_base import ProjectsTestBase
+
+
+class TestScalaTestprojectsIntegration(ProjectsTestBase):
+
+  def test_scala_testprojects(self) -> None:
+    self.assert_valid_projects("testprojects/src/scala::", "testprojects/tests/scala::")

--- a/tests/python/pants_test/projects/test_thrift_projects_integration.py
+++ b/tests/python/pants_test/projects/test_thrift_projects_integration.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants_test.projects.projects_test_base import ProjectsTestBase
+
+
+class TestThriftProjectsIntegration(ProjectsTestBase):
+
+  def test_thrift_projects(self) -> None:
+    self.assert_valid_projects("examples/src/thrift::", "testprojects/src/thrift::")

--- a/tests/python/pants_test/projects/test_wire_projects_integration.py
+++ b/tests/python/pants_test/projects/test_wire_projects_integration.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants_test.projects.projects_test_base import ProjectsTestBase
+
+
+class TestWireProjectsIntegration(ProjectsTestBase):
+
+  def test_wire_projects(self) -> None:
+    self.assert_valid_projects("examples/src/wire::")


### PR DESCRIPTION
The V2 test runner does not support method level sharding, as V1 does. We cannot keep `test_testprojects_integration.py` as one single target because it would take far too long to run, and one single flake would mean every test would need to re-run.

Instead, we split up the target into multiple targets based on the source root, such as all `antlr` code getting its own test file. 

This results in:

```
tests/python/pants_test/projects
├── BUILD
├── __init__.py
├── projects_test_base.py
├── test_antlr_projects_integration.py
├── test_java_examples_integration.py
├── test_java_testprojects_integration.py
├── test_maven_layout_integration.py
├── test_protobuf_projects_integration.py
├── test_python_examples_integration.py
├── test_python_testprojects_integration.py
├── test_scala_examples_integration.py
├── test_scala_testprojects_integration.py
├── test_thrift_projects_integration.py
└── test_wire_projects_integration.py
```