### PR TITLE
Add workflow option for -Youtline as an outliner

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -857,7 +857,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     else:
       main = 'rsc.cli.Main'
       tool_name = 'rsc'
-      tool_classpath = self._scalac_classpath
+      tool_classpath = self._rsc_classpath
       nailgun_classpath = self._nailgunnable_combined_classpath
 
     with self.context.new_workunit(tool_name) as wu:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -329,9 +329,19 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
   @memoized_method
   def _identify_workflow_tags(self, target):
+    all_tags = [self._compiler_tags.get(tag) for tag in target.tags]
+    filtered_tags = filter(None, all_tags)
+
+    prefix = self.get_options().force_compiler_tag_prefix
+    valid_values = [w.value for w in self.JvmCompileWorkflowType.all_values()]
+
+    for tag in target.tags:
+      if tag.startswith(f"{prefix}:"):
+        tag_workflow_value = tag.split(":")[1]
+        if tag_workflow_value not in valid_values:
+          raise ValueError(f"Invalid workflow tag specified for target {target}: {tag_workflow_value}; "
+          f"workflow must be one of {valid_values}")
     try:
-      all_tags = [self._compiler_tags.get(tag) for tag in target.tags]
-      filtered_tags = filter(None, all_tags)
       return assert_single_element(list(filtered_tags))
     except StopIteration:
       return None

--- a/src/python/pants/java/util.py
+++ b/src/python/pants/java/util.py
@@ -58,6 +58,8 @@ def execute_java(classpath, main, jvm_options=None, args=None, executor=None,
     a temporary directory will be provided and cleaned up upon process exit.
   :param file stdin: The stdin handle to use: by default None, meaning that stdin will
     not be propagated into the process.
+  :param bool force_subprocess: an optional boolean whether or not to force subprocess execution
+    regardless of executor
 
   Returns the exit code of the java program.
   Raises `pants.java.Executor.Error` if there was a problem launching java itself.

--- a/testprojects/src/scala/org/pantsbuild/testproject/mutual/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/mutual/BUILD
@@ -1,6 +1,4 @@
-scala_library(
-    tags = {"use-compiler:rsc-then-zinc"},
-)
+scala_library()
 
 jvm_binary(
     name = "bin",

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -13,7 +13,7 @@ python_tests(
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
   ],
   tags = {'integration'},
-  timeout=600,
+  timeout=720,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -13,7 +13,7 @@ python_tests(
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
   ],
   tags = {'integration'},
-  timeout=720,
+  timeout=600,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -8,9 +8,6 @@ python_library(
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
     'tests/python/pants_test:test_base',
-<<<<<<< 220a130e3688165583f0f1019fc81818a4d52737
-    'contrib/node:examples_directory',
-=======
   ],
 )
 
@@ -19,7 +16,7 @@ python_tests(
   sources=['test_rsc_compile_integration.py'],
   dependencies=[
     ':rsc_compile_integration_base',
->>>>>>> Separate RscCompileIntegration tests into rsc and youtline workflows
+    'contrib/node:examples_directory',
     'examples/src/scala/org/pantsbuild/example:hello_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:javadepsonscalatransitive_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:javasources_directory',

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -14,7 +14,7 @@ python_tests(
     'testprojects/src/scala/org/pantsbuild/testproject:javasources_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:mutual_directory',
   ],
-  timeout = 600,
+  timeout = 1200,
   tags = {'integration'},
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -1,20 +1,43 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_tests(
-  name='rsc_compile_integration',
-  sources=['test_rsc_compile_integration.py'],
+python_library(
+  name='rsc_compile_integration_base',
+  sources=['rsc_compile_integration_base.py'],
   dependencies=[
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
     'tests/python/pants_test:test_base',
+<<<<<<< 220a130e3688165583f0f1019fc81818a4d52737
     'contrib/node:examples_directory',
+=======
+  ],
+)
+
+python_tests(
+  name='rsc_compile_integration',
+  sources=['test_rsc_compile_integration.py'],
+  dependencies=[
+    ':rsc_compile_integration_base',
+>>>>>>> Separate RscCompileIntegration tests into rsc and youtline workflows
     'examples/src/scala/org/pantsbuild/example:hello_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:javadepsonscalatransitive_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:javasources_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:mutual_directory',
   ],
-  timeout = 1200,
+  timeout = 600,
+  tags = {'integration'},
+)
+
+python_tests(
+  name='rsc_compile_integration_youtline',
+  sources=['test_rsc_compile_integration_youtline.py'],
+  dependencies=[
+    ':rsc_compile_integration_base',
+    'examples/src/scala/org/pantsbuild/example:hello_directory',
+    'testprojects/src/scala/org/pantsbuild/testproject:mutual_directory',
+  ],
+  timeout = 600,
   tags = {'integration'},
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/rsc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/rsc_compile_integration_base.py
@@ -1,0 +1,50 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.jvm.tasks.jvm_compile.rsc.rsc_compile import RscCompile
+from pants.util.contextutil import environment_as
+from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
+
+
+def ensure_compile_rsc_execution_strategy(workflow):
+  """A decorator for running an integration test with ivy and coursier as the resolver."""
+
+  def decorator(f):
+    def wrapper(self, *args, **kwargs):
+      for strategy in RscCompile.ExecutionStrategy.all_values():
+        with environment_as(
+          HERMETIC_ENV='PANTS_COMPILE_RSC_EXECUTION_STRATEGY',
+          PANTS_COMPILE_RSC_EXECUTION_STRATEGY=strategy.value,
+          PANTS_COMPILE_RSC_WORKFLOW=workflow.value,
+          PANTS_CACHE_COMPILE_RSC_IGNORE='True'):
+          f(self, *args, **kwargs)
+
+    return wrapper
+  return decorator
+
+class RscCompileIntegrationBase(BaseCompileIT):
+
+  rsc_and_zinc = RscCompile.JvmCompileWorkflowType.rsc_and_zinc
+  outline_and_zinc = RscCompile.JvmCompileWorkflowType.outline_and_zinc
+
+  def _test_hermetic_jvm_options(self, workflow):
+    pants_run = self.run_pants(['compile', 'examples/src/scala/org/pantsbuild/example/hello/exe'],
+      config={
+        'cache.compile.rsc': {'ignore': True},
+        'jvm-platform': {'compiler': 'rsc'},
+        'compile.rsc': {
+          'workflow': workflow.value,
+          'execution_strategy': 'hermetic',
+        },
+        'rsc': {
+          'jvm_options': [
+            '-Djava.security.manager=java.util.Optional'
+          ]
+        }
+      })
+    self.assert_failure(pants_run)
+    self.assertIn(
+      'Could not create SecurityManager: java.util.Optional',
+      pants_run.stdout_data,
+      'Pants run is expected to fail and contain error about loading an invalid security '
+      'manager class, but it did not.')

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/rsc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/rsc_compile_integration_base.py
@@ -21,6 +21,7 @@ def ensure_compile_rsc_execution_strategy(workflow):
 
     return wrapper
   return decorator
+  
 
 class RscCompileIntegrationBase(BaseCompileIT):
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
@@ -49,7 +49,7 @@ class RscCompileTest(NailgunTaskTestBase):
       target_type=JavaLibrary,
       sources=['com/example/Foo.java'],
       dependencies=[],
-      tags={'use-compiler:rsc-and-zinc'}
+      tags={f'use-compiler:{RscCompile.JvmCompileWorkflowType.rsc_and_zinc.value}'}
     )
     scala_target = self.make_target(
       'scala/classpath:scala_lib',
@@ -104,7 +104,7 @@ class RscCompileTest(NailgunTaskTestBase):
       target_type=ScalaLibrary,
       sources=['com/example/Foo.scala'],
       dependencies=[],
-      tags={'use-compiler:rsc-and-zinc'},
+      tags={f'use-compiler:{RscCompile.JvmCompileWorkflowType.rsc_and_zinc.value}'},
     )
 
     with temporary_dir() as tmp_dir:
@@ -129,9 +129,13 @@ class RscCompileTest(NailgunTaskTestBase):
                      }
                      write_to_cache(java/classpath:java_lib) <- {}
                      double_check_cache(scala/classpath:scala_lib) <- {
-                       zinc[zinc-only](scala/classpath:scala_lib)
+                       rsc(scala/classpath:scala_lib),
+                       zinc[rsc-and-zinc](scala/classpath:scala_lib)
                      }
-                     zinc[zinc-only](scala/classpath:scala_lib) <- {
+                     rsc(scala/classpath:scala_lib) <- {
+                       write_to_cache(scala/classpath:scala_lib)
+                     }
+                     zinc[rsc-and-zinc](scala/classpath:scala_lib) <- {
                        write_to_cache(scala/classpath:scala_lib)
                      }
                      write_to_cache(scala/classpath:scala_lib) <- {}

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
@@ -49,7 +49,7 @@ class RscCompileTest(NailgunTaskTestBase):
       target_type=JavaLibrary,
       sources=['com/example/Foo.java'],
       dependencies=[],
-      tags={'use-compiler:rsc-then-zinc'}
+      tags={'use-compiler:rsc-and-zinc'}
     )
     scala_target = self.make_target(
       'scala/classpath:scala_lib',
@@ -104,7 +104,7 @@ class RscCompileTest(NailgunTaskTestBase):
       target_type=ScalaLibrary,
       sources=['com/example/Foo.scala'],
       dependencies=[],
-      tags={'use-compiler:rsc-then-zinc'},
+      tags={'use-compiler:rsc-and-zinc'},
     )
 
     with temporary_dir() as tmp_dir:
@@ -174,8 +174,21 @@ class RscCompileTest(NailgunTaskTestBase):
         dependee_graph)
 
   def test_rsc_dep_for_scala_java_and_test_targets(self):
+    self._test_outlining_dep_for_scala_java_and_test_targets(False)
+
+  def test_youtline_dep_for_scala_java_and_test_targets(self):
+    self._test_outlining_dep_for_scala_java_and_test_targets(True)
+
+  def _test_outlining_dep_for_scala_java_and_test_targets(self, youtline):
+    if youtline:
+      workflow = RscCompile.JvmCompileWorkflowType.outline_and_zinc
+      key_str = "outline"
+    else:
+      workflow = RscCompile.JvmCompileWorkflowType.rsc_and_zinc
+      key_str = "rsc"
+
     self.set_options(workflow=RankedValue(
-      value=RscCompile.JvmCompileWorkflowType.rsc_and_zinc,
+      value=workflow,
       rank=RankedValue.CONFIG,
     ))
     self.init_dependencies_for_scala_libraries()
@@ -222,52 +235,53 @@ class RscCompileTest(NailgunTaskTestBase):
       dependee_graph = self.construct_dependee_graph_str(jobs, task)
 
       self.maxDiff = None
-      self.assertEqual(dedent("""
-                     double_check_cache(java/classpath:java_lib) <- {
+      # Double curly braces {{}} because f-string
+      self.assertEqual(dedent(f"""
+                     double_check_cache(java/classpath:java_lib) <- {{
                        zinc[zinc-java](java/classpath:java_lib)
-                     }
-                     zinc[zinc-java](java/classpath:java_lib) <- {
+                     }}
+                     zinc[zinc-java](java/classpath:java_lib) <- {{
                        write_to_cache(java/classpath:java_lib)
-                     }
-                     write_to_cache(java/classpath:java_lib) <- {}
-                     double_check_cache(scala/classpath:scala_lib) <- {
-                       rsc(scala/classpath:scala_lib),
-                       zinc[rsc-and-zinc](scala/classpath:scala_lib)
-                     }
-                     rsc(scala/classpath:scala_lib) <- {
+                     }}
+                     write_to_cache(java/classpath:java_lib) <- {{}}
+                     double_check_cache(scala/classpath:scala_lib) <- {{
+                       {key_str}(scala/classpath:scala_lib),
+                       zinc[{key_str}-and-zinc](scala/classpath:scala_lib)
+                     }}
+                     {key_str}(scala/classpath:scala_lib) <- {{
                        write_to_cache(scala/classpath:scala_lib),
                        double_check_cache(scala/classpath:scala_test),
                        zinc[zinc-only](scala/classpath:scala_test)
-                     }
-                     zinc[rsc-and-zinc](scala/classpath:scala_lib) <- {
+                     }}
+                     zinc[{key_str}-and-zinc](scala/classpath:scala_lib) <- {{
                        write_to_cache(scala/classpath:scala_lib)
-                     }
-                     write_to_cache(scala/classpath:scala_lib) <- {}
-                     double_check_cache(scala/classpath:scala_dep) <- {
-                       rsc(scala/classpath:scala_dep),
-                       zinc[rsc-and-zinc](scala/classpath:scala_dep)
-                     }
-                     rsc(scala/classpath:scala_dep) <- {
+                     }}
+                     write_to_cache(scala/classpath:scala_lib) <- {{}}
+                     double_check_cache(scala/classpath:scala_dep) <- {{
+                       {key_str}(scala/classpath:scala_dep),
+                       zinc[{key_str}-and-zinc](scala/classpath:scala_dep)
+                     }}
+                     {key_str}(scala/classpath:scala_dep) <- {{
                        double_check_cache(scala/classpath:scala_lib),
-                       rsc(scala/classpath:scala_lib),
-                       zinc[rsc-and-zinc](scala/classpath:scala_lib),
+                       {key_str}(scala/classpath:scala_lib),
+                       zinc[{key_str}-and-zinc](scala/classpath:scala_lib),
                        write_to_cache(scala/classpath:scala_dep),
                        double_check_cache(scala/classpath:scala_test),
                        zinc[zinc-only](scala/classpath:scala_test)
-                     }
-                     zinc[rsc-and-zinc](scala/classpath:scala_dep) <- {
+                     }}
+                     zinc[{key_str}-and-zinc](scala/classpath:scala_dep) <- {{
                        double_check_cache(java/classpath:java_lib),
                        zinc[zinc-java](java/classpath:java_lib),
                        write_to_cache(scala/classpath:scala_dep)
-                     }
-                     write_to_cache(scala/classpath:scala_dep) <- {}
-                     double_check_cache(scala/classpath:scala_test) <- {
+                     }}
+                     write_to_cache(scala/classpath:scala_dep) <- {{}}
+                     double_check_cache(scala/classpath:scala_test) <- {{
                        zinc[zinc-only](scala/classpath:scala_test)
-                     }
-                     zinc[zinc-only](scala/classpath:scala_test) <- {
+                     }}
+                     zinc[zinc-only](scala/classpath:scala_test) <- {{
                        write_to_cache(scala/classpath:scala_test)
-                     }
-                     write_to_cache(scala/classpath:scala_test) <- {}
+                     }}
+                     write_to_cache(scala/classpath:scala_test) <- {{}}
                      """).strip(),
         dependee_graph)
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -51,8 +51,6 @@ class RscCompileIntegration(BaseCompileIT):
         pants_run.workdir,
         'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/rsc',
         'm.jar')
-      import pdb
-      pdb.set_trace()
       self.assert_is_file(rsc_header_jar)
 
   @ensure_compile_rsc_execution_strategy

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -8,24 +8,30 @@ from pants.util.contextutil import environment_as
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
 
 
-def ensure_compile_rsc_execution_strategy(f):
+def ensure_compile_rsc_execution_strategy(workflow):
   """A decorator for running an integration test with ivy and coursier as the resolver."""
 
-  def wrapper(self, *args, **kwargs):
-    for strategy in RscCompile.ExecutionStrategy.all_values():
-      with environment_as(
-        HERMETIC_ENV='PANTS_COMPILE_RSC_EXECUTION_STRATEGY',
-        PANTS_COMPILE_RSC_EXECUTION_STRATEGY=strategy.value,
-        PANTS_COMPILE_RSC_WORKFLOW='rsc-and-zinc',
-        PANTS_CACHE_COMPILE_RSC_IGNORE='True'):
-        f(self, *args, **kwargs)
+  def decorator(f):
+    def wrapper(self, *args, **kwargs):
+      for strategy in RscCompile.ExecutionStrategy.all_values():
+        with environment_as(
+          HERMETIC_ENV='PANTS_COMPILE_RSC_EXECUTION_STRATEGY',
+          PANTS_COMPILE_RSC_EXECUTION_STRATEGY=strategy.value,
+          PANTS_COMPILE_RSC_WORKFLOW=workflow.value,
+          PANTS_CACHE_COMPILE_RSC_IGNORE='True'):
+          f(self, *args, **kwargs)
 
-  return wrapper
+    return wrapper
+  return  decorator
 
 
 class RscCompileIntegration(BaseCompileIT):
 
-  @ensure_compile_rsc_execution_strategy
+  rsc_and_zinc = RscCompile.JvmCompileWorkflowType.rsc_and_zinc
+  outline_and_zinc = RscCompile.JvmCompileWorkflowType.outline_and_zinc
+
+  @ensure_compile_rsc_execution_strategy(outline_and_zinc)
+  @ensure_compile_rsc_execution_strategy(rsc_and_zinc)
   def test_basic_binary(self):
     with self.do_command_yielding_workdir('compile', 'testprojects/src/scala/org/pantsbuild/testproject/mutual:bin') as pants_run:
       zinc_compiled_classfile = os.path.join(
@@ -39,30 +45,16 @@ class RscCompileIntegration(BaseCompileIT):
         'm.jar')
       self.assert_is_file(rsc_header_jar)
 
-  @ensure_compile_rsc_execution_strategy
-  def test_basic_binary_youtline(self):
-    with self.do_command_yielding_workdir('--compile-rsc-workflow=outline-and-zinc', 'compile', 'testprojects/src/scala/org/pantsbuild/testproject/mutual:bin') as pants_run:
-      zinc_compiled_classfile = os.path.join(
-        pants_run.workdir,
-        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/zinc',
-        'classes/org/pantsbuild/testproject/mutual/A.class')
-      self.assert_is_file(zinc_compiled_classfile)
-      rsc_header_jar = os.path.join(
-        pants_run.workdir,
-        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/rsc',
-        'm.jar')
-      self.assert_is_file(rsc_header_jar)
-
-  @ensure_compile_rsc_execution_strategy
+  @ensure_compile_rsc_execution_strategy(rsc_and_zinc)
   def test_executing_multi_target_binary(self):
     pants_run = self.do_command('run', 'examples/src/scala/org/pantsbuild/example/hello/exe')
     self.assertIn('Hello, Resource World!', pants_run.stdout_data)
 
-  @ensure_compile_rsc_execution_strategy
+  @ensure_compile_rsc_execution_strategy(rsc_and_zinc)
   def test_java_with_transitive_exported_scala_dep(self):
     self.do_command('compile', 'testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive:java-in-different-package')
 
-  @ensure_compile_rsc_execution_strategy
+  @ensure_compile_rsc_execution_strategy(rsc_and_zinc)
   def test_java_sources(self):
     self.do_command('compile', 'testprojects/src/scala/org/pantsbuild/testproject/javasources')
 
@@ -71,34 +63,18 @@ class RscCompileIntegration(BaseCompileIT):
     self.do_command('compile', 'contrib/node/examples/src/java/org/pantsbuild/testproject/jsresources')
 
   def test_rsc_hermetic_jvm_options(self):
-    pants_run = self.run_pants(['compile', 'examples/src/scala/org/pantsbuild/example/hello/exe'],
-      config={
-        'cache.compile.rsc': {'ignore': True},
-        'jvm-platform': {'compiler': 'rsc'},
-        'compile.rsc': {
-          'workflow': 'rsc-and-zinc',
-          'execution_strategy': 'hermetic',
-        },
-        'rsc': {
-          'jvm_options': [
-            '-Djava.security.manager=java.util.Optional'
-          ]
-        }
-      })
-    self.assert_failure(pants_run)
-    self.assertIn(
-      'Could not create SecurityManager: java.util.Optional',
-      pants_run.stdout_data,
-      'Pants run is expected to fail and contain error about loading an invalid security '
-      'manager class, but it did not.')
+    self._test_hermetic_jvm_options(self.rsc_and_zinc)
 
   def test_youtline_hermetic_jvm_options(self):
+    self._test_hermetic_jvm_options(self.outline_and_zinc)
+
+  def _test_hermetic_jvm_options(self, workflow):
     pants_run = self.run_pants(['compile', 'examples/src/scala/org/pantsbuild/example/hello/exe'],
       config={
         'cache.compile.rsc': {'ignore': True},
         'jvm-platform': {'compiler': 'rsc'},
         'compile.rsc': {
-          'workflow': 'outline-and-zinc',
+          'workflow': workflow.value,
           'execution_strategy': 'hermetic',
         },
         'rsc': {

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -3,35 +3,15 @@
 
 import os
 
-from pants.backend.jvm.tasks.jvm_compile.rsc.rsc_compile import RscCompile
-from pants.util.contextutil import environment_as
-from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
+from pants_test.backend.jvm.tasks.jvm_compile.rsc.rsc_compile_integration_base import (
+  RscCompileIntegrationBase,
+  ensure_compile_rsc_execution_strategy,
+)
 
 
-def ensure_compile_rsc_execution_strategy(workflow):
-  """A decorator for running an integration test with ivy and coursier as the resolver."""
+class RscCompileIntegration(RscCompileIntegrationBase):
 
-  def decorator(f):
-    def wrapper(self, *args, **kwargs):
-      for strategy in RscCompile.ExecutionStrategy.all_values():
-        with environment_as(
-          HERMETIC_ENV='PANTS_COMPILE_RSC_EXECUTION_STRATEGY',
-          PANTS_COMPILE_RSC_EXECUTION_STRATEGY=strategy.value,
-          PANTS_COMPILE_RSC_WORKFLOW=workflow.value,
-          PANTS_CACHE_COMPILE_RSC_IGNORE='True'):
-          f(self, *args, **kwargs)
-
-    return wrapper
-  return  decorator
-
-
-class RscCompileIntegration(BaseCompileIT):
-
-  rsc_and_zinc = RscCompile.JvmCompileWorkflowType.rsc_and_zinc
-  outline_and_zinc = RscCompile.JvmCompileWorkflowType.outline_and_zinc
-
-  @ensure_compile_rsc_execution_strategy(outline_and_zinc)
-  @ensure_compile_rsc_execution_strategy(rsc_and_zinc)
+  @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.rsc_and_zinc)
   def test_basic_binary(self):
     with self.do_command_yielding_workdir('compile', 'testprojects/src/scala/org/pantsbuild/testproject/mutual:bin') as pants_run:
       zinc_compiled_classfile = os.path.join(
@@ -45,47 +25,22 @@ class RscCompileIntegration(BaseCompileIT):
         'm.jar')
       self.assert_is_file(rsc_header_jar)
 
-  @ensure_compile_rsc_execution_strategy(rsc_and_zinc)
+  @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.rsc_and_zinc)
   def test_executing_multi_target_binary(self):
     pants_run = self.do_command('run', 'examples/src/scala/org/pantsbuild/example/hello/exe')
     self.assertIn('Hello, Resource World!', pants_run.stdout_data)
 
-  @ensure_compile_rsc_execution_strategy(rsc_and_zinc)
+  @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.rsc_and_zinc)
   def test_java_with_transitive_exported_scala_dep(self):
     self.do_command('compile', 'testprojects/src/scala/org/pantsbuild/testproject/javadepsonscalatransitive:java-in-different-package')
 
-  @ensure_compile_rsc_execution_strategy(rsc_and_zinc)
+  @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.rsc_and_zinc)
   def test_java_sources(self):
     self.do_command('compile', 'testprojects/src/scala/org/pantsbuild/testproject/javasources')
 
-  @ensure_compile_rsc_execution_strategy
+  @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.rsc_and_zinc)
   def test_node_dependencies(self):
     self.do_command('compile', 'contrib/node/examples/src/java/org/pantsbuild/testproject/jsresources')
 
   def test_rsc_hermetic_jvm_options(self):
     self._test_hermetic_jvm_options(self.rsc_and_zinc)
-
-  def test_youtline_hermetic_jvm_options(self):
-    self._test_hermetic_jvm_options(self.outline_and_zinc)
-
-  def _test_hermetic_jvm_options(self, workflow):
-    pants_run = self.run_pants(['compile', 'examples/src/scala/org/pantsbuild/example/hello/exe'],
-      config={
-        'cache.compile.rsc': {'ignore': True},
-        'jvm-platform': {'compiler': 'rsc'},
-        'compile.rsc': {
-          'workflow': workflow.value,
-          'execution_strategy': 'hermetic',
-        },
-        'rsc': {
-          'jvm_options': [
-            '-Djava.security.manager=java.util.Optional'
-          ]
-        }
-      })
-    self.assert_failure(pants_run)
-    self.assertIn(
-      'Could not create SecurityManager: java.util.Optional',
-      pants_run.stdout_data,
-      'Pants run is expected to fail and contain error about loading an invalid security '
-      'manager class, but it did not.')

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
@@ -1,0 +1,29 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+
+from pants_test.backend.jvm.tasks.jvm_compile.rsc.rsc_compile_integration_base import (
+  RscCompileIntegrationBase,
+  ensure_compile_rsc_execution_strategy,
+)
+
+
+class RscCompileIntegration(RscCompileIntegrationBase):
+
+  @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.outline_and_zinc)
+  def test_basic_binary(self):
+    with self.do_command_yielding_workdir('compile', 'testprojects/src/scala/org/pantsbuild/testproject/mutual:bin') as pants_run:
+      zinc_compiled_classfile = os.path.join(
+        pants_run.workdir,
+        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/zinc',
+        'classes/org/pantsbuild/testproject/mutual/A.class')
+      self.assert_is_file(zinc_compiled_classfile)
+      rsc_header_jar = os.path.join(
+        pants_run.workdir,
+        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/rsc',
+        'm.jar')
+      self.assert_is_file(rsc_header_jar)
+
+  def test_youtline_hermetic_jvm_options(self):
+    self._test_hermetic_jvm_options(self.outline_and_zinc)


### PR DESCRIPTION
### Problem

Starting with `scalac` `2.12.9`, there is a `-Youtline` option to produce `.sig`
files, similar to `rsc`'s "header" `.class` files. Unlike `rsc`, `-Youtline`
supports full Scala, making it much more of a plug-and-play solution. Thus we
want to add an option for using `-Youtline` as the outliner.

### Solution

Add a new JVM compile workflow option, `outline-and-zinc`, which will act like
`rsc-and-zinc` but using `scalac -Youtline` as the outlining technology. In
addition, `wartremover` will be used to enforce the `PublicInference` rule, as
type ascriptions will have a significant performance impact on outlining.

### Result

Users will be able to use `-Youtline` in their builds.
