### PR TITLE
Add `@frozen_after_init` decorator to make some @dataclass uses safer with V2

### DIFF
--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -72,13 +72,16 @@ python_library(
   name = 'memo',
   sources = ['memo.py'],
   dependencies = [
-      ':meta'
+    ':meta'
   ],
 )
 
 python_library(
   name = 'meta',
   sources = ['meta.py'],
+  dependencies = [
+    '3rdparty/python:dataclasses'
+  ],
   tags = {'type_checked'},
 )
 

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -1,6 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from dataclasses import FrozenInstanceError
+from functools import wraps
 from typing import Any, Callable, Optional, Type, TypeVar, Union
 
 
@@ -107,3 +109,32 @@ def staticproperty(func: Union[staticmethod, Callable]) -> ClassPropertyDescript
     func = staticmethod(func)
 
   return ClassPropertyDescriptor(func, doc)
+
+
+def freeze_after_init(cls: Type[T]) -> Type[T]:
+  """Class decorator to freeze any modifications to the object after __init__() is done.
+
+  The primary use case is for @dataclasses who cannot use frozen=True due to the need for a custom
+  __init__(), but who still want to remain as immutable as possible (e.g. for safety with the V2
+  engine). When using with dataclasses, this should be the first decorator applied, i.e. be used
+  before @dataclass."""
+
+  prev_init = cls.__init__
+  prev_setattr = cls.__setattr__
+
+  @wraps(prev_init)
+  def new_init(self, *args: Any, **kwargs: Any) -> None:
+    prev_init(self, *args, **kwargs)  # type: ignore
+    self._is_frozen = True
+
+  @wraps(prev_setattr)
+  def new_setattr(self, key: Any, value: Any) -> None:
+    if getattr(self, "_is_frozen", False):
+      raise FrozenInstanceError(
+        f"Attempting to modify the attribute {key} after the object {self} was created."
+      )
+    prev_setattr(self, key, value)
+
+  cls.__init__ = new_init  # type: ignore
+  cls.__setattr__ = new_setattr  # type: ignore
+  return cls

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -128,7 +128,7 @@ def freeze_after_init(cls: Type[T]) -> Type[T]:
     self._is_frozen = True
 
   @wraps(prev_setattr)
-  def new_setattr(self, key: Any, value: Any) -> None:
+  def new_setattr(self, key: str, value: Any) -> None:
     if getattr(self, "_is_frozen", False):
       raise FrozenInstanceError(
         f"Attempting to modify the attribute {key} after the object {self} was created."

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -111,7 +111,7 @@ def staticproperty(func: Union[staticmethod, Callable]) -> ClassPropertyDescript
   return ClassPropertyDescriptor(func, doc)
 
 
-def freeze_after_init(cls: Type[T]) -> Type[T]:
+def frozen_after_init(cls: Type[T]) -> Type[T]:
   """Class decorator to freeze any modifications to the object after __init__() is done.
 
   The primary use case is for @dataclasses who cannot use frozen=True due to the need for a custom

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -83,6 +83,7 @@ python_tests(
   name = 'meta',
   sources = ['test_meta.py'],
   dependencies = [
+    '3rdparty/python:dataclasses',
     'src/python/pants/util:meta',
     'tests/python/pants_test:test_base',
   ],

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -291,13 +291,25 @@ class FreezeAfterInitTest(unittest.TestCase):
     with self.assertRaises(FrozenInstanceError):
       test.y = "abc"
 
+  def test_explicitly_call_setattr_after_init(self) -> None:
+    @freeze_after_init
+    class Test:
+
+      def __init__(self, x: int) -> None:
+        self.x: x
+
+    test = Test(x=0)
+    with self.assertRaises(FrozenInstanceError):
+      setattr(test, "x", 1)
+
   def test_works_with_dataclass(self) -> None:
     @freeze_after_init
     @dataclass(frozen=False)
     class Test:
       x: int
+      y: str
 
-      def __init__(self, x: int):
+      def __init__(self, x: int) -> None:
         self.x = x
         self.y = "abc"
 

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -253,8 +253,8 @@ class FreezeAfterInitTest(unittest.TestCase):
     class Test:
       pass
 
+    test = Test()
     with self.assertRaises(FrozenInstanceError):
-      test = Test()
       test.x = 1
 
   def test_init_still_works(self):
@@ -276,8 +276,8 @@ class FreezeAfterInitTest(unittest.TestCase):
       def __init__(self, x: int) -> None:
         self.x = x
 
+    test = Test(x=0)
     with self.assertRaises(FrozenInstanceError):
-      test = Test(0)
       test.x = 1
 
   def test_add_new_field_after_init(self) -> None:
@@ -287,8 +287,8 @@ class FreezeAfterInitTest(unittest.TestCase):
       def __init__(self, x: int) -> None:
         self.x: x
 
+    test = Test(x=0)
     with self.assertRaises(FrozenInstanceError):
-      test = Test(0)
       test.y = "abc"
 
   def test_works_with_dataclass(self) -> None:

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -5,7 +5,7 @@ import unittest
 from abc import ABC, abstractmethod
 from dataclasses import FrozenInstanceError, dataclass
 
-from pants.util.meta import SingletonMetaclass, classproperty, freeze_after_init, staticproperty
+from pants.util.meta import SingletonMetaclass, classproperty, frozen_after_init, staticproperty
 from pants_test.test_base import TestBase
 
 
@@ -246,10 +246,10 @@ with an @classproperty decorator."""):
     self.assertEqual(Concrete2.f, 'hello')
 
 
-class FreezeAfterInitTest(unittest.TestCase):
+class FrozenAfterInitTest(unittest.TestCase):
 
   def test_no_init(self) -> None:
-    @freeze_after_init
+    @frozen_after_init
     class Test:
       pass
 
@@ -258,7 +258,7 @@ class FreezeAfterInitTest(unittest.TestCase):
       test.x = 1
 
   def test_init_still_works(self):
-    @freeze_after_init
+    @frozen_after_init
     class Test:
 
       def __init__(self, x: int) -> None:
@@ -270,7 +270,7 @@ class FreezeAfterInitTest(unittest.TestCase):
     self.assertEqual(test.y, "abc")
 
   def test_modify_preexisting_field_after_init(self) -> None:
-    @freeze_after_init
+    @frozen_after_init
     class Test:
 
       def __init__(self, x: int) -> None:
@@ -281,7 +281,7 @@ class FreezeAfterInitTest(unittest.TestCase):
       test.x = 1
 
   def test_add_new_field_after_init(self) -> None:
-    @freeze_after_init
+    @frozen_after_init
     class Test:
 
       def __init__(self, x: int) -> None:
@@ -292,7 +292,7 @@ class FreezeAfterInitTest(unittest.TestCase):
       test.y = "abc"
 
   def test_explicitly_call_setattr_after_init(self) -> None:
-    @freeze_after_init
+    @frozen_after_init
     class Test:
 
       def __init__(self, x: int) -> None:
@@ -303,7 +303,7 @@ class FreezeAfterInitTest(unittest.TestCase):
       setattr(test, "x", 1)
 
   def test_works_with_dataclass(self) -> None:
-    @freeze_after_init
+    @frozen_after_init
     @dataclass(frozen=False)
     class Test:
       x: int

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -293,7 +293,7 @@ class FreezeAfterInitTest(unittest.TestCase):
 
   def test_works_with_dataclass(self) -> None:
     @freeze_after_init
-    @dataclass
+    @dataclass(frozen=False)
     class Test:
       x: int
 


### PR DESCRIPTION
### Problem
In https://github.com/pantsbuild/pants/pull/8423#issue-325939000, we realized the need to be able to not always use `frozen=True` when using dataclasses for the V2 engine. Specifically, when we need a custom `__init__()`, we cannot have `frozen=True` because `__init__()` must be able to mutate the object's attributes.

However, we still want to keep the benefits of `frozen=True` as much as possible. After we create the object, we do not want to allow any additional modifications. This is important because the V2 engine uses the `__hash__()` of an object to determine its node ID - if the object mutates after creation, the ID will become invalid.

### Solution
As suggested in https://github.com/pantsbuild/pants/pull/8423#issuecomment-539810058, introduce a new decorator `@frozen_after_init` that only allows setting attributes in the `__init__()` and then marks the object as frozen after.

This is done by setting a flag in the `__init__()` to mark that the object should there-on-out be frozen. Then, we modify `__setattr__()` to check for that flag to prohibit any mutations other than those in the `__init__()`.

### Result
`@dataclass(unsafe_hash=True)` can now be marked with `@frozen_after_init` so that we can have the custom `__init__()`s but not lose the benefits of `frozen=True`.

This also works on any arbitrary class.

We do not yet enforce that dataclasses _must_ use this attribute (or `frozen=True`), which is left for https://github.com/pantsbuild/pants/pull/8181.