### PR TITLE
Add a buffer for queueing process execution to remote timeout 

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -373,7 +373,11 @@ impl super::CommandRunner for CommandRunner {
                               (1 + iter_num) * command_runner.backoff_incremental_wait,
                             );
 
-                            // take the grpc result and cancel the op if too much time has passed.
+                            // Take the grpc result and cancel the op if too much time has passed.
+                            // This timeout is here to make sure that if something goes wrong, e.g.
+                            // the connection hangs, we don't poll forever. We add a buffer time
+                            // for queuing the process so that the requested timeout more accurately
+                            // reflects how long the caller intended the process to last.
                             let elapsed = start_time.elapsed();
                             let queue_buffer_time = std::time::Duration::from_secs(45);
 

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -375,8 +375,9 @@ impl super::CommandRunner for CommandRunner {
 
                             // take the grpc result and cancel the op if too much time has passed.
                             let elapsed = start_time.elapsed();
+                            let queue_buffer_time = std::time::Duration::from_secs(45);
 
-                            if elapsed > timeout {
+                            if elapsed > timeout + queue_buffer_time {
                               let ExecutionHistory {
                                 mut attempts,
                                 mut current_attempt,

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -379,7 +379,12 @@ impl super::CommandRunner for CommandRunner {
                             // for queuing the process so that the requested timeout more accurately
                             // reflects how long the caller intended the process to last.
                             let elapsed = start_time.elapsed();
-                            let queue_buffer_time = std::time::Duration::from_secs(45);
+                            let queue_buffer_time = Duration::from_secs(
+                              match std::env::var_os("OVERRIDE_QUEUE_TIMEOUT_FOR_TESTING") {
+                                // We use a low number for tests so that they do not take long to execute.
+                                Some(_) => 1,
+                                None => 45,
+                            });
 
                             if elapsed > timeout + queue_buffer_time {
                               let ExecutionHistory {

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -769,6 +769,7 @@ pub fn sends_headers() {
     store,
     Platform::Linux,
     runtime.clone(),
+    Duration::from_secs(0),
     Duration::from_millis(0),
     Duration::from_secs(0),
   )
@@ -932,6 +933,7 @@ fn ensure_inline_stdio_is_stored() {
     store,
     Platform::Linux,
     runtime.clone(),
+    Duration::from_secs(0),
     Duration::from_millis(0),
     Duration::from_secs(0),
   )
@@ -1464,6 +1466,7 @@ fn execute_missing_file_uploads_if_known() {
     store,
     Platform::Linux,
     runtime.clone(),
+    Duration::from_secs(0),
     Duration::from_millis(0),
     Duration::from_secs(0),
   )
@@ -1570,6 +1573,7 @@ fn execute_missing_file_uploads_if_known_status() {
     store,
     Platform::Linux,
     runtime.clone(),
+    Duration::from_secs(0),
     Duration::from_millis(0),
     Duration::from_secs(0),
   )
@@ -1649,6 +1653,7 @@ fn execute_missing_file_errors_if_unknown() {
     store,
     Platform::Linux,
     runtime.clone(),
+    Duration::from_secs(0),
     Duration::from_millis(0),
     Duration::from_secs(0),
   )
@@ -2462,6 +2467,7 @@ fn create_command_runner(
     store,
     Platform::Linux,
     runtime,
+    Duration::from_secs(1), // We use a low queue_buffer_time to ensure that tests do not take too long.
     backoff_incremental_wait,
     backoff_max_wait,
   )

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1029,8 +1029,10 @@ fn successful_execution_after_four_getoperations() {
 
 #[test]
 fn timeout_after_sufficiently_delayed_getoperations() {
-  let request_timeout = Duration::new(4, 0);
-  let delayed_operation_time = Duration::new(5, 0);
+  let request_timeout = Duration::new(1, 0);
+  // The request should timeout after 2 seconds, with 1 second due to the queue_buffer_time and
+  // 1 due to the request_timeout.
+  let delayed_operation_time = Duration::new(2, 500);
 
   let execute_request = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -361,6 +361,7 @@ fn main() {
           store.clone(),
           Platform::Linux,
           executor.clone(),
+          std::time::Duration::from_secs(45),
           std::time::Duration::from_millis(500),
           std::time::Duration::from_secs(5),
         )

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -182,6 +182,7 @@ impl Core {
             // need to take an option all the way down here and into the remote::CommandRunner struct.
             Platform::Linux,
             executor.clone(),
+            std::time::Duration::from_secs(45),
             std::time::Duration::from_millis(500),
             std::time::Duration::from_secs(5),
           )?),


### PR DESCRIPTION
The V2 remote timeout starts when an ExecuteProcessRequest (EPR) gets queued and includes both the queue time and the actual process execution time.

On the Python side, when specifying an EPR's `timeout`, we do not want to have to worry about how long the queue takes. Instead, that value should only be the expected time for the EPR to run. By adding a buffer, we attempt to cover any time necessary for queuing so that the EPR's `timeout` accurately represents how long the process should run.

Here, we hardcode a buffer of 45 seconds for the queue. Down the road, we may decide to expose this as a global option to users so that they can choose a different buffer time.