### PR TITLE
Replace majority of remaining `datatype()`s with `@dataclass`

### DIFF
--- a/src/python/pants/backend/native/targets/BUILD
+++ b/src/python/pants/backend/native/targets/BUILD
@@ -4,12 +4,12 @@
 
 python_library(
   dependencies=[
+    '3rdparty/python:dataclasses',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',
-    'src/python/pants/util:objects',
     'src/python/pants/util:memo',
   ],
 )

--- a/src/python/pants/backend/native/targets/external_native_library.py
+++ b/src/python/pants/backend/native/targets/external_native_library.py
@@ -11,6 +11,7 @@ from pants.base.payload_field import PayloadField
 from pants.base.validation import assert_list
 from pants.build_graph.target import Target
 from pants.util.memo import memoized_property
+from pants.util.meta import frozen_after_init
 
 
 # TODO: generalize this to a DatatypeSetField subclass in payload_field.py!
@@ -20,6 +21,7 @@ class ConanRequirementSetField(tuple, PayloadField):
     return stable_json_sha1(tuple(hash(req) for req in self))
 
 
+@frozen_after_init
 @dataclass(unsafe_hash=True)
 class ConanRequirement:
   """A specification for a conan package to be resolved against a remote repository.

--- a/src/python/pants/backend/native/targets/native_artifact.py
+++ b/src/python/pants/backend/native/targets/native_artifact.py
@@ -16,11 +16,15 @@ class NativeArtifact(PayloadField):
   """A BUILD file object declaring a target can be exported to other languages with a native ABI."""
   lib_name: str
 
+  def __init__(self, lib_name: str) -> None:
+    self.lib_name = lib_name
+    self._is_frozen = True
+
   def __hash__(self) -> int:
     return hash(self.lib_name)
 
   def __setattr__(self, key: str, value: Any) -> None:
-    if key == "lib_name":
+    if hasattr(self, "_is_frozen") and key == "lib_name":
       raise FrozenInstanceError(
         f"Attempting to modify the attribute {key} with value {value} on {self}."
       )

--- a/src/python/pants/backend/native/targets/native_artifact.py
+++ b/src/python/pants/backend/native/targets/native_artifact.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from dataclasses import dataclass, FrozenInstanceError
+from dataclasses import FrozenInstanceError, dataclass
 from hashlib import sha1
 from typing import Any
 

--- a/src/python/pants/backend/native/targets/native_artifact.py
+++ b/src/python/pants/backend/native/targets/native_artifact.py
@@ -7,7 +7,11 @@ from hashlib import sha1
 from pants.base.payload_field import PayloadField
 
 
-@dataclass(frozen=True)
+# NB: We do not decorate this with @frozen_after_init because PayloadField must still mutate
+# _fingerprint_memo. Even though PayloadField will change the value of _fingerprint_memo, the hash
+# is still stable for NativeArtifact because unsafe_hash=True will only calculate it based on the
+# `lib` attribute defined here. This works, so long as someone doesn't change the lib attribute.
+@dataclass(unsafe_hash=True)
 class NativeArtifact(PayloadField):
   """A BUILD file object declaring a target can be exported to other languages with a native ABI."""
   lib_name: str

--- a/src/python/pants/backend/native/targets/native_artifact.py
+++ b/src/python/pants/backend/native/targets/native_artifact.py
@@ -1,14 +1,16 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from dataclasses import dataclass
 from hashlib import sha1
 
 from pants.base.payload_field import PayloadField
-from pants.util.objects import datatype
 
 
-class NativeArtifact(datatype(['lib_name']), PayloadField):
+@dataclass(frozen=True)
+class NativeArtifact(PayloadField):
   """A BUILD file object declaring a target can be exported to other languages with a native ABI."""
+  lib_name: str
 
   # TODO: This should probably be made into an @classproperty (see PR #5901).
   @classmethod

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -3,7 +3,9 @@
 
 import logging
 import os
+from dataclasses import dataclass
 from textwrap import dedent
+from typing import Tuple
 
 from pants.backend.native.subsystems.native_toolchain import NativeToolchain
 from pants.backend.native.targets.native_library import NativeLibrary
@@ -16,7 +18,7 @@ from pants.binaries.executable_pex_tool import ExecutablePexTool
 from pants.engine.rules import optionable_rule, rule
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
-from pants.util.objects import SubclassesOf, TypedCollection, datatype, string_type
+from pants.util.objects import SubclassesOf
 from pants.util.strutil import safe_shlex_join, safe_shlex_split
 
 
@@ -142,10 +144,10 @@ class BuildSetupRequiresPex(ExecutablePexTool):
     ]
 
 
-class PexBuildEnvironment(datatype([
-    ('cpp_flags', TypedCollection(string_type)),
-    ('ld_flags', TypedCollection(string_type)),
-])):
+@dataclass(frozen=True)
+class PexBuildEnvironment:
+  cpp_flags: Tuple[str, ...]
+  ld_flags: Tuple[str, ...]
 
   @property
   def invocation_environment_dict(self):

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -141,6 +141,7 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:filtering',
     'src/python/pants/util:memo',
+    'src/python/pants/util:meta',
   ],
 )
 

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -16,11 +16,11 @@ python_library(
   name = 'project_tree',
   sources = ['file_system_project_tree.py', 'project_tree.py', 'project_tree_factory.py'],
   dependencies = [
+    '3rdparty/python:dataclasses',
     '3rdparty/python:pathspec',
     ':build_environment',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-    'src/python/pants/util:objects',
   ]
 )
 

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -141,7 +141,6 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:filtering',
     'src/python/pants/util:memo',
-    'src/python/pants/util:objects',
   ],
 )
 

--- a/src/python/pants/base/payload_field.py
+++ b/src/python/pants/base/payload_field.py
@@ -3,6 +3,7 @@
 
 from abc import ABC, abstractmethod
 from hashlib import sha1
+from typing import ClassVar, Optional
 
 from twitter.common.collections import OrderedSet
 
@@ -24,7 +25,7 @@ class PayloadField(ABC):
 
   :API: public
   """
-  _fingerprint_memo = None
+  _fingerprint_memo: ClassVar[Optional[str]] = None
 
   def fingerprint(self):
     """A memoized sha1 hexdigest hashing the contents of this PayloadField

--- a/src/python/pants/base/project_tree.py
+++ b/src/python/pants/base/project_tree.py
@@ -198,7 +198,7 @@ class Stat(ABC):
   """An existing filesystem path with a known type, relative to the ProjectTree's buildroot.
 
   Note that in order to preserve these invariants, end-user functions are not able to instantiate
-  this base class (init=False).
+  this base class (via the `init=False` argument to the dataclass decorator).
   """
   path: str
 

--- a/src/python/pants/base/project_tree.py
+++ b/src/python/pants/base/project_tree.py
@@ -4,12 +4,12 @@
 import logging
 import os
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 
 from pathspec.pathspec import PathSpec
 from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 
 from pants.util.dirutil import fast_relpath
-from pants.util.objects import datatype
 
 
 logger = logging.getLogger(__name__)
@@ -193,35 +193,29 @@ class ProjectTree(ABC):
     return relpath
 
 
+@dataclass(init=False, frozen=True)
 class Stat(ABC):
   """An existing filesystem path with a known type, relative to the ProjectTree's buildroot.
 
-  Note that in order to preserve these invariants, end-user functions should never directly
-  instantiate Stat instances.
+  Note that in order to preserve these invariants, end-user functions are not able to instantiate
+  this base class (init=False).
   """
-
-  @property
-  @abstractmethod
-  def path(self):
-    """:returns: The string path for this Stat."""
+  path: str
 
 
-class File(datatype(['path']), Stat):
+@dataclass(frozen=True)
+class File(Stat):
   """A file."""
-
-  def __new__(cls, path):
-    return super().__new__(cls, path)
+  path: str
 
 
-class Dir(datatype(['path']), Stat):
+@dataclass(frozen=True)
+class Dir(Stat):
   """A directory."""
-
-  def __new__(cls, path):
-    return super().__new__(cls, path)
+  path: str
 
 
-class Link(datatype(['path']), Stat):
+@dataclass(frozen=True)
+class Link(Stat):
   """A symbolic link."""
-
-  def __new__(cls, path):
-    return super().__new__(cls, path)
+  path: str

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -11,6 +11,7 @@ from pants.util.collections import assert_single_element
 from pants.util.dirutil import fast_relpath_optional, recursive_dirname
 from pants.util.filtering import create_filters, wrap_filters
 from pants.util.memo import memoized_property
+from pants.util.meta import frozen_after_init
 
 
 class Spec(ABC):
@@ -210,6 +211,7 @@ def more_specific(spec1: Spec, spec2: Spec) -> Spec:
   return spec1 if _specificity[type(spec1)] < _specificity[type(spec2)] else spec2
 
 
+@frozen_after_init
 @dataclass(unsafe_hash=True)
 class SpecsMatcher:
   """Contains filters for the output of a Specs match.
@@ -249,6 +251,7 @@ class SpecsMatcher:
     return self._target_tag_matches(target) and not self._excluded_by_pattern(address)
 
 
+@frozen_after_init
 @dataclass(unsafe_hash=True)
 class Specs:
   """A collection of Specs representing Spec subclasses, and a SpecsMatcher to filter results."""

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -169,6 +169,8 @@ python_library(
     ':selectors',
     'src/python/pants/base:specs',
     'src/python/pants/util:collections',
+    'src/python/pants/util:memo',
+    'src/python/pants/util:meta',
   ]
 )
 

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -169,7 +169,6 @@ python_library(
     ':selectors',
     'src/python/pants/base:specs',
     'src/python/pants/util:collections',
-    'src/python/pants/util:objects',
   ]
 )
 

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -213,7 +213,6 @@ python_library(
     'src/python/pants/binaries',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-    'src/python/pants/util:objects'
   ],
 )
 

--- a/src/python/pants/engine/legacy/BUILD
+++ b/src/python/pants/engine/legacy/BUILD
@@ -47,6 +47,7 @@ python_library(
   name='structs',
   sources=['structs.py'],
   dependencies=[
+    '3rdparty/python:dataclasses',
     'src/python/pants/base:deprecated',
     'src/python/pants/build_graph',
     'src/python/pants/engine:fs',

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -22,6 +22,7 @@ from pants.engine.goal import Goal
 from pants.engine.selectors import Get
 from pants.util.collections import assert_single_element
 from pants.util.memo import memoized
+from pants.util.meta import frozen_after_init
 
 
 logger = logging.getLogger(__name__)
@@ -465,6 +466,7 @@ class Rule(ABC):
     return ()
 
 
+@frozen_after_init
 @dataclass(unsafe_hash=True)
 class TaskRule(Rule):
   """A Rule that runs a task function when all of its input selectors are satisfied.
@@ -520,6 +522,7 @@ class TaskRule(Rule):
     return self._dependency_optionables
 
 
+@frozen_after_init
 @dataclass(unsafe_hash=True)
 class RootRule(Rule):
   """Represents a root input to an execution of a rule graph.

--- a/src/python/pants/java/jar/jar_dependency.py
+++ b/src/python/pants/java/jar/jar_dependency.py
@@ -1,6 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import dataclasses
 import os
 from dataclasses import dataclass
 from typing import Optional, Sequence, Tuple
@@ -163,13 +164,12 @@ class JarDependency:
   def copy(self, **replacements):
     """Returns a clone of this JarDependency with the given replacements kwargs overlaid."""
     cls = type(self)
-    kwargs = self._asdict()
-    for key, val in replacements.items():
-      if key == 'excludes':
-        val = JarDependency._prepare_excludes(val)
-      kwargs[key] = val
+    kwargs = dataclasses.asdict(self)
+    kwargs.update(replacements)
     org = kwargs.pop('org')
     base_name = kwargs.pop('base_name')
+    # NB: This calls __init__() so will set things up properly for us, such as calling
+    # _prepare_excludes.
     return cls(org, base_name, **kwargs)
 
   @memoized_property

--- a/src/python/pants/java/junit/BUILD
+++ b/src/python/pants/java/junit/BUILD
@@ -4,8 +4,9 @@
 python_library(
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:dataclasses',
     'src/python/pants/util:dirutil',
-    'src/python/pants/util:objects',
+    'src/python/pants/util:meta',
     'src/python/pants/util:xml_parser',
   ]
 )

--- a/src/python/pants/java/junit/junit_xml_parser.py
+++ b/src/python/pants/java/junit/junit_xml_parser.py
@@ -4,20 +4,27 @@
 import fnmatch
 import os
 from collections import defaultdict
+from dataclasses import dataclass
+from typing import Optional
 
 from twitter.common.collections import OrderedSet
 
 from pants.util.dirutil import safe_walk
-from pants.util.objects import datatype
+from pants.util.meta import frozen_after_init
 from pants.util.xml_parser import XmlParser
 
 
-class Test(datatype(['classname', 'methodname'])):
+@frozen_after_init
+@dataclass(unsafe_hash=True, order=True)
+class Test:
   """Describes a junit-style test or collection of tests."""
+  classname: str
+  methodname: Optional[str]
 
-  def __new__(cls, classname, methodname=None):
+  def __init__(self, classname: str, methodname: Optional[str] = None) -> None:
+    self.classname = classname
     # We deliberately normalize an empty methodname ('') to None.
-    return super().__new__(cls, classname, methodname or None)
+    self.methodname = methodname or None
 
   def enclosing(self):
     """Return a test representing all the tests in this test's enclosing class.

--- a/src/python/pants/pantsd/service/BUILD
+++ b/src/python/pants/pantsd/service/BUILD
@@ -5,7 +5,8 @@ python_library(
   name = 'pants_service',
   sources = ['pants_service.py'],
   dependencies = [
-    'src/python/pants/util:objects'
+    '3rdparty/python:dataclasses',
+    'src/python/pants/util:meta'
   ]
 )
 

--- a/src/python/pants/pantsd/service/pants_service.py
+++ b/src/python/pants/pantsd/service/pants_service.py
@@ -199,15 +199,18 @@ class PantsServices:
   def __init__(
     self,
     services: Optional[Tuple[PantsService, ...]] = None,
-    # A dict of (port_name -> port_info) for named ports hosted by the services.
     port_map: Optional[Dict] = None,
-    # A lock to guard lifecycle changes for the services. This can be used by individual services
-    # to safeguard daemon-synchronous sections that should be protected from abrupt teardown.
-    # Notably, this lock is currently acquired for an entire pailgun request (by PailgunServer).
-    # NB: This is a `threading.RLock` instance, but the constructor for RLock is an alias for a
-    # native function, rather than an actual type.
     lifecycle_lock: Optional = None
   ) -> None:
+    """
+    :param port_map: A dict of (port_name -> port_info) for named ports hosted by the services.
+    :param lifecycle_lock: A lock to guard lifecycle changes for the services. This can be used by
+                           individual services to safeguard daemon-synchronous sections that should
+                           be protected from abrupt teardown. Notably, this lock is currently
+                           acquired for an entire pailgun request (by PailgunServer). NB: This is a
+                           `threading.RLock` instance, but the constructor for RLock is an alias for
+                           a native function, rather than an actual type.
+    """
     self.services = services or tuple()
     self.port_map = port_map or dict()
     self.lifecycle_lock = lifecycle_lock or threading.RLock()

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -3,7 +3,7 @@
 
 import re
 import shlex
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 
 def ensure_binary(text_or_binary: Union[bytes, str]) -> bytes:
@@ -54,7 +54,7 @@ def shell_quote(s: str) -> str:
   return "'" + s.replace("'", "'\"'\"'") + "'"
 
 
-def safe_shlex_join(arg_list: List[str]) -> str:
+def safe_shlex_join(arg_list: Sequence[str]) -> str:
   """Join a list of strings into a shlex-able string.
 
   Shell-quotes each argument with `shell_quote()`.
@@ -63,7 +63,7 @@ def safe_shlex_join(arg_list: List[str]) -> str:
 
 
 def create_path_env_var(
-  new_entries: List[str],
+  new_entries: Sequence[str],
   env: Optional[Dict[str, str]] = None,
   env_var: str = 'PATH',
   delimiter: str = ':',

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -195,7 +195,6 @@ python_tests(
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',
     'src/python/pants/engine:scheduler',
-    'src/python/pants/util:objects',
     'tests/python/pants_test/engine/examples:scheduler_inputs',
     'tests/python/pants_test:test_base',
   ]


### PR DESCRIPTION
Builds off of https://github.com/pantsbuild/pants/pull/8423.

For `native.py`, we must use `typing.NamedTuple` because those call sites can only use basic Python primitives. This is the same as a normal `namedtuple`, only that it uses a class-based definition with types built-in.