### PR TITLE
Explicitly delete file before writing it using the materialize_directory API

### DIFF
--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -62,7 +62,7 @@ impl TestData {
 }
 
 pub struct TestDirectory {
-  directory: bazel_protos::remote_execution::Directory,
+  pub directory: bazel_protos::remote_execution::Directory,
 }
 
 impl TestDirectory {


### PR DESCRIPTION
### Problem

I noticed a bug where using the new v2 version of the binary goal, which writes a .pex file to the `dist` directory, would result in a corrupted .pex if there was already a `.pex` file there with the same name created by the v1 version of the rule. I am not entirely sure why this corruption happens, but explicitly deleting the file before overwriting it fixes the problem. 

### Solution

Explicitly delete the file if it exists before writing to it.

### Result

Works around the corrupt .pex bug and potential future issues involving writing to file paths that already exist.