### PR TITLE
DO NOT MERGE: Showcase monkey-patching of Black for two spaces indent

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -13,6 +13,7 @@ from pants.backend.python.rules import (
   python_fmt,
   python_test_runner,
 )
+from pants.backend.python.subsystems.grey import rules as grey_rules
 from pants.backend.python.subsystems.python_native_code import PythonNativeCode
 from pants.backend.python.subsystems.python_native_code import rules as python_native_code_rules
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEnvironment
@@ -100,6 +101,7 @@ def rules():
   return (
     download_pex_bin.rules() +
     inject_init.rules() +
+    grey_rules() +
     python_fmt.rules() +
     python_test_runner.rules() +
     python_create_binary.rules() +

--- a/src/python/pants/backend/python/subsystems/grey.py
+++ b/src/python/pants/backend/python/subsystems/grey.py
@@ -1,0 +1,75 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.engine.fs import Digest, FileContent, InputFilesContent
+from pants.engine.rules import rule
+from pants.engine.selectors import Get
+from pants.option.custom_types import file_option
+from pants.subsystem.subsystem import Subsystem
+
+
+# Highjack the `Line.__str__` function from black.py and replace it with one that
+# formats with 2 spaces indent.
+# Note: when we update black's version, we will need to manually make sure that this
+# monkey patch remains in sync with the upstream code.
+# See: https://github.com/psf/black/blob/master/black.py
+grey_patch_content = b'''
+import itertools
+import black
+
+def str_with_two_chars_indent(self) -> str:
+    """Render the line."""
+    if not self:
+        return "\\n"
+
+    indent = "  " * self.depth
+    leaves = iter(self.leaves)
+    first = next(leaves)
+    res = f"{first.prefix}{indent}{first.value}"
+    for leaf in leaves:
+        res += str(leaf)
+    for comment in itertools.chain.from_iterable(self.comments.values()):
+        res += str(comment)
+    return res + "\\n"
+
+
+black.Line.__str__ = str_with_two_chars_indent
+
+black.patched_main()
+'''
+
+
+@dataclass (frozen=True)
+class GreyPatchDigest:
+  entry_point: str
+  digest: Digest
+
+
+@rule
+def patch_black_into_grey() -> GreyPatchDigest:
+  # Materialize a "grey.py" file with an entry point: "grey", which behaves like black but
+  # formats with a two spaces indentation.
+  grey_patch_digest = yield Get(Digest, InputFilesContent((
+      FileContent(path = "grey.py", content = grey_patch_content, is_executable = False),
+  )))
+  yield GreyPatchDigest("grey", grey_patch_digest)
+
+
+class Grey(Subsystem):
+  options_scope = 'black_with_two_spaces_indent'
+  default_interpreter_constraints = ["CPython>=3.6"]
+
+  def get_requirement_specs(self):
+    return ['black==19.3b0', 'setuptools']
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register('--config', advanced=True, type=file_option, fingerprint=True,
+             help="Path to formatting tool's config file")
+
+def rules():
+  return [patch_black_into_grey]

--- a/src/python/pants/backend/python/subsystems/python_formatter.py
+++ b/src/python/pants/backend/python/subsystems/python_formatter.py
@@ -1,0 +1,26 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.option.custom_types import file_option
+from pants.subsystem.subsystem import Subsystem
+from pants.util.objects import enum
+
+
+class PythonFormattingTool(enum([
+  "black",
+  "black_with_two_spaces_indent",
+  ])): pass
+
+
+class PythonFormatter(Subsystem):
+  options_scope = 'python_fmt'
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register('--tool',
+             advanced=True,
+             type=PythonFormattingTool,
+             default=PythonFormattingTool.black,
+             fingerprint=True,
+             help="Path to formatting tool's config file")

--- a/tests/python/pants_test/backend/python/rules/test_python_fmt_integration.py
+++ b/tests/python/pants_test/backend/python/rules/test_python_fmt_integration.py
@@ -4,7 +4,7 @@
 from os.path import relpath
 from pathlib import Path
 
-from pants.util.contextutil import temporary_file, temporary_file_path
+from pants.util.contextutil import temporary_dir, temporary_file, temporary_file_path
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
 
 
@@ -60,19 +60,63 @@ class PythonFmtIntegrationTest(PantsRunIntegrationTest):
     self.assertIn("1 file failed to reformat", pants_run.stderr_data)
 
 
-  def test_black_should_format_python_code(self):
-    # Open file in the greet target as the BUILD file globs python files from there
-    with temporary_file(root_dir="./examples/src/python/example/hello/greet/", suffix=".py") as code:
-      file_name = code.name
-      code.write(b"x     = 42")
-      code.close()
+  def test_grey_should_pickup_non_default_config(self):
+    # If a valid toml file without a black configuration section is picked up,
+    # Black won't skip the compilation_failure and will fail
+    with temporary_file_path(root_dir=".", suffix=".toml") as empty_config:
       command = [
         'fmt-v2',
-        'examples/src/python/example/hello/greet:greet'
+        'testprojects/src/python/unicode/compilation_failure::',
+        '--python_fmt-tool=black_with_two_spaces_indent',
+        f'--black_with_two_spaces_indent-config={relpath(empty_config)}'
         ]
       pants_run = self.run_pants(command=command)
-      formatted = Path(file_name).read_text();
-      self.assertEqual("x = 42\n", formatted)
-    self.assert_success(pants_run)
+    self.assert_failure(pants_run)
+    self.assertNotIn("reformatted", pants_run.stderr_data)
+    self.assertNotIn("unchanged", pants_run.stderr_data)
+    self.assertIn("1 file failed to reformat", pants_run.stderr_data)
+
+
+  def test_black_should_format_python_code_with_4_spaces_indent(self):
+    # Open file in the greet target as the BUILD file globs python files from there
+    with temporary_dir(root_dir=".") as root_dir:
+      code = Path(root_dir, "code.py")
+      code.touch()
+      code.write_text("def hello():x=42")
+      build = Path(root_dir, "BUILD")
+      build.touch()
+      build.write_text("python_library()")
+      command = [
+        'fmt-v2',
+        f'{root_dir}:'
+        ]
+      pants_run = self.run_pants(command=command)
+      self.assert_success(pants_run)
+      formatted = Path(code).read_text();
+      self.assertEqual("def hello():\n    x = 42\n", formatted)
     self.assertIn("1 file reformatted", pants_run.stderr_data)
-    self.assertIn("2 files left unchanged", pants_run.stderr_data)
+    self.assertNotIn("unchanged", pants_run.stderr_data)
+    self.assertNotIn("failed", pants_run.stderr_data)
+
+
+  def test_grey_should_format_python_code_with_2_spaces_indent(self):
+    # Open file in the greet target as the BUILD file globs python files from there
+    with temporary_dir(root_dir=".") as root_dir:
+      code = Path(root_dir, "code.py")
+      code.touch()
+      code.write_text("def hello():x=42")
+      build = Path(root_dir, "BUILD")
+      build.touch()
+      build.write_text("python_library()")
+      command = [
+        'fmt-v2',
+        '--python_fmt-tool=black_with_two_spaces_indent',
+        f'{root_dir}:'
+        ]
+      pants_run = self.run_pants(command=command)
+      self.assert_success(pants_run)
+      formatted = Path(code).read_text();
+      self.assertEqual("def hello():\n  x = 42\n", formatted)
+    self.assertIn("1 file reformatted", pants_run.stderr_data)
+    self.assertNotIn("unchanged", pants_run.stderr_data)
+    self.assertNotIn("failed", pants_run.stderr_data)


### PR DESCRIPTION
### Problem

We are currently debating whether we should format our code with vanilla black (including the 4-spaces indent opinion) or whether we should monkey patch black to allow 2-spaces indent instead.

I felt there was a certain amount of uncertainty in what work was needed for the monkey-patching.

### Solution

Implement 2-spaces black monkey patching to inform the discussion by giving an idea of the scope of work required.

### Result

Now we can discuss the alternatives with a bit more information at hand.