### PR TITLE
Add duration to Job to prep for calculating critical path

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -70,6 +70,7 @@ python_library(
   sources = ['execution_graph.py'],
   dependencies = [
     'src/python/pants/base:worker_pool',
+    'src/python/pants/util:contextutil',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
@@ -9,6 +9,7 @@ from collections import defaultdict, deque
 from heapq import heappop, heappush
 
 from pants.base.worker_pool import Work
+from pants.util.contextutil import Timer
 
 
 class Job:
@@ -18,7 +19,8 @@ class Job:
   keys of its dependent jobs.
   """
 
-  def __init__(self, key, fn, dependencies, size=0, on_success=None, on_failure=None, run_asap=False):
+  def __init__(self, key, fn, dependencies, size=0, on_success=None, on_failure=None,
+    run_asap=False, duration=None):
     """
 
     :param key: Key used to reference and look up jobs
@@ -37,6 +39,7 @@ class Job:
     self.on_success = on_success
     self.on_failure = on_failure
     self.run_asap = run_asap
+    self.duration = duration
 
   def __call__(self):
     self.fn()
@@ -278,11 +281,12 @@ class ExecutionGraph:
       def worker(worker_key, work):
         status_table.mark_as(RUNNING, worker_key)
         try:
-          work()
-          result = (worker_key, SUCCESSFUL, None)
+          with Timer() as timer:
+            work()
+          result = (worker_key, SUCCESSFUL, None, timer.elapsed)
         except BaseException:
           _, exc_value, exc_traceback = sys.exc_info()
-          result = (worker_key, FAILED, (exc_value, traceback.format_tb(exc_traceback)))
+          result = (worker_key, FAILED, (exc_value, traceback.format_tb(exc_traceback)), timer.elapsed)
         finished_queue.put(result)
         jobs_in_flight.decrement()
 
@@ -300,7 +304,7 @@ class ExecutionGraph:
 
       while not status_table.are_all_done():
         try:
-          finished_key, result_status, value = finished_queue.get(timeout=10)
+          finished_key, result_status, value, duration = finished_queue.get(timeout=10)
         except queue.Empty:
           self.log_progress(log, status_table)
 
@@ -308,6 +312,7 @@ class ExecutionGraph:
           continue
 
         finished_job = self._jobs[finished_key]
+        finished_job.duration = duration
         direct_dependees = self._dependees[finished_key]
         status_table.mark_as(result_status, finished_key)
 
@@ -342,11 +347,12 @@ class ExecutionGraph:
         # Log success or failure for this job.
         if result_status is FAILED:
           exception, tb = value
-          log.error("{} failed: {}".format(finished_key, exception))
+          log.error("{} failed: {} in {}".format(finished_key, exception, finished_job.duration))
           if self._print_stack_trace:
             log.error('Traceback:\n{}'.format('\n'.join(tb)))
         else:
-          log.debug("{} finished with status {}".format(finished_key, result_status))
+          log.debug("{} finished with status {} and in {}".format(finished_key, result_status,
+            finished_job.duration))
     except ExecutionFailure:
       raise
     except Exception as e:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
@@ -306,10 +306,9 @@ class ExecutionGraph:
 
       while not status_table.are_all_done():
         try:
-          finished_key, result_status, value, duration = finished_queue.get(timeout=10)
+          (finished_key, result_status, value, duration) = finished_queue.get(timeout=10)
         except queue.Empty:
           self.log_progress(log, status_table)
-
           try_to_submit_jobs_from_heap()
           continue
 
@@ -344,7 +343,7 @@ class ExecutionGraph:
           for dependee in direct_dependees:
             if status_table.is_unstarted(dependee):
               status_table.mark_queued(dependee)
-              finished_queue.put((dependee, CANCELED, None))
+              finished_queue.put((dependee, CANCELED, None, 0))
 
         # Log success or failure for this job.
         if result_status is FAILED:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
@@ -20,7 +20,7 @@ class Job:
   """
 
   def __init__(self, key, fn, dependencies, size=0, on_success=None, on_failure=None,
-    run_asap=False, duration=None):
+    run_asap=False, duration=None, options_scope=None, target=None):
     """
 
     :param key: Key used to reference and look up jobs
@@ -40,6 +40,8 @@ class Job:
     self.on_failure = on_failure
     self.run_asap = run_asap
     self.duration = duration
+    self.options_scope = options_scope
+    self.target = target
 
   def __call__(self):
     self.fn()

--- a/tests/python/pants_test/tasks/test_execution_graph.py
+++ b/tests/python/pants_test/tasks/test_execution_graph.py
@@ -313,9 +313,10 @@ class ExecutionGraphTest(unittest.TestCase):
       graph.execute(ImmediatelyExecutingPool(), capturing_logger)
     error_logs = capturing_logger.log_entries['error']
     self.assertEqual(2, len(error_logs), msg=f'Wanted one error log, got: {error_logs}')
-    self.assertEqual("A failed: I'm an error", error_logs[0])
+    regex = re.compile("A failed: I'm an error.*")
+    self.assertRegex(error_logs[0], regex)
     regex = re.compile(
-      "Traceback:.*in raising_wrapper.*raise Exception\\(\"I'm an error\"\\)",
+      "Traceback:.*in raising_wrapper.*raise Exception\\(\"I'm an error.*\"\\)",
       re.DOTALL,
     )
     self.assertRegex(error_logs[1], regex)


### PR DESCRIPTION
### Problem

Having a critical-path subset of a Zipkin trace to analyze to look for bottlenecks would be useful. We should be able to compute this from the information the ExecutionGraph has for v1 only. 

### Solution

Step 1: Add duration and other info (to be able to post to RunTracker stats) to a Job, so that we can compute the critical path of compiles in v1
(will be following up with PRs that do the computation)
