### PR TITLE
Only resolve requirements from PythonRequirementLibrary targets for setup_requires in python_dist()

### DIFF
--- a/src/python/pants/backend/python/tasks/build_local_python_distributions.py
+++ b/src/python/pants/backend/python/tasks/build_local_python_distributions.py
@@ -93,9 +93,10 @@ class BuildLocalPythonDistributions(Task):
     reqs_to_resolve = set()
 
     for setup_req_lib_addr in dist_target.setup_requires:
-      for req_lib in self.context.build_graph.resolve(setup_req_lib_addr):
-        for req in req_lib.requirements:
-          reqs_to_resolve.add(req)
+      for maybe_req_lib in self.context.build_graph.resolve(setup_req_lib_addr):
+        if isinstance(maybe_req_lib, PythonRequirementLibrary):
+          for req in maybe_req_lib.requirements:
+            reqs_to_resolve.add(req)
 
     if not reqs_to_resolve:
       return None

--- a/testprojects/3rdparty/python/BUILD
+++ b/testprojects/3rdparty/python/BUILD
@@ -1,6 +1,1 @@
-python_requirement_library(
-  name='numpy',
-  requirements=[
-    python_requirement('numpy==1.14.5')
-  ]
-)
+python_requirements()

--- a/testprojects/3rdparty/python/requirements.txt
+++ b/testprojects/3rdparty/python/requirements.txt
@@ -1,0 +1,2 @@
+checksumdir==1.1.7
+numpy==1.14.5

--- a/testprojects/src/python/python_distribution/setup_requires/BUILD
+++ b/testprojects/src/python/python_distribution/setup_requires/BUILD
@@ -1,0 +1,20 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_dist(
+  name='checksummed_version_dist',
+  setup_requires=[
+    # NB: This particular requirement is selected because it is unlikely to already be available to
+    # the python interpreter.
+    'testprojects/3rdparty/python:checksumdir',
+  ],
+)
+
+# NB: The default `sources` for this target is 'test_*.py', so its default sources don't intersect
+# with the `python_dist()`'s default sources.
+python_tests(
+  name='tests',
+  dependencies=[
+    ':checksummed_version_dist',
+  ],
+)

--- a/testprojects/src/python/python_distribution/setup_requires/setup.py
+++ b/testprojects/src/python/python_distribution/setup_requires/setup.py
@@ -4,7 +4,6 @@
 import os
 from pathlib import Path
 from setuptools import find_packages, setup
-from textwrap import dedent
 
 # NB: In this example project, we import a module added via `setup_requires` in our BUILD file, and
 # make some modifications to the `setup.py` project. These get picked up and tested in
@@ -15,10 +14,9 @@ this_dir_hash = dirhash('.', 'sha256')
 
 checksum_module_dir = Path('checksum')
 checksum_module_dir.mkdir()
-with (checksum_module_dir / '__init__.py').open(mode='w') as f:
-  f.write(dedent(f"""\
-  checksum = '{this_dir_hash}'
-  """))
+checksum_module_dir.joinpath('__init__.py').write_text(f"""\
+checksum = '{this_dir_hash}'
+""")
 
 setup(
   name='checksummed_version_dist',

--- a/testprojects/src/python/python_distribution/setup_requires/setup.py
+++ b/testprojects/src/python/python_distribution/setup_requires/setup.py
@@ -1,0 +1,27 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+from pathlib import Path
+from setuptools import find_packages, setup
+from textwrap import dedent
+
+# NB: In this example project, we import a module added via `setup_requires` in our BUILD file, and
+# make some modifications to the `setup.py` project. These get picked up and tested in
+# `test_setup_requires.py`.
+from checksumdir import dirhash
+
+this_dir_hash = dirhash('.', 'sha256')
+
+checksum_module_dir = Path('checksum')
+checksum_module_dir.mkdir()
+with (checksum_module_dir / '__init__.py').open(mode='w') as f:
+  f.write(dedent(f"""\
+  checksum = '{this_dir_hash}'
+  """))
+
+setup(
+  name='checksummed_version_dist',
+  version='0.0.1',
+  packages=find_packages(),
+)

--- a/testprojects/src/python/python_distribution/setup_requires/test_setup_requires.py
+++ b/testprojects/src/python/python_distribution/setup_requires/test_setup_requires.py
@@ -1,0 +1,13 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import re
+
+from checksum import checksum
+
+
+# TODO: validate the checksum's value itself?
+def test_dist_version():
+  assert checksum is not None
+  assert isinstance(checksum, str)
+  assert len(checksum) == 64


### PR DESCRIPTION
# Problem

I created https://github.com/cosmicexplorer/example-pants-python-dist today to showcase how to use a pants `python_dist()` target to wrap an existing setup.py-based project, namely https://github.com/facebookresearch/maskrcnn-benchmark. This didn't immediately work, because the build graph's `.resolve()` method for the address spec of a `PythonRequirementLibrary` created from the `python_requirements()` build file macro returns a `Files` target in addition to the requested `PythonRequirementLibrary` target.

### Solution

- Only read requirements from `PythonRequirementLibrary` targets returned by `self.context.build_graph.resolve()`.

### Result

After checking out this pants PR and cd-ing into a clone of https://github.com/cosmicexplorer/example-pants-python-dist, you can run:
```bash
> /path/to/your/pants/checkout/of/this/PR/pants run example-usage-of-python-dist-lib/bin
...
['DEPRECATED_KEYS', 'IMMUTABLE', 'NEW_ALLOWED', 'RENAMED_KEYS', '__class__', '__contains__', '__delattr__', '__delitem__', '__deprecated_keys__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattr__', '__getattribute__', '__getitem__', '__gt__', '__hash__', '__immutable__', '__init__', '__init_subclass__', '__iter__', '__le__', '__len__', '__lt__', '__module__', '__ne__', '__new__', '__new_allowed__', '__reduce__', '__reduce_ex__', '__renamed_keys__', '__repr__', '__setattr__', '__setitem__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_create_config_tree_from_dict', '_decode_cfg_value', '_immutable', '_load_cfg_from_file', '_load_cfg_from_yaml_str', '_load_cfg_py_source', 'clear', 'clone', 'copy', 'defrost', 'dump', 'freeze', 'fromkeys', 'get', 'is_frozen', 'is_new_allowed', 'items', 'key_is_deprecated', 'key_is_renamed', 'keys', 'load_cfg', 'merge_from_file', 'merge_from_list', 'merge_from_other_cfg', 'pop', 'popitem', 'raise_key_rename_error', 'register_deprecated_key', 'register_renamed_key', 'setdefault', 'update', 'values']
```