### PR TITLE
Use `collections.Enum` instead of `enum()`

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -126,15 +126,13 @@ python_library(
   name = 'shader',
   sources = ['shader.py'],
   dependencies = [
-    'src/python/pants/java/jar',
     'src/python/pants/backend/jvm/tasks:classpath_util',
     'src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin',
     'src/python/pants/java/distribution',
     'src/python/pants/java:executor',
+    'src/python/pants/java/jar',
     'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
-    'src/python/pants/util:memo',
-    'src/python/pants/util:objects',
   ]
 )
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -3,6 +3,7 @@
 
 import functools
 import os
+from enum import Enum
 from multiprocessing import cpu_count
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -3,7 +3,6 @@
 
 import functools
 import os
-from enum import Enum
 from multiprocessing import cpu_count
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext

--- a/src/python/pants/backend/native/config/BUILD
+++ b/src/python/pants/backend/native/config/BUILD
@@ -5,7 +5,6 @@ python_library(
   dependencies=[
     'src/python/pants/engine:rules',
     'src/python/pants/engine:platform',
-    'src/python/pants/util:objects',
     'src/python/pants/util:osutil',
   ],
 )

--- a/src/python/pants/backend/native/subsystems/BUILD
+++ b/src/python/pants/backend/native/subsystems/BUILD
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 

--- a/src/python/pants/backend/native/subsystems/BUILD
+++ b/src/python/pants/backend/native/subsystems/BUILD
@@ -11,6 +11,8 @@ python_library(
     'src/python/pants/engine:rules',
     'src/python/pants/engine:selectors',
     'src/python/pants/subsystem',
+    'src/python/pants/util:collections',
     'src/python/pants/util:memo',
+    'src/python/pants/util:meta',
   ],
 )

--- a/src/python/pants/backend/native/subsystems/binaries/BUILD
+++ b/src/python/pants/backend/native/subsystems/binaries/BUILD
@@ -8,7 +8,7 @@ python_library(
     'src/python/pants/backend/native/subsystems/utils',
     'src/python/pants/binaries',
     'src/python/pants/engine:rules',
-    'src/python/pants/engine:selectors',
-    'src/python/pants/util:objects',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
   ],
 )

--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -40,10 +40,10 @@ class GCC(NativeTool):
 
   @memoized_method
   def _common_lib_dirs(self, platform):
-    lib64_tuples = platform.resolve_for_enum_variant({
-      'darwin': [],
-      'linux': [('lib64',)],
-    })
+    lib64_tuples = {
+      Platform.darwin: [],
+      Platform.linux: [('lib64',)]
+    }[platform]
     return self._filemap(lib64_tuples + [
       ('lib',),
       ('lib/gcc',),

--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -40,10 +40,10 @@ class GCC(NativeTool):
 
   @memoized_method
   def _common_lib_dirs(self, platform):
-    lib64_tuples = {
+    lib64_tuples = platform.match({
       Platform.darwin: [],
       Platform.linux: [('lib64',)]
-    }[platform]
+    })
     return self._filemap(lib64_tuples + [
       ('lib',),
       ('lib/gcc',),

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -79,10 +79,10 @@ class LLVM(NativeTool):
   def linker(self, platform):
     return Linker(
       path_entries=self.path_entries,
-      exe_filename={
+      exe_filename=platform.match({
         Platform.darwin: "ld64.lld",
         Platform.linux: "lld",
-      }[platform],
+      }),
       library_dirs=[],
       linking_library_dirs=[],
       extra_args=[],

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -79,10 +79,10 @@ class LLVM(NativeTool):
   def linker(self, platform):
     return Linker(
       path_entries=self.path_entries,
-      exe_filename=platform.resolve_for_enum_variant({
-        'darwin': 'ld64.lld',
-        'linux': 'lld',
-      }),
+      exe_filename={
+        Platform.darwin: "ld64.lld",
+        Platform.linux: "lld",
+      }[platform],
       library_dirs=[],
       linking_library_dirs=[],
       extra_args=[],

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -37,10 +37,10 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
                   'for targets of this language.')
 
     register('--toolchain-variant', advanced=True,
-             default={
+             default=Platform.current.match({
                Platform.darwin: ToolchainVariant.llvm,
                Platform.linux: ToolchainVariant.gnu,
-             }[Platform.current],
+             }),
              type=ToolchainVariant,
              help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Note that "
                   "currently, despite the choice of toolchain, all linking is done with binutils "

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import abstractmethod
+from enum import Enum
 
 from pants.backend.native.config.environment import Platform
 from pants.build_graph.mirrored_target_option_mixin import MirroredTargetOptionMixin
@@ -9,10 +10,11 @@ from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
 from pants.util.meta import classproperty
-from pants.util.objects import enum
 
 
-class ToolchainVariant(enum(['gnu', 'llvm'])): pass
+class ToolchainVariant(Enum):
+  gnu = "gnu"
+  llvm = "llvm"
 
 
 class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsystem):

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -37,10 +37,10 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
                   'for targets of this language.')
 
     register('--toolchain-variant', advanced=True,
-             default=Platform.current.resolve_for_enum_variant({
-               'darwin': ToolchainVariant.llvm,
-               'linux': ToolchainVariant.gnu,
-             }),
+             default={
+               Platform.darwin: ToolchainVariant.llvm,
+               Platform.linux: ToolchainVariant.gnu,
+             }[Platform.current],
              type=ToolchainVariant,
              help="Whether to use gcc (gnu) or clang (llvm) to compile C and C++. Note that "
                   "currently, despite the choice of toolchain, all linking is done with binutils "

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -2,12 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import abstractmethod
-from enum import Enum
 
 from pants.backend.native.config.environment import Platform
 from pants.build_graph.mirrored_target_option_mixin import MirroredTargetOptionMixin
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.subsystem.subsystem import Subsystem
+from pants.util.collections import Enum
 from pants.util.memo import memoized_property
 from pants.util.meta import classproperty
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -119,10 +119,10 @@ class LLVMCppToolchain:
 @rule
 def select_libc_objects(platform: Platform, native_toolchain: NativeToolchain) -> LibcObjects:
   # We use lambdas here to avoid searching for libc on osx, where it will fail.
-  paths = {
+  paths = platform.match({
     Platform.darwin: lambda: [],
     Platform.linux: lambda: native_toolchain._libc_dev.get_libc_objects(),
-  }[platform]()
+  })()
   yield LibcObjects(paths)
 
 
@@ -329,10 +329,7 @@ class ToolchainVariantRequest:
 
 @rule
 def select_c_toolchain(toolchain_variant_request: ToolchainVariantRequest) -> CToolchain:
-  use_gcc = {
-    ToolchainVariant.gnu: True,
-    ToolchainVariant.llvm: False,
-  }[toolchain_variant_request.variant]
+  use_gcc = toolchain_variant_request.variant == ToolchainVariant.gnu
   if use_gcc:
     toolchain_resolved = yield Get(GCCCToolchain, NativeToolchain, toolchain_variant_request.toolchain)
   else:
@@ -342,10 +339,7 @@ def select_c_toolchain(toolchain_variant_request: ToolchainVariantRequest) -> CT
 
 @rule
 def select_cpp_toolchain(toolchain_variant_request: ToolchainVariantRequest) -> CppToolchain:
-  use_gcc = {
-    ToolchainVariant.gnu: True,
-    ToolchainVariant.llvm: False,
-  }[toolchain_variant_request.variant]
+  use_gcc = toolchain_variant_request.variant == ToolchainVariant.gnu
   if use_gcc:
     toolchain_resolved = yield Get(
       GCCCppToolchain, NativeToolchain, toolchain_variant_request.toolchain

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -119,10 +119,10 @@ class LLVMCppToolchain:
 @rule
 def select_libc_objects(platform: Platform, native_toolchain: NativeToolchain) -> LibcObjects:
   # We use lambdas here to avoid searching for libc on osx, where it will fail.
-  paths = platform.resolve_for_enum_variant({
-    'darwin': lambda: [],
-    'linux': lambda: native_toolchain._libc_dev.get_libc_objects(),
-  })()
+  paths = {
+    Platform.darwin: lambda: [],
+    Platform.linux: lambda: native_toolchain._libc_dev.get_libc_objects(),
+  }[platform]()
   yield LibcObjects(paths)
 
 

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -329,31 +329,31 @@ class ToolchainVariantRequest:
 
 @rule
 def select_c_toolchain(toolchain_variant_request: ToolchainVariantRequest) -> CToolchain:
-  native_toolchain = toolchain_variant_request.toolchain
-  # TODO(#5933): make an enum exhaustiveness checking method that works with `yield Get(...)`!
-  use_gcc = toolchain_variant_request.variant.resolve_for_enum_variant({
-    'gnu': True,
-    'llvm': False,
-  })
+  use_gcc = {
+    ToolchainVariant.gnu: True,
+    ToolchainVariant.llvm: False,
+  }[toolchain_variant_request.variant]
   if use_gcc:
-    toolchain_resolved = yield Get(GCCCToolchain, NativeToolchain, native_toolchain)
+    toolchain_resolved = yield Get(GCCCToolchain, NativeToolchain, toolchain_variant_request.toolchain)
   else:
-    toolchain_resolved = yield Get(LLVMCToolchain, NativeToolchain, native_toolchain)
+    toolchain_resolved = yield Get(LLVMCToolchain, NativeToolchain, toolchain_variant_request.toolchain)
   yield toolchain_resolved.c_toolchain
 
 
 @rule
 def select_cpp_toolchain(toolchain_variant_request: ToolchainVariantRequest) -> CppToolchain:
-  native_toolchain = toolchain_variant_request.toolchain
-  # TODO(#5933): make an enum exhaustiveness checking method that works with `yield Get(...)`!
-  use_gcc = toolchain_variant_request.variant.resolve_for_enum_variant({
-    'gnu': True,
-    'llvm': False,
-  })
+  use_gcc = {
+    ToolchainVariant.gnu: True,
+    ToolchainVariant.llvm: False,
+  }[toolchain_variant_request.variant]
   if use_gcc:
-    toolchain_resolved = yield Get(GCCCppToolchain, NativeToolchain, native_toolchain)
+    toolchain_resolved = yield Get(
+      GCCCppToolchain, NativeToolchain, toolchain_variant_request.toolchain
+    )
   else:
-    toolchain_resolved = yield Get(LLVMCppToolchain, NativeToolchain, native_toolchain)
+    toolchain_resolved = yield Get(
+      LLVMCppToolchain, NativeToolchain, toolchain_variant_request.toolchain
+    )
   yield toolchain_resolved.cpp_toolchain
 
 

--- a/src/python/pants/backend/native/targets/BUILD
+++ b/src/python/pants/backend/native/targets/BUILD
@@ -10,6 +10,7 @@ python_library(
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',
+    'src/python/pants/engine:platform',
     'src/python/pants/util:memo',
   ],
 )

--- a/src/python/pants/backend/native/targets/native_artifact.py
+++ b/src/python/pants/backend/native/targets/native_artifact.py
@@ -38,10 +38,10 @@ class NativeArtifact(PayloadField):
 
   def as_shared_lib(self, platform):
     # TODO: check that the name conforms to some format in the constructor (e.g. no dots?).
-    return {
+    return platform.match({
       Platform.darwin: f"lib{self.lib_name}.dylib",
       Platform.linux: f"lib{self.lib_name}.so",
-    }[platform]
+    })
 
   def _compute_fingerprint(self):
     # TODO: This fingerprint computation boilerplate is error-prone and could probably be

--- a/src/python/pants/backend/native/targets/native_artifact.py
+++ b/src/python/pants/backend/native/targets/native_artifact.py
@@ -6,6 +6,7 @@ from hashlib import sha1
 from typing import Any
 
 from pants.base.payload_field import PayloadField
+from pants.engine.platform import Platform
 
 
 # NB: We manually implement __hash__(), rather than using unsafe_hash=True, because PayloadField
@@ -37,10 +38,10 @@ class NativeArtifact(PayloadField):
 
   def as_shared_lib(self, platform):
     # TODO: check that the name conforms to some format in the constructor (e.g. no dots?).
-    return platform.resolve_for_enum_variant({
-      'darwin': 'lib{}.dylib'.format(self.lib_name),
-      'linux': 'lib{}.so'.format(self.lib_name),
-    })
+    return {
+      Platform.darwin: f"lib{self.lib_name}.dylib",
+      Platform.linux: f"lib{self.lib_name}.so",
+    }[platform]
 
   def _compute_fingerprint(self):
     # TODO: This fingerprint computation boilerplate is error-prone and could probably be

--- a/src/python/pants/backend/native/tasks/conan_fetch.py
+++ b/src/python/pants/backend/native/tasks/conan_fetch.py
@@ -118,10 +118,10 @@ class ConanFetch(SimpleCodegenTask):
 
   @memoized_property
   def _conan_os_name(self):
-    return Platform.current.resolve_for_enum_variant({
-      'darwin': 'Macos',
-      'linux': 'Linux',
-    })
+    return {
+      Platform.darwin: "Macos",
+      Platform.linux: "Linux",
+    }[Platform.current]
 
   @property
   def _copy_target_attributes(self):

--- a/src/python/pants/backend/native/tasks/conan_fetch.py
+++ b/src/python/pants/backend/native/tasks/conan_fetch.py
@@ -118,10 +118,10 @@ class ConanFetch(SimpleCodegenTask):
 
   @memoized_property
   def _conan_os_name(self):
-    return {
+    return Platform.current.match({
       Platform.darwin: "Macos",
       Platform.linux: "Linux",
-    }[Platform.current]
+    })
 
   @property
   def _copy_target_attributes(self):

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -161,16 +161,16 @@ class LinkSharedLibraries(NativeTask):
 
     self.context.log.debug("resulting_shared_lib_path: {}".format(resulting_shared_lib_path))
     # We are executing in the results_dir, so get absolute paths for everything.
-    cmd = ([linker.exe_filename] +
-           self.platform.resolve_for_enum_variant({
-             'darwin': ['-Wl,-dylib'],
-             'linux': ['-shared'],
-           }) +
-           linker.extra_args +
-           ['-o', os.path.abspath(resulting_shared_lib_path)] +
-           ['-L{}'.format(lib_dir) for lib_dir in link_request.external_lib_dirs] +
-           ['-l{}'.format(lib_name) for lib_name in link_request.external_lib_names] +
-           [os.path.abspath(obj) for obj in object_files])
+    cmd = [
+      linker.exe_filename,
+      {Platform.darwin: ['-Wl,-dylib'], Platform.linux: ['-shared']}[self.platform],
+      *linker.extra_args,
+      '-o',
+      os.path.abspath(resulting_shared_lib_path),
+      *['-L{}'.format(lib_dir) for lib_dir in link_request.external_lib_dirs],
+      *['-l{}'.format(lib_name) for lib_name in link_request.external_lib_names],
+      * [os.path.abspath(obj) for obj in object_files]
+    ]
 
     self.context.log.info("selected linker exe name: '{}'".format(linker.exe_filename))
     self.context.log.debug("linker argv: {}".format(cmd))

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -161,16 +161,15 @@ class LinkSharedLibraries(NativeTask):
 
     self.context.log.debug("resulting_shared_lib_path: {}".format(resulting_shared_lib_path))
     # We are executing in the results_dir, so get absolute paths for everything.
-    cmd = [
-      linker.exe_filename,
-      {Platform.darwin: ['-Wl,-dylib'], Platform.linux: ['-shared']}[self.platform],
-      *linker.extra_args,
-      '-o',
-      os.path.abspath(resulting_shared_lib_path),
-      *['-L{}'.format(lib_dir) for lib_dir in link_request.external_lib_dirs],
-      *['-l{}'.format(lib_name) for lib_name in link_request.external_lib_names],
-      * [os.path.abspath(obj) for obj in object_files]
-    ]
+    cmd = (
+      [linker.exe_filename] +
+      {Platform.darwin: ['-Wl,-dylib'], Platform.linux: ['-shared']}[self.platform] +
+      linker.extra_args +
+      ['-o', os.path.abspath(resulting_shared_lib_path)] +
+      ['-L{}'.format(lib_dir) for lib_dir in link_request.external_lib_dirs] +
+      ['-l{}'.format(lib_name) for lib_name in link_request.external_lib_names] +
+      [os.path.abspath(obj) for obj in object_files]
+    )
 
     self.context.log.info("selected linker exe name: '{}'".format(linker.exe_filename))
     self.context.log.debug("linker argv: {}".format(cmd))

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -166,7 +166,9 @@ class LinkSharedLibraries(NativeTask):
     # We are executing in the results_dir, so get absolute paths for everything.
     cmd = (
       [linker.exe_filename] +
-      {Platform.darwin: ['-Wl,-dylib'], Platform.linux: ['-shared']}[self.platform] +
+      self.platform.match(
+        {Platform.darwin: ['-Wl,-dylib'], Platform.linux: ['-shared']}
+      ) +
       linker.extra_args +
       ['-o', os.path.abspath(resulting_shared_lib_path)] +
       ['-L{}'.format(lib_dir) for lib_dir in link_request.external_lib_dirs] +

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -62,7 +62,7 @@ class LinkSharedLibraries(NativeTask):
     return self.get_cpp_toolchain_variant(native_library_target).cpp_linker
 
   @memoized_property
-  def platform(self):
+  def platform(self) -> Platform:
     # TODO: convert this to a v2 engine dependency injection.
     return Platform.current
 
@@ -130,8 +130,11 @@ class LinkSharedLibraries(NativeTask):
         os.path.join(get_buildroot(), ext_dep._sources_field.rel_path, ext_dep.lib_relpath))
 
       native_lib_names = ext_dep.native_lib_names
-      if isinstance(ext_dep.native_lib_names, dict):
-        native_lib_names = self.platform.resolve_for_enum_variant(native_lib_names)
+      if isinstance(native_lib_names, dict):
+        # `native_lib_names` is a dictionary mapping the string representation of the Platform
+        # ('darwin' vs. 'linux') to a list of strings. We use the Enum's `.value` to get the
+        # underlying string value to lookup the relevant key in the dictionary.
+        native_lib_names = native_lib_names[self.platform.value]
       external_lib_names.extend(native_lib_names)
 
     link_request = LinkSharedLibraryRequest(

--- a/src/python/pants/backend/project_info/rules/BUILD
+++ b/src/python/pants/backend/project_info/rules/BUILD
@@ -10,7 +10,6 @@ python_library(
     'src/python/pants/rules/core',
     'src/python/pants/subsystem',
     'src/python/pants/util:memo',
-    'src/python/pants/util:objects',
   ],
 )
 

--- a/src/python/pants/backend/project_info/rules/BUILD
+++ b/src/python/pants/backend/project_info/rules/BUILD
@@ -9,6 +9,7 @@ python_library(
     'src/python/pants/engine/legacy:graph',
     'src/python/pants/rules/core',
     'src/python/pants/subsystem',
+    'src/python/pants/util:collections',
     'src/python/pants/util:memo',
   ],
 )

--- a/src/python/pants/backend/project_info/rules/source_file_validator.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator.py
@@ -4,7 +4,6 @@
 import itertools
 import re
 from dataclasses import dataclass
-from enum import Enum
 from typing import Tuple
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
@@ -16,6 +15,7 @@ from pants.engine.objects import Collection
 from pants.engine.rules import console_rule, optionable_rule, rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
+from pants.util.collections import Enum
 from pants.util.memo import memoized_method
 
 

--- a/src/python/pants/backend/project_info/rules/source_file_validator.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator.py
@@ -4,6 +4,7 @@
 import itertools
 import re
 from dataclasses import dataclass
+from enum import Enum
 from typing import Tuple
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
@@ -16,10 +17,9 @@ from pants.engine.rules import console_rule, optionable_rule, rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method
-from pants.util.objects import enum
 
 
-class DetailLevel(enum(['none', 'summary', 'nonmatching', 'all'])):
+class DetailLevel(Enum):
   """How much detail about validation to emit to the console.
 
   none: Emit nothing.
@@ -27,7 +27,10 @@ class DetailLevel(enum(['none', 'summary', 'nonmatching', 'all'])):
   nonmatching: Emit details for source files that failed to match at least one required pattern.
   all: Emit details for all source files.
   """
-  pass
+  none = "none"
+  summary = "summary"
+  nonmatching = "nonmatching"
+  all = "all"
 
 
 class Validate(Goal):

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -153,7 +153,6 @@ python_library(
   sources=['platform.py'],
   dependencies=[
       ':rules',
-      'src/python/pants/util:objects',
       'src/python/pants/util:memo',
       'src/python/pants/util:osutil',
   ]

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -153,6 +153,7 @@ python_library(
   sources=['platform.py'],
   dependencies=[
       ':rules',
+      'src/python/pants/util:collections',
       'src/python/pants/util:memo',
       'src/python/pants/util:osutil',
   ]

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -18,10 +18,10 @@ class Platform(Enum):
 
   @memoized_property
   def runtime_lib_path_env_var(self):
-    return {
+    return self.match({
       self.darwin: "DYLD_LIBRARY_PATH",
       self.linux: "LD_LIBRARY_PATH",
-    }[self]
+    })
 
 
 class PlatformConstraint(Enum):

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -14,7 +14,7 @@ class Platform(Enum):
 
   # TODO: try to turn all of these accesses into v2 dependency injections!
   @memoized_classproperty
-  def current(cls):
+  def current(cls) -> 'Platform':
     return cls(get_normalized_os_name())
 
   @memoized_property

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -1,9 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from enum import Enum
-
 from pants.engine.rules import rule
+from pants.util.collections import Enum
 from pants.util.memo import memoized_classproperty, memoized_property
 from pants.util.osutil import get_normalized_os_name
 

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -1,13 +1,16 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from enum import Enum
+
 from pants.engine.rules import rule
 from pants.util.memo import memoized_classproperty, memoized_property
-from pants.util.objects import enum
-from pants.util.osutil import all_normalized_os_names, get_normalized_os_name
+from pants.util.osutil import get_normalized_os_name
 
 
-class Platform(enum(all_normalized_os_names())):
+class Platform(Enum):
+  darwin = "darwin"
+  linux = "linux"
 
   # TODO: try to turn all of these accesses into v2 dependency injections!
   @memoized_classproperty
@@ -16,13 +19,17 @@ class Platform(enum(all_normalized_os_names())):
 
   @memoized_property
   def runtime_lib_path_env_var(self):
-    return self.resolve_for_enum_variant({
-      'darwin': 'DYLD_LIBRARY_PATH',
-      'linux': 'LD_LIBRARY_PATH',
-    })
+    return {
+      self.darwin: "DYLD_LIBRARY_PATH",
+      self.linux: "LD_LIBRARY_PATH",
+    }[self]
 
 
-class PlatformConstraint(enum(list(all_normalized_os_names()) + ['none'])):
+class PlatformConstraint(Enum):
+  darwin = "darwin"
+  linux = "linux"
+  none = "none"
+
   @memoized_classproperty
   def local_platform(cls):
     return cls(Platform.current.value)

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -13,6 +13,7 @@ python_library(
     'src/python/pants/base:deprecated',
     'src/python/pants/base:hash_utils',
     'src/python/pants/engine:selectors',
+    'src/python/pants/util:collections',
     'src/python/pants/util:eval',
     'src/python/pants/util:meta',
     'src/python/pants/util:memo',

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -16,7 +16,6 @@ python_library(
     'src/python/pants/util:eval',
     'src/python/pants/util:meta',
     'src/python/pants/util:memo',
-    'src/python/pants/util:objects',
     'src/python/pants/util:strutil',
   ]
 )

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -16,7 +16,6 @@ from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot, get_pants_cachedir, get_pants_configdir
 from pants.util.eval import parse_expression
-from pants.util.objects import datatype
 
 
 class Config(ABC):

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -3,9 +3,9 @@
 
 import os
 import re
-from enum import Enum
 
 from pants.option.errors import ParseError
+from pants.util.collections import Enum
 from pants.util.eval import parse_expression
 from pants.util.memo import memoized_method
 

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -3,11 +3,11 @@
 
 import os
 import re
+from enum import Enum
 
 from pants.option.errors import ParseError
 from pants.util.eval import parse_expression
 from pants.util.memo import memoized_method
-from pants.util.objects import enum
 
 
 class UnsetBool:
@@ -318,9 +318,11 @@ class DictValueComponent:
     return '{} {}'.format(self.action, self.val)
 
 
-class GlobExpansionConjunction(enum(['any_match', 'all_match'])):
+class GlobExpansionConjunction(Enum):
   """Describe whether to require that only some or all glob strings match in a target's sources.
 
   NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
   be aware of any changes to this object's definition.
   """
+  any_match = "any_match"
+  all_match = "all_match"

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -5,6 +5,7 @@ import multiprocessing
 import os
 import sys
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 from pants.base.build_environment import (
@@ -20,15 +21,17 @@ from pants.option.errors import OptionsError
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
-from pants.util.objects import enum
 
 
-class GlobMatchErrorBehavior(enum(['ignore', 'warn', 'error'])):
+class GlobMatchErrorBehavior(Enum):
   """Describe the action to perform when matching globs in BUILD files to source files.
 
   NB: this object is interpreted from within Snapshot::lift_path_globs() -- that method will need to
   be aware of any changes to this object's definition.
   """
+  ignore = "ignore"
+  warn = "warn"
+  error = "error"
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -5,7 +5,6 @@ import multiprocessing
 import os
 import sys
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any
 
 from pants.base.build_environment import (
@@ -21,6 +20,7 @@ from pants.option.errors import OptionsError
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
+from pants.util.collections import Enum
 
 
 class GlobMatchErrorBehavior(Enum):

--- a/src/python/pants/rules/core/BUILD
+++ b/src/python/pants/rules/core/BUILD
@@ -11,6 +11,7 @@ python_library(
       'src/python/pants/engine/legacy:graph',
       'src/python/pants/goal',
       'src/python/pants/source',
+      'src/python/pants/util:collections',
     ]
 )
 

--- a/src/python/pants/rules/core/core_test_model.py
+++ b/src/python/pants/rules/core/core_test_model.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from enum import Enum
 
 from pants.engine.rules import union
+from pants.util.collections import Enum
 
 
 class Status(Enum):

--- a/src/python/pants/rules/core/core_test_model.py
+++ b/src/python/pants/rules/core/core_test_model.py
@@ -2,12 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
+from enum import Enum
 
 from pants.engine.rules import union
-from pants.util.objects import enum
 
 
-class Status(enum(['SUCCESS', 'FAILURE'])): pass
+class Status(Enum):
+  SUCCESS = "SUCCESS"
+  FAILURE = "FAILURE"
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -17,7 +17,6 @@ from pants.engine.legacy.structs import (
 )
 from pants.engine.rules import console_rule, union
 from pants.engine.selectors import Get
-from pants.util.objects import datatype
 
 
 @dataclass(frozen=True)

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -26,7 +26,7 @@ def invoke_pex_for_output(pex_file_to_run):
 def _toolchain_variants(func):
   @wraps(func)
   def wrapper(*args, **kwargs):
-    for variant in ToolchainVariant.all_variants:
+    for variant in ToolchainVariant:
       func(*args, toolchain_variant=variant, **kwargs)
   return wrapper
 
@@ -73,20 +73,20 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       # for both C and C++ compilation.
       # TODO(#6866): don't parse info logs for testing! There is a TODO in test_cpp_compile.py
       # in the native backend testing to traverse the PATH to find the selected compiler.
-      compiler_names_to_check = toolchain_variant.resolve_for_enum_variant({
-        'gnu': ['gcc', 'g++'],
-        'llvm': ['clang', 'clang++'],
-      })
+      compiler_names_to_check = {
+        ToolchainVariant.gnu: ['gcc', 'g++'],
+        ToolchainVariant.llvm: ['clang', 'clang++'],
+      }[toolchain_variant]
       for compiler_name in compiler_names_to_check:
         self.assertIn("selected compiler exe name: '{}'".format(compiler_name),
                       pants_run.stdout_data)
 
       # All of our toolchains currently use the C++ compiler's filename as argv[0] for the linker,
       # so there is only one name to check.
-      linker_names_to_check = toolchain_variant.resolve_for_enum_variant({
-        'gnu': ['g++'],
-        'llvm': ['clang++'],
-      })
+      linker_names_to_check = {
+        ToolchainVariant.gnu: ['g++'],
+        ToolchainVariant.llvm: ['clang++'],
+      }[toolchain_variant]
       for linker_name in linker_names_to_check:
         self.assertIn("selected linker exe name: '{}'".format(linker_name),
                       pants_run.stdout_data)
@@ -103,10 +103,10 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
       dist_name, dist_version, wheel_platform = name_and_platform(wheel_dist)
       self.assertEqual(dist_name, 'ctypes_test')
-      contains_current_platform = Platform.current.resolve_for_enum_variant({
-        'darwin': wheel_platform.startswith('macosx'),
-        'linux': wheel_platform.startswith('linux'),
-      })
+      contains_current_platform = {
+        Platform.darwin: wheel_platform.startswith('macosx'),
+        Platform.linux: wheel_platform.startswith('linux'),
+      }[Platform.current]
       self.assertTrue(contains_current_platform)
 
       # Verify that the wheel contains our shared libraries.
@@ -152,18 +152,17 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         workdir=os.path.join(buildroot.new_buildroot, '.pants.d'),
       )
       self.assert_failure(pants_binary_strict_deps_failure)
-      self.assertIn(toolchain_variant.resolve_for_enum_variant({
-        'gnu': "fatal error: some_math.h: No such file or directory",
-        'llvm': "fatal error: 'some_math.h' file not found",
-      }),
-                    pants_binary_strict_deps_failure.stdout_data)
+      self.assertIn({
+        ToolchainVariant.gnu: "fatal error: some_math.h: No such file or directory",
+        ToolchainVariant.llvm: "fatal error: 'some_math.h' file not found"
+      }[toolchain_variant], pants_binary_strict_deps_failure.stdout_data)
 
     # TODO(#6848): we need to provide the libstdc++.so.6.dylib which comes with gcc on osx in the
     # DYLD_LIBRARY_PATH during the 'run' goal somehow.
-    attempt_pants_run = Platform.current.resolve_for_enum_variant({
-      'darwin': toolchain_variant == ToolchainVariant.llvm,
-      'linux': True,
-    })
+    attempt_pants_run = {
+      Platform.darwin: toolchain_variant == ToolchainVariant.llvm,
+      Platform.linux: True,
+    }[Platform.current]
     if attempt_pants_run:
       pants_run_interop = self.run_pants(['-q', 'run', self._binary_target_with_interop], config={
         'native-build-step': {
@@ -188,10 +187,10 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
     # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
     # be available on the runtime library path.
-    attempt_pants_run = Platform.current.resolve_for_enum_variant({
-      'darwin': toolchain_variant == ToolchainVariant.llvm,
-      'linux': True,
-    })
+    attempt_pants_run = {
+      Platform.darwin: toolchain_variant == ToolchainVariant.llvm,
+      Platform.linux: True,
+    }[Platform.current]
     if attempt_pants_run:
       pants_run = self.run_pants(['-q', 'run', self._binary_target_with_third_party], config={
         'native-build-step': {
@@ -234,10 +233,10 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     """
     # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
     # be available on the runtime library path.
-    attempt_pants_run = Platform.current.resolve_for_enum_variant({
-      'darwin': toolchain_variant == ToolchainVariant.llvm,
-      'linux': True,
-    })
+    attempt_pants_run = {
+      Platform.darwin: toolchain_variant == ToolchainVariant.llvm,
+      Platform.linux: True,
+    }[Platform.current]
     if not attempt_pants_run:
       return
 

--- a/tests/python/pants_test/backend/python/tasks/util/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/util/BUILD
@@ -2,6 +2,8 @@ python_library(
   dependencies=[
     'src/python/pants/backend/native',
     'src/python/pants/backend/python/tasks',
+    'src/python/pants/util:collections',
+    'src/python/pants/util:meta',
     'tests/python/pants_test/backend/python/tasks:python_task_test_base',
     'tests/python/pants_test/engine:scheduler_test_base',
   ]

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -3,6 +3,7 @@
 
 import re
 from abc import abstractmethod
+from enum import Enum
 
 from pants.backend.native.register import rules as native_backend_rules
 from pants.backend.native.subsystems.libc_dev import LibcDev
@@ -15,7 +16,6 @@ from pants.backend.python.tasks.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants.util.collections import assert_single_element
 from pants.util.meta import classproperty
-from pants.util.objects import enum
 from pants_test.backend.python.tasks.python_task_test_base import (
   PythonTaskTestBase,
   name_and_platform,
@@ -99,8 +99,10 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, DeclarativeTaskT
 
     return context, synthetic_target, snapshot_version
 
-  class ExpectedPlatformType(enum(['any', 'current'])):
+  class ExpectedPlatformType(Enum):
     """Whether to check that the produced wheel has the 'any' platform, or the current one."""
+    any = "any"
+    current = "current"
 
   def _assert_dist_and_wheel_identity(self, expected_name, expected_version, expected_platform,
                                       dist_target, **kwargs):
@@ -118,8 +120,8 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, DeclarativeTaskT
     self.assertEquals(dist, expected_name)
     self.assertEquals(version, expected_snapshot_version)
 
-    expected_platform = expected_platform.resolve_for_enum_variant({
-      'any': 'any',
-      'current': normalized_current_platform(),
-    })
+    expected_platform = {
+      BuildLocalPythonDistributionsTestBase.ExpectedPlatformType.any: "any",
+      BuildLocalPythonDistributionsTestBase.ExpectedPlatformType.current: normalized_current_platform(),
+    }[expected_platform]
     self.assertEquals(platform, expected_platform)

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -119,8 +119,8 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, DeclarativeTaskT
     self.assertEquals(dist, expected_name)
     self.assertEquals(version, expected_snapshot_version)
 
-    expected_platform = {
+    expected_platform = expected_platform.match({
       BuildLocalPythonDistributionsTestBase.ExpectedPlatformType.any: "any",
       BuildLocalPythonDistributionsTestBase.ExpectedPlatformType.current: normalized_current_platform(),
-    }[expected_platform]
+    })
     self.assertEquals(platform, expected_platform)

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -3,7 +3,6 @@
 
 import re
 from abc import abstractmethod
-from enum import Enum
 
 from pants.backend.native.register import rules as native_backend_rules
 from pants.backend.native.subsystems.libc_dev import LibcDev
@@ -14,7 +13,7 @@ from pants.backend.python.tasks.build_local_python_distributions import (
 )
 from pants.backend.python.tasks.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks.select_interpreter import SelectInterpreter
-from pants.util.collections import assert_single_element
+from pants.util.collections import Enum, assert_single_element
 from pants.util.meta import classproperty
 from pants_test.backend.python.tasks.python_task_test_base import (
   PythonTaskTestBase,

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -178,7 +178,6 @@ python_tests(
     'src/python/pants/engine:console',
     'src/python/pants/engine:rules',
     'src/python/pants/engine:selectors',
-    'src/python/pants/util:objects',
     'tests/python/pants_test/engine/examples:parsers',
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test:test_base',


### PR DESCRIPTION
### Problem
When we first realized the need for enums, we still had to support Python 2.7. Enums were not officially added until Python 3.3. So, we created our own abstraction in `objects.py` and over time added extra features like `resolve_for_enum_variant`.

However, MyPy does not understand our `enum()` type because using a function as the base clase does not work, similar to `datatype()` not working.

### Solution
Use `collections.Enum` (introduced in https://github.com/pantsbuild/pants/pull/8451).

### Result
Almost all uses of `enum()` are converted to something MyPy understands. 

The remaining usages are handled in another PR for a more manageable diff. 