### PR TITLE
Allow ignoring flake errors by name in addition to code.

### DIFF
--- a/contrib/python/tests/python/pants_test/contrib/python/checks/checker/test_pyflakes.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/checker/test_pyflakes.py
@@ -28,3 +28,7 @@ class PyflakesCheckerTest(CheckstylePluginTestBase):
   def test_pyflakes_ignore(self):
     plugin = self.get_plugin('import os', ignore=['F401'])
     self.assertEqual([], list(plugin.nits()))
+
+  def test_pyflakes_ignore(self):
+    plugin = self.get_plugin('import os', ignore=['UnusedImport'])
+    self.assertEqual([], list(plugin.nits()))


### PR DESCRIPTION
### Problem

The error codes assigned to pyflakes error classes are fragile: there are 48 error classes, of which we have codes assigned to just a handful. When a message has not yet been classified, the code `F999` is used, but the effect of ignoring `F999` is that you ignore "everything", which is risky.

### Solution

Allow pyflake messages to be ignored by the error class name in addition to by their code.

### Result

Less fragility and risk as pyflakes are added.