### PR TITLE
Fix missing digest for m.jar

### DIFF
--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -1,4 +1,5 @@
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:cache_compile_integration
+tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc:rsc_compile_integration_not_remoted
 tests/python/pants_test/backend/python/tasks/native:integration
 tests/python/pants_test/backend/python/tasks:build_local_python_distributions_integration
 tests/python/pants_test/backend/python/tasks:pytest_run_integration

--- a/src/python/pants/backend/jvm/subsystems/rsc.py
+++ b/src/python/pants/backend/jvm/subsystems/rsc.py
@@ -18,6 +18,8 @@ class Rsc(NativeTool):
 
     register('--native-image', fingerprint=True, type=bool,
              help='Use a pre-compiled native-image for rsc. Requires running in hermetic mode')
+    register('--jvm-options', type=list, metavar='<option>...',
+      help='Run the RSC with these jvm options.')
 
   @property
   def use_native_image(self):

--- a/src/python/pants/backend/jvm/subsystems/rsc.py
+++ b/src/python/pants/backend/jvm/subsystems/rsc.py
@@ -19,7 +19,7 @@ class Rsc(NativeTool):
     register('--native-image', fingerprint=True, type=bool,
              help='Use a pre-compiled native-image for rsc. Requires running in hermetic mode')
     register('--jvm-options', type=list, metavar='<option>...',
-      help='Run the RSC with these jvm options.')
+      help='Run RSC with these jvm options.')
 
   @property
   def use_native_image(self):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -674,15 +674,13 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     # TODO: parse the output of -Xprint:timings for rsc and write it to self._record_target_stats()!
 
     res.output_directory_digest.dump(ctx.rsc_jar_file.path)
-
-    ctx.rsc_jar_file._directory_digest = res.output_directory_digest
-
     self.context._scheduler.materialize_directories((
       DirectoryToMaterialize(
         # NB the first element here is the root to materialize into, not the dir to snapshot
         get_buildroot(),
         res.output_directory_digest),
     ))
+    ctx.rsc_jar_file.hydrate_missing_directory_digest(res.output_directory_digest)
 
     return res
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -342,13 +342,10 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         classpath_paths = []
 
         def _get_zinc_compiler_snapshot():
-          all_snap = []
           # Security manager is baked into the shaded zinc compiler jar.
-          # zinc_compiler_classpath = super(RscCompile, self).get_zinc_compiler_classpath()
-          rel_compiler_jar_paths = [fast_relpath(cp, get_buildroot()) for cp in super(RscCompile, self).get_zinc_compiler_classpath()]
           compiler_jar_snapshot, = self.context._scheduler.capture_snapshots([
             PathGlobsAndRoot(
-              PathGlobs(rel_compiler_jar_paths),
+              PathGlobs(fast_relpath_collection(super(RscCompile, self).get_zinc_compiler_classpath())),
               get_buildroot(),
             ),
           ])

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -338,7 +338,6 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         dependencies_for_target = list(
           DependencyContext.global_instance().dependencies_respecting_strict_deps(target))
 
-
         classpath_paths = []
         classpath_directory_digests = []
         classpath_product = self.context.products.get_data('rsc_mixed_compile_classpath')

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -606,14 +606,13 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     tool_classpath_abs = self._rsc_classpath
     tool_classpath = fast_relpath_collection(tool_classpath_abs)
 
-    jvm_options = self._jvm_options
+    rsc_jvm_options = Rsc.global_instance().get_options().jvm_options
 
     if self._rsc.use_native_image:
-      #jvm_options = []
-      if jvm_options:
+      if rsc_jvm_options:
         raise ValueError(
           "`{}` got non-empty jvm_options when running with a graal native-image, but this is "
-          "unsupported. jvm_options received: {}".format(self.options_scope, safe_shlex_join(jvm_options))
+          "unsupported. jvm_options received: {}".format(self.options_scope, safe_shlex_join(rsc_jvm_options))
         )
       native_image_path, native_image_snapshot = self._rsc.native_image(self.context)
       additional_snapshots = [native_image_snapshot]
@@ -622,7 +621,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       additional_snapshots = []
       initial_args = [
         distribution.java,
-      ] + self.get_options().jvm_options + [
+      ] + rsc_jvm_options + [
         '-cp', os.pathsep.join(tool_classpath),
         main,
       ]

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -675,7 +675,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
     res.output_directory_digest.dump(ctx.rsc_jar_file.path)
 
-    ctx.rsc_jar_file = ClasspathEntry(ctx.rsc_jar_file.path, res.output_directory_digest)
+    ctx.rsc_jar_file._directory_digest = res.output_directory_digest
 
     self.context._scheduler.materialize_directories((
       DirectoryToMaterialize(

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -365,23 +365,10 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
           def hermetic_digest_classpath():
             jdk_libs_rel, jdk_libs_digest = self._jdk_libs_paths_and_digest(distribution)
 
-            def _get_zinc_compiler_snapshot():
-              # Security manager is baked into the shaded zinc compiler jar.
-              compiler_jar_snapshot, = self.context._scheduler.capture_snapshots([
-                PathGlobsAndRoot(
-                  PathGlobs(fast_relpath_collection(super(RscCompile, self).get_zinc_compiler_classpath())),
-                  get_buildroot(),
-                ),
-              ])
-              return compiler_jar_snapshot
-
-            zinc_compiler_snapshot = _get_zinc_compiler_snapshot()
             merged_sources_and_jdk_digest = self.context._scheduler.merge_directories(
-              (jdk_libs_digest, sources_snapshot.directory_digest) + tuple(classpath_directory_digests)
-              + (zinc_compiler_snapshot.directory_digest,))
+              (jdk_libs_digest, sources_snapshot.directory_digest) + tuple(classpath_directory_digests))
             classpath_rel_jdk = classpath_paths + jdk_libs_rel
             return (merged_sources_and_jdk_digest, classpath_rel_jdk)
-
           def nonhermetic_digest_classpath():
             classpath_abs_jdk = classpath_paths + self._jdk_libs_abs(distribution)
             return ((EMPTY_DIRECTORY_DIGEST), classpath_abs_jdk)
@@ -616,12 +603,13 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       ))
 
   def _runtool_hermetic(self, main, tool_name, distribution, input_digest, ctx):
-    tool_classpath_abs = self._rsc_classpath + super(RscCompile, self).get_zinc_compiler_classpath()
+    tool_classpath_abs = self._rsc_classpath
     tool_classpath = fast_relpath_collection(tool_classpath_abs)
 
     jvm_options = self._jvm_options
 
     if self._rsc.use_native_image:
+      #jvm_options = []
       if jvm_options:
         raise ValueError(
           "`{}` got non-empty jvm_options when running with a graal native-image, but this is "

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -13,7 +13,7 @@ python_tests(
     'testprojects/src/scala/org/pantsbuild/testproject:javasources_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:mutual_directory',
   ],
-  timeout = 600,
+  timeout = 800,
   tags = {'integration'},
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -17,6 +17,19 @@ python_tests(
   tags = {'integration'},
 )
 
+python_tests(
+  name='rsc_compile_integration_not_remoted',
+  sources=['test_rsc_compile_integration_not_remoted.py'],
+  dependencies=[
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
+    'tests/python/pants_test:test_base',
+    'examples/src/scala/org/pantsbuild/example:hello_directory',
+  ],
+  timeout = 800,
+  tags = {'integration'},
+)
+
 
 python_tests(
   name = 'rsc_compile',

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -102,11 +102,11 @@ class RscCompileIntegration(BaseCompileIT, AbstractTestGenerator):
           'workflow': 'rsc-and-zinc',
           'execution_strategy': 'hermetic',
         },
-        'rsc': {
-          'jvm_options': [
-            '-Djava.security.manager=java.util.Optional'
-          ]
-        }
+        # 'rsc': {
+        #   'jvm_options': [
+        #     '-Djava.security.manager=java.util.Optional'
+        #   ]
+        # }
       })
     self.assert_failure(pants_run)
     self.assertIn(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -94,7 +94,7 @@ class RscCompileIntegration(BaseCompileIT, AbstractTestGenerator):
       config=config)
 
   def test_rsc_hermetic_jvm_options(self):
-    pants_run = self.do_command('compile', 'examples/src/scala/org/pantsbuild/example/hello/exe',
+    pants_run = self.run_pants(['compile', 'examples/src/scala/org/pantsbuild/example/hello/exe'],
       config={
         'cache.compile.rsc': {'ignore': True},
         'jvm-platform': {'compiler': 'rsc'},
@@ -106,7 +106,7 @@ class RscCompileIntegration(BaseCompileIT, AbstractTestGenerator):
           'jvm_options': [
             '-Djava.security.manager=org.pantsbuild.DefinitelyNonExistentSecurityManagerClass']
         }
-      }, success=False)
+      })
     self.assert_failure(pants_run)
     self.assertIn(
       'Could not create SecurityManager: org.pantsbuild.DefinitelyNonExistentSecurityManagerClass',

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -93,20 +93,5 @@ class RscCompileIntegration(BaseCompileIT, AbstractTestGenerator):
       'compile', 'testprojects/src/scala/org/pantsbuild/testproject/javasources',
       config=config)
 
-  def test_rsc_zinc_hermetic_integration(self):
-    pants_run = self.run_pants(
-      ['compile', 'examples/src/scala/org/pantsbuild/example/hello/exe'],
-      config={
-        'compile.rsc': {
-          'execution_strategy': 'hermetic',
-          'incremental': False,
-          'workflow': 'rsc-and-zinc'
-        },
-        'cache': {
-          'ignore': True
-        }
-      })
-    self.assert_success(pants_run)
-
 
 RscCompileIntegration.generate_tests()

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -93,27 +93,5 @@ class RscCompileIntegration(BaseCompileIT, AbstractTestGenerator):
       'compile', 'testprojects/src/scala/org/pantsbuild/testproject/javasources',
       config=config)
 
-  def test_rsc_hermetic_jvm_options(self):
-    pants_run = self.run_pants(['compile', 'examples/src/scala/org/pantsbuild/example/hello/exe'],
-      config={
-        'cache.compile.rsc': {'ignore': True},
-        'jvm-platform': {'compiler': 'rsc'},
-        'compile.rsc': {
-          'workflow': 'rsc-and-zinc',
-          'execution_strategy': 'hermetic',
-        },
-        'rsc': {
-          'jvm_options': [
-            '-Djava.security.manager=java.util.Optional'
-          ]
-        }
-      })
-    self.assert_failure(pants_run)
-    self.assertIn(
-      'Could not create SecurityManager: java.util.Optional',
-      pants_run.stdout_data,
-      'Pants run is expected to fail and contain error about loading an invalid security '
-      'manager class, but it did not.')
-
 
 RscCompileIntegration.generate_tests()

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -102,11 +102,11 @@ class RscCompileIntegration(BaseCompileIT, AbstractTestGenerator):
           'workflow': 'rsc-and-zinc',
           'execution_strategy': 'hermetic',
         },
-        # 'rsc': {
-        #   'jvm_options': [
-        #     '-Djava.security.manager=java.util.Optional'
-        #   ]
-        # }
+        'rsc': {
+          'jvm_options': [
+            '-Djava.security.manager=java.util.Optional'
+          ]
+        }
       })
     self.assert_failure(pants_run)
     self.assertIn(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -104,7 +104,8 @@ class RscCompileIntegration(BaseCompileIT, AbstractTestGenerator):
         },
         'rsc': {
           'jvm_options': [
-            '-Djava.security.manager=org.pantsbuild.DefinitelyNonExistentSecurityManagerClass']
+            # '-Djava.security.manager=org.pantsbuild.DefinitelyNonExistentSecurityManagerClass'
+          ]
         }
       })
     self.assert_failure(pants_run)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -93,5 +93,20 @@ class RscCompileIntegration(BaseCompileIT, AbstractTestGenerator):
       'compile', 'testprojects/src/scala/org/pantsbuild/testproject/javasources',
       config=config)
 
+  def test_rsc_zinc_hermetic_integration(self):
+    pants_run = self.run_pants(
+      ['compile', 'examples/src/scala/org/pantsbuild/example/hello/exe'],
+      config={
+        'compile.rsc': {
+          'execution_strategy': 'hermetic',
+          'incremental': False,
+          'workflow': 'rsc-and-zinc'
+        },
+        'cache': {
+          'ignore': True
+        }
+      })
+    self.assert_success(pants_run)
+
 
 RscCompileIntegration.generate_tests()

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -104,15 +104,15 @@ class RscCompileIntegration(BaseCompileIT, AbstractTestGenerator):
         },
         'rsc': {
           'jvm_options': [
-            # '-Djava.security.manager=org.pantsbuild.DefinitelyNonExistentSecurityManagerClass'
+            '-Djava.security.manager=java.util.Optional'
           ]
         }
       })
     self.assert_failure(pants_run)
     self.assertIn(
-      'Could not create SecurityManager: org.pantsbuild.DefinitelyNonExistentSecurityManagerClass',
+      'Could not create SecurityManager: java.util.Optional',
       pants_run.stdout_data,
-      'Pants run is expected to fail and contain error about loading the non existent security '
+      'Pants run is expected to fail and contain error about loading an invalid security '
       'manager class, but it did not.')
 
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_not_remoted.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_not_remoted.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_not_remoted.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_not_remoted.py
@@ -1,0 +1,29 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
+
+
+class RscCompileIntegrationNotRemoted(BaseCompileIT):
+
+  def test_rsc_hermetic_jvm_options(self):
+    pants_run = self.run_pants(['compile', 'examples/src/scala/org/pantsbuild/example/hello/exe'],
+      config={
+        'cache.compile.rsc': {'ignore': True},
+        'jvm-platform': {'compiler': 'rsc'},
+        'compile.rsc': {
+          'workflow': 'rsc-and-zinc',
+          'execution_strategy': 'hermetic',
+        },
+        'rsc': {
+          'jvm_options': [
+            '-Djava.security.manager=java.util.Optional'
+          ]
+        }
+      })
+    self.assert_failure(pants_run)
+    self.assertIn(
+      'Could not create SecurityManager: java.util.Optional',
+      pants_run.stdout_data,
+      'Pants run is expected to fail and contain error about loading an invalid security '
+      'manager class, but it did not.')

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_not_remoted.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_not_remoted.py
@@ -27,3 +27,18 @@ class RscCompileIntegrationNotRemoted(BaseCompileIT):
       pants_run.stdout_data,
       'Pants run is expected to fail and contain error about loading an invalid security '
       'manager class, but it did not.')
+
+  def test_rsc_zinc_hermetic_integration(self):
+    pants_run = self.run_pants(
+      ['compile', 'examples/src/scala/org/pantsbuild/example/hello/exe'],
+      config={
+        'compile.rsc': {
+          'execution_strategy': 'hermetic',
+          'incremental': False,
+          'workflow': 'rsc-and-zinc'
+        },
+        'cache': {
+          'ignore': True
+        }
+      })
+    self.assert_success(pants_run)


### PR DESCRIPTION
### Problem

```
[ 27/207] Rsc-ing 302 mixed sources in 1 target ('<some target>).
rsc(finagle/finagle-core/src/main:main) failed: 
ClasspathEntry ClasspathEntry(path='<some path>/source/.pants.d/compile/rsc/c1e3836b60e5/finagle.finagle-core.src.main.main/current/rsc/m.jar', directory_digest=None) didn't have a Digest, so won't be present for hermetic 
```

The issue is that when we are setting the directory like this
```
ctx.rsc_jar_file = ClasspathEntry(ctx.rsc_jar_file.path, res.output_directory_digest)
```
it creates an new object and assign it to `ctx.rsc_jar_file`, whereas somewhere else in the code still points to the `ClasspathEntry` that `ctx.rsc_jar_file` used to point to.

### Solution

Do not create an object, but change its attribute.

### Result

RSC does not choke on this anymore.