### PR TITLE
Add collections.Enum class that extends stdlib Enum with ~pattern matching

### DIFF
--- a/build-support/bin/check_banned_imports.py
+++ b/build-support/bin/check_banned_imports.py
@@ -4,47 +4,58 @@
 
 import re
 from glob import glob
-from typing import List
+from typing import Iterable, Set
 
 from common import die
 
 
 def main() -> None:
   rust_files = find_files("src/rust/engine", extension=".rs")
+  python_files = find_files(
+    "src", "tests", "pants-plugins", "contrib", extension=".py"
+  )
 
+  check_banned_import(
+    python_files - {"src/python/pants/util/collections.py"},
+    bad_import_regex=r"^from enum import.*Enum|^import enum$",
+    correct_import_message="from pants.util.collections import Enum",
+  )
   check_banned_import(
     rust_files,
     bad_import_regex=r"^use std::sync::.*(Mutex|RwLock)",
-    correct_import_message="`parking_lot::(Mutex|RwLock)`"
+    correct_import_message="parking_lot::(Mutex|RwLock)"
   )
 
 
-def find_files(*directories: str, extension: str) -> List[str]:
-  return [
+def find_files(*directories: str, extension: str) -> Set[str]:
+  return {
     fp
     for directory in directories
     for fp in glob(f"{directory}/**/*{extension}", recursive=True)
-  ]
+  }
 
 
-def filter_files(files: List[str], *, snippet_regex: str) -> List[str]:
+def filter_files(files: Iterable[str], *, snippet_regex: str) -> Set[str]:
   """Only return files that contain the snippet_regex."""
   regex = re.compile(snippet_regex)
-  result: List[str] = []
+  result: Set[str] = set()
   for fp in files:
     with open(fp, 'r') as f:
       if any(re.search(regex, line) for line in f.readlines()):
-        result.append(fp)
+        result.add(fp)
   return result
 
 
-def check_banned_import(files: List[str], *, bad_import_regex: str, correct_import_message: str) -> None:
-  bad_files: List[str] = filter_files(files, snippet_regex=bad_import_regex)
+def check_banned_import(
+  files: Iterable[str], *, bad_import_regex: str, correct_import_message: str
+) -> None:
+  bad_files = filter_files(files, snippet_regex=bad_import_regex)
   if bad_files:
-    bad_files_str = "\n".join(bad_files)
+    bad_files_str = "\n".join(sorted(bad_files))
     die(
       f"Found forbidden imports matching `{bad_import_regex}`. Instead, you should use "
-      f"{correct_import_message}. Bad files:\n{bad_files_str}")
+      f"`{correct_import_message}`. Bad files:\n{bad_files_str}"
+    )
 
 
 if __name__ == "__main__":

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -57,8 +57,11 @@ python_library(
     'src/python/pants/goal:products',
     'src/python/pants/option',
     'src/python/pants/reporting',
+    'src/python/pants/util:collections',
+    'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:fileutil',
+    'src/python/pants/util:memo',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -1,7 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import enum
 import functools
 import os
 from multiprocessing import cpu_count
@@ -39,6 +38,7 @@ from pants.java.distribution.distribution import DistributionLocator
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.option.ranked_value import RankedValue
 from pants.reporting.reporting_utils import items_to_report_element
+from pants.util.collections import Enum
 from pants.util.contextutil import Timer, temporary_dir
 from pants.util.dirutil import (
   fast_relpath,
@@ -68,7 +68,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
 
   size_estimators = create_size_estimators()
 
-  class Compiler(enum.Enum):
+  class Compiler(Enum):
     ZINC = 'zinc'
     RSC = 'rsc'
     JAVAC = 'javac'

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -15,11 +15,11 @@ from typing import (
 )
 
 
-K = TypeVar('K')
-V = TypeVar('V')
+_K = TypeVar('_K')
+_V = TypeVar('_V')
 
 
-def factory_dict(value_factory: Callable[[K], V], *args, **kwargs) -> DefaultDict:
+def factory_dict(value_factory: Callable[[_K], _V], *args, **kwargs) -> DefaultDict:
   """A dict whose values are computed by `value_factory` when a `__getitem__` key is missing.
 
   Note that values retrieved by any other method will not be lazily computed; eg: via `get`.
@@ -55,10 +55,10 @@ def recursively_update(d: MutableMapping, d2: MutableMapping) -> None:
     d[k] = v
 
 
-T = TypeVar('T')
+_T = TypeVar('_T')
 
 
-def assert_single_element(iterable: Iterable[T]) -> T:
+def assert_single_element(iterable: Iterable[_T]) -> _T:
   """Get the single element of `iterable`, or raise an error.
 
   :raise: :class:`StopIteration` if there is no element.
@@ -75,7 +75,7 @@ def assert_single_element(iterable: Iterable[T]) -> T:
   raise ValueError(f"iterable {iterable!r} has more than one element.")
 
 
-E = TypeVar('E', bound='Enum')
+_E = TypeVar('_E', bound='Enum')
 
 
 class EnumMatchError(ValueError):
@@ -96,7 +96,7 @@ class Enum(StdLibEnum):
   def all_values(cls) -> ValuesView['Enum']:
     return cls.__members__.values()
 
-  def match(self, enum_values_to_results: Mapping[E, V]) -> V:
+  def match(self, enum_values_to_results: Mapping[_E, _V]) -> _V:
     unrecognized_values = [
       value for value in enum_values_to_results if value not in self.all_values()
     ]
@@ -111,5 +111,5 @@ class Enum(StdLibEnum):
       raise InexhaustiveMatchError(
         f"All enum values must be covered by the match. Missing: {missing_values}"
       )
-    typed_self = cast(E, self)
+    typed_self = cast(_E, self)
     return enum_values_to_results[typed_self]

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -78,15 +78,15 @@ def assert_single_element(iterable: Iterable[T]) -> T:
 E = TypeVar('E', bound='Enum')
 
 
-class PatternMatchError(ValueError):
-  """Issue when using pattern_match() on an enum."""
+class EnumMatchError(ValueError):
+  """Issue when using match() on an enum."""
 
 
-class InexhaustivePatternsError(PatternMatchError):
+class InexhaustiveMatchError(EnumMatchError):
   """Not all values of the enum specified in the pattern match."""
 
 
-class UnrecognizedPatternError(PatternMatchError):
+class UnrecognizedMatchError(EnumMatchError):
   """A value is used that is not a part of the enum."""
 
 
@@ -95,7 +95,7 @@ class Enum(StdLibEnum):
   def all_values(self) -> ValuesView['Enum']:
     return self.__class__.__members__.values()
 
-  def pattern_match(self, enum_values_to_results: Mapping[E, V]) -> V:
+  def match(self, enum_values_to_results: Mapping[E, V]) -> V:
     unrecognized_values = [
       value for value in enum_values_to_results if value not in self.all_values()
     ]
@@ -103,12 +103,12 @@ class Enum(StdLibEnum):
       value for value in self.all_values() if value not in enum_values_to_results
     ]
     if unrecognized_values:
-      raise UnrecognizedPatternError(
-        f"Pattern match includes values not defined in the enum. Unrecognized: {unrecognized_values}"
+      raise UnrecognizedMatchError(
+        f"Match includes values not defined in the enum. Unrecognized: {unrecognized_values}"
       )
     if missing_values:
-      raise InexhaustivePatternsError(
-        f"All enum values must be covered by the pattern match. Missing: {missing_values}"
+      raise InexhaustiveMatchError(
+        f"All enum values must be covered by the match. Missing: {missing_values}"
       )
     typed_self = cast(E, self)
     return enum_values_to_results[typed_self]

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -92,8 +92,9 @@ class UnrecognizedMatchError(EnumMatchError):
 
 class Enum(StdLibEnum):
 
-  def all_values(self) -> ValuesView['Enum']:
-    return self.__class__.__members__.values()
+  @classmethod
+  def all_values(cls) -> ValuesView['Enum']:
+    return cls.__members__.values()
 
   def match(self, enum_values_to_results: Mapping[E, V]) -> V:
     unrecognized_values = [

--- a/tests/python/pants_test/util/test_collections.py
+++ b/tests/python/pants_test/util/test_collections.py
@@ -6,8 +6,8 @@ from typing import List
 
 from pants.util.collections import (
   Enum,
-  InexhaustivePatternsError,
-  UnrecognizedPatternError,
+  InexhaustiveMatchError,
+  UnrecognizedMatchError,
   assert_single_element,
   factory_dict,
   recursively_update,
@@ -104,25 +104,25 @@ class EnumTest(unittest.TestCase):
     cat = 1
     pig = 2
 
-  def test_valid_patterns(self) -> None:
-    pattern_mapping = {
+  def test_valid_match(self) -> None:
+    match_mapping = {
       EnumTest.Test.dog: "woof",
       EnumTest.Test.cat: "meow",
       EnumTest.Test.pig: "oink",
     }
-    self.assertEqual("woof", EnumTest.Test.dog.pattern_match(pattern_mapping))
-    self.assertEqual("meow", EnumTest.Test.cat.pattern_match(pattern_mapping))
-    self.assertEqual("oink", EnumTest.Test.pig.pattern_match(pattern_mapping))
+    self.assertEqual("woof", EnumTest.Test.dog.match(match_mapping))
+    self.assertEqual("meow", EnumTest.Test.cat.match(match_mapping))
+    self.assertEqual("oink", EnumTest.Test.pig.match(match_mapping))
 
-  def test_incomplete_patterns(self) -> None:
-    with self.assertRaises(InexhaustivePatternsError):
-      EnumTest.Test.pig.pattern_match({
+  def test_inexhaustive_match(self) -> None:
+    with self.assertRaises(InexhaustiveMatchError):
+      EnumTest.Test.pig.match({
         EnumTest.Test.pig: "oink",
       })
 
-  def test_unrecognized_patterns(self) -> None:
-    with self.assertRaises(UnrecognizedPatternError):
-      EnumTest.Test.pig.pattern_match({  # type: ignore
+  def test_unrecognized_match(self) -> None:
+    with self.assertRaises(UnrecognizedMatchError):
+      EnumTest.Test.pig.match({  # type: ignore
         EnumTest.Test.dog: "woof",
         EnumTest.Test.cat: "meow",
         EnumTest.Test.pig: "oink",

--- a/tests/python/pants_test/util/test_collections.py
+++ b/tests/python/pants_test/util/test_collections.py
@@ -104,6 +104,11 @@ class EnumTest(unittest.TestCase):
     cat = 1
     pig = 2
 
+  def test_all_values(self) -> None:
+    self.assertEqual(
+      {EnumTest.Test.dog, EnumTest.Test.cat, EnumTest.Test.pig}, set(EnumTest.Test.all_values())
+    )
+
   def test_valid_match(self) -> None:
     match_mapping = {
       EnumTest.Test.dog: "woof",


### PR DESCRIPTION
### Problem
https://github.com/pantsbuild/pants/pull/8443 replaces the custom `enum()` with the standard library `enum.Enum`. Even though it adds an alternative idiom for `.resolve_for_enum_variant`, this alternative loses the benefit of ensuring the exhaustiveness of the match, i.e. ensuring that every single value of the enum has a corresponding entry.

We want the benefits of `ChoiceMixin` from `objects.py`. However, at the same time, MyPy chokes on any import of `objects.py`. We need to get the same functionality but in a way that MyPy understands.

### Solution
Add `Enum` to `collections.py`, which extends `enum.Enum` to add the functions `all_values()` and `match()` as additional methods beyond the typical `enum.Enum` functionality.

This code is fully typed and understood by MyPy.

`match()` implements the same functionality of `.resolve_for_enum_variant()`, including checking for exhaustiveness. It has the added benefit of using the enum's symbols / names for the keys, rather than strings. For example:

```python
from pants.util.collections import Enum

class Animal(Enum):
  dog = 0
  cat = 1
  pig = 2

animal_sound = my_pet.match({
  Animal.dog: "woof",
  Animal.cat: "meow",
  Animal.pig: "oink",
})
```

We enforce in `check_banned_imports.py` that we only ever use our custom `Enum`, as it behaves identically to `enum.Enum` beyond having these two additional methods.

### Result
We can now use `pants.util.collections.Enum` in our codebase for enums that are fully understood by MyPy. Users of `pants.util.collections.Enum` can completely ignore `match()` and `all_values()` if desired and still use enums normally.