### PR TITLE
Run FUSE tests on OSX again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2083,6 +2083,7 @@ matrix:
     - find build-support -name "*.py[co]" -delete
     before_install:
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
+    - brew cask install osxfuse
     before_script:
     - ulimit -c unlimited
     - ulimit -n 8192
@@ -2103,7 +2104,7 @@ matrix:
     - CACHE_NAME=rust_tests.osx
     name: Rust tests - OSX
     os: osx
-    osx_image: xcode11
+    osx_image: xcode8.3
     script:
     - ./build-support/bin/ci.py --rust-tests
     stage: Test Pants

--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -465,8 +465,7 @@ def run_rust_tests() -> None:
   command = [
     "build-support/bin/native/cargo",
     "test",
-    # Until we can run fuse tests on macos travis images, we omit --all on them.
-    *([] if is_macos else ["--all"]),
+    "--all",
     # We pass --tests to skip doc tests, because our generated protos contain invalid doc tests in
     # their comments.
     "--tests",

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -589,16 +589,13 @@ def rust_tests_osx() -> Dict:
     **_RUST_TESTS_BASE,
     "name": "Rust tests - OSX",
     "os": "osx",
-    "osx_image": "xcode11",
-    # We cannot currently run fuse tests in CI, as the osx_image doesn't support it.
-    # Until that changes, no need to install osxfuse.
-    # "addons": {
-    #   "homebrew": {
-    #     "casks": ["osxfuse"]
-    #   }
-    # },
+    # We need to use xcode8.3 because newer versions of OSX won't let new kexts be installed
+    # without travis taking some action, and we need the osxfuse kext.
+    # See https://github.com/travis-ci/travis-ci/issues/10017
+    "osx_image": "xcode8.3",
     "before_install": [
       './build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"',
+      "brew cask install osxfuse",
     ],
     "env": _osx_env_with_pyenv(python_version=PythonVersion.py36) + [
       "CACHE_NAME=rust_tests.osx"

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -595,7 +595,16 @@ def rust_tests_osx() -> Dict:
     "osx_image": "xcode8.3",
     "before_install": [
       './build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"',
+      # We don't use the standard travis "addons" section here because it will either silently
+      # fail (on older images) or cause a multi-minute `brew update` (on newer images), neither of
+      # which we want. This doesn't happen if we just manually run `brew cask install`.
+      #
+      # Also, you will notice in the travis log that it says that OSX needs to be rebooted before
+      # this install will work. This is a lie.
       "brew cask install osxfuse",
+      # We don't need to install openssl because it already happens to be installed on this image.
+      # This is good, because `brew install openssl` would trigger the same issues as noted on why
+      # we don't use the `addons` section.
     ],
     "env": _osx_env_with_pyenv(python_version=PythonVersion.py36) + [
       "CACHE_NAME=rust_tests.osx"


### PR DESCRIPTION
Things I learnt on this journey:
* The Travis brew plugin (using `addons`) will either silently fail on older images because it's a really old brew, or will force an upgrade of brew which is super slow. Manually running `brew cask install` does not.
* `openssl` is already installed on the image, so we don't need to install it.
* If you try`brew install openssl` it will spend minutes upgrading `brew`, only to tell you that `openssl` was already installed.
* The fact that this config is no longer shared with our other OSX shards (thanks @benjyw) made it a lot easier to consider these changes in isolation :)
* OSX versions newer than the one used on the xcode8.3 image don't let you install FUSE without setting up the image specially beforehand which only travis can do (see https://github.com/travis-ci/travis-ci/issues/10017), but the `brew install` will succeed, things will just fail in weird ways.
* The xcode8.3 image prints a message saying that OSXFUSE won't work without a system reboot. This is a lie.