### PR TITLE
Improve support for `Enum`s as option types

### DIFF
--- a/build-support/bin/check_banned_imports.py
+++ b/build-support/bin/check_banned_imports.py
@@ -16,7 +16,12 @@ def main() -> None:
   )
 
   check_banned_import(
-    python_files - {"src/python/pants/util/collections.py", "src/python/pants/option/parser.py"},
+    python_files - {
+      "src/python/pants/base/hash_utils.py",
+      "src/python/pants/option/parser.py",
+      "src/python/pants/util/collections.py",
+      "tests/python/pants_test/base/test_hash_utils.py",
+    },
     bad_import_regex=r"^from enum import.*Enum|^import enum$",
     correct_import_message="from pants.util.collections import Enum",
   )

--- a/build-support/bin/check_banned_imports.py
+++ b/build-support/bin/check_banned_imports.py
@@ -16,7 +16,7 @@ def main() -> None:
   )
 
   check_banned_import(
-    python_files - {"src/python/pants/util/collections.py"},
+    python_files - {"src/python/pants/util/collections.py", "src/python/pants/option/parser.py"},
     bad_import_regex=r"^from enum import.*Enum|^import enum$",
     correct_import_message="from pants.util.collections import Enum",
   )

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -7,6 +7,7 @@ import logging
 import typing
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping, Set
+from enum import Enum
 from pathlib import Path
 from typing import Any, Optional, Type, Union
 
@@ -79,7 +80,7 @@ def hash_dir(path: Path, *, digest: Optional[Digest] = None) -> str:
 class CoercingEncoder(json.JSONEncoder):
   """An encoder which performs coercions in order to serialize many otherwise illegal objects.
 
-  The python documentation (https://docs.python.org/2/library/json.html#json.dumps) states that
+  The python documentation (https://docs.python.org/3/library/json.html#json.dumps) states that
   dict keys are coerced to strings in json.dumps, but this appears to be incorrect -- it throws a
   TypeError on things we might to throw at it, like a set, or a dict with tuple keys.
   """
@@ -107,6 +108,8 @@ class CoercingEncoder(json.JSONEncoder):
       # we call this function very often.
       # TODO(#7658) Figure out why we call this function so often.
       return o
+    if isinstance(o, Enum):
+      return o.value
     if isinstance(o, Mapping):
       # Preserve order to avoid collisions for OrderedDict inputs to json.dumps(). We don't do this
       # for general mappings because dicts have an arbitrary key ordering in some versions of python

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -7,6 +7,7 @@ import math
 import re
 import unittest
 from collections import OrderedDict
+from enum import Enum
 from pathlib import Path
 
 from twitter.common.collections import OrderedSet
@@ -179,6 +180,12 @@ class CoercingJsonEncodingTest(unittest.TestCase):
     self.assertEqual(self._coercing_json_encode([('b', 4), ('a', 3)]), '[["b", 4], ["a", 3]]')
     self.assertEqual(self._coercing_json_encode([{'b': 4, 'a': 3}]), '[{"b": 4, "a": 3}]')
 
+  def test_enum(self) -> None:
+    class Test(Enum):
+      dog = 0
+      cat = 1
+      pig = 2
+    self.assertEqual(self._coercing_json_encode([Test.dog, Test.cat, Test.pig]), '[0, 1, 2]')
 
 class JsonHashingTest(unittest.TestCase):
 

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -39,7 +39,7 @@ from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.parser import Parser
 from pants.option.ranked_value import RankedValue
 from pants.option.scope import ScopeInfo
-from pants.util.collections import assert_single_element
+from pants.util.collections import Enum, assert_single_element
 from pants.util.contextutil import temporary_file, temporary_file_path
 from pants.util.dirutil import safe_mkdtemp
 from pants.util.objects import enum
@@ -105,6 +105,10 @@ class OptionsTest(TestBase):
                         task('separate-enum-opt-scope')]
 
   class SomeEnumOption(enum(['a-value', 'another-value'])): pass
+
+  class AnotherEnumOption(Enum):
+    a_value = "a-value"
+    another_value = "another-value"
 
   def _register(self, options):
     def register_global(*args, **kwargs):
@@ -213,11 +217,13 @@ class OptionsTest(TestBase):
     options.register('fingerprinting', '--definitely-not-fingerprinted', fingerprint=False)
 
     # For enum tests
-    options.register('enum-opt', '--some-enum',
-                     type=self.SomeEnumOption)
+    options.register('enum-opt', '--some-enum', type=self.SomeEnumOption)
+    options.register('enum-opt', '--another-enum', type=self.AnotherEnumOption)
     # For testing the default value
     options.register('separate-enum-opt-scope', '--some-enum-with-default',
                      default=self.SomeEnumOption.a_value, type=self.SomeEnumOption)
+    options.register('separate-enum-opt-scope', '--another-enum-with-default',
+                     default=self.AnotherEnumOption.a_value, type=self.AnotherEnumOption)
 
   def test_env_type_int(self):
     options = Options.create(env={'PANTS_FOO_BAR': "['123','456']"},
@@ -803,10 +809,10 @@ class OptionsTest(TestBase):
 
   def test_drop_flag_values(self):
     options = self._parse(
-      './pants --bar-baz=fred -n33 --pants-foo=red enum-opt --some-enum=another-value simple -n1',
+      './pants --bar-baz=fred -n33 --pants-foo=red enum-opt --some-enum=another-value --another-enum=another-value simple -n1',
       env={'PANTS_FOO': 'BAR'},
       config={'simple': {'num': 42},
-              'enum-opt': {'some-enum': 'a-value'}})
+              'enum-opt': {'some-enum': 'a-value', 'another-enum': 'a-value'}})
     defaulted_only_options = options.drop_flag_values()
 
     # No option value supplied in any form.
@@ -827,11 +833,17 @@ class OptionsTest(TestBase):
 
     # Overriding an enum option value.
     self.assertEqual(self.SomeEnumOption.another_value, options.for_scope('enum-opt').some_enum)
+    self.assertEqual(self.AnotherEnumOption.another_value, options.for_scope('enum-opt').another_enum)
 
     # Getting the default value for an enum option.
     self.assertEqual(
       self.SomeEnumOption.a_value,
-      defaulted_only_options.for_scope('separate-enum-opt-scope').some_enum_with_default)
+      defaulted_only_options.for_scope('separate-enum-opt-scope').some_enum_with_default
+    )
+    self.assertEqual(
+      self.AnotherEnumOption.a_value,
+      defaulted_only_options.for_scope('separate-enum-opt-scope').another_enum_with_default
+    )
 
   def test_enum_option_type_parse_error(self):
     self.maxDiff = None
@@ -840,6 +852,11 @@ class OptionsTest(TestBase):
         "Error applying type 'SomeEnumOption' to option value 'invalid-value', for option '--some_enum' in scope 'enum-opt'"):
       options = self._parse('./pants enum-opt --some-enum=invalid-value')
       options.for_scope('enum-opt').some_enum
+    with self.assertRaisesWithMessageContaining(
+      ParseError,
+      "Error applying type 'AnotherEnumOption' to option value 'invalid-value', for option '--another_enum' in scope 'enum-opt'"):
+      options = self._parse('./pants enum-opt --another-enum=invalid-value')
+      options.for_scope('enum-opt').another_enum
 
   def test_deprecated_option_past_removal(self):
     """Ensure that expired options raise CodeRemovedError on attempted use."""


### PR DESCRIPTION
### Problem
While we can currently use `enum.Enum` as an option and everything works automatically with default values, the experience is less than ideal when the user types an incorrect value that is not defined in the Enum. See https://github.com/pantsbuild/pants/pull/8451#discussion_r334075761.

### Solution
Update `parser.py` to better support incorrect values for `Enum` types. This only requires:

1) Update `to_value_type()` to check for `ValueError`, which is what `Enum` throws upon an unrecognized value
2) Update `check()` to also check for subclasses of `Enum`.

Finally, add tests to `test_options.py` to ensure that we correctly support `enum.Enum` types.

### Result
An invalid enum option now triggers an exception closer to what we get when this happens with `enum()`:

```
$ ./pants --glob-expansion-failure=foo

...
pants.option.errors.ParseError: Error applying type 'GlobMatchErrorBehavior' to option value 'foo', for option '--glob_expansion_failure' in global scope: 'foo' is not a valid GlobMatchErrorBehavior
```