### PR TITLE
Use `collections.Enum` for Nailgun task related code

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -212,7 +212,7 @@ class Zinc:
   def dist(self) -> Distribution:
     """Return the `Distribution` selected for Zinc based on execution strategy."""
     underlying_dist = self.underlying_dist
-    if self._execution_strategy == NailgunTaskBase.HERMETIC:
+    if self._execution_strategy == NailgunTaskBase.ExecutionStrategy.hermetic:
       return underlying_dist
     # symlink .pants.d/.jdk -> /some/java/home/
     jdk_home_symlink = Path(

--- a/src/python/pants/backend/jvm/tasks/analysis_extraction.py
+++ b/src/python/pants/backend/jvm/tasks/analysis_extraction.py
@@ -56,7 +56,7 @@ class AnalysisExtraction(NailgunTask):
   @memoized_property
   def _zinc(self):
     return Zinc.Factory.global_instance().create(
-      self.context.products, self.execution_strategy_enum
+      self.context.products, self.execution_strategy
     )
 
   def _jdeps_output_json(self, vt):

--- a/src/python/pants/backend/jvm/tasks/analysis_extraction.py
+++ b/src/python/pants/backend/jvm/tasks/analysis_extraction.py
@@ -55,7 +55,9 @@ class AnalysisExtraction(NailgunTask):
 
   @memoized_property
   def _zinc(self):
-    return Zinc.Factory.global_instance().create(self.context.products, self.get_options().execution_strategy)
+    return Zinc.Factory.global_instance().create(
+      self.context.products, self.execution_strategy_enum
+    )
 
   def _jdeps_output_json(self, vt):
     return os.path.join(vt.results_dir, 'jdeps_output.json')

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -116,7 +116,7 @@ class JavacCompile(JvmCompile):
         '-target', str(settings.target_level),
       ])
 
-    if self.execution_strategy == self.HERMETIC:
+    if self.execution_strategy_enum == self.ExecutionStrategy.hermetic:
       javac_args.extend([
         # We need to strip the source root from our output files. Outputting to a directory, and
         # capturing that directory, does the job.
@@ -157,7 +157,7 @@ class JavacCompile(JvmCompile):
       javac_cmd.extend(j_args)
       javac_cmd.extend(batched_args)
 
-      if self.execution_strategy == self.HERMETIC:
+      if self.execution_strategy_enum == self.ExecutionStrategy.hermetic:
         self._execute_hermetic_compile(javac_cmd, ctx)
       else:
         with self.context.new_workunit(name='javac',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -116,7 +116,7 @@ class JavacCompile(JvmCompile):
         '-target', str(settings.target_level),
       ])
 
-    if self.execution_strategy_enum == self.ExecutionStrategy.hermetic:
+    if self.execution_strategy == self.ExecutionStrategy.hermetic:
       javac_args.extend([
         # We need to strip the source root from our output files. Outputting to a directory, and
         # capturing that directory, does the job.
@@ -157,7 +157,7 @@ class JavacCompile(JvmCompile):
       javac_cmd.extend(j_args)
       javac_cmd.extend(batched_args)
 
-      if self.execution_strategy_enum == self.ExecutionStrategy.hermetic:
+      if self.execution_strategy == self.ExecutionStrategy.hermetic:
         self._execute_hermetic_compile(javac_cmd, ctx)
       else:
         with self.context.new_workunit(name='javac',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -218,7 +218,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
 
   @memoized_property
   def _zinc(self):
-    return Zinc.Factory.global_instance().create(self.context.products, self.execution_strategy_enum)
+    return Zinc.Factory.global_instance().create(self.context.products, self.execution_strategy)
 
   def _zinc_tool_classpath(self, toolname):
     return self._zinc.tool_classpath_from_products(self.context.products,
@@ -476,7 +476,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     invalid_targets = [vt.target for vt in invalidation_check.invalid_vts]
     valid_targets = [vt.target for vt in invalidation_check.all_vts if vt.valid]
 
-    if self.execution_strategy_enum == self.ExecutionStrategy.hermetic:
+    if self.execution_strategy == self.ExecutionStrategy.hermetic:
       self._set_directory_digests_for_valid_target_classpath_directories(valid_targets, compile_contexts)
 
     for valid_target in valid_targets:
@@ -932,7 +932,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     # See: https://github.com/pantsbuild/pants/issues/6416 for covering using
     #      different jdks in remote builds.
     local_distribution = self._local_jvm_distribution()
-    return self.execution_strategy_enum.match({
+    return self.execution_strategy.match({
       self.ExecutionStrategy.subprocess: lambda: local_distribution,
       self.ExecutionStrategy.nailgun: lambda: local_distribution,
       self.ExecutionStrategy.hermetic: lambda: self._HermeticDistribution('.jdk', local_distribution),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -218,7 +218,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
 
   @memoized_property
   def _zinc(self):
-    return Zinc.Factory.global_instance().create(self.context.products, self.execution_strategy)
+    return Zinc.Factory.global_instance().create(self.context.products, self.execution_strategy_enum)
 
   def _zinc_tool_classpath(self, toolname):
     return self._zinc.tool_classpath_from_products(self.context.products,
@@ -476,7 +476,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     invalid_targets = [vt.target for vt in invalidation_check.invalid_vts]
     valid_targets = [vt.target for vt in invalidation_check.all_vts if vt.valid]
 
-    if self.execution_strategy == self.HERMETIC:
+    if self.execution_strategy_enum == self.ExecutionStrategy.hermetic:
       self._set_directory_digests_for_valid_target_classpath_directories(valid_targets, compile_contexts)
 
     for valid_target in valid_targets:
@@ -932,10 +932,10 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     # See: https://github.com/pantsbuild/pants/issues/6416 for covering using
     #      different jdks in remote builds.
     local_distribution = self._local_jvm_distribution()
-    return self.execution_strategy_enum.resolve_for_enum_variant({
-      self.SUBPROCESS: lambda: local_distribution,
-      self.NAILGUN: lambda: local_distribution,
-      self.HERMETIC: lambda: self._HermeticDistribution('.jdk', local_distribution),
+    return self.execution_strategy_enum.match({
+      self.ExecutionStrategy.subprocess: lambda: local_distribution,
+      self.ExecutionStrategy.nailgun: lambda: local_distribution,
+      self.ExecutionStrategy.hermetic: lambda: self._HermeticDistribution('.jdk', local_distribution),
     })()
 
   def _default_double_check_cache_for_vts(self, vts):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -18,8 +18,10 @@ python_library(
     'src/python/pants/java/distribution',
     'src/python/pants/java/jar',
     'src/python/pants/option',
+    'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
+    'src/python/pants/util:strutil',
   ],
 )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -157,7 +157,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       '{prefix}:{workflow_name}'.format(
         prefix=self.get_options().force_compiler_tag_prefix,
         workflow_name=workflow.value): workflow
-      for workflow in self.JvmCompileWorkflowType.all_variants
+      for workflow in self.JvmCompileWorkflowType.all_values()
     }
 
   @classmethod

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -216,7 +216,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
   # Overrides the normal zinc compiler classpath, which only contains zinc.
   def get_zinc_compiler_classpath(self):
-    return self.execution_strategy_enum.match({
+    return self.execution_strategy.match({
       # NB: We must use the verbose version of super() here, possibly because of the lambda.
       self.ExecutionStrategy.hermetic: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.ExecutionStrategy.subprocess: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
@@ -347,7 +347,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         classpath_entries = classpath_product.get_classpath_entries_for_targets(dependencies_for_target)
         for _conf, classpath_entry in classpath_entries:
           classpath_paths.append(fast_relpath(classpath_entry.path, get_buildroot()))
-          if self.execution_strategy_enum == self.ExecutionStrategy.hermetic and not classpath_entry.directory_digest:
+          if self.execution_strategy == self.ExecutionStrategy.hermetic and not classpath_entry.directory_digest:
             raise AssertionError(
               "ClasspathEntry {} didn't have a Digest, so won't be present for hermetic "
               "execution of rsc".format(classpath_entry)
@@ -376,7 +376,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             classpath_abs_jdk = classpath_paths + self._jdk_libs_abs(distribution)
             return ((EMPTY_DIRECTORY_DIGEST), classpath_abs_jdk)
 
-          (input_digest, classpath_entry_paths) = self.execution_strategy_enum.match({
+          (input_digest, classpath_entry_paths) = self.execution_strategy.match({
             self.ExecutionStrategy.hermetic: hermetic_digest_classpath,
             self.ExecutionStrategy.subprocess: nonhermetic_digest_classpath,
             self.ExecutionStrategy.nailgun: nonhermetic_digest_classpath,
@@ -482,7 +482,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         v
       )
     record('workflow', workflow.value)
-    record('execution_strategy', self.execution_strategy_enum.value)
+    record('execution_strategy', self.execution_strategy.value)
 
     # Create the cache doublecheck job.
     workflow.match({
@@ -717,7 +717,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     main = 'rsc.cli.Main'
     tool_name = 'rsc'
     with self.context.new_workunit(tool_name) as wu:
-      return self.execution_strategy_enum.match({
+      return self.execution_strategy.match({
         self.ExecutionStrategy.hermetic: lambda: self._runtool_hermetic(
           main, tool_name, distribution, input_digest, ctx),
         self.ExecutionStrategy.subprocess: lambda: self._runtool_nonhermetic(

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -29,11 +29,10 @@ from pants.engine.fs import (
 from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
 from pants.java.jar.jar_dependency import JarDependency
 from pants.reporting.reporting_utils import items_to_report_element
-from pants.util.collections import assert_single_element
+from pants.util.collections import Enum, assert_single_element
 from pants.util.contextutil import Timer
 from pants.util.dirutil import fast_relpath, fast_relpath_optional, safe_mkdir
 from pants.util.memo import memoized_method, memoized_property
-from pants.util.objects import enum
 from pants.util.strutil import safe_shlex_join
 
 
@@ -127,7 +126,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
   def implementation_version(cls):
     return super().implementation_version() + [('RscCompile', 174)]
 
-  class JvmCompileWorkflowType(enum(['zinc-only', 'zinc-java', 'rsc-and-zinc'])):
+  class JvmCompileWorkflowType(Enum):
     """Target classifications used to correctly schedule Zinc and Rsc jobs.
 
     There are some limitations we have to work around before we can compile everything through Rsc
@@ -148,6 +147,9 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         Rsc products of their dependencies. The Rsc compile uses the Rsc products of Rsc compatible
         targets and the Zinc products of zinc-only targets.
     """
+    zinc_only = "zinc-only"
+    zinc_java = "zinc-java"
+    rsc_and_zinc = "rsc-and-zinc"
 
   @memoized_property
   def _compiler_tags(self):
@@ -214,11 +216,11 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
   # Overrides the normal zinc compiler classpath, which only contains zinc.
   def get_zinc_compiler_classpath(self):
-    return self.execution_strategy_enum.resolve_for_enum_variant({
+    return self.execution_strategy_enum.match({
       # NB: We must use the verbose version of super() here, possibly because of the lambda.
-      self.HERMETIC: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
-      self.SUBPROCESS: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
-      self.NAILGUN: lambda: self._nailgunnable_combined_classpath,
+      self.ExecutionStrategy.hermetic: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
+      self.ExecutionStrategy.subprocess: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
+      self.ExecutionStrategy.nailgun: lambda: self._nailgunnable_combined_classpath,
     })()
 
   def register_extra_products_from_contexts(self, targets, compile_contexts):
@@ -233,10 +235,10 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       rsc_cc = merged_cc.rsc_cc
       zinc_cc = merged_cc.zinc_cc
       if rsc_cc.workflow is not None:
-        cp_entries = rsc_cc.workflow.resolve_for_enum_variant({
-          'zinc-only': lambda: confify([self._classpath_for_context(zinc_cc)]),
-          'zinc-java': lambda: confify([self._classpath_for_context(zinc_cc)]),
-          'rsc-and-zinc': lambda: confify([rsc_cc.rsc_jar_file]),
+        cp_entries = rsc_cc.workflow.match({
+          self.JvmCompileWorkflowType.zinc_only: lambda: confify([self._classpath_for_context(zinc_cc)]),
+          self.JvmCompileWorkflowType.zinc_java: lambda: confify([self._classpath_for_context(zinc_cc)]),
+          self.JvmCompileWorkflowType.rsc_and_zinc: lambda: confify([rsc_cc.rsc_jar_file]),
         })()
         self.context.products.get_data('rsc_mixed_compile_classpath').add_for_target(
           target,
@@ -287,20 +289,20 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
   def _key_for_target_as_dep(self, target, workflow):
     # used for jobs that are either rsc jobs or zinc jobs run against rsc
-    return workflow.resolve_for_enum_variant({
-      'zinc-only': lambda: self._zinc_key_for_target(target, workflow),
-      'zinc-java': lambda: self._zinc_key_for_target(target, workflow),
-      'rsc-and-zinc': lambda: self._rsc_key_for_target(target),
+    return workflow.match({
+      self.JvmCompileWorkflowType.zinc_only: lambda: self._zinc_key_for_target(target, workflow),
+      self.JvmCompileWorkflowType.zinc_java: lambda: self._zinc_key_for_target(target, workflow),
+      self.JvmCompileWorkflowType.rsc_and_zinc: lambda: self._rsc_key_for_target(target),
     })()
 
   def _rsc_key_for_target(self, target):
     return 'rsc({})'.format(target.address.spec)
 
   def _zinc_key_for_target(self, target, workflow):
-    return workflow.resolve_for_enum_variant({
-      'zinc-only': lambda: 'zinc[zinc-only]({})'.format(target.address.spec),
-      'zinc-java': lambda: 'zinc[zinc-java]({})'.format(target.address.spec),
-      'rsc-and-zinc': lambda: 'zinc[rsc-and-zinc]({})'.format(target.address.spec),
+    return workflow.match({
+      self.JvmCompileWorkflowType.zinc_only: lambda: 'zinc[zinc-only]({})'.format(target.address.spec),
+      self.JvmCompileWorkflowType.zinc_java: lambda: 'zinc[zinc-java]({})'.format(target.address.spec),
+      self.JvmCompileWorkflowType.rsc_and_zinc: lambda: 'zinc[rsc-and-zinc]({})'.format(target.address.spec),
     })()
 
   def _write_to_cache_key_for_target(self, target):
@@ -345,7 +347,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         classpath_entries = classpath_product.get_classpath_entries_for_targets(dependencies_for_target)
         for _conf, classpath_entry in classpath_entries:
           classpath_paths.append(fast_relpath(classpath_entry.path, get_buildroot()))
-          if self.HERMETIC == self.execution_strategy_enum.value and not classpath_entry.directory_digest:
+          if self.execution_strategy_enum == self.ExecutionStrategy.hermetic and not classpath_entry.directory_digest:
             raise AssertionError(
               "ClasspathEntry {} didn't have a Digest, so won't be present for hermetic "
               "execution of rsc".format(classpath_entry)
@@ -374,10 +376,10 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             classpath_abs_jdk = classpath_paths + self._jdk_libs_abs(distribution)
             return ((EMPTY_DIRECTORY_DIGEST), classpath_abs_jdk)
 
-          (input_digest, classpath_entry_paths) = self.execution_strategy_enum.resolve_for_enum_variant({
-            self.HERMETIC: hermetic_digest_classpath,
-            self.SUBPROCESS: nonhermetic_digest_classpath,
-            self.NAILGUN: nonhermetic_digest_classpath,
+          (input_digest, classpath_entry_paths) = self.execution_strategy_enum.match({
+            self.ExecutionStrategy.hermetic: hermetic_digest_classpath,
+            self.ExecutionStrategy.subprocess: nonhermetic_digest_classpath,
+            self.ExecutionStrategy.nailgun: nonhermetic_digest_classpath,
           })()
 
           target_sources = ctx.sources
@@ -480,36 +482,36 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         v
       )
     record('workflow', workflow.value)
-    record('execution_strategy', self.execution_strategy)
+    record('execution_strategy', self.execution_strategy_enum.value)
 
     # Create the cache doublecheck job.
-    workflow.resolve_for_enum_variant({
-      'zinc-only': lambda: cache_doublecheck_jobs.append(
+    workflow.match({
+      self.JvmCompileWorkflowType.zinc_only: lambda: cache_doublecheck_jobs.append(
         make_cache_doublecheck_job(list(all_zinc_rsc_invalid_dep_keys(invalid_dependencies)))
       ),
-      'zinc-java': lambda: cache_doublecheck_jobs.append(
+      self.JvmCompileWorkflowType.zinc_java: lambda: cache_doublecheck_jobs.append(
         make_cache_doublecheck_job(list(only_zinc_invalid_dep_keys(invalid_dependencies)))
       ),
-      'rsc-and-zinc': lambda: cache_doublecheck_jobs.append(
+      self.JvmCompileWorkflowType.rsc_and_zinc: lambda: cache_doublecheck_jobs.append(
         make_cache_doublecheck_job(list(all_zinc_rsc_invalid_dep_keys(invalid_dependencies)))
       ),
     })()
 
     # Create the rsc job.
     # Currently, rsc only supports outlining scala.
-    workflow.resolve_for_enum_variant({
-      'zinc-only': lambda: None,
-      'zinc-java': lambda: None,
-      'rsc-and-zinc': lambda: rsc_jobs.append(make_rsc_job(compile_target, invalid_dependencies)),
+    workflow.match({
+      self.JvmCompileWorkflowType.zinc_only: lambda: None,
+      self.JvmCompileWorkflowType.zinc_java: lambda: None,
+      self.JvmCompileWorkflowType.rsc_and_zinc: lambda: rsc_jobs.append(make_rsc_job(compile_target, invalid_dependencies)),
     })()
 
     # Create the zinc compile jobs.
     # - Scala zinc compile jobs depend on the results of running rsc on the scala target.
     # - Java zinc compile jobs depend on the zinc compiles of their dependencies, because we can't
     #   generate jars that make javac happy at this point.
-    workflow.resolve_for_enum_variant({
+    workflow.match({
       # NB: zinc-only zinc jobs run zinc and depend on rsc and/or zinc compile outputs.
-      'zinc-only': lambda: zinc_jobs.append(
+      self.JvmCompileWorkflowType.zinc_only: lambda: zinc_jobs.append(
         make_zinc_job(
           compile_target,
           input_product_key='rsc_mixed_compile_classpath',
@@ -520,7 +522,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
           dep_keys=list(all_zinc_rsc_invalid_dep_keys(invalid_dependencies)))),
       # NB: javac can't read rsc output yet, so we need it to depend strictly on zinc
       # compilations of dependencies.
-      'zinc-java': lambda: zinc_jobs.append(
+      self.JvmCompileWorkflowType.zinc_java: lambda: zinc_jobs.append(
         make_zinc_job(
           compile_target,
           input_product_key='runtime_classpath',
@@ -529,7 +531,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             self.context.products.get_data('rsc_mixed_compile_classpath'),
           ],
           dep_keys=list(only_zinc_invalid_dep_keys(invalid_dependencies)))),
-      'rsc-and-zinc': lambda: zinc_jobs.append(
+      self.JvmCompileWorkflowType.rsc_and_zinc: lambda: zinc_jobs.append(
         # NB: rsc-and-zinc jobs run zinc and depend on both rsc and zinc compile outputs.
         make_zinc_job(
           compile_target,
@@ -715,12 +717,12 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     main = 'rsc.cli.Main'
     tool_name = 'rsc'
     with self.context.new_workunit(tool_name) as wu:
-      return self.execution_strategy_enum.resolve_for_enum_variant({
-        self.HERMETIC: lambda: self._runtool_hermetic(
+      return self.execution_strategy_enum.match({
+        self.ExecutionStrategy.hermetic: lambda: self._runtool_hermetic(
           main, tool_name, distribution, input_digest, ctx),
-        self.SUBPROCESS: lambda: self._runtool_nonhermetic(
+        self.ExecutionStrategy.subprocess: lambda: self._runtool_nonhermetic(
           wu, self._rsc_classpath, main, tool_name, distribution, ctx),
-        self.NAILGUN: lambda: self._runtool_nonhermetic(
+        self.ExecutionStrategy.nailgun: lambda: self._runtool_nonhermetic(
           wu, self._nailgunnable_combined_classpath, main, tool_name, distribution, ctx),
       })()
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -177,7 +177,7 @@ class BaseZincCompile(JvmCompile):
 
   @memoized_property
   def _zinc(self):
-    return Zinc.Factory.global_instance().create(self.context.products, self.execution_strategy_enum)
+    return Zinc.Factory.global_instance().create(self.context.products, self.execution_strategy)
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
@@ -187,7 +187,7 @@ class BaseZincCompile(JvmCompile):
     # Validate zinc options.
     ZincCompile.validate_arguments(self.context.log, self.get_options().whitelisted_args,
                                    self._args)
-    if self.execution_strategy_enum == self.ExecutionStrategy.hermetic:
+    if self.execution_strategy == self.ExecutionStrategy.hermetic:
       try:
         fast_relpath(self.get_options().pants_workdir, get_buildroot())
       except ValueError:
@@ -263,7 +263,7 @@ class BaseZincCompile(JvmCompile):
 
     self._verify_zinc_classpath(
       absolute_classpath,
-      allow_dist=(self.execution_strategy_enum != self.ExecutionStrategy.hermetic)
+      allow_dist=(self.execution_strategy != self.ExecutionStrategy.hermetic)
     )
     # TODO: Investigate upstream_analysis for hermetic compiles
     self._verify_zinc_classpath(upstream_analysis.keys())
@@ -363,7 +363,7 @@ class BaseZincCompile(JvmCompile):
     self.log_zinc_file(ctx.analysis_file)
     self.write_argsfile(ctx, zinc_args)
 
-    return self.execution_strategy_enum.match({
+    return self.execution_strategy.match({
       self.ExecutionStrategy.hermetic: lambda: self._compile_hermetic(
         jvm_options, ctx, classes_dir, jar_file, compiler_bridge_classpath_entry,
         dependency_classpath, scalac_classpath_entries),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -177,7 +177,7 @@ class BaseZincCompile(JvmCompile):
 
   @memoized_property
   def _zinc(self):
-    return Zinc.Factory.global_instance().create(self.context.products, self.execution_strategy)
+    return Zinc.Factory.global_instance().create(self.context.products, self.execution_strategy_enum)
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
@@ -187,7 +187,7 @@ class BaseZincCompile(JvmCompile):
     # Validate zinc options.
     ZincCompile.validate_arguments(self.context.log, self.get_options().whitelisted_args,
                                    self._args)
-    if self.execution_strategy == self.HERMETIC:
+    if self.execution_strategy_enum == self.ExecutionStrategy.hermetic:
       try:
         fast_relpath(self.get_options().pants_workdir, get_buildroot())
       except ValueError:
@@ -261,7 +261,10 @@ class BaseZincCompile(JvmCompile):
     if self.get_options().capture_classpath:
       self._record_compile_classpath(absolute_classpath, ctx.target, ctx.classes_dir.path)
 
-    self._verify_zinc_classpath(absolute_classpath, allow_dist=(self.execution_strategy != self.HERMETIC))
+    self._verify_zinc_classpath(
+      absolute_classpath,
+      allow_dist=(self.execution_strategy_enum != self.ExecutionStrategy.hermetic)
+    )
     # TODO: Investigate upstream_analysis for hermetic compiles
     self._verify_zinc_classpath(upstream_analysis.keys())
 
@@ -360,12 +363,12 @@ class BaseZincCompile(JvmCompile):
     self.log_zinc_file(ctx.analysis_file)
     self.write_argsfile(ctx, zinc_args)
 
-    return self.execution_strategy_enum.resolve_for_enum_variant({
-      self.HERMETIC: lambda: self._compile_hermetic(
+    return self.execution_strategy_enum.match({
+      self.ExecutionStrategy.hermetic: lambda: self._compile_hermetic(
         jvm_options, ctx, classes_dir, jar_file, compiler_bridge_classpath_entry,
         dependency_classpath, scalac_classpath_entries),
-      self.SUBPROCESS: lambda: self._compile_nonhermetic(jvm_options, ctx, classes_dir),
-      self.NAILGUN: lambda: self._compile_nonhermetic(jvm_options, ctx, classes_dir),
+      self.ExecutionStrategy.subprocess: lambda: self._compile_nonhermetic(jvm_options, ctx, classes_dir),
+      self.ExecutionStrategy.nailgun: lambda: self._compile_nonhermetic(jvm_options, ctx, classes_dir),
     })()
 
   class ZincCompileError(TaskError):

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -46,7 +46,7 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
                           ])
 
   @property
-  def execution_strategy_enum(self):
+  def execution_strategy(self):
     return self.get_options().execution_strategy
 
   @classmethod
@@ -71,7 +71,7 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
     Call only in execute() or later. TODO: Enforce this.
     """
     dist = dist or self.dist
-    if self.execution_strategy_enum == self.ExecutionStrategy.nailgun:
+    if self.execution_strategy == self.ExecutionStrategy.nailgun:
       classpath = os.pathsep.join(self.tool_classpath('nailgun-server'))
       return NailgunExecutor(self._identity,
                              self._executor_workdir,
@@ -98,7 +98,7 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
     # Creating synthetic jar to work around system arg length limit is not necessary
     # when `NailgunExecutor` is used because args are passed through socket, therefore turning off
     # creating synthetic jar if nailgun is used.
-    create_synthetic_jar = self.execution_strategy_enum != self.ExecutionStrategy.nailgun
+    create_synthetic_jar = self.execution_strategy != self.ExecutionStrategy.nailgun
     try:
       return util.execute_java(classpath=classpath,
                                main=main,

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -25,7 +25,7 @@ class RscCompileIntegration(BaseCompileIT, AbstractTestGenerator):
 
     for worker_count in [1, 2]:
       for resolver in JvmResolveSubsystem.CHOICES:
-        for execution_strategy in RscCompile.ExecutionStrategy.all_variants:
+        for execution_strategy in RscCompile.ExecutionStrategy.all_values():
           with temporary_dir() as cache_dir:
             config = {
               'cache.compile.rsc': {'write_to': [cache_dir]},

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -46,10 +46,10 @@ class RscCompileIntegration(BaseCompileIT, AbstractTestGenerator):
                 'use_classpath_jars': False,
               })
 
-            execution_strategy.resolve_for_enum_variant({
-              'nailgun': lambda: None,
-              'subprocess': lambda: None,
-              'hermetic': populate_necessary_hermetic_options,
+            execution_strategy.match({
+              RscCompile.ExecutionStrategy.nailgun: lambda: None,
+              RscCompile.ExecutionStrategy.subprocess: lambda: None,
+              RscCompile.ExecutionStrategy.hermetic: populate_necessary_hermetic_options,
             })()
 
             for name, test in tests_with_generated_config.items():

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_compile.py
@@ -65,12 +65,16 @@ class BaseZincCompileJDKTest(NailgunTaskTestBase):
 
   def test_subprocess_compile_jdk_being_symlink(self):
     context = self.context(target_roots=[])
-    zinc = Zinc.Factory.global_instance().create(context.products, NailgunTaskBase.SUBPROCESS)
+    zinc = Zinc.Factory.global_instance().create(
+      context.products, NailgunTaskBase.ExecutionStrategy.subprocess
+    )
     self.assertTrue(os.path.islink(zinc.dist.home))
 
   def test_hermetic_jdk_being_underlying_dist(self):
     context = self.context(target_roots=[])
-    zinc = Zinc.Factory.global_instance().create(context.products, NailgunTaskBase.HERMETIC)
+    zinc = Zinc.Factory.global_instance().create(
+      context.products, NailgunTaskBase.ExecutionStrategy.hermetic
+    )
     self.assertFalse(
       os.path.islink(zinc.dist.home),
       "Expected {} to not be a link, it was.".format(zinc.dist.home)


### PR DESCRIPTION
### Problem
`nailgun_task.py` had two ways of implementing enum-like behavior: an `enum()` instance and 3 string constants mirroring the enum. This is confusing to have both ways of doing it.

Further, we want to use `collections.Enum` so that MyPy can understand this code, as MyPy does not understand function base classes like `enum()`.

### Solution
Consolidate everything around `Enum`. This requires updating several call sites.

### Result
The end-user experience is the same. Code is now easier to read and safer due to no longer using string constants.