### PR TITLE
Type check core base code

### DIFF
--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -47,7 +47,8 @@ python_library(
   dependencies = [
     '3rdparty/python:packaging',
     ':version-resource',
-  ]
+  ],
+  tags = {"type_checked"},
 )
 
 resources(

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -10,6 +10,7 @@ python_library(
     'src/python/pants/scm:git',
     'src/python/pants:version',
   ],
+  tags = {"type_checked"},
 )
 
 python_library(
@@ -21,7 +22,8 @@ python_library(
     ':build_environment',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -32,7 +34,7 @@ python_library(
     '3rdparty/python:pathspec',
     'src/python/pants/util:dirutil',
     ':project_tree',
-  ]
+  ],
 )
 
 python_library(
@@ -47,6 +49,7 @@ python_library(
   dependencies = [
     'src/python/pants/util:meta',
   ],
+  tags = {"type_checked"},
 )
 
 python_library(
@@ -56,7 +59,8 @@ python_library(
     ':revision',
     'src/python/pants:version',
     'src/python/pants/util:memo',
-  ]
+  ],
+  tags = {"type_checked"},
 )
 
 python_library(
@@ -76,14 +80,13 @@ python_library(
   dependencies = [
     ':exiter',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
   name = 'fingerprint_strategy',
   sources = ['fingerprint_strategy.py'],
-  dependencies = [
-    ':deprecated',
-  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -101,9 +104,9 @@ python_library(
   sources = ['hash_utils.py'],
   dependencies = [
     '3rdparty/python:typing-extensions',
-    ':deprecated',
     'src/python/pants/util:objects',
-  ]
+    'src/python/pants/util:strutil',
+  ],
 )
 
 python_library(
@@ -132,7 +135,6 @@ python_library(
   sources = ['payload_field.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    ':deprecated',
     ':hash_utils',
   ]
 )
@@ -165,6 +167,7 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants:version',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -194,6 +197,7 @@ python_library(
     ':workunit',
     'src/python/pants/reporting:report', # TODO(pl): Bust this out
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -231,5 +235,6 @@ python_tests(
   name='tests',
   dependencies=[
     ':specs'
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -13,12 +13,12 @@ from pants.version import VERSION as _VERSION
 logger = logging.getLogger(__name__)
 
 
-def pants_version():
+def pants_version() -> str:
   """Returns the pants semantic version number as a string: http://semver.org/"""
   return _VERSION
 
 
-def pants_release():
+def pants_release() -> str:
   """Returns a user-friendly release label."""
   return ('Pants {version} https://pypi.org/pypi/pantsbuild.pants/{version}'
           .format(version=pants_version()))
@@ -32,7 +32,7 @@ def get_buildroot() -> str:
   return BuildRoot().path
 
 
-def get_pants_cachedir():
+def get_pants_cachedir() -> str:
   """Return the pants global cache directory."""
   # Follow the unix XDB base spec: http://standards.freedesktop.org/basedir-spec/latest/index.html.
   cache_home = os.environ.get('XDG_CACHE_HOME')
@@ -41,7 +41,7 @@ def get_pants_cachedir():
   return os.path.expanduser(os.path.join(cache_home, 'pants'))
 
 
-def get_pants_configdir():
+def get_pants_configdir() -> str:
   """Return the pants global config directory."""
   # Follow the unix XDB base spec: http://standards.freedesktop.org/basedir-spec/latest/index.html.
   config_home = os.environ.get('XDG_CONFIG_HOME')

--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -69,6 +69,8 @@ class BuildRoot(metaclass=SingletonMetaclass):
   @contextmanager
   def temporary(self, path: str) -> Iterator[None]:
     """Establishes a temporary build root, restoring the prior build root on exit."""
+    if path is None:
+      raise ValueError('Can only temporarily establish a build root given a path.')
     prior = self._root_dir
     self._root_dir = path
     try:

--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -4,6 +4,7 @@
 import os
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator, Optional
 
 from pants.util.meta import SingletonMetaclass
 
@@ -36,10 +37,10 @@ class BuildRoot(metaclass=SingletonMetaclass):
     return str(buildroot)
 
   def __init__(self) -> None:
-    self._root_dir = None
+    self._root_dir: Optional[str] = None
 
   @property
-  def path(self):
+  def path(self) -> str:
     """Returns the build root for the current workspace."""
     if self._root_dir is None:
       # This env variable is for testing purpose.
@@ -51,25 +52,23 @@ class BuildRoot(metaclass=SingletonMetaclass):
     return self._root_dir
 
   @path.setter
-  def path(self, root_dir):
+  def path(self, root_dir: str) -> None:
     """Manually establishes the build root for the current workspace."""
     path = os.path.realpath(root_dir)
     if not os.path.exists(path):
       raise ValueError(f'Build root does not exist: {root_dir}')
     self._root_dir = path
 
-  def reset(self):
+  def reset(self) -> None:
     """Clears the last calculated build root for the current workspace."""
     self._root_dir = None
 
-  def __str__(self):
+  def __str__(self) -> str:
     return f'BuildRoot({self._root_dir})'
 
   @contextmanager
-  def temporary(self, path):
+  def temporary(self, path: str) -> Iterator[None]:
     """Establishes a temporary build root, restoring the prior build root on exit."""
-    if path is None:
-      raise ValueError('Can only temporarily establish a build root given a path.')
     prior = self._root_dir
     self._root_dir = path
     try:

--- a/src/python/pants/build_graph/BUILD
+++ b/src/python/pants/build_graph/BUILD
@@ -1,7 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
 python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -23,7 +23,7 @@ python_library(
     'src/python/pants/util:osutil',
     'src/python/pants/util:socket',
     'src/python/pants/util:strutil',
-  ]
+  ],
 )
 
 python_library(

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -18,12 +18,11 @@ from pants.util.strutil import ensure_binary, ensure_text
 # 40 is Linux's hard-coded limit for total symlinks followed when resolving a path.
 MAX_SYMLINKS_IN_REALPATH = 40
 GIT_HASH_LENGTH = 20
-# Precompute these because ensure_binary is slow and we'll need them a lot
-SLASH = ensure_binary('/')
-NUL = ensure_binary('\0')
-SPACE = ensure_binary(' ')
-NEWLINE = ensure_binary('\n')
-EMPTY_STRING = ensure_binary("")
+
+NUL = b'\0'
+SPACE = b' '
+NEWLINE = b'\n'
+EMPTY_STRING = b""
 
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/scm/scm.py
+++ b/src/python/pants/scm/scm.py
@@ -30,7 +30,7 @@ class Scm(ABC):
 
   @property
   @abstractmethod
-  def current_rev_identifier(self):
+  def current_rev_identifier(self) -> str:
     """Identifier for the tip/head of the current branch eg. "HEAD" in git.
 
     :API: public
@@ -38,7 +38,7 @@ class Scm(ABC):
 
   @property
   @abstractmethod
-  def commit_id(self):
+  def commit_id(self) -> str:
     """Returns the id of the current commit.
 
     :API: public
@@ -46,12 +46,12 @@ class Scm(ABC):
 
   @property
   @abstractmethod
-  def server_url(self):
+  def server_url(self) -> str:
     """Returns the url of the (default) remote server."""
 
   @property
   @abstractmethod
-  def tag_name(self):
+  def tag_name(self) -> str:
     """Returns the name of the current tag if any.
 
     :API: public
@@ -59,7 +59,7 @@ class Scm(ABC):
 
   @property
   @abstractmethod
-  def branch_name(self):
+  def branch_name(self) -> str:
     """Returns the name of the current branch if any.
 
     :API: public

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -11,8 +11,10 @@ from packaging.version import Version
 _PANTS_VERSION_OVERRIDE = '_PANTS_VERSION_OVERRIDE'
 
 
-VERSION = (os.environ.get(_PANTS_VERSION_OVERRIDE) or
-           pkgutil.get_data(__name__, 'VERSION').strip().decode())
+VERSION: str = (
+  os.environ.get(_PANTS_VERSION_OVERRIDE) or
+  pkgutil.get_data(__name__, 'VERSION').decode().strip()  # type: ignore
+)
 
 
 PANTS_SEMVER = Version(VERSION)

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -7,8 +7,8 @@ python_tests(
   dependencies = [
     'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',
-    'src/python/pants/util:fileutil',
-  ]
+  ],
+  tags = {"type_checked"},
 )
 
 python_tests(
@@ -66,7 +66,7 @@ python_tests(
     'src/python/pants/util:collections',
     'src/python/pants:version',
     'tests/python/pants_test:test_base',
-  ]
+  ],
 )
 
 python_tests(

--- a/tests/python/pants_test/base/test_build_environment.py
+++ b/tests/python/pants_test/base/test_build_environment.py
@@ -5,32 +5,31 @@ import os
 import unittest
 
 from pants.base.build_environment import get_pants_cachedir, get_pants_configdir
-from pants.util.contextutil import environment_as
-from pants.util.fileutil import temporary_file
+from pants.util.contextutil import environment_as, temporary_file
 
 
 class TestBuildEnvironment(unittest.TestCase):
   """Test class for pants.base.build_environment."""
 
-  def test_get_configdir(self):
+  def test_get_configdir(self) -> None:
     with environment_as(XDG_CONFIG_HOME=''):
       self.assertEqual(os.path.expanduser('~/.config/pants'), get_pants_configdir())
 
-  def test_get_cachedir(self):
+  def test_get_cachedir(self) -> None:
     with environment_as(XDG_CACHE_HOME=''):
       self.assertEqual(os.path.expanduser('~/.cache/pants'), get_pants_cachedir())
 
-  def test_set_configdir(self):
+  def test_set_configdir(self) -> None:
     with temporary_file() as temp:
       with environment_as(XDG_CONFIG_HOME=temp.name):
         self.assertEqual(os.path.join(temp.name, 'pants'),  get_pants_configdir())
 
-  def test_set_cachedir(self):
+  def test_set_cachedir(self) -> None:
     with temporary_file() as temp:
       with environment_as(XDG_CACHE_HOME=temp.name):
         self.assertEqual(os.path.join(temp.name, 'pants'), get_pants_cachedir())
 
-  def test_expand_home_configdir(self):
+  def test_expand_home_configdir(self) -> None:
     with environment_as(XDG_CONFIG_HOME='~/somewhere/in/home'):
       self.assertEqual(os.path.expanduser(os.path.join('~/somewhere/in/home', 'pants')),
                         get_pants_configdir())

--- a/tests/python/pants_test/base/test_build_root.py
+++ b/tests/python/pants_test/base/test_build_root.py
@@ -11,26 +11,26 @@ from pants.util.dirutil import safe_mkdir, safe_mkdtemp, safe_rmtree, touch
 
 class BuildRootTest(unittest.TestCase):
 
-  def setUp(self):
+  def setUp(self) -> None:
     self.build_root = BuildRoot()
     self.original_path = self.build_root.path
     self.new_path = os.path.realpath(safe_mkdtemp())
     self.build_root.reset()
 
-  def tearDown(self):
+  def tearDown(self) -> None:
     self.build_root.reset()
     safe_rmtree(self.new_path)
 
-  def test_via_set(self):
+  def test_via_set(self) -> None:
     self.build_root.path = self.new_path
     self.assertEqual(self.new_path, self.build_root.path)
 
-  def test_reset(self):
+  def test_reset(self) -> None:
     self.build_root.path = self.new_path
     self.build_root.reset()
     self.assertEqual(self.original_path, self.build_root.path)
 
-  def test_via_pants_runner(self):
+  def test_via_pants_runner(self) -> None:
     with temporary_dir() as root:
       root = os.path.realpath(root)
       touch(os.path.join(root, "BUILD_ROOT"))
@@ -43,23 +43,23 @@ class BuildRootTest(unittest.TestCase):
       with pushd(child):
         self.assertEqual(root, self.build_root.path)
 
-  def test_temporary(self):
+  def test_temporary(self) -> None:
     with self.build_root.temporary(self.new_path):
       self.assertEqual(self.new_path, self.build_root.path)
     self.assertEqual(self.original_path, self.build_root.path)
 
-  def test_singleton(self):
+  def test_singleton(self) -> None:
     self.assertEqual(BuildRoot().path, BuildRoot().path)
     BuildRoot().path = self.new_path
     self.assertEqual(BuildRoot().path, BuildRoot().path)
 
-  def test_not_found(self):
+  def test_not_found(self) -> None:
     with temporary_dir() as root:
       root = os.path.realpath(root)
       with pushd(root):
         self.assertRaises(BuildRoot.NotFoundError, lambda: self.build_root.path)
 
-  def test_buildroot_override(self):
+  def test_buildroot_override(self) -> None:
     with temporary_dir() as root:
       with environment_as(PANTS_BUILDROOT_OVERRIDE=root):
         self.assertEqual(self.build_root.path, root)


### PR DESCRIPTION
The `base` folder is used widely throughout the project. This PR fixes some issues that happened directly upon import of these files, along with type checking all the code to improve the foundation of type hints for the project.