### PR TITLE
Use `partially_type_checked` tag for incremental type hinting of Pants repo

### DIFF
--- a/build-support/bin/mypy.py
+++ b/build-support/bin/mypy.py
@@ -13,11 +13,14 @@ def main() -> None:
   try:
     subprocess.run([
       "./pants",
-      "--tag=type_checked",
+      # We run MyPy against targets with either the tag `type_checked` or `partially_type_checked`.
+      # `partially_type_checked` means that the target is still missing type hints, but that we
+      # still want to run MyPy against it so that we can enforce the type hints that may be there
+      # already and we can make sure that we don't revert in adding code that MyPy flags as an
+      # error.
+      "--tag=type_checked,partially_type_checked",
       "--backend-packages=pants.contrib.mypy",
       "lint",
-      "--lint-mypy-verbose",
-      "--lint-mypy-whitelist-tag-name=type_checked",
       "--lint-mypy-config-file=build-support/mypy/mypy.ini",
       *globs,
     ], check=True)

--- a/build-support/bin/mypy.py
+++ b/build-support/bin/mypy.py
@@ -2,26 +2,37 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import argparse
 import subprocess
+
+from common import die
 
 
 def main() -> None:
-  subprocess.run([
-    "./pants",
-    # We filter by tag to avoid irrelevant targets causing issues due to prerequisite goals against
-    # the lint goal.
-    "--tag=type_checked",
-    "--backend-packages=pants.contrib.mypy",
-    "lint",
-    "--lint-mypy-verbose",
-    "--lint-mypy-whitelist-tag-name=type_checked",
-    "--lint-mypy-config-file=build-support/mypy/mypy.ini",
-    "build-support::",
-    "contrib::",
-    "src/python::",
-    "tests/python::",
-    "pants-plugins::",
-  ], check=True)
+  globs = create_parser().parse_args().globs
+  try:
+    subprocess.run([
+      "./pants",
+      "--tag=type_checked",
+      "--backend-packages=pants.contrib.mypy",
+      "lint",
+      "--lint-mypy-verbose",
+      "--lint-mypy-whitelist-tag-name=type_checked",
+      "--lint-mypy-config-file=build-support/mypy/mypy.ini",
+      *globs,
+    ], check=True)
+  except subprocess.CalledProcessError:
+    die("Please fix the above errors and run again.")
+
+
+def create_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+    "globs",
+    nargs='*',
+    default=["build-support::", "contrib::", "src/python::", "tests/python::", "pants-plugins::"]
+  )
+  return parser
 
 
 if __name__ == '__main__':

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -38,6 +38,7 @@ python_library(
 python_library(
   name = 'build_file_target_factory',
   sources = ['build_file_target_factory.py'],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -82,7 +83,7 @@ python_library(
   sources = ['fingerprint_strategy.py'],
   dependencies = [
     ':deprecated',
-  ]
+  ],
 )
 
 python_library(
@@ -91,7 +92,8 @@ python_library(
   dependencies = [
     ':mustache',
     '3rdparty/python:pystache',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -109,17 +111,20 @@ python_library(
   sources = ['mustache.py'],
   dependencies = [
     '3rdparty/python:pystache',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
   name = 'parse_context',
   sources = ['parse_context.py'],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
   name = 'payload',
   sources = ['payload.py'],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -143,11 +148,13 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
   name = 'revision',
   sources = ['revision.py'],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -177,6 +184,7 @@ python_library(
   dependencies = [
     '3rdparty/python:dataclasses',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -196,6 +204,7 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants/util:rwbuf',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -205,6 +214,7 @@ python_library(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -213,7 +223,8 @@ python_library(
   dependencies=[
     'src/python/pants/util:fileutil',
     'src/python/pants/util:strutil',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(

--- a/src/python/pants/scm/BUILD
+++ b/src/python/pants/scm/BUILD
@@ -6,6 +6,7 @@ python_library(
   dependencies = [
     'src/python/pants/util:contextutil',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -17,4 +18,5 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants/util:strutil',
   ],
+  tags = {'partially_type_checked'},
 )

--- a/src/python/pants/scm/subsystems/BUILD
+++ b/src/python/pants/scm/subsystems/BUILD
@@ -10,5 +10,5 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/goal:workspace',
     'src/python/pants/subsystem',
-  ]
+  ],
 )

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -66,6 +66,7 @@ python_library(
 python_library(
   name = 'filtering',
   sources = ['filtering.py'],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -74,6 +75,7 @@ python_library(
   dependencies = [
     ':meta'
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -88,6 +90,7 @@ python_library(
 python_library(
   name = 'netrc',
   sources = ['netrc.py'],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -110,16 +113,19 @@ python_library(
 python_library(
   name = 'process_handler',
   sources = ['process_handler.py'],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
   name = 'retry',
   sources = ['retry.py'],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
   name = 'rwbuf',
   sources = ['rwbuf.py'],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -141,6 +147,7 @@ python_binary(
 python_library(
   name = 'socket',
   sources = ['socket.py'],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -158,4 +165,5 @@ python_library(
 python_library(
   name = 'xml_parser',
   sources = ['xml_parser.py'],
+  tags = {'partially_type_checked'},
 )


### PR DESCRIPTION
### Problem

Currently, to have MyPy run against a target, you must mark it with `type_checked` or it must be a dependency of a target marked with this tag.

Often, Pants devs want to add 1-2 type hints but don't have time to type check the whole target. So, they must decide if they should still add `type_checked` even though the target is not fully typed. If they add it, it now becomes much harder for us to track what work remains.

We want some way to:

1. Have MyPy check partially typed targets, even if the target is not entirely typed.
1. Track what is partially vs. fully typed.

### Solution
Introduce the `partially_type_checked` tag and have `mypy.py` run against any targets with `partially_type_checked` or `type_checked`.

### Result
The barrier to entry becomes much lower to adding some type hints to a target and enforcing that they work.

This PR allows us to pursue a new strategy for the type hint migration (https://github.com/pantsbuild/pants/issues/6742): get as many targets as possible to work with `partially_type_checked`. **Even if a target has zero type hints, we should add `partially_type_checked` to it** so that we enforce that we do not introduce any new errors and so that when we add do add type hints, we know the rest of the codebase is using things correctly.