### PR TITLE
Fix `PantsRunIntegrationTest.mock_buildroot()` to work with `--chroot`

### DIFF
--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -1,8 +1,4 @@
-tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:cache_compile_integration
-tests/python/pants_test/backend/python/tasks/native:integration
-tests/python/pants_test/backend/python/tasks:build_local_python_distributions_integration
 tests/python/pants_test/backend/python/tasks:pytest_run_integration
-tests/python/pants_test/backend/python/tasks:python_binary_integration
 tests/python/pants_test/backend/python/tasks:setup_py_integration
 tests/python/pants_test/backend/python:integration
 tests/python/pants_test/pantsd:pantsd_integration

--- a/build-support/ci_lists/integration_v2_blacklist.txt
+++ b/build-support/ci_lists/integration_v2_blacklist.txt
@@ -1,4 +1,5 @@
 tests/python/pants_test/backend/jvm/subsystems:jar_dependency_management_integration
+tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:cache_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:java_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/java:zinc_compile_integration
 tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc:rsc_compile_integration

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -31,9 +31,11 @@ python_tests(
     'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
+    'testprojects/src/python:python_distribution_directory',
+    'testprojects/tests/python:example_test_directory',
   ],
   tags = {'integration'},
-  timeout=450
+  timeout = 180,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/python/tasks/native/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/native/BUILD
@@ -47,5 +47,5 @@ python_tests(
     'testprojects/src/python:python_distribution_directory',
   ],
   tags={'platform_specific_behavior', 'integration'},
-  timeout=2400,
+  timeout=240,
 )

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -126,7 +126,8 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     # TODO: consider making this mock_buildroot/run_pants_with_workdir into a
     # PantsRunIntegrationTest method!
     with self.mock_buildroot(
-        dirs_to_copy=[self._binary_interop_target_dir]) as buildroot, buildroot.pushd():
+        dirs_to_copy=[self._binary_interop_target_dir]
+    ) as buildroot, buildroot.pushd():
 
       # Replace strict_deps=False with nothing so we can override it (because target values for this
       # option take precedence over subsystem options).
@@ -149,7 +150,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
           },
         },
         workdir=os.path.join(buildroot.new_buildroot, '.pants.d'),
-        build_root=buildroot.new_buildroot)
+      )
       self.assert_failure(pants_binary_strict_deps_failure)
       self.assertIn(toolchain_variant.resolve_for_enum_variant({
         'gnu': "fatal error: some_math.h: No such file or directory",

--- a/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_build_local_python_distributions_integration.py
@@ -19,7 +19,6 @@ class BuildLocalPythonDistributionsIntegrationTest(PantsRunIntegrationTest):
     return False
 
   hello_install_requires_dir = 'testprojects/src/python/python_distribution/hello_with_install_requires'
-  hello_setup_requires = 'examples/src/python/example/python_distribution/hello/setup_requires'
   py_dist_test = 'testprojects/tests/python/example_test/python_distribution'
 
   def _assert_nation_and_greeting(self, output, punctuation='!'):

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from operator import eq, ne
 from threading import Lock
-from typing import Any, List, Optional, Union
+from typing import Any, Callable, List, Optional, Union
 
 from colors import strip_color
 
@@ -586,23 +586,25 @@ class PantsRunIntegrationTest(unittest.TestCase):
 
     @dataclass(frozen=True)
     class Manager:
-      write_file: Any
+      write_file: Callable[[str, str], None]
       pushd: Any
-      new_buildroot: Any
+      new_buildroot: str
 
     # N.B. BUILD.tools, contrib, 3rdparty needs to be copied vs symlinked to avoid
     # symlink prefix check error in v1 and v2 engine.
     files_to_copy = ('BUILD.tools',)
-    files_to_link = ('.pants.d',
-                     'build-support',
-                     'pants',
-                     'pants.pex',
-                     'pants-plugins',
-                     'pants.ini',
-                     'pants.travis-ci.ini',
-                     'pyproject.toml',
-                     'rust-toolchain',
-                     'src')
+    files_to_link = (
+      '.pants.d',
+      'build-support',
+      'pants',
+      'pants.pex',
+      'pants-plugins',
+      'pants.ini',
+      'pants.travis-ci.ini',
+      'pyproject.toml',
+      'rust-toolchain',
+      'src',
+    )
     dirs_to_copy = ('3rdparty', 'contrib') + tuple(dirs_to_copy or [])
 
     with self.temporary_workdir() as tmp_dir:

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -594,8 +594,11 @@ class PantsRunIntegrationTest(unittest.TestCase):
     # symlink prefix check error in v1 and v2 engine.
     files_to_copy = ('BUILD.tools',)
     files_to_link = (
+      'BUILD_ROOT',
       '.pants.d',
       'build-support',
+      # NB: when running with --chroot or the V2 engine, `pants` refers to the source root-stripped
+      # directory src/python/pants, not the script `./pants`.
       'pants',
       'pants.pex',
       'pants-plugins',


### PR DESCRIPTION
The `mock_buildroot()` method would correctly set up the new build root, but because it did not include the file `BUILD_ROOT`, Pants would traverse upwards outside of the temporary build root back into the original build root.

This fix brings integration tests to the following breakdown:
* 3% V1 no chroot (-3%)
* 13% V1 chroot (+1%)
* 84% V2 remote (+2%)