### PR TITLE
Port `test_pytest_run_integration.py` to V2

### DIFF
--- a/build-support/ci_lists/integration_chroot_blacklist.txt
+++ b/build-support/ci_lists/integration_chroot_blacklist.txt
@@ -1,4 +1,3 @@
-tests/python/pants_test/backend/python/tasks:pytest_run_integration
 tests/python/pants_test/backend/python/tasks:setup_py_integration
 tests/python/pants_test/backend/python:integration
 tests/python/pants_test/pantsd:pantsd_integration

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -110,8 +110,8 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     with temporary_dir() as coverage_dir:
       pants_run = self.run_pants(['clean-all',
                                   'test.pytest',
-                                  '--coverage=pants',
-                                  '--test-pytest-coverage-output-dir={}'.format(coverage_dir),
+                                  '--coverage=pants.constants_only',
+                                  f'--test-pytest-coverage-output-dir={coverage_dir}',
                                   'testprojects/tests/python/pants/constants_only'])
       self.assert_success(pants_run)
       self.assertTrue(os.path.exists(os.path.join(coverage_dir, 'coverage.xml')))


### PR DESCRIPTION
We were incorrectly specifying the coverage module name in the test as `pants`, which works without a chroot because the `pants` namespace is present. With a chroot, `pants` is no longer discoverable.

Instead, the test should use the namespace of the testproject: `pants.constants_only`.