### PR TITLE
Modify `engine.objects.Collection` to work with type hints

### DIFF
--- a/pants
+++ b/pants
@@ -123,7 +123,8 @@ for arg in "$@"; do
   fi
 done
 if [[ "${test_goal_used}" == 'true' && "${TRAVIS}" != 'true' ]]; then
-  "$HERE/build-support/bin/bootstrap_pants_pex.sh"
+  #"$HERE/build-support/bin/bootstrap_pants_pex.sh"
+  :
 fi
 
 exec_pants_bare "$@"

--- a/pants
+++ b/pants
@@ -123,8 +123,7 @@ for arg in "$@"; do
   fi
 done
 if [[ "${test_goal_used}" == 'true' && "${TRAVIS}" != 'true' ]]; then
-  #"$HERE/build-support/bin/bootstrap_pants_pex.sh"
-  :
+  "$HERE/build-support/bin/bootstrap_pants_pex.sh"
 fi
 
 exec_pants_bare "$@"

--- a/src/python/pants/backend/project_info/rules/source_file_validator.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator.py
@@ -11,7 +11,7 @@ from pants.engine.console import Console
 from pants.engine.fs import Digest, FilesContent
 from pants.engine.goal import Goal
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
-from pants.engine.objects import Collection
+from pants.engine.objects import CollectionMypy as Collection
 from pants.engine.rules import console_rule, optionable_rule, rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
@@ -90,7 +90,7 @@ class RegexMatchResult:
   nonmatching: Tuple
 
 
-RegexMatchResults = Collection.of(RegexMatchResult)
+RegexMatchResults = Collection[RegexMatchResult]
 
 
 class Matcher:

--- a/src/python/pants/backend/project_info/rules/source_file_validator.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator.py
@@ -11,7 +11,7 @@ from pants.engine.console import Console
 from pants.engine.fs import Digest, FilesContent
 from pants.engine.goal import Goal
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
-from pants.engine.objects import CollectionMypy as Collection
+from pants.engine.objects import Collection
 from pants.engine.rules import console_rule, optionable_rule, rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -130,10 +130,6 @@ python_library(
 python_library(
   name='objects',
   sources=['objects.py'],
-  dependencies=[
-    'src/python/pants/util:memo',
-    'src/python/pants/util:objects',
-  ]
 )
 
 python_library(

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -8,11 +8,12 @@ from functools import update_wrapper
 
 from pants.base.specs import Spec
 from pants.build_graph.address import Address, BuildFileAddress
-from pants.engine.objects import Collection, Resolvable, Serializable
+from pants.engine.objects import CollectionMypy as Collection
+from pants.engine.objects import Resolvable, Serializable
 from pants.util.objects import TypeConstraintError
 
 
-Addresses = Collection.of(Address)
+Addresses = Collection[Address]
 
 
 @dataclass(frozen=True)
@@ -22,14 +23,14 @@ class ProvenancedBuildFileAddress:
   provenance: Spec
 
 
-class BuildFileAddresses(Collection.of(BuildFileAddress)):
+class BuildFileAddresses(Collection[BuildFileAddress]):
   @property
   def addresses(self):
     """Converts the BuildFileAddress objects in this collection to Address objects."""
     return [bfa.to_address() for bfa in self]
 
 
-ProvenancedBuildFileAddresses = Collection.of(ProvenancedBuildFileAddress)
+ProvenancedBuildFileAddresses = Collection[ProvenancedBuildFileAddress]
 
 
 class NotSerializableError(TypeError):

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -8,8 +8,7 @@ from functools import update_wrapper
 
 from pants.base.specs import Spec
 from pants.build_graph.address import Address, BuildFileAddress
-from pants.engine.objects import CollectionMypy as Collection
-from pants.engine.objects import Resolvable, Serializable
+from pants.engine.objects import Collection, Resolvable, Serializable
 from pants.util.objects import TypeConstraintError
 
 

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Iterable, Optional, Tuple
 
-from pants.engine.objects import Collection
+from pants.engine.objects import CollectionMypy as Collection
 from pants.engine.rules import RootRule
 from pants.option.custom_types import GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
@@ -28,7 +28,7 @@ class FileContent:
     )
 
 
-FilesContent = Collection.of(FileContent)
+FilesContent = Collection[FileContent]
 
 
 class InputFilesContent(FilesContent):
@@ -170,7 +170,7 @@ class DirectoryToMaterialize:
   directory_digest: Digest
 
 
-DirectoriesToMaterialize = Collection.of(DirectoryToMaterialize)
+DirectoriesToMaterialize = Collection[DirectoryToMaterialize]
 
 
 @dataclass(frozen=True)
@@ -179,7 +179,7 @@ class MaterializeDirectoryResult:
   output_paths: Tuple[str, ...]
 
 
-MaterializeDirectoriesResult = Collection.of(MaterializeDirectoryResult)
+MaterializeDirectoriesResult = Collection[MaterializeDirectoryResult]
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -5,7 +5,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Iterable, Optional, Tuple
 
-from pants.engine.objects import CollectionMypy as Collection
+from pants.engine.objects import Collection
 from pants.engine.rules import RootRule
 from pants.option.custom_types import GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -25,7 +25,7 @@ from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
 from pants.engine.legacy.structs import BundleAdaptor, BundlesField, HydrateableField, SourcesField
 from pants.engine.mapper import AddressMapper
-from pants.engine.objects import Collection
+from pants.engine.objects import CollectionMypy as Collection
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
@@ -378,7 +378,7 @@ class TransitiveHydratedTargets:
   closure: Any
 
 
-class HydratedTargets(Collection.of(HydratedTarget)):
+class HydratedTargets(Collection[HydratedTarget]):
   """An intransitive set of HydratedTarget objects."""
 
 

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -25,7 +25,7 @@ from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
 from pants.engine.legacy.structs import BundleAdaptor, BundlesField, HydrateableField, SourcesField
 from pants.engine.mapper import AddressMapper
-from pants.engine.objects import CollectionMypy as Collection
+from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get

--- a/src/python/pants/engine/objects.py
+++ b/src/python/pants/engine/objects.py
@@ -3,8 +3,10 @@
 
 import inspect
 import sys
+import typing
 from abc import ABC, abstractmethod
-from collections import namedtuple
+from collections import Iterable, namedtuple
+from typing import Generic, Iterator, TypeVar
 
 from pants.util.memo import memoized_classmethod
 from pants.util.objects import Exactly, TypedCollection, datatype
@@ -146,6 +148,27 @@ class Validatable(ABC):
 
     :raises: :class:`ValidationError` if this object is invalid.
     """
+
+
+_C = TypeVar("_C")
+
+class CollectionMypy(Generic[_C], Iterable):
+  """Constructs classes representing collections of objects of a particular type.
+
+  The produced class will expose its values under a field named dependencies - this is a stable API
+  which may be consumed e.g. over FFI from the engine.
+
+  Python consumers of a Collection should prefer to use its standard iteration API.
+  """
+
+  def __init__(self, dependencies: typing.Iterable[_C]) -> None:
+    self.dependencies = tuple(dependencies)
+
+  def __iter__(self) -> Iterator[_C]:
+    return iter(self.dependencies)
+
+  def __bool__(self) -> bool:
+    return bool(self.dependencies)
 
 
 class Collection:

--- a/src/python/pants/engine/objects.py
+++ b/src/python/pants/engine/objects.py
@@ -2,14 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import inspect
-import sys
 import typing
 from abc import ABC, abstractmethod
 from collections import Iterable, namedtuple
 from typing import Generic, Iterator, TypeVar
-
-from pants.util.memo import memoized_classmethod
-from pants.util.objects import Exactly, TypedCollection, datatype
 
 
 class SerializationError(Exception):
@@ -152,7 +148,7 @@ class Validatable(ABC):
 
 _C = TypeVar("_C")
 
-class CollectionMypy(Generic[_C], Iterable):
+class Collection(Generic[_C], Iterable):
   """Constructs classes representing collections of objects of a particular type.
 
   The produced class will expose its values under a field named dependencies - this is a stable API
@@ -168,40 +164,4 @@ class CollectionMypy(Generic[_C], Iterable):
     return iter(self.dependencies)
 
   def __bool__(self) -> bool:
-    return bool(self.dependencies)
-
-
-class Collection:
-  """Constructs classes representing collections of objects of a particular type.
-
-  The produced class will expose its values under a field named dependencies - this is a stable API
-  which may be consumed e.g. over FFI from the engine.
-
-  Python consumers of a Collection should prefer to use its standard iteration API.
-
-  Note that elements of a Collection are type-checked upon construction.
-  """
-
-  @memoized_classmethod
-  def of(cls, *element_types):
-    union = '|'.join(element_type.__name__ for element_type in element_types)
-    type_name = '{}.of({})'.format(cls.__name__, union)
-    type_checked_collection_class = datatype([
-      # Create a datatype with a single field 'dependencies' which is type-checked on construction
-      # to be a collection containing elements of only the exact `element_types` specified.
-      ('dependencies', TypedCollection(Exactly(*element_types)))
-    ], superclass_name=cls.__name__)
-    supertypes = (cls, type_checked_collection_class)
-    properties = {'element_types': element_types}
-    collection_of_type = type(type_name, supertypes, properties)
-
-    # Expose the custom class type at the module level to be pickle compatible.
-    setattr(sys.modules[cls.__module__], type_name, collection_of_type)
-
-    return collection_of_type
-
-  def __iter__(self):
-    return iter(self.dependencies)
-
-  def __bool__(self):
     return bool(self.dependencies)

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -37,7 +37,7 @@ from pants.engine.isolated_process import (
 )
 from pants.engine.native import Function, TypeId
 from pants.engine.nodes import Return, Throw
-from pants.engine.objects import Collection
+from pants.engine.objects import CollectionMypy as Collection
 from pants.engine.rules import RuleIndex, TaskRule
 from pants.engine.selectors import Params
 from pants.util.contextutil import temporary_file_path
@@ -322,13 +322,13 @@ class Scheduler:
     )
 
 
-_PathGlobsAndRootCollection = Collection.of(PathGlobsAndRoot)
+_PathGlobsAndRootCollection = Collection[PathGlobsAndRoot]
 
 
-_DirectoryDigests = Collection.of(Digest)
+_DirectoryDigests = Collection[Digest]
 
 
-_DirectoriesToMaterialize = Collection.of(DirectoryToMaterialize)
+_DirectoriesToMaterialize = Collection[DirectoryToMaterialize]
 
 
 class SchedulerSession:

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -37,7 +37,7 @@ from pants.engine.isolated_process import (
 )
 from pants.engine.native import Function, TypeId
 from pants.engine.nodes import Return, Throw
-from pants.engine.objects import CollectionMypy as Collection
+from pants.engine.objects import Collection
 from pants.engine.rules import RuleIndex, TaskRule
 from pants.engine.selectors import Params
 from pants.util.contextutil import temporary_file_path

--- a/src/python/pants/fs/BUILD
+++ b/src/python/pants/fs/BUILD
@@ -12,7 +12,9 @@ python_library(
 python_tests(
   name = "tests",
   dependencies = [
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:test_base',
     'tests/python/pants_test:console_rule_test_base',
-    'tests/python/pants_test/engine:util'
+    'tests/python/pants_test/engine:util',
   ]
 )

--- a/src/python/pants/fs/test_fs.py
+++ b/src/python/pants/fs/test_fs.py
@@ -10,11 +10,11 @@ from pants.engine.fs import (
   DirectoryToMaterialize,
   FileContent,
   InputFilesContent,
-  MaterializeDirectoriesResult,
   MaterializeDirectoryResult,
   Workspace,
 )
 from pants.engine.goal import Goal
+from pants.engine.objects import Collection
 from pants.engine.rules import RootRule, console_rule
 from pants.engine.selectors import Get
 from pants.util.contextutil import temporary_dir
@@ -92,7 +92,12 @@ class FileSystemTest(TestBase):
         DirectoryToMaterialize(path=tmp_dir, directory_digest=digest),
       ))
 
-      self.assertEqual(type(output), MaterializeDirectoriesResult)
+      # Generic classes lose type variable information at runtime, so, at runtime, `output` is a
+      # generic `pants.engine.objects.Collection`, even though MyPy can distinguish that it really
+      # is a `Collection[MaterializeDirectoryResult]` (aka `MaterializeDirectoriesResult`):
+      # https://mypy.readthedocs.io/en/latest/generics.html#generic-class-internals. We rely on
+      # MyPy to enforce valid type usage at compile-time for us.
+      self.assertEqual(type(output), Collection)
       materialize_result = output.dependencies[0]
       self.assertEqual(type(materialize_result), MaterializeDirectoryResult)
       self.assertEqual(materialize_result.output_paths,

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Optional, Sequence, Set
 
 from pants.base.project_tree_factory import get_project_tree
-from pants.engine.objects import CollectionMypy as Collection
+from pants.engine.objects import Collection
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method, memoized_property
 

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Optional, Sequence, Set
 
 from pants.base.project_tree_factory import get_project_tree
-from pants.engine.objects import Collection
+from pants.engine.objects import CollectionMypy as Collection
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method, memoized_property
 
@@ -26,7 +26,7 @@ class SourceRoot:
   category: str
 
 
-class AllSourceRoots(Collection.of(SourceRoot)):
+class AllSourceRoots(Collection[SourceRoot]):
   pass
 
 

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -229,6 +229,5 @@ python_tests(
   sources=['test_objects.py'],
   dependencies=[
     'src/python/pants/engine:objects',
-    'src/python/pants/util:objects',
   ],
 )

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -229,6 +229,6 @@ python_tests(
   sources=['test_objects.py'],
   dependencies=[
     'src/python/pants/engine:objects',
-    'tests/python/pants_test:test_base',
+    'src/python/pants/util:objects',
   ],
 )

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -19,7 +19,7 @@ from pants.engine.mapper import (
   DuplicateNameError,
   UnaddressableObjectError,
 )
-from pants.engine.objects import Collection
+from pants.engine.objects import CollectionMypy as Collection
 from pants.engine.parser import HydratedStruct, SymbolTable
 from pants.engine.rules import rule
 from pants.engine.selectors import Get
@@ -132,7 +132,7 @@ class AddressFamilyTest(unittest.TestCase):
                                        {'one': Thing(name='one', age=37)})])
 
 
-HydratedStructs = Collection.of(HydratedStruct)
+HydratedStructs = Collection[HydratedStruct]
 
 
 @rule

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -19,7 +19,7 @@ from pants.engine.mapper import (
   DuplicateNameError,
   UnaddressableObjectError,
 )
-from pants.engine.objects import CollectionMypy as Collection
+from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct, SymbolTable
 from pants.engine.rules import rule
 from pants.engine.selectors import Get

--- a/tests/python/pants_test/engine/test_objects.py
+++ b/tests/python/pants_test/engine/test_objects.py
@@ -1,44 +1,16 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import re
 import unittest
 
-from pants.engine.objects import Collection, CollectionMypy
-from pants.util.objects import TypeCheckError
+from pants.engine.objects import Collection
 
 
 class CollectionTest(unittest.TestCase):
 
-  def test_collection_iteration(self):
-    self.assertEqual([1, 2], [x for x in Collection.of(int)([1, 2])])
-
-  def test_element_typechecking(self):
-    IntColl = Collection.of(int)
-    with self.assertRaisesRegexp(TypeCheckError, re.escape(
-      "field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) "
-      "matching iterable object [3, 'hello']: value 'hello' (with type 'str') must satisfy this "
-      "type constraint: Exactly(int).")):
-      IntColl([3, "hello"])
-
-    IntOrStringColl = Collection.of(int, str)
-    self.assertEqual([3, "hello"], [x for x in IntOrStringColl([3, "hello"])])
-    with self.assertRaisesRegex(TypeCheckError, re.escape(
-      "field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int or "
-      "str)) matching iterable object [()]: value () (with type 'tuple') must satisfy this type "
-      "constraint: Exactly(int or str).""")):
-      IntOrStringColl([()])
-
-  def test_collection_bool(self):
-    self.assertTrue(bool(Collection.of(int)([0])))
-    self.assertFalse(bool(Collection.of(int)([])))
-
-
-class CollectionMypyTest(unittest.TestCase):
-
   def test_collection_iteration(self) -> None:
-    self.assertEqual([1, 2], [x for x in CollectionMypy([1, 2])])
+    self.assertEqual([1, 2], [x for x in Collection([1, 2])])
 
   def test_collection_bool(self) -> None:
-    self.assertTrue(bool(CollectionMypy([0])))
-    self.assertFalse(bool(CollectionMypy([])))
+    self.assertTrue(bool(Collection([0])))
+    self.assertFalse(bool(Collection([])))

--- a/tests/python/pants_test/engine/test_objects.py
+++ b/tests/python/pants_test/engine/test_objects.py
@@ -2,13 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import re
+import unittest
 
-from pants.engine.objects import Collection
+from pants.engine.objects import Collection, CollectionMypy
 from pants.util.objects import TypeCheckError
-from pants_test.test_base import TestBase
 
 
-class CollectionTest(TestBase):
+class CollectionTest(unittest.TestCase):
+
   def test_collection_iteration(self):
     self.assertEqual([1, 2], [x for x in Collection.of(int)([1, 2])])
 
@@ -22,7 +23,7 @@ class CollectionTest(TestBase):
 
     IntOrStringColl = Collection.of(int, str)
     self.assertEqual([3, "hello"], [x for x in IntOrStringColl([3, "hello"])])
-    with self.assertRaisesRegexp(TypeCheckError, re.escape(
+    with self.assertRaisesRegex(TypeCheckError, re.escape(
       "field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int or "
       "str)) matching iterable object [()]: value () (with type 'tuple') must satisfy this type "
       "constraint: Exactly(int or str).""")):
@@ -31,3 +32,13 @@ class CollectionTest(TestBase):
   def test_collection_bool(self):
     self.assertTrue(bool(Collection.of(int)([0])))
     self.assertFalse(bool(Collection.of(int)([])))
+
+
+class CollectionMypyTest(unittest.TestCase):
+
+  def test_collection_iteration(self) -> None:
+    self.assertEqual([1, 2], [x for x in CollectionMypy([1, 2])])
+
+  def test_collection_bool(self) -> None:
+    self.assertTrue(bool(CollectionMypy([0])))
+    self.assertFalse(bool(CollectionMypy([])))


### PR DESCRIPTION
### Problem
MyPy does not understand `Collection.of(int)` because it depends on runtime evaluation of the types. We need to move the type information into compile-time information.

We also do not want to lose the API of `engine.objects.Collection`, which is used across our FFI boundary. For example, it is not enough to use a type alias - we must still be creating a new class so that the engine can distinguish between something like `FilesContent` and `InputFilesContent`, which both have the same "structure" (i.e. same fields):

https://github.com/pantsbuild/pants/blob/2dfb86ffd4e3d2612d1386c5165ccd7613a48496/src/python/pants/engine/fs.py#L31-L38


### Solution
Use a _generic_ class to achieve the same mechanism and maintain the same API (minus type checking moving from runtime to compile-time). See https://mypy.readthedocs.io/en/latest/generics.html.

Instead of `Addresses = Collection.of(Address)`, we now write `Addresses = Collection[Address]`.

Whereas previously a Union would be represented through multiple args, like `Collection.of(float, int)`, now we use PEP 484's `Union`: `Collection[Union[int, float]]`.

### Result
MyPy now understands our `Collection` abstraction.