### PR TITLE
Revert 9ce0100 due to breaking change with pantsd

### DIFF
--- a/src/python/pants/backend/project_info/rules/source_file_validator.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator.py
@@ -93,7 +93,7 @@ class RegexMatchResult:
   nonmatching: Tuple
 
 
-RegexMatchResults = Collection[RegexMatchResult]
+RegexMatchResults = Collection.of(RegexMatchResult)
 
 
 class Matcher:

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -130,6 +130,10 @@ python_library(
 python_library(
   name='objects',
   sources=['objects.py'],
+  dependencies=[
+    'src/python/pants/util:memo',
+    'src/python/pants/util:objects',
+  ]
 )
 
 python_library(

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -12,7 +12,7 @@ from pants.engine.objects import Collection, Resolvable, Serializable
 from pants.util.objects import TypeConstraintError
 
 
-Addresses = Collection[Address]
+Addresses = Collection.of(Address)
 
 
 @dataclass(frozen=True)
@@ -22,14 +22,14 @@ class ProvenancedBuildFileAddress:
   provenance: Spec
 
 
-class BuildFileAddresses(Collection[BuildFileAddress]):
+class BuildFileAddresses(Collection.of(BuildFileAddress)):
   @property
   def addresses(self):
     """Converts the BuildFileAddress objects in this collection to Address objects."""
     return [bfa.to_address() for bfa in self]
 
 
-ProvenancedBuildFileAddresses = Collection[ProvenancedBuildFileAddress]
+ProvenancedBuildFileAddresses = Collection.of(ProvenancedBuildFileAddress)
 
 
 class NotSerializableError(TypeError):

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -28,7 +28,7 @@ class FileContent:
     )
 
 
-FilesContent = Collection[FileContent]
+FilesContent = Collection.of(FileContent)
 
 
 class InputFilesContent(FilesContent):
@@ -170,7 +170,7 @@ class DirectoryToMaterialize:
   directory_digest: Digest
 
 
-DirectoriesToMaterialize = Collection[DirectoryToMaterialize]
+DirectoriesToMaterialize = Collection.of(DirectoryToMaterialize)
 
 
 @dataclass(frozen=True)
@@ -179,7 +179,7 @@ class MaterializeDirectoryResult:
   output_paths: Tuple[str, ...]
 
 
-MaterializeDirectoriesResult = Collection[MaterializeDirectoryResult]
+MaterializeDirectoriesResult = Collection.of(MaterializeDirectoryResult)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -378,7 +378,7 @@ class TransitiveHydratedTargets:
   closure: Any
 
 
-class HydratedTargets(Collection[HydratedTarget]):
+class HydratedTargets(Collection.of(HydratedTarget)):
   """An intransitive set of HydratedTarget objects."""
 
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -322,13 +322,13 @@ class Scheduler:
     )
 
 
-_PathGlobsAndRootCollection = Collection[PathGlobsAndRoot]
+_PathGlobsAndRootCollection = Collection.of(PathGlobsAndRoot)
 
 
-_DirectoryDigests = Collection[Digest]
+_DirectoryDigests = Collection.of(Digest)
 
 
-_DirectoriesToMaterialize = Collection[DirectoryToMaterialize]
+_DirectoriesToMaterialize = Collection.of(DirectoryToMaterialize)
 
 
 class SchedulerSession:

--- a/src/python/pants/fs/BUILD
+++ b/src/python/pants/fs/BUILD
@@ -12,9 +12,7 @@ python_library(
 python_tests(
   name = "tests",
   dependencies = [
-    'src/python/pants/util:contextutil',
-    'tests/python/pants_test:test_base',
     'tests/python/pants_test:console_rule_test_base',
-    'tests/python/pants_test/engine:util',
+    'tests/python/pants_test/engine:util'
   ]
 )

--- a/src/python/pants/fs/test_fs.py
+++ b/src/python/pants/fs/test_fs.py
@@ -10,11 +10,11 @@ from pants.engine.fs import (
   DirectoryToMaterialize,
   FileContent,
   InputFilesContent,
+  MaterializeDirectoriesResult,
   MaterializeDirectoryResult,
   Workspace,
 )
 from pants.engine.goal import Goal
-from pants.engine.objects import Collection
 from pants.engine.rules import RootRule, console_rule
 from pants.engine.selectors import Get
 from pants.util.contextutil import temporary_dir
@@ -92,12 +92,7 @@ class FileSystemTest(TestBase):
         DirectoryToMaterialize(path=tmp_dir, directory_digest=digest),
       ))
 
-      # Generic classes lose type variable information at runtime, so, at runtime, `output` is a
-      # generic `pants.engine.objects.Collection`, even though MyPy can distinguish that it really
-      # is a `Collection[MaterializeDirectoryResult]` (aka `MaterializeDirectoriesResult`):
-      # https://mypy.readthedocs.io/en/latest/generics.html#generic-class-internals. We rely on
-      # MyPy to enforce valid type usage at compile-time for us.
-      self.assertEqual(type(output), Collection)
+      self.assertEqual(type(output), MaterializeDirectoriesResult)
       materialize_result = output.dependencies[0]
       self.assertEqual(type(materialize_result), MaterializeDirectoryResult)
       self.assertEqual(materialize_result.output_paths,

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -26,7 +26,7 @@ class SourceRoot:
   category: str
 
 
-class AllSourceRoots(Collection[SourceRoot]):
+class AllSourceRoots(Collection.of(SourceRoot)):
   pass
 
 

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -228,5 +228,6 @@ python_tests(
   sources=['test_objects.py'],
   dependencies=[
     'src/python/pants/engine:objects',
+    'tests/python/pants_test:test_base',
   ],
 )

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -132,7 +132,7 @@ class AddressFamilyTest(unittest.TestCase):
                                        {'one': Thing(name='one', age=37)})])
 
 
-HydratedStructs = Collection[HydratedStruct]
+HydratedStructs = Collection.of(HydratedStruct)
 
 
 @rule

--- a/tests/python/pants_test/engine/test_objects.py
+++ b/tests/python/pants_test/engine/test_objects.py
@@ -1,16 +1,33 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import unittest
+import re
 
 from pants.engine.objects import Collection
+from pants.util.objects import TypeCheckError
+from pants_test.test_base import TestBase
 
 
-class CollectionTest(unittest.TestCase):
+class CollectionTest(TestBase):
+  def test_collection_iteration(self):
+    self.assertEqual([1, 2], [x for x in Collection.of(int)([1, 2])])
 
-  def test_collection_iteration(self) -> None:
-    self.assertEqual([1, 2], [x for x in Collection([1, 2])])
+  def test_element_typechecking(self):
+    IntColl = Collection.of(int)
+    with self.assertRaisesRegexp(TypeCheckError, re.escape(
+      "field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int)) "
+      "matching iterable object [3, 'hello']: value 'hello' (with type 'str') must satisfy this "
+      "type constraint: Exactly(int).")):
+      IntColl([3, "hello"])
 
-  def test_collection_bool(self) -> None:
-    self.assertTrue(bool(Collection([0])))
-    self.assertFalse(bool(Collection([])))
+    IntOrStringColl = Collection.of(int, str)
+    self.assertEqual([3, "hello"], [x for x in IntOrStringColl([3, "hello"])])
+    with self.assertRaisesRegexp(TypeCheckError, re.escape(
+      "field 'dependencies' was invalid: in wrapped constraint TypedCollection(Exactly(int or "
+      "str)) matching iterable object [()]: value () (with type 'tuple') must satisfy this type "
+      "constraint: Exactly(int or str).""")):
+      IntOrStringColl([()])
+
+  def test_collection_bool(self):
+    self.assertTrue(bool(Collection.of(int)([0])))
+    self.assertFalse(bool(Collection.of(int)([])))


### PR DESCRIPTION
### Problem

Master is broken (see https://travis-ci.org/pantsbuild/pants/jobs/598005991)

### Solution

Revert offending commit (From local bisect)

### Result

Revert "Modify `engine.objects.Collection` to work with type hints (#8467)"

This reverts commit 9ce010093aea9081ca6c60ac7829ce0c7b6b1681.