### PR TITLE
capture the rest (?) of the exceptions from CFFI objects

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -297,23 +297,32 @@ class Scheduler:
 
   def _run_and_return_roots(self, session, execution_request):
     raw_roots = self._native.lib.scheduler_execute(self._scheduler, session, execution_request)
-    remaining_runtime_exceptions_to_capture = deque(self._native.cffi_extern_method_runtime_exceptions())
-    self._native.reset_cffi_extern_method_runtime_exceptions()
+    remaining_runtime_exceptions_to_capture = deque(self._native.consume_cffi_extern_method_runtime_exceptions())
     try:
       roots = []
       for raw_root in self._native.unpack(raw_roots.nodes_ptr, raw_roots.nodes_len):
         # Check if there were any uncaught exceptions within rules that were executed.
-        remaining_runtime_exceptions_to_capture.extend(
-          self._native.cffi_extern_method_runtime_exceptions())
-        self._native.reset_cffi_extern_method_runtime_exceptions()
+        remaining_runtime_exceptions_to_capture.extend(self._native.consume_cffi_extern_method_runtime_exceptions())
 
         if raw_root.is_throw:
           state = Throw(self._from_value(raw_root.handle))
+        elif raw_root.handle == self._native.ffi.NULL:
+          # NB: We expect all NULL handles to correspond to uncaught exceptions which are collected
+          # in `self._native._peek_cffi_extern_method_runtime_exceptions()`!
+          if not remaining_runtime_exceptions_to_capture:
+            raise ExecutionError('Internal logic error in scheduler: expected more elements in '
+                                 '`self._native._peek_cffi_extern_method_runtime_exceptions()`.')
+          matching_runtime_exception = remaining_runtime_exceptions_to_capture.popleft()
+          state = Throw(matching_runtime_exception)
         else:
           state = Return(self._from_value(raw_root.handle))
         roots.append(state)
     finally:
       self._native.lib.nodes_destroy(raw_roots)
+
+    if remaining_runtime_exceptions_to_capture:
+      raise ExecutionError('Internal logic error in scheduler: expected elements in '
+                           '`self._native._peek_cffi_extern_method_runtime_exceptions()`.')
     return roots
 
   def lease_files_in_graph(self):
@@ -496,7 +505,7 @@ class SchedulerSession:
     except:                     # noqa: T803
       # If there are any exceptions during CFFI extern method calls, we want to return an error with
       # them and whatever failure results from it. This typically results from unhashable types.
-      if self._scheduler._native.cffi_extern_method_runtime_exceptions():
+      if self._scheduler._native._peek_cffi_extern_method_runtime_exceptions():
         raised_exception = sys.exc_info()[0:3]
       else:
         # Otherwise, this is likely an exception coming from somewhere else, and we don't want to
@@ -506,7 +515,7 @@ class SchedulerSession:
     # We still want to raise whenever there are any exceptions in any CFFI extern methods, even if
     # that didn't lead to an exception in generating the execution request for some reason, so we
     # check the extern exceptions list again.
-    internal_errors = self._scheduler._native.cffi_extern_method_runtime_exceptions()
+    internal_errors = self._scheduler._native.consume_cffi_extern_method_runtime_exceptions()
     if internal_errors:
       error_tracebacks = [
         ''.join(
@@ -524,10 +533,6 @@ class SchedulerSession:
           CFFI extern methods listed above, as CFFI externs return None upon error:
           {}
         """).format(''.join(traceback.format_exception(etype=exc_type, value=exc_value, tb=tb)))
-
-      # Zero out the errors raised in CFFI callbacks in case this one is caught and pants doesn't
-      # exit.
-      self._scheduler._native.reset_cffi_extern_method_runtime_exceptions()
 
       raise ExecutionError(dedent("""\
         {error_description} raised in CFFI extern methods:

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -297,7 +297,7 @@ class Scheduler:
 
   def _run_and_return_roots(self, session, execution_request):
     raw_roots = self._native.lib.scheduler_execute(self._scheduler, session, execution_request)
-    remaining_runtime_exceptions_to_capture = deque(self._native.consume_cffi_extern_method_runtime_exceptions())
+    remaining_runtime_exceptions_to_capture = list(self._native.consume_cffi_extern_method_runtime_exceptions())
     try:
       roots = []
       for raw_root in self._native.unpack(raw_roots.nodes_ptr, raw_roots.nodes_len):
@@ -312,7 +312,7 @@ class Scheduler:
           if not remaining_runtime_exceptions_to_capture:
             raise ExecutionError('Internal logic error in scheduler: expected more elements in '
                                  '`self._native._peek_cffi_extern_method_runtime_exceptions()`.')
-          matching_runtime_exception = remaining_runtime_exceptions_to_capture.popleft()
+          matching_runtime_exception = remaining_runtime_exceptions_to_capture.pop(0)
           state = Throw(matching_runtime_exception)
         else:
           state = Return(self._from_value(raw_root.handle))

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -372,7 +372,7 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
     with self.assertRaises(ExecutionError) as cm:
       with unittest.mock.patch.object(SchedulerSession, 'execution_request',
                              **PATCH_OPTS) as mock_exe_request:
-        with unittest.mock.patch.object(Native, 'cffi_extern_method_runtime_exceptions',
+        with unittest.mock.patch.object(Native, '_peek_cffi_extern_method_runtime_exceptions',
                                **PATCH_OPTS) as mock_cffi_exceptions:
           mock_exe_request.return_value = None
           mock_cffi_exceptions.return_value = [create_cffi_exception()]


### PR DESCRIPTION
### Problem

#7532 first added methods to `Native` to check for whether an exception had been raised within a coroutine (e.g. an `@rule`), and #8182 showed that there were incorrect assumptions made about the handling of `KeyboardInterrupt`. This issue still shows up on occasion, with the output:
```
timestamp: 2019-10-15T15:49:24.874402
Exception caught: (builtins.RuntimeError)
  ...
  File "/Users/dmcclanahan/tools/pants-v6/src/python/pants/engine/scheduler.py", line 430, in execute
    self._scheduler._run_and_return_roots(self._session, execution_request.native)))
  File "/Users/dmcclanahan/tools/pants-v6/src/python/pants/engine/scheduler.py", line 306, in _run_and_return_roots
    state = Return(self._from_value(raw_root.handle))
  File "/Users/dmcclanahan/tools/pants-v6/src/python/pants/engine/scheduler.py", line 172, in _from_value
    return self._native.context.from_value(val)
  File "/Users/dmcclanahan/tools/pants-v6/src/python/pants/engine/native.py", line 593, in from_value
    return self._ffi.from_handle(val)

Exception message: cannot use from_handle() on NULL pointer
```

This behavior reproduces if you attempt to write a python-executing `@console_rule` and hit <kbd>ctrl-c</kbd> while it executes the subprocess (@gshuflin found this!).

### Solution

- Check for cffi exceptions upon every iteration of the unpacked `raw_root`s.
- Expose `.consume_cffi_runtime_exceptions()` to avoid having to remember to reset the exceptions every time they're observed.

### Result

An `@console_rule` can be written which handles `KeyboardInterrupt`, for example (although we probably don't want to actually allow that behavior).

**Note:** This should contain tests, but our current tests of <kbd>ctrl-c</kbd> interaction are flaky or disabled, and I didn't want to add more. I believe that this greater issue should be addressed at some point.