### PR TITLE
Fix undigested m.jar under validated targets

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -424,7 +424,6 @@ class BaseZincCompile(JvmCompile):
               "ClasspathEntry {} didn't have a Digest, so won't be present for hermetic "
               "execution of zinc".format(dep)
             )
-          directory_digests.append(dep.directory_digest)
           relpath = fast_relpath(dep.path, get_buildroot())
           classes_dir_snapshot, = self.context._scheduler.capture_snapshots([
             PathGlobsAndRoot(
@@ -434,6 +433,7 @@ class BaseZincCompile(JvmCompile):
             ),
           ])
           dep.hydrate_missing_directory_digest(classes_dir_snapshot.directory_digest)
+          directory_digests.append(dep.directory_digest)
 
     directory_digests.extend(
       classpath_entry.directory_digest for classpath_entry in scalac_classpath_entries

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -28,7 +28,7 @@ from pants.engine.fs import (
   DirectoryToMaterialize,
   PathGlobs,
   PathGlobsAndRoot,
-  Digest)
+)
 from pants.engine.isolated_process import ExecuteProcessRequest
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import fast_relpath
@@ -415,26 +415,13 @@ class BaseZincCompile(JvmCompile):
     directory_digests = [
       entry.directory_digest for entry in relevant_classpath_entries if entry.directory_digest
     ]
-
     if len(directory_digests) != len(relevant_classpath_entries):
       for dep in relevant_classpath_entries:
         if not dep.directory_digest:
-          if not os.path.exists(dep.path):
-            raise AssertionError(
-              "ClasspathEntry {} didn't have a Digest, so won't be present for hermetic "
-              "execution of zinc".format(dep)
-            )
-          relpath = fast_relpath(dep.path, get_buildroot())
-          classes_dir_snapshot, = self.context._scheduler.capture_snapshots([
-            PathGlobsAndRoot(
-              PathGlobs([relpath]),
-              get_buildroot(),
-              Digest.load(relpath),
-            ),
-          ])
-          dep.hydrate_missing_directory_digest(classes_dir_snapshot.directory_digest)
-          directory_digests.append(dep.directory_digest)
-
+          raise AssertionError(
+            "ClasspathEntry {} didn't have a Digest, so won't be present for hermetic "
+            "execution of zinc".format(dep)
+          )
     directory_digests.extend(
       classpath_entry.directory_digest for classpath_entry in scalac_classpath_entries
     )


### PR DESCRIPTION
### Problem

For hermetic rsc+zinc, m.jar in validated targets are not digested, causing downstream targets to error out with missing digest. E.g.
```
zinc[rsc-and-zinc](<target>) failed: ClasspathEntry ClasspathEntry(path='/Users/user/workspace/s2/.pants.d/compile/rsc/c1e3836b60e5/<target_id>/current/rsc/m.jar', directory_digest=None) didn't have a Digest, so won't be present for hermetic execution of zinc
                   Traceback:
                     File "/Users/user/workspace/pants/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py", line 281, in worker
                       work()
                   
                     File "/Users/user/workspace/pants/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py", line 42, in __call__
                       self.fn()
                   
                     File "/Users/user/workspace/pants/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py", line 982, in _default_work_for_vts
                       counter)
                   
                     File "/Users/user/workspace/pants/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py", line 593, in _compile_vts
                       self._get_plugin_map('scalac', ScalaPlatform.global_instance(), ctx.target),
```

### Solution

Make sure m.jar in validated targets are digested.