### PR TITLE
fix NameError in ExceptionSink.trapped_signals() if .reset_signal_handler() raises

### DIFF
--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -371,8 +371,6 @@ class ExceptionSink:
 
     NB: This method calls signal.signal(), which will crash if not called from the main thread!
     """
-    # NB: It's possible for the `.reset_signal_handler()` call to raise, but it's not yet clear when
-    # this happens.
     previous_signal_handler = cls.reset_signal_handler(new_signal_handler)
     try:
       yield

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -371,15 +371,13 @@ class ExceptionSink:
 
     NB: This method calls signal.signal(), which will crash if not called from the main thread!
     """
-    # NB: We set `previous_signal_handler` to None at the start of the method in case resetting the
-    # signal handler within the `try` raises an error for some reason.
-    previous_signal_handler = None
+    # NB: It's possible for the `.reset_signal_handler()` call to raise, but it's not yet clear when
+    # this happens.
+    previous_signal_handler = cls.reset_signal_handler(new_signal_handler)
     try:
-      previous_signal_handler = cls.reset_signal_handler(new_signal_handler)
       yield
     finally:
-      if previous_signal_handler:
-        cls.reset_signal_handler(previous_signal_handler)
+      cls.reset_signal_handler(previous_signal_handler)
 
   @classmethod
   @contextmanager

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -371,11 +371,13 @@ class ExceptionSink:
 
     NB: This method calls signal.signal(), which will crash if not called from the main thread!
     """
+    previous_signal_handler = None
     try:
       previous_signal_handler = cls.reset_signal_handler(new_signal_handler)
       yield
     finally:
-      cls.reset_signal_handler(previous_signal_handler)
+      if previous_signal_handler:
+        cls.reset_signal_handler(previous_signal_handler)
 
   @classmethod
   @contextmanager

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -371,6 +371,8 @@ class ExceptionSink:
 
     NB: This method calls signal.signal(), which will crash if not called from the main thread!
     """
+    # NB: We set `previous_signal_handler` to None at the start of the method in case resetting the
+    # signal handler within the `try` raises an error for some reason.
     previous_signal_handler = None
     try:
       previous_signal_handler = cls.reset_signal_handler(new_signal_handler)


### PR DESCRIPTION
Note: As noted in #8478, I didn't want to add any more flaky signal handling tests. I would love to be able to add testing for this behavior, and am very open to suggestions.

### Problem

Currently, if `ExceptionSink.reset_signal_handler()` raises within `.trapped_signals()`, the variable `previous_signal_handler` is undefined, see: https://github.com/pantsbuild/pants/blob/0e993240518d344c5db9a066f14467cb81048fa7/src/python/pants/base/exception_sink.py#L374-L378 The cases where this shows up have not yet been investigated.

### Solution

- Define `previous_signal_handler = None` at the top of the method.

### Result

We don't add an unrelated `NameError` exception to the stacktrace if resetting the signal handler fails!