### PR TITLE
Upgrade pex to 1.6.12.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -11,7 +11,7 @@ Markdown==2.1.1
 packaging==16.8
 parameterized==0.6.1
 pathspec==0.5.9
-pex==1.6.11
+pex==1.6.12
 psutil==5.6.3
 Pygments==2.3.1
 pyopenssl==17.3.0

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -60,8 +60,8 @@ class DownloadedPexBin(HermeticPex):
 @rule
 def download_pex_bin() -> DownloadedPexBin:
   # TODO: Inject versions and digests here through some option, rather than hard-coding it.
-  url = 'https://github.com/pantsbuild/pex/releases/download/v1.6.11/pex'
-  digest = Digest('7a8fdfce2de22d25ba38afaa9df0282c33dd436959b3a5c3f788ded2ccc2cae9', 1867604)
+  url = 'https://github.com/pantsbuild/pex/releases/download/v1.6.12/pex'
+  digest = Digest('ce64cb72cd23d2123dd48126af54ccf2b718d9ecb98c2ed3045ed1802e89e7e1', 1842359)
   snapshot = yield Get(Snapshot, UrlToFetch(url, digest))
   yield DownloadedPexBin(executable=snapshot.files[0], directory_digest=snapshot.directory_digest)
 


### PR DESCRIPTION
This picks up the --intransitive option which can be used in future rules
to provide reproduceable transitive resolves pre-done to pex.
