### PR TITLE
improve ergonomics of checking for @union types with new @decorated_type_checkable decorator

### DIFF
--- a/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
+++ b/src/python/pants/backend/awslambda/common/awslambda_common_rules.py
@@ -9,7 +9,8 @@ from pants.engine.console import Console
 from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.legacy.graph import HydratedTarget
-from pants.engine.rules import console_rule, rule, union
+from pants.engine.objects import union
+from pants.engine.rules import console_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.rules.core.distdir import DistDir
 

--- a/src/python/pants/backend/python/lint/python_format_target.py
+++ b/src/python/pants/backend/python/lint/python_format_target.py
@@ -12,7 +12,8 @@ from pants.engine.legacy.structs import (
   PythonTestsAdaptor,
   TargetAdaptor,
 )
-from pants.engine.rules import UnionMembership, UnionRule, rule, union
+from pants.engine.objects import union
+from pants.engine.rules import UnionMembership, UnionRule, rule
 from pants.engine.selectors import Get
 from pants.rules.core.fmt import AggregatedFmtResults, FmtResult, FormatTarget
 

--- a/src/python/pants/backend/python/lint/python_lint_target.py
+++ b/src/python/pants/backend/python/lint/python_lint_target.py
@@ -11,7 +11,8 @@ from pants.engine.legacy.structs import (
   PythonTestsAdaptor,
   TargetAdaptor,
 )
-from pants.engine.rules import UnionMembership, UnionRule, rule, union
+from pants.engine.objects import union
+from pants.engine.rules import UnionMembership, UnionRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.rules.core.lint import LintResult, LintResults, LintTarget
 

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -11,8 +11,8 @@ from typing import Any, Callable
 from pants.build_graph.target import Target
 from pants.engine.addressable import addressable_list
 from pants.engine.fs import GlobExpansionConjunction, PathGlobs
-from pants.engine.objects import Locatable
-from pants.engine.rules import UnionRule, union
+from pants.engine.objects import Locatable, union
+from pants.engine.rules import UnionRule
 from pants.engine.struct import Struct, StructWithDeps
 from pants.source import wrapped_globs
 from pants.util.contextutil import exception_logging

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -37,6 +37,7 @@ from pants.engine.isolated_process import (
   FallibleExecuteProcessResult,
   MultiPlatformExecuteProcessRequest,
 )
+from pants.engine.objects import union
 from pants.engine.selectors import Get
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import read_file, safe_mkdir, safe_mkdtemp
@@ -315,7 +316,7 @@ class _FFISpecification(object):
     """Return whether or not a type is a member of a union"""
     c = self._ffi.from_handle(context_handle)
     input_type = c.from_id(type_id.tup_0)
-    return bool(getattr(input_type, '_is_union', None))
+    return union.is_instance(input_type)
 
   _do_raise_keyboardinterrupt_on_identify = bool(os.environ.get('_RAISE_KEYBOARDINTERRUPT_IN_CFFI_IDENTIFY', False))
 

--- a/src/python/pants/engine/objects.py
+++ b/src/python/pants/engine/objects.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from collections.abc import Iterable
 from typing import Generic, Iterator, TypeVar
 
-from pants.util.meta import sentinel_attribute
+from pants.util.meta import decorated_type_checkable
 
 
 class SerializationError(Exception):
@@ -171,7 +171,7 @@ class Collection(Generic[_C], Iterable):
     return bool(self.dependencies)
 
 
-@sentinel_attribute
+@decorated_type_checkable
 def union(cls):
   """A class decorator which other classes can specify that they can resolve to with `UnionRule`.
 

--- a/src/python/pants/engine/objects.py
+++ b/src/python/pants/engine/objects.py
@@ -204,4 +204,6 @@ def union(cls):
     desc = f' ("{cls.__doc__}")' if cls.__doc__ else ''
     return f'Type {type(subject).__name__} is not a member of the {cls.__name__} @union{desc}'
 
-  return union.define_instance_of(cls, non_member_error_message=staticmethod(non_member_error_message))
+  return union.define_instance_of(
+    cls,
+    non_member_error_message=staticmethod(non_member_error_message))

--- a/src/python/pants/engine/objects.py
+++ b/src/python/pants/engine/objects.py
@@ -171,7 +171,7 @@ class Collection(Generic[_C], Iterable):
     return bool(self.dependencies)
 
 
-@sentinel_attribute('_is_union')
+@sentinel_attribute
 def union(cls):
   """A class decorator which other classes can specify that they can resolve to with `UnionRule`.
 

--- a/src/python/pants/engine/objects.py
+++ b/src/python/pants/engine/objects.py
@@ -8,6 +8,8 @@ from collections import namedtuple
 from collections.abc import Iterable
 from typing import Generic, Iterator, TypeVar
 
+from pants.util.meta import sentinel_attribute
+
 
 class SerializationError(Exception):
   """Indicates an error serializing an object."""

--- a/src/python/pants/engine/objects.py
+++ b/src/python/pants/engine/objects.py
@@ -167,3 +167,39 @@ class Collection(Generic[_C], Iterable):
 
   def __bool__(self) -> bool:
     return bool(self.dependencies)
+
+
+@sentinel_attribute('_is_union')
+def union(cls):
+  """A class decorator which other classes can specify that they can resolve to with `UnionRule`.
+
+  Annotating a class with @union allows other classes to use a UnionRule() instance to indicate that
+  they can be resolved to this base union class. This class will never be instantiated, and should
+  have no members -- it is used as a tag only, and will be replaced with whatever object is passed
+  in as the subject of a `await Get(...)`. See the following example:
+
+  @union
+  class UnionBase: pass
+
+  @rule
+  async def get_some_union_type(x: X) -> B:
+    result = await Get(ResultType, UnionBase, x.f())
+    # ...
+
+  If there exists a single path from (whatever type the expression `x.f()` returns) -> `ResultType`
+  in the rule graph, the engine will retrieve and execute that path to produce a `ResultType` from
+  `x.f()`. This requires also that whatever type `x.f()` returns was registered as a union member of
+  `UnionBase` with a `UnionRule`.
+
+  Unions allow @rule bodies to be written without knowledge of what types may eventually be provided
+  as input -- rather, they let the engine check that there is a valid path to the desired result.
+  """
+  # TODO: Check that the union base type is used as a tag and nothing else (e.g. no attributes)!
+  assert isinstance(cls, type)
+  def non_member_error_message(subject):
+    if hasattr(cls, 'non_member_error_message'):
+      return cls.non_member_error_message(subject)
+    desc = f' ("{cls.__doc__}")' if cls.__doc__ else ''
+    return f'Type {type(subject).__name__} is not a member of the {cls.__name__} @union{desc}'
+
+  return union.define_instance_of(cls, non_member_error_message=staticmethod(non_member_error_message))

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -22,7 +22,7 @@ from pants.engine.fs import (
 )
 from pants.engine.native import Function, TypeId
 from pants.engine.nodes import Return, Throw
-from pants.engine.objects import Collection
+from pants.engine.objects import Collection, union
 from pants.engine.rules import RuleIndex, TaskRule
 from pants.engine.selectors import Params
 from pants.util.contextutil import temporary_file_path
@@ -187,7 +187,7 @@ class Scheduler:
       self._native.lib.tasks_add_get(self._tasks, self._to_type(product), self._to_type(subject))
 
     for the_get in rule.input_gets:
-      if getattr(the_get.subject_declared_type, '_is_union', False):
+      if union.is_instance(the_get.subject_declared_type):
         # If the registered subject type is a union, add Get edges to all registered union members.
         for union_member in union_rules.get(the_get.subject_declared_type, []):
           add_get_edge(the_get.product, union_member)

--- a/src/python/pants/fs/fs.py
+++ b/src/python/pants/fs/fs.py
@@ -74,4 +74,3 @@ def expand_path(path):
 def is_child_of(path: Path, directory: Path) -> bool:
   abs_path = path if path.is_absolute() else directory.joinpath(path).resolve()
   return directory == abs_path or directory in abs_path.parents
-

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -9,7 +9,8 @@ from pants.engine.console import Console
 from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.legacy.graph import HydratedTarget
-from pants.engine.rules import console_rule, rule, union
+from pants.engine.objects import union
+from pants.engine.rules import console_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.rules.core.distdir import DistDir
 

--- a/src/python/pants/rules/core/core_test_model.py
+++ b/src/python/pants/rules/core/core_test_model.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 
 from pants.engine.isolated_process import FallibleExecuteProcessResult
-from pants.engine.rules import union
+from pants.engine.objects import union
 from pants.util.collections import Enum
 
 

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -10,8 +10,8 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.isolated_process import ExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.legacy.structs import TargetAdaptor
-from pants.engine.rules import UnionMembership, console_rule
 from pants.engine.objects import union
+from pants.engine.rules import UnionMembership, console_rule
 from pants.engine.selectors import Get, MultiGet
 
 

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -10,7 +10,8 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.isolated_process import ExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.legacy.structs import TargetAdaptor
-from pants.engine.rules import UnionMembership, console_rule, union
+from pants.engine.rules import UnionMembership, console_rule
+from pants.engine.objects import union
 from pants.engine.selectors import Get, MultiGet
 
 

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -8,8 +8,8 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.isolated_process import FallibleExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.legacy.structs import TargetAdaptor
-from pants.engine.objects import Collection
-from pants.engine.rules import UnionMembership, console_rule, union
+from pants.engine.objects import Collection, union
+from pants.engine.rules import UnionMembership, console_rule
 from pants.engine.selectors import Get, MultiGet
 
 

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -130,19 +130,19 @@ class _ClassDecoratorWithSentinelAttribute(ABC):
   """
 
   @abstractmethod
-  def __call__(self, cls: type) -> type: ...
+  def __call__(self, cls: Type) -> Type: ...
 
-  def define_instance_of(self, obj: type, **kwargs) -> type:
+  def define_instance_of(self, obj: Type, **kwargs) -> Type:
     return type(obj.__name__, (obj,), {
       '_sentinel_attribute_type': type(self),
       **kwargs
     })
 
-  def is_instance(self, obj: type) -> bool:
-    return (getattr(obj, '_sentinel_attribute_type', None) == type(self))
+  def is_instance(self, obj: Type) -> bool:
+    return getattr(obj, '_sentinel_attribute_type', None) is type(self)
 
 
-def sentinel_attribute(decorator: Callable[[type], type]) -> _ClassDecoratorWithSentinelAttribute:
+def sentinel_attribute(decorator: Callable[[Type], Type]) -> _ClassDecoratorWithSentinelAttribute:
   """Wraps a class decorator to add a "sentinel attribute" to decorated classes.
 
   A "sentinel attribute" is an attribute added to the wrapped class decorator's result with
@@ -156,7 +156,7 @@ def sentinel_attribute(decorator: Callable[[type], type]) -> _ClassDecoratorWith
 
   class WrappedFunction(_ClassDecoratorWithSentinelAttribute):
     @wraps(decorator)
-    def __call__(self, cls: type) -> type:
+    def __call__(self, cls: Type) -> Type:
       return decorator(cls)
 
   return WrappedFunction()

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -187,7 +187,7 @@ def frozen_after_init(cls: C) -> C:
       )
     prev_setattr(self, key, value)  # type: ignore[call-arg]
 
-  cls.__init__ = new_init  # type: ignore[assignment]
-  cls.__setattr__ = new_setattr  # type: ignore[assignment]
+  cls.__init__ = new_init
+  cls.__setattr__ = new_setattr
 
-  return frozen_after_init.define_instance_of(cls)
+  return cls

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -126,7 +126,7 @@ def staticproperty(func: Callable[..., T]) -> T:
 class _ClassDecoratorWithSentinelAttribute(ABC):
   """Base class to wrap a class decorator which sets a "sentinel attribute".
 
-  This functionality is exposed via the `@sentinel_attribute` decorator.
+  This functionality is exposed via the `@decorated_type_checkable` decorator.
   """
 
   @abstractmethod
@@ -134,15 +134,15 @@ class _ClassDecoratorWithSentinelAttribute(ABC):
 
   def define_instance_of(self, obj: Type, **kwargs) -> Type:
     return type(obj.__name__, (obj,), {
-      '_sentinel_attribute_type': type(self),
+      '_decorated_type_checkable_type': type(self),
       **kwargs
     })
 
   def is_instance(self, obj: Type) -> bool:
-    return getattr(obj, '_sentinel_attribute_type', None) is type(self)
+    return getattr(obj, '_decorated_type_checkable_type', None) is type(self)
 
 
-def sentinel_attribute(decorator: Callable[[Type], Type]) -> _ClassDecoratorWithSentinelAttribute:
+def decorated_type_checkable(decorator: Callable[[Type], Type]) -> _ClassDecoratorWithSentinelAttribute:
   """Wraps a class decorator to add a "sentinel attribute" to decorated classes.
 
   A "sentinel attribute" is an attribute added to the wrapped class decorator's result with
@@ -162,7 +162,7 @@ def sentinel_attribute(decorator: Callable[[Type], Type]) -> _ClassDecoratorWith
   return WrappedFunction()
 
 
-@sentinel_attribute
+@decorated_type_checkable
 def frozen_after_init(cls: C) -> C:
   """Class decorator to freeze any modifications to the object after __init__() is done.
 

--- a/tests/python/pants_test/build_graph/test_build_configuration.py
+++ b/tests/python/pants_test/build_graph/test_build_configuration.py
@@ -10,7 +10,8 @@ from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases, TargetMacro
 from pants.build_graph.target import Target
-from pants.engine.rules import UnionRule, union
+from pants.engine.objects import union
+from pants.engine.rules import UnionRule
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import touch
 

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -227,6 +227,7 @@ python_tests(
   sources=['test_objects.py'],
   dependencies=[
     'src/python/pants/engine:objects',
+    'src/python/pants/util:meta',
   ],
   tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -10,7 +10,8 @@ from textwrap import dedent
 from typing import List
 
 from pants.engine.native import Native
-from pants.engine.rules import RootRule, UnionRule, rule, union
+from pants.engine.objects import union
+from pants.engine.rules import RootRule, UnionRule, rule
 from pants.engine.scheduler import ExecutionError, SchedulerSession
 from pants.engine.selectors import Get, Params
 from pants.testutil.engine.util import assert_equal_with_printing, remove_locations_from_traceback

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -255,7 +255,7 @@ with an @classproperty decorator."""):
 class SentinelAttributeTest(unittest.TestCase):
 
   def test_sentinel_attribute(self):
-    @sentinel_attribute('_test_attr_name')
+    @sentinel_attribute
     def f(cls):
       return f.define_instance_of(cls)
 
@@ -263,8 +263,7 @@ class SentinelAttributeTest(unittest.TestCase):
     class C:
       pass
 
-    self.assertEqual(f.sentinel_attribute, '_test_attr_name')
-    self.assertTrue(C._test_attr_name)
+    self.assertEqual(C._sentinel_attribute_type, type(f))
     self.assertTrue(f.is_instance(C))
 
 

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -9,8 +9,8 @@ from pants.testutil.test_base import TestBase
 from pants.util.meta import (
   SingletonMetaclass,
   classproperty,
+  decorated_type_checkable,
   frozen_after_init,
-  sentinel_attribute,
   staticproperty,
 )
 
@@ -254,8 +254,8 @@ with an @classproperty decorator."""):
 
 class SentinelAttributeTest(unittest.TestCase):
 
-  def test_sentinel_attribute(self):
-    @sentinel_attribute
+  def test_decorated_type_checkable(self):
+    @decorated_type_checkable
     def f(cls):
       return f.define_instance_of(cls)
 
@@ -263,7 +263,7 @@ class SentinelAttributeTest(unittest.TestCase):
     class C:
       pass
 
-    self.assertEqual(C._sentinel_attribute_type, type(f))
+    self.assertEqual(C._decorated_type_checkable_type, type(f))
     self.assertTrue(f.is_instance(C))
 
 

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -6,8 +6,13 @@ from abc import ABC, abstractmethod
 from dataclasses import FrozenInstanceError, dataclass
 
 from pants.testutil.test_base import TestBase
-from pants.util.meta import (SingletonMetaclass, classproperty, frozen_after_init,
-                             sentinel_attribute, staticproperty)
+from pants.util.meta import (
+  SingletonMetaclass,
+  classproperty,
+  frozen_after_init,
+  sentinel_attribute,
+  staticproperty,
+)
 
 
 class AbstractClassTest(TestBase):

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -266,6 +266,19 @@ class SentinelAttributeTest(unittest.TestCase):
     self.assertEqual(C._decorated_type_checkable_type, type(f))
     self.assertTrue(f.is_instance(C))
 
+    # Check that .is_instance() is only true for exactly the decorator @g used on the class D!
+    @decorated_type_checkable
+    def g(cls):
+      return g.define_instance_of(cls)
+
+    @g
+    class D:
+      pass
+
+    self.assertEqual(D._decorated_type_checkable_type, type(g))
+    self.assertTrue(g.is_instance(D))
+    self.assertFalse(f.is_instance(D))
+
 
 class FrozenAfterInitTest(unittest.TestCase):
 

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -6,7 +6,8 @@ from abc import ABC, abstractmethod
 from dataclasses import FrozenInstanceError, dataclass
 
 from pants.testutil.test_base import TestBase
-from pants.util.meta import SingletonMetaclass, classproperty, frozen_after_init, staticproperty
+from pants.util.meta import (SingletonMetaclass, classproperty, frozen_after_init,
+                             sentinel_attribute, staticproperty)
 
 
 class AbstractClassTest(TestBase):
@@ -244,6 +245,22 @@ with an @classproperty decorator."""):
       def f(cls):
         return 'hello'
     self.assertEqual(Concrete2.f, 'hello')
+
+
+class SentinelAttributeTest(unittest.TestCase):
+
+  def test_sentinel_attribute(self):
+    @sentinel_attribute('_test_attr_name')
+    def f(cls):
+      return f.define_instance_of(cls)
+
+    @f
+    class C:
+      pass
+
+    self.assertEqual(f.sentinel_attribute, '_test_attr_name')
+    self.assertTrue(C._test_attr_name)
+    self.assertTrue(f.is_instance(C))
 
 
 class FrozenAfterInitTest(unittest.TestCase):


### PR DESCRIPTION
### Problem

We manually check `getattr(some_type, '_is_union', False)` in multiple places in order to check if `some_type` was declared with the `@union` annotation. We would like to canonicalize this check and make it type-safe in some sense.

### Solution

- Create `@decorated_type_checkable` in `pants.util.meta`, which contains two methods:
  1. `define_instance_of(cls)`, which wraps a class `cls` and sets the attribute `_decorated_type_checkable_type` to the return value of `@decorated_type_checkable`.
  2. `is_instance(cls)`, which checks whether the sentinel attribute `_decorated_type_checkable_type` matches the type of the return value of `@decorated_type_checkable`.