### PR TITLE
Bump conan version

### DIFF
--- a/src/python/pants/backend/native/subsystems/packaging/conan.py
+++ b/src/python/pants/backend/native/subsystems/packaging/conan.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class Conan(PythonToolBase):
   options_scope = 'conan'
   default_requirements = [
-    'conan==1.9.2',
+    'conan==1.19.2',
     # NB: Only versions of pylint below `2.0.0` support use in python 2.
     'pylint==1.9.3',
   ]


### PR DESCRIPTION
### Problem

I was running into an error message when running `isort.sh` in the pre-commit checks, namely `ERROR: Invalid setting '9' is not a valid 'settings.compiler.version' value.` 

### Solution
Bumping the conan version fixes this error.

