### PR TITLE
make option removal_version fail eagerly, and fix options past their sell-by date

### DIFF
--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -57,8 +57,6 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
   @classmethod
   def register_options(cls, register):
-    register('--mypy-version', default='0.720', help='The version of mypy to use.',
-             removal_version='1.24.0.dev1', removal_hint='Use --version instead.')
     register('--version', default='0.720', help='The version of mypy to use.')
     register('--include-requirements', type=bool, default=False,
              help='Whether to include the transitive requirements of targets being checked. This is'
@@ -156,7 +154,7 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
   def _get_mypy_pex(self, py3_interpreter: PythonInterpreter, *extra_pexes: PEX) -> PEX:
     options = self.get_options()
-    mypy_version = options.mypy_version if options.is_flagged('mypy_version') else options.version
+    mypy_version = options.version
     extras_hash = hash_utils.hash_all(hash_utils.hash_dir(Path(extra_pex.path()))
                                       for extra_pex in extra_pexes)
 
@@ -194,7 +192,7 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
             site.getsitepackages = lambda: sys.path[:]
 
-            
+
             runpy.run_module('mypy', run_name='__main__')
           """))
           exe_fp.flush()

--- a/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
@@ -291,12 +291,6 @@ class JvmPlatformExplain(JvmPlatformAnalysisMixin, ConsoleTask):
              help='Limit jvm platform possibility explanation to targets whose specs match this '
                   'regex pattern.')
 
-    # TODO: remove `_register_console_transitivity_option` from ConsoleTask when this deprecation
-    # cycle is complete!
-    register('--transitive', type=bool,
-             removal_version='1.22.0.dev0',
-             removal_hint='Use --list-transitive-deps instead!',
-             help='List transitive dependencies in analysis output.')
     register('--list-transitive-deps', type=bool,
              help='List transitive dependencies in analysis output.')
 

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -135,7 +135,8 @@ def warn_or_error(
   stacklevel: int = 3,
   frame_info: Optional[inspect.FrameInfo] = None,
   context: int = 1,
-  ensure_stderr: bool = False
+  ensure_stderr: bool = False,
+  print_warning: bool = True,
 ) -> None:
   """Check the removal_version against the current pants version.
 
@@ -187,7 +188,7 @@ def warn_or_error(
   else:
     context_lines = '<no code context available>'
 
-  if removal_semver > PANTS_SEMVER:
+  if removal_semver > PANTS_SEMVER and print_warning:
     if ensure_stderr:
       # No warning filters can stop us from printing this message directly to stderr.
       warning_msg = warnings.formatwarning(

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -430,6 +430,10 @@ class Parser:
     if self._frozen:
       raise FrozenRegistration(self.scope, args[0])
 
+    # NB: If an option has an expired `removal_version`, fail early, at option registration time!
+    dest = self.parse_dest(*args, **kwargs)
+    self._check_deprecated(dest, kwargs, print_warning=False)
+
     # Prevent further registration in enclosing scopes.
     ancestor = self._parent_parser
     while ancestor:
@@ -458,7 +462,7 @@ class Parser:
         raise OptionAlreadyRegistered(self.scope, arg)
     self._known_args.update(args)
 
-  def _check_deprecated(self, dest, kwargs):
+  def _check_deprecated(self, dest, kwargs, print_warning=True):
     """Checks option for deprecation and issues a warning/error if necessary."""
     removal_version = kwargs.get('removal_version', None)
     if removal_version is not None:
@@ -467,7 +471,9 @@ class Parser:
         deprecated_entity_description="option '{}' in {}".format(dest, self._scope_str()),
         deprecation_start_version=kwargs.get('deprecation_start_version', None),
         hint=kwargs.get('removal_hint', None),
-        stacklevel=9999)  # Out of range stacklevel to suppress printing src line.
+        stacklevel=9999,        # Out of range stacklevel to suppress printing src line.
+        print_warning=print_warning,
+      )
 
   _allowed_registration_kwargs = {
     'type', 'member_type', 'choices', 'dest', 'default', 'implicit_value', 'metavar',

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -156,8 +156,12 @@ class OptionsTest(TestBase):
                     removal_hint='use a less crufty global option')
     register_global('--global-crufty-boolean', type=bool, removal_version='999.99.9.dev0',
                       removal_hint='say no to crufty global options')
-    register_global('--global-crufty-expired', removal_version='0.0.1.dev0',
-                    removal_hint='use a less crufty global option')
+
+    # Test that an option past the `removal_version` fails at option registration time.
+    with self.assertRaises(CodeRemovedError):
+      register_global('--global-crufty-expired', removal_version='0.0.1.dev0',
+                      removal_hint='use a less crufty global option')
+
     register_global('--global-delayed-deprecated-option',
                     removal_version='999.99.9.dev0',
                     deprecation_start_version='500.0.0.dev0')
@@ -842,22 +846,6 @@ class OptionsTest(TestBase):
         "Error applying type 'SomeEnumOption' to option value 'invalid-value', for option '--some_enum' in scope 'enum-opt'"):
       options = self._parse('./pants enum-opt --some-enum=invalid-value')
       options.for_scope('enum-opt').some_enum
-
-  def test_deprecated_option_past_removal(self):
-    """Ensure that expired options raise CodeRemovedError on attempted use."""
-    # NB: these exceptions are triggered by the `Parser#parse_args()` method, not
-    # `Options#for_scope()`!
-    # Test option past removal from flag
-    with self.assertRaises(CodeRemovedError):
-      self._parse('./pants --global-crufty-expired=way2crufty').for_global_scope()
-
-    # Test option past removal from env
-    with self.assertRaises(CodeRemovedError):
-      self._parse('./pants', env={'PANTS_GLOBAL_CRUFTY_EXPIRED':'way2crufty'}).for_global_scope()
-
-    #Test option past removal from config
-    with self.assertRaises(CodeRemovedError):
-      self._parse('./pants', config={'GLOBAL':{'global_crufty_expired':'way2crufty'}}).for_global_scope()
 
   def assertOptionWarning(self, w, option_string):
     single_warning = assert_single_element(w)


### PR DESCRIPTION
### Problem

As exposed in #8485, options don't raise an exception upon registration if a `removal_version` is out of date -- they currently raise only if the option is used at all.

### Solution

- Make the `register` method fail eagerly if `removal_version` is out of date.
- Fix a couple options which suddenly started causing failures.

### Result

Options will now raise errors faster when they become out of date!