### PR TITLE
make match() on Enum into a top-level function in meta.py

### DIFF
--- a/build-support/bin/check_banned_imports.py
+++ b/build-support/bin/check_banned_imports.py
@@ -11,20 +11,7 @@ from common import die
 
 def main() -> None:
   rust_files = find_files("src/rust/engine", extension=".rs")
-  python_files = find_files(
-    "src", "tests", "pants-plugins", "contrib", extension=".py"
-  )
 
-  check_banned_import(
-    python_files - {
-      "src/python/pants/base/hash_utils.py",
-      "src/python/pants/option/parser.py",
-      "src/python/pants/util/collections.py",
-      "tests/python/pants_test/base/test_hash_utils.py",
-    },
-    bad_import_regex=r"^from enum import.*Enum|^import enum$",
-    correct_import_message="from pants.util.collections import Enum",
-  )
   check_banned_import(
     rust_files,
     bad_import_regex=r"^use std::sync::.*(Mutex|RwLock)",

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -573,6 +573,7 @@ python_library(
     'src/python/pants/java:util',
     'src/python/pants/process',
     'src/python/pants/task',
+    'src/python/pants/util:enums',
   ],
   tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -62,6 +62,7 @@ python_library(
     'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:enums',
     'src/python/pants/util:fileutil',
     'src/python/pants/util:memo',
   ],

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -3,6 +3,7 @@
 
 import functools
 import os
+from enum import Enum
 from multiprocessing import cpu_count
 from typing import Optional
 
@@ -39,7 +40,6 @@ from pants.java.distribution.distribution import DistributionLocator
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.option.ranked_value import RankedValue
 from pants.reporting.reporting_utils import items_to_report_element
-from pants.util.collections import Enum
 from pants.util.contextutil import Timer, temporary_dir
 from pants.util.dirutil import (
   fast_relpath,
@@ -51,6 +51,7 @@ from pants.util.dirutil import (
 )
 from pants.util.fileutil import create_size_estimators
 from pants.util.memo import memoized_method, memoized_property
+from pants.util.meta import match
 
 
 # Well known metadata file to register javac plugins.
@@ -958,7 +959,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     # See: https://github.com/pantsbuild/pants/issues/6416 for covering using
     #      different jdks in remote builds.
     local_distribution = self._local_jvm_distribution()
-    return self.execution_strategy.match({
+    return match(self.execution_strategy, {
       self.ExecutionStrategy.subprocess: lambda: local_distribution,
       self.ExecutionStrategy.nailgun: lambda: local_distribution,
       self.ExecutionStrategy.hermetic: lambda: self._HermeticDistribution('.jdk', local_distribution),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -40,7 +40,6 @@ from pants.java.distribution.distribution import DistributionLocator
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.option.ranked_value import RankedValue
 from pants.reporting.reporting_utils import items_to_report_element
-from pants.util import enums
 from pants.util.contextutil import Timer, temporary_dir
 from pants.util.dirutil import (
   fast_relpath,
@@ -50,6 +49,7 @@ from pants.util.dirutil import (
   safe_mkdir,
   safe_rmtree,
 )
+from pants.util.enums import match
 from pants.util.fileutil import create_size_estimators
 from pants.util.memo import memoized_method, memoized_property
 
@@ -959,7 +959,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     # See: https://github.com/pantsbuild/pants/issues/6416 for covering using
     #      different jdks in remote builds.
     local_distribution = self._local_jvm_distribution()
-    return enums.match(self.execution_strategy, {
+    return match(self.execution_strategy, {
       self.ExecutionStrategy.subprocess: lambda: local_distribution,
       self.ExecutionStrategy.nailgun: lambda: local_distribution,
       self.ExecutionStrategy.hermetic: lambda: self._HermeticDistribution('.jdk', local_distribution),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -40,6 +40,7 @@ from pants.java.distribution.distribution import DistributionLocator
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.option.ranked_value import RankedValue
 from pants.reporting.reporting_utils import items_to_report_element
+from pants.util import enums
 from pants.util.contextutil import Timer, temporary_dir
 from pants.util.dirutil import (
   fast_relpath,
@@ -51,7 +52,6 @@ from pants.util.dirutil import (
 )
 from pants.util.fileutil import create_size_estimators
 from pants.util.memo import memoized_method, memoized_property
-from pants.util.meta import match
 
 
 # Well known metadata file to register javac plugins.
@@ -959,7 +959,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     # See: https://github.com/pantsbuild/pants/issues/6416 for covering using
     #      different jdks in remote builds.
     local_distribution = self._local_jvm_distribution()
-    return match(self.execution_strategy, {
+    return enums.match(self.execution_strategy, {
       self.ExecutionStrategy.subprocess: lambda: local_distribution,
       self.ExecutionStrategy.nailgun: lambda: local_distribution,
       self.ExecutionStrategy.hermetic: lambda: self._HermeticDistribution('.jdk', local_distribution),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -21,6 +21,7 @@ python_library(
     'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:enums',
     'src/python/pants/util:memo',
     'src/python/pants/util:strutil',
   ],

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -31,11 +31,11 @@ from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecute
 from pants.java.jar.jar_dependency import JarDependency
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.task.scm_publish_mixin import Semver
+from pants.util import enums
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import Timer
 from pants.util.dirutil import fast_relpath, fast_relpath_optional, safe_mkdir
 from pants.util.memo import memoized_method, memoized_property
-from pants.util.meta import match
 from pants.util.strutil import safe_shlex_join
 
 
@@ -161,7 +161,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
   def _compiler_tags(self):
     return {
       f'{self.get_options().force_compiler_tag_prefix}:{workflow.value}': workflow
-      for workflow in list(self.JvmCompileWorkflowType)
+      for workflow in self.JvmCompileWorkflowType
     }
 
   @classmethod
@@ -173,12 +173,12 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
            'specified on the cli.')
 
     register('--workflow', type=cls.JvmCompileWorkflowType,
-      choices=cls.JvmCompileWorkflowType.all_values(),
+      choices=list(cls.JvmCompileWorkflowType),
       default=cls.JvmCompileWorkflowType.zinc_only, metavar='<workflow>',
       help='The default workflow to use to compile JVM targets. This is overriden on a per-target basis with the force-compiler-tag-prefix tag.', fingerprint=True)
 
     register('--scala-workflow-override', type=cls.JvmCompileWorkflowType,
-      choices=cls.JvmCompileWorkflowType.all_values(),
+      choices=list(cls.JvmCompileWorkflowType),
       default=None, metavar='<workflow_override>',
       help='Experimental option. The workflow to use to compile Scala targets, overriding the "workflow" option as well as any force-compiler-tag-prefix tags applied to targets. An example use case is to quickly turn off outlining workflows in case of errors.', fingerprint=True)
 
@@ -260,7 +260,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
   # Overrides the normal zinc compiler classpath, which only contains zinc.
   def get_zinc_compiler_classpath(self):
-    return match(self.execution_strategy, {
+    return enums.match(self.execution_strategy, {
       # NB: We must use the verbose version of super() here, possibly because of the lambda.
       self.ExecutionStrategy.hermetic: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.ExecutionStrategy.subprocess: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
@@ -291,7 +291,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         rsc_cc.rsc_jar_file.hydrate_missing_directory_digest(classes_dir_snapshot.directory_digest)
 
       if rsc_cc.workflow is not None:
-        cp_entries = match(rsc_cc.workflow, {
+        cp_entries = enums.match(rsc_cc.workflow, {
           self.JvmCompileWorkflowType.zinc_only: lambda: confify([self._classpath_for_context(zinc_cc)]),
           self.JvmCompileWorkflowType.zinc_java: lambda: confify([self._classpath_for_context(zinc_cc)]),
           self.JvmCompileWorkflowType.rsc_and_zinc: lambda: confify([rsc_cc.rsc_jar_file]),
@@ -349,7 +349,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
   def _key_for_target_as_dep(self, target, workflow):
     # used for jobs that are either rsc jobs or zinc jobs run against rsc
-    return match(workflow, {
+    return enums.match(workflow, {
       self.JvmCompileWorkflowType.zinc_only: lambda: self._zinc_key_for_target(target, workflow),
       self.JvmCompileWorkflowType.zinc_java: lambda: self._zinc_key_for_target(target, workflow),
       self.JvmCompileWorkflowType.rsc_and_zinc: lambda: self._rsc_key_for_target(target),
@@ -363,7 +363,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     return f'outline({target.address.spec})'
 
   def _zinc_key_for_target(self, target, workflow):
-    return match(workflow, {
+    return enums.match(workflow, {
       self.JvmCompileWorkflowType.zinc_only: lambda: f'zinc[zinc-only]({target.address.spec})',
       self.JvmCompileWorkflowType.zinc_java: lambda: f'zinc[zinc-java]({target.address.spec})',
       self.JvmCompileWorkflowType.rsc_and_zinc: lambda: f'zinc[rsc-and-zinc]({target.address.spec})',
@@ -454,7 +454,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             classpath_abs_jdk = classpath_paths + self._jdk_libs_abs(distribution)
             return ((EMPTY_DIRECTORY_DIGEST), classpath_abs_jdk)
 
-          (input_digest, classpath_entry_paths) = match(self.execution_strategy, {
+          (input_digest, classpath_entry_paths) = enums.match(self.execution_strategy, {
             self.ExecutionStrategy.hermetic: hermetic_digest_classpath,
             self.ExecutionStrategy.subprocess: nonhermetic_digest_classpath,
             self.ExecutionStrategy.nailgun: nonhermetic_digest_classpath,
@@ -586,7 +586,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     record('execution_strategy', self.execution_strategy.value)
 
     # Create the cache doublecheck job.
-    match(workflow, {
+    enums.match(workflow, {
       self.JvmCompileWorkflowType.zinc_only: lambda: cache_doublecheck_jobs.append(
         make_cache_doublecheck_job(list(all_zinc_rsc_invalid_dep_keys(invalid_dependencies)))
       ),
@@ -603,7 +603,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
     # Create the rsc job.
     # Currently, rsc only supports outlining scala.
-    match(workflow, {
+    enums.match(workflow, {
       self.JvmCompileWorkflowType.zinc_only: lambda: None,
       self.JvmCompileWorkflowType.zinc_java: lambda: None,
       self.JvmCompileWorkflowType.rsc_and_zinc: lambda: rsc_jobs.append(make_outline_job(compile_target, invalid_dependencies)),
@@ -614,7 +614,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     # - Scala zinc compile jobs depend on the results of running rsc on the scala target.
     # - Java zinc compile jobs depend on the zinc compiles of their dependencies, because we can't
     #   generate jars that make javac happy at this point.
-    match(workflow, {
+    enums.match(workflow, {
       # NB: zinc-only zinc jobs run zinc and depend on rsc and/or zinc compile outputs.
       self.JvmCompileWorkflowType.zinc_only: lambda: zinc_jobs.append(
         make_zinc_job(
@@ -899,7 +899,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       nailgun_classpath = self._nailgunnable_combined_classpath
 
     with self.context.new_workunit(tool_name) as wu:
-      return match(self.execution_strategy, {
+      return enums.match(self.execution_strategy, {
         self.ExecutionStrategy.hermetic: lambda: self._runtool_hermetic(
           main, tool_name, distribution, input_digest, ctx),
         self.ExecutionStrategy.subprocess: lambda: self._runtool_nonhermetic(

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass
+from enum import Enum
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext  # noqa
 from pants.backend.jvm.subsystems.rsc import Rsc
@@ -30,10 +31,11 @@ from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecute
 from pants.java.jar.jar_dependency import JarDependency
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.task.scm_publish_mixin import Semver
-from pants.util.collections import Enum, assert_single_element
+from pants.util.collections import assert_single_element
 from pants.util.contextutil import Timer
 from pants.util.dirutil import fast_relpath, fast_relpath_optional, safe_mkdir
 from pants.util.memo import memoized_method, memoized_property
+from pants.util.meta import match
 from pants.util.strutil import safe_shlex_join
 
 
@@ -159,7 +161,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
   def _compiler_tags(self):
     return {
       f'{self.get_options().force_compiler_tag_prefix}:{workflow.value}': workflow
-      for workflow in self.JvmCompileWorkflowType.all_values()
+      for workflow in list(self.JvmCompileWorkflowType)
     }
 
   @classmethod
@@ -214,11 +216,11 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         ),
       ],
       custom_rules=[
-        Shader.exclude_package('scala', recursive=True), 
-        Shader.exclude_package('xsbt', recursive=True), 
-        Shader.exclude_package('xsbti', recursive=True), 
-        # Unfortunately, is loaded reflectively by the compiler. 
-        Shader.exclude_package('org.apache.logging.log4j', recursive=True), 
+        Shader.exclude_package('scala', recursive=True),
+        Shader.exclude_package('xsbt', recursive=True),
+        Shader.exclude_package('xsbti', recursive=True),
+        # Unfortunately, is loaded reflectively by the compiler.
+        Shader.exclude_package('org.apache.logging.log4j', recursive=True),
       ]
     )
 
@@ -258,7 +260,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
   # Overrides the normal zinc compiler classpath, which only contains zinc.
   def get_zinc_compiler_classpath(self):
-    return self.execution_strategy.match({
+    return match(self.execution_strategy, {
       # NB: We must use the verbose version of super() here, possibly because of the lambda.
       self.ExecutionStrategy.hermetic: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
       self.ExecutionStrategy.subprocess: lambda: super(RscCompile, self).get_zinc_compiler_classpath(),
@@ -289,7 +291,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         rsc_cc.rsc_jar_file.hydrate_missing_directory_digest(classes_dir_snapshot.directory_digest)
 
       if rsc_cc.workflow is not None:
-        cp_entries = rsc_cc.workflow.match({
+        cp_entries = match(rsc_cc.workflow, {
           self.JvmCompileWorkflowType.zinc_only: lambda: confify([self._classpath_for_context(zinc_cc)]),
           self.JvmCompileWorkflowType.zinc_java: lambda: confify([self._classpath_for_context(zinc_cc)]),
           self.JvmCompileWorkflowType.rsc_and_zinc: lambda: confify([rsc_cc.rsc_jar_file]),
@@ -347,7 +349,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
   def _key_for_target_as_dep(self, target, workflow):
     # used for jobs that are either rsc jobs or zinc jobs run against rsc
-    return workflow.match({
+    return match(workflow, {
       self.JvmCompileWorkflowType.zinc_only: lambda: self._zinc_key_for_target(target, workflow),
       self.JvmCompileWorkflowType.zinc_java: lambda: self._zinc_key_for_target(target, workflow),
       self.JvmCompileWorkflowType.rsc_and_zinc: lambda: self._rsc_key_for_target(target),
@@ -361,7 +363,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     return f'outline({target.address.spec})'
 
   def _zinc_key_for_target(self, target, workflow):
-    return workflow.match({
+    return match(workflow, {
       self.JvmCompileWorkflowType.zinc_only: lambda: f'zinc[zinc-only]({target.address.spec})',
       self.JvmCompileWorkflowType.zinc_java: lambda: f'zinc[zinc-java]({target.address.spec})',
       self.JvmCompileWorkflowType.rsc_and_zinc: lambda: f'zinc[rsc-and-zinc]({target.address.spec})',
@@ -452,7 +454,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             classpath_abs_jdk = classpath_paths + self._jdk_libs_abs(distribution)
             return ((EMPTY_DIRECTORY_DIGEST), classpath_abs_jdk)
 
-          (input_digest, classpath_entry_paths) = self.execution_strategy.match({
+          (input_digest, classpath_entry_paths) = match(self.execution_strategy, {
             self.ExecutionStrategy.hermetic: hermetic_digest_classpath,
             self.ExecutionStrategy.subprocess: nonhermetic_digest_classpath,
             self.ExecutionStrategy.nailgun: nonhermetic_digest_classpath,
@@ -468,7 +470,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
             ]
 
           target_sources = ctx.sources
-          
+
           # TODO: m.jar digests aren't found, so hermetic will fail.
           if use_youtline and not hermetic and self.get_options().zinc_outline:
             self._zinc_outline(ctx, classpath_paths, target_sources, youtline_args)
@@ -584,7 +586,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     record('execution_strategy', self.execution_strategy.value)
 
     # Create the cache doublecheck job.
-    workflow.match({
+    match(workflow, {
       self.JvmCompileWorkflowType.zinc_only: lambda: cache_doublecheck_jobs.append(
         make_cache_doublecheck_job(list(all_zinc_rsc_invalid_dep_keys(invalid_dependencies)))
       ),
@@ -601,7 +603,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
     # Create the rsc job.
     # Currently, rsc only supports outlining scala.
-    workflow.match({
+    match(workflow, {
       self.JvmCompileWorkflowType.zinc_only: lambda: None,
       self.JvmCompileWorkflowType.zinc_java: lambda: None,
       self.JvmCompileWorkflowType.rsc_and_zinc: lambda: rsc_jobs.append(make_outline_job(compile_target, invalid_dependencies)),
@@ -612,7 +614,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     # - Scala zinc compile jobs depend on the results of running rsc on the scala target.
     # - Java zinc compile jobs depend on the zinc compiles of their dependencies, because we can't
     #   generate jars that make javac happy at this point.
-    workflow.match({
+    match(workflow, {
       # NB: zinc-only zinc jobs run zinc and depend on rsc and/or zinc compile outputs.
       self.JvmCompileWorkflowType.zinc_only: lambda: zinc_jobs.append(
         make_zinc_job(
@@ -725,7 +727,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
   def _runtool_hermetic(self, main, tool_name, distribution, input_digest, ctx):
     use_youtline = tool_name == 'scalac-outliner'
-    
+
     tool_classpath_abs = self._scalac_classpath if use_youtline else self._rsc_classpath
     tool_classpath = fast_relpath_collection(tool_classpath_abs)
 
@@ -897,7 +899,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
       nailgun_classpath = self._nailgunnable_combined_classpath
 
     with self.context.new_workunit(tool_name) as wu:
-      return self.execution_strategy.match({
+      return match(self.execution_strategy, {
         self.ExecutionStrategy.hermetic: lambda: self._runtool_hermetic(
           main, tool_name, distribution, input_digest, ctx),
         self.ExecutionStrategy.subprocess: lambda: self._runtool_nonhermetic(

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/BUILD
@@ -20,6 +20,7 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:enums',
     'src/python/pants/util:memo',
     'src/python/pants/util:strutil',
   ],

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -31,10 +31,11 @@ from pants.engine.fs import (
   PathGlobsAndRoot,
 )
 from pants.engine.isolated_process import ExecuteProcessRequest
+from pants.util import enums
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import fast_relpath
 from pants.util.memo import memoized_method, memoized_property
-from pants.util.meta import classproperty, match
+from pants.util.meta import classproperty
 from pants.util.strutil import safe_shlex_join
 
 
@@ -364,7 +365,7 @@ class BaseZincCompile(JvmCompile):
     self.log_zinc_file(ctx.analysis_file)
     self.write_argsfile(ctx, zinc_args)
 
-    return match(self.execution_strategy, {
+    return enums.match(self.execution_strategy, {
       self.ExecutionStrategy.hermetic: lambda: self._compile_hermetic(
         jvm_options, ctx, classes_dir, jar_file, compiler_bridge_classpath_entry,
         dependency_classpath, scalac_classpath_entries),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -31,9 +31,9 @@ from pants.engine.fs import (
   PathGlobsAndRoot,
 )
 from pants.engine.isolated_process import ExecuteProcessRequest
-from pants.util import enums
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import fast_relpath
+from pants.util.enums import match
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.meta import classproperty
 from pants.util.strutil import safe_shlex_join
@@ -365,7 +365,7 @@ class BaseZincCompile(JvmCompile):
     self.log_zinc_file(ctx.analysis_file)
     self.write_argsfile(ctx, zinc_args)
 
-    return enums.match(self.execution_strategy, {
+    return match(self.execution_strategy, {
       self.ExecutionStrategy.hermetic: lambda: self._compile_hermetic(
         jvm_options, ctx, classes_dir, jar_file, compiler_bridge_classpath_entry,
         dependency_classpath, scalac_classpath_entries),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -34,7 +34,7 @@ from pants.engine.isolated_process import ExecuteProcessRequest
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import fast_relpath
 from pants.util.memo import memoized_method, memoized_property
-from pants.util.meta import classproperty
+from pants.util.meta import classproperty, match
 from pants.util.strutil import safe_shlex_join
 
 
@@ -364,7 +364,7 @@ class BaseZincCompile(JvmCompile):
     self.log_zinc_file(ctx.analysis_file)
     self.write_argsfile(ctx, zinc_args)
 
-    return self.execution_strategy.match({
+    return match(self.execution_strategy, {
       self.ExecutionStrategy.hermetic: lambda: self._compile_hermetic(
         jvm_options, ctx, classes_dir, jar_file, compiler_bridge_classpath_entry,
         dependency_classpath, scalac_classpath_entries),

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from enum import Enum
 
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.build_environment import get_buildroot
@@ -12,7 +13,6 @@ from pants.java.jar.jar_dependency import JarDependency
 from pants.java.nailgun_executor import NailgunExecutor, NailgunProcessGroup
 from pants.process.subprocess import Subprocess
 from pants.task.task import Task, TaskBase
-from pants.util.collections import Enum
 
 
 class NailgunTaskBase(JvmToolTaskMixin, TaskBase):

--- a/src/python/pants/backend/native/subsystems/BUILD
+++ b/src/python/pants/backend/native/subsystems/BUILD
@@ -13,6 +13,7 @@ python_library(
     'src/python/pants/engine:selectors',
     'src/python/pants/subsystem',
     'src/python/pants/util:collections',
+    'src/python/pants/util:enums',
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
   ],

--- a/src/python/pants/backend/native/subsystems/binaries/BUILD
+++ b/src/python/pants/backend/native/subsystems/binaries/BUILD
@@ -10,6 +10,7 @@ python_library(
     'src/python/pants/engine:rules',
     'src/python/pants/engine:platform',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:enums',
     'src/python/pants/util:memo',
   ],
   tags = {"partially_type_checked"},

--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -9,6 +9,7 @@ from pants.binaries.binary_tool import NativeTool
 from pants.engine.platform import Platform
 from pants.engine.rules import rule
 from pants.util.memo import memoized_method, memoized_property
+from pants.util.meta import match
 
 
 class GCC(NativeTool):
@@ -41,7 +42,7 @@ class GCC(NativeTool):
 
   @memoized_method
   def _common_lib_dirs(self, platform):
-    lib64_tuples = platform.match({
+    lib64_tuples = match(platform, {
       Platform.darwin: [],
       Platform.linux: [('lib64',)]
     })

--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -8,8 +8,8 @@ from pants.backend.native.subsystems.utils.archive_file_mapper import ArchiveFil
 from pants.binaries.binary_tool import NativeTool
 from pants.engine.platform import Platform
 from pants.engine.rules import rule
+from pants.util import enums
 from pants.util.memo import memoized_method, memoized_property
-from pants.util.meta import match
 
 
 class GCC(NativeTool):
@@ -42,7 +42,7 @@ class GCC(NativeTool):
 
   @memoized_method
   def _common_lib_dirs(self, platform):
-    lib64_tuples = match(platform, {
+    lib64_tuples = enums.match(platform, {
       Platform.darwin: [],
       Platform.linux: [('lib64',)]
     })

--- a/src/python/pants/backend/native/subsystems/binaries/gcc.py
+++ b/src/python/pants/backend/native/subsystems/binaries/gcc.py
@@ -8,7 +8,7 @@ from pants.backend.native.subsystems.utils.archive_file_mapper import ArchiveFil
 from pants.binaries.binary_tool import NativeTool
 from pants.engine.platform import Platform
 from pants.engine.rules import rule
-from pants.util import enums
+from pants.util.enums import match
 from pants.util.memo import memoized_method, memoized_property
 
 
@@ -42,7 +42,7 @@ class GCC(NativeTool):
 
   @memoized_method
   def _common_lib_dirs(self, platform):
-    lib64_tuples = enums.match(platform, {
+    lib64_tuples = match(platform, {
       Platform.darwin: [],
       Platform.linux: [('lib64',)]
     })

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -9,9 +9,9 @@ from pants.binaries.binary_tool import NativeTool
 from pants.binaries.binary_util import BinaryToolUrlGenerator
 from pants.engine.platform import Platform
 from pants.engine.rules import RootRule, rule
+from pants.util import enums
 from pants.util.dirutil import is_readable_dir
 from pants.util.memo import memoized_method, memoized_property
-from pants.util.meta import match
 
 
 class LLVMReleaseUrlGenerator(BinaryToolUrlGenerator):
@@ -82,7 +82,7 @@ class LLVM(NativeTool):
   def linker(self, platform: Platform) -> Linker:
     return Linker(
       path_entries=self.path_entries,
-      exe_filename=match(platform, {
+      exe_filename=enums.match(platform, {
         Platform.darwin: "ld64.lld",
         Platform.linux: "lld",
       }),

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -9,8 +9,8 @@ from pants.binaries.binary_tool import NativeTool
 from pants.binaries.binary_util import BinaryToolUrlGenerator
 from pants.engine.platform import Platform
 from pants.engine.rules import RootRule, rule
-from pants.util import enums
 from pants.util.dirutil import is_readable_dir
+from pants.util.enums import match
 from pants.util.memo import memoized_method, memoized_property
 
 
@@ -82,7 +82,7 @@ class LLVM(NativeTool):
   def linker(self, platform: Platform) -> Linker:
     return Linker(
       path_entries=self.path_entries,
-      exe_filename=enums.match(platform, {
+      exe_filename=match(platform, {
         Platform.darwin: "ld64.lld",
         Platform.linux: "lld",
       }),

--- a/src/python/pants/backend/native/subsystems/binaries/llvm.py
+++ b/src/python/pants/backend/native/subsystems/binaries/llvm.py
@@ -11,6 +11,7 @@ from pants.engine.platform import Platform
 from pants.engine.rules import RootRule, rule
 from pants.util.dirutil import is_readable_dir
 from pants.util.memo import memoized_method, memoized_property
+from pants.util.meta import match
 
 
 class LLVMReleaseUrlGenerator(BinaryToolUrlGenerator):
@@ -81,7 +82,7 @@ class LLVM(NativeTool):
   def linker(self, platform: Platform) -> Linker:
     return Linker(
       path_entries=self.path_entries,
-      exe_filename=platform.match({
+      exe_filename=match(platform, {
         Platform.darwin: "ld64.lld",
         Platform.linux: "lld",
       }),

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -2,14 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from abc import abstractmethod
+from enum import Enum
 
 from pants.build_graph.mirrored_target_option_mixin import MirroredTargetOptionMixin
 from pants.engine.platform import Platform
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.subsystem.subsystem import Subsystem
-from pants.util.collections import Enum
 from pants.util.memo import memoized_property
-from pants.util.meta import classproperty
+from pants.util.meta import classproperty, match
 
 
 class ToolchainVariant(Enum):
@@ -37,7 +37,7 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
                   'for targets of this language.')
 
     register('--toolchain-variant', advanced=True,
-             default=Platform.current.match({
+             default=match(Platform.current, {
                Platform.darwin: ToolchainVariant.llvm,
                Platform.linux: ToolchainVariant.gnu,
              }),

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -8,7 +8,7 @@ from pants.build_graph.mirrored_target_option_mixin import MirroredTargetOptionM
 from pants.engine.platform import Platform
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.subsystem.subsystem import Subsystem
-from pants.util import enums
+from pants.util.enums import match
 from pants.util.memo import memoized_property
 from pants.util.meta import classproperty
 
@@ -38,7 +38,7 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
                   'for targets of this language.')
 
     register('--toolchain-variant', advanced=True,
-             default=enums.match(Platform.current, {
+             default=match(Platform.current, {
                Platform.darwin: ToolchainVariant.llvm,
                Platform.linux: ToolchainVariant.gnu,
              }),

--- a/src/python/pants/backend/native/subsystems/native_build_step.py
+++ b/src/python/pants/backend/native/subsystems/native_build_step.py
@@ -8,8 +8,9 @@ from pants.build_graph.mirrored_target_option_mixin import MirroredTargetOptionM
 from pants.engine.platform import Platform
 from pants.option.compiler_option_sets_mixin import CompilerOptionSetsMixin
 from pants.subsystem.subsystem import Subsystem
+from pants.util import enums
 from pants.util.memo import memoized_property
-from pants.util.meta import classproperty, match
+from pants.util.meta import classproperty
 
 
 class ToolchainVariant(Enum):
@@ -37,7 +38,7 @@ class NativeBuildStep(CompilerOptionSetsMixin, MirroredTargetOptionMixin, Subsys
                   'for targets of this language.')
 
     register('--toolchain-variant', advanced=True,
-             default=match(Platform.current, {
+             default=enums.match(Platform.current, {
                Platform.darwin: ToolchainVariant.llvm,
                Platform.linux: ToolchainVariant.gnu,
              }),

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -23,6 +23,7 @@ from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
+from pants.util.meta import match
 
 
 class NativeToolchain(Subsystem):
@@ -119,7 +120,7 @@ class LLVMCppToolchain:
 @rule
 async def select_libc_objects(platform: Platform, native_toolchain: NativeToolchain) -> LibcObjects:
   # We use lambdas here to avoid searching for libc on osx, where it will fail.
-  paths = platform.match({
+  paths = match(platform, {
     Platform.darwin: lambda: [],
     Platform.linux: lambda: native_toolchain._libc_dev.get_libc_objects(),
   })()

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -22,7 +22,7 @@ from pants.engine.platform import Platform
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
-from pants.util import enums
+from pants.util.enums import match
 from pants.util.memo import memoized_property
 
 
@@ -120,7 +120,7 @@ class LLVMCppToolchain:
 @rule
 async def select_libc_objects(platform: Platform, native_toolchain: NativeToolchain) -> LibcObjects:
   # We use lambdas here to avoid searching for libc on osx, where it will fail.
-  paths = enums.match(platform, {
+  paths = match(platform, {
     Platform.darwin: lambda: [],
     Platform.linux: lambda: native_toolchain._libc_dev.get_libc_objects(),
   })()

--- a/src/python/pants/backend/native/subsystems/native_toolchain.py
+++ b/src/python/pants/backend/native/subsystems/native_toolchain.py
@@ -22,8 +22,8 @@ from pants.engine.platform import Platform
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get
 from pants.subsystem.subsystem import Subsystem
+from pants.util import enums
 from pants.util.memo import memoized_property
-from pants.util.meta import match
 
 
 class NativeToolchain(Subsystem):
@@ -120,7 +120,7 @@ class LLVMCppToolchain:
 @rule
 async def select_libc_objects(platform: Platform, native_toolchain: NativeToolchain) -> LibcObjects:
   # We use lambdas here to avoid searching for libc on osx, where it will fail.
-  paths = match(platform, {
+  paths = enums.match(platform, {
     Platform.darwin: lambda: [],
     Platform.linux: lambda: native_toolchain._libc_dev.get_libc_objects(),
   })()

--- a/src/python/pants/backend/native/targets/BUILD
+++ b/src/python/pants/backend/native/targets/BUILD
@@ -11,6 +11,7 @@ python_library(
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',
     'src/python/pants/engine:platform',
+    'src/python/pants/util:enums',
     'src/python/pants/util:memo',
   ],
   tags = {"partially_type_checked"},

--- a/src/python/pants/backend/native/targets/native_artifact.py
+++ b/src/python/pants/backend/native/targets/native_artifact.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from pants.base.payload_field import PayloadField
 from pants.engine.platform import Platform
-from pants.util import enums
+from pants.util.enums import match
 
 
 # NB: We manually implement __hash__(), rather than using unsafe_hash=True, because PayloadField
@@ -39,7 +39,7 @@ class NativeArtifact(PayloadField):
 
   def as_shared_lib(self, platform):
     # TODO: check that the name conforms to some format in the constructor (e.g. no dots?).
-    return enums.match(platform, {
+    return match(platform, {
       Platform.darwin: f"lib{self.lib_name}.dylib",
       Platform.linux: f"lib{self.lib_name}.so",
     })

--- a/src/python/pants/backend/native/targets/native_artifact.py
+++ b/src/python/pants/backend/native/targets/native_artifact.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pants.base.payload_field import PayloadField
 from pants.engine.platform import Platform
+from pants.util.meta import match
 
 
 # NB: We manually implement __hash__(), rather than using unsafe_hash=True, because PayloadField
@@ -38,7 +39,7 @@ class NativeArtifact(PayloadField):
 
   def as_shared_lib(self, platform):
     # TODO: check that the name conforms to some format in the constructor (e.g. no dots?).
-    return platform.match({
+    return match(platform, {
       Platform.darwin: f"lib{self.lib_name}.dylib",
       Platform.linux: f"lib{self.lib_name}.so",
     })

--- a/src/python/pants/backend/native/targets/native_artifact.py
+++ b/src/python/pants/backend/native/targets/native_artifact.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from pants.base.payload_field import PayloadField
 from pants.engine.platform import Platform
-from pants.util.meta import match
+from pants.util import enums
 
 
 # NB: We manually implement __hash__(), rather than using unsafe_hash=True, because PayloadField
@@ -39,7 +39,7 @@ class NativeArtifact(PayloadField):
 
   def as_shared_lib(self, platform):
     # TODO: check that the name conforms to some format in the constructor (e.g. no dots?).
-    return match(platform, {
+    return enums.match(platform, {
       Platform.darwin: f"lib{self.lib_name}.dylib",
       Platform.linux: f"lib{self.lib_name}.so",
     })

--- a/src/python/pants/backend/native/tasks/BUILD
+++ b/src/python/pants/backend/native/tasks/BUILD
@@ -16,6 +16,7 @@ python_library(
     'src/python/pants/task',
     'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:enums',
     'src/python/pants/util:memo',
     'src/python/pants/util:objects',
     'src/python/pants/util:strutil',

--- a/src/python/pants/backend/native/tasks/conan_fetch.py
+++ b/src/python/pants/backend/native/tasks/conan_fetch.py
@@ -16,6 +16,7 @@ from pants.task.simple_codegen_task import SimpleCodegenTask
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import mergetree, safe_file_dump, safe_mkdir
 from pants.util.memo import memoized_property
+from pants.util.meta import match
 
 
 class ConanFetch(SimpleCodegenTask):
@@ -118,7 +119,7 @@ class ConanFetch(SimpleCodegenTask):
 
   @memoized_property
   def _conan_os_name(self):
-    return Platform.current.match({
+    return match(Platform.current, {
       Platform.darwin: "Macos",
       Platform.linux: "Linux",
     })

--- a/src/python/pants/backend/native/tasks/conan_fetch.py
+++ b/src/python/pants/backend/native/tasks/conan_fetch.py
@@ -13,10 +13,10 @@ from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.engine.platform import Platform
 from pants.task.simple_codegen_task import SimpleCodegenTask
+from pants.util import enums
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import mergetree, safe_file_dump, safe_mkdir
 from pants.util.memo import memoized_property
-from pants.util.meta import match
 
 
 class ConanFetch(SimpleCodegenTask):
@@ -119,7 +119,7 @@ class ConanFetch(SimpleCodegenTask):
 
   @memoized_property
   def _conan_os_name(self):
-    return match(Platform.current, {
+    return enums.match(Platform.current, {
       Platform.darwin: "Macos",
       Platform.linux: "Linux",
     })

--- a/src/python/pants/backend/native/tasks/conan_fetch.py
+++ b/src/python/pants/backend/native/tasks/conan_fetch.py
@@ -13,9 +13,9 @@ from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.engine.platform import Platform
 from pants.task.simple_codegen_task import SimpleCodegenTask
-from pants.util import enums
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import mergetree, safe_file_dump, safe_mkdir
+from pants.util.enums import match
 from pants.util.memo import memoized_property
 
 
@@ -119,7 +119,7 @@ class ConanFetch(SimpleCodegenTask):
 
   @memoized_property
   def _conan_os_name(self):
-    return enums.match(Platform.current, {
+    return match(Platform.current, {
       Platform.darwin: "Macos",
       Platform.linux: "Linux",
     })

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -15,8 +15,8 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.engine.platform import Platform
+from pants.util import enums
 from pants.util.memo import memoized_property
-from pants.util.meta import match
 
 
 @dataclass(frozen=True)
@@ -168,7 +168,7 @@ class LinkSharedLibraries(NativeTask):
     # We are executing in the results_dir, so get absolute paths for everything.
     cmd = (
       [linker.exe_filename] +
-      match(self.platform,
+      enums.match(self.platform,
         {Platform.darwin: ['-Wl,-dylib'], Platform.linux: ['-shared']}
       ) +
       list(linker.extra_args) +

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -16,6 +16,7 @@ from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.engine.platform import Platform
 from pants.util.memo import memoized_property
+from pants.util.meta import match
 
 
 @dataclass(frozen=True)
@@ -167,7 +168,7 @@ class LinkSharedLibraries(NativeTask):
     # We are executing in the results_dir, so get absolute paths for everything.
     cmd = (
       [linker.exe_filename] +
-      self.platform.match(
+      match(self.platform,
         {Platform.darwin: ['-Wl,-dylib'], Platform.linux: ['-shared']}
       ) +
       list(linker.extra_args) +

--- a/src/python/pants/backend/native/tasks/link_shared_libraries.py
+++ b/src/python/pants/backend/native/tasks/link_shared_libraries.py
@@ -15,7 +15,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.engine.platform import Platform
-from pants.util import enums
+from pants.util.enums import match
 from pants.util.memo import memoized_property
 
 
@@ -168,7 +168,7 @@ class LinkSharedLibraries(NativeTask):
     # We are executing in the results_dir, so get absolute paths for everything.
     cmd = (
       [linker.exe_filename] +
-      enums.match(self.platform,
+      match(self.platform,
         {Platform.darwin: ['-Wl,-dylib'], Platform.linux: ['-shared']}
       ) +
       list(linker.extra_args) +

--- a/src/python/pants/backend/project_info/rules/BUILD
+++ b/src/python/pants/backend/project_info/rules/BUILD
@@ -10,6 +10,7 @@ python_library(
     'src/python/pants/rules/core',
     'src/python/pants/subsystem',
     'src/python/pants/util:collections',
+    'src/python/pants/util:enums',
     'src/python/pants/util:memo',
   ],
   tags = {"partially_type_checked"},

--- a/src/python/pants/backend/project_info/rules/source_file_validator.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator.py
@@ -4,6 +4,7 @@
 import itertools
 import re
 from dataclasses import dataclass
+from enum import Enum
 from typing import Tuple
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
@@ -15,7 +16,6 @@ from pants.engine.objects import Collection
 from pants.engine.rules import console_rule, optionable_rule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.subsystem.subsystem import Subsystem
-from pants.util.collections import Enum
 from pants.util.memo import memoized_method
 
 

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -171,10 +171,11 @@ python_library(
   name='platform',
   sources=['platform.py'],
   dependencies=[
-      ':rules',
-      'src/python/pants/util:collections',
-      'src/python/pants/util:memo',
-      'src/python/pants/util:osutil',
+    ':rules',
+    'src/python/pants/util:collections',
+    'src/python/pants/util:enums',
+    'src/python/pants/util:memo',
+    'src/python/pants/util:osutil',
   ],
   tags = {"type_checked"},
 )

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -151,7 +151,7 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
 
   # NB: Some pythons throw an UnboundLocalError for `idx` if it is a simple local variable.
   # TODO(#8496): create a decorator for functions which declare a sentinel variable like this!
-  maybe_consume.idx = 0         # type: ignore
+  maybe_consume.idx = 0         # type: ignore[attr-defined]
 
   # 'zip' the previously-requested dependencies back together as struct fields.
   def consume_dependencies(item, args=None):

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -5,8 +5,8 @@ from enum import Enum
 from typing import Callable, List
 
 from pants.engine.rules import rule
+from pants.util import enums
 from pants.util.memo import memoized_classproperty, memoized_property
-from pants.util.meta import match
 from pants.util.osutil import get_normalized_os_name
 
 
@@ -21,7 +21,7 @@ class Platform(Enum):
 
   @memoized_property
   def runtime_lib_path_env_var(self) -> str:
-    return match(self, {
+    return enums.match(self, {
       self.darwin: "DYLD_LIBRARY_PATH",
       self.linux: "LD_LIBRARY_PATH",
     })

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Callable, List
 
 from pants.engine.rules import rule
-from pants.util import enums
+from pants.util.enums import match
 from pants.util.memo import memoized_classproperty, memoized_property
 from pants.util.osutil import get_normalized_os_name
 
@@ -21,7 +21,7 @@ class Platform(Enum):
 
   @memoized_property
   def runtime_lib_path_env_var(self) -> str:
-    return enums.match(self, {
+    return match(self, {
       Platform.darwin: "DYLD_LIBRARY_PATH",
       Platform.linux: "LD_LIBRARY_PATH",
     })

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -22,8 +22,8 @@ class Platform(Enum):
   @memoized_property
   def runtime_lib_path_env_var(self) -> str:
     return enums.match(self, {
-      self.darwin: "DYLD_LIBRARY_PATH",
-      self.linux: "LD_LIBRARY_PATH",
+      Platform.darwin: "DYLD_LIBRARY_PATH",
+      Platform.linux: "LD_LIBRARY_PATH",
     })
 
 

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -1,11 +1,12 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from enum import Enum
 from typing import Callable, List
 
 from pants.engine.rules import rule
-from pants.util.collections import Enum
 from pants.util.memo import memoized_classproperty, memoized_property
+from pants.util.meta import match
 from pants.util.osutil import get_normalized_os_name
 
 
@@ -20,9 +21,9 @@ class Platform(Enum):
 
   @memoized_property
   def runtime_lib_path_env_var(self) -> str:
-    return self.match({
-      Platform.darwin: "DYLD_LIBRARY_PATH",
-      Platform.linux: "LD_LIBRARY_PATH",
+    return match(self, {
+      self.darwin: "DYLD_LIBRARY_PATH",
+      self.linux: "LD_LIBRARY_PATH",
     })
 
 

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -3,9 +3,9 @@
 
 import os
 import re
+from enum import Enum
 
 from pants.option.errors import ParseError
-from pants.util.collections import Enum
 from pants.util.eval import parse_expression
 from pants.util.memo import memoized_method
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -5,6 +5,7 @@ import multiprocessing
 import os
 import sys
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 from pants.base.build_environment import (
@@ -19,7 +20,6 @@ from pants.option.errors import OptionsError
 from pants.option.optionable import Optionable
 from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
-from pants.util.collections import Enum
 
 
 class GlobMatchErrorBehavior(Enum):

--- a/src/python/pants/rules/core/core_test_model.py
+++ b/src/python/pants/rules/core/core_test_model.py
@@ -2,10 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
+from enum import Enum
 
 from pants.engine.isolated_process import FallibleExecuteProcessResult
 from pants.engine.objects import union
-from pants.util.collections import Enum
 
 
 class Status(Enum):

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -44,6 +44,12 @@ python_library(
 )
 
 python_library(
+  name = 'enums',
+  sources = ['enums.py'],
+  tags = {'type_checked'},
+)
+
+python_library(
   name = 'eval',
   sources = ['eval.py'],
   tags = {'type_checked'},

--- a/src/python/pants/util/collections.py
+++ b/src/python/pants/util/collections.py
@@ -2,17 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import collections
-from enum import Enum as StdLibEnum
-from typing import (
-  Callable,
-  DefaultDict,
-  Iterable,
-  Mapping,
-  MutableMapping,
-  TypeVar,
-  ValuesView,
-  cast,
-)
+from typing import Callable, DefaultDict, Iterable, MutableMapping, TypeVar
 
 
 _K = TypeVar('_K')
@@ -73,43 +63,3 @@ def assert_single_element(iterable: Iterable[_T]) -> _T:
     return first_item
 
   raise ValueError(f"iterable {iterable!r} has more than one element.")
-
-
-_E = TypeVar('_E', bound='Enum')
-
-
-class EnumMatchError(ValueError):
-  """Issue when using match() on an enum."""
-
-
-class InexhaustiveMatchError(EnumMatchError):
-  """Not all values of the enum specified in the pattern match."""
-
-
-class UnrecognizedMatchError(EnumMatchError):
-  """A value is used that is not a part of the enum."""
-
-
-class Enum(StdLibEnum):
-
-  @classmethod
-  def all_values(cls) -> ValuesView['Enum']:
-    return cls.__members__.values()
-
-  def match(self, enum_values_to_results: Mapping[_E, _V]) -> _V:
-    unrecognized_values = [
-      value for value in enum_values_to_results if value not in self.all_values()
-    ]
-    missing_values = [
-      value for value in self.all_values() if value not in enum_values_to_results
-    ]
-    if unrecognized_values:
-      raise UnrecognizedMatchError(
-        f"Match includes values not defined in the enum. Unrecognized: {unrecognized_values}"
-      )
-    if missing_values:
-      raise InexhaustiveMatchError(
-        f"All enum values must be covered by the match. Missing: {missing_values}"
-      )
-    typed_self = cast(_E, self)
-    return enum_values_to_results[typed_self]

--- a/src/python/pants/util/enums.py
+++ b/src/python/pants/util/enums.py
@@ -1,0 +1,42 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from enum import Enum
+from typing import FrozenSet, Mapping, TypeVar
+
+
+class EnumMatchError(ValueError):
+  """Issue when using match() on an enum."""
+
+
+class InexhaustiveMatchError(EnumMatchError):
+  """Not all values of the enum specified in the pattern match."""
+
+
+class UnrecognizedMatchError(EnumMatchError):
+  """A value is used that is not a part of the enum."""
+
+
+_E = TypeVar('_E', bound=Enum)
+_V = TypeVar('_V')
+
+
+def match(enum_instance: _E, enum_values_to_results: Mapping[_E, _V]) -> _V:
+  # TODO: consider memoizing the result of this entire method, as well as the value of
+  # `all_instances` for a given enum class!
+  all_instances: FrozenSet[_E] = frozenset(type(enum_instance))
+  unrecognized_values = [
+    value for value in enum_values_to_results if value not in all_instances
+  ]
+  missing_values = [
+    value for value in all_instances if value not in enum_values_to_results
+  ]
+  if unrecognized_values:
+    raise UnrecognizedMatchError(
+      f"Match includes values not defined in the enum. Unrecognized: {unrecognized_values}"
+    )
+  if missing_values:
+    raise InexhaustiveMatchError(
+      f"All enum values must be covered by the match. Missing: {missing_values}"
+    )
+  return enum_values_to_results[enum_instance]

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -3,9 +3,8 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import FrozenInstanceError
-from enum import Enum
 from functools import wraps
-from typing import Any, Callable, Mapping, Optional, Type, TypeVar, Union, cast
+from typing import Any, Callable, Optional, Type, TypeVar, Union
 
 
 T = TypeVar("T")

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -3,8 +3,9 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import FrozenInstanceError
+from enum import Enum
 from functools import wraps
-from typing import Any, Callable, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Mapping, Optional, Type, TypeVar, Union, cast
 
 
 T = TypeVar("T")

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/rsc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/rsc_compile_integration_base.py
@@ -13,7 +13,7 @@ def ensure_compile_rsc_execution_strategy(workflow, **env_kwargs):
 
   def decorator(f):
     def wrapper(self, *args, **kwargs):
-      for strategy in RscCompile.ExecutionStrategy.all_values():
+      for strategy in RscCompile.ExecutionStrategy:
         with environment_as(
           HERMETIC_ENV='PANTS_COMPILE_RSC_EXECUTION_STRATEGY',
           PANTS_COMPILE_RSC_EXECUTION_STRATEGY=strategy.value,
@@ -24,7 +24,7 @@ def ensure_compile_rsc_execution_strategy(workflow, **env_kwargs):
 
     return wrapper
   return decorator
-  
+
 
 class RscCompileIntegrationBase(BaseCompileIT):
 

--- a/tests/python/pants_test/backend/python/tasks/native/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/native/BUILD
@@ -42,6 +42,7 @@ python_tests(
     'src/python/pants/backend/python/tasks',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:int-test',
+    'src/python/pants/util:enums',
     'tests/python/pants_test/backend/python/tasks/util',
     'tests/python/pants_test/engine:scheduler_test_base',
     'testprojects/src/python:python_distribution_directory',

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -13,10 +13,10 @@ from pants.backend.native.config.environment import Platform
 from pants.backend.native.subsystems.native_build_step import ToolchainVariant
 from pants.option.scope import GLOBAL_SCOPE_CONFIG_SECTION
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
+from pants.util import enums
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import is_executable, read_file, safe_file_dump
-from pants.util.meta import match
 from pants_test.backend.python.tasks.python_task_test_base import name_and_platform
 
 
@@ -27,7 +27,7 @@ def invoke_pex_for_output(pex_file_to_run):
 def _toolchain_variants(func):
   @wraps(func)
   def wrapper(*args, **kwargs):
-    for variant in ToolchainVariant.__members__.values():
+    for variant in ToolchainVariant:
       func(*args, toolchain_variant=variant, **kwargs)
   return wrapper
 
@@ -74,7 +74,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       # for both C and C++ compilation.
       # TODO(#6866): don't parse info logs for testing! There is a TODO in test_cpp_compile.py
       # in the native backend testing to traverse the PATH to find the selected compiler.
-      compiler_names_to_check = match(toolchain_variant, {
+      compiler_names_to_check = enums.match(toolchain_variant, {
         ToolchainVariant.gnu: ['gcc', 'g++'],
         ToolchainVariant.llvm: ['clang', 'clang++'],
       })
@@ -84,7 +84,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
       # All of our toolchains currently use the C++ compiler's filename as argv[0] for the linker,
       # so there is only one name to check.
-      linker_names_to_check = match(toolchain_variant, {
+      linker_names_to_check = enums.match(toolchain_variant, {
         ToolchainVariant.gnu: ['g++'],
         ToolchainVariant.llvm: ['clang++'],
       })
@@ -104,7 +104,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
       dist_name, dist_version, wheel_platform = name_and_platform(wheel_dist)
       self.assertEqual(dist_name, 'ctypes_test')
-      contains_current_platform = match(Platform.current, {
+      contains_current_platform = enums.match(Platform.current, {
         Platform.darwin: wheel_platform.startswith('macosx'),
         Platform.linux: wheel_platform.startswith('linux'),
       })
@@ -153,14 +153,14 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         workdir=os.path.join(buildroot.new_buildroot, '.pants.d'),
       )
       self.assert_failure(pants_binary_strict_deps_failure)
-      self.assertIn(match(toolchain_variant, {
+      self.assertIn(enums.match(toolchain_variant, {
         ToolchainVariant.gnu: "fatal error: some_math.h: No such file or directory",
         ToolchainVariant.llvm: "fatal error: 'some_math.h' file not found"
       }), pants_binary_strict_deps_failure.stdout_data)
 
     # TODO(#6848): we need to provide the libstdc++.so.6.dylib which comes with gcc on osx in the
     # DYLD_LIBRARY_PATH during the 'run' goal somehow.
-    attempt_pants_run = match(Platform.current, {
+    attempt_pants_run = enums.match(Platform.current, {
       Platform.darwin: toolchain_variant == ToolchainVariant.llvm,
       Platform.linux: True,
     })
@@ -188,7 +188,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
     # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
     # be available on the runtime library path.
-    attempt_pants_run = match(Platform.current, {
+    attempt_pants_run = enums.match(Platform.current, {
       Platform.darwin: toolchain_variant == ToolchainVariant.llvm,
       Platform.linux: True,
     })
@@ -234,7 +234,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     """
     # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
     # be available on the runtime library path.
-    attempt_pants_run = match(Platform.current, {
+    attempt_pants_run = enums.match(Platform.current, {
       Platform.darwin: toolchain_variant == ToolchainVariant.llvm,
       Platform.linux: True,
     })

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -13,10 +13,10 @@ from pants.backend.native.config.environment import Platform
 from pants.backend.native.subsystems.native_build_step import ToolchainVariant
 from pants.option.scope import GLOBAL_SCOPE_CONFIG_SECTION
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
-from pants.util import enums
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import is_executable, read_file, safe_file_dump
+from pants.util.enums import match
 from pants_test.backend.python.tasks.python_task_test_base import name_and_platform
 
 
@@ -74,7 +74,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
       # for both C and C++ compilation.
       # TODO(#6866): don't parse info logs for testing! There is a TODO in test_cpp_compile.py
       # in the native backend testing to traverse the PATH to find the selected compiler.
-      compiler_names_to_check = enums.match(toolchain_variant, {
+      compiler_names_to_check = match(toolchain_variant, {
         ToolchainVariant.gnu: ['gcc', 'g++'],
         ToolchainVariant.llvm: ['clang', 'clang++'],
       })
@@ -84,7 +84,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
       # All of our toolchains currently use the C++ compiler's filename as argv[0] for the linker,
       # so there is only one name to check.
-      linker_names_to_check = enums.match(toolchain_variant, {
+      linker_names_to_check = match(toolchain_variant, {
         ToolchainVariant.gnu: ['g++'],
         ToolchainVariant.llvm: ['clang++'],
       })
@@ -104,7 +104,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
       dist_name, dist_version, wheel_platform = name_and_platform(wheel_dist)
       self.assertEqual(dist_name, 'ctypes_test')
-      contains_current_platform = enums.match(Platform.current, {
+      contains_current_platform = match(Platform.current, {
         Platform.darwin: wheel_platform.startswith('macosx'),
         Platform.linux: wheel_platform.startswith('linux'),
       })
@@ -153,14 +153,14 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
         workdir=os.path.join(buildroot.new_buildroot, '.pants.d'),
       )
       self.assert_failure(pants_binary_strict_deps_failure)
-      self.assertIn(enums.match(toolchain_variant, {
+      self.assertIn(match(toolchain_variant, {
         ToolchainVariant.gnu: "fatal error: some_math.h: No such file or directory",
         ToolchainVariant.llvm: "fatal error: 'some_math.h' file not found"
       }), pants_binary_strict_deps_failure.stdout_data)
 
     # TODO(#6848): we need to provide the libstdc++.so.6.dylib which comes with gcc on osx in the
     # DYLD_LIBRARY_PATH during the 'run' goal somehow.
-    attempt_pants_run = enums.match(Platform.current, {
+    attempt_pants_run = match(Platform.current, {
       Platform.darwin: toolchain_variant == ToolchainVariant.llvm,
       Platform.linux: True,
     })
@@ -188,7 +188,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
 
     # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
     # be available on the runtime library path.
-    attempt_pants_run = enums.match(Platform.current, {
+    attempt_pants_run = match(Platform.current, {
       Platform.darwin: toolchain_variant == ToolchainVariant.llvm,
       Platform.linux: True,
     })
@@ -234,7 +234,7 @@ class CTypesIntegrationTest(PantsRunIntegrationTest):
     """
     # TODO(#6848): this fails when run with gcc on osx as it requires gcc's libstdc++.so.6.dylib to
     # be available on the runtime library path.
-    attempt_pants_run = enums.match(Platform.current, {
+    attempt_pants_run = match(Platform.current, {
       Platform.darwin: toolchain_variant == ToolchainVariant.llvm,
       Platform.linux: True,
     })

--- a/tests/python/pants_test/backend/python/tasks/util/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/util/BUILD
@@ -3,6 +3,7 @@ python_library(
     'src/python/pants/backend/native',
     'src/python/pants/backend/python/tasks',
     'src/python/pants/util:collections',
+    'src/python/pants/util:enums',
     'src/python/pants/util:meta',
     'tests/python/pants_test/backend/python/tasks:python_task_test_base',
     'tests/python/pants_test/engine:scheduler_test_base',

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -15,8 +15,9 @@ from pants.backend.python.tasks.build_local_python_distributions import (
 from pants.backend.python.tasks.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants.testutil.task_test_base import DeclarativeTaskTestMixin
+from pants.util import enums
 from pants.util.collections import assert_single_element
-from pants.util.meta import classproperty, match
+from pants.util.meta import classproperty
 from pants_test.backend.python.tasks.python_task_test_base import (
   PythonTaskTestBase,
   name_and_platform,
@@ -120,7 +121,7 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, DeclarativeTaskT
     self.assertEquals(dist, expected_name)
     self.assertEquals(version, expected_snapshot_version)
 
-    expected_platform = match(expected_platform, {
+    expected_platform = enums.match(expected_platform, {
       BuildLocalPythonDistributionsTestBase.ExpectedPlatformType.any: "any",
       BuildLocalPythonDistributionsTestBase.ExpectedPlatformType.current: normalized_current_platform(),
     })

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -15,8 +15,8 @@ from pants.backend.python.tasks.build_local_python_distributions import (
 from pants.backend.python.tasks.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants.testutil.task_test_base import DeclarativeTaskTestMixin
-from pants.util import enums
 from pants.util.collections import assert_single_element
+from pants.util.enums import match
 from pants.util.meta import classproperty
 from pants_test.backend.python.tasks.python_task_test_base import (
   PythonTaskTestBase,
@@ -121,7 +121,7 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, DeclarativeTaskT
     self.assertEquals(dist, expected_name)
     self.assertEquals(version, expected_snapshot_version)
 
-    expected_platform = enums.match(expected_platform, {
+    expected_platform = match(expected_platform, {
       BuildLocalPythonDistributionsTestBase.ExpectedPlatformType.any: "any",
       BuildLocalPythonDistributionsTestBase.ExpectedPlatformType.current: normalized_current_platform(),
     })

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -3,6 +3,7 @@
 
 import re
 from abc import abstractmethod
+from enum import Enum
 
 from pants.backend.native.register import rules as native_backend_rules
 from pants.backend.native.subsystems.libc_dev import LibcDev
@@ -14,8 +15,8 @@ from pants.backend.python.tasks.build_local_python_distributions import (
 from pants.backend.python.tasks.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants.testutil.task_test_base import DeclarativeTaskTestMixin
-from pants.util.collections import Enum, assert_single_element
-from pants.util.meta import classproperty
+from pants.util.collections import assert_single_element
+from pants.util.meta import classproperty, match
 from pants_test.backend.python.tasks.python_task_test_base import (
   PythonTaskTestBase,
   name_and_platform,
@@ -119,7 +120,7 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, DeclarativeTaskT
     self.assertEquals(dist, expected_name)
     self.assertEquals(version, expected_snapshot_version)
 
-    expected_platform = expected_platform.match({
+    expected_platform = match(expected_platform, {
       BuildLocalPythonDistributionsTestBase.ExpectedPlatformType.any: "any",
       BuildLocalPythonDistributionsTestBase.ExpectedPlatformType.current: normalized_current_platform(),
     })

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -201,6 +201,7 @@ python_tests(
     'src/python/pants/base:exception_sink',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:enums',
     'src/python/pants/util:osutil',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/option',

--- a/tests/python/pants_test/base/test_exception_sink.py
+++ b/tests/python/pants_test/base/test_exception_sink.py
@@ -10,6 +10,7 @@ from pants.base.exception_sink import ExceptionSink
 from pants.engine.platform import Platform
 from pants.testutil.test_base import TestBase
 from pants.util.contextutil import temporary_dir
+from pants.util.enums import match
 
 
 class TestExceptionSink(TestBase):
@@ -42,7 +43,7 @@ class TestExceptionSink(TestBase):
     # creating a new directory with safe_mkdir(), Linux errors out trying to create the directory
     # for its log files with safe_open(). This may be due to differences in the filesystems.
     # TODO: figure out why we error out at different points here!
-    err_str = Platform.current.match({
+    err_str = match(Platform.current, {
       Platform.darwin: "The provided exception sink path at '/' is not writable or could not be created: [Errno 21] Is a directory: '/'.",
       Platform.linux: "Error opening fatal error log streams for log location '/': [Errno 13] Permission denied: '/.pids'"
     })

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -7,6 +7,7 @@ import os
 import shlex
 import unittest.mock
 from contextlib import contextmanager
+from enum import Enum
 from textwrap import dedent
 
 import yaml
@@ -41,7 +42,7 @@ from pants.option.ranked_value import RankedValue
 from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.testutil.option.fakes import create_options
 from pants.testutil.test_base import TestBase
-from pants.util.collections import Enum, assert_single_element
+from pants.util.collections import assert_single_element
 from pants.util.contextutil import temporary_file, temporary_file_path
 from pants.util.dirutil import safe_mkdtemp
 from pants.util.strutil import safe_shlex_join

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -44,6 +44,16 @@ python_tests(
 )
 
 python_tests(
+  name = 'enums',
+  sources = ['test_enums.py'],
+  coverage = ['pants.util.enums'],
+  dependencies = [
+    'src/python/pants/util:enums',
+  ],
+  tags = {'type_checked'},
+)
+
+python_tests(
   name = 'eval',
   sources = ['test_eval.py'],
   dependencies = [

--- a/tests/python/pants_test/util/test_collections.py
+++ b/tests/python/pants_test/util/test_collections.py
@@ -4,14 +4,7 @@
 import unittest
 from typing import List
 
-from pants.util.collections import (
-  Enum,
-  InexhaustiveMatchError,
-  UnrecognizedMatchError,
-  assert_single_element,
-  factory_dict,
-  recursively_update,
-)
+from pants.util.collections import assert_single_element, factory_dict, recursively_update
 
 
 class TestCollections(unittest.TestCase):
@@ -95,41 +88,3 @@ class TestCollections(unittest.TestCase):
       assert_single_element(too_many_elements)
     expected_msg = "iterable [1, 2] has more than one element."
     self.assertEqual(expected_msg, str(cm.exception))
-
-
-class EnumTest(unittest.TestCase):
-
-  class Test(Enum):
-    dog = 0
-    cat = 1
-    pig = 2
-
-  def test_all_values(self) -> None:
-    self.assertEqual(
-      {EnumTest.Test.dog, EnumTest.Test.cat, EnumTest.Test.pig}, set(EnumTest.Test.all_values())
-    )
-
-  def test_valid_match(self) -> None:
-    match_mapping = {
-      EnumTest.Test.dog: "woof",
-      EnumTest.Test.cat: "meow",
-      EnumTest.Test.pig: "oink",
-    }
-    self.assertEqual("woof", EnumTest.Test.dog.match(match_mapping))
-    self.assertEqual("meow", EnumTest.Test.cat.match(match_mapping))
-    self.assertEqual("oink", EnumTest.Test.pig.match(match_mapping))
-
-  def test_inexhaustive_match(self) -> None:
-    with self.assertRaises(InexhaustiveMatchError):
-      EnumTest.Test.pig.match({
-        EnumTest.Test.pig: "oink",
-      })
-
-  def test_unrecognized_match(self) -> None:
-    with self.assertRaises(UnrecognizedMatchError):
-      EnumTest.Test.pig.match({  # type: ignore[type-var] # intended to fail type check
-        EnumTest.Test.dog: "woof",
-        EnumTest.Test.cat: "meow",
-        EnumTest.Test.pig: "oink",
-        "horse": "neigh",
-      })

--- a/tests/python/pants_test/util/test_enums.py
+++ b/tests/python/pants_test/util/test_enums.py
@@ -1,0 +1,40 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import unittest
+from enum import Enum
+
+from pants.util import enums
+
+
+class EnumMatchTest(unittest.TestCase):
+
+  class Test(Enum):
+    dog = 0
+    cat = 1
+    pig = 2
+
+  def test_valid_match(self) -> None:
+    match_mapping = {
+      EnumMatchTest.Test.dog: "woof",
+      EnumMatchTest.Test.cat: "meow",
+      EnumMatchTest.Test.pig: "oink",
+    }
+    self.assertEqual("woof", enums.match(EnumMatchTest.Test.dog, match_mapping))
+    self.assertEqual("meow", enums.match(EnumMatchTest.Test.cat, match_mapping))
+    self.assertEqual("oink", enums.match(EnumMatchTest.Test.pig, match_mapping))
+
+  def test_inexhaustive_match(self) -> None:
+    with self.assertRaises(enums.InexhaustiveMatchError):
+      enums.match(EnumMatchTest.Test.pig, {
+        EnumMatchTest.Test.pig: "oink",
+      })
+
+  def test_unrecognized_match(self) -> None:
+    with self.assertRaises(enums.UnrecognizedMatchError):
+      enums.match(EnumMatchTest.Test.pig, {  # type: ignore
+        EnumMatchTest.Test.dog: "woof",
+        EnumMatchTest.Test.cat: "meow",
+        EnumMatchTest.Test.pig: "oink",
+        "horse": "neigh",
+      })

--- a/tests/python/pants_test/util/test_enums.py
+++ b/tests/python/pants_test/util/test_enums.py
@@ -32,7 +32,7 @@ class EnumMatchTest(unittest.TestCase):
 
   def test_unrecognized_match(self) -> None:
     with self.assertRaises(enums.UnrecognizedMatchError):
-      enums.match(EnumMatchTest.Test.pig, {  # type: ignore
+      enums.match(EnumMatchTest.Test.pig, {  # type: ignore[type-var]
         EnumMatchTest.Test.dog: "woof",
         EnumMatchTest.Test.cat: "meow",
         EnumMatchTest.Test.pig: "oink",

--- a/tests/python/pants_test/util/test_enums.py
+++ b/tests/python/pants_test/util/test_enums.py
@@ -4,7 +4,7 @@
 import unittest
 from enum import Enum
 
-from pants.util.enums import match
+from pants.util.enums import InexhaustiveMatchError, UnrecognizedMatchError, match
 
 
 class EnumMatchTest(unittest.TestCase):
@@ -25,13 +25,13 @@ class EnumMatchTest(unittest.TestCase):
     self.assertEqual("oink", match(EnumMatchTest.Test.pig, match_mapping))
 
   def test_inexhaustive_match(self) -> None:
-    with self.assertRaises(enums.InexhaustiveMatchError):
+    with self.assertRaises(InexhaustiveMatchError):
       match(EnumMatchTest.Test.pig, {
         EnumMatchTest.Test.pig: "oink",
       })
 
   def test_unrecognized_match(self) -> None:
-    with self.assertRaises(enums.UnrecognizedMatchError):
+    with self.assertRaises(UnrecognizedMatchError):
       match(EnumMatchTest.Test.pig, {  # type: ignore[type-var]
         EnumMatchTest.Test.dog: "woof",
         EnumMatchTest.Test.cat: "meow",

--- a/tests/python/pants_test/util/test_enums.py
+++ b/tests/python/pants_test/util/test_enums.py
@@ -4,7 +4,7 @@
 import unittest
 from enum import Enum
 
-from pants.util import enums
+from pants.util.enums import match
 
 
 class EnumMatchTest(unittest.TestCase):
@@ -20,19 +20,19 @@ class EnumMatchTest(unittest.TestCase):
       EnumMatchTest.Test.cat: "meow",
       EnumMatchTest.Test.pig: "oink",
     }
-    self.assertEqual("woof", enums.match(EnumMatchTest.Test.dog, match_mapping))
-    self.assertEqual("meow", enums.match(EnumMatchTest.Test.cat, match_mapping))
-    self.assertEqual("oink", enums.match(EnumMatchTest.Test.pig, match_mapping))
+    self.assertEqual("woof", match(EnumMatchTest.Test.dog, match_mapping))
+    self.assertEqual("meow", match(EnumMatchTest.Test.cat, match_mapping))
+    self.assertEqual("oink", match(EnumMatchTest.Test.pig, match_mapping))
 
   def test_inexhaustive_match(self) -> None:
     with self.assertRaises(enums.InexhaustiveMatchError):
-      enums.match(EnumMatchTest.Test.pig, {
+      match(EnumMatchTest.Test.pig, {
         EnumMatchTest.Test.pig: "oink",
       })
 
   def test_unrecognized_match(self) -> None:
     with self.assertRaises(enums.UnrecognizedMatchError):
-      enums.match(EnumMatchTest.Test.pig, {  # type: ignore[type-var]
+      match(EnumMatchTest.Test.pig, {  # type: ignore[type-var]
         EnumMatchTest.Test.dog: "woof",
         EnumMatchTest.Test.cat: "meow",
         EnumMatchTest.Test.pig: "oink",

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
 import unittest
 from abc import ABC, abstractmethod
 from dataclasses import FrozenInstanceError, dataclass

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -1,6 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+
 import unittest
 from abc import ABC, abstractmethod
 from dataclasses import FrozenInstanceError, dataclass
@@ -345,36 +346,3 @@ class FrozenAfterInitTest(unittest.TestCase):
     test = Test(x=0)
     with self.assertRaises(FrozenInstanceError):
       test.x = 1
-
-
-class EnumMatchTest(unittest.TestCase):
-
-  class Test(Enum):
-    dog = 0
-    cat = 1
-    pig = 2
-
-  def test_valid_match(self) -> None:
-    match_mapping = {
-      EnumMatchTest.Test.dog: "woof",
-      EnumMatchTest.Test.cat: "meow",
-      EnumMatchTest.Test.pig: "oink",
-    }
-    self.assertEqual("woof", match(EnumMatchTest.Test.dog, match_mapping))
-    self.assertEqual("meow", match(EnumMatchTest.Test.cat, match_mapping))
-    self.assertEqual("oink", match(EnumMatchTest.Test.pig, match_mapping))
-
-  def test_inexhaustive_match(self) -> None:
-    with self.assertRaises(InexhaustiveMatchError):
-      match(EnumMatchTest.Test.pig, {
-        EnumMatchTest.Test.pig: "oink",
-      })
-
-  def test_unrecognized_match(self) -> None:
-    with self.assertRaises(UnrecognizedMatchError):
-      match(EnumMatchTest.Test.pig, {  # type: ignore
-        EnumMatchTest.Test.dog: "woof",
-        EnumMatchTest.Test.cat: "meow",
-        EnumMatchTest.Test.pig: "oink",
-        "horse": "neigh",
-      })

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -4,10 +4,15 @@
 import unittest
 from abc import ABC, abstractmethod
 from dataclasses import FrozenInstanceError, dataclass
-from enum import Enum
 
 from pants.testutil.test_base import TestBase
-from pants.util.meta import InexhaustiveMatchError, SingletonMetaclass, UnrecognizedMatchError, classproperty, decorated_type_checkable, frozen_after_init, staticproperty
+from pants.util.meta import (
+  SingletonMetaclass,
+  classproperty,
+  decorated_type_checkable,
+  frozen_after_init,
+  staticproperty,
+)
 
 
 class AbstractClassTest(TestBase):


### PR DESCRIPTION
### Problem

Importing via `from pants.util.collections import Enum` induces an indirection which isn't necessary for most users of `Enum` (the ones that don't use the `.match()` function).

### Solution

- Use the normal stdlib enum type.
- Make `match` into a top-level function in `meta.py`.
- Migrate the codebase.

### Result

An awkward import is resolved, and a new import is born! Complete credit for the solution goes to @jsirois in the `#engine` channel on our Slack.