### PR TITLE
fix mypy type error in meta.py

### DIFF
--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -137,8 +137,8 @@ def frozen_after_init(cls: Type[T]) -> Type[T]:
 
   cls.__init__ = new_init  # type: ignore
   cls.__setattr__ = new_setattr  # type: ignore
-  setattr(cls, frozen_after_init.sentinel_attr, True)
+  setattr(cls, frozen_after_init.sentinel_attr, True) # type: ignore
 
   return cls
 
-frozen_after_init.sentinel_attr = '_frozen_after_init'
+frozen_after_init.sentinel_attr = '_frozen_after_init' # type: ignore

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -428,5 +428,5 @@ class RuleIndexingErrorTest(TestBase):
     with self.assertRaisesWithMessage(TypeError, dedent("""\
       @rule output type <class 'pants_test.engine.test_scheduler.NonFrozenDataclass'> is a dataclass declared without `frozen=True`, or without both `unsafe_hash=True` and the `@frozen_after_init` decorator! The engine requires that fields in params are immutable for stable hashing!""")):
       @rule
-      def f(x: int) -> NonFrozenDataclass:
+      def g(x: int) -> NonFrozenDataclass:
         return NonFrozenDataclass(x=x)


### PR DESCRIPTION
### Problem

`pants.util.meta.frozen_after_init` has a couple mypy type checking errors, specifically at: https://github.com/pantsbuild/pants/blob/00c4f8cc4a997f80a34f78b6d5fd6fca746befa7/src/python/pants/util/meta.py#L140-L144

This caused a failure on master, see https://travis-ci.org/pantsbuild/pants/jobs/600466692.

### Solution

- Add `# type: ignore` to the offending lines until #8496 is merged.

### Result

CI is unbroken!