### PR TITLE
move the subdirectory for exception logs to .pids/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ out/
 /build-support/phab/
 /dist/
 /lib/
-/.pants-fatal-exception-logs/
 # This is created by the very handy `build-support/bin/get_failing_travis_targets_for_pr.sh`.
 /logs/
 arc.sh

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ out/
 /build-support/phab/
 /dist/
 /lib/
+/.pants-fatal-exception-logs/
 # This is created by the very handy `build-support/bin/get_failing_travis_targets_for_pr.sh`.
 /logs/
 arc.sh

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -272,7 +272,7 @@ class ExceptionSink:
     in_dir = in_dir or cls._log_dir
     return os.path.join(
       in_dir,
-      '.pants-fatal-exception-logs',
+      '.pids',
       'exceptions{}.log'.format(intermediate_filename_component))
 
   @classmethod

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -272,7 +272,7 @@ class ExceptionSink:
     in_dir = in_dir or cls._log_dir
     return os.path.join(
       in_dir,
-      'logs',
+      '.pants-fatal-exception-logs',
       'exceptions{}.log'.format(intermediate_filename_component))
 
   @classmethod

--- a/tests/python/pants_test/base/test_exception_sink.py
+++ b/tests/python/pants_test/base/test_exception_sink.py
@@ -10,7 +10,6 @@ from pants.base.exception_sink import ExceptionSink
 from pants.engine.platform import Platform
 from pants.testutil.test_base import TestBase
 from pants.util.contextutil import temporary_dir
-from pants.util.osutil import get_normalized_os_name
 
 
 class TestExceptionSink(TestBase):

--- a/tests/python/pants_test/base/test_exception_sink.py
+++ b/tests/python/pants_test/base/test_exception_sink.py
@@ -69,7 +69,7 @@ class TestExceptionSink(TestBase):
         getproctitle_mock.assert_called_once()
 
       # This should have created two log files, one specific to the current pid.
-      self.assertEqual(os.listdir(tmpdir), ['logs'])
+      self.assertEqual(os.listdir(tmpdir), ['.pants-fatal-exception-logs'])
 
       cur_process_error_log_path = ExceptionSink.exceptions_log_path(for_pid=pid, in_dir=tmpdir)
       self.assertTrue(os.path.isfile(cur_process_error_log_path))

--- a/tests/python/pants_test/base/test_exception_sink.py
+++ b/tests/python/pants_test/base/test_exception_sink.py
@@ -33,11 +33,10 @@ class TestExceptionSink(TestBase):
   def test_set_invalid_log_location(self):
     self.assertFalse(os.path.isdir('/does/not/exist'))
     sink = self._gen_sink_subclass()
-    err_rx = re.escape(
-      "The provided exception sink path at '/does/not/exist' is not writable or could not be created: [Errno 13]")
-    with self.assertRaisesRegexp(ExceptionSink.ExceptionSinkError, err_rx):
+    with self.assertRaisesWithMessageContaining(
+        ExceptionSink.ExceptionSinkError,
+        "The provided exception sink path at '/does/not/exist' is not writable or could not be created"):
       sink.reset_log_location('/does/not/exist')
-
 
     # NB: This target is marked with 'platform_specific_behavior' because OSX errors out here at
     # creating a new directory with safe_mkdir(), Linux errors out trying to create the directory
@@ -69,7 +68,7 @@ class TestExceptionSink(TestBase):
         getproctitle_mock.assert_called_once()
 
       # This should have created two log files, one specific to the current pid.
-      self.assertEqual(os.listdir(tmpdir), ['.pants-fatal-exception-logs'])
+      self.assertEqual(os.listdir(tmpdir), ['.pids'])
 
       cur_process_error_log_path = ExceptionSink.exceptions_log_path(for_pid=pid, in_dir=tmpdir)
       self.assertTrue(os.path.isfile(cur_process_error_log_path))


### PR DESCRIPTION
### Problem

Right now, if pants fails with an uncaught exception during import time, it will write a timestamped stacktrace to `<buildroot>/logs/exceptions.log`. This is a little confusing for users, who don't know whether they're supposed to gitignore it or check it in.

### Solution

- Use `.pids` instead of `logs`.
- Fix our `.gitignore`.

### Result

It's now more clear that these logs are specifically generated by pants, and that they can safely be gitignored and/or deleted. Fixes #8809.