### PR TITLE
pin cryptography lib to 2.7

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -4,6 +4,8 @@ beautifulsoup4>=4.6.0,<4.7
 cffi==1.12.3
 contextlib2==0.5.5
 coverage>=4.5,<4.6
+# TODO remove this pin once we resolve https://github.com/pantsbuild/pants/issues/8502
+cryptography==2.7
 dataclasses==0.6
 docutils==0.14
 fasteners==0.14.1


### PR DESCRIPTION
### Problem

Cryptography==2.8 is a transient dep of requests and pyopenssl. Pip resolves a manylinux2010 whl from pypi which breaks the pants.pex build in the release script. Probably fixed by pantsbuild/pex#778

### Solution

pin to last working version

### Result
 
unblocks release