### PR TITLE
Don't display a ubiquitous warning triggered on python 3.7.

### DIFF
--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -33,6 +33,9 @@ class PantsLoader:
     # TODO: Eric-Arellano has emailed the author to see if he is willing to accept a PR fixing the
     # deprecation warnings and to release the fix. If he says yes, remove this once fixed.
     warnings.filterwarnings('ignore', category=DeprecationWarning, module="ansicolors")
+    # Silence this ubiquitous warning. Several of our 3rd party deps incur this.
+    warnings.filterwarnings('ignore', category=DeprecationWarning,
+        message="Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated")
 
   @classmethod
   def ensure_locale(cls):


### PR DESCRIPTION
Several of our 3rdparty deps trigger it, and until they fix
themselves to be 3.8 compatible, there's nothing we can do,
and no point in annoying our users with these warnings.
