### PR TITLE
Log actual uploaded digests not just count

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -42,7 +42,7 @@ use hashing::Digest;
 use protobuf::Message;
 use serde_derive::Serialize;
 pub use serverset::BackoffConfig;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
@@ -71,11 +71,11 @@ mod remote_tests;
 // Summary of the files and directories uploaded with an operation
 // ingested_file_{count, bytes}: Number and combined size of processed files
 // uploaded_file_{count, bytes}: Number and combined size of files uploaded to the remote
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
 pub struct UploadSummary {
   pub ingested_file_count: usize,
   pub ingested_file_bytes: usize,
-  pub uploaded_file_count: usize,
+  pub uploaded_files: BTreeSet<hashing::Digest>,
   pub uploaded_file_bytes: usize,
   #[serde(skip)]
   pub upload_wall_time: Duration,
@@ -553,8 +553,8 @@ impl Store {
         UploadSummary {
           ingested_file_count: ingested_file_sizes.len(),
           ingested_file_bytes: ingested_file_sizes.sum(),
-          uploaded_file_count: uploaded_file_sizes.len(),
           uploaded_file_bytes: uploaded_file_sizes.sum(),
+          uploaded_files: uploaded_digests.into_iter().collect(),
           upload_wall_time: start_time.elapsed(),
         }
       })

--- a/src/rust/engine/hashing/src/lib.rs
+++ b/src/rust/engine/hashing/src/lib.rs
@@ -148,7 +148,7 @@ impl<'de> Deserialize<'de> for Fingerprint {
 /// It is equivalent to a Bazel Remote Execution Digest, but without the overhead (and awkward API)
 /// of needing to create an entire protobuf to pass around the two fields.
 ///
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub struct Digest(pub Fingerprint, pub usize);
 
 impl Serialize for Digest {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -227,10 +227,23 @@ impl FallibleExecuteProcessResult {
   }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct LengthSerializedBTreeSet {
+  length: usize,
+  values: BTreeSet<hashing::Digest>,
+}
+
+impl LengthSerializedBTreeSet {
+  fn extend<I: Iterator<Item = hashing::Digest>>(&mut self, other: I) {
+    self.values.extend(other);
+    self.length = self.values.len();
+  }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ExecutionStats {
   uploaded_bytes: usize,
-  uploaded_file_count: usize,
+  uploaded_files: LengthSerializedBTreeSet,
   upload: Duration,
   remote_queue: Option<Duration>,
   remote_input_fetch: Option<Duration>,
@@ -241,7 +254,9 @@ pub struct ExecutionStats {
 
 impl AddAssign<UploadSummary> for ExecutionStats {
   fn add_assign(&mut self, summary: UploadSummary) {
-    self.uploaded_file_count += summary.uploaded_file_count;
+    self
+      .uploaded_files
+      .extend(summary.uploaded_files.into_iter());
     self.uploaded_bytes += summary.uploaded_file_bytes;
     self.upload += summary.upload_wall_time;
   }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -433,18 +433,13 @@ impl super::CommandRunner for CommandRunner {
               )
             },
           )
-          .map(move |resp| {
-            let mut attempts = String::new();
-            for (i, attempt) in resp.execution_attempts.iter().enumerate() {
-              attempts += &format!("\nAttempt {}: {:?}", i, attempt);
-            }
+          .inspect(move |resp| {
             debug!(
-              "Finished remote exceution of {} after {} attempts: Stats: {}",
+              "Finished remote execution of {} after {} attempts: Stats: {}",
               description2,
               resp.execution_attempts.len(),
-              attempts
+              resp.execution_attempts.iter().enumerate().map(|(i, attempt)| format!("\nAttempt {}: {:?}", i, attempt)).collect::<Vec<_>>().join(""),
             );
-            resp
           })
           .to_boxed()
       }
@@ -639,7 +634,7 @@ impl CommandRunner {
         let status = execute_response.take_status();
         if grpcio::RpcStatusCode::from(status.get_code()) == grpcio::RpcStatusCode::Ok {
           let mut execution_attempts = std::mem::replace(&mut attempts.attempts, vec![]);
-          execution_attempts.push(attempts.current_attempt);
+          execution_attempts.push(attempts.current_attempt.clone());
           return populate_fallible_execution_result(
             self.store.clone(),
             execute_response,


### PR DESCRIPTION
This is useful for debugging. It's only computed or printed at debug
level.