### PR TITLE
Move CallOption construction to common location

### DIFF
--- a/src/rust/engine/process_execution/bazel_protos/src/lib.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/lib.rs
@@ -16,6 +16,9 @@ mod conversions;
 #[cfg(test)]
 mod conversions_tests;
 
+mod metadata;
+pub use metadata::call_option;
+
 mod verification;
 pub use crate::verification::verify_directory_canonical;
 #[cfg(test)]

--- a/src/rust/engine/process_execution/bazel_protos/src/metadata.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/metadata.rs
@@ -1,0 +1,34 @@
+use protobuf::Message;
+use std::collections::BTreeMap;
+
+pub fn call_option(
+  headers: &BTreeMap<String, String>,
+  build_id: Option<String>,
+) -> Result<grpcio::CallOption, String> {
+  let mut builder = grpcio::MetadataBuilder::with_capacity(headers.len() + 1);
+  for (header_name, header_value) in headers {
+    builder
+      .add_str(header_name, header_value)
+      .map_err(|err| format!("Error setting header {}: {}", header_name, err))?;
+  }
+  if let Some(build_id) = build_id {
+    let mut metadata = crate::remote_execution::RequestMetadata::new();
+    metadata.set_tool_details({
+      let mut tool_details = crate::remote_execution::ToolDetails::new();
+      tool_details.set_tool_name(String::from("pants"));
+      tool_details
+    });
+    metadata.set_tool_invocation_id(build_id);
+    // TODO: Maybe set action_id too
+    let bytes = metadata
+      .write_to_bytes()
+      .map_err(|err| format!("Error serializing request metadata proto bytes: {}", err))?;
+    builder
+      .add_bytes(
+        "google.devtools.remoteexecution.v1test.requestmetadata-bin",
+        &bytes,
+      )
+      .map_err(|err| format!("Error setting request metadata header: {}", err))?;
+  }
+  Ok(grpcio::CallOption::default().headers(builder.build()))
+}


### PR DESCRIPTION
I'm about to add more headers around passing build_id and action_id into
the metadata header, including from the Store. This is the first step.