### PR TITLE
Set action_id for metadata header

### DIFF
--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -137,7 +137,9 @@ impl ByteStore {
     self
       .with_byte_stream_client(move |client| {
         match client
-          .write_opt(try_future!(call_option(&store.headers, None)).timeout(store.upload_timeout))
+          .write_opt(
+            try_future!(call_option(&store.headers, None, None)).timeout(store.upload_timeout),
+          )
           .map(|v| (v, client))
         {
           Err(err) => future::err(format!(
@@ -260,7 +262,7 @@ impl ByteStore {
               req.set_read_limit(0);
               req
             },
-            try_future!(call_option(&store.headers, None)),
+            try_future!(call_option(&store.headers, None, None)),
           )
           .map(|stream| (stream, client))
         {
@@ -329,7 +331,7 @@ impl ByteStore {
     self
       .with_cas_client(move |client| {
         client
-          .find_missing_blobs_opt(&request, call_option(&store.headers, None)?)
+          .find_missing_blobs_opt(&request, call_option(&store.headers, None, None)?)
           .map_err(|err| {
             format!(
               "Error from server in response to find_missing_blobs_request: {:?}",

--- a/src/rust/engine/process_execution/bazel_protos/src/metadata.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/metadata.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 pub fn call_option(
   headers: &BTreeMap<String, String>,
   build_id: Option<String>,
+  action_digest: Option<hashing::Digest>,
 ) -> Result<grpcio::CallOption, String> {
   let mut builder = grpcio::MetadataBuilder::with_capacity(headers.len() + 1);
   for (header_name, header_value) in headers {
@@ -11,15 +12,19 @@ pub fn call_option(
       .add_str(header_name, header_value)
       .map_err(|err| format!("Error setting header {}: {}", header_name, err))?;
   }
-  if let Some(build_id) = build_id {
+  if build_id.is_some() || action_digest.is_some() {
     let mut metadata = crate::remote_execution::RequestMetadata::new();
     metadata.set_tool_details({
       let mut tool_details = crate::remote_execution::ToolDetails::new();
       tool_details.set_tool_name(String::from("pants"));
       tool_details
     });
-    metadata.set_tool_invocation_id(build_id);
-    // TODO: Maybe set action_id too
+    if let Some(build_id) = build_id {
+      metadata.set_tool_invocation_id(build_id);
+    }
+    if let Some(action_digest) = action_digest {
+      metadata.set_action_id(format!("{}-{}", action_digest.0, action_digest.1));
+    }
     let bytes = metadata
       .write_to_bytes()
       .map_err(|err| format!("Error serializing request metadata proto bytes: {}", err))?;


### PR DESCRIPTION
A follow-up will also set this for RPCs from the Store if they're
happening in the context of a remote execution.