### PR TITLE
Add lock around bootstrap compiler bridge jar

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -7,6 +7,7 @@ import os
 import re
 import textwrap
 import zipfile
+from asyncio import Lock
 from collections import defaultdict
 from contextlib import closing
 from xml.etree import ElementTree
@@ -300,7 +301,9 @@ class BaseZincCompile(JvmCompile):
     if self.get_options().use_barebones_logger:
       zinc_args.append('--use-barebones-logger')
 
-    compiler_bridge_classpath_entry = self._zinc.compile_compiler_bridge(self.context)
+    lock = Lock()
+    with (yield from lock):
+      compiler_bridge_classpath_entry = self._zinc.compile_compiler_bridge(self.context)
     zinc_args.extend(['-compiled-bridge-jar', relative_to_exec_root(compiler_bridge_classpath_entry.path)])
     zinc_args.extend(['-scala-path', ':'.join(scala_path)])
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -7,7 +7,6 @@ import os
 import re
 import textwrap
 import zipfile
-from asyncio import Lock
 from collections import defaultdict
 from contextlib import closing
 from xml.etree import ElementTree
@@ -301,9 +300,7 @@ class BaseZincCompile(JvmCompile):
     if self.get_options().use_barebones_logger:
       zinc_args.append('--use-barebones-logger')
 
-    lock = Lock()
-    with (yield from lock):
-      compiler_bridge_classpath_entry = self._zinc.compile_compiler_bridge(self.context)
+    compiler_bridge_classpath_entry = self._zinc.compile_compiler_bridge(self.context)
     zinc_args.extend(['-compiled-bridge-jar', relative_to_exec_root(compiler_bridge_classpath_entry.path)])
     zinc_args.extend(['-scala-path', ':'.join(scala_path)])
 


### PR DESCRIPTION
### Problem

Concurrent compile.rsc workers could launch parallel bootstrap of compiler bridge jar, causing
```
00:39:16 01:16         [zinc-subsystem]
                       
00:39:16 01:16         [zinc-subsystem]
                       [0m[[0m[0minfo[0m] [0m[0mNon-compiled module 'compiler-interface' for Scala 2.12.10. Compiling...[0m
                       [0m[[0m[0minfo[0m] [0m[0m  Compilation completed in 8.963s.[0m
                       [0m[[0m[0minfo[0m] [0m[0mNon-compiled module 'compiler-interface' for Scala 2.12.10. Compiling...[0m
                       [0m[[0m[0minfo[0m] [0m[0m  Compilation completed in 8.963s.[0m
                       
                     Invalidated 1 target.
00:39:27 01:27         [coursier]
                   zinc[zinc-java](util/util-app/src/main/java/com/twitter/app:app) failed: [Errno 2] No such file or directory: '/var/lib/mesos/slaves/d44de250-26ea-47f3-8fc2-26241f6ae198-S7268/frameworks/201104070004-0000002563-0000/executors/thermos-scoot-service-prod-scoot-worker-2941-5b1cad3a-8678-4e4d-956b-57022d322076/runs/251f7dca-9be1-4488-a887-b4acc3786e02/sandbox/workspace/source/.pants.d/zinc/compiler-bridge/a5ad0747942f/scala-compiler-bridge.jar' -> '/var/lib/mesos/slaves/d44de250-26ea-47f3-8fc2-26241f6ae198-S7268/frameworks/201104070004-0000002563-0000/executors/thermos-scoot-service-prod-scoot-worker-2941-5b1cad3a-8678-4e4d-956b-57022d322076/runs/251f7dca-9be1-4488-a887-b4acc3786e02/sandbox/.cache/pants/zinc/compiler-bridge/a5ad0747942f/scala-compiler-bridge.jar' in 79.5340564250946
                   Traceback:
                     File "/var/lib/mesos/slaves/d44de250-26ea-47f3-8fc2-26241f6ae198-S7268/frameworks/201104070004-0000002563-0000/executors/thermos-scoot-service-prod-scoot-worker-2941-5b1cad3a-8678-4e4d-956b-57022d322076/runs/251f7dca-9be1-4488-a887-b4acc3786e02/sandbox/workspace/source/.pex/install/pantsbuild.pants-1.22.0rc0+gitd095904d-cp36-abi3-linux_x86_64.whl.d662b34e70df6bcd6af3c130a7aedd5ac32d8ad7/pantsbuild.pants-1.22.0rc0+gitd095904d-cp36-abi3-linux_x86_64.whl/pants/backend/jvm/tasks/jvm_compile/execution_graph.py", line 287, in worker
                       work()
```
which also has duplicated workunit for ` [zinc-subsystem]`

Problematic sector of code in concurrent setting: https://github.com/pantsbuild/pants/blob/94bc795caf30e2853c399494bd4822832b33a417/src/python/pants/backend/jvm/subsystems/zinc.py#L365-L373

### Solution

Add a lock around it.

### Result

Verified with 20 runs after bumping the cache key. 