### PR TITLE
Increase our client count and sync bootstrapped files

### DIFF
--- a/build-support/bin/get_ci_bootstrapped_pants_pex.sh
+++ b/build-support/bin/get_ci_bootstrapped_pants_pex.sh
@@ -28,3 +28,9 @@ chmod 755 ./pants.pex
 # bytes before the zip magic number (in our case, the pex shebang), even though the unzip
 # operation otherwise succeeds.
 unzip -j pants.pex pants/engine/native_engine.so -d src/python/pants/engine/ || true
+
+# TODO: As of 2019/10/24, we've seen sigbus errors while starting tests that feel potentially related
+# to either the PEX or native_engine.so just having finished extraction. If we continue to see those
+# issues, we can assume that this `sync` call is not necessary: otherwise, can assume that it is due
+# to some behavior of either 1) the aws tool, 2) chmod, 3) zip extraction.
+sync

--- a/pants.remote.ini
+++ b/pants.remote.ini
@@ -25,7 +25,7 @@ remote_execution_extra_platform_properties: [
 
 # This should correspond to the number of workers running in Google RBE. See
 # https://console.cloud.google.com/apis/api/remotebuildexecution.googleapis.com/quotas?project=pants-remoting-beta&folder&organizationId&duration=PT6H.
-process_execution_remote_parallelism: 16
+process_execution_remote_parallelism: 32
 process_execution_speculation_strategy: remote_first
 # p95 of RBE appears to be ~ 2 seconds, but we need to factor in local queue time which can be much longer, but no metrics yet.
 process_execution_speculation_delay: 15


### PR DESCRIPTION
### Problem

We increased the RBE worker pool size to improve the runtime of the integration test shard, but I did not increase the client count (based on the assumption that some of the delay was due to contention between multiple travis runs, rather than due to straight line concurrency of one travis shard).

Additionally, we have been seeing periodic SIGBUS errors while starting pants immediately after bootstrapping it.

### Solution

Increase our client count to match our RBE worker pool size. If we have multiple travis runs going on at once, some of them might starve, but this at least increases the chances of saturating the backend.

Additionally, based on the hypothesis that the SIGBUS error has something to do with the bootstrap process itself not syncing files to disk, add a manual sync to leave in place until we either confirm or deny that hypothesis.