### PR TITLE
Allow users to override compile.rsc workflows via env var and add --allow-public-inference option

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -177,6 +177,9 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     register('--extra-rsc-args', type=list, default=[],
              help='Extra arguments to pass to the rsc invocation.')
 
+    register('--allow-public-inference', type=bool, default=False,
+             help='Allow public type member inference when workflow is outline-and-zinc. Otherwise, unannotated public types will be a compile error.', fingerprint=True)
+
     cls.register_jvm_tool(
       register,
       'rsc',
@@ -475,15 +478,19 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
           youtline_args = []
           if use_youtline:
-            youtline_args = [
+            wartremover_args = [
               f"-Xplugin:{self._wartremover_classpath[0]}",
               "-P:wartremover:traverser:org.wartremover.warts.PublicInference",
               "-Ycache-plugin-class-loader:last-modified",
+            ]
+            youtline_args = [
               "-Youtline",
               "-Ystop-after:pickler",
               "-Ypickle-write",
               rsc_jar_file_relative_path,
             ]
+            if not self.get_options().allow_public_inference:
+              youtline_args = wartremover_args + youtline_args
 
           target_sources = ctx.sources
           args = [

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -494,11 +494,6 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
           youtline_args = []
           if use_youtline:
-            wartremover_args = [
-              f"-Xplugin:{self._wartremover_classpath[0]}",
-              "-P:wartremover:traverser:org.wartremover.warts.PublicInference",
-              "-Ycache-plugin-class-loader:last-modified",
-            ]
             youtline_args = [
               "-Youtline",
               "-Ystop-after:pickler",
@@ -506,6 +501,11 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
               rsc_jar_file_relative_path,
             ]
             if not self.get_options().allow_public_inference:
+              wartremover_args = [
+                f"-Xplugin:{self._wartremover_classpath[0]}",
+                "-P:wartremover:traverser:org.wartremover.warts.PublicInference",
+                "-Ycache-plugin-class-loader:last-modified",
+              ]
               youtline_args = wartremover_args + youtline_args
 
           target_sources = ctx.sources

--- a/testprojects/src/scala/org/pantsbuild/testproject/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/BUILD
@@ -14,6 +14,7 @@ target(
     ':javasources_directory',
     ':mutual_directory',
     ':procedure_syntax_directory',
+    ':public_inference_directory',
     ':publish_directory',
     ':rsc_compat_directory',
     ':scaladepsonboth_directory',
@@ -75,6 +76,11 @@ files(
 files(
   name = 'procedure_syntax_directory',
   sources = rglobs('procedure_syntax/*'),
+)
+
+files(
+  name = 'public_inference_directory',
+  sources = rglobs('public_inference/*'),
 )
 
 files(

--- a/testprojects/src/scala/org/pantsbuild/testproject/public_inference/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/public_inference/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+scala_library()

--- a/testprojects/src/scala/org/pantsbuild/testproject/public_inference/PublicInference.scala
+++ b/testprojects/src/scala/org/pantsbuild/testproject/public_inference/PublicInference.scala
@@ -1,0 +1,8 @@
+// Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.public_inference
+
+object PublicInference {
+  def foo = 42
+}

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -33,6 +33,7 @@ python_tests(
     ':rsc_compile_integration_base',
     'examples/src/scala/org/pantsbuild/example:hello_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:mutual_directory',
+    'testprojects/src/scala/org/pantsbuild/testproject:public_inference_directory',
   ],
   timeout = 600,
   tags = {'integration'},

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/rsc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/rsc_compile_integration_base.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
+
 from pants.backend.jvm.tasks.jvm_compile.rsc.rsc_compile import RscCompile
 from pants.util.contextutil import environment_as
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
@@ -28,6 +30,35 @@ class RscCompileIntegrationBase(BaseCompileIT):
 
   rsc_and_zinc = RscCompile.JvmCompileWorkflowType.rsc_and_zinc
   outline_and_zinc = RscCompile.JvmCompileWorkflowType.outline_and_zinc
+
+  def _testproject_compile(self, project, target, clazz, *command_args, success=True, zinc_result=True, outline_result=True):
+    testproject_base = 'testprojects/src/scala/org/pantsbuild/testproject'
+    project_dir = os.path.join(testproject_base, project)
+    spec = f"{project_dir}:{target}"
+
+    args = list(command_args) + ['compile', spec]
+
+    with self.do_command_yielding_workdir(*args, success=success) as pants_run:
+      results_path = f"compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.{project}.{project}/current"
+      zinc_compiled_classfile = os.path.join(
+        pants_run.workdir,
+        results_path,
+        f"zinc/classes/org/pantsbuild/testproject/{project}/{clazz}.class"
+      )
+      outline_jar = os.path.join(
+        pants_run.workdir,
+        results_path,
+        "rsc/m.jar"
+      )
+      if zinc_result:
+        self.assert_is_file(zinc_compiled_classfile)
+      else:
+        self.assert_is_not_file(zinc_compiled_classfile)
+
+      if outline_result:
+        self.assert_is_file(outline_jar)
+      else:
+        self.assert_is_not_file(outline_jar)
 
   def _test_hermetic_jvm_options(self, workflow):
     pants_run = self.run_pants(['compile', 'examples/src/scala/org/pantsbuild/example/hello/exe'],

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/rsc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/rsc_compile_integration_base.py
@@ -6,7 +6,7 @@ from pants.util.contextutil import environment_as
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
 
 
-def ensure_compile_rsc_execution_strategy(workflow):
+def ensure_compile_rsc_execution_strategy(workflow, **env_kwargs):
   """A decorator for running an integration test with ivy and coursier as the resolver."""
 
   def decorator(f):
@@ -16,7 +16,8 @@ def ensure_compile_rsc_execution_strategy(workflow):
           HERMETIC_ENV='PANTS_COMPILE_RSC_EXECUTION_STRATEGY',
           PANTS_COMPILE_RSC_EXECUTION_STRATEGY=strategy.value,
           PANTS_COMPILE_RSC_WORKFLOW=workflow.value,
-          PANTS_CACHE_COMPILE_RSC_IGNORE='True'):
+          PANTS_CACHE_COMPILE_RSC_IGNORE='True',
+          **env_kwargs):
           f(self, *args, **kwargs)
 
     return wrapper

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -15,7 +15,7 @@ class RscCompileIntegration(RscCompileIntegrationBase):
 
   @ensure_compile_rsc_execution_strategy(
     RscCompileIntegrationBase.rsc_and_zinc,
-    PANTS_WORKFLOW_OVERRIDE="zinc-only")
+    PANTS_COMPILE_RSC_WORKFLOW_OVERRIDE="zinc-only")
   def test_workflow_override(self):
     self._testproject_compile("mutual", "bin", "A", outline_result=False)
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -25,6 +25,22 @@ class RscCompileIntegration(RscCompileIntegrationBase):
         'm.jar')
       self.assert_is_file(rsc_header_jar)
 
+  @ensure_compile_rsc_execution_strategy(
+    RscCompileIntegrationBase.rsc_and_zinc,
+    PANTS_WORKFLOW_OVERRIDE="zinc-only")
+  def test_workflow_override(self):
+    with self.do_command_yielding_workdir('compile', 'testprojects/src/scala/org/pantsbuild/testproject/mutual:bin') as pants_run:
+      zinc_compiled_classfile = os.path.join(
+        pants_run.workdir,
+        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/zinc',
+        'classes/org/pantsbuild/testproject/mutual/A.class')
+      self.assert_is_file(zinc_compiled_classfile)
+      rsc_header_jar = os.path.join(
+        pants_run.workdir,
+        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/rsc',
+        'm.jar')
+      self.assert_is_not_file(rsc_header_jar)
+
   @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.rsc_and_zinc)
   def test_executing_multi_target_binary(self):
     pants_run = self.do_command('run', 'examples/src/scala/org/pantsbuild/example/hello/exe')

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration.py
@@ -1,8 +1,6 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
-
 from pants_test.backend.jvm.tasks.jvm_compile.rsc.rsc_compile_integration_base import (
   RscCompileIntegrationBase,
   ensure_compile_rsc_execution_strategy,
@@ -13,33 +11,13 @@ class RscCompileIntegration(RscCompileIntegrationBase):
 
   @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.rsc_and_zinc)
   def test_basic_binary(self):
-    with self.do_command_yielding_workdir('compile', 'testprojects/src/scala/org/pantsbuild/testproject/mutual:bin') as pants_run:
-      zinc_compiled_classfile = os.path.join(
-        pants_run.workdir,
-        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/zinc',
-        'classes/org/pantsbuild/testproject/mutual/A.class')
-      self.assert_is_file(zinc_compiled_classfile)
-      rsc_header_jar = os.path.join(
-        pants_run.workdir,
-        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/rsc',
-        'm.jar')
-      self.assert_is_file(rsc_header_jar)
+    self._testproject_compile("mutual", "bin", "A")
 
   @ensure_compile_rsc_execution_strategy(
     RscCompileIntegrationBase.rsc_and_zinc,
     PANTS_WORKFLOW_OVERRIDE="zinc-only")
   def test_workflow_override(self):
-    with self.do_command_yielding_workdir('compile', 'testprojects/src/scala/org/pantsbuild/testproject/mutual:bin') as pants_run:
-      zinc_compiled_classfile = os.path.join(
-        pants_run.workdir,
-        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/zinc',
-        'classes/org/pantsbuild/testproject/mutual/A.class')
-      self.assert_is_file(zinc_compiled_classfile)
-      rsc_header_jar = os.path.join(
-        pants_run.workdir,
-        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/rsc',
-        'm.jar')
-      self.assert_is_not_file(rsc_header_jar)
+    self._testproject_compile("mutual", "bin", "A", outline_result=False)
 
   @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.rsc_and_zinc)
   def test_executing_multi_target_binary(self):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
@@ -23,7 +23,7 @@ class RscCompileIntegrationYoutline(RscCompileIntegrationBase):
 
   @ensure_compile_rsc_execution_strategy(
     RscCompileIntegrationBase.outline_and_zinc,
-    PANTS_WORKFLOW_OVERRIDE="zinc-only")
+    PANTS_COMPILE_RSC_WORKFLOW_OVERRIDE="zinc-only")
   def test_workflow_override(self):
     self._testproject_compile("mutual", "bin", "A", outline_result=False)
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
@@ -25,5 +25,21 @@ class RscCompileIntegration(RscCompileIntegrationBase):
         'm.jar')
       self.assert_is_file(rsc_header_jar)
 
+  @ensure_compile_rsc_execution_strategy(
+    RscCompileIntegrationBase.outline_and_zinc,
+    PANTS_WORKFLOW_OVERRIDE="zinc-only")
+  def test_workflow_override(self):
+    with self.do_command_yielding_workdir('compile', 'testprojects/src/scala/org/pantsbuild/testproject/mutual:bin') as pants_run:
+      zinc_compiled_classfile = os.path.join(
+        pants_run.workdir,
+        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/zinc',
+        'classes/org/pantsbuild/testproject/mutual/A.class')
+      self.assert_is_file(zinc_compiled_classfile)
+      rsc_header_jar = os.path.join(
+        pants_run.workdir,
+        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/rsc',
+        'm.jar')
+      self.assert_is_not_file(rsc_header_jar)
+
   def test_youtline_hermetic_jvm_options(self):
     self._test_hermetic_jvm_options(self.outline_and_zinc)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
@@ -1,45 +1,31 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
-
 from pants_test.backend.jvm.tasks.jvm_compile.rsc.rsc_compile_integration_base import (
   RscCompileIntegrationBase,
   ensure_compile_rsc_execution_strategy,
 )
 
 
-class RscCompileIntegration(RscCompileIntegrationBase):
+class RscCompileIntegrationYoutline(RscCompileIntegrationBase):
 
   @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.outline_and_zinc)
   def test_basic_binary(self):
-    with self.do_command_yielding_workdir('compile', 'testprojects/src/scala/org/pantsbuild/testproject/mutual:bin') as pants_run:
-      zinc_compiled_classfile = os.path.join(
-        pants_run.workdir,
-        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/zinc',
-        'classes/org/pantsbuild/testproject/mutual/A.class')
-      self.assert_is_file(zinc_compiled_classfile)
-      rsc_header_jar = os.path.join(
-        pants_run.workdir,
-        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/rsc',
-        'm.jar')
-      self.assert_is_file(rsc_header_jar)
+    self._testproject_compile("mutual", "bin", "A")
+
+  @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.outline_and_zinc)
+  def test_public_inference_allowed(self):
+    self._testproject_compile("public_inference", "public_inference", "PublicInference", "--compile-rsc-allow-public-inference")
+      
+  @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.outline_and_zinc)
+  def test_public_inference_disallowed(self):
+    self._testproject_compile("public_inference", "public_inference", "PublicInference", success=False, zinc_result=True, outline_result=False)
 
   @ensure_compile_rsc_execution_strategy(
     RscCompileIntegrationBase.outline_and_zinc,
     PANTS_WORKFLOW_OVERRIDE="zinc-only")
   def test_workflow_override(self):
-    with self.do_command_yielding_workdir('compile', 'testprojects/src/scala/org/pantsbuild/testproject/mutual:bin') as pants_run:
-      zinc_compiled_classfile = os.path.join(
-        pants_run.workdir,
-        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/zinc',
-        'classes/org/pantsbuild/testproject/mutual/A.class')
-      self.assert_is_file(zinc_compiled_classfile)
-      rsc_header_jar = os.path.join(
-        pants_run.workdir,
-        'compile/rsc/current/testprojects.src.scala.org.pantsbuild.testproject.mutual.mutual/current/rsc',
-        'm.jar')
-      self.assert_is_not_file(rsc_header_jar)
+    self._testproject_compile("mutual", "bin", "A", outline_result=False)
 
   def test_youtline_hermetic_jvm_options(self):
     self._test_hermetic_jvm_options(self.outline_and_zinc)

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -531,7 +531,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
     self.assertTrue(os.path.isfile(file_path), f'file path {file_path} does not exist!')
 
   def assert_is_not_file(self, file_path):
-    self.assertTrue(not os.path.isfile(file_path), f'file path {file_path} exists!')
+    self.assertFalse(os.path.isfile(file_path), f'file path {file_path} exists!')
 
   def normalize(self, s: str) -> str:
     """Removes escape sequences (e.g. colored output) and all whitespace from string s."""

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -530,6 +530,9 @@ class PantsRunIntegrationTest(unittest.TestCase):
   def assert_is_file(self, file_path):
     self.assertTrue(os.path.isfile(file_path), f'file path {file_path} does not exist!')
 
+  def assert_is_not_file(self, file_path):
+    self.assertTrue(not os.path.isfile(file_path), f'file path {file_path} exists!')
+
   def normalize(self, s: str) -> str:
     """Removes escape sequences (e.g. colored output) and all whitespace from string s."""
     return ''.join(strip_color(s).split())


### PR DESCRIPTION
### Problem

This patch addresses 2 problems related to outlining workflows:
  1) We would like to be able to override the default workflow as well as all
  specified workflows for targets. For example, this would allow a user to
  quickly switch to zinc-only compiles even for targets which have been marked
  with a `use-compiler:{workflow}` tag.  
  2) We would like to allow public inference if wanted when using `scalac
  -Youtline` as the outliner.

### Solution

We introduce a `--allow-public-inference` flag under `compile.rsc` to disable
`wartremover` and its `PublicInference` rule from running during outlining. We
also add a `--workflow-override` option which will override every target's
`workflow` in the compile graph, regardless of the default `workflow` and tags.

### Result

Problems will have been solved.
