### PR TITLE
add PYTHONWARNINGS=ignore::DeprecationWarning to integration tests

### DIFF
--- a/tests/python/pants_test/bin/test_runner_integration.py
+++ b/tests/python/pants_test/bin/test_runner_integration.py
@@ -21,7 +21,7 @@ class RunnerIntegrationTest(PantsRunIntegrationTest):
       'deprecation-warning-task',
     ]
 
-    warning_run = self.run_pants(cmdline)
+    warning_run = self.run_pants(cmdline, extra_env={'PYTHONWARNINGS': ''})
     self.assert_success(warning_run)
     self.assertRegex(
       warning_run.stderr_data,

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -355,6 +355,8 @@ class PantsRunIntegrationTest(unittest.TestCase):
           env[h] = os.getenv(h)
     else:
       env = os.environ.copy()
+
+    env.update(PYTHONWARNINGS='ignore::DeprecationWarning')
     if extra_env:
       env.update(extra_env)
     env.update(PYTHONPATH=os.pathsep.join(sys.path))


### PR DESCRIPTION
### Problem

Fixes #8539.

### Solution

- Ignore deprecation warning messages on all integration tests.

### Result

master is unbroken!