### PR TITLE
Trim travis cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ matrix:
     before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
     - find build-support -name "*.py[co]" -delete
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
@@ -104,6 +105,7 @@ matrix:
     before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
     - find build-support -name "*.py[co]" -delete
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
@@ -146,6 +148,7 @@ matrix:
     before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
     - find build-support -name "*.py[co]" -delete
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
       -o /usr/local/bin/jq
@@ -187,6 +190,7 @@ matrix:
     before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
     - find build-support -name "*.py[co]" -delete
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
       -o /usr/local/bin/jq
@@ -239,6 +243,7 @@ matrix:
     before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
     - find build-support -name "*.py[co]" -delete
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
@@ -282,6 +287,7 @@ matrix:
     before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
     - find build-support -name "*.py[co]" -delete
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64
       -o /usr/local/bin/jq
@@ -339,6 +345,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -400,6 +407,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -461,6 +469,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -518,6 +527,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -558,6 +568,7 @@ matrix:
   - before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
     - find build-support -name "*.py[co]" -delete
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -636,6 +647,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -696,6 +708,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -756,6 +769,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -851,6 +865,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -908,6 +923,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -965,6 +981,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1022,6 +1039,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1079,6 +1097,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1136,6 +1155,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1193,6 +1213,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1250,6 +1271,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1308,6 +1330,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1366,6 +1389,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1424,6 +1448,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1482,6 +1507,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1540,6 +1566,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1598,6 +1625,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1656,6 +1684,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1714,6 +1743,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1772,6 +1802,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1830,6 +1861,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1888,6 +1920,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -1946,6 +1979,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -2004,6 +2038,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -2044,6 +2079,7 @@ matrix:
   - before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
     - find build-support -name "*.py[co]" -delete
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -2081,6 +2117,7 @@ matrix:
   - before_cache:
     - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
     - find build-support -name "*.py[co]" -delete
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - ./build-support/bin/install_python_for_ci.sh "${PYENV_PY36_VERSION}"
     - brew cask install osxfuse
@@ -2283,6 +2320,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -2343,6 +2381,7 @@ matrix:
     - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
     - rm -rf ${HOME}/.ivy2/pants/com.example
     - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
     before_install:
     - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -363,7 +363,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -425,7 +424,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -484,7 +482,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -542,7 +539,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -665,7 +661,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -726,7 +721,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -785,7 +779,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -880,7 +873,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -938,7 +930,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -996,7 +987,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1054,7 +1044,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1112,7 +1101,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1170,7 +1158,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1228,7 +1215,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1286,7 +1272,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1345,7 +1330,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1404,7 +1388,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1463,7 +1446,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1522,7 +1504,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1581,7 +1562,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1640,7 +1620,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1699,7 +1678,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1758,7 +1736,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1817,7 +1794,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1876,7 +1852,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1935,7 +1910,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -1994,7 +1968,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -2053,7 +2026,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -2339,7 +2311,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants
@@ -2400,7 +2371,6 @@ matrix:
       directories:
       - ${AWS_CLI_ROOT}
       - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
       - ${HOME}/.ivy2/pants

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ env:
   - PYENV_PY27_VERSION=2.7.15
   - PYENV_PY36_VERSION=3.6.8
   - PYENV_PY37_VERSION=3.7.2
-  - PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"
+  - PYENV_ROOT_OSX=${HOME}/.pants_pyenv
+  - PYENV_ROOT="${PYENV_ROOT:-${PYENV_ROOT_OSX}}"
   - PATH="${PYENV_ROOT}/shims:${PATH}"
   - AWS_CLI_ROOT="${HOME}/.aws_cli"
   - AWS_ACCESS_KEY_ID__TO_BE_REEXPORTED_ON_DEPLOYS=AKIAV6A6G7RQWPRUWIXR
@@ -57,7 +58,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -114,7 +115,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -161,7 +162,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -203,7 +204,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -252,7 +253,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -300,7 +301,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -361,7 +362,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -423,7 +424,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -482,7 +483,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -540,7 +541,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -585,7 +586,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -663,7 +664,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -724,7 +725,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -783,7 +784,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -878,7 +879,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -936,7 +937,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -994,7 +995,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1052,7 +1053,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1110,7 +1111,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1168,7 +1169,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1226,7 +1227,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1284,7 +1285,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1343,7 +1344,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1402,7 +1403,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1461,7 +1462,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1520,7 +1521,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1579,7 +1580,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1638,7 +1639,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1697,7 +1698,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1756,7 +1757,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1815,7 +1816,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1874,7 +1875,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1933,7 +1934,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1992,7 +1993,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -2051,7 +2052,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -2096,7 +2097,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -2127,7 +2128,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -2337,7 +2338,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -2398,7 +2399,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
+      - ${PYENV_ROOT_OSX}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -113,6 +114,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -159,6 +161,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -200,6 +203,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -248,6 +252,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -295,6 +300,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -355,6 +361,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -416,6 +423,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -474,6 +482,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -531,6 +540,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -575,6 +585,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -652,6 +663,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -712,6 +724,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -770,6 +783,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -864,6 +878,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -921,6 +936,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -978,6 +994,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1035,6 +1052,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1092,6 +1110,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1149,6 +1168,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1206,6 +1226,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1263,6 +1284,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1321,6 +1343,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1379,6 +1402,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1437,6 +1461,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1495,6 +1520,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1553,6 +1579,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1611,6 +1638,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1669,6 +1697,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1727,6 +1756,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1785,6 +1815,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1843,6 +1874,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1901,6 +1933,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1959,6 +1992,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -2017,6 +2051,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -2061,6 +2096,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -2091,6 +2127,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -2300,6 +2337,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -2360,6 +2398,7 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -114,7 +113,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -161,7 +159,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -203,7 +200,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -252,7 +248,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -300,7 +295,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -361,7 +355,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -423,7 +416,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -482,7 +474,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -540,7 +531,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -585,7 +575,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -663,7 +652,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -724,7 +712,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -783,7 +770,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -878,7 +864,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -936,7 +921,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -994,7 +978,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1052,7 +1035,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1110,7 +1092,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1168,7 +1149,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1226,7 +1206,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1284,7 +1263,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1343,7 +1321,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1402,7 +1379,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1461,7 +1437,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1520,7 +1495,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1579,7 +1553,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1638,7 +1611,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1697,7 +1669,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1756,7 +1727,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1815,7 +1785,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1874,7 +1843,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1933,7 +1901,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -1992,7 +1959,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -2051,7 +2017,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -2096,7 +2061,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -2127,7 +2091,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/rust/cargo
       - build-support/virtualenvs
       - src/rust/engine/target
@@ -2337,7 +2300,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc
@@ -2398,7 +2360,6 @@ matrix:
     cache:
       directories:
       - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT}
       - ${HOME}/.cache/pants/lmdb_store
       - ${HOME}/.cache/pants/tools
       - ${HOME}/.cache/pants/zinc

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -156,7 +156,7 @@ def docker_run_travis_ci_image(command: str) -> str:
 # The default timeout is 180 seconds, and our larger cache uploads exceed this.
 # TODO: Now that we trim caches, perhaps we no longer need this modified timeout.
 _cache_timeout = 500
-_cache_common_directories = ['${AWS_CLI_ROOT}', '${PYENV_ROOT}']
+_cache_common_directories = ['${AWS_CLI_ROOT}']
 # Ensure permissions to do the below removals, which happen with or without caching enabled.
 _cache_set_required_permissions = 'sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"'
 

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -204,9 +204,6 @@ CACHE_PANTS_RUN = {
   "cache": {
     "timeout": _cache_timeout,
     "directories": _cache_common_directories + [
-      # We include the lmdb_store to include a local process cache, so that hopefully we don't
-      # need to re-run processes (particularly tests) which have already run.
-      '${HOME}/.cache/pants/lmdb_store',
       '${HOME}/.cache/pants/tools',
       '${HOME}/.cache/pants/zinc',
       '${HOME}/.ivy2/pants',

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -154,7 +154,7 @@ def docker_run_travis_ci_image(command: str) -> str:
 # ----------------------------------------------------------------------
 
 # The default timeout is 180 seconds, and our larger cache uploads exceed this.
-# TODO: Figure out why we have such large caches (2-7GB) and try to trim them.
+# TODO: Now that we trim caches, perhaps we no longer need this modified timeout.
 _cache_timeout = 500
 _cache_common_directories = ['${AWS_CLI_ROOT}', '${PYENV_ROOT}']
 # Ensure permissions to do the below removals, which happen with or without caching enabled.
@@ -167,6 +167,7 @@ CACHE_NATIVE_ENGINE = {
     # get bytecode compiled in non-yet-understood circumstances leading to
     # a full cache re-pack due to new bytecode files.
     'find build-support -name "*.py[co]" -delete',
+    './build-support/bin/prune_travis_cache.sh',
   ],
   "cache": {
     "timeout": _cache_timeout,
@@ -195,13 +196,13 @@ CACHE_PANTS_RUN = {
     'rm -rf ${HOME}/.ivy2/pants/com.example',
     # Render a summary to assist with further tuning the cache.
     'du -m -d2 ${HOME}/.cache/pants | sort -r -n',
+    './build-support/bin/prune_travis_cache.sh',
   ],
   "cache": {
     "timeout": _cache_timeout,
     "directories": _cache_common_directories + [
       # We include the lmdb_store to include a local process cache, so that hopefully we don't
       # need to re-run processes (particularly tests) which have already run.
-      # TODO(#8041): Prune this directory before storing the cache.
       '${HOME}/.cache/pants/lmdb_store',
       '${HOME}/.cache/pants/tools',
       '${HOME}/.cache/pants/zinc',

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -58,7 +58,8 @@ GLOBAL_ENV_VARS = [
   # NB: We must set `PYENV_ROOT` on macOS for Pyenv to work properly. However, on Linux, we must not
   # override the default value because Linux pre-installs Python via Pyenv and we must keep their
   # $PYENV_ROOT for this to still work.
-  'PYENV_ROOT="${PYENV_ROOT:-${HOME}/.pants_pyenv}"',
+  'PYENV_ROOT_OSX=${HOME}/.pants_pyenv',
+  'PYENV_ROOT="${PYENV_ROOT:-${PYENV_ROOT_OSX}}"',
   'PATH="${PYENV_ROOT}/shims:${PATH}"',
   'AWS_CLI_ROOT="${HOME}/.aws_cli"',
   # NB: We use this verbose name so that AWS does not pick up the env var $AWS_ACCESS_KEY_ID on
@@ -156,7 +157,9 @@ def docker_run_travis_ci_image(command: str) -> str:
 # The default timeout is 180 seconds, and our larger cache uploads exceed this.
 # TODO: Now that we trim caches, perhaps we no longer need this modified timeout.
 _cache_timeout = 500
-_cache_common_directories = ['${AWS_CLI_ROOT}']
+# NB: Attempting to cache directories that don't exist (e.g., the custom osx pyenv root on linux) causes no harm,
+# and simplifies the code.
+_cache_common_directories = ['${AWS_CLI_ROOT}', '${PYENV_ROOT_OSX}']
 # Ensure permissions to do the below removals, which happen with or without caching enabled.
 _cache_set_required_permissions = 'sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"'
 

--- a/build-support/bin/prune_travis_cache.sh
+++ b/build-support/bin/prune_travis_cache.sh
@@ -3,11 +3,11 @@
 function nuke_if_too_big() {
   path=$1
   limit_mb=$2
-  actual_mb=$(du -m -d0 ${path} | cut -f 1)
+  actual_mb=$(du -m -d0 "${path}" | cut -f 1)
   echo "Size of ${path}: ${actual_mb}MB"
-  if (( ${actual_mb} > ${limit_mb} )); then
+  if (( actual_mb > limit_mb )); then
     echo "${path} is too large, nuking it."
-    rm -rf ${path}
+    rm -rf "${path}"
   fi
 }
 
@@ -16,13 +16,13 @@ function nuke_if_too_big() {
 # Note that some of these dirs are only relevant to native code building shards, and others only to
 # pants running shards. However there's no harm in checking them all in both cases.
 
-nuke_if_too_big ${HOME}/.pants_pyenv 9999
-nuke_if_too_big ${HOME}/.aws_cli 9999
-nuke_if_too_big ${HOME}/.cache/pants/lmdb_store 1024
-nuke_if_too_big ${HOME}/.cache/pants/tools 9999
-nuke_if_too_big ${HOME}/.cache/pants/zinc 9999
-nuke_if_too_big ${HOME}/.ivy2/pants 9999
-nuke_if_too_big ${HOME}/.npm 9999
-nuke_if_too_big ${HOME}/.cache/pants/rust/cargo 9999
+nuke_if_too_big "${HOME}/.pants_pyenv" 9999
+nuke_if_too_big "${HOME}/.aws_cli" 9999
+nuke_if_too_big "${HOME}/.cache/pants/lmdb_store" 1024
+nuke_if_too_big "${HOME}/.cache/pants/tools" 9999
+nuke_if_too_big "${HOME}/.cache/pants/zinc" 9999
+nuke_if_too_big "${HOME}/.ivy2/pants" 9999
+nuke_if_too_big "${HOME}/.npm" 9999
+nuke_if_too_big "${HOME}/.cache/pants/rust/cargo" 9999
 nuke_if_too_big build-support/virtualenvs 9999
 nuke_if_too_big src/rust/engine/target 9999

--- a/build-support/bin/prune_travis_cache.sh
+++ b/build-support/bin/prune_travis_cache.sh
@@ -31,7 +31,7 @@ nuke_if_too_big "${HOME}/.cache/pants/zinc" 128
 nuke_if_too_big "${HOME}/.ivy2/pants" 512
 nuke_if_too_big "${HOME}/.npm" 128
 nuke_if_too_big build-support/virtualenvs 128
-nuke_if_too_big src/rust/engine/target 1024
+nuke_if_too_big src/rust/engine/target 3072
 
 # Note that we don't prune all of ${HOME}/.cache/pants/rust/cargo, as it mostly contains git
 # checkouts of rust deps, notably grpc, which is huge and takes forever to clone.

--- a/build-support/bin/prune_travis_cache.sh
+++ b/build-support/bin/prune_travis_cache.sh
@@ -21,8 +21,10 @@ function nuke_if_too_big() {
 
 # Prune the dirs we cache on travis if they get too big.
 # Note that some of these dirs are only relevant to native code building shards, and others only to
-# pants running shards. However there's no harm in checking them all in both cases.
+# pants running shards. And some only to linux or only to osx.
+# However there's no harm in checking them all in all cases.
 
+nuke_if_too_big "${HOME}/.pants_pyenv" 512
 nuke_if_too_big "${HOME}/.aws_cli" 128
 nuke_if_too_big "${HOME}/.cache/pants/lmdb_store" 1024
 nuke_if_too_big "${HOME}/.cache/pants/tools" 128

--- a/build-support/bin/prune_travis_cache.sh
+++ b/build-support/bin/prune_travis_cache.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+function nuke_if_too_big() {
+  path=$1
+  limit_mb=$2
+  actual_mb=$(du -m -d0 ${path} | cut -f 1)
+  echo "Size of ${path}: ${actual_mb}MB"
+  if (( ${actual_mb} > ${limit_mb} )); then
+    echo "${path} is too large, nuking it."
+    rm -rf ${path}
+  fi
+}
+
+
+# Prune the dirs we cache on travis if they get too big.
+# Note that some of these dirs are only relevant to native code building shards, and others only to
+# pants running shards. However there's no harm in checking them all in both cases.
+
+nuke_if_too_big ${HOME}/.pants_pyenv 9999
+nuke_if_too_big ${HOME}/.aws_cli 9999
+nuke_if_too_big ${HOME}/.cache/pants/lmdb_store 1024
+nuke_if_too_big ${HOME}/.cache/pants/tools 9999
+nuke_if_too_big ${HOME}/.cache/pants/zinc 9999
+nuke_if_too_big ${HOME}/.ivy2/pants 9999
+nuke_if_too_big ${HOME}/.npm 9999
+nuke_if_too_big ${HOME}/.cache/pants/rust/cargo 9999
+nuke_if_too_big build-support/virtualenvs 9999
+nuke_if_too_big src/rust/engine/target 9999

--- a/build-support/bin/prune_travis_cache.sh
+++ b/build-support/bin/prune_travis_cache.sh
@@ -3,11 +3,18 @@
 function nuke_if_too_big() {
   path=$1
   limit_mb=$2
-  actual_mb=$(du -m -d0 "${path}" | cut -f 1)
-  echo "Size of ${path}: ${actual_mb}MB"
-  if (( actual_mb > limit_mb )); then
-    echo "${path} is too large, nuking it."
-    rm -rf "${path}"
+  echo "## Pruning ${path} (if larger than ${limit_mb}MB)..."
+  if [ -d ${path} ]; then
+    actual_mb=$(du -m -d0 "${path}" | cut -f 1)
+    echo "Size of ${path}: ${actual_mb}MB"
+    if (( actual_mb > limit_mb )); then
+      echo "${path} is too large, nuking it."
+      rm -rf "${path}"
+    else
+      echo "${path} is not too large, leaving it."
+    fi
+  else
+    echo "Directory ${path} doesn't exist."
   fi
 }
 
@@ -16,13 +23,12 @@ function nuke_if_too_big() {
 # Note that some of these dirs are only relevant to native code building shards, and others only to
 # pants running shards. However there's no harm in checking them all in both cases.
 
-nuke_if_too_big "${HOME}/.pants_pyenv" 9999
-nuke_if_too_big "${HOME}/.aws_cli" 9999
+nuke_if_too_big "${HOME}/.aws_cli" 128
 nuke_if_too_big "${HOME}/.cache/pants/lmdb_store" 1024
-nuke_if_too_big "${HOME}/.cache/pants/tools" 9999
-nuke_if_too_big "${HOME}/.cache/pants/zinc" 9999
-nuke_if_too_big "${HOME}/.ivy2/pants" 9999
-nuke_if_too_big "${HOME}/.npm" 9999
-nuke_if_too_big "${HOME}/.cache/pants/rust/cargo" 9999
-nuke_if_too_big build-support/virtualenvs 9999
-nuke_if_too_big src/rust/engine/target 9999
+nuke_if_too_big "${HOME}/.cache/pants/tools" 128
+nuke_if_too_big "${HOME}/.cache/pants/zinc" 128
+nuke_if_too_big "${HOME}/.ivy2/pants" 512
+nuke_if_too_big "${HOME}/.npm" 128
+nuke_if_too_big "${HOME}/.cache/pants/rust/cargo" 1024
+nuke_if_too_big build-support/virtualenvs 128
+nuke_if_too_big src/rust/engine/target 1024

--- a/build-support/bin/prune_travis_cache.sh
+++ b/build-support/bin/prune_travis_cache.sh
@@ -31,6 +31,10 @@ nuke_if_too_big "${HOME}/.cache/pants/tools" 128
 nuke_if_too_big "${HOME}/.cache/pants/zinc" 128
 nuke_if_too_big "${HOME}/.ivy2/pants" 512
 nuke_if_too_big "${HOME}/.npm" 128
-nuke_if_too_big "${HOME}/.cache/pants/rust/cargo" 1024
 nuke_if_too_big build-support/virtualenvs 128
 nuke_if_too_big src/rust/engine/target 1024
+
+# Note that we don't prune all of ${HOME}/.cache/pants/rust/cargo, as it mostly contains git
+# checkouts of rust deps, notably grpc, which is huge and takes forever to clone.
+# We don't expect that data to grow rapidly anyway.
+nuke_if_too_big "${HOME}/.cache/pants/rust/cargo/registry" 512

--- a/build-support/bin/prune_travis_cache.sh
+++ b/build-support/bin/prune_travis_cache.sh
@@ -26,7 +26,6 @@ function nuke_if_too_big() {
 
 nuke_if_too_big "${HOME}/.pants_pyenv" 512
 nuke_if_too_big "${HOME}/.aws_cli" 128
-nuke_if_too_big "${HOME}/.cache/pants/lmdb_store" 1024
 nuke_if_too_big "${HOME}/.cache/pants/tools" 128
 nuke_if_too_big "${HOME}/.cache/pants/zinc" 128
 nuke_if_too_big "${HOME}/.ivy2/pants" 512

--- a/build-support/bin/prune_travis_cache.sh
+++ b/build-support/bin/prune_travis_cache.sh
@@ -4,7 +4,7 @@ function nuke_if_too_big() {
   path=$1
   limit_mb=$2
   echo "## Pruning ${path} (if larger than ${limit_mb}MB)..."
-  if [ -d ${path} ]; then
+  if [[ -d "${path}" ]]; then
     actual_mb=$(du -m -d0 "${path}" | cut -f 1)
     echo "Size of ${path}: ${actual_mb}MB"
     if (( actual_mb > limit_mb )); then


### PR DESCRIPTION
Should save time on uploads when the cache gets bloated.
May also help fix the SIGBUS error, as it might be related
to overly large lmdb mmaps.
