### PR TITLE
Temporarily disable speculation in travis

### DIFF
--- a/pants.remote.ini
+++ b/pants.remote.ini
@@ -26,7 +26,9 @@ remote_execution_extra_platform_properties: [
 # This should correspond to the number of workers running in Google RBE. See
 # https://console.cloud.google.com/apis/api/remotebuildexecution.googleapis.com/quotas?project=pants-remoting-beta&folder&organizationId&duration=PT6H.
 process_execution_remote_parallelism: 32
-process_execution_speculation_strategy: remote_first
+# TODO: Temporarily disabling speculation until we're able to confirm that it never causes a
+# negative performance impact.
+process_execution_speculation_strategy: none
 # p95 of RBE appears to be ~ 2 seconds, but we need to factor in local queue time which can be much longer, but no metrics yet.
 process_execution_speculation_delay: 15
 


### PR DESCRIPTION
### Problem

Speculation currently seems to cause a significant performance impact in the context of remote testing: see #8498. 

### Solution

Until we have time to investigate and fix that issue (hopefully later this week), let's disable it. Fixes #8498.