### PR TITLE
Shard the v2 integration tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -429,7 +429,7 @@ matrix:
     - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
     - CACHE_NAME=integration.v2.py37
     language: python
-    name: Integration tests - V2 (Python 3.7)
+    name: Integration tests - V2 - shard 0 (Python 3.7)
     os: linux
     python:
     - '2.7'
@@ -437,7 +437,70 @@ matrix:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --integration-tests-v2 --remote-execution-enabled --python-version 3.7
+      --integration-tests-v2 --integration-shard 0/2 --remote-execution-enabled --python-version
+      3.7
+    stage: Test Pants (Cron)
+    sudo: required
+  - addons:
+      apt:
+        packages:
+        - lib32stdc++6
+        - lib32z1
+        - lib32z1-dev
+        - gcc-multilib
+        - python-dev
+        - openssl
+        - libssl-dev
+        - jq
+        - unzip
+        - shellcheck
+    after_failure:
+    - ./build-support/bin/ci-failure.sh
+    before_cache:
+    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
+    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
+    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
+    - rm -rf ${HOME}/.ivy2/pants/com.example
+    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    before_install:
+    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
+    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - sudo sysctl fs.inotify.max_user_watches=524288
+    - ./build-support/bin/install_aws_cli_for_ci.sh
+    - pyenv global 2.7.15 3.6.7 3.7.1
+    - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
+      | tar -zxvf - travis-wait-enhanced
+    - mv travis-wait-enhanced /home/travis/bin/
+    before_script:
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
+      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    cache:
+      directories:
+      - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
+      - ${HOME}/.cache/pants/lmdb_store
+      - ${HOME}/.cache/pants/tools
+      - ${HOME}/.cache/pants/zinc
+      - ${HOME}/.ivy2/pants
+      - ${HOME}/.npm
+      timeout: 500
+    dist: xenial
+    env:
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
+    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
+    - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
+    - CACHE_NAME=integration.v2.py37
+    language: python
+    name: Integration tests - V2 - shard 1 (Python 3.7)
+    os: linux
+    python:
+    - '2.7'
+    - '3.6'
+    - '3.7'
+    script:
+    - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
+      --integration-tests-v2 --integration-shard 1/2 --remote-execution-enabled --python-version
+      3.7
     stage: Test Pants (Cron)
     sudo: required
   - addons:
@@ -724,7 +787,7 @@ matrix:
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v2.py36
     language: python
-    name: Integration tests - V2 (Python 3.6)
+    name: Integration tests - V2 - shard 0 (Python 3.6)
     os: linux
     python:
     - '2.7'
@@ -732,7 +795,69 @@ matrix:
     - '3.7'
     script:
     - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --integration-tests-v2 --remote-execution-enabled --python-version 3.6
+      --integration-tests-v2 --integration-shard 0/2 --remote-execution-enabled --python-version
+      3.6
+    stage: Test Pants
+    sudo: required
+  - addons:
+      apt:
+        packages:
+        - lib32stdc++6
+        - lib32z1
+        - lib32z1-dev
+        - gcc-multilib
+        - python-dev
+        - openssl
+        - libssl-dev
+        - jq
+        - unzip
+        - shellcheck
+    after_failure:
+    - ./build-support/bin/ci-failure.sh
+    before_cache:
+    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
+    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
+    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
+    - rm -rf ${HOME}/.ivy2/pants/com.example
+    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    before_install:
+    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
+    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - sudo sysctl fs.inotify.max_user_watches=524288
+    - ./build-support/bin/install_aws_cli_for_ci.sh
+    - pyenv global 2.7.15 3.6.7 3.7.1
+    - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
+      | tar -zxvf - travis-wait-enhanced
+    - mv travis-wait-enhanced /home/travis/bin/
+    before_script:
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
+      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    cache:
+      directories:
+      - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT}
+      - ${HOME}/.cache/pants/lmdb_store
+      - ${HOME}/.cache/pants/tools
+      - ${HOME}/.cache/pants/zinc
+      - ${HOME}/.ivy2/pants
+      - ${HOME}/.npm
+      timeout: 500
+    dist: xenial
+    env:
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
+    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
+    - CACHE_NAME=integration.v2.py36
+    language: python
+    name: Integration tests - V2 - shard 1 (Python 3.6)
+    os: linux
+    python:
+    - '2.7'
+    - '3.6'
+    - '3.7'
+    script:
+    - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
+      --integration-tests-v2 --integration-shard 1/2 --remote-execution-enabled --python-version
+      3.6
     stage: Test Pants
     sudo: required
   - addons:

--- a/build-support/bin/ci.py
+++ b/build-support/bin/ci.py
@@ -50,7 +50,8 @@ def main() -> None:
     if args.integration_tests_v1:
       run_integration_tests_v1(shard=args.integration_shard)
     if args.integration_tests_v2:
-      run_integration_tests_v2(oauth_token_path=remote_execution_oauth_token_path)
+      run_integration_tests_v2(oauth_token_path=remote_execution_oauth_token_path,
+                               shard=args.integration_shard)
     if args.plugin_tests:
       run_plugin_tests(oauth_token_path=remote_execution_oauth_token_path)
     if args.platform_specific_tests:
@@ -511,14 +512,14 @@ def run_integration_tests_v1(*, shard: Optional[str]) -> None:
     )
 
 
-def run_integration_tests_v2(*, oauth_token_path: Optional[str] = None) -> None:
+def run_integration_tests_v2(*, oauth_token_path: Optional[str], shard: Optional[str]) -> None:
   target_sets = TestTargetSets.calculate(
     test_type=TestType.integration, remote_execution_enabled=oauth_token_path is not None
   )
   if target_sets.v2_remote:
     _run_command(
       command=TestStrategy.v2_remote.pants_command(
-        targets=target_sets.v2_remote, oauth_token_path=oauth_token_path
+        targets=target_sets.v2_remote, oauth_token_path=oauth_token_path, shard=shard
       ),
       slug="IntegrationTestsV2Remote",
       start_message="Running integration tests via V2 remote strategy.",
@@ -526,7 +527,7 @@ def run_integration_tests_v2(*, oauth_token_path: Optional[str] = None) -> None:
     )
   if target_sets.v2_local:
     _run_command(
-      command=TestStrategy.v2_local.pants_command(targets=target_sets.v2_local),
+      command=TestStrategy.v2_local.pants_command(targets=target_sets.v2_local, shard=shard),
       slug="IntegrationTestsV2Local",
       start_message="Running integration tests via V2 local strategy.",
       die_message="Integration test failure (V2 local)",


### PR DESCRIPTION
The single shard runs for over an hour, which causes
GCP tokens to expire.
