### PR TITLE
Revert "Cache the result of readlink(".pants.d"): (#8302)"

### DIFF
--- a/src/python/pants/cache/cache_setup.py
+++ b/src/python/pants/cache/cache_setup.py
@@ -270,11 +270,7 @@ class CacheFactory:
     if compression not in range(1, 10):
       raise ValueError('compression_level must be an integer 1-9: {}'.format(compression))
 
-    # While compiling a largish target for the first time we end up making
-    # ~500k calls to readlink to expand the .pants.d symlink, which, in a
-    # virtual filesystem like FUSE might not be cached. Caching it improves the
-    # build time by upto 30%.
-    artifact_root = os.readlink(self._options.pants_workdir) if os.path.islink(self._options.pants_workdir) else self._options.pants_workdir
+    artifact_root = self._options.pants_workdir
 
     def create_local_cache(parent_path):
       path = os.path.join(parent_path, self._cache_dirname)


### PR DESCRIPTION
This reverts commit 725d5d5b9aed59a800eaa1b60f3e488c95f8c8c4.

### Problem

It breaks caching in that the tgz will contain content that goes outside the root of the destination directory.

E.g.
```

[tw-mbp-user 456t]$ tar -xvf /Users/user/.cache/pants/buildcache//2c0541bbbe9eb526b794621efc071cccf1a4b2e0/.pants.d.gen.scrooge.55f6998c5e42.src.thr.b046fec79eca05a4.com.example.timelines.render.thrift-scala/62ecbbbe2910bdc04bf6b6c029326769a632a274-ResolvedJarAwareFingerprintStrategy.c141cc01c5a4_575ab3bdd369.tgz
--
x ../../../Users/user/workspace/s2/.pants.d/compile/rsc/c1e3836b60e5/.pants.d.gen.scrooge.55f6998c5e42.src.thr.b046fec79eca05a4.com.example.timelines.render.thrift-scala/010431ca9da3/: Path contains '..'
x ../../../Users/user/workspace/s2/.pants.d/compile/rsc/c1e3836b60e5/.pants.d.gen.scrooge.55f6998c5e42.src.thr.b046fec79eca05a4.com.example.timelines.render.thrift-scala/010431ca9da3/zinc/: Path contains '..'
```
which then followed by a silent tarball decompress. 