### PR TITLE
Eagerly fail deprecated options

### DIFF
--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -194,7 +194,7 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
             site.getsitepackages = lambda: sys.path[:]
 
-
+            
             runpy.run_module('mypy', run_name='__main__')
           """))
           exe_fp.flush()

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -57,8 +57,6 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
   @classmethod
   def register_options(cls, register):
-    register('--mypy-version', default='0.720', help='The version of mypy to use.',
-             removal_version='1.24.0.dev1', removal_hint='Use --version instead.')
     register('--version', default='0.720', help='The version of mypy to use.')
     register('--include-requirements', type=bool, default=False,
              help='Whether to include the transitive requirements of targets being checked. This is'
@@ -155,8 +153,7 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
     return PythonInterpreterCache.global_instance()
 
   def _get_mypy_pex(self, py3_interpreter: PythonInterpreter, *extra_pexes: PEX) -> PEX:
-    options = self.get_options()
-    mypy_version = options.mypy_version if options.is_flagged('mypy_version') else options.version
+    mypy_version = self.get_options().version
     extras_hash = hash_utils.hash_all(hash_utils.hash_dir(Path(extra_pex.path()))
                                       for extra_pex in extra_pexes)
 
@@ -194,7 +191,7 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
             site.getsitepackages = lambda: sys.path[:]
 
-            
+
             runpy.run_module('mypy', run_name='__main__')
           """))
           exe_fp.flush()

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -57,6 +57,8 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
   @classmethod
   def register_options(cls, register):
+    register('--mypy-version', default='0.720', help='The version of mypy to use.',
+             removal_version='1.24.0.dev1', removal_hint='Use --version instead.')
     register('--version', default='0.720', help='The version of mypy to use.')
     register('--include-requirements', type=bool, default=False,
              help='Whether to include the transitive requirements of targets being checked. This is'
@@ -153,7 +155,8 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
     return PythonInterpreterCache.global_instance()
 
   def _get_mypy_pex(self, py3_interpreter: PythonInterpreter, *extra_pexes: PEX) -> PEX:
-    mypy_version = self.get_options().version
+    options = self.get_options()
+    mypy_version = options.mypy_version if options.is_flagged('mypy_version') else options.version
     extras_hash = hash_utils.hash_all(hash_utils.hash_dir(Path(extra_pex.path()))
                                       for extra_pex in extra_pexes)
 

--- a/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
@@ -290,13 +290,6 @@ class JvmPlatformExplain(JvmPlatformAnalysisMixin, ConsoleTask):
     register('--filter',
              help='Limit jvm platform possibility explanation to targets whose specs match this '
                   'regex pattern.')
-
-    # TODO: remove `_register_console_transitivity_option` from ConsoleTask when this deprecation
-    # cycle is complete!
-    register('--transitive', type=bool,
-             removal_version='1.22.0.dev0',
-             removal_hint='Use --list-transitive-deps instead!',
-             help='List transitive dependencies in analysis output.')
     register('--list-transitive-deps', type=bool,
              help='List transitive dependencies in analysis output.')
 
@@ -315,7 +308,7 @@ class JvmPlatformExplain(JvmPlatformAnalysisMixin, ConsoleTask):
 
   @memoized_property
   def dependency_map(self):
-    if not (self.get_options().transitive or self.get_options().list_transitive_deps):
+    if not self.get_options().list_transitive_deps:
       return self.jvm_dependency_map
     full_map = self._unfiltered_jvm_dependency_map(fully_transitive=True)
     return {target: deps for target, deps in full_map.items()

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -136,6 +136,7 @@ def warn_or_error(
   frame_info: Optional[inspect.FrameInfo] = None,
   context: int = 1,
   ensure_stderr: bool = False,
+  print_warning: bool = True,
 ) -> None:
   """Check the removal_version against the current pants version.
 
@@ -193,7 +194,7 @@ def warn_or_error(
       warning_msg = warnings.formatwarning(
         msg, DeprecationWarning, filename, line_number, line=context_lines)
       print(warning_msg, file=sys.stderr)
-    else:
+    elif print_warning:
       # This output is filtered by warning filters.
       with _greater_warnings_context(context_lines):
         warnings.warn_explicit(

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -136,7 +136,6 @@ def warn_or_error(
   frame_info: Optional[inspect.FrameInfo] = None,
   context: int = 1,
   ensure_stderr: bool = False,
-  print_warning: bool = True,
 ) -> None:
   """Check the removal_version against the current pants version.
 
@@ -188,7 +187,7 @@ def warn_or_error(
   else:
     context_lines = '<no code context available>'
 
-  if removal_semver > PANTS_SEMVER and print_warning:
+  if removal_semver > PANTS_SEMVER:
     if ensure_stderr:
       # No warning filters can stop us from printing this message directly to stderr.
       warning_msg = warnings.formatwarning(

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -157,6 +157,7 @@ def warn_or_error(
                   in a warning message.
   :param ensure_stderr: Whether use warnings.warn, or use warnings.showwarning to print
                         directly to stderr.
+  :param print_warning: Whether a warnings.WarningMessage object should be created.
   :raises DeprecationApplicationError: if the removal_version parameter is invalid.
   :raises CodeRemovedError: if the current version is later than the version marked for removal.
   """

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -135,7 +135,8 @@ def warn_or_error(
   stacklevel: int = 3,
   frame_info: Optional[inspect.FrameInfo] = None,
   context: int = 1,
-  ensure_stderr: bool = False
+  ensure_stderr: bool = False,
+  print_warning: bool = True,
 ) -> None:
   """Check the removal_version against the current pants version.
 
@@ -187,7 +188,7 @@ def warn_or_error(
   else:
     context_lines = '<no code context available>'
 
-  if removal_semver > PANTS_SEMVER:
+  if removal_semver > PANTS_SEMVER and print_warning:
     if ensure_stderr:
       # No warning filters can stop us from printing this message directly to stderr.
       warning_msg = warnings.formatwarning(

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -157,7 +157,9 @@ def warn_or_error(
                   in a warning message.
   :param ensure_stderr: Whether use warnings.warn, or use warnings.showwarning to print
                         directly to stderr.
-  :param print_warning: Whether a warnings.WarningMessage object should be created.
+  :param print_warning: Whether to print a warning for deprecations *before* their removal.
+                        If this flag is off, an exception will still be raised for options
+                        past their deprecation date.
   :raises DeprecationApplicationError: if the removal_version parameter is invalid.
   :raises CodeRemovedError: if the current version is later than the version marked for removal.
   """

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -432,7 +432,7 @@ class Parser:
 
     if args:
       dest = self.parse_dest(*args, **kwargs)
-      self._check_deprecated(dest, kwargs, print_warning=False)
+      self._check_deprecated(dest, kwargs)
     
     # Prevent further registration in enclosing scopes.
     ancestor = self._parent_parser
@@ -462,7 +462,7 @@ class Parser:
         raise OptionAlreadyRegistered(self.scope, arg)
     self._known_args.update(args)
 
-  def _check_deprecated(self, dest, kwargs, print_warning=True):
+  def _check_deprecated(self, dest, kwargs):
     """Checks option for deprecation and issues a warning/error if necessary."""
     removal_version = kwargs.get('removal_version', None)
     if removal_version is not None:
@@ -472,8 +472,7 @@ class Parser:
         deprecation_start_version=kwargs.get('deprecation_start_version', None),
         hint=kwargs.get('removal_hint', None),
         stacklevel=9999,  # Out of range stacklevel to suppress printing src line.
-        print_warning=print_warning,
-    )  
+      )
 
   _allowed_registration_kwargs = {
     'type', 'member_type', 'choices', 'dest', 'default', 'implicit_value', 'metavar',

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -432,7 +432,7 @@ class Parser:
 
     if args:
       dest = self.parse_dest(*args, **kwargs)
-      self._check_deprecated(dest, kwargs)
+      self._check_deprecated(dest, kwargs, print_warning=False)
     
     # Prevent further registration in enclosing scopes.
     ancestor = self._parent_parser
@@ -462,7 +462,7 @@ class Parser:
         raise OptionAlreadyRegistered(self.scope, arg)
     self._known_args.update(args)
 
-  def _check_deprecated(self, dest, kwargs):
+  def _check_deprecated(self, dest, kwargs, print_warning=True):
     """Checks option for deprecation and issues a warning/error if necessary."""
     removal_version = kwargs.get('removal_version', None)
     if removal_version is not None:
@@ -472,6 +472,7 @@ class Parser:
         deprecation_start_version=kwargs.get('deprecation_start_version', None),
         hint=kwargs.get('removal_hint', None),
         stacklevel=9999,  # Out of range stacklevel to suppress printing src line.
+        print_warning=print_warning,
       )
 
   _allowed_registration_kwargs = {

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -430,6 +430,10 @@ class Parser:
     if self._frozen:
       raise FrozenRegistration(self.scope, args[0])
 
+    if args:
+      dest = self.parse_dest(*args, **kwargs)
+      self._check_deprecated(dest, kwargs, print_warning=False)
+    
     # Prevent further registration in enclosing scopes.
     ancestor = self._parent_parser
     while ancestor:
@@ -458,7 +462,7 @@ class Parser:
         raise OptionAlreadyRegistered(self.scope, arg)
     self._known_args.update(args)
 
-  def _check_deprecated(self, dest, kwargs):
+  def _check_deprecated(self, dest, kwargs, print_warning=True):
     """Checks option for deprecation and issues a warning/error if necessary."""
     removal_version = kwargs.get('removal_version', None)
     if removal_version is not None:
@@ -467,7 +471,9 @@ class Parser:
         deprecated_entity_description="option '{}' in {}".format(dest, self._scope_str()),
         deprecation_start_version=kwargs.get('deprecation_start_version', None),
         hint=kwargs.get('removal_hint', None),
-        stacklevel=9999)  # Out of range stacklevel to suppress printing src line.
+        stacklevel=9999,  # Out of range stacklevel to suppress printing src line.
+        print_warning=print_warning,
+    )  
 
   _allowed_registration_kwargs = {
     'type', 'member_type', 'choices', 'dest', 'default', 'implicit_value', 'metavar',

--- a/src/python/pants/task/console_task.py
+++ b/src/python/pants/task/console_task.py
@@ -20,10 +20,7 @@ class ConsoleTask(QuietTaskMixin, HasTransitiveOptionMixin, Task):
 
   @classproperty
   def _register_console_transitivity_option(cls):
-    """Some tasks register their own --transitive option, which act differently.
-
-    TODO: This method is temporary and should be removed in 1.22.0.dev0.
-    """
+    """Some tasks register their own --transitive option, which act differently."""
     return True
 
   @classmethod

--- a/testprojects/src/python/plugins/dummy_options/tasks/dummy_options.py
+++ b/testprojects/src/python/plugins/dummy_options/tasks/dummy_options.py
@@ -13,8 +13,6 @@ class DummyOptionsTask(Task):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    register('--dummy-crufty-expired', removal_version='0.0.1.dev0',
-                removal_hint='blah')
     register('--dummy-crufty-deprecated-but-still-functioning', removal_version='999.99.9.dev0',
                 removal_hint='blah')
     register('--normal-option')

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -847,11 +847,9 @@ class OptionsTest(TestBase):
       options.for_scope('enum-opt').some_enum
 
   def assertOptionWarning(self, w, option_string):
-    single_warning = assert_single_element(w)
-    self.assertEqual(single_warning.category, DeprecationWarning)
-    warning_message = single_warning.message
-    self.assertIn("will be removed in version", str(warning_message))
-    self.assertIn(option_string, str(warning_message))
+    for warning in w:
+      self.assertEqual(warning.category, DeprecationWarning)
+      self.assertIn("will be removed in version", str(warning.message))
 
   def test_deprecated_options_flag(self):
     with self.warnings_catcher() as w:
@@ -897,7 +895,7 @@ class OptionsTest(TestBase):
     # Make sure the warnings don't come out for regular options.
     with self.warnings_catcher() as w:
       self._parse('./pants stale --pants-foo stale --still-good')
-      self.assertEqual(0, len(w))
+      self.assertEqual(5, len(w))
 
   def test_deprecated_options_env(self):
     with self.warnings_catcher() as w:
@@ -930,7 +928,7 @@ class OptionsTest(TestBase):
         .for_global_scope()
         .global_delayed_deprecated_option)
       self.assertEqual(delayed_deprecation_option_value, 'xxx')
-      self.assertEqual(0, len(w))
+      self.assertEqual(5, len(w))
 
     with self.warnings_catcher() as w:
       delayed_passed_option_value = (

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -156,14 +156,17 @@ class OptionsTest(TestBase):
                     removal_hint='use a less crufty global option')
     register_global('--global-crufty-boolean', type=bool, removal_version='999.99.9.dev0',
                       removal_hint='say no to crufty global options')
-    register_global('--global-crufty-expired', removal_version='0.0.1.dev0',
-                    removal_hint='use a less crufty global option')
     register_global('--global-delayed-deprecated-option',
                     removal_version='999.99.9.dev0',
                     deprecation_start_version='500.0.0.dev0')
     register_global('--global-delayed-but-already-passed-deprecated-option',
                     removal_version='999.99.9.dev0',
                     deprecation_start_version=_FAKE_CUR_VERSION)
+
+    # Test that an option past the `removal_version` fails at option registration time.
+    with self.assertRaises(CodeRemovedError):
+      register_global('--global-crufty-expired', removal_version='0.0.1.dev0',
+                      removal_hint='use a less crufty global option')
 
     # Mutual Exclusive options
     register_global('--mutex-foo', mutually_exclusive_group='mutex')
@@ -842,22 +845,6 @@ class OptionsTest(TestBase):
         "Error applying type 'SomeEnumOption' to option value 'invalid-value', for option '--some_enum' in scope 'enum-opt'"):
       options = self._parse('./pants enum-opt --some-enum=invalid-value')
       options.for_scope('enum-opt').some_enum
-
-  def test_deprecated_option_past_removal(self):
-    """Ensure that expired options raise CodeRemovedError on attempted use."""
-    # NB: these exceptions are triggered by the `Parser#parse_args()` method, not
-    # `Options#for_scope()`!
-    # Test option past removal from flag
-    with self.assertRaises(CodeRemovedError):
-      self._parse('./pants --global-crufty-expired=way2crufty').for_global_scope()
-
-    # Test option past removal from env
-    with self.assertRaises(CodeRemovedError):
-      self._parse('./pants', env={'PANTS_GLOBAL_CRUFTY_EXPIRED':'way2crufty'}).for_global_scope()
-
-    #Test option past removal from config
-    with self.assertRaises(CodeRemovedError):
-      self._parse('./pants', config={'GLOBAL':{'global_crufty_expired':'way2crufty'}}).for_global_scope()
 
   def assertOptionWarning(self, w, option_string):
     single_warning = assert_single_element(w)

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -847,9 +847,11 @@ class OptionsTest(TestBase):
       options.for_scope('enum-opt').some_enum
 
   def assertOptionWarning(self, w, option_string):
-    for warning in w:
-      self.assertEqual(warning.category, DeprecationWarning)
-      self.assertIn("will be removed in version", str(warning.message))
+    single_warning = assert_single_element(w)
+    self.assertEqual(single_warning.category, DeprecationWarning)
+    warning_message = single_warning.message
+    self.assertIn("will be removed in version", str(warning_message))
+    self.assertIn(option_string, str(warning_message))
 
   def test_deprecated_options_flag(self):
     with self.warnings_catcher() as w:
@@ -895,7 +897,7 @@ class OptionsTest(TestBase):
     # Make sure the warnings don't come out for regular options.
     with self.warnings_catcher() as w:
       self._parse('./pants stale --pants-foo stale --still-good')
-      self.assertEqual(5, len(w))
+      self.assertEqual(0, len(w))
 
   def test_deprecated_options_env(self):
     with self.warnings_catcher() as w:
@@ -928,7 +930,7 @@ class OptionsTest(TestBase):
         .for_global_scope()
         .global_delayed_deprecated_option)
       self.assertEqual(delayed_deprecation_option_value, 'xxx')
-      self.assertEqual(5, len(w))
+      self.assertEqual(0, len(w))
 
     with self.warnings_catcher() as w:
       delayed_passed_option_value = (

--- a/tests/python/pants_test/option/test_options_integration.py
+++ b/tests/python/pants_test/option/test_options_integration.py
@@ -129,7 +129,6 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
       self.assertIn('dummy-options.normal_option', pants_run.stdout_data)
       self.assertIn('dummy-options.dummy_crufty_deprecated_but_still_functioning',
                     pants_run.stdout_data)
-      self.assertNotIn('dummy-options.dummy_crufty_expired', pants_run.stdout_data)
 
   def test_from_config_invalid_section(self):
     with temporary_dir(root_dir=os.path.abspath('.')) as tempdir:


### PR DESCRIPTION
### Problem

Options don't raise an exception upon registration if a `removal_version` is out of date.
[Relevant Github issue](https://github.com/pantsbuild/pants/issues/7335)

### Solution

#8485 was originally submitted to remove an expired `--transitive` option. @cosmicexplorer and I both went down paths to then eagerly fail deprecated options upon registration. His work is found in #8503. This PR is largely a combination of #8485 and #8503

### Result

Expired options now raise upon being registered.