### PR TITLE
Add Zinc for outlining support

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -739,7 +739,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
         # While allowing it to use RscCompileContexts for outlining.
         analysis_file=os.path.join(rsc_dir, 'z.analysis.outline'),
         classes_dir=ClasspathEntry(os.path.join(rsc_dir, 'zinc_classes'), None),
-        jar_file=ClasspathEntry(os.path.join(rsc_dir, 'z.jar.useless')),
+        jar_file=None,
         args_file=os.path.join(rsc_dir, 'rsc_args'),
         rsc_jar_file=ClasspathEntry(os.path.join(rsc_dir, 'm.jar')),
         log_dir=os.path.join(rsc_dir, 'logs'),

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
@@ -14,12 +14,8 @@ class RscCompileIntegrationYoutline(RscCompileIntegrationBase):
     self._testproject_compile("mutual", "bin", "A")
 
   @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.outline_and_zinc)
-  def test_public_inference_allowed(self):
-    self._testproject_compile("public_inference", "public_inference", "PublicInference", "--compile-rsc-allow-public-inference")
-      
-  @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.outline_and_zinc)
-  def test_public_inference_disallowed(self):
-    self._testproject_compile("public_inference", "public_inference", "PublicInference", success=False, zinc_result=True, outline_result=False)
+  def test_public_inference(self):
+    self._testproject_compile("public_inference", "public_inference", "PublicInference")
 
   @ensure_compile_rsc_execution_strategy(
     RscCompileIntegrationBase.outline_and_zinc,


### PR DESCRIPTION
### Problem

`scalac`'s built-in `-Youtline` mode can be used by `zinc` if the underlying
Scala version is at least `2.12.9`. The previous implementation of `-Youtline`
support doesn't allow this, and has an issue where `zinc` and a standalone
`scalac` causes a race condition when they are run in the same nailgun. Thus,
`scalac -Youtline` is forced to run as a subprocess, which is too slow, or in
`hermetic`.

### Solution

We introduce a `compile.rsc` flag, `--zinc-outline`.  When this flag
is true under a non-hermetic `outline-and-zinc` workflow, we follow logic
similar to `ZincCompile.compile` which will pass the necessary `-Youtline`
arguments to `zinc`.

### Result

`scalac` outlining will be able to use the same nailgun as `zinc`.
