### PR TITLE
Async workunits

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -106,7 +106,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
       v2_ui = options.for_global_scope().v2_ui
       zipkin_trace_v2 = options.for_scope('reporting').zipkin_trace_v2
-      should_report_workunits = True
+      should_report_workunits = False
       graph_session = graph_scheduler_helper.new_session(zipkin_trace_v2, RunTracker.global_instance().run_id, v2_ui, should_report_workunits)
     return graph_session, graph_session.scheduler_session
 

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -106,7 +106,8 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
       v2_ui = options.for_global_scope().v2_ui
       zipkin_trace_v2 = options.for_scope('reporting').zipkin_trace_v2
-      graph_session = graph_scheduler_helper.new_session(zipkin_trace_v2, RunTracker.global_instance().run_id, v2_ui)
+      should_report_workunits = True
+      graph_session = graph_scheduler_helper.new_session(zipkin_trace_v2, RunTracker.global_instance().run_id, v2_ui, should_report_workunits)
     return graph_session, graph_session.scheduler_session
 
   @staticmethod

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -106,6 +106,11 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
       v2_ui = options.for_global_scope().v2_ui
       zipkin_trace_v2 = options.for_scope('reporting').zipkin_trace_v2
+      #TODO(gregorys) This should_report_workunits flag must be set to True for
+      # AsyncWorkunitHandler to receive WorkUnits. It should eventually
+      # be merged with the zipkin_trace_v2 flag, since they both involve most
+      # of the same engine functionality, but for now is separate to avoid
+      # breaking functionality associated with zipkin tracing while iterating on async workunit reporting.
       should_report_workunits = False
       graph_session = graph_scheduler_helper.new_session(zipkin_trace_v2, RunTracker.global_instance().run_id, v2_ui, should_report_workunits)
     return graph_session, graph_session.scheduler_session

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -873,8 +873,18 @@ class Native(metaclass=SingletonMetaclass):
       self.lib.execution_request_create(),
       self.lib.execution_request_destroy)
 
-  def new_session(self, scheduler, should_record_zipkin_spans, should_render_ui, ui_worker_count, build_id):
-    return self.gc(self.lib.session_create(scheduler, should_record_zipkin_spans, should_render_ui, ui_worker_count, self.context.utf8_buf(build_id)), self.lib.session_destroy)
+  def new_session(self, scheduler, should_record_zipkin_spans, should_render_ui, ui_worker_count, build_id, should_report_workunits: bool):
+    return self.gc(
+      self.lib.session_create(
+        scheduler,
+        should_record_zipkin_spans,
+        should_render_ui,
+        ui_worker_count,
+        self.context.utf8_buf(build_id),
+        should_report_workunits,
+      ),
+      self.lib.session_destroy
+    )
 
   def new_scheduler(self,
                     tasks,

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -276,10 +276,7 @@ def _make_rule(
       for p, s in rule_visitor.gets)
 
     # Register dependencies for @console_rule/Goal.
-    if is_goal_cls:
-      dependency_rules = (optionable_rule(return_type.Options),)
-    else:
-      dependency_rules = None
+    dependency_rules = (optionable_rule(return_type.Options),) if is_goal_cls else None
 
     func.rule = TaskRule(
         return_type,

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -205,11 +205,7 @@ class LegacyGraphSession:
     :returns: An exit code.
     """
 
-    def reporter_callback(workunits):
-      for workunit in workunits:
-        print(workunit)
-
-    async_reporter = AsyncWorkunitHandler(self.scheduler_session, callback=reporter_callback, report_interval_seconds=0.01)
+    async_reporter = AsyncWorkunitHandler(self.scheduler_session, callback=None, report_interval_seconds=0.01)
     subject = target_roots.specs
     console = Console(
       use_colors=options_bootstrapper.bootstrap_options.for_global_scope().colors

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -205,7 +205,7 @@ class LegacyGraphSession:
     :returns: An exit code.
     """
 
-    async_reporter = AsyncWorkunitHandler(self.scheduler_session, callback=None, report_interval_seconds=0.01)
+    async_reporter = AsyncWorkunitHandler(self.scheduler_session, callback=None)
     subject = target_roots.specs
     console = Console(
       use_colors=options_bootstrapper.bootstrap_options.for_global_scope().colors

--- a/src/python/pants/reporting/async_workunit_handler.py
+++ b/src/python/pants/reporting/async_workunit_handler.py
@@ -21,6 +21,9 @@ class AsyncWorkunitHandler:
     self._thread_runner.start()
 
   def end(self):
+    #poll workunits one last time before exiting
+    workunits = self.scheduler.poll_workunits()
+    self.callback(workunits)
     if self._thread_runner:
       self._thread_runner.stop_request.set()
 

--- a/src/python/pants/reporting/async_workunit_handler.py
+++ b/src/python/pants/reporting/async_workunit_handler.py
@@ -1,0 +1,55 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import threading
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Optional
+
+
+DEFAULT_REPORT_INTERVAL_SECONDS = 10
+
+
+class AsyncWorkunitHandler:
+  def __init__(self, scheduler: Any, callback: Optional[Callable], report_interval_seconds: float = DEFAULT_REPORT_INTERVAL_SECONDS):
+    self.scheduler = scheduler
+    self.report_interval = report_interval_seconds
+    self.callback = callback
+    self._thread_runner = None
+
+  def start(self):
+    self._thread_runner = _InnerHandler(self.scheduler, self.callback, self.report_interval)
+    self._thread_runner.start()
+
+  def end(self):
+    if self._thread_runner:
+      self._thread_runner.stop_request.set()
+
+  @contextmanager
+  def session(self) -> Iterator[None]:
+    self.start()
+    try:
+      yield
+    except Exception as e:
+      self.end()
+      raise e
+    self.end()
+
+
+class _InnerHandler(threading.Thread):
+  def __init__(self, scheduler: Any, callback: Optional[Callable], report_interval: float):
+    super(_InnerHandler, self).__init__()
+    self.scheduler = scheduler
+    self.stop_request = threading.Event()
+    self.report_interval = report_interval
+    self.callback = callback
+
+  def run(self):
+    while not self.stop_request.isSet():
+      workunits = self.scheduler.poll_workunits()
+      if self.callback:
+        self.callback(workunits)
+      self.stop_request.wait(timeout=self.report_interval)
+
+  def join(self, timeout=None):
+    self.stop_request.set()
+    super(_InnerHandler, self).join(timeout)

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -52,7 +52,6 @@ use logging::{Destination, Logger};
 use rule_graph::{GraphMaker, RuleGraph};
 use std::any::Any;
 use std::borrow::Borrow;
-use std::collections::HashSet;
 use std::ffi::CStr;
 use std::fs::File;
 use std::io;
@@ -390,9 +389,8 @@ fn make_core(
   )
 }
 
-fn workunits_to_py_tuple_value(workunits: &HashSet<WorkUnit>) -> Value {
+fn workunits_to_py_tuple_value<'a>(workunits: &mut impl Iterator<Item = &'a WorkUnit>) -> Value {
   let workunit_values = workunits
-    .iter()
     .map(|workunit: &WorkUnit| {
       let mut workunit_zipkin_trace_info = vec![
         externs::store_utf8("name"),
@@ -419,6 +417,22 @@ fn workunits_to_py_tuple_value(workunits: &HashSet<WorkUnit>) -> Value {
   externs::store_tuple(&workunit_values)
 }
 
+#[no_mangle]
+pub extern "C" fn poll_session_workunits(
+  scheduler_ptr: *mut Scheduler,
+  session_ptr: *mut Session,
+) -> Handle {
+  with_scheduler(scheduler_ptr, |_scheduler| {
+    with_session(session_ptr, |session| {
+      let value = session.workunit_store().with_latest_workunits(|workunits| {
+        let mut iter = workunits.iter();
+        workunits_to_py_tuple_value(&mut iter)
+      });
+      value.into()
+    })
+  })
+}
+
 ///
 /// Returns a Handle representing a dictionary where key is metric name string and value is
 /// metric value int.
@@ -437,8 +451,9 @@ pub extern "C" fn scheduler_metrics(
         .collect::<Vec<_>>();
       if session.should_record_zipkin_spans() {
         let workunits = session.workunit_store().get_workunits();
-
-        let value = workunits_to_py_tuple_value(&workunits.lock());
+        let locked = workunits.lock();
+        let mut iter = locked.iter();
+        let value = workunits_to_py_tuple_value(&mut iter);
         values.push(externs::store_utf8("engine_workunits"));
         values.push(value);
       };
@@ -649,6 +664,7 @@ pub extern "C" fn session_create(
   should_render_ui: bool,
   ui_worker_count: u64,
   build_id: Buffer,
+  should_report_workunits: bool,
 ) -> *const Session {
   let build_id = build_id
     .to_string()
@@ -660,6 +676,7 @@ pub extern "C" fn session_create(
       should_render_ui,
       ui_worker_count as usize,
       build_id,
+      should_report_workunits,
     )))
   })
 }

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -389,7 +389,7 @@ fn make_core(
   )
 }
 
-fn workunits_to_py_tuple_value<'a>(workunits: &mut impl Iterator<Item = &'a WorkUnit>) -> Value {
+fn workunits_to_py_tuple_value<'a>(workunits: impl Iterator<Item = &'a WorkUnit>) -> Value {
   let workunit_values = workunits
     .map(|workunit: &WorkUnit| {
       let mut workunit_zipkin_trace_info = vec![

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -452,7 +452,7 @@ pub extern "C" fn scheduler_metrics(
       if session.should_record_zipkin_spans() {
         let workunits = session.workunit_store().get_workunits();
         let locked = workunits.lock();
-        let mut iter = locked.iter();
+        let mut iter = locked.workunits.iter();
         let value = workunits_to_py_tuple_value(&mut iter);
         values.push(externs::store_utf8("engine_workunits"));
         values.push(value);

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1205,7 +1205,10 @@ impl Node for NodeKey {
 
   fn run(self, context: Context) -> NodeFuture<NodeResult> {
     let span_id = generate_random_64bit_string();
-    let node_workunit_params = if context.session.should_record_zipkin_spans() {
+
+    let handle_workunits =
+      context.session.should_report_workunits() || context.session.should_record_zipkin_spans();
+    let node_workunit_params = if handle_workunits {
       let node_name = format!("{}", self);
       let start_time = std::time::SystemTime::now();
       Some((node_name, start_time, span_id.clone()))

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -40,6 +40,7 @@ struct InnerSession {
   // A place to store info about workunits in rust part
   workunit_store: WorkUnitStore,
   build_id: String,
+  should_report_workunits: bool,
 }
 
 #[derive(Clone)]
@@ -52,15 +53,17 @@ impl Session {
     should_render_ui: bool,
     ui_worker_count: usize,
     build_id: String,
+    should_report_workunits: bool,
   ) -> Session {
     let inner_session = InnerSession {
       preceding_graph_size: scheduler.core.graph.len(),
       roots: Mutex::new(HashSet::new()),
       display: EngineDisplay::create(ui_worker_count, should_render_ui)
         .map(|x| Arc::new(Mutex::new(x))),
-      should_record_zipkin_spans: should_record_zipkin_spans,
+      should_record_zipkin_spans,
       workunit_store: WorkUnitStore::new(),
-      build_id: build_id,
+      build_id,
+      should_report_workunits,
     };
     Session(Arc::new(inner_session))
   }
@@ -85,6 +88,10 @@ impl Session {
 
   pub fn should_record_zipkin_spans(&self) -> bool {
     self.0.should_record_zipkin_spans
+  }
+
+  pub fn should_report_workunits(&self) -> bool {
+    self.0.should_report_workunits
   }
 
   pub fn workunit_store(&self) -> WorkUnitStore {

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -44,36 +44,45 @@ pub struct WorkUnit {
 
 #[derive(Clone, Default)]
 pub struct WorkUnitStore {
-  workunits: Arc<Mutex<Vec<WorkUnit>>>,
-  last_seen_workunit: Arc<Mutex<usize>>,
+  inner: Arc<Mutex<WorkUnitInnerStore>>,
+}
+
+#[derive(Default)]
+pub struct WorkUnitInnerStore {
+  pub workunits: Vec<WorkUnit>,
+  last_seen_workunit: usize,
 }
 
 impl WorkUnitStore {
   pub fn new() -> WorkUnitStore {
     WorkUnitStore {
-      workunits: Arc::new(Mutex::new(Vec::new())),
-      last_seen_workunit: Arc::new(Mutex::new(0)),
+      inner: Arc::new(Mutex::new(WorkUnitInnerStore {
+        workunits: Vec::new(),
+        last_seen_workunit: 0,
+      })),
     }
   }
 
-  pub fn get_workunits(&self) -> Arc<Mutex<Vec<WorkUnit>>> {
-    self.workunits.clone()
+  pub fn get_workunits(&self) -> Arc<Mutex<WorkUnitInnerStore>> {
+    self.inner.clone()
   }
 
   pub fn add_workunit(&self, workunit: WorkUnit) {
-    self.workunits.lock().push(workunit.clone());
+    self.inner.lock().workunits.push(workunit.clone());
   }
 
   pub fn with_latest_workunits<F, T>(&mut self, f: F) -> T
   where
     F: FnOnce(&[WorkUnit]) -> T,
   {
-    let workunits = self.workunits.lock();
+    let mut inner_guard = (*self.inner).lock();
+    let inner_store: &mut WorkUnitInnerStore = &mut *inner_guard;
+    let workunits = &inner_store.workunits;
     let cur_len = workunits.len();
-    let mut latest_guard = (*self.last_seen_workunit).lock();
-    let latest: &mut usize = &mut *latest_guard;
-    let output = f(&workunits[*latest..cur_len]);
-    *latest = cur_len;
+    let latest: usize = inner_store.last_seen_workunit;
+
+    let output = f(&workunits[latest..cur_len]);
+    inner_store.last_seen_workunit = cur_len;
     output
   }
 }
@@ -94,6 +103,7 @@ pub fn workunits_with_constant_span_id(workunit_store: &WorkUnitStore) -> HashSe
   workunit_store
     .get_workunits()
     .lock()
+    .workunits
     .iter()
     .map(|workunit| WorkUnit {
       span_id: String::from("ignore"),

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -45,14 +45,14 @@ pub struct WorkUnit {
 #[derive(Clone, Default)]
 pub struct WorkUnitStore {
   workunits: Arc<Mutex<Vec<WorkUnit>>>,
-  last_seen_workunit: usize,
+  last_seen_workunit: Arc<Mutex<usize>>,
 }
 
 impl WorkUnitStore {
   pub fn new() -> WorkUnitStore {
     WorkUnitStore {
       workunits: Arc::new(Mutex::new(Vec::new())),
-      last_seen_workunit: 0,
+      last_seen_workunit: Arc::new(Mutex::new(0)),
     }
   }
 
@@ -70,9 +70,11 @@ impl WorkUnitStore {
   {
     let workunits = self.workunits.lock();
     let cur_len = workunits.len();
-    let latest = self.last_seen_workunit;
-    self.last_seen_workunit = cur_len;
-    f(&workunits[latest..cur_len])
+    let mut latest_guard = (*self.last_seen_workunit).lock();
+    let latest: &mut usize = &mut *latest_guard;
+    let output = f(&workunits[*latest..cur_len]);
+    *latest = cur_len;
+    output
   }
 }
 

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -109,6 +109,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/engine/examples:scheduler_inputs',
     'src/python/pants/testutil/engine:util',
+    'src/python/pants/reporting',
   ]
 )
 

--- a/tests/python/pants_test/engine/scheduler_test_base.py
+++ b/tests/python/pants_test/engine/scheduler_test_base.py
@@ -45,7 +45,9 @@ class SchedulerTestBase:
                    union_rules=None,
                    project_tree=None,
                    work_dir=None,
-                   include_trace_on_error=True):
+                   include_trace_on_error=True,
+                   should_report_workunits=False,
+                   ):
     """Creates a SchedulerSession for a Scheduler with the given Rules installed."""
     rules = rules or []
     work_dir = work_dir or self._create_work_dir()
@@ -58,7 +60,7 @@ class SchedulerTestBase:
                           union_rules,
                           DEFAULT_EXECUTION_OPTIONS,
                           include_trace_on_error=include_trace_on_error)
-    return scheduler.new_session(zipkin_trace_v2=False, build_id="buildid_for_test")
+    return scheduler.new_session(zipkin_trace_v2=False, build_id="buildid_for_test", should_report_workunits=should_report_workunits)
 
   def context_with_scheduler(self, scheduler, *args, **kwargs):
     return self.context(*args, scheduler=scheduler, **kwargs)

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -2,12 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import unittest
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from textwrap import dedent
+from typing import List
 
 from pants.engine.rules import RootRule, rule
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Get
+from pants.reporting.async_workunit_handler import AsyncWorkunitHandler
 from pants.testutil.engine.util import assert_equal_with_printing, remove_locations_from_traceback
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
 
@@ -234,3 +236,31 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         ''').strip(),
       str(cm.exception)
     )
+
+  def test_async_reporting(self):
+    rules = [ fib, RootRule(int)]
+    scheduler = self.mk_scheduler(rules, include_trace_on_error=False, should_report_workunits=True)
+
+    @dataclass
+    class Tracker:
+      workunits: List[dict] = field(default_factory=list)
+
+      def add(self, workunits) -> None:
+        self.workunits.extend(workunits)
+
+    tracker = Tracker()
+    async_reporter = AsyncWorkunitHandler(scheduler, callback=tracker.add, report_interval_seconds=0.01)
+    with async_reporter.session():
+      scheduler.product_request(Fib, subjects=[0])
+
+    # One workunit should be coming from the `Select` intrinsic, and the other from the single execution
+    # of the `fib` rule, for two total workunits being appended during the run of this rule.
+    self.assertEquals(len(tracker.workunits), 2)
+
+    tracker.workunits = []
+    with async_reporter.session():
+      scheduler.product_request(Fib, subjects=[10])
+
+    # Requesting a bigger fibonacci number will result in more rule executions and thus more reported workunits.
+    # In this case, we expect 10 invocations of the `fib` rule + the one Select for a total of 11.
+    self.assertEquals(len(tracker.workunits), 11)


### PR DESCRIPTION
### Problem

We would like to be able to request Workunits asynchronously while a potentially-long-running pants run is active, instead of waiting until the pants run is finished (like the current logic for reporting results to Zipkin does).

### Solution

This code is based around a python class `AsyncWorkunitHandler`, which is provisioned with a callback and a polling frequency in seconds. If the `start` method is called on this class, it will spawn a new python that thread that, every n seconds, polls the engine for all new Workunits, and passes them to a callback. When the run is done the `end` method is called to shut down that thread.

### Result

Right now, this change should have no user-observable new behavior, and in fact the variable that turns on asynchronous workunit reporting in Rust is hard-coded to `False`. Future commits that make use of this functionality will add logic to flip that boolean on/off as required, and define a callback function doing useful work that can be passed into `AsyncWorkunitHandler`.
