### PR TITLE
add compiler_option_sets_enabled_scalac_plugins option to JvmCompile

### DIFF
--- a/examples/src/scala/org/pantsbuild/example/scalac/plugin/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/scalac/plugin/BUILD
@@ -35,6 +35,7 @@ scala_library(
   dependencies = [
     ':simple_scalac_plugin'
   ],
+  compiler_option_sets={'option-set-requiring-scalac-plugin'},
 )
 
 # The plugin will only run on this target if told to via options, but if it

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -101,7 +101,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
              default=list(cls.get_no_warning_args_default()),
              help='Extra compiler args to use when warnings are disabled.')
 
-    register('--compiler-option-sets-required-scalac-plugins', advanced=True, type=dict,
+    register('--compiler-option-sets-enabled-scalac-plugins', advanced=True, type=dict,
              fingerprint=True,
              help='A mapping of (compiler option set name) -> (list of scalac plugin names to '
                   'be enabled when this option set is enabled).')
@@ -649,7 +649,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
       tuple(
         plugin_name
         for option_set_name in compiler_option_sets
-        for plugin_name in self.get_options().compiler_option_sets_required_scalac_plugins.get(option_set_name, [])
+        for plugin_name in self.get_options().compiler_option_sets_enabled_scalac_plugins.get(option_set_name, [])
       )
     )
     # Allow multiple flags and also comma-separated values in a single flag.

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -101,6 +101,11 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
              default=list(cls.get_no_warning_args_default()),
              help='Extra compiler args to use when warnings are disabled.')
 
+    register('--compiler-option-sets-required-scalac-plugins', advanced=True, type=dict,
+             fingerprint=True,
+             help='A mapping of (compiler option set name) -> (list of scalac plugin names to '
+                  'be enabled when this option set is enabled).')
+
     register('--debug-symbols', type=bool, fingerprint=True,
              help='Compile with debug symbol enabled.')
 
@@ -633,10 +638,19 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
     # Note that we get() options and getattr() target fields and task methods,
     # so we're robust when those don't exist (or are None).
     plugins_key = '{}_plugins'.format(compiler)
+
+    dep_context = DependencyContext.global_instance()
+    compiler_option_sets = dep_context.defaulted_property(target, 'compiler_option_sets')
+
     requested_plugins = (
       tuple(getattr(self, plugins_key, []) or []) +
       tuple(options_src.get_options().get(plugins_key, []) or []) +
-      tuple((getattr(target, plugins_key, []) or []))
+      tuple((getattr(target, plugins_key, []) or [])) +
+      tuple(
+        plugin_name
+        for option_set_name in compiler_option_sets
+        for plugin_name in self.get_options().compiler_option_sets_required_scalac_plugins.get(option_set_name, [])
+      )
     )
     # Allow multiple flags and also comma-separated values in a single flag.
     requested_plugins = {p for val in requested_plugins for p in val.split(',')}

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scalac_plugin_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scalac_plugin_integration.py
@@ -76,7 +76,7 @@ class ScalacPluginIntegrationTest(BaseCompileIT):
     }
     self._do_test(['args', 'from', 'target', 'local'], config, 'local')
 
-  def test_compiler_option_sets_required_scalac_plugins(self):
+  def test_compiler_option_sets_enabled_scalac_plugins(self):
     self._do_test_global(
       args=[],
       extra_config={
@@ -87,7 +87,7 @@ class ScalacPluginIntegrationTest(BaseCompileIT):
               '-S-P:simple_scalac_plugin:def',
             ],
           },
-          'compiler_option_sets_required_scalac_plugins': {
+          'compiler_option_sets_enabled_scalac_plugins': {
             'option-set-requiring-scalac-plugin': ['simple_scalac_plugin'],
           },
         }

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scalac_plugin_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scalac_plugin_integration.py
@@ -17,17 +17,18 @@ class ScalacPluginIntegrationTest(BaseCompileIT):
 
   # Note that in the terminology of this test, "global" means specified via options for
   # all targets, and "local" means specified on an individual target.
-  def _do_test_global(self, args):
+  def _do_test_global(self, args, extra_config={}, expected_args=None):
     config = {
       'scala': {
         'scalac_plugins': ['simple_scalac_plugin'],
         'scalac_plugin_args': {
           'simple_scalac_plugin': args
         },
-      }
+      },
+      **extra_config
     }
     # Must compile the plugin explicitly, since there's no dep.
-    self._do_test(args, config, 'global')
+    self._do_test((expected_args or args), config, 'global')
 
   def _do_test_local_with_global_args(self, args):
     config = {
@@ -74,3 +75,22 @@ class ScalacPluginIntegrationTest(BaseCompileIT):
       }
     }
     self._do_test(['args', 'from', 'target', 'local'], config, 'local')
+
+  def test_compiler_option_sets_required_scalac_plugins(self):
+    self._do_test_global(
+      args=[],
+      extra_config={
+        'compile.rsc': {
+          'compiler_option_sets_enabled_args': {
+            'option-set-requiring-scalac-plugin': [
+              '-S-P:simple_scalac_plugin:abc',
+              '-S-P:simple_scalac_plugin:def',
+            ],
+          },
+          'compiler_option_sets_required_scalac_plugins': {
+            'option-set-requiring-scalac-plugin': ['simple_scalac_plugin'],
+          },
+        }
+      },
+      expected_args=['abc', 'def'],
+    )


### PR DESCRIPTION
### Problem

When working with @ShaneDelmore on an automated change to the twitter monorepo, we began to want to turn on and off different compiler options which belonged to an internal scalac plugin. While `compiler_option_sets_{en,dis}abled_args` are able to manually add arguments which get passed to a plugin via prefixing them with `-S-P:<plugin_name>:<arg...>`, the value of `compiler_option_sets` for some target is not able to ensure that the scalac plugin is also on the classpath.

This means that a target which wants to declare args with `compiler_option_sets` for a scalac plugin must also declare `scalac_plugins={'<plugin_name>'}`. This redundancy makes it more difficult to make automated changes, and may be mildly confusing for users.

### Solution

- Add the new `--compiler-option-sets-enabled-scalac-plugins` dict option to `JvmCompile`, which maps (a compiler option set name) -> (a list of scalac plugins that should also be registered when that option set is enabled).

### Result

A compiler option set can now implicitly require a named scalac plugin! Option sets can now be developed which span across scalac plugins as well, making them even more flexible and allowing monorepo caretakers to safely make even more changes to the build, without requiring a change in pants code.