### PR TITLE
create RequestsSession.Factory global subsystem, and use it to configure urllib3.util.Retry for http artifact cache downloads

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -148,6 +148,7 @@ function execute_packaged_pants_with_internal_backends() {
         'pants.backend.native',\
         'pants.backend.project_info',\
         'pants.backend.python',\
+        'pants.cache',\
         'internal_backend.repositories',\
         'internal_backend.sitegen',\
         'internal_backend.utilities',\

--- a/src/python/pants/cache/register.py
+++ b/src/python/pants/cache/register.py
@@ -1,0 +1,8 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.cache.restful_artifact_cache import RequestsSession
+
+
+def global_subsystems():
+  return {RequestsSession.Factory}

--- a/src/python/pants/cache/register.py
+++ b/src/python/pants/cache/register.py
@@ -5,4 +5,4 @@ from pants.cache.restful_artifact_cache import RequestsSession
 
 
 def global_subsystems():
-  return {RequestsSession.Factory}
+    return {RequestsSession.Factory}

--- a/src/python/pants/cache/restful_artifact_cache.py
+++ b/src/python/pants/cache/restful_artifact_cache.py
@@ -5,27 +5,167 @@ import logging
 import multiprocessing
 import queue
 import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
+from typing import Generator, Optional
 
 import requests
 from requests import RequestException
+from urllib3.exceptions import MaxRetryError
+from urllib3.util.retry import Retry
 
 from pants.cache.artifact_cache import ArtifactCache, NonfatalArtifactCacheError, UnreadableArtifact
+from pants.subsystem.subsystem import Subsystem
+from pants.util.memo import memoized_classmethod
 
 logger = logging.getLogger(__name__)
 
-# Reduce the somewhat verbose logging of requests.
-# TODO do this in a central place
-logging.getLogger("requests").setLevel(logging.WARNING)
+
+class LogLevel(Enum):
+  warning = 'WARNING'
+  info = 'INFO'
+  debug = 'DEBUG'
 
 
+@dataclass(frozen=True)
 class RequestsSession:
-    _session = None
+    """Configuration for the session object used to fetch HTTP(S) artifact cache entries.
+
+    See
+    https://github.com/psf/requests/blob/d2590ee46c0641958b6d4792a206bd5171cb247d/requests/adapters.py#L113
+    for documentation on the HTTPAdapter class, and check out
+    https://urllib3.readthedocs.io/en/latest/advanced-usage.html#customizing-pool-behavior for
+    a description of the connection pooling implementation in urllib3.
+
+    See
+    https://github.com/urllib3/urllib3/blob/f4b36ad045ccfbbfaaadd8e69f9b32c5d81cbd84/src/urllib3/util/retry.py#L29
+    for the Retry class (also from urllib3) which is used here to configure request retries.
+    """
+    max_connection_pools: int
+    max_connections_within_pool: int
+    max_retries: int
+    max_retries_on_connection_errors: int
+    max_retries_on_read_errors: int
+    backoff_factor: float
+    blocking_pool: bool
+    slow_download_timeout_seconds: int
+
+    # Global flag which is set to True if our global connection pool singleton raises a MaxRetryError.
+    _max_retries_exceeded = False
 
     @classmethod
-    def instance(cls):
-        if cls._session is None:
-            cls._session = requests.Session()
-        return cls._session
+    def has_exceeded_retries(cls) -> bool:
+        return cls._max_retries_exceeded
+
+    class Factory(Subsystem):
+        options_scope = 'http-artifact-cache'
+
+        # Maintain a connection pool of max size equaling the larger of the number of available cores,
+        # or the default from the requests package (which is usually 10).
+        _default_pool_size = max(multiprocessing.cpu_count(), requests.adapters.DEFAULT_POOLSIZE)
+        # By default, don't perform any retries.
+        _default_retries = 0
+
+        @classmethod
+        def register_options(cls, register):
+            super().register_options(register)
+            # TODO: Pull the `choices` from the registered log levels in the `logging` module somehow!
+            register('--requests-logging-level', choices=list(LogLevel),
+                     # Reduce the somewhat verbose logging of requests.
+               default=LogLevel.warning,
+                     advanced=True,
+                     help='The logging level to set the requests logger to.')
+            register('--max-connection-pools', type=int, default=cls._default_pool_size,
+                     help='The max number of separate hosts to maintain urllib3 pools for. '
+                     'Corresponds to `pool_connections` in `requests.adapters.HTTPAdapter`.')
+            register('--max-connections-within-pool', type=int, default=cls._default_pool_size,
+                     help='The max number of connections to retain within a single pool. '
+                     'Corresponds to `pool_maxsize` in `requests.adapters.HTTPAdapter`.')
+            register('--max-retries', type=int, default=cls._default_retries,
+                     help='The max number of retries to perform for failed artifact cache requests. '
+                     'Corresponds to `max_retries` in in `requests.adapters.HTTPAdapter`.')
+            # TODO: raise an exception if these secondary retry limits exceed --max-retries (which will
+            # just have no effect)?
+            register('--max-retries-on-connection-errors', type=int, default=cls._default_retries,
+                     help='The maximum number of retries to perform for requests which fail to connect.'
+                     '\n\n--max-retries takes precedence over this option, so if this number is '
+                     'greater than --max-retries, the additional retries are ignored.')
+            register('--max-retries-on-read-errors', type=int, default=cls._default_retries,
+                     help='The maximum number of retries to perform for requests which fail after the '
+                     'request is sent to the server.'
+                     '\n\n--max-retries takes precedence over this option, so if this number is '
+                     'greater than --max-retries, the additional retries are ignored.')
+            register('--backoff-factor', type=float, default=0,
+                     help='The backoff factor to apply between retry attempts. '
+                     'Set to 0 to disable backoff.')
+            register('--blocking-pool', type=bool,
+                     help='Whether a connection pool should block instead of creating a new connection '
+                     'when the connection pool is already at its maximum size. '
+                     'Corresponds to `pool_block` in `requests.adapters.HTTPAdapter`.')
+            # TODO: Make a custom option type for timeout lengths which validates that the value is
+            # nonzero, and perhaps parameterized by time unit (seconds, ms, ns?)!
+            register('--slow-download-timeout-seconds', type=int, default=60,
+                     help='The time to wait while downloading a cache artifact before printing a warning '
+                     'about a slow artifact download.')
+
+        @classmethod
+        def create(cls, logger) -> 'RequestsSession':
+            options = cls.global_instance().get_options()
+            level = getattr(logging, options.requests_logging_level)
+            logger.setLevel(level)
+
+            return RequestsSession(
+                max_connection_pools=options.max_connection_pools,
+                max_connections_within_pool=options.max_connections_within_pool,
+                max_retries=options.max_retries,
+                max_retries_on_connection_errors=options.max_retries_on_connection_errors,
+                max_retries_on_read_errors=options.max_retries_on_read_errors,
+                backoff_factor=options.backoff_factor,
+                blocking_pool=options.blocking_pool,
+                slow_download_timeout_seconds=options.slow_download_timeout_seconds,
+            )
+
+    @memoized_classmethod
+    def _instance(cls) -> 'RequestsSession':
+        requests_logger = logging.getLogger('requests')
+        return cls.Factory.create(requests_logger)
+
+    def should_check_for_max_retry_error(self) -> bool:
+        """Helper method extracted for convenience in testing.
+
+        If this method returns False, pants will convert a MaxRetryError into a
+        NonfatalArtifactCacheError. Otherwise, it will re-raise the MaxRetryError.
+        """
+        return bool(self.max_retries)
+
+    @memoized_classmethod
+    def session(cls) -> requests.Session:
+        instance = cls._instance()
+
+        session = requests.Session()
+
+        retry_config = Retry(
+            total=instance.max_retries,
+            connect=instance.max_retries_on_connection_errors,
+            read=instance.max_retries_on_read_errors,
+            redirect=0,
+            backoff_factor=instance.backoff_factor,
+            raise_on_redirect=True,
+            raise_on_status=True,
+        )
+
+        http_connection_adapter = requests.adapters.HTTPAdapter(
+            pool_connections=instance.max_connection_pools,
+            pool_maxsize=instance.max_connections_within_pool,
+            max_retries=retry_config,
+            pool_block=instance.blocking_pool,
+        )
+
+        session.mount('http://', http_connection_adapter)
+        session.mount('https://', http_connection_adapter)
+
+        return session
 
 
 class RESTfulArtifactCache(ArtifactCache):
@@ -67,26 +207,35 @@ class RESTfulArtifactCache(ArtifactCache):
         if self._localcache.has(cache_key):
             return self._localcache.use_cached_files(cache_key, results_dir)
 
+        # The queue is used as a semaphore here, containing only a single None element. A background
+        # thread is kicked off which waits with the specified timeout for the single queue element, and
+        # prints a warning message if the timeout is breached.
         queue = multiprocessing.Queue()
         try:
-            response = self._request("GET", cache_key)
+            response = self._request('GET', cache_key)
             if response is not None:
                 threading.Thread(
                     target=_log_if_no_response,
                     args=(
-                        60,
+                        RequestsSession._instance().slow_download_timeout_seconds,
                         "\nStill downloading artifacts (either they're very large or the connection to the cache is slow)",
                         queue.get,
-                    ),
+                    )
                 ).start()
-                # Delegate storage and extraction to local cache
-                byte_iter = response.iter_content(self.READ_SIZE_BYTES)
-                res = self._localcache.store_and_use_artifact(cache_key, byte_iter, results_dir)
-                queue.put(None)
-                return res
-        except Exception as e:
-            logger.warning("\nError while reading from remote artifact cache: {0}\n".format(e))
+            # Delegate storage and extraction to local cache
+            byte_iter = response.iter_content(self.READ_SIZE_BYTES)
+            res = self._localcache.store_and_use_artifact(cache_key, byte_iter, results_dir)
             queue.put(None)
+            return res
+        except Exception as e:
+            logger.warning('\nError while reading from remote artifact cache: {0}\n'.format(e))
+            queue.put(None)
+            # If we exceed the retry limits, set a global flag to avoid using the cache for the rest of
+            # the pants process lifetime.
+            if isinstance(e, MaxRetryError):
+                logger.warning('\nMaximum retries were exceeded for the current connection pool. Avoiding '
+                               'the remote cache for the rest of the pants process lifetime.\n')
+                RequestsSession._max_retries_exceeded = True
             # TODO(peiyu): clean up partially downloaded local file if any
             return UnreadableArtifact(cache_key, e)
 
@@ -96,48 +245,62 @@ class RESTfulArtifactCache(ArtifactCache):
         self._localcache.delete(cache_key)
         self._request("DELETE", cache_key)
 
-    # Returns a response if we get a 200, None if we get a 404 and raises an exception otherwise.
-    def _request(self, method, cache_key, body=None):
+    @contextmanager
+    def _request_session(self, method, url) -> Generator[requests.Session, None, None]:
+        try:
+            logger.debug(f'Sending {method} request to {url}')
+            # TODO: fix memo.py so @memoized_classmethod is correctly recognized by mypy!
+            yield RequestsSession.session() # type: ignore[call-arg]
+        except RequestException as e:
+            if RequestsSession._instance().should_check_for_max_retry_error(): # type: ignore[call-arg]
+                # TODO: Determine if there's a more canonical way to extract a MaxRetryError from a
+                # RequestException.
+                base_exc = e.args[0]
+            if isinstance(base_exc, MaxRetryError):
+                raise base_exc from e
+        raise NonfatalArtifactCacheError(f'Failed to {method} {url}. Error: {e}')
 
-        session = RequestsSession.instance()
+    # Returns a response if we get a 200, None if we get a 404 and raises an exception otherwise.
+    def _request(self, method, cache_key, body=None) -> Optional[requests.Response]:
+        # If our connection pool has experienced too many retries, we no-op on every successive
+        # artifact download for the rest of the pants process lifetime.
+        if RequestsSession.has_exceeded_retries():
+            return None
+
         with self.best_url_selector.select_best_url() as best_url:
             url = self._url_for_key(best_url, cache_key)
-            logger.debug("Sending {0} request to {1}".format(method, url))
-            try:
-                if "PUT" == method:
-                    response = session.put(
-                        url, data=body, timeout=self._write_timeout_secs, allow_redirects=True
-                    )
-                elif "GET" == method:
-                    response = session.get(
-                        url, timeout=self._read_timeout_secs, stream=True, allow_redirects=True
-                    )
-                elif "HEAD" == method:
-                    response = session.head(
-                        url, timeout=self._read_timeout_secs, allow_redirects=True
-                    )
-                elif "DELETE" == method:
-                    response = session.delete(
-                        url, timeout=self._write_timeout_secs, allow_redirects=True
-                    )
+            with self._request_session(method, url) as session:
+                if 'PUT' == method:
+                    response = session.put(url,
+                                           data=body,
+                                           timeout=self._write_timeout_secs,
+                                           alalow_redirects=True)
+                elif 'GET' == method:
+                    response = session.get(url,
+                                           timeout=self._read_timeout_secs,
+                                           stream=True,
+                                           allow_redirects=True)
+                elif 'HEAD' == method:
+                    response = session.head(url,
+                                            timeout=self._read_timeout_secs,
+                                            allow_redirects=True)
+                elif 'DELETE' == method:
+                    response = session.delete(url,
+                                              timeout=self._write_timeout_secs,
+                                              allow_redirects=True)
                 else:
-                    raise ValueError("Unknown request method {0}".format(method))
-            except RequestException as e:
-                raise NonfatalArtifactCacheError(
-                    "Failed to {0} {1}. Error: {2}".format(method, url, e)
-                )
+                    raise ValueError('Unknown request method {0}'.format(method))
+
             # Allow all 2XX responses. E.g., nginx returns 201 on PUT. HEAD may return 204.
             if int(response.status_code / 100) == 2:
                 return response
             elif response.status_code == 404:
-                logger.debug("404 returned for {0} request to {1}".format(method, url))
+                logger.debug('404 returned for {0} request to {1}'.format(method, url))
                 return None
             else:
-                raise NonfatalArtifactCacheError(
-                    "Failed to {0} {1}. Error: {2} {3}".format(
-                        method, url, response.status_code, response.reason
-                    )
-                )
+                raise NonfatalArtifactCacheError('Failed to {0} {1}. Error: {2} {3}'
+                                                 .format(method, url,
+                                                         response.status_code, response.reason))
 
     def _url_suffix_for_key(self, cache_key):
         return "{0}/{1}.tgz".format(cache_key.id, cache_key.hash)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -299,6 +299,7 @@ class GlobalOptions(Subsystem):
                 "pants.backend.codegen.grpcio.python",
                 "pants.backend.codegen.wire.java",
                 "pants.backend.project_info",
+                "pants.cache",
             ],
             help="Register v1 tasks from these backends. The backend packages must be present on "
             "the PYTHONPATH, typically because they are in the pants core dist, in a "
@@ -1066,7 +1067,6 @@ class GlobalOptions(Subsystem):
             raise OptionsError(
                 "The `--loop` option requires `--enable-pantsd`, in order to watch files."
             )
-
 
         if opts.remote_execution and not opts.remote_execution_server:
             raise OptionsError(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1067,6 +1067,7 @@ class GlobalOptions(Subsystem):
                 "The `--loop` option requires `--enable-pantsd`, in order to watch files."
             )
 
+
         if opts.remote_execution and not opts.remote_execution_server:
             raise OptionsError(
                 "The `--remote-execution` option requires also setting "

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -23,7 +23,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:test_base',
-    'tests/python/pants_test/subsystem:subsystem_utils',
+    'src/python/pants/testutil/subsystem',
   ],
   tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -23,6 +23,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:test_base',
+    'tests/python/pants_test/subsystem:subsystem_utils',
   ],
   tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/cache/cache_server.py
+++ b/tests/python/pants_test/cache/cache_server.py
@@ -93,6 +93,13 @@ class FailRESTHandler(http.server.SimpleHTTPRequestHandler):
         return self._return_failed()
 
 
+class ConnectionErrorRESTHandler(FailRESTHandler):
+  """Fail to connect to all requests."""
+
+  def _return_failed(self):
+    raise Exception('Intentional connection failure!')
+
+
 class TestCacheServer:
     """A wrapper class that represents the underlying REST server.
 
@@ -135,10 +142,12 @@ def _cache_server_process(queue, return_failed, cache_root):
         with temporary_dir() as tmpdir:
             cache_root = cache_root if cache_root else tmpdir
             with pushd(cache_root):  # SimpleRESTHandler serves from the cwd.
-                if return_failed:
+                if return_failed is True:
                     handler = FailRESTHandler
-                else:
+                elif return_failed is False:
                     handler = SimpleRESTHandler
+                elif return_failed == 'connection-error':
+                  handler = ConnectionErrorRESTHandler
                 httpd = socketserver.TCPServer(("localhost", 0), handler)
                 port = httpd.server_address[1]
                 queue.put(port)

--- a/tests/python/pants_test/cache/cache_server.py
+++ b/tests/python/pants_test/cache/cache_server.py
@@ -94,10 +94,10 @@ class FailRESTHandler(http.server.SimpleHTTPRequestHandler):
 
 
 class ConnectionErrorRESTHandler(FailRESTHandler):
-  """Fail to connect to all requests."""
+    """Fail to connect to all requests."""
 
-  def _return_failed(self):
-    raise Exception('Intentional connection failure!')
+    def _return_failed(self):
+        raise Exception("Intentional connection failure!")
 
 
 class TestCacheServer:
@@ -146,8 +146,8 @@ def _cache_server_process(queue, return_failed, cache_root):
                     handler = FailRESTHandler
                 elif return_failed is False:
                     handler = SimpleRESTHandler
-                elif return_failed == 'connection-error':
-                  handler = ConnectionErrorRESTHandler
+                elif return_failed == "connection-error":
+                    handler = ConnectionErrorRESTHandler
                 httpd = socketserver.TCPServer(("localhost", 0), handler)
                 port = httpd.server_address[1]
                 queue.put(port)

--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -1,8 +1,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import logging
 import os
+import unittest.mock
 from contextlib import contextmanager
+from typing import Iterator
 
 import pytest
 
@@ -14,11 +17,13 @@ from pants.cache.artifact_cache import (
 )
 from pants.cache.local_artifact_cache import LocalArtifactCache, TempLocalArtifactCache
 from pants.cache.pinger import BestUrlSelector, InvalidRESTfulCacheProtoError
-from pants.cache.restful_artifact_cache import RESTfulArtifactCache
+from pants.cache.restful_artifact_cache import RequestsSession, RESTfulArtifactCache
 from pants.invalidation.build_invalidator import CacheKey
+from pants.testutil.subsystem.util import init_subsystems
 from pants.testutil.test_base import TestBase
 from pants.util.contextutil import temporary_dir, temporary_file, temporary_file_path
 from pants.util.dirutil import safe_mkdir
+from pants.util.meta import classproperty
 from pants_test.cache.cache_server import cache_server
 
 TEST_CONTENT1 = b"muppet"
@@ -26,6 +31,10 @@ TEST_CONTENT2 = b"kermit"
 
 
 class TestArtifactCache(TestBase):
+    @classproperty
+    def subsystems(cls):
+        return super().subsystems + (RequestsSession.Factory,)
+
     @contextmanager
     def setup_local_cache(self):
         with temporary_dir() as artifact_root:
@@ -45,6 +54,29 @@ class TestArtifactCache(TestBase):
                 yield RESTfulArtifactCache(artifact_root, BestUrlSelector([server.url]), local)
 
     @contextmanager
+    def restore_max_retries_flag(self) -> Iterator[None]:
+        try:
+            yield
+        finally:
+            RequestsSession._max_retries_exceeded = False
+
+    @contextmanager
+    def override_check_for_max_retry(self, should_check: bool) -> Iterator[None]:
+        patch_opts = dict(autospec=True, spec_set=True)
+        with self.restore_max_retries_flag(),\
+             unittest.mock.patch.object(RequestsSession, 'should_check_for_max_retry_error',
+                                    **patch_opts) as check_max_retry_predicate:
+            check_max_retry_predicate.return_value = should_check
+            yield
+
+    def setUp(self):
+        super().setUp()
+        # Init engine because decompression now goes through native code.
+        self._init_engine()
+        TarballArtifact.NATIVE_BINARY = self._scheduler._scheduler._native
+        init_subsystems([RequestsSession.Factory])
+
+    @contextmanager
     def setup_test_file(self, parent):
         with temporary_file(parent) as f:
             # Write the file.
@@ -52,12 +84,6 @@ class TestArtifactCache(TestBase):
             path = f.name
             f.close()
             yield path
-
-    def setUp(self):
-        super().setUp()
-        # Init engine because decompression now goes through native code.
-        self._init_engine()
-        TarballArtifact.NATIVE_BINARY = self._scheduler._scheduler._native
 
     def test_local_cache(self):
         with self.setup_local_cache() as artifact_cache:
@@ -200,19 +226,65 @@ class TestArtifactCache(TestBase):
 
     @pytest.mark.flaky(retries=1)  # https://github.com/pantsbuild/pants/issues/6838
     def test_multiproc(self):
-        key = CacheKey("muppet_key", "fake_hash")
+        key = CacheKey('muppet_key', 'fake_hash')
 
-        with self.setup_local_cache() as cache:
+       with self.setup_local_cache() as cache:
+           self.assertFalse(call_use_cached_files((cache, key, None)))
+           with self.setup_test_file(cache.artifact_root) as path:
+               call_insert((cache, key, [path], False))
+               self.assertTrue(call_use_cached_files((cache, key, None)))
+
+       with self.setup_rest_cache() as cache:
+           self.assertFalse(call_use_cached_files((cache, key, None)))
+           with self.setup_test_file(cache.artifact_root) as path:
+               call_insert((cache, key, [path], False))
+               self.assertTrue(call_use_cached_files((cache, key, None)))
+
+    def test_failed_multiproc(self):
+        key = CacheKey('muppet_key', 'fake_hash')
+
+        # Failed requests should return failure status, but not raise exceptions
+        with self.setup_rest_cache(return_failed=True) as cache:
             self.assertFalse(call_use_cached_files((cache, key, None)))
             with self.setup_test_file(cache.artifact_root) as path:
                 call_insert((cache, key, [path], False))
-            self.assertTrue(call_use_cached_files((cache, key, None)))
+                self.assertFalse(call_use_cached_files((cache, key, None)))
 
-        with self.setup_rest_cache() as cache:
+    def test_noops_after_max_retries_exceeded(self):
+        key = CacheKey('muppet_key', 'fake_hash')
+
+      with self.setup_rest_cache() as cache:
+          # Assert that the artifact doesn't exist, then insert it and check that it exists.
+          self.assertFalse(call_use_cached_files((cache, key, None)))
+          with self.setup_test_file(cache.artifact_root) as path:
+              call_insert((cache, key, [path], False))
+              self.assertTrue(call_use_cached_files((cache, key, None)))
+
+          # No failed requests should have occurred yet, so no retries should have been triggered.
+          self.assertFalse(RequestsSession._max_retries_exceeded)
+
+          # Now assert that when max retries are exceeded, the cache returns 404s.
+          with self.restore_max_retries_flag():
+              RequestsSession._max_retries_exceeded = True
+              self.assertFalse(call_use_cached_files((cache, key, None)))
+          # After the flag is toggled back, the cache successfully finds the entry.
+          self.assertTrue(call_use_cached_files((cache, key, None)))
+
+    def test_max_retries_exceeded(self):
+        key = CacheKey('muppet_key', 'fake_hash')
+
+        # Assert that the global "retries exceeded" flag is set when retries are exceeded.
+        with self.override_check_for_max_retry(should_check=True),\
+             self.setup_rest_cache(return_failed='connection-error') as cache,\
+             self.captured_logging(logging.WARNING) as captured:
+
             self.assertFalse(call_use_cached_files((cache, key, None)))
-            with self.setup_test_file(cache.artifact_root) as path:
-                call_insert((cache, key, [path], False))
-            self.assertTrue(call_use_cached_files((cache, key, None)))
+            self.assertTrue(RequestsSession._max_retries_exceeded)
+
+            _, retry_warning = tuple(captured.warnings())
+            self.assertIn(
+                'Maximum retries were exceeded for the current connection pool. Avoiding the remote cache for the rest of the pants process lifetime.',
+                retry_warning)
 
     def test_failed_multiproc(self):
         key = CacheKey("muppet_key", "fake_hash")


### PR DESCRIPTION
### Problem

Pants users have described multiple issues that arise when using pants on a slow or flaky connection to a remote http artifact cache. The main ones that this PR attempts to solve are:
1. The urllib3 connection pool we use keeps a maximum of 10 cached connections at once. When run on machines with more than 10 processors (e.g. our internal CI boxes), and the connection pool becomes saturated, urllib3 will create an ephemeral connection and print a warning to the console that it is dropping a connection to the remote host. This suggests that we're working against the available parallelism on the machine by using the defaults.
2. Pants seems not to attempt to retry any connection that fails e.g. with a read or a connection error.
3. After multiple cache read errors, pants will continue to attempt to pull down every single possible artifact from the remote cache that it can. When on a flaky connection, this means pants will create many long-running http requests, many of which will fail, and the user will be kept waiting until each individual one times out. This takes an incredibly long time, and it's not clear why pants can't just see that the requests are flaking, and stop trying to pull from the remote cache.

### Solution

- Create `RequestsSession.Factory` subsystem with options corresponding to `requests.adapters.HTTPAdapter` or `urllib3.util.Retry` constructor arguments.
  - This required making `pants.cache` into a tiny backend, which only exposes `RequestsSession.Factory` as a global subsystem.
  - Make `RequestsSession` itself into a `@dataclass` which wraps the option parameters.
- Check for any raised `MaxRetryError`, and disable remote artifact caching for the rest of the pants run if the number of retries exceeds `--max-retries*`.
- Add testing for this retry mechanism and for automatically disabling the http artifact cache after exceeding the retry limit.

### Result

- Connection pool size can now be modified with an option (and defaults to the number of available processors).
- Retry capabilities were added.
- Pants will stop trying to fetch artifacts at all if the connection is too flaky.

Pants should now be a lot less difficult to use on the train and/or plane!