### PR TITLE
Fix fingerprint dict with files

### DIFF
--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -171,10 +171,10 @@ class OptionsFingerprinter:
     converted to encode its keys with `stable_option_fingerprint()`, as is done in the `fingerprint()`
     method.
     """
-    final = defaultdict(dict)
+    final = defaultdict(list)
     for k, v in option_val.items():
-      for path in v.split(','):
+      for path in sorted(v.split(',')):
         with open(path, 'r') as f:
-          final[k][path] = f.read()
+          final[k].append(f.read())
     fingerprint = stable_option_fingerprint(final)
     return fingerprint

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -173,8 +173,11 @@ class OptionsFingerprinter:
     """
     final = defaultdict(list)
     for k, v in option_val.items():
-      for path in sorted(v.split(',')):
-        with open(path, 'r') as f:
-          final[k].append(f.read())
+      for sub_value in sorted(v.split(',')):
+        if os.path.isfile(sub_value):
+          with open(sub_value, 'r') as f:
+            final[k].append(f.read())
+        else:
+          final[k].append(sub_value)
     fingerprint = stable_option_fingerprint(final)
     return fingerprint

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from collections import defaultdict
 from hashlib import sha1
 
 from pants.base.build_environment import get_buildroot
@@ -170,13 +171,10 @@ class OptionsFingerprinter:
     converted to encode its keys with `stable_option_fingerprint()`, as is done in the `fingerprint()`
     method.
     """
-    return stable_option_fingerprint({
-      k: self._expand_possible_file_value(v) for k, v in option_val.items()
-    })
-
-  def _expand_possible_file_value(self, value):
-    """If the value is a file, returns its contents. Otherwise return the original value."""
-    if value and os.path.isfile(str(value)):
-      with open(value, 'r') as f:
-        return f.read()
-    return value
+    final = defaultdict(dict)
+    for k, v in option_val.items():
+      for path in v.split(','):
+        with open(path, 'r') as f:
+          final[k][path] = f.read()
+    fingerprint = stable_option_fingerprint(final)
+    return fingerprint


### PR DESCRIPTION
### Problem

```
[test.checkstyle]
properties: {
    'checkstyle.suppression.files': (
      '%(pants_supportdir)s/checkstyle/1.xml,'
      '%(pants_supportdir)s/checkstyle/2.xml,'
      '%(pants_supportdir)s/checkstyle/3.xml'
    )
  }
```
Changing the content of those xmls do not invalidate the task. 

### Solution

Split the option into different files and add their content into fingerprint if they are files.