### PR TITLE
Deduplicate requirements in V2 pex generation rule

### DIFF
--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -1,6 +1,8 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import Tuple
+
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -21,7 +23,7 @@ class PyTest(Subsystem):
              help='Requirements string for the unittest2 library, which some python versions '
                   'may need.')
 
-  def get_requirement_strings(self):
+  def get_requirement_strings(self) -> Tuple[str, ...]:
     """Returns a tuple of requirements-style strings for pytest and related libraries.
 
     Make sure the requirements are satisfied in any environment used for running tests.


### PR DESCRIPTION
### Problem
When working on another change, I encountered this error:

>     Computing Task(create_pex(), (CreatePex(output_filename='pytest-with-requirements.pex', requirements=PexRequirements(requirements=('Markdown==2.1.1', 'PyYAML==5.1.2', 'Pygments==2.3.1', 'ansicolors==1.0.2', 'asttokens==1.1.13', 'cffi==1.12.3', 'contextlib2==0.5.5', 'dataclasses==0.6', 'docutils==0.14', 'fasteners==0.14.1', "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'", "more-itertools<6.0.0 ; python_version<'3'"

This keeps going for over 400 more (soft-wrapped) lines.

Although the end functionality still works, we do not intend to request any requirement more than once.

### Solution
Fix bad indentation so that we only add the `pytest.requirement_strings()` once, not not once per every target. Also use a frozenset data structure instead of a tuple.