### PR TITLE
Directly use `option.scope` instead of re-exports

### DIFF
--- a/src/python/pants/backend/docgen/tasks/generate_pants_reference.py
+++ b/src/python/pants/backend/docgen/tasks/generate_pants_reference.py
@@ -8,8 +8,7 @@ from pants.goal.goal import Goal
 from pants.help.build_dictionary_info_extracter import BuildDictionaryInfoExtracter
 from pants.help.help_info_extracter import HelpInfoExtracter
 from pants.help.scope_info_iterator import ScopeInfoIterator
-from pants.option.arg_splitter import GLOBAL_SCOPE
-from pants.option.scope import ScopeInfo
+from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.task.task import Task
 from pants.util.dirutil import safe_open
 

--- a/src/python/pants/core_tasks/bash_completion.py
+++ b/src/python/pants/core_tasks/bash_completion.py
@@ -10,7 +10,7 @@ from pants.base.exceptions import TaskError
 from pants.base.generator import Generator
 from pants.goal.goal import Goal
 from pants.help.help_info_extracter import HelpInfoExtracter
-from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.scope import GLOBAL_SCOPE
 from pants.task.console_task import ConsoleTask
 from pants.task.task import TaskBase
 

--- a/src/python/pants/core_tasks/explain_options_task.py
+++ b/src/python/pants/core_tasks/explain_options_task.py
@@ -6,9 +6,9 @@ import json
 from colors import black, blue, cyan, green, magenta, red, white
 from packaging.version import Version
 
-from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.options_fingerprinter import CoercingOptionEncoder
 from pants.option.ranked_value import RankedValue
+from pants.option.scope import GLOBAL_SCOPE
 from pants.task.console_task import ConsoleTask
 from pants.version import PANTS_SEMVER
 

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -8,14 +8,13 @@ from pants.goal.goal import Goal
 from pants.help.help_formatter import HelpFormatter
 from pants.help.scope_info_iterator import ScopeInfoIterator
 from pants.option.arg_splitter import (
-  GLOBAL_SCOPE,
   GoalsHelp,
   NoGoalHelp,
   OptionsHelp,
   UnknownGoalHelp,
   VersionHelp,
 )
-from pants.option.scope import ScopeInfo
+from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 
 
 class HelpPrinter:

--- a/src/python/pants/help/scope_info_iterator.py
+++ b/src/python/pants/help/scope_info_iterator.py
@@ -2,10 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.parser_hierarchy import enclosing_scope
-from pants.option.scope import ScopeInfo
+from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 
 

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -8,12 +8,7 @@ from collections import namedtuple
 
 from twitter.common.collections import OrderedSet
 
-from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION, ScopeInfo
-
-
-# TODO: Switch all clients to reference pants.option.scope directly.
-GLOBAL_SCOPE = GLOBAL_SCOPE
-GLOBAL_SCOPE_CONFIG_SECTION = GLOBAL_SCOPE_CONFIG_SECTION
+from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 
 
 class ArgSplitterError(Exception):

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.scope import GLOBAL_SCOPE
 
 
 class OptionsError(Exception):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -14,11 +14,10 @@ from pants.base.build_environment import (
   get_pants_configdir,
   pants_version,
 )
-from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.custom_types import dir_option, file_option
 from pants.option.errors import OptionsError
 from pants.option.optionable import Optionable
-from pants.option.scope import ScopeInfo
+from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 from pants.util.collections import Enum
 

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -7,14 +7,14 @@ import sys
 from dataclasses import dataclass
 
 from pants.base.deprecated import warn_or_error
-from pants.option.arg_splitter import GLOBAL_SCOPE, ArgSplitter
+from pants.option.arg_splitter import ArgSplitter
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.option_tracker import OptionTracker
 from pants.option.option_util import is_list_option
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.parser import Parser
 from pants.option.parser_hierarchy import ParserHierarchy, all_enclosing_scopes, enclosing_scope
-from pants.option.scope import ScopeInfo
+from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.meta import frozen_after_init
 

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -11,11 +11,11 @@ from typing import Tuple
 
 from pants.base.build_environment import get_default_pants_config_file
 from pants.engine.fs import FileContent
-from pants.option.arg_splitter import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION
 from pants.option.config import Config
 from pants.option.custom_types import ListValueComponent
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.options import Options
+from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION
 from pants.util.dirutil import read_file
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.strutil import ensure_text

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -16,7 +16,6 @@ import Levenshtein
 import yaml
 
 from pants.base.deprecated import validate_deprecation_semver, warn_or_error
-from pants.option.arg_splitter import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION
 from pants.option.config import Config
 from pants.option.custom_types import (
   DictValueComponent,
@@ -46,7 +45,7 @@ from pants.option.errors import (
 )
 from pants.option.option_util import is_dict_option, is_list_option
 from pants.option.ranked_value import RankedValue
-from pants.option.scope import ScopeInfo
+from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION, ScopeInfo
 from pants.util.meta import frozen_after_init
 
 

--- a/src/python/pants/option/parser_hierarchy.py
+++ b/src/python/pants/option/parser_hierarchy.py
@@ -3,9 +3,9 @@
 
 import re
 
-from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.config import Config
 from pants.option.parser import Parser
+from pants.option.scope import GLOBAL_SCOPE
 
 
 class InvalidScopeError(Exception):

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -18,9 +18,9 @@ from pants.engine.native import Native
 from pants.init.engine_initializer import EngineInitializer
 from pants.init.logging import init_rust_logger, setup_logging
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
-from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.options_fingerprinter import OptionsFingerprinter
+from pants.option.scope import GLOBAL_SCOPE
 from pants.pantsd.process_manager import FingerprintedProcessManager
 from pants.pantsd.service.fs_event_service import FSEventService
 from pants.pantsd.service.pailgun_service import PailgunService

--- a/src/python/pants/subsystem/subsystem_client_mixin.py
+++ b/src/python/pants/subsystem/subsystem_client_mixin.py
@@ -7,9 +7,8 @@ from typing import Any, Optional
 
 from twitter.common.collections import OrderedSet
 
-from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.optionable import OptionableFactory
-from pants.option.scope import ScopeInfo
+from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 
 
 class SubsystemClientError(Exception): pass

--- a/tests/python/pants_test/help/test_scope_info_iterator.py
+++ b/tests/python/pants_test/help/test_scope_info_iterator.py
@@ -4,9 +4,8 @@
 import unittest
 
 from pants.help.scope_info_iterator import ScopeInfoIterator
-from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.global_options import GlobalOptionsRegistrar
-from pants.option.scope import ScopeInfo
+from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.subsystem.subsystem import Subsystem
 from pants.subsystem.subsystem_client_mixin import SubsystemDependency
 from pants.task.task import Task

--- a/tests/python/pants_test/option/test_enclosing_scopes.py
+++ b/tests/python/pants_test/option/test_enclosing_scopes.py
@@ -1,8 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.parser_hierarchy import InvalidScopeError, all_enclosing_scopes, enclosing_scope
+from pants.option.scope import GLOBAL_SCOPE
 from pants_test.test_base import TestBase
 
 

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -15,7 +15,6 @@ from packaging.version import Version
 from pants.base.deprecated import CodeRemovedError
 from pants.base.hash_utils import CoercingEncoder
 from pants.engine.fs import FileContent
-from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.config import Config
 from pants.option.custom_types import UnsetBool, file_option, target_option
 from pants.option.errors import (
@@ -39,7 +38,7 @@ from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.parser import Parser
 from pants.option.ranked_value import RankedValue
-from pants.option.scope import ScopeInfo
+from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.util.collections import Enum, assert_single_element
 from pants.util.contextutil import temporary_file, temporary_file_path
 from pants.util.dirutil import safe_mkdtemp

--- a/tests/python/pants_test/task/test_task.py
+++ b/tests/python/pants_test/task/test_task.py
@@ -9,7 +9,7 @@ from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.files import Files
 from pants.build_graph.target_filter_subsystem import TargetFilter
 from pants.cache.cache_setup import CacheSetup
-from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.scope import GLOBAL_SCOPE
 from pants.subsystem.subsystem import Subsystem
 from pants.subsystem.subsystem_client_mixin import SubsystemDependency
 from pants.task.task import Task


### PR DESCRIPTION
We were using `option.arg_splitter` to export `option.scope` constants, rather than directly using `option.scope`.

This caused several MyPy issues.