### PR TITLE
Allow console_rule to request a single `BuildFileAddress`

### DIFF
--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -21,7 +21,7 @@ from pants.build_graph.address import BuildFileAddress
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.remote_sources import RemoteSources
 from pants.engine.addressable import BuildFileAddresses
-from pants.engine.build_files import ProvenancedBuildFileAddresses, create_graph_rules
+from pants.engine.build_files import create_graph_rules
 from pants.engine.console import Console
 from pants.engine.fs import Workspace, create_fs_rules
 from pants.engine.goal import Goal
@@ -378,11 +378,12 @@ class EngineInitializer:
     def single_build_file_address(specs: Specs) -> BuildFileAddress:
       build_file_addresses = yield Get(BuildFileAddresses, Specs, specs)
       if len(build_file_addresses.dependencies) != 1:
-        provenanced_addresses = yield Get(ProvenancedBuildFileAddresses, Specs, specs)
-        matched_addrs = [addr.build_file_address.to_address() for addr in provenanced_addresses]
-        output = '\n '.join(f':{addr}' for addr in matched_addrs)
+        potential_addresses = yield Get(BuildFileAddresses, Specs, specs)
+        targets = [bfa.to_address() for bfa in potential_addresses]
+        output = '\n '.join(f'{target}' for target in targets)
+
         raise ResolveError(
-          "This goal only works with a single target, but has been given multiple targets:\n"
+          "Expected a single target, but was given multiple targets:\n"
           f"Did you mean one of:\n {output}"
         )
       yield build_file_addresses.dependencies[0]

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -380,7 +380,7 @@ class EngineInitializer:
       if len(build_file_addresses.dependencies) != 1:
         potential_addresses = yield Get(BuildFileAddresses, Specs, specs)
         targets = [bfa.to_address() for bfa in potential_addresses]
-        output = '\n '.join(f'{target}' for target in targets)
+        output = '\n '.join(str(target) for target in targets)
 
         raise ResolveError(
           "Expected a single target, but was given multiple targets:\n"

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -377,7 +377,9 @@ class EngineInitializer:
     @rule
     def single_build_file_address(specs: Specs) -> BuildFileAddress:
       build_file_addresses = yield Get(BuildFileAddresses, Specs, specs)
-      if len(build_file_addresses.dependencies) != 1:
+      if len(build_file_addresses.dependencies) == 0:
+        raise ResolveError("No targets were matched")
+      if len(build_file_addresses.dependencies) > 1:
         potential_addresses = yield Get(BuildFileAddresses, Specs, specs)
         targets = [bfa.to_address() for bfa in potential_addresses]
         output = '\n '.join(str(target) for target in targets)

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -3,8 +3,7 @@
 
 from pathlib import Path
 
-from pants.build_graph.address import Address
-from pants.engine.addressable import BuildFileAddresses
+from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.console import Console
 from pants.engine.fs import DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal
@@ -20,12 +19,8 @@ class Run(Goal):
   name = 'run'
 
 
-#TODO(gregs) - the `run` rule should really only accept a single target, but we don't have the infrastructure
-# yet to support a console rule that can request one and only one target (rather than BuildFileAddresses plural
-# or Specs plural). 
 @console_rule
-def run(console: Console, workspace: Workspace, runner: InteractiveRunner, addresses: BuildFileAddresses) -> Run:
-  bfa = addresses.dependencies[0]
+def run(console: Console, workspace: Workspace, runner: InteractiveRunner, bfa: BuildFileAddress) -> Run:
   target = bfa.to_address()
   binary = yield Get(CreatedBinary, Address, target)
 

--- a/tests/python/pants_test/rules/test_run.py
+++ b/tests/python/pants_test/rules/test_run.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.build_graph.address import Address, BuildFileAddress
-from pants.engine.addressable import BuildFileAddresses
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Workspace
 from pants.engine.interactive_runner import InteractiveRunner
 from pants.rules.core import run
@@ -33,8 +32,7 @@ class RunTest(ConsoleRuleTestBase):
       target_name=address.target_name,
       rel_path=f'{address.spec_path}/BUILD'
     )
-    build_file_addresses = BuildFileAddresses((bfa,))
-    res = run_rule(run.run, console, workspace, interactive_runner, build_file_addresses, {
+    res = run_rule(run.run, console, workspace, interactive_runner, bfa, {
       (CreatedBinary, Address): lambda _: self.create_mock_binary(program_text)
     })
     return res


### PR DESCRIPTION
### Problem

We want to limit the `run` goal to requesting a single target

### Solution

Create a new `@rule` that can turn `Specs` into a single `BuildFileAddress`, by checking that the `BuildFileAddresses`. This allows the `run` `@console_rule` to be rewritten to request only a single `BuildFileAddress`. The new `@rule` will throw an exception if multiple targets are specified on the command line for a `@console_rule` that requests only a single `BuildFileAddress`.
