### PR TITLE
Partially type check core `base`, `engine`, `option`, and `subsystem` code

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -35,6 +35,7 @@ python_library(
     'src/python/pants/util:dirutil',
     ':project_tree',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -72,6 +73,7 @@ python_library(
     ':build_environment',
     ':exiter',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -106,6 +108,7 @@ python_library(
     '3rdparty/python:typing-extensions',
     'src/python/pants/util:strutil',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -135,7 +138,8 @@ python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':hash_utils',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(

--- a/src/python/pants/cache/BUILD
+++ b/src/python/pants/cache/BUILD
@@ -10,5 +10,6 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -28,7 +28,7 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/util:memo',
     'src/python/pants/util:objects',
-  ]
+  ],
 )
 
 python_library(
@@ -141,6 +141,7 @@ python_library(
 python_library(
   name='objects',
   sources=['objects.py'],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -163,7 +164,7 @@ python_library(
       'src/python/pants/util:collections',
       'src/python/pants/util:memo',
       'src/python/pants/util:osutil',
-  ]
+  ],
 )
 
 python_library(
@@ -177,7 +178,7 @@ python_library(
     'src/python/pants/util:collections',
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
-  ]
+  ],
 )
 
 python_library(
@@ -187,7 +188,8 @@ python_library(
     '3rdparty/python:dataclasses',
     'src/python/pants/util:meta',
     'src/python/pants/util:objects',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -232,6 +234,7 @@ python_library(
   dependencies=[
     '3rdparty/python:ansicolors',
   ],
+  tags = {'partially_type_checked'},
 )
 
 resources(

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -53,7 +53,8 @@ python_library(
     'src/python/pants/base:project_tree',
     'src/python/pants/option',
     'src/python/pants/util:meta',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -65,7 +66,8 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -179,6 +181,7 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -197,7 +197,8 @@ class Workspace:
   _scheduler: Any
 
   def materialize_directories(self, directories_to_materialize: Tuple[DirectoryToMaterialize, ...]) -> MaterializeDirectoriesResult:
-    return self._scheduler.materialize_directories(directories_to_materialize)
+    result: MaterializeDirectoriesResult = self._scheduler.materialize_directories(directories_to_materialize)
+    return result
 
 
 # TODO: don't recreate this in python, get this from fs::EMPTY_DIGEST somehow.

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -14,6 +14,7 @@ from pants.util.meta import classproperty
 
 
 @dataclass(frozen=True)
+# type: ignore # tracked by https://github.com/python/mypy/issues/5374, which they put as high priority.
 class Goal(metaclass=ABCMeta):
   """The named product of a `@console_rule`.
 

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from collections.abc import Iterable
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Any, Callable, Dict, Optional, Tuple, Type, cast
+from typing import Any, Callable, Dict, Optional, Tuple, Type
 
 import asttokens
 from twitter.common.collections import OrderedSet
@@ -314,7 +314,7 @@ def _ensure_type_annotation(
   if not isinstance(annotation, type):
     raise raise_type(f'The annotation for {name} must be a type, '
                      f'got {annotation} of type {type(annotation)}.')
-  return cast(type, annotation)
+  return annotation
 
 
 def rule(*args, cacheable=True) -> Callable:
@@ -470,7 +470,7 @@ class TaskRule(Rule):
     self._output_type = output_type
     self.input_selectors = input_selectors
     self.input_gets = input_gets
-    self.func = func
+    self.func = func  # type: ignore
     self._dependency_rules = dependency_rules or ()
     self._dependency_optionables = dependency_optionables or ()
     self.cacheable = cacheable

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -18,5 +18,6 @@ python_library(
     'src/python/pants/util:meta',
     'src/python/pants/util:memo',
     'src/python/pants/util:strutil',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -4,6 +4,7 @@
 import functools
 import re
 from abc import ABC, ABCMeta, abstractmethod
+from typing import Optional
 
 from pants.engine.selectors import Get
 from pants.option.errors import OptionsError
@@ -56,8 +57,8 @@ class Optionable(OptionableFactory, metaclass=ABCMeta):
   """A mixin for classes that can register options on some scope."""
 
   # Subclasses must override.
-  options_scope = None
-  options_scope_category = None
+  options_scope: Optional[str] = None
+  options_scope_category: Optional[str] = None
 
   # Subclasses may override these to specify a deprecated former name for this Optionable's scope.
   # Option values can be read from the deprecated scope, but a deprecation warning will be issued.
@@ -146,4 +147,4 @@ class Optionable(OptionableFactory, metaclass=ABCMeta):
     # subclass anyway.
     cls = type(self)
     if not isinstance(cls.options_scope, str):
-      raise NotImplementedError('{} must set an options_scope class-level property.'.format(cls))
+      raise NotImplementedError(f'{cls} must set an options_scope class-level property.')

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -171,7 +171,7 @@ class Parser:
       """
       self.flag_value_map = self._create_flag_value_map(flags_in_scope)
       self.namespace = namespace
-      self.get_all_scoped_flag_names = get_all_scoped_flag_names
+      self.get_all_scoped_flag_names = get_all_scoped_flag_names  # type: ignore
       self.levenshtein_max_distance = levenshtein_max_distance
 
     @staticmethod

--- a/src/python/pants/subsystem/BUILD
+++ b/src/python/pants/subsystem/BUILD
@@ -7,4 +7,5 @@ python_library(
     '3rdparty/python:dataclasses',
     'src/python/pants/option',
   ],
+  tags = {'partially_type_checked'},
 )

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import inspect
+from typing import Dict, Tuple
 
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
@@ -38,9 +39,10 @@ class Subsystem(SubsystemClientMixin, Optionable):
 
   class UninitializedSubsystemError(SubsystemError):
     def __init__(self, class_name, scope):
-      super(Subsystem.UninitializedSubsystemError, self).__init__(
-        'Subsystem "{}" not initialized for scope "{}". '
-        'Is subsystem missing from subsystem_dependencies() in a task? '.format(class_name, scope))
+      super().__init__(
+        f'Subsystem "{class_name}" not initialized for scope "{scope}". Is subsystem missing'
+        'from subsystem_dependencies() in a task? '
+      )
 
   @classmethod
   def is_subsystem_type(cls, obj):
@@ -78,29 +80,26 @@ class Subsystem(SubsystemClientMixin, Optionable):
     return cls._options is not None
 
   # A cache of (cls, scope) -> the instance of cls tied to that scope.
-  _scoped_instances = {}
+  _scoped_instances: Dict[Tuple["Subsystem", str], "Subsystem"] = {}
 
   @classmethod
-  def global_instance(cls):
+  def global_instance(cls) -> "Subsystem":
     """Returns the global instance of this subsystem.
 
     :API: public
 
     :returns: The global subsystem instance.
-    :rtype: :class:`pants.subsystem.subsystem.Subsystem`
     """
-    return cls._instance_for_scope(cls.options_scope)
+    return cls._instance_for_scope(cls.options_scope)  # type: ignore
 
   @classmethod
-  def scoped_instance(cls, optionable):
+  def scoped_instance(cls, optionable: Optionable) -> "Subsystem":
     """Returns an instance of this subsystem for exclusive use by the given `optionable`.
 
     :API: public
 
     :param optionable: An optionable type or instance to scope this subsystem under.
-    :type: :class:`pants.option.optionable.Optionable`
     :returns: The scoped subsystem instance.
-    :rtype: :class:`pants.subsystem.subsystem.Subsystem`
     """
     if not isinstance(optionable, Optionable) and not issubclass(optionable, Optionable):
       raise TypeError('Can only scope an instance against an Optionable, given {} of type {}.'
@@ -108,7 +107,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
     return cls._instance_for_scope(cls.subscope(optionable.options_scope))
 
   @classmethod
-  def _instance_for_scope(cls, scope):
+  def _instance_for_scope(cls, scope: str) -> "Subsystem":
     if cls._options is None:
       raise cls.UninitializedSubsystemError(cls.__name__, scope)
     key = (cls, scope)
@@ -126,7 +125,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
       cls._options = None
     cls._scoped_instances = {}
 
-  def __init__(self, scope, scoped_options):
+  def __init__(self, scope: str, scoped_options) -> None:
     """Note: A subsystem has no access to options in scopes other than its own.
 
     TODO: We'd like that to be true of Tasks some day. Subsystems will help with that.
@@ -141,8 +140,11 @@ class Subsystem(SubsystemClientMixin, Optionable):
     self._scoped_options = scoped_options
     self._fingerprint = None
 
+  # It's safe to override the signature from Optionable because we validate
+  # that every Optionable has `options_scope` defined as a `str` in the __init__. This code is
+  # complex, though, and may be worth refactoring.
   @property
-  def options_scope(self):
+  def options_scope(self) -> str:  # type: ignore
     return self._scope
 
   @property


### PR DESCRIPTION
These targets are widely used (https://docs.google.com/spreadsheets/d/1MKg82Fs3uIMOZDoWeNUBD-VirVkOzHU8Tte7oY6ypP0/edit#gid=1479336346). Due to their current issues, this means that any dependee cannot start using MyPy.

Here, we make the bare minimum of changes necessary and only mark with `partially_type_checked` (opposed to `type_checked`) to unblock future MyPy work. These targets will still need a pass for complete type checking.