### PR TITLE
Fix V2 pytest caching issues from using FrozenSet

### DIFF
--- a/src/python/pants/backend/python/rules/python_fmt.py
+++ b/src/python/pants/backend/python/rules/python_fmt.py
@@ -61,7 +61,7 @@ def get_black_input(
     Pex, CreatePex(
       output_filename="black.pex",
       requirements=PexRequirements(requirements=tuple(black.get_requirement_specs())),
-      interpreter_constraints=PexInterpreterConstraints(constraint_set=frozenset(black.default_interpreter_constraints)),
+      interpreter_constraints=PexInterpreterConstraints(constraint_set=tuple(black.default_interpreter_constraints)),
       entry_point=black.get_entry_point(),
     )
   )

--- a/tests/python/pants_test/backend/python/rules/test_pex.py
+++ b/tests/python/pants_test/backend/python/rules/test_pex.py
@@ -132,4 +132,4 @@ class TestResolveRequirements(TestBase):
         constraint_set=("CPython>=2.7,<3", "CPython>=3.6,<4")
     )
     pex_info = self.create_pex_and_get_pex_info(interpreter_constraints=constraints)
-    self.assertEqual(frozenset(pex_info["interpreter_constraints"]), constraints.constraint_set)
+    self.assertEqual(set(pex_info["interpreter_constraints"]), set(constraints.constraint_set))

--- a/tests/python/pants_test/backend/python/rules/test_pex.py
+++ b/tests/python/pants_test/backend/python/rules/test_pex.py
@@ -129,6 +129,7 @@ class TestResolveRequirements(TestBase):
 
   def test_interpreter_constraints(self) -> None:
     constraints = PexInterpreterConstraints(
-        constraint_set=frozenset(sorted({"CPython>=2.7,<3", "CPython>=3.6,<4"})))
+        constraint_set=("CPython>=2.7,<3", "CPython>=3.6,<4")
+    )
     pex_info = self.create_pex_and_get_pex_info(interpreter_constraints=constraints)
     self.assertEqual(frozenset(pex_info["interpreter_constraints"]), constraints.constraint_set)


### PR DESCRIPTION
### Problem
Even though frozen sets are immutable in Python, sets are never deterministic. This means that the V2 cache will almost never work properly.

Tangibly, https://github.com/pantsbuild/pants/pull/8577 broke caching for the rule `create_pex` and thus the V2 pytest runner.

### Solution
Stop using `FrozenSet` and instead use the safer `Tuple`. We still use sets in the intermediate logic because we want the de-duplication, but we then cast to a sorted tuple. The sorting is important for determinism.

### Result
Caching works again.