### PR TITLE
Allow @rule-authors to give rules names

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -107,10 +107,10 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
       v2_ui = options.for_global_scope().v2_ui
       zipkin_trace_v2 = options.for_scope('reporting').zipkin_trace_v2
       #TODO(gregorys) This should_report_workunits flag must be set to True for
-      # AsyncWorkunitHandler to receive WorkUnits. It should eventually
+      # StreamingWorkunitHandler to receive WorkUnits. It should eventually
       # be merged with the zipkin_trace_v2 flag, since they both involve most
       # of the same engine functionality, but for now is separate to avoid
-      # breaking functionality associated with zipkin tracing while iterating on async workunit reporting.
+      # breaking functionality associated with zipkin tracing while iterating on streaming workunit reporting.
       should_report_workunits = False
       graph_session = graph_scheduler_helper.new_session(zipkin_trace_v2, RunTracker.global_instance().run_id, v2_ui, should_report_workunits)
     return graph_session, graph_session.scheduler_session

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -21,6 +21,7 @@ from pants.init.target_roots_calculator import TargetRootsCalculator
 from pants.option.arg_splitter import UnknownGoalHelp
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.reporting.reporting import Reporting
+from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
 from pants.util.contextutil import maybe_profiled
 
 
@@ -106,13 +107,13 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
       v2_ui = options.for_global_scope().v2_ui
       zipkin_trace_v2 = options.for_scope('reporting').zipkin_trace_v2
-      #TODO(gregorys) This should_report_workunits flag must be set to True for
+      #TODO(#8658) This should_report_workunits flag must be set to True for
       # StreamingWorkunitHandler to receive WorkUnits. It should eventually
       # be merged with the zipkin_trace_v2 flag, since they both involve most
       # of the same engine functionality, but for now is separate to avoid
       # breaking functionality associated with zipkin tracing while iterating on streaming workunit reporting.
-      should_report_workunits = False
-      graph_session = graph_scheduler_helper.new_session(zipkin_trace_v2, RunTracker.global_instance().run_id, v2_ui, should_report_workunits)
+      stream_workunits = options.for_scope('reporting').stream_workunits
+      graph_session = graph_scheduler_helper.new_session(zipkin_trace_v2, RunTracker.global_instance().run_id, v2_ui, should_report_workunits=stream_workunits)
     return graph_session, graph_session.scheduler_session
 
   @staticmethod
@@ -319,7 +320,11 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     try:
       self._maybe_handle_help()
 
-      engine_result = self._maybe_run_v2()
+      stream_workunits = self._options.for_scope('reporting').stream_workunits
+      streaming_reporter = StreamingWorkunitHandler(self._scheduler_session, callback=None)
+      with streaming_reporter.session():
+        engine_result = self._maybe_run_v2()
+
       goal_runner_result = self._maybe_run_v1()
     finally:
       try:

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -320,7 +320,6 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     try:
       self._maybe_handle_help()
 
-      stream_workunits = self._options.for_scope('reporting').stream_workunits
       streaming_reporter = StreamingWorkunitHandler(self._scheduler_session, callback=None)
       with streaming_reporter.session():
         engine_result = self._maybe_run_v2()

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -337,11 +337,11 @@ def _ensure_type_annotation(
   return annotation
 
 
-PUBLIC_RULE_DECORATOR_ARGUMENTS = set(['name'])
+PUBLIC_RULE_DECORATOR_ARGUMENTS = {'name'}
 # We don't want @rule-writers to use 'cacheable' as a kwarg directly, but rather
 # set it implicitly based on whether the rule annotation is @rule or @console_rule.
 # So we leave it out of PUBLIC_RULE_DECORATOR_ARGUMENTS.
-IMPLICIT_PRIVATE_RULE_DECORATOR_ARGUMENTS = set(['cacheable'])
+IMPLICIT_PRIVATE_RULE_DECORATOR_ARGUMENTS = {'cacheable'}
 
 
 def rule_decorator(*args, **kwargs) -> Callable:
@@ -358,7 +358,7 @@ def rule_decorator(*args, **kwargs) -> Callable:
 
   func = args[0]
 
-  cacheable = kwargs['cacheable'] # type: bool
+  cacheable: bool = kwargs['cacheable']
   name = kwargs.get('name')
 
   signature = inspect.signature(func)

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -215,7 +215,8 @@ def _get_starting_indent(source):
 
 
 def _make_rule(
-  return_type: type, parameter_types: typing.Iterable[type], cacheable: bool = True
+  return_type: type, parameter_types: typing.Iterable[type], cacheable: bool = True,
+  name: Optional[bool] = None
 ) -> Callable[[Callable], Callable]:
   """A @decorator that declares that a particular static function may be used as a TaskRule.
 
@@ -285,6 +286,12 @@ def _make_rule(
     # Register dependencies for @console_rule/Goal.
     dependency_rules = (optionable_rule(return_type.Options),) if is_goal_cls else None
 
+    # Set a default name for Goal classes if one is not explicitly provided
+    if is_goal_cls and name is None:
+      effective_name = return_type.name
+    else:
+      effective_name = name
+
     func.rule = TaskRule(
         return_type,
         tuple(parameter_types),
@@ -292,6 +299,7 @@ def _make_rule(
         input_gets=tuple(gets),
         dependency_rules=dependency_rules,
         cacheable=cacheable,
+        name=effective_name,
       )
 
     return func
@@ -300,6 +308,14 @@ def _make_rule(
 
 class InvalidTypeAnnotation(TypeError):
   """Indicates an incorrect type annotation for an `@rule`."""
+
+
+class UnrecognizedRuleArgument(TypeError):
+  """Indicates an unrecognized keyword argument to a `@rule`."""
+
+
+class MissingTypeAnnotation(TypeError):
+  """Indicates a missing type annotation for an `@rule`."""
 
 
 class MissingReturnTypeAnnotation(InvalidTypeAnnotation):
@@ -321,14 +337,29 @@ def _ensure_type_annotation(
   return annotation
 
 
-def rule(*args, cacheable=True) -> Callable:
+PUBLIC_RULE_DECORATOR_ARGUMENTS = set(['name'])
+
+
+def rule_decorator(*args, **kwargs) -> Callable:
   if len(args) != 1 and not inspect.isfunction(args[0]):
     raise ValueError(
       'The @rule decorator expects no arguments and for the function it decorates to be '
       f'type-annotated. Given {args}.'
     )
 
+  # We don't want @rule-writers to use 'cacheable' as a kwarg directly, but rather
+  # set it implicitly based on whether the rule annotation is @rule or @console_rule.
+  # So we leave it out of PUBLIC_RULE_DECORATOR_ARGUMENTS.
+  if len(set(kwargs) - PUBLIC_RULE_DECORATOR_ARGUMENTS - set(['cacheable'])) != 0:
+    raise UnrecognizedRuleArgument(
+      f"`@rule`s and `@console_rule`s only accept the following keyword arguments: {PUBLIC_RULE_DECORATOR_ARGUMENTS}"
+    )
+
   func = args[0]
+
+  cacheable = kwargs.get('cacheable', True) # type: bool
+  name = kwargs.get('name')
+
   signature = inspect.signature(func)
   func_id = f'@rule {func.__module__}:{func.__name__}'
   return_type = _ensure_type_annotation(
@@ -346,11 +377,24 @@ def rule(*args, cacheable=True) -> Callable:
     )
     for name, parameter in signature.parameters.items()
   )
-  return _make_rule(return_type, parameter_types, cacheable=cacheable)(func)
+  return _make_rule(return_type, parameter_types, cacheable=cacheable, name=name)(func)
 
 
-def console_rule(*args) -> Callable:
-  return rule(*args, cacheable=False)
+def inner_rule(*args, **kwargs) -> Callable:
+  if len(args) == 1 and inspect.isfunction(args[0]):
+    return rule_decorator(*args, **kwargs)
+  else:
+    def wrapper(*args):
+      return rule_decorator(*args, **kwargs)
+    return wrapper
+
+
+def rule(*args, **kwargs) -> Callable:
+  return inner_rule(*args, **kwargs, cacheable=True)
+
+
+def console_rule(*args, **kwargs) -> Callable:
+  return inner_rule(*args, **kwargs, cacheable=False)
 
 
 def union(cls):
@@ -460,6 +504,7 @@ class TaskRule(Rule):
   _dependency_rules: Tuple
   _dependency_optionables: Tuple
   cacheable: bool
+  name: Optional[str]
 
   def __init__(
     self,
@@ -470,6 +515,7 @@ class TaskRule(Rule):
     dependency_rules: Optional[Tuple] = None,
     dependency_optionables: Optional[Tuple] = None,
     cacheable: bool = True,
+    name: Optional[str] = None,
   ):
     self._output_type = output_type
     self.input_selectors = input_selectors
@@ -478,14 +524,17 @@ class TaskRule(Rule):
     self._dependency_rules = dependency_rules or ()
     self._dependency_optionables = dependency_optionables or ()
     self.cacheable = cacheable
+    self.name = name
 
   def __str__(self):
-    return ('({}, {!r}, {}, gets={}, opts={})'
+    return ('({}, {!r}, {}, gets={}, opts={} name={})'
             .format(self.output_type.__name__,
                     self.input_selectors,
                     self.func.__name__,
                     self.input_gets,
-                    self.dependency_optionables))
+                    self.dependency_optionables,
+                    self.name or '<not defined>',
+                    ))
 
   @property
   def output_type(self):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -167,12 +167,15 @@ class Scheduler:
         else:
           raise ValueError('Unexpected Rule type: {}'.format(rule))
 
-  def _register_task(self, output_type, rule, union_rules):
+  def _register_task(self, output_type, rule: TaskRule, union_rules):
     """Register the given TaskRule with the native scheduler."""
     func = Function(self._to_key(rule.func))
     self._native.lib.tasks_task_begin(self._tasks, func, self._to_type(output_type), rule.cacheable)
     for selector in rule.input_selectors:
       self._native.lib.tasks_add_select(self._tasks, self._to_type(selector))
+
+    if rule.name:
+      self._native.lib.tasks_add_display_info(self._tasks, rule.name.encode())
 
     def add_get_edge(product, subject):
       self._native.lib.tasks_add_get(self._tasks, self._to_type(product), self._to_type(subject))

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -56,7 +56,7 @@ from pants.option.global_options import (
   ExecutionOptions,
   GlobMatchErrorBehavior,
 )
-from pants.reporting.async_workunit_handler import AsyncWorkunitHandler
+from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
 
 
 logger = logging.getLogger(__name__)
@@ -205,7 +205,7 @@ class LegacyGraphSession:
     :returns: An exit code.
     """
 
-    async_reporter = AsyncWorkunitHandler(self.scheduler_session, callback=None)
+    streaming_reporter = StreamingWorkunitHandler(self.scheduler_session, callback=None)
     subject = target_roots.specs
     console = Console(
       use_colors=options_bootstrapper.bootstrap_options.for_global_scope().colors
@@ -213,7 +213,7 @@ class LegacyGraphSession:
     workspace = Workspace(self.scheduler_session)
     interactive_runner = InteractiveRunner(self.scheduler_session)
 
-    with async_reporter.session():
+    with streaming_reporter.session():
       for goal in goals:
         goal_product = self.goal_map[goal]
         params = Params(subject, options_bootstrapper, console, workspace, interactive_runner)

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -184,7 +184,8 @@ class SchedulerService(PantsService):
     build_id = RunTracker.global_instance().run_id
     v2_ui = options.for_global_scope().v2_ui
     zipkin_trace_v2 = options.for_scope('reporting').zipkin_trace_v2
-    session = self._graph_helper.new_session(zipkin_trace_v2, build_id, v2_ui)
+    stream_workunits = options.for_scope('reporting').stream_workunits
+    session = self._graph_helper.new_session(zipkin_trace_v2, build_id, v2_ui, should_report_workunits=stream_workunits)
 
     if options.for_global_scope().loop:
       fn = self._loop

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -63,6 +63,8 @@ class Reporting(Subsystem):
     register('--zipkin-max-span-batch-size', advanced=True, type=int, default=100,
               help='Spans in a Zipkin trace are sent to the Zipkin server in batches.' 
                    'zipkin-max-span-batch-size sets the max size of one batch.')
+    register('--stream-workunits', advanced=True, type=bool, default=False,
+        help="If set to true, report workunit information while pants is running")
 
   def initialize(self, run_tracker, all_options, start_time=None):
     """Initialize with the given RunTracker.

--- a/src/python/pants/reporting/streaming_workunit_handler.py
+++ b/src/python/pants/reporting/streaming_workunit_handler.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Iterator, Optional
 DEFAULT_REPORT_INTERVAL_SECONDS = 10
 
 
-class AsyncWorkunitHandler:
+class StreamingWorkunitHandler:
   def __init__(self, scheduler: Any, callback: Optional[Callable], report_interval_seconds: float = DEFAULT_REPORT_INTERVAL_SECONDS):
     self.scheduler = scheduler
     self.report_interval = report_interval_seconds

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -410,6 +410,10 @@ fn workunits_to_py_tuple_value<'a>(workunits: impl Iterator<Item = &'a WorkUnit>
         workunit_zipkin_trace_info.push(externs::store_utf8("parent_id"));
         workunit_zipkin_trace_info.push(externs::store_utf8(parent_id));
       }
+      if let Some(display_info) = &workunit.display_info {
+        workunit_zipkin_trace_info.push(externs::store_utf8("display_info"));
+        workunit_zipkin_trace_info.push(externs::store_utf8(display_info));
+      }
       externs::store_dict(&workunit_zipkin_trace_info)
     })
     .collect::<Vec<_>>();
@@ -548,6 +552,16 @@ pub extern "C" fn tasks_add_get(tasks_ptr: *mut Tasks, product: TypeId, subject:
 pub extern "C" fn tasks_add_select(tasks_ptr: *mut Tasks, product: TypeId) {
   with_tasks(tasks_ptr, |tasks| {
     tasks.add_select(product);
+  })
+}
+
+#[no_mangle]
+pub extern "C" fn tasks_add_display_info(tasks_ptr: *mut Tasks, name_ptr: *const raw::c_char) {
+  let name: String = unsafe { CStr::from_ptr(name_ptr) }
+    .to_string_lossy()
+    .into_owned();
+  with_tasks(tasks_ptr, |tasks| {
+    tasks.add_display_info(name);
   })
 }
 

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -410,10 +410,6 @@ fn workunits_to_py_tuple_value<'a>(workunits: impl Iterator<Item = &'a WorkUnit>
         workunit_zipkin_trace_info.push(externs::store_utf8("parent_id"));
         workunit_zipkin_trace_info.push(externs::store_utf8(parent_id));
       }
-      if let Some(display_info) = &workunit.display_info {
-        workunit_zipkin_trace_info.push(externs::store_utf8("display_info"));
-        workunit_zipkin_trace_info.push(externs::store_utf8(display_info));
-      }
       externs::store_dict(&workunit_zipkin_trace_info)
     })
     .collect::<Vec<_>>();

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -223,6 +223,7 @@ impl ByteStore {
           time_span: TimeSpan::since(&start_time),
           span_id: workunit_store::generate_random_64bit_string(),
           parent_id: workunit_store::get_parent_id(),
+          display_info: None,
         };
         workunit_store.add_workunit(workunit);
         future
@@ -302,6 +303,7 @@ impl ByteStore {
           time_span: TimeSpan::since(&start_time),
           span_id: workunit_store::generate_random_64bit_string(),
           parent_id: workunit_store::get_parent_id(),
+          display_info: None,
         };
         workunit_store.add_workunit(workunit);
         future
@@ -350,6 +352,7 @@ impl ByteStore {
           time_span: TimeSpan::since(&start_time),
           span_id: workunit_store::generate_random_64bit_string(),
           parent_id: workunit_store::get_parent_id(),
+          display_info: None,
         };
         workunit_store.add_workunit(workunit);
         future

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -15,7 +15,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use uuid;
-use workunit_store::WorkUnitStore;
+use workunit_store::{WorkUnit, WorkUnitStore};
 
 #[derive(Clone)]
 pub struct ByteStore {
@@ -218,12 +218,11 @@ impl ByteStore {
         }
       })
       .then(move |future| {
-        let workunit = workunit_store::WorkUnit {
-          name: workunit_name.clone(),
-          time_span: TimeSpan::since(&start_time),
-          span_id: workunit_store::generate_random_64bit_string(),
-          parent_id: workunit_store::get_parent_id(),
-        };
+        let workunit = WorkUnit::new(
+          workunit_name.clone(),
+          TimeSpan::since(&start_time),
+          workunit_store::get_parent_id(),
+        );
         workunit_store.add_workunit(workunit);
         future
       })
@@ -297,12 +296,11 @@ impl ByteStore {
         }
       })
       .then(move |future| {
-        let workunit = workunit_store::WorkUnit {
-          name: workunit_name.clone(),
-          time_span: TimeSpan::since(&start_time),
-          span_id: workunit_store::generate_random_64bit_string(),
-          parent_id: workunit_store::get_parent_id(),
-        };
+        let workunit = WorkUnit::new(
+          workunit_name.clone(),
+          TimeSpan::since(&start_time),
+          workunit_store::get_parent_id(),
+        );
         workunit_store.add_workunit(workunit);
         future
       })
@@ -345,12 +343,11 @@ impl ByteStore {
           })
       })
       .then(move |future| {
-        let workunit = workunit_store::WorkUnit {
-          name: workunit_name.clone(),
-          time_span: TimeSpan::since(&start_time),
-          span_id: workunit_store::generate_random_64bit_string(),
-          parent_id: workunit_store::get_parent_id(),
-        };
+        let workunit = WorkUnit::new(
+          workunit_name.clone(),
+          TimeSpan::since(&start_time),
+          workunit_store::get_parent_id(),
+        );
         workunit_store.add_workunit(workunit);
         future
       })

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -223,7 +223,6 @@ impl ByteStore {
           time_span: TimeSpan::since(&start_time),
           span_id: workunit_store::generate_random_64bit_string(),
           parent_id: workunit_store::get_parent_id(),
-          display_info: None,
         };
         workunit_store.add_workunit(workunit);
         future
@@ -303,7 +302,6 @@ impl ByteStore {
           time_span: TimeSpan::since(&start_time),
           span_id: workunit_store::generate_random_64bit_string(),
           parent_id: workunit_store::get_parent_id(),
-          display_info: None,
         };
         workunit_store.add_workunit(workunit);
         future
@@ -352,7 +350,6 @@ impl ByteStore {
           time_span: TimeSpan::since(&start_time),
           span_id: workunit_store::generate_random_64bit_string(),
           parent_id: workunit_store::get_parent_id(),
-          display_info: None,
         };
         workunit_store.add_workunit(workunit);
         future

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -830,6 +830,7 @@ fn maybe_add_workunit(
       time_span,
       span_id: generate_random_64bit_string(),
       parent_id,
+      display_info: None,
     };
     workunit_store.add_workunit(workunit);
   }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 use std;
 use std::cmp::min;
-use workunit_store::{generate_random_64bit_string, get_parent_id, WorkUnit, WorkUnitStore};
+use workunit_store::{get_parent_id, WorkUnit, WorkUnitStore};
 
 // Environment variable which is exclusively used for cache key invalidation.
 // This may be not specified in an ExecuteProcessRequest, and may be populated only by the
@@ -825,12 +825,7 @@ fn maybe_add_workunit(
   //  TODO: workunits for scheduling, fetching, executing and uploading should be recorded
   //   only if '--reporting-zipkin-trace-v2' is set
   if !result_cached {
-    let workunit = WorkUnit {
-      name: String::from(name),
-      time_span,
-      span_id: generate_random_64bit_string(),
-      parent_id,
-    };
+    let workunit = WorkUnit::new(name.to_string(), time_span, parent_id);
     workunit_store.add_workunit(workunit);
   }
 }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -830,7 +830,6 @@ fn maybe_add_workunit(
       time_span,
       span_id: generate_random_64bit_string(),
       parent_id,
-      display_info: None,
     };
     workunit_store.add_workunit(workunit);
   }

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2219,7 +2219,6 @@ fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      display_info: None
     },
     WorkUnit {
       name: String::from("remote execution worker input fetching"),
@@ -2229,7 +2228,6 @@ fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      display_info: None,
     },
     WorkUnit {
       name: String::from("remote execution worker command executing"),
@@ -2239,7 +2237,6 @@ fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      display_info: None,
     },
     WorkUnit {
       name: String::from("remote execution worker output uploading"),
@@ -2249,7 +2246,6 @@ fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
-      display_info: None,
     }
   };
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -2219,6 +2219,7 @@ fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
+      display_info: None
     },
     WorkUnit {
       name: String::from("remote execution worker input fetching"),
@@ -2228,6 +2229,7 @@ fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
+      display_info: None,
     },
     WorkUnit {
       name: String::from("remote execution worker command executing"),
@@ -2237,6 +2239,7 @@ fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
+      display_info: None,
     },
     WorkUnit {
       name: String::from("remote execution worker output uploading"),
@@ -2246,6 +2249,7 @@ fn remote_workunits_are_stored() {
       },
       span_id: String::from("ignore"),
       parent_id: None,
+      display_info: None,
     }
   };
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -24,13 +24,13 @@ use maplit::{btreemap, hashset};
 use mock::execution_server::MockOperation;
 use protobuf::well_known_types::Timestamp;
 use spectral::prelude::*;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::iter::{self, FromIterator};
 use std::ops::Sub;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use tokio::timer::Delay;
-use workunit_store::{workunits_with_constant_span_id, WorkUnit, WorkUnitStore};
+use workunit_store::{WorkUnit, WorkUnitStore};
 
 #[derive(Debug, PartialEq)]
 enum StdoutType {
@@ -2167,6 +2167,19 @@ fn extract_output_files_from_response_no_prefix() {
     extract_output_files_from_response(&execute_response),
     Ok(TestDirectory::containing_roland().digest())
   )
+}
+
+fn workunits_with_constant_span_id(workunit_store: &WorkUnitStore) -> HashSet<WorkUnit> {
+  workunit_store
+    .get_workunits()
+    .lock()
+    .workunits
+    .iter()
+    .map(|workunit| WorkUnit {
+      span_id: String::from("ignore"),
+      ..workunit.clone()
+    })
+    .collect()
 }
 
 #[test]

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1217,6 +1217,7 @@ impl Node for NodeKey {
       let span_id = generate_random_64bit_string();
       let maybe_display_info: Option<String> = match self {
         NodeKey::Task(ref task) => task.get_display_info().map(|s| s.to_owned()),
+        NodeKey::Snapshot(_) => Some(format!("{}", self)),
         _ => None,
       };
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1216,7 +1216,7 @@ impl Node for NodeKey {
       context.session.should_report_workunits() || context.session.should_record_zipkin_spans();
 
     let maybe_display_info: Option<String> = match self {
-      NodeKey::Task(ref task) => task.get_display_info().map(|s| s.to_owned()),
+      NodeKey::Task(ref task) if handle_workunits => task.get_display_info().map(|s| s.to_owned()),
       _ => None,
     };
 

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -93,6 +93,7 @@ pub struct Task {
   pub gets: Vec<Get>,
   pub func: Function,
   pub cacheable: bool,
+  pub display_info: Option<String>,
 }
 
 ///
@@ -188,6 +189,7 @@ impl Tasks {
       clause: Vec::new(),
       gets: Vec::new(),
       func: func,
+      display_info: None,
     });
   }
 
@@ -210,6 +212,14 @@ impl Tasks {
       .expect("Must `begin()` a task creation before adding clauses!")
       .clause
       .push(Select::new(product));
+  }
+
+  pub fn add_display_info(&mut self, display_info: String) {
+    let mut task = self
+      .preparing
+      .as_mut()
+      .expect("Must `begin()` a task creation before adding display info!");
+    task.display_info = Some(display_info);
   }
 
   pub fn task_end(&mut self) {

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -40,6 +40,7 @@ pub struct WorkUnit {
   pub time_span: TimeSpan,
   pub span_id: String,
   pub parent_id: Option<String>,
+  pub display_info: Option<String>,
 }
 
 #[derive(Clone, Default)]

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -31,7 +31,6 @@ use futures::task_local;
 use parking_lot::Mutex;
 use rand::thread_rng;
 use rand::Rng;
-use std::collections::HashSet;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -40,6 +39,18 @@ pub struct WorkUnit {
   pub time_span: TimeSpan,
   pub span_id: String,
   pub parent_id: Option<String>,
+}
+
+impl WorkUnit {
+  pub fn new(name: String, time_span: TimeSpan, parent_id: Option<String>) -> WorkUnit {
+    let span_id = generate_random_64bit_string();
+    WorkUnit {
+      name,
+      time_span,
+      span_id,
+      parent_id,
+    }
+  }
 }
 
 #[derive(Clone, Default)]
@@ -95,21 +106,6 @@ pub fn generate_random_64bit_string() -> String {
 
 fn hex_16_digit_string(number: u64) -> String {
   format!("{:016.x}", number)
-}
-
-pub fn workunits_with_constant_span_id(workunit_store: &WorkUnitStore) -> HashSet<WorkUnit> {
-  //  This function is for the test purpose.
-
-  workunit_store
-    .get_workunits()
-    .lock()
-    .workunits
-    .iter()
-    .map(|workunit| WorkUnit {
-      span_id: String::from("ignore"),
-      ..workunit.clone()
-    })
-    .collect()
 }
 
 task_local! {

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -40,7 +40,6 @@ pub struct WorkUnit {
   pub time_span: TimeSpan,
   pub span_id: String,
   pub parent_id: Option<String>,
-  pub display_info: Option<String>,
 }
 
 #[derive(Clone, Default)]

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -44,7 +44,7 @@ class Fib:
   val: int
 
 
-@rule
+@rule(name="fib")
 def fib(n: int) -> Fib:
   if n < 2:
     yield Fib(n)
@@ -253,14 +253,13 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     with async_reporter.session():
       scheduler.product_request(Fib, subjects=[0])
 
-    # One workunit should be coming from the `Select` intrinsic, and the other from the single execution
-    # of the `fib` rule, for two total workunits being appended during the run of this rule.
-    self.assertEquals(len(tracker.workunits), 2)
+    # The execution of the single named @rule "fib" should be providing this one workunit.
+    self.assertEquals(len(tracker.workunits), 1)
 
     tracker.workunits = []
     with async_reporter.session():
       scheduler.product_request(Fib, subjects=[10])
 
     # Requesting a bigger fibonacci number will result in more rule executions and thus more reported workunits.
-    # In this case, we expect 10 invocations of the `fib` rule + the one Select for a total of 11.
-    self.assertEquals(len(tracker.workunits), 11)
+    # In this case, we expect 10 invocations of the `fib` rule.
+    self.assertEquals(len(tracker.workunits), 10)

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -9,7 +9,7 @@ from typing import List
 from pants.engine.rules import RootRule, rule
 from pants.engine.scheduler import ExecutionError
 from pants.engine.selectors import Get
-from pants.reporting.async_workunit_handler import AsyncWorkunitHandler
+from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
 from pants.testutil.engine.util import assert_equal_with_printing, remove_locations_from_traceback
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
 
@@ -249,7 +249,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         self.workunits.extend(workunits)
 
     tracker = Tracker()
-    async_reporter = AsyncWorkunitHandler(scheduler, callback=tracker.add, report_interval_seconds=0.01)
+    async_reporter = StreamingWorkunitHandler(scheduler, callback=tracker.add, report_interval_seconds=0.01)
     with async_reporter.session():
       scheduler.product_request(Fib, subjects=[0])
 

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -17,6 +17,7 @@ from pants.engine.rules import (
   MissingReturnTypeAnnotation,
   RootRule,
   RuleIndex,
+  UnrecognizedRuleArgument,
   _RuleVisitor,
   console_rule,
   rule,
@@ -104,6 +105,28 @@ class RuleIndexTest(TestBase):
       "'pants_test.engine.test_rules.A'>. Rules either extend Rule or UnionRule, or "
       "are static functions decorated with @rule."""):
       RuleIndex.create([A()])
+
+
+class RuleArgumentAnnotationTest(unittest.TestCase):
+  def test_name_kwarg(self):
+    @rule(name='A named rule')
+    def named_rule(a: int, b: str) -> bool:
+      return False
+    self.assertIsNotNone(named_rule.rule)
+    self.assertEqual(named_rule.rule.name, "A named rule")
+
+  def test_bogus_rule(self):
+    with self.assertRaises(UnrecognizedRuleArgument):
+      @rule(bogus_kwarg='TOTALLY BOGUS!!!!!!')
+      def named_rule(a: int, b: str) -> bool:
+        return False
+
+  def test_console_rule_automatically_gets_name_from_goal(self):
+    @console_rule
+    def some_console_rule(console: Console) -> Example:
+      yield Example(exit_code=0)
+
+    self.assertEqual(some_console_rule.rule.name, "example")
 
 
 class RuleTypeAnnotationTest(unittest.TestCase):

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -128,6 +128,13 @@ class RuleArgumentAnnotationTest(unittest.TestCase):
 
     self.assertEqual(some_console_rule.rule.name, "example")
 
+  def test_can_override_console_rule_name(self):
+    @console_rule(name='example but **COOLER**')
+    def some_console_rule(console: Console) -> Example:
+      yield Example(exit_code=0)
+
+    self.assertEqual(some_console_rule.rule.name, "example but **COOLER**")
+
 
 class RuleTypeAnnotationTest(unittest.TestCase):
   def test_nominal(self):

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -124,14 +124,14 @@ class RuleArgumentAnnotationTest(unittest.TestCase):
   def test_console_rule_automatically_gets_name_from_goal(self):
     @console_rule
     def some_console_rule(console: Console) -> Example:
-      yield Example(exit_code=0)
+      return Example(exit_code=0)
 
     self.assertEqual(some_console_rule.rule.name, "example")
 
   def test_can_override_console_rule_name(self):
     @console_rule(name='example but **COOLER**')
     def some_console_rule(console: Console) -> Example:
-      yield Example(exit_code=0)
+      return Example(exit_code=0)
 
     self.assertEqual(some_console_rule.rule.name, "example but **COOLER**")
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -259,10 +259,11 @@ class SchedulerWithNestedRaiseTest(TestBase):
       nested_raise,
     ]
 
+  #TODO(#8675) - This test (and others like it) that rely on matching a specific string repr of a complex python object is fragile.
   def test_get_type_match_failure(self):
     """Test that Get(...)s are now type-checked during rule execution, to allow for union types."""
     expected_msg = """\
-Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Task(Task { product: A, clause: [Select { product: TypeCheckFailWrapper }], gets: [Get { product: A, subject: B }], func: a_typecheck_fail_test(), cacheable: true }) })) did not declare a dependency on JustGet(Get { product: A, subject: A })
+Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Task(Task { product: A, clause: [Select { product: TypeCheckFailWrapper }], gets: [Get { product: A, subject: B }], func: a_typecheck_fail_test(), cacheable: true, display_info: None }) })) did not declare a dependency on JustGet(Get { product: A, subject: A })
 """
     with assert_execution_error(self, expected_msg):
       # `a_typecheck_fail_test` above expects `wrapper.inner` to be a `B`.

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -281,7 +281,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
 
       trace = assert_single_element(ZipkinHandler.traces.values())
 
-      v2_span_name_part = "Scandir"
+      v2_span_name_part = "Snapshot"
       self.assertTrue(any(v2_span_name_part in span['name'] for span in trace),
         "There is no span that contains '{}' in it's name. The trace:{}".format(
         v2_span_name_part, trace
@@ -311,7 +311,7 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
 
       trace = assert_single_element(ZipkinHandler.traces.values())
 
-      v2_span_name_part = "Scandir"
+      v2_span_name_part = "Snapshot"
       self.assertTrue(any(v2_span_name_part in span['name'] for span in trace),
         "There is no span that contains '{}' in it's name. The trace:{}".format(
         v2_span_name_part, trace


### PR DESCRIPTION
## Problem

We want rule authors to be able to control what `@rule`s are and are not important enough to be reported, to avoid creating gigantic numbers of workunits that would clog up any reporting infrastructure built on top of workunits.

## Solution

This commit adds the ability to specify a `name: str` keyword argument to `@rule` and `@console_rule`s (e..g `@rule(name='Some human-readable name')\ndef a_rule_fn(a: A) -> B`). `@console_rule`s names are automatically filled in from the name of their associated goal, although this can be overridden with an explicit argument.

When a workunit is about to be created in `nodes.rs` as part of the `NodeKey` run function, we check to see whether this Node has a defined `display_info` - a string that right now is only provided by the `name` parameter to an `@rule`, although we can extend this in the future. If there is such a string, we add a workunit whose name is that string to the workunit store. If not, we ignore it. (Note that we also add Workunits to the store with hardcoded names in a few places pertaining to filesystem and remote operations, which this commit doesn't change). 

## Result

With this commit, the number of workunits recorded in the workunit store (and thus reported to zipkin) will be drastically decreased, since now only `@console_rules` have a name by default. A rule author can restore workunits associated with any `@rule` by giving that `@rule` a name.