### PR TITLE
Partially type check `binaries`, `source`, `fs`, `net`, and more of  `engine`

### DIFF
--- a/src/python/pants/backend/python/subsystems/pex_build_util.py
+++ b/src/python/pants/backend/python/subsystems/pex_build_util.py
@@ -82,7 +82,7 @@ def targets_by_platform(targets, python_setup):
 def identify_missing_init_files(sources: Sequence[str]) -> Set[str]:
   """Return the list of paths that would need to be added to ensure that every package has
   an __init__.py. """
-  packages = set()
+  packages: Set[str] = set()
   for source in sources:
     if source.endswith('.py'):
       pkg_dir = os.path.dirname(source)

--- a/src/python/pants/binaries/BUILD
+++ b/src/python/pants/binaries/BUILD
@@ -18,4 +18,5 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants/util:osutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -4,6 +4,7 @@
 import logging
 import os
 import threading
+from typing import Optional
 
 from pants.binaries.binary_util import BinaryRequest, BinaryUtil
 from pants.engine.fs import PathGlobs, PathGlobsAndRoot
@@ -25,9 +26,9 @@ class BinaryToolBase(Subsystem):
   """
   # Subclasses must set these to appropriate values for the tool they define.
   # They must also set options_scope appropriately.
-  platform_dependent = None
-  archive_type = None  # See pants.fs.archive.archive for valid string values.
-  default_version = None
+  platform_dependent: Optional[bool] = None
+  archive_type: Optional[str] = None  # See pants.fs.archive.archive for valid string values.
+  default_version: Optional[str] = None
 
   # Subclasses may set this to the tool name as understood by BinaryUtil.
   # If unset, it defaults to the value of options_scope.

--- a/src/python/pants/binaries/executable_pex_tool.py
+++ b/src/python/pants/binaries/executable_pex_tool.py
@@ -1,6 +1,8 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import TYPE_CHECKING, List, Optional
+
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
@@ -10,17 +12,23 @@ from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import is_executable, safe_concurrent_creation
 
 
+if TYPE_CHECKING:
+  from pants.backend.python.python_requirement import PythonRequirement  # noqa
+
+
 class ExecutablePexTool(Subsystem):
 
   entry_point = None
 
-  base_requirements = []
+  base_requirements: List['PythonRequirement'] = []
 
   @classmethod
   def subsystem_dependencies(cls):
     return super().subsystem_dependencies() + (PexBuilderWrapper.Factory,)
 
-  def bootstrap(self, interpreter, pex_file_path, extra_reqs=None):
+  def bootstrap(
+    self, interpreter, pex_file_path, extra_reqs: Optional[List['PythonRequirement']] = None
+  ) -> PEX:
     # Caching is done just by checking if the file at the specified path is already executable.
     if not is_executable(pex_file_path):
       pex_info = PexInfo.default(interpreter=interpreter)

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -5,6 +5,7 @@ import logging
 import os
 import weakref
 from hashlib import sha1
+from typing import Optional, Sequence, Union
 
 from twitter.common.collections import OrderedSet
 
@@ -831,12 +832,12 @@ class Target(AbstractTarget):
 
   # List of glob patterns, or a single glob pattern.
   # Subclasses can override, typically to specify a file extension (e.g., '*.java').
-  default_sources_globs = None
+  default_sources_globs: Optional[Union[str, Sequence[str]]] = None
 
   # List of glob patterns, or a single glob pattern.
   # Subclasses can override, to specify files that should be excluded from the
   # default_sources_globs (e.g., '*Test.java').
-  default_sources_exclude_globs = None
+  default_sources_exclude_globs: Optional[Union[str, Sequence[str]]] = None
 
   @classmethod
   def supports_default_sources(cls):

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -228,6 +228,7 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -110,7 +110,8 @@ python_library(
     'src/python/pants/base:exception_sink',
     ':rules',
     ':platform',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -120,10 +121,10 @@ python_library(
     '3rdparty/python:dataclasses',
     ':fs',
     ':rules',
-    ':selectors',
     ':platform',
     'src/python/pants/util:meta',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -167,6 +168,7 @@ python_library(
       'src/python/pants/util:memo',
       'src/python/pants/util:osutil',
   ],
+  tags = {"type_checked"},
 )
 
 python_library(
@@ -210,7 +212,7 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/base:specs',
     'src/python/pants/rules/core:core',
-  ]
+  ],
 )
 
 python_library(

--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -2,10 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Any, Tuple
+from typing import TYPE_CHECKING, Tuple
 
 from pants.base.exception_sink import ExceptionSink
 from pants.engine.rules import RootRule
+
+
+if TYPE_CHECKING:
+  from pants.engine.scheduler import SchedulerSession
 
 
 @dataclass(frozen=True)
@@ -22,7 +26,7 @@ class InteractiveProcessRequest:
 
 @dataclass(frozen=True)
 class InteractiveRunner:
-  _scheduler: Any
+  _scheduler: 'SchedulerSession'
 
   def run_local_interactive_process(self, request: InteractiveProcessRequest) -> InteractiveProcessResult:
     ExceptionSink.toggle_ignoring_sigint_v2_engine(True)

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -56,7 +56,7 @@ class ExecuteProcessRequest:
     self.argv = argv
     self.input_files = input_files
     self.description = description
-    self.env = tuple(item for pair in env.items() for item in pair) if env else ()
+    self.env = tuple(item for pair in env.items() for item in pair) if env is not None else ()  # type: ignore
     self.output_files = output_files or ()
     self.output_directories = output_directories or ()
     self.timeout_seconds = timeout_seconds
@@ -84,13 +84,13 @@ class MultiPlatformExecuteProcessRequest:
       if PlatformConstraint(constraint.value)
     )
     if len({req.description for req in request_dict.values()}) != 1:
-      raise ValueError(f"The `description` of all execute_process_requests in a {self.__name__} must be identical.")
+      raise ValueError(f"The `description` of all execute_process_requests in a {MultiPlatformExecuteProcessRequest.__name__} must be identical.")
 
     self.platform_constraints = validated_constraints
     self.execute_process_requests = tuple(request_dict.values())
 
   @property
-  def product_description(self):
+  def product_description(self) -> ProductDescription:
     # we can safely extract the first description because we guarantee that at
     # least one request exists and that all of their descriptions are the same
     # in __new__

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import Callable, List
+
 from pants.engine.rules import rule
 from pants.util.collections import Enum
 from pants.util.memo import memoized_classproperty, memoized_property
@@ -14,13 +16,13 @@ class Platform(Enum):
   # TODO: try to turn all of these accesses into v2 dependency injections!
   @memoized_classproperty
   def current(cls) -> 'Platform':
-    return cls(get_normalized_os_name())
+    return Platform(get_normalized_os_name())
 
   @memoized_property
-  def runtime_lib_path_env_var(self):
+  def runtime_lib_path_env_var(self) -> str:
     return self.match({
-      self.darwin: "DYLD_LIBRARY_PATH",
-      self.linux: "LD_LIBRARY_PATH",
+      Platform.darwin: "DYLD_LIBRARY_PATH",
+      Platform.linux: "LD_LIBRARY_PATH",
     })
 
 
@@ -30,16 +32,17 @@ class PlatformConstraint(Enum):
   none = "none"
 
   @memoized_classproperty
-  def local_platform(cls):
-    return cls(Platform.current.value)
+  def local_platform(cls) -> 'PlatformConstraint':
+    return PlatformConstraint(Platform.current.value)
 
 
 # TODO We will want to allow users to specify the execution platform for rules,
 # which means replacing this singleton rule with a RootRule populated by an option.
 @rule
 def materialize_platform() -> Platform:
-  return Platform.current
+  current: Platform = Platform.current
+  return current
 
 
-def create_platform_rules():
+def create_platform_rules() -> List[Callable]:
   return [materialize_platform]

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -9,12 +9,11 @@ import time
 import traceback
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE
 from pants.engine.fs import Digest, DirectoryToMaterialize, PathGlobsAndRoot
-from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveProcessResult
 from pants.engine.native import Function, TypeId
 from pants.engine.nodes import Return, Throw
 from pants.engine.objects import Collection
@@ -23,6 +22,10 @@ from pants.engine.selectors import Params
 from pants.util.contextutil import temporary_file_path
 from pants.util.dirutil import check_no_overlapping_paths
 from pants.util.strutil import pluralize
+
+
+if TYPE_CHECKING:
+  from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveProcessResult
 
 
 logger = logging.getLogger(__name__)
@@ -546,14 +549,17 @@ class SchedulerSession:
     )
     return self._scheduler._raise_or_return(result)
 
-  def run_local_interactive_process(self, request: InteractiveProcessRequest) -> InteractiveProcessResult:
+  def run_local_interactive_process(
+    self, request: 'InteractiveProcessRequest'
+  ) -> 'InteractiveProcessResult':
     sched_pointer = self._scheduler._scheduler
 
-    result  = self._scheduler._native.lib.run_local_interactive_process(
+    wrapped_result  = self._scheduler._native.lib.run_local_interactive_process(
       sched_pointer,
       self._scheduler._to_value(request)
     )
-    return self._scheduler._raise_or_return(result)
+    result: 'InteractiveProcessResult' = self._scheduler._raise_or_return(wrapped_result)
+    return result
 
   def materialize_directories(self, directories_paths_and_digests):
     """Creates the specified directories on the file system.

--- a/src/python/pants/fs/BUILD
+++ b/src/python/pants/fs/BUILD
@@ -6,7 +6,8 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:strutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/src/python/pants/net/BUILD
+++ b/src/python/pants/net/BUILD
@@ -8,4 +8,5 @@ python_library(
     '3rdparty/python:pyopenssl',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/source/BUILD
+++ b/src/python/pants/source/BUILD
@@ -16,6 +16,7 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(

--- a/src/python/pants/source/BUILD
+++ b/src/python/pants/source/BUILD
@@ -15,7 +15,7 @@ python_library(
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-  ]
+  ],
 )
 
 python_library(


### PR DESCRIPTION
These targets are used widely (https://docs.google.com/spreadsheets/d/1MKg82Fs3uIMOZDoWeNUBD-VirVkOzHU8Tte7oY6ypP0/edit#gid=1479336346) and their failures prevented most targets from working with MyPy.

This introduces a new pattern to avoid cyclic imports that are solely needed for type checking:

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
  import foo

def example(x: 'Foo') -> int:
  ...
```

The code is safely ignored at runtime, but evaluated by MyPy.