### PR TITLE
Remove duplicate target name for `backend/python/targets`

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/BUILD
@@ -6,7 +6,7 @@ python_library(
     '3rdparty/python:pex',
     ':resources',
     'src/python/pants/backend/python/subsystems',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/backend/python/tasks',
     'src/python/pants/backend/python:interpreter_cache',
     'src/python/pants/base:exceptions',

--- a/pants-plugins/src/python/internal_backend/utilities/BUILD
+++ b/pants-plugins/src/python/internal_backend/utilities/BUILD
@@ -6,7 +6,7 @@ python_library(
   sources=['register.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/backend/python:python_artifact',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',

--- a/src/python/pants/backend/codegen/antlr/python/BUILD
+++ b/src/python/pants/backend/codegen/antlr/python/BUILD
@@ -3,7 +3,6 @@
 
 python_library(
   dependencies = [
-    'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/backend/python/targets',

--- a/src/python/pants/backend/codegen/thrift/python/BUILD
+++ b/src/python/pants/backend/codegen/thrift/python/BUILD
@@ -4,7 +4,7 @@
 python_library(
   dependencies = [
     'src/python/pants/backend/codegen/thrift/lib',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/base:exceptions',
     'src/python/pants/engine:fs',
     'src/python/pants/goal:task_registrar',

--- a/src/python/pants/backend/project_info/tasks/BUILD
+++ b/src/python/pants/backend/project_info/tasks/BUILD
@@ -78,7 +78,7 @@ python_library(
   dependencies = [
     ':idea_resources',
     'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:generator',

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -10,7 +10,7 @@ python_library(
     ':python_requirement',
     ':python_requirements',
     'src/python/pants/backend/python/rules',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/backend/python/tasks',
     'src/python/pants/build_graph',
     'src/python/pants/goal:task_registrar',
@@ -55,7 +55,7 @@ python_library(
   sources = ['pants_requirement.py'],
   dependencies = [
     'src/python/pants/backend/python:python_requirement',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',

--- a/src/python/pants/backend/python/targets/BUILD
+++ b/src/python/pants/backend/python/targets/BUILD
@@ -13,10 +13,3 @@ python_library(
     'src/python/pants/build_graph',
   ],
 )
-
-
-# TODO: Old name.  Remove after all references are fixed to refer directly to the target above.
-target(
-  name = 'python',
-  dependencies = [':targets'],
-)

--- a/tests/python/pants_test/backend/codegen/grpcio/BUILD
+++ b/tests/python/pants_test/backend/codegen/grpcio/BUILD
@@ -4,7 +4,7 @@
 
 python_tests(
   dependencies=[
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/base:build_environment',
     'src/python/pants/testutil:task_test_base',
   ],

--- a/tests/python/pants_test/backend/codegen/thrift/python/BUILD
+++ b/tests/python/pants_test/backend/codegen/thrift/python/BUILD
@@ -8,7 +8,7 @@ python_tests(
     'src/python/pants/backend/codegen/thrift/python',
     'src/python/pants/backend/python:interpreter_cache',
     'src/python/pants/backend/python/subsystems',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil/subsystem',

--- a/tests/python/pants_test/backend/graph_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/graph_info/tasks/BUILD
@@ -9,7 +9,7 @@ python_tests(
   dependencies=[
     'src/python/pants/backend/graph_info/tasks',
     'src/python/pants/backend/jvm/targets:java',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/base:build_environment',
     'src/python/pants/testutil:task_test_base',
   ]
@@ -34,7 +34,7 @@ python_tests(
     'src/python/pants/java/jar',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
   ]
@@ -45,7 +45,7 @@ python_tests(
   sources = ['test_filemap.py'],
   dependencies = [
     'src/python/pants/backend/graph_info/tasks',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
   ],
@@ -58,7 +58,7 @@ python_tests(
     'src/python/pants/backend/docgen/targets',
     'src/python/pants/backend/graph_info/tasks',
     'src/python/pants/backend/jvm/targets:java',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
@@ -74,7 +74,7 @@ python_tests(
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/build_graph',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:console_rule_test_base',
   ],
@@ -85,7 +85,7 @@ python_tests(
   sources = ['test_minimal_cover.py'],
   dependencies = [
     'src/python/pants/backend/graph_info/tasks',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
   ],
@@ -116,7 +116,7 @@ python_tests(
   sources = ['test_sort_targets.py'],
   dependencies = [
     'src/python/pants/backend/graph_info/tasks',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
   ],

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -17,7 +17,7 @@ python_tests(
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/project_info/tasks:dependencies',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/backend/python:python_requirement',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -7,7 +7,7 @@ python_tests(
   dependencies=[
     'src/python/pants/backend/python:python_requirement',
     'src/python/pants/backend/python:plugin',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/base:build_environment',
     'src/python/pants/testutil:test_base',
   ]
@@ -17,7 +17,7 @@ python_tests(
   name='python_requirement_list',
   sources=['test_python_requirement_list.py'],
   dependencies=[
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/backend/python:python_requirement',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',

--- a/tests/python/pants_test/targets/BUILD
+++ b/tests/python/pants_test/targets/BUILD
@@ -54,7 +54,7 @@ python_tests(
   sources = ['test_python_binary.py'],
   dependencies = [
     ':base',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/build_graph',
   ]
 )
@@ -78,7 +78,7 @@ python_tests(
   dependencies = [
     'src/python/pants/backend/jvm:artifact',
     'src/python/pants/backend/jvm:repository',
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/targets',
     'src/python/pants/backend/python:python_artifact',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',


### PR DESCRIPTION
This has been a TODO since 2016.