### PR TITLE
Add tags and scope attribute passthrough to ScroogeGen

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -297,4 +297,4 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
 
   @property
   def _copy_target_attributes(self):
-    return ['provides', 'strict_deps']
+    return super()._copy_target_attributes + ['strict_deps']

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -95,6 +95,7 @@ class ScroogeGenTest(NailgunTaskTestBase):
         language='{language}',
         compiler_args={compiler_args},
         strict_deps=True,
+        tags=['my_tag'],
       )
     '''.format(language=language, compiler_args=compiler_args_str))
 
@@ -130,6 +131,7 @@ class ScroogeGenTest(NailgunTaskTestBase):
       self.assertEqual(call_kwargs['provides'], None)
       self.assertEqual(call_kwargs['derived_from'], target)
       self.assertEqual(call_kwargs['strict_deps'], True)
+      self.assertEqual(call_kwargs['tags'], {'my_tag'})
 
       sources = call_kwargs['sources']
       self.assertEqual(sources.files, ())


### PR DESCRIPTION
### Problem

`ScroogeGen` overrides the default `_copy_target_attributes` property from
`SimpleCodegenTask`, removing the `tags` and `scope` passthroughs and adding
`strict_deps`. Removing these properties may prevent easy implementation of
certain solutions, such as adding `use-compiler:rsc-and-zinc` tags to Scala
thrift library targets.

### Solution

`ScroogeGen._copy_target_attributes` will not remove any attributes from the
default list, and only add `strict_deps`.

### Result

Users would be able to pass along attributes such as
`tags = {"use-compiler:rsc-and-zinc"}` to generated thrift targets.