### PR TITLE
Fix sorting of junit tests in presence of a timeout

### DIFF
--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -350,10 +350,12 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
     if result == 0:
       return TestResult.successful
 
+    # NB: If the TestRegistry fails to find the owning target of a failed test, the target key in
+    # this dictionary will be None: helper methods in this block account for that.
     target_to_failed_test = parse_failed_targets(test_registry, output_dir, parse_error_handler)
 
     def sort_owning_target(t):
-      return t.address.spec if t else None
+      return t.address.spec if t else ''
 
     failed_targets = sorted(target_to_failed_test, key=sort_owning_target)
     error_message_lines = []


### PR DESCRIPTION
### Problem

When we timeout or when junit XML is corrupted for some reason, it can prevent us from identifying the target that failed, which causes us to default to a `None` cluster of tests.

We knew this already though, and the codepath that parsed tests accounted for it. But we had missed a case.

### Solution

Default to the empty string rather than `None` when sorting tests.