### PR TITLE
Partially type check `auth`, `build_graph`, `goal`, `java`, `process`, and `reporting`

### DIFF
--- a/build-support/mypy/mypy.ini
+++ b/build-support/mypy/mypy.ini
@@ -46,8 +46,3 @@ show_traceback = True
 ignore_missing_imports = True
 follow_imports = normal
 follow_imports_for_stubs = False
-
-# Ignore complaints about our dynamic programming
-# TODO: write a plugin that teaches MyPy how these work!
-# See https://mypy-lang.blogspot.com/2019/03/extending-mypy-with-plugins.html.
-always_true = enum,datatype

--- a/src/python/pants/auth/BUILD
+++ b/src/python/pants/auth/BUILD
@@ -13,4 +13,5 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants:version',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/auth/basic_auth.py
+++ b/src/python/pants/auth/basic_auth.py
@@ -58,11 +58,9 @@ class BasicAuth(Subsystem):
   def authenticate(self, provider: str, creds: Optional[BasicAuthCreds] = None, cookies: Optional[Cookies] = None) -> None:
     """Authenticate against the specified provider.
 
-    :param str provider: Authorize against this provider.
-    :param pants.auth.basic_auth.BasicAuthCreds creds: The creds to use.
-      If unspecified, assumes that creds are set in the netrc file.
-    :param pants.auth.cookies.Cookies cookies: Store the auth cookies in this instance.
-      If unspecified, uses the global instance.
+    :param provider: Authorize against this provider.
+    :param creds: The creds to use. If unspecified, assumes that creds are set in the netrc file.
+    :param cookies: Store the auth cookies in this instance. If unspecified, uses the global instance.
     :raises pants.auth.basic_auth.BasicAuthException: If auth fails due to misconfiguration or
       rejection by the server.
     """
@@ -81,10 +79,10 @@ class BasicAuth(Subsystem):
     if not self.get_options().allow_insecure_urls and not url.startswith('https://'):
       raise BasicAuthException(f'Auth url for provider {provider} is not secure: {url}.')
 
-    if creds:
-      auth = requests.auth.HTTPBasicAuth(creds.username, creds.password)
-    else:
-      auth = None  # requests will use the netrc creds.
+    auth = (
+      requests.auth.HTTPBasicAuth(creds.username, creds.password)
+      if creds else None
+    )
     response = requests.get(url, auth=auth, headers={'User-Agent': f'pants/v{VERSION}'})
 
     if response.status_code != requests.codes.ok:

--- a/src/python/pants/build_graph/BUILD
+++ b/src/python/pants/build_graph/BUILD
@@ -27,5 +27,6 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
     'src/python/pants/util:netrc',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/build_graph/dependency_context.py
+++ b/src/python/pants/build_graph/dependency_context.py
@@ -1,6 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import Any, Dict
 
 from pants.build_graph.aliased_target import AliasTarget
 from pants.build_graph.target import Target
@@ -10,4 +11,4 @@ class DependencyContext:
 
   alias_types = (AliasTarget, Target)
   types_with_closure = ()
-  target_closure_kwargs = {}
+  target_closure_kwargs: Dict[str, Any] = {}

--- a/src/python/pants/build_graph/prep_command.py
+++ b/src/python/pants/build_graph/prep_command.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import FrozenSet
+
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
@@ -22,20 +24,20 @@ class PrepCommand(Target):
 
   :API: public
   """
-  _goals=frozenset()
+  _goals: FrozenSet[str] = frozenset()
 
   @staticmethod
-  def add_allowed_goal(goal):
+  def add_allowed_goal(goal: str) -> None:
     """Add a named goal to the list of valid goals for the 'goal' parameter."""
     PrepCommand._goals = frozenset(list(PrepCommand._goals) + [goal])
 
   @classmethod
-  def reset(cls):
+  def reset(cls) -> None:
     """Used for testing purposes to reset state."""
     cls._goals = frozenset()
 
   @staticmethod
-  def allowed_goals():
+  def allowed_goals() -> FrozenSet[str]:
     return PrepCommand._goals
 
   def __init__(self, address=None, payload=None, prep_executable=None, prep_args=None,

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -7,6 +7,7 @@ python_library(
   dependencies = [
     ':goal',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -14,7 +15,8 @@ python_library(
   sources = ['aggregated_timings.py'],
   dependencies = [
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 # this is in goal because of run_tracker
@@ -24,7 +26,8 @@ python_library(
   dependencies = [
     'src/python/pants/cache',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -43,11 +46,13 @@ python_library(
     'src/python/pants/reporting:report',
     'src/python/pants/source',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
   name = 'error',
   sources = ['error.py'],
+  tags = {"partially_type_checked"},
 )
 
 # TODO(benjy): As a result of a renaming, we ended up with this target owning only one source
@@ -61,13 +66,13 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
   name = 'pantsd_stats',
   sources = ['pantsd_stats.py'],
-  dependencies = [
-  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -78,6 +83,7 @@ python_library(
     'src/python/pants/util:collections',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -95,11 +101,12 @@ python_library(
     'src/python/pants/base:worker_pool',
     'src/python/pants/base:workunit',
     'src/python/pants/option',
-    'src/python/pants/reporting', # XXX(fixme)
+    'src/python/pants/reporting',
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -109,4 +116,5 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/scm',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -1,6 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import Dict
+
 from pants.goal.error import GoalError
 from pants.option.optionable import Optionable
 from pants.util.memo import memoized
@@ -36,7 +38,7 @@ class Goal:
 
   :API: public
   """
-  _goal_by_name = dict()
+  _goal_by_name: Dict[str, "_Goal"] = {}
 
   def __new__(cls, *args, **kwargs):
     raise TypeError('Do not instantiate {0}. Call by_name() instead.'.format(cls))

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -355,7 +355,8 @@ class RunTracker(Subsystem):
 
   @property
   def _stats_version(self) -> int:
-    return self.get_options().stats_version
+    stats_version: int = self.get_options().stats_version
+    return stats_version
 
   def log(self, level, *msg_elements):
     """Log a message against the current workunit."""

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -9,7 +9,8 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -24,6 +25,7 @@ python_library(
     'src/python/pants/util:socket',
     'src/python/pants/util:strutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -32,7 +34,8 @@ python_library(
   dependencies = [
     '3rdparty/python:contextlib2',
     ':nailgun_protocol'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -41,7 +44,8 @@ python_library(
   dependencies = [
     '3rdparty/python:dataclasses',
     'src/python/pants/util:osutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -55,6 +59,7 @@ python_library(
     'src/python/pants/pantsd:process_manager',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -68,4 +73,5 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:process_handler',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/java/distribution/BUILD
+++ b/src/python/pants/java/distribution/BUILD
@@ -11,6 +11,7 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:osutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 resources(

--- a/src/python/pants/java/jar/BUILD
+++ b/src/python/pants/java/jar/BUILD
@@ -11,4 +11,5 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants/util:objects',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/java/junit/BUILD
+++ b/src/python/pants/java/junit/BUILD
@@ -8,5 +8,6 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:meta',
     'src/python/pants/util:xml_parser',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/pantsd/BUILD
+++ b/src/python/pants/pantsd/BUILD
@@ -9,7 +9,8 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/process',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -9,6 +9,7 @@ import subprocess
 import time
 import traceback
 from contextlib import contextmanager
+from typing import Optional
 
 import psutil
 
@@ -541,7 +542,7 @@ class FingerprintedProcessManager(ProcessManager):
   """A `ProcessManager` subclass that provides a general strategy for process fingerprinting."""
 
   FINGERPRINT_KEY = 'fingerprint'
-  FINGERPRINT_CMD_KEY = None
+  FINGERPRINT_CMD_KEY: Optional[str] = None
   FINGERPRINT_CMD_SEP = '='
 
   @property

--- a/src/python/pants/process/BUILD
+++ b/src/python/pants/process/BUILD
@@ -7,5 +7,6 @@ python_library(
     '3rdparty/python:psutil',
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/reporting/BUILD
+++ b/src/python/pants/reporting/BUILD
@@ -5,6 +5,7 @@ python_library(
   sources=globs('*.py', exclude=[['report.py']]),
   dependencies=[
     '3rdparty/python:ansicolors',
+    '3rdparty/python:dataclasses',
     '3rdparty/python:pystache',
     '3rdparty/python:py-zipkin',
     '3rdparty/python:requests',
@@ -22,7 +23,8 @@ python_library(
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 resources(
@@ -33,6 +35,5 @@ resources(
 python_library(
   name='report',
   sources=['report.py'],
-  dependencies=[
-  ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/reporting/html_reporter.py
+++ b/src/python/pants/reporting/html_reporter.py
@@ -6,7 +6,8 @@ import os
 import re
 import time
 import uuid
-from collections import defaultdict, namedtuple
+from collections import defaultdict
+from dataclasses import dataclass
 from itertools import zip_longest
 from textwrap import dedent
 
@@ -36,14 +37,14 @@ class HtmlReporter(Reporter):
   ad-hoc templates and client-side spaghetti code.
   """
 
-  # HTML reporting settings.
-  #   html_dir: Where the report files go.
-  #   template_dir: Where to find mustache templates.
-  Settings = namedtuple('Settings', Reporter.Settings._fields + ('html_dir', 'template_dir'))
+  @dataclass(frozen=True)
+  class Settings(Reporter.Settings):
+    html_dir: str  # Where the report files go.
+    template_dir: str  # Where to find mustache templates.
 
   def __init__(self, run_tracker, settings):
     super().__init__(run_tracker, settings)
-     # The main report, and associated tool outputs, go under this dir.
+    # The main report, and associated tool outputs, go under this dir.
     self._html_dir = settings.html_dir
 
     # We render HTML from mustache templates.

--- a/src/python/pants/reporting/json_reporter.py
+++ b/src/python/pants/reporting/json_reporter.py
@@ -1,7 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from collections import defaultdict, namedtuple
+from collections import defaultdict
+from dataclasses import dataclass
 from itertools import zip_longest
 
 from pants.reporting.reporter import Reporter
@@ -18,8 +19,9 @@ class JsonReporter(Reporter):
     'DEBUG',
   ]
 
-  # JSON reporting settings.
-  Settings = namedtuple('Settings', Reporter.Settings._fields)
+  @dataclass(frozen=True)
+  class Settings(Reporter.Settings):
+    pass
 
   def __init__(self, run_tracker, settings):
     super().__init__(run_tracker, settings)

--- a/src/python/pants/reporting/plaintext_reporter.py
+++ b/src/python/pants/reporting/plaintext_reporter.py
@@ -1,7 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from collections import namedtuple
+from dataclasses import dataclass
+from typing import Any
 
 from colors import cyan, green, red, yellow
 
@@ -48,17 +49,16 @@ class PlainTextReporter(PlainTextReporterBase):
   confusing to try and show progress for background work too.
   """
 
-  # Console reporting settings.
-  #   outfile: Write output to this file-like object (analogous to stdout).
-  #   errfile: Write error output to this file-like object (analogous to stderr).
-  #   color: use ANSI colors in output.
-  #   indent: Whether to indent the reporting to reflect the nesting of workunits.
-  #   timing: Show timing report at the end of the run.
-  #   cache_stats: Show artifact cache report at the end of the run.
-  Settings = namedtuple('Settings',
-                        Reporter.Settings._fields + ('outfile', 'errfile', 'color', 'indent',
-                                                     'timing', 'cache_stats', 'label_format',
-                                                     'tool_output_format'))
+  @dataclass(frozen=True)
+  class Settings(Reporter.Settings):
+    outfile: Any  # Write output to this file-like object (analogous to stdout).
+    errfile: Any  # Write error output to this file-like object (analogous to stderr).
+    color: bool  # use ANSI colors in output.
+    indent: bool  # Whether to indent the reporting to reflect the nesting of workunits.
+    timing: bool  # Show timing report at the end of the run.
+    cache_stats: bool  # Show artifact cache report at the end of the run.
+    label_format: Any
+    tool_output_format: Any
 
   _COLOR_BY_LEVEL = {
     Report.FATAL: red,

--- a/src/python/pants/reporting/quiet_reporter.py
+++ b/src/python/pants/reporting/quiet_reporter.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import sys
-from collections import namedtuple
+from dataclasses import dataclass
 
 from colors import red
 
@@ -13,7 +13,12 @@ from pants.reporting.reporter import Reporter
 
 class QuietReporter(PlainTextReporterBase):
   """Squelched plaintext reporting, only prints errors and timing/cache stats (if requested)."""
-  Settings = namedtuple('Settings', Reporter.Settings._fields + ('color', 'timing', 'cache_stats'))
+
+  @dataclass(frozen=True)
+  class Settings(Reporter.Settings):
+    color: bool
+    timing: bool
+    cache_stats: bool
 
   def open(self):
     """Implementation of Reporter callback."""

--- a/src/python/pants/reporting/reporter.py
+++ b/src/python/pants/reporting/reporter.py
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from collections import namedtuple
+from dataclasses import dataclass
 
 from pants.reporting.report import Report
 
@@ -18,10 +18,13 @@ class Reporter:
   functionality, e.g., to console or to browser.
   """
 
-  # Generic reporting settings.
-  #   log_level: Display log messages up to this level.
-  #   subsettings: subclass-specific settings.
-  Settings = namedtuple('Settings', ['log_level'])
+  @dataclass(frozen=True)
+  class Settings:
+    """Generic reporting settings.
+
+    Subclasses of Reporter should extend their own Settings and add any additional settings they'd
+    like."""
+    log_level: str  # Display log messages up to this level.
 
   def __init__(self, run_tracker, settings):
     self.run_tracker = run_tracker

--- a/src/python/pants/source/BUILD
+++ b/src/python/pants/source/BUILD
@@ -26,4 +26,5 @@ python_library(
     ':source',
     'src/python/pants/engine:fs',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import inspect
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Type, TypeVar
 
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
@@ -11,6 +11,9 @@ from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin, Subsyst
 
 class SubsystemError(Exception):
   """An error in a subsystem."""
+
+
+S = TypeVar("S", bound="Subsystem")
 
 
 class Subsystem(SubsystemClientMixin, Optionable):
@@ -83,7 +86,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
   _scoped_instances: Dict[Tuple["Subsystem", str], "Subsystem"] = {}
 
   @classmethod
-  def global_instance(cls) -> "Subsystem":
+  def global_instance(cls: Type[S]) -> S:
     """Returns the global instance of this subsystem.
 
     :API: public
@@ -93,7 +96,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
     return cls._instance_for_scope(cls.options_scope)  # type: ignore
 
   @classmethod
-  def scoped_instance(cls, optionable: Optionable) -> "Subsystem":
+  def scoped_instance(cls: Type[S], optionable: Optionable) -> S:
     """Returns an instance of this subsystem for exclusive use by the given `optionable`.
 
     :API: public
@@ -107,7 +110,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
     return cls._instance_for_scope(cls.subscope(optionable.options_scope))
 
   @classmethod
-  def _instance_for_scope(cls, scope: str) -> "Subsystem":
+  def _instance_for_scope(cls: Type[S], scope: str) -> S:
     if cls._options is None:
       raise cls.UninitializedSubsystemError(cls.__name__, scope)
     key = (cls, scope)
@@ -116,7 +119,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
     return cls._scoped_instances[key]
 
   @classmethod
-  def reset(cls, reset_options=True):
+  def reset(cls, reset_options: bool = True) -> None:
     """Forget all option values and cached subsystem instances.
 
     Used primarily for test isolation and to reset subsystem state for pantsd.

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -13,7 +13,7 @@ class SubsystemError(Exception):
   """An error in a subsystem."""
 
 
-S = TypeVar("S", bound="Subsystem")
+_S = TypeVar("_S", bound="Subsystem")
 
 
 class Subsystem(SubsystemClientMixin, Optionable):
@@ -86,7 +86,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
   _scoped_instances: Dict[Tuple["Subsystem", str], "Subsystem"] = {}
 
   @classmethod
-  def global_instance(cls: Type[S]) -> S:
+  def global_instance(cls: Type[_S]) -> _S:
     """Returns the global instance of this subsystem.
 
     :API: public
@@ -96,7 +96,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
     return cls._instance_for_scope(cls.options_scope)  # type: ignore
 
   @classmethod
-  def scoped_instance(cls: Type[S], optionable: Optionable) -> S:
+  def scoped_instance(cls: Type[_S], optionable: Optionable) -> _S:
     """Returns an instance of this subsystem for exclusive use by the given `optionable`.
 
     :API: public
@@ -110,7 +110,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
     return cls._instance_for_scope(cls.subscope(optionable.options_scope))
 
   @classmethod
-  def _instance_for_scope(cls: Type[S], scope: str) -> S:
+  def _instance_for_scope(cls: Type[_S], scope: str) -> _S:
     if cls._options is None:
       raise cls.UninitializedSubsystemError(cls.__name__, scope)
     key = (cls, scope)


### PR DESCRIPTION
Brings us closer to being able to run MyPy on any arbitrary target without issues.

This fixes `subsystem.py` to be much more precise in its return types. Rather than returning generic `Subsystem`s, MyPy now views the return type as whatever the subclass is, such as `Cookies` or `PythonSetup`. This idiom comes from https://stackoverflow.com/a/44644576.