### PR TITLE
add --transitive-only option to export-classpath!

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
@@ -36,9 +36,8 @@ class RuntimeClasspathPublisher(Task):
     basedir = os.path.join(self.get_options().pants_distdir, self._output_folder)
     runtime_classpath = self.context.products.get_data('runtime_classpath')
 
-    targets = self.context.targets()
-    if self.get_options().transitive_only:
-      targets = list(OrderedSet(targets) - set(self.context.target_roots))
+    targets = OrderedSet(self.get_targets()) - set(self.context.target_roots) \
+      if self.get_options().transitive_only else self.get_targets()
 
     if self.get_options().manifest_jar_only:
       classpath = ClasspathUtil.classpath(targets, runtime_classpath)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_classpath_published.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_classpath_published.py
@@ -79,3 +79,53 @@ class RuntimeClasspathPublisherTest(TaskTestBase):
             os.pathsep.join([os.path.join(jar_dir, 'z2.jar'), os.path.join(jar_dir, 'z3.jar')]) + '\n'
           ]
         )
+
+  def _assert_jars_created(self, *, transitive_only: bool) -> None:
+    with temporary_dir(root_dir=self.pants_workdir) as jar_dir, \
+         temporary_dir(root_dir=self.pants_workdir) as dist_dir:
+      self.set_options(pants_distdir=dist_dir,
+                       transitive_only=transitive_only)
+
+      init_target = self.make_target(
+        'java/classpath:java_lib',
+        target_type=JavaLibrary,
+        sources=['com/foo/Bar.java'],
+      )
+      target_with_dep = self.make_target(
+        'java/classpath:java_lib_with_dep',
+        target_type=JavaLibrary,
+        sources=['com/foo/Bar.java'],
+        dependencies=[init_target],
+      )
+      context = self.context(target_roots=[target_with_dep])
+      runtime_classpath = context.products.get_data('runtime_classpath',
+                                                    init_func=ClasspathProducts.init_func(self.pants_workdir))
+      task = self.create_task(context)
+
+      target_classpath_output = os.path.join(dist_dir, self.options_scope)
+
+      # Create a classpath entry.
+      touch(os.path.join(jar_dir, 'dep-target.jar'))
+      touch(os.path.join(jar_dir, 'root-target.jar'))
+      runtime_classpath.add_for_target(init_target, [(self.DEFAULT_CONF, os.path.join(jar_dir, 'dep-target.jar'))])
+      runtime_classpath.add_for_target(target_with_dep, [(self.DEFAULT_CONF, os.path.join(jar_dir, 'root-target.jar'))])
+      task.execute()
+
+      all_output = os.listdir(target_classpath_output)
+
+      # Check only one symlink and classpath.txt were created.
+      expected_artifacts = 2 if transitive_only else 4
+      self.assertEqual(len(all_output), expected_artifacts)
+
+
+      self.assertIn('java.classpath.java_lib-0.jar', all_output)
+      if transitive_only:
+        self.assertNotIn('java.classpath.java_lib_with_dep-0.jar', all_output)
+      else:
+        self.assertIn('java.classpath.java_lib_with_dep-0.jar', all_output)
+
+  def test_transitive_only(self):
+    self._assert_jars_created(transitive_only=True)
+
+  def test_no_transitive_only(self):
+    self._assert_jars_created(transitive_only=False)


### PR DESCRIPTION
### Problem

We would like to be able to provide binary versions of all dependencies of specified root targets to an IDE with `export-classpath`, without providing binary versions of the target roots themselves (because the IDE will be indexing those itself, as source files). `--query` from #7350 might help here, but until that's developed a little further, it would be great to have this functionality now.

@olafurpg requested this change to help integrate pants with metals.

### Solution

- Add `--transitive-only` option to the `export-classpath` task which avoids publishing jars for target roots, and instead only pulls in their dependencies!