### PR TITLE
add --internal-classpath-only to export-classpath!

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
@@ -16,9 +16,13 @@ class RuntimeClasspathPublisher(Task):
   def register_options(cls, register):
     super().register_options(register)
     register('--manifest-jar-only', type=bool, default=False,
+             removal_version='1.25.0.dev2',
+             removal_hint='Use --manifest-jar instead, which respects --internal-classpath-only!',
              help='Only export classpath in a manifest jar.')
+    register('--manifest-jar', type=bool, default=False,
+             help='Export classpath in a manifest jar instead of symlinks in the dist dir.')
     register('--internal-classpath-only', type=bool, default=True,
-             help='Only export the classpath of source targets, not 3rdparty jars.')
+             help='Only export the classpath of source targets, not jar_library()s.')
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -31,8 +35,16 @@ class RuntimeClasspathPublisher(Task):
   def execute(self):
     basedir = os.path.join(self.get_options().pants_distdir, self._output_folder)
     runtime_classpath = self.context.products.get_data('runtime_classpath')
-    targets = self.context.targets()
-    if self.get_options().manifest_jar_only:
+    targets = self.get_targets()
+    if self.get_options().manifest_jar:
+      classpath_entries = runtime_classpath.get_internal_classpath_entries_for_targets(targets)
+      if not self.get_options().internal_classpath_only:
+        classpath_entries.extend(runtime_classpath.get_artifact_classpath_entries_for_targets(targets))
+      cp_paths = [entry.path for _conf, entry in classpath_entries]
+      self.context.log.debug(f'paths: {cp_paths}, entries: {classpath_entries}')
+      # Safely create e.g. dist/export-classpath/manifest.jar
+      safe_classpath(cp_paths, basedir, "manifest.jar")
+    elif self.get_options().manifest_jar_only:
       classpath = ClasspathUtil.classpath(targets, runtime_classpath)
       # Safely create e.g. dist/export-classpath/manifest.jar
       safe_classpath(classpath, basedir, "manifest.jar")

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
@@ -17,6 +17,8 @@ class RuntimeClasspathPublisher(Task):
     super().register_options(register)
     register('--manifest-jar-only', type=bool, default=False,
              help='Only export classpath in a manifest jar.')
+    register('--internal-classpath-only', type=bool, default=True,
+             help='Only export the classpath of source targets, not 3rdparty jars.')
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -35,7 +37,9 @@ class RuntimeClasspathPublisher(Task):
       # Safely create e.g. dist/export-classpath/manifest.jar
       safe_classpath(classpath, basedir, "manifest.jar")
     else:
-      ClasspathProducts.create_canonical_classpath(runtime_classpath,
-                                                   targets,
-                                                   basedir,
-                                                   save_classpath_file=True)
+      ClasspathProducts.create_canonical_classpath(
+        runtime_classpath,
+        targets,
+        basedir,
+        internal_classpath_only=self.get_options().internal_classpath_only,
+        save_classpath_file=True)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_classpath_published.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_classpath_published.py
@@ -2,10 +2,16 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from textwrap import dedent
 
+from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.backend.jvm.tasks.classpath_entry import ArtifactClasspathEntry
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.jvm_compile.jvm_classpath_publisher import RuntimeClasspathPublisher
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.java.jar.jar_dependency import JarDependency
+from pants.java.jar.jar_dependency_utils import M2Coordinate
 from pants.testutil.task_test_base import TaskTestBase
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_open, touch
@@ -17,6 +23,18 @@ class RuntimeClasspathPublisherTest(TaskTestBase):
   @classmethod
   def task_type(cls):
     return RuntimeClasspathPublisher
+
+  @classmethod
+  def alias_groups(cls):
+    return BuildFileAliases(
+      targets={
+        'java_library': JavaLibrary,
+        'jar_library': JarLibrary,
+      },
+      objects={
+        'jar': JarDependency,
+      }
+    )
 
   # TODO (peiyu) This overlaps with test cases in `ClasspathUtilTest`. Clean this up once we
   # fully switch to `target.id` based canonical classpath.
@@ -79,3 +97,66 @@ class RuntimeClasspathPublisherTest(TaskTestBase):
             os.pathsep.join([os.path.join(jar_dir, 'z2.jar'), os.path.join(jar_dir, 'z3.jar')]) + '\n'
           ]
         )
+
+  def _assert_internal_classpath_option(self, *, internal_classpath_only: bool) -> None:
+    with temporary_dir(root_dir=self.pants_workdir) as jar_dir, \
+         temporary_dir(root_dir=self.pants_workdir) as dist_dir:
+      self.set_options(pants_distdir=dist_dir,
+                       internal_classpath_only=internal_classpath_only)
+      self.set_options_for_scope('resolver', resolver='coursier')
+
+      self.add_to_build_file('java/classpath', dedent("""\
+      jar_library(
+        name='jar-lib',
+        jars=[
+          jar(org='commons-io', name='commons-io', rev='2.6'),
+        ],
+      )
+
+      java_library(
+        name='java-lib',
+        sources=['com/foo/Bar.java'],
+        dependencies=[
+          ':jar-lib',
+        ],
+      )
+      """))
+      jar_lib = self.target('java/classpath:jar-lib')
+      init_target = self.target('java/classpath:java-lib')
+      context = self.context(target_roots=[jar_lib, init_target])
+      runtime_classpath = context.products.get_data('runtime_classpath',
+                                                    init_func=ClasspathProducts.init_func(self.pants_workdir))
+      task = self.create_task(context)
+
+      target_classpath_output = os.path.join(dist_dir, self.options_scope)
+
+      # Create a classpath entry.
+      touch(os.path.join(jar_dir, 'jar-lib-target.jar'))
+      touch(os.path.join(jar_dir, 'java-lib-target.jar'))
+
+      cache_path = os.path.join(jar_dir, 'jar-lib-target.jar')
+      runtime_classpath.add_for_target(jar_lib, [(self.DEFAULT_CONF, ArtifactClasspathEntry(
+        path=cache_path,
+        coordinate=M2Coordinate(org='commons-io', name='commons-io', rev='2.6'),
+        cache_path=cache_path,
+      ))])
+      runtime_classpath.add_for_target(init_target, [(self.DEFAULT_CONF, os.path.join(jar_dir, 'java-lib-target.jar'))])
+
+      task.execute()
+
+      all_output = os.listdir(target_classpath_output)
+
+      # Check that the artifacts from the jar library are only exported with
+      # --no-internal-classpath-only.
+      if internal_classpath_only:
+        self.assertEqual(len(all_output), 2)
+        self.assertNoIn('java.classpath.jar-lib-0.jar', all_output)
+      else:
+        self.assertEqual(len(all_output), 4)
+        self.assertIn('java.classpath.jar-lib-0.jar', all_output)
+
+  def test_internal_classpath_only(self):
+    self._assert_internal_classpath_option(internal_classpath_only=True)
+
+  def test_no_internal_classpath_only(self):
+    self._assert_internal_classpath_option(internal_classpath_only=False)


### PR DESCRIPTION
### Problem

The `export-classpath` task will currently output a classpath for all the specified targets, but it won't include 3rdparty dependencies. Using pants with an IDE currently requires doing a hacky `bundle` in order to force pants to produce a classpath with 3rdparty jars.

### Solution

- Add `--internal-classpath-only` to the `export-classpath` task (defaulting to True to avoid changing default behavior).
  - When this option is switched off, pants will include 3rdparty jars in `dist/export-classpath` as well as jars of compiled sources!
- Add `--manifest-jar` option to have the correct behavior with `--internal-classpath-only`, and deprecate `--manifest-jar-only`, which currently contains non-internal classpath entries.
- Add testing for the `--manifest-jar` option for the first time!

### Result

`export-classpath` can be used directly by IDEs without having to separately obtain 3rdparty jars with a separate pants command!