### PR TITLE
Allow coursier use local cache

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -451,7 +451,7 @@ enable_libc_search: True
 [sourcefile-validation]
 config: @build-support/regexes/config.yaml
 
-[cache.resolve]
+[cache.resolve.coursier]
 # Only use local artifact for coursier because the cache content contains abs path
 # and is not portable.
 read_from: ["%(local_artifact_cache)s"]

--- a/pants.ini
+++ b/pants.ini
@@ -453,6 +453,8 @@ config: @build-support/regexes/config.yaml
 
 [cache.resolve.coursier]
 # Only use local artifact for coursier because the cache content contains abs path
-# and is not portable.
+# and is not portable. That said, if remote cache is enabled, this would not break
+# but would be less performant, as the task will validate the entry paths from cache
+# and decide to rerun coursier since the paths are invalid.
 read_from: ["%(local_artifact_cache)s"]
 write_to: ["%(local_artifact_cache)s"]

--- a/pants.ini
+++ b/pants.ini
@@ -450,3 +450,9 @@ enable_libc_search: True
 
 [sourcefile-validation]
 config: @build-support/regexes/config.yaml
+
+[cache.resolve]
+# Only use local artifact for coursier because the cache content contains abs path
+# and is not portable.
+read_from: ["%(local_artifact_cache)s"]
+write_to: ["%(local_artifact_cache)s"]

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -163,14 +163,12 @@ class CoursierMixin(JvmResolverBase):
           # Check each individual target without context first
           # If the individuals are valid, check them as a VersionedTargetSet
           # The order of 'or' statement matters, because checking for cache is more expensive.
-          if not invalidation_check.invalid_vts and \
-            (resolve_vts.valid or len(self.check_artifact_cache([resolve_vts])[0]) == len(resolve_vts.targets)):
-            if resolve_vts.valid:
-              # Load up from the results dir
-              success = self._load_from_results_dir(compile_classpath, vt_set_results_dir,
-                coursier_cache_dir, invalidation_check, pants_jar_base_dir)
-              if success:
-                return
+          if resolve_vts.valid or len(self.check_artifact_cache([resolve_vts])[0]) == len(resolve_vts.targets):
+            # Load up from the results dir
+            success = self._load_from_results_dir(compile_classpath, vt_set_results_dir,
+              coursier_cache_dir, invalidation_check, pants_jar_base_dir)
+            if success:
+              return
 
         jars_to_resolve, pinned_coords = self._compute_jars_to_resolve_and_pin(raw_jar_deps,
                                                                                artifact_set,

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -162,13 +162,15 @@ class CoursierMixin(JvmResolverBase):
         if not self.get_options().report:
           # Check each individual target without context first
           # If the individuals are valid, check them as a VersionedTargetSet
-          (cached, uncached, uncached_causes) = self.check_artifact_cache([resolve_vts])
-          if not invalidation_check.invalid_vts and len(cached) == len(resolve_vts.targets):
-            # Load up from the results dir
-            success = self._load_from_results_dir(compile_classpath, vt_set_results_dir,
-                                                  coursier_cache_dir, invalidation_check, pants_jar_base_dir)
-            if success:
-              return
+          # The order of 'or' statement matters, because checking for cache is more expensive.
+          if not invalidation_check.invalid_vts and \
+            (resolve_vts.valid or len(self.check_artifact_cache([resolve_vts])[0]) == len(resolve_vts.targets)):
+            if resolve_vts.valid:
+              # Load up from the results dir
+              success = self._load_from_results_dir(compile_classpath, vt_set_results_dir,
+                coursier_cache_dir, invalidation_check, pants_jar_base_dir)
+              if success:
+                return
 
         jars_to_resolve, pinned_coords = self._compute_jars_to_resolve_and_pin(raw_jar_deps,
                                                                                artifact_set,
@@ -185,8 +187,8 @@ class CoursierMixin(JvmResolverBase):
         self._populate_results_dir(vt_set_results_dir, results)
         resolve_vts.update()
 
-        # if self.artifact_cache_writes_enabled():
-        self.update_artifact_cache([(resolve_vts, [vt_set_results_dir])])
+        if self.artifact_cache_writes_enabled():
+          self.update_artifact_cache([(resolve_vts, [vt_set_results_dir])])
 
   def _override_classifiers_for_conf(self, conf):
      # TODO Encapsulate this in the result from coursier instead of here.

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -166,7 +166,7 @@ class CoursierMixin(JvmResolverBase):
           if resolve_vts.valid or len(self.check_artifact_cache([resolve_vts])[0]) == len(resolve_vts.targets):
             # Load up from the results dir
             success = self._load_from_results_dir(compile_classpath, vt_set_results_dir,
-              coursier_cache_dir, invalidation_check, pants_jar_base_dir)
+                                                  coursier_cache_dir, invalidation_check, pants_jar_base_dir)
             if success:
               resolve_vts.update()
               return

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -163,7 +163,8 @@ class CoursierMixin(JvmResolverBase):
           # Check each individual target without context first
           # If the individuals are valid, check them as a VersionedTargetSet
           # The order of 'or' statement matters, because checking for cache is more expensive.
-          if resolve_vts.valid or len(self.check_artifact_cache([resolve_vts])[0]) == len(resolve_vts.targets):
+          if resolve_vts.valid or (self.artifact_cache_reads_enabled() and
+                                   len(self.check_artifact_cache([resolve_vts])[0]) == len(resolve_vts.targets)):
             # Load up from the results dir
             success = self._load_from_results_dir(compile_classpath, vt_set_results_dir,
                                                   coursier_cache_dir, invalidation_check, pants_jar_base_dir)

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -168,6 +168,7 @@ class CoursierMixin(JvmResolverBase):
             success = self._load_from_results_dir(compile_classpath, vt_set_results_dir,
               coursier_cache_dir, invalidation_check, pants_jar_base_dir)
             if success:
+              resolve_vts.update()
               return
 
         jars_to_resolve, pinned_coords = self._compute_jars_to_resolve_and_pin(raw_jar_deps,

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -162,7 +162,8 @@ class CoursierMixin(JvmResolverBase):
         if not self.get_options().report:
           # Check each individual target without context first
           # If the individuals are valid, check them as a VersionedTargetSet
-          if not invalidation_check.invalid_vts and resolve_vts.valid:
+          (cached, uncached, uncached_causes) = self.check_artifact_cache([resolve_vts])
+          if not invalidation_check.invalid_vts and len(cached) == len(resolve_vts.targets):
             # Load up from the results dir
             success = self._load_from_results_dir(compile_classpath, vt_set_results_dir,
                                                   coursier_cache_dir, invalidation_check, pants_jar_base_dir)
@@ -183,6 +184,9 @@ class CoursierMixin(JvmResolverBase):
 
         self._populate_results_dir(vt_set_results_dir, results)
         resolve_vts.update()
+
+        # if self.artifact_cache_writes_enabled():
+        self.update_artifact_cache([(resolve_vts, [vt_set_results_dir])])
 
   def _override_classifiers_for_conf(self, conf):
      # TODO Encapsulate this in the result from coursier instead of here.

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -40,9 +40,6 @@ class CoursierResolveTest(NailgunTaskTestBase):
 
   def setUp(self):
     super().setUp()
-    self.set_options_for_scope('cache.{}'.format(self.options_scope),
-                               read_from=None,
-                               write_to=None)
     self.set_options_for_scope('resolver', resolver='coursier')
 
   def _cache_dir_regex(self, cache_type):
@@ -55,28 +52,38 @@ class CoursierResolveTest(NailgunTaskTestBase):
     self.execute(context)
     return context.products.get_data('compile_classpath')
 
+  @contextmanager
+  def _temp_task_cache_dir(self):
+    with temporary_dir() as cache_dir:
+      self.set_options_for_scope('cache.{}'.format(self.options_scope),
+        read_from=[cache_dir],
+        write_to=[cache_dir])
+      yield
+
   def test_resolve_specific(self):
-    # Create a jar_library with a single dep, and another library with no deps.
-    dep = JarDependency('commons-lang', 'commons-lang', '2.5')
-    jar_lib = self.make_target('//:a', JarLibrary, jars=[dep])
-    scala_lib = self.make_target('//:b', JavaLibrary, sources=[])
-    # Confirm that the deps were added to the appropriate targets.
-    compile_classpath = self.resolve([jar_lib, scala_lib])
-    self.assertEqual(1, len(compile_classpath.get_for_target(jar_lib)))
-    self.assertEqual(0, len(compile_classpath.get_for_target(scala_lib)))
+    with self._temp_task_cache_dir():
+      # Create a jar_library with a single dep, and another library with no deps.
+      dep = JarDependency('commons-lang', 'commons-lang', '2.5')
+      jar_lib = self.make_target('//:a', JarLibrary, jars=[dep])
+      scala_lib = self.make_target('//:b', JavaLibrary, sources=[])
+      # Confirm that the deps were added to the appropriate targets.
+      compile_classpath = self.resolve([jar_lib, scala_lib])
+      self.assertEqual(1, len(compile_classpath.get_for_target(jar_lib)))
+      self.assertEqual(0, len(compile_classpath.get_for_target(scala_lib)))
 
   def test_resolve_with_remote_url(self):
-    dep_with_url = JarDependency('a', 'b', 'c',
-                                 url='http://central.maven.org/maven2/junit/junit/4.12/junit-4.12.jar')
-    dep_with_url_lib = self.make_target('//:a', JarLibrary, jars=[dep_with_url])
+    with self._temp_task_cache_dir():
+      dep_with_url = JarDependency('a', 'b', 'c',
+                                   url='http://central.maven.org/maven2/junit/junit/4.12/junit-4.12.jar')
+      dep_with_url_lib = self.make_target('//:a', JarLibrary, jars=[dep_with_url])
 
-    compile_classpath = self.resolve([dep_with_url_lib])
-    # Get paths on compile classpath and assert that it starts with '.../coursier/cache/relative'
-    paths = [tup[1] for tup in compile_classpath.get_for_target(dep_with_url_lib)]
-    self.assertTrue(any(self._cache_dir_regex('relative').search(path) for path in paths), str(paths))
+      compile_classpath = self.resolve([dep_with_url_lib])
+      # Get paths on compile classpath and assert that it starts with '.../coursier/cache/relative'
+      paths = [tup[1] for tup in compile_classpath.get_for_target(dep_with_url_lib)]
+      self.assertTrue(any(self._cache_dir_regex('relative').search(path) for path in paths), str(paths))
 
   def test_resolve_with_local_url(self):
-    with temporary_file_path(suffix='.jar') as url:
+    with temporary_file_path(suffix='.jar') as url, self._temp_task_cache_dir():
       dep_with_url = JarDependency('commons-lang', 'commons-lang', '2.5', url='file://' + url)
       dep_with_url_lib = self.make_target('//:a', JarLibrary, jars=[dep_with_url])
 
@@ -86,48 +93,50 @@ class CoursierResolveTest(NailgunTaskTestBase):
       self.assertTrue(any(self._cache_dir_regex('absolute').search(path) for path in paths), str(paths))
 
   def test_resolve_specific_with_sources_javadocs(self):
-    # Create a jar_library with a single dep, and another library with no deps.
-    dep = JarDependency('commons-lang', 'commons-lang', '2.5')
-    jar_lib = self.make_target('//:a', JarLibrary, jars=[dep])
-    scala_lib = self.make_target('//:b', JavaLibrary, sources=[])
-    with self._temp_workdir() as workdir:
-      # Confirm that the deps were added to the appropriate targets.
-      context = self.context(target_roots=[jar_lib, scala_lib])
-      task = self.prepare_execute(context)
-      compile_classpath = context.products.get_data('compile_classpath',
-        init_func=ClasspathProducts.init_func(workdir)
-      )
-      task.resolve([jar_lib, scala_lib], compile_classpath, sources=True, javadoc=True, executor=None)
+    with self._temp_task_cache_dir():
+      # Create a jar_library with a single dep, and another library with no deps.
+      dep = JarDependency('commons-lang', 'commons-lang', '2.5')
+      jar_lib = self.make_target('//:a', JarLibrary, jars=[dep])
+      scala_lib = self.make_target('//:b', JavaLibrary, sources=[])
+      with self._temp_workdir() as workdir:
+        # Confirm that the deps were added to the appropriate targets.
+        context = self.context(target_roots=[jar_lib, scala_lib])
+        task = self.prepare_execute(context)
+        compile_classpath = context.products.get_data('compile_classpath',
+          init_func=ClasspathProducts.init_func(workdir)
+        )
+        task.resolve([jar_lib, scala_lib], compile_classpath, sources=True, javadoc=True, executor=None)
 
-      # Both javadoc and sources jars are added to the classpath product
-      self.assertEqual(['default', 'src_doc', 'src_doc'],
-       sorted([c[0] for c in compile_classpath.get_for_target(jar_lib)]))
-      self.assertEqual(0, len(compile_classpath.get_for_target(scala_lib)))
+        # Both javadoc and sources jars are added to the classpath product
+        self.assertEqual(['default', 'src_doc', 'src_doc'],
+         sorted([c[0] for c in compile_classpath.get_for_target(jar_lib)]))
+        self.assertEqual(0, len(compile_classpath.get_for_target(scala_lib)))
 
   def test_resolve_conflicted(self):
-    losing_dep = JarDependency('com.google.guava', 'guava', '16.0')
-    winning_dep = JarDependency('com.google.guava', 'guava', '16.0.1')
-    losing_lib = self.make_target('//:a', JarLibrary, jars=[losing_dep])
-    winning_lib = self.make_target('//:b', JarLibrary, jars=[winning_dep])
+    with self._temp_task_cache_dir():
+      losing_dep = JarDependency('com.google.guava', 'guava', '16.0')
+      winning_dep = JarDependency('com.google.guava', 'guava', '16.0.1')
+      losing_lib = self.make_target('//:a', JarLibrary, jars=[losing_dep])
+      winning_lib = self.make_target('//:b', JarLibrary, jars=[winning_dep])
 
-    compile_classpath = self.resolve([losing_lib, winning_lib])
+      compile_classpath = self.resolve([losing_lib, winning_lib])
 
-    losing_cp = compile_classpath.get_for_target(losing_lib)
-    winning_cp = compile_classpath.get_for_target(winning_lib)
+      losing_cp = compile_classpath.get_for_target(losing_lib)
+      winning_cp = compile_classpath.get_for_target(winning_lib)
 
-    self.assertEqual(losing_cp, winning_cp)
+      self.assertEqual(losing_cp, winning_cp)
 
-    self.assertEqual(1, len(winning_cp))
-    conf, path = winning_cp[0]
-    self.assertEqual('default', conf)
-    self.assertEqual('guava-16.0.1.jar', os.path.basename(path))
+      self.assertEqual(1, len(winning_cp))
+      conf, path = winning_cp[0]
+      self.assertEqual('default', conf)
+      self.assertEqual('guava-16.0.1.jar', os.path.basename(path))
 
   def test_resolve_ignores_jars_with_rev_left_off(self):
     """If a resolve jar leaves off the rev, we're supposed to get the latest version,
        but coursier doesn't currently support that.
        https://github.com/coursier/coursier/issues/209
     """
-    with self.assertRaises(TaskError) as cm:
+    with self.assertRaises(TaskError) as cm, self._temp_task_cache_dir():
       jar = JarDependency('com.google.guava', 'guava')
       lib = self.make_target('//:b', JarLibrary, jars=[jar])
 
@@ -142,68 +151,70 @@ class CoursierResolveTest(NailgunTaskTestBase):
     def coordinates_for(cp):
       return {resolved_jar.coordinate for conf, resolved_jar in cp}
 
-    no_classifier = JarDependency('org.apache.commons', 'commons-compress', rev='1.4.1')
-    classifier = JarDependency('org.apache.commons', 'commons-compress', rev='1.4.1', classifier='tests')
+    with self._temp_task_cache_dir():
+      no_classifier = JarDependency('org.apache.commons', 'commons-compress', rev='1.4.1')
+      classifier = JarDependency('org.apache.commons', 'commons-compress', rev='1.4.1', classifier='tests')
 
-    self.set_options_for_scope('coursier', fetch_options=['-A', 'jar,bundle,test-jar,maven-plugin,src,doc'])
+      self.set_options_for_scope('coursier', fetch_options=['-A', 'jar,bundle,test-jar,maven-plugin,src,doc'])
 
-    no_classifier_lib = self.make_target('//:a', JarLibrary, jars=[no_classifier])
-    classifier_lib = self.make_target('//:b', JarLibrary, jars=[classifier])
-    classifier_and_no_classifier_lib = self.make_target('//:c', JarLibrary,
-                                                        jars=[classifier, no_classifier])
+      no_classifier_lib = self.make_target('//:a', JarLibrary, jars=[no_classifier])
+      classifier_lib = self.make_target('//:b', JarLibrary, jars=[classifier])
+      classifier_and_no_classifier_lib = self.make_target('//:c', JarLibrary,
+                                                          jars=[classifier, no_classifier])
 
-    compile_classpath = self.resolve([no_classifier_lib,
-                                      classifier_lib,
-                                      classifier_and_no_classifier_lib])
+      compile_classpath = self.resolve([no_classifier_lib,
+                                        classifier_lib,
+                                        classifier_and_no_classifier_lib])
 
-    no_classifier_cp = compile_classpath.get_classpath_entries_for_targets([no_classifier_lib])
-    classifier_cp = compile_classpath.get_classpath_entries_for_targets([classifier_lib])
-    classifier_and_no_classifier_cp = compile_classpath.get_classpath_entries_for_targets(
-      classifier_and_no_classifier_lib.closure(bfs=True))
+      no_classifier_cp = compile_classpath.get_classpath_entries_for_targets([no_classifier_lib])
+      classifier_cp = compile_classpath.get_classpath_entries_for_targets([classifier_lib])
+      classifier_and_no_classifier_cp = compile_classpath.get_classpath_entries_for_targets(
+        classifier_and_no_classifier_lib.closure(bfs=True))
 
-    classifier_and_no_classifier_coords = coordinates_for(classifier_and_no_classifier_cp)
+      classifier_and_no_classifier_coords = coordinates_for(classifier_and_no_classifier_cp)
 
-    self.assertIn(no_classifier.coordinate, classifier_and_no_classifier_coords)
-    self.assertIn(classifier.coordinate, classifier_and_no_classifier_coords)
+      self.assertIn(no_classifier.coordinate, classifier_and_no_classifier_coords)
+      self.assertIn(classifier.coordinate, classifier_and_no_classifier_coords)
 
-    self.assertNotIn(classifier.coordinate, coordinates_for(no_classifier_cp))
-    self.assertIn(no_classifier.coordinate, coordinates_for(no_classifier_cp))
+      self.assertNotIn(classifier.coordinate, coordinates_for(no_classifier_cp))
+      self.assertIn(no_classifier.coordinate, coordinates_for(no_classifier_cp))
 
-    self.assertNotIn(no_classifier.coordinate, coordinates_for(classifier_cp))
-    self.assertIn(classifier.coordinate, coordinates_for(classifier_cp))
+      self.assertNotIn(no_classifier.coordinate, coordinates_for(classifier_cp))
+      self.assertIn(classifier.coordinate, coordinates_for(classifier_cp))
 
   def test_excludes_in_java_lib_excludes_all_from_jar_lib(self):
-    junit_jar_lib = self._make_junit_target()
+    with self._temp_task_cache_dir():
+      junit_jar_lib = self._make_junit_target()
 
-    excluding_target = self.make_target('//:b', JavaLibrary, sources=[],
-                                        excludes=[Exclude('junit', 'junit')])
-    compile_classpath = self.resolve([junit_jar_lib, excluding_target])
+      excluding_target = self.make_target('//:b', JavaLibrary, sources=[],
+                                          excludes=[Exclude('junit', 'junit')])
+      compile_classpath = self.resolve([junit_jar_lib, excluding_target])
 
-    junit_jar_cp = compile_classpath.get_for_target(junit_jar_lib)
-    excluding_cp = compile_classpath.get_for_target(excluding_target)
+      junit_jar_cp = compile_classpath.get_for_target(junit_jar_lib)
+      excluding_cp = compile_classpath.get_for_target(excluding_target)
 
-    self.assertEqual(2, len(junit_jar_cp))
-    self.assertEqual(0, len(excluding_cp))
+      self.assertEqual(2, len(junit_jar_cp))
+      self.assertEqual(0, len(excluding_cp))
 
-    def get_coord_in_classpath(cp, targets):
-      """
-      Get the simple coords that are going to be on the classpath
-      """
-      conf_art_tuples_ex = cp.get_classpath_entries_for_targets(targets)
-      simple_coords = {x[1].coordinate.simple_coord for x in conf_art_tuples_ex}
-      return simple_coords
+      def get_coord_in_classpath(cp, targets):
+        """
+        Get the simple coords that are going to be on the classpath
+        """
+        conf_art_tuples_ex = cp.get_classpath_entries_for_targets(targets)
+        simple_coords = {x[1].coordinate.simple_coord for x in conf_art_tuples_ex}
+        return simple_coords
 
-    # If we grab the transitive closure of the coordinates just for junit, then
-    # both junit and hamcrest should be in it.
-    simple_coords = get_coord_in_classpath(compile_classpath, [junit_jar_lib])
-    self.assertIn('junit:junit:4.12', simple_coords)
-    self.assertIn('org.hamcrest:hamcrest-core:1.3', simple_coords)
+      # If we grab the transitive closure of the coordinates just for junit, then
+      # both junit and hamcrest should be in it.
+      simple_coords = get_coord_in_classpath(compile_classpath, [junit_jar_lib])
+      self.assertIn('junit:junit:4.12', simple_coords)
+      self.assertIn('org.hamcrest:hamcrest-core:1.3', simple_coords)
 
-    # If we grab transitive closure of the coordinates for junit along with a JavaLibrary
-    # target that excludes junit, then junit should not be on the classpath.
-    simple_coords = get_coord_in_classpath(compile_classpath, [excluding_target, junit_jar_lib])
-    self.assertNotIn('junit:junit:4.12', simple_coords)
-    self.assertIn('org.hamcrest:hamcrest-core:1.3', simple_coords)
+      # If we grab transitive closure of the coordinates for junit along with a JavaLibrary
+      # target that excludes junit, then junit should not be on the classpath.
+      simple_coords = get_coord_in_classpath(compile_classpath, [excluding_target, junit_jar_lib])
+      self.assertNotIn('junit:junit:4.12', simple_coords)
+      self.assertIn('org.hamcrest:hamcrest-core:1.3', simple_coords)
 
   def test_resolve_no_deps(self):
     # Resolve a library with no deps, and confirm that the empty product is created.
@@ -212,7 +223,7 @@ class CoursierResolveTest(NailgunTaskTestBase):
 
   def test_second_noop_does_not_invoke_coursier(self):
     junit_jar_lib = self._make_junit_target()
-    with self._temp_workdir():
+    with self._temp_workdir(), self._temp_task_cache_dir():
       # Initial resolve does a resolve and populates elements.
       initial_context = self.context(target_roots=[junit_jar_lib])
       task = self.execute(initial_context)
@@ -225,7 +236,7 @@ class CoursierResolveTest(NailgunTaskTestBase):
   def test_when_invalid_hardlink_and_coursier_cache_should_trigger_resolve(self):
     jar_lib = self._make_junit_target()
     with self._temp_workdir():
-      with temporary_dir() as couriser_cache_dir:
+      with temporary_dir() as couriser_cache_dir, self._temp_task_cache_dir():
         self.set_options_for_scope('coursier', cache_dir=couriser_cache_dir)
 
         context = self.context(target_roots=[jar_lib])
@@ -259,14 +270,15 @@ class CoursierResolveTest(NailgunTaskTestBase):
         util.execute_runner.assert_called()
 
   def test_resolve_jarless_pom(self):
-    jar = JarDependency('org.apache.commons', 'commons-weaver-privilizer-parent', '1.3')
-    lib = self.make_target('//:b', JarLibrary, jars=[jar])
+    with self._temp_task_cache_dir():
+      jar = JarDependency('org.apache.commons', 'commons-weaver-privilizer-parent', '1.3')
+      lib = self.make_target('//:b', JarLibrary, jars=[jar])
 
-    compile_classpath = self.resolve([lib])
+      compile_classpath = self.resolve([lib])
 
-    lib_cp = compile_classpath.get_for_target(lib)
+      lib_cp = compile_classpath.get_for_target(lib)
 
-    self.assertEqual(0, len(lib_cp))
+      self.assertEqual(0, len(lib_cp))
 
   def _make_junit_target(self):
     junit_dep = JarDependency('junit', 'junit', rev='4.12')


### PR DESCRIPTION
### Problem & Solution

Previously couriser resolve result can only be validated but not fetch from cache. This change allows the result to be stored in cache and then later fetched from cache.

#### Before
```
$ for i in `seq 1 5`; do time ./pants --resolver-resolver=coursier clean-all resolve examples/tests/scala/org/pantsbuild/example/hello/welcome/  &> /dev/null; done

real	0m6.031s
user	0m5.278s
sys	0m0.722s

real	0m5.799s
user	0m5.298s
sys	0m0.740s

real	0m5.776s
user	0m5.334s
sys	0m0.717s

real	0m5.876s
user	0m5.389s
sys	0m0.733s

real	0m6.026s
user	0m5.382s
sys	0m0.743s
```

#### After
```
$ for i in `seq 1 5`; do time ./pants --resolver-resolver=coursier clean-all resolve examples/tests/scala/org/pantsbuild/example/hello/welcome/  &> /dev/null; done

real	0m3.993s
user	0m4.796s
sys	0m0.632s

real	0m3.930s
user	0m4.896s
sys	0m0.630s

real	0m3.869s
user	0m4.872s
sys	0m0.614s

real	0m3.932s
user	0m4.901s
sys	0m0.621s

real	0m3.825s
user	0m4.886s
sys	0m0.616s
```

