### PR TITLE
Allow test sharding on scalatest classes

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/ScalaTestUtil.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ScalaTestUtil.java
@@ -1,6 +1,11 @@
 package org.pantsbuild.tools.junit.impl;
 
+import org.junit.runner.Description;
 import org.junit.runner.Runner;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.manipulation.Filterable;
+import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runner.notification.RunNotifier;
 
 public final class ScalaTestUtil {
   private ScalaTestUtil() {}
@@ -19,13 +24,44 @@ public final class ScalaTestUtil {
   }
 
   /**
+   * This is added temporarily to fix the sharding of scala tests
+   * Issue: https://github.com/pantsbuild/pants/issues/8594
+   * TODO: Remove this when https://github.com/scalatest/scalatestplus-junit/pull/8 is merged
+   */
+  private static class ScalaTestJunitRunnerWrapper extends Runner implements Filterable {
+      private Runner delegate;
+      private Class<?> suite;
+
+      private ScalaTestJunitRunnerWrapper(Runner delegate, Class<?> suite) {
+        this.delegate = delegate;
+        this.suite = suite;
+      }
+
+      @Override
+      public Description getDescription() {
+          return Description.createSuiteDescription(suite);
+      }
+
+      @Override
+      public void run(RunNotifier notifier) {
+          delegate.run(notifier);
+      }
+
+      @Override
+      public void filter(Filter filter) throws NoTestsRemainException {
+        if (!filter.shouldRun(getDescription())) throw new NoTestsRemainException();
+      }
+  }
+
+  /**
    * Returns a scalatest junit runner using reflection.
    * @param clazz the test class
    *
    * @return a new scalatest junit runner
    */
   public static Runner getJUnitRunner(Class<?> clazz) throws Exception {
-    return (Runner) junitRunnerClass.getConstructor(Class.class).newInstance(clazz);
+    return new ScalaTestJunitRunnerWrapper(
+            (Runner) junitRunnerClass.getConstructor(Class.class).newInstance(clazz), clazz);
   }
 
   /**

--- a/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
@@ -72,8 +72,7 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestBase {
 
   @Test
   public void testShardedTesting12() {
-    invokeConsoleRunner("MockTest1 MockTest2 MockTest3 "
-        + "-test-shard 1/2");
+    invokeConsoleRunner("MockTest1 MockTest2 MockTest3 -test-shard 1/2");
     assertEquals("test12 test21 test31", TestRegistry.getCalledTests());
   }
 
@@ -118,6 +117,41 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestBase {
   public void testShardedTesting34() {
     invokeConsoleRunner("MockTest1 MockTest2 MockTest3 -test-shard 3/4");
     assertEquals("test21", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testShardedTesting02Scala() {
+    invokeConsoleRunner("MockScalaTest MockScalaTest1 MockScalaTest2 MockScalaTest3 "
+        + "-test-shard 0/2");
+    assertEquals("MockScalaTest-1 MockScalaTest-3", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testShardedTesting12Scala() {
+    invokeConsoleRunner("MockScalaTest MockScalaTest1 MockScalaTest2 MockScalaTest3 "
+        + "-test-shard 1/2");
+    assertEquals("MockScalaTest-2 MockScalaTest-4", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testShardedTesting03Scala() {
+    invokeConsoleRunner("MockScalaTest MockScalaTest1 MockScalaTest2 MockScalaTest3 "
+        + "-test-shard 0/3");
+    assertEquals("MockScalaTest-1 MockScalaTest-4", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testShardedTesting13Scala() {
+    invokeConsoleRunner("MockScalaTest MockScalaTest1 MockScalaTest2 MockScalaTest3 "
+        + "-test-shard 1/3");
+    assertEquals("MockScalaTest-2", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testShardedTesting23Scala() {
+    invokeConsoleRunner("MockScalaTest MockScalaTest1 MockScalaTest2 MockScalaTest3 "
+        + "-test-shard 2/3");
+    assertEquals("MockScalaTest-3", TestRegistry.getCalledTests());
   }
 
   @Test

--- a/tests/scala/org/pantsbuild/tools/junit/lib/MockScalaTest1.scala
+++ b/tests/scala/org/pantsbuild/tools/junit/lib/MockScalaTest1.scala
@@ -1,0 +1,11 @@
+package org.pantsbuild.tools.junit.lib
+
+import org.scalatest.FreeSpec
+
+class MockScalaTest1 extends FreeSpec {
+  "test" - {
+    "should pass" in {
+      TestRegistry.registerTestCall("MockScalaTest-2")
+    }
+  }
+}

--- a/tests/scala/org/pantsbuild/tools/junit/lib/MockScalaTest2.scala
+++ b/tests/scala/org/pantsbuild/tools/junit/lib/MockScalaTest2.scala
@@ -1,0 +1,11 @@
+package org.pantsbuild.tools.junit.lib
+
+import org.scalatest.FreeSpec
+
+class MockScalaTest2 extends FreeSpec {
+  "test" - {
+    "should pass" in {
+      TestRegistry.registerTestCall("MockScalaTest-3")
+    }
+  }
+}

--- a/tests/scala/org/pantsbuild/tools/junit/lib/MockScalaTest3.scala
+++ b/tests/scala/org/pantsbuild/tools/junit/lib/MockScalaTest3.scala
@@ -1,0 +1,11 @@
+package org.pantsbuild.tools.junit.lib
+
+import org.scalatest.FreeSpec
+
+class MockScalaTest3 extends FreeSpec {
+  "test" - {
+    "should pass" in {
+      TestRegistry.registerTestCall("MockScalaTest-4")
+    }
+  }
+}


### PR DESCRIPTION
### Problem

Scala tests are not sharded when providing --test-junit-test-shard argument, as shown by the tests added to ConsoleRunnerTest

### Solution

We fix this by providing a facade for JUnitRunner (scalatestplus-junit) used to run scala tests, which implements Filterable and thus now used by the filter (cf https://github.com/junit-team/junit4/blob/0e2d999c11e28369b5057c96fc7c20e162adee72/src/main/java/org/junit/runner/manipulation/Filter.java#L93)

### Result

Scala tests are now sharded by spec class.