### PR TITLE
Support gpg2 for jar signing.

### DIFF
--- a/build-support/ivy/ivy.xml
+++ b/build-support/ivy/ivy.xml
@@ -11,13 +11,13 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
   <info organisation="org.pantsbuild" module="ivy"/>
 
   <dependencies defaultconf="default">
-    <dependency org="org.apache.ivy" name="ivy" rev="2.4.0"/>
+    <dependency org="org.apache.ivy" name="ivy" rev="2.5.0"/>
 
-    <!-- Enable support for the more robust commons-httpclient downloader. -->
-    <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1"/>
+    <!-- Enable support for the more robust httpcomponents-client downloader. -->
+    <dependency org="org.apache.httpcomponents" name="httpcomponents-client" rev="4.5.10"/>
 
-    <!-- support for the pgp signer -->
-    <dependency org="org.bouncycastle" name="bcpg-jdk14" rev="1.45"/>
-    <dependency org="org.bouncycastle" name="bcprov-jdk14" rev="1.45"/>
+    <!-- Enable support for the pgp signer -->
+    <dependency org="org.bouncycastle" name="bcpg-jdk14" rev="1.64"/>
+    <dependency org="org.bouncycastle" name="bcprov-jdk14" rev="1.64"/>
   </dependencies>
 </ivy-module>

--- a/build-support/ivy/ivysettings.xml
+++ b/build-support/ivy/ivysettings.xml
@@ -12,15 +12,11 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
   <property name="m2.repo.artifact"
             value="${m2.repo.relpath}/[artifact]-[revision](-[classifier]).[ext]"/>
   <property name="m2.repo.dir" value="${user.home}/.m2/repository" override="false"/>
-  <property name="kythe.artifact" value="[organisation]/[artifact]/[revision]/[artifact]-[revision].[ext]"/>
-  <!-- for retrieving jacoco snapshot, remove when a version containing cli is released -->
-  <!-- see https://github.com/pantsbuild/pants/issues/5010 -->
-  <property name="sonatype.nexus.snapshots.url" value="https://oss.sonatype.org/content/repositories/snapshots/" />
 
-  <properties environment="env"/>
+  <property name="kythe.artifact"
+            value="[organisation]/[artifact]/[revision]/[artifact]-[revision].[ext]"/>
 
   <resolvers>
-
     <chain name="pants-chain-repos" returnFirst="true">
       <!-- By default ivy does not require metadata (or successful metadata downloads).
            This can lead to jars downloading without their transitive deps which leads
@@ -43,7 +39,7 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
 
       <!-- Custom repo for Kythe jars, as Google don't currently publish them anywhere. -->
       <url name="toolchainlabs/binhost">
-        <artifact pattern="https://github.com/toolchainlabs/binhost/raw/master/${kythe.artifact}" />
+        <artifact pattern="https://github.com/toolchainlabs/binhost/raw/master/${kythe.artifact}"/>
       </url>
     </chain>
   </resolvers>


### PR DESCRIPTION
Newer bouncycastle supports gpg2 and newer ivy supports newer
bouncycastle. Upgrade both and replace commons-httpclient with
org.apache.httpcomponents#httpcomponents-client which ivy has since
switched to.

In addition, switch mainline jvm resolves to use coursier since resolve
mapping assumptions appear to be broken by ivy 2.5.0 and coursier is
what we reccommend to users.