### PR TITLE
Add `--version` and `--pytest-plugins` options to Pytest and deprecate old options

### DIFF
--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -1,7 +1,7 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Tuple
+from typing import List, Tuple
 
 from pants.subsystem.subsystem import Subsystem
 
@@ -12,28 +12,65 @@ class PyTest(Subsystem):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    # TODO: This is currently bounded below `3.7` due to #6282.
+    register('--version', default='pytest>=3.0.7,<3.7', help="Requirement string for Pytest.")
+    register(
+      '--pytest-plugins',
+      type=list,
+      default=[
+        'pytest-timeout>=1.2,<1.3',
+        'pytest-cov>=2.4,<2.5',
+        "unittest2>=0.6.0,<=1.9.0 ; python_version<'3'"
+      ],
+      help="Requirement strings for any plugins or additional requirements you'd like to use.",
+    )
     register('--requirements', advanced=True, default='pytest>=3.0.7,<3.7',
-             help='Requirements string for the pytest library.')
+             help='Requirements string for the pytest library.',
+             removal_version="1.25.0.dev0", removal_hint="Use --version instead.")
     register('--timeout-requirements', advanced=True, default='pytest-timeout>=1.2,<1.3',
-             help='Requirements string for the pytest-timeout library.')
+             help='Requirements string for the pytest-timeout library.',
+             removal_version="1.25.0.dev0", removal_hint="Use --pytest-plugins instead.")
     register('--cov-requirements', advanced=True, default='pytest-cov>=2.4,<2.5',
-             help='Requirements string for the pytest-cov library.')
-    register('--unittest2-requirements', advanced=True, default='unittest2>=0.6.0,<=1.9.0',
+             help='Requirements string for the pytest-cov library.',
+             removal_version="1.25.0.dev0", removal_hint="Use --pytest-plugins instead.")
+    register('--unittest2-requirements', advanced=True,
+             default="unittest2>=0.6.0,<=1.9.0 ; python_version<'3'",
              help='Requirements string for the unittest2 library, which some python versions '
-                  'may need.')
+                  'may need.',
+             removal_version="1.25.0.dev0", removal_hint="Use --pytest-plugins instead.")
 
   def get_requirement_strings(self) -> Tuple[str, ...]:
-    """Returns a tuple of requirements-style strings for pytest and related libraries.
-
-    Make sure the requirements are satisfied in any environment used for running tests.
-    """
+    """Returns a tuple of requirements-style strings for Pytest and Pytest plugins."""
     opts = self.get_options()
-    # TODO(6282): once we can upgrade Pytest to 4.2.1+, we can remove the more-itertools requirement
+
+    def configured_opts(*opt_names: str) -> List[str]:
+      return [opt for opt in opt_names if not opts.is_default(opt)]
+
+    def format_opts(opt_symbol_names: List[str]) -> str:
+      cli_formatted = (f"--pytest-{opt.replace('_', '-')}" for opt in opt_symbol_names)
+      return ', '.join(cli_formatted)
+
+    configured_new_options = configured_opts("version", "pytest_plugins")
+    configured_deprecated_option = configured_opts(
+      "requirements", "timeout_requirements", "cov_requirements", "unittest2_requirements",
+    )
+
+    if configured_new_options and configured_deprecated_option:
+      raise ValueError(
+        "Conflicting options for --pytest used. You provided these options in the new, preferred "
+        f"style: `{format_opts(configured_new_options)}`, but also provided these options in the "
+        f"deprecated style: `{format_opts(configured_deprecated_option)}`.\nPlease use only one "
+        f"approach (preferably the new approach of `--version` and `--pytest-plugins`)."
+      )
+    if configured_deprecated_option:
+      return (
+        "more-itertools<6.0.0 ; python_version<'3'",
+        opts.requirements,
+        opts.timeout_requirements,
+        opts.cov_requirements,
+        opts.unittest2_requirements,
+      )
     return (
       "more-itertools<6.0.0 ; python_version<'3'",
-      opts.requirements,
-      opts.timeout_requirements,
-      opts.cov_requirements,
-      opts.unittest2_requirements,
+      opts.version,
+      *opts.pytest_plugins
     )


### PR DESCRIPTION
### Problem
The options config for the V1 `Pytest` subsystem is not ideal. Rather than a specific option for each plugin like `--unittest2-requirements`, we should have a generic `--plugins` option that is a `list` type so that users can easily add or remove plugins.

We need this to add the plugin `pytest-rerunfailures`.

### Solution
Add new options `--version` and `--pytest-plugins` to the `Pytest` subsystem. Deprecate the old options.

Set up the parsing logic as follows:

- it's invalid to specify both the new and old style
- if the old style was manually configured, entirely use the old style
- otherwise, use the new style

### Result
It's now much easier to add and remove plugins to the subsystem.

If the user uses the old style, we print:

>  [WARN] /Users/eric/DocsLocal/code/projects/pants/src/python/pants/bin/pants_loader.py:85: DeprecationWarning: DEPRECATED: option 'requirements' in scope 'pytest' will be removed in version 1.25.0.dev0.
  Use --version instead.

If the user specifies both the old and new style, we print:


> Exception message: Conflicting options for --pytest used. You provided these options in the new, preferred style: `--pytest-version`, but also provided these options in the deprecated style: `--pytest-requirements, --pytest-timeout-requirements`.
Please use only one approach (preferably the new approach of `--version` and `--pytest-plugins`).
