### PR TITLE
Removing the exception when setup_py task has no work to do.

### DIFF
--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -605,8 +605,6 @@ class SetupPy(Task):
 
     exported_python_targets = OrderedSet(t for t in self.context.target_roots
                                          if is_exported_python_target(t))
-    if not exported_python_targets:
-      raise TaskError('setup-py target(s) must provide an artifact.')
 
     dist_dir = self.get_options().pants_distdir
 

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -291,9 +291,8 @@ class TestSetupPy(SetupPyTestBase):
 
   def test_no_exported(self):
     foo = self.create_python_library(relpath='foo', name='foo')
-    with self.assertRaises(TaskError):
-      with self.run_execute(foo):
-        self.fail('Should not have gotten past run_execute.')
+    with self.run_execute(foo):
+      pass
 
   def test_no_owner(self):
     self.create_python_library(relpath='foo', name='foo')


### PR DESCRIPTION
### Problem
The setup_py task raises a TaskError when it does not have any tasks to do. This is causing a problem when I am developing a DockerBuild plugin that will consume the python wheels that were created by the SetupPy task. 

My DockerBuild task marks the output of `SetupPy` as `optional_data` input. However not all docker image targets I am generating actually consume a generated python wheel. In such cases, the SetupPy is still invoked by the `RoundManager` which then fails with a `TaskError`.
### Solution

To fix this issue, I modified the SetupPy task to not raise a `TaskError` when there is nothing to do.
### Result
As a result, the `SetupPy` task behaves like all other tasks that do not have any targets it can action on and quietly returns.