### PR TITLE
Point RBE at a mirror of maven central.

### DIFF
--- a/build-support/ivy/remote.ivysettings.xml
+++ b/build-support/ivy/remote.ivysettings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+Licensed under the Apache License, Version 2.0 (see LICENSE).
+-->
+
+<ivysettings>
+  <settings defaultResolver="maven-central-mirror"/>
+  <resolvers>
+    <!--
+    We tweak two attributes away from defaults:
+
+    1. @descriptor: By default ivy does not require metadata (or successful metadata downloads).
+       This can lead to jars downloading without their transitive deps which leads to confusing
+       failures later when classpaths are constructed and used. We setup the maven central
+       resolver to require successful pom downloads here.
+
+    2. @root: We point remote execution at the RBE maven central mirror to avoid DDOSing maven
+       central.
+    -->
+    <ibiblio
+      name="maven-central-mirror"
+      m2compatible="true"
+      descriptor="required"
+      root="https://maven-central.storage-download.googleapis.com/repos/central/data"
+    />
+  </resolvers>
+</ivysettings>

--- a/pants.remote.ini
+++ b/pants.remote.ini
@@ -32,6 +32,11 @@ process_execution_speculation_strategy: none
 # p95 of RBE appears to be ~ 2 seconds, but we need to factor in local queue time which can be much longer, but no metrics yet.
 process_execution_speculation_delay: 15
 
+# DRY up maven central mirror setup in variables used below.
+maven_central_mirror_root_url: https://maven-central.storage-download.googleapis.com/repos/central/data
+maven_central_mirror_ivy_bootstrap_jar_url: %(maven_central_mirror_root_url)s/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar
+maven_central_mirror_ivy_settings: %(pants_supportdir)s/ivy/remote.ivysettings.xml
+
 [python-setup]
 # TODO(#7735): This config is not ideal, that we must specify the PATH for both local and remote
 # platforms. This should be replaced by a proper mechanism to differentiate between the two.
@@ -47,3 +52,28 @@ interpreter_search_paths: [
 [python-native-code]
 ld_flags: []
 cpp_flags: []
+
+[ivy]
+bootstrap_jar_url: %(maven_central_mirror_ivy_bootstrap_jar_url)s
+bootstrap_ivy_settings: %(maven_central_mirror_ivy_settings)s
+ivy_settings: %(maven_central_mirror_ivy_settings)s
+
+[ivy.outdated]
+bootstrap_jar_url: %(maven_central_mirror_ivy_bootstrap_jar_url)s
+bootstrap_ivy_settings: %(maven_central_mirror_ivy_settings)s
+ivy_settings: %(maven_central_mirror_ivy_settings)s
+
+[ivy.outdated.ivy]
+bootstrap_jar_url: %(maven_central_mirror_ivy_bootstrap_jar_url)s
+bootstrap_ivy_settings: %(maven_central_mirror_ivy_settings)s
+ivy_settings: %(maven_central_mirror_ivy_settings)s
+
+[coursier]
+repos: [
+    # Google RBE maven central mirror that avoids DDOSing maven central.
+    '%(maven_central_mirror_root_url)s',
+
+    # Custom repo for Kythe jars, as Google doesn't currently publish them anywhere.
+    'https://raw.githubusercontent.com/toolchainlabs/binhost/master/'
+  ]
+


### PR DESCRIPTION
This avoids us DDOSing maven central and getting HTTP errors as a
result.