### PR TITLE
Return success if V2 test runner is passed an empty target

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -67,7 +67,14 @@ def run_python_test(
   # test_fail.py, do not unintentionally end up being run as tests.
 
   source_root_stripped_test_target_sources = yield Get(
-      SourceRootStrippedSources, Address, test_target.address.to_address()
+    SourceRootStrippedSources, Address, test_target.address.to_address()
+  )
+
+  if not source_root_stripped_test_target_sources.snapshot.files:
+    yield TestResult(
+      status=Status.SUCCESS,
+      stdout="",
+      stderr="",
     )
 
   source_root_stripped_sources = yield [

--- a/tests/python/pants_test/backend/python/rules/BUILD
+++ b/tests/python/pants_test/backend/python/rules/BUILD
@@ -30,6 +30,22 @@ python_tests(
 )
 
 python_tests(
+  name='python_test_runner',
+  source='test_python_test_runner.py',
+  dependencies=[
+    'src/python/pants/backend/python/rules',
+    'src/python/pants/backend/python/subsystems',
+    'src/python/pants/engine:fs',
+    'src/python/pants/engine:rules',
+    'src/python/pants/engine:selectors',
+    'src/python/pants/util:collections',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/testutil:test_base',
+    'src/python/pants/testutil/subsystem',
+  ]
+)
+
+python_tests(
   name='python_test_runner_integration',
   source='test_python_test_runner_integration.py',
   dependencies=[

--- a/tests/python/pants_test/backend/python/rules/BUILD
+++ b/tests/python/pants_test/backend/python/rules/BUILD
@@ -35,13 +35,17 @@ python_tests(
   dependencies=[
     'src/python/pants/backend/python/rules',
     'src/python/pants/backend/python/subsystems',
+    'src/python/pants/build_graph',
     'src/python/pants/engine:fs',
+    'src/python/pants/engine:isolated_process',
     'src/python/pants/engine:rules',
-    'src/python/pants/engine:selectors',
+    'src/python/pants/engine/legacy:graph',
+    'src/python/pants/engine/legacy:structs',
+    'src/python/pants/rules/core',
+    'src/python/pants/testutil:test_base',
+    'src/python/pants/testutil/engine:util',
     'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
-    'src/python/pants/testutil:test_base',
-    'src/python/pants/testutil/subsystem',
   ]
 )
 

--- a/tests/python/pants_test/backend/python/rules/test_python_test_runner.py
+++ b/tests/python/pants_test/backend/python/rules/test_python_test_runner.py
@@ -1,70 +1,75 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.rules.download_pex_bin import download_pex_bin
-from pants.backend.python.rules.inject_init import inject_init
-from pants.backend.python.rules.pex import CreatePex, create_pex
+from pants.backend.python.rules.inject_init import InjectedInitDigest
+from pants.backend.python.rules.pex import CreatePex, Pex
 from pants.backend.python.rules.python_test_runner import run_python_test
 from pants.backend.python.subsystems.pytest import PyTest
-from pants.backend.python.subsystems.python_native_code import (
-  PythonNativeCode,
-  create_pex_native_build_environment,
-)
 from pants.backend.python.subsystems.python_setup import PythonSetup
-from pants.backend.python.subsystems.subprocess_environment import (
-  SubprocessEnvironment,
-  create_subprocess_encoding_environment,
-)
+from pants.backend.python.subsystems.subprocess_environment import SubprocessEnvironment
+from pants.build_graph.address import Address, BuildFileAddress
+from pants.engine.fs import EMPTY_SNAPSHOT, Digest, DirectoriesToMerge
+from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
+from pants.engine.legacy.graph import BuildFileAddresses, HydratedTarget, TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonTestsAdaptor
-from pants.engine.rules import RootRule
-from pants.engine.selectors import Params
 from pants.rules.core.core_test_model import Status, TestResult
-from pants.rules.core.strip_source_root import strip_source_root
-from pants.source.source_root import SourceRootConfig
-from pants.testutil.subsystem.util import init_subsystems
+from pants.rules.core.strip_source_root import SourceRootStrippedSources
+from pants.testutil.engine.util import MockGet, run_rule
 from pants.testutil.test_base import TestBase
-from pants.util.collections import assert_single_element
 
 
 class TestPythonTestRunner(TestBase):
 
-  @classmethod
-  def rules(cls):
-    return super().rules() + [
+  def test_empty_target_succeeds(self) -> None:
+    # NB: Because this particular edge case should early return, we can avoid providing valid
+    # mocked yield gets for most of the rule's body. Future tests added to this file will need to
+    # provide valid mocks instead.
+    unimplemented_mock = lambda _: NotImplemented
+    target = PythonTestsAdaptor(address=BuildFileAddress(target_name="target", rel_path="test"))
+    result: TestResult = run_rule(
       run_python_test,
-      create_pex,
-      strip_source_root,
-      inject_init,
-      create_pex_native_build_environment,
-      create_subprocess_encoding_environment,
-      download_pex_bin,
-      RootRule(PythonTestsAdaptor),
-      RootRule(CreatePex),
-      RootRule(PyTest),
-      RootRule(PythonSetup),
-      RootRule(PythonNativeCode),
-      RootRule(SubprocessEnvironment),
-      RootRule(SourceRootConfig),
-    ]
-
-  def setUp(self):
-    super().setUp()
-    init_subsystems([
-      PythonSetup, PythonNativeCode, SubprocessEnvironment, PyTest, SourceRootConfig
-    ])
-
-  def run_pytest(self, target: PythonTestsAdaptor) -> TestResult:
-    return assert_single_element(
-      self.scheduler.product_request(TestResult, [Params(
+      rule_args=[
         target,
         PyTest.global_instance(),
         PythonSetup.global_instance(),
         SubprocessEnvironment.global_instance(),
-        PythonNativeCode.global_instance(),
-        SourceRootConfig.global_instance(),
-      )])
+      ],
+      mock_gets=[
+        MockGet(
+          product_type=TransitiveHydratedTargets,
+          subject_type=BuildFileAddresses,
+          mock=lambda _: TransitiveHydratedTargets(roots=(), closure=())
+        ),
+        MockGet(
+          product_type=SourceRootStrippedSources,
+          subject_type=Address,
+          mock=lambda _: SourceRootStrippedSources(snapshot=EMPTY_SNAPSHOT),
+        ),
+        MockGet(
+          product_type=SourceRootStrippedSources,
+          subject_type=HydratedTarget,
+          mock=unimplemented_mock,
+        ),
+        MockGet(
+          product_type=Digest,
+          subject_type=DirectoriesToMerge,
+          mock=unimplemented_mock,
+        ),
+        MockGet(
+          product_type=InjectedInitDigest,
+          subject_type=Digest,
+          mock=unimplemented_mock,
+        ),
+        MockGet(
+          product_type=Pex,
+          subject_type=CreatePex,
+          mock=unimplemented_mock,
+        ),
+        MockGet(
+          product_type=FallibleExecuteProcessResult,
+          subject_type=ExecuteProcessRequest,
+          mock=unimplemented_mock,
+        ),
+      ],
     )
-
-  def test_empty_target_succeeds(self) -> None:
-    result = self.run_pytest(target=PythonTestsAdaptor(name="test", sources=[]))
     self.assertEqual(result.status, Status.SUCCESS)

--- a/tests/python/pants_test/backend/python/rules/test_python_test_runner.py
+++ b/tests/python/pants_test/backend/python/rules/test_python_test_runner.py
@@ -1,0 +1,70 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.rules.download_pex_bin import download_pex_bin
+from pants.backend.python.rules.inject_init import inject_init
+from pants.backend.python.rules.pex import CreatePex, create_pex
+from pants.backend.python.rules.python_test_runner import run_python_test
+from pants.backend.python.subsystems.pytest import PyTest
+from pants.backend.python.subsystems.python_native_code import (
+  PythonNativeCode,
+  create_pex_native_build_environment,
+)
+from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.backend.python.subsystems.subprocess_environment import (
+  SubprocessEnvironment,
+  create_subprocess_encoding_environment,
+)
+from pants.engine.legacy.structs import PythonTestsAdaptor
+from pants.engine.rules import RootRule
+from pants.engine.selectors import Params
+from pants.rules.core.core_test_model import Status, TestResult
+from pants.rules.core.strip_source_root import strip_source_root
+from pants.source.source_root import SourceRootConfig
+from pants.testutil.subsystem.util import init_subsystems
+from pants.testutil.test_base import TestBase
+from pants.util.collections import assert_single_element
+
+
+class TestPythonTestRunner(TestBase):
+
+  @classmethod
+  def rules(cls):
+    return super().rules() + [
+      run_python_test,
+      create_pex,
+      strip_source_root,
+      inject_init,
+      create_pex_native_build_environment,
+      create_subprocess_encoding_environment,
+      download_pex_bin,
+      RootRule(PythonTestsAdaptor),
+      RootRule(CreatePex),
+      RootRule(PyTest),
+      RootRule(PythonSetup),
+      RootRule(PythonNativeCode),
+      RootRule(SubprocessEnvironment),
+      RootRule(SourceRootConfig),
+    ]
+
+  def setUp(self):
+    super().setUp()
+    init_subsystems([
+      PythonSetup, PythonNativeCode, SubprocessEnvironment, PyTest, SourceRootConfig
+    ])
+
+  def run_pytest(self, target: PythonTestsAdaptor) -> TestResult:
+    return assert_single_element(
+      self.scheduler.product_request(TestResult, [Params(
+        target,
+        PyTest.global_instance(),
+        PythonSetup.global_instance(),
+        SubprocessEnvironment.global_instance(),
+        PythonNativeCode.global_instance(),
+        SourceRootConfig.global_instance(),
+      )])
+    )
+
+  def test_empty_target_succeeds(self) -> None:
+    result = self.run_pytest(target=PythonTestsAdaptor(name="test", sources=[]))
+    self.assertEqual(result.status, Status.SUCCESS)


### PR DESCRIPTION
### Problem
Currently, passing a `python_tests` target to `./pants --no-v1 --v2 test` will result in Pytest's test-discovery triggering and trying to run over anything it discovers. This results in running tests on dependencies like `unittest2`.

Meanwhile, V1 will simply not run Pytest and return with an exit code of 0. We want the semantics to be the same.

### Solution
Early return if there are no test target source files.

We also move the source file handling logic higher in the rule's body so that this early return can trigger before the costly resolve requirements logic.

Finally, this sets up a new unit test file `test_python_test_runner`. With this now setup, it will be easier to write additional unit tests for the rule rather than adding on costly integration tests.

### Result
It's now safe to run `./pants --no-v1 --v2 test` against a target with no sources.