### PR TITLE
Improve signature of `run_rule()` test util to be more explicit

### DIFF
--- a/src/python/pants/rules/core/list_roots_test.py
+++ b/src/python/pants/rules/core/list_roots_test.py
@@ -7,7 +7,7 @@ from pants.engine.fs import Digest, PathGlobs, Snapshot
 from pants.rules.core import list_roots
 from pants.source.source_root import SourceRoot, SourceRootCategories, SourceRootConfig
 from pants.testutil.console_rule_test_base import ConsoleRuleTestBase
-from pants.testutil.engine.util import run_rule
+from pants.testutil.engine.util import MockedYieldGet, run_rule
 from pants.testutil.test_base import TestBase
 
 
@@ -56,9 +56,13 @@ class AllRootsTest(TestBase):
       )
       return Snapshot(Digest('abcdef', 10), (), dirs)
 
-    output = run_rule(list_roots.all_roots, source_root_config, {
-      (Snapshot, PathGlobs): provider_rule
-    })
+    output = run_rule(
+      list_roots.all_roots,
+      rule_args=[source_root_config],
+      mocked_yield_gets=[
+        MockedYieldGet(product_type=Snapshot, subject_type=PathGlobs, mock=provider_rule),
+      ],
+    )
 
     self.assertEqual({SourceRoot('contrib/go/examples/3rdparty/go', ('go',), THIRDPARTY),
                        SourceRoot('contrib/go/examples/src/go/src', ('go',), SOURCE),

--- a/src/python/pants/rules/core/list_roots_test.py
+++ b/src/python/pants/rules/core/list_roots_test.py
@@ -7,7 +7,7 @@ from pants.engine.fs import Digest, PathGlobs, Snapshot
 from pants.rules.core import list_roots
 from pants.source.source_root import SourceRoot, SourceRootCategories, SourceRootConfig
 from pants.testutil.console_rule_test_base import ConsoleRuleTestBase
-from pants.testutil.engine.util import MockedYieldGet, run_rule
+from pants.testutil.engine.util import MockGet, run_rule
 from pants.testutil.test_base import TestBase
 
 
@@ -59,8 +59,8 @@ class AllRootsTest(TestBase):
     output = run_rule(
       list_roots.all_roots,
       rule_args=[source_root_config],
-      mocked_yield_gets=[
-        MockedYieldGet(product_type=Snapshot, subject_type=PathGlobs, mock=provider_rule),
+      mock_gets=[
+        MockGet(product_type=Snapshot, subject_type=PathGlobs, mock=provider_rule),
       ],
     )
 

--- a/src/python/pants/testutil/engine/BUILD
+++ b/src/python/pants/testutil/engine/BUILD
@@ -17,6 +17,7 @@ python_library(
   source = 'util.py',
   dependencies = [
     '3rdparty/python:ansicolors',
+    '3rdparty/python:dataclasses',
     'src/python/pants/base:project_tree',
     'src/python/pants/binaries',
     'src/python/pants/engine:addressable',

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -34,22 +34,33 @@ def run_rule(
   rule_args: Optional[Sequence[Any]] = None,
   mocked_yield_gets: Optional[Sequence[MockedYieldGet]] = None
 ):
-  """A test helper function that runs an @rule with a set of arguments and Get providers.
+  """A test helper function that runs an @rule with a set of arguments and mocked Get providers.
 
   An @rule named `my_rule` that takes one argument and makes no `Get` requests can be invoked
   like so (although you could also just invoke it directly):
   ```
-  return_value = run_rule(my_rule, arg1)
+  return_value = run_rule(my_rule, rule_args=[arg1])
   ```
 
-  In the case of an @rule that makes Get requests, things get more interesting: an extra argument
-  is required that represents a dict mapping (product, subject) type pairs to one argument functions
-  that take a subject value and return a product value.
+  In the case of an @rule that makes Get requests, things get more interesting: the
+  `mocked_yield_gets` argument must be provided as a sequence of `MockedYieldGet`s. Each
+  MockedYieldGet takes the Product and Subject type, along with a one-argument function that
+  takes a subject value and returns a product value.
 
   So in the case of an @rule named `my_co_rule` that takes one argument and makes Get requests
-  for product and subject types (Listing, Dir), the invoke might look like:
+  for a product type `Listing` with subject type `Dir`, the invoke might look like:
   ```
-  return_value = run_rule(my_co_rule, arg1, {(Listing, Dir): lambda x: Listing(..)})
+  return_value = run_rule(
+    my_co_rule,
+    rule_args=[arg1],
+    mocked_yield_gets=[
+      MockedYieldGet(
+        product_type=Listing,
+        subject_type=Dir,
+        mock=lambda subject_val: Listing(..),
+      ),
+    ],
+  )
   ```
 
   :returns: The return value of the completed @rule.

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -21,6 +21,8 @@ from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS
 from pants.util.objects import SubclassesOf
 
 
+# TODO(#6742): Improve the type signature by using generics and type vars. `mock` should be
+#  `Callable[[SubjectType], ProductType]`.
 @dataclass(frozen=True)
 class MockGet:
   product_type: Type
@@ -43,9 +45,9 @@ def run_rule(
   ```
 
   In the case of an @rule that makes Get requests, things get more interesting: the
-  `mocked_yield_gets` argument must be provided as a sequence of `MockedYieldGet`s. Each
-  MockedYieldGet takes the Product and Subject type, along with a one-argument function that
-  takes a subject value and returns a product value.
+  `mock_gets` argument must be provided as a sequence of `MockGet`s. Each MockGet takes the Product
+  and Subject type, along with a one-argument function that takes a subject value and returns a
+  product value.
 
   So in the case of an @rule named `my_co_rule` that takes one argument and makes Get requests
   for a product type `Listing` with subject type `Dir`, the invoke might look like:
@@ -57,7 +59,7 @@ def run_rule(
       MockGet(
         product_type=Listing,
         subject_type=Dir,
-        mock=lambda subject_val: Listing(..),
+        mock=lambda dir_subject: Listing(..),
       ),
     ],
   )

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -22,7 +22,7 @@ from pants.util.objects import SubclassesOf
 
 
 @dataclass(frozen=True)
-class MockedYieldGet:
+class MockGet:
   product_type: Type
   subject_type: Type
   mock: Callable[[Any], Any]
@@ -32,7 +32,7 @@ def run_rule(
   rule,
   *,
   rule_args: Optional[Sequence[Any]] = None,
-  mocked_yield_gets: Optional[Sequence[MockedYieldGet]] = None
+  mock_gets: Optional[Sequence[MockGet]] = None
 ):
   """A test helper function that runs an @rule with a set of arguments and mocked Get providers.
 
@@ -53,8 +53,8 @@ def run_rule(
   return_value = run_rule(
     my_co_rule,
     rule_args=[arg1],
-    mocked_yield_gets=[
-      MockedYieldGet(
+    mock_gets=[
+      MockGet(
         product_type=Listing,
         subject_type=Dir,
         mock=lambda subject_val: Listing(..),
@@ -74,9 +74,9 @@ def run_rule(
     raise ValueError('Rule expected to receive arguments of the form: {}; got: {}'.format(
       task_rule.input_selectors, rule_args))
 
-  if mocked_yield_gets is not None and len(mocked_yield_gets) != len(task_rule.input_gets):
+  if mock_gets is not None and len(mock_gets) != len(task_rule.input_gets):
     raise ValueError('Rule expected to receive Get providers for {}; got: {}'.format(
-      task_rule.input_gets, mocked_yield_gets))
+      task_rule.input_gets, mock_gets))
 
   res = rule(*(rule_args or ()))
   if not isinstance(res, GeneratorType):
@@ -84,9 +84,9 @@ def run_rule(
 
   def get(product, subject):
     provider = next((
-      mocked_yield_get.mock
-      for mocked_yield_get in mocked_yield_gets
-      if mocked_yield_get.product_type == product and mocked_yield_get.subject_type == type(subject)
+      mock_get.mock
+      for mock_get in mock_gets
+      if mock_get.product_type == product and mock_get.subject_type == type(subject)
     ), None)
     if provider is None:
       raise AssertionError('Rule requested: Get{}, which cannot be satisfied.'.format(

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -23,7 +23,7 @@ from pants.engine.nodes import Return, Throw
 from pants.engine.parser import HydratedStruct, SymbolTable
 from pants.engine.rules import rule
 from pants.engine.struct import Struct, StructWithDeps
-from pants.testutil.engine.util import Target, run_rule
+from pants.testutil.engine.util import MockedYieldGet, Target, run_rule
 from pants.util.objects import Exactly
 from pants_test.engine.examples.parsers import (
   JsonParser,
@@ -37,10 +37,22 @@ class ParseAddressFamilyTest(unittest.TestCase):
   def test_empty(self):
     """Test that parsing an empty BUILD file results in an empty AddressFamily."""
     address_mapper = AddressMapper(JsonParser(TEST_TABLE))
-    af = run_rule(parse_address_family, address_mapper, Dir('/dev/null'), {
-        (Snapshot, PathGlobs): lambda _: Snapshot(Digest('abc', 10), ('/dev/null/BUILD',), ()),
-        (FilesContent, Digest): lambda _: FilesContent([FileContent('/dev/null/BUILD', b'', False)]),
-      })
+    af = run_rule(
+      parse_address_family,
+      rule_args=[address_mapper, Dir('/dev/null')],
+      mocked_yield_gets=[
+        MockedYieldGet(
+          product_type=Snapshot,
+          subject_type=PathGlobs,
+          mock=lambda _: Snapshot(Digest('abc', 10), ('/dev/null/BUILD',), ()),
+        ),
+        MockedYieldGet(
+          product_type=FilesContent,
+          subject_type=Digest,
+          mock=lambda _: FilesContent([FileContent('/dev/null/BUILD', b'', False)]),
+        ),
+      ],
+    )
     self.assertEqual(len(af.objects_by_name), 0)
 
 
@@ -53,11 +65,23 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     return Snapshot(Digest('xx', 2), ('root/BUILD',), ())
 
   def _resolve_build_file_addresses(self, specs, address_family, snapshot, address_mapper):
-    pbfas = run_rule(provenanced_addresses_from_address_families, address_mapper, specs, {
-      (Snapshot, PathGlobs): lambda _: snapshot,
-      (AddressFamily, Dir): lambda _: address_family,
-    })
-    return run_rule(remove_provenance, pbfas)
+    pbfas = run_rule(
+      provenanced_addresses_from_address_families,
+      rule_args=[address_mapper, specs],
+      mocked_yield_gets=[
+        MockedYieldGet(
+          product_type=Snapshot,
+          subject_type=PathGlobs,
+          mock=lambda _: snapshot,
+        ),
+        MockedYieldGet(
+          product_type=AddressFamily,
+          subject_type=Dir,
+          mock=lambda _: address_family,
+        ),
+      ],
+    )
+    return run_rule(remove_provenance, rule_args=[pbfas])
 
   def test_duplicated(self):
     """Test that matching the same Spec twice succeeds."""
@@ -145,12 +169,9 @@ class ApacheThriftConfiguration(StructWithDeps):
   # dictionary entry.
 
   def __init__(self, name=None, version=None, strict=None, lang=None, options=None, **kwargs):
-    super().__init__(name=name,
-                                                    version=version,
-                                                    strict=strict,
-                                                    lang=lang,
-                                                    options=options,
-                                                    **kwargs)
+    super().__init__(
+      name=name, version=version, strict=strict, lang=lang, options=options, **kwargs
+    )
 
   # An example of a validatable bit of config.
   def validate_concrete(self):

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -23,7 +23,7 @@ from pants.engine.nodes import Return, Throw
 from pants.engine.parser import HydratedStruct, SymbolTable
 from pants.engine.rules import rule
 from pants.engine.struct import Struct, StructWithDeps
-from pants.testutil.engine.util import MockedYieldGet, Target, run_rule
+from pants.testutil.engine.util import MockGet, Target, run_rule
 from pants.util.objects import Exactly
 from pants_test.engine.examples.parsers import (
   JsonParser,
@@ -40,13 +40,13 @@ class ParseAddressFamilyTest(unittest.TestCase):
     af = run_rule(
       parse_address_family,
       rule_args=[address_mapper, Dir('/dev/null')],
-      mocked_yield_gets=[
-        MockedYieldGet(
+      mock_gets=[
+        MockGet(
           product_type=Snapshot,
           subject_type=PathGlobs,
           mock=lambda _: Snapshot(Digest('abc', 10), ('/dev/null/BUILD',), ()),
         ),
-        MockedYieldGet(
+        MockGet(
           product_type=FilesContent,
           subject_type=Digest,
           mock=lambda _: FilesContent([FileContent('/dev/null/BUILD', b'', False)]),
@@ -68,13 +68,13 @@ class AddressesFromAddressFamiliesTest(unittest.TestCase):
     pbfas = run_rule(
       provenanced_addresses_from_address_families,
       rule_args=[address_mapper, specs],
-      mocked_yield_gets=[
-        MockedYieldGet(
+      mock_gets=[
+        MockGet(
           product_type=Snapshot,
           subject_type=PathGlobs,
           mock=lambda _: snapshot,
         ),
-        MockedYieldGet(
+        MockGet(
           product_type=AddressFamily,
           subject_type=Dir,
           mock=lambda _: address_family,

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -24,6 +24,7 @@ from pants.engine.rules import (
 from pants.engine.selectors import Get
 from pants.testutil.engine.util import (
   TARGET_TABLE,
+  MockedYieldGet,
   assert_equal_with_printing,
   create_scheduler,
   run_rule,
@@ -87,9 +88,11 @@ def a_console_rule_generator(console: Console) -> Example:
 
 class RuleTest(unittest.TestCase):
   def test_run_rule_console_rule_generator(self):
-    res = run_rule(a_console_rule_generator, Console(), {
-        (A, str): lambda _: A(),
-      })
+    res = run_rule(
+      a_console_rule_generator,
+      rule_args=[Console()],
+      mocked_yield_gets=[MockedYieldGet(product_type=A, subject_type=str, mock=lambda _: A())],
+    )
     self.assertEquals(res, Example(0))
 
 

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -24,7 +24,7 @@ from pants.engine.rules import (
 from pants.engine.selectors import Get
 from pants.testutil.engine.util import (
   TARGET_TABLE,
-  MockedYieldGet,
+  MockGet,
   assert_equal_with_printing,
   create_scheduler,
   run_rule,
@@ -91,7 +91,7 @@ class RuleTest(unittest.TestCase):
     res = run_rule(
       a_console_rule_generator,
       rule_args=[Console()],
-      mocked_yield_gets=[MockedYieldGet(product_type=A, subject_type=str, mock=lambda _: A())],
+      mock_gets=[MockGet(product_type=A, subject_type=str, mock=lambda _: A())],
     )
     self.assertEquals(res, Example(0))
 

--- a/tests/python/pants_test/rules/test_run.py
+++ b/tests/python/pants_test/rules/test_run.py
@@ -7,7 +7,7 @@ from pants.engine.interactive_runner import InteractiveRunner
 from pants.rules.core import run
 from pants.rules.core.binary import CreatedBinary
 from pants.testutil.console_rule_test_base import ConsoleRuleTestBase
-from pants.testutil.engine.util import MockConsole, MockedYieldGet, run_rule
+from pants.testutil.engine.util import MockConsole, MockGet, run_rule
 
 
 class RunTest(ConsoleRuleTestBase):
@@ -35,8 +35,8 @@ class RunTest(ConsoleRuleTestBase):
     res = run_rule(
       run.run,
       rule_args=[console, workspace, interactive_runner, bfa],
-      mocked_yield_gets=[
-        MockedYieldGet(
+      mock_gets=[
+        MockGet(
           product_type=CreatedBinary,
           subject_type=Address,
           mock=lambda _: self.create_mock_binary(program_text)

--- a/tests/python/pants_test/rules/test_test.py
+++ b/tests/python/pants_test/rules/test_test.py
@@ -18,7 +18,7 @@ from pants.rules.core.test import (
   coordinator_of_tests,
   fast_test,
 )
-from pants.testutil.engine.util import MockConsole, MockedYieldGet, run_rule
+from pants.testutil.engine.util import MockConsole, MockGet, run_rule
 from pants.testutil.test_base import TestBase
 
 
@@ -30,8 +30,8 @@ class TestTest(TestBase):
     res = run_rule(
       fast_test,
       rule_args=[console, (addr,)],
-      mocked_yield_gets=[
-        MockedYieldGet(
+      mock_gets=[
+        MockGet(
           product_type=AddressAndTestResult,
           subject_type=Address,
           mock=lambda _: AddressAndTestResult(addr, result),
@@ -91,8 +91,8 @@ class TestTest(TestBase):
     res = run_rule(
       fast_test,
       rule_args=[console, (target1, target2)],
-      mocked_yield_gets=[
-        MockedYieldGet(product_type=AddressAndTestResult, subject_type=Address, mock=make_result),
+      mock_gets=[
+        MockGet(product_type=AddressAndTestResult, subject_type=Address, mock=make_result),
       ],
     )
 
@@ -132,8 +132,8 @@ class TestTest(TestBase):
           UnionMembership(union_rules={TestTarget: [PythonTestsAdaptor]}),
           AddressProvenanceMap(bfaddr_to_spec={}),
         ],
-        mocked_yield_gets=[
-          MockedYieldGet(
+        mock_gets=[
+          MockGet(
             product_type=TestResult,
             subject_type=PythonTestsAdaptor,
             mock=lambda _: TestResult(status=Status.FAILURE, stdout='foo', stderr=''),
@@ -157,8 +157,8 @@ class TestTest(TestBase):
           UnionMembership(union_rules={TestTarget: [PythonTestsAdaptor]}),
           AddressProvenanceMap(bfaddr_to_spec={bfaddr: DescendantAddresses(directory='some/dir')}),
         ],
-        mocked_yield_gets=[
-          MockedYieldGet(
+        mock_gets=[
+          MockGet(
             product_type=TestResult,
             subject_type=PythonTestsAdaptor,
             mock=lambda _: TestResult(status=Status.SUCCESS, stdout='foo', stderr=''),
@@ -183,8 +183,8 @@ class TestTest(TestBase):
           UnionMembership(union_rules={TestTarget: [PythonTestsAdaptor]}),
           AddressProvenanceMap(bfaddr_to_spec={bfaddr: DescendantAddresses(directory='some/dir')}),
         ],
-        mocked_yield_gets=[
-          MockedYieldGet(
+        mock_gets=[
+          MockGet(
             product_type=TestResult,
             subject_type=PythonTestsAdaptor,
             mock=lambda _: TestResult(status=Status.SUCCESS, stdout='foo', stderr=''),
@@ -214,8 +214,8 @@ class TestTest(TestBase):
               bfaddr: SingleAddress(directory='some/dir', name='bin'),
             }),
           ],
-          mocked_yield_gets=[
-            MockedYieldGet(
+          mock_gets=[
+            MockGet(
               product_type=TestResult,
               subject_type=PythonTestsAdaptor,
               mock=lambda _: TestResult(status=Status.SUCCESS, stdout='foo', stderr=''),


### PR DESCRIPTION
### Problem
`testutil.engine.util.run_rule` has fantastic documentation, but the function signature and subsequent call sites are more challenging to understand than need be.

### Solution
This leverages dataclasses, type hints, and keyword-only args to make `run_rule` more accessible for rule test authors.

It keeps the same runtime checks as before.

### Result
Hopefully easier to understand and write tests for rules, especially for people who are new to writing rules.

Instead of:

```python
return_value = run_rule(my_co_rule, arg1, {(Listing, Dir): lambda x: Listing(..)})
```

Now, we write:

```python
return_value = run_rule(
     my_co_rule,
     rule_args=[arg1],
     mock_gets=[
       MockGet(
         product_type=Listing,
         subject_type=Dir,
         mock=lambda dir_subject: Listing(..),
       ),
     ],
   )
```