### PR TITLE
Bump to the latest versions of various self-published JVM 3rdparty dependencies

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -16,7 +16,7 @@ class JarTool(JvmToolMixin, Subsystem):
     cls.register_jvm_tool(register,
                           'jar-tool',
                           classpath=[
-                            JarDependency(org='org.pantsbuild', name='jar-tool', rev='0.0.10'),
+                            JarDependency(org='org.pantsbuild', name='jar-tool', rev='0.0.16'),
                           ])
 
   def run(self, context, runjava, args):

--- a/src/python/pants/backend/jvm/subsystems/junit.py
+++ b/src/python/pants/backend/jvm/subsystems/junit.py
@@ -17,7 +17,7 @@ class JUnit(JvmToolMixin, InjectablesMixin, Subsystem):
   RUNNER_MAIN = 'org.pantsbuild.tools.junit.ConsoleRunner'
 
   LIBRARY_JAR = JarDependency(org='junit', name='junit', rev=LIBRARY_REV)
-  _RUNNER_JAR = JarDependency(org='org.pantsbuild', name='junit-runner', rev='1.0.26')
+  _RUNNER_JAR = JarDependency(org='org.pantsbuild', name='junit-runner', rev='1.0.27')
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
@@ -35,7 +35,7 @@ class Scoverage(CoverageEngine):
 
       def scoverage_report_jar(**kwargs):
         return JarDependency(org='org.pantsbuild', name='scoverage-report-generator_2.12',
-          rev='0.0.1', **kwargs)
+          rev='0.0.2', **kwargs)
 
       # We need to inject report generator at runtime.
       cls.register_jvm_tool(register,

--- a/src/python/pants/backend/jvm/tasks/ivy_outdated.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_outdated.py
@@ -35,7 +35,7 @@ class IvyOutdated(NailgunTask):
                           classpath=[
                             JarDependency(org='org.pantsbuild',
                                           name='ivy-dependency-update-checker',
-                                          rev='0.0.1'),
+                                          rev='0.0.4'),
                           ],
                           main=cls._IVY_DEPENDENCY_UPDATE_MAIN,
                           custom_rules=[


### PR DESCRIPTION
### Problem

New versions of various self-published JVM 3rdparty libraries were available (`junit-runner`, `jar-tool`, `scoverage-report-generator`, `ivy-dependency-update-checker`, etc), but had not been consumed.

### Solution

Consume them.