### PR TITLE
Move ivy and coursier bootstrapping to BinaryUtil.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -262,7 +262,7 @@ class CoursierMixin(JvmResolverBase):
     """
     # Prepare coursier args
     coursier_subsystem_instance = CoursierSubsystem.global_instance()
-    coursier_jar = coursier_subsystem_instance.bootstrap_coursier(self.context.new_workunit)
+    coursier_jar = coursier_subsystem_instance.select()
 
     repos = coursier_subsystem_instance.get_options().repos
     # make [repoX, repoY] -> ['-r', repoX, '-r', repoY]

--- a/tests/python/pants_test/ivy/test_bootstrapper.py
+++ b/tests/python/pants_test/ivy/test_bootstrapper.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
 import unittest
 
 from pants.ivy.bootstrapper import Bootstrapper
@@ -20,9 +19,6 @@ class BootstrapperTest(unittest.TestCase):
     ivy = bootstrapper.ivy()
     self.assertIsNotNone(ivy.ivy_resolution_cache_dir)
     self.assertIsNone(ivy.ivy_settings)
-    bootstrap_jar_path = os.path.join(ivy_subsystem.get_options().pants_bootstrapdir,
-                                      'tools', 'jvm', 'ivy', 'bootstrap.jar')
-    self.assertTrue(os.path.exists(bootstrap_jar_path))
 
   def test_reset(self):
     bootstrapper1 = Bootstrapper.instance()


### PR DESCRIPTION
### Problem

`ivy` and `coursier` both use an older pattern to bootstrap their initial jar (ivy continues on to actually resolve itself), meaning that they don't support multiple bootstrap URLs.

### Solution

Swap them to `BinaryTool`/`BinaryUtil`, with a slight twist to allow them to use multiple bootstrap URLs in addition to accessing our S3 bucket.

### Result

Better defaults and less flaky bootstrapping of those tools.