### PR TITLE
allow async/await syntax in @rules to enable mypy type checking

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -5,7 +5,7 @@ import os
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, cast
 
 from pants.util.collections import assert_single_element
 from pants.util.dirutil import fast_relpath_optional, recursive_dirname
@@ -197,22 +197,18 @@ _specificity = {
   SiblingAddresses: 1,
   AscendantAddresses: 2,
   DescendantAddresses: 3,
+  type(None): 99
 }
 
 
-def more_specific(spec1: Optional[Spec], spec2: Optional[Spec]) -> Spec:
+def more_specific(spec1: Optional[Spec], spec2: Spec) -> Spec:
   """Returns which of the two specs is more specific.
 
   This is useful when a target matches multiple specs, and we want to associate it with
   the "most specific" one, which will make the most intuitive sense to the user.
   """
   # Note that if either of spec1 or spec2 is None, the other will be returned.
-  if spec1 is None:
-    assert spec2 is not None
-    return spec2
-  if spec2 is None:
-    return spec1
-  return spec1 if _specificity[type(spec1)] < _specificity[type(spec2)] else spec2
+  return cast(Spec, spec1) if _specificity[type(spec1)] < _specificity[type(spec2)] else spec2
 
 
 @frozen_after_init

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -197,17 +197,21 @@ _specificity = {
   SiblingAddresses: 1,
   AscendantAddresses: 2,
   DescendantAddresses: 3,
-  type(None): 99
 }
 
 
-def more_specific(spec1: Spec, spec2: Spec) -> Spec:
+def more_specific(spec1: Optional[Spec], spec2: Optional[Spec]) -> Spec:
   """Returns which of the two specs is more specific.
 
   This is useful when a target matches multiple specs, and we want to associate it with
   the "most specific" one, which will make the most intuitive sense to the user.
   """
   # Note that if either of spec1 or spec2 is None, the other will be returned.
+  if spec1 is None:
+    assert spec2 is not None
+    return spec2
+  if spec2 is None:
+    return spec1
   return spec1 if _specificity[type(spec1)] < _specificity[type(spec2)] else spec2
 
 
@@ -255,11 +259,11 @@ class SpecsMatcher:
 @dataclass(unsafe_hash=True)
 class Specs:
   """A collection of Specs representing Spec subclasses, and a SpecsMatcher to filter results."""
-  dependencies: Tuple
+  dependencies: Tuple[Spec, ...]
   matcher: SpecsMatcher
 
   def __init__(
-    self, dependencies: Tuple, tags: Optional[Tuple] = None, exclude_patterns: Tuple = ()
+    self, dependencies: Tuple[Spec, ...], tags: Optional[Tuple] = None, exclude_patterns: Tuple = ()
   ) -> None:
     self.dependencies = tuple(dependencies)
     self.matcher = SpecsMatcher(tags=tags, exclude_patterns=exclude_patterns)

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -56,7 +56,7 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/util:meta',
   ],
-  tags = {'partially_type_checked'},
+  tags = {'type_checked'},
 )
 
 python_library(
@@ -89,6 +89,7 @@ python_library(
     'src/python/pants/util:filtering',
     'src/python/pants/util:objects',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -56,7 +56,7 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/util:meta',
   ],
-  tags = {'type_checked'},
+  tags = {'partially_type_checked'},
 )
 
 python_library(

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import MutableMapping, MutableSequence
 from dataclasses import dataclass
 from os.path import dirname, join
-from typing import Dict, Tuple
+from typing import Dict
 
 from twitter.common.collections import OrderedSet
 
@@ -131,9 +131,8 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
   collect_inline_dependencies(struct)
 
   # And then hydrate the inline dependencies.
-  hydrated_inline_dependencies: Tuple[HydratedStruct, ...] = await MultiGet(
-    Get[HydratedStruct](Address, a) for a in inline_dependencies
-  )
+  hydrated_inline_dependencies = await MultiGet(Get[HydratedStruct](Address, a)
+                                                for a in inline_dependencies)
   dependencies = [d.value for d in hydrated_inline_dependencies]
 
   def maybe_consume(outer_key, value):

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -49,8 +49,8 @@ async def parse_address_family(address_mapper: AddressMapper, directory: Dir) ->
   """
   patterns = tuple(join(directory.path, p) for p in address_mapper.build_patterns)
   path_globs = PathGlobs(include=patterns, exclude=address_mapper.build_ignore_patterns)
-  snapshot: Snapshot = await Get(Snapshot, PathGlobs, path_globs)
-  files_content: FilesContent = await Get(FilesContent, Digest, snapshot.directory_digest)
+  snapshot = await Get[Snapshot](PathGlobs, path_globs)
+  files_content = await Get[FilesContent](Digest, snapshot.directory_digest)
 
   if not files_content:
     raise ResolveError(
@@ -89,7 +89,7 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
   dependencies field, since those should be requested explicitly by rules.
   """
 
-  address_family: AddressFamily = await Get(AddressFamily, Dir(address.spec_path))
+  address_family = await Get[AddressFamily](Dir(address.spec_path))
 
   struct = address_family.addressables.get(address)
   addresses = address_family.addressables
@@ -132,7 +132,7 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
 
   # And then hydrate the inline dependencies.
   hydrated_inline_dependencies: Tuple[HydratedStruct, ...] = await MultiGet(
-    Get(HydratedStruct, Address, a) for a in inline_dependencies
+    Get[HydratedStruct](Address, a) for a in inline_dependencies
   )
   dependencies = [d.value for d in hydrated_inline_dependencies]
 
@@ -214,9 +214,9 @@ async def provenanced_addresses_from_address_families(
 :raises: :class:`AddressLookupError` if no targets are matched for non-SingleAddress specs.
 """
   # Capture a Snapshot covering all paths for these Specs, then group by directory.
-  snapshot = await Get(Snapshot, PathGlobs, _spec_to_globs(address_mapper, specs))
+  snapshot = await Get[Snapshot](PathGlobs, _spec_to_globs(address_mapper, specs))
   dirnames = {dirname(f) for f in snapshot.files}
-  address_families = await MultiGet(Get(AddressFamily, Dir(d)) for d in dirnames)
+  address_families = await MultiGet(Get[AddressFamily](Dir(d)) for d in dirnames)
   address_family_by_directory = {af.namespace: af for af in address_families}
 
   matched_addresses = OrderedSet()

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -4,7 +4,7 @@
 import re
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Any, Iterable, Optional, Tuple
+from typing import Any, Dict, Iterable, Optional, Tuple
 
 from pants.build_graph.address import BuildFileAddress
 from pants.engine.objects import Serializable
@@ -94,7 +94,7 @@ class AddressFamily:
   objects_by_name: Any
 
   @classmethod
-  def create(cls, spec_path, address_maps):
+  def create(cls, spec_path, address_maps) -> 'AddressFamily':
     """Creates an address family from the given set of address maps.
 
     :param spec_path: The directory prefix shared by all address_maps.
@@ -113,7 +113,7 @@ class AddressFamily:
                                      .format(spec_path, address_map.path))
 
 
-    objects_by_name = {}
+    objects_by_name: Dict[str, Tuple[str, Any]] = {}
     for address_map in address_maps:
       current_path = address_map.path
       for name, obj in address_map.objects_by_name.items():

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -505,6 +505,13 @@ class _FFISpecification(object):
         # Break.
         response.tag = self._lib.Broke
         response.broke = (c.to_value(res),)
+    except StopIteration as e:
+      if e.args:
+        # This was a `return` from a generator function.
+        response.tag = self._lib.Broke
+        response.broke = (c.to_value(e.value),)
+      else:
+        raise
     except Exception as e:
       # Throw.
       response.tag = self._lib.Throw

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -508,13 +508,12 @@ class _FFISpecification(object):
         response.tag = self._lib.Broke
         response.broke = (c.to_value(res),)
     except StopIteration as e:
-      if e.args:
-        # This was a `return` from a generator or coroutine, as opposed to a `StopIteration` raised
-        # by calling `next()` on an empty iterator.
-        response.tag = self._lib.Broke
-        response.broke = (c.to_value(e.value),)
-      else:
+      if not e.args:
         raise
+      # This was a `return` from a generator or coroutine, as opposed to a `StopIteration` raised
+      # by calling `next()` on an empty iterator.
+      response.tag = self._lib.Broke
+      response.broke = (c.to_value(e.value),)
     except Exception as e:
       # Throw.
       response.tag = self._lib.Throw

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -509,7 +509,8 @@ class _FFISpecification(object):
         response.broke = (c.to_value(res),)
     except StopIteration as e:
       if e.args:
-        # This was a `return` from a generator function.
+        # This was a `return` from a generator or coroutine, as opposed to a `StopIteration` raised
+        # by calling `next()` on an empty iterator.
         response.tag = self._lib.Broke
         response.broke = (c.to_value(e.value),)
       else:
@@ -577,7 +578,7 @@ class EngineTypes(NamedTuple):
   multi_platform_process_request: TypeId
   process_result: TypeId
   generator: TypeId
-  async_generator: TypeId
+  coroutine: TypeId
   url_to_fetch: TypeId
   string: TypeId
   bytes: TypeId
@@ -935,7 +936,7 @@ class Native(metaclass=SingletonMetaclass):
         multi_platform_process_request=ti(MultiPlatformExecuteProcessRequest),
         process_result=ti(FallibleExecuteProcessResult),
         generator=ti(GeneratorType),
-        async_generator=ti(CoroutineType),
+        coroutine=ti(CoroutineType),
         url_to_fetch=ti(UrlToFetch),
         string=ti(str),
         bytes=ti(bytes),

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -502,6 +502,8 @@ class _FFISpecification(object):
             c.identities_buf([c.identify(g.subject) for g in res]),
           )
       else:
+        # TODO: this will soon become obsolete when all @rules are fully mypy-annotated and must
+        # `return` instead of `yield` at the end!
         # Break.
         response.tag = self._lib.Broke
         response.broke = (c.to_value(res),)

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -9,7 +9,7 @@ import sys
 import sysconfig
 import traceback
 from contextlib import closing
-from types import GeneratorType
+from types import CoroutineType, GeneratorType
 from typing import Any, NamedTuple, Tuple, Type
 
 import cffi
@@ -577,6 +577,7 @@ class EngineTypes(NamedTuple):
   multi_platform_process_request: TypeId
   process_result: TypeId
   generator: TypeId
+  async_generator: TypeId
   url_to_fetch: TypeId
   string: TypeId
   bytes: TypeId
@@ -934,6 +935,7 @@ class Native(metaclass=SingletonMetaclass):
         multi_platform_process_request=ti(MultiPlatformExecuteProcessRequest),
         process_result=ti(FallibleExecuteProcessResult),
         generator=ti(GeneratorType),
+        async_generator=ti(CoroutineType),
         url_to_fetch=ti(UrlToFetch),
         string=ti(str),
         bytes=ti(bytes),

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -343,7 +343,7 @@ def rule(*args, cacheable=True) -> Callable:
     annotation=signature.return_annotation,
     name=f'{func_id} return',
     empty_value=inspect.Signature.empty,
-    raise_type=MissingReturnTypeAnnotation,
+    raise_type=MissingReturnTypeAnnotation
   )
   parameter_types = tuple(
     _ensure_type_annotation(

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -142,17 +142,8 @@ The rule defined by function `{func_name}` begins at:
       return True
     return False
 
-  def _matches_get_name(self, node: Any) -> bool:
-    return isinstance(node, ast.Name) and node.id == Get.__name__
-
-  def _is_get(self, node: Any) -> bool:
-    if isinstance(node, ast.Call):
-      if self._matches_get_name(node.func):
-        return True
-      if isinstance(node.func, ast.Subscript) and self._matches_get_name(node.func.value):
-        return True
-      return False
-    return False
+  def _is_get(self, node):
+    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == Get.__name__
 
   def visit_Call(self, node) -> None:
     self.generic_visit(node)

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -142,8 +142,16 @@ The rule defined by function `{func_name}` begins at:
       return True
     return False
 
+  def _matches_get_name(self, node):
+    return isinstance(node, ast.Name) and node.id == Get.__name__
+
   def _is_get(self, node):
-    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == Get.__name__
+    if isinstance(node, ast.Call):
+      if self._matches_get_name(node.func):
+        return True
+      if isinstance(node.func, ast.Subscript) and self._matches_get_name(node.func.value):
+        return True
+      return False
 
   def visit_Call(self, node):
     self.generic_visit(node)

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -9,11 +9,10 @@ import sys
 import typing
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from collections.abc import Generator as BaseGenerator
 from collections.abc import Iterable
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Type
 
 import asttokens
 from twitter.common.collections import OrderedSet
@@ -29,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class _RuleVisitor(ast.NodeVisitor):
-  """Pull `Get` calls out of an @rule body and validate `yield` statements."""
+  """Pull `Get` calls out of an @rule body and validate `yield` or `await` statements."""
 
   def __init__(self, func, func_node, func_source, orig_indent, parents_table):
     super().__init__()
@@ -147,17 +146,18 @@ The rule defined by function `{func_name}` begins at:
     return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == Get.__name__
 
   def visit_Call(self, node):
+    self.generic_visit(node)
     if self._is_get(node):
       self._gets.append(Get.extract_constraints(node))
 
   def visit_Assign(self, node):
-    if isinstance(node.value, ast.Yield):
+    if isinstance(node.value, (ast.Yield, ast.Await)):
       self._yields_in_assignments.add(node.value)
     self.generic_visit(node)
 
-  def visit_Yield(self, node):
+  def _visit_await_or_yield_compat(self, node, *, is_yield: bool):
     self.generic_visit(node)
-    if node not in self._yields_in_assignments:
+    if is_yield and (node not in self._yields_in_assignments):
       # The current yield "expr" is the child of an "Expr" "stmt".
       expr_for_yield = self._parents_table[node]
 
@@ -186,6 +186,12 @@ The rule defined by function `{func_name}` begins at:
           Note that any `yield Get(...)` in an @rule without assignment is also currently not
           supported. See https://github.com/pantsbuild/pants/pull/8227 for progress.
           """)))
+
+  def visit_Await(self, node):
+    return self._visit_await_or_yield_compat(node, is_yield=False)
+
+  def visit_Yield(self, node):
+    return self._visit_await_or_yield_compat(node, is_yield=True)
 
 
 @memoized
@@ -257,7 +263,7 @@ def _make_rule(
     gets = OrderedSet()
     rule_func_node = assert_single_element(
       node for node in ast.iter_child_nodes(module_ast)
-      if isinstance(node, ast.FunctionDef) and node.name == func.__name__)
+      if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func.__name__)
 
     parents_table = {}
     for parent in ast.walk(rule_func_node):
@@ -300,52 +306,15 @@ class MissingReturnTypeAnnotation(InvalidTypeAnnotation):
   """Indicates a missing return type annotation for an `@rule`."""
 
 
-class InvalidGeneratorReturnTypeAnnotation(InvalidTypeAnnotation):
-  """Indicates an incorrect Generator return type annotation for an `@rule`."""
-
-
 class MissingParameterTypeAnnotation(InvalidTypeAnnotation):
   """Indicates a missing parameter type annotation for an `@rule`."""
 
 
-def _validate_get_yield_type(yield_type: Any) -> bool:
-  if yield_type is Get:
-    return True
-  mypy_base_type = getattr(yield_type, '__origin__', None)
-  if mypy_base_type is None:
-    return False
-  if mypy_base_type is list:
-    # If the type was List[Get].
-    element_type, = yield_type.__args__
-    return _validate_get_yield_type(element_type)
-  if mypy_base_type is Union:
-    # If the type was Union[Get, List[Get]].
-    return all(_validate_get_yield_type(t) for t in yield_type.__args__)
-  return False
-
-
-def _maybe_extract_generator(*, name: str, annotation: Any) -> Optional[type]:
-  if getattr(annotation, '__origin__', None) is not BaseGenerator:
-    return None
-  yield_type, send_type, return_type = annotation.__args__
-  if isinstance(return_type, type) and _validate_get_yield_type(yield_type):
-    return return_type
-  raise InvalidGeneratorReturnTypeAnnotation(
-    f'The return type annotation for {name} was a generator, and generator return types must '
-    'specify Get, List[Get], or Union[Get, List[Get]] as the "yield type", and a `type` as the '
-    f'"return type". The annotation type was: Generator[{yield_type}, {send_type}, {return_type}].')
-
-
 def _ensure_type_annotation(
-  *, annotation: Any, name: str, empty_value: Any, raise_type: Type[InvalidTypeAnnotation],
-  allow_generator: bool = False,
+  annotation: Any, name: str, empty_value: Any, raise_type: Type[InvalidTypeAnnotation],
 ) -> type:
   if annotation == empty_value:
     raise raise_type(f'{name} is missing a type annotation.')
-  if allow_generator:
-    maybe_generator_type = _maybe_extract_generator(name=name, annotation=annotation)
-    if maybe_generator_type is not None:
-      return maybe_generator_type
   if not isinstance(annotation, type):
     raise raise_type(f'The annotation for {name} must be a type, '
                      f'got {annotation} of type {type(annotation)}.')
@@ -367,7 +336,6 @@ def rule(*args, cacheable=True) -> Callable:
     name=f'{func_id} return',
     empty_value=inspect.Signature.empty,
     raise_type=MissingReturnTypeAnnotation,
-    allow_generator=True,
   )
   parameter_types = tuple(
     _ensure_type_annotation(

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -4,28 +4,36 @@
 import ast
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Any, Iterable, Tuple, Type
+from typing import Any, Generator, Generic, Iterable, Optional, Tuple, Type, TypeVar, cast
 
 from pants.util.meta import frozen_after_init
 from pants.util.objects import TypeConstraint
 
 
+_Product = TypeVar("_Product")
+
+
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class Get:
+class Get(Generic[_Product]):
   """Experimental synchronous generator API.
 
   May be called equivalently as either:
     # verbose form: Get(product_type, subject_declared_type, subject)
     # shorthand form: Get(product_type, subject_type(subject))
   """
-  product: Type
-  subject_declared_type: Type
-  subject: Any
+  product: Type[_Product]
+  subject_declared_type: type
+  subject: Optional[Any]
 
-  def __await__(self):
+  def __await__(self) -> 'Generator[Any, Any, _Product]':
+    """Allow a Get to be `await`ed, returning a type-checked result."""
     result = yield self
-    return result
+    return cast(_Product, result)
+
+  @classmethod
+  def __class_getitem__(cls, product_type):
+    return lambda *args: cls(product_type, *args)
 
   def __init__(self, *args: Any) -> None:
     if len(args) not in (2, 3):
@@ -63,32 +71,47 @@ class Get:
     :param call_node: An `ast.Call` node representing a call to `Get(..)`.
     :return: A tuple of product type id and subject type id.
     """
-    def render_args():
+    def render_args(args):
       return ', '.join(
         # Dump the Name's id to simplify output when available, falling back to the name of the
         # node's class.
         getattr(a, 'id', type(a).__name__)
-        for a in call_node.args)
+        for a in args)
 
-    if len(call_node.args) == 2:
-      product_type, subject_constructor = call_node.args
+    # If the Get was provided with a type parameter, use that as the `product_type`.
+    func = call_node.func
+    if isinstance(func, ast.Name):
+      subscript_args = ()
+    elif isinstance(func, ast.Subscript):
+      index_expr = func.slice.value
+      if isinstance(index_expr, ast.Name):
+        subscript_args = (index_expr,)
+      else:
+        raise ValueError(f'Unrecognized Get type index arg: {index_expr}')
+    else:
+      raise ValueError(f'Unrecognized Get call node type: {func}')
+
+    combined_args = subscript_args + tuple(call_node.args)
+
+    if len(combined_args) == 2:
+      product_type, subject_constructor = combined_args
       if not isinstance(product_type, ast.Name) or not isinstance(subject_constructor, ast.Call):
         # TODO(#7114): describe what types of objects are expected in the get call, not just the
         # argument names. After #7114 this will be easier because they will just be types!
         raise ValueError(
           'Two arg form of {} expected (product_type, subject_type(subject)), but '
-                        'got: ({})'.format(Get.__name__, render_args()))
+                        'got: ({})'.format(Get.__name__, render_args(combined_args)))
       return (product_type.id, subject_constructor.func.id)
-    elif len(call_node.args) == 3:
-      product_type, subject_declared_type, _ = call_node.args
+    elif len(combined_args) == 3:
+      product_type, subject_declared_type, _ = combined_args
       if not isinstance(product_type, ast.Name) or not isinstance(subject_declared_type, ast.Name):
         raise ValueError(
           'Three arg form of {} expected (product_type, subject_declared_type, subject), but '
-                        'got: ({})'.format(Get.__name__, render_args()))
+                        'got: ({})'.format(Get.__name__, render_args(combined_args)))
       return (product_type.id, subject_declared_type.id)
     else:
       raise ValueError('Invalid {}; expected either two or three args, but '
-                      'got: ({})'.format(Get.__name__, render_args()))
+                      'got: ({})'.format(Get.__name__, render_args(combined_args)))
 
   @classmethod
   def create_statically_for_rule_graph(cls, product_type, subject_type):
@@ -102,15 +125,15 @@ class Get:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class MultiGet:
+class MultiGet(Generic[_Product]):
   """Can be constructed with an iterable of `Get()`s and `await`ed to evaluate them in parallel."""
-  gets: Tuple[Get, ...]
+  gets: Tuple[Get[_Product], ...]
 
-  def __await__(self):
+  def __await__(self) -> Generator[Any, Any, Tuple[_Product, ...]]:
     result = yield self.gets
-    return result
+    return cast(Tuple[_Product, ...], result)
 
-  def __init__(self, gets: Iterable[Get]) -> None:
+  def __init__(self, gets: Iterable[Get[_Product]]) -> None:
     self.gets = tuple(gets)
 
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1068,7 +1068,7 @@ impl WrappedNode for Task {
       .then(move |task_result| match task_result {
         Ok(val) => match externs::get_type_for(&val) {
           t if t == context.core.types.generator => Self::generate(context, params, entry, val),
-          t if t == context.core.types.async_generator => {
+          t if t == context.core.types.coroutine => {
             Self::generate(context, params, entry, val)
           }
           t if t == product => ok(val),

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1068,6 +1068,9 @@ impl WrappedNode for Task {
       .then(move |task_result| match task_result {
         Ok(val) => match externs::get_type_for(&val) {
           t if t == context.core.types.generator => Self::generate(context, params, entry, val),
+          t if t == context.core.types.async_generator => {
+            Self::generate(context, params, entry, val)
+          }
           t if t == product => ok(val),
           _ => err(throw(&format!(
             "{:?} returned a result value that did not satisfy its constraints: {:?}",

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1067,8 +1067,7 @@ impl WrappedNode for Task {
       })
       .then(move |task_result| match task_result {
         Ok(val) => match externs::get_type_for(&val) {
-          t if t == context.core.types.generator => Self::generate(context, params, entry, val),
-          t if t == context.core.types.coroutine => {
+          t if t == context.core.types.generator || t == context.core.types.coroutine => {
             Self::generate(context, params, entry, val)
           }
           t if t == product => ok(val),

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -26,7 +26,7 @@ pub struct Types {
   pub multi_platform_process_request: TypeId,
   pub process_result: TypeId,
   pub generator: TypeId,
-  pub async_generator: TypeId,
+  pub coroutine: TypeId,
   pub url_to_fetch: TypeId,
   pub string: TypeId,
   pub bytes: TypeId,

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -26,6 +26,7 @@ pub struct Types {
   pub multi_platform_process_request: TypeId,
   pub process_result: TypeId,
   pub generator: TypeId,
+  pub async_generator: TypeId,
   pub url_to_fetch: TypeId,
   pub string: TypeId,
   pub bytes: TypeId,


### PR DESCRIPTION
### Problem

Fixes #7077.

See https://github.com/pantsbuild/pants/pull/8635#issuecomment-554607589. As of #8330, we annotate all `@rule`s with a single return type, even for rules which call `yield Get(...)` within the method body. MyPy doesn't like this, and requests that rules be given a `Generator` or `Iterable` return type. This blocks type-checking (even partially) for many targets which define rules.

### Solution

- Expand `_RuleVisitor` in `rules.py` to extract `Get` calls from `async def` rules.
- Add an `__await__()` method to `Get` and create `MultiGet` to allow awaiting on multiple `Get`s in parallel (named to match the corresponding rust type).
  - Lists cannot be `await`ed in the way that it is possible to `yield [Get(...) ...]` -- the expression must be *awaitable* -- see https://www.python.org/dev/peps/pep-0492/#await-expression. In this case, `MultiGet` wrapping an iterable of `Get`s and exposing an `__await__()` method is a complete replacement for the previous `yield [Get(...) ...]` syntax.
- Edit `native.py` to allow for `@rule` coroutine methods to `return` at the end instead of `yield`.
- Convert the `@rule`s in `build_files.py` into `async` methods, and type-check the `:build_files` target!

### Result

`@rule`s can now be defined with `async`/`await` syntax:
```python
@rule
async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> HydratedStruct:
  # ...
  address_family: AddressFamily = await Get(AddressFamily, Dir(address.spec_path))
  # ...
  hydrated_inline_dependencies: Tuple[HydratedStruct, ...] = await MultiGet(Get(HydratedStruct, Address, a)
                                                for a in inline_dependencies)
  # ...
  return HydratedStruct(consume_dependencies(struct, args={"address": address}))
```

As a result, plugins and backends that define `@rule`s can now be checked with MyPy!

#### Alternative Solution: Returning `Generator[Any, Any, T]`

In [the first few commits of this PR](https://github.com/pantsbuild/pants/pull/8639/files/43f73f1ac2d1e86301936a895ef08ffe8787d0f7..f7e8534c72965c5e6daa143ccefcdc7428192291), MyPy type annotations were added to `build_files.py` without adding any support for `async` methods. This worked by first adding support for `return` at the end of an `@rule` body in `native.py`, as in this PR, and annotating `@rule`s with the return type `-> Generator[Any, Any, T]`, `T` being the rule's actual return type.

This worked, but required a lot of extra effort to extract the return type `T` from the `Generator[Any, Any, T]` annotation, so this was discarded because `async def` rules require no additional work to extract the output type. For the record, this would have looked like:
```python
@rule
def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Generator[Any, Any, HydratedStruct]:
  # ...
  address_family: AddressFamily
  address_family = yield Get(AddressFamily, Dir(address.spec_path))
  # ...
  hydrated_inline_dependencies: Tuple[HydratedStruct, ...]
  hydrated_inline_dependencies = yield [Get(HydratedStruct, Address, a)
                                                for a in inline_dependencies]
  # ...
  return HydratedStruct(consume_dependencies(struct, args={"address": address}))
```

Note that `x: X = yield Get(X, Y(...))` is not a valid python expression -- this is another benefit of the `async`/`await` approach.

#### Follow-Up Extension: Type-Checked `await Get[X](...)`

Another alternative extending the `await Get()` syntax was proposed in order to automatically type-check the result of the `await` call. This would have looked like:

```python
@rule
async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> HydratedStruct:
  # ...
  address_family = await Get[AddressFamily](Dir(address.spec_path))
  # ...
  hydrated_inline_dependencies = await MultiGet(Get[HydratedStruct](Address, a)
                                                for a in inline_dependencies)
  # ...
  return HydratedStruct(consume_dependencies(struct, args={"address": address}))
```

**Note that the `await Get[X](...)` calls are type-checked to return the type `X`!** This means that mypy can check that later uses of the `address_family` and `hydrated_inline_dependencies` objects above are correct, which it couldn't do without a separate redundant `address_family: AddressFamily` annotation before.

The syntax extension for `Get[X](...)` was reverted in e92fecbd2dd56e64653ad627043dcbc1ff1c62aa in order to reduce complexity of the initial implementation.