### PR TITLE
python: update cffi to 1.13.2

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,7 +1,7 @@
 ansicolors==1.0.2
 asttokens==1.1.13
 beautifulsoup4>=4.6.0,<4.7
-cffi==1.12.3
+cffi==1.13.2
 contextlib2==0.5.5
 coverage>=4.5,<4.6
 # TODO remove this pin once we resolve https://github.com/pantsbuild/pants/issues/8502


### PR DESCRIPTION
###  Problem

cffi is out of date

###  Solution.

Update cffi

###  Result

cffi is up to date.
