### PR TITLE
[python] avoid use of deprecated log.warn

### DIFF
--- a/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
+++ b/src/python/pants/backend/codegen/thrift/python/py_thrift_namespace_clash_check.py
@@ -102,7 +102,7 @@ and/or files which need to be edited will be dumped to: {}
       if is_strict:
         raise error
       else:
-        self.context.log.warn(str(error))
+        self.context.log.warning(str(error))
     return py_namespaces_by_target
 
   class ClashingNamespaceError(TaskError): pass
@@ -137,7 +137,7 @@ Errors:
       if is_strict:
         raise error
       else:
-        self.context.log.warn(str(error))
+        self.context.log.warning(str(error))
     return namespaces_by_files
 
   def execute(self):

--- a/src/python/pants/backend/docgen/tasks/markdown_to_html.py
+++ b/src/python/pants/backend/docgen/tasks/markdown_to_html.py
@@ -204,7 +204,7 @@ class MarkdownToHtml(Task):
       if returncode != 0:
         message = '{} rendered with errors.'.format(source_path)
         if self.get_options().ignore_failure:
-          self.context.log.warn(message)
+          self.context.log.warning(message)
         else:
           raise TaskError(message, exit_code=returncode, failed_targets=[page])
 

--- a/src/python/pants/backend/jvm/tasks/coverage/cobertura.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/cobertura.py
@@ -244,9 +244,9 @@ class Cobertura(CoverageEngine):
 
   def should_report(self, execution_failed_exception=None):
     if execution_failed_exception:
-      self._settings.log.warn('Test failed: {0}'.format(execution_failed_exception))
+      self._settings.log.warning('Test failed: {0}'.format(execution_failed_exception))
       if self._settings.coverage_force:
-        self._settings.log.warn('Generating report even though tests failed.')
+        self._settings.log.warning('Generating report even though tests failed.')
         return True
       else:
         return False

--- a/src/python/pants/backend/jvm/tasks/coverage/jacoco.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/jacoco.py
@@ -123,9 +123,9 @@ class Jacoco(CoverageEngine):
 
   def report(self, output_dir, execution_failed_exception=None):
     if execution_failed_exception:
-      self._settings.log.warn('Test failed: {}'.format(execution_failed_exception))
+      self._settings.log.warning('Test failed: {}'.format(execution_failed_exception))
       if self._coverage_force:
-        self._settings.log.warn('Generating report even though tests failed, because the'
+        self._settings.log.warning('Generating report even though tests failed, because the'
                                 'coverage-force flag is set.')
       else:
         return

--- a/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
@@ -136,9 +136,9 @@ class Scoverage(CoverageEngine):
 
   def report(self, output_dir, execution_failed_exception=None):
     if execution_failed_exception:
-      self._settings.log.warn('Test failed: {}'.format(execution_failed_exception))
+      self._settings.log.warning('Test failed: {}'.format(execution_failed_exception))
       if self._coverage_force:
-        self._settings.log.warn('Generating report even though tests failed, because the'
+        self._settings.log.warning('Generating report even though tests failed, because the'
                                 'coverage-force flag is set.')
       else:
         return

--- a/src/python/pants/backend/jvm/tasks/detect_duplicates.py
+++ b/src/python/pants/backend/jvm/tasks/detect_duplicates.py
@@ -152,15 +152,15 @@ class DuplicateDetector(JvmBinaryTask):
     return conflicts_by_artifacts
 
   def _log_conflicts(self, conflicts_by_artifacts, target):
-    self.context.log.warn('\n ===== For target {}:'.format(target))
+    self.context.log.warning('\n ===== For target {}:'.format(target))
     for artifacts, duplicate_files in conflicts_by_artifacts.items():
       if len(artifacts) < 2:
         continue
-      self.context.log.warn(
+      self.context.log.warning(
         'Duplicate classes and/or resources detected in artifacts: {}'.format(artifacts))
       dup_list = list(duplicate_files)
       for duplicate_file in dup_list[:self.max_dups]:
-        self.context.log.warn('     {}'.format(duplicate_file))
+        self.context.log.warning('     {}'.format(duplicate_file))
       if len(dup_list) > self.max_dups:
-        self.context.log.warn('     ... {remaining} more ...'
+        self.context.log.warning('     ... {remaining} more ...'
                               .format(remaining=(len(dup_list) - self.max_dups)))

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -156,18 +156,18 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
 
     if options.default_concurrency == JUnitTests.CONCURRENCY_PARALLEL_CLASSES_AND_METHODS:
       if not options.use_experimental_runner:
-        self.context.log.warn('--default-concurrency=PARALLEL_CLASSES_AND_METHODS is '
+        self.context.log.warning('--default-concurrency=PARALLEL_CLASSES_AND_METHODS is '
                               'experimental, use --use-experimental-runner.')
       args.append('-default-concurrency')
       args.append('PARALLEL_CLASSES_AND_METHODS')
     elif options.default_concurrency == JUnitTests.CONCURRENCY_PARALLEL_METHODS:
       if not options.use_experimental_runner:
-        self.context.log.warn('--default-concurrency=PARALLEL_METHODS is experimental, use '
+        self.context.log.warning('--default-concurrency=PARALLEL_METHODS is experimental, use '
                               '--use-experimental-runner.')
       if options.test_shard:
         # NB(zundel): The experimental junit runner doesn't support test sharding natively.  The
         # legacy junit runner allows both methods and classes to run in parallel with this option.
-        self.context.log.warn('--default-concurrency=PARALLEL_METHODS with test sharding will '
+        self.context.log.warning('--default-concurrency=PARALLEL_METHODS with test sharding will '
                               'run classes in parallel too.')
       args.append('-default-concurrency')
       args.append('PARALLEL_METHODS')

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -570,7 +570,7 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
                    compiled individually.
     """
     if not ctx.sources:
-      self.context.log.warn('Skipping {} compile for targets with no sources:\n  {}'
+      self.context.log.warning('Skipping {} compile for targets with no sources:\n  {}'
                             .format(self.name(), vts.targets))
     else:
       counter_val = str(counter()).rjust(counter.format_length(), ' ')
@@ -715,11 +715,11 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
         self.context.log.info(suggestion_msg)
 
       if no_suggestions:
-        self.context.log.warn('Unable to find any deps from target\'s transitive '
+        self.context.log.warning('Unable to find any deps from target\'s transitive '
                                'dependencies that provide the following missing classes:')
         no_suggestion_msg = '\n   '.join(sorted(list(no_suggestions)))
-        self.context.log.warn('  {}'.format(no_suggestion_msg))
-        self.context.log.warn(self.get_options().missing_deps_not_found_msg)
+        self.context.log.warning('  {}'.format(no_suggestion_msg))
+        self.context.log.warning(self.get_options().missing_deps_not_found_msg)
 
   def _upstream_analysis(self, compile_contexts, classpath_entries):
     """Returns tuples of classes_dir->analysis_file for the closure of the target."""

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -60,7 +60,7 @@ class BaseZincCompile(JvmCompile):
       for pattern, has_argument in valid_patterns.items():
         if pattern.match(arg):
           return 2 if has_argument else 1
-      log.warn("Zinc argument '{}' is not supported, and is subject to change/removal!".format(arg))
+      log.warning("Zinc argument '{}' is not supported, and is subject to change/removal!".format(arg))
       return 1
 
     arg_index = 0

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -187,10 +187,10 @@ class JvmDependencyUsage(Task):
               lambda spec: next(self.context.resolve(spec).__iter__())
             )
         except Exception:
-          self.context.log.warn("Can't deserialize json for target {}".format(target))
+          self.context.log.warning("Can't deserialize json for target {}".format(target))
           return Node(target.concrete_derived_from)
       else:
-        self.context.log.warn("No cache entry for {}".format(target))
+        self.context.log.warning("No cache entry for {}".format(target))
         return Node(target.concrete_derived_from)
 
     return creator

--- a/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
@@ -183,7 +183,7 @@ class JvmPlatformValidate(JvmPlatformAnalysisMixin, Task):
     try:
       sort_targets(self.jvm_targets)
     except CycleException:
-      self.context.log.warn('Cannot validate dependencies when cycles exist in the build graph.')
+      self.context.log.warning('Cannot validate dependencies when cycles exist in the build graph.')
       return
 
     try:
@@ -209,7 +209,7 @@ class JvmPlatformValidate(JvmPlatformAnalysisMixin, Task):
         raise e
       else:
         assert self.check == 'warn'
-        self.context.log.warn(error_message)
+        self.context.log.warning(error_message)
         return error_message
 
   def _create_individual_error_message(self, target, invalid_dependencies):

--- a/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
@@ -197,7 +197,7 @@ class JvmdocGen(SkipAndTransitiveOptionsRegistrar, HasSkipAndTransitiveOptionsMi
       message = 'Failed to process {} for {} [{}]: {}'.format(
                 self.jvmdoc().tool_name, targetlist, result, " ".join(command))
       if self.ignore_failure:
-        self.context.log.warn(message)
+        self.context.log.warning(message)
       else:
         raise TaskError(message)
 

--- a/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
+++ b/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
@@ -178,7 +178,7 @@ class IdeaPluginGen(ConsoleTask):
     jvm_target_num = len([x for x in self.context.target_roots if isinstance(x, JvmTarget)])
     python_target_num = len([x for x in self.context.target_roots if isinstance(x, PythonTarget)])
     if python_target_num > jvm_target_num:
-      logging.warn('This is likely a python project. Please make sure to '
+      logging.warning('This is likely a python project. Please make sure to '
                    'select the proper python interpreter as Project SDK in IntelliJ.')
 
     ide_file = self.generate_project()

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -251,7 +251,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
   def _scrub_cov_env_vars(self):
     cov_env_vars = {k: v for k, v in os.environ.items() if self._is_coverage_env_var(k)}
     if cov_env_vars:
-      self.context.log.warn('Scrubbing coverage environment variables\n\t{}'
+      self.context.log.warning('Scrubbing coverage environment variables\n\t{}'
                             .format('\n\t'.join(sorted(f'{k}={v}'
                                                        for k, v in cov_env_vars.items()))))
       with environment_as(**{k: None for k in cov_env_vars}):
@@ -355,7 +355,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
               # ... and we end up appending <pex_src_root>/foo/bar to the coverage_sources.
               break
           if not found_target_base:
-            self.context.log.warn(f'Coverage path {morf} is not in any target. Skipping.')
+            self.context.log.warning(f'Coverage path {morf} is not in any target. Skipping.')
         else:
           # The source is to be interpreted as a package name.
           coverage_morfs.append(morf)
@@ -381,7 +381,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
         with self._maybe_run_in_chroot():
           # On failures or timeouts, the .coverage file won't be written.
           if not os.path.exists('.coverage'):
-            self.context.log.warn('No .coverage file was found! Skipping coverage reporting.')
+            self.context.log.warning('No .coverage file was found! Skipping coverage reporting.')
           else:
             coverage_workdir = workdirs.coverage_path
             coverage_reports = self.get_options().coverage_reports

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -534,7 +534,7 @@ class SetupPy(Task):
           # hygiene.
           # raise cls.UndefinedSource('{} is source but does not belong to a package!'
           #                           .format(filename))
-          self.context.log.warn('{} is source but does not belong to a package.'
+          self.context.log.warning('{} is source but does not belong to a package.'
                                 .format(real_filename))
         else:
           continue

--- a/src/python/pants/cache/cache_setup.py
+++ b/src/python/pants/cache/cache_setup.py
@@ -223,7 +223,7 @@ class CacheFactory:
       # no-op
       return spec
     except Resolver.ResolverError as e:
-      self._log.warn('Error while resolving from {0}: {1}'.format(spec.remote, str(e)))
+      self._log.warning('Error while resolving from {0}: {1}'.format(spec.remote, str(e)))
       # If for some reason resolver fails we continue to use local cache
       if spec.local:
         return CacheSpec(local=spec.local, remote=None)

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -748,7 +748,7 @@ class RunTrackerLogger:
   def info(self, *msg_elements):
     self._run_tracker.log(Report.INFO, *msg_elements)
 
-  def warn(self, *msg_elements):
+  def warning(self, *msg_elements):
     self._run_tracker.log(Report.WARN, *msg_elements)
 
   def error(self, *msg_elements):

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -260,7 +260,7 @@ class TestRunnerTaskMixin:
         try:
           process_handler.wait(timeout=wait_time)
         except subprocess.TimeoutExpired:
-          self.context.log.warn(
+          self.context.log.warning(
             'Timed out test did not terminate gracefully after {} seconds, killing...'.format(wait_time))
           process_handler.kill()
 
@@ -289,7 +289,7 @@ class TestRunnerTaskMixin:
     timeout_maximum = self.get_options().timeout_maximum
     if timeout is not None and timeout_maximum is not None:
       if timeout > timeout_maximum:
-        self.context.log.warn(
+        self.context.log.warning(
           "Warning: Timeout for {target} ({timeout}s) exceeds {timeout_maximum}s. Capping.".format(
             target=target.address.spec,
             timeout=timeout,

--- a/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
+++ b/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
@@ -144,13 +144,13 @@ class MarkdownToHtmlTest(TaskTestBase):
     self.set_options(ignore_failure=True)
     bad_rst = self.target(':bad_rst')
     context = self.context(target_roots=[bad_rst])
-    context.log.warn = unittest.mock.Mock()
+    context.log.warning = unittest.mock.Mock()
     task = self.create_task(context)
     task.execute()
 
     # The render error should have been logged.
-    self.assertEqual(1, context.log.warn.call_count)
-    args, kwargs = context.log.warn.call_args
+    self.assertEqual(1, context.log.warning.call_count)
+    args, kwargs = context.log.warning.call_args
     self.assertEqual(0, len(kwargs))
     self.assertEqual(1, len(args))
     self.assertIn('bad.rst', args[0])


### PR DESCRIPTION
\### Problem
log.warn was replaced with log.warning and in fact raises a
DeprecationWarning when used.

\### Solution
Replace log.warn with log.warning

\### Result
No DeprecationWarning when logging warnings