### PR TITLE
Add support for producing target sources via urls

### DIFF
--- a/src/python/pants/build_graph/files.py
+++ b/src/python/pants/build_graph/files.py
@@ -6,19 +6,28 @@ from pants.build_graph.target import Target
 
 
 class Files(Target):
-  """A collection of loose files."""
+  """A collection of loose files.
+
+  Exactly one of `sources` or `urls` should be specified.
+  """
 
   @classmethod
   def alias(cls):
     return 'files'
 
-  def __init__(self, address=None, payload=None, sources=None, **kwargs):
+  def __init__(self, address=None, payload=None, sources=None, urls=None, **kwargs):
     """
     :API: public
 
-    :param sources: Files to "include". Paths are relative to the BUILD file's directory.
-    :type sources: :class:`pants.source.wrapped_globs.FilesetWithSpec` or list of strings
+    :param sources: File names or globs to "include" as data dependencies. Paths are relative to
+      the BUILD file's directory.
+    :param urls: HTTP urls to fetch and "include" as data dependencies.
+    :type urls: List of UrlToFetch instances (produced by the `url` alias in a BUILD file).
     """
+
+    # NB: URLs are fetched, snapshotted, and converted to a sources argument during target
+    # hydration, so we discard the argument here. See #4535.
+
     payload = payload or Payload()
     payload.add_fields({
       'sources': self.create_sources_field(sources,

--- a/src/python/pants/build_graph/register.py
+++ b/src/python/pants/build_graph/register.py
@@ -16,6 +16,7 @@ from pants.build_graph.remote_sources import RemoteSources
 from pants.build_graph.resources import Resources
 from pants.build_graph.target import Target
 from pants.build_graph.target_scopes import ScopedDependencyFactory
+from pants.engine.fs import Digest, UrlToFetch
 from pants.source.wrapped_globs import Globs, RGlobs, ZGlobs
 from pants.util.netrc import Netrc
 
@@ -45,9 +46,11 @@ def build_file_aliases():
       'target': Target,
     },
     objects={
+      'digest': Digest,
       'get_buildroot': get_buildroot,
       'netrc': Netrc,
       'pants_version': pants_version,
+      'url': UrlToFetch,
     },
     context_aware_object_factories={
       'buildfile_path': BuildFilePath,

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -195,6 +195,12 @@ class UrlToFetch:
   digest: Digest
   name: Optional[str] = None
 
+  def __post_init__(self):
+    if not isinstance(self.url, str):
+      raise TypeError(f'Expected the `url` argument to be a `str`: was {self.url}')
+    if not isinstance(self.digest, Digest):
+      raise TypeError(f'Expected the `digest` argument to be a `Digest`: was {self.digest}')
+
 
 @dataclass(frozen=True)
 class Workspace:

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -187,8 +187,13 @@ class MaterializeDirectoriesResult(Collection[MaterializeDirectoryResult]):
 
 @dataclass(frozen=True)
 class UrlToFetch:
+  """A SHA-256 digested HTTP URL with an optional output name.
+
+  If the name is not specified, an attempt is made to infer it from the URL.
+  """
   url: str
   digest: Digest
+  name: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -32,6 +32,7 @@ from pants.engine.legacy.graph import LegacyBuildGraph, create_legacy_graph_task
 from pants.engine.legacy.options_parsing import create_options_parsing_rules
 from pants.engine.legacy.parser import LegacyPythonCallbacksParser
 from pants.engine.legacy.structs import (
+  FilesAdaptor,
   JvmAppAdaptor,
   JvmBinaryAdaptor,
   PageAdaptor,
@@ -91,7 +92,7 @@ def _apply_default_sources_globs(base_class, target_type):
 
 # TODO: These calls mutate the adaptor classes for some known library types to copy over
 # their default source globs while preserving their concrete types. As with the alias replacement
-# below, this is a delaying tactic to avoid elevating the TargetAdaptor API.
+# below, this is a delaying tactic to avoid elevating the TargetAdaptor API. See #4535.
 _apply_default_sources_globs(JvmAppAdaptor, JvmApp)
 _apply_default_sources_globs(PythonAppAdaptor, PythonApp)
 _apply_default_sources_globs(JvmBinaryAdaptor, JvmBinary)
@@ -129,9 +130,8 @@ def _legacy_symbol_table(build_file_aliases):
       )
 
   # TODO: The alias replacement here is to avoid elevating "TargetAdaptors" into the public
-  # API until after https://github.com/pantsbuild/pants/issues/3560 has been completed.
-  # These should likely move onto Target subclasses as the engine gets deeper into beta
-  # territory.
+  # API until after #4535 has been completed.
+  table['files'] = FilesAdaptor
   table['python_library'] = PythonTargetAdaptor
   table['jvm_app'] = JvmAppAdaptor
   table['jvm_binary'] = JvmBinaryAdaptor

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -124,7 +124,7 @@ pub extern "C" fn externs_set(
   externs::set_externs(Externs {
     context,
     log_level,
-    none,
+    none: Value::new(none),
     call,
     generator_send,
     get_type_for,
@@ -809,10 +809,10 @@ pub extern "C" fn capture_snapshots(
         nodes::Snapshot::lift_path_globs(&externs::project_ignoring_type(&value, "path_globs"));
       let digest_hint = {
         let maybe_digest = externs::project_ignoring_type(&value, "digest_hint");
-        if maybe_digest == Value::from(externs::none()) {
-          None
+        if let Some(digest) = maybe_digest.into_option() {
+          Some(nodes::lift_digest(&digest)?)
         } else {
-          Some(nodes::lift_digest(&maybe_digest)?)
+          None
         }
       };
       path_globs.map(|path_globs| (path_globs, root, digest_hint))

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -278,6 +278,10 @@ impl Store {
   ) -> BoxFuture<Snapshot, String> {
     let store = self.clone();
 
+    if name.file_name().is_none() {
+      return future::err(format!("Got invalid name for snapshotted file: {:?}", name)).to_boxed();
+    }
+
     #[derive(Clone)]
     struct Digester {
       digest: hashing::Digest,

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -243,6 +243,17 @@ impl Value {
   pub fn new(handle: Handle) -> Value {
     Value(Arc::new(handle))
   }
+
+  ///
+  /// If this Value is Python's None, returns an optional None: otherwise, the Value.
+  ///
+  pub fn into_option(self) -> Option<Value> {
+    if externs::is_none(&self) {
+      None
+    } else {
+      Some(self)
+    }
+  }
 }
 
 impl Deref for Value {

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -18,8 +18,12 @@ use parking_lot::RwLock;
 use std::collections::BTreeMap;
 
 /// Return the Python value None.
-pub fn none() -> Handle {
-  with_externs(|e| (e.clone_val)(e.context, &e.none))
+pub fn none() -> Value {
+  with_externs(|e| e.none.clone())
+}
+
+pub fn is_none(h: &Handle) -> bool {
+  with_externs(|e| (e.equals)(e.context, h, &e.none as &Handle))
 }
 
 pub fn get_value_from_type_id(ty: TypeId) -> Value {
@@ -374,7 +378,7 @@ pub type ExternContext = raw::c_void;
 pub struct Externs {
   pub context: *const ExternContext,
   pub log_level: u8,
-  pub none: Handle,
+  pub none: Value,
   pub call: CallExtern,
   pub generator_send: GeneratorSendExtern,
   pub get_type_for: GetTypeForExtern,
@@ -501,7 +505,7 @@ impl From<Result<Value, String>> for PyResult {
 
 impl From<Result<(), String>> for PyResult {
   fn from(res: Result<(), String>) -> Self {
-    PyResult::from(res.map(|()| Value::from(none())))
+    PyResult::from(res.map(|()| none()))
   }
 }
 

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -549,6 +549,21 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
           81
         ))
 
+  def test_download_with_name(self):
+    with self.isolated_local_store():
+      with http_server(StubHandler) as port:
+        expected_name = "some_other_name/with/a/unix/path"
+        url = UrlToFetch(
+            "http://localhost:{}/CNAME".format(port),
+            self.pantsbuild_digest,
+            name=expected_name,
+          )
+        snapshot, = self.scheduler.product_request(Snapshot, subjects=[url])
+        self.assert_snapshot_equals(snapshot, [expected_name], Digest(
+          "97698a6f727c5bf312fa6da3dd9739229d6f17da7c30020f4425b4233d4ebeea",
+          89
+        ))
+
   def test_download_missing_file(self):
     with self.isolated_local_store():
       with http_server(StubHandler) as port:


### PR DESCRIPTION
The `Add a 'urls' argument to 'Files' targets` commit here is a sketch of adding support for a `urls` kwarg on the `files` target. I began adding this yesterday while investigating whether we could add support for embedding bootstrap binaries in our targets to avoid needing to bootstrap them at runtime, but later realized that we didn't need it for that usecase.

Syntax currently looks like:
```python
files(
  name='ivy',
  urls=[
    url(
      'https://repo1.maven.org/maven2/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar',
      digest('ce81cb234406b093b5b8de9f6f5b2a50ed0824d6a235891353e8d3e941a53970', 1282424),
    ),
  ],
)
```
Which works as you'd expect:
```bash
$ ./pants filedeps src/python/pants:ivy
/Users/stuhood/src/pants/src/python/pants/BUILD
/Users/stuhood/src/pants/src/python/pants/ivy-2.4.0.jar
```

----

There is prior art here, which is that we have `unpacked_jars` and `unpacked_whls` target types that consume and extract JVM and python resolves (respectively), and can be converted into targets via `remote_sources`. This syntax would be slightly overlapping I think, but has different/simpler usecases (such as including large binaries as `resources` or `files` without unpacking).

I think that if we wanted to support this kind of syntax, we might want to:
1. do this for all target types, not just `files(..)`
2. merge this into the `sources` argument, rather than having a mutually exclusive `urls` argument (ie: the `sources` field would support `globs` and `url`s)

Alternatively, we might want to add a `url` target type and add it to the types that `remote_sources` can consume? 

Feedback welcome.