### PR TITLE
Deprecate not explicitly setting `--chroot` and `--fast` for test goal

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -403,15 +403,17 @@ timeout_default: 60
 
 
 [test.junit]
-fast: false
+# TODO(#8649): Switch to --no-fast.
+fast: true
 chroot: true
 timeouts: true
 timeout_default: 60
 
 
 [test.go]
-fast: false
-chroot: true
+# TODO(#8649): Switch to --no-fast --chroot.
+fast: true
+chroot: false
 
 
 [buildgen.go]

--- a/pants.ini
+++ b/pants.ini
@@ -403,9 +403,15 @@ timeout_default: 60
 
 
 [test.junit]
+fast: false
 chroot: true
 timeouts: true
 timeout_default: 60
+
+
+[test.go]
+fast: false
+chroot: true
 
 
 [buildgen.go]

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -454,26 +454,27 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
 
     deprecated_conditional(
       lambda: self.get_options().is_default("fast"),
-      removal_version="1.25.0.dev1",
+      removal_version="1.25.0.dev2",
       entity_description="using the default value for --no-fast/--fast",
-      hint_message="Please explicitly set the flag --fast. The default will change from --fast to"
-                   "--no-fast in 1.25.0.dev1, and the option will be removed in 1.27.0.dev1. We "
-                   "recommend setting the option to --no-fast for better isolation of tests and to"
-                   "prepare for Pants eventually dropping the option."
+      hint_message="Please explicitly set the flag `--fast`. The default will change from `--fast` "
+                   "to `--no-fast` in 1.25.0.dev2, and the option will be removed in 1.27.0.dev2. "
+                   "We recommend setting the option to `--no-fast` for better isolation of tests "
+                   "and to prepare for Pants eventually dropping the option."
     )
     deprecated_conditional(
       lambda: self.get_options().is_default("chroot"),
-      removal_version="1.25.0.dev1",
+      removal_version="1.25.0.dev2",
       entity_description="using the default value for --no-chroot/--chroot",
-      hint_message="Please explicitly set the flag --chroot. The default will change from "
-                   "--no-chroot to --chroot in 1.25.0.dev1, and the option will likely be removed in"
-                   " 1.29.0.dev1. We recommend setting the option to --chroot for better isolation"
-                   "of tests and to prepare for Pants eventually dropping the option.\n\nSetting "
-                   "--chroot may result in failures at first due to not being able to find imports "
-                   "or resource files. The solution is to mark dependencies explicitly in the test "
-                   "target's BUILD. For loose files accessed via the language's file system (e.g. "
-                   "Python's `with open()`, declare those loose files as a new `files()` target "
-                   "and then depend on that `files()` target in the test target's BUILD."
+      hint_message="Please explicitly set the flag `--chroot`. The default will change from "
+                   "`--no-chroot` to `--chroot` in 1.25.0.dev2, and the option will likely be "
+                   "removed in 1.29.0.dev2. We recommend setting the option to `--chroot` for "
+                   "better isolation of tests and to prepare for Pants eventually dropping the "
+                   "option.\n\nSetting `--chroot` may result in failures at first due to not being "
+                   "able to find imports or resource files. The solution is to mark dependencies "
+                   "explicitly in the test target's BUILD. For loose files accessed via the "
+                   "language's file system (e.g. Python's `with open()`, declare those loose files "
+                   "as a new `files()` target and then depend on that `files()` target in the test "
+                   "target's BUILD."
     )
 
     test_targets = self._get_test_targets()

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -11,6 +11,7 @@ from abc import abstractmethod
 from contextlib import contextmanager
 
 from pants.base.build_environment import get_buildroot
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import ErrorWhileTesting, TaskError
 from pants.build_graph.files import Files
 from pants.invalidation.cache_manager import VersionedTargetSet
@@ -450,6 +451,31 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
         yield chroot
 
   def _execute(self, all_targets):
+
+    deprecated_conditional(
+      lambda: self.get_options().is_default("fast"),
+      removal_version="1.25.0.dev1",
+      entity_description="using the default value for --no-fast/--fast",
+      hint_message="Please explicitly set the flag --fast. The default will change from --fast to"
+                   "--no-fast in 1.25.0.dev1, and the option will be removed in 1.27.0.dev1. We "
+                   "recommend setting the option to --no-fast for better isolation of tests and to"
+                   "prepare for Pants eventually dropping the option."
+    )
+    deprecated_conditional(
+      lambda: self.get_options().is_default("chroot"),
+      removal_version="1.25.0.dev1",
+      entity_description="using the default value for --no-chroot/--chroot",
+      hint_message="Please explicitly set the flag --chroot. The default will change from "
+                   "--no-chroot to --chroot in 1.25.0.dev1, and the option will likely be removed in"
+                   " 1.29.0.dev1. We recommend setting the option to --chroot for better isolation"
+                   "of tests and to prepare for Pants eventually dropping the option.\n\nSetting "
+                   "--chroot may result in failures at first due to not being able to find imports "
+                   "or resource files. The solution is to mark dependencies explicitly in the test "
+                   "target's BUILD. For loose files accessed via the language's file system (e.g. "
+                   "Python's `with open()`, declare those loose files as a new `files()` target "
+                   "and then depend on that `files()` target in the test target's BUILD."
+    )
+
     test_targets = self._get_test_targets()
     if not test_targets:
       return


### PR DESCRIPTION
### Problem
`--fast` and `--no-chroot` are bad defaults for our V1 test runners. They are only that value due to historical reasons, i.e. that we did not have these options until after `./pants test` was widely in use.

Beyond changing the default to `--chroot --no-fast` resulting in our users writing better-isolated tests, this change is tangibly meant to prepare users for the migration to the V2 test runner.

### Solution
Deprecate using the default for the two options so that in 1.25.0.dev1 we can switch the default.

Once the default changes, we can then in later Pants versions completely drop the options so that the only way to run tests with Pants is via `--no-fast --chroot`.

### Result
Leaving off the options will result in a warning.

For example, this prints when leaving off the options for `go.test`:

```
16:44:05 00:03     [go]23:44:05 [WARN] /Users/eric/DocsLocal/code/projects/pants/src/python/pants/task/testrunner_task_mixin.py:141: DeprecationWarning: DEPRECATED: using the default value for --no-fast/--fast will be removed in version 1.25.0.dev1.
  Please explicitly set the flag --fast. The default will change from --fast to --no-fast in 1.25.0.dev1, and the option will be removed in 1.27.0.dev1. We recommend setting the option to --no-fast for better isolation of tests and to prepare for Pants eventually dropping the option.
  self._execute(all_targets)

23:44:05 [WARN] /Users/eric/DocsLocal/code/projects/pants/src/python/pants/task/testrunner_task_mixin.py:141: DeprecationWarning: DEPRECATED: using the default value for --no-chroot/--chroot will be removed in version 1.25.0.dev1.
  Please explicitly set the flag --chroot. The default will change from --no-chroot to --chroot in 1.25.0.dev1, and the option will likely be removed in 1.29.0.dev1. We recommend setting the option to --chroot for better isolation of tests and to prepare for Pants eventually dropping the option.
Setting --chroot may result in failures at first due to not being able to find imports or resource files. The solution is to mark dependencies explicitly in the test target's BUILD. For loose files accessed via the language's file system (e.g. Python's `with open()`, declare those loose files as a new `files()` target and then depend on that `files()` target in the test target's BUILD.
  self._execute(all_targets)
```