### PR TITLE
Try RBE's Maven mirror before going to Maven Central.

### DIFF
--- a/build-support/ivy/ivysettings.xml
+++ b/build-support/ivy/ivysettings.xml
@@ -26,6 +26,13 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
            This can lead to jars downloading without their transitive deps which leads
            to confusing failures later when classpaths are constructed and used.
            We setup the maven central resolver to require successful pom downloads here. -->
+
+      <!-- First try RBE's maven central mirror, as we can get throttled by
+           maven central due to all RBE traffic appearing to them as coming from a single IP.
+           There's no harm in trying this even outside RBE, as it is world-visible. -->
+      <ibiblio name="maven-central-mirror" m2compatible="true" descriptor="required"
+               root="https://maven-central.storage-download.googleapis.com/repos/central/data"/>
+
       <ibiblio name="maven-central" m2compatible="true" descriptor="required"/>
 
       <!-- The mvn standard local filesystem repo/cache -->

--- a/pants.ini
+++ b/pants.ini
@@ -451,6 +451,17 @@ enable_libc_search: True
 [sourcefile-validation]
 config: @build-support/regexes/config.yaml
 
+[coursier]
+repos: [
+    # First try RBE's maven central mirror, as we can get throttled by
+    # maven central due to all RBE traffic appearing to them as coming from a single IP.
+    # There's no harm in trying this even outside RBE, as it is world-visible.
+    'https://maven-central.storage-download.googleapis.com/repos/central/data',
+    'https://repo1.maven.org/maven2',
+    # Custom repo for Kythe jars, as Google doesn't currently publish them anywhere.
+    'https://raw.githubusercontent.com/toolchainlabs/binhost/master/'
+  ]
+
 [cache.resolve.coursier]
 # Only use local artifact for coursier because the cache content contains abs path
 # and is not portable. That said, if remote cache is enabled, this would not break


### PR DESCRIPTION
Should help mitigate any remaining issues with being
throttled by Maven Central.
