### PR TITLE
Bump default Pytest to 4.6 and add warning for future change to Pytest 5

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -399,6 +399,7 @@ resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
 
 
 [pytest]
+version: pytest>=5.2.4
 # TODO(#8651): We need this until we switch to implicit namespace packages so that pytest-cov
 #  understands our __init__ files. NB: this version matches 3rdparty/python/requirements.txt.
 pytest_plugins: +["setuptools==40.6.3"]

--- a/pants.ini
+++ b/pants.ini
@@ -398,6 +398,12 @@ interpreter_cache_dir: %(pants_bootstrapdir)s/python_cache/interpreters
 resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
 
 
+[pytest]
+# TODO(#8651): We need this until we switch to implicit namespace packages so that pytest-cov
+#  understands our __init__ files. NB: this version matches 3rdparty/python/requirements.txt.
+pytest_plugins: +["setuptools==40.6.3"]
+
+
 [test.pytest]
 fast: false
 chroot: true

--- a/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
@@ -67,7 +67,7 @@ class TestPythonTestRunnerIntegration(PantsRunIntegrationTest):
 
         pants/dummies/test_pass.py .                                             [100%]
 
-        =========================== 1 passed in SOME_TEXT ===========================
+        ============================== 1 passed in SOME_TEXT ===============================
 
 
         testprojects/tests/python/pants/dummies:passing_target                          .....   SUCCESS
@@ -98,7 +98,7 @@ class TestPythonTestRunnerIntegration(PantsRunIntegrationTest):
         E     assert False
 
         pants/dummies/test_fail.py:2: AssertionError
-        =========================== 1 failed in SOME_TEXT ===========================
+        ============================== 1 failed in SOME_TEXT ===============================
 
 
         testprojects/tests/python/pants/dummies:failing_target                          .....   FAILURE
@@ -130,7 +130,7 @@ class TestPythonTestRunnerIntegration(PantsRunIntegrationTest):
         E     assert False
 
         pants/dummies/test_fail.py:2: AssertionError
-        =========================== 1 failed in SOME_TEXT ===========================
+        ============================== 1 failed in SOME_TEXT ===============================
 
         testprojects/tests/python/pants/dummies:passing_target stdout:
         ============================= test session starts ==============================
@@ -141,7 +141,7 @@ class TestPythonTestRunnerIntegration(PantsRunIntegrationTest):
 
         pants/dummies/test_pass.py .                                             [100%]
 
-        =========================== 1 passed in SOME_TEXT ===========================
+        ============================== 1 passed in SOME_TEXT ===============================
 
 
         testprojects/tests/python/pants/dummies:failing_target                          .....   FAILURE
@@ -165,7 +165,7 @@ class TestPythonTestRunnerIntegration(PantsRunIntegrationTest):
 
         pants/dummies/test_with_source_dep_absolute_import.py .                  [100%]
 
-        =========================== 1 passed in SOME_TEXT ===========================
+        ============================== 1 passed in SOME_TEXT ===============================
 
 
         testprojects/tests/python/pants/dummies:target_with_source_dep_absolute_import  .....   SUCCESS
@@ -188,7 +188,7 @@ class TestPythonTestRunnerIntegration(PantsRunIntegrationTest):
 
         pants/dummies/test_with_source_dep_relative_import.py .                  [100%]
 
-        =========================== 1 passed in SOME_TEXT ===========================
+        ============================== 1 passed in SOME_TEXT ===============================
 
 
         testprojects/tests/python/pants/dummies:target_with_source_dep_relative_import  .....   SUCCESS
@@ -211,7 +211,7 @@ class TestPythonTestRunnerIntegration(PantsRunIntegrationTest):
 
         pants/dummies/test_with_thirdparty_dep.py .                              [100%]
 
-        =========================== 1 passed in SOME_TEXT ===========================
+        ============================== 1 passed in SOME_TEXT ===============================
 
 
         testprojects/tests/python/pants/dummies:target_with_thirdparty_dep              .....   SUCCESS
@@ -234,7 +234,7 @@ class TestPythonTestRunnerIntegration(PantsRunIntegrationTest):
 
         pants/dummies/test_with_transitive_dep.py .                              [100%]
 
-        =========================== 1 passed in SOME_TEXT ===========================
+        ============================== 1 passed in SOME_TEXT ===============================
 
 
         testprojects/tests/python/pants/dummies:target_with_transitive_dep              .....   SUCCESS

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -12,28 +12,24 @@ class PyTest(Subsystem):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    register('--version', default='pytest>=3.0.7,<3.7', help="Requirement string for Pytest.")
+    register('--version', default='pytest>=5.2.4', help="Requirement string for Pytest.")
     register(
       '--pytest-plugins',
       type=list,
-      default=[
-        'pytest-timeout>=1.2,<1.3',
-        'pytest-cov>=2.4,<2.5',
-        "unittest2>=0.6.0,<=1.9.0 ; python_version<'3'"
-      ],
+      default=['pytest-timeout>=1.3.3', 'pytest-cov>=2.8.1'],
       help="Requirement strings for any plugins or additional requirements you'd like to use.",
     )
-    register('--requirements', advanced=True, default='pytest>=3.0.7,<3.7',
+    register('--requirements', advanced=True, default='pytest>=5.2.4',
              help='Requirements string for the pytest library.',
              removal_version="1.25.0.dev0", removal_hint="Use --version instead.")
-    register('--timeout-requirements', advanced=True, default='pytest-timeout>=1.2,<1.3',
+    register('--timeout-requirements', advanced=True, default='pytest-timeout>=1.3.3',
              help='Requirements string for the pytest-timeout library.',
              removal_version="1.25.0.dev0", removal_hint="Use --pytest-plugins instead.")
-    register('--cov-requirements', advanced=True, default='pytest-cov>=2.4,<2.5',
+    register('--cov-requirements', advanced=True, default='pytest-cov>=2.8.1',
              help='Requirements string for the pytest-cov library.',
              removal_version="1.25.0.dev0", removal_hint="Use --pytest-plugins instead.")
     register('--unittest2-requirements', advanced=True,
-             default="unittest2>=0.6.0,<=1.9.0 ; python_version<'3'",
+             default="unittest2>=1.1.0 ; python_version<'3'",
              help='Requirements string for the unittest2 library, which some python versions '
                   'may need.',
              removal_version="1.25.0.dev0", removal_hint="Use --pytest-plugins instead.")
@@ -63,14 +59,9 @@ class PyTest(Subsystem):
       )
     if configured_deprecated_option:
       return (
-        "more-itertools<6.0.0 ; python_version<'3'",
         opts.requirements,
         opts.timeout_requirements,
         opts.cov_requirements,
         opts.unittest2_requirements,
       )
-    return (
-      "more-itertools<6.0.0 ; python_version<'3'",
-      opts.version,
-      *opts.pytest_plugins
-    )
+    return (opts.version, *opts.pytest_plugins)

--- a/src/python/pants/testutil/base/context_utils.py
+++ b/src/python/pants/testutil/base/context_utils.py
@@ -37,10 +37,12 @@ class TestContext(Context):
    """
 
     def output(self, name):
-      return sys.stderr
+      return sys.stderr.buffer
 
     def set_outcome(self, outcome):
-      return sys.stderr.write('\nWorkUnit outcome: {}\n'.format(WorkUnit.outcome_string(outcome)))
+      return sys.stderr.buffer.write(
+        f'\nWorkUnit outcome: {WorkUnit.outcome_string(outcome)}\n'.encode()
+      )
 
   class DummyRunTracker:
     """A runtracker stand-in that does no actual tracking."""

--- a/testprojects/tests/python/pants/dummies/BUILD
+++ b/testprojects/tests/python/pants/dummies/BUILD
@@ -33,7 +33,7 @@ python_tests(
   name = 'target_with_thirdparty_dep',
   sources = ['test_with_thirdparty_dep.py'],
   dependencies = [
-    '3rdparty/python:ansicolors',
+    '3rdparty/python:typing-extensions',
   ],
 )
 

--- a/testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py
+++ b/testprojects/tests/python/pants/dummies/test_with_thirdparty_dep.py
@@ -1,8 +1,9 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from colors import red, strip_color
+from typing_extensions import Literal
 
 
 def test_f():
-  assert strip_color(red("foo")) == "foo"
+  assert Literal[1] == Literal[1]
+  assert Literal[1] != Literal[2]

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -141,6 +141,10 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
           'python-setup': {
             'interpreter_cache_dir': interpreters_cache,
             'interpreter_search_paths': ['<PEXRC>'],
+          },
+          # NB: we pin Pytest to 4.6 to ensure Pytest still works with Python 2.
+          'pytest': {
+            'version': 'pytest==4.6.6',
           }
         }
         pants_run_27 = self.run_pants(
@@ -167,6 +171,10 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
         'python-setup': {
           'interpreter_constraints': ['CPython>=2.7,<4'],
           'interpreter_cache_dir': interpreters_cache,
+        },
+        # NB: we pin Pytest to 4.6 to ensure Pytest still works with Python 2.
+        'pytest': {
+          'version': 'pytest==4.6.6',
         }
       }
       pants_run_2 = self.run_pants(


### PR DESCRIPTION
### Problem
We're using an old version of Pytest from 2018 and are two major releases behind. This means users are missing out on new features like Pytest 5.0 enabling `faulthandler` by default and that certain plugins won't work because Pytest is too outdated.

However, Pytest 5.0 drops support for running tests with Python 2.

### Solution
Set the default Pytest to 4.6.x, which is the last minor series to support Python 2. This brings nice benefits to users without being majorly breaking.

Then, we add a deprecation for users not specifying `--pytest-version` to ensure that they don't get bit by us switching to Pytest 5 in two major releases.

Finally, we set our own internal Pytest to the newest release so that we get the newest and greatest, e.g. default `faulthandler`.

### Result
Users who have not specified `--pytest-version` will get this warning:

> [WARN] /Users/eric/DocsLocal/code/projects/pants/src/python/pants/backend/python/tasks/pytest_prep.py:92: DeprecationWarning: DEPRECATED: Pants defaulting to a Python 2-compatible Pytest version will be removed in version 1.25.0.dev2.
  Pants will soon start defaulting to Pytest 5.x, which no longer supports running tests with Python 2. In preparation for this change, you should explicitly set what version of Pytest to use in your `pants.ini` under the section `pytest`.
>
> If you need to keep running tests with Python 2, set `version` to `pytest>=4.6.6,<4.7` (the current default). If you don't have any tests with Python 2 and want the newest Pytest, set `version` to `pytest>=5.2.4`.