### PR TITLE
Remove yielding @rules

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,5 +1,4 @@
 ansicolors==1.0.2
-asttokens==1.1.13
 beautifulsoup4>=4.6.0,<4.7
 cffi==1.13.2
 contextlib2==0.5.5

--- a/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
+++ b/pants-plugins/src/python/internal_backend/rules_for_testing/register.py
@@ -19,7 +19,7 @@ def fast_list_and_die_for_testing(
 ) -> ListAndDieForTesting:
   for address in addresses.dependencies:
     console.print_stdout(address.spec)
-  yield ListAndDieForTesting(exit_code=42)
+  return ListAndDieForTesting(exit_code=42)
 
 
 def rules():

--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -57,12 +57,12 @@ class DownloadedPexBin(HermeticPex):
 
 
 @rule
-def download_pex_bin() -> DownloadedPexBin:
+async def download_pex_bin() -> DownloadedPexBin:
   # TODO: Inject versions and digests here through some option, rather than hard-coding it.
   url = 'https://github.com/pantsbuild/pex/releases/download/v1.6.12/pex'
   digest = Digest('ce64cb72cd23d2123dd48126af54ccf2b718d9ecb98c2ed3045ed1802e89e7e1', 1842359)
-  snapshot = yield Get(Snapshot, UrlToFetch(url, digest))
-  yield DownloadedPexBin(executable=snapshot.files[0], directory_digest=snapshot.directory_digest)
+  snapshot = await Get(Snapshot, UrlToFetch(url, digest))
+  return DownloadedPexBin(executable=snapshot.files[0], directory_digest=snapshot.directory_digest)
 
 
 def rules():

--- a/src/python/pants/backend/python/rules/inject_init.py
+++ b/src/python/pants/backend/python/rules/inject_init.py
@@ -17,7 +17,7 @@ class InjectedInitDigest:
 
 
 @rule
-def inject_init(snapshot: Snapshot) -> InjectedInitDigest:
+async def inject_init(snapshot: Snapshot) -> InjectedInitDigest:
   """Ensure that every package has an __init__.py file in it."""
   missing_init_files = tuple(sorted(identify_missing_init_files(snapshot.files)))
   if not missing_init_files:
@@ -31,11 +31,11 @@ def inject_init(snapshot: Snapshot) -> InjectedInitDigest:
       description="Inject missing __init__.py files: {}".format(", ".join(missing_init_files)),
       input_files=snapshot.directory_digest,
     )
-    touch_init_result = yield Get(ExecuteProcessResult, ExecuteProcessRequest, touch_init_request)
+    touch_init_result = await Get(ExecuteProcessResult, ExecuteProcessRequest, touch_init_request)
     new_init_files_digest = touch_init_result.output_directory_digest
   # TODO(#7710): Once this gets fixed, merge the original source digest and the new init digest
   # into one unified digest.
-  yield InjectedInitDigest(directory_digest=new_init_files_digest)
+  return InjectedInitDigest(directory_digest=new_init_files_digest)
 
 
 def rules():

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -85,7 +85,7 @@ class Pex(HermeticPex):
 # TODO: This is non-hermetic because the requirements will be resolved on the fly by
 # pex, where it should be hermetically provided in some way.
 @rule
-def create_pex(
+async def create_pex(
     request: CreatePex,
     pex_bin: DownloadedPexBin,
     python_setup: PythonSetup,
@@ -106,9 +106,9 @@ def create_pex(
 
   argv.append(f'--sources-directory={source_dir_name}')
   sources_digest = request.input_files_digest if request.input_files_digest else EMPTY_DIRECTORY_DIGEST
-  sources_digest_as_subdir = yield Get(Digest, DirectoryWithPrefixToAdd(sources_digest, source_dir_name))
+  sources_digest_as_subdir = await Get(Digest, DirectoryWithPrefixToAdd(sources_digest, source_dir_name))
   all_inputs = (pex_bin.directory_digest, sources_digest_as_subdir,)
-  merged_digest = yield Get(Digest, DirectoriesToMerge(directories=all_inputs))
+  merged_digest = await Get(Digest, DirectoriesToMerge(directories=all_inputs))
 
   # NB: PEX outputs are platform dependent so in order to get a PEX that we can use locally, without
   # cross-building, we specify that out PEX command be run on the current local platform. When we
@@ -134,12 +134,12 @@ def create_pex(
     }
   )
 
-  result = yield Get(
+  result = await Get(
     ExecuteProcessResult,
     MultiPlatformExecuteProcessRequest,
     execute_process_request
   )
-  yield Pex(directory_digest=result.output_directory_digest, output_filename=request.output_filename)
+  return Pex(directory_digest=result.output_directory_digest, output_filename=request.output_filename)
 
 
 def rules():

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -14,15 +14,15 @@ from pants.engine.fs import Digest, DirectoriesToMerge
 from pants.engine.legacy.graph import BuildFileAddresses, HydratedTarget, TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonBinaryAdaptor
 from pants.engine.rules import UnionRule, rule
-from pants.engine.selectors import Get
+from pants.engine.selectors import Get, MultiGet
 from pants.rules.core.binary import BinaryTarget, CreatedBinary
 from pants.rules.core.strip_source_root import SourceRootStrippedSources
 
 
 @rule
-def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor,
+async def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor,
   python_setup: PythonSetup) -> CreatedBinary:
-  transitive_hydrated_targets = yield Get(
+  transitive_hydrated_targets = await Get(
     TransitiveHydratedTargets, BuildFileAddresses((python_binary_adaptor.address,))
   )
   all_targets = transitive_hydrated_targets.closure
@@ -34,10 +34,10 @@ def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor,
     python_setup=python_setup
   )
 
-  source_root_stripped_sources = yield [
+  source_root_stripped_sources = await MultiGet(
     Get(SourceRootStrippedSources, HydratedTarget, target_adaptor)
     for target_adaptor in all_targets
-  ]
+  )
 
   #TODO(#8420) This way of calculating the entry point works but is a bit hackish.
   entry_point = None
@@ -47,15 +47,15 @@ def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor,
     sources_snapshot = python_binary_adaptor.sources.snapshot
     if len(sources_snapshot.files) == 1:
       target = transitive_hydrated_targets.roots[0]
-      output = yield Get(SourceRootStrippedSources, HydratedTarget, target)
+      output = await Get(SourceRootStrippedSources, HydratedTarget, target)
       root_filename = output.snapshot.files[0]
       entry_point = PythonBinary.translate_source_path_to_py_module_specifier(root_filename)
 
   stripped_sources_digests = [stripped_sources.snapshot.directory_digest for stripped_sources in source_root_stripped_sources]
-  sources_digest = yield Get(Digest, DirectoriesToMerge(directories=tuple(stripped_sources_digests)))
-  inits_digest = yield Get(InjectedInitDigest, Digest, sources_digest)
+  sources_digest = await Get(Digest, DirectoriesToMerge(directories=tuple(stripped_sources_digests)))
+  inits_digest = await Get(InjectedInitDigest, Digest, sources_digest)
   all_input_digests = [sources_digest, inits_digest.directory_digest]
-  merged_input_files = yield Get(Digest, DirectoriesToMerge, DirectoriesToMerge(directories=tuple(all_input_digests)))
+  merged_input_files = await Get(Digest, DirectoriesToMerge, DirectoriesToMerge(directories=tuple(all_input_digests)))
 
   requirements = PexRequirements.create_from_adaptors(all_target_adaptors)
   output_filename = f"{python_binary_adaptor.address.target_name}.pex"
@@ -68,8 +68,8 @@ def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor,
     input_files_digest=merged_input_files,
   )
 
-  pex = yield Get(Pex, CreatePex, create_requirements_pex)
-  yield CreatedBinary(digest=pex.directory_digest, binary_name=pex.output_filename)
+  pex = await Get(Pex, CreatePex, create_requirements_pex)
+  return CreatedBinary(digest=pex.directory_digest, binary_name=pex.output_filename)
 
 
 def rules():

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -17,13 +17,13 @@ from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecute
 from pants.engine.legacy.graph import BuildFileAddresses, HydratedTarget, TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonTestsAdaptor
 from pants.engine.rules import UnionRule, optionable_rule, rule
-from pants.engine.selectors import Get
+from pants.engine.selectors import Get, MultiGet
 from pants.rules.core.core_test_model import Status, TestResult, TestTarget
 from pants.rules.core.strip_source_root import SourceRootStrippedSources
 
 
 @rule
-def run_python_test(
+async def run_python_test(
   test_target: PythonTestsAdaptor,
   pytest: PyTest,
   python_setup: PythonSetup,
@@ -33,7 +33,7 @@ def run_python_test(
 
   # TODO(7726): replace this with a proper API to get the `closure` for a
   # TransitiveHydratedTarget.
-  transitive_hydrated_targets = yield Get(
+  transitive_hydrated_targets = await Get(
     TransitiveHydratedTargets, BuildFileAddresses((test_target.address,))
   )
   all_targets = transitive_hydrated_targets.closure
@@ -44,28 +44,28 @@ def run_python_test(
   # https://pytest.org/en/latest/goodpractices.html#test-discovery. In addition to a performance
   # optimization, this ensures that any transitive sources, such as a test project file named
   # test_fail.py, do not unintentionally end up being run as tests.
-  source_root_stripped_test_target_sources = yield Get(
+  source_root_stripped_test_target_sources = await Get(
     SourceRootStrippedSources, Address, test_target.address.to_address()
   )
 
   if not source_root_stripped_test_target_sources.snapshot.files:
-    yield TestResult(
+    return TestResult(
       status=Status.SUCCESS,
       stdout="",
       stderr="",
     )
 
-  source_root_stripped_sources = yield [
+  source_root_stripped_sources = await MultiGet(
     Get(SourceRootStrippedSources, HydratedTarget, target_adaptor)
     for target_adaptor in all_targets
-  ]
+  )
 
   stripped_sources_digests = [stripped_sources.snapshot.directory_digest for stripped_sources in source_root_stripped_sources]
-  sources_digest = yield Get(
+  sources_digest = await Get(
     Digest, DirectoriesToMerge(directories=tuple(stripped_sources_digests)),
   )
 
-  inits_digest = yield Get(InjectedInitDigest, Digest, sources_digest)
+  inits_digest = await Get(InjectedInitDigest, Digest, sources_digest)
 
   interpreter_constraints = PexInterpreterConstraints.create_from_adaptors(
     adaptors=tuple(all_target_adaptors),
@@ -78,7 +78,7 @@ def run_python_test(
     additional_requirements=pytest.get_requirement_strings()
   )
 
-  resolved_requirements_pex = yield Get(
+  resolved_requirements_pex = await Get(
     Pex, CreatePex(
       output_filename=output_pytest_requirements_pex_filename,
       requirements=requirements,
@@ -87,7 +87,7 @@ def run_python_test(
     )
   )
 
-  merged_input_files = yield Get(
+  merged_input_files = await Get(
     Digest,
     DirectoriesToMerge(
       directories=(
@@ -111,10 +111,10 @@ def run_python_test(
     timeout_seconds=getattr(test_target, 'timeout', 60)
   )
 
-  result = yield Get(FallibleExecuteProcessResult, ExecuteProcessRequest, request)
+  result = await Get(FallibleExecuteProcessResult, ExecuteProcessRequest, request)
   status = Status.SUCCESS if result.exit_code == 0 else Status.FAILURE
 
-  yield TestResult(
+  return TestResult(
     status=status,
     stdout=result.stdout.decode(),
     stderr=result.stderr.decode(),

--- a/src/python/pants/backend/python/rules/python_test_runner_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_test.py
@@ -22,7 +22,7 @@ class TestPythonTestRunner(TestBase):
 
   def test_empty_target_succeeds(self) -> None:
     # NB: Because this particular edge case should early return, we can avoid providing valid
-    # mocked yield gets for most of the rule's body. Future tests added to this file will need to
+    # mocked await gets for most of the rule's body. Future tests added to this file will need to
     # provide valid mocks instead.
     unimplemented_mock = lambda _: NotImplemented
     target = PythonTestsAdaptor(address=BuildFileAddress(target_name="target", rel_path="test"))

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -197,7 +197,6 @@ _specificity = {
   SiblingAddresses: 1,
   AscendantAddresses: 2,
   DescendantAddresses: 3,
-  type(None): 99
 }
 
 

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -201,14 +201,16 @@ _specificity = {
 }
 
 
-def more_specific(spec1: Optional[Spec], spec2: Spec) -> Spec:
+def more_specific(spec1: Optional[Spec], spec2: Optional[Spec]) -> Spec:
   """Returns which of the two specs is more specific.
 
   This is useful when a target matches multiple specs, and we want to associate it with
   the "most specific" one, which will make the most intuitive sense to the user.
   """
   # Note that if either of spec1 or spec2 is None, the other will be returned.
-  return cast(Spec, spec1) if _specificity[type(spec1)] < _specificity[type(spec2)] else spec2
+  if spec1 is None and spec2 is None:
+    raise ValueError('internal error: both specs provided to more_specific() were None')
+  return cast(Spec, spec1 if _specificity[type(spec1)] < _specificity[type(spec2)] else spec2)
 
 
 @frozen_after_init

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -197,6 +197,7 @@ _specificity = {
   SiblingAddresses: 1,
   AscendantAddresses: 2,
   DescendantAddresses: 3,
+  type(None): 99
 }
 
 

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -56,7 +56,7 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/util:meta',
   ],
-  tags = {'partially_type_checked'},
+  tags = {'type_checked'},
 )
 
 python_library(

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -56,7 +56,7 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/util:meta',
   ],
-  tags = {'type_checked'},
+  tags = {'partially_type_checked'},
 )
 
 python_library(

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -181,7 +181,6 @@ python_library(
   name='rules',
   sources=['rules.py'],
   dependencies=[
-    '3rdparty/python:asttokens',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':goal',
     ':selectors',

--- a/src/python/pants/engine/README.md
+++ b/src/python/pants/engine/README.md
@@ -28,7 +28,7 @@ produce the requested value.
 ### Products and Params
 
 The engine executes your `@rule`s in order to (recursively) compute a `Product` of the requested
-type for a set of `Param`s. This recursive type search leads to a loosely coupled (and yet still 
+type for a set of `Param`s. This recursive type search leads to a loosely coupled (and yet still
 statically checked) form of dependency injection.
 
 When an `@rule` runs, it requires a set of `Param`s that the engine has determined are needed to
@@ -79,7 +79,7 @@ fail with a useful error message.
 ### Datatypes
 
 In practical use, builtin types like `str` or `int` do not provide enough information to
-disambiguate between various types of data in `@rule` signatures, so declaring small `datatype` 
+disambiguate between various types of data in `@rule` signatures, so declaring small `datatype`
 definitions to provide a unique and descriptive type is highly recommended:
 
 ```python
@@ -135,7 +135,7 @@ the rule graph and then passed in.
 
 The second case for introducing new `Params` occurs within the running graph when an `@rule` needs
 to pass values to its dependencies that are necessary to compute a product. In this case, `@rule`s
-may be written as coroutines (ie, using the python `yield` statement) that yield "`Get` requests"
+may be written as `async` methods that `await` on "`Get` requests"
 that request products for other `Params`. Just like `@rule` parameter selectors, `Get` requests
 instantiated in the body of an `@rule` are statically checked to be satisfiable in the set of
 installed `@rule`s.
@@ -147,13 +147,13 @@ and then concatentates that content into a (datatype-wrapped) string:
 
 ```python
 @rule
-def concat(files: Files) -> ConcattedFiles:
-  file_content_list = yield [Get(FileContent, File(f)) for f in files]
-  yield ConcattedFiles(''.join(fc.content for fc in file_content_list))
+async def concat(files: Files) -> ConcattedFiles:
+  file_content_list = await MultiGet(Get(FileContent, File(f)) for f in files)
+  return ConcattedFiles(''.join(fc.content for fc in file_content_list))
 ```
 
 This `@rule` declares that: "for any `Params` for which we can compute `Files`, we can also compute
-`ConcattedFiles`". Each yielded `Get` request results in FileContent for a different File `Param`
+`ConcattedFiles`". Each awaited `Get` request results in FileContent for a different File `Param`
 from the Files list. And, happily, all of these requests can proceed in parallel.
 
 ### Advanced Param Usage

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import MutableMapping, MutableSequence
 from dataclasses import dataclass
 from os.path import dirname, join
-from typing import Dict, Tuple
+from typing import Dict
 
 from twitter.common.collections import OrderedSet
 
@@ -131,9 +131,8 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
   collect_inline_dependencies(struct)
 
   # And then hydrate the inline dependencies.
-  hydrated_inline_dependencies: Tuple[HydratedStruct, ...] = await MultiGet(
-    Get[HydratedStruct](Address, a) for a in inline_dependencies
-  )
+  hydrated_inline_dependencies = await MultiGet(Get[HydratedStruct](Address, a)
+                                                for a in inline_dependencies)
   dependencies = [d.value for d in hydrated_inline_dependencies]
 
   def maybe_consume(outer_key, value):

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -49,8 +49,8 @@ async def parse_address_family(address_mapper: AddressMapper, directory: Dir) ->
   """
   patterns = tuple(join(directory.path, p) for p in address_mapper.build_patterns)
   path_globs = PathGlobs(include=patterns, exclude=address_mapper.build_ignore_patterns)
-  snapshot: Snapshot = await Get(Snapshot, PathGlobs, path_globs)
-  files_content: FilesContent = await Get(FilesContent, Digest, snapshot.directory_digest)
+  snapshot = await Get[Snapshot](PathGlobs, path_globs)
+  files_content = await Get[FilesContent](Digest, snapshot.directory_digest)
 
   if not files_content:
     raise ResolveError(
@@ -89,7 +89,7 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
   dependencies field, since those should be requested explicitly by rules.
   """
 
-  address_family: AddressFamily = await Get(AddressFamily, Dir(address.spec_path))
+  address_family = await Get[AddressFamily](Dir(address.spec_path))
 
   struct = address_family.addressables.get(address)
   addresses = address_family.addressables
@@ -132,7 +132,7 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
 
   # And then hydrate the inline dependencies.
   hydrated_inline_dependencies: Tuple[HydratedStruct, ...] = await MultiGet(
-    Get(HydratedStruct, Address, a) for a in inline_dependencies
+    Get[HydratedStruct](Address, a) for a in inline_dependencies
   )
   dependencies = [d.value for d in hydrated_inline_dependencies]
 
@@ -214,9 +214,9 @@ async def provenanced_addresses_from_address_families(
 :raises: :class:`AddressLookupError` if no targets are matched for non-SingleAddress specs.
 """
   # Capture a Snapshot covering all paths for these Specs, then group by directory.
-  snapshot = await Get(Snapshot, PathGlobs, _spec_to_globs(address_mapper, specs))
+  snapshot = await Get[Snapshot](PathGlobs, _spec_to_globs(address_mapper, specs))
   dirnames = {dirname(f) for f in snapshot.files}
-  address_families = await MultiGet(Get(AddressFamily, Dir(d)) for d in dirnames)
+  address_families = await MultiGet(Get[AddressFamily](Dir(d)) for d in dirnames)
   address_family_by_directory = {af.namespace: af for af in address_families}
 
   matched_addresses = OrderedSet()

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -205,7 +205,7 @@ def _hydrate(item_type, spec_path, **kwargs):
 @rule
 async def provenanced_addresses_from_address_families(
     address_mapper: AddressMapper, specs: Specs
-) -> ProvenancedBuildFileAddresses:
+) -> Generator[Union[Get, List[Get]], Any, ProvenancedBuildFileAddresses]:
   """Given an AddressMapper and list of Specs, return matching ProvenancedBuildFileAddresses.
 
 :raises: :class:`ResolveError` if:

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -205,7 +205,7 @@ def _hydrate(item_type, spec_path, **kwargs):
 @rule
 async def provenanced_addresses_from_address_families(
     address_mapper: AddressMapper, specs: Specs
-) -> Generator[Union[Get, List[Get]], Any, ProvenancedBuildFileAddresses]:
+) -> ProvenancedBuildFileAddresses:
   """Given an AddressMapper and list of Specs, return matching ProvenancedBuildFileAddresses.
 
 :raises: :class:`ResolveError` if:

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -510,7 +510,7 @@ class _FFISpecification(object):
     except StopIteration as e:
       if not e.args:
         raise
-      # This was a `return` from a generator or coroutine, as opposed to a `StopIteration` raised
+      # This was a `return` from a coroutine, as opposed to a `StopIteration` raised
       # by calling `next()` on an empty iterator.
       response.tag = self._lib.Broke
       response.broke = (c.to_value(e.value),)

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -502,11 +502,7 @@ class _FFISpecification(object):
             c.identities_buf([c.identify(g.subject) for g in res]),
           )
       else:
-        # TODO: this will soon become obsolete when all @rules are fully mypy-annotated and must
-        # `return` instead of `yield` at the end!
-        # Break.
-        response.tag = self._lib.Broke
-        response.broke = (c.to_value(res),)
+        raise ValueError(f'internal engine error: unrecognized coroutine result {res}')
     except StopIteration as e:
       if not e.args:
         raise
@@ -576,7 +572,6 @@ class EngineTypes(NamedTuple):
   link: TypeId
   multi_platform_process_request: TypeId
   process_result: TypeId
-  generator: TypeId
   coroutine: TypeId
   url_to_fetch: TypeId
   string: TypeId
@@ -934,7 +929,6 @@ class Native(metaclass=SingletonMetaclass):
         link=ti(Link),
         multi_platform_process_request=ti(MultiPlatformExecuteProcessRequest),
         process_result=ti(FallibleExecuteProcessResult),
-        generator=ti(GeneratorType),
         coroutine=ti(CoroutineType),
         url_to_fetch=ti(UrlToFetch),
         string=ti(str),

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -9,7 +9,7 @@ import sys
 import sysconfig
 import traceback
 from contextlib import closing
-from types import CoroutineType, GeneratorType
+from types import CoroutineType
 from typing import Any, NamedTuple, Tuple, Type
 
 import cffi

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -375,7 +375,7 @@ def rule_decorator(*args, **kwargs) -> Callable:
     annotation=signature.return_annotation,
     name=f'{func_id} return',
     empty_value=inspect.Signature.empty,
-    raise_type=MissingReturnTypeAnnotation,
+    raise_type=MissingReturnTypeAnnotation
   )
   parameter_types = tuple(
     _ensure_type_annotation(

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
-import asttokens
 from twitter.common.collections import OrderedSet
 
 from pants.engine.goal import Goal
@@ -28,170 +27,23 @@ logger = logging.getLogger(__name__)
 
 
 class _RuleVisitor(ast.NodeVisitor):
-  """Pull `Get` calls out of an @rule body and validate `yield` or `await` statements."""
+  """Pull `Get` calls out of an @rule body."""
 
-  def __init__(self, func, func_node, func_source, orig_indent, parents_table):
+  def __init__(self):
     super().__init__()
     self._gets: List[Get] = []
-    self._func = func
-    self._func_node = func_node
-    self._func_source = func_source
-    self._orig_indent = orig_indent
-    self._parents_table = parents_table
-    self._yields_in_assignments = set()
 
   @property
   def gets(self) -> List[Get]:
     return self._gets
 
-  def _generate_ast_error_message(self, node, msg) -> str:
-    # This is the location info of the start of the decorated @rule.
-    filename = inspect.getsourcefile(self._func)
-    source_lines, line_number = inspect.getsourcelines(self._func)
+  def _is_get(self, node: ast.Call):
+    return isinstance(node.func, ast.Name) and node.func.id == Get.__name__
 
-    # The asttokens library is able to keep track of line numbers and column offsets for us -- the
-    # stdlib ast library only provides these relative to each parent node.
-    tokenized_rule_body = asttokens.ASTTokens(self._func_source,
-                                              tree=self._func_node,
-                                              filename=filename)
-    start_offset, _ = tokenized_rule_body.get_text_range(node)
-    line_offset, col_offset = asttokens.LineNumbers(self._func_source).offset_to_line(start_offset)
-    node_file_line = line_number + line_offset - 1
-    # asttokens also very helpfully lets us provide the exact text of the node we want to highlight
-    # in an error message.
-    node_text = tokenized_rule_body.get_text(node)
-
-    fully_indented_node_col = col_offset + self._orig_indent
-    indented_node_text = '{}{}'.format(
-      # The node text doesn't have any initial whitespace, so we have to add it back.
-      col_offset * ' ',
-      '\n'.join(
-        # We removed the indentation from the original source in order to parse it with the ast
-        # library (otherwise it raises an exception), so we add it back here.
-        '{}{}'.format(self._orig_indent * ' ', l)
-        for l in node_text.split('\n')))
-
-    return ("""In function {func_name}: {msg}
-The invalid statement was:
-{filename}:{node_line_number}:{node_col}
-{node_text}
-
-The rule defined by function `{func_name}` begins at:
-{filename}:{line_number}:{orig_indent}
-{source_lines}
-""".format(func_name=self._func.__name__, msg=msg,
-           filename=filename, line_number=line_number, orig_indent=self._orig_indent,
-           node_line_number=node_file_line,
-           node_col=fully_indented_node_col,
-           node_text=indented_node_text,
-           # Strip any leading or trailing newlines from the start of the rule body.
-           source_lines=''.join(source_lines).strip('\n')))
-
-  class YieldVisitError(Exception): pass
-
-  @staticmethod
-  def _maybe_end_of_stmt_list(attr_value: Optional[Any]) -> Optional[Any]:
-    """If `attr_value` is a non-empty iterable, return its final element."""
-    if (attr_value is not None) and isinstance(attr_value, Iterable):
-      result = list(attr_value)
-      if len(result) > 0:
-        return result[-1]
-    return None
-
-  def _stmt_is_at_end_of_parent_list(self, stmt) -> bool:
-    """Determine if `stmt` is at the end of a list of statements (i.e. can be an implicit `return`).
-
-    If there are any statements following `stmt` at the same level of nesting, this method returns
-    False, such as the following (if `stmt` is the Expr for `yield 'good'`):
-
-    if 2 + 2 == 5:
-      yield 'good'
-      a = 3
-
-    Note that this returns False even if the statement following `stmt` is a `return`.
-
-    However, if `stmt` is at the end of a list of statements, it can be made more clear that `stmt`
-    is intended to represent a `return`. Another way to view this method is as a dead code
-    elimination check, for a `stmt` which is intended to represent control flow moving out of the
-    current @rule. For example, this method would return True for both of the yield Expr statements
-    in the below snippet.
-
-    if True:
-      yield 3
-    else:
-      a = 3
-      yield a
-
-    This checking is performed by getting the parent of `stmt` with a pre-generated table passed
-    into the constructor.
-
-    See https://docs.python.org/2/library/ast.html#abstract-grammar for the grammar specification.
-    'body', 'orelse', and 'finalbody' are the only attributes on any AST nodes which can contain
-    lists of stmts.  'body' is also an attribute in the Exec statement for some reason, but as a
-    single expr, so we simply check if it is iterable in `_maybe_end_of_stmt_list()`.
-    """
-    parent_stmt = self._parents_table[stmt]
-    last_body_stmt = self._maybe_end_of_stmt_list(getattr(parent_stmt, 'body', None))
-    if stmt == last_body_stmt:
-      return True
-    last_orelse_stmt = self._maybe_end_of_stmt_list(getattr(parent_stmt, 'orelse', None))
-    if stmt == last_orelse_stmt:
-      return True
-    last_finally_stmt = self._maybe_end_of_stmt_list(getattr(parent_stmt, 'finalbody', None))
-    if stmt == last_finally_stmt:
-      return True
-    return False
-
-  def _is_get(self, node):
-    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == Get.__name__
-
-  def visit_Call(self, node) -> None:
+  def visit_Call(self, node: ast.Call) -> None:
     self.generic_visit(node)
     if self._is_get(node):
       self._gets.append(Get.extract_constraints(node))
-
-  def visit_Assign(self, node) -> None:
-    if isinstance(node.value, (ast.Yield, ast.Await)):
-      self._yields_in_assignments.add(node.value)
-    self.generic_visit(node)
-
-  def _visit_await_or_yield_compat(self, node, *, is_yield: bool) -> None:
-    self.generic_visit(node)
-    if is_yield and (node not in self._yields_in_assignments):
-      # The current yield "expr" is the child of an "Expr" "stmt".
-      expr_for_yield = self._parents_table[node]
-
-      if self._stmt_is_at_end_of_parent_list(expr_for_yield):
-        if self._is_get(node.value):
-          raise self.YieldVisitError(
-            self._generate_ast_error_message(node, dedent("""\
-            `yield Get(...)` in @rule is currently not allowed without an assignment.
-
-            Use something like the following instead:
-                x = yield Get(...)
-                yield x
-
-            See https://github.com/pantsbuild/pants/pull/8227 for progress.
-            """)))
-      else:
-        raise self.YieldVisitError(
-          self._generate_ast_error_message(node, dedent("""\
-          yield in @rule without assignment must come at the end of a series of statements.
-
-          A yield in an @rule without an assignment is equivalent to a return, and we
-          currently require that no statements follow such a yield at the same level of nesting.
-          Use `_ = yield Get(...)` if you wish to yield control to the engine and discard the
-          result.
-
-          Note that any `yield Get(...)` in an @rule without assignment is also currently not
-          supported. See https://github.com/pantsbuild/pants/pull/8227 for progress.
-          """)))
-
-  def visit_Await(self, node) -> None:
-    self._visit_await_or_yield_compat(node, is_yield=False)
-
-  def visit_Yield(self, node) -> None:
-    self._visit_await_or_yield_compat(node, is_yield=True)
 
 
 @memoized
@@ -208,7 +60,7 @@ def optionable_rule(optionable_factory):
 
 
 def _get_starting_indent(source):
-  """Remove leading indentation from `source` so ast.parse() doesn't raise an exception."""
+  """Used to remove leading indentation from `source` so ast.parse() doesn't raise an exception."""
   if source.startswith(" "):
     return sum(1 for _ in itertools.takewhile(lambda c: c in {' ', b' '}, source))
   return 0
@@ -225,7 +77,7 @@ def _make_rule(
 
   :param return_type: The return/output type for the Rule. This must be a concrete Python type.
   :param parameter_types: A sequence of types that matches the number and order of arguments to the
-                          @decorated decorated function.
+                          decorated function.
   :param cacheable: Whether the results of executing the Rule should be cached as keyed by all of
                     its inputs.
   """
@@ -271,13 +123,7 @@ def _make_rule(
       for child in ast.iter_child_nodes(parent):
         parents_table[child] = parent
 
-    rule_visitor = _RuleVisitor(
-      func=func,
-      func_node=rule_func_node,
-      func_source=source,
-      orig_indent=beginning_indent,
-      parents_table=parents_table,
-    )
+    rule_visitor = _RuleVisitor()
     rule_visitor.visit(rule_func_node)
     gets.update(
       Get.create_statically_for_rule_graph(resolve_type(p), resolve_type(s))

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -142,16 +142,17 @@ The rule defined by function `{func_name}` begins at:
       return True
     return False
 
-  def _matches_get_name(self, node):
+  def _matches_get_name(self, node: Any) -> bool:
     return isinstance(node, ast.Name) and node.id == Get.__name__
 
-  def _is_get(self, node):
+  def _is_get(self, node: Any) -> bool:
     if isinstance(node, ast.Call):
       if self._matches_get_name(node.func):
         return True
       if isinstance(node.func, ast.Subscript) and self._matches_get_name(node.func.value):
         return True
       return False
+    return False
 
   def visit_Call(self, node) -> None:
     self.generic_visit(node)

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -142,17 +142,8 @@ The rule defined by function `{func_name}` begins at:
       return True
     return False
 
-  def _matches_get_name(self, node: Any) -> bool:
-    return isinstance(node, ast.Name) and node.id == Get.__name__
-
-  def _is_get(self, node: Any) -> bool:
-    if isinstance(node, ast.Call):
-      if self._matches_get_name(node.func):
-        return True
-      if isinstance(node.func, ast.Subscript) and self._matches_get_name(node.func.value):
-        return True
-      return False
-    return False
+  def _is_get(self, node):
+    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == Get.__name__
 
   def visit_Call(self, node) -> None:
     self.generic_visit(node)

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -9,6 +9,7 @@ import sys
 import typing
 from abc import ABC, abstractmethod
 from collections import OrderedDict
+from collections.abc import Generator as BaseGenerator
 from collections.abc import Iterable
 from dataclasses import dataclass
 from textwrap import dedent
@@ -322,15 +323,52 @@ class MissingReturnTypeAnnotation(InvalidTypeAnnotation):
   """Indicates a missing return type annotation for an `@rule`."""
 
 
+class InvalidGeneratorReturnTypeAnnotation(InvalidTypeAnnotation):
+  """Indicates an incorrect Generator return type annotation for an `@rule`."""
+
+
 class MissingParameterTypeAnnotation(InvalidTypeAnnotation):
   """Indicates a missing parameter type annotation for an `@rule`."""
 
 
+def _validate_get_yield_type(yield_type: Any) -> bool:
+  if yield_type is Get:
+    return True
+  mypy_base_type = getattr(yield_type, '__origin__', None)
+  if mypy_base_type is None:
+    return False
+  if mypy_base_type is list:
+    # If the type was List[Get].
+    element_type, = yield_type.__args__
+    return _validate_get_yield_type(element_type)
+  if mypy_base_type is Union:
+    # If the type was Union[Get, List[Get]].
+    return all(_validate_get_yield_type(t) for t in yield_type.__args__)
+  return False
+
+
+def _maybe_extract_generator(*, name: str, annotation: Any) -> Optional[type]:
+  if getattr(annotation, '__origin__', None) is not BaseGenerator:
+    return None
+  yield_type, send_type, return_type = annotation.__args__
+  if isinstance(return_type, type) and _validate_get_yield_type(yield_type):
+    return return_type
+  raise InvalidGeneratorReturnTypeAnnotation(
+    f'The return type annotation for {name} was a generator, and generator return types must '
+    'specify Get, List[Get], or Union[Get, List[Get]] as the "yield type", and a `type` as the '
+    f'"return type". The annotation type was: Generator[{yield_type}, {send_type}, {return_type}].')
+
+
 def _ensure_type_annotation(
-  annotation: Any, name: str, empty_value: Any, raise_type: Type[InvalidTypeAnnotation],
+  *, annotation: Any, name: str, empty_value: Any, raise_type: Type[InvalidTypeAnnotation],
+  allow_generator: bool = False,
 ) -> type:
   if annotation == empty_value:
     raise raise_type(f'{name} is missing a type annotation.')
+  if allow_generator:
+    maybe_generator_type = _maybe_extract_generator(name=name, annotation=annotation)
+    if maybe_generator_type is not None:
+      return maybe_generator_type
   if not isinstance(annotation, type):
     raise raise_type(f'The annotation for {name} must be a type, '
                      f'got {annotation} of type {type(annotation)}.')
@@ -367,7 +405,8 @@ def rule_decorator(*args, **kwargs) -> Callable:
     annotation=signature.return_annotation,
     name=f'{func_id} return',
     empty_value=inspect.Signature.empty,
-    raise_type=MissingReturnTypeAnnotation
+    raise_type=MissingReturnTypeAnnotation,
+    allow_generator=True,
   )
   parameter_types = tuple(
     _ensure_type_annotation(

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -9,9 +9,7 @@ import sys
 import typing
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from collections.abc import Iterable
 from dataclasses import dataclass
-from textwrap import dedent
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 from twitter.common.collections import OrderedSet
@@ -250,14 +248,14 @@ def union(cls):
   Annotating a class with @union allows other classes to use a UnionRule() instance to indicate that
   they can be resolved to this base union class. This class will never be instantiated, and should
   have no members -- it is used as a tag only, and will be replaced with whatever object is passed
-  in as the subject of a `yield Get(...)`. See the following example:
+  in as the subject of a `await Get(...)`. See the following example:
 
   @union
   class UnionBase: pass
 
   @rule
   def get_some_union_type(x: X) -> B:
-    result = yield Get(ResultType, UnionBase, x.f())
+    result = await Get(ResultType, UnionBase, x.f())
     # ...
 
   If there exists a single path from (whatever type the expression `x.f()` returns) -> `ResultType`

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -9,7 +9,6 @@ import sys
 import typing
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from collections.abc import Generator as BaseGenerator
 from collections.abc import Iterable
 from dataclasses import dataclass
 from textwrap import dedent
@@ -323,52 +322,15 @@ class MissingReturnTypeAnnotation(InvalidTypeAnnotation):
   """Indicates a missing return type annotation for an `@rule`."""
 
 
-class InvalidGeneratorReturnTypeAnnotation(InvalidTypeAnnotation):
-  """Indicates an incorrect Generator return type annotation for an `@rule`."""
-
-
 class MissingParameterTypeAnnotation(InvalidTypeAnnotation):
   """Indicates a missing parameter type annotation for an `@rule`."""
 
 
-def _validate_get_yield_type(yield_type: Any) -> bool:
-  if yield_type is Get:
-    return True
-  mypy_base_type = getattr(yield_type, '__origin__', None)
-  if mypy_base_type is None:
-    return False
-  if mypy_base_type is list:
-    # If the type was List[Get].
-    element_type, = yield_type.__args__
-    return _validate_get_yield_type(element_type)
-  if mypy_base_type is Union:
-    # If the type was Union[Get, List[Get]].
-    return all(_validate_get_yield_type(t) for t in yield_type.__args__)
-  return False
-
-
-def _maybe_extract_generator(*, name: str, annotation: Any) -> Optional[type]:
-  if getattr(annotation, '__origin__', None) is not BaseGenerator:
-    return None
-  yield_type, send_type, return_type = annotation.__args__
-  if isinstance(return_type, type) and _validate_get_yield_type(yield_type):
-    return return_type
-  raise InvalidGeneratorReturnTypeAnnotation(
-    f'The return type annotation for {name} was a generator, and generator return types must '
-    'specify Get, List[Get], or Union[Get, List[Get]] as the "yield type", and a `type` as the '
-    f'"return type". The annotation type was: Generator[{yield_type}, {send_type}, {return_type}].')
-
-
 def _ensure_type_annotation(
-  *, annotation: Any, name: str, empty_value: Any, raise_type: Type[InvalidTypeAnnotation],
-  allow_generator: bool = False,
+  annotation: Any, name: str, empty_value: Any, raise_type: Type[InvalidTypeAnnotation],
 ) -> type:
   if annotation == empty_value:
     raise raise_type(f'{name} is missing a type annotation.')
-  if allow_generator:
-    maybe_generator_type = _maybe_extract_generator(name=name, annotation=annotation)
-    if maybe_generator_type is not None:
-      return maybe_generator_type
   if not isinstance(annotation, type):
     raise raise_type(f'The annotation for {name} must be a type, '
                      f'got {annotation} of type {type(annotation)}.')
@@ -406,7 +368,6 @@ def rule_decorator(*args, **kwargs) -> Callable:
     name=f'{func_id} return',
     empty_value=inspect.Signature.empty,
     raise_type=MissingReturnTypeAnnotation,
-    allow_generator=True,
   )
   parameter_types = tuple(
     _ensure_type_annotation(

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -142,8 +142,16 @@ The rule defined by function `{func_name}` begins at:
       return True
     return False
 
+  def _matches_get_name(self, node):
+    return isinstance(node, ast.Name) and node.id == Get.__name__
+
   def _is_get(self, node):
-    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == Get.__name__
+    if isinstance(node, ast.Call):
+      if self._matches_get_name(node.func):
+        return True
+      if isinstance(node.func, ast.Subscript) and self._matches_get_name(node.func.value):
+        return True
+      return False
 
   def visit_Call(self, node) -> None:
     self.generic_visit(node)

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -61,7 +61,7 @@ class Get:
           args were: Get({args!r})
 
           Get.create_statically_for_rule_graph() should be used to generate a Get() for
-          the `input_gets` field of a rule. If you are using a `yield Get(...)` in a rule
+          the `input_gets` field of a rule. If you are using a `await Get(...)` in a rule
           and a type was intended, use the 3-argument version:
           Get({product!r}, {subject_type!r}, {subject!r})
           """.format(args=args, product=product, subject_type=type(subject), subject=subject)

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -4,29 +4,26 @@
 import ast
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Any, Generator, Generic, Iterable, Optional, Tuple, Type, TypeVar, cast
+from typing import Any, Generator, Iterable, Tuple, Type, cast
 
 from pants.util.meta import frozen_after_init
 from pants.util.objects import TypeConstraint
 
 
-_Product = TypeVar("_Product")
-
-
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class Get(Generic[_Product]):
+class Get:
   """Experimental synchronous generator API.
 
   May be called equivalently as either:
-    # verbose form: Get[product](subject_declared_type, subject)
-    # shorthand form: Get[product](subject_declared_type(<constructor args for subject>))
+    # verbose form: Get(product, subject_declared_type, subject)
+    # shorthand form: Get(product, subject_declared_type(<constructor args for subject>))
   """
-  product: Type[_Product]
-  subject_declared_type: type
-  subject: Optional[Any]
+  product: Type
+  subject_declared_type: Type
+  subject: Any
 
-  def __await__(self) -> Generator[Any, Any, _Product]:
+  def __await__(self) -> Generator[Any, Any, Any]:
     """Allow a Get to be `await`ed within an `async` method, returning a strongly-typed result.
 
     The `yield`ed value `self` is interpreted by the engine within `extern_generator_send()` in
@@ -47,12 +44,7 @@ class Get(Generic[_Product]):
     https://www.python.org/dev/peps/pep-0492/#await-expression.
     """
     result = yield self
-    return cast(_Product, result)
-
-  @classmethod
-  def __class_getitem__(cls, product_type):
-    """Override the behavior of Get[T] to shuffle over the product T into the constructor args."""
-    return lambda *args: cls(product_type, *args)
+    return result
 
   def __init__(self, *args: Any) -> None:
     if len(args) not in (2, 3):
@@ -90,47 +82,30 @@ class Get(Generic[_Product]):
     :param call_node: An `ast.Call` node representing a call to `Get(..)`.
     :return: A tuple of product type id and subject type id.
     """
-    def render_args(args):
+    def render_args():
       return ', '.join(
         # Dump the Name's id to simplify output when available, falling back to the name of the
         # node's class.
         getattr(a, 'id', type(a).__name__)
-        for a in args)
+        for a in call_node.args)
 
-    # If the Get was provided with a type parameter, use that as the `product_type`.
-    func = call_node.func
-    if isinstance(func, ast.Name):
-      subscript_args = ()
-    elif isinstance(func, ast.Subscript):
-      index_expr = func.slice.value
-      if isinstance(index_expr, ast.Name):
-        subscript_args = (index_expr,)
-      else:
-        raise ValueError(f'Unrecognized type argument T for Get[T]: {ast.dump(index_expr)}')
-    else:
-      raise ValueError(
-        f'Unrecognized Get call node type: expected Get or Get[T], received {ast.dump(call_node)}')
-
-    # Shuffle over the type parameter to be the first argument, if provided.
-    combined_args = subscript_args + tuple(call_node.args)
-
-    if len(combined_args) == 2:
-      product_type, subject_constructor = combined_args
+    if len(call_node.args) == 2:
+      product_type, subject_constructor = call_node.args
       if not isinstance(product_type, ast.Name) or not isinstance(subject_constructor, ast.Call):
         raise ValueError(
-          f'Two arg form of {Get.__name__} expected (product_type, subject_type(subject)), but '
-          f'got: ({render_args(combined_args)})')
+          'Two arg form of {} expected (product_type, subject_type(subject)), but '
+                        'got: ({})'.format(Get.__name__, render_args()))
       return (product_type.id, subject_constructor.func.id)
-    elif len(combined_args) == 3:
-      product_type, subject_declared_type, _ = combined_args
+    elif len(call_node.args) == 3:
+      product_type, subject_declared_type, _ = call_node.args
       if not isinstance(product_type, ast.Name) or not isinstance(subject_declared_type, ast.Name):
         raise ValueError(
-          f'Three arg form of {Get.__name__} expected (product_type, subject_declared_type, subject), but '
-          f'got: ({render_args(combined_args)})')
+          'Three arg form of {} expected (product_type, subject_declared_type, subject), but '
+                        'got: ({})'.format(Get.__name__, render_args()))
       return (product_type.id, subject_declared_type.id)
     else:
-      raise ValueError(f'Invalid {Get.__name__}; expected either two or three args, but '
-                       f'got: ({render_args(combined_args)})')
+      raise ValueError('Invalid {}; expected either two or three args, but '
+                      'got: ({})'.format(Get.__name__, render_args()))
 
   @classmethod
   def create_statically_for_rule_graph(cls, product_type, subject_type) -> 'Get':
@@ -144,20 +119,20 @@ class Get(Generic[_Product]):
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class MultiGet(Generic[_Product]):
+class MultiGet:
   """Can be constructed with an iterable of `Get()`s and `await`ed to evaluate them in parallel."""
-  gets: Tuple[Get[_Product], ...]
+  gets: Tuple[Get, ...]
 
-  def __await__(self) -> Generator[Any, Any, Tuple[_Product, ...]]:
+  def __await__(self) -> Generator[Any, Any, Tuple[Any, ...]]:
     """Yield a tuple of Get instances with the same subject/product type pairs all at once.
 
     The `yield`ed value `self.gets` is interpreted by the engine within `extern_generator_send()` in
     `native.py`. This class will yield a tuple of Get instances, which is converted into
     `PyGeneratorResponse::GetMulti` from `externs.rs`.
 
-    The engine will fulfill these Get instances in parallel, and return a tuple of _Product
+    The engine will fulfill these Get instances in parallel, and return a tuple of T
     instances to this method, which then returns this tuple to the `@rule` which called
-    `await MultiGet(Get[_Product](...) for ... in ...)`.
+    `await MultiGet(Get(T, ...) for ... in ...)`.
     """
     result = yield self.gets
     return cast(Tuple[Any, ...], result)

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -4,24 +4,27 @@
 import ast
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Any, Generator, Iterable, Tuple, Type, cast
+from typing import Any, Generator, Generic, Iterable, Optional, Tuple, Type, TypeVar, cast
 
 from pants.util.meta import frozen_after_init
 from pants.util.objects import TypeConstraint
 
 
+_Product = TypeVar("_Product")
+
+
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class Get:
+class Get(Generic[_Product]):
   """Experimental synchronous generator API.
 
   May be called equivalently as either:
     # verbose form: Get(product, subject_declared_type, subject)
     # shorthand form: Get(product, subject_declared_type(<constructor args for subject>))
   """
-  product: Type
-  subject_declared_type: Type
-  subject: Any
+  product: Type[_Product]
+  subject_declared_type: type
+  subject: Optional[Any]
 
   def __await__(self) -> Generator[Any, Any, Any]:
     """Allow a Get to be `await`ed within an `async` method, returning a strongly-typed result.
@@ -44,7 +47,11 @@ class Get:
     https://www.python.org/dev/peps/pep-0492/#await-expression.
     """
     result = yield self
-    return result
+    return cast(_Product, result)
+
+  @classmethod
+  def __class_getitem__(cls, product_type):
+    return lambda *args: cls(product_type, *args)
 
   def __init__(self, *args: Any) -> None:
     if len(args) not in (2, 3):
@@ -82,30 +89,45 @@ class Get:
     :param call_node: An `ast.Call` node representing a call to `Get(..)`.
     :return: A tuple of product type id and subject type id.
     """
-    def render_args():
+    def render_args(args):
       return ', '.join(
         # Dump the Name's id to simplify output when available, falling back to the name of the
         # node's class.
         getattr(a, 'id', type(a).__name__)
-        for a in call_node.args)
+        for a in args)
 
-    if len(call_node.args) == 2:
-      product_type, subject_constructor = call_node.args
+    # If the Get was provided with a type parameter, use that as the `product_type`.
+    func = call_node.func
+    if isinstance(func, ast.Name):
+      subscript_args = ()
+    elif isinstance(func, ast.Subscript):
+      index_expr = func.slice.value
+      if isinstance(index_expr, ast.Name):
+        subscript_args = (index_expr,)
+      else:
+        raise ValueError(f'Unrecognized Get type index arg: {index_expr}')
+    else:
+      raise ValueError(f'Unrecognized Get call node type: {func}')
+
+    combined_args = subscript_args + tuple(call_node.args)
+
+    if len(combined_args) == 2:
+      product_type, subject_constructor = combined_args
       if not isinstance(product_type, ast.Name) or not isinstance(subject_constructor, ast.Call):
         raise ValueError(
           'Two arg form of {} expected (product_type, subject_type(subject)), but '
-                        'got: ({})'.format(Get.__name__, render_args()))
+                        'got: ({})'.format(Get.__name__, render_args(combined_args)))
       return (product_type.id, subject_constructor.func.id)
-    elif len(call_node.args) == 3:
-      product_type, subject_declared_type, _ = call_node.args
+    elif len(combined_args) == 3:
+      product_type, subject_declared_type, _ = combined_args
       if not isinstance(product_type, ast.Name) or not isinstance(subject_declared_type, ast.Name):
         raise ValueError(
           'Three arg form of {} expected (product_type, subject_declared_type, subject), but '
-                        'got: ({})'.format(Get.__name__, render_args()))
+                        'got: ({})'.format(Get.__name__, render_args(combined_args)))
       return (product_type.id, subject_declared_type.id)
     else:
       raise ValueError('Invalid {}; expected either two or three args, but '
-                      'got: ({})'.format(Get.__name__, render_args()))
+                      'got: ({})'.format(Get.__name__, render_args(combined_args)))
 
   @classmethod
   def create_statically_for_rule_graph(cls, product_type, subject_type) -> 'Get':
@@ -119,9 +141,9 @@ class Get:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class MultiGet:
+class MultiGet(Generic[_Product]):
   """Can be constructed with an iterable of `Get()`s and `await`ed to evaluate them in parallel."""
-  gets: Tuple[Get, ...]
+  gets: Tuple[Get[_Product], ...]
 
   def __await__(self) -> Generator[Any, Any, Tuple[Any, ...]]:
     """Yield a tuple of Get instances with the same subject/product type pairs all at once.

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -34,7 +34,7 @@ class MockWorkspaceGoal(Goal):
 
 @console_rule
 def workspace_console_rule(console: Console, workspace: Workspace, msg: MessageToConsoleRule) -> MockWorkspaceGoal:
-  digest = yield Get(Digest, InputFilesContent, msg.input_files_content)
+  digest = await Get(Digest, InputFilesContent, msg.input_files_content)
   output = workspace.materialize_directories((
     DirectoryToMaterialize(path=msg.tmp_dir, directory_digest=digest),
   ))

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -33,14 +33,14 @@ class MockWorkspaceGoal(Goal):
 
 
 @console_rule
-def workspace_console_rule(console: Console, workspace: Workspace, msg: MessageToConsoleRule) -> MockWorkspaceGoal:
+async def workspace_console_rule(console: Console, workspace: Workspace, msg: MessageToConsoleRule) -> MockWorkspaceGoal:
   digest = await Get(Digest, InputFilesContent, msg.input_files_content)
   output = workspace.materialize_directories((
     DirectoryToMaterialize(path=msg.tmp_dir, directory_digest=digest),
   ))
   output_path = output.dependencies[0].output_paths[0]
   console.print_stdout(str(Path(msg.tmp_dir, output_path)), end='')
-  yield MockWorkspaceGoal(exit_code=0)
+  return MockWorkspaceGoal(exit_code=0)
 
 
 class WorkspaceInConsoleRuleTest(ConsoleRuleTestBase):

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -376,12 +376,12 @@ class EngineInitializer:
       return BuildRoot.instance
 
     @rule
-    def single_build_file_address(specs: Specs) -> BuildFileAddress:
-      build_file_addresses = yield Get(BuildFileAddresses, Specs, specs)
+    async def single_build_file_address(specs: Specs) -> BuildFileAddress:
+      build_file_addresses = await Get(BuildFileAddresses, Specs, specs)
       if len(build_file_addresses.dependencies) == 0:
         raise ResolveError("No targets were matched")
       if len(build_file_addresses.dependencies) > 1:
-        potential_addresses = yield Get(BuildFileAddresses, Specs, specs)
+        potential_addresses = await Get(BuildFileAddresses, Specs, specs)
         targets = [bfa.to_address() for bfa in potential_addresses]
         output = '\n '.join(str(target) for target in targets)
 
@@ -389,7 +389,7 @@ class EngineInitializer:
           "Expected a single target, but was given multiple targets:\n"
           f"Did you mean one of:\n {output}"
         )
-      yield build_file_addresses.dependencies[0]
+      return build_file_addresses.dependencies[0]
 
     # Create a Scheduler containing graph and filesystem rules, with no installed goals. The
     # LegacyBuildGraph will explicitly request the products it needs.

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -12,10 +12,10 @@ from pants.option.scope import Scope, ScopedOptions, ScopeInfo
 from pants.util.meta import classproperty
 
 
-def _construct_optionable(optionable_factory):
+async def _construct_optionable(optionable_factory):
   scope = optionable_factory.options_scope
-  scoped_options = yield Get(ScopedOptions, Scope(str(scope)))
-  yield optionable_factory.optionable_cls(scope, scoped_options.options)
+  scoped_options = await Get(ScopedOptions, Scope(str(scope)))
+  return optionable_factory.optionable_cls(scope, scoped_options.options)
 
 
 class OptionableFactory(ABC):

--- a/src/python/pants/rules/core/cloc.py
+++ b/src/python/pants/rules/core/cloc.py
@@ -32,12 +32,12 @@ class DownloadedClocScript:
 #TODO(#7790) - We can't call this feature-complete with the v1 version of cloc
 # until we have a way to download the cloc binary without hardcoding it
 @rule
-def download_cloc_script() -> DownloadedClocScript:
+async def download_cloc_script() -> DownloadedClocScript:
   url = "https://binaries.pantsbuild.org/bin/cloc/1.80/cloc"
   sha_256 = "2b23012b1c3c53bd6b9dd43cd6aa75715eed4feb2cb6db56ac3fbbd2dffeac9d"
   digest = Digest(sha_256, 546279)
-  snapshot = yield Get(Snapshot, UrlToFetch(url, digest))
-  yield DownloadedClocScript(script_path=snapshot.files[0], digest=snapshot.directory_digest)
+  snapshot = await Get(Snapshot, UrlToFetch(url, digest))
+  return DownloadedClocScript(script_path=snapshot.files[0], digest=snapshot.directory_digest)
 
 
 class CountLinesOfCode(Goal):
@@ -54,17 +54,17 @@ class CountLinesOfCode(Goal):
 
 
 @console_rule
-def run_cloc(console: Console, options: CountLinesOfCode.Options, cloc_script: DownloadedClocScript, specs: Specs) -> CountLinesOfCode:
+async def run_cloc(console: Console, options: CountLinesOfCode.Options, cloc_script: DownloadedClocScript, specs: Specs) -> CountLinesOfCode:
   """Runs the cloc perl script in an isolated process"""
 
   transitive = options.values.transitive
   ignored = options.values.ignored
 
   if transitive:
-    targets = yield Get(TransitiveHydratedTargets, Specs, specs)
+    targets = await Get(TransitiveHydratedTargets, Specs, specs)
     all_target_adaptors = {t.adaptor for t in targets.closure}
   else:
-    targets = yield Get(HydratedTargets, Specs, specs)
+    targets = await Get(HydratedTargets, Specs, specs)
     all_target_adaptors = {t.adaptor for t in targets}
 
   digests_to_merge = []
@@ -83,11 +83,11 @@ def run_cloc(console: Console, options: CountLinesOfCode.Options, cloc_script: D
   report_filename = 'report.txt'
   ignore_filename = 'ignored.txt'
 
-  input_file_list = InputFilesContent(FilesContent((FileContent(path=input_files_filename, content=file_content),)))
-  input_file_digest = yield Get(Digest, InputFilesContent, input_file_list)
+  input_file_list = InputFilesContent(FilesContent((FileContent(path=input_files_filename, content=file_content, is_executable=False),)))
+  input_file_digest = await Get(Digest, InputFilesContent, input_file_list)
   cloc_script_digest = cloc_script.digest
   digests_to_merge.extend([cloc_script_digest, input_file_digest])
-  digest = yield Get(Digest, DirectoriesToMerge(directories=tuple(digests_to_merge)))
+  digest = await Get(Digest, DirectoriesToMerge(directories=tuple(digests_to_merge)))
 
   cmd = (
     '/usr/bin/perl',
@@ -105,8 +105,8 @@ def run_cloc(console: Console, options: CountLinesOfCode.Options, cloc_script: D
     description='cloc',
   )
 
-  exec_result = yield Get(ExecuteProcessResult, ExecuteProcessRequest, req)
-  files_content = yield Get(FilesContent, Digest, exec_result.output_directory_digest)
+  exec_result = await Get(ExecuteProcessResult, ExecuteProcessRequest, req)
+  files_content = await Get(FilesContent, Digest, exec_result.output_directory_digest)
 
   file_outputs = {fc.path: fc.content.decode() for fc in files_content.dependencies}
 
@@ -121,7 +121,7 @@ def run_cloc(console: Console, options: CountLinesOfCode.Options, cloc_script: D
     for line in ignored.splitlines():
       console.print_stdout(line)
 
-  yield CountLinesOfCode(exit_code=0)
+  return CountLinesOfCode(exit_code=0)
 
 
 def rules():

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -7,7 +7,7 @@ from pants.engine.console import Console
 from pants.engine.goal import Goal
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.rules import UnionMembership, console_rule
-from pants.engine.selectors import Get
+from pants.engine.selectors import Get, MultiGet
 from pants.rules.core.fmt import TargetWithSources
 
 
@@ -27,14 +27,14 @@ class Lint(Goal):
 
 
 @console_rule
-def lint(console: Console, targets: HydratedTargets, union_membership: UnionMembership) -> Lint:
-  results = yield [
+async def lint(console: Console, targets: HydratedTargets, union_membership: UnionMembership) -> Lint:
+  results = await MultiGet(
     Get(LintResult, TargetWithSources, target.adaptor)
     for target in targets
     # TODO: make TargetAdaptor return a 'sources' field with an empty snapshot instead of
     # raising to remove the hasattr() checks here!
     if union_membership.is_member(TargetWithSources, target.adaptor) and hasattr(target.adaptor, "sources")
-  ]
+  )
 
   exit_code = 0
   for result in results:
@@ -45,7 +45,7 @@ def lint(console: Console, targets: HydratedTargets, union_membership: UnionMemb
     if result.exit_code != 0:
       exit_code = result.exit_code
 
-  yield Lint(exit_code)
+  return Lint(exit_code)
 
 
 def rules():

--- a/src/python/pants/rules/core/list_roots.py
+++ b/src/python/pants/rules/core/list_roots.py
@@ -17,7 +17,7 @@ class Roots(LineOriented, Goal):
 
 
 @rule
-def all_roots(source_root_config: SourceRootConfig) -> AllSourceRoots:
+async def all_roots(source_root_config: SourceRootConfig) -> AllSourceRoots:
 
   source_roots = source_root_config.get_source_roots()
 
@@ -28,7 +28,7 @@ def all_roots(source_root_config: SourceRootConfig) -> AllSourceRoots:
     else:
       all_paths.add(f"**/{path}/")
 
-  snapshot = yield Get(Snapshot, PathGlobs(include=tuple(all_paths)))
+  snapshot = await Get(Snapshot, PathGlobs(include=tuple(all_paths)))
 
   all_source_roots: Set[SourceRoot] = set()
 
@@ -41,16 +41,16 @@ def all_roots(source_root_config: SourceRootConfig) -> AllSourceRoots:
     if match:
       all_source_roots.add(match)
 
-  yield AllSourceRoots(all_source_roots)
+  return AllSourceRoots(all_source_roots)
 
 
 @console_rule
-def list_roots(console: Console, options: Roots.Options, all_roots: AllSourceRoots) -> Roots:
+async def list_roots(console: Console, options: Roots.Options, all_roots: AllSourceRoots) -> Roots:
   with Roots.line_oriented(options, console) as print_stdout:
     for src_root in sorted(all_roots, key=lambda x: x.path):
       all_langs = ','.join(sorted(src_root.langs))
       print_stdout(f"{src_root.path}: {all_langs or '*'}")
-  yield Roots(exit_code=0)
+  return Roots(exit_code=0)
 
 
 def rules():

--- a/src/python/pants/rules/core/list_targets.py
+++ b/src/python/pants/rules/core/list_targets.py
@@ -29,13 +29,13 @@ class List(LineOriented, Goal):
 
 
 @console_rule
-def list_targets(console: Console, list_options: List.Options, specs: Specs) -> List:
+async def list_targets(console: Console, list_options: List.Options, specs: Specs) -> List:
   provides = list_options.values.provides
   provides_columns = list_options.values.provides_columns
   documented = list_options.values.documented
   if provides or documented:
     # To get provides clauses or documentation, we need hydrated targets.
-    collection = yield Get(HydratedTargets, Specs, specs)
+    collection = await Get(HydratedTargets, Specs, specs)
     if provides:
       extractors = dict(
           address=lambda target: target.address.spec,
@@ -65,7 +65,7 @@ def list_targets(console: Console, list_options: List.Options, specs: Specs) -> 
       print_fn = print_documented
   else:
     # Otherwise, we can use only addresses.
-    collection = yield Get(BuildFileAddresses, Specs, specs)
+    collection = await Get(BuildFileAddresses, Specs, specs)
     print_fn = lambda address: address.spec
 
   with List.line_oriented(list_options, console) as print_stdout:
@@ -77,7 +77,7 @@ def list_targets(console: Console, list_options: List.Options, specs: Specs) -> 
       if result:
         print_stdout(result)
 
-  yield List(exit_code=0)
+  return List(exit_code=0)
 
 
 def rules():

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -20,9 +20,9 @@ class Run(Goal):
 
 
 @console_rule
-def run(console: Console, workspace: Workspace, runner: InteractiveRunner, bfa: BuildFileAddress) -> Run:
+async def run(console: Console, workspace: Workspace, runner: InteractiveRunner, bfa: BuildFileAddress) -> Run:
   target = bfa.to_address()
-  binary = yield Get(CreatedBinary, Address, target)
+  binary = await Get(CreatedBinary, Address, target)
 
   with temporary_dir(cleanup=True) as tmpdir:
     dirs_to_materialize = (DirectoryToMaterialize(path=str(tmpdir), directory_digest=binary.digest),)
@@ -47,7 +47,7 @@ def run(console: Console, workspace: Workspace, runner: InteractiveRunner, bfa: 
       console.write_stderr(f"Exception when attempting to run {target} : {e}\n")
       exit_code = -1
 
-  yield Run(exit_code)
+  return Run(exit_code)
 
 
 def rules():

--- a/src/python/pants/rules/core/strip_source_root.py
+++ b/src/python/pants/rules/core/strip_source_root.py
@@ -18,7 +18,7 @@ class SourceRootStrippedSources:
 
 
 @rule
-def strip_source_root(
+async def strip_source_root(
   hydrated_target: HydratedTarget, source_root_config: SourceRootConfig
 ) -> SourceRootStrippedSources:
   """Relativize targets to their source root, e.g.
@@ -30,7 +30,7 @@ def strip_source_root(
   # TODO: make TargetAdaptor return a 'sources' field with an empty snapshot instead of raising to
   # simplify the hasattr() checks here!
   if not hasattr(target_adaptor, 'sources'):
-    yield SourceRootStrippedSources(snapshot=EMPTY_SNAPSHOT)
+    return SourceRootStrippedSources(snapshot=EMPTY_SNAPSHOT)
 
   digest = target_adaptor.sources.snapshot.directory_digest
   source_root = source_roots.find_by_path(target_adaptor.address.spec_path)
@@ -41,15 +41,15 @@ def strip_source_root(
   if target_adaptor.type_alias == Files.alias():
     source_root = None
 
-  resulting_digest = yield Get(
+  resulting_digest = await Get(
     Digest,
     DirectoryWithPrefixToStrip(
       directory_digest=digest,
       prefix=source_root.path if source_root else ""
     )
   )
-  resulting_snapshot = yield Get(Snapshot, Digest, resulting_digest)
-  yield SourceRootStrippedSources(snapshot=resulting_snapshot)
+  resulting_snapshot = await Get(Snapshot, Digest, resulting_digest)
+  return SourceRootStrippedSources(snapshot=resulting_snapshot)
 
 
 def rules():

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1071,7 +1071,7 @@ impl WrappedNode for Task {
       })
       .then(move |task_result| match task_result {
         Ok(val) => match externs::get_type_for(&val) {
-          t if t == context.core.types.generator || t == context.core.types.coroutine => {
+          t if t == context.core.types.coroutine => {
             Self::generate(context, params, entry, val)
           }
           t if t == product => ok(val),

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1071,9 +1071,7 @@ impl WrappedNode for Task {
       })
       .then(move |task_result| match task_result {
         Ok(val) => match externs::get_type_for(&val) {
-          t if t == context.core.types.coroutine => {
-            Self::generate(context, params, entry, val)
-          }
+          t if t == context.core.types.coroutine => Self::generate(context, params, entry, val),
           t if t == product => ok(val),
           _ => err(throw(&format!(
             "{:?} returned a result value that did not satisfy its constraints: {:?}",

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -25,7 +25,6 @@ pub struct Types {
   pub link: TypeId,
   pub multi_platform_process_request: TypeId,
   pub process_result: TypeId,
-  pub generator: TypeId,
   pub coroutine: TypeId,
   pub url_to_fetch: TypeId,
   pub string: TypeId,

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -8,7 +8,7 @@ from typing import List
 
 from pants.engine.rules import RootRule, rule
 from pants.engine.scheduler import ExecutionError
-from pants.engine.selectors import Get
+from pants.engine.selectors import Get, MultiGet
 from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
 from pants.testutil.engine.util import assert_equal_with_printing, remove_locations_from_traceback
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
@@ -48,7 +48,7 @@ class Fib:
 async def fib(n: int) -> Fib:
   if n < 2:
     return Fib(n)
-  x, y = await Get(Fib, int(n-2)), Get(Fib, int(n-1))
+  x, y = tuple(await MultiGet([Get(Fib, int(n-2)), Get(Fib, int(n-1))]))
   return Fib(x.val + y.val)
 
 

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -45,11 +45,11 @@ class Fib:
 
 
 @rule(name="fib")
-def fib(n: int) -> Fib:
+async def fib(n: int) -> Fib:
   if n < 2:
-    yield Fib(n)
-  x, y = yield Get(Fib, int(n-2)), Get(Fib, int(n-1))
-  yield Fib(x.val + y.val)
+    return Fib(n)
+  x, y = await Get(Fib, int(n-2)), Get(Fib, int(n-1))
+  return Fib(x.val + y.val)
 
 
 @dataclass(frozen=True)
@@ -64,7 +64,7 @@ class MyFloat:
 
 @rule
 def upcast(n: MyInt) -> MyFloat:
-  yield MyFloat(float(n.val))
+  return MyFloat(float(n.val))
 
 
 class EngineTest(unittest.TestCase, SchedulerTestBase):

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -77,16 +77,16 @@ class CatExecutionRequest:
 
 
 @rule
-def cat_files_process_result_concatted(cat_exe_req: CatExecutionRequest) -> Concatted:
+async def cat_files_process_result_concatted(cat_exe_req: CatExecutionRequest) -> Concatted:
   cat_bin = cat_exe_req.shell_cat
-  cat_files_snapshot = yield Get(Snapshot, PathGlobs, cat_exe_req.path_globs)
+  cat_files_snapshot = await Get(Snapshot, PathGlobs, cat_exe_req.path_globs)
   process_request = ExecuteProcessRequest(
     argv=cat_bin.argv_from_snapshot(cat_files_snapshot),
     input_files=cat_files_snapshot.directory_digest,
     description='cat some files',
   )
-  cat_process_result = yield Get(ExecuteProcessResult, ExecuteProcessRequest, process_request)
-  yield Concatted(cat_process_result.stdout.decode())
+  cat_process_result = await Get(ExecuteProcessResult, ExecuteProcessRequest, process_request)
+  return Concatted(cat_process_result.stdout.decode())
 
 
 def create_cat_stdout_rules():
@@ -115,16 +115,16 @@ class JavacVersionOutput:
 
 
 @rule
-def get_javac_version_output(javac_version_command: JavacVersionExecutionRequest) -> JavacVersionOutput:
+async def get_javac_version_output(javac_version_command: JavacVersionExecutionRequest) -> JavacVersionOutput:
   javac_version_proc_req = ExecuteProcessRequest(
     argv=javac_version_command.gen_argv(),
     description=javac_version_command.description,
     input_files=EMPTY_DIRECTORY_DIGEST,
   )
-  javac_version_proc_result = yield Get(
+  javac_version_proc_result = await Get(
     ExecuteProcessResult, ExecuteProcessRequest, javac_version_proc_req)
 
-  yield JavacVersionOutput(javac_version_proc_result.stderr.decode())
+  return JavacVersionOutput(javac_version_proc_result.stderr.decode())
 
 
 @dataclass(frozen=True)
@@ -167,12 +167,12 @@ class JavacCompileResult:
 # This rule/test should be deleted when we have more real java rules (or anything else which serves
 # as a suitable rule-writing example).
 @rule
-def javac_compile_process_result(javac_compile_req: JavacCompileRequest) -> JavacCompileResult:
+async def javac_compile_process_result(javac_compile_req: JavacCompileRequest) -> JavacCompileResult:
   java_files = javac_compile_req.javac_sources.java_files
   for java_file in java_files:
     if not java_file.endswith(".java"):
       raise ValueError(f"Can only compile .java files but got {java_file}")
-  sources_snapshot = yield Get(Snapshot, PathGlobs, PathGlobs(java_files, ()))
+  sources_snapshot = await Get(Snapshot, PathGlobs, PathGlobs(java_files, ()))
   output_dirs = tuple({os.path.dirname(java_file) for java_file in java_files})
   process_request = ExecuteProcessRequest(
     argv=javac_compile_req.argv_from_source_snapshot(sources_snapshot),
@@ -180,9 +180,9 @@ def javac_compile_process_result(javac_compile_req: JavacCompileRequest) -> Java
     output_directories=output_dirs,
     description='javac compilation'
   )
-  javac_proc_result = yield Get(ExecuteProcessResult, ExecuteProcessRequest, process_request)
+  javac_proc_result = await Get(ExecuteProcessResult, ExecuteProcessRequest, process_request)
 
-  yield JavacCompileResult(
+  return JavacCompileResult(
     javac_proc_result.stdout.decode(),
     javac_proc_result.stderr.decode(),
     javac_proc_result.output_directory_digest,

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -22,7 +22,7 @@ from pants.engine.mapper import (
 from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct, SymbolTable
 from pants.engine.rules import rule
-from pants.engine.selectors import Get
+from pants.engine.selectors import Get, MultiGet
 from pants.engine.struct import Struct
 from pants.testutil.engine.util import TARGET_TABLE, Target
 from pants.util.dirutil import safe_open
@@ -136,9 +136,9 @@ HydratedStructs = Collection[HydratedStruct]
 
 
 @rule
-def unhydrated_structs(build_file_addresses: BuildFileAddresses) -> HydratedStructs:
-  tacs = yield [Get(HydratedStruct, Address, a) for a in build_file_addresses.addresses]
-  yield HydratedStructs(tacs)
+async def unhydrated_structs(build_file_addresses: BuildFileAddresses) -> HydratedStructs:
+  tacs = await MultiGet(Get(HydratedStruct, Address, a) for a in build_file_addresses.addresses)
+  return HydratedStructs(tacs)
 
 
 class AddressMapperTest(unittest.TestCase, SchedulerTestBase):

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -80,7 +80,7 @@ class Example(Goal):
 async def a_console_rule_generator(console: Console) -> Example:
   a = await Get(A, str('a str!'))
   console.print_stdout(str(a))
-  return await Example(exit_code=0)
+  return Example(exit_code=0)
 
 
 class RuleTest(unittest.TestCase):

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -57,9 +57,9 @@ class D:
 
 
 @rule
-def transitive_coroutine_rule(c: C) -> D:
-  b = yield Get(B, C, c)
-  yield D(b)
+async def transitive_coroutine_rule(c: C) -> D:
+  b = await Get(B, C, c)
+  return D(b)
 
 
 @union
@@ -104,9 +104,9 @@ def select_union_b(union_b: UnionB) -> A:
 
 # TODO: add GetMulti testing for unions!
 @rule
-def a_union_test(union_wrapper: UnionWrapper) -> A:
-  union_a = yield Get(A, UnionBase, union_wrapper.inner)
-  yield union_a
+async def a_union_test(union_wrapper: UnionWrapper) -> A:
+  union_a = await Get(A, UnionBase, union_wrapper.inner)
+  return union_a
 
 
 class UnionX:
@@ -114,15 +114,15 @@ class UnionX:
 
 
 @rule
-def error_msg_test_rule(union_wrapper: UnionWrapper) -> UnionX:
-  union_x = yield Get(UnionX, UnionWithNonMemberErrorMsg, union_wrapper.inner)
-  yield union_x
+async def error_msg_test_rule(union_wrapper: UnionWrapper) -> UnionX:
+  union_x = await Get(UnionX, UnionWithNonMemberErrorMsg, union_wrapper.inner)
+  return union_x
 
 
 class TypeCheckFailWrapper:
   """
   This object wraps another object which will be used to demonstrate a type check failure when the
-  engine processes a `yield Get(...)` statement.
+  engine processes an `await Get(...)` statement.
   """
 
   def __init__(self, inner):
@@ -130,19 +130,19 @@ class TypeCheckFailWrapper:
 
 
 @rule
-def a_typecheck_fail_test(wrapper: TypeCheckFailWrapper) -> A:
-  # This `yield` would use the `nested_raise` rule, but it won't get to the point of raising since
+async def a_typecheck_fail_test(wrapper: TypeCheckFailWrapper) -> A:
+  # This `await` would use the `nested_raise` rule, but it won't get to the point of raising since
   # the type check will fail at the Get.
-  _ = yield Get(A, B, wrapper.inner) # noqa: F841
-  yield A()
+  _ = await Get(A, B, wrapper.inner) # noqa: F841
+  return A()
 
 
 @rule
-def c_unhashable(_: TypeCheckFailWrapper) -> C:
-  # This `yield` would use the `nested_raise` rule, but it won't get to the point of raising since
+async def c_unhashable(_: TypeCheckFailWrapper) -> C:
+  # This `await` would use the `nested_raise` rule, but it won't get to the point of raising since
   # the hashability check will fail.
-  _ = yield Get(A, B, list()) # noqa: F841
-  yield C()
+  _ = await Get(A, B, list()) # noqa: F841
+  return C()
 
 
 @dataclass(frozen=True)
@@ -151,11 +151,11 @@ class CollectionType:
 
 
 @rule
-def c_unhashable_dataclass(_: CollectionType) -> C:
+async def c_unhashable_dataclass(_: CollectionType) -> C:
   # This `yield` would use the `nested_raise` rule, but it won't get to the point of raising since
   # the hashability check will fail.
-  _ = yield Get(A, B, list()) # noqa: F841
-  yield C()
+  _ = await Get(A, B, list()) # noqa: F841
+  return C()
 
 
 @contextmanager

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -152,7 +152,7 @@ class CollectionType:
 
 @rule
 async def c_unhashable_dataclass(_: CollectionType) -> C:
-  # This `yield` would use the `nested_raise` rule, but it won't get to the point of raising since
+  # This `await` would use the `nested_raise` rule, but it won't get to the point of raising since
   # the hashability check will fail.
   _ = await Get(A, B, list()) # noqa: F841
   return C()

--- a/tests/python/pants_test/engine/test_selectors.py
+++ b/tests/python/pants_test/engine/test_selectors.py
@@ -35,7 +35,7 @@ The two-argument form of Get does not accept a type as its second argument.
 args were: Get(({a!r}, {b!r}))
 
 Get.create_statically_for_rule_graph() should be used to generate a Get() for
-the `input_gets` field of a rule. If you are using a `yield Get(...)` in a rule
+the `input_gets` field of a rule. If you are using a `await Get(...)` in a rule
 and a type was intended, use the 3-argument version:
 Get({a!r}, {t!r}, {b!r})
 """.format(a=AClass, t=type(BClass), b=BClass), str(cm.exception))

--- a/tests/python/pants_test/init/test_extension_loader.py
+++ b/tests/python/pants_test/init/test_extension_loader.py
@@ -102,7 +102,7 @@ class WrapperType:
 
 @rule
 def example_rule(root_type: RootType) -> WrapperType:
-  yield WrapperType(root_type.value)
+  return WrapperType(root_type.value)
 
 
 class PluginProduct:
@@ -111,7 +111,7 @@ class PluginProduct:
 
 @rule
 def example_plugin_rule(root_type: RootType) -> PluginProduct:
-  yield PluginProduct()
+  return PluginProduct()
 
 
 class LoaderTest(unittest.TestCase):


### PR DESCRIPTION
### Problem

We believe the new `async`/`await` syntax for coroutine `@rule`s is superior to `yield`ing generators, in part because it allows mypy to successfully be run on files defining `@rule`s.

### Solution

- Convert `yield`ing `@rule`s into `async` methods, and use `await Get(...)` and `await MultiGet(...)` instead of `yield Get(...)` and `yield [Get(...) ...]`.
- Remove the `asttokens` 3rdparty library and a *ridiculous* amount of code in `rules.py`!!!