### PR TITLE
[bootstrap] Permit using compilers other than gcc

### DIFF
--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -3,6 +3,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd -P)
+CC=${CC:-gcc}
 
 # shellcheck source=build-support/common.sh
 source "${REPO_ROOT}/build-support/common.sh"
@@ -39,10 +40,10 @@ function create_venv() {
   "${REPO_ROOT}/build-support/virtualenv" "$(venv_dir)"
 }
 
-function ensure_gcc() {
-  if ! GCC_VERSION="$(gcc -v 2>&1)"; then
+function ensure_c_compiler() {
+  if ! CC_VERSION="$(${CC} -v 2>&1)"; then
     die "$(cat << MESSAGE
-ERROR: unable to execute 'gcc'. Please verify that your compiler is installed, in your
+ERROR: unable to execute '${CC}'. Please verify that your compiler is installed, in your
        \$PATH and functional.
 
 Hint: on Mac OS X, you may need to accept the XCode EULA: 'sudo xcodebuild -license accept'.
@@ -51,7 +52,7 @@ MESSAGE
   fi
   # Prevent bootstrapping failure due to unrecognized flag:
   # https://github.com/pantsbuild/pants/issues/78
-  if [[ "$GCC_VERSION" == *503.0.38* ]]; then
+  if [[ "$CC_VERSION" == *503.0.38* ]]; then
     # Required for clang version 503.0.38
     export ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future
   fi
@@ -80,7 +81,7 @@ function activate_pants_venv() {
     activate_venv || die "Failed to activate venv."
 
     # Needed for compilation of native python distributions.
-    ensure_gcc
+    ensure_c_compiler
 
     for req in "${REQUIREMENTS[@]}"; do
       pip install ${pip_extra} -r "${req}" || \


### PR DESCRIPTION
Problem

Many (most?) modern systems lack gcc and instead use other compilers.

Solution

Permit setting CC to use a different C compile

Result

bootstrap continues past python installation on more systems