### PR TITLE
Deprecate not setting `--python-setup-interpreter-constraints` in preparation for default changing to Python 3.6+

### DIFF
--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/examples/BUILD
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/examples/BUILD
@@ -4,7 +4,7 @@
 python_requirement_library(
   name = 'pycountry',
   requirements = [
-    python_requirement('pycountry==18.5.20'),
+    python_requirement('pycountry==19.8.18'),
   ],
 )
 

--- a/contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python/test_python_awslambda_integration.py
+++ b/contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python/test_python_awslambda_integration.py
@@ -34,7 +34,12 @@ class PythonAWSLambdaIntegrationTest(PantsRunIntegrationTest):
       # is distinct from the pex's entry point - a handler must be a function with two arguments,
       # whereas the pex entry point is a module).
       awslambda = os.path.join(distdir, 'hello-lambda.pex')
-      output = subprocess.check_output(env={'PEX_INTERPRETER': '1'}, args=[
-        '{} -c "from lambdex_handler import handler; handler(None, None)"'.format(awslambda)
-      ], shell=True)
-      self.assertEquals(b'Hello from the United States!', output.strip())
+      result = subprocess.run(
+        f'{awslambda} -c "from lambdex_handler import handler; handler(None, None)"',
+        shell=True,
+        env={'PEX_INTERPRETER': '1', 'PATH': os.environ["PATH"]},
+        stdout=subprocess.PIPE,
+        encoding="utf-8",
+        check=True,
+      )
+      self.assertEquals('Hello from the United States!', result.stdout.strip())

--- a/pants.ini
+++ b/pants.ini
@@ -390,7 +390,6 @@ verify_commit: False
 
 
 [python-setup]
-interpreter_constraints: ["CPython>=3.6,<4"]
 interpreter_cache_dir: %(pants_bootstrapdir)s/python_cache/interpreters
 resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
 

--- a/pants.ini
+++ b/pants.ini
@@ -390,6 +390,7 @@ verify_commit: False
 
 
 [python-setup]
+interpreter_constraints: ["CPython>=3.6,<4"]
 interpreter_cache_dir: %(pants_bootstrapdir)s/python_cache/interpreters
 resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
 

--- a/src/python/pants/backend/python/subsystems/BUILD
+++ b/src/python/pants/backend/python/subsystems/BUILD
@@ -10,6 +10,7 @@ python_library(
     'src/python/pants/backend/native/targets',
     'src/python/pants/backend/python/targets',
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
     'src/python/pants/option',

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -23,7 +23,7 @@ class PythonSetup(Subsystem):
   def register_options(cls, register):
     super().register_options(register)
     register('--interpreter-constraints', advanced=True, fingerprint=True, type=list,
-             default=['CPython>=2.7,<3', 'CPython>=3.6,<4'],
+             default=['CPython>=3.6,<4'],
              metavar='<requirement>',
              help="Constrain the selected Python interpreter.  Specify with requirement syntax, "
                   "e.g. 'CPython>=2.7,<3' (A CPython interpreter with version >=2.7 AND version <3)"

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -7,6 +7,7 @@ import subprocess
 
 from pex.variables import Variables
 
+from pants.base.deprecated import deprecated_conditional
 from pants.option.custom_types import UnsetBool
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
@@ -23,7 +24,7 @@ class PythonSetup(Subsystem):
   def register_options(cls, register):
     super().register_options(register)
     register('--interpreter-constraints', advanced=True, fingerprint=True, type=list,
-             default=['CPython>=3.6,<4'],
+             default=['CPython>=2.7,<3', 'CPython>=3.6,<4'],
              metavar='<requirement>',
              help="Constrain the selected Python interpreter.  Specify with requirement syntax, "
                   "e.g. 'CPython>=2.7,<3' (A CPython interpreter with version >=2.7 AND version <3)"
@@ -65,6 +66,20 @@ class PythonSetup(Subsystem):
 
   @property
   def interpreter_constraints(self):
+    deprecated_conditional(
+      lambda: self.get_options().is_default("interpreter_constraints"),
+      removal_version="1.25.0.dev2",
+      entity_description="Pants defaulting to Python 2.7+ for --python-setup-interpreter-constraints",
+      hint_message="Pants will soon default to using Python 3.6+ for Python commands like "
+                   "`./pants test` and `./pants repl`, whereas now it defaults to Python 2.7 or "
+                   "Python 3.6+. In preparation for this change, you should explicitly mark what "
+                   "Python version(s) your project uses in your `pants.ini` under the section "
+                   "`python-setup`.\n\nFor example, if you need to still support Python 2, set "
+                   "`interpreter_constraints` to `['CPython>=2.7,<3', 'CPython>=3.6<4']`. "
+                   "Otherwise, set the value to something like `['CPython>=3.6<4']`. See "
+                   "https://www.pantsbuild.org/python_readme.html#configure-the-python-version "
+                   "for more information on setting interpreter constraints."
+    )
     return tuple(self.get_options().interpreter_constraints)
 
   @memoized_property

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -455,7 +455,7 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
     deprecated_conditional(
       lambda: self.get_options().is_default("fast"),
       removal_version="1.25.0.dev2",
-      entity_description="using the default value for --no-fast/--fast",
+      entity_description="Pants defaulting to `--fast` for tests",
       hint_message="Please explicitly set the flag `--fast`. The default will change from `--fast` "
                    "to `--no-fast` in 1.25.0.dev2, and the option will be removed in 1.27.0.dev2. "
                    "We recommend setting the option to `--no-fast` for better isolation of tests "
@@ -464,7 +464,7 @@ class PartitionedTestRunnerTaskMixin(TestRunnerTaskMixin, Task):
     deprecated_conditional(
       lambda: self.get_options().is_default("chroot"),
       removal_version="1.25.0.dev2",
-      entity_description="using the default value for --no-chroot/--chroot",
+      entity_description="Pants defaulting to `--no-chroot` for tests",
       hint_message="Please explicitly set the flag `--chroot`. The default will change from "
                    "`--no-chroot` to `--chroot` in 1.25.0.dev2, and the option will likely be "
                    "removed in 1.29.0.dev2. We recommend setting the option to `--chroot` for "

--- a/tests/python/pants_test/backend/python/tasks/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_repl.py
@@ -132,8 +132,8 @@ class PythonReplTest(PythonTaskTestBase):
 
   def test_requirement(self):
     self.do_test_repl(code=['import six',
-                            'print("python 2?:{}".format(six.PY2))'],
-                      expected=['python 2?:True'],
+                            'print("python 3?:{}".format(six.PY3))'],
+                      expected=['python 3?:True'],
                       targets=[self.six])
 
   def test_mixed_python(self):
@@ -142,10 +142,10 @@ class PythonReplTest(PythonTaskTestBase):
                             'from lib.lib import go',
                             'print("teapot response code is: {}".format(requests.codes.teapot))',
                             'go()',
-                            'print("python 2?:{}".format(six.PY2))'],
+                            'print("python 3?:{}".format(six.PY3))'],
                       expected=['teapot response code is: 418',
                                 'gogogo!',
-                                'python 2?:True'],
+                                'python 3?:True'],
                       targets=[self.requests, self.binary])
 
   def test_disallowed_mix(self):

--- a/tests/python/pants_test/backend/python/tasks/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_repl.py
@@ -132,8 +132,8 @@ class PythonReplTest(PythonTaskTestBase):
 
   def test_requirement(self):
     self.do_test_repl(code=['import six',
-                            'print("python 3?:{}".format(six.PY3))'],
-                      expected=['python 3?:True'],
+                            'six._print("Hello there")'],
+                      expected=['Hello there'],
                       targets=[self.six])
 
   def test_mixed_python(self):
@@ -142,10 +142,10 @@ class PythonReplTest(PythonTaskTestBase):
                             'from lib.lib import go',
                             'print("teapot response code is: {}".format(requests.codes.teapot))',
                             'go()',
-                            'print("python 3?:{}".format(six.PY3))'],
+                            'six._print("Hello there")'],
                       expected=['teapot response code is: 418',
                                 'gogogo!',
-                                'python 3?:True'],
+                                'Hello there'],
                       targets=[self.requests, self.binary])
 
   def test_disallowed_mix(self):


### PR DESCRIPTION
### Problem
If a user has Python 2 discoverable through `--python-setup-interpreter-search-paths`—and unless the user explicitly sets `--python-setup-interpreter-constraints`—Pants will use Python 2 for all subprocesses like Pytest.

[Python 2.7 loses official support](https://www.python.org/doc/sunset-python-2/) in only 40 days. We should default to Python 3 and allow users to opt into Python 2 if they are still migrating.

However, our deprecation policy means that we should not make this very breaking change overnight.

### Solution
Deprecate not explicitly setting `--python-setup-interpreter-constraints` so that we can safely make the change in 1.25.0.dev2.

Also, fix some tests so that they become agnostic to what interpreter constraints we use.


### Result
Users with the default settings will get this warning:

> [pyprep]
14:20:08 00:02     [interpreter]21:20:08 [WARN] /Users/eric/DocsLocal/code/projects/pants/src/python/pants/backend/python/subsystems/python_setup.py:139: DeprecationWarning: DEPRECATED: Pants defaulting to Python 2.7+ will be removed in version 1.25.0.dev2.
  Pants will soon default to using Python 3.6+ for Python commands like `./pants test` and `./pants repl`, whereas now it defaults to Python 2.7 or Python 3.6+. In preparation for this change, you should explicitly mark what Python version(s) your project uses in your `pants.ini` under the section `python-setup`.
>
> For example, if you need to still support Python 2, set `interpreter_constraints` to `['CPython>=2.7,<3', 'CPython>=3.6<4']`. Otherwise, set the value to something like `['CPython>=3.6<4']`. See https://www.pantsbuild.org/python_readme.html#configure-the-python-version for more information on setting interpreter constraints.