### PR TITLE
Add `--fmt-v2-transitive` and `--lint-v2-transitive` options

### DIFF
--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 
 from pants.cache.cache_setup import CacheSetup
+from pants.option.option_value_container import OptionValueContainer
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
@@ -67,7 +68,7 @@ class Goal(metaclass=ABCMeta):
 
       @classmethod
       def register_options(cls, register):
-        super(_Options, cls).register_options(register)
+        super().register_options(register)
         # Delegate to the outer class.
         outer_cls.register_options(register)
 
@@ -92,9 +93,9 @@ class Goal(metaclass=ABCMeta):
 
       options_scope_category = ScopeInfo.GOAL
 
-      def __init__(self, scope, scoped_options):
+      def __init__(self, scope: str, scoped_options: OptionValueContainer) -> None:
         # NB: This constructor is shaped to meet the contract of `Optionable(Factory).signature`.
-        super(_Options, self).__init__()
+        super().__init__()
         self._scope = scope
         self._scoped_options = scoped_options
 

--- a/src/python/pants/rules/core/BUILD
+++ b/src/python/pants/rules/core/BUILD
@@ -21,6 +21,11 @@ python_tests(
   name = "tests",
   dependencies = [
     ':core',
+    'src/python/pants/engine:fs',
+    'src/python/pants/engine:rules',
+    'src/python/pants/engine/legacy:graph',
+    'src/python/pants/engine/legacy:structs',
+    'src/python/pants/option',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil:console_rule_test_base',
     'src/python/pants/testutil/engine:util',

--- a/src/python/pants/rules/core/fmt_test.py
+++ b/src/python/pants/rules/core/fmt_test.py
@@ -1,0 +1,73 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import List
+
+from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, FilesContent
+from pants.engine.legacy.graph import HydratedTarget, TransitiveHydratedTargets
+from pants.engine.legacy.structs import PythonTargetAdaptor
+from pants.engine.rules import UnionMembership
+from pants.option.option_value_container import OptionValueContainer, RankedValue
+from pants.rules.core.fmt import Fmt, FmtResult, TargetWithSources, fmt
+from pants.testutil.engine.util import MockConsole, MockGet, run_rule
+
+
+def test_transitive_option() -> None:
+  dependency = HydratedTarget(
+    address="src/dep",
+    adaptor=PythonTargetAdaptor(sources=(), name="dep"),
+    dependencies=()
+  )
+  root = HydratedTarget(
+    address="src/root",
+    adaptor=PythonTargetAdaptor(sources=(), name="root"),
+    dependencies=(dependency,)
+  )
+  targets = TransitiveHydratedTargets(closure=(dependency, root), roots=(root,))
+
+  def assert_targets_formatted(
+    *, transitive: bool, expected_targets: List[HydratedTarget]
+  ) -> None:
+    console = MockConsole(use_colors=False)
+
+    # TODO: make it more ergonomic in tests to set an @console_rules's Options when using
+    #  engine.util.run_rule().
+    options = OptionValueContainer()
+    options.transitive = RankedValue(RankedValue.HARDCODED, transitive)
+
+    run_rule(
+      fmt,
+      rule_args=[
+        console,
+        Fmt.Options(
+          scope=Fmt.name,
+          scoped_options=options,
+        ),
+        targets,
+        UnionMembership(union_rules={TargetWithSources: [PythonTargetAdaptor]})
+      ],
+      mock_gets=[
+        MockGet(
+          product_type=FmtResult,
+          subject_type=PythonTargetAdaptor,
+          mock=lambda target: FmtResult(
+            digest=EMPTY_DIRECTORY_DIGEST,
+            stdout=f"The target `{target.name}` is so pretty now 🔥",
+            stderr=""
+          ),
+        ),
+        MockGet(
+          product_type=FilesContent,
+          subject_type=Digest,
+          mock=lambda _: FilesContent([])
+        ),
+      ],
+    )
+    for target in expected_targets:
+      assert (
+        f"The target `{target.adaptor.name}` is so pretty now 🔥" in
+        console.stdout.getvalue().splitlines()
+      )
+
+  assert_targets_formatted(transitive=True, expected_targets=[dependency, root])
+  assert_targets_formatted(transitive=False, expected_targets=[root])

--- a/src/python/pants/rules/core/lint_test.py
+++ b/src/python/pants/rules/core/lint_test.py
@@ -1,0 +1,67 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import List
+
+from pants.engine.legacy.graph import HydratedTarget, TransitiveHydratedTargets
+from pants.engine.legacy.structs import PythonTargetAdaptor
+from pants.engine.rules import UnionMembership
+from pants.option.option_value_container import OptionValueContainer, RankedValue
+from pants.rules.core.lint import Lint, LintResult, TargetWithSources, lint
+from pants.testutil.engine.util import MockConsole, MockGet, run_rule
+
+
+def test_transitive_option() -> None:
+  dependency = HydratedTarget(
+    address="src/dep",
+    adaptor=PythonTargetAdaptor(sources=(), name="dep"),
+    dependencies=()
+  )
+  root = HydratedTarget(
+    address="src/root",
+    adaptor=PythonTargetAdaptor(sources=(), name="root"),
+    dependencies=(dependency,)
+  )
+  targets = TransitiveHydratedTargets(closure=(dependency, root), roots=(root,))
+
+  def assert_targets_linted(
+    *, transitive: bool, expected_targets: List[HydratedTarget]
+  ) -> None:
+    console = MockConsole(use_colors=False)
+
+    # TODO: make it more ergonomic in tests to set an @console_rules's Options when using
+    #  engine.util.run_rule().
+    options = OptionValueContainer()
+    options.transitive = RankedValue(RankedValue.HARDCODED, transitive)
+
+    run_rule(
+      lint,
+      rule_args=[
+        console,
+        Lint.Options(
+          scope=Lint.name,
+          scoped_options=options,
+        ),
+        targets,
+        UnionMembership(union_rules={TargetWithSources: [PythonTargetAdaptor]})
+      ],
+      mock_gets=[
+        MockGet(
+          product_type=LintResult,
+          subject_type=PythonTargetAdaptor,
+          mock=lambda target: LintResult(
+            exit_code=0,
+            stdout=f"The target `{target.name}` looks good!",
+            stderr="",
+          ),
+        ),
+      ],
+    )
+    for target in expected_targets:
+      assert (
+        f"The target `{target.adaptor.name}` looks good!" in
+        console.stdout.getvalue().splitlines()
+      )
+
+  assert_targets_linted(transitive=False, expected_targets=[root])
+  assert_targets_linted(transitive=True, expected_targets=[dependency, root])


### PR DESCRIPTION
### Problem
We currently provide the options `--{fmt,lint}-transitive` to control whether the goals operate on the entire transitive closure or solely the specified targets. The V2 rules need to implement this as well.

### Solution
Add logic to implement this for both union rules, particularly by changing the rules' to request `TransitiveHydratedTargets` instead of `HydratedTargets`.

Also, write new unit tests for both files. This is the first time we've written a `run_rule()` based test for a rule that has `Goal.Options`, so this will hopefully make it easier for other rules to have similar tests.

### Result
In a followup, we will deprecate using `--fmt-transitive` recursively, e.g. `--fmt-isort-transitive`. 

This gets us one step closer to being able to rename `fmt-v2` to `fmt` and `lint-v2` to `lint`.