### PR TITLE
Add `testutil.engine.util.mock_goal_options()` to simplify testing console rules

### DIFF
--- a/src/python/pants/testutil/engine/BUILD
+++ b/src/python/pants/testutil/engine/BUILD
@@ -21,11 +21,13 @@ python_library(
     'src/python/pants/base:project_tree',
     'src/python/pants/binaries',
     'src/python/pants/engine:addressable',
+    'src/python/pants/engine:goal',
     'src/python/pants/engine:native',
     'src/python/pants/engine:parser',
     'src/python/pants/engine:rules',
     'src/python/pants/engine:scheduler',
     'src/python/pants/engine:struct',
+    'src/python/pants/option',
     'src/python/pants/util:objects',
   ],
 )

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -6,18 +6,20 @@ import re
 from dataclasses import dataclass
 from io import StringIO
 from types import GeneratorType
-from typing import Any, Callable, Optional, Sequence, Type
+from typing import Any, Callable, Dict, Optional, Sequence, Type
 
 from colors import blue, green, red
 
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.engine.addressable import addressable_list
+from pants.engine.goal import Goal
 from pants.engine.native import Native
 from pants.engine.parser import SymbolTable
 from pants.engine.scheduler import Scheduler
 from pants.engine.selectors import Get
 from pants.engine.struct import Struct
 from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS
+from pants.option.option_value_container import OptionValueContainer, RankedValue
 from pants.util.objects import SubclassesOf
 
 
@@ -197,3 +199,10 @@ class MockConsole:
 
   def red(self, text):
     return self._safe_color(text, red)
+
+
+def mock_goal_options(goal: Type[Goal], scoped_options: Dict[str, Any]) -> Goal.Options:
+  options_container = OptionValueContainer()
+  for option, val in scoped_options.items():
+    setattr(options_container, option, RankedValue(RankedValue.HARDCODED, val))
+  return goal.Options(scope=goal.name, scoped_options=options_container)


### PR DESCRIPTION
### Problem
We currently do test via `run_rule()` any console rules that depend on `Goals.Options`. https://github.com/pantsbuild/pants/pull/8660 shows how we could do this. As shown in the PR, mocking a `Goal.Options` like `Fmt.Options` is awkward.

We want it to be ergonomic and enjoyable to write test rules via `run_rule()`, as this is roughly the way to unit test a rule (whereas `ConsoleRuleTestBase.execute_rule()` is closer to an IT). 

### Result
Instead of this old idiom:

```python
from pants.option.option_value_container import OptionValueContainer, RankedValue

options = OptionValueContainer()
options.transitive = RankedValue(RankedValue.HARDCODED, True)

run_rule(lint, rule_args=[Lint.Options(scope=Lint.name, scoped_options=options)])
```

Now, we can write:

```python
from pants.testutil.engine.util import mock_goal_options

run_rule(lint, rule_args=[mock_goal_options(Lint, {"transitive": True})])
```