### PR TITLE
[bootstrap] permit compiling on non-linux *nix

### DIFF
--- a/build-support/bin/native/bootstrap_code.sh
+++ b/build-support/bin/native/bootstrap_code.sh
@@ -10,17 +10,11 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd -P)"
 source "${REPO_ROOT}/build-support/common.sh"
 
 KERNEL=$(uname -s | tr '[:upper:]' '[:lower:]')
-case "${KERNEL}" in
-  linux)
-    readonly LIB_EXTENSION=so
-    ;;
-  darwin)
-    readonly LIB_EXTENSION=dylib
-    ;;
-  *)
-    die "Unknown kernel ${KERNEL}, cannot bootstrap pants native code!"
-    ;;
-esac
+LIB_EXTENSION="so"
+if [ "${KERNEL}" = "darwin" ]
+then
+  LIB_EXTENSION="dylib"
+fi
 
 readonly NATIVE_ROOT="${REPO_ROOT}/src/rust/engine"
 readonly NATIVE_ENGINE_BINARY="native_engine.so"


### PR DESCRIPTION
Problem

Pants ought to be able to bootstrap on non-linux *nix but can't due
to a system check instead of a feature check.

Solution

Remove system check

Result

Pants completes python portion of bootstrap on non-linux *nix.