### PR TITLE
[*] avoid absolute bash path

### DIFF
--- a/build-support/python/clean.sh
+++ b/build-support/python/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 PANTS_BASE=$(dirname "$0")/../..
 rm -rf "${HOME}/.pex"

--- a/build-support/python/clean.sh
+++ b/build-support/python/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PANTS_BASE=$(dirname "$0")/../..
 rm -rf "${HOME}/.pex"

--- a/src/docs/orgs.md
+++ b/src/docs/orgs.md
@@ -41,7 +41,7 @@ For most users, the following script would work well for a pull-request builder 
 
 <!-- TODO(#7346): Update this script to use --query! -->
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -x
 set -o

--- a/src/docs/publish_via_git.sh
+++ b/src/docs/publish_via_git.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/src/python/pants/core_tasks/templates/bash_completion/autocomplete.sh.mustache
+++ b/src/python/pants/core_tasks/templates/bash_completion/autocomplete.sh.mustache
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 #
@@ -8,7 +8,7 @@
 #
 # To use, copy this script to a file. You can either install it by:
 #
-#  - Copying the script to /etc/bash-completion.d/pants-completion.bash.
+#  - Copying the script to ${PREFIX}/etc/bash-completion.d/pants-completion.bash.
 #  - Using the "source" command to include it in your ~/.bashrc file.
 #
 # Note that the autocompletion will not work if you just run the file.

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -260,7 +260,7 @@ class TestInputFileCreation(TestBase):
 
   def test_not_executable(self):
     file_name = 'echo.sh'
-    file_contents = b'#!/bin/bash -eu\necho "Hello"\n'
+    file_contents = b'#!/bin/sh -eu\necho "Hello"\n'
 
     input_file = InputFilesContent((FileContent(path=file_name, content=file_contents, is_executable=False),))
     digest, = self.scheduler.product_request(Digest, [input_file])
@@ -276,7 +276,7 @@ class TestInputFileCreation(TestBase):
 
   def test_executable(self):
     file_name = 'echo.sh'
-    file_contents = b'#!/bin/bash -eu\necho "Hello"\n'
+    file_contents = b'#!/bin/sh -e\necho "Hello"\n'
 
     input_file = InputFilesContent((FileContent(path=file_name, content=file_contents, is_executable=True),))
     digest, = self.scheduler.product_request(Digest, [input_file])
@@ -320,7 +320,7 @@ class IsolatedProcessTest(TestBase, unittest.TestCase):
 
   def test_write_file(self):
     request = ExecuteProcessRequest(
-      argv=("/bin/bash", "-c", "echo -n 'European Burmese' > roland"),
+      argv=("/bin/sh", "-c", "echo -n 'European Burmese' > roland"),
       description="echo roland",
       output_files=("roland",),
       input_files=EMPTY_DIRECTORY_DIGEST,
@@ -351,7 +351,7 @@ class IsolatedProcessTest(TestBase, unittest.TestCase):
 
   def test_timeout(self):
     request = ExecuteProcessRequest(
-      argv=("/bin/bash", "-c", "/bin/sleep 0.2; /bin/echo -n 'European Burmese'"),
+      argv=("/bin/sh", "-c", "/bin/sleep 0.2; /bin/echo -n 'European Burmese'"),
       timeout_seconds=0.1,
       description='sleepy-cat',
       input_files=EMPTY_DIRECTORY_DIGEST,
@@ -422,7 +422,7 @@ class Broken {
 
   def test_fallible_failing_command_returns_exited_result(self):
     request = ExecuteProcessRequest(
-      argv=("/bin/bash", "-c", "exit 1"),
+      argv=("/bin/sh", "-c", "exit 1"),
       description='one-cat',
       input_files=EMPTY_DIRECTORY_DIGEST,
     )
@@ -433,7 +433,7 @@ class Broken {
 
   def test_non_fallible_failing_command_raises(self):
     request = ExecuteProcessRequest(
-      argv=("/bin/bash", "-c", "exit 1"),
+      argv=("/bin/sh", "-c", "exit 1"),
       description='one-cat',
       input_files=EMPTY_DIRECTORY_DIGEST,
     )


### PR DESCRIPTION
Problem

Many (most?) modern systems don't have bash in /bin but may have it in
other paths such as /usr/local/bin or /opt/local/bin.

Solution

since we don't know where bash is, respect PATH and find
"bash" on the PATH.  In some cases, where we are already a POSIX script,
use the default shell in /bin/sh and assume it is POSIX compliant.

Result

We get farther bootstrapping outselves on systems without /bin/bash