### PR TITLE
Refactor V2 Black implementation

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -13,12 +13,8 @@ from pants.backend.python.rules import (
   python_create_binary,
   python_test_runner,
 )
-from pants.backend.python.subsystems.python_native_code import PythonNativeCode
-from pants.backend.python.subsystems.python_native_code import rules as python_native_code_rules
-from pants.backend.python.subsystems.subprocess_environment import SubprocessEnvironment
-from pants.backend.python.subsystems.subprocess_environment import (
-  rules as subprocess_environment_rules,
-)
+from pants.backend.python.subsystems import python_native_code, subprocess_environment
+from pants.backend.python.targets import formattable_python_target
 from pants.backend.python.targets.python_app import PythonApp
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_distribution import PythonDistribution
@@ -51,7 +47,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def global_subsystems():
-  return (SubprocessEnvironment, PythonNativeCode)
+  return python_native_code.PythonNativeCode, subprocess_environment.SubprocessEnvironment
 
 
 def build_file_aliases():
@@ -100,10 +96,11 @@ def rules():
   return (
     *black.rules(),
     *download_pex_bin.rules(),
+    *formattable_python_target.rules(),
     *inject_init.rules(),
+    *pex.rules(),
     *python_test_runner.rules(),
     *python_create_binary.rules(),
-    *python_native_code_rules(),
-    *pex.rules(),
-    *subprocess_environment_rules(),
+    *python_native_code.rules(),
+    *subprocess_environment.rules(),
   )

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -6,11 +6,11 @@ from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.python_requirements import PythonRequirements
 from pants.backend.python.rules import (
+  black,
   download_pex_bin,
   inject_init,
   pex,
   python_create_binary,
-  python_fmt,
   python_test_runner,
 )
 from pants.backend.python.subsystems.python_native_code import PythonNativeCode
@@ -98,12 +98,12 @@ def register_goals():
 
 def rules():
   return (
-    download_pex_bin.rules() +
-    inject_init.rules() +
-    python_fmt.rules() +
-    python_test_runner.rules() +
-    python_create_binary.rules() +
-    python_native_code_rules() +
-    pex.rules() +
-    subprocess_environment_rules()
+    *black.rules(),
+    *download_pex_bin.rules(),
+    *inject_init.rules(),
+    *python_test_runner.rules(),
+    *python_create_binary.rules(),
+    *python_native_code_rules(),
+    *pex.rules(),
+    *subprocess_environment_rules(),
   )

--- a/src/python/pants/backend/python/rules/black.py
+++ b/src/python/pants/backend/python/rules/black.py
@@ -1,10 +1,9 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Set, Tuple
+from typing import Optional, Tuple
 
 from pants.backend.python.rules.pex import (
   CreatePex,

--- a/src/python/pants/backend/python/rules/black.py
+++ b/src/python/pants/backend/python/rules/black.py
@@ -36,19 +36,13 @@ class BlackSetup:
   resolved_requirements_pex: Pex
   merged_input_files: Digest
 
-  def generate_pex_arg_list(self, *, files: Set[str], check_only: bool) -> Tuple[str, ...]:
+  def generate_pex_arg_list(self, *, files: Tuple[str, ...], check_only: bool) -> Tuple[str, ...]:
     pex_args = []
     if check_only:
       pex_args.append("--check")
     if self.config_path is not None:
       pex_args.extend(["--config", self.config_path])
-    if files:
-      pex_args.extend(["--include", "|".join(re.escape(f) for f in files)])
-    # Black normally operates on all passed folders/files and traverses them recursively. We pass
-    # the directories we want and, crucially, use --include to ensure that Black only runs on the
-    # actual files we care about.
-    dirs = {f"{Path(filename).parent}" for filename in files}
-    pex_args.extend(sorted(dirs))
+    pex_args.extend(files)
     return tuple(pex_args)
 
   def create_execute_request(

--- a/src/python/pants/backend/python/rules/black.py
+++ b/src/python/pants/backend/python/rules/black.py
@@ -16,9 +16,6 @@ from pants.backend.python.subsystems.black import Black
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.targets.formattable_python_target import FormattablePythonTarget
-from pants.backend.python.targets.formattable_python_target import (
-  rules as formattable_python_target_rules,
-)
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
 from pants.engine.isolated_process import (
   ExecuteProcessRequest,
@@ -150,7 +147,6 @@ async def lint(
 
 def rules():
   return [
-    *formattable_python_target_rules(),
     setup_black,
     fmt,
     lint,

--- a/src/python/pants/backend/python/rules/black_integration_test.py
+++ b/src/python/pants/backend/python/rules/black_integration_test.py
@@ -3,11 +3,10 @@
 
 import os
 from contextlib import contextmanager
-from os.path import relpath
 from pathlib import Path
 
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
-from pants.util.contextutil import temporary_dir, temporary_file_path
+from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_file_dump
 
 
@@ -83,32 +82,19 @@ class BlackIntegrationTest(PantsRunIntegrationTest):
     self.assertNotIn("reformatted", pants_run.stderr_data)
     self.assertIn("2 files left unchanged", pants_run.stderr_data)
 
-  def test_black_should_pickup_default_config(self):
-    # If the default config (pyproject.toml is picked up, the compilation_failure target will be skipped
+  def test_black_respects_config(self):
+    # If our config pyproject.toml is used, the compilation_failure target will be skipped.
+    # Otherwise, it will be used and Black will error out.
     command = [
       'fmt-v2',
-      'testprojects/src/python/unicode/compilation_failure::'
-      ]
+      'testprojects/src/python/unicode/compilation_failure::',
+      "--black-config=pyproject.toml",
+    ]
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
     self.assertNotIn("reformatted", pants_run.stderr_data)
     self.assertNotIn("unchanged", pants_run.stderr_data)
     self.assertIn("Nothing to do", pants_run.stderr_data)
-
-  def test_black_should_pickup_non_default_config(self):
-    # If a valid toml file without a black configuration section is picked up,
-    # Black won't skip the compilation_failure and will fail
-    with temporary_file_path(root_dir=".", suffix=".toml") as empty_config:
-      command = [
-        'fmt-v2',
-        'testprojects/src/python/unicode/compilation_failure::',
-        f'--black-config={relpath(empty_config)}'
-        ]
-      pants_run = self.run_pants(command=command)
-    self.assert_failure(pants_run)
-    self.assertNotIn("reformatted", pants_run.stderr_data)
-    self.assertNotIn("unchanged", pants_run.stderr_data)
-    self.assertIn("1 file failed to reformat", pants_run.stderr_data)
 
   def test_black_should_format_python_code(self):
     with build_directory() as root_dir:

--- a/src/python/pants/backend/python/rules/black_integration_test.py
+++ b/src/python/pants/backend/python/rules/black_integration_test.py
@@ -37,7 +37,7 @@ def build_directory():
     yield root_dir
 
 
-class PythonFmtIntegrationTest(PantsRunIntegrationTest):
+class BlackIntegrationTest(PantsRunIntegrationTest):
   def test_black_one_python_source_should_leave_one_file_unchanged(self):
     with build_directory() as root_dir:
       code = write_consistently_formatted_file(root_dir, "hello.py")

--- a/src/python/pants/backend/python/subsystems/black.py
+++ b/src/python/pants/backend/python/subsystems/black.py
@@ -15,6 +15,6 @@ class Black(PythonToolBase):
   def register_options(cls, register):
     super().register_options(register)
     register(
-      '--config', type=file_option, default=None,
+      '--config', type=file_option, default=None, advanced=True,
       help="Path to Black's pyproject.toml config file"
     )

--- a/src/python/pants/backend/python/subsystems/black.py
+++ b/src/python/pants/backend/python/subsystems/black.py
@@ -14,5 +14,7 @@ class Black(PythonToolBase):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    register('--config', advanced=True, type=file_option, fingerprint=True,
-              help="Path to formatting tool's config file")
+    register(
+      '--config', type=file_option, default=None,
+      help="Path to Black's pyproject.toml config file"
+    )

--- a/src/python/pants/backend/python/targets/formattable_python_target.py
+++ b/src/python/pants/backend/python/targets/formattable_python_target.py
@@ -1,0 +1,68 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+
+from pants.engine.legacy.structs import (
+  PantsPluginAdaptor,
+  PythonAppAdaptor,
+  PythonBinaryAdaptor,
+  PythonTargetAdaptor,
+  PythonTestsAdaptor,
+  TargetAdaptor,
+)
+from pants.engine.rules import UnionRule, rule
+from pants.rules.core.fmt import TargetWithSources
+
+
+# Note: this is a workaround until https://github.com/pantsbuild/pants/issues/8343 is addressed
+# We have to write this type which basically represents a union of all various kinds of targets
+# containing python files so we can have one single type used as an input in the run_black rule.
+@dataclass(frozen=True)
+class FormattablePythonTarget:
+  target: TargetAdaptor
+
+
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
+@rule
+def target_adaptor(target: PythonTargetAdaptor) -> FormattablePythonTarget:
+  return FormattablePythonTarget(target)
+
+
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
+@rule
+def app_adaptor(target: PythonAppAdaptor) -> FormattablePythonTarget:
+  return FormattablePythonTarget(target)
+
+
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
+@rule
+def binary_adaptor(target: PythonBinaryAdaptor) -> FormattablePythonTarget:
+  return FormattablePythonTarget(target)
+
+
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
+@rule
+def tests_adaptor(target: PythonTestsAdaptor) -> FormattablePythonTarget:
+  return FormattablePythonTarget(target)
+
+
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
+@rule
+def plugin_adaptor(target: PantsPluginAdaptor) -> FormattablePythonTarget:
+  return FormattablePythonTarget(target)
+
+
+def rules():
+  return [
+    target_adaptor,
+    app_adaptor,
+    binary_adaptor,
+    tests_adaptor,
+    plugin_adaptor,
+    UnionRule(TargetWithSources, PythonTargetAdaptor),
+    UnionRule(TargetWithSources, PythonAppAdaptor),
+    UnionRule(TargetWithSources, PythonBinaryAdaptor),
+    UnionRule(TargetWithSources, PythonTestsAdaptor),
+    UnionRule(TargetWithSources, PantsPluginAdaptor),
+  ]

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -28,7 +28,7 @@ from pants.engine.mapper import AddressMapper
 from pants.engine.objects import Collection
 from pants.engine.parser import HydratedStruct
 from pants.engine.rules import RootRule, rule
-from pants.engine.selectors import Get
+from pants.engine.selectors import Get, MultiGet
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.source.filespec import any_matches_filespec
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetRelPathWrapper
@@ -317,7 +317,7 @@ class _DependentGraph(object):
       self._implicit_dependent_address_map[dep].add(target_adaptor.address)
 
   def dependents_of_addresses(self, addresses):
-    """Given an iterable of addresses, yield all of those addresses dependents."""
+    """Given an iterable of addresses, return all of those addresses dependents."""
     seen = OrderedSet(addresses)
     for address in addresses:
       seen.update(self._dependent_address_map[address])
@@ -325,7 +325,7 @@ class _DependentGraph(object):
     return seen
 
   def transitive_dependents_of_addresses(self, addresses):
-    """Given an iterable of addresses, yield all of those addresses dependents, transitively."""
+    """Given an iterable of addresses, return all of those addresses dependents, transitively."""
     closure = set()
     result = []
     to_visit = deque(addresses)
@@ -392,7 +392,7 @@ class OwnersRequest:
 
 
 @rule
-def find_owners(
+async def find_owners(
   build_configuration: BuildConfiguration,
   address_mapper: AddressMapper,
   owners_request: OwnersRequest
@@ -402,7 +402,7 @@ def find_owners(
 
   # Walk up the buildroot looking for targets that would conceivably claim changed sources.
   candidate_specs = tuple(AscendantAddresses(directory=d) for d in dirs_set)
-  candidate_targets = yield Get(HydratedTargets, Specs(candidate_specs))
+  candidate_targets = await Get(HydratedTargets, Specs(candidate_specs))
 
   # Match the source globs against the expanded candidate targets.
   def owns_any_source(legacy_target):
@@ -428,26 +428,28 @@ def find_owners(
 
   # If the OwnersRequest does not require dependees, then we're done.
   if owners_request.include_dependees == 'none':
-    yield BuildFileAddresses(direct_owners)
+    return BuildFileAddresses(direct_owners)
   else:
     # Otherwise: find dependees.
-    all_addresses = yield Get(BuildFileAddresses, Specs((DescendantAddresses(''),)))
-    all_structs = yield [Get(HydratedStruct, Address, a.to_address()) for a in all_addresses]
-    all_structs = [s.value for s in all_structs]
+    all_addresses = await Get(BuildFileAddresses, Specs((DescendantAddresses(''),)))
+    all_hydrated_structs = await MultiGet(
+      Get(HydratedStruct, Address, a.to_address()) for a in all_addresses
+    )
+    all_structs = [hs.value for hs in all_hydrated_structs]
 
     bfa = build_configuration.registered_aliases()
     graph = _DependentGraph.from_iterable(target_types_from_build_file_aliases(bfa),
                                           address_mapper,
                                           all_structs)
     if owners_request.include_dependees == 'direct':
-      yield BuildFileAddresses(tuple(graph.dependents_of_addresses(direct_owners)))
+      return BuildFileAddresses(tuple(graph.dependents_of_addresses(direct_owners)))
     else:
       assert owners_request.include_dependees == 'transitive'
-      yield BuildFileAddresses(tuple(graph.transitive_dependents_of_addresses(direct_owners)))
+      return BuildFileAddresses(tuple(graph.transitive_dependents_of_addresses(direct_owners)))
 
 
 @rule
-def transitive_hydrated_targets(
+async def transitive_hydrated_targets(
   build_file_addresses: BuildFileAddresses
 ) -> TransitiveHydratedTargets:
   """Given BuildFileAddresses, kicks off recursion on expansion of TransitiveHydratedTargets.
@@ -458,8 +460,9 @@ def transitive_hydrated_targets(
   roots, their structure will be shared.
   """
 
-  transitive_hydrated_targets = yield [Get(TransitiveHydratedTarget, Address, a)
-                                       for a in build_file_addresses.addresses]
+  transitive_hydrated_targets = await MultiGet(
+    Get(TransitiveHydratedTarget, Address, a) for a in build_file_addresses.addresses
+  )
 
   closure = OrderedSet()
   to_visit = deque(transitive_hydrated_targets)
@@ -471,20 +474,20 @@ def transitive_hydrated_targets(
     closure.add(tht.root)
     to_visit.extend(tht.dependencies)
 
-  yield TransitiveHydratedTargets(tuple(tht.root for tht in transitive_hydrated_targets), closure)
+  return TransitiveHydratedTargets(tuple(tht.root for tht in transitive_hydrated_targets), closure)
 
 
 @rule
-def transitive_hydrated_target(root: HydratedTarget) -> TransitiveHydratedTarget:
-  dependencies = yield [Get(TransitiveHydratedTarget, Address, d) for d in root.dependencies]
-  yield TransitiveHydratedTarget(root, dependencies)
+async def transitive_hydrated_target(root: HydratedTarget) -> TransitiveHydratedTarget:
+  dependencies = await MultiGet(Get(TransitiveHydratedTarget, Address, d) for d in root.dependencies)
+  return TransitiveHydratedTarget(root, dependencies)
 
 
 @rule
-def hydrated_targets(build_file_addresses: BuildFileAddresses) -> HydratedTargets:
+async def hydrated_targets(build_file_addresses: BuildFileAddresses) -> HydratedTargets:
   """Requests HydratedTarget instances for BuildFileAddresses."""
-  targets = yield [Get(HydratedTarget, Address, a) for a in build_file_addresses.addresses]
-  yield HydratedTargets(targets)
+  targets = await MultiGet(Get(HydratedTarget, Address, a) for a in build_file_addresses.addresses)
+  return HydratedTargets(targets)
 
 
 @dataclass(frozen=True)
@@ -495,18 +498,19 @@ class HydratedField:
 
 
 @rule
-def hydrate_target(hydrated_struct: HydratedStruct) -> HydratedTarget:
+async def hydrate_target(hydrated_struct: HydratedStruct) -> HydratedTarget:
   target_adaptor = hydrated_struct.value
   """Construct a HydratedTarget from a TargetAdaptor and hydrated versions of its adapted fields."""
   # Hydrate the fields of the adaptor and re-construct it.
-  hydrated_fields = yield [Get(HydratedField, HydrateableField, fa)
-                           for fa in target_adaptor.field_adaptors]
+  hydrated_fields = await MultiGet(
+    Get(HydratedField, HydrateableField, fa) for fa in target_adaptor.field_adaptors
+  )
   kwargs = target_adaptor.kwargs()
   for field in hydrated_fields:
     kwargs[field.name] = field.value
-  yield HydratedTarget(target_adaptor.address,
-                       type(target_adaptor)(**kwargs),
-                       tuple(target_adaptor.dependencies))
+  return HydratedTarget(
+    target_adaptor.address, type(target_adaptor)(**kwargs), tuple(target_adaptor.dependencies)
+  )
 
 
 def _eager_fileset_with_spec(spec_path, filespec, snapshot, include_dirs=False):
@@ -524,7 +528,7 @@ def _eager_fileset_with_spec(spec_path, filespec, snapshot, include_dirs=False):
 
 
 @rule
-def hydrate_sources(
+async def hydrate_sources(
   sources_field: SourcesField, glob_match_error_behavior: GlobMatchErrorBehavior
 ) -> HydratedField:
   """Given a SourcesField, request a Snapshot for its path_globs and create an EagerFilesetWithSpec.
@@ -534,17 +538,17 @@ def hydrate_sources(
   path_globs = dataclasses.replace(
     sources_field.path_globs, glob_match_error_behavior=glob_match_error_behavior
   )
-  snapshot = yield Get(Snapshot, PathGlobs, path_globs)
+  snapshot = await Get(Snapshot, PathGlobs, path_globs)
   fileset_with_spec = _eager_fileset_with_spec(
     sources_field.address.spec_path,
     sources_field.filespecs,
     snapshot)
   sources_field.validate_fn(fileset_with_spec)
-  yield HydratedField(sources_field.arg, fileset_with_spec)
+  return HydratedField(sources_field.arg, fileset_with_spec)
 
 
 @rule
-def hydrate_bundles(
+async def hydrate_bundles(
   bundles_field: BundlesField, glob_match_error_behavior: GlobMatchErrorBehavior
 ) -> HydratedField:
   """Given a BundlesField, request Snapshots for each of its filesets and create BundleAdaptors."""
@@ -552,7 +556,7 @@ def hydrate_bundles(
     dataclasses.replace(pg, glob_match_error_behavior=glob_match_error_behavior)
     for pg in bundles_field.path_globs_list
   ]
-  snapshot_list = yield [Get(Snapshot, PathGlobs, pg) for pg in path_globs_with_match_errors]
+  snapshot_list = await MultiGet(Get(Snapshot, PathGlobs, pg) for pg in path_globs_with_match_errors)
 
   spec_path = bundles_field.address.spec_path
 
@@ -571,7 +575,7 @@ def hydrate_bundles(
                                                  snapshot,
                                                  include_dirs=True)
     bundles.append(BundleAdaptor(**kwargs))
-  yield HydratedField('bundles', bundles)
+  return HydratedField('bundles', bundles)
 
 
 def create_legacy_graph_tasks():


### PR DESCRIPTION
We will soon be adding a V2 implementation for isort. This PR is prework to make the Black code a bit more generic so that we can have Black and isort coincide as two rules for `fmt-v2` and `lint-v2`.

* Splits out `python_fmt` into `rules/black.py` and `targets/formattable_python_target`
    - This will allow the new isort logic to live in `rules/isort.py` and reuse the `FormattablePythonTarget` abstraction created originally for Black
* Move `_generate_black_pex_args()` and `_generate_black_request()` onto methods defined on `BlackInput`/`BlackSetup` to mirror our `Pex` dataclass
* Rename `BlackInput` to `BlackSetup` and add docstring explaining why we use this abstraction.
* Use the new `async await` style for rules
* Change `--black-config` to not use `fingerprint=True`, which is irrelevant in a V2 world.