### PR TITLE
Add `--black-enable` option to turn Black on and off

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -83,7 +83,9 @@ pants_ignore: +[
   ]
 
 [black]
+enable: False
 config: pyproject.toml
+
 
 [cache]
 # Caching is on globally by default, but we disable it here for development purposes.

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -13,12 +13,8 @@ from pants.backend.python.rules import (
   python_create_binary,
   python_test_runner,
 )
-from pants.backend.python.subsystems.python_native_code import PythonNativeCode
-from pants.backend.python.subsystems.python_native_code import rules as python_native_code_rules
-from pants.backend.python.subsystems.subprocess_environment import SubprocessEnvironment
-from pants.backend.python.subsystems.subprocess_environment import (
-  rules as subprocess_environment_rules,
-)
+from pants.backend.python.subsystems import python_native_code, subprocess_environment
+from pants.backend.python.targets import formattable_python_target
 from pants.backend.python.targets.python_app import PythonApp
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_distribution import PythonDistribution
@@ -51,7 +47,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def global_subsystems():
-  return (SubprocessEnvironment, PythonNativeCode)
+  return python_native_code.PythonNativeCode, subprocess_environment.SubprocessEnvironment
 
 
 def build_file_aliases():
@@ -100,10 +96,11 @@ def rules():
   return (
     *black.rules(),
     *download_pex_bin.rules(),
+    *formattable_python_target.rules(),
     *inject_init.rules(),
+    *pex.rules(),
     *python_test_runner.rules(),
     *python_create_binary.rules(),
-    *python_native_code_rules(),
-    *pex.rules(),
-    *subprocess_environment_rules(),
+    *python_native_code.rules(),
+    *subprocess_environment.rules(),
   )

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -6,11 +6,11 @@ from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.python_requirements import PythonRequirements
 from pants.backend.python.rules import (
+  black,
   download_pex_bin,
   inject_init,
   pex,
   python_create_binary,
-  python_fmt,
   python_test_runner,
 )
 from pants.backend.python.subsystems.python_native_code import PythonNativeCode
@@ -98,12 +98,12 @@ def register_goals():
 
 def rules():
   return (
-    download_pex_bin.rules() +
-    inject_init.rules() +
-    python_fmt.rules() +
-    python_test_runner.rules() +
-    python_create_binary.rules() +
-    python_native_code_rules() +
-    pex.rules() +
-    subprocess_environment_rules()
+    *black.rules(),
+    *download_pex_bin.rules(),
+    *inject_init.rules(),
+    *python_test_runner.rules(),
+    *python_create_binary.rules(),
+    *python_native_code_rules(),
+    *pex.rules(),
+    *subprocess_environment_rules(),
   )

--- a/src/python/pants/backend/python/rules/black.py
+++ b/src/python/pants/backend/python/rules/black.py
@@ -98,11 +98,15 @@ async def setup_black(wrapped_target: FormattablePythonTarget, black: Black) -> 
 
 @rule
 async def fmt(
+  black: Black,
   wrapped_target: FormattablePythonTarget,
   black_setup: BlackSetup,
   python_setup: PythonSetup,
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> FmtResult:
+  if not black.get_options().enable:
+    return FmtResult.noop()
+
   request = black_setup.create_execute_request(
     wrapped_target=wrapped_target,
     python_setup=python_setup,
@@ -119,11 +123,15 @@ async def fmt(
 
 @rule
 async def lint(
+  black: Black,
   wrapped_target: FormattablePythonTarget,
   black_setup: BlackSetup,
   python_setup: PythonSetup,
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> LintResult:
+  if not black.get_options().enable:
+    return LintResult.noop()
+
   request = black_setup.create_execute_request(
     wrapped_target=wrapped_target,
     python_setup=python_setup,

--- a/src/python/pants/backend/python/rules/black.py
+++ b/src/python/pants/backend/python/rules/black.py
@@ -1,10 +1,9 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Set, Tuple
+from typing import Optional, Tuple
 
 from pants.backend.python.rules.pex import (
   CreatePex,

--- a/src/python/pants/backend/python/rules/black.py
+++ b/src/python/pants/backend/python/rules/black.py
@@ -36,19 +36,13 @@ class BlackSetup:
   resolved_requirements_pex: Pex
   merged_input_files: Digest
 
-  def generate_pex_arg_list(self, *, files: Set[str], check_only: bool) -> Tuple[str, ...]:
+  def generate_pex_arg_list(self, *, files: Tuple[str, ...], check_only: bool) -> Tuple[str, ...]:
     pex_args = []
     if check_only:
       pex_args.append("--check")
     if self.config_path is not None:
       pex_args.extend(["--config", self.config_path])
-    if files:
-      pex_args.extend(["--include", "|".join(re.escape(f) for f in files)])
-    # Black normally operates on all passed folders/files and traverses them recursively. We pass
-    # the directories we want and, crucially, use --include to ensure that Black only runs on the
-    # actual files we care about.
-    dirs = {f"{Path(filename).parent}" for filename in files}
-    pex_args.extend(sorted(dirs))
+    pex_args.extend(files)
     return tuple(pex_args)
 
   def create_execute_request(

--- a/src/python/pants/backend/python/rules/black.py
+++ b/src/python/pants/backend/python/rules/black.py
@@ -16,9 +16,6 @@ from pants.backend.python.subsystems.black import Black
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
 from pants.backend.python.targets.formattable_python_target import FormattablePythonTarget
-from pants.backend.python.targets.formattable_python_target import (
-  rules as formattable_python_target_rules,
-)
 from pants.engine.fs import Digest, DirectoriesToMerge, PathGlobs, Snapshot
 from pants.engine.isolated_process import (
   ExecuteProcessRequest,
@@ -150,7 +147,6 @@ async def lint(
 
 def rules():
   return [
-    *formattable_python_target_rules(),
     setup_black,
     fmt,
     lint,

--- a/src/python/pants/backend/python/rules/black_integration_test.py
+++ b/src/python/pants/backend/python/rules/black_integration_test.py
@@ -37,7 +37,7 @@ def build_directory():
     yield root_dir
 
 
-class PythonFmtIntegrationTest(PantsRunIntegrationTest):
+class BlackIntegrationTest(PantsRunIntegrationTest):
   def test_black_one_python_source_should_leave_one_file_unchanged(self):
     with build_directory() as root_dir:
       code = write_consistently_formatted_file(root_dir, "hello.py")

--- a/src/python/pants/backend/python/rules/black_test.py
+++ b/src/python/pants/backend/python/rules/black_test.py
@@ -1,0 +1,76 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.backend.python.rules.black import BlackSetup, fmt, lint
+from pants.backend.python.rules.pex import Pex
+from pants.backend.python.subsystems.black import Black
+from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.backend.python.subsystems.subprocess_environment import SubprocessEnvironment
+from pants.backend.python.targets.formattable_python_target import FormattablePythonTarget
+from pants.engine.fs import EMPTY_DIRECTORY_DIGEST
+from pants.engine.isolated_process import (
+  ExecuteProcessRequest,
+  ExecuteProcessResult,
+  FallibleExecuteProcessResult,
+)
+from pants.engine.legacy.structs import TargetAdaptor
+from pants.rules.core.fmt import FmtResult
+from pants.rules.core.lint import LintResult
+from pants.testutil.engine.util import MockGet, run_rule
+from pants.testutil.subsystem.util import global_subsystem_instance
+from pants.testutil.test_base import TestBase
+
+
+class TestPythonTestRunner(TestBase):
+
+  def test_noops_when_disabled(self) -> None:
+    black_subsystem = global_subsystem_instance(Black, {Black.options_scope: {"enable": False}})
+    target = FormattablePythonTarget(target=TargetAdaptor())
+    mock_black_setup = BlackSetup(
+      config_path=None,
+      merged_input_files=EMPTY_DIRECTORY_DIGEST,
+      resolved_requirements_pex=Pex(
+        directory_digest=EMPTY_DIRECTORY_DIGEST, output_filename="./fake.pex"
+      ),
+    )
+    rule_args = [
+      black_subsystem,
+      target,
+      mock_black_setup,
+      PythonSetup.global_instance(),
+      SubprocessEnvironment.global_instance(),
+    ]
+
+    fmt_result: FmtResult = run_rule(
+      fmt,
+      rule_args=rule_args,
+      mock_gets=[
+        MockGet(
+          product_type=ExecuteProcessResult,
+          subject_type=ExecuteProcessRequest,
+          mock=lambda _: ExecuteProcessResult(
+            output_directory_digest=EMPTY_DIRECTORY_DIGEST, stdout=b"bad", stderr=b"bad",
+          ),
+        )
+      ],
+    )
+
+    lint_result: LintResult = run_rule(
+      lint,
+      rule_args=rule_args,
+      mock_gets=[
+        MockGet(
+          product_type=FallibleExecuteProcessResult,
+          subject_type=ExecuteProcessRequest,
+          mock=lambda _: FallibleExecuteProcessResult(
+            stdout=b"bad",
+            stderr=b"bad",
+            exit_code=127,
+            output_directory_digest=EMPTY_DIRECTORY_DIGEST,
+          ),
+        ),
+      ],
+    )
+
+    self.assertEqual(fmt_result, FmtResult.noop())
+    self.assertEqual(lint_result, LintResult.noop())

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -49,11 +49,7 @@ def run_python_test(
   )
 
   if not source_root_stripped_test_target_sources.snapshot.files:
-    yield TestResult(
-      status=Status.SUCCESS,
-      stdout="",
-      stderr="",
-    )
+    yield TestResult.noop()
 
   source_root_stripped_sources = yield [
     Get(SourceRootStrippedSources, HydratedTarget, target_adaptor)

--- a/src/python/pants/backend/python/rules/python_test_runner_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_test.py
@@ -36,14 +36,14 @@ class TestPythonTestRunner(TestBase):
       ],
       mock_gets=[
         MockGet(
-          product_type=TransitiveHydratedTargets,
-          subject_type=BuildFileAddresses,
-          mock=lambda _: TransitiveHydratedTargets(roots=(), closure=())
-        ),
-        MockGet(
           product_type=SourceRootStrippedSources,
           subject_type=Address,
           mock=lambda _: SourceRootStrippedSources(snapshot=EMPTY_SNAPSHOT),
+        ),
+        MockGet(
+          product_type=TransitiveHydratedTargets,
+          subject_type=BuildFileAddresses,
+          mock=unimplemented_mock,
         ),
         MockGet(
           product_type=SourceRootStrippedSources,

--- a/src/python/pants/backend/python/subsystems/black.py
+++ b/src/python/pants/backend/python/subsystems/black.py
@@ -15,6 +15,10 @@ class Black(PythonToolBase):
   def register_options(cls, register):
     super().register_options(register)
     register(
+      '--enable', type=bool, default=False,
+      help="Enable Black in the `fmt` and `lint` goals."
+    )
+    register(
       '--config', type=file_option, default=None,
       help="Path to Black's pyproject.toml config file"
     )

--- a/src/python/pants/backend/python/subsystems/black.py
+++ b/src/python/pants/backend/python/subsystems/black.py
@@ -14,5 +14,7 @@ class Black(PythonToolBase):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    register('--config', advanced=True, type=file_option, fingerprint=True,
-              help="Path to formatting tool's config file")
+    register(
+      '--config', type=file_option, default=None,
+      help="Path to Black's pyproject.toml config file"
+    )

--- a/src/python/pants/backend/python/targets/formattable_python_target.py
+++ b/src/python/pants/backend/python/targets/formattable_python_target.py
@@ -1,0 +1,68 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+
+from pants.engine.legacy.structs import (
+  PantsPluginAdaptor,
+  PythonAppAdaptor,
+  PythonBinaryAdaptor,
+  PythonTargetAdaptor,
+  PythonTestsAdaptor,
+  TargetAdaptor,
+)
+from pants.engine.rules import UnionRule, rule
+from pants.rules.core.fmt import TargetWithSources
+
+
+# Note: this is a workaround until https://github.com/pantsbuild/pants/issues/8343 is addressed
+# We have to write this type which basically represents a union of all various kinds of targets
+# containing python files so we can have one single type used as an input in the run_black rule.
+@dataclass(frozen=True)
+class FormattablePythonTarget:
+  target: TargetAdaptor
+
+
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
+@rule
+def target_adaptor(target: PythonTargetAdaptor) -> FormattablePythonTarget:
+  return FormattablePythonTarget(target)
+
+
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
+@rule
+def app_adaptor(target: PythonAppAdaptor) -> FormattablePythonTarget:
+  return FormattablePythonTarget(target)
+
+
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
+@rule
+def binary_adaptor(target: PythonBinaryAdaptor) -> FormattablePythonTarget:
+  return FormattablePythonTarget(target)
+
+
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
+@rule
+def tests_adaptor(target: PythonTestsAdaptor) -> FormattablePythonTarget:
+  return FormattablePythonTarget(target)
+
+
+# TODO: remove this workaround once https://github.com/pantsbuild/pants/issues/8343 is addressed
+@rule
+def plugin_adaptor(target: PantsPluginAdaptor) -> FormattablePythonTarget:
+  return FormattablePythonTarget(target)
+
+
+def rules():
+  return [
+    target_adaptor,
+    app_adaptor,
+    binary_adaptor,
+    tests_adaptor,
+    plugin_adaptor,
+    UnionRule(TargetWithSources, PythonTargetAdaptor),
+    UnionRule(TargetWithSources, PythonAppAdaptor),
+    UnionRule(TargetWithSources, PythonBinaryAdaptor),
+    UnionRule(TargetWithSources, PythonTestsAdaptor),
+    UnionRule(TargetWithSources, PantsPluginAdaptor),
+  ]

--- a/src/python/pants/rules/core/core_test_model.py
+++ b/src/python/pants/rules/core/core_test_model.py
@@ -21,6 +21,10 @@ class TestResult:
   # Prevent this class from being detected by pytest as a test class.
   __test__ = False
 
+  @staticmethod
+  def noop() -> "TestResult":
+    return TestResult(status=Status.SUCCESS, stdout="", stderr="")
+
 
 @union
 class TestTarget:

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from pants.base.build_environment import get_buildroot
 from pants.engine.console import Console
-from pants.engine.fs import Digest, FilesContent
+from pants.engine.fs import Digest, FilesContent, EMPTY_DIRECTORY_DIGEST
 from pants.engine.goal import Goal
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.rules import UnionMembership, console_rule, union
@@ -18,6 +18,10 @@ class FmtResult:
   digest: Digest
   stdout: str
   stderr: str
+
+  @staticmethod
+  def noop() -> "FmtResult":
+    return FmtResult(digest=EMPTY_DIRECTORY_DIGEST, stdout="", stderr="")
 
 
 @union

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from pants.base.build_environment import get_buildroot
 from pants.engine.console import Console
-from pants.engine.fs import Digest, FilesContent, EMPTY_DIRECTORY_DIGEST
+from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, FilesContent
 from pants.engine.goal import Goal
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.rules import UnionMembership, console_rule, union

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -17,6 +17,10 @@ class LintResult:
   stdout: str
   stderr: str
 
+  @staticmethod
+  def noop() -> "LintResult":
+    return LintResult(exit_code=0, stdout="", stderr="")
+
 
 class Lint(Goal):
   """Lint source code."""


### PR DESCRIPTION
_NOTE: this is made on top of https://github.com/pantsbuild/pants/pull/8671. See https://github.com/Eric-Arellano/pants/compare/refactor-black...Eric-Arellano:black-enable for the difference between the two._

### Problem

We need a mechanism for users to say that they want to use a tool like Black or not. Not every codebase will want to use the tool, such as Pants not yet using it, but users should still be able to do `./pants fmt-v2` and `./pants lint-v2`.

We currently do this in V1 through the `--skip` option, which is applied recursively so allows for `--fmt-skip`, `--fmt-black-skip`, `--fmt-isort-skip`, etc. This will not work with V2, however, because we cannot have options on specific "tasks" anymore. Options must either reside at the Goal level or in a subsystem. 

### Solution

Define the skip/enable mechanism directly on the tool itself, i.e. `--no-black-enable` and `--black-enable`.

This has a major benefit that in V2 we are setting up tools to provide both `fmt` and `lint` implementations, where possible. This means that Black will run under both `./pants fmt` and `./pants lint`. Were we to keep the V1 `--skip` implementation, we would need to configure:

```ini
[fmt.black]
skip: True

[lint.black]
skip: True
```

This rarely seems to be desirable. Presumably, if one is autoformatting with Black, they would also want to enforce that this is actually happening. (Note that discussion is irrelevant for linters like `Pylint`).

Instead, this approach looks like:

```ini
[black]
enable: True
```

### Result

We can now write new rules for `fmt-v2` and `lint-v2`, like implementing isort, without having those commands trigger Black when Black is not used by the codebase.