### PR TITLE
Fix ant compatible xml reporting for scala tests

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -725,7 +725,7 @@ public class ConsoleRunnerImpl {
 
       @Override
       public boolean shouldRun(Description desc) {
-        if (desc.isSuite()) {
+        if (desc.isSuite() && !ScalaTestUtil.isScalaTestTest(desc.getTestClass())) {
           return true;
         }
         String descString = Util.getPantsFriendlyDisplayName(desc);

--- a/src/java/org/pantsbuild/tools/junit/impl/ScalaTestUtil.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ScalaTestUtil.java
@@ -29,17 +29,15 @@ public final class ScalaTestUtil {
    * TODO: Remove this when https://github.com/scalatest/scalatestplus-junit/pull/8 is merged
    */
   private static class ScalaTestJunitRunnerWrapper extends Runner implements Filterable {
-      private Runner delegate;
-      private Class<?> suite;
+      private final Runner delegate;
 
-      private ScalaTestJunitRunnerWrapper(Runner delegate, Class<?> suite) {
+      private ScalaTestJunitRunnerWrapper(Runner delegate) {
         this.delegate = delegate;
-        this.suite = suite;
       }
 
       @Override
       public Description getDescription() {
-          return Description.createSuiteDescription(suite);
+        return delegate.getDescription();
       }
 
       @Override
@@ -61,7 +59,7 @@ public final class ScalaTestUtil {
    */
   public static Runner getJUnitRunner(Class<?> clazz) throws Exception {
     return new ScalaTestJunitRunnerWrapper(
-            (Runner) junitRunnerClass.getConstructor(Class.class).newInstance(clazz), clazz);
+            (Runner) junitRunnerClass.getConstructor(Class.class).newInstance(clazz));
   }
 
   /**

--- a/tests/java/org/pantsbuild/tools/junit/impl/XmlReportTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/XmlReportTest.java
@@ -28,6 +28,7 @@ import org.pantsbuild.tools.junit.lib.XmlReportFirstTestIngoredTest;
 import org.pantsbuild.tools.junit.lib.XmlReportIgnoredTestSuiteTest;
 import org.pantsbuild.tools.junit.lib.XmlReportMockitoStubbingTest;
 import org.pantsbuild.tools.junit.lib.XmlReportTestSuite;
+import org.pantsbuild.tools.junit.lib.MockScalaTest;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
@@ -335,6 +336,27 @@ public class XmlReportTest extends ConsoleRunnerTestBase {
     assertEquals("java.lang.RuntimeException", testCase.getError().getType());
     assertThat(testCase.getError().getStacktrace(),
         containsString(FailingTestRunner.class.getCanonicalName() + ".getTestRules("));
+  }
+
+  @Test
+  public void testXmlReportOnScalaSuite() throws Exception {
+    String testClassName = MockScalaTest.class.getCanonicalName();
+    AntJunitXmlReportListener.TestSuite testSuite = runTestAndParseXml(testClassName, false);
+
+    assertNotNull(testSuite);
+    assertEquals(1, testSuite.getTests());
+    assertEquals(0, testSuite.getFailures());
+    assertEquals(0, testSuite.getErrors());
+    assertEquals(0, testSuite.getSkipped());
+    assertEquals(testClassName, testSuite.getName());
+
+    List<AntJunitXmlReportListener.TestCase> testCases = testSuite.getTestCases();
+    assertEquals(1, testCases.size());
+
+    AntJunitXmlReportListener.TestCase testCase = testCases.get(0);
+    assertEquals(testClassName, testCase.getClassname());
+    assertNull(testCase.getFailure());
+    assertNull(testCase.getError());
   }
 
   protected File runTestAndReturnXmlFile(String testClassName, boolean shouldFail)


### PR DESCRIPTION
### Problem

Recent changes to ScalaTestUtil (specifically the ScalaTestJunitRunnerWrapper facade) broke the xml reporting (AntJUnitXmlReporter) because the description of the runner had changed and didn't describe children of the suite correctly.

### Solution

The solution implemented here, calls the getDescription method on the delegate as should be.

### Result

This fixes the regression introduced by replacing the original JUnitRunner of scalatests by ScalaTestJunitRunnerWrapper
