### PR TITLE
Ensure idea-plugin projects contain at least one module

### DIFF
--- a/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
+++ b/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
@@ -84,6 +84,8 @@ class IdeaPluginGen(ConsoleTask):
                                          'project-12.mustache')
     self.workspace_template = os.path.join(_TEMPLATE_BASEDIR,
                                            'workspace-12.mustache')
+    self.rootmodule_template = os.path.join(_TEMPLATE_BASEDIR,
+                                           'rootmodule-12.mustache')
     self.java_language_level = self.get_options().java_language_level
 
     if self.get_options().java_jdk_name:
@@ -102,6 +104,8 @@ class IdeaPluginGen(ConsoleTask):
                                            '{}.ipr'.format(project_name))
       self.workspace_filename = os.path.join(self.gen_project_workdir,
                                              '{}.iws'.format(project_name))
+      self.rootmodule_filename = os.path.join(self.gen_project_workdir,
+                                              'rootmodule.iml')
       self.intellij_output_dir = os.path.join(self.gen_project_workdir, 'out')
 
   @classmethod
@@ -147,9 +151,12 @@ class IdeaPluginGen(ConsoleTask):
 
     ipr = gen_file(self.project_template, project=configured_project)
     iws = gen_file(self.workspace_template, workspace=configured_workspace)
+    iml_root = gen_file(self.workspace_template)
 
     shutil.move(ipr, self.project_filename)
     shutil.move(iws, self.workspace_filename)
+    shutil.move(iml_root, self.rootmodule_filename)
+
     return self.project_filename
 
   def _generate_to_tempfile(self, generator):

--- a/src/python/pants/backend/project_info/tasks/templates/idea/project-12.mustache
+++ b/src/python/pants/backend/project_info/tasks/templates/idea/project-12.mustache
@@ -34,6 +34,7 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
 
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/rootmodule.iml" filepath="$PROJECT_DIR$/rootmodule.iml" /> {{! IntelliJ 2019.3 requires at least one module in IPR project }}
       {{#project.modules}}
       <module fileurl="file://{{path}}"
               filepath="{{path}}"/>

--- a/src/python/pants/backend/project_info/tasks/templates/idea/rootmodule-12.mustache
+++ b/src/python/pants/backend/project_info/tasks/templates/idea/rootmodule-12.mustache
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+</module>


### PR DESCRIPTION
Intellij 2019.3 reports an error when en IPR project does not contain any modules

Also submitted to IntelliJ issue tracker
https://youtrack.jetbrains.com/issue/IDEA-227246

Addresses https://github.com/pantsbuild/intellij-pants-plugin/issues/433

### Problem
IntelliJ 2019.3 was reporting "Failed to save settings error" when trying to open pants-generatoed project. More details here: https://github.com/pantsbuild/pants/issues/8631

### Solution
IntelliJ 2019.3 fails when opening an IPR project containing no modules. So I added a dummy root module generation.
(There are two formats of IntelliJ projects: IPR-based and directory-based, `pants idea-plugin` command generates and IPR project)

### Result
1. IntelliJ 2019.3 works with pants-generated projects
2. pants-generated projects contain an empty "rootmodule" module