### PR TITLE
Improve stability of CI through retries and tweaked timeouts

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -400,9 +400,14 @@ resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
 
 [pytest]
 version: pytest>=5.2.4
-# TODO(#8651): We need this until we switch to implicit namespace packages so that pytest-cov
-#  understands our __init__ files. NB: this version matches 3rdparty/python/requirements.txt.
-pytest_plugins: +["pytest-rerunfailures>=8.0", "setuptools==40.6.3"]
+pytest_plugins: +[
+    # TODO(8528): implement a generic retry mechanism for the V2 test runner instead of using this
+    #  plugin.
+    "pytest-rerunfailures>=8.0",
+    # TODO(#8651): We need this until we switch to implicit namespace packages so that pytest-cov
+    #  understands our __init__ files. NB: this version matches 3rdparty/python/requirements.txt.
+    "setuptools==40.6.3",
+  ]
 
 
 [test.pytest]

--- a/pants.ini
+++ b/pants.ini
@@ -402,7 +402,7 @@ resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
 version: pytest>=5.2.4
 # TODO(#8651): We need this until we switch to implicit namespace packages so that pytest-cov
 #  understands our __init__ files. NB: this version matches 3rdparty/python/requirements.txt.
-pytest_plugins: +["setuptools==40.6.3"]
+pytest_plugins: +["pytest-rerunfailures>=8.0", "setuptools==40.6.3"]
 
 
 [test.pytest]

--- a/pants.travis-ci.ini
+++ b/pants.travis-ci.ini
@@ -11,9 +11,9 @@ execution_strategy: subprocess
 worker_count: 4
 
 [test.pytest]
-# NB: We set a maximum timeout of 9 minutes to fail before hitting Travis' 10 minute timeout (which
+# NB: We set a maximum timeout of 9.8 minutes to fail before hitting Travis' 10 minute timeout (which
 # doesn't give us useful debug info).
-timeout_maximum: 540
+timeout_maximum: 590
 
 
 [test.junit]

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -361,7 +361,7 @@ fn main() {
           store.clone(),
           Platform::Linux,
           executor.clone(),
-          std::time::Duration::from_secs(150),
+          std::time::Duration::from_secs(160),
           std::time::Duration::from_millis(500),
           std::time::Duration::from_secs(5),
         )

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -182,7 +182,7 @@ impl Core {
             // need to take an option all the way down here and into the remote::CommandRunner struct.
             Platform::Linux,
             executor.clone(),
-            std::time::Duration::from_secs(150),
+            std::time::Duration::from_secs(160),
             std::time::Duration::from_millis(500),
             std::time::Duration::from_secs(5),
           )?),

--- a/tests/python/pants_test/backend/graph_info/tasks/test_list_targets.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_list_targets.py
@@ -4,6 +4,8 @@
 import os
 from textwrap import dedent
 
+import pytest
+
 from pants.backend.jvm.artifact import Artifact
 from pants.backend.jvm.repository import Repository
 from pants.backend.jvm.scala_artifact import ScalaArtifact
@@ -106,6 +108,7 @@ class ListTargetsTest(ConsoleRuleTestBase):
         'a/b/e:e1',
         args=['a/b::'])
 
+  @pytest.mark.flaky(retries=1)  # https://github.com/pantsbuild/pants/issues/8678
   def test_list_all(self):
     self.assert_entries('\n',
         'a:a',

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -214,7 +214,7 @@ python_tests(
   tags = {'platform_specific_behavior', 'integration'},
   # NB: This frequently times out, but due to hanging. So, we want to fail eagerly. See
   # https://github.com/pantsbuild/pants/issues/8127.
-  timeout = 120,
+  timeout = 200,
 )
 
 python_tests(

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -212,7 +212,9 @@ python_tests(
     'testprojects:pants_plugins_directory',
   ],
   tags = {'platform_specific_behavior', 'integration'},
-  timeout = 540,
+  # NB: This frequently times out, but due to hanging. So, we want to fail eagerly. See
+  # https://github.com/pantsbuild/pants/issues/8127.
+  timeout = 120,
 )
 
 python_tests(

--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -4,6 +4,8 @@
 import os
 from contextlib import contextmanager
 
+import pytest
+
 from pants.cache.artifact import TarballArtifact
 from pants.cache.artifact_cache import (
   NonfatalArtifactCacheError,
@@ -62,6 +64,7 @@ class TestArtifactCache(TestBase):
     with self.setup_local_cache() as artifact_cache:
       self.do_test_artifact_cache(artifact_cache)
 
+  @pytest.mark.flaky(retries=1)  # https://github.com/pantsbuild/pants/issues/6838
   def test_restful_cache(self):
     with self.assertRaises(InvalidRESTfulCacheProtoError):
       RESTfulArtifactCache('foo', BestUrlSelector(['ftp://localhost/bar']), 'foo')
@@ -69,6 +72,7 @@ class TestArtifactCache(TestBase):
     with self.setup_rest_cache() as artifact_cache:
       self.do_test_artifact_cache(artifact_cache)
 
+  @pytest.mark.flaky(retries=1)  # https://github.com/pantsbuild/pants/issues/6838
   def test_restful_cache_failover(self):
     bad_url = 'http://badhost:123'
 
@@ -185,6 +189,7 @@ class TestArtifactCache(TestBase):
             self.assertTrue(os.path.exists(results_dir))
             self.assertTrue(len(os.listdir(results_dir)) == 0)
 
+  @pytest.mark.flaky(retries=1)  # https://github.com/pantsbuild/pants/issues/6838
   def test_multiproc(self):
     key = CacheKey('muppet_key', 'fake_hash')
 

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -10,6 +10,7 @@ import unittest.mock
 from contextlib import contextmanager
 
 import psutil
+import pytest
 
 from pants.pantsd.process_manager import (
   ProcessGroup,
@@ -140,6 +141,7 @@ class TestProcessMetadataManager(TestBase):
         self.TEST_VALUE_INT
       )
 
+  @pytest.mark.flaky(retries=1)  # https://github.com/pantsbuild/pants/issues/6836
   def test_deadline_until(self):
     with self.assertRaises(ProcessMetadataManager.Timeout):
       with self.captured_logging(logging.INFO) as captured:


### PR DESCRIPTION
CI is painfully flaky. While the most robust solution would be to fix the flakes themselves, we can provide some improved stability now through these changes:

* Install the `pytest-rerunfailures` plugin to allow us to mark tests as `@pytest.mark.flaky(retries=1)`
    * We should be careful to not abuse this. This plugin means that we are normalizing flakes even more than we have already.
    * We should never use `retries>1`. If a test is so flaky that it needs 3 runs to work, then it should be skipped, deleted, or fixed.
* Mark 6 tests as flaky.
* Bump the Rust queue_buffer_time from 150 s to 160 s. Yesterday, I saw the unit test shard fail over 10 tests due to time out, even though those tests only take 1 second to run each.  
* Bump the max timeout from 540 seconds to 590 seconds for V1. Travis caps us at 600 seconds, so we just need to time out before that. The extra 50 seconds should reduce the number of time outs we get.
* Lower the timeout for `exception_sink_integration` so that fail eagerly when it hangs.