### PR TITLE
Refactor `FileContent` to use default argument for `is_executable`

### DIFF
--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -94,8 +94,8 @@ class TestResolveRequirements(TestBase):
 
   def test_generic_pex_creation(self) -> None:
     input_files_content = InputFilesContent((
-      FileContent(path='main.py', content=b'print("from main")', is_executable=False),
-      FileContent(path='subdir/sub.py', content=b'print("from sub")', is_executable=False),
+      FileContent(path='main.py', content=b'print("from main")'),
+      FileContent(path='subdir/sub.py', content=b'print("from sub")'),
     ))
 
     input_files, = self.scheduler.product_request(Digest, [input_files_content])

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -18,7 +18,7 @@ class FileContent:
   """The content of a file."""
   path: str
   content: bytes
-  is_executable: bool
+  is_executable: bool = False
 
   def __repr__(self):
     return 'FileContent(path={}, content=(len:{}), is_executable={})'.format(

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -56,7 +56,7 @@ class WorkspaceInConsoleRuleTest(ConsoleRuleTestBase):
   def test(self):
     with temporary_dir() as tmp_dir:
       input_files_content = InputFilesContent((
-        FileContent(path='a.txt', content=b'hello', is_executable=False),
+        FileContent(path='a.txt', content=b'hello'),
       ))
 
       msg = MessageToConsoleRule(tmp_dir=tmp_dir, input_files_content=input_files_content)
@@ -75,8 +75,8 @@ class FileSystemTest(TestBase):
     workspace = Workspace(self.scheduler)
 
     input_files_content = InputFilesContent((
-      FileContent(path='a.txt', content=b'hello', is_executable=False),
-      FileContent(path='subdir/b.txt', content=b'goodbye', is_executable=False),
+      FileContent(path='a.txt', content=b'hello'),
+      FileContent(path='subdir/b.txt', content=b'goodbye'),
     ))
 
     digest, = self.scheduler.product_request(Digest, [input_files_content])

--- a/src/python/pants/rules/core/cloc.py
+++ b/src/python/pants/rules/core/cloc.py
@@ -83,7 +83,7 @@ def run_cloc(console: Console, options: CountLinesOfCode.Options, cloc_script: D
   report_filename = 'report.txt'
   ignore_filename = 'ignored.txt'
 
-  input_file_list = InputFilesContent(FilesContent((FileContent(path=input_files_filename, content=file_content, is_executable=False),)))
+  input_file_list = InputFilesContent(FilesContent((FileContent(path=input_files_filename, content=file_content),)))
   input_file_digest = yield Get(Digest, InputFilesContent, input_file_list)
   cloc_script_digest = cloc_script.digest
   digests_to_merge.extend([cloc_script_digest, input_file_digest])

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -49,7 +49,7 @@ class ParseAddressFamilyTest(unittest.TestCase):
         MockGet(
           product_type=FilesContent,
           subject_type=Digest,
-          mock=lambda _: FilesContent([FileContent('/dev/null/BUILD', b'', False)]),
+          mock=lambda _: FilesContent([FileContent(path='/dev/null/BUILD', content=b'')]),
         ),
       ],
     )

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -377,8 +377,8 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
 
   def test_add_prefix(self):
     input_files_content = InputFilesContent((
-      FileContent(path='main.py', content=b'print("from main")', is_executable=False),
-      FileContent(path='subdir/sub.py', content=b'print("from sub")', is_executable=False),
+      FileContent(path='main.py', content=b'print("from main")'),
+      FileContent(path='subdir/sub.py', content=b'print("from sub")'),
     ))
 
     digest, = self.scheduler.product_request(Digest, [input_files_content])

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -213,7 +213,7 @@ class TestInputFileCreation(TestBase):
     file_name = 'some.filename'
     file_contents = b'some file contents'
 
-    input_file = InputFilesContent((FileContent(path=file_name, content=file_contents, is_executable=False),))
+    input_file = InputFilesContent((FileContent(path=file_name, content=file_contents),))
     digest, = self.scheduler.product_request(Digest, [input_file])
 
     req = ExecuteProcessRequest(
@@ -227,8 +227,8 @@ class TestInputFileCreation(TestBase):
 
   def test_multiple_file_creation(self):
     input_files_content = InputFilesContent((
-      FileContent(path='a.txt', content=b'hello', is_executable=False),
-      FileContent(path='b.txt', content=b'goodbye', is_executable=False),
+      FileContent(path='a.txt', content=b'hello'),
+      FileContent(path='b.txt', content=b'goodbye'),
     ))
 
     digest, = self.scheduler.product_request(Digest, [input_files_content])
@@ -246,7 +246,7 @@ class TestInputFileCreation(TestBase):
     path = 'somedir/filename'
     content = b'file contents'
 
-    input_file = InputFilesContent((FileContent(path=path, content=content, is_executable=False),))
+    input_file = InputFilesContent((FileContent(path=path, content=content),))
     digest, = self.scheduler.product_request(Digest, [input_file])
 
     req = ExecuteProcessRequest(
@@ -262,7 +262,7 @@ class TestInputFileCreation(TestBase):
     file_name = 'echo.sh'
     file_contents = b'#!/bin/bash -eu\necho "Hello"\n'
 
-    input_file = InputFilesContent((FileContent(path=file_name, content=file_contents, is_executable=False),))
+    input_file = InputFilesContent((FileContent(path=file_name, content=file_contents),))
     digest, = self.scheduler.product_request(Digest, [input_file])
 
     req = ExecuteProcessRequest(

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -1517,5 +1517,5 @@ class OptionsTestStringPayloads(OptionsTest):
       fp.seek(0)
       payload = fp.read()
       return Config.load_file_contents(
-        config_payloads=[FileContent('blah', payload, is_executable=False)],
+        config_payloads=[FileContent(path='blah', content=payload)],
       )


### PR DESCRIPTION
Over 90% of our usages set the value to `False`. We only didn't use a default because we couldn't until recently using `@dataclass` over `datatype()`.