### PR TITLE
Skip two flaky tests and tweak more test timeouts

### DIFF
--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1081,6 +1081,7 @@ fn timeout_after_sufficiently_delayed_getoperations() {
 }
 
 #[test]
+#[ignore] // https://github.com/pantsbuild/pants/issues/8405
 fn dropped_request_cancels() {
   let request_timeout = Duration::new(10, 0);
   let delayed_operation_time = Duration::new(5, 0);

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -22,7 +22,7 @@ python_tests(
     'testprojects/src/scala/org/pantsbuild/testproject:javasources_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:mutual_directory',
   ],
-  timeout = 600,
+  timeout = 660,
   tags = {'integration'},
 )
 
@@ -35,7 +35,7 @@ python_tests(
     'testprojects/src/scala/org/pantsbuild/testproject:mutual_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:public_inference_directory',
   ],
-  timeout = 600,
+  timeout = 800,
   tags = {'integration'},
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile_integration_youtline.py
@@ -1,6 +1,8 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import pytest
+
 from pants_test.backend.jvm.tasks.jvm_compile.rsc.rsc_compile_integration_base import (
   RscCompileIntegrationBase,
   ensure_compile_rsc_execution_strategy,
@@ -13,6 +15,7 @@ class RscCompileIntegrationYoutline(RscCompileIntegrationBase):
   def test_basic_binary(self):
     self._testproject_compile("mutual", "bin", "A")
 
+  @pytest.mark.flaky(retries=1)
   @ensure_compile_rsc_execution_strategy(RscCompileIntegrationBase.outline_and_zinc)
   def test_public_inference(self):
     self._testproject_compile("public_inference", "public_inference", "PublicInference")

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
@@ -9,6 +9,6 @@ python_tests(
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
     'examples/src/scala/org/pantsbuild/example:scalac_directory',
   ],
-  timeout = 600,
+  timeout = 640,
   tags = {'integration'},
 )

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -49,6 +49,7 @@ python_tests(
     'testprojects:pants_plugins_directory',
   ],
   tags={'integration'},
+  timeout = 120,
 )
 
 python_library(

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -31,7 +31,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:phrases_directory',
   ],
   tags = {'integration'},
-  timeout = 500,
+  timeout = 530,
 )
 
 python_tests(


### PR DESCRIPTION
### Skip some exception sink integration tests on macOS
These shards have chronically flaked by hanging since at least July https://github.com/pantsbuild/pants/issues/8127. They are our most egregious Python flake.

We will still test these four tests on Linux and only skip them on macOS, as this is a macOS specific 
issue.

### Skip `remote::tests::dropped_request_cancels`
This seems to flake roughly 40% of the time https://github.com/pantsbuild/pants/issues/8405. It is our most egregious Rust flake.

### Tweak some other tests
We mark some other tests as flaky and bump their timeouts as relevant to hopefully stabilize CI further.