### PR TITLE
Add available targets to the exported json in order to support proper highlighting in the BUILD files

### DIFF
--- a/src/docs/export.md
+++ b/src/docs/export.md
@@ -177,6 +177,11 @@ The following is an abbreviated export file from a command in the pants repo:
 
 # Export Format Changes
 
+## 1.0.13
+
+Add `--available-target-types` option, which exports currently available target types. 
+Same ones as the ones obtained by invoking `pants targets` task.
+
 ## 1.0.12
 
 Add `export-dep-as-jar` task, which exports target roots as sources and dependencies as jars.

--- a/src/python/pants/backend/project_info/tasks/export_version.py
+++ b/src/python/pants/backend/project_info/tasks/export_version.py
@@ -13,4 +13,4 @@
 #
 # Note format changes in src/docs/export.md and update the Changelog section.
 #
-DEFAULT_EXPORT_VERSION = '1.0.12'
+DEFAULT_EXPORT_VERSION = '1.0.13'


### PR DESCRIPTION
### Problem

This is most likely needed for https://github.com/pantsbuild/intellij-pants-plugin/issues/355

Need to be confirmed by @wisechengyi , but the general problem is:
```
currently pants dictionary keywords are highlighted by python plugin as unresolved symbols, so they need to be recognize correctly first before further assistance can be provided.
```

### Solution

I reused part of the code used for `pants targets` to be added to the export command.

### Result

Output file from the `export` command will contain an additional section on `available_targets`