### PR TITLE
Refactor `fmt-v2` to use Workspace

### DIFF
--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -154,7 +154,7 @@ class Snapshot:
 
 @dataclass(frozen=True)
 class DirectoriesToMerge:
-  directories: Tuple
+  directories: Tuple[Digest, ...]
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -46,6 +46,9 @@ async def fmt(
     if union_membership.is_member(TargetWithSources, target.adaptor) and hasattr(target.adaptor, "sources")
   )
 
+  if not results:
+    return Fmt(exit_code=0)
+
   # NB: this will fail if there are any conflicting changes, which we want to happen rather than
   # silently having one result override the other.
   # TODO(#8722): how should we handle multiple auto-formatters touching the same files?
@@ -61,8 +64,7 @@ async def fmt(
 
   # Since the rules to produce FmtResult should use ExecuteRequest, rather than
   # FallibleExecuteProcessRequest, we assume that there were no failures.
-  exit_code = 0
-  return Fmt(exit_code)
+  return Fmt(exit_code=0)
 
 
 def rules():

--- a/src/python/pants/rules/core/fmt_test.py
+++ b/src/python/pants/rules/core/fmt_test.py
@@ -1,53 +1,92 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Callable, List, Tuple, Type
+from pathlib import Path
+from typing import List, Tuple, Type
 
-from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, FilesContent
+from pants.engine.fs import Digest, FileContent, InputFilesContent, Workspace
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
 from pants.engine.legacy.structs import JvmAppAdaptor, PythonTargetAdaptor, TargetAdaptor
 from pants.engine.rules import UnionMembership
 from pants.rules.core.fmt import Fmt, FmtResult, TargetWithSources, fmt
 from pants.testutil.engine.util import MockConsole, MockGet, run_rule
+from pants.testutil.test_base import TestBase
 
 
-def make_target(
-  *, name: str = "target", adaptor_type: Type[TargetAdaptor] = PythonTargetAdaptor
-) -> HydratedTarget:
-  return HydratedTarget(
-    address=f"src/{name}",
-    adaptor=adaptor_type(sources=(), name=name),
-    dependencies=()
-  )
+class FmtTest(TestBase):
 
+  formatted_file = Path("formatted.txt")
+  formatted_content = "I'm so pretty now!\n"
 
-def run_fmt_rule(
-  *,
-  targets: List[HydratedTarget],
-  mock_formatter: Callable[[PythonTargetAdaptor], FmtResult],
-) -> Tuple[Fmt, MockConsole]:
-  console = MockConsole(use_colors=False)
-  result: Fmt = run_rule(
-    fmt,
-    rule_args=[
-      console,
-      HydratedTargets(targets),
-      UnionMembership(union_rules={TargetWithSources: [PythonTargetAdaptor]})
-    ],
-    mock_gets=[
-      MockGet(product_type=FmtResult, subject_type=PythonTargetAdaptor, mock=mock_formatter),
-      MockGet(product_type=FilesContent, subject_type=Digest, mock=lambda _: FilesContent([]))
-    ],
-  )
-  return result, console
+  @staticmethod
+  def make_hydrated_target(
+    *, name: str = "target", adaptor_type: Type[TargetAdaptor] = PythonTargetAdaptor
+  ) -> HydratedTarget:
+    return HydratedTarget(
+      address=f"src/{name}",
+      adaptor=adaptor_type(sources=(), name=name),
+      dependencies=()
+    )
 
+  def run_fmt_rule(self, *, targets: List[HydratedTarget]) -> Tuple[Fmt, MockConsole]:
+    result_digest = self.request_single_product(
+      Digest,
+      InputFilesContent([
+        FileContent(path=str(self.formatted_file), content=self.formatted_content.encode())
+      ])
+    )
+    console = MockConsole(use_colors=False)
+    result: Fmt = run_rule(
+      fmt,
+      rule_args=[
+        console,
+        HydratedTargets(targets),
+        Workspace(self.scheduler),
+        UnionMembership(union_rules={TargetWithSources: [PythonTargetAdaptor]})
+      ],
+      mock_gets=[
+        MockGet(
+          product_type=FmtResult,
+          subject_type=PythonTargetAdaptor,
+          mock=lambda adaptor: FmtResult(
+            digest=result_digest, stdout=f"Formatted target `{adaptor.name}`", stderr=""
+          )
+        ),
+      ],
+    )
+    return result, console
 
-def test_non_union_member_noops() -> None:
-  result, console = run_fmt_rule(
-    targets=[make_target(adaptor_type=JvmAppAdaptor)],
-    mock_formatter=lambda adaptor: FmtResult(
-      digest=EMPTY_DIRECTORY_DIGEST, stdout=f"Formatted target `{adaptor.name}`", stderr=""
-    ),
-  )
-  assert result.exit_code == 0
-  assert console.stdout.getvalue().strip() == ""
+  def assert_workspace_modified(self, modified: bool = True) -> None:
+    formatted_file = Path(self.build_root, self.formatted_file)
+    if not modified:
+      assert not formatted_file.is_file()
+      return
+    assert formatted_file.is_file()
+    assert formatted_file.read_text() == self.formatted_content
+
+  def test_non_union_member_noops(self) -> None:
+    result, console = self.run_fmt_rule(
+      targets=[self.make_hydrated_target(adaptor_type=JvmAppAdaptor)]
+    )
+    assert result.exit_code == 0
+    assert console.stdout.getvalue().strip() == ""
+    self.assert_workspace_modified(modified=False)
+
+  def test_single_target(self) -> None:
+    result, console = self.run_fmt_rule(targets=[self.make_hydrated_target()])
+    assert result.exit_code == 0
+    assert console.stdout.getvalue().strip() == "Formatted target `target`"
+    self.assert_workspace_modified()
+
+  def test_multiple_targets(self) -> None:
+    result, console = self.run_fmt_rule(
+      targets=[self.make_hydrated_target(name="t1"), self.make_hydrated_target(name="t2")]
+    )
+    assert result.exit_code == 0
+    assert console.stdout.getvalue().splitlines() == [
+      "Formatted target `t1`", "Formatted target `t2`"
+    ]
+    # NB: these targets result in the same `FmtResult.digest`s, meaning that they will overwrite
+    # each other when the formatting is applied. This test ensures that we properly
+    # handle overlapping `FmtResult.digest`s.
+    self.assert_workspace_modified()

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -36,6 +36,9 @@ async def lint(console: Console, targets: HydratedTargets, union_membership: Uni
     if union_membership.is_member(TargetWithSources, target.adaptor) and hasattr(target.adaptor, "sources")
   )
 
+  if not results:
+    return Lint(exit_code=0)
+
   exit_code = 0
   for result in results:
     if result.stdout:

--- a/src/python/pants/rules/core/lint_test.py
+++ b/src/python/pants/rules/core/lint_test.py
@@ -1,63 +1,75 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Callable, List, Tuple, Type
+from typing import Callable, List, Optional, Tuple, Type
 
 from pants.engine.legacy.graph import HydratedTarget, HydratedTargets
 from pants.engine.legacy.structs import JvmAppAdaptor, PythonTargetAdaptor, TargetAdaptor
 from pants.engine.rules import UnionMembership
 from pants.rules.core.lint import Lint, LintResult, TargetWithSources, lint
 from pants.testutil.engine.util import MockConsole, MockGet, run_rule
+from pants.testutil.test_base import TestBase
 
 
-def make_target(
-  *, name: str = "target", adaptor_type: Type[TargetAdaptor] = PythonTargetAdaptor
-) -> HydratedTarget:
-  return HydratedTarget(
-    address=f"src/{name}",
-    adaptor=adaptor_type(sources=(), name=name),
-    dependencies=()
-  )
+class LintTest(TestBase):
 
+  @staticmethod
+  def make_hydrated_target(
+    *, name: str = "target", adaptor_type: Type[TargetAdaptor] = PythonTargetAdaptor
+  ) -> HydratedTarget:
+    return HydratedTarget(
+      address=f"src/{name}",
+      adaptor=adaptor_type(sources=(), name=name),
+      dependencies=()
+    )
 
-def run_lint_rule(
-  *,
-  targets: List[HydratedTarget],
-  mock_linter: Callable[[PythonTargetAdaptor], LintResult],
-) -> Tuple[Lint, MockConsole]:
-  console = MockConsole(use_colors=False)
-  result: Lint = run_rule(
-    lint,
-    rule_args=[
-      console,
-      HydratedTargets(targets),
-      UnionMembership(union_rules={TargetWithSources: [PythonTargetAdaptor]})
-    ],
-    mock_gets=[
-      MockGet(product_type=LintResult, subject_type=PythonTargetAdaptor, mock=mock_linter),
-    ],
-  )
-  return result, console
+  @staticmethod
+  def run_lint_rule(
+    *,
+    targets: List[HydratedTarget],
+    mock_linter: Optional[Callable[[PythonTargetAdaptor], LintResult]] = None,
+  ) -> Tuple[Lint, MockConsole]:
+    if mock_linter is None:
+      mock_linter = lambda target_adaptor: LintResult(
+        exit_code=1, stdout=f"Linted the target `{target_adaptor.name}`", stderr=""
+      )
+    console = MockConsole(use_colors=False)
+    result: Lint = run_rule(
+      lint,
+      rule_args=[
+        console,
+        HydratedTargets(targets),
+        UnionMembership(union_rules={TargetWithSources: [PythonTargetAdaptor]})
+      ],
+      mock_gets=[
+        MockGet(product_type=LintResult, subject_type=PythonTargetAdaptor, mock=mock_linter),
+      ],
+    )
+    return result, console
 
+  def test_non_union_member_noops(self) -> None:
+    result, console = self.run_lint_rule(
+      targets=[self.make_hydrated_target(adaptor_type=JvmAppAdaptor)],
+    )
+    assert result.exit_code == 0
+    assert console.stdout.getvalue().strip() == ""
 
-def test_non_union_member_noops() -> None:
-  result, console = run_lint_rule(
-    targets=[make_target(adaptor_type=JvmAppAdaptor)],
-    mock_linter=lambda target: LintResult(exit_code=1, stdout="", stderr=""),
-  )
-  assert result.exit_code == 0
-  assert console.stdout.getvalue().strip() == ""
+  def test_single_target(self) -> None:
+    result, console = self.run_lint_rule(targets=[self.make_hydrated_target()])
+    assert result.exit_code == 1
+    assert console.stdout.getvalue().strip() == "Linted the target `target`"
 
+  def test_multiple_targets(self) -> None:
+    # Notably, if any single target fails, the error code should propagate to the whole run.
+    def mock_linter(adaptor: PythonTargetAdaptor) -> LintResult:
+      if adaptor.name == "bad":
+        return LintResult(exit_code=127, stdout="failure", stderr="failure")
+      return LintResult(exit_code=0, stdout=f"Linted the target `{adaptor.name}`", stderr="..")
 
-def test_failure_for_a_single_target_propagates():
-  def mock_linter(adaptor: PythonTargetAdaptor) -> LintResult:
-    if adaptor.name == "bad":
-      return LintResult(exit_code=127, stdout="failure", stderr="failure")
-    return LintResult(exit_code=0, stdout=f"Linted the target `{adaptor.name}`", stderr="..")
-
-  result, console = run_lint_rule(
-    targets=[make_target(name="good"), make_target(name="bad")], mock_linter=mock_linter,
-  )
-  assert result.exit_code == 127
-  assert console.stdout.getvalue().splitlines() == ["Linted the target `good`", "failure"]
-  assert console.stderr.getvalue().splitlines() == ["..", "failure"]
+    result, console = self.run_lint_rule(
+      targets=[self.make_hydrated_target(name="good"), self.make_hydrated_target(name="bad")],
+      mock_linter=mock_linter,
+    )
+    assert result.exit_code == 127
+    assert console.stdout.getvalue().splitlines() == ["Linted the target `good`", "failure"]
+    assert console.stderr.getvalue().splitlines() == ["..", "failure"]


### PR DESCRIPTION
### Problem

When writing the original `fmt-v2` goal, `Workspace` was not yet landed in master. So, we had to hackily use Python file system APIs to save the `FmtResult`'s digest into the actual workspace. This works but is not ideal because it does not use V2 abstractions and has a performance hit— materializing `FilesContent` to memory is expensive and the old implementation missed out on parallelism.

### Solution

Use `Workspace` and add unit tests for it.

This also addresses the concern from https://github.com/pantsbuild/pants/pull/8684#pullrequestreview-321465344 that we should be testing how `fmt-v2` and `lint-v2` operate against multiple targets.

### Result

* More idiomatic code
* More comprehensive tests
* Detection of conflicting changes, compared to silently overriding each other
* Improved performance