### PR TITLE
Workunit Subsystem

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -22,6 +22,7 @@ from pants.option.arg_splitter import UnknownGoalHelp
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.reporting.reporting import Reporting
 from pants.reporting.streaming_workunit_handler import StreamingWorkunitHandler
+from pants.reporting.workunits import Workunits
 from pants.util.contextutil import maybe_profiled
 
 
@@ -320,7 +321,11 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     try:
       self._maybe_handle_help()
 
-      streaming_reporter = StreamingWorkunitHandler(self._scheduler_session, callback=None)
+      stream_workunits = self._options.for_scope('reporting').stream_workunits
+      workunits = Workunits.global_instance()
+      callback = workunits.make_http_request if stream_workunits else None
+
+      streaming_reporter = StreamingWorkunitHandler(self._scheduler_session, callback=callback)
       with streaming_reporter.session():
         engine_result = self._maybe_run_v2()
 

--- a/src/python/pants/init/global_subsystems.py
+++ b/src/python/pants/init/global_subsystems.py
@@ -7,6 +7,7 @@ from pants.goal.run_tracker import RunTracker
 from pants.init.repro import Reproducer
 from pants.process.subprocess import Subprocess
 from pants.reporting.reporting import Reporting
+from pants.reporting.workunits import Workunits
 from pants.scm.subsystems.changed import Changed
 from pants.source.source_root import SourceRootConfig
 
@@ -21,6 +22,7 @@ class GlobalSubsystems:
       Reproducer,
       RunTracker,
       Changed,
+      Workunits,
       BinaryUtil.Factory,
       Subprocess.Factory
     }

--- a/src/python/pants/reporting/workunits.py
+++ b/src/python/pants/reporting/workunits.py
@@ -1,0 +1,32 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import json
+from typing import Tuple
+
+import requests
+from requests.exceptions import RequestException
+
+from pants.subsystem.subsystem import Subsystem
+
+
+class Workunits(Subsystem):
+  options_scope = 'workunits'
+
+  @classmethod
+  def register_options(cls, register):
+    register("--http-endpoint", type=str, help="Where to make HTTP requests to")
+
+  def make_http_request(self, workunits: Tuple[dict,...]):
+    options =  self.get_options()
+    http_endpoint = options.http_endpoint
+    data = { "workunits": workunits }
+
+    if not http_endpoint:
+      print("Streaming workunits are activated, but there is no specified HTTP endpoint to send them to")
+      return
+
+    try:
+      requests.post(http_endpoint, data=json.dumps(data))
+    except RequestException as e:
+      print(f"Failed to make a request: {e}")


### PR DESCRIPTION
### Problem

Now that we have streaming workunits, we want to be able to do something useful with them, like periodically send a JSON blob representing them to a specified HTTP server.

### Solution

Create a new subsystem Workunits that does exactly this.

TODO: add tests