### PR TITLE
Assign names to some `@rule`s

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -103,7 +103,7 @@ async def setup_black(wrapped_target: FormattablePythonTarget, black: Black) -> 
   return BlackSetup(config_path, resolved_requirements_pex, merged_input_files)
 
 
-@rule
+@rule(name="Format using black")
 async def fmt(
   wrapped_target: FormattablePythonTarget,
   black_setup: BlackSetup,
@@ -124,7 +124,7 @@ async def fmt(
   )
 
 
-@rule
+@rule(name="Lint using black")
 async def lint(
   wrapped_target: FormattablePythonTarget,
   black_setup: BlackSetup,

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -84,7 +84,7 @@ class Pex(HermeticPex):
 
 # TODO: This is non-hermetic because the requirements will be resolved on the fly by
 # pex, where it should be hermetically provided in some way.
-@rule
+@rule(name="Create PEX")
 async def create_pex(
     request: CreatePex,
     pex_bin: DownloadedPexBin,

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -22,7 +22,7 @@ from pants.rules.core.core_test_model import Status, TestResult, TestTarget
 from pants.rules.core.strip_source_root import SourceRootStrippedSources
 
 
-@rule
+@rule(name="Run pytest")
 async def run_python_test(
   test_target: PythonTestsAdaptor,
   pytest: PyTest,


### PR DESCRIPTION
### Problem

Now that we have the named rules abstraction, we should start giving names to rules that we think are important enough to be reflected in workunit reporting.

### Solution

This is a small set of `@rule`s that we're reasonably sure justify having names - the rule to run python tests, to create a PEX, and formatting/linting python code with black. 

### Result

The above-mentioned `@rule`s will be reflected in workunit reporting, including zipkin. 