### PR TITLE
Treat all `MaterializeToDirectories` paths as relative to the buildroot

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -372,7 +372,7 @@ class Zinc:
     if not os.path.exists(bridge_jar):
       res = self._run_bootstrapper(bridge_jar, context)
       context._scheduler.materialize_directories((
-        DirectoryToMaterialize(get_buildroot(), res.output_directory_digest),
+        DirectoryToMaterialize("", res.output_directory_digest),
       ))
       # For the workaround above to work, we need to store a copy of the bridge in
       # the bootstrapdir cache (.cache).

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -4,12 +4,14 @@
 import logging
 import os
 import subprocess
+from pathlib import Path
 
 from pants.backend.jvm import argfile
 from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.jvm_compile.jvm_compile import JvmCompile
+from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.engine.fs import DirectoryToMaterialize
@@ -169,9 +171,10 @@ class JavacCompile(JvmCompile):
           workunit.set_outcome(WorkUnit.FAILURE if return_code else WorkUnit.SUCCESS)
           if return_code:
             raise TaskError('javac exited with return code {rc}'.format(rc=return_code))
+        classes_directory = Path(ctx.classes_dir.path).relative_to(get_buildroot())
         self.context._scheduler.materialize_directories((
           DirectoryToMaterialize(
-            ctx.classes_dir.path,
+            str(classes_directory),
             self.post_compile_extra_resources_digest(ctx, prepend_post_merge_relative_path=False)),
         ))
 
@@ -230,7 +233,7 @@ class JavacCompile(JvmCompile):
         exec_result.output_directory_digest,
         self.post_compile_extra_resources_digest(ctx, prepend_post_merge_relative_path=False),
       ])
-    classes_directory = ctx.classes_dir.path
+    classes_directory = Path(ctx.classes_dir.path).relative_to(get_buildroot())
     self.context._scheduler.materialize_directories((
-      DirectoryToMaterialize(classes_directory, merged_directories),
+      DirectoryToMaterialize(str(classes_directory), merged_directories),
     ))

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -800,10 +800,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
     res.output_directory_digest.dump(ctx.rsc_jar_file.path)
     self.context._scheduler.materialize_directories((
-      DirectoryToMaterialize(
-        # NB the first element here is the root to materialize into, not the dir to snapshot
-        get_buildroot(),
-        res.output_directory_digest),
+      DirectoryToMaterialize("", res.output_directory_digest),
     ))
     ctx.rsc_jar_file.hydrate_missing_directory_digest(res.output_directory_digest)
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -379,7 +379,7 @@ class BaseZincCompile(JvmCompile):
     # Populate the resources to merge post compile onto disk for the nonhermetic case,
     # where `--post-compile-merge-dir` was added is the relevant part.
     self.context._scheduler.materialize_directories((
-      DirectoryToMaterialize(get_buildroot(), self.post_compile_extra_resources_digest(ctx)),
+      DirectoryToMaterialize("", self.post_compile_extra_resources_digest(ctx)),
     ))
 
     exit_code = self.runjava(classpath=self.get_zinc_compiler_classpath(),
@@ -517,7 +517,7 @@ class BaseZincCompile(JvmCompile):
 
     # TODO: Materialize as a batch in do_compile or somewhere
     self.context._scheduler.materialize_directories((
-      DirectoryToMaterialize(get_buildroot(), res.output_directory_digest),
+      DirectoryToMaterialize("", res.output_directory_digest),
     ))
 
     # TODO: This should probably return a ClasspathEntry rather than a Digest

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -29,7 +29,6 @@ from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
 from pants.testutil.subsystem.util import init_subsystems
 from pants.testutil.test_base import TestBase
-from pants.util.contextutil import temporary_dir
 from pants.util.strutil import create_path_env_var
 
 
@@ -75,14 +74,13 @@ class TestResolveRequirements(TestBase):
         PythonNativeCode.global_instance()
       )
     )
-    with temporary_dir() as tmp_dir:
-      self.scheduler.materialize_directories((
-        DirectoryToMaterialize(path=tmp_dir, directory_digest=requirements_pex.directory_digest),
-      ))
-      with zipfile.ZipFile(os.path.join(tmp_dir, "test.pex"), "r") as pex:
-        with pex.open("PEX-INFO", "r") as pex_info:
-          pex_info_content = pex_info.readline().decode()
-          pex_list = pex.namelist()
+    self.scheduler.materialize_directories((
+      DirectoryToMaterialize(path="", directory_digest=requirements_pex.directory_digest),
+    ))
+    with zipfile.ZipFile(os.path.join(self.build_root, "test.pex"), "r") as pex:
+      with pex.open("PEX-INFO", "r") as pex_info:
+        pex_info_content = pex_info.readline().decode()
+        pex_list = pex.namelist()
     return {'pex': requirements_pex, 'info': json.loads(pex_info_content), 'files': pex_list}
 
   def create_pex_and_get_pex_info(

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -3,7 +3,7 @@
 
 import os
 from dataclasses import dataclass
-from typing import Any, Iterable, Optional, Tuple
+from typing import TYPE_CHECKING, Iterable, Optional, Tuple
 
 from pants.engine.objects import Collection
 from pants.engine.rules import RootRule
@@ -11,6 +11,10 @@ from pants.option.custom_types import GlobExpansionConjunction as GlobExpansionC
 from pants.option.global_options import GlobMatchErrorBehavior
 from pants.util.dirutil import maybe_read_file, safe_delete, safe_file_dump
 from pants.util.meta import frozen_after_init
+
+
+if TYPE_CHECKING:
+  from pants.engine.scheduler import SchedulerSession
 
 
 @dataclass(frozen=True)
@@ -194,11 +198,12 @@ class UrlToFetch:
 @dataclass(frozen=True)
 class Workspace:
   """Abstract handle for operations that touch the real local filesystem."""
-  _scheduler: Any
+  _scheduler: "SchedulerSession"
 
-  def materialize_directories(self, directories_to_materialize: Tuple[DirectoryToMaterialize, ...]) -> MaterializeDirectoriesResult:
-    result: MaterializeDirectoriesResult = self._scheduler.materialize_directories(directories_to_materialize)
-    return result
+  def materialize_directories(
+    self, directories_to_materialize: Tuple[DirectoryToMaterialize, ...]
+  ) -> MaterializeDirectoriesResult:
+    return self._scheduler.materialize_directories(directories_to_materialize)
 
 
 # TODO: don't recreate this in python, get this from fs::EMPTY_DIGEST somehow.

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -3,6 +3,7 @@
 
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, Optional, Tuple
 
 from pants.engine.objects import Collection
@@ -173,6 +174,13 @@ class DirectoryToMaterialize:
   """A request to materialize the contents of a directory digest at the provided path."""
   path: str
   directory_digest: Digest
+
+  def __post_init__(self) -> None:
+    if Path(self.path).is_absolute():
+      raise ValueError(
+        f"The path must be relative for {self}, as the engine materializes directories relative to "
+        f"the build root."
+      )
 
 
 class DirectoriesToMaterialize(Collection[DirectoryToMaterialize]):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -8,7 +8,6 @@ import sys
 import time
 import traceback
 from dataclasses import dataclass
-from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Dict, Tuple
 
@@ -26,7 +25,7 @@ from pants.engine.objects import Collection
 from pants.engine.rules import RuleIndex, TaskRule
 from pants.engine.selectors import Params
 from pants.util.contextutil import temporary_file_path
-from pants.util.dirutil import check_all_relative, check_no_overlapping_paths
+from pants.util.dirutil import check_no_overlapping_paths
 from pants.util.strutil import pluralize
 
 
@@ -588,7 +587,6 @@ class SchedulerSession:
     # build root).
     dir_list = [dtm.path for dtm in directories_to_materialize]
     check_no_overlapping_paths(dir_list)
-    check_all_relative(*[Path(d) for d in dir_list])
 
     wrapped_result = self._scheduler._native.lib.materialize_directories(
       self._scheduler._scheduler,

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -582,9 +582,8 @@ class SchedulerSession:
     directories_to_materialize: Tuple[DirectoryToMaterialize, ...]
   ) -> MaterializeDirectoriesResult:
     """Creates the specified directories on the file system."""
-    # Ensure that there isn't more than one of the same directory paths, that paths do not have
-    # the same prefix, and that all paths are relative (the engine materializes relative to the
-    # build root).
+    # Ensure that there isn't more than one of the same directory paths and paths do not have the
+    # same prefix.
     dir_list = [dtm.path for dtm in directories_to_materialize]
     check_no_overlapping_paths(dir_list)
 

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -19,12 +19,10 @@ from pants.engine.rules import RootRule, console_rule
 from pants.engine.selectors import Get
 from pants.testutil.console_rule_test_base import ConsoleRuleTestBase
 from pants.testutil.test_base import TestBase
-from pants.util.contextutil import temporary_dir
 
 
 @dataclass(frozen=True)
 class MessageToConsoleRule:
-  tmp_dir: str
   input_files_content: InputFilesContent
 
 
@@ -36,10 +34,10 @@ class MockWorkspaceGoal(Goal):
 async def workspace_console_rule(console: Console, workspace: Workspace, msg: MessageToConsoleRule) -> MockWorkspaceGoal:
   digest = await Get(Digest, InputFilesContent, msg.input_files_content)
   output = workspace.materialize_directories((
-    DirectoryToMaterialize(path=msg.tmp_dir, directory_digest=digest),
+    DirectoryToMaterialize(path="", directory_digest=digest),
   ))
   output_path = output.dependencies[0].output_paths[0]
-  console.print_stdout(str(Path(msg.tmp_dir, output_path)), end='')
+  console.print_stdout(output_path, end='')
   return MockWorkspaceGoal(exit_code=0)
 
 
@@ -54,16 +52,12 @@ class WorkspaceInConsoleRuleTest(ConsoleRuleTestBase):
     return super().rules() + [RootRule(MessageToConsoleRule), workspace_console_rule]
 
   def test(self):
-    with temporary_dir() as tmp_dir:
-      input_files_content = InputFilesContent((
-        FileContent(path='a.txt', content=b'hello'),
-      ))
-
-      msg = MessageToConsoleRule(tmp_dir=tmp_dir, input_files_content=input_files_content)
-      output_path = str(Path(tmp_dir, 'a.txt'))
-      self.assert_console_output_contains(output_path, additional_params=[msg])
-      contents = open(output_path).read()
-      self.assertEqual(contents, 'hello')
+    msg = MessageToConsoleRule(
+      input_files_content=InputFilesContent([FileContent(path='a.txt', content=b'hello')])
+    )
+    output_path = Path(self.build_root, 'a.txt')
+    self.assert_console_output_contains(str(output_path), additional_params=[msg])
+    assert output_path.read_text() == "hello"
 
 
 #TODO(gshuflin) - it would be nice if this test, which tests that the MaterializeDirectoryResults value
@@ -81,20 +75,19 @@ class FileSystemTest(TestBase):
 
     digest = self.request_single_product(Digest, input_files_content)
 
-    with temporary_dir() as tmp_dir:
-      path1 = Path(tmp_dir, 'a.txt')
-      path2 = Path(tmp_dir, 'subdir', 'b.txt')
+    path1 = Path('a.txt')
+    path2 = Path('subdir/b.txt')
 
-      self.assertFalse(path1.is_file())
-      self.assertFalse(path2.is_file())
+    assert not path1.is_file()
+    assert not path2.is_file()
 
-      output = workspace.materialize_directories((
-        DirectoryToMaterialize(path=tmp_dir, directory_digest=digest),
-      ))
+    output = workspace.materialize_directories((
+      DirectoryToMaterialize(path="", directory_digest=digest),
+    ))
 
-      self.assertEqual(type(output), MaterializeDirectoriesResult)
-      materialize_result = output.dependencies[0]
-      self.assertEqual(type(materialize_result), MaterializeDirectoryResult)
-      self.assertEqual(materialize_result.output_paths,
-        (str(Path(tmp_dir, 'a.txt')), str(Path(tmp_dir, 'subdir/b.txt')),)
-      )
+    assert type(output) == MaterializeDirectoriesResult
+    materialize_result = output.dependencies[0]
+    assert type(materialize_result) == MaterializeDirectoryResult
+    assert materialize_result.output_paths == tuple(
+      str(Path(self.build_root, p)) for p in [path1, path2]
+    )

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 
+from pants.base.build_root import BuildRoot
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.console import Console
 from pants.engine.fs import DirectoryToMaterialize, Workspace
@@ -20,12 +21,21 @@ class Run(Goal):
 
 
 @console_rule
-async def run(console: Console, workspace: Workspace, runner: InteractiveRunner, bfa: BuildFileAddress) -> Run:
+async def run(
+  console: Console,
+  workspace: Workspace,
+  runner: InteractiveRunner,
+  build_root: BuildRoot,
+  bfa: BuildFileAddress,
+) -> Run:
   target = bfa.to_address()
   binary = await Get(CreatedBinary, Address, target)
 
-  with temporary_dir(cleanup=True) as tmpdir:
-    dirs_to_materialize = (DirectoryToMaterialize(path=str(tmpdir), directory_digest=binary.digest),)
+  with temporary_dir(root_dir=str(Path(build_root.path, ".pants.d")), cleanup=True) as tmpdir:
+    path_relative_to_build_root = Path(tmpdir).relative_to(build_root.path)
+    dirs_to_materialize = (DirectoryToMaterialize(
+      path=path_relative_to_build_root, directory_digest=binary.digest),
+    )
     workspace.materialize_directories(dirs_to_materialize)
 
     console.write_stdout(f"Running target: {target}\n")

--- a/src/python/pants/rules/core/run_test.py
+++ b/src/python/pants/rules/core/run_test.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pants.base.build_root import BuildRoot
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.fs import Digest, FileContent, InputFilesContent, Workspace
 from pants.engine.interactive_runner import InteractiveRunner
@@ -32,9 +33,10 @@ class RunTest(ConsoleRuleTestBase):
       target_name=address.target_name,
       rel_path=f'{address.spec_path}/BUILD'
     )
+    BuildRoot.path = self.build_root
     res = run_rule(
       run.run,
-      rule_args=[console, workspace, interactive_runner, bfa],
+      rule_args=[console, workspace, interactive_runner, BuildRoot, bfa],
       mock_gets=[
         MockGet(
           product_type=CreatedBinary,

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -394,6 +394,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
       build_file_imports_behavior='allow',
       native=init_native(),
       options_bootstrapper=OptionsBootstrapper.create(args=['--pants-config-files=[]']),
+      build_root=self.build_root,
       build_configuration=self.build_config(),
       build_ignore_patterns=None,
     ).new_session(zipkin_trace_v2=False, build_id="buildid_for_test")

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -11,7 +11,6 @@ import threading
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
-from pathlib import PurePath
 from typing import (
   Any,
   Callable,
@@ -604,12 +603,6 @@ def check_no_overlapping_paths(paths: Iterable[str]) -> None:
     for p in list_copy_without_path:
       if path in p:
         raise ValueError('{} and {} have the same prefix. All paths must be unique and cannot overlap.'.format(path, p))
-
-
-def check_all_relative(*paths: PurePath) -> None:
-  absolute_paths = [p for p in paths if p.is_absolute()]
-  if absolute_paths:
-    raise ValueError(f"Not all paths are relative: {', '.join(str(p) for p in absolute_paths)}")
 
 
 def is_executable(path: str) -> bool:

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -11,6 +11,7 @@ import threading
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
+from pathlib import PurePath
 from typing import (
   Any,
   Callable,
@@ -593,7 +594,7 @@ def split_basename_and_dirname(path: str) -> Tuple[str, str]:
   return os.path.dirname(path), os.path.basename(path)
 
 
-def check_no_overlapping_paths(paths: Sequence[str]) -> None:
+def check_no_overlapping_paths(paths: Iterable[str]) -> None:
   """Given a list of paths, ensure that all are unique and do not have the same prefix."""
   for path in paths:
     list_copy_without_path = list(paths)
@@ -603,6 +604,12 @@ def check_no_overlapping_paths(paths: Sequence[str]) -> None:
     for p in list_copy_without_path:
       if path in p:
         raise ValueError('{} and {} have the same prefix. All paths must be unique and cannot overlap.'.format(path, p))
+
+
+def check_all_relative(*paths: PurePath) -> None:
+  absolute_paths = [p for p in paths if p.is_absolute()]
+  if absolute_paths:
+    raise ValueError(f"Not all paths are relative: {', '.join(str(p) for p in absolute_paths)}")
 
 
 def is_executable(path: str) -> bool:

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -1000,12 +1000,17 @@ pub extern "C" fn materialize_directories(
       dir_and_digests
         .into_iter()
         .map(|(dir, digest)| {
+          // NB: all DirectoryToMaterialize paths are validated in Python to be relative paths.
+          // Here, we join them with the build root.
+          let mut destination = PathBuf::new();
+          destination.push(scheduler.core.build_root.clone());
+          destination.push(dir);
           let metadata = scheduler.core.store().materialize_directory(
-            dir.clone(),
+            destination.clone(),
             digest,
             workunit_store.clone(),
           );
-          metadata.map(|m| (dir, m))
+          metadata.map(|m| (destination, m))
         })
         .collect::<Vec<_>>(),
     )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/test_rsc_compile.py
@@ -59,7 +59,7 @@ class RscCompileTest(NailgunTaskTestBase):
       tags={'use-compiler:zinc-only'}
     )
 
-    with temporary_dir() as tmp_dir:
+    with temporary_dir(root_dir=self.build_root) as tmp_dir:
       invalid_targets = [java_target, scala_target]
       task = self.create_task_with_target_roots(
         target_roots=[java_target]
@@ -107,7 +107,7 @@ class RscCompileTest(NailgunTaskTestBase):
       tags={f'use-compiler:{RscCompile.JvmCompileWorkflowType.rsc_and_zinc.value}'},
     )
 
-    with temporary_dir() as tmp_dir:
+    with temporary_dir(root_dir=self.build_root) as tmp_dir:
       invalid_targets = [java_target, scala_target]
       task = self.create_task_with_target_roots(
         target_roots=[java_target]
@@ -152,7 +152,7 @@ class RscCompileTest(NailgunTaskTestBase):
       dependencies=[]
     )
 
-    with temporary_dir() as tmp_dir:
+    with temporary_dir(root_dir=self.build_root) as tmp_dir:
       invalid_targets = [scala_target]
       task = self.create_task_with_target_roots(
         target_roots=[scala_target],
@@ -224,7 +224,7 @@ class RscCompileTest(NailgunTaskTestBase):
       tags={'use-compiler:zinc-only'}
     )
 
-    with temporary_dir() as tmp_dir:
+    with temporary_dir(root_dir=self.build_root) as tmp_dir:
       invalid_targets = [java_target, scala_target, scala_dep, test_target]
       task = self.create_task_with_target_roots(
         target_roots=[java_target, scala_target, test_target]
@@ -312,7 +312,7 @@ class RscCompileTest(NailgunTaskTestBase):
       dependencies=[]
     )
 
-    with temporary_dir() as tmp_dir:
+    with temporary_dir(root_dir=self.build_root) as tmp_dir:
       invalid_targets = [
         java_target,
         scala_target_direct_java_sources,

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -8,6 +8,7 @@ import unittest
 import unittest.mock
 from contextlib import contextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterator, Tuple, Union
 
 from pants.util import dirutil
@@ -17,6 +18,7 @@ from pants.util.dirutil import (
   ExistingFileError,
   _mkdtemp_unregister_cleaner,
   absolute_symlink,
+  check_all_relative,
   check_no_overlapping_paths,
   fast_relpath,
   get_basedir,
@@ -589,3 +591,11 @@ class AbsoluteSymlinkTest(unittest.TestCase):
     paths = ["/he/went/to/the/store", "/she/saw/a/movie", "/no/one/knew/where/to/go"]
     # This test is successful if nothing happens when calling check_no_overlapping_paths(paths)
     check_no_overlapping_paths(paths)
+
+  def test_check_all_relative(self) -> None:
+    valid_paths = ["", "./", "./test", "../", "test", "test/nested", "./f.txt", "f.txt", "test/f.txt"]
+    invalid_paths = ["/", "/usr/lib", "/User/f.txt"]
+    check_all_relative(*[Path(fp) for fp in valid_paths])
+    with self.assertRaises(ValueError) as e:
+      check_all_relative(*[Path(fp) for fp in invalid_paths])
+      assert ", ".join(invalid_paths) in str(e)

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -8,7 +8,6 @@ import unittest
 import unittest.mock
 from contextlib import contextmanager
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Iterator, Tuple, Union
 
 from pants.util import dirutil
@@ -18,7 +17,6 @@ from pants.util.dirutil import (
   ExistingFileError,
   _mkdtemp_unregister_cleaner,
   absolute_symlink,
-  check_all_relative,
   check_no_overlapping_paths,
   fast_relpath,
   get_basedir,
@@ -591,11 +589,3 @@ class AbsoluteSymlinkTest(unittest.TestCase):
     paths = ["/he/went/to/the/store", "/she/saw/a/movie", "/no/one/knew/where/to/go"]
     # This test is successful if nothing happens when calling check_no_overlapping_paths(paths)
     check_no_overlapping_paths(paths)
-
-  def test_check_all_relative(self) -> None:
-    valid_paths = ["", "./", "./test", "../", "test", "test/nested", "./f.txt", "f.txt", "test/f.txt"]
-    invalid_paths = ["/", "/usr/lib", "/User/f.txt"]
-    check_all_relative(*[Path(fp) for fp in valid_paths])
-    with self.assertRaises(ValueError) as e:
-      check_all_relative(*[Path(fp) for fp in invalid_paths])
-      assert ", ".join(invalid_paths) in str(e)


### PR DESCRIPTION
### Problem

We want to be able to safely use relative paths when writing rules, such as `binary.py` using the path `dist/` and `fmt-v2` uses the path `./`. Currently, Rust will accept this as-is, thus creating the directory relative to the cwd, instead of relative to the build root.

There is no use case we can imagine where we want to allow writing to an absolute path. For testing, our `TestBase` code already sets up a new temporary build root for every test. When we need a temporary directory, we can set that to live within `.pants.d`.

### Solution

Modify the Rust code to join the final destination path with the build root.

Also, add a runtime Python check that every passed path is relative. Otherwise, the engine would fail.

Finally, fix an oversight in `TestBase` so that `_init_engine()` passes the temporary `build_root` property to the engine session creation. Otherwise, the session will use the global `get_buildroot()`, which we want to avoid due to persisting state between tests.