### PR TITLE
add types to await Get[X](...)!!

### DIFF
--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -207,13 +207,13 @@ async def provenanced_addresses_from_address_families(
 ) -> ProvenancedBuildFileAddresses:
   """Given an AddressMapper and list of Specs, return matching ProvenancedBuildFileAddresses.
 
-:raises: :class:`ResolveError` if:
-   - there were no matching AddressFamilies, or
-   - the Spec matches no addresses for SingleAddresses.
-:raises: :class:`AddressLookupError` if no targets are matched for non-SingleAddress specs.
-"""
+  :raises: :class:`ResolveError` if:
+     - there were no matching AddressFamilies, or
+     - the Spec matches no addresses for SingleAddresses.
+  :raises: :class:`AddressLookupError` if no targets are matched for non-SingleAddress specs.
+  """
   # Capture a Snapshot covering all paths for these Specs, then group by directory.
-  snapshot = await Get[Snapshot](PathGlobs, _spec_to_globs(address_mapper, specs))
+  snapshot: Snapshot = await Get(Snapshot, PathGlobs, _spec_to_globs(address_mapper, specs))
   dirnames = {dirname(f) for f in snapshot.files}
   address_families = await MultiGet(Get[AddressFamily](Dir(d)) for d in dirnames)
   address_family_by_directory = {af.namespace: af for af in address_families}

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import logging
 from collections.abc import MutableMapping, MutableSequence
 from dataclasses import dataclass
 from os.path import dirname, join
@@ -27,9 +26,6 @@ from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, MultiGet
 from pants.engine.struct import Struct
 from pants.util.objects import TypeConstraintError
-
-
-logger = logging.getLogger(__name__)
 
 
 class ResolvedTypeMismatchError(ResolveError):
@@ -213,7 +209,7 @@ async def provenanced_addresses_from_address_families(
   :raises: :class:`AddressLookupError` if no targets are matched for non-SingleAddress specs.
   """
   # Capture a Snapshot covering all paths for these Specs, then group by directory.
-  snapshot: Snapshot = await Get(Snapshot, PathGlobs, _spec_to_globs(address_mapper, specs))
+  snapshot = await Get[Snapshot](PathGlobs, _spec_to_globs(address_mapper, specs))
   dirnames = {dirname(f) for f in snapshot.files}
   address_families = await MultiGet(Get[AddressFamily](Dir(d)) for d in dirnames)
   address_family_by_directory = {af.namespace: af for af in address_families}

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import MutableMapping, MutableSequence
 from dataclasses import dataclass
 from os.path import dirname, join
-from typing import Dict, Tuple
+from typing import Dict
 
 from twitter.common.collections import OrderedSet
 
@@ -49,8 +49,8 @@ async def parse_address_family(address_mapper: AddressMapper, directory: Dir) ->
   """
   patterns = tuple(join(directory.path, p) for p in address_mapper.build_patterns)
   path_globs = PathGlobs(include=patterns, exclude=address_mapper.build_ignore_patterns)
-  snapshot: Snapshot = await Get(Snapshot, PathGlobs, path_globs)
-  files_content: FilesContent = await Get(FilesContent, Digest, snapshot.directory_digest)
+  snapshot = await Get[Snapshot](PathGlobs, path_globs)
+  files_content = await Get[FilesContent](Digest, snapshot.directory_digest)
 
   if not files_content:
     raise ResolveError(
@@ -89,7 +89,7 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
   dependencies field, since those should be requested explicitly by rules.
   """
 
-  address_family: AddressFamily = await Get(AddressFamily, Dir(address.spec_path))
+  address_family = await Get[AddressFamily](Dir(address.spec_path))
 
   struct = address_family.addressables.get(address)
   addresses = address_family.addressables
@@ -131,9 +131,8 @@ async def hydrate_struct(address_mapper: AddressMapper, address: Address) -> Hyd
   collect_inline_dependencies(struct)
 
   # And then hydrate the inline dependencies.
-  hydrated_inline_dependencies: Tuple[HydratedStruct, ...] = await MultiGet(
-    Get(HydratedStruct, Address, a) for a in inline_dependencies
-  )
+  hydrated_inline_dependencies = await MultiGet(Get[HydratedStruct](Address, a)
+                                                for a in inline_dependencies)
   dependencies = [d.value for d in hydrated_inline_dependencies]
 
   def maybe_consume(outer_key, value):
@@ -214,9 +213,9 @@ async def provenanced_addresses_from_address_families(
 :raises: :class:`AddressLookupError` if no targets are matched for non-SingleAddress specs.
 """
   # Capture a Snapshot covering all paths for these Specs, then group by directory.
-  snapshot = await Get(Snapshot, PathGlobs, _spec_to_globs(address_mapper, specs))
+  snapshot = await Get[Snapshot](PathGlobs, _spec_to_globs(address_mapper, specs))
   dirnames = {dirname(f) for f in snapshot.files}
-  address_families = await MultiGet(Get(AddressFamily, Dir(d)) for d in dirnames)
+  address_families = await MultiGet(Get[AddressFamily](Dir(d)) for d in dirnames)
   address_family_by_directory = {af.namespace: af for af in address_families}
 
   matched_addresses = OrderedSet()

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -35,8 +35,17 @@ class _RuleVisitor(ast.NodeVisitor):
   def gets(self) -> List[Get]:
     return self._gets
 
-  def _is_get(self, node: ast.Call):
-    return isinstance(node.func, ast.Name) and node.func.id == Get.__name__
+  def _matches_get_name(self, node: Any) -> bool:
+    return isinstance(node, ast.Name) and node.id == Get.__name__
+
+  def _is_get(self, node: Any) -> bool:
+    if isinstance(node, ast.Call):
+      if self._matches_get_name(node.func):
+        return True
+      if isinstance(node.func, ast.Subscript) and self._matches_get_name(node.func.value):
+        return True
+      return False
+    return False
 
   def visit_Call(self, node: ast.Call) -> None:
     self.generic_visit(node)

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -4,7 +4,6 @@
 import ast
 import inspect
 import itertools
-import logging
 import sys
 import typing
 from abc import ABC, abstractmethod
@@ -19,9 +18,6 @@ from pants.engine.selectors import Get
 from pants.util.collections import assert_single_element
 from pants.util.memo import memoized
 from pants.util.meta import frozen_after_init
-
-
-logger = logging.getLogger(__name__)
 
 
 class _RuleVisitor(ast.NodeVisitor):

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -4,26 +4,29 @@
 import ast
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import Any, Generator, Iterable, Tuple, Type, cast
+from typing import Any, Generator, Generic, Iterable, Optional, Tuple, Type, TypeVar, cast
 
 from pants.util.meta import frozen_after_init
 from pants.util.objects import TypeConstraint
 
 
+_Product = TypeVar("_Product")
+
+
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class Get:
+class Get(Generic[_Product]):
   """Experimental synchronous generator API.
 
   May be called equivalently as either:
-    # verbose form: Get(product, subject_declared_type, subject)
-    # shorthand form: Get(product, subject_declared_type(<constructor args for subject>))
+    # verbose form: Get[product](subject_declared_type, subject)
+    # shorthand form: Get[product](subject_declared_type(<constructor args for subject>))
   """
-  product: Type
-  subject_declared_type: Type
-  subject: Any
+  product: Type[_Product]
+  subject_declared_type: type
+  subject: Optional[Any]
 
-  def __await__(self) -> Generator[Any, Any, Any]:
+  def __await__(self) -> 'Generator[Get[_Product], None, _Product]':
     """Allow a Get to be `await`ed within an `async` method, returning a strongly-typed result.
 
     The `yield`ed value `self` is interpreted by the engine within `extern_generator_send()` in
@@ -44,7 +47,12 @@ class Get:
     https://www.python.org/dev/peps/pep-0492/#await-expression.
     """
     result = yield self
-    return result
+    return cast(_Product, result)
+
+  @classmethod
+  def __class_getitem__(cls, product_type):
+    """Override the behavior of Get[T] to shuffle over the product T into the constructor args."""
+    return lambda *args: cls(product_type, *args)
 
   def __init__(self, *args: Any) -> None:
     if len(args) not in (2, 3):
@@ -82,30 +90,47 @@ class Get:
     :param call_node: An `ast.Call` node representing a call to `Get(..)`.
     :return: A tuple of product type id and subject type id.
     """
-    def render_args():
+    def render_args(args):
       return ', '.join(
         # Dump the Name's id to simplify output when available, falling back to the name of the
         # node's class.
         getattr(a, 'id', type(a).__name__)
-        for a in call_node.args)
+        for a in args)
 
-    if len(call_node.args) == 2:
-      product_type, subject_constructor = call_node.args
+    # If the Get was provided with a type parameter, use that as the `product_type`.
+    func = call_node.func
+    if isinstance(func, ast.Name):
+      subscript_args = ()
+    elif isinstance(func, ast.Subscript):
+      index_expr = func.slice.value
+      if isinstance(index_expr, ast.Name):
+        subscript_args = (index_expr,)
+      else:
+        raise ValueError(f'Unrecognized type argument T for Get[T]: {ast.dump(index_expr)}')
+    else:
+      raise ValueError(
+        f'Unrecognized Get call node type: expected Get or Get[T], received {ast.dump(call_node)}')
+
+    # Shuffle over the type parameter to be the first argument, if provided.
+    combined_args = subscript_args + tuple(call_node.args)
+
+    if len(combined_args) == 2:
+      product_type, subject_constructor = combined_args
       if not isinstance(product_type, ast.Name) or not isinstance(subject_constructor, ast.Call):
         raise ValueError(
-          'Two arg form of {} expected (product_type, subject_type(subject)), but '
-                        'got: ({})'.format(Get.__name__, render_args()))
+          f'Two arg form of {Get.__name__} expected (product_type, subject_type(subject)), but '
+          f'got: ({render_args(combined_args)})')
       return (product_type.id, subject_constructor.func.id)
-    elif len(call_node.args) == 3:
-      product_type, subject_declared_type, _ = call_node.args
+    elif len(combined_args) == 3:
+      product_type, subject_declared_type, _ = combined_args
       if not isinstance(product_type, ast.Name) or not isinstance(subject_declared_type, ast.Name):
         raise ValueError(
-          'Three arg form of {} expected (product_type, subject_declared_type, subject), but '
-                        'got: ({})'.format(Get.__name__, render_args()))
+          f'Three arg form of {Get.__name__} expected (product_type, subject_declared_type, subject), but '
+          f'got: ({render_args(combined_args)})')
       return (product_type.id, subject_declared_type.id)
     else:
-      raise ValueError('Invalid {}; expected either two or three args, but '
-                      'got: ({})'.format(Get.__name__, render_args()))
+      raise ValueError(f'Invalid {Get.__name__}; expected either two or three args, but '
+                       f'got: ({render_args(combined_args)})')
 
   @classmethod
   def create_statically_for_rule_graph(cls, product_type, subject_type) -> 'Get':
@@ -119,25 +144,25 @@ class Get:
 
 @frozen_after_init
 @dataclass(unsafe_hash=True)
-class MultiGet:
+class MultiGet(Generic[_Product]):
   """Can be constructed with an iterable of `Get()`s and `await`ed to evaluate them in parallel."""
-  gets: Tuple[Get, ...]
+  gets: Tuple[Get[_Product], ...]
 
-  def __await__(self) -> Generator[Any, Any, Tuple[Any, ...]]:
+  def __await__(self) -> Generator[Tuple[Get[_Product], ...], None, Tuple[_Product, ...]]:
     """Yield a tuple of Get instances with the same subject/product type pairs all at once.
 
     The `yield`ed value `self.gets` is interpreted by the engine within `extern_generator_send()` in
     `native.py`. This class will yield a tuple of Get instances, which is converted into
     `PyGeneratorResponse::GetMulti` from `externs.rs`.
 
-    The engine will fulfill these Get instances in parallel, and return a tuple of T
+    The engine will fulfill these Get instances in parallel, and return a tuple of _Product
     instances to this method, which then returns this tuple to the `@rule` which called
-    `await MultiGet(Get(T, ...) for ... in ...)`.
+    `await MultiGet(Get[_Product](...) for ... in ...)`.
     """
     result = yield self.gets
-    return cast(Tuple[Any, ...], result)
+    return cast(Tuple[_Product, ...], result)
 
-  def __init__(self, gets: Iterable[Get]) -> None:
+  def __init__(self, gets: Iterable[Get[_Product]]) -> None:
     """Create a MultiGet from a generator expression.
 
     This constructor will infer this class's _Product parameter from the input `gets`.

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -2,12 +2,16 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import ast
+import logging
 from dataclasses import dataclass
 from textwrap import dedent
 from typing import Any, Generator, Generic, Iterable, Optional, Tuple, Type, TypeVar, cast
 
 from pants.util.meta import frozen_after_init
 from pants.util.objects import TypeConstraint
+
+
+logger = logging.getLogger(__name__)
 
 
 _Product = TypeVar("_Product")
@@ -52,7 +56,11 @@ class Get(Generic[_Product]):
   @classmethod
   def __class_getitem__(cls, product_type):
     """Override the behavior of Get[T] to shuffle over the product T into the constructor args."""
-    return lambda *args: cls(product_type, *args)
+    def f(*args):
+      logger.info(f'product_type: {product_type}')
+      logger.info(f'args: {args}')
+      return cls(product_type, *args)
+    return f
 
   def __init__(self, *args: Any) -> None:
     if len(args) not in (2, 3):
@@ -113,6 +121,9 @@ class Get(Generic[_Product]):
 
     # Shuffle over the type parameter to be the first argument, if provided.
     combined_args = subscript_args + tuple(call_node.args)
+
+    logger.info(f'call_node: {ast.dump(call_node)}')
+    logger.info(f'combined_args: {combined_args}')
 
     if len(combined_args) == 2:
       product_type, subject_constructor = combined_args

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -10,6 +10,9 @@ from pants.util.meta import frozen_after_init
 from pants.util.objects import TypeConstraint
 
 
+# This type variable is used as the `product` field in a `Get`, and represents the type that the
+# engine will return from an `await Get[_Product](...)` expression. This type variable is also used
+# in the `Tuple[X, ...]` type returned by `await MultiGet(Get[X](...)...)`.
 _Product = TypeVar("_Product")
 
 

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -65,6 +65,7 @@ class Get(Generic[_Product]):
     return f
 
   def __init__(self, *args: Any) -> None:
+    logger.info(f'get args: {args}')
     if len(args) not in (2, 3):
       raise ValueError(
         f'Expected either two or three arguments to {Get.__name__}; got {args}.'
@@ -89,6 +90,8 @@ class Get(Generic[_Product]):
     else:
       product, subject_declared_type, subject = args
 
+    if product == subject_declared_type:
+      raise ValueError(f'product: {product}, subj_d: {subject_declared_type}, s: {subject}: product and subject are the same?')
     self.product = product
     self.subject_declared_type = subject_declared_type
     self.subject = subject
@@ -125,7 +128,7 @@ class Get(Generic[_Product]):
     combined_args = subscript_args + tuple(call_node.args)
 
     logger.info(f'call_node: {ast.dump(call_node)}')
-    logger.info(f'combined_args: {combined_args}')
+    logger.info(f'combined_args: {[ast.dump(n) for n in combined_args]}')
 
     if len(combined_args) == 2:
       product_type, subject_constructor = combined_args

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -27,7 +27,9 @@ class Get(Generic[_Product]):
     # shorthand form: Get[product](subject_declared_type(<constructor args for subject>))
   """
   product: Type[_Product]
-  subject_declared_type: type
+  # TODO: Consider attemping to create a Get[_Product, _Subject] which still allows for the 2-arg
+  # Get form, and then making this Type[_Subject]!
+  subject_declared_type: Type
   subject: Optional[Any]
 
   def __await__(self) -> 'Generator[Get[_Product], None, _Product]':

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -36,7 +36,7 @@ class Fmt(Goal):
 @console_rule
 async def fmt(console: Console, targets: HydratedTargets, union_membership: UnionMembership) -> Fmt:
   results = await MultiGet(
-    Get(FmtResult, TargetWithSources, target.adaptor)
+    Get[FmtResult](TargetWithSources, target.adaptor)
     for target in targets
     # TODO: make TargetAdaptor return a 'sources' field with an empty snapshot instead of
     # raising to remove the hasattr() checks here!
@@ -44,7 +44,7 @@ async def fmt(console: Console, targets: HydratedTargets, union_membership: Unio
   )
 
   for result in results:
-    files_content = await Get(FilesContent, Digest, result.digest)
+    files_content = await Get[FilesContent](Digest, result.digest)
     # TODO: This is hacky and inefficient, and should be replaced by using the Workspace type
     # once that is available on master.
     # Blocked on: https://github.com/pantsbuild/pants/pull/8329


### PR DESCRIPTION
### Problem

While #8639 allowed mypy type-checking of `@rule`s, it didn't do quite as much as it could have. In particular, while we already require explicitly writing the return type in every `Get(X, ...)` call, we don't yet have mypy automatically inferring the return type of the `await Get(X, ...)` must be `X`.

### Proposed Solution

- Have `Get` and `MultiGet` both mix in `Generic[_Product]`, and use the inferred `_Product` type to deduce the `ReturnType` for the `__await__` generator.
- Override `__class_getitem__` on `Get` to allow `Get[X](...)` to be converted to `Get(X, ...)`.
- Modify `rules.py` to recognize both `Get(...)` and `Get[X](...)` calls in the `_RuleVisitor`.

#### Other Solutions Considered

1. An attempt was made to parameterize the `Get`'s *`subject_declared_type`* and make that available on the type level as well:
```python
@rule
async def f() -> Y:
  # In this PR now (s: Snapshot is inferred):
  s = await Get[Snapshot](Digest(...))
  # What we might like to try (s: Snapshot is inferred,
  # d: Digest is also inferred and type-checked with mypy!):
  s = await Get[Snapshot, Digest](d)
  ...
```

This wasn't implemented yet because it wasn't as clear that that was as useful as just the product type, and it seemed better to put that into a followup PR. A remaining question is whether/how we can integrate the existing 2-argument `Get` constructor syntax while also inferring types as above.

2. It might be possible to avoid having to explicitly type out the square brackets for `Get[X](...)`, and instead try to infer that from the existing constructor arguments (i.e. it might be possible to have the appropriate mypy types without changing the `Get(X, ...)` calls that exist now).

Since the return type of a `Get` right now is always a concrete type (not an `@union` or something), it seemed like we didn't lose much information by making it into a type argument instead, and it seemed nicer to explicitly annotate the type to make it easier to quickly scan code and understand what the output type of a `Get[X]` is supposed to be.

### Result

`await Get[X](...)` calls will now have mypy infer the return type `X`!