### PR TITLE
Add `TestBase.request_single_product()` for less boilerplate in V2 tests

### DIFF
--- a/src/python/pants/backend/python/rules/inject_init_test.py
+++ b/src/python/pants/backend/python/rules/inject_init_test.py
@@ -5,7 +5,6 @@ from pants.backend.python.rules.inject_init import InjectedInitDigest, inject_in
 from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, EMPTY_SNAPSHOT, Snapshot
 from pants.engine.rules import RootRule
 from pants.testutil.test_base import TestBase
-from pants.util.collections import assert_single_element
 
 
 class TestInjectInit(TestBase):
@@ -15,9 +14,7 @@ class TestInjectInit(TestBase):
     return super().rules() + [inject_init, RootRule(Snapshot)]
 
   def assert_result(self, input_snapshot, expected_digest):
-    injected_digest = assert_single_element(
-      self.scheduler.product_request(InjectedInitDigest, [input_snapshot])
-    )
+    injected_digest = self.request_single_product(InjectedInitDigest, input_snapshot)
     self.assertEqual(injected_digest.directory_digest, expected_digest)
 
   def test_noops_when_empty_snapshot(self):

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -29,7 +29,6 @@ from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
 from pants.testutil.subsystem.util import init_subsystems
 from pants.testutil.test_base import TestBase
-from pants.util.collections import assert_single_element
 from pants.util.contextutil import temporary_dir
 from pants.util.strutil import create_path_env_var
 
@@ -67,13 +66,14 @@ class TestResolveRequirements(TestBase):
       entry_point=entry_point,
       input_files_digest=input_files,
     )
-    requirements_pex = assert_single_element(
-      self.scheduler.product_request(Pex, [Params(
+    requirements_pex = self.request_single_product(
+      Pex,
+      Params(
         request,
         PythonSetup.global_instance(),
         SubprocessEnvironment.global_instance(),
         PythonNativeCode.global_instance()
-      )])
+      )
     )
     with temporary_dir() as tmp_dir:
       self.scheduler.materialize_directories((
@@ -98,7 +98,7 @@ class TestResolveRequirements(TestBase):
       FileContent(path='subdir/sub.py', content=b'print("from sub")'),
     ))
 
-    input_files, = self.scheduler.product_request(Digest, [input_files_content])
+    input_files = self.request_single_product(Digest, input_files_content)
     pex_output = self.create_pex_and_get_all_data(entry_point='main', input_files=input_files)
 
     pex_files = pex_output['files']
@@ -112,7 +112,7 @@ class TestResolveRequirements(TestBase):
     pex = pex_output['pex']
 
     req = ExecuteProcessRequest(argv=('python', 'test.pex'), env=env, input_files=pex.directory_digest, description="Run the pex and make sure it works")
-    result, = self.scheduler.product_request(ExecuteProcessResult, [req])
+    result = self.request_single_product(ExecuteProcessResult, req)
     self.assertEqual(result.stdout, b"from main\n")
 
   def test_resolves_dependencies(self) -> None:

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -79,7 +79,7 @@ class FileSystemTest(TestBase):
       FileContent(path='subdir/b.txt', content=b'goodbye'),
     ))
 
-    digest, = self.scheduler.product_request(Digest, [input_files_content])
+    digest = self.request_single_product(Digest, input_files_content)
 
     with temporary_dir() as tmp_dir:
       path1 = Path(tmp_dir, 'a.txt')

--- a/src/python/pants/rules/core/run_test.py
+++ b/src/python/pants/rules/core/run_test.py
@@ -17,7 +17,7 @@ class RunTest(ConsoleRuleTestBase):
     input_files_content = InputFilesContent((
       FileContent(path='program.py', content=program_text, is_executable=True),
     ))
-    digest, = self.scheduler.product_request(Digest, [input_files_content])
+    digest = self.request_single_product(Digest, input_files_content)
     return CreatedBinary(
       binary_name='program.py',
       digest=digest,

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -34,8 +34,9 @@ class StripSourceRootsTests(TestBase):
     if target_type_alias:
       adaptor.type_alias = target_type_alias
     target = HydratedTarget('some/target/address', adaptor, tuple())
-    output = self.scheduler.product_request(SourceRootStrippedSources, [Params(target, SourceRootConfig.global_instance())])
-    stripped_sources = output[0]
+    stripped_sources = self.request_single_product(
+      SourceRootStrippedSources, Params(target, SourceRootConfig.global_instance())
+    )
     self.assertEqual(stripped_sources.snapshot.files, (expected_path,))
 
   def test_source_roots_python(self):

--- a/tests/python/pants_test/build_graph/test_source_mapper.py
+++ b/tests/python/pants_test/build_graph/test_source_mapper.py
@@ -22,7 +22,7 @@ class SourceMapperTest(TestBase):
 
   def owner(self, owner, f):
     request = OwnersRequest(sources=(f,), include_dependees=str('none'))
-    addresses, = self.scheduler.product_request(BuildFileAddresses, [request])
+    addresses = self.request_single_product(BuildFileAddresses, request)
     self.assertEqual(set(owner), {i.spec for i in addresses})
 
   def test_target_address_for_source_yields_unique_addresses(self):

--- a/tests/python/pants_test/engine/legacy/test_options_parsing.py
+++ b/tests/python/pants_test/engine/legacy/test_options_parsing.py
@@ -47,7 +47,7 @@ class TestEngineOptionsParsing(TestBase):
       return self._ob(args=['./pants', '-ldebug', 'binary', 'src/python::'])
     def parse(ob):
       params = Params(Scope(str(GLOBAL_SCOPE)), ob)
-      return self.scheduler.product_request(ScopedOptions, [params])
+      return self.request_single_product(ScopedOptions, params)
 
     # If two OptionsBootstrapper instances are not equal, memoization will definitely not kick in.
     one_opts = ob()
@@ -56,7 +56,7 @@ class TestEngineOptionsParsing(TestBase):
     self.assertEquals(hash(one_opts), hash(two_opts))
 
     # If they are equal, executing parsing on them should result in a memoized object.
-    one, = parse(one_opts)
-    two, = parse(two_opts)
+    one = parse(one_opts)
+    two = parse(two_opts)
     self.assertEqual(one, two)
     self.assertIs(one, two)

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -193,30 +193,30 @@ class SchedulerTest(TestBase):
   def test_use_params(self):
     # Confirm that we can pass in Params in order to provide multiple inputs to an execution.
     a, b = A(), B()
-    result_str, = self.scheduler.product_request(str, [Params(a, b)])
+    result_str = self.request_single_product(str, Params(a, b))
     self.assertEquals(result_str, consumes_a_and_b(a, b))
 
     # And confirm that a superset of Params is also accepted.
-    result_str, = self.scheduler.product_request(str, [Params(a, b, self)])
+    result_str = self.request_single_product(str, Params(a, b, self))
     self.assertEquals(result_str, consumes_a_and_b(a, b))
 
     # But not a subset.
     expected_msg = ("No installed @rules can compute {} for input Params(A), but"
                     .format(str.__name__))
     with self.assertRaisesRegexp(Exception, re.escape(expected_msg)):
-      self.scheduler.product_request(str, [Params(a)])
+      self.request_single_product(str, Params(a))
 
   def test_transitive_params(self):
     # Test that C can be provided and implicitly converted into a B with transitive_b_c() to satisfy
     # the selectors of consumes_a_and_b().
     a, c = A(), C()
-    result_str, = self.scheduler.product_request(str, [Params(a, c)])
+    result_str = self.request_single_product(str, Params(a, c))
     self.assertEquals(remove_locations_from_traceback(result_str),
                       remove_locations_from_traceback(consumes_a_and_b(a, transitive_b_c(c))))
 
     # Test that an inner Get in transitive_coroutine_rule() is able to resolve B from C due to the
     # existence of transitive_b_c().
-    result_d, = self.scheduler.product_request(D, [Params(c)])
+    result_d = self.request_single_product(D, Params(c))
     # We don't need the inner B objects to be the same, and we know the arguments are type-checked,
     # we're just testing transitively resolving products in this file.
     self.assertTrue(isinstance(result_d, D))
@@ -227,22 +227,22 @@ class SchedulerTest(TestBase):
       yield
 
   def test_union_rules(self):
-    a, = self.scheduler.product_request(A, [Params(UnionWrapper(UnionA()))])
+    a = self.request_single_product(A, Params(UnionWrapper(UnionA())))
     # TODO: figure out what to assert here!
     self.assertTrue(isinstance(a, A))
-    a, = self.scheduler.product_request(A, [Params(UnionWrapper(UnionB()))])
+    a = self.request_single_product(A, Params(UnionWrapper(UnionB())))
     self.assertTrue(isinstance(a, A))
     # Fails due to no union relationship from A -> UnionBase.
     expected_msg = """\
 Type A is not a member of the UnionBase @union
 """
     with self._assert_execution_error(expected_msg):
-      self.scheduler.product_request(A, [Params(UnionWrapper(A()))])
+      self.request_single_product(A, Params(UnionWrapper(A())))
 
   def test_union_rules_no_docstring(self):
     expected_msg = "specific error message for UnionA instance"
     with self._assert_execution_error(expected_msg):
-      self.scheduler.product_request(UnionX, [Params(UnionWrapper(UnionA()))])
+      self.request_single_product(UnionX, Params(UnionWrapper(UnionA())))
 
 
 class SchedulerWithNestedRaiseTest(TestBase):
@@ -266,7 +266,7 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
 """
     with assert_execution_error(self, expected_msg):
       # `a_typecheck_fail_test` above expects `wrapper.inner` to be a `B`.
-      self.scheduler.product_request(A, [Params(TypeCheckFailWrapper(A()))])
+      self.request_single_product(A, Params(TypeCheckFailWrapper(A())))
 
   def test_unhashable_failure(self):
     """Test that unhashable Get(...) params result in a structured error."""
@@ -295,7 +295,7 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
     # Test that the error contains the full traceback from within the CFFI context as well
     # (mentioning which specific extern method ended up raising the exception).
     with self.assertRaises(ExecutionError) as cm:
-      self.scheduler.product_request(C, [Params(CollectionType([1, 2, 3]))])
+      self.request_single_product(C, Params(CollectionType([1, 2, 3])))
     exc_str = remove_locations_from_traceback(str(cm.exception))
     # TODO: convert these manual self.assertTrue() conditionals to a self.assertStartsWith() method
     # in TestBase!
@@ -323,7 +323,7 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
                                **PATCH_OPTS) as mock_cffi_exceptions:
           mock_exe_request.return_value = None
           mock_cffi_exceptions.return_value = [create_cffi_exception()]
-          self.scheduler.product_request(C, [Params(CollectionType([1, 2, 3]))])
+          self.request_single_product(C, Params(CollectionType([1, 2, 3])))
     exc_str = remove_locations_from_traceback(str(cm.exception))
     assert_has_cffi_extern_traceback_header(exc_str)
     self.assertIn("Exception: test cffi exception", exc_str)
@@ -336,7 +336,7 @@ Exception: WithDeps(Inner(InnerEntry { params: {TypeCheckFailWrapper}, rule: Tas
       with unittest.mock.patch.object(SchedulerSession, 'execution_request',
                              **PATCH_OPTS) as mock_exe_request:
         mock_exe_request.side_effect = TestError('non-CFFI error')
-        self.scheduler.product_request(C, [Params(CollectionType([1, 2, 3]))])
+        self.request_single_product(C, Params(CollectionType([1, 2, 3])))
 
   def test_trace_includes_rule_exception_traceback(self):
     # Execute a request that will trigger the nested raise, and then directly inspect its trace.

--- a/tests/python/pants_test/source/test_filespec.py
+++ b/tests/python/pants_test/source/test_filespec.py
@@ -27,7 +27,7 @@ class FilespecTest(TestBase):
         self.create_dir(expected)
       else:
         self.create_file(expected)
-    snapshot, = self.scheduler.product_request(Snapshot, [PathGlobs([glob])])
+    snapshot = self.request_single_product(Snapshot, PathGlobs([glob]))
     if negate:
       subset = set(expected_matches).intersection(set(snapshot.files))
       self.assertEquals(subset, set(), f'{glob} {match_state} path(s) {subset}')


### PR DESCRIPTION
### Problem

We currently have three ways of making a synchronous product request to the engine:

```python
result, = self.scheduler.product_request(Product, [Params(s1, s2, ...)]
```

```python
result = self.scheduler.product_request(Product, [Params(s1, s2, ...)][0]
```

```python
from pants.util.collections import assert_single_element

result = assert_single_element(self.scheduler.product_request(Product, [Params(s1, s2, ...)])
```

All of these result from the API that `SchedulerSession.product_request` takes an iterable of `Subject`s and returns a product for each subject. There is a place for this flexibility: we do sometimes take advantage of this multiple-subjects idiom both in tests and in production.

However, over 90% of our usages only ever request one single product result. So, we end up with much more boilerplate than necessary and more complex call sites than necessary.

### Solution

Add `TestBase.request_single_product` as a simple wrapper around `self.scheduler.product_request`. This new utility has an added benefit of being typed with MyPy through type vars.

Still keep `SchedulerSession.product_request`. This provides the underlying mechanism for the new utility and there is a time and place to use this more flexible API.

#### Why only add this as a test utility?
1. Production code should be using the asynchronous API instead (`async/await/Get`).
1. Reduced boilerplate for tests, which is the main user of synchronous V2 calls. It's more discoverable and less typing to write `self.request_single_product` than `self.session.request_single_product`.

### Result

Writing V2 ~integration style tests has less ceremony. (There are still other low hanging fruit).

Production/src code is not changed.