### PR TITLE
Convert `contrib/confluence`, `contrib/thrifty`, `contrib/cpp`, `contrib/scrooge`, `contrib/scalajs` to use fstrings

### DIFF
--- a/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
+++ b/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
@@ -70,10 +70,10 @@ class ConfluencePublish(Task):
     for page, wiki_artifact in pages:
       html_info = genmap.get((wiki_artifact, page))
       if len(html_info) > 1:
-        raise TaskError('Unexpected resources for {}: {}'.format(page, html_info))
+        raise TaskError(f'Unexpected resources for {page}: {html_info}')
       basedir, htmls = list(html_info.items())[0]
       if len(htmls) != 1:
-        raise TaskError('Unexpected resources for {}: {}'.format(page, htmls))
+        raise TaskError(f'Unexpected resources for {page}: {htmls}')
       with safe_open(os.path.join(basedir, htmls[0]), 'r') as contents:
         url = self.publish_page(
           page.address,
@@ -85,7 +85,7 @@ class ConfluencePublish(Task):
         )
         if url:
           urls.append(url)
-          self.context.log.info('Published {} to {}'.format(page, url))
+          self.context.log.info(f'Published {page} to {url}')
     
     if self.open and urls:
       try:
@@ -108,7 +108,7 @@ class ConfluencePublish(Task):
     existing = wiki.getpage(space, title)
     if existing:
       if not self.force and existing['content'].strip() == body.strip():
-        self.context.log.warn("Skipping publish of '{}' - no changes".format(title))
+        self.context.log.warn(f"Skipping publish of '{title}' - no changes")
         return
       
       pageopts['id'] = existing['id']
@@ -118,12 +118,12 @@ class ConfluencePublish(Task):
       page = wiki.create_html_page(space, title, body, parent, **pageopts)
       return page['url']
     except ConfluenceError as e:
-      raise TaskError('Failed to update confluence: {}'.format(e))
+      raise TaskError(f'Failed to update confluence: {e!r}')
   
   def login(self):
     if not self._wiki:
       try:
         self._wiki = Confluence.login(self.url, self.user, self.api())
       except ConfluenceError as e:
-        raise TaskError('Failed to login to confluence: {}'.format(e))
+        raise TaskError(f'Failed to login to confluence: {e!r}')
     return self._wiki

--- a/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_binary_create.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_binary_create.py
@@ -48,7 +48,7 @@ class CppBinaryCreate(CppTask):
     for basedir, objs in self.context.products.get('objs').get(target).items():
       objects.extend([os.path.join(basedir, obj) for obj in objs])
     self._link_binary(target, binary_path, objects)
-    self.context.log.info('Built c++ binary: {0}'.format(binary_path))
+    self.context.log.info(f'Built c++ binary: {binary_path}')
 
   def _libname(self, libpath):
     """Converts a full library filepath to the library's name.
@@ -77,11 +77,11 @@ class CppBinaryCreate(CppTask):
       libraries.extend(target.libraries)
 
     cmd.extend(objects)
-    cmd.extend(('-L{0}'.format(L) for L in library_dirs))
-    cmd.extend(('-l{0}'.format(l) for l in libraries))
+    cmd.extend((f'-L{L}' for L in library_dirs))
+    cmd.extend((f'-l{l}' for l in libraries))
     cmd.extend(['-o' + binary_path])
     if self.get_options().ld_options != None:
-      cmd.extend(('-Wl,{0}'.format(o) for o in self.get_options().ld_options.split(' ')))
+      cmd.extend((f'-Wl,{o}' for o in self.get_options().ld_options.split(' ')))
 
     with self.context.new_workunit(name='cpp-link', labels=[WorkUnitLabel.COMPILER]) as workunit:
       self.run_command(cmd, workunit)

--- a/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_compile.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_compile.py
@@ -80,7 +80,7 @@ class CppCompile(CppTask):
 
     cmd = [self.cpp_toolchain.compiler]
     cmd.extend(['-c'])
-    cmd.extend(('-I{0}'.format(i) for i in include_dirs))
+    cmd.extend((f'-I{i}' for i in include_dirs))
     cmd.extend(['-o' + obj, abs_source])
     cmd.extend(self.get_options().cc_options)
 
@@ -88,4 +88,4 @@ class CppCompile(CppTask):
     with self.context.new_workunit(name='cpp-compile', labels=[WorkUnitLabel.COMPILER]) as workunit:
       self.run_command(cmd, workunit)
 
-    self.context.log.info('Built c++ object: {0}'.format(obj))
+    self.context.log.info(f'Built c++ object: {obj}')

--- a/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_library_create.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_library_create.py
@@ -43,7 +43,7 @@ class CppLibraryCreate(CppTask):
       objects = [os.path.join(basedir, obj) for obj in objs]
     # TODO: copy public headers to work dir.
     output = self._link_library(target, results_dir, objects)
-    self.context.log.info('Built c++ library: {0}'.format(output))
+    self.context.log.info(f'Built c++ library: {output}')
     return output
 
   def _libpath(self, target, results_dir):

--- a/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_task.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_task.py
@@ -36,11 +36,11 @@ class CppTask(Task):
 
   def run_command(self, cmd, workunit):
     try:
-      self.context.log.debug('Executing: {0}'.format(cmd))
+      self.context.log.debug(f'Executing: {cmd}')
       # TODO: capture stdout/stderr and redirect to log
       subprocess.check_call(cmd, stdout=workunit.output('stdout'), stderr=workunit.output('stderr'))
     except subprocess.CalledProcessError as e:
-      raise TaskError('Execution failed: {0}'.format(e))
+      raise TaskError(f'Execution failed: {e!r}')
 
   @property
   def cpp_toolchain(self):

--- a/contrib/cpp/src/python/pants/contrib/cpp/toolchain/cpp_toolchain.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/toolchain/cpp_toolchain.py
@@ -58,6 +58,6 @@ class CppToolchain:
 
     tool_path = which(tool)
     if tool_path is None:
-      raise self.Error('Failed to locate {0}. Please install.'.format(tool))
+      raise self.Error(f'Failed to locate {tool}. Please install.')
     self._validated_tools[name] = tool_path
     return tool_path

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/tasks/scala_js_link.py
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/tasks/scala_js_link.py
@@ -50,7 +50,7 @@ class ScalaJSLink(NailgunTask):
     return isinstance(target, ScalaJSBinary)
 
   def _target_file(self, vt):
-    return os.path.join(vt.results_dir, "{}.js".format(vt.target.name))
+    return os.path.join(vt.results_dir, f"{vt.target.name}.js")
 
   def execute(self):
     scala_js_binaries = self.context.products.get_data('scala_js_binaries',
@@ -61,10 +61,10 @@ class ScalaJSLink(NailgunTask):
         invalidate_dependents=True) as invalidation_check:
       for vt in invalidation_check.all_vts:
         if not vt.valid:
-          self.context.log.debug('Linking {}...'.format(vt.target.address.spec))
+          self.context.log.debug(f'Linking {vt.target.address.spec}...')
           self._link(vt.target, self._target_file(vt), classpaths)
         else:
-          self.context.log.debug('Already linked {}'.format(vt.target.address.spec))
+          self.context.log.debug(f'Already linked {vt.target.address.spec}')
         scala_js_binaries[vt.target].add_abs_paths(vt.results_dir, [self._target_file(vt)])
         classpaths.add_for_target(vt.target, [('default', vt.results_dir)])
 

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -103,7 +103,7 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
           self.context.build_graph.maybe_inject_address_closure(dep_address)
           dependencies.add(self.context.build_graph.get_target(dep_address))
         except AddressLookupError as e:
-          raise AddressLookupError('{}\n  referenced from {} scope'.format(e, self.options_scope))
+          raise AddressLookupError(f'{e}\n  referenced from {self.options_scope} scope')
     return deps
 
   def _validate_language(self, target):
@@ -111,7 +111,7 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
     if language not in self._registered_language_aliases():
       raise TargetDefinitionException(
         target,
-        'language {} not supported: expected one of {}.'.format(language, list(self._registered_language_aliases().keys())))
+        f'language {language} not supported: expected one of {list(self._registered_language_aliases().keys())}.')
     return language
 
   @memoized_method
@@ -124,9 +124,9 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
     registered_aliases = self.context.build_configuration.registered_aliases()
     target_types = registered_aliases.target_types_by_alias.get(alias_for_lang, None)
     if not target_types:
-      raise TaskError('Registered target type `{0}` for language `{1}` does not exist!'.format(alias_for_lang, language))
+      raise TaskError(f'Registered target type `{alias_for_lang}` for language `{language}` does not exist!')
     if len(target_types) > 1:
-      raise TaskError('More than one target type registered for language `{0}`'.format(language))
+      raise TaskError(f'More than one target type registered for language `{language}`')
     return next(iter(target_types))
 
   def execute_codegen(self, target, target_workdir):
@@ -157,7 +157,7 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
     args.extend(['--language', partial_cmd.language])
 
     for lhs, rhs in partial_cmd.namespace_map:
-      args.extend(['--namespace-map', '%s=%s' % (lhs, rhs)])
+      args.extend(['--namespace-map', f'{lhs}={rhs}'])
 
     args.extend(['--dest', target_workdir])
 
@@ -185,7 +185,7 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
                               args=args,
                               workunit_name='scrooge-gen')
     if 0 != returncode:
-      raise TaskError('Scrooge compiler exited non-zero for {} ({})'.format(target, returncode))
+      raise TaskError(f'Scrooge compiler exited non-zero for {target} ({returncode})')
 
   @staticmethod
   def _declares_exception(source):
@@ -245,9 +245,9 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
     if mismatched_compiler_configs:
       msg = ['Thrift dependency trees must be generated with a uniform compiler configuration.\n\n']
       for tgt in sorted(mismatched_compiler_configs.keys()):
-        msg.append('%s - %s\n' % (tgt, compiler_config(tgt)))
+        msg.append(f'{tgt} - {compiler_config(tgt)}\n')
         for dep in mismatched_compiler_configs[tgt]:
-          msg.append('    %s - %s\n' % (dep, compiler_config(dep)))
+          msg.append(f'    {dep} - {compiler_config(dep)}\n')
       raise TaskError(''.join(msg))
 
   def _must_have_sources(self, target):

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
@@ -70,7 +70,7 @@ class ThriftLinter(LintTaskMixin, NailgunTask):
     return self._to_bool(self.get_options().strict_default)
 
   def _lint(self, target, classpath):
-    self.context.log.debug('Linting {0}'.format(target.address.spec))
+    self.context.log.debug(f'Linting {target.address.spec}')
 
     config_args = []
 
@@ -103,7 +103,7 @@ class ThriftLinter(LintTaskMixin, NailgunTask):
 
     if returncode != 0:
       raise ThriftLintError(
-        'Lint errors in target {0} for {1}.'.format(target.address.spec, paths))
+        f'Lint errors in target {target.address.spec} for {paths}.')
 
   def execute(self):
     thrift_targets = self.get_targets(self._is_thrift)

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_util.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_util.py
@@ -30,7 +30,7 @@ def find_includes(basedirs, source, log=None):
           include = os.path.join(basedir, capture)
           if os.path.exists(include):
             if log:
-              log.debug('{} has include {}'.format(source, include))
+              log.debug(f'{source} has include {include}')
             includes.add(include)
             added = True
         if not added:

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -81,9 +81,9 @@ class ScroogeGenTest(NailgunTaskTestBase):
     self._test_help('scala', ScalaLibrary, [], sources)
 
   def compiler_args_to_string(self, compiler_args):
-    quoted = ["'{}'".format(x) for x in compiler_args]
+    quoted = [f"'{x}'" for x in compiler_args]
     comma_separated = ', '.join(quoted)
-    return '[{}]'.format(comma_separated)
+    return f'[{comma_separated}]'
 
   def _test_create_build_str(self, language, compiler_args):
     compiler_args_str = self.compiler_args_to_string(compiler_args)

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
@@ -17,7 +17,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
 
   @classmethod
   def thrift_test_target(cls, name):
-    return '{}:{}'.format(cls.thrift_folder_root, name)
+    return f'{cls.thrift_folder_root}:{name}'
 
   def rename_build_file(func):
     """This decorator implements the TEST_BUILD pattern.

--- a/contrib/thrifty/src/python/pants/contrib/thrifty/java_thrifty_gen.py
+++ b/contrib/thrifty/src/python/pants/contrib/thrifty/java_thrifty_gen.py
@@ -48,9 +48,9 @@ class JavaThriftyGen(NailgunTaskBase, SimpleCodegenTask):
 
   def format_args_for_target(self, target, target_workdir):
     sources = OrderedSet(target.sources_relative_to_buildroot())
-    args = ['--out={0}'.format(target_workdir)]
+    args = [f'--out={target_workdir}']
     for include_path in self._compute_include_paths(target):
-      args.append('--path={0}'.format(include_path))
+      args.append(f'--path={include_path}')
     args.extend(sources)
     return args
 
@@ -63,7 +63,7 @@ class JavaThriftyGen(NailgunTaskBase, SimpleCodegenTask):
                             workunit_name='compile',
                             workunit_labels=[WorkUnitLabel.TOOL])
       if result != 0:
-        raise TaskError('Thrifty compiler exited non-zero ({0})'.format(result))
+        raise TaskError(f'Thrifty compiler exited non-zero ({result})')
 
   def _compute_include_paths(self, target):
     """Computes the set of paths that thrifty uses to lookup imports.

--- a/contrib/thrifty/tests/python/pants_test/pants/contrib/thrifty/test_thrifty_gen.py
+++ b/contrib/thrifty/tests/python/pants_test/pants/contrib/thrifty/test_thrifty_gen.py
@@ -34,8 +34,8 @@ class JavaThriftyGenTest(TaskTestBase):
     context = self.context(target_roots=[target])
     task = self.create_task(context)
     self.assertEqual([
-      '--out={}'.format(self.TARGET_WORKDIR),
-      '--path={}/src/thrifty'.format(self.build_root),
+      f'--out={self.TARGET_WORKDIR}',
+      f'--path={self.build_root}/src/thrifty',
       'src/thrifty/foo.thrift'],
       task.format_args_for_target(target, self.TARGET_WORKDIR))
 
@@ -48,7 +48,7 @@ class JavaThriftyGenTest(TaskTestBase):
     context = self.context(target_roots=[upstream, downstream])
     task = self.create_task(context)
     self.assertEqual([
-      '--out={}'.format(self.TARGET_WORKDIR),
-      '--path={}/src/thrifty'.format(self.build_root),
+      f'--out={self.TARGET_WORKDIR}',
+      f'--path={self.build_root}/src/thrifty',
       'src/thrifty/downstream.thrift'],
       task.format_args_for_target(downstream, self.TARGET_WORKDIR))


### PR DESCRIPTION
I used a tool to convert this part of the code to use f-strings.
https://github.com/ikamensh/flynt
I didn't want to have a single PR for all of the code base... I feel that would be too big.
This is somewhat manageable. I will be following up with more PRs for other parts of the code