### PR TITLE
correctly fingerprint scoverage options and copy output into dist/

### DIFF
--- a/examples/src/scala/org/pantsbuild/example/scalac/plugin/README.md
+++ b/examples/src/scala/org/pantsbuild/example/scalac/plugin/README.md
@@ -24,14 +24,14 @@ scalac_plugin(
 )
 ```
 
-A scalac plugin target has the same fields as a `scala_library` target, 
+A scalac plugin target has the same fields as a `scala_library` target,
 plus two extra:
 
 - `classname`: The name of the `Plugin` implementation class. Required.
 - `plugin`: The logical name of the plugin, as returned by the `Plugin`
-  class's `getName()` method.  If unspecified, this field defaults to 
+  class's `getName()` method.  If unspecified, this field defaults to
   the target name.
-  
+
 Building a plugin target will, in addition to compiling the code, generate
 the appropriate metadata into `scalac-plugin.xml`, so
 that scalac can load the plugin by name at runtime.
@@ -50,10 +50,10 @@ Plugins can be integrated in one of two ways:
 
 #### Global plugins
 
-Global plugins are specified using the `scalac_plugins` key in the `compile.rsc` section of `pants.ini`:
+Global plugins are specified using the `scalac_plugins` key in the `scala` section of `pants.ini`:
 
 ```
-[compile.rsc]
+[scala]
 scalac_plugins: ['simple_scalac_plugin']
 
 ```
@@ -61,8 +61,8 @@ scalac_plugins: ['simple_scalac_plugin']
 Plugins can optionally take arguments, specified like this:
 
 ```
-[compile.rsc]
-scalac_plugins: ['simple_scalac_plugin]
+[scala]
+scalac_plugins: ['simple_scalac_plugin']
 scalac_plugin_args: {
     'simple_scalac_plugin': ['arg1', 'arg2']
   }
@@ -85,10 +85,10 @@ scala_library(
 
 #### Depending on plugins
 
-In order to load a plugin, it has to be on scalac's classpath. 
+In order to load a plugin, it has to be on scalac's classpath.
 This can be achieved in one of two ways:
 
-- Have targets that must be compiled with a plugin depend (directly or indirectly) 
+- Have targets that must be compiled with a plugin depend (directly or indirectly)
 either on the `scalac_plugin` target, or on a `jar_library` pointing to a published version
 of the plugin.
 - Have a `scalac-plugin-dep` target in `BUILD.tools`:
@@ -98,18 +98,18 @@ jar_library(name='scalac-plugin-dep',
             jars = [jar(org='com.foo', name='foo_plugin', rev='1.2.3')],
 ```
 
-Note that, as always with `BUILD.tools`, plugin locations specified via `scala-plugin-dep` 
+Note that, as always with `BUILD.tools`, plugin locations specified via `scala-plugin-dep`
 must be published jars. They cannot be local `scalac_plugin` targets.
 
-Usually, it will make more sense to use `scala-plugin-dep` with global plugins, to avoid 
+Usually, it will make more sense to use `scala-plugin-dep` with global plugins, to avoid
 laborious repetition of that dependency, and to use target dependencies for per-target plugins,
 to keep the dependencies selective.
 
 Depending directly on the `scalac_plugin` has the added advantage of allowing plugin changes
-to be picked up when compiling the target that uses the plugin, with no need for an intermediate 
+to be picked up when compiling the target that uses the plugin, with no need for an intermediate
 publishing step.
 
-Note that, to avoid a chicken-and-egg problem, an in-repo plugin will not be used when 
+Note that, to avoid a chicken-and-egg problem, an in-repo plugin will not be used when
 compiling its own `scalac_plugin` target, or any of that target's dependencies.
 To use a plugin on its own code, you must publish it and consume the published plugin
 via `scala-plugin-dep`.

--- a/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scoverage_platform.py
@@ -25,14 +25,18 @@ class ScoveragePlatform(InjectablesMixin, Subsystem):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    register('--enable-scoverage',
+    register(
+      '--enable-scoverage',
       default=False,
+      fingerprint=True,
       type=bool,
       help='Specifies whether to generate scoverage reports for scala test targets. '
            'Default value is False. If True, '
            'implies --test-junit-coverage-processor=scoverage.')
 
-    register('--blacklist-targets',
+    register(
+      '--blacklist-targets',
+      fingerprint=True,
       type=list,
       member_type=target_option,
       help='List of targets not to be instrumented. Accepts Regex patterns. All '

--- a/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
@@ -60,7 +60,7 @@ class Scoverage(CoverageEngine):
              'filter.')
 
       register(
-        '--coverage-output-dir', type=dir_option, default=None, fingerprint=False,
+        '--output-dir', type=dir_option, default=None, fingerprint=False,
         help='Directory to copy coverage output to.'
       )
 
@@ -81,7 +81,7 @@ class Scoverage(CoverageEngine):
 
       opts = Scoverage.Factory.global_instance().get_options()
       target_filters = opts.target_filters
-      coverage_output_dir = opts.coverage_output_dir
+      coverage_output_dir = opts.output_dir
 
       return Scoverage(report_path, target_filters, settings, targets, execute_java_for_targets,
                        coverage_output_dir=coverage_output_dir)
@@ -163,15 +163,6 @@ class Scoverage(CoverageEngine):
     safe_mkdir(html_report_path, clean=True)
     safe_mkdir(xml_report_path, clean=True)
 
-    self._settings.log.info(f'output dir: {self._coverage_output_dir}')
-    if self._coverage_output_dir:
-      self._settings.log.debug(f'Scoverage output also written to: {self._coverage_output_dir}!')
-      mergetree(output_dir, self._coverage_output_dir)
-
-    import glob
-    dir_globbed = glob.glob(os.path.join(output_dir, '**'))
-    self._settings.log.debug(f'output_dir: {output_dir}, /**: {dir_globbed}')
-
     final_target_dirs = []
     for parent_measurements_dir in self._iter_datadirs(output_dir):
       final_target_dirs += self.filter_scoverage_targets(parent_measurements_dir)
@@ -194,6 +185,10 @@ class Scoverage(CoverageEngine):
 
     self._settings.log.info(f"Scoverage html reports available at {html_report_path}")
     self._settings.log.info(f"Scoverage xml reports available at {xml_report_path}")
+
+    if self._coverage_output_dir:
+      self._settings.log.debug(f'Scoverage output also written to: {self._coverage_output_dir}!')
+      mergetree(output_dir, self._coverage_output_dir)
 
     if self._settings.coverage_open:
       return os.path.join(html_report_path, 'index.html')

--- a/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
@@ -51,7 +51,7 @@ class Scoverage(CoverageEngine):
       )
 
       register(
-        '--target-filters', type=list, default=[], fingerprint=True,
+        '--target-filters', type=list, default=[], fingerprint=False,
         help='Regex patterns passed to scoverage report generator, specifying which targets '
              'should be '
              'included in reports. All targets matching any of the patterns will be '
@@ -163,6 +163,15 @@ class Scoverage(CoverageEngine):
     safe_mkdir(html_report_path, clean=True)
     safe_mkdir(xml_report_path, clean=True)
 
+    self._settings.log.info(f'output dir: {self._coverage_output_dir}')
+    if self._coverage_output_dir:
+      self._settings.log.debug(f'Scoverage output also written to: {self._coverage_output_dir}!')
+      mergetree(output_dir, self._coverage_output_dir)
+
+    import glob
+    dir_globbed = glob.glob(os.path.join(output_dir, '**'))
+    self._settings.log.debug(f'output_dir: {output_dir}, /**: {dir_globbed}')
+
     final_target_dirs = []
     for parent_measurements_dir in self._iter_datadirs(output_dir):
       final_target_dirs += self.filter_scoverage_targets(parent_measurements_dir)
@@ -185,10 +194,6 @@ class Scoverage(CoverageEngine):
 
     self._settings.log.info(f"Scoverage html reports available at {html_report_path}")
     self._settings.log.info(f"Scoverage xml reports available at {xml_report_path}")
-
-    if self._coverage_output_dir:
-      self._settings.log.debug(f'Scoverage output also written to: {self._coverage_output_dir}!')
-      mergetree(output_dir, self._coverage_output_dir)
 
     if self._settings.coverage_open:
       return os.path.join(html_report_path, 'index.html')

--- a/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
@@ -59,11 +59,6 @@ class Scoverage(CoverageEngine):
              'targets are included, which would be the same as specifying ".*" as a '
              'filter.')
 
-      register(
-        '--output-dir', type=dir_option, default=None, fingerprint=False,
-        help='Directory to copy coverage output to.'
-      )
-
     def create(self, settings, targets, execute_java_for_targets):
       """
       :param settings: Generic code coverage settings.
@@ -81,7 +76,7 @@ class Scoverage(CoverageEngine):
 
       opts = Scoverage.Factory.global_instance().get_options()
       target_filters = opts.target_filters
-      coverage_output_dir = opts.output_dir
+      coverage_output_dir = settings.context.options.for_global_scope().pants_distdir
 
       return Scoverage(report_path, target_filters, settings, targets, execute_java_for_targets,
                        coverage_output_dir=coverage_output_dir)

--- a/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/scoverage.py
@@ -9,7 +9,6 @@ from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.backend.jvm.tasks.coverage.engine import CoverageEngine
 from pants.base.exceptions import TaskError
 from pants.java.jar.jar_dependency import JarDependency
-from pants.option.custom_types import dir_option
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import mergetree, safe_mkdir, safe_walk
 

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -278,6 +278,7 @@ class JUnitRun(PartitionedTestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
         batch_output_dir = os.path.join(batch_output_dir, f'batch-{batch_id}')
 
       run_modifications = coverage.run_modifications(batch_output_dir)
+      self.context.log.debug(f'run_modifications: {run_modifications}')
 
       extra_jvm_options = run_modifications.extra_jvm_options
 

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -462,6 +462,7 @@ python_tests(
   sources = ['test_junit_run_integration.py'],
   dependencies = [
     ':missing_jvm_check',
+    'examples/tests/scala/org/pantsbuild/example:hello_directory',
     'src/python/pants/base:build_environment',
     'src/python/pants/testutil:int-test',
     'testprojects/tests/java/org/pantsbuild/testproject:coverage_directory',

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -9,7 +9,6 @@ from contextlib import contextmanager
 
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
-from pants.util.contextutil import temporary_dir
 
 
 class JunitRunIntegrationTest(PantsRunIntegrationTest):
@@ -72,24 +71,23 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
       yield ET.parse(coverage_xml).getroot(), read_utf8(coverage_html)
 
   def do_test_junit_run_with_coverage_succeeds_scoverage(self, tests=(), args=()):
-    with temporary_dir() as tmp_dir:
-      with self.coverage(
-          processor='scoverage',
-          xml_path='scoverage/reports/xml/scoverage.xml',
-          html_path='scoverage/reports/html/org.pantsbuild.example.hello.welcome.html',
-          test_project='examples/tests/scala/org/pantsbuild/example/hello/welcome',
-          test_class='org.pantsbuild.example.hello.welcome',
-          pre_args=['--scoverage-enable-scoverage'],
-          tests=tests,
-          args=args) as (xml_report, html_report_string):
+    with self.coverage(
+        processor='scoverage',
+        xml_path='scoverage/reports/xml/scoverage.xml',
+        html_path='scoverage/reports/html/org.pantsbuild.example.hello.welcome.html',
+        test_project='examples/tests/scala/org/pantsbuild/example/hello/welcome',
+        test_class='org.pantsbuild.example.hello.welcome',
+        pre_args=['--scoverage-enable-scoverage'],
+        tests=tests,
+        args=args) as (xml_report, html_report_string):
 
-        # Validate 100% coverage; ie a line coverage rate of 1.
-        self.assertEqual('scoverage', xml_report.tag)
-        self.assertEqual(100.0, float(xml_report.attrib['statement-rate']))
+      # Validate 100% coverage; ie a line coverage rate of 1.
+      self.assertEqual('scoverage', xml_report.tag)
+      self.assertEqual(100.0, float(xml_report.attrib['statement-rate']))
 
-        # Validate that the html report was able to find sources for annotation.
-        self.assertIn('WelcomeEverybody', html_report_string)
-        self.assertIn('Welcome.scala', html_report_string)
+      # Validate that the html report was able to find sources for annotation.
+      self.assertIn('WelcomeEverybody', html_report_string)
+      self.assertIn('Welcome.scala', html_report_string)
 
   def test_junit_run_with_coverage_succeeds_scoverage(self):
     self.do_test_junit_run_with_coverage_succeeds_scoverage(args=['--no-chroot', '--fast'])


### PR DESCRIPTION
### Problem

- Scoverage reports will continue to be created even after the option is disabled, because the `--scoverage-enable-scoverage` option isn't registered with `fingerprint=True`.
- Separately, we'd like to be able to provide an output dir to scoverage so that we can know where the output of the most recent run was placed.

### Solution

- Add `fingerprint=True` to most scoverage options.
- Copy `scoverage` output to `dist/`.

### Result

- Scoverage should invalidate as users expect, and
- Users can inspect the `dist/` dir after running tests with scoverage enabled to extract and view the results!