### PR TITLE
Add `SchedulerSession.materialize_directory()` for less boilerplate in V2 rules

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -371,9 +371,9 @@ class Zinc:
 
     if not os.path.exists(bridge_jar):
       res = self._run_bootstrapper(bridge_jar, context)
-      context._scheduler.materialize_directories((
-        DirectoryToMaterialize("", res.output_directory_digest),
-      ))
+      context._scheduler.materialize_directory(
+        DirectoryToMaterialize("", res.output_directory_digest)
+      )
       # For the workaround above to work, we need to store a copy of the bridge in
       # the bootstrapdir cache (.cache).
       safe_mkdir(global_bridge_cache_dir)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -172,11 +172,12 @@ class JavacCompile(JvmCompile):
           if return_code:
             raise TaskError('javac exited with return code {rc}'.format(rc=return_code))
         classes_directory = Path(ctx.classes_dir.path).relative_to(get_buildroot())
-        self.context._scheduler.materialize_directories((
+        self.context._scheduler.materialize_directory(
           DirectoryToMaterialize(
             str(classes_directory),
-            self.post_compile_extra_resources_digest(ctx, prepend_post_merge_relative_path=False)),
-        ))
+            self.post_compile_extra_resources_digest(ctx, prepend_post_merge_relative_path=False)
+          ),
+        )
 
     self._create_context_jar(ctx)
 
@@ -234,6 +235,6 @@ class JavacCompile(JvmCompile):
         self.post_compile_extra_resources_digest(ctx, prepend_post_merge_relative_path=False),
       ])
     classes_directory = Path(ctx.classes_dir.path).relative_to(get_buildroot())
-    self.context._scheduler.materialize_directories((
+    self.context._scheduler.materialize_directory(
       DirectoryToMaterialize(str(classes_directory), merged_directories),
-    ))
+    )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -799,9 +799,9 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
     # TODO: parse the output of -Xprint:timings for rsc and write it to self._record_target_stats()!
 
     res.output_directory_digest.dump(ctx.rsc_jar_file.path)
-    self.context._scheduler.materialize_directories((
+    self.context._scheduler.materialize_directory(
       DirectoryToMaterialize("", res.output_directory_digest),
-    ))
+    )
     ctx.rsc_jar_file.hydrate_missing_directory_digest(res.output_directory_digest)
 
     return res

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -378,9 +378,9 @@ class BaseZincCompile(JvmCompile):
   def _compile_nonhermetic(self, jvm_options, ctx, classes_directory):
     # Populate the resources to merge post compile onto disk for the nonhermetic case,
     # where `--post-compile-merge-dir` was added is the relevant part.
-    self.context._scheduler.materialize_directories((
+    self.context._scheduler.materialize_directory(
       DirectoryToMaterialize("", self.post_compile_extra_resources_digest(ctx)),
-    ))
+    )
 
     exit_code = self.runjava(classpath=self.get_zinc_compiler_classpath(),
                              main=Zinc.ZINC_COMPILE_MAIN,
@@ -516,9 +516,9 @@ class BaseZincCompile(JvmCompile):
       req, self.name(), [WorkUnitLabel.COMPILER])
 
     # TODO: Materialize as a batch in do_compile or somewhere
-    self.context._scheduler.materialize_directories((
+    self.context._scheduler.materialize_directory(
       DirectoryToMaterialize("", res.output_directory_digest),
-    ))
+    )
 
     # TODO: This should probably return a ClasspathEntry rather than a Digest
     return res.output_directory_digest

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -74,9 +74,9 @@ class TestResolveRequirements(TestBase):
         PythonNativeCode.global_instance()
       )
     )
-    self.scheduler.materialize_directories((
+    self.scheduler.materialize_directory(
       DirectoryToMaterialize(path="", directory_digest=requirements_pex.directory_digest),
-    ))
+    )
     with zipfile.ZipFile(os.path.join(self.build_root, "test.pex"), "r") as pex:
       with pex.open("PEX-INFO", "r") as pex_info:
         pex_info_content = pex_info.readline().decode()

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -208,6 +208,11 @@ class Workspace:
   """Abstract handle for operations that touch the real local filesystem."""
   _scheduler: "SchedulerSession"
 
+  def materialize_directory(
+    self, directory_to_materialize: DirectoryToMaterialize
+  ) -> MaterializeDirectoryResult:
+    return self._scheduler.materialize_directory(directory_to_materialize)
+
   def materialize_directories(
     self, directories_to_materialize: Tuple[DirectoryToMaterialize, ...]
   ) -> MaterializeDirectoriesResult:

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -211,11 +211,14 @@ class Workspace:
   def materialize_directory(
     self, directory_to_materialize: DirectoryToMaterialize
   ) -> MaterializeDirectoryResult:
+    """Materialize one single directory digest to disk. If you need to materialize multiple, you
+    should use the parallel materialize_directories() instead."""
     return self._scheduler.materialize_directory(directory_to_materialize)
 
   def materialize_directories(
     self, directories_to_materialize: Tuple[DirectoryToMaterialize, ...]
   ) -> MaterializeDirectoriesResult:
+    """Materialize multiple directory digests to disk in parallel."""
     return self._scheduler.materialize_directories(directories_to_materialize)
 
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -581,12 +581,14 @@ class SchedulerSession:
   def materialize_directory(
     self, directory_to_materialize: DirectoryToMaterialize
   ) -> MaterializeDirectoryResult:
+    """Materialize one single directory digest to disk. If you need to materialize multiple, you
+    should use the parallel materialize_directories() instead."""
     return self.materialize_directories((directory_to_materialize,)).dependencies[0]
 
   def materialize_directories(
     self, directories_to_materialize: Tuple[DirectoryToMaterialize, ...]
   ) -> MaterializeDirectoriesResult:
-    """Creates the specified directories on the file system."""
+    """Materialize multiple directory digests to disk in parallel."""
     # Ensure that there isn't more than one of the same directory paths and paths do not have the
     # same prefix.
     dir_list = [dtm.path for dtm in directories_to_materialize]

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -17,6 +17,7 @@ from pants.engine.fs import (
   Digest,
   DirectoryToMaterialize,
   MaterializeDirectoriesResult,
+  MaterializeDirectoryResult,
   PathGlobsAndRoot,
 )
 from pants.engine.native import Function, TypeId
@@ -577,9 +578,13 @@ class SchedulerSession:
     result: 'InteractiveProcessResult' = self._scheduler._raise_or_return(wrapped_result)
     return result
 
+  def materialize_directory(
+    self, directory_to_materialize: DirectoryToMaterialize
+  ) -> MaterializeDirectoryResult:
+    return self.materialize_directories((directory_to_materialize,)).dependencies[0]
+
   def materialize_directories(
-    self,
-    directories_to_materialize: Tuple[DirectoryToMaterialize, ...]
+    self, directories_to_materialize: Tuple[DirectoryToMaterialize, ...]
   ) -> MaterializeDirectoriesResult:
     """Creates the specified directories on the file system."""
     # Ensure that there isn't more than one of the same directory paths and paths do not have the

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -33,11 +33,10 @@ class MockWorkspaceGoal(Goal):
 @console_rule
 async def workspace_console_rule(console: Console, workspace: Workspace, msg: MessageToConsoleRule) -> MockWorkspaceGoal:
   digest = await Get(Digest, InputFilesContent, msg.input_files_content)
-  output = workspace.materialize_directories((
-    DirectoryToMaterialize(path="", directory_digest=digest),
-  ))
-  output_path = output.dependencies[0].output_paths[0]
-  console.print_stdout(output_path, end='')
+  output = workspace.materialize_directory(
+    DirectoryToMaterialize(path="", directory_digest=digest)
+  )
+  console.print_stdout(output.output_paths[0], end='')
   return MockWorkspaceGoal(exit_code=0)
 
 

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -33,10 +33,9 @@ async def run(
 
   with temporary_dir(root_dir=str(Path(build_root.path, ".pants.d")), cleanup=True) as tmpdir:
     path_relative_to_build_root = Path(tmpdir).relative_to(build_root.path)
-    dirs_to_materialize = (DirectoryToMaterialize(
-      path=path_relative_to_build_root, directory_digest=binary.digest),
+    workspace.materialize_directory(
+      DirectoryToMaterialize(path=path_relative_to_build_root, directory_digest=binary.digest)
     )
-    workspace.materialize_directories(dirs_to_materialize)
 
     console.write_stdout(f"Running target: {target}\n")
     full_path = str(Path(tmpdir, binary.binary_name))

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -362,7 +362,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
     digest = Digest(
       "63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16", 80
     )
-    self.scheduler.materialize_directories((DirectoryToMaterialize("test", digest),))
+    self.scheduler.materialize_directory(DirectoryToMaterialize("test", digest))
     assert Path(self.build_root, "test/roland").read_text() == "European Burmese"
 
   def test_add_prefix(self):


### PR DESCRIPTION
`SchedulerSession.materialize_directories()` is useful and has its place, but over 90% of our call sites only every try to materialize one single directory. We can reduce boilerplate by wrapping `materialize_directories()` with `materialize_directory` and letting the caller decide which is needed for the rule.