### PR TITLE
Use default argument for `DirectoryToMaterialize`'s `path_prefix`

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -371,9 +371,7 @@ class Zinc:
 
     if not os.path.exists(bridge_jar):
       res = self._run_bootstrapper(bridge_jar, context)
-      context._scheduler.materialize_directory(
-        DirectoryToMaterialize("", res.output_directory_digest)
-      )
+      context._scheduler.materialize_directory(DirectoryToMaterialize(res.output_directory_digest))
       # For the workaround above to work, we need to store a copy of the bridge in
       # the bootstrapdir cache (.cache).
       safe_mkdir(global_bridge_cache_dir)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -175,7 +175,7 @@ class JavacCompile(JvmCompile):
         self.context._scheduler.materialize_directory(
           DirectoryToMaterialize(
             self.post_compile_extra_resources_digest(ctx, prepend_post_merge_relative_path=False),
-            path=str(classes_directory),
+            path_prefix=str(classes_directory),
           ),
         )
 
@@ -236,5 +236,5 @@ class JavacCompile(JvmCompile):
       ])
     classes_directory = Path(ctx.classes_dir.path).relative_to(get_buildroot())
     self.context._scheduler.materialize_directory(
-      DirectoryToMaterialize(merged_directories, path=str(classes_directory)),
+      DirectoryToMaterialize(merged_directories, path_prefix=str(classes_directory)),
     )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -174,8 +174,8 @@ class JavacCompile(JvmCompile):
         classes_directory = Path(ctx.classes_dir.path).relative_to(get_buildroot())
         self.context._scheduler.materialize_directory(
           DirectoryToMaterialize(
-            str(classes_directory),
-            self.post_compile_extra_resources_digest(ctx, prepend_post_merge_relative_path=False)
+            self.post_compile_extra_resources_digest(ctx, prepend_post_merge_relative_path=False),
+            path=str(classes_directory),
           ),
         )
 
@@ -236,5 +236,5 @@ class JavacCompile(JvmCompile):
       ])
     classes_directory = Path(ctx.classes_dir.path).relative_to(get_buildroot())
     self.context._scheduler.materialize_directory(
-      DirectoryToMaterialize(str(classes_directory), merged_directories),
+      DirectoryToMaterialize(merged_directories, path=str(classes_directory)),
     )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -800,7 +800,7 @@ class RscCompile(ZincCompile, MirroredTargetOptionMixin):
 
     res.output_directory_digest.dump(ctx.rsc_jar_file.path)
     self.context._scheduler.materialize_directory(
-      DirectoryToMaterialize("", res.output_directory_digest),
+      DirectoryToMaterialize(res.output_directory_digest),
     )
     ctx.rsc_jar_file.hydrate_missing_directory_digest(res.output_directory_digest)
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -379,7 +379,7 @@ class BaseZincCompile(JvmCompile):
     # Populate the resources to merge post compile onto disk for the nonhermetic case,
     # where `--post-compile-merge-dir` was added is the relevant part.
     self.context._scheduler.materialize_directory(
-      DirectoryToMaterialize("", self.post_compile_extra_resources_digest(ctx)),
+      DirectoryToMaterialize(self.post_compile_extra_resources_digest(ctx)),
     )
 
     exit_code = self.runjava(classpath=self.get_zinc_compiler_classpath(),
@@ -517,7 +517,7 @@ class BaseZincCompile(JvmCompile):
 
     # TODO: Materialize as a batch in do_compile or somewhere
     self.context._scheduler.materialize_directory(
-      DirectoryToMaterialize("", res.output_directory_digest),
+      DirectoryToMaterialize(res.output_directory_digest)
     )
 
     # TODO: This should probably return a ClasspathEntry rather than a Digest

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -75,7 +75,7 @@ class TestResolveRequirements(TestBase):
       )
     )
     self.scheduler.materialize_directory(
-      DirectoryToMaterialize(path="", directory_digest=requirements_pex.directory_digest),
+      DirectoryToMaterialize(requirements_pex.directory_digest),
     )
     with zipfile.ZipFile(os.path.join(self.build_root, "test.pex"), "r") as pex:
       with pex.open("PEX-INFO", "r") as pex_info:

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -171,16 +171,16 @@ class DirectoryWithPrefixToAdd:
 
 @dataclass(frozen=True)
 class DirectoryToMaterialize:
-  """A request to materialize the contents of a directory digest at the provided path,
-  relative to the buildroot."""
+  """A request to materialize the contents of a directory digest at the build root, optionally with
+  a path prefix (relative to the build root)."""
   directory_digest: Digest
-  path: str = ""  # i.e. at the root level of the build root
+  path_prefix: str = ""  # i.e., we default to the root level of the build root
 
   def __post_init__(self) -> None:
-    if Path(self.path).is_absolute():
+    if Path(self.path_prefix).is_absolute():
       raise ValueError(
-        f"The path must be relative for {self}, as the engine materializes directories relative to "
-        f"the build root."
+        f"The path_prefix must be relative for {self}, as the engine materializes directories "
+        f"relative to the build root."
       )
 
 

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -171,9 +171,10 @@ class DirectoryWithPrefixToAdd:
 
 @dataclass(frozen=True)
 class DirectoryToMaterialize:
-  """A request to materialize the contents of a directory digest at the provided path."""
-  path: str
+  """A request to materialize the contents of a directory digest at the provided path,
+  relative to the buildroot."""
   directory_digest: Digest
+  path: str = ""  # i.e. at the root level of the build root
 
   def __post_init__(self) -> None:
     if Path(self.path).is_absolute():

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -591,7 +591,7 @@ class SchedulerSession:
     """Materialize multiple directory digests to disk in parallel."""
     # Ensure that there isn't more than one of the same directory paths and paths do not have the
     # same prefix.
-    dir_list = [dtm.path for dtm in directories_to_materialize]
+    dir_list = [dtm.path_prefix for dtm in directories_to_materialize]
     check_no_overlapping_paths(dir_list)
 
     wrapped_result = self._scheduler._native.lib.materialize_directories(

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -33,9 +33,7 @@ class MockWorkspaceGoal(Goal):
 @console_rule
 async def workspace_console_rule(console: Console, workspace: Workspace, msg: MessageToConsoleRule) -> MockWorkspaceGoal:
   digest = await Get(Digest, InputFilesContent, msg.input_files_content)
-  output = workspace.materialize_directory(
-    DirectoryToMaterialize(path="", directory_digest=digest)
-  )
+  output = workspace.materialize_directory(DirectoryToMaterialize(directory_digest=digest))
   console.print_stdout(output.output_paths[0], end='')
   return MockWorkspaceGoal(exit_code=0)
 
@@ -80,9 +78,7 @@ class FileSystemTest(TestBase):
     assert not path1.is_file()
     assert not path2.is_file()
 
-    output = workspace.materialize_directories((
-      DirectoryToMaterialize(path="", directory_digest=digest),
-    ))
+    output = workspace.materialize_directories((DirectoryToMaterialize(directory_digest=digest),))
 
     assert type(output) == MaterializeDirectoriesResult
     materialize_result = output.dependencies[0]

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -33,7 +33,7 @@ class MockWorkspaceGoal(Goal):
 @console_rule
 async def workspace_console_rule(console: Console, workspace: Workspace, msg: MessageToConsoleRule) -> MockWorkspaceGoal:
   digest = await Get(Digest, InputFilesContent, msg.input_files_content)
-  output = workspace.materialize_directory(DirectoryToMaterialize(directory_digest=digest))
+  output = workspace.materialize_directory(DirectoryToMaterialize(digest))
   console.print_stdout(output.output_paths[0], end='')
   return MockWorkspaceGoal(exit_code=0)
 
@@ -78,7 +78,7 @@ class FileSystemTest(TestBase):
     assert not path1.is_file()
     assert not path2.is_file()
 
-    output = workspace.materialize_directories((DirectoryToMaterialize(directory_digest=digest),))
+    output = workspace.materialize_directories((DirectoryToMaterialize(digest),))
 
     assert type(output) == MaterializeDirectoriesResult
     materialize_result = output.dependencies[0]

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -37,7 +37,7 @@ async def create_binary(addresses: BuildFileAddresses, console: Console, workspa
     print_stdout("Generating binaries in `dist/`")
     binaries = await MultiGet(Get(CreatedBinary, Address, address.to_address()) for address in addresses)
     dirs_to_materialize = tuple(
-      DirectoryToMaterialize(path='dist/', directory_digest=binary.digest) for binary in binaries
+      DirectoryToMaterialize(binary.digest, path='dist/') for binary in binaries
     )
     results = workspace.materialize_directories(dirs_to_materialize)
     for result in results.dependencies:

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -37,7 +37,7 @@ async def create_binary(addresses: BuildFileAddresses, console: Console, workspa
     print_stdout("Generating binaries in `dist/`")
     binaries = await MultiGet(Get(CreatedBinary, Address, address.to_address()) for address in addresses)
     dirs_to_materialize = tuple(
-      DirectoryToMaterialize(binary.digest, path='dist/') for binary in binaries
+      DirectoryToMaterialize(binary.digest, path_prefix='dist/') for binary in binaries
     )
     results = workspace.materialize_directories(dirs_to_materialize)
     for result in results.dependencies:

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -34,7 +34,7 @@ async def run(
   with temporary_dir(root_dir=str(Path(build_root.path, ".pants.d")), cleanup=True) as tmpdir:
     path_relative_to_build_root = Path(tmpdir).relative_to(build_root.path)
     workspace.materialize_directory(
-      DirectoryToMaterialize(path=path_relative_to_build_root, directory_digest=binary.digest)
+      DirectoryToMaterialize(binary.digest, path=path_relative_to_build_root)
     )
 
     console.write_stdout(f"Running target: {target}\n")

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -34,7 +34,7 @@ async def run(
   with temporary_dir(root_dir=str(Path(build_root.path, ".pants.d")), cleanup=True) as tmpdir:
     path_relative_to_build_root = Path(tmpdir).relative_to(build_root.path)
     workspace.materialize_directory(
-      DirectoryToMaterialize(binary.digest, path=path_relative_to_build_root)
+      DirectoryToMaterialize(binary.digest, path_prefix=path_relative_to_build_root)
     )
 
     console.write_stdout(f"Running target: {target}\n")

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -362,7 +362,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
     digest = Digest(
       "63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16", 80
     )
-    self.scheduler.materialize_directory(DirectoryToMaterialize("test", digest))
+    self.scheduler.materialize_directory(DirectoryToMaterialize(digest, path="test/"))
     assert Path(self.build_root, "test/roland").read_text() == "European Burmese"
 
   def test_add_prefix(self):

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -362,7 +362,7 @@ class FSTest(TestBase, SchedulerTestBase, metaclass=ABCMeta):
     digest = Digest(
       "63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16", 80
     )
-    self.scheduler.materialize_directory(DirectoryToMaterialize(digest, path="test/"))
+    self.scheduler.materialize_directory(DirectoryToMaterialize(digest, path_prefix="test/"))
     assert Path(self.build_root, "test/roland").read_text() == "European Burmese"
 
   def test_add_prefix(self):


### PR DESCRIPTION
### Problem

We now always materialize directories relative to the build root (https://github.com/pantsbuild/pants/pull/8696). In making that change, the vast majority of use cases showed that we usually want to write at the root level of the build root.

For example, if the digest is for a file called `tests/foo.txt` and a file called `bar.txt`, then we would want the build root to end up with the files `/User/.../pants/bar.txt` and `/User/.../pants/tests/foo.txt`.

Right now, all of those call sites must set `path=""`, which results in a lot of boilerplate and is also not very intuitive what that means. 

### Solution

Use a default argument, which we could not do until recently now that we have dataclasses.

This requires reordering the args for the dataclass, which results in a small Rust change.