### PR TITLE
Add `rootify_rules()` test utility to reduce boilerplate in V2 tests

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -3,18 +3,17 @@
 
 from typing import List, Optional, Tuple
 
-from pants.backend.python.lint.black.rules import BlackSetup, fmt, lint, setup_black
+from pants.backend.python.lint.black.rules import BlackSetup
+from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.backend.python.lint.black.subsystem import Black
-from pants.backend.python.rules.download_pex_bin import download_pex_bin
-from pants.backend.python.rules.pex import CreatePex, create_pex
-from pants.backend.python.subsystems.python_native_code import (
-  PythonNativeCode,
-  create_pex_native_build_environment,
-)
+from pants.backend.python.rules.download_pex_bin import rules as download_pex_bin_rules
+from pants.backend.python.rules.pex import rules as pex_rules
+from pants.backend.python.subsystems.python_native_code import PythonNativeCode
+from pants.backend.python.subsystems.python_native_code import rules as python_native_code_rules
 from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.backend.python.subsystems.subprocess_environment import SubprocessEnvironment
 from pants.backend.python.subsystems.subprocess_environment import (
-  SubprocessEnvironment,
-  create_subprocess_encoding_environment,
+  rules as subprocess_environment_rules,
 )
 from pants.backend.python.targets.formattable_python_target import FormattablePythonTarget
 from pants.build_graph.address import Address
@@ -25,6 +24,7 @@ from pants.engine.selectors import Params
 from pants.rules.core.fmt import FmtResult
 from pants.rules.core.lint import LintResult
 from pants.source.wrapped_globs import EagerFilesetWithSpec
+from pants.testutil.engine.util import rootify_rules
 from pants.testutil.subsystem.util import global_subsystem_instance, init_subsystems
 from pants.testutil.test_base import TestBase
 
@@ -37,22 +37,15 @@ class BlackIntegrationTest(TestBase):
 
   @classmethod
   def rules(cls):
-    return (
+    return rootify_rules(
       *super().rules(),
-      fmt,
-      lint,
-      setup_black,
-      create_pex,
-      create_subprocess_encoding_environment,
-      create_pex_native_build_environment,
-      download_pex_bin,
-      RootRule(CreatePex),
-      RootRule(FormattablePythonTarget),
-      RootRule(Black),
+      *black_rules(),
+      *pex_rules(),
+      *download_pex_bin_rules(),
+      *python_native_code_rules(),
+      *subprocess_environment_rules(),
       RootRule(BlackSetup),
-      RootRule(PythonSetup),
-      RootRule(PythonNativeCode),
-      RootRule(SubprocessEnvironment),
+      RootRule(FormattablePythonTarget),
     )
 
   def setUp(self):

--- a/src/python/pants/backend/python/rules/inject_init_test.py
+++ b/src/python/pants/backend/python/rules/inject_init_test.py
@@ -11,7 +11,7 @@ class TestInjectInit(TestBase):
 
   @classmethod
   def rules(cls):
-    return super().rules() + [inject_init, RootRule(Snapshot)]
+    return (*super().rules(), inject_init, RootRule(Snapshot))
 
   def assert_result(self, input_snapshot, expected_digest):
     injected_digest = self.request_single_product(InjectedInitDigest, input_snapshot)

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -6,27 +6,26 @@ import os.path
 import zipfile
 from typing import Dict, List
 
-from pants.backend.python.rules.download_pex_bin import download_pex_bin
+from pants.backend.python.rules.download_pex_bin import rules as download_pex_bin_rules
 from pants.backend.python.rules.pex import (
   CreatePex,
   Pex,
   PexInterpreterConstraints,
   PexRequirements,
-  create_pex,
 )
-from pants.backend.python.subsystems.python_native_code import (
-  PythonNativeCode,
-  create_pex_native_build_environment,
-)
+from pants.backend.python.rules.pex import rules as pex_rules
+from pants.backend.python.subsystems.python_native_code import PythonNativeCode
+from pants.backend.python.subsystems.python_native_code import rules as python_native_code_rules
 from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.backend.python.subsystems.subprocess_environment import SubprocessEnvironment
 from pants.backend.python.subsystems.subprocess_environment import (
-  SubprocessEnvironment,
-  create_subprocess_encoding_environment,
+  rules as subprocess_environment_rules,
 )
 from pants.engine.fs import Digest, DirectoryToMaterialize, FileContent, InputFilesContent
 from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
+from pants.testutil.engine.util import rootify_rules
 from pants.testutil.subsystem.util import init_subsystems
 from pants.testutil.test_base import TestBase
 from pants.util.strutil import create_path_env_var
@@ -36,16 +35,14 @@ class TestResolveRequirements(TestBase):
 
   @classmethod
   def rules(cls):
-    return super().rules() + [
-      create_pex,
-      create_pex_native_build_environment,
-      create_subprocess_encoding_environment,
-      download_pex_bin,
+    return rootify_rules(
+      *super().rules(),
+      *pex_rules(),
+      *download_pex_bin_rules(),
+      *python_native_code_rules(),
+      *subprocess_environment_rules(),
       RootRule(CreatePex),
-      RootRule(PythonSetup),
-      RootRule(PythonNativeCode),
-      RootRule(SubprocessEnvironment)
-    ]
+    )
 
   def setUp(self):
     super().setUp()

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -48,7 +48,7 @@ class WorkspaceInConsoleRuleTest(ConsoleRuleTestBase):
 
   @classmethod
   def rules(cls):
-    return super().rules() + [RootRule(MessageToConsoleRule), workspace_console_rule]
+    return (*super().rules(), workspace_console_rule, RootRule(MessageToConsoleRule))
 
   def test(self):
     msg = MessageToConsoleRule(

--- a/src/python/pants/rules/core/cloc_test.py
+++ b/src/python/pants/rules/core/cloc_test.py
@@ -14,7 +14,7 @@ class ClocTest(ConsoleRuleTestBase):
 
   @classmethod
   def rules(cls):
-    return super().rules() + cloc.rules()
+    return (*super().rules(), *cloc.rules())
 
   @classmethod
   def alias_groups(cls):

--- a/src/python/pants/rules/core/filedeps_test.py
+++ b/src/python/pants/rules/core/filedeps_test.py
@@ -23,7 +23,7 @@ class FileDepsTest(ConsoleRuleTestBase):
 
   @classmethod
   def rules(cls):
-    return super().rules() + filedeps.rules()
+    return (*super().rules(), *filedeps.rules())
 
   @classmethod
   def alias_groups(cls) -> BuildFileAliases:

--- a/src/python/pants/rules/core/list_roots_test.py
+++ b/src/python/pants/rules/core/list_roots_test.py
@@ -82,7 +82,7 @@ class RootsTest(ConsoleRuleTestBase):
 
   @classmethod
   def rules(cls):
-    return super().rules() + list_roots.rules()
+    return (*super().rules(), *list_roots.rules())
 
   def test_no_langs(self):
     source_roots = json.dumps({'fakeroot': tuple()})

--- a/src/python/pants/rules/core/strip_source_roots_test.py
+++ b/src/python/pants/rules/core/strip_source_roots_test.py
@@ -8,8 +8,10 @@ from pants.engine.fs import create_fs_rules
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.rules import RootRule
 from pants.engine.selectors import Params
-from pants.rules.core.strip_source_root import SourceRootStrippedSources, strip_source_root
+from pants.rules.core.strip_source_root import SourceRootStrippedSources
+from pants.rules.core.strip_source_root import rules as strip_source_root_rules
 from pants.source.source_root import SourceRootConfig
+from pants.testutil.engine.util import rootify_rules
 from pants.testutil.subsystem.util import init_subsystem
 from pants.testutil.test_base import TestBase
 
@@ -17,14 +19,15 @@ from pants.testutil.test_base import TestBase
 class StripSourceRootsTests(TestBase):
   @classmethod
   def rules(cls):
-    return super().rules() + [
-      strip_source_root,
-      RootRule(SourceRootConfig),
-      RootRule(HydratedTarget),
-    ] + create_fs_rules()
+    return rootify_rules(
+      *super().rules(), *create_fs_rules(), *strip_source_root_rules(), RootRule(HydratedTarget),
+    )
+
+  def setUp(self):
+    super().setUp()
+    init_subsystem(SourceRootConfig)
 
   def assert_stripped_source_file(self, *, original_path: str, expected_path: str, target_type_alias = None):
-    init_subsystem(SourceRootConfig)
     adaptor = Mock()
     adaptor.sources = Mock()
     source_files = {original_path: "print('random python')"}

--- a/tests/python/pants_test/backend/graph_info/tasks/test_list_targets.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_list_targets.py
@@ -40,7 +40,7 @@ class ListTargetsTest(ConsoleRuleTestBase):
 
   @classmethod
   def rules(cls):
-    return super().rules() + list_targets.rules()
+    return (*super().rules(), *list_targets.rules())
 
   def setUp(self) -> None:
     super().setUp()

--- a/tests/python/pants_test/backend/native/tasks/native_task_test_base.py
+++ b/tests/python/pants_test/backend/native/tasks/native_task_test_base.py
@@ -12,9 +12,10 @@ from pants.testutil.task_test_base import TaskTestBase
 
 
 class NativeTaskTestBase(TaskTestBase):
+
   @classmethod
   def rules(cls):
-    return super().rules() + register.rules()
+    return (*super().rules(), *register.rules())
 
 
 class NativeCompileTestMixin:

--- a/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/util/build_local_dists_test_base.py
@@ -39,7 +39,7 @@ class BuildLocalPythonDistributionsTestBase(PythonTaskTestBase, DeclarativeTaskT
 
   @classmethod
   def rules(cls):
-    return super().rules() + native_backend_rules()
+    return (*super().rules(), *native_backend_rules())
 
   @classproperty
   @abstractmethod

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -295,10 +295,13 @@ class IsolatedProcessTest(TestBase, unittest.TestCase):
 
   @classmethod
   def rules(cls):
-    return super().rules() + [
-      RootRule(JavacVersionExecutionRequest),
+    return (
+      *super().rules(),
+      *create_cat_stdout_rules(),
+      *create_javac_compile_rules(),
       get_javac_version_output,
-    ] + create_cat_stdout_rules() + create_javac_compile_rules()
+      RootRule(JavacVersionExecutionRequest),
+    )
 
   def test_integration_concat_with_snapshots_stdout(self):
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -169,7 +169,8 @@ class SchedulerTest(TestBase):
 
   @classmethod
   def rules(cls):
-    return super().rules() + [
+    return (
+      *super().rules(),
       RootRule(A),
       # B is both a RootRule and an intermediate product here.
       RootRule(B),
@@ -188,7 +189,7 @@ class SchedulerTest(TestBase):
       RootRule(UnionB),
       select_union_b,
       a_union_test,
-    ]
+    )
 
   def test_use_params(self):
     # Confirm that we can pass in Params in order to provide multiple inputs to an execution.
@@ -249,7 +250,8 @@ class SchedulerWithNestedRaiseTest(TestBase):
 
   @classmethod
   def rules(cls):
-    return super().rules() + [
+    return (
+      *super().rules(),
       RootRule(B),
       RootRule(TypeCheckFailWrapper),
       RootRule(CollectionType),
@@ -257,7 +259,7 @@ class SchedulerWithNestedRaiseTest(TestBase):
       c_unhashable,
       c_unhashable_dataclass,
       nested_raise,
-    ]
+    )
 
   #TODO(#8675) - This test (and others like it) that rely on matching a specific string repr of a complex python object is fragile.
   def test_get_type_match_failure(self):


### PR DESCRIPTION
### Problem

Registering rules in a `TestBase.request_single_product`-style test is painful, particularly when the rules being tested use an `optionable_rule`/`Subsystem` somewhere in the rule graph. 

Specifically, we cannot use this style:

```python
from pants.rules.core.fmt import rules as fmt_rules

class TestFmt(TestBase):

  @classmethod
  def rules():
    return (*super.rules(), *fmt_rules())
  ```

Why? This will require having `OptionsBootstrapper` registered, which leads to a can of worms to get set up properly. 

While `ConsoleRuleTestBase` solves this, not every test should use `ConsoleRuleTestBase` - for example, `pex_test.py` would have no clear way to use that test base as it never writes to the console.

Instead, we have to individually register every individual subsystem and rule used transitively, like this:

 ```python
from pants.rules.core.fmt import rules as fmt_rules

class TestFmt(TestBase):

  @classmethod
  def rules():
    return (
      *super.rules(),
      fmt,
      RootRule(PythonSetup),
    )
```


### Solution

Add a new utility `testutil.engine.util.rootify_rules` that will convert any `optionable_rule` into a `RootRule` and no-op on the other rules.

Also, tweak all `rules()` registrations in tests to use list unpacking. Rather than:

```python
def rules():
  return super().rules() + [fmt] + fs_rules()
```

Use this style, which makes it much simpler to combine sequences of rules with individual rules:

```python
def rules():
  return (*super().rules(), *fs_rules(), fmt)
```

### Result

Now tests that depend on an `optionable_rule` may use this style:

```python
from pants.rules.core.fmt import rules as fmt_rules
from pants.testutil.engine.util import rootify_rules

class TestFmt(TestBase):

  @classmethod
  def rules():
    return rootify_rules(*super.rules(), *fmt_rules())
```