### PR TITLE
Add option to attach Subsystems to streaming workunits

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -502,6 +502,12 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--lock', advanced=True, type=bool, default=True,
              help='Use a global lock to exclude other versions of pants from running during '
                   'critical operations.')
+    register('--streaming-workunits-handlers', type=list, member_type=str, default=[],
+        advanced=True,
+        help="Use this option to name Subsystems which will receive streaming workunit events. "
+        """For instance, `--streaming-workunits-handlers="['pants.reporting.workunit.Workunits']"` will """
+        """register a Subsystem called Workunits defined in the module "pants.reporting.workunit"."""
+    )
 
   @classmethod
   def validate_instance(cls, opts):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -505,8 +505,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--streaming-workunits-handlers', type=list, member_type=str, default=[],
         advanced=True,
         help="Use this option to name Subsystems which will receive streaming workunit events. "
-        """For instance, `--streaming-workunits-handlers="['pants.reporting.workunit.Workunits']"` will """
-        """register a Subsystem called Workunits defined in the module "pants.reporting.workunit"."""
+        "For instance, `--streaming-workunits-handlers=\"['pants.reporting.workunit.Workunits']\"` will "
+        "register a Subsystem called Workunits defined in the module \"pants.reporting.workunit\"."
     )
 
   @classmethod

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -184,8 +184,7 @@ class SchedulerService(PantsService):
     build_id = RunTracker.global_instance().run_id
     v2_ui = options.for_global_scope().v2_ui
     zipkin_trace_v2 = options.for_scope('reporting').zipkin_trace_v2
-    stream_workunits = options.for_scope('reporting').stream_workunits
-    session = self._graph_helper.new_session(zipkin_trace_v2, build_id, v2_ui, should_report_workunits=stream_workunits)
+    session = self._graph_helper.new_session(zipkin_trace_v2, build_id, v2_ui)
 
     if options.for_global_scope().loop:
       fn = self._loop

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -63,8 +63,6 @@ class Reporting(Subsystem):
     register('--zipkin-max-span-batch-size', advanced=True, type=int, default=100,
               help='Spans in a Zipkin trace are sent to the Zipkin server in batches.' 
                    'zipkin-max-span-batch-size sets the max size of one batch.')
-    register('--stream-workunits', advanced=True, type=bool, default=False,
-        help="If set to true, report workunit information while pants is running")
 
   def initialize(self, run_tracker, all_options, start_time=None):
     """Initialize with the given RunTracker.

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -1,13 +1,18 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import importlib
 import inspect
-from typing import Dict, Optional, Tuple, Type, TypeVar, Union, cast
+import logging
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Type, TypeVar, Union, cast
 
 from pants.option.optionable import Optionable
 from pants.option.options import Options
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin, SubsystemDependency
+
+
+logger = logging.getLogger(__name__)
 
 
 class SubsystemError(Exception):
@@ -169,3 +174,55 @@ class Subsystem(SubsystemClientMixin, Optionable):
     :API: public
     """
     return self._scoped_options
+
+  @staticmethod
+  def get_streaming_workunit_callbacks(subsystem_names: Iterable[str]) -> List[Callable]:
+
+    """
+    This method is used to dynamically generate a list of callables
+    intended to be passed to StreamingWorkunitHandler. The caller provides a
+    collection of strings representing a Python import path to a class that
+    implements the `Subsystem` class. It will then inspect these classes for
+    the presence of a special method called `handle_workunits`, which expects a
+    single non-self argument - namely, a tuple of Python dictionaries
+    representing workunits.
+
+    For instance, you might invoke this method with something like:
+
+    `Subsystem.get_streaming_workunit_callbacks(["pants.reporting.workunits.Workunit"])`
+
+    And this will result in the method attempting to dynamically-import a
+    module called "pants.reporting.workunits", inspecting it for the presence
+    of a class called `Workunit`, getting a global instance of this Subsystem,
+    and returning a list containing a single reference to the
+    `handle_workunits` method defined on it - and returning an empty list and
+    emitting warnings if any of these steps fail.
+    """
+
+    callables = []
+
+    for name in subsystem_names:
+      try:
+        module_name = '.'.join(name.split(".")[:-1])
+        class_name = name.split(".")[-1]
+        module = importlib.import_module(module_name)
+        subsystem_class = getattr(module, class_name)
+      except (IndexError, AttributeError, ModuleNotFoundError, ValueError) as e:
+        logger.warning(f"Invalid module name: {name}: {e}")
+        continue
+      except ImportError as e:
+        logger.warning(f"Could not import {module_name}: {e}")
+        continue
+      try:
+        subsystem = subsystem_class.global_instance()
+      except AttributeError:
+        logger.warning(f"{subsystem_class} is not a global subsystem.")
+        continue
+
+      try:
+        callables.append(subsystem.handle_workunits)
+      except AttributeError:
+        logger.warning(f"{subsystem_class} does not have a method named `handle_workunits` defined.")
+        continue
+
+    return callables

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -203,8 +203,9 @@ class Subsystem(SubsystemClientMixin, Optionable):
 
     for name in subsystem_names:
       try:
-        module_name = '.'.join(name.split(".")[:-1])
-        class_name = name.split(".")[-1]
+        name_components = name.split(".")
+        module_name = ".".join(name_components[:-1])
+        class_name = name_components[-1]
         module = importlib.import_module(module_name)
         subsystem_class = getattr(module, class_name)
       except (IndexError, AttributeError, ModuleNotFoundError, ValueError) as e:

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -177,7 +177,6 @@ class Subsystem(SubsystemClientMixin, Optionable):
 
   @staticmethod
   def get_streaming_workunit_callbacks(subsystem_names: Iterable[str]) -> List[Callable]:
-
     """
     This method is used to dynamically generate a list of callables
     intended to be passed to StreamingWorkunitHandler. The caller provides a

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -249,7 +249,7 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
         self.workunits.extend(workunits)
 
     tracker = Tracker()
-    async_reporter = StreamingWorkunitHandler(scheduler, callback=tracker.add, report_interval_seconds=0.01)
+    async_reporter = StreamingWorkunitHandler(scheduler, callbacks=[tracker.add], report_interval_seconds=0.01)
     with async_reporter.session():
       scheduler.product_request(Fib, subjects=[0])
 

--- a/tests/python/pants_test/subsystem/BUILD
+++ b/tests/python/pants_test/subsystem/BUILD
@@ -8,7 +8,6 @@ python_tests(
     'src/python/pants/subsystem',
     'src/python/pants/testutil:test_base',
   ],
-  tags = {"partially_type_checked"},
 )
 
 python_library(

--- a/tests/python/pants_test/subsystem/BUILD
+++ b/tests/python/pants_test/subsystem/BUILD
@@ -6,6 +6,7 @@ python_tests(
   dependencies=[
     'src/python/pants/option',
     'src/python/pants/subsystem',
+    'src/python/pants/testutil:test_base',
   ],
   tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -281,6 +281,24 @@ class SubsystemTest(TestBase):
     callables_list = Subsystem.get_streaming_workunit_callbacks([import_str])
     assert len(callables_list) == 1
 
+  def test_streaming_workunit_callbacks_bad_module(self):
+    import_str = "nonexistent_module.AClassThatDoesntActuallyExist"
+    with self.captured_logging(level = logging.WARNING) as captured:
+      callables_list = Subsystem.get_streaming_workunit_callbacks([import_str])
+      warnings = captured.warnings()
+      assert len(warnings) == 1
+      assert len(callables_list) == 0
+      assert "No module named 'nonexistent_module'" in warnings[0]
+
+  def test_streaming_workunit_callbacks_good_module_bad_class(self):
+    import_str = "pants_test.subsystem.test_subsystem.ANonexistentClass"
+    with self.captured_logging(level = logging.WARNING) as captured:
+      callables_list = Subsystem.get_streaming_workunit_callbacks([import_str])
+      warnings = captured.warnings()
+      assert len(warnings) == 1
+      assert len(callables_list) == 0
+      assert "module 'pants_test.subsystem.test_subsystem' has no attribute 'ANonexistentClass'" in warnings[0]
+
   def test_streaming_workunit_callbacks_with_invalid_subsystem(self):
     import_str = "pants_test.subsystem.test_subsystem.DummySubsystem"
     with self.captured_logging(level = logging.WARNING) as captured:


### PR DESCRIPTION
### Problem

Now that we have the infrastructure to stream workunits while pants is running, we need a way to be able to tell some component of the code to do something useful with those workunits. We also want plugins to be able to receive streamed workunits.

### Solution

A global Subsystem with a specific method `handle_workunits` can be registered to receive streaming workunits, by using the new global option `--streaming-workunit-handlers`, which expects a list of Python import paths as strings. At the beginning of a pants run, pants_local_runner will dynamically import all specified Subsystem classes, and every time `StreamingWorkunitHandler` receives workunits from the engine, it will pass them along to the `handle_workunits` method of all registered `Subsystem`s.

The string arguments need to be a fully-qualified import path *including* the class of the Subsystem itself.  For instance, `./pants --v2 --no-v1 --streaming-workunits-handlers="['pants.reporting.workunits.Workunits']" binary examples/src/python/example/hello/main/` will register a `Subsystem` subclass `Workunits` defined in the module `pants.reporting.workunits` to receive streaming workunits.