### PR TITLE
Don't check that plugins are exact requirements.

### DIFF
--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -5,18 +5,17 @@ import hashlib
 import logging
 import os
 import site
+import uuid
 
 from pex import resolver
-from pex.base import requirement_is_exact
 from pex.interpreter import PythonInterpreter
-from pkg_resources import Requirement, RequirementParseError
 from pkg_resources import working_set as global_working_set
 from wheel.install import WheelFile
 
 from pants.backend.python.subsystems.python_repos import PythonRepos
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_mkdir, safe_open
+from pants.util.dirutil import safe_delete, safe_mkdir, safe_open
 from pants.util.memo import memoized_property
 from pants.util.strutil import ensure_text
 from pants.version import PANTS_SEMVER
@@ -60,6 +59,7 @@ class PluginResolver:
     bootstrap_options = self._options_bootstrapper.get_bootstrap_options().for_global_scope()
     self._plugin_requirements = bootstrap_options.plugins
     self._plugin_cache_dir = bootstrap_options.plugin_cache_dir
+    self._plugins_force_resolve = bootstrap_options.plugins_force_resolve
 
   def resolve(self, working_set=None):
     """Resolves any configured plugins and adds them to the global working set.
@@ -77,25 +77,6 @@ class PluginResolver:
     return working_set
 
   def _resolve_plugin_locations(self):
-    def _requirement_is_exact(req):
-      try:
-        return requirement_is_exact(Requirement.parse(req))
-      except RequirementParseError:
-        # Requirement string may be URL, which Requirement.parse does not handle.
-        return False
-
-    # We jump through some hoops here to avoid a live resolve if possible for purposes of speed.
-    # Even with a local resolve cache fully up to date, running a resolve to activate a plugin
-    # takes ~250ms whereas loading from a pre-cached list takes ~50ms.
-    # TODO: Never live-resolve, even if we can't prove that requirements aren't exact.
-    #  Instead, support some way of forcing a new resolve. This will allow requirement strings
-    #  that are not of the foo==x.y.z form, e.g., URLs to .whl files.
-    if all(_requirement_is_exact(req) for req in self._plugin_requirements):
-      return self._resolve_exact_plugin_locations()
-    else:
-      return (plugin.location for plugin in self._resolve_plugins())
-
-  def _resolve_exact_plugin_locations(self):
     hasher = hashlib.sha1()
 
     # Assume we have platform-specific plugin requirements and pessimistically mix the ABI
@@ -107,8 +88,11 @@ class PluginResolver:
     resolve_hash = hasher.hexdigest()
     resolved_plugins_list = os.path.join(self.plugin_cache_dir, f'plugins-{resolve_hash}.txt')
 
+    if self._plugins_force_resolve:
+      safe_delete(resolved_plugins_list)
+
     if not os.path.exists(resolved_plugins_list):
-      tmp_plugins_list = resolved_plugins_list + '~'
+      tmp_plugins_list = f'{resolved_plugins_list}.{uuid.uuid4().hex}'
       with safe_open(tmp_plugins_list, 'w') as fp:
         for plugin in self._resolve_plugins():
           fp.write(ensure_text(plugin.location))
@@ -133,7 +117,7 @@ class PluginResolver:
                                       use_manylinux=True)
     return [resolved_dist.distribution for resolved_dist in resolved_dists]
 
-  @memoized_property
+  @property
   def plugin_cache_dir(self):
     """The path of the directory pants plugins bdists are cached in."""
     return self._plugin_cache_dir

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -173,6 +173,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   'Useful when printing help messages.')
 
     register('--plugins', advanced=True, type=list, help='Load these plugins.')
+    register('--plugins-force-resolve', advanced=True, type=bool, default=False,
+             help='Re-resolve plugins even if previously resolved.')
     register('--plugin-cache-dir', advanced=True,
              default=os.path.join(get_pants_cachedir(), 'plugins'),
              help='Cache resolved plugin requirements here.')


### PR DESCRIPTION
Instead, use cached resolve on every run, regardless of
whether we can detect that the requirements are exact.
Adds a new option, --plugins-force-resolve, to force a resolution when
necessary.

This allows us to use URL and VCS requirements, whose exactness
we can't know, without incurring the re-resolve penalty.

Repos that know they must be strict about this can set the
new option in pants.ini. But we should strongly discourage this,
and expect requirements to be exact in practice (whether
or not we can detect this).
