### PR TITLE
[IntelliJ] Export source jars of dependencies in `export-dep-as-jar`

### DIFF
--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -32,15 +32,13 @@ class ExportDepAsJar(ConsoleTask):
   jvm dependencies instead of sources.
   """
 
-  options_scope = "export-dep-as-jar"
-
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
     register('--formatted', type=bool, implicit_value=False,
       help='Causes output to be a single line of JSON.')
     register('--sources', type=bool,
-      help='Causes sources to be output.')
+      help='Causes the sources of dependencies to be zipped and included in the project.')
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -266,6 +264,13 @@ class ExportDepAsJar(ConsoleTask):
       if preferred_distributions:
         graph_info['preferred_jvm_distributions'][platform_name] = preferred_distributions
 
+    def zip_sources(target, location, suffix='.jar'):
+      with temporary_file(root_dir=location, cleanup=False, suffix=suffix) as f:
+        with zipfile.ZipFile(f, 'a') as zip_file:
+          for src_from_source_root, src_from_build_root in zip(target.sources_relative_to_source_root(), target.sources_relative_to_buildroot()):
+            zip_file.write(os.path.join(get_buildroot(), src_from_build_root), src_from_source_root)
+      return f
+
     if runtime_classpath:
       graph_info['libraries'] = self._resolve_jars_info(targets, runtime_classpath)
       # Using resolved path in preparation for VCFS.
@@ -279,13 +284,10 @@ class ExportDepAsJar(ConsoleTask):
         if target_type == SourceRootTypes.RESOURCE or target_type == SourceRootTypes.TEST_RESOURCE:
           # yic assumed that the cost to fingerprint the target may not be that lower than
           # just zipping up the resources anyway.
-          with temporary_file(root_dir=resource_jar_root, cleanup=False, suffix='.jar') as f:
-            with zipfile.ZipFile(f, 'a') as zip_file:
-              for src_from_source_root, src_from_build_root in zip(t.sources_relative_to_source_root(), t.sources_relative_to_buildroot()):
-                zip_file.write(os.path.join(get_buildroot(), src_from_build_root), src_from_source_root)
+          jarred_resources = zip_sources(t, resource_jar_root)
           targets_map[t.address.spec]['pants_target_type'] = 'jar_library'
           targets_map[t.address.spec]['libraries'] = [t.id]
-          graph_info['libraries'][t.id]['default'] = f.name
+          graph_info['libraries'][t.id]['default'] = jarred_resources.name
           continue
 
         targets_map[t.address.spec]['pants_target_type'] = 'jar_library'
@@ -297,7 +299,12 @@ class ExportDepAsJar(ConsoleTask):
           if 'z.jar' in jar_entry:
             graph_info['libraries'][t.id][conf] = jar_entry
         if self.get_options().sources:
-          graph_info['libraries'][t.id]['sources'] = f"{t.id}-sources.jar"
+          # NB: We create the jar in the same place as we create the resources
+          # (as opposed to where we store the z.jar), because the path to the z.jar depends
+          # on tasks outside of this one.
+          # In addition to that, we may not want to depend on z.jar existing to export source jars.
+          jarred_sources = zip_sources(t, resource_jar_root, suffix='-sources.jar')
+          graph_info['libraries'][t.id]['sources'] = jarred_sources.name
 
 
     return graph_info

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -32,11 +32,15 @@ class ExportDepAsJar(ConsoleTask):
   jvm dependencies instead of sources.
   """
 
+  options_scope = "export-dep-as-jar"
+
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
     register('--formatted', type=bool, implicit_value=False,
       help='Causes output to be a single line of JSON.')
+    register('--sources', type=bool,
+      help='Causes sources to be output.')
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -292,6 +296,9 @@ class ExportDepAsJar(ConsoleTask):
           # If not, zip up the classes/ dir here.
           if 'z.jar' in jar_entry:
             graph_info['libraries'][t.id][conf] = jar_entry
+        if self.get_options().sources:
+          graph_info['libraries'][t.id]['sources'] = f"{t.id}-sources.jar"
+
 
     return graph_info
 


### PR DESCRIPTION
### Problem

In `export-dep-as-jar`, the only thing we export for each dependency is it's compiled jar, `z.jar`. This means that when a user tries to `Go To Definition` of a class defined in a source dependency, it will direct to the (decompiled) classfile:

<img width="1070" alt="Screenshot 2019-11-27 at 14 44 29" src="https://user-images.githubusercontent.com/5861182/69733063-a7353b80-1124-11ea-9a14-91a22d57c6de.png">

### Solution

Bundle up the sources field of dependencies into a `-sources.jar`, and add that to the export of the project via the `sources` Maven classifier. This feature is hidden behind a flag, because it might affect performance.

### Result

When the feature is enabled in the IntelliJ plugin, the dependencies will be imported with sources attached to them:

<img width="1408" alt="Screenshot 2019-11-27 at 14 49 06" src="https://user-images.githubusercontent.com/5861182/69733349-1ca10c00-1125-11ea-84ee-becbc0255323.png">

Commits should be independently reviewable.