### PR TITLE
Add parent-build-id option to know what runs are inner runs and not to run them with pantsd

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -225,11 +225,10 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
   def set_start_time(self, start_time):
     # Launch RunTracker as early as possible (before .run() is called).
     self._run_tracker = RunTracker.global_instance()
-    # We don't support parallel runs in pantsd, and therefore if this pants command
-    # triggers any other pants command, we want it to not use pantsd at all.
-    # See https://github.com/pantsbuild/pants/issues/7881 for context.
-    if self._is_daemon:
-      os.environ['PANTS_PARENT_BUILD_ID'] = self._run_tracker.run_id
+
+    # Propagates parent_build_id to pants runs that may be called from this pants run.
+    os.environ['PANTS_PARENT_BUILD_ID'] = self._run_tracker.run_id
+
     self._reporting = Reporting.global_instance()
 
     self._run_start_time = start_time

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -45,15 +45,15 @@ class PantsRunner(ExceptionSink.AccessGlobalExiterMixin):
     # When running with pantsd if a ./pants command, somewhere in its process calls ./pants again
     # (e.g. to build a pex), the inner run will wait for the outer run to finish,
     # which will never happen.
-    # Setting the 'PANTS_INNER_RUN' environmental variable when pantsd handles first request
-    # to run ./pants command will allow us to mark all pants inner runs
-    # and not to run them with pantsd.
-    is_inner_run = 'PANTS_INNER_RUN' in self._env and self._env['PANTS_INNER_RUN'] == 'True'
+    # The parent_build_id option is set only for pants inner runs which parent is pantsd run.
+    # This will allow us not to run them with pantsd and to know who was the parent
+    # of pants inner runs.
+    is_inner_run_from_pantsd = global_bootstrap_options.parent_build_id is not None
     # If we want concurrent pants runs, we can't have pantsd enabled.
     return global_bootstrap_options.enable_pantsd and \
            not self.will_terminate_pantsd() and \
            not global_bootstrap_options.concurrent and \
-           not is_inner_run
+           not is_inner_run_from_pantsd
 
   @staticmethod
   def scrub_pythonpath():

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -219,6 +219,8 @@ class RunTracker(Subsystem):
     self.run_info = RunInfo(os.path.join(self.run_info_dir, 'info'))
     self.run_info.add_basic_info(self.run_id, self._run_timestamp)
     self.run_info.add_info('cmd_line', self._cmd_line)
+    if self.get_options().parent_build_id:
+      self.run_info.add_info('parent_build_id', self.get_options().parent_build_id)
 
     # Create a 'latest' symlink, after we add_infos, so we're guaranteed that the file exists.
     link_to_latest = os.path.join(os.path.dirname(self.run_info_dir), 'latest')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -289,6 +289,9 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   'start up all concurrent invocations (e.g. in other terminals) without pantsd. '
                   'Enabling this option requires parallel pants invocations to block on the first')
 
+    register('--parent_build_id', advanced=True, default=None,
+             help='')
+
     # Shutdown pantsd after the current run.
     # This needs to be accessed at the same time as enable_pantsd,
     # so we register it at bootstrap time.

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -289,9 +289,12 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   'start up all concurrent invocations (e.g. in other terminals) without pantsd. '
                   'Enabling this option requires parallel pants invocations to block on the first')
 
-    # Calling pants command (inner run) from other pants command is not the intended behaviour.
-    # Pants commands with this option set don't use pantsd.
-    # This option allows us to know who was the parent of pants inner runs.
+    # Calling pants command (inner run) from other pants command is unusual behaviour,
+    # and most users should never set this flag.
+    # It is automatically set by pants when an inner run is detected.
+    # Currently, pants commands with this option set don't use pantsd,
+    # but this effect should not be relied upon.
+    # This option allows us to know who was the parent of pants inner runs for informational purposes.
     register('--parent-build-id', advanced=True, default=None,
              help='The build ID of the other pants run which spawned this one, if any.')
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -289,8 +289,11 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
                   'start up all concurrent invocations (e.g. in other terminals) without pantsd. '
                   'Enabling this option requires parallel pants invocations to block on the first')
 
-    register('--parent_build_id', advanced=True, default=None,
-             help='')
+    # Calling pants command (inner run) from other pants command is not the intended behaviour.
+    # Pants commands with this option set don't use pantsd.
+    # This option allows us to know who was the parent of pants inner runs.
+    register('--parent-build-id', advanced=True, default=None,
+             help='The build ID of the other pants run which spawned this one, if any.')
 
     # Shutdown pantsd after the current run.
     # This needs to be accessed at the same time as enable_pantsd,

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -80,11 +80,6 @@ class PailgunHandler(PailgunHandlerBase):
     self.logger.info('handling pailgun request: `{}`'.format(' '.join(arguments)))
     self.logger.debug('pailgun request environment: %s', environment)
 
-    # We don't support parallel runs in pantsd, and therefore if this pailgun request
-    # triggers any pants command, we want it to not use pantsd at all.
-    # See https://github.com/pantsbuild/pants/issues/7881 for context.
-    environment["PANTS_INNER_RUN"] = "True"
-
     # Execute the requested command with optional daemon-side profiling.
     with maybe_profiled(environment.get('PANTSD_PROFILE')):
       self._run_pants(self.request, arguments, environment)

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -83,7 +83,7 @@ class PailgunHandler(PailgunHandlerBase):
     # We don't support parallel runs in pantsd, and therefore if this pailgun request
     # triggers any pants command, we want it to not use pantsd at all.
     # See https://github.com/pantsbuild/pants/issues/7881 for context.
-    environment["PANTS_CONCURRENT"] = "True"
+    environment["PANTS_INNER_RUN"] = "True"
 
     # Execute the requested command with optional daemon-side profiling.
     with maybe_profiled(environment.get('PANTSD_PROFILE')):

--- a/src/python/pants/testutil/pants_run_integration_test.py
+++ b/src/python/pants/testutil/pants_run_integration_test.py
@@ -357,6 +357,10 @@ class PantsRunIntegrationTest(unittest.TestCase):
       env.update(extra_env)
     env.update(PYTHONPATH=os.pathsep.join(sys.path))
 
+    # Pants command that was called from the test shouldn't have a parent.
+    if env.get('PANTS_PARENT_BUILD_ID'):
+      del env['PANTS_PARENT_BUILD_ID']
+
     # Don't overwrite the profile of this process in the called process.
     # Instead, write the profile into a sibling file.
     if env.get('PANTS_PROFILE'):

--- a/src/python/pants/testutil/pants_run_integration_test.py
+++ b/src/python/pants/testutil/pants_run_integration_test.py
@@ -358,7 +358,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
     env.update(PYTHONPATH=os.pathsep.join(sys.path))
 
     # Pants command that was called from the test shouldn't have a parent.
-    if env.get('PANTS_PARENT_BUILD_ID'):
+    if 'PANTS_PARENT_BUILD_ID' in env:
       del env['PANTS_PARENT_BUILD_ID']
 
     # Don't overwrite the profile of this process in the called process.

--- a/testprojects/src/python/nested_runs/run_pants_with_pantsd.py
+++ b/testprojects/src/python/nested_runs/run_pants_with_pantsd.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import subprocess
 import sys
@@ -5,16 +6,15 @@ import sys
 
 def main():
   workdir = sys.argv[1]
-  config = pathlib.Path(workdir) / 'pants.ini'
+  config_path = pathlib.Path(workdir) / 'pants.ini'
+  config = [f'--pants-config-files={config_path}'] if os.path.isfile(config_path) else []
 
   cmd = [
     './pants',
     '--no-pantsrc',
-    f'--pants-config-files={config}',
     '--print-exception-stacktrace=True',
     f'--pants-workdir={workdir}',
-    'goals'
-  ]
+  ] + config + ['goals']
   print(f'Running pants with command {cmd}')
   subprocess.run(cmd, check=True)
 

--- a/testprojects/src/python/nested_runs/run_pants_with_pantsd.py
+++ b/testprojects/src/python/nested_runs/run_pants_with_pantsd.py
@@ -10,7 +10,7 @@ def main():
   config = [f'--pants-config-files={config_path}'] if os.path.isfile(config_path) else []
 
   cmd = [
-    './pants',
+    './pants.pex',
     '--no-pantsrc',
     '--print-exception-stacktrace=True',
     f'--pants-workdir={workdir}',

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -10,6 +10,7 @@ python_tests(
     'src/python/pants/option',
     'src/python/pants/testutil:int-test',
     'testprojects:pants_plugins_directory',
+    'testprojects/src/python:nested_runs_directory',
   ],
   tags = {'integration'},
 )

--- a/tests/python/pants_test/bin/test_runner_integration.py
+++ b/tests/python/pants_test/bin/test_runner_integration.py
@@ -1,5 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import os
 from pathlib import Path
 

--- a/tests/python/pants_test/bin/test_runner_integration.py
+++ b/tests/python/pants_test/bin/test_runner_integration.py
@@ -1,6 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
+import os
 from pathlib import Path
 
 from pants.base.build_environment import get_buildroot
@@ -37,3 +37,41 @@ class RunnerIntegrationTest(PantsRunIntegrationTest):
     })
     self.assert_success(non_warning_run)
     self.assertNotIn('test warning', non_warning_run.stderr_data)
+
+  def test_parent_build_id_set_only_for_pants_runs_called_by_other_pants_runs(self):
+    with self.temporary_workdir() as workdir:
+      config = {
+        'GLOBAL': {
+          'colors': True,
+        }
+      }
+      command = [
+        'run',
+        'testprojects/src/python/nested_runs',
+        '--',
+        workdir,
+      ]
+      result = self.run_pants_with_workdir(
+        command,
+        workdir,
+        config,
+      )
+      self.assert_success(result)
+
+      run_tracker_dir = os.path.join(workdir, 'run-tracker')
+      self.assertTrue(os.path.isdir(run_tracker_dir), f'dir path {run_tracker_dir} does not exist!')
+      run_tracker_sub_dirs = (os.path.join(run_tracker_dir, dir_name) for dir_name in os.listdir(run_tracker_dir) if dir_name != 'latest')
+      for run_tracker_sub_dir in run_tracker_sub_dirs:
+        info_path = os.path.join(run_tracker_sub_dir, 'info')
+        self.assert_is_file(info_path)
+        with open(info_path, 'r') as info_f:
+          info = info_f.read()
+          self.assertIn('cmd_line', info)
+          info_f.seek(0)
+          for line in info_f:
+            if 'cmd_line' in line:
+              if 'testprojects/src/python/nested_runs' in line:
+                self.assertNotIn('parent_build_id', info)
+              elif 'goals' in line:
+                self.assertIn('parent_build_id', info)
+              break


### PR DESCRIPTION
### Problem
Some pants runs call other pants runs (inner runs). This is not intended behaviour. It is also causing problems when running with pantsd. The problem is described here #7881 

Previous solution #7884 used concurrent flag to disable pantsd for inner runs. 
But the concurrent flag is a user-facing flag, so using it won't allow distinguishing pants runs where users disabled pantsd from inner runs. 

### Solution
Add a parent_build_id option (default None) and use it to propagate parent run_id to children pants runs (inner runs) by setting env var PANTS_PARENT_BUILD_ID.
