### PR TITLE
Deprecate `--run-py-args` and `--run-cpp-args`

### DIFF
--- a/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_run.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_run.py
@@ -13,9 +13,10 @@ class CppRun(CppTask):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    register('--args',
-             type=list,
-             help='Append these options to the executable command line.')
+    register(
+      '--args', type=list, help='Append these options to the executable command line.',
+      removal_version="1.26.0.dev0", removal_hint="Use `--passthrough-args` instead of `--args`."
+    )
 
   @classmethod
   def supports_passthru_args(cls):

--- a/examples/src/python/example/README.md
+++ b/examples/src/python/example/README.md
@@ -129,7 +129,7 @@ run the PEX:
 You can also run the binary "from source" with the `run` goal:
 
     :::bash
-    $ ./pants run.py --args='Whirled' examples/src/python/example/hello/main
+    $ ./pants run.py examples/src/python/example/hello/main -- 'Whirled'
          ...much output...
     14:32:01 00:00     [py]
     14:32:02 00:01       [run]

--- a/src/python/pants/backend/python/tasks/python_run.py
+++ b/src/python/pants/backend/python/tasks/python_run.py
@@ -17,7 +17,10 @@ class PythonRun(PythonExecutionTaskBase):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    register('--args', type=list, help='Run with these extra args to main().')
+    register(
+      '--args', type=list, help='Run with these extra args to main().',
+      removal_version="1.26.0.dev0", removal_hint="Use `--passthrough-args` instead of `--args`."
+    )
 
   @classmethod
   def supports_passthru_args(cls):


### PR DESCRIPTION
These arguments are repetitive as the V1 tasks already provide `--run-py-passthrough-args` and `--run-cpp-passthrough-args`, along with the style `-- ...`.

Specifically, these options are preventing us from adding `--args` to the V2 goal `run` because `--run-args` would conflict with `--run-{py,cpp}-args`.
