### PR TITLE
Add `shlexable_str_member_type` to enable V2-style passthrough args

### DIFF
--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -112,6 +112,14 @@ def dict_with_files_option(s):
   return dict_option(s)
 
 
+def shlexable_str_member_type(s):
+  """When the `type` is `list`, this can be used for the `member_type` to allow passing a shlexed
+  string, e.g. `--isort-args='arg1 arg2' or '--isort-args=+['arg1 arg2']."""
+  # NB: we no-op here as parser.py will call shlex.split() and then flatten the list for us. This
+  # function only exists as a marker to parser.py that it should do this.
+  return s
+
+
 def _convert(val, acceptable_types):
   """Ensure that val is one of the acceptable types, converting it if needed.
 


### PR DESCRIPTION
### Problem

For V2, we are planning to emulate passthrough args through normal options on the subsystems for the tools and goals themselves, e.g. `--black-args`, `--isort-args`, and `--run-args`.

For this to be convenient, however, we need to avoid having the user think too much about escaping things on the command line. We also must have these `--args` options be `type=list` so that you can, for example, set args in `pants.ini` and append to them at the command line.

We want to enable you to simply write:

```bash
./pants fmt --isort-args="--arg1=test --arg2" path/to:target`
```

Rather than having to type:

```bash
./pants fmt --isort-args="+['--arg1=test', '--arg2']" path/to:target`
```

### Solution

Add a new member type `shlexable_str_member_type` that will call `shlex.split()` to split something like `arg1 arg2` into `[arg1, arg2]`. This will then get flattened into a single list of normalized args.