### PR TITLE
Allow passing arguments to Pytest, Isort, and Black in V2

### DIFF
--- a/src/python/pants/backend/python/lint/black/BUILD
+++ b/src/python/pants/backend/python/lint/black/BUILD
@@ -42,5 +42,5 @@ python_tests(
     'src/python/pants/testutil/subsystem',
   ],
   tags = {'integration'},
-  timeout = 90,
+  timeout = 120,
 )

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -1,8 +1,11 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import Tuple
+
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.option.custom_types import file_option
+from pants.option.option_util import flatten_shlexed_list
 
 
 class Black(PythonToolBase):
@@ -15,6 +18,14 @@ class Black(PythonToolBase):
   def register_options(cls, register):
     super().register_options(register)
     register(
+      '--args', type=list, member_type=str,
+      help="Arguments to pass directly to Black, e.g. "
+           "`--black-args=\"--target-version=py37 --quiet\"`",
+    )
+    register(
       '--config', type=file_option, default=None, advanced=True,
       help="Path to Black's pyproject.toml config file"
     )
+
+  def get_args(self) -> Tuple[str, ...]:
+    return flatten_shlexed_list(self.get_options().args)

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -1,8 +1,11 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import Tuple
+
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.option.custom_types import file_option
+from pants.option.option_util import flatten_shlexed_list
 
 
 class Isort(PythonToolBase):
@@ -14,6 +17,14 @@ class Isort(PythonToolBase):
   def register_options(cls, register):
     super().register_options(register)
     register(
+      '--args', type=list, member_type=str,
+      help="Arguments to pass directly to isort, e.g. "
+           "`--isort-args=\"--case-sensitive --trailing-comma\"`",
+    )
+    register(
       '--config', type=list, member_type=file_option, default=None,
       help="Path to `isort.cfg` or alternative isort config file(s)"
     )
+
+  def get_args(self) -> Tuple[str, ...]:
+    return flatten_shlexed_list(self.get_options().args)

--- a/src/python/pants/backend/python/rules/BUILD
+++ b/src/python/pants/backend/python/rules/BUILD
@@ -47,5 +47,5 @@ python_tests(
     'testprojects/tests/python/pants:dummies_directory',
   ],
   tags = {'integration'},
-  timeout = 90,
+  timeout = 120,
 )

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -95,7 +95,7 @@ async def run_python_test(
     python_setup=python_setup,
     subprocess_encoding_environment=subprocess_encoding_environment,
     pex_path=f'./{output_pytest_requirements_pex_filename}',
-    pex_args=test_target_sources_file_names,
+    pex_args=(*pytest.get_args(), *test_target_sources_file_names),
     input_files=merged_input_files,
     description=f'Run Pytest for {test_target.address.reference()}',
     # TODO(#8584): hook this up to TestRunnerTaskMixin so that we can configure the default timeout

--- a/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_integration_test.py
@@ -240,3 +240,27 @@ class TestPythonTestRunnerIntegration(PantsRunIntegrationTest):
         testprojects/tests/python/pants/dummies:target_with_transitive_dep              .....   SUCCESS
         """)
     )
+
+  def test_respects_passthrough_args(self):
+    pants_run = self.run_passing_pants_test([
+      '--pytest-args=-k test_run_me',
+      'testprojects/tests/python/pants/dummies:needs_config',
+    ])
+    self.assert_fuzzy_string_match(
+      pants_run.stdout_data,
+      dedent("""\
+        testprojects/tests/python/pants/dummies:needs_config stdout:
+        ============================= test session starts ==============================
+        platform SOME_TEXT
+        rootdir: SOME_TEXT
+        plugins: SOME_TEXT
+        collected 2 items / 1 deselected / 1 selected
+
+        pants/dummies/test_config_works.py .                                     [100%]
+
+        ======================= 1 passed, 1 deselected in SOME_TEXT ========================
+
+
+        testprojects/tests/python/pants/dummies:needs_config                            .....   SUCCESS
+        """)
+    )

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -4,6 +4,7 @@
 from typing import List, Tuple
 
 from pants.base.deprecated import deprecated_conditional
+from pants.option.option_util import flatten_shlexed_list
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -13,6 +14,10 @@ class PyTest(Subsystem):
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
+    register(
+      '--args', type=list, member_type=str,
+      help="Arguments to pass directly to Pytest, e.g. `--pytest-args=\"-k test_foo --quiet\"`",
+    )
     register('--version', default='pytest>=4.6.6,<4.7', help="Requirement string for Pytest.")
     register(
       '--pytest-plugins',
@@ -85,3 +90,6 @@ class PyTest(Subsystem):
         opts.unittest2_requirements,
       )
     return (opts.version, *opts.pytest_plugins)
+
+  def get_args(self) -> Tuple[str, ...]:
+    return flatten_shlexed_list(self.get_options().args)

--- a/src/python/pants/backend/python/tasks/isort_run.py
+++ b/src/python/pants/backend/python/tasks/isort_run.py
@@ -49,7 +49,10 @@ class IsortRun(FmtTaskMixin, Task):
         return
 
       isort = self.context.products.get_data(IsortPrep.tool_instance_cls)
-      args = self.get_passthru_args() + ['--filter-files'] + sources
+      isort_subsystem = IsortPrep.tool_subsystem_cls.global_instance()
+      args = [
+        *self.get_passthru_args(), *isort_subsystem.get_args(), '--filter-files', *sources
+      ]
 
       # NB: We execute isort out of process to avoid unwanted side-effects from importing it:
       #   https://github.com/timothycrosley/isort/issues/456

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -16,6 +16,7 @@ from io import StringIO
 from textwrap import dedent
 from typing import Any
 
+from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.gather_sources import GatherSources
 from pants.backend.python.tasks.pytest_prep import PytestPrep
@@ -635,7 +636,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
                                                                     pytest_rootdir):
       # Validate that the user didn't provide any passthru args that conflict
       # with those we must set ourselves.
-      for arg in self.get_passthru_args():
+      for arg in (*self.get_passthru_args(), *PyTest.global_instance().get_args()):
         if arg.startswith('--junitxml') or arg.startswith('--confcutdir'):
           raise TaskError(f'Cannot pass this arg through to pytest: {arg}')
 
@@ -656,7 +657,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
       if self.get_options().colors:
         args.extend(['--color', 'yes'])
 
-      args.extend(self.get_passthru_args())
+      args.extend([*self.get_passthru_args(), *PyTest.global_instance().get_args()])
 
       args.extend(test_args)
       args.extend(sources_map.keys())

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -21,3 +21,10 @@ python_library(
   ],
   tags = {'partially_type_checked'},
 )
+
+python_tests(
+  name="tests",
+  dependencies=[
+    ':option',
+  ],
+)

--- a/src/python/pants/option/option_util.py
+++ b/src/python/pants/option/option_util.py
@@ -1,6 +1,9 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import shlex
+from typing import Sequence, Tuple
+
 from pants.option.custom_types import dict_with_files_option, list_option
 
 
@@ -11,3 +14,15 @@ def is_list_option(kwargs):
 
 def is_dict_option(kwargs):
   return kwargs.get('type') in (dict, dict_with_files_option)
+
+
+# TODO: consider moving this directly into the option system, e.g. allowing registration of an
+#  option with `type=flattened_list, member_type=shlexed`.
+def flatten_shlexed_list(shlexed_args: Sequence[str]) -> Tuple[str, ...]:
+  """Convert a list of shlexed args into a flattened list of individual args.
+
+   For example, ['arg1 arg2=foo', '--arg3'] would be converted to ['arg1', 'arg2=foo', '--arg3'].
+   """
+  return tuple(
+    arg for shlexed_arg in shlexed_args for arg in shlex.split(shlexed_arg)
+  )

--- a/src/python/pants/option/option_util_test.py
+++ b/src/python/pants/option/option_util_test.py
@@ -1,0 +1,14 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from unittest import TestCase
+
+from pants.option.option_util import flatten_shlexed_list
+
+
+class OptionUtilTest(TestCase):
+
+  def test_flatten_shlexed_list(self) -> None:
+    assert flatten_shlexed_list(["arg1", "arg2"]) == ("arg1", "arg2")
+    assert flatten_shlexed_list(["arg1 arg2"]) == ("arg1", "arg2")
+    assert flatten_shlexed_list(["arg1 arg2=foo", "--arg3"]) == ("arg1", "arg2=foo", "--arg3")

--- a/src/python/pants/option/option_util_test.py
+++ b/src/python/pants/option/option_util_test.py
@@ -12,3 +12,4 @@ class OptionUtilTest(TestCase):
     assert flatten_shlexed_list(["arg1", "arg2"]) == ("arg1", "arg2")
     assert flatten_shlexed_list(["arg1 arg2"]) == ("arg1", "arg2")
     assert flatten_shlexed_list(["arg1 arg2=foo", "--arg3"]) == ("arg1", "arg2=foo", "--arg3")
+    assert flatten_shlexed_list(["arg1='foo bar'", "arg2='baz'"]) == ("arg1=foo bar", "arg2=baz")

--- a/testprojects/tests/python/pants/dummies/BUILD
+++ b/testprojects/tests/python/pants/dummies/BUILD
@@ -52,3 +52,8 @@ python_tests(
     ':transitive_dep',
   ],
 )
+
+python_tests(
+  name = 'needs_config',
+  source = "test_config_works.py",
+)

--- a/testprojects/tests/python/pants/dummies/test_config_works.py
+++ b/testprojects/tests/python/pants/dummies/test_config_works.py
@@ -1,0 +1,5 @@
+def test_run_me():
+  pass
+
+def test_ignore_me():
+  pass

--- a/testprojects/tests/python/pants/dummies/test_config_works.py
+++ b/testprojects/tests/python/pants/dummies/test_config_works.py
@@ -1,5 +1,6 @@
 def test_run_me():
   pass
 
+
 def test_ignore_me():
   pass


### PR DESCRIPTION
### Problem

We need a mechanism for passthrough args in V2, as described in https://github.com/pantsbuild/pants/issues/8579 and https://docs.google.com/document/d/18-WFAYiktq3DAfOQPrnU5yaycT6V1K27yrnFPoGgTIA/edit.

We decided there to move passthrough args support from the task-level to the subsystem and goal-level, e.g. `--isort-args`, `--pytest-args`, and `--run-args`.

Further, we decided (for now at least) to not support the `-- ...` style with V2. This greatly simplifies our implementation and works around the issue of ambiguity in where to apply passthrough args—for example, `./pants fmt-v2 :: -- arg1 arg2` would pass those args through to every single autoformatter installed, which is almost certainly not what's desired.

### Solution

Add `--args` to the Pytest, Black, and Isort subsystems as a list of strings. We use a new simple utility to allow shlexed strings so that the user may simply call:

```bash
./pants test path/to:target --pytest-args="-k test_foo --quiet"
```

instead of the more verbose:

```bash
./pants test path/to:target --pytest-args="+['-k', 'test_foo', '--quiet']"
```

#### Does not yet hook up `--run-args`

We can't add `--run-args` until we finish removing `--run-py-args` and `--run-cpp-args` or we decide to rename `run` to `run-v2`.

### Result

Closes https://github.com/pantsbuild/pants/issues/8579.

Users may use passthrough args via the CLI, config file, and env var. Examples:

```ini
[pytest]
args: "-qfr"
```

```bash
./pants test path/to:target --pytest-args="-k test_foo"
```
