### PR TITLE
Allow V2 isort to use multiple config files

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -246,7 +246,7 @@ eslint_config: %(pants_supportdir)s/eslint/.eslintrc
 eslint_ignore: %(pants_supportdir)s/eslint/.eslintignore
 
 [isort]
-config: .isort.cfg
+config: [".isort.cfg", "contrib/.isort.cfg", "examples/.isort.cfg"]
 
 
 [lint]

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import List, Optional, Tuple
 
 from pants.backend.python.lint.isort.subsystem import Isort
 from pants.backend.python.rules.pex import (
@@ -34,8 +34,8 @@ class IsortSetup:
 
 @rule
 async def setup_isort(isort: Isort) -> IsortSetup:
-  config_path = isort.get_options().config
-  config_snapshot = await Get[Snapshot](PathGlobs(include=(config_path,)))
+  config_path: Optional[List[str]] = isort.get_options().config
+  config_snapshot = await Get[Snapshot](PathGlobs(include=config_path or ()))
   requirements_pex = await Get[Pex](
     CreatePex(
       output_filename="isort.pex",

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -82,7 +82,7 @@ class IsortIntegrationTest(TestBase):
       )
     )
     isort_subsystem = global_subsystem_instance(
-      Isort, options={Isort.options_scope: {"config": ".isort.cfg" if config else None}}
+      Isort, options={Isort.options_scope: {"config": [".isort.cfg"] if config else None}}
     )
     isort_setup = self.request_single_product(
       IsortSetup,

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -14,6 +14,6 @@ class Isort(PythonToolBase):
   def register_options(cls, register):
     super().register_options(register)
     register(
-      '--config', type=file_option, default=None,
-      help="Path to `isort.cfg` or alternative isort config file"
+      '--config', type=list, member_type=file_option, default=None,
+      help="Path to `isort.cfg` or alternative isort config file(s)"
     )


### PR DESCRIPTION
### Problem

Isort allows using multiple config files, unlike other tools like Black. We rely on this fact in the Pants repo for formatting of `contrib` vs `examples` vs. everything else. This is necessary so that `contrib` correctly treats `pants.contrib` as first-party but `pants` and `pants_test` as 3rd party.

V2 isort needs to support this reality for us to use it in the Pants repo.

### Solution

Change the `type` of `--config` to `list`.

### Result

Users with a single config file can still use it the same way as before, thanks to how we parse list options: 

```bash
./pants --isort-config=".isort.cfg" fmt-v2 ::
```

Users with multiple config files can specify them as a list:

```ini
[isort]
config: [".isort.cfg", "contrib/.isort.cfg"]
```