### PR TITLE
Refactor V2 Black and Isort for better de-duplication

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -30,55 +30,16 @@ from pants.rules.core.lint import LintResult
 
 @dataclass(frozen=True)
 class BlackSetup:
-  """This abstraction is used to deduplicate the implementations for the `fmt` and `lint` rules,
-  which only differ in whether or not to append `--check` to the Black CLI args."""
-  config_path: Optional[Path]
-  resolved_requirements_pex: Pex
-  merged_input_files: Digest
-
-  def generate_pex_arg_list(self, *, files: Tuple[str, ...], check_only: bool) -> Tuple[str, ...]:
-    pex_args = []
-    if check_only:
-      pex_args.append("--check")
-    if self.config_path is not None:
-      pex_args.extend(["--config", self.config_path])
-    # NB: For some reason, Black's --exclude option only works on recursive invocations, meaning
-    # calling Black on a directory(s) and letting it auto-discover files. However, we don't want
-    # Black to run over everything recursively under the directory of our target, as Black should
-    # only touch files in the target's `sources`. We can use `--include` to ensure that Black only
-    # operates on the files we actually care about.
-    pex_args.extend(["--include", "|".join(re.escape(f) for f in files)])
-    pex_args.extend(str(Path(f).parent) for f in files)
-    return tuple(pex_args)
-
-  def create_execute_request(
-    self,
-    *,
-    wrapped_target: FormattablePythonTarget,
-    python_setup: PythonSetup,
-    subprocess_encoding_environment: SubprocessEncodingEnvironment,
-    check_only: bool,
-  ) -> ExecuteProcessRequest:
-    target = wrapped_target.target
-    return self.resolved_requirements_pex.create_execute_request(
-      python_setup=python_setup,
-      subprocess_encoding_environment=subprocess_encoding_environment,
-      pex_path="./black.pex",
-      pex_args=self.generate_pex_arg_list(
-        files=target.sources.snapshot.files, check_only=check_only
-      ),
-      input_files=self.merged_input_files,
-      output_files=target.sources.snapshot.files,
-      description=f'Run Black for {target.address.reference()}',
-    )
+  requirements_pex: Pex
+  config_snapshot: Snapshot
 
 
 @rule
-async def setup_black(wrapped_target: FormattablePythonTarget, black: Black) -> BlackSetup:
+async def setup_black(black: Black) -> BlackSetup:
   config_path: Optional[str] = black.get_options().config
-  config_snapshot = await Get(Snapshot, PathGlobs(include=(config_path,)))
-  resolved_requirements_pex = await Get(
-    Pex, CreatePex(
+  config_snapshot = await Get[Snapshot](PathGlobs(include=(config_path,)))
+  requirements_pex = await Get[Pex](
+    CreatePex(
       output_filename="black.pex",
       requirements=PexRequirements(requirements=tuple(black.get_requirement_specs())),
       interpreter_constraints=PexInterpreterConstraints(
@@ -87,69 +48,77 @@ async def setup_black(wrapped_target: FormattablePythonTarget, black: Black) -> 
       entry_point=black.get_entry_point(),
     )
   )
+  return BlackSetup(requirements_pex=requirements_pex, config_snapshot=config_snapshot)
 
-  sources_digest = wrapped_target.target.sources.snapshot.directory_digest
 
-  merged_input_files = await Get(
-    Digest,
+@dataclass(frozen=True)
+class BlackArgs:
+  args: Tuple[str, ...]
+
+  @staticmethod
+  def create(
+    *, wrapped_target: FormattablePythonTarget, black_setup: BlackSetup, check_only: bool
+  ) -> "BlackArgs":
+    files = wrapped_target.target.sources.snapshot.files
+    pex_args = []
+    if check_only:
+      pex_args.append("--check")
+    if black_setup.config_snapshot.files:
+      pex_args.extend(["--config", black_setup.config_snapshot.files[0]])
+    # NB: For some reason, Black's --exclude option only works on recursive invocations, meaning
+    # calling Black on a directory(s) and letting it auto-discover files. However, we don't want
+    # Black to run over everything recursively under the directory of our target, as Black should
+    # only touch files in the target's `sources`. We can use `--include` to ensure that Black only
+    # operates on the files we actually care about.
+    pex_args.extend(["--include", "|".join(re.escape(f) for f in files)])
+    pex_args.extend(str(Path(f).parent) for f in files)
+    return BlackArgs(tuple(pex_args))
+
+
+@rule
+async def create_black_request(
+  wrapped_target: FormattablePythonTarget,
+  black_args: BlackArgs,
+  black_setup: BlackSetup,
+  python_setup: PythonSetup,
+  subprocess_encoding_environment: SubprocessEncodingEnvironment,
+) -> ExecuteProcessRequest:
+  target = wrapped_target.target
+  merged_input_files = await Get[Digest](
     DirectoriesToMerge(
       directories=(
-        sources_digest,
-        resolved_requirements_pex.directory_digest,
-        config_snapshot.directory_digest,
+        target.sources.snapshot.directory_digest,
+        black_setup.requirements_pex.directory_digest,
+        black_setup.config_snapshot.directory_digest,
       )
     ),
   )
-  return BlackSetup(config_path, resolved_requirements_pex, merged_input_files)
-
-
-@rule(name="Format using black")
-async def fmt(
-  wrapped_target: FormattablePythonTarget,
-  black_setup: BlackSetup,
-  python_setup: PythonSetup,
-  subprocess_encoding_environment: SubprocessEncodingEnvironment,
-) -> FmtResult:
-  request = black_setup.create_execute_request(
-    wrapped_target=wrapped_target,
-    python_setup=python_setup,
-    subprocess_encoding_environment=subprocess_encoding_environment,
-    check_only=False
-  )
-  result = await Get(ExecuteProcessResult, ExecuteProcessRequest, request)
-  return FmtResult(
-    digest=result.output_directory_digest,
-    stdout=result.stdout.decode(),
-    stderr=result.stderr.decode(),
+  return black_setup.requirements_pex.create_execute_request(
+      python_setup=python_setup,
+      subprocess_encoding_environment=subprocess_encoding_environment,
+      pex_path="./black.pex",
+      pex_args=black_args.args,
+      input_files=merged_input_files,
+      output_files=target.sources.snapshot.files,
+      description=f'Run Black for {target.address.reference()}',
   )
 
 
-@rule(name="Lint using black")
-async def lint(
-  wrapped_target: FormattablePythonTarget,
-  black_setup: BlackSetup,
-  python_setup: PythonSetup,
-  subprocess_encoding_environment: SubprocessEncodingEnvironment,
-) -> LintResult:
-  request = black_setup.create_execute_request(
-    wrapped_target=wrapped_target,
-    python_setup=python_setup,
-    subprocess_encoding_environment=subprocess_encoding_environment,
-    check_only=True
-  )
-  result = await Get(FallibleExecuteProcessResult, ExecuteProcessRequest, request)
-  return LintResult(
-    exit_code=result.exit_code,
-    stdout=result.stdout.decode(),
-    stderr=result.stderr.decode(),
-  )
+@rule(name="Format using Black")
+async def fmt(wrapped_target: FormattablePythonTarget, black_setup: BlackSetup) -> FmtResult:
+  args = BlackArgs.create(black_setup=black_setup, wrapped_target=wrapped_target, check_only=False)
+  request = await Get[ExecuteProcessRequest](BlackArgs, args)
+  result = await Get[ExecuteProcessResult](ExecuteProcessRequest, request)
+  return FmtResult.from_execute_process_result(result)
+
+
+@rule(name="Lint using Black")
+async def lint(wrapped_target: FormattablePythonTarget, black_setup: BlackSetup) -> LintResult:
+  args = BlackArgs.create(black_setup=black_setup, wrapped_target=wrapped_target, check_only=True)
+  request = await Get[ExecuteProcessRequest](BlackArgs, args)
+  result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, request)
+  return LintResult.from_fallible_execute_process_result(result)
 
 
 def rules():
-  return [
-    setup_black,
-    fmt,
-    lint,
-    optionable_rule(Black),
-    optionable_rule(PythonSetup),
-  ]
+  return [setup_black, create_black_request, fmt, lint, optionable_rule(Black)]

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -110,15 +110,8 @@ async def run_python_test(
     #  and also use the specified max timeout time.
     timeout_seconds=getattr(test_target, 'timeout', 60)
   )
-
   result = await Get(FallibleExecuteProcessResult, ExecuteProcessRequest, request)
-  status = Status.SUCCESS if result.exit_code == 0 else Status.FAILURE
-
-  return TestResult(
-    status=status,
-    stdout=result.stdout.decode(),
-    stderr=result.stderr.decode(),
-  )
+  return TestResult.from_fallible_execute_process_result(result)
 
 
 def rules():

--- a/src/python/pants/rules/core/core_test_model.py
+++ b/src/python/pants/rules/core/core_test_model.py
@@ -3,6 +3,7 @@
 
 from dataclasses import dataclass
 
+from pants.engine.isolated_process import FallibleExecuteProcessResult
 from pants.engine.rules import union
 from pants.util.collections import Enum
 
@@ -20,6 +21,16 @@ class TestResult:
 
   # Prevent this class from being detected by pytest as a test class.
   __test__ = False
+
+  @staticmethod
+  def from_fallible_execute_process_result(
+    process_result: FallibleExecuteProcessResult
+  ) -> "TestResult":
+    return TestResult(
+      status=Status.SUCCESS if process_result.exit_code == 0 else Status.FAILURE,
+      stdout=process_result.stdout.decode(),
+      stderr=process_result.stderr.decode(),
+    )
 
 
 @union

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pants.engine.console import Console
 from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal
+from pants.engine.isolated_process import ExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.rules import UnionMembership, console_rule, union
 from pants.engine.selectors import Get, MultiGet
@@ -16,6 +17,14 @@ class FmtResult:
   digest: Digest
   stdout: str
   stderr: str
+
+  @staticmethod
+  def from_execute_process_result(process_result: ExecuteProcessResult) -> "FmtResult":
+    return FmtResult(
+      digest=process_result.output_directory_digest,
+      stdout=process_result.stdout.decode(),
+      stderr=process_result.stderr.decode(),
+    )
 
 
 @union

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from pants.engine.console import Console
 from pants.engine.goal import Goal
+from pants.engine.isolated_process import FallibleExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.rules import UnionMembership, console_rule
 from pants.engine.selectors import Get, MultiGet
@@ -16,6 +17,16 @@ class LintResult:
   exit_code: int
   stdout: str
   stderr: str
+
+  @staticmethod
+  def from_fallible_execute_process_result(
+    process_result: FallibleExecuteProcessResult
+  ) -> "LintResult":
+    return LintResult(
+      exit_code=process_result.exit_code,
+      stdout=process_result.stdout.decode(),
+      stderr=process_result.stderr.decode(),
+    )
 
 
 class Lint(Goal):


### PR DESCRIPTION
### Problem

It was proposed in https://github.com/pantsbuild/pants/pull/8729#discussion_r351581286 that `BlackSetup` and `IsortSetup` were not doing the right thing by including information about the target in the dataclasses. Instead, those should only have the setup that is used for every target, such as the config file location.

### Solution

Following the above recommendation leads to substantial de-duplication, particularly in the implementation of `fmt` and `lint`. New `BlackArgs` and `IsortArgs` dataclasses are created to capture the main difference between `fmt` and `lint` of whether they should pass `--check` in their CLI args. This allows creating new rules to return the `ExecuteProcessResult`.

### Result

Fewer lines of code and improved readability. Better caching because now `BlackSetup` and `IsortSetup` can be used across many targets.