### PR TITLE
Fix internal unmatched globs warnings

### DIFF
--- a/contrib/node/examples/src/node/javascriptstyle-empty/BUILD
+++ b/contrib/node/examples/src/node/javascriptstyle-empty/BUILD
@@ -1,5 +1,0 @@
-node_module(
-  name='javascriptstyle-empty',
-  sources=rglobs('package.json', 'yarn.lock', '*.js', '.eslintignore'),
-  package_manager='yarn',
-)

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_lint_integration.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_lint_integration.py
@@ -1,36 +1,48 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from contextlib import contextmanager
+from pathlib import Path
+from textwrap import dedent
+from typing import Iterator
+
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class NodeLintIntegrationTest(PantsRunIntegrationTest):
 
-  def test_lint_success(self):
-    command = ['lint',
-               'contrib/node/examples/src/node/hello::']
-    pants_run = self.run_pants(command=command)
+  EMPTY_DIRECTORY = Path('contrib/node/examples/src/node/javascriptstyle-empty')
 
+  @contextmanager
+  def setup_empty_directory_build_file(self) -> Iterator[None]:
+    path = self.EMPTY_DIRECTORY / 'BUILD'
+    content = dedent("""\
+      node_module(
+        name='javascriptstyle-empty',
+        sources=rglobs('package.json', 'yarn.lock', '*.js', '.eslintignore'),
+        package_manager='yarn',
+      )
+      """)
+    with self.temporary_file_content(str(path), content, binary_mode=False):
+      yield
+
+  def test_lint_success(self):
+    command = ['lint', 'contrib/node/examples/src/node/hello::']
+    pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
 
   def test_lint_success_with_target_level_ignore(self):
-    path = 'contrib/node/examples/src/node/javascriptstyle-empty/index.js'
-    content = 'const console = require(\'console\');\nconsole.log("Double Quotes");\n'
-
-    with self.temporary_file_content(path, content, binary_mode=False):
-      command = ['lint',
-                 'contrib/node/examples/src/node/javascriptstyle-empty']
+    path = self.EMPTY_DIRECTORY / 'index.js'
+    content = b'const console = require(\'console\');\nconsole.log("Double Quotes");\n'
+    with self.setup_empty_directory_build_file(), self.temporary_file_content(str(path), content):
+      command = ['lint', str(self.EMPTY_DIRECTORY)]
       pants_run = self.run_pants(command=command)
-
       self.assert_success(pants_run)
 
   def test_lint_failure_without_target_level_ignore(self):
-    path = 'contrib/node/examples/src/node/javascriptstyle-empty/not_ignored_index.js'
-    content = 'const console = require(\'console\');\nconsole.log("Double Quotes");\n'
-
-    with self.temporary_file_content(path, content, binary_mode=False):
-      command = ['lint',
-                 'contrib/node/examples/src/node/javascriptstyle-empty']
+    path = self.EMPTY_DIRECTORY / 'not_ignored_index.js'
+    content = b'const console = require(\'console\');\nconsole.log("Double Quotes");\n'
+    with self.setup_empty_directory_build_file(), self.temporary_file_content(str(path), content):
+      command = ['lint', str(self.EMPTY_DIRECTORY)]
       pants_run = self.run_pants(command=command)
-
       self.assert_failure(pants_run)

--- a/src/python/pants/backend/python/lint/black/BUILD
+++ b/src/python/pants/backend/python/lint/black/BUILD
@@ -17,15 +17,6 @@ python_library(
 )
 
 python_tests(
-  name='tests',
-  sources=globs('*_test.py', exclude=[globs('*_integration_test.py')]),
-  dependencies=[
-    ':black',
-  ],
-)
-
-
-python_tests(
   name='integration',
   sources=globs('*_integration_test.py'),
   dependencies=[

--- a/src/python/pants/backend/python/lint/isort/BUILD
+++ b/src/python/pants/backend/python/lint/isort/BUILD
@@ -17,15 +17,6 @@ python_library(
 )
 
 python_tests(
-  name='tests',
-  sources=globs('*_test.py', exclude=[globs('*_integration_test.py')]),
-  dependencies=[
-    ':isort',
-  ],
-)
-
-
-python_tests(
   name='integration',
   sources=globs('*_integration_test.py'),
   dependencies=[

--- a/testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD
@@ -67,15 +67,6 @@ jvm_binary(name = 'bundle-bin',
   ]
 )
 
-# This should fail because the relpath is wrong
-jvm_app(name='missing-files',
-  basename = 'bundle-example',
-  binary=':bundle-bin',
-  bundles=[
-    bundle(fileset=['data/no-such-file']),
-  ]
-)
-
 # Tests resources ordering via integration test.
 jvm_binary(
   name='bundle-resource-ordering',
@@ -86,15 +77,4 @@ jvm_binary(
     'testprojects/src/resources/org/pantsbuild/testproject/bundleresources:resources',
     'testprojects/tests/resources/org/pantsbuild/testproject/bundleresources:resources',
   ]
-)
-
-jvm_app(name='missing-bundle-fileset',
-  binary=':bundle-bin',
-  bundles=[
-    bundle(fileset=['a/b/file1.txt']),
-    bundle(fileset=rglobs('*.aaaa', '*.bbbb')),
-    bundle(fileset=globs('*.aaaa')),
-    bundle(fileset=zglobs('**/*.abab')),
-    bundle(fileset=['file1.aaaa', 'file2.aaaa']),
-  ],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/junit/failing/tests/org/pantsbuild/tmp/tests/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/junit/failing/tests/org/pantsbuild/tmp/tests/BUILD
@@ -7,6 +7,7 @@ target(
 )
 
 java_library(name='base',
+  sources=[],
   dependencies=['3rdparty:junit'],
 )
 

--- a/testprojects/src/java/org/pantsbuild/testproject/manifest/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/manifest/BUILD
@@ -45,4 +45,5 @@ jvm_app(
 java_agent(
   name = 'agent',
   agent_class = 'org.pantsbuild.testproject.manifest.Agent',
+  sources = ['Agent.java'],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/manifest/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/manifest/BUILD
@@ -45,5 +45,4 @@ jvm_app(
 java_agent(
   name = 'agent',
   agent_class = 'org.pantsbuild.testproject.manifest.Agent',
-  sources = ['Agent.java'],
 )

--- a/testprojects/src/python/sources/BUILD
+++ b/testprojects/src/python/sources/BUILD
@@ -1,10 +1,6 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-scala_library(
-  name='missing-sources',
-)
-
 python_library(
   dependencies=[
     ':text',
@@ -15,37 +11,4 @@ python_library(
 resources(
   name='text',
   sources=globs('*.txt'),
-)
-
-resources(
-  name='missing-globs',
-  sources=globs('*.a'),
-)
-
-resources(
-  name='missing-rglobs',
-  sources=rglobs('*.a'),
-)
-
-resources(
-  name='missing-zglobs',
-  sources=zglobs('**/*.a'),
-)
-
-resources(
-  name='missing-literal-files',
-  sources=[
-    'nonexistent_test_file.txt',
-    'another_nonexistent_file.txt',
-  ],
-)
-
-resources(
-  name='some-missing-some-not',
-  sources=globs('*.txt', '*.rs'),
-)
-
-resources(
-  name='overlapping-globs',
-  sources=globs('sources.txt', '*.txt'),
 )

--- a/testprojects/src/scala/org/pantsbuild/testproject/javasources/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/javasources/BUILD
@@ -8,9 +8,3 @@ scala_library(
   ],
   sources = rglobs('*.scala')
 )
-
-benchmark(name='benchmark',
-  dependencies=[
-  ],
-  sources=rglobs('org/pantsbuild/testproject/javasources/*.scala')
-)

--- a/testprojects/tests/java/org/pantsbuild/testproject/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/BUILD
@@ -11,7 +11,6 @@ target(
     ':cwdexample_directory',
     ':depman_directory',
     ':dummies_directory',
-    ':empty_directory',
     ':exports_directory',
     ':fail256_directory',
     ':htmlreport_directory',
@@ -79,11 +78,6 @@ files(
 files(
   name='dummies_directory',
   sources=rglobs('dummies/*'),
-)
-
-files(
-  name='empty_directory',
-  sources=rglobs('empty/*'),
 )
 
 files(

--- a/testprojects/tests/java/org/pantsbuild/testproject/buildrefactor/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/buildrefactor/BUILD
@@ -3,19 +3,23 @@
 
 java_library(
     name = "X",
+    sources = [],
 )
 
 java_library(
     name = "A",
+    sources = [],
     dependencies = [":X"],
 )
 
 java_library(
     name = "B",
+    sources = [],
     dependencies = [":X"],
 )
 
 java_library(
     name = "C",
+    sources = [],
     dependencies = [":X"],
 )

--- a/testprojects/tests/java/org/pantsbuild/testproject/buildrefactor/x/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/buildrefactor/x/BUILD
@@ -3,4 +3,5 @@
 
 java_library(
     name = "X",
+    sources = [],
 )

--- a/testprojects/tests/java/org/pantsbuild/testproject/empty/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/empty/BUILD
@@ -1,2 +1,0 @@
-# These sources intentionally missing.
-junit_tests()

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
@@ -42,12 +42,12 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
                                     classname='org.pantsbuild.example.hello.welcome.WelSpec')
 
   def test_junit_test(self):
-    with self.temporary_workdir() as workdir:
-      pants_run = self.run_pants_with_workdir([
-          'test',
-          'testprojects/tests/scala/org/pantsbuild/testproject/empty'],
-          workdir)
-      self.assert_failure(pants_run)
+    empty_directory_path = 'testprojects/tests/java/org/pantsbuild/testproject/empty'
+    empty_target = b"junit_tests()\n"
+    with self.temporary_file_content(f"{empty_directory_path}/BUILD", empty_target), \
+         self.temporary_workdir() as workdir:
+      pants_run = self.run_pants_with_workdir(['test', empty_directory_path], workdir)
+    self.assert_failure(pants_run)
 
   def test_junit_test_with_test_option_with_classname(self):
     with self.temporary_workdir() as workdir:

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from pathlib import Path
 
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
@@ -42,11 +43,13 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
                                     classname='org.pantsbuild.example.hello.welcome.WelSpec')
 
   def test_junit_test(self):
-    empty_directory_path = 'testprojects/tests/java/org/pantsbuild/testproject/empty'
+    empty_directory_path = Path('testprojects/tests/java/org/pantsbuild/testproject/empty')
+    empty_directory_path.mkdir()
     empty_target = b"junit_tests()\n"
     with self.temporary_file_content(f"{empty_directory_path}/BUILD", empty_target), \
          self.temporary_workdir() as workdir:
       pants_run = self.run_pants_with_workdir(['test', empty_directory_path], workdir)
+    empty_directory_path.rmdir()
     self.assert_failure(pants_run)
 
   def test_junit_test_with_test_option_with_classname(self):

--- a/tests/python/pants_test/engine/legacy/test_changed_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_changed_integration.py
@@ -351,13 +351,7 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, AbstractTestGenerator):
       safe_delete(os.path.join(worktree, 'src/python/sources/sources.txt'))
       pants_run = self.run_pants(['list', '--changed-parent=HEAD'])
       self.assert_success(pants_run)
-      changed_targets = [
-        'src/python/sources:overlapping-globs',
-        'src/python/sources:some-missing-some-not',
-        'src/python/sources:text',
-      ]
-      self.assertEqual(pants_run.stdout_data.strip(),
-                       '\n'.join(changed_targets))
+      self.assertEqual(pants_run.stdout_data.strip(), 'src/python/sources:text')
 
   def test_changed_with_deleted_target_transitive(self):
     with create_isolated_git_repo() as worktree:

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -111,7 +111,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         # Run target that throws an exception in pants.
         self.assert_failure(
           self.run_pants_with_workdir(
-            ['test', 'testprojects/src/python/unicode/compilation_failure'],
+            ['lint', 'testprojects/src/python/unicode/compilation_failure'],
             workdir,
             pantsd_config)
         )

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -111,7 +111,7 @@ class TestPantsDaemonIntegration(PantsDaemonIntegrationTestBase):
         # Run target that throws an exception in pants.
         self.assert_failure(
           self.run_pants_with_workdir(
-            ['bundle', 'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-files'],
+            ['test', 'testprojects/src/python/unicode/compilation_failure'],
             workdir,
             pantsd_config)
         )

--- a/tests/python/pants_test/projects/projects_test_base.py
+++ b/tests/python/pants_test/projects/projects_test_base.py
@@ -31,7 +31,6 @@ class ProjectsTestBase(PantsRunIntegrationTest):
     negative_test_targets = [
       'testprojects/maven_layout/provided_patching/leaf:fail',
       'testprojects/src/antlr/python/test:antlr_failure',
-      'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-files',
       'testprojects/src/java/org/pantsbuild/testproject/compilation_warnings:fatal',
       'testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target',
       'testprojects/src/java/org/pantsbuild/testproject/junit/earlyexit:tests',
@@ -47,7 +46,6 @@ class ProjectsTestBase(PantsRunIntegrationTest):
       'testprojects/src/thrift/org/pantsbuild/thrift_linter:',
       'testprojects/src/java/org/pantsbuild/testproject/provided:c',
       'testprojects/tests/java/org/pantsbuild/testproject/dummies:failing_target',
-      'testprojects/tests/java/org/pantsbuild/testproject/empty:',
       'testprojects/tests/java/org/pantsbuild/testproject/fail256:fail256',
       'testprojects/tests/python/pants/dummies:failing_target',
       'testprojects/tests/scala/org/pantsbuild/testproject/non_exports:C',


### PR DESCRIPTION
### Problem

Running `./pants lint-v2 ::` results in these warnings:


We want to be able to start running `./pants lint-v2 ::` and `./pants fmt-v2 ::` and these warnings cause noise that makes the output harder to parse.

```bash
./pants lint-v2 ::
Scrubbed PYTHONPATH=/Users/eric/DocsLocal/code/projects/pants/src/python: from the environment.
05:49:09 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["testprojects/src/python/sources/*.rs"].
05:49:09 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["testprojects/src/python/sources/*.a"].
05:49:09 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["testprojects/src/python/sources/**/*.a"].
05:49:09 [WARN] Globs did not match. Excludes were: ["testprojects/src/python/sources/*Test.scala", "testprojects/src/python/sources/*Spec.scala"]. Unmatched globs were: ["testprojects/src/python/sources/*.scala"].
05:49:09 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["testprojects/src/python/sources/another_nonexistent_file.txt", "testprojects/src/python/sources/nonexistent_test_file.txt"].
05:49:09 [WARN] Globs did not match. Excludes were: ["src/python/pants/backend/python/lint/isort/*_integration_test.py"]. Unmatched globs were: ["src/python/pants/backend/python/lint/isort/*_test.py"].
05:49:09 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["testprojects/src/scala/org/pantsbuild/testproject/javasources/org/pantsbuild/testproject/javasources/**/*.scala"].
05:49:09 [WARN] Globs did not match. Excludes were: ["testprojects/tests/java/org/pantsbuild/testproject/buildrefactor/x/*Test.java"]. Unmatched globs were: ["testprojects/tests/java/org/pantsbuild/testproject/buildrefactor/x/*.java"].
05:49:09 [WARN] Globs did not match. Excludes were: ["src/python/pants/backend/python/lint/black/*_integration_test.py"]. Unmatched globs were: ["src/python/pants/backend/python/lint/black/*_test.py"].
05:49:09 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["contrib/node/examples/src/node/javascriptstyle-empty/**/*.js"].
05:49:09 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["testprojects/src/java/org/pantsbuild/testproject/bundle/**/*.aaaa", "testprojects/src/java/org/pantsbuild/testproject/bundle/**/*.bbbb"].
05:49:09 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["testprojects/src/java/org/pantsbuild/testproject/bundle/*.aaaa"].
05:49:09 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["testprojects/src/java/org/pantsbuild/testproject/bundle/**/*.abab"].
05:49:09 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["testprojects/src/java/org/pantsbuild/testproject/bundle/file1.aaaa", "testprojects/src/java/org/pantsbuild/testproject/bundle/file2.aaaa"].
05:49:09 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["testprojects/src/java/org/pantsbuild/testproject/bundle/data/no-such-file"].
05:49:09 [WARN] Globs did not match. Excludes were: ["testprojects/tests/java/org/pantsbuild/testproject/buildrefactor/*Test.java"]. Unmatched globs were: ["testprojects/tests/java/org/pantsbuild/testproject/buildrefactor/*.java"].
05:49:09 [WARN] Globs did not match. Excludes were: ["testprojects/src/java/org/pantsbuild/testproject/junit/failing/tests/org/pantsbuild/tmp/tests/*Test.java"]. Unmatched globs were: ["testprojects/src/java/org/pantsbuild/testproject/junit/failing/tests/org/pantsbuild/tmp/tests/*.java"].
05:49:09 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["testprojects/tests/java/org/pantsbuild/testproject/empty/*Spec.scala", "testprojects/tests/java/org/pantsbuild/testproject/empty/*Test.java", "testprojects/tests/java/org/pantsbuild/testproject/empty/*Test.scala"].
05:49:09 [WARN] Globs did not match. Excludes were: []. Unmatched globs were: ["testprojects/src/java/org/pantsbuild/testproject/manifest/Agent.java"].
```

We don't want to simply configure `pants.ini` to ignore these issues because it is a useful check.

### Result

Now `./pants lint-v2 ::` returns this:

```bash
./pants lint-v2 ::
Scrubbed PYTHONPATH=/Users/eric/DocsLocal/code/projects/pants/src/python: from the environment.
```