### PR TITLE
Include transitive target dependencies in export-dep-as-jar

### DIFF
--- a/examples/src/scala/org/pantsbuild/example/strict_deps/A.scala
+++ b/examples/src/scala/org/pantsbuild/example/strict_deps/A.scala
@@ -1,0 +1,3 @@
+package a
+
+class Foo

--- a/examples/src/scala/org/pantsbuild/example/strict_deps/B.scala
+++ b/examples/src/scala/org/pantsbuild/example/strict_deps/B.scala
@@ -1,0 +1,3 @@
+package b
+
+class Foo

--- a/examples/src/scala/org/pantsbuild/example/strict_deps/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/strict_deps/BUILD
@@ -1,0 +1,32 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+scala_library(
+  name = "a",
+  sources = ["A.scala"],
+)
+
+scala_library(
+  name = "b",
+  sources = ["B.scala"],
+)
+
+scala_library(
+  name = "c",
+  sources = ["C.scala"],
+  dependencies = [":a"],
+)
+
+scala_library(
+  name = "d",
+  sources = ["D.scala"],
+  dependencies = [":b", ":c"],
+  strict_deps = True,
+)
+
+scala_library(
+  name = "e",
+  sources = ["E.scala"],
+  dependencies = [":b", ":c"],
+  strict_deps = False,
+)

--- a/examples/src/scala/org/pantsbuild/example/strict_deps/C.scala
+++ b/examples/src/scala/org/pantsbuild/example/strict_deps/C.scala
@@ -1,0 +1,5 @@
+package a
+
+class C {
+  val implementationDetail: Any = new a.Foo()
+}

--- a/examples/src/scala/org/pantsbuild/example/strict_deps/D.scala
+++ b/examples/src/scala/org/pantsbuild/example/strict_deps/D.scala
@@ -1,0 +1,8 @@
+package d
+
+import a._
+import b._
+
+class App {
+  val foo: Foo = new Foo()
+}

--- a/examples/src/scala/org/pantsbuild/example/strict_deps/E.scala
+++ b/examples/src/scala/org/pantsbuild/example/strict_deps/E.scala
@@ -1,0 +1,7 @@
+package e
+
+import a.Foo
+
+class App {
+  val foo: Foo = new Foo()
+}

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 
 from twitter.common.collections import OrderedSet
 
+from pants.backend.jvm.subsystems.dependency_context import DependencyContext
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.targets.jar_library import JarLibrary
@@ -31,6 +32,10 @@ class ExportDepAsJar(ConsoleTask):
   This is an experimental task that mimics export but uses the jars for
   jvm dependencies instead of sources.
   """
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super().subsystem_dependencies() + (DependencyContext,)
 
   @classmethod
   def register_options(cls, register):
@@ -150,6 +155,7 @@ class ExportDepAsJar(ConsoleTask):
       info = {
         # this means 'dependencies'
         'targets': [],
+        'transitive_targets': [],
         'libraries': [],
         'roots': [],
         'id': current_target.id,
@@ -190,6 +196,11 @@ class ExportDepAsJar(ConsoleTask):
           target_libraries.update(iter_transitive_jars(dep))
         if isinstance(dep, Resources):
           resource_target_map[dep] = current_target
+
+      if hasattr(current_target, 'strict_deps'):
+        transitive_targets = DependencyContext.global_instance().dependencies_respecting_strict_deps(current_target)
+        for dep in transitive_targets:
+          info['transitive_targets'].append(dep.address.spec)
 
       if isinstance(current_target, ScalaLibrary):
         for dep in current_target.java_sources:


### PR DESCRIPTION
Previously, `export-dep-as-jar` did not include the full list of
transitive target dependencies. This meant that client tools like the
IntelliJ compiler and Bloop export were left to traverse the build graph
in order to construct the full classpath of a target.

Now, the output of `export-dep-as-jar` includes a new field
`transitive_targets` field that is similar to `targets` except that it
includes transitive target dependencies respecting `strict_deps`.  For
example, assuming `c -> b -> a` the value of `transitive_targets` is the
following:

```diff
++ new export-dep-as-jar output
 {
   "c:c": {
     "targets": ["b:b"],
+    "transitive_targets": ["b:b", "a:a"],
   }
 }
```
This change allows clients to faithfully reproduce the same classpath as
`./pants compile` without exposing `strict_deps` into the
`export-dep-as-jar` output.