### PR TITLE
Partially type check 300 more files

### DIFF
--- a/contrib/avro/src/python/pants/contrib/avro/BUILD
+++ b/contrib/avro/src/python/pants/contrib/avro/BUILD
@@ -13,4 +13,5 @@ contrib_plugin(
   description='Avro Java code generation support for pants',
   build_file_aliases=True,
   register_goals=True,
+  tags = {"partially_type_checked"},
 )

--- a/contrib/avro/src/python/pants/contrib/avro/targets/BUILD
+++ b/contrib/avro/src/python/pants/contrib/avro/targets/BUILD
@@ -6,4 +6,5 @@ python_library(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:payload',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/avro/src/python/pants/contrib/avro/tasks/BUILD
+++ b/contrib/avro/src/python/pants/contrib/avro/tasks/BUILD
@@ -14,4 +14,5 @@ python_library(
     'src/python/pants/task',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/subsystems/BUILD
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/subsystems/BUILD
@@ -4,5 +4,5 @@
 python_library(
   dependencies = [
     'src/python/pants/backend/python/subsystems',
-  ]
+  ],
 )

--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/targets/BUILD
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/targets/BUILD
@@ -4,5 +4,6 @@
 python_library(
   dependencies = [
     'src/python/pants/backend/python/targets',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/buildgen/src/python/pants/contrib/buildgen/BUILD
+++ b/contrib/buildgen/src/python/pants/contrib/buildgen/BUILD
@@ -22,5 +22,6 @@ python_library(
   sources = ['build_file_manipulator.py'],
   dependencies = [
     'src/python/pants/build_graph',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/BUILD
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/BUILD
@@ -16,5 +16,6 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/binaries'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/BUILD
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/BUILD
@@ -4,7 +4,8 @@
 
 python_library(
   name='buildozer_util',
-  sources=['buildozer_util.py']
+  sources=['buildozer_util.py'],
+  tags = {"partially_type_checked"},
 )
 
 

--- a/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/BUILD
+++ b/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/BUILD
@@ -11,4 +11,5 @@ contrib_plugin(
   distribution_name='pantsbuild.pants.contrib.codeanalysis',
   description='Support for various code analysis tools in Pants.',
   register_goals=True,
+  tags = {"partially_type_checked"},
 )

--- a/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/BUILD
+++ b/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/BUILD
@@ -10,5 +10,6 @@ python_library(
     'src/python/pants/base:revision',
     'src/python/pants/build_graph',
     'src/python/pants/java/jar',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/confluence/src/python/pants/contrib/confluence/BUILD
+++ b/contrib/confluence/src/python/pants/contrib/confluence/BUILD
@@ -1,7 +1,5 @@
-# coding=utf-8
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 
 contrib_plugin(
   name='plugin',
@@ -13,4 +11,5 @@ contrib_plugin(
   distribution_name='pantsbuild.pants.contrib.confluence',
   description='Confluence pants plugin',
   register_goals=True,
+  tags = {"partially_type_checked"},
 )

--- a/contrib/confluence/src/python/pants/contrib/confluence/tasks/BUILD
+++ b/contrib/confluence/src/python/pants/contrib/confluence/tasks/BUILD
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
@@ -12,5 +11,5 @@ python_library(
     'src/python/pants/util:desktop',
     'src/python/pants/util:dirutil',
   ],
-  sources=globs('*.py'),
+  tags = {"partially_type_checked"},
 )

--- a/contrib/confluence/src/python/pants/contrib/confluence/util/BUILD
+++ b/contrib/confluence/src/python/pants/contrib/confluence/util/BUILD
@@ -1,8 +1,6 @@
-# coding=utf-8
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
 python_library(
-  sources = globs('*.py'),
+  tags = {"partially_type_checked"},
 )

--- a/contrib/cpp/src/python/pants/contrib/cpp/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/BUILD
@@ -14,4 +14,5 @@ contrib_plugin(
   description='C++ pants plugin.',
   build_file_aliases=True,
   register_goals=True,
+  tags = {"partially_type_checked"},
 )

--- a/contrib/cpp/src/python/pants/contrib/cpp/targets/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/targets/BUILD
@@ -14,4 +14,5 @@ python_library(
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/cpp/src/python/pants/contrib/cpp/tasks/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/tasks/BUILD
@@ -18,4 +18,5 @@ python_library(
     'src/python/pants/task',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/cpp/src/python/pants/contrib/cpp/toolchain/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/toolchain/BUILD
@@ -1,11 +1,6 @@
-# coding=utf-8
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources=[
-    'cpp_toolchain.py',
-  ],
-  dependencies=[
-  ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/errorprone/src/python/pants/contrib/errorprone/BUILD
+++ b/contrib/errorprone/src/python/pants/contrib/errorprone/BUILD
@@ -11,4 +11,5 @@ contrib_plugin(
   distribution_name='pantsbuild.pants.contrib.errorprone',
   description='Error Prone pants plugin',
   register_goals=True,
+  tags = {"partially_type_checked"},
 )

--- a/contrib/errorprone/src/python/pants/contrib/errorprone/tasks/BUILD
+++ b/contrib/errorprone/src/python/pants/contrib/errorprone/tasks/BUILD
@@ -2,9 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources=[
-    'errorprone.py',
-  ],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/jvm/subsystems:shader',
@@ -14,5 +11,6 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/findbugs/src/python/pants/contrib/findbugs/BUILD
+++ b/contrib/findbugs/src/python/pants/contrib/findbugs/BUILD
@@ -11,4 +11,5 @@ contrib_plugin(
   distribution_name='pantsbuild.pants.contrib.findbugs',
   description='FindBugs pants plugin',
   register_goals=True,
+  tags = {"partially_type_checked"},
 )

--- a/contrib/findbugs/src/python/pants/contrib/findbugs/tasks/BUILD
+++ b/contrib/findbugs/src/python/pants/contrib/findbugs/tasks/BUILD
@@ -2,9 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources=[
-    'findbugs.py',
-  ],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/jvm/subsystems:shader',
@@ -16,5 +13,6 @@ python_library(
     'src/python/pants/base:workunit',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:xml_parser',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/go/src/python/pants/contrib/go/subsystems/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/BUILD
@@ -15,4 +15,5 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/go/src/python/pants/contrib/go/targets/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/targets/BUILD
@@ -9,4 +9,5 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/source',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/BUILD
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/BUILD
@@ -1,7 +1,9 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(sources=['googlejavaformat.py'])
+python_library(
+  sources=['googlejavaformat.py'],
+)
 
 contrib_plugin(
   name='plugin',

--- a/contrib/jax_ws/src/python/pants/contrib/jax_ws/BUILD
+++ b/contrib/jax_ws/src/python/pants/contrib/jax_ws/BUILD
@@ -13,4 +13,5 @@ contrib_plugin(
   description='JAX-WS Pants plugin',
   build_file_aliases=True,
   register_goals=True,
+  tags = {"partially_type_checked"},
 )

--- a/contrib/jax_ws/src/python/pants/contrib/jax_ws/targets/BUILD
+++ b/contrib/jax_ws/src/python/pants/contrib/jax_ws/targets/BUILD
@@ -2,11 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources=[
-    'jax_ws_library.py',
-  ],
   dependencies=[
     'src/python/pants/base:payload_field',
     'src/python/pants/backend/jvm/targets:java',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/jax_ws/src/python/pants/contrib/jax_ws/tasks/BUILD
+++ b/contrib/jax_ws/src/python/pants/contrib/jax_ws/tasks/BUILD
@@ -2,9 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources=[
-    'jax_ws_gen.py',
-  ],
   dependencies=[
     'contrib/jax_ws/src/python/pants/contrib/jax_ws/targets:targets',
     'src/python/pants/backend/jvm/targets:java',
@@ -12,5 +9,6 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/task',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/node/src/python/pants/contrib/node/subsystems/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/BUILD
@@ -9,4 +9,5 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/BUILD
@@ -19,7 +19,8 @@ python_library(
     'src/python/pants/util:contextutil',
     'contrib/node/src/python/pants/contrib/node/targets:node_module',
     'contrib/node/src/python/pants/contrib/node/tasks:node_resolve',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -35,7 +36,8 @@ python_library(
     'src/python/pants/util:dirutil',
     'contrib/node/src/python/pants/contrib/node/targets:node_preinstalled_module',
     'contrib/node/src/python/pants/contrib/node/tasks:node_resolve',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -44,5 +46,6 @@ python_library(
   dependencies=[
     'src/python/pants/base:build_environment',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/node/src/python/pants/contrib/node/targets/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/targets/BUILD
@@ -18,6 +18,7 @@ python_library(
     'src/python/pants/base:payload',
     'src/python/pants/fs',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -27,6 +28,7 @@ python_library(
     ':node_package',
     'src/python/pants/base:payload',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -37,6 +39,7 @@ python_library(
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -47,6 +50,7 @@ python_library(
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -56,7 +60,8 @@ python_library(
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -66,5 +71,6 @@ python_library(
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/node/src/python/pants/contrib/node/tasks/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/tasks/BUILD
@@ -17,6 +17,7 @@ target(
 python_library(
   name='node_paths',
   sources=['node_paths.py'],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -28,7 +29,8 @@ python_library(
     'src/python/pants/base:workunit',
     'src/python/pants/task',
     'src/python/pants/util:contextutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -40,7 +42,8 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/fs',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -52,7 +55,8 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/task',
     'src/python/pants/util:contextutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -68,7 +72,8 @@ python_library(
     'src/python/pants/base:workunit',
     'src/python/pants/task',
     'src/python/pants/util:memo',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -79,7 +84,8 @@ python_library(
     ':node_task',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -91,7 +97,8 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/util:contextutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -104,7 +111,8 @@ python_library(
     'src/python/pants/base:workunit',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:process_handler',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -119,7 +127,7 @@ python_library(
     'src/python/pants/task',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:process_handler',
-  ]
+  ],
 )
 
 python_library(
@@ -131,5 +139,6 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/util:contextutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_build.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_build.py
@@ -4,7 +4,8 @@
 import os
 from collections import defaultdict
 
-from pants.backend.jvm.tasks.classpath_products import ClasspathEntry, ClasspathProducts
+from pants.backend.jvm.tasks.classpath_entry import ClasspathEntry
+from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_install.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_install.py
@@ -32,4 +32,6 @@ class NodeInstall(NodeTask):
         # By requiring NodePathsLocal, the node resolver walks through each node_module target and installs
         # them in topological order in the root source target path.
         node_paths = self.context.products.get_data(NodePathsLocal)
-        self.context.log.debug('Start installing node_module target: {} in path'.format(target, node_paths.node_path(target)))
+        self.context.log.debug(
+          f'Start installing node_module target: {target} in path {node_paths.node_path(target)}'
+        )

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/subsystems/BUILD
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/subsystems/BUILD
@@ -9,4 +9,5 @@ python_library(
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
@@ -28,6 +28,7 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -48,8 +49,7 @@ python_library(
 python_library(
   name='thrift_util',
   sources=['thrift_util.py'],
-  dependencies = [
-  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -59,4 +59,5 @@ python_library(
     'src/python/pants/backend/codegen/thrift/java',
     'src/python/pants/base:fingerprint_strategy',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/thrifty/src/python/pants/contrib/thrifty/BUILD
+++ b/contrib/thrifty/src/python/pants/contrib/thrifty/BUILD
@@ -1,7 +1,10 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(sources=['java_thrifty_gen.py', 'java_thrifty_library.py'])
+python_library(
+  sources=['java_thrifty_gen.py', 'java_thrifty_library.py'],
+  tags={"partially_type_checked"},
+)
 
 contrib_plugin(
   name='plugin',

--- a/pants-plugins/src/python/internal_backend/BUILD
+++ b/pants-plugins/src/python/internal_backend/BUILD
@@ -8,5 +8,6 @@ target(
     'pants-plugins/src/python/internal_backend/rules_for_testing:plugin',
     'pants-plugins/src/python/internal_backend/sitegen:plugin',
     'pants-plugins/src/python/internal_backend/utilities:plugin',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/pants-plugins/src/python/internal_backend/repositories/BUILD
+++ b/pants-plugins/src/python/internal_backend/repositories/BUILD
@@ -3,12 +3,12 @@
 
 python_library(
   name = 'plugin',
-  sources = ['__init__.py', 'register.py'],
   dependencies = [
     'src/python/pants/backend/jvm:artifact',
     'src/python/pants/backend/jvm:ossrh_publication_metadata',
     'src/python/pants/backend/jvm:repository',
     'src/python/pants/build_graph',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 

--- a/pants-plugins/src/python/internal_backend/rules_for_testing/BUILD
+++ b/pants-plugins/src/python/internal_backend/rules_for_testing/BUILD
@@ -10,5 +10,6 @@ python_library(
     'src/python/pants/engine:console',
     'src/python/pants/engine:rules',
     'src/python/pants/engine:selectors',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/pants-plugins/src/python/internal_backend/sitegen/BUILD
+++ b/pants-plugins/src/python/internal_backend/sitegen/BUILD
@@ -3,9 +3,9 @@
 
 python_library(
   name = 'plugin',
-  sources = ['__init__.py', 'register.py'],
   dependencies = [
     'pants-plugins/src/python/internal_backend/sitegen/tasks:all',
     'src/python/pants/goal:task_registrar',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/pants-plugins/src/python/internal_backend/sitegen/tasks/BUILD
+++ b/pants-plugins/src/python/internal_backend/sitegen/tasks/BUILD
@@ -16,5 +16,6 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/task',
     'src/python/pants/backend/docgen/tasks'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/pants-plugins/src/python/internal_backend/utilities/BUILD
+++ b/pants-plugins/src/python/internal_backend/utilities/BUILD
@@ -3,7 +3,6 @@
 
 python_library(
   name='plugin',
-  sources=['register.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/python/targets',
@@ -11,6 +10,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 

--- a/pants-plugins/tests/python/internal_backend_test/sitegen/BUILD
+++ b/pants-plugins/tests/python/internal_backend_test/sitegen/BUILD
@@ -7,4 +7,5 @@ python_tests(
     'pants-plugins/3rdparty/python:beautifulsoup4',
     'pants-plugins/src/python/internal_backend/sitegen/tasks:sitegen',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/pants-plugins/tests/python/internal_backend_test/utilities/BUILD
+++ b/pants-plugins/tests/python/internal_backend_test/utilities/BUILD
@@ -6,4 +6,5 @@ python_tests(
     'pants-plugins/src/python/internal_backend/utilities:plugin',
     'src/python/pants/base:revision',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/codegen/antlr/java/BUILD
+++ b/src/python/pants/backend/codegen/antlr/java/BUILD
@@ -15,4 +15,5 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/codegen/antlr/python/BUILD
+++ b/src/python/pants/backend/codegen/antlr/python/BUILD
@@ -14,4 +14,5 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/codegen/jaxb/BUILD
+++ b/src/python/pants/backend/codegen/jaxb/BUILD
@@ -11,4 +11,5 @@ python_library(
     'src/python/pants/goal:task_registrar',
     'src/python/pants/task',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/codegen/protobuf/java/BUILD
+++ b/src/python/pants/backend/codegen/protobuf/java/BUILD
@@ -19,4 +19,5 @@ python_library(
     'src/python/pants/goal:task_registrar',
     'src/python/pants/task',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/codegen/protobuf/subsystems/BUILD
+++ b/src/python/pants/backend/codegen/protobuf/subsystems/BUILD
@@ -5,4 +5,5 @@ python_library(
   dependencies = [
     'src/python/pants/binaries'
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/codegen/ragel/java/BUILD
+++ b/src/python/pants/backend/codegen/ragel/java/BUILD
@@ -13,4 +13,5 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/codegen/ragel/subsystems/BUILD
+++ b/src/python/pants/backend/codegen/ragel/subsystems/BUILD
@@ -5,4 +5,5 @@ python_library(
   dependencies = [
     'src/python/pants/binaries'
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/codegen/wire/java/BUILD
+++ b/src/python/pants/backend/codegen/wire/java/BUILD
@@ -17,4 +17,5 @@ python_library(
     'src/python/pants/task',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/docgen/targets/BUILD
+++ b/src/python/pants/backend/docgen/targets/BUILD
@@ -9,4 +9,5 @@ python_library(
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/docgen/tasks/BUILD
+++ b/src/python/pants/backend/docgen/tasks/BUILD
@@ -24,6 +24,7 @@ python_library(
     'src/python/pants/util:desktop',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 resources(

--- a/src/python/pants/backend/graph_info/BUILD
+++ b/src/python/pants/backend/graph_info/BUILD
@@ -1,10 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
 python_library(
   name = 'plugin',
-  sources = ['register.py'],
   dependencies = [
     'src/python/pants/backend/graph_info/tasks',
     'src/python/pants/goal:task_registrar',

--- a/src/python/pants/backend/graph_info/subsystems/BUILD
+++ b/src/python/pants/backend/graph_info/subsystems/BUILD
@@ -5,4 +5,5 @@ python_library(
   dependencies = [
     'src/python/pants/binaries',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/graph_info/tasks/BUILD
+++ b/src/python/pants/backend/graph_info/tasks/BUILD
@@ -18,4 +18,5 @@ python_library(
     'src/python/pants/util:process_handler',
     'src/python/pants/util:strutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -12,6 +12,7 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/java/jar',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -101,6 +102,7 @@ python_library(
     'src/python/pants/subsystem',
     'src/python/pants/task',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -154,7 +156,8 @@ python_library(
     ':shader',
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -173,6 +176,7 @@ python_library(
   dependencies=[
     'src/python/pants/subsystem',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -185,4 +189,5 @@ python_library(
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/jvm/subsystems/zinc.py
+++ b/src/python/pants/backend/jvm/subsystems/zinc.py
@@ -5,6 +5,7 @@ import os
 from hashlib import sha1
 from pathlib import Path
 from threading import Lock
+from typing import cast
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext
 from pants.backend.jvm.subsystems.java import Java
@@ -12,7 +13,7 @@ from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.subsystems.shader import Shader
 from pants.backend.jvm.targets.scala_jar_dependency import ScalaJarDependency
-from pants.backend.jvm.tasks.classpath_products import ClasspathEntry
+from pants.backend.jvm.tasks.classpath_entry import ClasspathEntry
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.backend.jvm.tasks.nailgun_task import NailgunTaskBase
 from pants.base.build_environment import get_buildroot
@@ -227,14 +228,14 @@ class Zinc:
       # (e.g., a JDK that is no longer present), or points to the wrong JDK.
       if not jdk_home_symlink.exists() or jdk_home_symlink.resolve() != Path(underlying_dist.home):
         safe_delete(str(jdk_home_symlink))  # Safe-delete, in case it's a broken symlink.
-        safe_mkdir_for(jdk_home_symlink)
+        safe_mkdir_for(str(jdk_home_symlink))
         jdk_home_symlink.symlink_to(underlying_dist.home)
 
     return Distribution(home_path=jdk_home_symlink)
 
   @property
   def underlying_dist(self) -> Distribution:
-    return self._zinc_factory.dist
+    return cast(Distribution, self._zinc_factory.dist)
 
   @memoized_property
   def _compiler_bridge(self):

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -61,6 +61,7 @@ python_library(
     'src/python/pants/task',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -75,6 +76,7 @@ python_library(
     'src/python/pants/java:util',
     'src/python/pants/task',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -85,6 +87,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -95,6 +98,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -134,6 +138,7 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:fileutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -144,6 +149,7 @@ python_library(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/task',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -208,6 +214,7 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -271,6 +278,7 @@ python_library(
     'src/python/pants/java/jar',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -289,6 +297,7 @@ python_library(
     'src/python/pants/util:strutil',
     'src/python/pants/backend/jvm/subsystems:resolve_subsystem'
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -300,6 +309,7 @@ python_library(
     'src/python/pants/base:workunit',
     'src/python/pants/backend/jvm/targets:jvm',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -307,7 +317,8 @@ python_library(
   sources=['jar_import_products.py'],
   dependencies=[
     'src/python/pants/backend/jvm/targets:jvm',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -333,6 +344,7 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:strutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 resources(
@@ -356,6 +368,7 @@ python_library(
     'src/python/pants/java/jar',
     'src/python/pants/util:contextutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -368,6 +381,7 @@ python_library(
     'src/python/pants/java:executor',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -403,6 +417,7 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants/util:strutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -421,6 +436,7 @@ python_library(
     'src/python/pants/util:fileutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -435,7 +451,8 @@ python_library(
     'src/python/pants/java/distribution',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -455,6 +472,7 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -469,7 +487,8 @@ python_library(
     'src/python/pants/task',
     'src/python/pants/util:fileutil',
     'src/python/pants/util:memo',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -481,7 +500,8 @@ python_library(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/task',
     'src/python/pants/util:memo',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -499,6 +519,7 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:strutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -510,6 +531,7 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/task',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -534,6 +556,7 @@ python_library(
     'src/python/pants/util:desktop',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -564,6 +587,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -577,11 +601,13 @@ python_library(
     'src/python/pants/base:payload_field',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
   name = 'properties',
   sources = ['properties.py'],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -595,6 +621,7 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -604,11 +631,13 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/task',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
   name = 'resolve_shared',
   sources = ['resolve_shared.py'],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -623,6 +652,7 @@ python_library(
     'src/python/pants/java:executor',
     'src/python/pants/task',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -637,6 +667,7 @@ python_library(
     'src/python/pants/java/distribution',
     'src/python/pants/task',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -649,6 +680,7 @@ python_library(
     'src/python/pants/java/distribution',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -662,7 +694,7 @@ python_library(
     'src/python/pants/java/jar',
     'src/python/pants/option',
     'src/python/pants/task',
-  ]
+  ],
 )
 
 python_library(
@@ -676,7 +708,7 @@ python_library(
     'src/python/pants/java/jar',
     'src/python/pants/option',
     'src/python/pants/task',
-  ]
+  ],
 )
 
 python_library(
@@ -690,7 +722,8 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -719,7 +752,8 @@ python_library(
     'src/python/pants/base:fingerprint_strategy',
     'src/python/pants/fs',
     'src/python/pants/task',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -730,4 +764,5 @@ python_library(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/task',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/jvm/tasks/coursier/BUILD
+++ b/src/python/pants/backend/jvm/tasks/coursier/BUILD
@@ -11,4 +11,5 @@ python_library(
     'src/python/pants/util:strutil',
     'src/python/pants/backend/jvm/subsystems:resolve_subsystem'
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/jvm/tasks/coverage/BUILD
+++ b/src/python/pants/backend/jvm/tasks/coverage/BUILD
@@ -16,4 +16,5 @@ python_library(
     'src/python/pants/util:meta',
     'src/python/pants/util:strutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -17,7 +17,8 @@ python_library(
   sources = ['compile_context.py'],
   dependencies = [
     'src/python/pants/util:contextutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -30,7 +31,8 @@ python_library(
     'src/python/pants/task',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:fileutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -63,6 +65,7 @@ python_library(
     'src/python/pants/util:fileutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -72,6 +75,7 @@ python_library(
     'src/python/pants/base:worker_pool',
     'src/python/pants/util:contextutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -84,4 +88,5 @@ python_library(
     '3rdparty/python:ansicolors',
     '3rdparty/python/twitter/commons:twitter.common.collections',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/BUILD
@@ -18,4 +18,5 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -4,6 +4,7 @@
 import functools
 import os
 from multiprocessing import cpu_count
+from typing import Optional
 
 from pants.backend.jvm.subsystems.dependency_context import DependencyContext
 from pants.backend.jvm.subsystems.java import Java
@@ -13,7 +14,7 @@ from pants.backend.jvm.subsystems.zinc import Zinc
 from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
 from pants.backend.jvm.targets.javac_plugin import JavacPlugin
 from pants.backend.jvm.targets.scalac_plugin import ScalacPlugin
-from pants.backend.jvm.tasks.classpath_products import ClasspathEntry
+from pants.backend.jvm.tasks.classpath_entry import ClasspathEntry
 from pants.backend.jvm.tasks.jvm_compile.class_not_found_error_patterns import (
   CLASS_NOT_FOUND_ERROR_PATTERNS,
 )
@@ -180,9 +181,9 @@ class JvmCompile(CompilerOptionSetsMixin, NailgunTaskBase):
 
   # Subclasses must implement.
   # --------------------------
-  _name = None
+  _name: Optional[str] = None
   # The name used in JvmPlatform to refer to this compiler task.
-  compiler_name = None
+  compiler_name: Optional[str] = None
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -24,4 +24,5 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants/util:strutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/rsc/rsc_compile.py
@@ -110,7 +110,7 @@ class RscCompileContext(CompileContext):
 class RscCompile(ZincCompile, MirroredTargetOptionMixin):
   """Compile Scala and Java code to classfiles using Rsc."""
 
-  _name = 'mixed' # noqa
+  _name = 'mixed'
   compiler_name = 'rsc'
 
   @classmethod

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/BUILD
@@ -23,4 +23,5 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants/util:strutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/jvm/tasks/reports/BUILD
+++ b/src/python/pants/backend/jvm/tasks/reports/BUILD
@@ -11,4 +11,5 @@ python_library(
     'src/python/pants/util:meta',
     'src/python/pants/util:strutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/backend/jvm/tasks/run_jvm_prep_command.py
+++ b/src/python/pants/backend/jvm/tasks/run_jvm_prep_command.py
@@ -1,6 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import Optional
+
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.targets.jvm_prep_command import JvmPrepCommand
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
@@ -26,7 +28,7 @@ class RunJvmPrepCommandBase(Task):
 
   :API: public
   """
-  goal = None
+  goal: Optional[str] = None
   classpath_product_only = False
 
   def __init__(self, context, workdir):

--- a/src/python/pants/backend/project_info/tasks/BUILD
+++ b/src/python/pants/backend/project_info/tasks/BUILD
@@ -23,6 +23,7 @@ python_library(
     'src/python/pants/base:payload_field',
     'src/python/pants/task',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -33,6 +34,7 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/task',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -86,6 +88,7 @@ python_library(
 python_library(
   name = 'export_version',
   sources = ['export_version.py'],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -98,6 +101,7 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/task',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(

--- a/src/python/pants/base/revision.py
+++ b/src/python/pants/base/revision.py
@@ -24,7 +24,7 @@ class Revision:
       return atom
 
   @classmethod
-  def semver(cls, rev):
+  def semver(cls, rev) -> "Revision":
     """Attempts to parse a Revision from a semantic version.
 
     See http://semver.org/ for the full specification.
@@ -64,7 +64,7 @@ class Revision:
       raise cls.BadRevision("Failed to parse '{}' as a semantic version number".format(rev))
 
   @classmethod
-  def lenient(cls, rev):
+  def lenient(cls, rev) -> "Revision":
     """A lenient revision parser that tries to split the version into logical components with
     heuristics inspired by PHP's version_compare.
 

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -32,7 +32,7 @@ class BinaryToolBase(Subsystem):
 
   # Subclasses may set this to the tool name as understood by BinaryUtil.
   # If unset, it defaults to the value of options_scope.
-  name = None
+  name: Optional[str] = None
 
   # Subclasses may set this to a suffix (e.g., '.pex') to add to the computed remote path.
   # Note that setting archive_type will add an appropriate archive suffix after this suffix.
@@ -40,8 +40,8 @@ class BinaryToolBase(Subsystem):
 
   # Subclasses may set these to effect migration from an old --version option to this one.
   # TODO(benjy): Remove these after migration to the mixin is complete.
-  replaces_scope = None
-  replaces_name = None
+  replaces_scope: Optional[str] = None
+  replaces_name: Optional[str] = None
 
   # Subclasses may set this to provide extra register() kwargs for the --version option.
   extra_version_option_kwargs = None

--- a/src/python/pants/build_graph/dependency_context.py
+++ b/src/python/pants/build_graph/dependency_context.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Any, Dict
+from typing import Any, Dict, Tuple, Type
 
 from pants.build_graph.aliased_target import AliasTarget
 from pants.build_graph.target import Target
@@ -10,5 +10,5 @@ from pants.build_graph.target import Target
 class DependencyContext:
 
   alias_types = (AliasTarget, Target)
-  types_with_closure = ()
+  types_with_closure: Tuple[Type, ...] = ()
   target_closure_kwargs: Dict[str, Any] = {}

--- a/src/python/pants/core_tasks/BUILD
+++ b/src/python/pants/core_tasks/BUILD
@@ -27,7 +27,8 @@ python_library(
     'src/python/pants/util:desktop',
     'src/python/pants/util:dirutil',
     'src/python/pants:version',
-  ])
+  ],
+)
 
 resources(
   name='templates',

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -18,6 +18,7 @@ python_library(
     'src/python/pants/base:workunit',
     'src/python/pants/goal',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(

--- a/src/python/pants/engine/legacy/BUILD
+++ b/src/python/pants/engine/legacy/BUILD
@@ -15,6 +15,7 @@ python_library(
     'src/python/pants/engine:selectors',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -29,6 +30,7 @@ python_library(
     'src/python/pants/engine:parser',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -41,6 +43,7 @@ python_library(
     'src/python/pants/engine:objects',
     'src/python/pants/option',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -82,4 +85,5 @@ python_library(
     'src/python/pants/source',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/pantsd/BUILD
+++ b/src/python/pants/pantsd/BUILD
@@ -20,7 +20,8 @@ python_library(
     'src/python/pants/java:nailgun_protocol',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:socket'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -31,7 +32,8 @@ python_library(
     'src/python/pants/util:retry',
     ':process_manager',
     ':watchman_client'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -41,7 +43,8 @@ python_library(
     ':watchman',
     'src/python/pants/binaries',
     'src/python/pants/util:memo',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -49,7 +52,8 @@ python_library(
   sources = ['watchman_client.py'],
   dependencies = [
     '3rdparty/python:pywatchman'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(

--- a/src/python/pants/pantsd/service/BUILD
+++ b/src/python/pants/pantsd/service/BUILD
@@ -7,7 +7,8 @@ python_library(
   dependencies = [
     '3rdparty/python:dataclasses',
     'src/python/pants/util:meta'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -16,7 +17,8 @@ python_library(
   dependencies = [
     ':pants_service',
     'src/python/pants/pantsd:watchman'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -25,7 +27,8 @@ python_library(
   dependencies = [
     ':pants_service',
     'src/python/pants/pantsd:pailgun_server'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -34,7 +37,8 @@ python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     ':pants_service'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -42,5 +46,6 @@ python_library(
   sources = ['store_gc_service.py'],
   dependencies = [
     ':pants_service',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/pantsd/service/pants_service.py
+++ b/src/python/pants/pantsd/service/pants_service.py
@@ -200,7 +200,7 @@ class PantsServices:
     self,
     services: Optional[Tuple[PantsService, ...]] = None,
     port_map: Optional[Dict] = None,
-    lifecycle_lock: Optional = None
+    lifecycle_lock=None
   ) -> None:
     """
     :param port_map: A dict of (port_name -> port_info) for named ports hosted by the services.

--- a/src/python/pants/releases/BUILD
+++ b/src/python/pants/releases/BUILD
@@ -8,6 +8,7 @@ python_binary(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 # Note that packages.py is not part of a target, it should be run with pex.

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -237,7 +237,7 @@ class TaskBase(SubsystemClientMixin, Optionable, metaclass=ABCMeta):
     return True
 
   @classproperty
-  def target_filtering_enabled(cls):
+  def target_filtering_enabled(cls) -> bool:
     """Whether this task should apply configured filters against targets.
 
     Tasks can override to enable target filtering (e.g. based on tags) and must

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -48,7 +48,7 @@ python_library(
     'src/python/pants/util:process_handler',
     'src/python/pants/util:strutil',
     'src/python/pants:entry_point',
-  ]
+  ],
 )
 
 target(
@@ -86,7 +86,7 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
-  ]
+  ],
 )
 
 python_library(
@@ -97,7 +97,7 @@ python_library(
     'src/python/pants/bin',
     'src/python/pants/init',
     'src/python/pants/util:meta',
-  ]
+  ],
 )
 
 python_library(
@@ -112,12 +112,13 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants/util:objects',
     ':test_base',
-  ]
+  ],
 )
 
 python_library(
   name='file_test_util',
   sources=['file_test_util.py'],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -128,11 +129,13 @@ python_library(
     'src/python/pants/scm:git',
     'src/python/pants/util:contextutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
   name='interpreter_selection_utils',
   sources=['interpreter_selection_utils.py'],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -141,6 +144,7 @@ python_library(
   dependencies = [
     'src/python/pants/reporting',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -149,6 +153,7 @@ python_library(
   dependencies = [
     ':git_util',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -158,4 +163,5 @@ python_library(
     '3rdparty/python:dataclasses',
     '3rdparty/python:psutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/testutil/base/BUILD
+++ b/src/python/pants/testutil/base/BUILD
@@ -10,5 +10,6 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/goal:context',
     'src/python/pants/goal:run_tracker',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/testutil/base/context_utils.py
+++ b/src/python/pants/testutil/base/context_utils.py
@@ -60,20 +60,18 @@ class TestContext(Context):
     def report_target_info(self, scope, target, keys, val): pass
 
 
-  class TestLogger(logging.getLoggerClass()):
+  class TestLogger(logging.getLoggerClass()):  # type: ignore[misc] # MyPy does't understand this dynamic base class
     """A logger that converts our structured records into flat ones.
 
     This is so we can use a regular logger in tests instead of our reporting machinery.
     """
 
-    def makeRecord(self, name, lvl, fn, lno, msg, args, exc_info, *pos_args, **kwargs):
-      # Python 2 and Python 3 have different arguments for makeRecord().
-      # For cross-compatibility, we are unpacking arguments.
-      # See https://stackoverflow.com/questions/44329421/logging-makerecord-takes-8-positional-arguments-but-11-were-given.
+    def makeRecord(
+      self, name, lvl, fn, lno, msg, args, exc_info, func=None, extra=None, sinfo=None
+    ):
       msg = ''.join([msg] + [a[0] if isinstance(a, (list, tuple)) else a for a in args])
       args = []
-      return super(TestContext.TestLogger, self).makeRecord(
-        name, lvl, fn, lno, msg, args, exc_info, *pos_args, **kwargs)
+      return super().makeRecord(name, lvl, fn, lno, msg, args, exc_info, func, extra, sinfo)
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)

--- a/src/python/pants/testutil/option/BUILD
+++ b/src/python/pants/testutil/option/BUILD
@@ -7,4 +7,5 @@ python_library(
     '//:pants_ini',
     'src/python/pants/option',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/testutil/subsystem/BUILD
+++ b/src/python/pants/testutil/subsystem/BUILD
@@ -6,4 +6,5 @@ python_library(
     'src/python/pants/subsystem',
     'src/python/pants/testutil/option',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/jvm/BUILD
+++ b/tests/python/pants_test/backend/jvm/BUILD
@@ -6,7 +6,8 @@ python_tests(
   sources = ['test_jar_dependency_utils.py'],
   dependencies = [
     'src/python/pants/java/jar',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/subsystems/BUILD
+++ b/tests/python/pants_test/backend/jvm/subsystems/BUILD
@@ -11,7 +11,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/targets/BUILD
+++ b/tests/python/pants_test/backend/jvm/targets/BUILD
@@ -17,7 +17,8 @@ python_tests(
     'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/java/jar',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -690,7 +690,8 @@ python_tests(
   sources = ['test_properties.py'],
   dependencies = [
     'src/python/pants/backend/jvm/tasks:properties',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -66,6 +66,7 @@ python_tests(
   dependencies = [
     'src/python/pants/backend/jvm/tasks/jvm_compile:missing_dependency_finder',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/native/targets/BUILD
+++ b/tests/python/pants_test/backend/native/targets/BUILD
@@ -5,4 +5,5 @@ python_tests(
   dependencies=[
     'src/python/pants/backend/native/targets',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/native/util/BUILD
+++ b/tests/python/pants_test/backend/native/util/BUILD
@@ -1,8 +1,10 @@
-# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
   dependencies=[
     'src/python/pants/backend/native/config',
     'src/python/pants/util:osutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/native/util/platform_utils.py
+++ b/tests/python/pants_test/backend/native/util/platform_utils.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.native.config.environment import Platform
+from pants.engine.platform import Platform
 from pants.util.osutil import all_normalized_os_names
 
 

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -73,7 +73,8 @@ python_tests(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_file',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -101,7 +102,8 @@ python_tests(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:hash_utils',
     'src/python/pants/util:contextutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -176,7 +178,8 @@ python_tests(
   dependencies = [
     'src/python/pants/base:worker_pool',
     'src/python/pants/util:contextutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -184,7 +187,8 @@ python_tests(
   sources = ['test_validation.py'],
   dependencies = [
     'src/python/pants/base:validation',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -22,7 +22,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -42,7 +43,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/engine/legacy:graph',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -71,7 +71,8 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:file_test_util',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -91,7 +92,8 @@ python_tests(
   dependencies = [
     'src/python/pants/cache',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -48,6 +48,7 @@ python_tests(
     'src/python/pants/engine:addressable',
     'src/python/pants/util:objects',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -83,7 +84,8 @@ python_tests(
   sources=['test_selectors.py'],
   dependencies=[
     'src/python/pants/engine:selectors',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -94,7 +96,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/engine:objects',
     'src/python/pants/engine:struct',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -110,7 +113,7 @@ python_tests(
     'tests/python/pants_test/engine/examples:scheduler_inputs',
     'src/python/pants/testutil/engine:util',
     'src/python/pants/reporting',
-  ]
+  ],
 )
 
 python_tests(
@@ -128,7 +131,7 @@ python_tests(
     'src/python/pants/util:objects',
     'tests/python/pants_test/engine/examples:graph_test',
     'tests/python/pants_test/engine/examples:parsers',
-  ]
+  ],
 )
 
 python_tests(
@@ -145,7 +148,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/engine/examples:mapper_test',
     'tests/python/pants_test/engine/examples:parsers',
-  ]
+  ],
 )
 
 python_tests(
@@ -154,7 +157,8 @@ python_tests(
   dependencies=[
     'tests/python/pants_test/engine/examples:parsers',
     'src/python/pants/engine:objects',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -187,7 +187,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/engine/legacy:parser',
     'src/python/pants/engine:parser',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -195,5 +196,6 @@ python_tests(
   sources = ['test_structs.py'],
   dependencies = [
     'src/python/pants/engine/legacy:structs',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/fs/BUILD
+++ b/tests/python/pants_test/fs/BUILD
@@ -6,5 +6,6 @@ python_tests(
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/help/BUILD
+++ b/tests/python/pants_test/help/BUILD
@@ -8,7 +8,8 @@ python_tests(
   dependencies=[
     'src/python/pants/build_graph',
     'src/python/pants/help',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -17,7 +18,8 @@ python_tests(
   coverage=['pants.help.help_formatter'],
   dependencies=[
     'src/python/pants/help',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -27,7 +29,8 @@ python_tests(
   dependencies=[
     'src/python/pants/help',
     'src/python/pants/option',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -39,14 +42,13 @@ python_tests(
     'src/python/pants/option',
     'src/python/pants/subsystem',
     'src/python/pants/task',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
   name='help_integration',
-  sources=[
-    'test_help_integration.py',
-  ],
+  sources=['test_help_integration.py'],
   dependencies=[
     'src/python/pants/testutil:int-test',
   ],

--- a/tests/python/pants_test/invalidation/BUILD
+++ b/tests/python/pants_test/invalidation/BUILD
@@ -9,7 +9,8 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/java/BUILD
+++ b/tests/python/pants_test/java/BUILD
@@ -18,7 +18,8 @@ python_tests(
   coverage = ['pants.java.nailgun_client'],
   dependencies = [
     'src/python/pants/java:nailgun_client',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -38,7 +39,8 @@ python_tests(
   coverage = ['pants.java.nailgun_io'],
   dependencies = [
     'src/python/pants/java:nailgun_io',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -47,7 +49,8 @@ python_tests(
   coverage = ['pants.java.nailgun_protocol'],
   dependencies = [
     'src/python/pants/java:nailgun_protocol',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -56,7 +59,8 @@ python_tests(
   dependencies = [
     'src/python/pants/java:util',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/java/jar/BUILD
+++ b/tests/python/pants_test/java/jar/BUILD
@@ -6,5 +6,6 @@ python_tests(
   sources = ['test_manifest.py'],
   dependencies = [
     'src/python/pants/java/jar',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/jvm/BUILD
+++ b/tests/python/pants_test/jvm/BUILD
@@ -16,7 +16,8 @@ python_tests(
   sources=['test_safeargs.py'],
   dependencies=[
     'src/python/pants/backend/jvm:argfile'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(

--- a/tests/python/pants_test/net/http/BUILD
+++ b/tests/python/pants_test/net/http/BUILD
@@ -8,5 +8,6 @@ python_tests(
     'src/python/pants/net',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/repo_scripts/BUILD
+++ b/tests/python/pants_test/repo_scripts/BUILD
@@ -9,5 +9,6 @@ python_tests(
     'src/python/pants/testutil:git_util',
     'build-support/bin:bash_scripts',
     'build-support/bin:python_scripts',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/scm/BUILD
+++ b/tests/python/pants_test/scm/BUILD
@@ -2,12 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'test_git',
   dependencies = [
     'src/python/pants/scm',
     'src/python/pants/scm:git',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:git_util',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/subsystem/BUILD
+++ b/tests/python/pants_test/subsystem/BUILD
@@ -7,6 +7,7 @@ python_tests(
     'src/python/pants/option',
     'src/python/pants/subsystem',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(

--- a/tests/python/pants_test/task/BUILD
+++ b/tests/python/pants_test/task/BUILD
@@ -51,7 +51,8 @@ python_tests(
   coverage=['pants.task.scm_publish_mixin'],
   dependencies=[
     'src/python/pants/task',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -43,7 +43,8 @@ python_tests(
   sources = ['test_execution_graph.py'],
   dependencies = [
     'src/python/pants/backend/jvm/tasks/jvm_compile:execution_graph',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/tasks/test_execution_graph.py
+++ b/tests/python/pants_test/tasks/test_execution_graph.py
@@ -4,6 +4,7 @@
 import re
 import unittest
 from collections import defaultdict
+from typing import Dict, List
 
 from pants.backend.jvm.tasks.jvm_compile.execution_graph import (
   ExecutionFailure,
@@ -33,12 +34,12 @@ class PrintLogger:
 
 class CapturingLogger:
 
-  log_entries = defaultdict(list)
+  log_entries: Dict[str, List[str]] = defaultdict(list)
 
-  def error(self, msg):
+  def error(self, msg: str) -> None:
     self.log_entries['error'].append(msg)
 
-  def debug(self, msg):
+  def debug(self, msg: str) -> None:
     self.log_entries['debug'].append(msg)
 
 

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -68,6 +68,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:filtering',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -77,6 +78,7 @@ python_tests(
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -95,6 +97,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:netrc',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -122,6 +125,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:process_handler',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -130,6 +134,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:retry',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -139,6 +144,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:rwbuf',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -148,6 +154,7 @@ python_tests(
   dependencies = [
     'src/python/pants/util:socket',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -166,6 +173,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:tarutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -174,6 +182,7 @@ python_library(
   dependencies = [
     'src/python/pants/util:contextutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -183,4 +192,5 @@ python_tests(
     'src/python/pants/util:xml_parser',
     'tests/python/pants_test/util:xml_test_base',
   ],
+  tags = {"partially_type_checked"},
 )


### PR DESCRIPTION
Brings the number of checked source files from 313 to 609. See https://docs.google.com/spreadsheets/d/1MKg82Fs3uIMOZDoWeNUBD-VirVkOzHU8Tte7oY6ypP0/edit for what remains.

The remaining major blockers for running MyPy against the entire repo are:

* `Goal.Options` not a valid type because it's a function
* `memo.py` is not typed and causes issues for `backend/native/subsystems`, _which consequently blocks any V2 code from using MyPy_
* `meta.py` not having precise enough of types