### PR TITLE
Remove deprecated option mypy_version

### DIFF
--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -57,8 +57,6 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
   @classmethod
   def register_options(cls, register):
-    register('--mypy-version', default='0.740', help='The version of mypy to use.',
-             removal_version='1.24.0.dev1', removal_hint='Use --version instead.')
     register('--version', default='0.740', help='The version of mypy to use.')
     register('--include-requirements', type=bool, default=False,
              help='Whether to include the transitive requirements of targets being checked. This is'
@@ -156,7 +154,7 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
 
   def _get_mypy_pex(self, py3_interpreter: PythonInterpreter, *extra_pexes: PEX) -> PEX:
     options = self.get_options()
-    mypy_version = options.mypy_version if options.is_flagged('mypy_version') else options.version
+    mypy_version = options.version
     extras_hash = hash_utils.hash_all(hash_utils.hash_dir(Path(extra_pex.path()))
                                       for extra_pex in extra_pexes)
 


### PR DESCRIPTION
### Problem

The version bumps for the 1.24.devX release cycle triggered the deprecation warnings of option `mypy_version` of the mypy plugin. It seems that this option has reached its end of life.
Relevant slack thread: https://pantsbuild.slack.com/archives/C15HUUSL9/p1575369599013500

### Solution

Remove the options and its usages in the pants codebase.

### Result

Plugin consumers will have to switch to using the `--version` option of the plugin.
The release cycles are unblocked.