### PR TITLE
Point zinc scala compiler to static location when working with nailMain.

### DIFF
--- a/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
@@ -40,11 +40,11 @@ object InputUtils {
   ): Inputs = {
     import settings._
 
-    val scalaJars = InputUtils.selectScalaJars(settings.scala)
+    val scalaJars = InputUtils.selectScalaJars(log)
 
     val instance = ScalaUtils.scalaInstance(scalaJars.compiler, scalaJars.extra, scalaJars.library)
-    val compiledBridgeJar = settings.compiledBridgeJar getOrElse Defaults.compiledBridgeJar.get
-    System.out.println(s"DEBUG selected compiledBridgeJar $compiledBridgeJar")
+    val compiledBridgeJar = Defaults.compiledBridgeJar.get
+    log.debug(s"Selected CompiledBridgeJar $compiledBridgeJar")
     val compilers = ZincUtil.compilers(instance, ClasspathOptionsUtil.auto, settings.javaHome, newScalaCompiler(instance, compiledBridgeJar))
 
     // TODO: Remove duplication once on Scala 2.12.x.
@@ -153,14 +153,10 @@ object InputUtils {
    * Prefer the explicit scala-compiler, scala-library, and scala-extra settings,
    * then the scala-path setting, then the scala-home setting. Default to bundled scala.
    */
-  def selectScalaJars(scala: ScalaLocation): ScalaJars = {
-    val jars = splitScala(scala.path) getOrElse Defaults.scalaJars
-    System.out.println(s"DEBUG Selected scala jars: $jars")
-    ScalaJars(
-      scala.compiler getOrElse jars.compiler,
-      scala.library getOrElse jars.library,
-      scala.extra ++ jars.extra
-    )
+  def selectScalaJars(log: Logger): ScalaJars = {
+    val jars = Defaults.scalaJars
+    log.debug(s"Selected scala jars: $jars")
+    jars
   }
 
   /**

--- a/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
@@ -40,7 +40,8 @@ object InputUtils {
   ): Inputs = {
     import settings._
 
-    val scalaJars = InputUtils.selectScalaJars(log)
+    val scalaJars = Defaults.scalaJars
+    log.debug(s"Selected scala jars: $scalaJars")
 
     val instance = ScalaUtils.scalaInstance(scalaJars.compiler, scalaJars.extra, scalaJars.library)
     val compiledBridgeJar = Defaults.compiledBridgeJar.get
@@ -148,18 +149,6 @@ object InputUtils {
   }
 
   /**
-   * Select the scala jars.
-   *
-   * Prefer the explicit scala-compiler, scala-library, and scala-extra settings,
-   * then the scala-path setting, then the scala-home setting. Default to bundled scala.
-   */
-  def selectScalaJars(log: Logger): ScalaJars = {
-    val jars = Defaults.scalaJars
-    log.debug(s"Selected scala jars: $jars")
-    jars
-  }
-
-  /**
    * Distinguish the compiler and library jars.
    */
   def splitScala(jars: Seq[File], excluded: Set[String] = Set.empty): Option[ScalaJars] = {
@@ -180,9 +169,7 @@ object InputUtils {
   val ScalaReflect             = JarFile("scala-reflect")
   val ScalaCompilerBridge      = JarFile("scala-compiler-bridge")
 
-  // TODO: The default jar locations here are definitely not helpful, but the existence
-  // of "some" value for each of these is assumed in a few places. Should remove and make
-  // them optional to more cleanly support Java-only compiles.
+  // Scala jars default to jars matching the JarFile patterns on the jvm classpath.
   object Defaults {
 
     val classpath = IO.parseClasspath(System.getProperty("java.class.path"))

--- a/src/scala/org/pantsbuild/zinc/compiler/Main.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Main.scala
@@ -180,7 +180,13 @@ object Main {
 
     Settings.SettingsParser.parse(preprocessArgs(context.getArgs), Settings()) match {
       case Some(settings) =>
-        mainImpl(settings.withAbsolutePaths(new File(context.getWorkingDirectory)), startTime, n => context.exit(n))
+        // We don't want to reload scala compiler everytime we call nailmain so just the version
+        // in the server directory. aka here.
+        var fixedScalaLocation = settings.scala.withAbsolutePaths(Paths.get(".").toAbsolutePath.toFile)
+        var fixedBridgeLocation = Util.normaliseOpt(Some(Paths.get(".").toAbsolutePath.toFile))(settings.compiledBridgeJar)
+        var settingsWithAbsPath = settings.withAbsolutePaths(new File(context.getWorkingDirectory))
+        settingsWithAbsPath = settingsWithAbsPath.copy(compiledBridgeJar = fixedBridgeLocation, scala = fixedScalaLocation)
+        mainImpl(settingsWithAbsPath, startTime, n => context.exit(n))
       case None => {
         println("See zinc-compiler --help for information about options")
         context.exit(1)
@@ -206,6 +212,7 @@ object Main {
 
     if (isDebug) {
       log.debug(s"Inputs: $inputs")
+      log.debug(s"Compiled bridge location: ${settings.compiledBridgeJar}")
     }
 
     try {

--- a/src/scala/org/pantsbuild/zinc/compiler/Main.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Main.scala
@@ -180,12 +180,7 @@ object Main {
 
     Settings.SettingsParser.parse(preprocessArgs(context.getArgs), Settings()) match {
       case Some(settings) =>
-        // We don't want to reload scala compiler everytime we call nailmain so just the version
-        // in the server directory. aka here.
-        var fixedScalaLocation = settings.scala.withAbsolutePaths(Paths.get(".").toAbsolutePath.toFile)
-        var fixedBridgeLocation = Util.normaliseOpt(Some(Paths.get(".").toAbsolutePath.toFile))(settings.compiledBridgeJar)
         var settingsWithAbsPath = settings.withAbsolutePaths(new File(context.getWorkingDirectory))
-        settingsWithAbsPath = settingsWithAbsPath.copy(compiledBridgeJar = fixedBridgeLocation, scala = fixedScalaLocation)
         mainImpl(settingsWithAbsPath, startTime, n => context.exit(n))
       case None => {
         println("See zinc-compiler --help for information about options")

--- a/src/scala/org/pantsbuild/zinc/compiler/Main.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Main.scala
@@ -123,10 +123,10 @@ object Main {
     }
   }
 
-  def preprocessArgs(rawArgs: Array[String]): Array[String] = {
+  def preprocessArgs(rawArgs: Array[String], nailMainCWD: Option[File]): Array[String] = {
     val (argFiles, partialArgs) = rawArgs.partition(_.startsWith("@"))
     val args = partialArgs ++ argFiles.flatMap { f =>
-      Files.readLines(new File(f.drop(1)), Charsets.UTF_8).asScala
+      Files.readLines(Util.normalizeIfExists(nailMainCWD)(new File(f.drop(1))), Charsets.UTF_8).asScala
     }
     val fixedArgs = args.flatMap { arg =>
       arg match {
@@ -164,7 +164,7 @@ object Main {
   def main(args: Array[String]): Unit = {
     val startTime = System.currentTimeMillis
 
-    val settings = Settings.SettingsParser.parse(preprocessArgs(args), Settings()) match {
+    val settings = Settings.SettingsParser.parse(preprocessArgs(args, None), Settings()) match {
       case Some(settings) => settings
       case None => {
         println("See zinc-compiler --help for information about options")
@@ -178,7 +178,7 @@ object Main {
   def nailMain(context: NGContext): Unit = {
     val startTime = System.currentTimeMillis
 
-    Settings.SettingsParser.parse(preprocessArgs(context.getArgs), Settings()) match {
+    Settings.SettingsParser.parse(preprocessArgs(context.getArgs, Some(new File(context.getWorkingDirectory))), Settings()) match {
       case Some(settings) =>
         var settingsWithAbsPath = settings.withAbsolutePaths(new File(context.getWorkingDirectory))
         mainImpl(settingsWithAbsPath, startTime, n => context.exit(n))
@@ -207,7 +207,6 @@ object Main {
 
     if (isDebug) {
       log.debug(s"Inputs: $inputs")
-      log.debug(s"Compiled bridge location: ${settings.compiledBridgeJar}")
     }
 
     try {

--- a/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
@@ -31,7 +31,6 @@ case class Settings(
   _classesDirectory: Option[File]   = None,
   _postCompileMergeDir: Option[File] = None,
   outputJar: Option[File]           = None,
-  scala: ScalaLocation              = ScalaLocation(),
   scalacOptions: Seq[String]        = Seq.empty,
   javaHome: Option[File]            = None,
   javaOnly: Boolean                 = false,
@@ -40,7 +39,6 @@ case class Settings(
   _incOptions: IncOptions           = IncOptions(),
   analysis: AnalysisOptions         = AnalysisOptions(),
   creationTime: Long                = 0,
-  compiledBridgeJar: Option[File]   = None,
   useBarebonesLogger: Boolean       = false
 ) {
   import Settings._

--- a/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
@@ -236,12 +236,6 @@ object Settings {
     help("help").text("Prints this usage message")
     version("version").text("Print version")
 
-    opt[File]("compiled-bridge-jar")
-      .abbr("compiled-bridge-jar")
-      .valueName("<file>")
-      .action((x, c) => c.copy(compiledBridgeJar = Some(x)))
-      .text("Path to pre-compiled compiler interface.")
-
     opt[Long]("jar-creation-time")
       .abbr("jar-creation-time")
       .action((x, c) => c.copy(creationTime = x))
@@ -305,36 +299,6 @@ object Settings {
       .abbr("jar")
       .action((x, c) => c.copy(outputJar =  Some(x)))
       .text("Jar destination for compiled classes")
-
-    opt[File]("scala-home")
-      .abbr("scala-home")
-      .valueName("<directory>")
-      .action((x, c) => c.copy(scala = c.scala.copy(home = Some(x))))
-      .text("Scala home directory (for locating jars)")
-
-    opt[Seq[File]]("scala-path")
-      .abbr("scala-path")
-      .valueName("<path>")
-      .action((x, c) => c.copy(scala = c.scala.copy(path = x)))
-      .text("Specify all Scala jars directly")
-
-    opt[File]("scala-compiler")
-      .abbr("scala-compiler")
-      .valueName("<file>")
-      .action((x, c) => c.copy(scala = c.scala.copy(compiler = Some(x))))
-      .text("Specify Scala compiler jar directly")
-
-    opt[File]("scala-library")
-      .abbr("scala-library")
-      .valueName("<file>")
-      .action((x, c) => c.copy(scala = c.scala.copy(library = Some(x))))
-      .text("Specify Scala library jar directly")
-
-    opt[Seq[File]]("scala-extra")
-      .abbr("scala-extra")
-      .valueName("<path>")
-      .action((x, c) => c.copy(scala = c.scala.copy(extra = x)))
-      .text("Specify extra Scala jars directly")
 
     opt[File]("java-home")
       .abbr("java-home")

--- a/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
@@ -238,7 +238,6 @@ object Settings {
 
     opt[File]("compiled-bridge-jar")
       .abbr("compiled-bridge-jar")
-      .required()
       .valueName("<file>")
       .action((x, c) => c.copy(compiledBridgeJar = Some(x)))
       .text("Path to pre-compiled compiler interface.")

--- a/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
@@ -74,11 +74,9 @@ case class Settings(
       classpath = normaliseSeq(classpath),
       _classesDirectory = normaliseOpt(_classesDirectory),
       outputJar = normaliseOpt(outputJar),
-      scala = scala.withAbsolutePaths(relativeTo),
       javaHome = normaliseOpt(javaHome),
       _incOptions = _incOptions.withAbsolutePaths(relativeTo),
       analysis = analysis.withAbsolutePaths(relativeTo),
-      compiledBridgeJar = normaliseOpt(compiledBridgeJar)
     )
   }
 }

--- a/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
@@ -13,6 +13,7 @@ import java.util.{List => JList, logging => jlogging}
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 import scala.util.matching.Regex
+import sbt.io.IO
 import sbt.io.syntax._
 import sbt.util.{Level, Logger}
 import xsbti.compile.{ClassFileManagerType, CompileOrder, TransactionalManagerType}

--- a/src/scala/org/pantsbuild/zinc/util/Util.scala
+++ b/src/scala/org/pantsbuild/zinc/util/Util.scala
@@ -85,6 +85,17 @@ object Util {
   }
 
   /**
+   * Normalize the files to CWD if the normalized path exists
+   */
+  def normalizeIfExists(cwd: Option[File])(file: File): File = {
+    if (cwd.isDefined) {
+      val normed = normalise(cwd)(file)
+      if (!normed.exists()) return file
+    }
+    return file
+  }
+
+  /**
    * Fully relativize a path, relative to any other base.
    */
   def relativize(base: File, path: File): String = {

--- a/src/scala/org/pantsbuild/zinc/util/Util.scala
+++ b/src/scala/org/pantsbuild/zinc/util/Util.scala
@@ -90,9 +90,9 @@ object Util {
   def normalizeIfExists(cwd: Option[File])(file: File): File = {
     if (cwd.isDefined) {
       val normed = normalise(cwd)(file)
-      if (!normed.exists()) return file
+      if (normed.exists()) normed else file
     }
-    return file
+    else file
   }
 
   /**


### PR DESCRIPTION
This PR is a dependee of #8750. View that PR for a full description of the problem this change is solving.

Our current zinc wrapper does not implement zinc's scala compiler cache, and instead creates a scala compiler with a ClassLoaderCache which may contain the previously loaded scala compiler class files. This change sets the scala compiler class paths to their locations in the nailgun server directory, so that successive scala compilers hit the class loader cache when being instantiated with different working directories with nailMain.