### PR TITLE
Simplify `.travis.yml` setup now that more shards can use remote execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -353,128 +353,6 @@ matrix:
     - sudo sysctl fs.inotify.max_user_watches=524288
     - ./build-support/bin/install_aws_cli_for_ci.sh
     - pyenv global 2.7.15 3.6.7 3.7.1
-    - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
-      | tar -zxvf - travis-wait-enhanced
-    - mv travis-wait-enhanced /home/travis/bin/
-    before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    cache:
-      directories:
-      - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/tools
-      - ${HOME}/.cache/pants/zinc
-      - ${HOME}/.ivy2/pants
-      - ${HOME}/.npm
-      timeout: 500
-    dist: xenial
-    env:
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
-    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
-    - CACHE_NAME=unit_tests.py37
-    language: python
-    name: Unit tests (Python 3.7)
-    os: linux
-    python:
-    - '2.7'
-    - '3.6'
-    - '3.7'
-    script:
-    - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --unit-tests --plugin-tests --remote-execution-enabled --python-version 3.7
-    stage: Test Pants (Cron)
-    sudo: required
-  - addons:
-      apt:
-        packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-        - jq
-        - unzip
-        - shellcheck
-    after_failure:
-    - ./build-support/bin/ci-failure.sh
-    before_cache:
-    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
-    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
-    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
-    - rm -rf ${HOME}/.ivy2/pants/com.example
-    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
-    - ./build-support/bin/prune_travis_cache.sh
-    before_install:
-    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - sudo sysctl fs.inotify.max_user_watches=524288
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.15 3.6.7 3.7.1
-    - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
-      | tar -zxvf - travis-wait-enhanced
-    - mv travis-wait-enhanced /home/travis/bin/
-    before_script:
-    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
-      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
-    cache:
-      directories:
-      - ${AWS_CLI_ROOT}
-      - ${PYENV_ROOT_OSX}
-      - ${HOME}/.cache/pants/tools
-      - ${HOME}/.cache/pants/zinc
-      - ${HOME}/.ivy2/pants
-      - ${HOME}/.npm
-      timeout: 500
-    dist: xenial
-    env:
-    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
-    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
-    - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
-    - CACHE_NAME=integration.v2.py37
-    language: python
-    name: Integration tests - V2 (Python 3.7)
-    os: linux
-    python:
-    - '2.7'
-    - '3.6'
-    - '3.7'
-    script:
-    - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
-      --integration-tests-v2 --remote-execution-enabled --python-version 3.7
-    stage: Test Pants (Cron)
-    sudo: required
-  - addons:
-      apt:
-        packages:
-        - lib32stdc++6
-        - lib32z1
-        - lib32z1-dev
-        - gcc-multilib
-        - python-dev
-        - openssl
-        - libssl-dev
-        - jq
-        - unzip
-        - shellcheck
-    after_failure:
-    - ./build-support/bin/ci-failure.sh
-    before_cache:
-    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
-    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
-    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
-    - rm -rf ${HOME}/.ivy2/pants/com.example
-    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
-    - ./build-support/bin/prune_travis_cache.sh
-    before_install:
-    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
-    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - sudo sysctl fs.inotify.max_user_watches=524288
-    - ./build-support/bin/install_aws_cli_for_ci.sh
-    - pyenv global 2.7.15 3.6.7 3.7.1
     before_script:
     - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
       ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
@@ -728,6 +606,67 @@ matrix:
       timeout: 500
     dist: xenial
     env:
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
+    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
+    - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
+    - CACHE_NAME=unit_tests.py37
+    language: python
+    name: Unit tests (Python 3.7)
+    os: linux
+    python:
+    - '2.7'
+    - '3.6'
+    - '3.7'
+    script:
+    - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
+      --unit-tests --plugin-tests --remote-execution-enabled --python-version 3.7
+    stage: Test Pants (Cron)
+    sudo: required
+  - addons:
+      apt:
+        packages:
+        - lib32stdc++6
+        - lib32z1
+        - lib32z1-dev
+        - gcc-multilib
+        - python-dev
+        - openssl
+        - libssl-dev
+        - jq
+        - unzip
+        - shellcheck
+    after_failure:
+    - ./build-support/bin/ci-failure.sh
+    before_cache:
+    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
+    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
+    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
+    - rm -rf ${HOME}/.ivy2/pants/com.example
+    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
+    before_install:
+    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
+    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - sudo sysctl fs.inotify.max_user_watches=524288
+    - ./build-support/bin/install_aws_cli_for_ci.sh
+    - pyenv global 2.7.15 3.6.7 3.7.1
+    - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
+      | tar -zxvf - travis-wait-enhanced
+    - mv travis-wait-enhanced /home/travis/bin/
+    before_script:
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
+      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    cache:
+      directories:
+      - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT_OSX}
+      - ${HOME}/.cache/pants/tools
+      - ${HOME}/.cache/pants/zinc
+      - ${HOME}/.ivy2/pants
+      - ${HOME}/.npm
+      timeout: 500
+    dist: xenial
+    env:
     - BOOTSTRAPPED_PEX_KEY_SUFFIX=py36.linux
     - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
     - CACHE_NAME=integration.v2.py36
@@ -742,6 +681,67 @@ matrix:
     - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
       --integration-tests-v2 --remote-execution-enabled --python-version 3.6
     stage: Test Pants
+    sudo: required
+  - addons:
+      apt:
+        packages:
+        - lib32stdc++6
+        - lib32z1
+        - lib32z1-dev
+        - gcc-multilib
+        - python-dev
+        - openssl
+        - libssl-dev
+        - jq
+        - unzip
+        - shellcheck
+    after_failure:
+    - ./build-support/bin/ci-failure.sh
+    before_cache:
+    - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
+    - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
+    - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
+    - rm -rf ${HOME}/.ivy2/pants/com.example
+    - du -m -d2 ${HOME}/.cache/pants | sort -r -n
+    - ./build-support/bin/prune_travis_cache.sh
+    before_install:
+    - PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin":$PATH
+    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - sudo sysctl fs.inotify.max_user_watches=524288
+    - ./build-support/bin/install_aws_cli_for_ci.sh
+    - pyenv global 2.7.15 3.6.7 3.7.1
+    - wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v0.2.1/travis-wait-enhanced_0.2.1_linux_x86_64.tar.gz"
+      | tar -zxvf - travis-wait-enhanced
+    - mv travis-wait-enhanced /home/travis/bin/
+    before_script:
+    - ./build-support/bin/get_ci_bootstrapped_pants_pex.sh ${BOOTSTRAPPED_PEX_BUCKET}
+      ${BOOTSTRAPPED_PEX_KEY_PREFIX}.${BOOTSTRAPPED_PEX_KEY_SUFFIX}
+    cache:
+      directories:
+      - ${AWS_CLI_ROOT}
+      - ${PYENV_ROOT_OSX}
+      - ${HOME}/.cache/pants/tools
+      - ${HOME}/.cache/pants/zinc
+      - ${HOME}/.ivy2/pants
+      - ${HOME}/.npm
+      timeout: 500
+    dist: xenial
+    env:
+    - BOOTSTRAPPED_PEX_KEY_SUFFIX=py37.linux
+    - PANTS_REMOTE_CA_CERTS_PATH=/usr/lib/google-cloud-sdk/lib/third_party/grpc/_cython/_credentials/roots.pem
+    - PANTS_NATIVE_BUILD_STEP_CPP_COMPILE_SETTINGS_DEFAULT_COMPILER_OPTION_SETS="[]"
+    - CACHE_NAME=integration.v2.py37
+    language: python
+    name: Integration tests - V2 (Python 3.7)
+    os: linux
+    python:
+    - '2.7'
+    - '3.6'
+    - '3.7'
+    script:
+    - travis-wait-enhanced --timeout 65m --interval 9m -- ./build-support/bin/ci.py
+      --integration-tests-v2 --remote-execution-enabled --python-version 3.7
+    stage: Test Pants (Cron)
     sudo: required
   - addons:
       apt:

--- a/build-support/bin/generate_travis_yml.py
+++ b/build-support/bin/generate_travis_yml.py
@@ -767,18 +767,11 @@ def main() -> None:
       *[bootstrap_osx(v) for v in PythonVersion],
       {**bootstrap_linux(PythonVersion.py36), "stage": Stage.bootstrap_cron.value},
       {**bootstrap_osx(PythonVersion.py36), "stage": Stage.bootstrap_cron.value},
-      # NB: We move both the unit test and V2 integration test shards up here to ensure that
-      # they are shards #5 and #6. Per the token generator design
-      # https://docs.google.com/document/d/1gL3D1f-AzL_LzRxWLskCpVQ2ZlB_26GTETgXkXsrpDY/edit#heading=h.akhkfdtqfpw,
-      # the RBE token server will only give tokens to job numbers #5 and #6, so we must do this
-      # for the cron jobs to work with remoting.
-      unit_tests(PythonVersion.py37),
-      integration_tests_v2(PythonVersion.py37),
       *[lint(v) for v in PythonVersion],
       clippy(),
       cargo_audit(),
-      unit_tests(PythonVersion.py36),
-      integration_tests_v2(PythonVersion.py36),
+      *[unit_tests(v) for v in PythonVersion],
+      *[integration_tests_v2(v) for v in PythonVersion],
       build_wheels_linux(),
       build_wheels_osx(),
       *integration_tests_v1(PythonVersion.py36),


### PR DESCRIPTION
We previously constrained which shards could get a token for RBE, which resulted in awkwardly moving the cron unit test and integration test shards to a different shard number than they'd otherwise be.

In https://github.com/pantsbuild/rbe-token-server/pull/14, we stopped caring about what shard a request comes from so can simplify this.