### PR TITLE
Change remote address of doc repo to be ssh instead of http

### DIFF
--- a/build-support/bin/publish_docs.sh
+++ b/build-support/bin/publish_docs.sh
@@ -4,7 +4,7 @@
 
 set -eo pipefail
 
-PANTS_GH_PAGES='https://github.com/pantsbuild/pantsbuild.github.io.git'
+PANTS_GH_PAGES='git@github.com:pantsbuild/pantsbuild.github.io.git'
 GIT_URL="${GIT_URL:-${PANTS_GH_PAGES}}"
 
 PANTS_SITE_URL='https://www.pantsbuild.org'


### PR DESCRIPTION
### Problem

We require 2-factor authentication for Pants committers. This means that we can't push to remotes like `https://github.com/pantsbuild/pantsbuild.github.io` from the command line, because git doesn't support that kind of two factor authentication.
The workaround is to push to repos via ssh remotes instead `git@github.com:pantsbuild/...`, using our ssh keys.
However, the script for publishing to the pantsbuild docsite is has hardcoded the remote in http, which means that people are not able to run it out of the box. 

### Solution

Change the address in `PANTS_GH_PAGES` to be over ssh instead of http.

### Result

People (hopefully) only need one try now to publish docs with the script.