### PR TITLE
Deprecate default behavior of dependencies, and the --external-only option.

### DIFF
--- a/src/python/pants/backend/project_info/tasks/dependencies.py
+++ b/src/python/pants/backend/project_info/tasks/dependencies.py
@@ -32,7 +32,7 @@ class Dependencies(ConsoleTask):
       help='Specifies that only external dependencies should be included in the graph output (only external jars).',
       removal_version="1.26.0.dev1",
       removal_hint="This feature is being removed. If you depend on this functionality, please let us know in the "
-                   "#general channel on slack. \nYou can join the pants slack here: "
+                   "#general channel on Slack at https://pantsbuild.slack.com/. \nYou can join the pants slack here: "
                    "https://pantsslack.herokuapp.com/ ",
     )
 
@@ -48,14 +48,13 @@ class Dependencies(ConsoleTask):
     deprecated_conditional(
       lambda: not self.is_external_only and not self.is_internal_only,
       removal_version="1.26.0.dev1",
-      entity_description="External dependencies will no longer be included in dependencies output.",
+      entity_description="The default dependencies output including external dependencies",
       hint_message="Pants will soon default to `--internal-only`, and remove the `--external-only` option. "
-                    "and return only target addresses. Currently, Pants defaults to include both internal "
-                    "and external dependencies which means this task will return a mix of both target addresses "
-                    "and requirement strings."
+                    "Currently, Pants defaults to include both internal and external dependencies, which means this "
+                    "task returns a mix of both target addresses and requirement strings."
                     "\n\nTo prepare, you can run this task with the `--internal-only` option. "
-                    "If you depend on the inclusion of external dependencies, please let us know in the #general "
-                    "channel on slack."
+                    "If you need still need support for including external dependencies in the output, please let us "
+                    "know in the #general channel on Slack at https://pantsbuild.slack.com/."
                     "\nYou can join the pants slack here: https://pantsslack.herokuapp.com/",
     )
     ordered_closure = OrderedSet()


### PR DESCRIPTION
## Problem

#8759 created a new `fast-dependencies` rule that has some desirable changes in behavior from the `dependencies` task. 

### Solution

Add deprecation warnings to the `--external-only` option and to the default behavior.

Since this is the removal of a feature, I've provided contact details in case anyone is relying on the current behavior or the `--external-only` option, in which case we can decide whether to reinstate the feature or create a new rule to provide that functionality.

### Result
```
./pants dependencies src/python/pants/backend/project_info/rules:rules                                                                              
Scrubbed PYTHONPATH=/Users/tansypants/code/pants/src/python: from the environment.
22:15:31 [WARN] /Users/tansypants/code/pants/src/python/pants/task/console_task.py:64: DeprecationWarning: DEPRECATED: The default dependencies output including external dependencies will be removed in version 1.26.0.dev1.
  Pants will soon default to `--internal-only`, and remove the `--external-only` option. Currently, Pants defaults to include both internal and external dependencies, which means this task returns a mix of both target addresses and requirement strings.

To prepare, you can run this task with the `--internal-only` option. If you need still need support for including external dependencies in the output, please let us know in the #general channel on Slack at https://pantsbuild.slack.com/.
You can join the pants slack here: https://pantsslack.herokuapp.com/
```

```
./pants dependencies --external-only src/python/pants/backend/project_info/rules:rules                                                            
Scrubbed PYTHONPATH=/Users/tansypants/code/pants/src/python: from the environment.
02:22:45 [WARN] /Users/tansypants/code/pants/src/python/pants/bin/pants_loader.py:85: DeprecationWarning: DEPRECATED: option 'external_only' in scope 'dependencies' will be removed in version 1.26.0.dev1.
  This feature is being removed. If you depend on this functionality, please let us know in the #general channel on Slack at https://pantsbuild.slack.com/.
You can join the pants slack here: https://pantsslack.herokuapp.com/
```

`./pants dependencies --internal-only src/python/pants/backend/project_info/rules:rules` does not change. 

### Follow Ups
Once this deprecation cycle is complete we can remove the `--external-only` option, delete about half the task code, and deprecate the `--internal-only` option, as it will now be the default behavior.