### PR TITLE
Get rid of write_stdout, write_stderr

### DIFF
--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -20,12 +20,6 @@ class Console:
   def stderr(self):
     return self._stderr
 
-  def write_stdout(self, payload):
-    self.stdout.write(payload)
-
-  def write_stderr(self, payload):
-    self.stderr.write(payload)
-
   def print_stdout(self, payload, end='\n'):
     print(payload, file=self.stdout, end=end)
 

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -37,7 +37,7 @@ async def run(
       DirectoryToMaterialize(binary.digest, path_prefix=path_relative_to_build_root)
     )
 
-    console.write_stdout(f"Running target: {target}\n")
+    console.print_stdout(f"Running target: {target}")
     full_path = str(Path(tmpdir, binary.binary_name))
     run_request = InteractiveProcessRequest(
       argv=[full_path],
@@ -48,12 +48,12 @@ async def run(
       result = runner.run_local_interactive_process(run_request)
       exit_code = result.process_exit_code
       if result.process_exit_code == 0:
-        console.write_stdout(f"{target} ran successfully.\n")
+        console.print_stdout(f"{target} ran successfully.")
       else:
-        console.write_stderr(f"{target} failed with code {result.process_exit_code}!\n")
+        console.print_stderr(f"{target} failed with code {result.process_exit_code}!")
 
     except Exception as e:
-      console.write_stderr(f"Exception when attempting to run {target} : {e}\n")
+      console.print_stderr(f"Exception when attempting to run {target} : {e}")
       exit_code = -1
 
   return Run(exit_code)

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -59,7 +59,7 @@ async def fast_test(console: Console, addresses: BuildFileAddresses) -> Test:
     if test_result.stdout:
       result = (console.red(test_result.stdout) if test_result.status == Status.FAILURE
         else test_result.stdout)
-      console.print_stdout("{address.reference()} stdout:\n{result}")
+      console.print_stdout(f"{address.reference()} stdout:\n{result}")
 
     if test_result.stderr:
       # NB: we write to stdout, rather than to stderr, to avoid potential issues interleaving the

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -57,25 +57,17 @@ async def fast_test(console: Console, addresses: BuildFileAddresses) -> Test:
     if test_result.status == Status.FAILURE:
       did_any_fail = True
     if test_result.stdout:
-      console.write_stdout(
-        "{} stdout:\n{}\n".format(
-          address.reference(),
-          (console.red(test_result.stdout) if test_result.status == Status.FAILURE
-           else test_result.stdout)
-        )
-      )
+      result = (console.red(test_result.stdout) if test_result.status == Status.FAILURE
+        else test_result.stdout)
+      console.print_stdout("{address.reference()} stdout:\n{result}")
+
     if test_result.stderr:
       # NB: we write to stdout, rather than to stderr, to avoid potential issues interleaving the
       # two streams.
-      console.write_stdout(
-        "{} stderr:\n{}\n".format(
-          address.reference(),
-          (console.red(test_result.stderr) if test_result.status == Status.FAILURE
-           else test_result.stderr)
-        )
-      )
-
-  console.write_stdout("\n")
+      result = (console.red(test_result.stderr) if test_result.status == Status.FAILURE
+        else test_result.stderr)
+      console.print_stdout(f"{address.reference()} stderr:\n{result}")
+  console.print_stdout("\n", end="")
 
   for address, test_result in filtered_results:
     console.print_stdout('{0:80}.....{1:>10}'.format(

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -178,12 +178,6 @@ class MockConsole:
     self.stderr = StringIO()
     self._use_colors = use_colors
 
-  def write_stdout(self, payload):
-    self.stdout.write(payload)
-
-  def write_stderr(self, payload):
-    self.stderr.write(payload)
-
   def print_stdout(self, payload):
     print(payload, file=self.stdout)
 

--- a/src/python/pants/testutil/engine/util.py
+++ b/src/python/pants/testutil/engine/util.py
@@ -178,11 +178,11 @@ class MockConsole:
     self.stderr = StringIO()
     self._use_colors = use_colors
 
-  def print_stdout(self, payload):
-    print(payload, file=self.stdout)
+  def print_stdout(self, payload, end='\n'):
+    print(payload, file=self.stdout, end=end)
 
-  def print_stderr(self, payload):
-    print(payload, file=self.stderr)
+  def print_stderr(self, payload, end='\n'):
+    print(payload, file=self.stderr, end=end)
 
   def _safe_color(self, text, color):
     return color(text) if self._use_colors else text


### PR DESCRIPTION
### Problem

The `Console` class in `console.py` defines pairs of methods `write_stdout`/`print_stdout` and `write_stderr`/`print_stderr` that basically do the same thing. The only difference is that the print_ methods have a kwarg argument for a trailing string, which is by default '\n'. This adds a bit of extra code for no good reason.

### Solution

Delete the write_ variants of these methods and fix the very small number of places in the codebase using them to use print_ instead.