### PR TITLE
create WorkunitOutput subsystem which redirects workunit output

### DIFF
--- a/src/python/pants/util/eval.py
+++ b/src/python/pants/util/eval.py
@@ -40,6 +40,8 @@ def parse_expression(
     return '\n'.join(lines)
 
   try:
+    # TODO: some test cases fail if this is converted to `ast.literal_eval()`, but that's probably
+    # safer?
     parsed_value = eval(val)
   except Exception as e:
     raise raise_type(dedent("""\

--- a/src/python/pants/util/rwbuf.py
+++ b/src/python/pants/util/rwbuf.py
@@ -1,8 +1,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import logging
+import subprocess
 import threading
 from io import BytesIO
+
+
+logger = logging.getLogger(__name__)
 
 
 class _RWBuf(object):
@@ -28,16 +33,19 @@ class _RWBuf(object):
       self._io.seek(pos)
       return self._io.read() if size == -1 else self._io.read(size)
 
+  def do_flush(self):
+    self._io.flush()
+
   def write(self, s):
     if not isinstance(s, bytes):
       raise ValueError('Expected bytes, not {}, for argument {}'.format(type(s), s))
     with self._lock:
       self.do_write(s)
-      self._io.flush()
+      self.do_flush()
 
   def flush(self):
     with self._lock:
-      self._io.flush()
+      self.do_flush()
 
   def close(self):
     self._io.close()
@@ -74,6 +82,66 @@ class FileBackedRWBuf(_RWBuf):
     self.fileno = self._io.fileno
 
   def do_write(self, s):
+    self._io.write(s)
+
+
+class OutputTeeingFileBackedRWBuf(_RWBuf):
+  """A read-write buffer that invokes 'tee' to spread output across multiple files, or stdout.
+
+  This buffer can be used in situations that require a real file, as it provides the file descriptor
+  of the underlying 'tee' process's stdin in `self.fileno`.
+  """
+
+  def __init__(self, backing_file, files_to_tee_to):
+    inherit_stdout = False
+
+    real_file_outputs = []
+    for f in files_to_tee_to:
+      if f == '/dev/stdout':
+        logger.debug(f'inheriting stdout for the output meant for {backing_file}')
+        inherit_stdout = True
+        continue
+      real_file_outputs.append(f)
+
+    logger.debug(f'opening backing file {backing_file}, teeing to {real_file_outputs}, inherit_stdout: {inherit_stdout}')
+    self.backing_tee_process = subprocess.Popen(
+      args=['tee', '-a', backing_file, *real_file_outputs],
+      stdin=subprocess.PIPE,
+      stdout=(None if inherit_stdout else subprocess.DEVNULL),
+      # Don't inherit stderr, and if we do inherit stdout, just send stderr to that as well.
+      stderr=subprocess.STDOUT,
+    )
+    super().__init__(self.backing_tee_process.stdin)
+
+    # Make the tee process the input for any subprocesses.
+    self.fileno = self.backing_tee_process.stdin.fileno
+
+    # Use a handle on the real file for reading any output.
+    self.real_file = open(backing_file, 'a+b')
+
+  def read(self, size=-1):
+    with self._lock:
+      self.real_file.seek(self._readpos)
+      ret = self.real_file.read() if size == -1 else self.real_file.read(size)
+      self._readpos = self.real_file.tell()
+      return ret
+
+  def read_from(self, pos, size=-1):
+    with self._lock:
+      self.real_file.seek(pos)
+      return self.real_file.read() if size == -1 else self.real_file.read(size)
+
+  def close(self):
+    # This should close the 'tee' process's stdin, which should cause it to quickly exit.
+    super().close()
+    rc = self.backing_tee_process.wait()
+    if rc != 0:
+      raise ValueError('backing tee process {self.backing_tee_process} exited with code {rc}!')
+    # Also close the handle to the real file!
+    self.real_file.close()
+
+  def do_write(self, s):
+    # This writes to the 'tee' process.
     self._io.write(s)
 
 


### PR DESCRIPTION
**TODO: test cases!!!**

### Problem

We would like to be able to get some parts of pants's output in different places, for multiple reasons:
- We might want to see the output/logging from pants when running a `./pants run`, but direct the process's output somewhere else (instead of amidst all the pants output).
- We might want to parse compiler error messages from outside of pants (this is a real use case at Twitter), without having to parse the output of pants itself to know where the compiler errors are.
- We might want to see helpful stdout/stderr messages from some tool like coursier, which pants currently just hides all output from, unless it fails.

For some background on how this particular interface came to be, see this comment which tangentially introduced the idea of redirecting output: https://github.com/pantsbuild/pants/issues/7071#issuecomment-456303950, although it was buried amidst a larger discussion of output in v2 rules.

### Solution

(also see: `./pants help workunit-output`)
- Create the `WorkunitOutput` subsystem and attach it to the `RunTracker`.
  - Parse `--redirections` as a dict mapping file names to "redirection specs", which are just nested dicts. This looks something like:
```bash
> ./pants --workunit-output-redirections="\
{'out.txt': [{
    'workunit_scope': '.*',
    'labels': ['TOOL', 'TEST'],
    'output_names': ['stdout', 'stderr'],
  }]}" test tests/python/pants_test/util: -- -vs
```
- The above command line would tee all output sent to workunits with path matching regex `.*` (everything), which declare any of the `TOOL` or `TEST` labels, on the outputs named `stdout` and `stderr` (exact match). In this precise command line, that would mean that all pytest output would be appended to a file named `out.txt`.
- Note that the output file name `/dev/stdout` is treated specially, and results in the `tee` subprocess inheriting the pants stdout. This means that workunit output which would normally be hidden (such as coursier) can be selectively toggled on by the user.
- All of the above is accomplished via introducing `OutputTeeingFileBackedRWBuf`, which uses a `tee` subprocess to spread output across multiple files.

### Result

Pants can redirect some of its output elsewhere with a command-line option without affecting the rest of the pants run!