### PR TITLE
Fix typos

### DIFF
--- a/examples/src/python/example/grpcio/client/imports_client.py
+++ b/examples/src/python/example/grpcio/client/imports_client.py
@@ -20,7 +20,7 @@ def run_example():
         print("[ERROR] Connection to server is unavailable. You should create a server instance first.")
         print("To start a gRPC server, execute: `./pants run examples/src/python/example/grpcio/server`")
       else:
-        print('An error occured! Error code: [{}] Error details: [{}]'.format(error.code(), error.details()))
+        print('An error occurred! Error code: [{}] Error details: [{}]'.format(error.code(), error.details()))
     else:
       print(reply.hello_reply.response)
       print('[SUCCESS]')

--- a/examples/src/python/example/grpcio/client/service_client.py
+++ b/examples/src/python/example/grpcio/client/service_client.py
@@ -17,7 +17,7 @@ def run_example():
         print("[ERROR] Connection to server is unavailable. You should create a server instance first.")
         print("To start a gRPC server, execute: `./pants run examples/src/python/example/grpcio/server`")
       else:
-        print('An error occured! Error code: [{}] Error details: [{}]'.format(error.code(), error.details()))
+        print('An error occurred! Error code: [{}] Error details: [{}]'.format(error.code(), error.details()))
     else:
       print(hello_response)
       print(bye_response)

--- a/pants
+++ b/pants
@@ -12,7 +12,7 @@
 # WRAPPER_REQUIREMENTS  This is a colon separated list of pip install compatible requirements.txt
 #                       files.
 #
-# For example, with a wrapping project layed out like so:
+# For example, with a wrapping project laid out like so:
 # /src/wrapper/
 #   src/main/python/
 #     wrapper/

--- a/src/java/org/pantsbuild/tools/junit/impl/experimental/ConcurrentComputer.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/experimental/ConcurrentComputer.java
@@ -57,7 +57,7 @@ public class ConcurrentComputer extends Computer {
             // TODO(zundel): Change long wait?
             boolean awaitResult = fService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
             if (!awaitResult) {
-              throw new ConcurrentTestRunnerException("Did not terminate all tests sucessfully.");
+              throw new ConcurrentTestRunnerException("Did not terminate all tests successfully.");
             }
             for (Future<?> testResult : testResults.keySet()) {
               if (testResult.isDone()) {

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -353,7 +353,7 @@ class BaseZincCompile(JvmCompile):
       # It will probably be loaded even on the regular classpath: If not found on the bootclasspath,
       # getSystemJavaCompiler() constructs a classloader that loads from the JDK's tools.jar.
       # That classloader will first delegate to its parent classloader, which will search the
-      # regular classpath.  However it's harder to guarantee that our javac will preceed any others
+      # regular classpath.  However it's harder to guarantee that our javac will precede any others
       # on the classpath, so it's safer to prefix it to the bootclasspath.
       jvm_options.extend(['-Xbootclasspath/p:{}'.format(':'.join(self.javac_classpath()))])
 

--- a/src/python/pants/backend/project_info/tasks/filedeps.py
+++ b/src/python/pants/backend/project_info/tasks/filedeps.py
@@ -32,7 +32,7 @@ class FileDeps(ConsoleTask):
     for target in targets:
       concrete_target = target.concrete_derived_from
       concrete_targets.add(concrete_target)
-      # TODO(John Sirois): This hacks around ScalaLibraries' psuedo-deps on JavaLibraries.  We've
+      # TODO(John Sirois): This hacks around ScalaLibraries' pseudo-deps on JavaLibraries.  We've
       # already tried to tuck away this hack by subclassing closure() in ScalaLibrary - but in this
       # case that's not enough when a ScalaLibrary with java_sources is an interior node of the
       # active context graph.  This awkwardness should be eliminated when ScalaLibrary can point

--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -67,7 +67,7 @@ class PythonBinary(PythonTarget):
     :param string entry_point: the default entry point for this binary.  if None, drops into the entry
       point that is defined by source. Something like
       "pants.bin.pants_exe:main", where "pants.bin.pants_exe" is the package
-      name and "main" is the function name (if ommitted, the module is
+      name and "main" is the function name (if omitted, the module is
       executed directly, presuming it has a ``__main.py__``).
     :param sources: Zero or one source files. If more than one file is required, it should be put in
       a python_library which should be added to dependencies.

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -134,7 +134,7 @@ class NailgunStreamStdinReader(_StoppableDaemonThread):
     # NailgunStreamStdinReader will close the file descriptor it's writing to when it's done.
     # Therefore, when _self_closing_pipe tries to clean up, it will try to close an already closed fd.
     # The alternative is passing an os.dup(write_fd) to NSSR, but then we have the problem where
-    # _self_closing_pipe doens't close the write_fd until the pants run is done, and that generates
+    # _self_closing_pipe doesn't close the write_fd until the pants run is done, and that generates
     # issues around piping stdin to interactive processes such as REPLs.
     pipe = Pipe.create(isatty)
     reader = NailgunStreamStdinReader(maybe_shutdown_socket, os.fdopen(pipe.write_fd, 'wb'))

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -117,7 +117,7 @@ class PailgunHandleRequestLock:
     """
     Try to acquire the lock, blocking until the timeout is reached. Will return immediately if the lock is acquired.
 
-    :return True if the lock was aquired, False if the timeout was reached.
+    :return True if the lock was acquired, False if the timeout was reached.
     """
     self.cond.acquire()
     if self.available:

--- a/src/rust/engine/async_semaphore/src/tests.rs
+++ b/src/rust/engine/async_semaphore/src/tests.rs
@@ -85,7 +85,7 @@ fn drop_while_waiting() {
   //
   // If the SECOND future was not removed from the waiters queue we would not get a signal
   // that thread3 acquired the lock because the 2nd task would be blocking the queue trying to
-  // poll a non existant future.
+  // poll a non existent future.
   let mut runtime = tokio::runtime::Runtime::new().unwrap();
   let sema = AsyncSemaphore::new(1);
   let handle1 = sema.clone();

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -201,7 +201,7 @@ pub enum ShrinkBehavior {
 // Note that Store doesn't implement ByteStore because it operates at a higher level of abstraction,
 // considering Directories as a standalone concept, rather than a buffer of bytes.
 // This has the nice property that Directories can be trusted to be valid and canonical.
-// We may want to re-visit this if we end up wanting to handle local/remote/merged interchangably.
+// We may want to re-visit this if we end up wanting to handle local/remote/merged interchangeably.
 impl Store {
   ///
   /// Make a store which only uses its local storage.

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -206,7 +206,7 @@ impl ByteStore {
                   Ok(digest)
                 } else {
                   Err(format!(
-                    "Uploading file with digest {:?}: want commited size {} but got {}",
+                    "Uploading file with digest {:?}: want committed size {} but got {}",
                     digest,
                     len,
                     received.get_committed_size()

--- a/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/Settings.scala
@@ -474,7 +474,7 @@ object Settings {
   }
 
   /**
-   * If a settings.classesDirectory option isnt specified, create a temporary directory for output
+   * If a settings.classesDirectory option isn't specified, create a temporary directory for output
    * classes to be written to.
    */
   def defaultClassesDirectory(): File = {

--- a/testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet/README.txt
+++ b/testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet/README.txt
@@ -1,3 +1,3 @@
 Part of publishing is displaying a changelog to the user to confirm that the new version number
-makes sense according to semver.  This README is being comitted with a commit message that
+makes sense according to semver.  This README is being committed with a commit message that
 contains unicode to ensure changelogs with unicode characters can be displayed without error.

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -111,7 +111,7 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
 
   @skip_unless_python27_and_python3_present
   def test_binary_uses_own_compatibility(self):
-    """Tests that a binary target uses its own compatiblity, rather than including that of its
+    """Tests that a binary target uses its own compatibility, rather than including that of its
     transitive dependencies.
     """
     # This target depends on a 2.7 minimum library, but does not declare its own compatibility.

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -633,7 +633,7 @@ Interrupted by user over pailgun client!
       blocked = True
       while blocked:
         log = '\n'.join(read_pantsd_log(workdir))
-        if "didn't aquire the lock on the first try, polling." in log:
+        if "didn't acquire the lock on the first try, polling." in log:
           blocked = False
         # NB: This sleep is totally deterministic, it's just so that we don't spend too many cycles
         # busy waiting.

--- a/tests/python/pants_test/scm/test_git.py
+++ b/tests/python/pants_test/scm/test_git.py
@@ -339,7 +339,7 @@ class GitTest(unittest.TestCase):
 
     To some extent this is just testing functionality of git not pants, since all pants says
     is that it will pass the diffspec to git diff-tree, but this should serve to at least document
-    the functionality we belive works.
+    the functionality we believe works.
     """
     with environment_as(GIT_DIR=self.gitdir, GIT_WORK_TREE=self.worktree):
       def commit_contents_to_files(content, *files):


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.