### PR TITLE
Fix V2 isort config option when only using a single config file

### DIFF
--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -22,7 +22,7 @@ class Isort(PythonToolBase):
            "`--isort-args=\"--case-sensitive --trailing-comma\"`",
     )
     register(
-      '--config', type=list, member_type=file_option, default=None,
+      '--config', type=list, member_type=file_option,
       help="Path to `isort.cfg` or alternative isort config file(s)"
     )
 


### PR DESCRIPTION
This did not work:

```ini
[isort]
config: .isort.cfg
```

Instead, you have to use:

```ini
[isort]
config: [".isort.cfg"]
```

This is because we were incorrectly setting the default for `--config` to `None` and you cannot append to `None`.