### PR TITLE
[V2 UI] Pipe Python-side `Console` to the engine when --v2-ui is set

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -300,6 +300,7 @@ class LocalPantsRunner(ExceptionSink.AccessGlobalExiterMixin):
 
     return self._graph_session.run_console_rules(
       self._options_bootstrapper,
+      self._options,
       goals,
       self._target_roots,
     )

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -244,6 +244,7 @@ python_library(
   name='console',
   sources=['console.py'],
   dependencies=[
+    ':native',
     '3rdparty/python:ansicolors',
   ],
   tags = {'partially_type_checked'},

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -2,14 +2,52 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import sys
+from typing import Any, Optional
 
 from colors import blue, green, red
 
+from pants.engine.native import Native
+
+
+#TODO this needs to be a file-like object/stream
+class NativeWriter:
+  def __init__(self, session: Any):
+    self._native = Native()
+    self._session = session._session
+
+  def write(self, payload: str):
+    raise NotImplementedError
+
+  def flush(self):
+    #I dunno what if anything needs to happen here
+    pass
+
+
+class NativeStdOut(NativeWriter):
+  def write(self, payload):
+    self._native.write_stdout(self._session, payload)
+
+
+class NativeStdErr(NativeWriter):
+  def write(self, payload):
+    self._native.write_stderr(self._session, payload)
+
 
 class Console:
-  def __init__(self, stdout=None, stderr=None, use_colors=True):
-    self._stdout = stdout or sys.stdout
-    self._stderr = stderr or sys.stderr
+  """Class responsible for writing text to the console while Pants is running. """
+
+  def __init__(self, stdout=None, stderr=None, use_colors: bool = True, session: Optional[Any] = None):
+    """`stdout` and `stderr` may be explicitly provided when Console is constructed. 
+    We use this in tests to provide a mock we can write tests against, rather than writing
+    to the system stdout/stderr. If they are not defined, the effective stdout/stderr are
+    proxied to Rust engine intrinsic code if there is a scheduler session provided, or just
+    written to the standard Python-provided stdout/stderr if it is None. A scheduler session
+    is provided if --v2-ui is set."""
+
+    has_scheduler = session is not None
+
+    self._stdout = stdout or (NativeStdOut(session) if has_scheduler else sys.stdout)
+    self._stderr = stderr or (NativeStdErr(session) if has_scheduler else sys.stderr)
     self._use_colors = use_colors
 
   @property

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -18,8 +18,9 @@ class NativeWriter:
   def write(self, payload: str):
     raise NotImplementedError
 
+  #TODO It's not clear yet what this function should do, it depends on how
+  # EngineDisplay in Rust ends up handling text.
   def flush(self):
-    #I dunno what if anything needs to happen here
     pass
 
 

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -855,6 +855,12 @@ class Native(metaclass=SingletonMetaclass):
     target = target.encode()
     return self.lib.write_log(msg, level, target)
 
+  def write_stdout(self, session, msg: str):
+    return self.lib.write_stdout(session, msg.encode())
+
+  def write_stderr(self, session, msg: str):
+    return self.lib.write_stdout(session, msg.encode())
+
   def flush_log(self):
     return self.lib.flush_log()
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -193,7 +193,7 @@ class LegacyGraphSession:
       )
       self.invalid_goals = invalid_goals
 
-  def run_console_rules(self, options_bootstrapper, goals, target_roots):
+  def run_console_rules(self, options_bootstrapper, options, goals, target_roots):
     """Runs @console_rules sequentially and interactively by requesting their implicit Goal products.
 
     For retryable failures, raises scheduler.ExecutionError.
@@ -204,9 +204,12 @@ class LegacyGraphSession:
     :returns: An exit code.
     """
 
+    global_options = options.for_global_scope()
+
     subject = target_roots.specs
     console = Console(
-      use_colors=options_bootstrapper.bootstrap_options.for_global_scope().colors
+      use_colors=global_options.colors,
+      session=self.scheduler_session if global_options.v2_ui else None
     )
     workspace = Workspace(self.scheduler_session)
     interactive_runner = InteractiveRunner(self.scheduler_session)

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -229,6 +229,7 @@ class SchedulerService(PantsService):
       # N.B. @console_rules run pre-fork in order to cache the products they request during execution.
       exit_code = session.run_console_rules(
           options_bootstrapper,
+          options,
           goals,
           target_roots,
         )

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -1093,6 +1093,22 @@ pub extern "C" fn write_log(msg: *const raw::c_char, level: u64, target: *const 
 }
 
 #[no_mangle]
+pub extern "C" fn write_stdout(session_ptr: *mut Session, msg: *const raw::c_char) {
+  with_session(session_ptr, |session| {
+    let message_str = unsafe { CStr::from_ptr(msg).to_string_lossy() };
+    session.write_stdout(&message_str);
+  });
+}
+
+#[no_mangle]
+pub extern "C" fn write_stderr(session_ptr: *mut Session, msg: *const raw::c_char) {
+  with_session(session_ptr, |session| {
+    let message_str = unsafe { CStr::from_ptr(msg).to_string_lossy() };
+    session.write_stderr(&message_str);
+  });
+}
+
+#[no_mangle]
 pub extern "C" fn flush_log() {
   LOGGER.flush();
 }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -33,7 +33,8 @@ struct InnerSession {
   preceding_graph_size: usize,
   // The set of roots that have been requested within this session.
   roots: Mutex<HashSet<Root>>,
-  // If enabled, the display that will render the progress of the V2 engine.
+  // If enabled, the display that will render the progress of the V2 engine. This is only
+  // Some(_) if the --v2-ui option is enabled.
   display: Option<Arc<Mutex<EngineDisplay>>>,
   // If enabled, Zipkin spans for v2 engine will be collected.
   should_record_zipkin_spans: bool,
@@ -100,6 +101,14 @@ impl Session {
 
   pub fn build_id(&self) -> &str {
     &self.0.build_id
+  }
+
+  pub fn write_stdout(&self, msg: &str) {
+    print!(" {}", msg);
+  }
+
+  pub fn write_stderr(&self, msg: &str) {
+    eprint!("{}", msg);
   }
 }
 

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -103,6 +103,8 @@ impl Session {
     &self.0.build_id
   }
 
+  //TODO Thsese two functions should eventually hook up intelligently to EngineDisplay
+  //instead of just naively printing to stdout/stderr.
   pub fn write_stdout(&self, msg: &str) {
     print!(" {}", msg);
   }


### PR DESCRIPTION
### Problem

This commit is a first chunk of work necessary for fixing https://github.com/pantsbuild/pants/issues/8062 . When the --v2-ui flag is enabled, we currently activate the Rust `EngineDisplay` system which grabs control of the terminal and sets it to raw mode, while simultaneously writing to stdout with the Python `Console`. This is bad and needs to be fixed.

We eventually want to solve this by having `EngineDisplay` be fully in charge of any text that needs to get written to the terminal while pants is running. The first step for doing this is to hook up `Console` to `EngineDisplay`.

### Solution

I'm going with the third solution @blorente mentioned in his comment on the above issue. When `Console` is initialized, if --v2-ui is set, then we pass it a reference to the current Python scheduler session, which in turns holds a reference to a Rust `Session`, which is the data structure that contains an `EngineDisplay`. When `Console` invokes one of its methods that write to stdout or stderr, it will pass the string to be printed plus a reference to the `Session` over FFI to two new functions `write_stdout` and `write_stderr`. These in turn will call similar methods on `Session`.

As of this commit, these methods on `Session` will simply write to stdout/stderr from Rust instead of from Python, but in a future commit it will be easy to hook these up to `EngineDisplay` and correctly handle printing this text to the console.


### Result

No user-visible changes should result from this commit.