### PR TITLE
add --use-native-image option to scalafmt and add thread parallelism to RewriteBase

### DIFF
--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -1,14 +1,79 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
+import subprocess
 from abc import abstractmethod
+from typing import List, cast
 
+from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
 from pants.base.exceptions import TaskError
+from pants.base.workunit import WorkUnitLabel
+from pants.binaries.binary_tool import NativeTool
+from pants.binaries.binary_util import BinaryToolUrlGenerator
+from pants.engine.platform import Platform
 from pants.java.jar.jar_dependency import JarDependency
 from pants.option.custom_types import file_option
 from pants.task.fmt_task_mixin import FmtTaskMixin
 from pants.task.lint_task_mixin import LintTaskMixin
+from pants.util.dirutil import chmod_plus_x
+from pants.util.memo import memoized_method
+
+
+class ScalaFmtNativeUrlGenerator(BinaryToolUrlGenerator):
+
+  _DIST_URL_FMT = 'https://github.com/scalameta/scalafmt/releases/download/v{version}/scalafmt-{system_id}.zip'
+
+  _SYSTEM_ID = {
+    'mac': 'macos',
+    'linux': 'linux',
+  }
+
+  def generate_urls(self, version, host_platform):
+    system_id = self._SYSTEM_ID[host_platform.os_name]
+    return [self._DIST_URL_FMT.format(version=version, system_id=system_id)]
+
+
+class ScalaFmtSubsystem(JvmToolMixin, NativeTool):
+  options_scope = 'scalafmt'
+  default_version = '2.3.1'
+  archive_type = 'zip'
+
+  def get_external_url_generator(self):
+    return ScalaFmtNativeUrlGenerator()
+
+  @memoized_method
+  def select(self):
+    """Reach into the unzipped directory and return the scalafmt executable.
+
+    Also make sure to chmod +x the scalafmt executable, since the release zip doesn't do that.
+    """
+    extracted_dir = super().select()
+    inner_dir_name = Platform.current.match({
+      Platform.darwin: 'scalafmt-macos',
+      Platform.linux: 'scalafmt-linux',
+    })
+    output_file = os.path.join(extracted_dir, inner_dir_name, 'scalafmt')
+    chmod_plus_x(output_file)
+    return output_file
+
+  @property
+  def use_native_image(self) -> bool:
+    return cast(bool, self.get_options().use_native_image)
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register('--use-native-image', type=bool, advanced=True, fingerprint=False,
+             help='Use a pre-compiled native-image for scalafmt.')
+
+    cls.register_jvm_tool(register,
+                          'scalafmt',
+                          classpath=[
+                          JarDependency(org='com.geirsson',
+                                        name='scalafmt-cli_2.11',
+                                        rev='1.5.1')])
 
 
 class ScalaFmt(RewriteBase):
@@ -19,18 +84,16 @@ class ScalaFmt(RewriteBase):
   """
 
   @classmethod
+  def subsystem_dependencies(cls):
+    return super().subsystem_dependencies() + (
+      ScalaFmtSubsystem.scoped(cls),
+    )
+
+  @classmethod
   def register_options(cls, register):
     super().register_options(register)
     register('--configuration', advanced=True, type=file_option, fingerprint=True,
               help='Path to scalafmt config file, if not specified default scalafmt config used')
-
-    cls.register_jvm_tool(register,
-                          'scalafmt',
-                          classpath=[
-                          JarDependency(org='com.geirsson',
-                                        name='scalafmt-cli_2.11',
-                                        rev='1.5.1')
-                          ])
 
   @classmethod
   def target_types(cls):
@@ -44,7 +107,23 @@ class ScalaFmt(RewriteBase):
   def implementation_version(cls):
     return super().implementation_version() + [('ScalaFmt', 5)]
 
+  @property
+  def _use_native_image(self) -> bool:
+    return ScalaFmtSubsystem.scoped_instance(self).use_native_image
+
+  def _native_image_path(self) -> str:
+    return ScalaFmtSubsystem.scoped_instance(self).select()
+
+  def _tool_classpath(self) -> List[str]:
+    subsystem = ScalaFmtSubsystem.scoped_instance(self)
+    return subsystem.tool_classpath_from_products(
+      self.context.products,
+      key='scalafmt',
+      scope=subsystem.options_scope)
+
   def invoke_tool(self, absolute_root, target_sources):
+    self.context.log.debug(f'scalafmt called with sources: {target_sources}')
+
     # If no config file is specified use default scalafmt config.
     config_file = self.get_options().configuration
     args = list(self.additional_args)
@@ -52,11 +131,21 @@ class ScalaFmt(RewriteBase):
       args.extend(['--config', config_file])
     args.extend([source for _target, source in target_sources])
 
-    return self.runjava(classpath=self.tool_classpath('scalafmt'),
-                        main='org.scalafmt.cli.Cli',
-                        args=args,
-                        workunit_name='scalafmt',
-                        jvm_options=self.get_options().jvm_options)
+    if self._use_native_image:
+      with self.context.new_workunit(name='scalafmt', labels=[WorkUnitLabel.COMPILER]) as workunit:
+        args = [self._native_image_path(), *args]
+        self.context.log.debug(f'executing scalafmt with native image with args: {args}')
+        return subprocess.run(
+          args=args,
+          stdout=workunit.output('stdout'),
+          stderr=workunit.output('stderr'),
+        ).returncode
+    else:
+      return self.runjava(classpath=self._tool_classpath(),
+                          main='org.scalafmt.cli.Cli',
+                          args=args,
+                          workunit_name='scalafmt',
+                          jvm_options=self.get_options().jvm_options)
 
   @property
   @abstractmethod

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -122,7 +122,6 @@ class ScalaFmt(RewriteBase):
       scope=subsystem.options_scope)
 
   def invoke_tool(self, current_workunit, absolute_root, target_sources):
-    self.context.run_tracker._threadlocal.current_workunit = current_workunit
     self.context.log.debug(f'scalafmt called with sources: {target_sources}')
 
     # If no config file is specified use default scalafmt config.

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -121,7 +121,8 @@ class ScalaFmt(RewriteBase):
       key='scalafmt',
       scope=subsystem.options_scope)
 
-  def invoke_tool(self, absolute_root, target_sources):
+  def invoke_tool(self, current_workunit, absolute_root, target_sources):
+    self.context.run_tracker._threadlocal.current_workunit = current_workunit
     self.context.log.debug(f'scalafmt called with sources: {target_sources}')
 
     # If no config file is specified use default scalafmt config.
@@ -132,7 +133,10 @@ class ScalaFmt(RewriteBase):
     args.extend([source for _target, source in target_sources])
 
     if self._use_native_image:
-      with self.context.new_workunit(name='scalafmt', labels=[WorkUnitLabel.COMPILER]) as workunit:
+      with self.context.run_tracker.new_workunit(
+          name='scalafmt',
+          labels=[WorkUnitLabel.COMPILER],
+      ) as workunit:
         args = [self._native_image_path(), *args]
         self.context.log.debug(f'executing scalafmt with native image with args: {args}')
         return subprocess.run(

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -187,6 +187,14 @@ class RunTracker(Subsystem):
   def set_v2_console_rule_names(self, v2_console_rule_names):
     self._v2_console_rule_names = v2_console_rule_names
 
+  def get_current_workunit(self):
+    """Return the workunit associated with the current thread.
+
+    This can be used along with .register_thread() to ensure spawned threads have access to the
+    parent workunit that spawned them!
+    """
+    return self._threadlocal.current_workunit
+
   def register_thread(self, parent_workunit):
     """Register the parent workunit for all work in the calling thread.
 
@@ -383,7 +391,7 @@ class RunTracker(Subsystem):
 
     if stats_version not in cls.SUPPORTED_STATS_VERSIONS:
       raise ValueError("Invalid stats version")
-    
+
 
     auth_data = BasicAuth.global_instance().get_auth_for_provider(auth_provider)
     headers = cls._get_headers(stats_version=stats_version)
@@ -462,7 +470,7 @@ class RunTracker(Subsystem):
     else:
       stats.update({
         'self_timings': self.self_timings.get_all(),
-        'critical_path_timings': self.get_critical_path_timings().get_all(),        
+        'critical_path_timings': self.get_critical_path_timings().get_all(),
         'outcomes': self.outcomes,
       })
     return stats

--- a/src/python/pants/process/xargs.py
+++ b/src/python/pants/process/xargs.py
@@ -2,7 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import errno
+import logging
 import subprocess
+
+
+logger = logging.getLogger(__name__)
 
 
 class Xargs:
@@ -40,11 +44,13 @@ class Xargs:
     :param list args: Extra arguments to pass to cmd.
     """
     all_args = list(args)
+    logger.debug(f'xargs all_args: {all_args}')
     try:
       return self._cmd(all_args)
     except OSError as e:
       if errno.E2BIG == e.errno:
         args1, args2 = self._split_args(all_args)
+        logger.debug(f'xargs split cmd line:\nargs1={args1},\nargs2={args2}!')
         result = self.execute(args1)
         if result != 0:
           return result

--- a/src/python/pants/process/xargs.py
+++ b/src/python/pants/process/xargs.py
@@ -45,13 +45,14 @@ class Xargs:
 
     :param list args: Extra arguments to pass to cmd.
     """
-    all_args = list(args)
-    logger.debug(f'xargs all_args: {all_args}')
+    splittable_args = list(args)
+    all_args_for_command_function = self._constant_args + [splittable_args]
+    logger.debug(f'xargs all_args_for_command_function: {all_args_for_command_function}')
     try:
-      return self._cmd(*(*self._constant_args, all_args))
+      return self._cmd(*all_args_for_command_function)
     except OSError as e:
       if errno.E2BIG == e.errno:
-        args1, args2 = self._split_args(all_args)
+        args1, args2 = self._split_args(splittable_args)
         logger.debug(f'xargs split cmd line:\nargs1={args1},\nargs2={args2}!')
         result = self.execute(args1)
         if result != 0:

--- a/src/python/pants/process/xargs.py
+++ b/src/python/pants/process/xargs.py
@@ -26,13 +26,15 @@ class Xargs:
       return subprocess.call(cmd + args, **kwargs)
     return cls(call)
 
-  def __init__(self, cmd):
+  def __init__(self, cmd, constant_args=None):
     """Creates an xargs engine that calls cmd with argument chunks.
 
     :param cmd: A function that can execute a command line in the form of a list of strings
       passed as its sole argument.
+    :param constant_args: Any positional arguments to be added to each invocation.
     """
     self._cmd = cmd
+    self._constant_args = constant_args or []
 
   def _split_args(self, args):
     half = len(args) // 2
@@ -46,7 +48,7 @@ class Xargs:
     all_args = list(args)
     logger.debug(f'xargs all_args: {all_args}')
     try:
-      return self._cmd(all_args)
+      return self._cmd(*(*self._constant_args, all_args))
     except OSError as e:
       if errno.E2BIG == e.errno:
         args1, args2 = self._split_args(all_args)

--- a/src/python/pants/testutil/base/context_utils.py
+++ b/src/python/pants/testutil/base/context_utils.py
@@ -49,6 +49,7 @@ class TestContext(Context):
 
     def __init__(self):
       self.logger = RunTrackerLogger(self)
+      self._cur_workunit = TestContext.DummyWorkUnit()
 
     class DummyArtifactCacheStats:
       def add_hits(self, cache_name, targets): pass
@@ -58,6 +59,16 @@ class TestContext(Context):
     artifact_cache_stats = DummyArtifactCacheStats()
 
     def report_target_info(self, scope, target, keys, val): pass
+
+    def get_current_workunit(self):
+      return self._cur_workunit
+
+    def register_thread(self, parent_workunit):
+      self._cur_workunit = parent_workunit
+
+    @contextmanager
+    def new_workunit(self, *args, **kwargs):
+      yield self.get_current_workunit()
 
 
   class TestLogger(logging.getLoggerClass()):  # type: ignore[misc] # MyPy does't understand this dynamic base class


### PR DESCRIPTION
### Problem

We would like to experiment with using the native-image version of scalafmt, and especially we would like to investigate parallelism in scalafmt. We suspect that this may be significantly faster and use much less memory than a JVM execution, as per [this conference doc for the Graal workshop at the CGO 2019 conference](https://docs.google.com/document/d/1iWINqg30nXaCYmBxma5h5RgWzx7sgFqWGJcQJ-RYpRE/edit?usp=sharing). At Twitter's 2018 hackweek, @ShaneDelmore and I were able to demonstrate better performance with a Graal `native-image`-compiled version of `scalafmt` than the nailgun approach.

### Solution

- Add the `ScalaFmtSubsystem` to contain the `scalafmt` JVM tool and the native-image version as a `NativeTool` (this is similar to what we've done for `Zinc`!).
- Add `--files-per-process` and `--total-number-parallel-processes` options to `RewriteBase`, implemented with threading, since formatting is an embarrassingly parallel problem!

### Benchmarking
Not complete yet, but:
```bash
> git checkout -- src/scala && ./pants -x -ldebug --scalafmt-use-native-image fmt.scalafmt --no-skip --files-per-process=2 src/scala::
...
Cumulative Timings
==================
7.024 main:fmt:scalafmt:scalafmt
5.215 main
2.064 main:background
1.279 main:fmt
0.808 main:fmt:scalafmt
...
```

```bash
> git checkout -- src/scala && ./pants -x -ldebug --no-scalafmt-use-native-image fmt.scalafmt --no-skip --files-per-process=2 src/scala::
...
Cumulative Timings
==================
5.145 main
5.080 main:fmt:scalafmt:scalafmt
2.138 main:background
1.304 main:fmt
0.857 main:fmt:scalafmt
...
```

This demonstrates that native-image beats a "warm" nailgun (a nailgun that has already been executed against several times) with `--files-per-process=2`, which is about half of the time when using scalafmt with nailgun and no splitting of files (~1.6s).

**Note that the `main:fmt:scalafmt` time is what matters**, not `main:fmt:scalafmt:scalafmt`, which describes the cumulative time over all threads.

#### Benchmarking in a larger repo
In a larger monorepo, we observed the following speedup on a 6-core i9 macbook pro (with hyper-threading):
```bash
# *with* native-image scalafmt, and 6 parallel processes:
> ./pants --enable-pantsd -x -ldebug --scalafmt-use-native-image fmt.scalafmt --no-skip --worker-count=6 --output-dir=./tmp src/scala::
...
Cumulative Timings
==================
324.825 main:fmt:scalafmt:scalafmt
223.646 main
90.191 main:background
87.217 main:setup
80.577 main:fmt
80.275 main:fmt:scalafmt
...

# with nailgun scalafmt, which uses only one python thread, but does its own threading (spawning 41 threads):
> ./pants --enable-pantsd -x -ldebug --no-scalafmt-use-native-image fmt.scalafmt --no-skip --output-dir=./tmp src/scala::
# I hit Ctrl-C after 8 minutes at 1000% cpu.
```

### Result

Scalafmt can now be run with configurable performance, and the native-image version can be used transparently by any pants user without extra configuration!