### PR TITLE
Remove deprecated `./pants mypy` in favor of `./pants lint.mypy`

### DIFF
--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -45,9 +45,6 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
   _MYPY_COMPATIBLE_INTERPETER_CONSTRAINT = '>=3.5'
   _PYTHON_SOURCE_EXTENSION = '.py'
 
-  deprecated_options_scope = 'mypy'
-  deprecated_options_scope_removal_version = '1.21.0.dev0'
-
   @classmethod
   def prepare(cls, options, round_manager):
     super().prepare(options, round_manager)

--- a/contrib/release_packages.sh
+++ b/contrib/release_packages.sh
@@ -112,7 +112,7 @@ function pkg_mypy_install_test() {
   local version=$1
   execute_packaged_pants_with_internal_backends \
     --plugins="['pantsbuild.pants.contrib.mypy==${version}']" \
-    --explain mypy &> /dev/null
+    --explain lint | grep "mypy" &> /dev/null
 }
 
 function pkg_avro_install_test() {


### PR DESCRIPTION
This should have been removed in Pants 1.21.0.dev0.

By removing the `mypy` goal scope, we are able to now reclaim `mypy` as a subsystem name.