### PR TITLE
Rename V2 goals to use the same naming scheme

### DIFF
--- a/build-support/bin/black.py
+++ b/build-support/bin/black.py
@@ -20,12 +20,13 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def main() -> None:
-  args= create_parser().parse_args()
+  args = create_parser().parse_args()
   merge_base = git_merge_base()
-  goal = "fmt-v2" if args.fix else "lint-v2"
+  goal = "fmt2" if args.fix else "lint2"
   command = ["./pants", f"--changed-parent={merge_base}", goal]
   process = subprocess.run(command)
   sys.exit(process.returncode)
+
 
 if __name__ == "__main__":
   main()

--- a/src/python/pants/backend/project_info/rules/dependencies.py
+++ b/src/python/pants/backend/project_info/rules/dependencies.py
@@ -13,7 +13,7 @@ from pants.engine.selectors import Get
 
 # TODO(#8762) Get this rule to feature parity with the dependencies task.
 class DependenciesOptions(LineOriented, GoalSubsystem):
-  name = 'fast-dependencies'
+  name = 'dependencies2'
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/rules/core/cloc.py
+++ b/src/python/pants/rules/core/cloc.py
@@ -41,7 +41,7 @@ async def download_cloc_script() -> DownloadedClocScript:
 
 
 class CountLinesOfCodeOptions(GoalSubsystem):
-  name = 'fast-cloc'
+  name = 'cloc2'
 
   @classmethod
   def register_options(cls, register) -> None:

--- a/src/python/pants/rules/core/cloc_test.py
+++ b/src/python/pants/rules/core/cloc_test.py
@@ -47,7 +47,7 @@ class ClocTest(ConsoleRuleTestBase):
     self.assert_counts(output, 'Python', num_files=3, blank=2, comment=3, code=3)
     self.assert_counts(output, 'Java', num_files=1, blank=0, comment=1, code=1)
 
-    output = self.execute_rule(args=['src/py/foo', 'src/java/foo', '--fast-cloc-no-transitive']).splitlines()
+    output = self.execute_rule(args=['src/py/foo', 'src/java/foo', '--cloc2-no-transitive']).splitlines()
     self.assert_counts(output, 'Python', num_files=2, blank=2, comment=3, code=2)
     self.assert_counts(output, 'Java', num_files=1, blank=0, comment=1, code=1)
 
@@ -57,7 +57,7 @@ class ClocTest(ConsoleRuleTestBase):
 
     self.add_to_build_file('src/py/foo', 'python_library(sources=["foo.py", "empty.py"])')
 
-    output = self.execute_rule(args=['src/py/foo', '--fast-cloc-ignored'])
+    output = self.execute_rule(args=['src/py/foo', '--cloc2-ignored'])
 
     self.assertIn("Ignored the following files:", output)
     self.assertIn("empty.py: zero sized file", output)

--- a/src/python/pants/rules/core/filedeps.py
+++ b/src/python/pants/rules/core/filedeps.py
@@ -17,7 +17,7 @@ class FiledepsOptions(LineOriented, GoalSubsystem):
   Files may be listed with absolute or relative paths and any BUILD files implied in the transitive
   closure of targets are also included.
   """
-  name = 'fast-filedeps'
+  name = 'filedeps2'
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/rules/core/filedeps_integration_test.py
+++ b/src/python/pants/rules/core/filedeps_integration_test.py
@@ -11,7 +11,7 @@ class FiledepsIntegrationTest(PantsRunIntegrationTest):
   def assert_filedeps(
     self, *, filedeps_options: Optional[List[str]] = None, expected_entries: List[str]
   ) -> None:
-    args = ['fast-filedeps', '--no-absolute'] + (filedeps_options or []) + [
+    args = ['filedeps2', '--no-absolute'] + (filedeps_options or []) + [
       'examples/src/scala/org/pantsbuild/example/hello/exe:exe',
       'examples/src/scala/org/pantsbuild/example/hello/welcome:welcome'
     ]

--- a/src/python/pants/rules/core/filedeps_test.py
+++ b/src/python/pants/rules/core/filedeps_test.py
@@ -55,9 +55,9 @@ class FileDepsTest(ConsoleRuleTestBase):
     )
 
   def assert_filedeps(self, *, targets: List[str], expected: Set[str], globs: bool = False) -> None:
-    args = ["--no-fast-filedeps-absolute"]
+    args = ["--no-filedeps2-absolute"]
     if globs:
-      args.append("--fast-filedeps-globs")
+      args.append("--filedeps2-globs")
     self.assert_console_output(*expected, args=args + targets)
 
   def test_no_target(self) -> None:

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -50,7 +50,7 @@ class FmtOptions(GoalSubsystem):
 
   # TODO: make this "fmt"
   # Blocked on https://github.com/pantsbuild/pants/issues/8351
-  name = 'fmt-v2'
+  name = 'fmt2'
 
 
 class Fmt(Goal):

--- a/src/python/pants/rules/core/lint.py
+++ b/src/python/pants/rules/core/lint.py
@@ -51,7 +51,7 @@ class LintOptions(GoalSubsystem):
 
   # TODO: make this "lint"
   # Blocked on https://github.com/pantsbuild/pants/issues/8351
-  name = 'lint-v2'
+  name = 'lint2'
 
 
 class Lint(Goal):


### PR DESCRIPTION
### Problem

When V2 goals conflict with V1 goals so that we are not able to reuse the same name, we have two conventions of naming the V2 goal:

* fast-rule, e.g. `fast-filedeps`
* rule-v2, e.g. `fmt-v2`

It is confusing to use two different conventions. There is no meaningful distinction between the two, only the history of what the rule author chose to use.

Further, both conventions are much longer to type than ideal. We want it to be extremely easy to run the V2 rule through the CLI.

### Solution

Converge on a new convetion of `rule2`. For example, `filedeps` is already claimed by V1 so we name the V2 rule `filedeps2`.