### PR TITLE
Make v2 binary goal pay attention to --pants-distdir

### DIFF
--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -40,6 +40,10 @@ class BuildRoot(metaclass=SingletonMetaclass):
     self._root_dir: Optional[str] = None
 
   @property
+  def pathlib_path(self) -> Path:
+    return Path(self.path)
+
+  @property
   def path(self) -> str:
     """Returns the build root for the current workspace."""
     if self._root_dir is None:

--- a/src/python/pants/fs/fs.py
+++ b/src/python/pants/fs/fs.py
@@ -3,6 +3,7 @@
 
 import hashlib
 import os
+from pathlib import Path
 
 
 # The max filename length for HFS+, extX and NTFS is 255, but many systems also have limits on the
@@ -68,3 +69,9 @@ def expand_path(path):
   :API: public
   """
   return os.path.abspath(os.path.expandvars(os.path.expanduser(path)))
+
+
+def is_child_of(path: Path, directory: Path) -> bool:
+  abs_path = path if path.is_absolute() else directory.joinpath(path).resolve()
+  return directory == abs_path or directory in abs_path.parents
+

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -17,6 +17,7 @@ from pants.engine.fs import (
 from pants.engine.goal import Goal
 from pants.engine.rules import RootRule, console_rule
 from pants.engine.selectors import Get
+from pants.fs.fs import is_child_of
 from pants.testutil.console_rule_test_base import ConsoleRuleTestBase
 from pants.testutil.test_base import TestBase
 
@@ -86,3 +87,17 @@ class FileSystemTest(TestBase):
     assert materialize_result.output_paths == tuple(
       str(Path(self.build_root, p)) for p in [path1, path2]
     )
+
+
+class IsChildOfTest(TestBase):
+  def test_is_child_of(self):
+    mock_build_root = Path("/mock/build/root")
+
+    assert is_child_of(Path("/mock/build/root/dist/dir"), mock_build_root)
+    assert is_child_of(Path("dist/dir"), mock_build_root)
+    assert is_child_of(Path("./dist/dir"), mock_build_root)
+    assert is_child_of(Path("../root/dist/dir"), mock_build_root)
+
+    assert not is_child_of(Path("/other/random/directory/root/dist/dir"), mock_build_root)
+    assert not is_child_of(Path("../not_root/dist/dir"), mock_build_root)
+

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -97,6 +97,8 @@ class IsChildOfTest(TestBase):
     assert is_child_of(Path("dist/dir"), mock_build_root)
     assert is_child_of(Path("./dist/dir"), mock_build_root)
     assert is_child_of(Path("../root/dist/dir"), mock_build_root)
+    assert is_child_of(Path(""), mock_build_root)
+    assert is_child_of(Path("./"), mock_build_root)
 
     assert not is_child_of(Path("/other/random/directory/root/dist/dir"), mock_build_root)
     assert not is_child_of(Path("../not_root/dist/dir"), mock_build_root)

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -2,7 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
+from pathlib import Path
 
+from pants.base.build_root import BuildRoot
 from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.console import Console
@@ -11,6 +13,8 @@ from pants.engine.goal import Goal, LineOriented
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.rules import console_rule, rule, union
 from pants.engine.selectors import Get, MultiGet
+from pants.fs.fs import is_child_of
+from pants.option.options_bootstrapper import OptionsBootstrapper
 
 
 @dataclass(frozen=True)
@@ -33,16 +37,29 @@ class CreatedBinary:
 
 @console_rule
 async def create_binary(
-  addresses: BuildFileAddresses, console: Console, workspace: Workspace, options: Binary.Options
-) -> Binary:
+    addresses: BuildFileAddresses,
+    console: Console,
+    workspace: Workspace,
+    options: Binary.Options,
+    options_bootstrapper: OptionsBootstrapper,
+    build_root: BuildRoot
+    ) -> Binary:
   with Binary.line_oriented(options, console) as print_stdout:
-    print_stdout("Generating binaries in `dist/`")
+    global_options = options_bootstrapper.bootstrap_options.for_global_scope()
+    pants_distdir = Path(global_options.pants_distdir)
+    if not is_child_of(pants_distdir, build_root.pathlib_path):
+      console.print_stderr(f"When set to an absolute path, `--pants-distdir` must be relative to the build root. You set it to {pants_distdir}. Instead, use a relative path or an absolute path relative to the build root.")
+      return Binary(exit_code=1)
+
+    relative_distdir = pants_distdir.relative_to(build_root.pathlib_path) if pants_distdir.is_absolute() else pants_distdir
+    print_stdout(f"Generating binaries in `./{relative_distdir}`")
+
     binaries = await MultiGet(Get[CreatedBinary](Address, address.to_address()) for address in addresses)
     merged_digest = await Get[Digest](
       DirectoriesToMerge(tuple(binary.digest for binary in binaries))
     )
     result = workspace.materialize_directory(
-      DirectoryToMaterialize(merged_digest, path_prefix="dist/")
+      DirectoryToMaterialize(merged_digest, path_prefix=str(relative_distdir))
     )
     for path in result.output_paths:
       print_stdout(f"Wrote {path}")

--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -48,7 +48,8 @@ async def create_binary(
     global_options = options_bootstrapper.bootstrap_options.for_global_scope()
     pants_distdir = Path(global_options.pants_distdir)
     if not is_child_of(pants_distdir, build_root.pathlib_path):
-      console.print_stderr(f"When set to an absolute path, `--pants-distdir` must be relative to the build root. You set it to {pants_distdir}. Instead, use a relative path or an absolute path relative to the build root.")
+      console.print_stderr(f"When set to an absolute path, `--pants-distdir` must be relative to the build root."
+      "You set it to {pants_distdir}. Instead, use a relative path or an absolute path relative to the build root.")
       return Binary(exit_code=1)
 
     relative_distdir = pants_distdir.relative_to(build_root.pathlib_path) if pants_distdir.is_absolute() else pants_distdir


### PR DESCRIPTION
### Problem

The v2 binary goal hard-coded the build root subdirectory `dist` as the place to put built binaries. 

### Solution

Have the place the binary goal writes to be `dist` by default, but use the value from the --pants-distdir flag if it exists, checking to be sure that the configured value is actually within the build root (and bailing out if it isn't).
