### PR TITLE
Fix V2 Black not being distributed to end users

### DIFF
--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -51,6 +51,8 @@ target(
     'src/python/pants/backend/jvm:plugin',
     'src/python/pants/backend/project_info:plugin',
     'src/python/pants/backend/python:plugin',
+    'src/python/pants/backend/python/lint/black',
+    'src/python/pants/backend/python/lint/isort',
     'src/python/pants/backend/native',
   ],
 )


### PR DESCRIPTION
For Pants users, this works:

```ini
backend_packages: +[
    "pants.backend.python.lint.isort",
  ]
```

But this does not work, complaining that the plugin cannot be found:

```ini
backend_packages: +[
    "pants.backend.python.lint.black",
  ]
```

The reason is that our packaged wheel does not include the target `src/python/pants/backend/python/lint/black`. That is, `./pants fast-dependencies --transitive src/python/pants/init:plugins | grep 'black'` returns nothing.

In contrast, we were including isort because the V1 implementation imports `src/python/pants/backend/python/lint/isort/subsystem.py`, so the entire V2 isort plugin was automatically included in the released wheel. That is, `./pants fast-dependencies --transitive src/python/pants/init:plugins | grep 'isort'` returned the `lint/isort` target.

Here, we explicitly mark the dependency for both new plugins.