### PR TITLE
Bump test_pytest_run.py timeout.

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -108,7 +108,7 @@ python_tests(
     'src/python/pants/testutil/subsystem',
     ':python_task_test_base',
   ],
-  timeout=360,
+  timeout=480,
 )
 
 python_tests(


### PR DESCRIPTION
The prior value of 360s does not deliver stably successful results in
CI.