### PR TITLE
Fix V2 binary to work with multiple targets

### DIFF
--- a/src/python/pants/rules/core/binary.py
+++ b/src/python/pants/rules/core/binary.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.console import Console
-from pants.engine.fs import Digest, DirectoryToMaterialize, Workspace
+from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryToMaterialize, Workspace
 from pants.engine.goal import Goal, LineOriented
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.rules import console_rule, rule, union
@@ -32,23 +32,26 @@ class CreatedBinary:
 
 
 @console_rule
-async def create_binary(addresses: BuildFileAddresses, console: Console, workspace: Workspace, options: Binary.Options) -> Binary:
+async def create_binary(
+  addresses: BuildFileAddresses, console: Console, workspace: Workspace, options: Binary.Options
+) -> Binary:
   with Binary.line_oriented(options, console) as print_stdout:
     print_stdout("Generating binaries in `dist/`")
-    binaries = await MultiGet(Get(CreatedBinary, Address, address.to_address()) for address in addresses)
-    dirs_to_materialize = tuple(
-      DirectoryToMaterialize(binary.digest, path_prefix='dist/') for binary in binaries
+    binaries = await MultiGet(Get[CreatedBinary](Address, address.to_address()) for address in addresses)
+    merged_digest = await Get[Digest](
+      DirectoriesToMerge(tuple(binary.digest for binary in binaries))
     )
-    results = workspace.materialize_directories(dirs_to_materialize)
-    for result in results.dependencies:
-      for path in result.output_paths:
-        print_stdout(f"Wrote {path}")
+    result = workspace.materialize_directory(
+      DirectoryToMaterialize(merged_digest, path_prefix="dist/")
+    )
+    for path in result.output_paths:
+      print_stdout(f"Wrote {path}")
   return Binary(exit_code=0)
 
 
 @rule
 async def coordinator_of_binaries(target: HydratedTarget) -> CreatedBinary:
-  binary = await Get(CreatedBinary, BinaryTarget, target.adaptor)
+  binary = await Get[CreatedBinary](BinaryTarget, target.adaptor)
   return binary
 
 


### PR DESCRIPTION
`./pants --no-v1 --v2 binary target1 target2` would fail with the exception message:

```
 ValueError: dist/ appeared more than once. All paths must be unique.
```

This is because the results are all trying to materialize directory digests with the path prefix `dist/`, which is not allowed. Instead, we can merge them into one digest and materialize the single digest (this is the same pattern we use for `fmt.py`).