### PR TITLE
Fix pantsbuild wheel publishing.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -283,6 +283,15 @@ function install_and_test_packages() {
     --no-cache-dir
   )
 
+  export PANTS_PYTHON_REPOS_REPOS="${DEPLOY_PANTS_WHEEL_DIR}/${VERSION}"
+
+  start_travis_section "wheel_check" "Validating ${VERSION} pantsbuild.pants wheels"
+  activate_twine
+  trap deactivate RETURN
+  twine check "${PANTS_PYTHON_REPOS_REPOS}"/*.whl || die "Failed to validate wheels."
+  deactivate
+  end_travis_section
+
   pre_install || die "Failed to setup virtualenv while testing ${NAME}-${VERSION}!"
 
   # Avoid caching plugin installs.
@@ -296,7 +305,6 @@ function install_and_test_packages() {
     $(run_packages_script list | grep '.' | awk '{print $1}')
   ) || die "Failed to list packages!"
 
-  export PANTS_PYTHON_REPOS_REPOS="${DEPLOY_PANTS_WHEEL_DIR}/${VERSION}"
   for package in "${packages[@]}"
   do
     start_travis_section "${package}" "Installing and testing package ${package}-${VERSION}"

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -287,7 +287,6 @@ function install_and_test_packages() {
 
   start_travis_section "wheel_check" "Validating ${VERSION} pantsbuild.pants wheels"
   activate_twine
-  trap deactivate RETURN
   twine check "${PANTS_PYTHON_REPOS_REPOS}"/*.whl || die "Failed to validate wheels."
   deactivate
   end_travis_section

--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -49,6 +49,7 @@ def pants_setup_py(name, description, additional_classifiers=None, **kwargs):
       version=VERSION,
       description=description,
       long_description=Path('src/python/pants/ABOUT.rst').read_text() + notes,
+      long_description_content_type='text/x-rst',
       url='https://github.com/pantsbuild/pants',
       project_urls={
           'Documentation': 'https://www.pantsbuild.org/',

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -278,12 +278,19 @@ def deprecated(
   return decorator
 
 
-def deprecated_module(removal_version: str, hint_message: Optional[str] = None) -> None:
+def deprecated_module(
+  removal_version: str,
+  hint_message: Optional[str] = None,
+  stacklevel: int = 3
+) -> None:
   """Marks an entire module as deprecated.
 
   Add a call to this at the top of the deprecated module, and it will print a warning message
   when the module is imported.
 
-  Arguments are as for deprecated(), above.
+  :param removal_version: The pantsbuild.pants version which will remove the deprecated
+                          function.
+  :param hint_message: An optional hint pointing to alternatives to the deprecation.
+  :param stacklevel: The stacklevel to pass to warnings.warn.
   """
-  warn_or_error(removal_version, 'module', hint_message)
+  warn_or_error(removal_version, 'module', hint_message, stacklevel=stacklevel)

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -27,10 +27,18 @@ python_library(
 )
 
 python_library(
+  name='deprecated_testinfra',
+  sources=['deprecated_testinfra.py'],
+  dependencies = [
+    'src/python/pants/base:deprecated',
+  ]
+)
+
+python_library(
   name = 'int-test-for-export',
   sources = ['pants_run_integration_test.py'],
   dependencies = [
-    'src/python/pants/base:deprecated',
+    ':deprecated_testinfra',
     'src/python/pants/testutil:int-test-for-export',
   ]
 )
@@ -56,7 +64,7 @@ python_library(
   name = 'console_rule_test_base',
   sources = ['console_rule_test_base.py'],
   dependencies = [
-    'src/python/pants/base:deprecated',
+    ':deprecated_testinfra',
     'src/python/pants/testutil:console_rule_test_base',
   ]
 )
@@ -66,7 +74,7 @@ python_library(
   name = 'task_test_base',
   sources = ['task_test_base.py'],
   dependencies = [
-    'src/python/pants/base:deprecated',
+    ':deprecated_testinfra',
     'src/python/pants/testutil:task_test_base',
   ]
 )
@@ -75,7 +83,7 @@ python_library(
   name='interpreter_selection_utils',
   sources=['interpreter_selection_utils.py'],
   dependencies = [
-    'src/python/pants/base:deprecated',
+    ':deprecated_testinfra',
     'src/python/pants/testutil:interpreter_selection_utils',
   ]
 )

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -18,8 +18,7 @@ python_library(
   ],
   provides=pants_setup_py(
     name='pantsbuild.pants.testinfra',
-    description='DEPRECATED: use pantsbuild.pants.testutil instead.\n\n'
-                'Test support for writing Pants plugins.',
+    description='Test support for writing Pants plugins.',
     namespace_packages=['pants_test'],
     additional_classifiers=[
       'Topic :: Software Development :: Testing',

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -49,8 +49,8 @@ python_library(
   name = 'context_utils',
   sources = ['context_utils.py'],
   dependencies = [
-    'src/python/pants/base:deprecated',
     'src/python/pants/testutil/base:context_utils',
+    'tests/python/pants_test:deprecated_testinfra',
   ]
 )
 

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -1,14 +1,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.base.context_utils import TestContext as TestContext  # noqa
 from pants.testutil.base.context_utils import (
   create_context_from_options as create_context_from_options,
 )  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.base.context_utils instead."
-)
+deprecated_testinfra_module()

--- a/tests/python/pants_test/console_rule_test_base.py
+++ b/tests/python/pants_test/console_rule_test_base.py
@@ -7,5 +7,6 @@ from pants.testutil.console_rule_test_base import ConsoleRuleTestBase as Console
 
 deprecated_module(
   removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.console_rule_test_base instead."
+  hint_message="Import pants.testutil.console_rule_test_base from the "
+               "pantsbuild.pants.testutil distribution instead."
 )

--- a/tests/python/pants_test/console_rule_test_base.py
+++ b/tests/python/pants_test/console_rule_test_base.py
@@ -1,12 +1,8 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.console_rule_test_base import ConsoleRuleTestBase as ConsoleRuleTestBase  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.console_rule_test_base from the "
-               "pantsbuild.pants.testutil distribution instead."
-)
+deprecated_testinfra_module()

--- a/tests/python/pants_test/deprecated_testinfra.py
+++ b/tests/python/pants_test/deprecated_testinfra.py
@@ -1,0 +1,25 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import inspect
+
+from pants.base.deprecated import deprecated_module
+
+
+def deprecated_testinfra_module(instead=None):
+  if not instead:
+    caller_frame_info = inspect.stack()[1]
+    caller_module = inspect.getmodule(caller_frame_info.frame)
+    caller_module_name = caller_module.__name__
+    assert caller_module_name.startswith('pants_test.'), (
+      'The `deprecated_testinfra_module` helper should only be used in `pants_test` code that has '
+      'been deprecated in favor of `pants.testutil` equivalent code. Detected use from module '
+      f'{caller_module_name}.'
+    )
+    instead = f'pants.testutil.{caller_module_name.lstrip("pants_test.")}'
+
+  deprecated_module(
+    removal_version='1.26.0.dev2',
+    hint_message=f'Import {instead} from the pantsbuild.pants.testutil distribution instead.',
+    stacklevel=4
+  )

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -5,8 +5,8 @@ python_library(
   name = 'util',
   sources = ['util.py'],
   dependencies = [
-    'src/python/pants/base:deprecated',
     'src/python/pants/testutil/engine:util',
+    'tests/python/pants_test:deprecated_testinfra',
   ],
 )
 
@@ -14,8 +14,8 @@ python_library(
   name = 'engine_test_base',
   sources = ['base_engine_test.py'],
   dependencies = [
-    'src/python/pants/base:deprecated',
     'src/python/pants/testutil/engine:engine_test_base',
+    'tests/python/pants_test:deprecated_testinfra',
   ]
 )
 

--- a/tests/python/pants_test/engine/base_engine_test.py
+++ b/tests/python/pants_test/engine/base_engine_test.py
@@ -1,11 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.engine.base_engine_test import EngineTestBase as EngineTestBase  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.engine.base_engine_test instead."
-)
+deprecated_testinfra_module()

--- a/tests/python/pants_test/engine/util.py
+++ b/tests/python/pants_test/engine/util.py
@@ -1,7 +1,6 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.engine.util import TARGET_TABLE as TARGET_TABLE  # noqa
 from pants.testutil.engine.util import MockConsole as MockConsole  # noqa
 from pants.testutil.engine.util import Target as Target  # noqa
@@ -12,9 +11,7 @@ from pants.testutil.engine.util import (
   remove_locations_from_traceback as remove_locations_from_traceback,
 )  # noqa
 from pants.testutil.engine.util import run_rule as run_rule  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.engine.util instead."
-)
+deprecated_testinfra_module()

--- a/tests/python/pants_test/interpreter_selection_utils.py
+++ b/tests/python/pants_test/interpreter_selection_utils.py
@@ -1,7 +1,6 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.interpreter_selection_utils import PY_2 as PY_2  # noqa
 from pants.testutil.interpreter_selection_utils import PY_3 as PY_3  # noqa
 from pants.testutil.interpreter_selection_utils import PY_27 as PY_27  # noqa
@@ -32,10 +31,7 @@ from pants.testutil.interpreter_selection_utils import (
 from pants.testutil.interpreter_selection_utils import (
   skip_unless_python36_present as skip_unless_python36_present,
 )  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.interpreter_selection_utils from the "
-               "pantsbuild.pants.testutil distribution instead."
-)
+deprecated_testinfra_module()

--- a/tests/python/pants_test/interpreter_selection_utils.py
+++ b/tests/python/pants_test/interpreter_selection_utils.py
@@ -36,5 +36,6 @@ from pants.testutil.interpreter_selection_utils import (
 
 deprecated_module(
   removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.interpreter_selection_utils instead."
+  hint_message="Import pants.testutil.interpreter_selection_utils from the "
+               "pantsbuild.pants.testutil distribution instead."
 )

--- a/tests/python/pants_test/jvm/BUILD
+++ b/tests/python/pants_test/jvm/BUILD
@@ -24,8 +24,8 @@ python_library(
   name='jvm_tool_task_test_base',
   sources=['jvm_tool_task_test_base.py'],
   dependencies=[
-    'src/python/pants/base:deprecated',
     'src/python/pants/testutil/jvm:jvm_tool_task_test_base',
+    'tests/python/pants_test:deprecated_testinfra',
   ]
 )
 
@@ -33,8 +33,8 @@ python_library(
   name='nailgun_task_test_base',
   sources=['nailgun_task_test_base.py'],
   dependencies=[
-    'src/python/pants/base:deprecated',
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
+    'tests/python/pants_test:deprecated_testinfra',
   ]
 )
 
@@ -42,8 +42,8 @@ python_library(
   name='jar_task_test_base',
   sources=['jar_task_test_base.py'],
   dependencies=[
-    'src/python/pants/base:deprecated',
     'src/python/pants/testutil/jvm:jar_task_test_base',
+    'tests/python/pants_test:deprecated_testinfra',
   ]
 )
 
@@ -51,7 +51,7 @@ python_library(
   name='jvm_task_test_base',
   sources=['jvm_task_test_base.py'],
   dependencies=[
-    'src/python/pants/base:deprecated',
     'src/python/pants/testutil/jvm:jvm_task_test_base',
+    'tests/python/pants_test:deprecated_testinfra',
   ]
 )

--- a/tests/python/pants_test/jvm/jar_task_test_base.py
+++ b/tests/python/pants_test/jvm/jar_task_test_base.py
@@ -1,11 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.jvm.jar_task_test_base import JarTaskTestBase as JarTaskTestBase  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.jvm.jar_task_test_base instead."
-)
+deprecated_testinfra_module()

--- a/tests/python/pants_test/jvm/jvm_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_task_test_base.py
@@ -1,11 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.jvm.jvm_task_test_base import JvmTaskTestBase as JvmTaskTestBase  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.jvm.jvm_task_test_base instead."
-)
+deprecated_testinfra_module()

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -1,11 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase as JvmToolTaskTestBase  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.jvm.jvm_tool_task_test_base instead."
-)
+deprecated_testinfra_module()

--- a/tests/python/pants_test/jvm/nailgun_task_test_base.py
+++ b/tests/python/pants_test/jvm/nailgun_task_test_base.py
@@ -1,11 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.jvm.nailgun_task_test_base import NailgunTaskTestBase as NailgunTaskTestBase  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.jvm.nailgun_task_test_base instead."
-)
+deprecated_testinfra_module()

--- a/tests/python/pants_test/option/util/BUILD
+++ b/tests/python/pants_test/option/util/BUILD
@@ -3,7 +3,7 @@
 
 python_library(
   dependencies=[
-    'src/python/pants/base:deprecated',
-    'src/python/pants/testutil/option'
+    'src/python/pants/testutil/option',
+    'tests/python/pants_test:deprecated_testinfra',
   ],
 )

--- a/tests/python/pants_test/option/util/fakes.py
+++ b/tests/python/pants_test/option/util/fakes.py
@@ -1,7 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.option.fakes import _FakeOptionValues as _FakeOptionValues  # noqa
 from pants.testutil.option.fakes import (
   _options_registration_function as _options_registration_function,
@@ -10,9 +9,7 @@ from pants.testutil.option.fakes import create_options as create_options  # noqa
 from pants.testutil.option.fakes import (
   create_options_for_optionables as create_options_for_optionables,
 )  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.option.fakes instead."
-)
+deprecated_testinfra_module('pants.testutil.option.fakes')

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -16,5 +16,6 @@ from pants.testutil.pants_run_integration_test import render_logs as render_logs
 
 deprecated_module(
   removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.pants_run_integration_test instead."
+  hint_message="Import pants.testutil.pants_run_integration_test from the "
+               "pantsbuild.pants.testutil distribution instead."
 )

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -1,7 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.pants_run_integration_test import PantsJoinHandle as PantsJoinHandle  # noqa
 from pants.testutil.pants_run_integration_test import PantsResult as PantsResult  # noqa
 from pants.testutil.pants_run_integration_test import (
@@ -12,10 +11,7 @@ from pants.testutil.pants_run_integration_test import ensure_daemon as ensure_da
 from pants.testutil.pants_run_integration_test import ensure_resolver as ensure_resolver  # noqa
 from pants.testutil.pants_run_integration_test import read_pantsd_log as read_pantsd_log  # noqa
 from pants.testutil.pants_run_integration_test import render_logs as render_logs  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.pants_run_integration_test from the "
-               "pantsbuild.pants.testutil distribution instead."
-)
+deprecated_testinfra_module()

--- a/tests/python/pants_test/subsystem/BUILD
+++ b/tests/python/pants_test/subsystem/BUILD
@@ -14,7 +14,7 @@ python_library(
   name='subsystem_utils',
   sources=['subsystem_util.py'],
   dependencies=[
-    'src/python/pants/base:deprecated',
     'src/python/pants/testutil/subsystem',
+    'tests/python/pants_test:deprecated_testinfra',
   ],
 )

--- a/tests/python/pants_test/subsystem/subsystem_util.py
+++ b/tests/python/pants_test/subsystem/subsystem_util.py
@@ -1,13 +1,10 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.subsystem.util import global_subsystem_instance as global_subsystem_instance  # noqa
 from pants.testutil.subsystem.util import init_subsystem as init_subsystem  # noqa
 from pants.testutil.subsystem.util import init_subsystems as init_subsystems  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.subsystem.util instead."
-)
+deprecated_testinfra_module('pants.testutil.subsystem.util')

--- a/tests/python/pants_test/task_test_base.py
+++ b/tests/python/pants_test/task_test_base.py
@@ -11,5 +11,6 @@ from pants.testutil.task_test_base import is_exe as is_exe  # noqa
 
 deprecated_module(
   removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.task_test_base instead."
+  hint_message="Import pants.testutil.task_test_base from the pantsbuild.pants.testutil "
+               "distribution instead."
 )

--- a/tests/python/pants_test/task_test_base.py
+++ b/tests/python/pants_test/task_test_base.py
@@ -1,16 +1,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.task_test_base import ConsoleTaskTestBase as ConsoleTaskTestBase  # noqa
 from pants.testutil.task_test_base import DeclarativeTaskTestMixin as DeclarativeTaskTestMixin  # noqa
 from pants.testutil.task_test_base import TaskTestBase as TaskTestBase  # noqa
 from pants.testutil.task_test_base import ensure_cached as ensure_cached  # noqa
 from pants.testutil.task_test_base import is_exe as is_exe  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.task_test_base from the pantsbuild.pants.testutil "
-               "distribution instead."
-)
+deprecated_testinfra_module()

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -8,5 +8,6 @@ from pants.testutil.test_base import TestBase as TestBase  # noqa
 
 deprecated_module(
   removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.test_base instead."
+  hint_message="Import pants.testutil.test_base from the pantsbuild.pants.testutil distribution "
+               "instead."
 )

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -1,13 +1,9 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.test_base import AbstractTestGenerator as AbstractTestGenerator  # noqa
 from pants.testutil.test_base import TestBase as TestBase  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.test_base from the pantsbuild.pants.testutil distribution "
-               "instead."
-)
+deprecated_testinfra_module()

--- a/tests/python/pants_test/testutils/BUILD
+++ b/tests/python/pants_test/testutils/BUILD
@@ -5,8 +5,8 @@ python_library(
   name = 'mock_logger',
   sources = globs('mock_logger.py'),
   dependencies = [
-    'src/python/pants/base:deprecated',
     'src/python/pants/testutil:mock_logger',
+    'tests/python/pants_test:deprecated_testinfra',
   ],
 )
 
@@ -16,8 +16,8 @@ python_library(
     'file_test_util.py',
   ],
   dependencies = [
-    'src/python/pants/base:deprecated',
     'src/python/pants/testutil:file_test_util',
+    'tests/python/pants_test:deprecated_testinfra',
   ],
 )
 
@@ -27,8 +27,8 @@ python_library(
     'git_util.py',
   ],
   dependencies = [
-    'src/python/pants/base:deprecated',
     'src/python/pants/testutil:git_util',
+    'tests/python/pants_test:deprecated_testinfra',
   ],
 )
 
@@ -38,8 +38,8 @@ python_library(
     'process_test_util.py',
   ],
   dependencies = [
-    'src/python/pants/base:deprecated',
     'src/python/pants/testutil:process_test_util',
+    'tests/python/pants_test:deprecated_testinfra',
   ],
 )
 
@@ -49,7 +49,7 @@ python_library(
     'pexrc_util.py',
   ],
   dependencies = [
-    'src/python/pants/base:deprecated',
     'src/python/pants/testutil:pexrc_util',
+    'tests/python/pants_test:deprecated_testinfra',
   ],
 )

--- a/tests/python/pants_test/testutils/file_test_util.py
+++ b/tests/python/pants_test/testutils/file_test_util.py
@@ -1,14 +1,11 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.file_test_util import check_file_content as check_file_content  # noqa
 from pants.testutil.file_test_util import check_symlinks as check_symlinks  # noqa
 from pants.testutil.file_test_util import contains_exact_files as contains_exact_files  # noqa
 from pants.testutil.file_test_util import exact_files as exact_files  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.file_test_util instead."
-)
+deprecated_testinfra_module('pants.testutil.file_test_util')

--- a/tests/python/pants_test/testutils/git_util.py
+++ b/tests/python/pants_test/testutils/git_util.py
@@ -1,13 +1,10 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.git_util import MIN_REQUIRED_GIT_VERSION as MIN_REQUIRED_GIT_VERSION  # noqa
 from pants.testutil.git_util import git_version as git_version  # noqa
 from pants.testutil.git_util import initialize_repo as initialize_repo  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.git_util instead."
-)
+deprecated_testinfra_module('pants.testutil.git_util')

--- a/tests/python/pants_test/testutils/mock_logger.py
+++ b/tests/python/pants_test/testutils/mock_logger.py
@@ -1,11 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.mock_logger import MockLogger as MockLogger  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.mock_logger instead."
-)
+deprecated_testinfra_module('pants.testutil.mock_logger')

--- a/tests/python/pants_test/testutils/pexrc_util.py
+++ b/tests/python/pants_test/testutils/pexrc_util.py
@@ -1,13 +1,10 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.pexrc_util import (
   setup_pexrc_with_pex_python_path as setup_pexrc_with_pex_python_path,
 )  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.pexrc_util instead."
-)
+deprecated_testinfra_module('pants.testutil.pexrc_util')

--- a/tests/python/pants_test/testutils/process_test_util.py
+++ b/tests/python/pants_test/testutils/process_test_util.py
@@ -1,7 +1,6 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.base.deprecated import deprecated_module
 from pants.testutil.process_test_util import ProcessStillRunning as ProcessStillRunning  # noqa
 from pants.testutil.process_test_util import TrackedProcessesContext as TrackedProcessesContext  # noqa
 from pants.testutil.process_test_util import _make_process_table as _make_process_table  # noqa
@@ -11,9 +10,7 @@ from pants.testutil.process_test_util import (
 from pants.testutil.process_test_util import (
   no_lingering_process_by_command as no_lingering_process_by_command,
 )  # noqa
+from pants_test.deprecated_testinfra import deprecated_testinfra_module
 
 
-deprecated_module(
-  removal_version="1.25.0.dev0",
-  hint_message="Import pants.testutil.process_test_util instead."
-)
+deprecated_testinfra_module('pants.testutil.process_test_util')


### PR DESCRIPTION
The `pantsbuild.pants.testinfra` distribution has been broken since
teh `1.23.0.dev1` release with an invalid description field. This has
prevented publishing of the package as well as any packages following
it in the release. Fixup the root problem and add a check that will
fail PR CI in the future for similar breaks.

In addition, cleanup a warning against our packages not declaring
`long_description_content_type` brought to light by the new check.