### PR TITLE
Add timeout options to Pytest rule

### DIFF
--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -26,7 +26,7 @@ from pants.rules.core.strip_source_root import SourceRootStrippedSources
 
 def calculate_timeout_seconds(
   *,
-  timeout_disabled: bool,
+  timeouts_enabled: bool,
   target_timeout: Optional[int],
   timeout_default: Optional[int],
   timeout_maximum: Optional[int],
@@ -35,7 +35,7 @@ def calculate_timeout_seconds(
 
   If a target has no timeout configured its timeout will be set to the default timeout.
   """
-  if timeout_disabled:
+  if not timeouts_enabled:
     return None
   if target_timeout is None:
     if timeout_default is None:
@@ -116,7 +116,7 @@ async def run_python_test(
 
   test_target_sources_file_names = sorted(source_root_stripped_test_target_sources.snapshot.files)
   timeout_seconds = calculate_timeout_seconds(
-    timeout_disabled=pytest.options.timeout_disabled,
+    timeouts_enabled=pytest.options.timeouts,
     target_timeout=getattr(test_target, 'timeout', None),
     timeout_default=pytest.options.timeout_default,
     timeout_maximum=pytest.options.timeout_maximum,

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -35,7 +35,6 @@ def get_timeout_seconds_for_target(test_target_timeout, timeout_default, timeout
   if test_target_timeout is None:
     test_target_timeout = timeout_default
   if timeout_maximum is not None and test_target_timeout > timeout_maximum:
-    # TODO Log a warning here.
     return timeout_maximum
   return test_target_timeout
 
@@ -116,8 +115,6 @@ async def run_python_test(
     pex_args=(*pytest.get_args(), *test_target_sources_file_names),
     input_files=merged_input_files,
     description=f'Run Pytest for {test_target.address.reference()}',
-    # TODO(#8584): hook this up to TestRunnerTaskMixin so that we can configure the default timeout
-    #  and also use the specified max timeout time.
     timeout_seconds=get_timeout_seconds_for_target(
       test_target_timeout=getattr(test_target, 'timeout', None),
       timeout_default=pytest.options.timeout_default,

--- a/src/python/pants/backend/python/rules/python_test_runner_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_test.py
@@ -1,0 +1,18 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import pytest
+
+from pants.backend.python.rules.python_test_runner import get_timeout_seconds_for_target
+
+
+@pytest.mark.parametrize(
+  "target_timeout,default_timeout,maximum_timeout,result",
+  [
+    (10, 1, 2, 2), # configured timeout greater than maximum --> maximum
+    (2, 1, 2, 2), # configured timeout OK --> configured timeout
+    (None, 1, 2, 1), # target has no configured timeout --> default
+    (None, 10, 2, 2), # target has no configured timeout and default is greater than maximum --> maximum
+  ])
+def test_get_timeout_seconds_for_target(target_timeout, default_timeout, maximum_timeout, result):
+  assert get_timeout_seconds_for_target(target_timeout, default_timeout, maximum_timeout) == result

--- a/src/python/pants/backend/python/rules/python_test_runner_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_test.py
@@ -1,18 +1,76 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import pytest
-
-from pants.backend.python.rules.python_test_runner import get_timeout_seconds_for_target
+from pants.backend.python.rules.python_test_runner import calculate_timeout_seconds
 
 
-@pytest.mark.parametrize(
-  "target_timeout,default_timeout,maximum_timeout,result",
-  [
-    (10, 1, 2, 2), # configured timeout greater than maximum --> maximum
-    (2, 1, 2, 2), # configured timeout OK --> configured timeout
-    (None, 1, 2, 1), # target has no configured timeout --> default
-    (None, 10, 2, 2), # target has no configured timeout and default is greater than maximum --> maximum
-  ])
-def test_get_timeout_seconds_for_target(target_timeout, default_timeout, maximum_timeout, result):
-  assert get_timeout_seconds_for_target(target_timeout, default_timeout, maximum_timeout) == result
+def test_configured_timeout_greater_than_max():
+  assert calculate_timeout_seconds(
+    timeouts=True,
+    test_target_timeout_seconds=10,
+    timeout_default_seconds=1,
+    timeout_maximum_seconds=2,
+  ) == 2
+
+
+def test_good_test_target_timeout():
+  assert calculate_timeout_seconds(
+    timeouts=True,
+    test_target_timeout_seconds=2,
+    timeout_default_seconds=1,
+    timeout_maximum_seconds=10,
+  ) == 2
+
+
+def test_no_configured_test_target_timeout():
+  assert calculate_timeout_seconds(
+    timeouts=True,
+    test_target_timeout_seconds=None,
+    timeout_default_seconds=1,
+    timeout_maximum_seconds=2,
+  ) == 1
+
+
+def test_no_configured_test_target_timeout_with_bad_default():
+  assert calculate_timeout_seconds(
+    timeouts=True,
+    test_target_timeout_seconds=None,
+    timeout_default_seconds=10,
+    timeout_maximum_seconds=2,
+  ) == 2
+
+
+def test_no_default_timeout():
+  assert calculate_timeout_seconds(
+    timeouts=True,
+    test_target_timeout_seconds=1,
+    timeout_default_seconds=None,
+    timeout_maximum_seconds=None,
+  ) == 1
+
+
+def test_no_maximum_timeout():
+  assert calculate_timeout_seconds(
+    timeouts=True,
+    test_target_timeout_seconds=1,
+    timeout_default_seconds=2,
+    timeout_maximum_seconds=None,
+  ) == 1
+
+
+def test_no_configured_timeouts():
+  assert calculate_timeout_seconds(
+    timeouts=True,
+    test_target_timeout_seconds=None,
+    timeout_default_seconds=None,
+    timeout_maximum_seconds=None,
+  ) == None
+
+
+def test_no_timeouts():
+  assert calculate_timeout_seconds(
+    timeouts=False,
+    test_target_timeout_seconds=10,
+    timeout_default_seconds=1,
+    timeout_maximum_seconds=2,
+  ) == None

--- a/src/python/pants/backend/python/rules/python_test_runner_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_test.py
@@ -6,7 +6,7 @@ from pants.backend.python.rules.python_test_runner import calculate_timeout_seco
 
 def test_configured_timeout_greater_than_max():
   assert calculate_timeout_seconds(
-    timeout_disabled=False,
+    timeouts_enabled=True,
     target_timeout=10,
     timeout_default=1,
     timeout_maximum=2,
@@ -15,7 +15,7 @@ def test_configured_timeout_greater_than_max():
 
 def test_good_target_timeout():
   assert calculate_timeout_seconds(
-    timeout_disabled=False,
+    timeouts_enabled=True,
     target_timeout=2,
     timeout_default=1,
     timeout_maximum=10,
@@ -24,7 +24,7 @@ def test_good_target_timeout():
 
 def test_no_configured_target_timeout():
   assert calculate_timeout_seconds(
-    timeout_disabled=False,
+    timeouts_enabled=True,
     target_timeout=None,
     timeout_default=1,
     timeout_maximum=2,
@@ -33,7 +33,7 @@ def test_no_configured_target_timeout():
 
 def test_no_configured_target_timeout_with_bad_default():
   assert calculate_timeout_seconds(
-    timeout_disabled=False,
+    timeouts_enabled=True,
     target_timeout=None,
     timeout_default=10,
     timeout_maximum=2,
@@ -42,7 +42,7 @@ def test_no_configured_target_timeout_with_bad_default():
 
 def test_no_default_timeout():
   assert calculate_timeout_seconds(
-    timeout_disabled=False,
+    timeouts_enabled=True,
     target_timeout=1,
     timeout_default=None,
     timeout_maximum=None,
@@ -51,7 +51,7 @@ def test_no_default_timeout():
 
 def test_no_maximum_timeout():
   assert calculate_timeout_seconds(
-    timeout_disabled=False,
+    timeouts_enabled=True,
     target_timeout=1,
     timeout_default=2,
     timeout_maximum=None,
@@ -60,7 +60,7 @@ def test_no_maximum_timeout():
 
 def test_no_configured_timeouts():
   assert calculate_timeout_seconds(
-    timeout_disabled=False,
+    timeouts_enabled=True,
     target_timeout=None,
     timeout_default=None,
     timeout_maximum=2,
@@ -69,7 +69,7 @@ def test_no_configured_timeouts():
 
 def test_no_timeouts():
   assert calculate_timeout_seconds(
-    timeout_disabled=True,
+    timeouts_enabled=False,
     target_timeout=10,
     timeout_default=1,
     timeout_maximum=2,

--- a/src/python/pants/backend/python/rules/python_test_runner_test.py
+++ b/src/python/pants/backend/python/rules/python_test_runner_test.py
@@ -6,71 +6,71 @@ from pants.backend.python.rules.python_test_runner import calculate_timeout_seco
 
 def test_configured_timeout_greater_than_max():
   assert calculate_timeout_seconds(
-    timeouts=True,
-    test_target_timeout_seconds=10,
-    timeout_default_seconds=1,
-    timeout_maximum_seconds=2,
+    timeout_disabled=False,
+    target_timeout=10,
+    timeout_default=1,
+    timeout_maximum=2,
   ) == 2
 
 
-def test_good_test_target_timeout():
+def test_good_target_timeout():
   assert calculate_timeout_seconds(
-    timeouts=True,
-    test_target_timeout_seconds=2,
-    timeout_default_seconds=1,
-    timeout_maximum_seconds=10,
+    timeout_disabled=False,
+    target_timeout=2,
+    timeout_default=1,
+    timeout_maximum=10,
   ) == 2
 
 
-def test_no_configured_test_target_timeout():
+def test_no_configured_target_timeout():
   assert calculate_timeout_seconds(
-    timeouts=True,
-    test_target_timeout_seconds=None,
-    timeout_default_seconds=1,
-    timeout_maximum_seconds=2,
+    timeout_disabled=False,
+    target_timeout=None,
+    timeout_default=1,
+    timeout_maximum=2,
   ) == 1
 
 
-def test_no_configured_test_target_timeout_with_bad_default():
+def test_no_configured_target_timeout_with_bad_default():
   assert calculate_timeout_seconds(
-    timeouts=True,
-    test_target_timeout_seconds=None,
-    timeout_default_seconds=10,
-    timeout_maximum_seconds=2,
+    timeout_disabled=False,
+    target_timeout=None,
+    timeout_default=10,
+    timeout_maximum=2,
   ) == 2
 
 
 def test_no_default_timeout():
   assert calculate_timeout_seconds(
-    timeouts=True,
-    test_target_timeout_seconds=1,
-    timeout_default_seconds=None,
-    timeout_maximum_seconds=None,
+    timeout_disabled=False,
+    target_timeout=1,
+    timeout_default=None,
+    timeout_maximum=None,
   ) == 1
 
 
 def test_no_maximum_timeout():
   assert calculate_timeout_seconds(
-    timeouts=True,
-    test_target_timeout_seconds=1,
-    timeout_default_seconds=2,
-    timeout_maximum_seconds=None,
+    timeout_disabled=False,
+    target_timeout=1,
+    timeout_default=2,
+    timeout_maximum=None,
   ) == 1
 
 
 def test_no_configured_timeouts():
   assert calculate_timeout_seconds(
-    timeouts=True,
-    test_target_timeout_seconds=None,
-    timeout_default_seconds=None,
-    timeout_maximum_seconds=None,
+    timeout_disabled=False,
+    target_timeout=None,
+    timeout_default=None,
+    timeout_maximum=2,
   ) == None
 
 
 def test_no_timeouts():
   assert calculate_timeout_seconds(
-    timeouts=False,
-    test_target_timeout_seconds=10,
-    timeout_default_seconds=1,
-    timeout_maximum_seconds=2,
+    timeout_disabled=True,
+    target_timeout=10,
+    timeout_default=1,
+    timeout_maximum=2,
   ) == None

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -71,13 +71,6 @@ class PyTest(Subsystem):
       default=120,
       help='The maximum timeout (in seconds) that can be set on a test target.',
     )
-    register(
-      '--timeout-terminate-wait',
-      type=int,
-      advanced=True,
-      default=10,
-      help='If a test does not terminate on a SIGTERM, how long to wait (in seconds) before sending a SIGKILL.',
-    )
 
   def get_requirement_strings(self) -> Tuple[str, ...]:
     """Returns a tuple of requirements-style strings for Pytest and Pytest plugins."""

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -44,6 +44,38 @@ class PyTest(Subsystem):
              help='Requirements string for the unittest2 library, which some python versions '
                   'may need.',
              removal_version="1.25.0.dev0", removal_hint="Use --pytest-plugins instead.")
+    register(
+      '--timeouts',
+      type=bool,
+      default=True,
+      help='Enable test target timeouts. If timeouts are enabled then tests with a '
+          'timeout= parameter set on their target will time out after the given number of '
+          'seconds if not completed. If no timeout is set, then either the default timeout '
+          'is used or no timeout is configured. In the current implementation, all the '
+          'timeouts for the test targets to be run are summed and all tests are run with '
+          'the total timeout covering the entire run of tests. If a single target in a '
+          'test run has no timeout and there is no default, the entire run will have no '
+          'timeout. This should change in the future to provide more granularity.',
+    )
+    register(
+      '--timeout-default',
+      type=int,
+      advanced=True,
+      help='The default timeout (in seconds) for a test if timeout is not set on the target.',
+    )
+    register(
+      '--timeout-maximum',
+      type=int,
+      advanced=True,
+      help='The maximum timeout (in seconds) that can be set on a test target.',
+    )
+    register(
+      '--timeout-terminate-wait',
+      type=int,
+      advanced=True,
+      default=10,
+      help='If a test does not terminate on a SIGTERM, how long to wait (in seconds) before sending a SIGKILL.',
+    )
 
   def get_requirement_strings(self) -> Tuple[str, ...]:
     """Returns a tuple of requirements-style strings for Pytest and Pytest plugins."""

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -45,10 +45,10 @@ class PyTest(Subsystem):
                   'may need.',
              removal_version="1.25.0.dev0", removal_hint="Use --pytest-plugins instead.")
     register(
-      '--timeout-disabled',
+      '--timeouts',
       type=bool,
-      default=False,
-      help='Disable test target timeouts. If timeouts are enabled then test targets with a '
+      default=True,
+      help='Enable test target timeouts. If timeouts are enabled then test targets with a '
           'timeout= parameter set on their target will time out after the given number of '
           'seconds if not completed. If no timeout is set, then either the default timeout '
           'is used or no timeout is configured.',

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -48,21 +48,17 @@ class PyTest(Subsystem):
       '--timeouts',
       type=bool,
       default=True,
-      help='Enable test target timeouts. If timeouts are enabled then tests with a '
+      help='Enable test target timeouts. If timeouts are enabled then test targets with a '
           'timeout= parameter set on their target will time out after the given number of '
           'seconds if not completed. If no timeout is set, then either the default timeout '
-          'is used or no timeout is configured. In the current implementation, all the '
-          'timeouts for the test targets to be run are summed and all tests are run with '
-          'the total timeout covering the entire run of tests. If a single target in a '
-          'test run has no timeout and there is no default, the entire run will have no '
-          'timeout. This should change in the future to provide more granularity.',
+          'is used or no timeout is configured.',
     )
     register(
       '--timeout-default',
       type=int,
       advanced=True,
       default=60,
-      help='The default timeout (in seconds) for a test if timeout is not set on the target.',
+      help='The default timeout (in seconds) for a test target if the timeout field is not set on the target.',
     )
     register(
       '--timeout-maximum',

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -61,12 +61,14 @@ class PyTest(Subsystem):
       '--timeout-default',
       type=int,
       advanced=True,
+      default=60,
       help='The default timeout (in seconds) for a test if timeout is not set on the target.',
     )
     register(
       '--timeout-maximum',
       type=int,
       advanced=True,
+      default=120,
       help='The maximum timeout (in seconds) that can be set on a test target.',
     )
     register(

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -45,10 +45,10 @@ class PyTest(Subsystem):
                   'may need.',
              removal_version="1.25.0.dev0", removal_hint="Use --pytest-plugins instead.")
     register(
-      '--timeouts',
+      '--timeout-disabled',
       type=bool,
-      default=True,
-      help='Enable test target timeouts. If timeouts are enabled then test targets with a '
+      default=False,
+      help='Disable test target timeouts. If timeouts are enabled then test targets with a '
           'timeout= parameter set on their target will time out after the given number of '
           'seconds if not completed. If no timeout is set, then either the default timeout '
           'is used or no timeout is configured.',
@@ -57,14 +57,12 @@ class PyTest(Subsystem):
       '--timeout-default',
       type=int,
       advanced=True,
-      default=60,
       help='The default timeout (in seconds) for a test target if the timeout field is not set on the target.',
     )
     register(
       '--timeout-maximum',
       type=int,
       advanced=True,
-      default=120,
       help='The maximum timeout (in seconds) that can be set on a test target.',
     )
 


### PR DESCRIPTION
### Problem

Pytest rule does not support the timeout related options of the pytest task.

### Solution

Add `--timeouts`, `--timeout-default`, and `--timeout-maximum`

### Result

Pytest rule supports timeout options.

There is one behavior change from the pytest V1 task which is that a timeout of 0 seconds is treated as a time out of 0 seconds, not as no timeout set. This was in response to some comments in [testrunner_task_mixin.py](https://github.com/pantsbuild/pants/blob/master/src/python/pants/task/testrunner_task_mixin.py#L310)

```
   TODO(sbrenn): This behavior where timeout=0 is the same as timeout=None has turned out to be
    very confusing, and should change so that timeout=0 actually sets the timeout to 0, and only
    timeout=None should set the timeout to the default timeout. This will require a deprecation
    cycle.
```

