### PR TITLE
Support working_directory in EPRs.

### DIFF
--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -31,8 +31,8 @@ class ExecuteProcessRequest:
   # reproduces this process execution request to make debugging remote executions effortless!
   argv: Tuple[str, ...]
   input_files: Digest
-  working_directory: Optional[str]
   description: str
+  working_directory: Optional[str]
   env: Tuple[str, ...]
   output_files: Tuple[str, ...]
   output_directories: Tuple[str, ...]
@@ -45,9 +45,9 @@ class ExecuteProcessRequest:
     self,
     argv: Tuple[str, ...],
     *,
-    working_directory: Optional[str] = None,
     input_files: Digest,
     description: str,
+    working_directory: Optional[str] = None,
     env: Optional[Dict[str, str]] = None,
     output_files: Optional[Tuple[str, ...]] = None,
     output_directories: Optional[Tuple[str, ...]] = None,
@@ -57,9 +57,9 @@ class ExecuteProcessRequest:
     is_nailgunnable: bool = False,
   ) -> None:
     self.argv = argv
-    self.working_directory = working_directory
     self.input_files = input_files
     self.description = description
+    self.working_directory = working_directory
     self.env = tuple(itertools.chain.from_iterable((env or {}).items()))
     self.output_files = output_files or ()
     self.output_directories = output_directories or ()

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -31,6 +31,7 @@ class ExecuteProcessRequest:
   # reproduces this process execution request to make debugging remote executions effortless!
   argv: Tuple[str, ...]
   input_files: Digest
+  working_directory: Optional[str]
   description: str
   env: Tuple[str, ...]
   output_files: Tuple[str, ...]
@@ -44,6 +45,7 @@ class ExecuteProcessRequest:
     self,
     argv: Tuple[str, ...],
     *,
+    working_directory: Optional[str] = None,
     input_files: Digest,
     description: str,
     env: Optional[Dict[str, str]] = None,
@@ -55,6 +57,7 @@ class ExecuteProcessRequest:
     is_nailgunnable: bool = False,
   ) -> None:
     self.argv = argv
+    self.working_directory = working_directory
     self.input_files = input_files
     self.description = description
     self.env = tuple(itertools.chain.from_iterable((env or {}).items()))

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -49,6 +49,7 @@ fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
       format!("{}", script_path.display()),
     ],
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("roland")].into_iter().collect(),
     output_directories: BTreeSet::new(),

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -3,7 +3,7 @@ use testutil;
 
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
-  FallibleExecuteProcessResult, Platform,
+  FallibleExecuteProcessResult, Platform, RelativePath,
 };
 use hashing::EMPTY_DIGEST;
 use spectral::{assert_that, string::StrAssertions};
@@ -23,13 +23,13 @@ fn stdout() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
     timeout: Duration::from_millis(1000),
     description: "echo foo".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -53,13 +53,13 @@ fn stdout_and_stderr_and_exit_code() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/bash", "-c", "echo -n foo ; echo >&2 -n bar ; exit 1"]),
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
     timeout: Duration::from_millis(1000),
     description: "echo foo and fail".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -84,13 +84,13 @@ fn capture_exit_code_signal() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/bash", "-c", "kill $$"]),
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
     timeout: Duration::from_millis(1000),
     description: "kill self".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -118,13 +118,13 @@ fn env() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["/usr/bin/env"]),
     env: env.clone(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
     timeout: Duration::from_millis(1000),
     description: "run env".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -158,13 +158,13 @@ fn env_is_deterministic() {
     ExecuteProcessRequest {
       argv: owned_string_vec(&["/usr/bin/env"]),
       env: env,
+      working_directory: None,
       input_files: EMPTY_DIGEST,
       output_files: BTreeSet::new(),
       output_directories: BTreeSet::new(),
       timeout: Duration::from_millis(1000),
       description: "run env".to_string(),
-      unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-        hashing::EMPTY_DIGEST,
+      unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
       jdk_home: None,
       target_platform: Platform::None,
       is_nailgunnable: false,
@@ -182,13 +182,13 @@ fn binary_not_found() {
   run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["echo", "-n", "foo"]),
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
     timeout: Duration::from_millis(1000),
     description: "echo foo".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -201,13 +201,13 @@ fn output_files_none() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&[&find_bash(), "-c", "exit 0"]),
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
     timeout: Duration::from_millis(1000),
     description: "bash".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -233,13 +233,13 @@ fn output_files_one() {
       format!("echo -n {} > {}", TestData::roland().string(), "roland"),
     ],
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("roland")].into_iter().collect(),
     output_directories: BTreeSet::new(),
     timeout: Duration::from_millis(1000),
     description: "bash".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -271,13 +271,13 @@ fn output_dirs() {
       ),
     ],
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("treats")].into_iter().collect(),
     output_directories: vec![PathBuf::from("cats")].into_iter().collect(),
     timeout: Duration::from_millis(1000),
     description: "bash".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -308,6 +308,7 @@ fn output_files_many() {
       ),
     ],
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("cats/roland"), PathBuf::from("treats")]
       .into_iter()
@@ -315,8 +316,7 @@ fn output_files_many() {
     output_directories: BTreeSet::new(),
     timeout: Duration::from_millis(1000),
     description: "treats-roland".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -347,13 +347,13 @@ fn output_files_execution_failure() {
       ),
     ],
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("roland")].into_iter().collect(),
     output_directories: BTreeSet::new(),
     timeout: Duration::from_millis(1000),
     description: "echo foo".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -380,6 +380,7 @@ fn output_files_partial_output() {
       format!("echo -n {} > {}", TestData::roland().string(), "roland"),
     ],
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("roland"), PathBuf::from("susannah")]
       .into_iter()
@@ -387,8 +388,7 @@ fn output_files_partial_output() {
     output_directories: BTreeSet::new(),
     timeout: Duration::from_millis(1000),
     description: "echo-roland".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -415,13 +415,13 @@ fn output_overlapping_file_and_dir() {
       format!("echo -n {} > cats/roland", TestData::roland().string()),
     ],
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("cats/roland")].into_iter().collect(),
     output_directories: vec![PathBuf::from("cats")].into_iter().collect(),
     timeout: Duration::from_millis(1000),
     description: "bash".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -448,13 +448,13 @@ fn jdk_symlink() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: vec!["/bin/cat".to_owned(), ".jdk/roland".to_owned()],
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
     timeout: Duration::from_millis(1000),
     description: "cat roland".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: Some(preserved_work_tmpdir.path().to_path_buf()),
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -484,13 +484,13 @@ fn test_directory_preservation() {
         format!("echo -n {} > {}", TestData::roland().string(), "roland"),
       ],
       env: BTreeMap::new(),
+      working_directory: None,
       input_files: EMPTY_DIGEST,
       output_files: vec![PathBuf::from("roland")].into_iter().collect(),
       output_directories: BTreeSet::new(),
       timeout: Duration::from_millis(1000),
       description: "bash".to_string(),
-      unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-        hashing::EMPTY_DIGEST,
+      unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
       jdk_home: None,
       target_platform: Platform::None,
       is_nailgunnable: false,
@@ -525,13 +525,13 @@ fn test_directory_preservation_error() {
     ExecuteProcessRequest {
       argv: vec!["doesnotexist".to_owned()],
       env: BTreeMap::new(),
+      working_directory: None,
       input_files: EMPTY_DIGEST,
       output_files: BTreeSet::new(),
       output_directories: BTreeSet::new(),
       timeout: Duration::from_millis(1000),
       description: "failing execution".to_string(),
-      unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-        hashing::EMPTY_DIGEST,
+      unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
       jdk_home: None,
       target_platform: Platform::None,
       is_nailgunnable: false,
@@ -563,13 +563,13 @@ fn all_containing_directories_for_outputs_are_created() {
       ),
     ],
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("cats/roland")].into_iter().collect(),
     output_directories: vec![PathBuf::from("birds/falcons")].into_iter().collect(),
     timeout: Duration::from_millis(1000),
     description: "create nonoverlapping directories and file".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -596,13 +596,13 @@ fn output_empty_dir() {
       "/bin/mkdir falcons".to_string(),
     ],
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: vec![PathBuf::from("falcons")].into_iter().collect(),
     timeout: Duration::from_millis(1000),
     description: "bash".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -643,7 +643,8 @@ fn local_only_scratch_files_materialized() {
     ExecuteProcessRequest {
       argv: vec![find_bash(), "-c".to_owned(), format!("echo -n ''")],
       env: BTreeMap::new(),
-      input_files: hashing::EMPTY_DIGEST,
+      working_directory: None,
+      input_files: EMPTY_DIGEST,
       output_files: vec![PathBuf::from("roland")].into_iter().collect(),
       output_directories: BTreeSet::new(),
       timeout: Duration::from_millis(1000),
@@ -681,13 +682,13 @@ fn timeout() {
       "/bin/sleep 0.2; /bin/echo -n 'European Burmese'".to_string(),
     ],
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
     timeout: Duration::from_millis(100),
     description: "sleepy-cat".to_string(),
-    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-      hashing::EMPTY_DIGEST,
+    unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
     jdk_home: None,
     target_platform: Platform::None,
     is_nailgunnable: false,
@@ -698,6 +699,58 @@ fn timeout() {
   let error_msg = String::from_utf8(result.stdout.to_vec()).unwrap();
   assert_that(&error_msg).contains("Exceeded timeout");
   assert_that(&error_msg).contains("sleepy-cat");
+}
+
+#[test]
+fn working_directory() {
+  let store_dir = TempDir::new().unwrap();
+  let executor = task_executor::Executor::new();
+  let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
+
+  // Prepare the store to contain /cats/roland, because the EPR needs to materialize it and then run
+  // from the ./cats directory.
+  executor
+    .block_on(store.store_file_bytes(TestData::roland().bytes(), false))
+    .expect("Error saving file bytes");
+  executor
+    .block_on(store.record_directory(&TestDirectory::containing_roland().directory(), true))
+    .expect("Error saving directory");
+  executor
+    .block_on(store.record_directory(&TestDirectory::nested().directory(), true))
+    .expect("Error saving directory");
+
+  let work_dir = TempDir::new().unwrap();
+  let result = run_command_locally_in_dir(
+    ExecuteProcessRequest {
+      argv: vec![find_bash(), "-c".to_owned(), "/bin/ls".to_string()],
+      env: BTreeMap::new(),
+      working_directory: Some(RelativePath::new("cats").unwrap()),
+      input_files: TestDirectory::nested().digest(),
+      output_files: BTreeSet::new(),
+      output_directories: BTreeSet::new(),
+      timeout: Duration::from_millis(100),
+      description: "confused-cat".to_string(),
+      unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
+      jdk_home: None,
+      target_platform: Platform::None,
+      is_nailgunnable: false,
+    },
+    work_dir.path().to_owned(),
+    true,
+    Some(store),
+    Some(executor),
+  );
+
+  assert_eq!(
+    result.unwrap(),
+    FallibleExecuteProcessResult {
+      stdout: as_bytes("roland\n"),
+      stderr: as_bytes(""),
+      exit_code: 0,
+      output_directory: EMPTY_DIGEST,
+      execution_attempts: vec![],
+    }
+  );
 }
 
 fn run_command_locally(req: ExecuteProcessRequest) -> Result<FallibleExecuteProcessResult, String> {

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -54,6 +54,7 @@ fn construct_nailgun_server_request(
   ExecuteProcessRequest {
     argv: full_args,
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: hashing::EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -77,6 +78,7 @@ fn construct_nailgun_client_request(
     input_files,
     description,
     env: original_request_env,
+    working_directory,
     output_files,
     output_directories,
     timeout,
@@ -91,6 +93,7 @@ fn construct_nailgun_client_request(
     input_files,
     description,
     env: original_request_env,
+    working_directory,
     output_files,
     output_directories,
     timeout,
@@ -218,7 +221,11 @@ impl CapturedWorkdir for CommandRunner {
     let nailgun_name = CommandRunner::calculate_nailgun_name(&client_main_class);
     let nailgun_name2 = nailgun_name.clone();
     let nailgun_name3 = nailgun_name.clone();
-    let client_workdir = workdir_path.to_path_buf();
+    let client_workdir = if let Some(working_directory) = &req.working_directory {
+      workdir_path.join(working_directory)
+    } else {
+      workdir_path.to_path_buf()
+    };
 
     let jdk_home = req
       .jdk_home

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -35,6 +35,7 @@ fn mock_nailgunnable_request(jdk_home: Option<PathBuf>) -> ExecuteProcessRequest
   ExecuteProcessRequest {
     argv: vec![],
     env: Default::default(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: Default::default(),
     output_directories: Default::default(),

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -892,6 +892,15 @@ pub fn make_execute_request(
   output_directories.sort();
   command.set_output_directories(protobuf::RepeatedField::from_vec(output_directories));
 
+  if let Some(working_directory) = &req.working_directory {
+    command.set_working_directory(
+      working_directory
+        .to_str()
+        .map(str::to_owned)
+        .unwrap_or_else(|| panic!("Non-UTF8 working directory path: {:?}", working_directory)),
+    )
+  }
+
   if req.jdk_home.is_some() {
     // Ideally, the JDK would be brought along as part of the input directory, but we don't
     // currently have support for that. Scoot supports this property, and will symlink .jdk to a

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -56,6 +56,7 @@ fn local_only_scratch_files_ignored() {
     env: vec![("SOME".to_owned(), "value".to_owned())]
       .into_iter()
       .collect(),
+    working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
     output_files: vec!["path/to/file", "other/file"]
@@ -80,6 +81,7 @@ fn local_only_scratch_files_ignored() {
     env: vec![("SOME".to_owned(), "value".to_owned())]
       .into_iter()
       .collect(),
+    working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
     output_files: vec!["path/to/file", "other/file"]
@@ -113,6 +115,7 @@ fn make_execute_request() {
     env: vec![("SOME".to_owned(), "value".to_owned())]
       .into_iter()
       .collect(),
+    working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
     output_files: vec!["path/to/file", "other/file"]
@@ -196,6 +199,7 @@ fn make_execute_request_with_instance_name() {
     env: vec![("SOME".to_owned(), "value".to_owned())]
       .into_iter()
       .collect(),
+    working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
     output_files: vec!["path/to/file", "other/file"]
@@ -287,6 +291,7 @@ fn make_execute_request_with_cache_key_gen_version() {
     env: vec![("SOME".to_owned(), "value".to_owned())]
       .into_iter()
       .collect(),
+    working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
     output_files: vec!["path/to/file", "other/file"]
@@ -381,6 +386,7 @@ fn make_execute_request_with_jdk() {
   let req = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "yo"]),
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: input_directory.digest(),
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -446,6 +452,7 @@ fn make_execute_request_with_jdk_and_extra_platform_properties() {
   let req = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "yo"]),
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: input_directory.digest(),
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -553,6 +560,7 @@ fn server_rejecting_execute_request_gives_error() {
           &ExecuteProcessRequest {
             argv: owned_string_vec(&["/bin/echo", "-n", "bar"]),
             env: BTreeMap::new(),
+            working_directory: None,
             input_files: EMPTY_DIGEST,
             output_files: BTreeSet::new(),
             output_directories: BTreeSet::new(),
@@ -1037,6 +1045,7 @@ fn timeout_after_sufficiently_delayed_getoperations() {
   let execute_request = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -1089,6 +1098,7 @@ fn dropped_request_cancels() {
   let execute_request = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -2269,6 +2279,7 @@ pub fn echo_foo_request() -> MultiPlatformExecuteProcessRequest {
   let req = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -2582,6 +2593,7 @@ fn cat_roland_request() -> MultiPlatformExecuteProcessRequest {
   let req = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/cat", "roland"]),
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: TestDirectory::containing_roland().digest(),
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -2600,6 +2612,7 @@ fn echo_roland_request() -> MultiPlatformExecuteProcessRequest {
   let req = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "meoooow"]),
     env: BTreeMap::new(),
+    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{ExecuteProcessRequest, Platform};
+use crate::{ExecuteProcessRequest, Platform, RelativePath};
 use hashing::{Digest, Fingerprint};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, BTreeSet};
@@ -11,6 +11,7 @@ fn execute_process_request_equality() {
         |description: String, timeout: Duration, unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: hashing::Digest| ExecuteProcessRequest {
             argv: vec![],
             env: BTreeMap::new(),
+            working_directory: None,
             input_files: hashing::EMPTY_DIGEST,
             output_files: BTreeSet::new(),
             output_directories: BTreeSet::new(),
@@ -67,4 +68,21 @@ fn execute_process_request_equality() {
   // but not other fields
   assert!(a != c);
   assert!(hash(&a) != hash(&c));
+}
+
+#[test]
+fn relative_path_ok() {
+  assert_eq!(Some("a"), RelativePath::new("a").unwrap().to_str());
+  assert_eq!(Some("a"), RelativePath::new("./a").unwrap().to_str());
+  assert_eq!(Some("a"), RelativePath::new("b/../a").unwrap().to_str());
+  assert_eq!(
+    Some("a/c"),
+    RelativePath::new("b/../a/././c").unwrap().to_str()
+  );
+}
+
+#[test]
+fn relative_path_err() {
+  assert!(RelativePath::new("../a").is_err());
+  assert!(RelativePath::new("/a").is_err());
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -28,7 +28,7 @@ use fs::{
 };
 use hashing;
 use process_execution::{
-  self, ExecuteProcessRequest, MultiPlatformExecuteProcessRequest, Platform,
+  self, ExecuteProcessRequest, MultiPlatformExecuteProcessRequest, Platform, RelativePath,
 };
 use rule_graph;
 
@@ -410,6 +410,16 @@ impl MultiPlatformExecuteProcess {
     target_platform: Platform,
   ) -> Result<ExecuteProcessRequest, String> {
     let env = externs::project_tuple_encoded_map(&value, "env")?;
+
+    let working_directory = {
+      let val = externs::project_str(&value, "working_directory");
+      if val.is_empty() {
+        None
+      } else {
+        Some(RelativePath::new(val.as_str())?)
+      }
+    };
+
     let digest = lift_digest(&externs::project_ignoring_type(&value, "input_files"))
       .map_err(|err| format!("Error parsing digest {}", err))?;
 
@@ -454,19 +464,20 @@ impl MultiPlatformExecuteProcess {
 
     Ok(process_execution::ExecuteProcessRequest {
       argv: externs::project_multi_strs(&value, "argv"),
-      env: env,
+      env,
+      working_directory,
       input_files: digest,
-      output_files: output_files,
-      output_directories: output_directories,
+      output_files,
+      output_directories,
       timeout: Duration::from_millis((timeout_in_seconds * 1000.0) as u64),
-      description: description,
-      unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule:
-        unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule,
-      jdk_home: jdk_home,
-      target_platform: target_platform,
-      is_nailgunnable: is_nailgunnable,
+      description,
+      unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule,
+      jdk_home,
+      target_platform,
+      is_nailgunnable,
     })
   }
+
   fn lift(value: &Value) -> Result<MultiPlatformExecuteProcess, String> {
     let constraint_parts = externs::project_multi_strs(&value, "platform_constraints");
     if constraint_parts.len() % 2 != 0 {


### PR DESCRIPTION
Both local and remote execution facilities supported the concept of
setting the working directory already; this just needed to be plumbed.
