### PR TITLE
Deprecate `--requirements` for PythonToolBase subclasses in favor of `--version` and `--extra-requirements`

### DIFF
--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/subsystems/lambdex.py
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/subsystems/lambdex.py
@@ -6,11 +6,8 @@ from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 
 class Lambdex(PythonToolBase):
   options_scope = 'lambdex'
-  default_requirements = [
-    'lambdex==0.1.3',
-
-    # TODO(John Sirois): Remove when we can upgrade to a version of lambdex with
-    # https://github.com/wickman/lambdex/issues/6 fixed.
-    'setuptools==40.8.0'
-  ]
+  default_version = 'lambdex==0.1.3'
+  # TODO(John Sirois): Remove when we can upgrade to a version of lambdex with
+  # https://github.com/wickman/lambdex/issues/6 fixed.
+  default_extra_requirements = ['setuptools==40.8.0']
   default_entry_point = 'lambdex.bin.lambdex'

--- a/src/python/pants/backend/codegen/grpcio/python/grpcio.py
+++ b/src/python/pants/backend/codegen/grpcio/python/grpcio.py
@@ -5,11 +5,10 @@ from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 
 
 class Grpcio(PythonToolBase):
-  grpcio_version = '1.17.1'
-
   options_scope = 'grpcio'
-  default_requirements = [
-    'grpcio-tools=={}'.format(grpcio_version),
-    'grpcio=={}'.format(grpcio_version),
-  ]
+
+  grpcio_version = '1.17.1'
+  default_version = f'grpcio=={grpcio_version}'
+  default_extra_requirements = [f'grpcio-tools=={grpcio_version}']
+
   default_entry_point = 'grpc_tools.protoc'

--- a/src/python/pants/backend/native/subsystems/packaging/conan.py
+++ b/src/python/pants/backend/native/subsystems/packaging/conan.py
@@ -11,10 +11,8 @@ logger = logging.getLogger(__name__)
 
 class Conan(PythonToolBase):
   options_scope = 'conan'
-  default_requirements = [
-    'conan==1.19.2',
-    # NB: Only versions of pylint below `2.0.0` support use in python 2.
-    'pylint==1.9.3',
-  ]
+  default_version = 'conan==1.19.2'
+  # NB: Only versions of pylint below `2.0.0` support use in python 2.
+  default_extra_requirements = ['pylint==1.9.3']
   default_entry_point = 'conans.conan'
   default_interpreter_constraints = ['CPython>=2.7,<4']

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -10,7 +10,8 @@ from pants.option.option_util import flatten_shlexed_list
 
 class Black(PythonToolBase):
   options_scope = 'black'
-  default_requirements = ['black==19.3b0', 'setuptools']
+  default_version = 'black==19.3b0'
+  default_extra_requirements = ['setuptools']
   default_entry_point = 'black:patched_main'
   default_interpreter_constraints = ["CPython>=3.6"]
 

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -10,7 +10,8 @@ from pants.option.option_util import flatten_shlexed_list
 
 class Flake8(PythonToolBase):
   options_scope = 'flake8'
-  default_requirements = ['flake8', 'setuptools']
+  default_version = 'flake8'
+  default_extra_requirements = ['setuptools']
   default_entry_point = 'flake8'
   default_interpreter_constraints = ["CPython>=2.7,<3", "CPython>=3.4"]
 

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -10,7 +10,8 @@ from pants.option.option_util import flatten_shlexed_list
 
 class Isort(PythonToolBase):
   options_scope = 'isort'
-  default_requirements = ['isort==4.3.20', 'setuptools']
+  default_version = 'isort==4.3.20'
+  default_extra_requirements = ['setuptools']
   default_entry_point = 'isort.main'
 
   @classmethod

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -57,15 +57,15 @@ class PyTest(Subsystem):
       return ', '.join(cli_formatted)
 
     configured_new_options = configured_opts("version", "pytest_plugins")
-    configured_deprecated_option = configured_opts(
+    configured_deprecated_options = configured_opts(
       "requirements", "timeout_requirements", "cov_requirements", "unittest2_requirements",
     )
 
-    if configured_new_options and configured_deprecated_option:
+    if configured_new_options and configured_deprecated_options:
       raise ValueError(
         "Conflicting options for --pytest used. You provided these options in the new, preferred "
         f"style: `{format_opts(configured_new_options)}`, but also provided these options in the "
-        f"deprecated style: `{format_opts(configured_deprecated_option)}`.\nPlease use only one "
+        f"deprecated style: `{format_opts(configured_deprecated_options)}`.\nPlease use only one "
         f"approach (preferably the new approach of `--version` and `--pytest-plugins`)."
       )
 
@@ -81,7 +81,7 @@ class PyTest(Subsystem):
                    "tests with Python 2 and want the newest Pytest, set `version` to "
                    "`pytest>=5.2.4`."
     )
-    if configured_deprecated_option:
+    if configured_deprecated_options:
       return (
         "more-itertools<6.0.0 ; python_version<'3'",
         opts.requirements,

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -47,8 +47,11 @@ class PythonToolBase(Subsystem):
     return self.get_options().interpreter_constraints
 
   def get_requirement_specs(self) -> Tuple[str, ...]:
+    defined_default_new_options = self.default_version is not None
+    defined_default_deprecated_options = self.default_requirements is not None
+
     deprecated_conditional(
-      lambda: self.default_requirements is not None,
+      lambda: defined_default_deprecated_options,
       removal_version="1.26.0.dev2",
       entity_description="Defining `default_requirements` for a subclass of `PythonToolBase`",
       hint_message="Instead of defining `default_requirements`, define `default_version` and, "
@@ -75,7 +78,7 @@ class PythonToolBase(Subsystem):
         f"only one approach (preferably the new approach of `--version` and "
         f"`--extra-requirements`)."
       )
-    if configured_deprecated_options:
+    if configured_deprecated_options or not defined_default_new_options:
       return tuple(opts.requirements)
     return (opts.version, *opts.extra_requirements)
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -1,8 +1,9 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence, Tuple
 
+from pants.base.deprecated import deprecated_conditional
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -10,21 +11,32 @@ class PythonToolBase(Subsystem):
   """Base class for subsystems that configure a python tool to be invoked out-of-process."""
 
   # Subclasses must set.
-  default_requirements: Optional[Sequence[str]] = None
+  default_version: Optional[str] = None
   default_entry_point: Optional[str] = None
-  # Subclasses need not override.
+  # Subclasses used to need to set this, but it's now deprecated
+  default_requirements: Optional[Sequence[str]] = None
+  # Subclasses do not need to override.
+  default_extra_requirements: Sequence[str] = []
   default_interpreter_constraints: Sequence[str] = []
 
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
+    register('--version', type=str, advanced=True, fingerprint=True, default=cls.default_version,
+             help="Requirement string for the tool.")
+    register('--extra-requirements', type=list, member_type=str, advanced=True, fingerprint=True,
+             default=cls.default_extra_requirements,
+             help="Requirement string for the tool.")
     register('--interpreter-constraints', type=list, advanced=True, fingerprint=True,
              default=cls.default_interpreter_constraints,
              help='Python interpreter constraints for this tool. An empty list uses the default '
                   'interpreter constraints for the repo.')
     register('--requirements', type=list, advanced=True, fingerprint=True,
              default=cls.default_requirements,
-             help='Python requirement strings for the tool.')
+             help='Python requirement strings for the tool.',
+             removal_version='1.26.0.dev2',
+             removal_hint="Instead of `--requirements`, use `--version` and, optionally, "
+                          "`--extra-requirements`.")
     register('--entry-point', type=str, advanced=True, fingerprint=True,
              default=cls.default_entry_point,
              help='The main module for the tool.')
@@ -32,8 +44,38 @@ class PythonToolBase(Subsystem):
   def get_interpreter_constraints(self):
     return self.get_options().interpreter_constraints
 
-  def get_requirement_specs(self):
-    return self.get_options().requirements
+  def get_requirement_specs(self) -> Tuple[str, ...]:
+    deprecated_conditional(
+      lambda: self.default_requirements is not None,
+      removal_version="1.26.0.dev2",
+      entity_description="Defining `default_requirements` for a subclass of `PythonToolBase`",
+      hint_message="Instead of defining `default_requirements`, define `default_version` and, "
+                   "optionally, `default_extra_requirements`."
+    )
+
+    opts = self.get_options()
+
+    def configured_opts(*opt_names: str) -> List[str]:
+      return [opt for opt in opt_names if not opts.is_default(opt)]
+
+    def format_opts(opt_symbol_names: List[str]) -> str:
+      cli_formatted = (f"--{opt.replace('_', '-')}" for opt in opt_symbol_names)
+      return ', '.join(cli_formatted)
+
+    configured_new_options = configured_opts('version', 'extra_requirements')
+    configured_deprecated_options = configured_opts('requirements')
+
+    if configured_new_options and configured_deprecated_options:
+      raise ValueError(
+        f"Conflicting options for requirements used. You provided these options in the new, "
+        f"preferred style: `{format_opts(configured_new_options)}`, but also provided these options"
+        f"in the deprecated style: `{format_opts(configured_deprecated_options)}`.\nPlease use "
+        f"only one approach (preferably the new approach of `--version` and "
+        f"`--extra-requirements`)."
+      )
+    if configured_deprecated_options:
+      return tuple(opts.requirements)
+    return (opts.version, *opts.extra_requirements)
 
   def get_entry_point(self):
     return self.get_options().entry_point

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -26,7 +26,9 @@ class PythonToolBase(Subsystem):
              help="Requirement string for the tool.")
     register('--extra-requirements', type=list, member_type=str, advanced=True, fingerprint=True,
              default=cls.default_extra_requirements,
-             help="Requirement string for the tool.")
+             help="Any additional requirement strings to use with the tool. This is useful if the "
+                  "tool allows you to install plugins or if you need to constrain a dependency to "
+                  "a certain version.")
     register('--interpreter-constraints', type=list, advanced=True, fingerprint=True,
              default=cls.default_interpreter_constraints,
              help='Python interpreter constraints for this tool. An empty list uses the default '

--- a/tests/python/pants_test/backend/python/tasks/test_python_tool.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_tool.py
@@ -14,9 +14,7 @@ from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTest
 class Tool(PythonToolBase):
   options_scope = 'test-tool'
   # TODO: make a fake pex tool instead of depending on a real python requirement!
-  default_requirements = [
-    'pex==1.5.3',
-  ]
+  default_version = 'pex==1.5.3'
   default_entry_point = 'pex.bin.pex:main'
 
   @classmethod


### PR DESCRIPTION
### Problem

Right now, the only way to change a tool version is through `--requirements`. This isn’t very convenient. `--requirements` is a list, so to actually change the version you have to do this:

```ini
[isort]
requirements: ["isort==12.0"]
```

rather than something like

```ini
[isort]
version: isort==12.0
```

This is even worse if the tool has other requirements in the default, like Black depending on `setuptools`. To avoid overriding the default, you'd need to do this to change the version for Black, which shows a leaky API:

```ini
[isort]
requirements: ["blakc==19.0b", "setuptools"]
```

### Solution

`PythonToolBase` subclasses now take two arguments: `--version` and `--extra-requirements`.
* `--version` is a simple string for whatever the underlying tool’s version should be.
* `--extra-requirements` is a list for anything additional. For example, it could be used to have MyPy include django-stubs.

### Result

Using `--requirements` will result in this deprecation:

```
23:32:22 [WARN] pants/src/python/pants/bin/pants_loader.py:85: DeprecationWarning: DEPRECATED: option 'requirements' in scope 'isort' will be removed in version 1.26.0.dev2.
  Instead of `--requirements`, use `--version` and, optionally, `--extra-requirements`.
```

Plugin authors who subclass `PythonToolBase` will get this deprecation if they defined `default_requirements`:

```
23:07:01 [WARN] pants/src/python/pants/backend/python/lint/isort/rules.py:43: DeprecationWarning: DEPRECATED: Defining `default_requirements` for a subclass of `PythonToolBase` will be removed in version 1.26.0.dev2.
  Instead of defining `default_requirements`, define `default_version` and, optionally, `default_extra_requirements`.
```