### PR TITLE
Add Flake8 linter to V2

### DIFF
--- a/src/python/pants/backend/python/lint/flake8/BUILD
+++ b/src/python/pants/backend/python/lint/flake8/BUILD
@@ -1,0 +1,38 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  dependencies=[
+    '3rdparty/python:dataclasses',
+    'src/python/pants/backend/python/subsystems',
+    'src/python/pants/backend/python/rules',
+    'src/python/pants/backend/python/targets',
+    'src/python/pants/engine:fs',
+    'src/python/pants/engine:isolated_process',
+    'src/python/pants/engine:rules',
+    'src/python/pants/engine:selectors',
+    'src/python/pants/option',
+    'src/python/pants/rules/core',
+  ],
+)
+
+python_tests(
+  name='integration',
+  sources=globs('*_integration_test.py'),
+  dependencies=[
+    ':flake8',
+    'src/python/pants/backend/python/subsystems',
+    'src/python/pants/backend/python/targets',
+    'src/python/pants/engine:fs',
+    'src/python/pants/engine:rules',
+    'src/python/pants/engine:selectors',
+    'src/python/pants/engine/legacy:structs',
+    'src/python/pants/rules/core',
+    'src/python/pants/source',
+    'src/python/pants/testutil:interpreter_selection_utils',
+    'src/python/pants/testutil:test_base',
+    'src/python/pants/testutil/subsystem',
+  ],
+  tags = {'integration'},
+  timeout = 210,
+)

--- a/src/python/pants/backend/python/lint/flake8/register.py
+++ b/src/python/pants/backend/python/lint/flake8/register.py
@@ -1,0 +1,13 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+from pants.backend.python.lint.flake8 import rules as flake8_rules
+from pants.backend.python.targets import formattable_python_target
+
+
+def rules():
+  return (
+    *flake8_rules.rules(),
+    *formattable_python_target.rules(),
+  )

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -47,7 +47,7 @@ async def lint(
   target = wrapped_target.target
 
   # NB: Flake8 output depends upon which Python interpreter version it's run with. We ensure that
-  # each target runs with its own interpreter constraints, which was not possible in V1. See
+  # each target runs with its own interpreter constraints. See
   # http://flake8.pycqa.org/en/latest/user/invocation.html.
   interpreter_constraints = PexInterpreterConstraints.create_from_adaptors(
     adaptors=[target] if isinstance(target, PythonTargetAdaptor) else [],

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -1,0 +1,90 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import Optional, Tuple
+
+from pants.backend.python.lint.flake8.subsystem import Flake8
+from pants.backend.python.rules.pex import (
+  CreatePex,
+  Pex,
+  PexInterpreterConstraints,
+  PexRequirements,
+)
+from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
+from pants.backend.python.targets.formattable_python_target import FormattablePythonTarget
+from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest, DirectoriesToMerge, PathGlobs, Snapshot
+from pants.engine.isolated_process import ExecuteProcessRequest, FallibleExecuteProcessResult
+from pants.engine.legacy.structs import PythonTargetAdaptor
+from pants.engine.rules import optionable_rule, rule
+from pants.engine.selectors import Get
+from pants.rules.core.fmt import FmtResult
+from pants.rules.core.lint import LintResult
+
+
+# TODO: allow registration of linters that do not have any rule to return `FmtResult`.
+@rule
+def fmt(_: FormattablePythonTarget) -> FmtResult:
+  return FmtResult(digest=EMPTY_DIRECTORY_DIGEST, stdout="", stderr="")
+
+
+def generate_args(wrapped_target: FormattablePythonTarget, flake8: Flake8) -> Tuple[str, ...]:
+  args = []
+  if flake8.get_options().config is not None:
+    args.append(f"--config={flake8.get_options().config}")
+  args.extend(flake8.get_args())
+  args.extend(sorted(wrapped_target.target.sources.snapshot.files))
+  return tuple(args)
+
+
+@rule(name="Lint using Flake8")
+async def lint(
+  wrapped_target: FormattablePythonTarget,
+  flake8: Flake8,
+  python_setup: PythonSetup,
+  subprocess_encoding_environment: SubprocessEncodingEnvironment,
+) -> LintResult:
+  target = wrapped_target.target
+
+  # NB: Flake8 output depends upon which Python interpreter version it's run with. We ensure that
+  # each target runs with its own interpreter constraints, which was not possible in V1. See
+  # http://flake8.pycqa.org/en/latest/user/invocation.html.
+  interpreter_constraints = PexInterpreterConstraints.create_from_adaptors(
+    adaptors=[target] if isinstance(target, PythonTargetAdaptor) else [],
+    python_setup=python_setup
+  )
+
+  config_path: Optional[str] = flake8.get_options().config
+  config_snapshot = await Get[Snapshot](PathGlobs(include=(config_path,)))
+  requirements_pex = await Get[Pex](
+    CreatePex(
+      output_filename="flake8.pex",
+      requirements=PexRequirements(requirements=tuple(flake8.get_requirement_specs())),
+      interpreter_constraints=interpreter_constraints,
+      entry_point=flake8.get_entry_point(),
+    )
+  )
+
+  merged_input_files = await Get[Digest](
+    DirectoriesToMerge(
+      directories=(
+        target.sources.snapshot.directory_digest,
+        requirements_pex.directory_digest,
+        config_snapshot.directory_digest,
+      )
+    ),
+  )
+  request = requirements_pex.create_execute_request(
+    python_setup=python_setup,
+    subprocess_encoding_environment=subprocess_encoding_environment,
+    pex_path=f'./flake8.pex',
+    pex_args=generate_args(wrapped_target, flake8),
+    input_files=merged_input_files,
+    description=f'Run Flake8 for {target.address.reference()}',
+  )
+  result = await Get[FallibleExecuteProcessResult](ExecuteProcessRequest, request)
+  return LintResult.from_fallible_execute_process_result(result)
+
+
+def rules():
+  return [fmt, lint, optionable_rule(Flake8)]

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -1,0 +1,127 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import List, Optional, Sequence
+
+from pants.backend.python.lint.flake8.rules import rules as flake8_rules
+from pants.backend.python.lint.flake8.subsystem import Flake8
+from pants.backend.python.rules import download_pex_bin, pex
+from pants.backend.python.rules.pex import CreatePex
+from pants.backend.python.subsystems import python_native_code, subprocess_environment
+from pants.backend.python.subsystems.python_native_code import PythonNativeCode
+from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.backend.python.subsystems.subprocess_environment import SubprocessEnvironment
+from pants.backend.python.targets.formattable_python_target import FormattablePythonTarget
+from pants.backend.python.targets.python_library import PythonLibrary
+from pants.build_graph.address import Address
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.engine.fs import FileContent, InputFilesContent, Snapshot
+from pants.engine.legacy.structs import PythonTargetAdaptor
+from pants.engine.rules import RootRule
+from pants.engine.selectors import Params
+from pants.rules.core.lint import LintResult
+from pants.source.wrapped_globs import EagerFilesetWithSpec
+from pants.testutil.interpreter_selection_utils import skip_unless_python27_and_python3_present
+from pants.testutil.subsystem.util import global_subsystem_instance, init_subsystems
+from pants.testutil.test_base import TestBase
+
+
+class Flake8IntegrationTest(TestBase):
+  good_source = FileContent(path="test/good.py", content=b"print('Nothing suspicious here..')\n")
+  bad_source = FileContent(path="test/bad.py", content=b"import typing\n")  # unused import
+  py3_only_source = FileContent(path="test/py3.py", content=b"version: str = 'Py3 > Py2'\n")
+
+  @classmethod
+  def alias_groups(cls) -> BuildFileAliases:
+    return BuildFileAliases(targets={'python_library': PythonLibrary})
+
+  @classmethod
+  def rules(cls):
+    return (
+      *super().rules(),
+      *flake8_rules(),
+      *download_pex_bin.rules(),
+      *pex.rules(),
+      *python_native_code.rules(),
+      *subprocess_environment.rules(),
+      RootRule(CreatePex),
+      RootRule(FormattablePythonTarget),
+      RootRule(Flake8),
+      RootRule(PythonSetup),
+      RootRule(PythonNativeCode),
+      RootRule(SubprocessEnvironment),
+    )
+
+  def setUp(self):
+    super().setUp()
+    init_subsystems([Flake8, PythonSetup, PythonNativeCode, SubprocessEnvironment])
+
+  def run_flake8(
+    self,
+    source_files: List[FileContent],
+    *,
+    config: Optional[str] = None,
+    passthrough_args: Optional[Sequence[str]] = None,
+    interpreter_constraints: Optional[Sequence[str]] = None,
+  ) -> LintResult:
+    if config is not None:
+      self.create_file(relpath=".flake8", contents=config)
+    input_snapshot = self.request_single_product(Snapshot, InputFilesContent(source_files))
+    target = FormattablePythonTarget(
+      PythonTargetAdaptor(
+        sources=EagerFilesetWithSpec('test', {'globs': []}, snapshot=input_snapshot),
+        address=Address.parse("test:target"),
+        compatibility=interpreter_constraints,
+      )
+    )
+    flake8_subsystem = global_subsystem_instance(
+      Flake8, options={Flake8.options_scope: {
+        "config": ".flake8" if config else None,
+        "args": passthrough_args or [],
+      }}
+    )
+    return self.request_single_product(
+      LintResult,
+      Params(
+        target,
+        flake8_subsystem,
+        PythonNativeCode.global_instance(),
+        PythonSetup.global_instance(),
+        SubprocessEnvironment.global_instance()
+      )
+    )
+
+  def test_passing_single_source(self) -> None:
+    result = self.run_flake8([self.good_source])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == ""
+
+  def test_failing_single_source(self) -> None:
+    result = self.run_flake8([self.bad_source])
+    assert result.exit_code == 1
+    assert "test/bad.py:1:1: F401" in result.stdout
+
+  def test_mixed_sources(self) -> None:
+    result = self.run_flake8([self.good_source, self.bad_source])
+    assert result.exit_code == 1
+    assert "test/good.py" not in result.stdout
+    assert "test/bad.py:1:1: F401" in result.stdout
+
+  @skip_unless_python27_and_python3_present
+  def test_uses_correct_python_version(self) -> None:
+    py2_result = self.run_flake8([self.py3_only_source], interpreter_constraints=['CPython==2.7.*'])
+    assert py2_result.exit_code == 1
+    assert "test/py3.py:1:8: E999 SyntaxError" in py2_result.stdout
+    py3_result = self.run_flake8([self.py3_only_source], interpreter_constraints=['CPython>=3.6'])
+    assert py3_result.exit_code == 0
+    assert py3_result.stdout.strip() == ""
+
+  def test_respects_config_file(self) -> None:
+    result = self.run_flake8([self.bad_source], config="[flake8]\nignore = F401\n")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == ""
+
+  def test_respects_passthrough_args(self) -> None:
+    result = self.run_flake8([self.bad_source], passthrough_args=["--ignore=F401"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == ""

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import Tuple
+
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.option.custom_types import file_option
+from pants.option.option_util import flatten_shlexed_list
+
+
+class Flake8(PythonToolBase):
+  options_scope = 'flake8'
+  default_requirements = ['flake8', 'setuptools']
+  default_entry_point = 'flake8'
+  default_interpreter_constraints = ["CPython>=2.7,<3", "CPython>=3.4"]
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register(
+      '--args', type=list, member_type=str,
+      help="Arguments to pass directly to Flake8, e.g. "
+           "`--flake8-args=\"--ignore E123,W456 --enable-extensions H111\"`",
+    )
+    register(
+      '--config', type=file_option, default=None, advanced=True,
+      help="Path to `.flake8` or alternative Flake8 config file"
+    )
+
+  def get_args(self) -> Tuple[str, ...]:
+    return flatten_shlexed_list(self.get_options().args)

--- a/src/python/pants/backend/python/rules/python_test_runner.py
+++ b/src/python/pants/backend/python/rules/python_test_runner.py
@@ -68,8 +68,8 @@ async def run_python_test(
   )
 
   source_root_stripped_sources = await MultiGet(
-    Get(SourceRootStrippedSources, HydratedTarget, target_adaptor)
-    for target_adaptor in all_targets
+    Get(SourceRootStrippedSources, HydratedTarget, hydrated_target)
+    for hydrated_target in all_targets
   )
 
   stripped_sources_digests = tuple(

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -52,6 +52,7 @@ target(
     'src/python/pants/backend/project_info:plugin',
     'src/python/pants/backend/python:plugin',
     'src/python/pants/backend/python/lint/black',
+    'src/python/pants/backend/python/lint/flake8',
     'src/python/pants/backend/python/lint/isort',
     'src/python/pants/backend/native',
   ],


### PR DESCRIPTION
V1 wraps `pycodestyle`. We want to be able to use that linter. Instead, we implement `flake8`, which is `pycodestyle + pyflakes + mccabe complexity`. Users who want to ignore pyflakes and McCabe complexity can do so by configuring the tool to ignore `pyflakes` and McCabe.

This brings several benefits over V1:
- Per-target interpreter constraints. Flake8's output depends on which interpreter is used, so this is helpful for mixed codebases.
- V2-style caching, e.g. remote execution
- No longer hardcode skipped error codes. We should make zero assumptions about what the user wants.

To activate this, users may add this to `pants.ini`:

```ini
backend_packages: +[
    'pants.backend.python.lint.flake8',
  ]
```

Then they may run `./pants lint-v2 ::`.

### Remaining issues
1) This cannot be registered at the same time as V2 Black or isort.
2) We have to provide a no-op implementation for `FmtResult`. Otherwise, the graph complains that `fmt-v2` has no way to get a `FmtResult`. 