### PR TITLE
add GCC to the PATH for `go test` to support -race by default!

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/tasks/BUILD
@@ -9,6 +9,7 @@ python_library(
     '3rdparty/python:dataclasses',
     'contrib/go/src/python/pants/contrib/go/subsystems',
     'contrib/go/src/python/pants/contrib/go/targets',
+    'src/python/pants/backend/native/subsystems/binaries',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:generator',


### PR DESCRIPTION
**TODO:** confirm with go developers what an appropriate test case for this would be. Since our travis image contains gcc, we would probably have to sandbox the PATH. I'm getting sign-off from go developers as to whether this fixes the problem that stops us from being able to use the `-race` flag with go tests.

**THE ABOVE HAS BEEN CONFIRMED BY GO DEVELOPERS!**

### Problem

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

(_describe the modifications you've made._)

### Result

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)