### PR TITLE
Fix enginedisplay printing

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1051,7 +1051,7 @@ name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3144,7 +3144,7 @@ version = "0.0.1"
 dependencies = [
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.3.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3770,7 +3770,7 @@ dependencies = [
 "checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
-"checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
+"checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -65,7 +65,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2734,18 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "1.5.1"
-source = "git+https://github.com/redox-os/termion.git?rev=ce6b43d071cd6edfc4b366bb945b45e06c239e2c#ce6b43d071cd6edfc4b366bb945b45e06c239e2c"
-dependencies = [
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "termion"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3154,7 +3143,7 @@ name = "ui"
 version = "0.0.1"
 dependencies = [
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.1 (git+https://github.com/redox-os/termion.git?rev=ce6b43d071cd6edfc4b366bb945b45e06c239e2c)",
+ "termion 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3742,8 +3731,7 @@ dependencies = [
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
-"checksum termion 1.5.1 (git+https://github.com/redox-os/termion.git?rev=ce6b43d071cd6edfc4b366bb945b45e06c239e2c)" = "<none>"
-"checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
+"checksum termion 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "818ef3700c2a7b447dca1a1dd28341fe635e6ee103c806c636bb9c929991b2cd"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -56,11 +56,18 @@ impl Session {
     build_id: String,
     should_report_workunits: bool,
   ) -> Session {
+    let display = if should_render_ui && EngineDisplay::stdout_is_tty() {
+      let mut display = EngineDisplay::new(0);
+      display.initialize(ui_worker_count);
+      Some(Arc::new(Mutex::new(display)))
+    } else {
+      None
+    };
+
     let inner_session = InnerSession {
       preceding_graph_size: scheduler.core.graph.len(),
       roots: Mutex::new(HashSet::new()),
-      display: EngineDisplay::create(ui_worker_count, should_render_ui)
-        .map(|x| Arc::new(Mutex::new(x))),
+      display,
       should_record_zipkin_spans,
       workunit_store: WorkUnitStore::new(),
       build_id,

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -113,11 +113,17 @@ impl Session {
   //TODO Thsese two functions should eventually hook up intelligently to EngineDisplay
   //instead of just naively printing to stdout/stderr.
   pub fn write_stdout(&self, msg: &str) {
-    print!(" {}", msg);
+    if let Some(display) = self.maybe_display() {
+      let mut d = display.lock();
+      d.write_stdout(msg);
+    }
   }
 
   pub fn write_stderr(&self, msg: &str) {
-    eprint!("{}", msg);
+    if let Some(display) = self.maybe_display() {
+      let mut d = display.lock();
+      d.write_stderr(msg);
+    }
   }
 }
 

--- a/src/rust/engine/ui/Cargo.toml
+++ b/src/rust/engine/ui/Cargo.toml
@@ -13,5 +13,5 @@ path = "src/main.rs"
 
 [dependencies]
 rand = "0.5.1"
-termion = { git = "https://github.com/redox-os/termion.git", rev = "ce6b43d071cd6edfc4b366bb945b45e06c239e2c" }
+termion = "1.5.4"
 unicode-segmentation = "1.2.1"

--- a/src/rust/engine/ui/Cargo.toml
+++ b/src/rust/engine/ui/Cargo.toml
@@ -14,4 +14,4 @@ path = "src/main.rs"
 [dependencies]
 rand = "0.5.1"
 termion = "1.5.4"
-unicode-segmentation = "1.2.1"
+unicode-segmentation = "1.6.0"

--- a/src/rust/engine/ui/src/main.rs
+++ b/src/rust/engine/ui/src/main.rs
@@ -38,7 +38,7 @@ use ui::EngineDisplay;
 // N.B. This is purely a demo/testing bin target for exercising the library.
 
 fn main() {
-  let mut display = EngineDisplay::for_stdout(0);
+  let mut display = EngineDisplay::new(0);
   display.start();
 
   let worker_ids = vec![
@@ -85,7 +85,8 @@ fn main() {
   thread::sleep(Duration::from_secs(1));
 
   while !done {
-    display.render_and_sleep();
+    display.render();
+    thread::sleep(Duration::from_millis(55));
 
     gen_display_work(
       &mut display,


### PR DESCRIPTION
### Problem

https://github.com/pantsbuild/pants/issues/8062

### Solution

This commit modifies EngineDisplay to buffer calls to write_stdout and write_stderr from the Python Console, and the prints them all at once after shutting down the live display. This means that we don't see Console messages interleaved with log messages while pants is running, but we do get a clean scrollback. 
