### PR TITLE
add --cache-monolithic-resolve to PexBuilderWrapper

### DIFF
--- a/src/python/pants/backend/python/subsystems/pex_build_util.py
+++ b/src/python/pants/backend/python/subsystems/pex_build_util.py
@@ -39,7 +39,7 @@ from pants.util.memo import memoized_method
 
 
 @dataclass(frozen=True)
-class PexResolveOptions:
+class PexResolveRequest:
   interpreter: PythonInterpreter
   requirements: Tuple[Requirement, ...]
   indexes: Tuple[str, ...]
@@ -59,7 +59,7 @@ class PexResolveOptions:
   @memoized_method
   def as_cache_key(self) -> str:
     return stable_json_sha1((
-      self.interpreter.identity.version_str,
+      str(self.interpreter.identity),
       self.requirements,
       self.indexes,
       self.find_links,
@@ -384,7 +384,7 @@ class PexBuilderWrapper:
     platforms = platforms or python_setup.platforms
     find_links = find_links or []
 
-    pex_resolve_options = PexResolveOptions(
+    pex_resolve_options = PexResolveRequest(
       requirements=[str(req.requirement) for req in requirements],
       interpreter=interpreter,
       indexes=python_repos.indexes,

--- a/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
@@ -1,15 +1,22 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import glob
+import json
 import os
 import subprocess
 from textwrap import dedent
+
+from colors import blue
+from pex.platforms import Platform
 
 from pants.backend.python.tasks.gather_sources import GatherSources
 from pants.backend.python.tasks.python_binary_create import PythonBinaryCreate
 from pants.backend.python.tasks.select_interpreter import SelectInterpreter
 from pants.base.run_info import RunInfo
 from pants.build_graph.register import build_file_aliases as register_core
+from pants.util.collections import assert_single_element
+from pants.util.contextutil import temporary_dir
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
 
 
@@ -22,13 +29,14 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
   def alias_groups(cls):
     return super().alias_groups().merge(register_core())
 
-  def _assert_pex(self, binary, expected_output=None, expected_shebang=None):
+  def _assert_pex(self, binary, expected_output=None, expected_shebang=None, **context_kwargs):
     # The easiest way to create products required by the PythonBinaryCreate task is to
     # execute the relevant tasks.
     si_task_type = self.synthesize_task_subtype(SelectInterpreter, 'si_scope')
     gs_task_type = self.synthesize_task_subtype(GatherSources, 'gs_scope')
 
-    task_context = self.context(for_task_types=[si_task_type, gs_task_type], target_roots=[binary])
+    task_context = self.context(for_task_types=[si_task_type, gs_task_type], target_roots=[binary],
+                                **context_kwargs)
     run_info_dir = os.path.join(self.pants_workdir, self.options_scope, 'test/info')
     task_context.run_tracker.run_info = RunInfo(run_info_dir)
 
@@ -107,3 +115,65 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
                                        dependencies=['src/python/lib'])
 
     self._assert_pex(binary, expected_output='Hello World!\n', expected_shebang=b'#!/usr/bin/env python2\n')
+
+  def test_monolithic_resolve_cache(self):
+    self.create_python_requirement_library('3rdparty/resolve-cache', 'ansicolors',
+                                           requirements=['ansicolors'])
+    self.create_python_library('src/resolve-cache', 'lib', {'main.py': dedent("""\
+    from colors import blue
+
+    print(blue('i just imported the ansicolors dependency!'))
+    """)})
+    binary = self.create_python_binary('src/resolve-cache', 'bin', 'main',
+                                       dependencies=[
+                                         '3rdparty/resolve-cache:ansicolors',
+                                         ':lib',
+                                       ])
+
+    with temporary_dir() as td:
+      def test_binary_create(cache_monolithic_resolve, use_manylinux):
+        self._assert_pex(binary,
+                         options={
+                           'pex-builder-wrapper': dict(
+                             cache_monolithic_resolve=cache_monolithic_resolve,
+                             monolithic_resolve_cache_dir=td,
+                           ),
+                           'python-setup': dict(resolver_use_manylinux=use_manylinux),
+                         },
+                         expected_output=dedent(f"""\
+        {blue('i just imported the ansicolors dependency!')}
+        """))
+
+      # Test that nothing is written to the cache unless the option is turned on.
+      test_binary_create(cache_monolithic_resolve=False, use_manylinux=True)
+      json_resolve_files = glob.glob(os.path.join(td, '*/*.json'))
+      self.assertEqual(len(json_resolve_files), 0)
+
+      # Test that a cache entry is created for a resolve when the option is turned on.
+      test_binary_create(cache_monolithic_resolve=True, use_manylinux=True)
+      json_resolve_files = glob.glob(os.path.join(td, '*/*.json'))
+      first_resolve_file = assert_single_element(json_resolve_files)
+      with open(first_resolve_file) as fp:
+        json_payload = json.load(fp)
+        all_dist_specs = json_payload[Platform.current().platform]
+        self.assertEqual(len(all_dist_specs), 1)
+        self.assertEqual('ansicolors', all_dist_specs[0]['project_name'])
+
+      # Assert that a separate json file is created if use_manylinux is toggled.
+      test_binary_create(cache_monolithic_resolve=True, use_manylinux=False)
+      json_resolve_files = glob.glob(os.path.join(td, '*/*.json'))
+      self.assertEqual(len(json_resolve_files), 2)
+      new_json_resolve_file = assert_single_element(
+        set(json_resolve_files) - set([first_resolve_file]))
+      with open(new_json_resolve_file) as fp:
+        json_payload = json.load(fp)
+        all_dist_specs = json_payload[Platform.current().platform]
+        self.assertEqual(len(all_dist_specs), 1)
+        self.assertEqual('ansicolors', all_dist_specs[0]['project_name'])
+
+      all_json_resolve_files = set(json_resolve_files)
+
+      # Assert that no new json file is created if we re-run a previously-cached resolve.
+      test_binary_create(cache_monolithic_resolve=True, use_manylinux=True)
+      json_resolve_files = glob.glob(os.path.join(td, '*/*.json'))
+      self.assertEqual(all_json_resolve_files, set(json_resolve_files))


### PR DESCRIPTION
### Problem

*Corollary to #8793.*

We would like to reduce the time spent waiting to create a pex file from a `python_binary()` target. When no dependencies have changed, pants/pex will still examine every single transitive requirement to determine which distributions to add to the resulting pex file. For large dependencies such as tensorflow, this implies a nontrivial amount of waiting for a no-op build.

### Solution

- Serialize the relevant pex resolver options and requirements into a new `PexResolveRequest` dataclass.
- Use the `PexResolveRequest` class to cache entire resolves in `~/.cache/pants/monolithic-pex-resolves` when the `--cache-monolithic-resolve` option is turned on.