### PR TITLE
Fix registration of unions that are split across multiple backends.

### DIFF
--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -155,7 +155,12 @@ class BuildConfiguration:
 
     # Store the rules and record their dependency Optionables.
     self._rules.update(indexed_rules)
-    self._union_rules.update(union_rules)
+    for union_base, new_members in union_rules.items():
+      existing_members = self._union_rules.get(union_base, None)
+      if existing_members is None:
+        self._union_rules[union_base] = new_members
+      else:
+        existing_members.update(new_members)
     dependency_optionables = {do
                               for rule in indexed_rules
                               for do in rule.dependency_optionables


### PR DESCRIPTION
### Problem

When a union was split across multiple backends/plugins, the call to `BuildConfiguration.register_rules` was overwriting the union members in each new backend, rather than merging them. This made it effectively impossible to split a union across backends.

### Solution

Merge union members in `BuildConfiguration`.