### PR TITLE
A rule to create a pex from a target closure.

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -11,7 +11,8 @@ from pants.backend.python.rules import (
   pex,
   pex_from_target_closure,
   python_create_binary,
-  python_test_runner)
+  python_test_runner,
+)
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.targets.python_app import PythonApp
 from pants.backend.python.targets.python_binary import PythonBinary

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -9,9 +9,9 @@ from pants.backend.python.rules import (
   download_pex_bin,
   inject_init,
   pex,
+  pex_from_target_closure,
   python_create_binary,
-  python_test_runner,
-)
+  python_test_runner)
 from pants.backend.python.subsystems import python_native_code, subprocess_environment
 from pants.backend.python.targets.python_app import PythonApp
 from pants.backend.python.targets.python_binary import PythonBinary
@@ -95,6 +95,7 @@ def rules():
     *download_pex_bin.rules(),
     *inject_init.rules(),
     *pex.rules(),
+    *pex_from_target_closure.rules(),
     *python_test_runner.rules(),
     *python_create_binary.rules(),
     *python_native_code.rules(),

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -1,9 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Iterable, List, Optional, Tuple
-
 from dataclasses import dataclass
+from typing import Iterable, List, Optional, Tuple
 
 from pants.backend.python.rules.download_pex_bin import DownloadedPexBin
 from pants.backend.python.rules.hermetic_pex import HermeticPex

--- a/src/python/pants/backend/python/rules/pex.py
+++ b/src/python/pants/backend/python/rules/pex.py
@@ -6,9 +6,11 @@ from typing import Iterable, List, Optional, Tuple
 
 from pants.backend.python.rules.download_pex_bin import DownloadedPexBin
 from pants.backend.python.rules.hermetic_pex import HermeticPex
+from pants.backend.python.rules.inject_init import InjectedInitDigest
 from pants.backend.python.subsystems.python_native_code import PexBuildEnvironment
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.subsystems.subprocess_environment import SubprocessEncodingEnvironment
+from pants.engine.addressable import BuildFileAddresses
 from pants.engine.fs import (
   EMPTY_DIRECTORY_DIGEST,
   Digest,
@@ -16,10 +18,12 @@ from pants.engine.fs import (
   DirectoryWithPrefixToAdd,
 )
 from pants.engine.isolated_process import ExecuteProcessResult, MultiPlatformExecuteProcessRequest
+from pants.engine.legacy.graph import HydratedTarget, TransitiveHydratedTargets
 from pants.engine.legacy.structs import PythonTargetAdaptor, TargetAdaptor
 from pants.engine.platform import Platform, PlatformConstraint
 from pants.engine.rules import optionable_rule, rule
-from pants.engine.selectors import Get
+from pants.engine.selectors import Get, MultiGet
+from pants.rules.core.strip_source_root import SourceRootStrippedSources
 
 
 @dataclass(frozen=True)
@@ -73,6 +77,14 @@ class CreatePex:
   interpreter_constraints: PexInterpreterConstraints = PexInterpreterConstraints()
   entry_point: Optional[str] = None
   input_files_digest: Optional[Digest] = None
+
+
+@dataclass(frozen=True)
+class CreatePexFromTargetClosure:
+  """Represents a request to create a PEX from the closure of a set of targets."""
+  build_file_addresses: BuildFileAddresses
+  output_filename: str
+  entry_point: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -142,8 +154,48 @@ async def create_pex(
   return Pex(directory_digest=result.output_directory_digest, output_filename=request.output_filename)
 
 
+@rule(name="Create PEX from targets")
+async def create_pex_from_target_closure(request: CreatePexFromTargetClosure,
+                                         python_setup: PythonSetup) -> Pex:
+  transitive_hydrated_targets = await Get(TransitiveHydratedTargets,
+                                          BuildFileAddresses, request.build_file_addresses)
+  all_targets = transitive_hydrated_targets.closure
+  all_target_adaptors = [t.adaptor for t in all_targets]
+
+  interpreter_constraints = PexInterpreterConstraints.create_from_adaptors(
+    adaptors=tuple(all_targets),
+    python_setup=python_setup
+  )
+
+  source_root_stripped_sources = await MultiGet(
+    Get(SourceRootStrippedSources, HydratedTarget, target_adaptor)
+    for target_adaptor in all_targets
+  )
+
+  stripped_sources_digests = [stripped_sources.snapshot.directory_digest
+                              for stripped_sources in source_root_stripped_sources]
+  sources_digest = await Get(Digest, DirectoriesToMerge(directories=tuple(stripped_sources_digests)))
+  inits_digest = await Get(InjectedInitDigest, Digest, sources_digest)
+  all_input_digests = [sources_digest, inits_digest.directory_digest]
+  merged_input_files = await Get(Digest, DirectoriesToMerge,
+                                 DirectoriesToMerge(directories=tuple(all_input_digests)))
+  requirements = PexRequirements.create_from_adaptors(all_target_adaptors)
+
+  create_pex_request = CreatePex(
+    output_filename=request.output_filename,
+    requirements=requirements,
+    interpreter_constraints=interpreter_constraints,
+    entry_point=request.entry_point,
+    input_files_digest=merged_input_files,
+  )
+
+  pex = await Get(Pex, CreatePex, create_pex_request)
+  return pex
+
+
 def rules():
   return [
     create_pex,
+    create_pex_from_target_closure,
     optionable_rule(PythonSetup),
   ]

--- a/src/python/pants/backend/python/rules/pex_from_target_closure.py
+++ b/src/python/pants/backend/python/rules/pex_from_target_closure.py
@@ -1,19 +1,19 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from dataclasses import dataclass
 from typing import Optional
 
-from dataclasses import dataclass
-
 from pants.backend.python.rules.inject_init import InjectedInitDigest
-from pants.backend.python.rules.pex import PexInterpreterConstraints, PexRequirements, CreatePex, \
-  Pex
+from pants.backend.python.rules.pex import (
+  CreatePex,
+  Pex,
+  PexInterpreterConstraints,
+  PexRequirements,
+)
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.engine.addressable import BuildFileAddresses
-from pants.engine.fs import (
-  Digest,
-  DirectoriesToMerge,
-)
+from pants.engine.fs import Digest, DirectoriesToMerge
 from pants.engine.legacy.graph import HydratedTarget, TransitiveHydratedTargets
 from pants.engine.rules import rule
 from pants.engine.selectors import Get, MultiGet

--- a/src/python/pants/backend/python/rules/pex_from_target_closure.py
+++ b/src/python/pants/backend/python/rules/pex_from_target_closure.py
@@ -1,0 +1,73 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import Optional
+
+from dataclasses import dataclass
+
+from pants.backend.python.rules.inject_init import InjectedInitDigest
+from pants.backend.python.rules.pex import PexInterpreterConstraints, PexRequirements, CreatePex, \
+  Pex
+from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.engine.addressable import BuildFileAddresses
+from pants.engine.fs import (
+  Digest,
+  DirectoriesToMerge,
+)
+from pants.engine.legacy.graph import HydratedTarget, TransitiveHydratedTargets
+from pants.engine.rules import rule
+from pants.engine.selectors import Get, MultiGet
+from pants.rules.core.strip_source_root import SourceRootStrippedSources
+
+
+@dataclass(frozen=True)
+class CreatePexFromTargetClosure:
+  """Represents a request to create a PEX from the closure of a set of targets."""
+  build_file_addresses: BuildFileAddresses
+  output_filename: str
+  entry_point: Optional[str] = None
+
+
+@rule(name="Create PEX from targets")
+async def create_pex_from_target_closure(request: CreatePexFromTargetClosure,
+                                         python_setup: PythonSetup) -> Pex:
+  transitive_hydrated_targets = await Get[TransitiveHydratedTargets](BuildFileAddresses,
+                                                                     request.build_file_addresses)
+  all_targets = transitive_hydrated_targets.closure
+  all_target_adaptors = [t.adaptor for t in all_targets]
+
+  interpreter_constraints = PexInterpreterConstraints.create_from_adaptors(
+    adaptors=tuple(all_targets),
+    python_setup=python_setup
+  )
+
+  source_root_stripped_sources = await MultiGet(
+    Get[SourceRootStrippedSources](HydratedTarget, target_adaptor)
+    for target_adaptor in all_targets
+  )
+
+  stripped_sources_digests = [stripped_sources.snapshot.directory_digest
+                              for stripped_sources in source_root_stripped_sources]
+  sources_digest = await Get[Digest](DirectoriesToMerge(directories=tuple(stripped_sources_digests)))
+  inits_digest = await Get[InjectedInitDigest](Digest, sources_digest)
+  all_input_digests = [sources_digest, inits_digest.directory_digest]
+  merged_input_files = await Get[Digest](DirectoriesToMerge,
+                                         DirectoriesToMerge(directories=tuple(all_input_digests)))
+  requirements = PexRequirements.create_from_adaptors(all_target_adaptors)
+
+  create_pex_request = CreatePex(
+    output_filename=request.output_filename,
+    requirements=requirements,
+    interpreter_constraints=interpreter_constraints,
+    entry_point=request.entry_point,
+    input_files_digest=merged_input_files,
+  )
+
+  pex = await Get[Pex](CreatePex, create_pex_request)
+  return pex
+
+
+def rules():
+  return [
+    create_pex_from_target_closure,
+  ]

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -1,7 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.rules.pex import CreatePexFromTargetClosure, Pex
+from pants.backend.python.rules.pex import Pex
+from pants.backend.python.rules.pex_from_target_closure import CreatePexFromTargetClosure
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.build_graph.address import Address
 from pants.engine.legacy.graph import BuildFileAddresses, HydratedTarget

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -1,44 +1,19 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.rules.inject_init import InjectedInitDigest
-from pants.backend.python.rules.pex import (
-  CreatePex,
-  Pex,
-  PexInterpreterConstraints,
-  PexRequirements,
-)
-from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.backend.python.rules.pex import CreatePexFromTargetClosure, Pex
 from pants.backend.python.targets.python_binary import PythonBinary
-from pants.engine.fs import Digest, DirectoriesToMerge
-from pants.engine.legacy.graph import BuildFileAddresses, HydratedTarget, TransitiveHydratedTargets
+from pants.build_graph.address import Address, BuildFileAddress
+from pants.engine.legacy.graph import BuildFileAddresses, HydratedTarget
 from pants.engine.legacy.structs import PythonBinaryAdaptor
 from pants.engine.rules import UnionRule, rule
-from pants.engine.selectors import Get, MultiGet
+from pants.engine.selectors import Get
 from pants.rules.core.binary import BinaryTarget, CreatedBinary
 from pants.rules.core.strip_source_root import SourceRootStrippedSources
 
 
 @rule
-async def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor,
-  python_setup: PythonSetup) -> CreatedBinary:
-  transitive_hydrated_targets = await Get(
-    TransitiveHydratedTargets, BuildFileAddresses((python_binary_adaptor.address,))
-  )
-  all_targets = transitive_hydrated_targets.closure
-  all_target_adaptors = [t.adaptor for t in all_targets]
-
-
-  interpreter_constraints = PexInterpreterConstraints.create_from_adaptors(
-    adaptors=tuple(all_targets),
-    python_setup=python_setup
-  )
-
-  source_root_stripped_sources = await MultiGet(
-    Get(SourceRootStrippedSources, HydratedTarget, target_adaptor)
-    for target_adaptor in all_targets
-  )
-
+async def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor) -> CreatedBinary:
   #TODO(#8420) This way of calculating the entry point works but is a bit hackish.
   entry_point = None
   if hasattr(python_binary_adaptor, 'entry_point'):
@@ -46,29 +21,18 @@ async def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor,
   else:
     sources_snapshot = python_binary_adaptor.sources.snapshot
     if len(sources_snapshot.files) == 1:
-      target = transitive_hydrated_targets.roots[0]
+      target = await Get(HydratedTarget, Address, python_binary_adaptor.address)
       output = await Get(SourceRootStrippedSources, HydratedTarget, target)
       root_filename = output.snapshot.files[0]
       entry_point = PythonBinary.translate_source_path_to_py_module_specifier(root_filename)
 
-  stripped_sources_digests = [stripped_sources.snapshot.directory_digest for stripped_sources in source_root_stripped_sources]
-  sources_digest = await Get(Digest, DirectoriesToMerge(directories=tuple(stripped_sources_digests)))
-  inits_digest = await Get(InjectedInitDigest, Digest, sources_digest)
-  all_input_digests = [sources_digest, inits_digest.directory_digest]
-  merged_input_files = await Get(Digest, DirectoriesToMerge, DirectoriesToMerge(directories=tuple(all_input_digests)))
-
-  requirements = PexRequirements.create_from_adaptors(all_target_adaptors)
-  output_filename = f"{python_binary_adaptor.address.target_name}.pex"
-
-  create_requirements_pex = CreatePex(
-    output_filename=output_filename,
-    requirements=requirements,
-    interpreter_constraints=interpreter_constraints,
+  request = CreatePexFromTargetClosure(
+    build_file_addresses=BuildFileAddresses((python_binary_adaptor.address,)),
     entry_point=entry_point,
-    input_files_digest=merged_input_files,
+    output_filename=f'{python_binary_adaptor.address.target_name}.pex'
   )
 
-  pex = await Get(Pex, CreatePex, create_requirements_pex)
+  pex = await Get(Pex, CreatePexFromTargetClosure, request)
   return CreatedBinary(digest=pex.directory_digest, binary_name=pex.output_filename)
 
 

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -21,8 +21,8 @@ async def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor) -> Cr
   else:
     sources_snapshot = python_binary_adaptor.sources.snapshot
     if len(sources_snapshot.files) == 1:
-      target = await Get(HydratedTarget, Address, python_binary_adaptor.address)
-      output = await Get(SourceRootStrippedSources, HydratedTarget, target)
+      target = await Get[HydratedTarget](Address, python_binary_adaptor.address)
+      output = await Get[SourceRootStrippedSources](HydratedTarget, target)
       root_filename = output.snapshot.files[0]
       entry_point = PythonBinary.translate_source_path_to_py_module_specifier(root_filename)
 
@@ -32,7 +32,7 @@ async def create_python_binary(python_binary_adaptor: PythonBinaryAdaptor) -> Cr
     output_filename=f'{python_binary_adaptor.address.target_name}.pex'
   )
 
-  pex = await Get(Pex, CreatePexFromTargetClosure, request)
+  pex = await Get[Pex](CreatePexFromTargetClosure, request)
   return CreatedBinary(digest=pex.directory_digest, binary_name=pex.output_filename)
 
 

--- a/src/python/pants/backend/python/rules/python_create_binary.py
+++ b/src/python/pants/backend/python/rules/python_create_binary.py
@@ -3,7 +3,7 @@
 
 from pants.backend.python.rules.pex import CreatePexFromTargetClosure, Pex
 from pants.backend.python.targets.python_binary import PythonBinary
-from pants.build_graph.address import Address, BuildFileAddress
+from pants.build_graph.address import Address
 from pants.engine.legacy.graph import BuildFileAddresses, HydratedTarget
 from pants.engine.legacy.structs import PythonBinaryAdaptor
 from pants.engine.rules import UnionRule, rule


### PR DESCRIPTION
Refactored out of the python binary creation rule.

It's useful in other contexts, e.g., to create an AWS Lambda.
