### PR TITLE
[IntelliJ] Export only modulizable targets when in `export-dep-as-jar`

### DIFF
--- a/src/docs/export.md
+++ b/src/docs/export.md
@@ -179,7 +179,7 @@ The following is an abbreviated export file from a command in the pants repo:
 
 ## 1.0.14
 
-Export only modulizable targets for `export-dep-as-jar`, and the rest of targets will appears as libraries.
+Export only modulizable targets for `export-dep-as-jar`, and the rest of targets will appear as libraries.
 
 Definition of `modulizable_targets`:
 1. Conceptually: targets that should appear as modules in IntelliJ.

--- a/src/docs/export.md
+++ b/src/docs/export.md
@@ -177,6 +177,28 @@ The following is an abbreviated export file from a command in the pants repo:
 
 # Export Format Changes
 
+## 1.0.14
+
+Export only modulizable targets for `export-dep-as-jar`, and the rest of targets will appears as libraries.
+
+Definition of `modulizable targets`: targets that should appear as modules in IntelliJ.
+
+For example, A -> B -> C -> D
+Given `./panst export-dep-as-jar A`,
+```
+modulizable_targets = [A]
+libraries = [B,C,D]
+```
+
+Given `./panst export-dep-as-jar A C`,
+ ```
+modulizable_targets = [A, B, C]
+libraries = [D]
+```
+In this case, `B` is forced into a module even though it is not a target root because IntelliJ
+does not allow a library to depend back onto a source module,
+i.e. `B` has to be a module to be able to depend on `C`.
+
 ## 1.0.13
 
 Add `--available-target-types` option, which exports currently available target types. 

--- a/src/docs/export.md
+++ b/src/docs/export.md
@@ -181,7 +181,9 @@ The following is an abbreviated export file from a command in the pants repo:
 
 Export only modulizable targets for `export-dep-as-jar`, and the rest of targets will appears as libraries.
 
-Definition of `modulizable targets`: targets that should appear as modules in IntelliJ.
+Definition of `modulizable_targets`:
+1. Conceptually: targets that should appear as modules in IntelliJ.
+2. Computationally: dependees of target roots within the transitive context.
 
 For example, A -> B -> C -> D
 Given `./panst export-dep-as-jar A`,

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -184,13 +184,13 @@ class ExportDepAsJar(ConsoleTask):
     if isinstance(current_target, JarLibrary):
       target_libraries = OrderedSet(iter_transitive_jars(current_target))
     for dep in current_target.dependencies:
+      if isinstance(dep, JarLibrary):
+        for jar in dep.jar_dependencies:
+          target_libraries.add(M2Coordinate(jar.org, jar.name, jar.rev))
+        # Add all the jars pulled in by this jar_library
+        target_libraries.update(iter_transitive_jars(dep))
       if dep in modulizable_target_set:
         info['targets'].append(dep.address.spec)
-        if isinstance(dep, JarLibrary):
-          for jar in dep.jar_dependencies:
-            target_libraries.add(M2Coordinate(jar.org, jar.name, jar.rev))
-          # Add all the jars pulled in by this jar_library
-          target_libraries.update(iter_transitive_jars(dep))
 
     if isinstance(current_target, ScalaLibrary):
       for dep in current_target.java_sources:

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -209,7 +209,7 @@ class ExportDepAsJar(ConsoleTask):
       return set(
         DependencyContext.global_instance().dependencies_respecting_strict_deps(t) if hasattr(t, 'strict_deps') else \
           DependencyContext.global_instance().all_dependencies(t)
-      )
+      ).difference({t}) # The transitive deps include the target itself, which we don't want
     info['libraries'].extend([dep.id for dep in _transitive_deps(current_target)])
 
     if current_target in target_roots_set:

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -207,7 +207,7 @@ class ExportDepAsJar(ConsoleTask):
 
     return info
 
-  def initialize_graph_info(self, targets_map):
+  def initialize_graph_info(self):
     scala_platform = ScalaPlatform.global_instance()
     scala_platform_map = {
       'scala_version': scala_platform.version,
@@ -229,7 +229,7 @@ class ExportDepAsJar(ConsoleTask):
 
     graph_info = {
       'version': DEFAULT_EXPORT_VERSION,
-      'targets': targets_map,
+      'targets': {},
       'jvm_platforms': jvm_platforms_map,
       'scala_platform': scala_platform_map,
       # `jvm_distributions` are static distribution settings from config,
@@ -280,7 +280,8 @@ class ExportDepAsJar(ConsoleTask):
         if isinstance(dep, Resources):
           resource_target_map[dep] = target
 
-    graph_info = self.initialize_graph_info(targets_map)
+    graph_info = self.initialize_graph_info()
+    graph_info['targets'] = targets_map
     graph_info['libraries'] = self._resolve_jars_info(all_targets, runtime_classpath)
 
     # Using resolved path in preparation for VCFS.

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -347,13 +347,6 @@ class ExportDepAsJar(ConsoleTask):
       info = self._process_target(target, modulizable_targets, resource_target_map, runtime_classpath)
       targets_map[target.address.spec] = info
 
-      # If it is a target root or it is already a jar_library target, then no-op.
-      if target in modulizable_targets or targets_map[target.address.spec]['pants_target_type'] == 'jar_library':
-        continue
-
-      targets_map[target.address.spec]['pants_target_type'] = 'jar_library'
-      targets_map[target.address.spec]['libraries'] = [t.id]
-
     graph_info = self.initialize_graph_info()
     graph_info['targets'] = targets_map
     graph_info['libraries'] = libraries_map

--- a/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
+++ b/src/python/pants/backend/project_info/tasks/export_dep_as_jar.py
@@ -154,7 +154,7 @@ class ExportDepAsJar(ConsoleTask):
     )
     return dependencies_to_include
 
-  def _process_target(self, current_target, target_roots_set, modulizable_target_set, resource_target_map, runtime_classpath):
+  def _process_target(self, current_target, modulizable_target_set, resource_target_map, runtime_classpath):
     """
     :type current_target:pants.build_graph.target.Target
     """
@@ -167,7 +167,7 @@ class ExportDepAsJar(ConsoleTask):
       'target_type': ExportDepAsJar._get_target_type(current_target, resource_target_map),
       'is_synthetic': current_target.is_synthetic,
       'pants_target_type': self._get_pants_target_alias(type(current_target)),
-      'is_target_root': current_target in target_roots_set,
+      'is_target_root': current_target in modulizable_target_set,
       'transitive': current_target.transitive,
       'scope': str(current_target.scope)
     }
@@ -210,7 +210,7 @@ class ExportDepAsJar(ConsoleTask):
       libraries_for_target.update(_full_library_set_for_target(dep))
     info['libraries'].extend(libraries_for_target)
 
-    if current_target in target_roots_set:
+    if current_target in modulizable_target_set:
       info['roots'] = [{
         'source_root': os.path.realpath(source_root_package_prefix[0]),
         'package_prefix': source_root_package_prefix[1]
@@ -344,11 +344,11 @@ class ExportDepAsJar(ConsoleTask):
       libraries_map[t.id] = self._make_libraries_entry(t, resource_target_map, runtime_classpath)
 
     for target in modulizable_targets:
-      info = self._process_target(target, target_roots_set, modulizable_targets, resource_target_map, runtime_classpath)
+      info = self._process_target(target, modulizable_targets, resource_target_map, runtime_classpath)
       targets_map[target.address.spec] = info
 
       # If it is a target root or it is already a jar_library target, then no-op.
-      if target in target_roots_set or targets_map[target.address.spec]['pants_target_type'] == 'jar_library':
+      if target in modulizable_targets or targets_map[target.address.spec]['pants_target_type'] == 'jar_library':
         continue
 
       targets_map[target.address.spec]['pants_target_type'] = 'jar_library'

--- a/src/python/pants/backend/project_info/tasks/export_version.py
+++ b/src/python/pants/backend/project_info/tasks/export_version.py
@@ -13,4 +13,4 @@
 #
 # Note format changes in src/docs/export.md and update the Changelog section.
 #
-DEFAULT_EXPORT_VERSION = '1.0.13'
+DEFAULT_EXPORT_VERSION = '1.0.14'

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -551,3 +551,22 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
       'project_info:jvm_target',
       result['targets'].keys()
     )
+
+  def test_target_roots_dont_generate_libs(self):
+    result = self.execute_export_json('project_info:scala_with_source_dep', 'project_info:jvm_target')
+    self.assertNotIn(
+      'project_info.scala_with_source_dep',
+      result['targets']['project_info:scala_with_source_dep']['libraries']
+    )
+    self.assertNotIn(
+      'project_info.jvm_target',
+      result['targets']['project_info:scala_with_source_dep']['libraries']
+    )
+    self.assertNotIn(
+      'project_info.scala_with_source_dep',
+      result['libraries'].keys()
+    )
+    self.assertNotIn(
+      'project_info.jvm_target',
+      result['libraries'].keys()
+    )

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -539,3 +539,10 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
       sorted(self.jvm_target_with_sources.sources_relative_to_source_root()),
       sorted(sources_jar_of_dep.namelist())
     )
+
+  def test_includes_targets_between_roots(self):
+    result = self.execute_export_json('project_info:scala_with_source_dep', 'project_info:jar_lib')
+    self.assertIn(
+      'project_info:jvm_target',
+      result['targets'].keys()
+    )

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_dep_as_jar.py
@@ -352,9 +352,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
       sorted(result['targets']['project_info:third']['targets'])
     )
     self.assertEqual(sorted(['org.scala-lang:scala-library:2.10.5',
-                             'org.apache:apache-jar:12.12.2012',
-                             '.scala-library',
-                             'project_info.jar_lib']),
+                             'org.apache:apache-jar:12.12.2012']),
                      sorted(result['targets']['project_info:third']['libraries']))
 
     self.assertEqual(1, len(result['targets']['project_info:third']['roots']))
@@ -367,7 +365,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
 
   def test_jvm_app(self):
     result = self.execute_export_json('project_info:jvm_app')
-    self.assertEqual(sorted(['org.apache:apache-jar:12.12.2012', 'project_info.jar_lib']),
+    self.assertEqual(sorted(['org.apache:apache-jar:12.12.2012']),
                      sorted(result['targets']['project_info:jvm_app']['libraries']))
 
   def test_jvm_target(self):
@@ -381,9 +379,7 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
                           'project_info/this/is/a/source/Bar.scala']},
       'libraries': sorted([
         'org.apache:apache-jar:12.12.2012',
-        'org.scala-lang:scala-library:2.10.5',
-        'project_info.jar_lib',
-        '.scala-library',
+        'org.scala-lang:scala-library:2.10.5'
       ]),
       'id': 'project_info.jvm_target',
       # 'is_code_gen': False,
@@ -411,20 +407,18 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
     self.assertEqual(sorted([
                        'org.apache:apache-jar:12.12.2012',
                        'junit:junit:{}'.format(JUnit.LIBRARY_REV),
-                       'project_info.jar_lib',
                        'project_info.test_resource',
-                       '.junit_library',
                      ]),
                      sorted(result['targets']['project_info:java_test']['libraries']))
 
   def test_jvm_binary(self):
     result = self.execute_export_json('project_info:jvm_binary')
-    self.assertEqual(sorted(['org.apache:apache-jar:12.12.2012', 'project_info.jar_lib']),
+    self.assertEqual(sorted(['org.apache:apache-jar:12.12.2012']),
                      sorted(result['targets']['project_info:jvm_binary']['libraries']))
 
   def test_top_dependency(self):
     result = self.execute_export_json('project_info:top_dependency')
-    self.assertEqual(sorted(['project_info.jvm_binary', 'project_info.jar_lib']),
+    self.assertEqual(sorted(['project_info.jvm_binary', 'org.apache:apache-jar:12.12.2012']),
                      sorted(result['targets']['project_info:top_dependency']['libraries']))
     self.assertEqual([], result['targets']['project_info:top_dependency']['targets'])
 
@@ -598,13 +592,12 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
         'project_info.d',
         'project_info.e',
         'org.scala-lang:scala-library:2.10.5',
-        '.scala-library',
       ]),
       sorted(result_a['targets'][a_spec]['libraries'])
     )
     result_ab = self.execute_export_json(a_spec, b_spec)
     self.assertEquals(
-      sorted(['org.scala-lang:scala-library:2.10.5', '.scala-library']),
+      sorted(['org.scala-lang:scala-library:2.10.5']),
       sorted(result_ab['targets'][a_spec]['libraries'])
     )
     self.assertIn(
@@ -617,7 +610,6 @@ class ExportDepAsJarTest(ConsoleTaskTestBase):
         'project_info.d',
         'project_info.e',
         'org.scala-lang:scala-library:2.10.5',
-        '.scala-library',
       ]),
       sorted(result_ab['targets'][b_spec]['libraries'])
     )


### PR DESCRIPTION
### Problem

As an optimization for exporting source dependencies as jars, we want to export `target` entries only for targets that are either:
- Target Roots, or
- Between target roots (e.g. if A -> B -> C and we `./pants export-dep-as-jar :A :C`, we want `:B` to also be in the output).

### Solution

Split the function `generate_targets_map` into three parts:
1.- We iterate over all targets to create the resource map. This is `O(|all_targets|)`
2.- We iterate over all targets to fill up the `graph_info['libraries']` section. This is also `O(|all_targets|)`.
3.- We calculate the printable targets (that fulfil the constraints above), and populate `targets_map` with entries for those. Figuring out the printable targets boils down to a call to `BuildGraph.transitive_dependees_of_addresses`, which is a DFS graph traversal. Populating `targets_map` can be quadratic, because for each modulizable target we must walk its transitive dependency graph to include all of those dependencies as libraries.

TODO before merging:
- [X] There are still a couple of failing tests, that will either have to be changed, or addressed before merging.
- [X] We need to include library entries for all the transitive deps that are not included in the final json in the targets that we print, to import them as library dependencies in IntelliJ (as opposed to module dependencies).

### Result

The output json will only include the targets that fulfil the constraints defined in `Problem` in the `targets` section, as opposed to all the targets in play.