### PR TITLE
Skip pythonstyle lint in internal mypy.py script

### DIFF
--- a/build-support/bin/mypy.py
+++ b/build-support/bin/mypy.py
@@ -20,6 +20,8 @@ def main() -> None:
       # error.
       "--tag=type_checked,partially_type_checked",
       "--backend-packages=pants.contrib.mypy",
+      "--pycheck-pyflakes-skip",
+      "--pycheck-newlines-skip",
       "lint",
       "--lint-mypy-config-file=build-support/mypy/mypy.ini",
       *globs,


### PR DESCRIPTION
### Problem

I was noticing that, on certain checkouts of the pants git repo, the ordinary pre-commit checks would fail with hundreds of spurious linter errors in files completely unrelated to the ones I had been changing. This was caused by the `mypy.py` build-support script, which the pre-commit checks run, doing additional linting beyond simply typechecking.

### Solution

Modify the invocation of `pants lint` in `mypy.py` to include these two flags:

--pycheck-newlines-skip
 --pycheck-pyflakes-skip

Which forces the script to only typecheck and ignore lint errors.

