### PR TITLE
pick scala library with same version as compiler

### DIFF
--- a/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
@@ -154,7 +154,6 @@ object InputUtils {
   def splitScala(jars: Seq[File], excluded: Set[String] = Set.empty): Option[ScalaJars] = {
     var  filtered = jars filterNot (excluded contains _.getName)
     // Added because the jars can be the entire classpath if using the default value.
-    filtered = filtered filter (_.getName matches ".*scala.*")
     val (compiler, other) = filtered partition (_.getName matches ScalaCompiler.pattern)
     val ScalaCompiler.regex(library_version) = compiler(0).getName
     val VersionedScalaLibraryJar = JarFile("scala-library", version=Some(library_version))

--- a/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
@@ -157,8 +157,12 @@ object InputUtils {
     val (compiler, other) = filtered partition (_.getName matches ScalaCompiler.pattern)
     val ScalaCompiler.regex(library_version) = compiler(0).getName
     val VersionedScalaLibraryJar = JarFile("scala-library", version=Some(library_version))
-    val (library, extra) = other partition (_.getName matches VersionedScalaLibraryJar.pattern)
-    if (compiler.nonEmpty && library.nonEmpty) Some(ScalaJars(compiler(0), library(0), extra)) else None
+    val VersionedScalaReflectJar = JarFile("scala-reflect", version=Some(library_version))
+    val ScalaXML = JarFile("scala-xml")
+    val (library, _) = other partition (_.getName matches VersionedScalaLibraryJar.pattern)
+    val (reflect, _) = other partition (_.getName matches VersionedScalaReflectJar.pattern)
+    val (xml, _) = other partition (_.getName matches ScalaXML.pattern)
+    if (compiler.nonEmpty && library.nonEmpty) Some(ScalaJars(compiler(0), library(0), reflect ++ xml)) else None
   }
 
   //


### PR DESCRIPTION
Follow up to #8753 
### Problem
The incorrect scala-library jar is pulled from the classpath by zinc

### Solution

Pick the scala-library on the classpath that has the same version as the scala-compiler on the classpath.

### Result

Integration tests in #8750 work again