### PR TITLE
Improve output of `./pants help`

### DIFF
--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -106,4 +106,3 @@ class IsChildOfTest(TestBase):
 
     assert not is_child_of(Path("/other/random/directory/root/dist/dir"), mock_build_root)
     assert not is_child_of(Path("../not_root/dist/dir"), mock_build_root)
-

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -4,7 +4,7 @@
 from textwrap import wrap
 from typing import List
 
-from colors import cyan, red
+from colors import cyan, magenta, red
 
 from pants.help.help_info_extracter import HelpInfoExtracter, OptionHelpInfo
 
@@ -20,11 +20,6 @@ class HelpFormatter:
   def _maybe_cyan(self, s):
     return self._maybe_color(cyan, s)
 
-  def _maybe_bright_cyan(self, s):
-    def bright_cyan(s: str) -> str:
-      return f"\x1b[96m{s}\x1b[0m"
-    return self._maybe_color(bright_cyan, s)
-
   def _maybe_bright_green(self, s):
     def bright_green(s: str) -> str:
       return f"\x1b[92m{s}\x1b[0m"
@@ -32,6 +27,9 @@ class HelpFormatter:
 
   def _maybe_red(self, s):
     return self._maybe_color(red, s)
+
+  def _maybe_magenta(self, s):
+    return self._maybe_color(magenta, s)
 
   def _maybe_color(self, color, s):
     return color(s) if self._color else s
@@ -77,7 +75,7 @@ class HelpFormatter:
     lines = []
     choices = f'one of: [{ohi.choices}] ' if ohi.choices else ''
     arg_line = '{args} {default}'.format(
-      args=self._maybe_bright_cyan(', '.join(ohi.display_args)),
+      args=self._maybe_magenta(', '.join(ohi.display_args)),
       default=self._maybe_cyan(f'({choices}default: {ohi.default})')
     )
     lines.append(f'  {arg_line}')

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -4,7 +4,7 @@
 from textwrap import wrap
 from typing import List
 
-from colors import cyan, magenta, red
+from colors import cyan, green, magenta, red
 
 from pants.help.help_info_extracter import HelpInfoExtracter, OptionHelpInfo
 
@@ -20,10 +20,8 @@ class HelpFormatter:
   def _maybe_cyan(self, s):
     return self._maybe_color(cyan, s)
 
-  def _maybe_bright_green(self, s):
-    def bright_green(s: str) -> str:
-      return f"\x1b[92m{s}\x1b[0m"
-    return self._maybe_color(bright_green, s)
+  def _maybe_green(self, s):
+    return self._maybe_color(green, s)
 
   def _maybe_red(self, s):
     return self._maybe_color(red, s)
@@ -47,9 +45,9 @@ class HelpFormatter:
       lines.append('')
       display_scope = scope or 'Global'
       if category:
-        lines.append(self._maybe_bright_green(f'{display_scope} {category}:'))
+        lines.append(self._maybe_green(f'{display_scope} {category}:'))
       else:
-        lines.append(self._maybe_bright_green(f'{display_scope}:'))
+        lines.append(self._maybe_green(f'{display_scope}:'))
         if description:
           lines.append(description)
       lines.append(' ')

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -15,27 +15,30 @@ class OptionHelpFormatterTest(unittest.TestCase):
                          deprecated_message=None, removal_version=None, removal_hint=None,
                          choices=None)
     ohi = ohi._replace(**kwargs)
-    lines = HelpFormatter(scope='', show_recursive=False, show_advanced=False,
-                          color=False).format_option(ohi)
-    self.assertEqual(len(lines), 2)
-    self.assertIn('help for foo', lines[1])
+    lines = HelpFormatter(
+      scope='', show_recursive=False, show_advanced=False, color=False
+    ).format_option(ohi)
+    assert len(lines) == 2
+    assert 'help for foo' in lines[1]
     return lines[0]
 
   def test_format_help(self):
     line = self.format_help_for_foo(default='MYDEFAULT')
-    self.assertEqual('--foo (default: MYDEFAULT)', line)
+    assert line.lstrip() == '--foo (default: MYDEFAULT)'
 
   def test_suppress_advanced(self):
     args = ['--foo']
     kwargs = {'advanced': True}
-    lines = HelpFormatter(scope='', show_recursive=False, show_advanced=False,
-                          color=False).format_options('', '', [(args, kwargs)])
-    self.assertEqual(0, len(lines))
-    lines = HelpFormatter(scope='', show_recursive=True, show_advanced=True,
-                          color=False).format_options('', '', [(args, kwargs)])
-    print(lines)
-    self.assertEqual(5, len(lines))
+    lines = HelpFormatter(
+      scope='', show_recursive=False, show_advanced=False, color=False
+    ).format_options(scope='', description='', option_registrations_iter=[(args, kwargs)])
+    assert len(lines) == 5
+    assert not any("--foo" in line for line in lines)
+    lines = HelpFormatter(
+      scope='', show_recursive=True, show_advanced=True, color=False
+    ).format_options(scope='', description='', option_registrations_iter=[(args, kwargs)])
+    assert len(lines) == 14
 
   def test_format_help_choices(self):
     line = self.format_help_for_foo(typ=str, default='kiwi', choices='apple, banana, kiwi')
-    self.assertEqual('--foo (one of: [apple, banana, kiwi] default: kiwi)', line)
+    assert line.lstrip() == '--foo (one of: [apple, banana, kiwi] default: kiwi)'

--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -10,41 +10,41 @@ class TestHelpIntegration(PantsRunIntegrationTest):
     command = ['help']
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
-    self.assertIn('Usage:', pants_run.stdout_data)
+    assert 'Usage:' in pants_run.stdout_data
     # spot check to see that a public global option is printed
-    self.assertIn('--level', pants_run.stdout_data)
-    self.assertIn('Global options:', pants_run.stdout_data)
+    assert '--level' in pants_run.stdout_data
+    assert 'Global:' in pants_run.stdout_data
 
   def test_help_advanced(self):
     command = ['help-advanced']
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
-    self.assertIn('Global advanced options:', pants_run.stdout_data)
+    assert 'Global advanced:' in pants_run.stdout_data
     # Spot check to see that a global advanced option is printed
-    self.assertIn('--pants-bootstrapdir', pants_run.stdout_data)
+    assert '--pants-bootstrapdir'in pants_run.stdout_data
 
   def test_help_all(self):
     command = ['help-all']
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
     # Spot check to see that scope headings are printed
-    self.assertIn('test.junit options:', pants_run.stdout_data)
+    assert 'test.junit:'in pants_run.stdout_data
     # Spot check to see that full args for all options are printed
-    self.assertIn('--binary-dup-max-dups', pants_run.stdout_data)
+    assert '--binary-dup-max-dups'in pants_run.stdout_data
     # Spot check to see that subsystem options are printing
-    self.assertIn('--jvm-options', pants_run.stdout_data)
+    assert '--jvm-options'in pants_run.stdout_data
 
   def test_help_all_advanced(self):
     command = ['--help-all', '--help-advanced']
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
     # Spot check to see that scope headings are printed even for advanced options
-    self.assertIn('test.junit options:', pants_run.stdout_data)
-    self.assertIn('cache.test.junit advanced options:', pants_run.stdout_data)
+    assert 'test.junit:'in pants_run.stdout_data
+    assert 'cache.test.junit advanced:'in pants_run.stdout_data
     # Spot check to see that full args for all options are printed
-    self.assertIn('--binary-dup-max-dups', pants_run.stdout_data)
-    self.assertIn('--cache-test-junit-read', pants_run.stdout_data)
+    assert '--binary-dup-max-dups'in pants_run.stdout_data
+    assert '--cache-test-junit-read'in pants_run.stdout_data
     # Spot check to see that subsystem options are printing
-    self.assertIn('--jvm-options', pants_run.stdout_data)
+    assert '--jvm-options'in pants_run.stdout_data
     # Spot check to see that advanced subsystem options are printing
-    self.assertIn('--jvm-max-subprocess-args', pants_run.stdout_data)
+    assert '--jvm-max-subprocess-args'in pants_run.stdout_data

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -121,10 +121,12 @@ class HelpPrinter:
     """
     scope = scope_info.scope
     description = scope_info.description
-    show_recursive = self._help_request.advanced
-    show_advanced = self._help_request.advanced
-    color = sys.stdout.isatty()
-    help_formatter = HelpFormatter(scope, show_recursive, show_advanced, color)
+    help_formatter = HelpFormatter(
+      scope=scope,
+      show_recursive=self._help_request.advanced,
+      show_advanced=self._help_request.advanced,
+      color=sys.stdout.isatty(),
+    )
     formatted_lines = help_formatter.format_options(
       scope, description, self._options.get_parser(scope).option_registrations_iter()
     )


### PR DESCRIPTION
### Changes

* Don't use blue, as it is not accessible for users with dark terminals.
* Change colors so that they read better on all backgrounds
    * For instance, the options are now magenta.
    * See https://i.stack.imgur.com/9UVnC.png for all the supported colors.
* Add one extra line between each subsystem for easier visual parsing.
   * If `--help-advanced` or `--help-recursive` are used, those options will still be only separated by one line for each subsystem. But, between the distinct subsystems, there will be two lines.
* Indent options by two single spaces.
   * Better shows the hierarchy of option scope > specific options.
* Show a message when a subsystem has no options available.
   * Without this, `./pants help fmt2` shows nothing at all, which is confusing.

(edit: Changes made to description after discussion in this PR)

### Before

![Screen Shot 2019-12-13 at 6 45 35 PM](https://user-images.githubusercontent.com/14852634/70841577-c268a200-1dd8-11ea-9d21-589388e86343.png)

![Screen Shot 2019-12-13 at 6 43 50 PM](https://user-images.githubusercontent.com/14852634/70841542-833a5100-1dd8-11ea-906b-596760afb7a8.png)

![Screen Shot 2019-12-13 at 6 44 39 PM](https://user-images.githubusercontent.com/14852634/70841560-9fd68900-1dd8-11ea-80fa-378643bfa89e.png)

![Screen Shot 2019-12-13 at 6 54 09 PM](https://user-images.githubusercontent.com/14852634/70841728-f4c6cf00-1dd9-11ea-8d7e-13f96057fb3a.png)

### After

<img width="572" alt="Screenshot 2019-12-17 at 15 53 48" src="https://user-images.githubusercontent.com/5861182/71012168-8f7b2280-20e6-11ea-8da2-aaf08ec28c99.png">

<img width="664" alt="Screenshot 2019-12-17 at 15 53 38" src="https://user-images.githubusercontent.com/5861182/71012145-8427f700-20e6-11ea-9a57-146384c24fe2.png">
