### PR TITLE
Fix V2 formatters failing when formatting the same file

### DIFF
--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -33,7 +33,7 @@ from pants.rules.core.lint import LintResult
 @dataclass(frozen=True)
 class BlackTarget:
   target: TargetAdaptor
-  prior_formatter_result_digest: Optional[Digest] = None
+  prior_formatter_result_digest: Digest
 
 
 @dataclass(frozen=True)
@@ -99,7 +99,7 @@ async def create_black_request(
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> ExecuteProcessRequest:
   target = wrapped_target.target
-  sources_digest = wrapped_target.prior_formatter_result_digest or target.sources.snapshot.directory_digest
+  sources_digest = wrapped_target.prior_formatter_result_digest
   merged_input_files = await Get[Digest](
     DirectoriesToMerge(
       directories=(

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -33,6 +33,7 @@ from pants.rules.core.lint import LintResult
 @dataclass(frozen=True)
 class BlackTarget:
   target: TargetAdaptor
+  prior_formatter_result_digest: Optional[Digest] = None
 
 
 @dataclass(frozen=True)
@@ -98,10 +99,11 @@ async def create_black_request(
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> ExecuteProcessRequest:
   target = wrapped_target.target
+  sources_digest = wrapped_target.prior_formatter_result_digest or target.sources.snapshot.directory_digest
   merged_input_files = await Get[Digest](
     DirectoriesToMerge(
       directories=(
-        target.sources.snapshot.directory_digest,
+        sources_digest,
         black_setup.requirements_pex.directory_digest,
         black_setup.config_snapshot.directory_digest,
       )

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -74,7 +74,8 @@ class BlackIntegrationTest(TestBase):
       TargetAdaptor(
         sources=EagerFilesetWithSpec('test', {'globs': []}, snapshot=input_snapshot),
         address=Address.parse("test:target"),
-      )
+      ),
+      prior_formatter_result_digest=input_snapshot.directory_digest,
     )
     black_subsystem = global_subsystem_instance(
       Black, options={Black.options_scope: {

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -31,7 +31,7 @@ from pants.rules.core.lint import LintResult
 @dataclass(frozen=True)
 class IsortTarget:
   target: TargetAdaptor
-  prior_formatter_result_digest: Optional[Digest] = None
+  prior_formatter_result_digest: Digest
 
 
 @dataclass(frozen=True)
@@ -91,7 +91,7 @@ async def create_isort_request(
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> ExecuteProcessRequest:
   target = wrapped_target.target
-  sources_digest = wrapped_target.prior_formatter_result_digest or target.sources.snapshot.directory_digest
+  sources_digest = wrapped_target.prior_formatter_result_digest
   merged_input_files = await Get[Digest](
     DirectoriesToMerge(
       directories=(

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -31,6 +31,7 @@ from pants.rules.core.lint import LintResult
 @dataclass(frozen=True)
 class IsortTarget:
   target: TargetAdaptor
+  prior_formatter_result_digest: Optional[Digest] = None
 
 
 @dataclass(frozen=True)
@@ -90,10 +91,11 @@ async def create_isort_request(
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> ExecuteProcessRequest:
   target = wrapped_target.target
+  sources_digest = wrapped_target.prior_formatter_result_digest or target.sources.snapshot.directory_digest
   merged_input_files = await Get[Digest](
     DirectoriesToMerge(
       directories=(
-        target.sources.snapshot.directory_digest,
+        sources_digest,
         isort_setup.requirements_pex.directory_digest,
         isort_setup.config_snapshot.directory_digest,
       )

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -82,7 +82,8 @@ class IsortIntegrationTest(TestBase):
       TargetAdaptor(
         sources=EagerFilesetWithSpec('test', {'globs': []}, snapshot=input_snapshot),
         address=Address.parse("test:target"),
-      )
+      ),
+      prior_formatter_result_digest=input_snapshot.directory_digest,
     )
     isort_subsystem = global_subsystem_instance(
       Isort, options={Isort.options_scope: {

--- a/src/python/pants/backend/python/lint/python_format_target.py
+++ b/src/python/pants/backend/python/lint/python_format_target.py
@@ -2,9 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List
 
-from pants.engine.fs import Digest
 from pants.engine.legacy.structs import (
   PantsPluginAdaptor,
   PythonAppAdaptor,
@@ -34,11 +33,12 @@ async def format_python_target(
 ) -> AggregatedFmtResults:
   """This aggregator allows us to have multiple formatters safely operate over the same Python
   targets, even if they modify the same files."""
-  prior_formatter_result_digest: Optional[Digest] = None
+  prior_formatter_result_digest = wrapped_target.target.sources.snapshot.directory_digest
   results: List[FmtResult] = []
   for member in union_membership.union_rules[PythonFormatTarget]:
     result = await Get[FmtResult](
-      PythonFormatTarget, member(wrapped_target.target, prior_formatter_result_digest)
+      PythonFormatTarget,
+      member(wrapped_target.target, prior_formatter_result_digest=prior_formatter_result_digest),
     )
     results.append(result)
     prior_formatter_result_digest = result.digest

--- a/src/python/pants/backend/python/lint/python_format_target.py
+++ b/src/python/pants/backend/python/lint/python_format_target.py
@@ -2,7 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
+from typing import List, Optional
 
+from pants.engine.fs import Digest
 from pants.engine.legacy.structs import (
   PantsPluginAdaptor,
   PythonAppAdaptor,
@@ -12,8 +14,8 @@ from pants.engine.legacy.structs import (
   TargetAdaptor,
 )
 from pants.engine.rules import UnionMembership, UnionRule, rule, union
-from pants.engine.selectors import Get, MultiGet
-from pants.rules.core.fmt import FmtResult, FmtResults, FormatTarget
+from pants.engine.selectors import Get
+from pants.rules.core.fmt import AggregatedFmtResults, FmtResult, FormatTarget
 
 
 @union
@@ -29,13 +31,18 @@ class _ConcretePythonFormatTarget:
 @rule
 async def format_python_target(
   wrapped_target: _ConcretePythonFormatTarget, union_membership: UnionMembership
-) -> FmtResults:
-  """This aggregator allows us to have multiple formatters operate over the same Python targets."""
-  results = await MultiGet(
-    Get[FmtResult](PythonFormatTarget, member(wrapped_target.target))
-    for member in union_membership.union_rules[PythonFormatTarget]
-  )
-  return FmtResults(results)
+) -> AggregatedFmtResults:
+  """This aggregator allows us to have multiple formatters safely operate over the same Python
+  targets, even if they modify the same files."""
+  prior_formatter_result_digest: Optional[Digest] = None
+  results: List[FmtResult] = []
+  for member in union_membership.union_rules[PythonFormatTarget]:
+    result = await Get[FmtResult](
+      PythonFormatTarget, member(wrapped_target.target, prior_formatter_result_digest)
+    )
+    results.append(result)
+    prior_formatter_result_digest = result.digest
+  return AggregatedFmtResults(tuple(results), combined_digest=prior_formatter_result_digest)
 
 
 @rule

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Tuple
 
 from pants.engine.console import Console
 from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryToMaterialize, Workspace
@@ -35,9 +35,10 @@ class AggregatedFmtResults:
 
   The `combined_digest` is used to ensure that none of the formatters overwrite each other. The
   language implementation should run each formatter one at a time and pipe the resulting digest of
-  one formatter into the next."""
+  one formatter into the next. The `combined_digest` must contain all files for the target,
+  including any which were not re-formatted."""
   results: Tuple[FmtResult, ...]
-  combined_digest: Optional[Digest]
+  combined_digest: Digest
 
 
 @union

--- a/src/python/pants/rules/core/fmt.py
+++ b/src/python/pants/rules/core/fmt.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
+from typing import Optional, Tuple
 
 from pants.engine.console import Console
 from pants.engine.fs import Digest, DirectoriesToMerge, DirectoryToMaterialize, Workspace
@@ -9,7 +10,6 @@ from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.isolated_process import ExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.legacy.structs import TargetAdaptor
-from pants.engine.objects import Collection
 from pants.engine.rules import UnionMembership, console_rule, union
 from pants.engine.selectors import Get, MultiGet
 
@@ -29,8 +29,15 @@ class FmtResult:
     )
 
 
-class FmtResults(Collection[FmtResult]):
-  """This collection allows us to aggregate multiple `FmtResult`s for a language."""
+@dataclass(frozen=True)
+class AggregatedFmtResults:
+  """This collection allows us to safely aggregate multiple `FmtResult`s for a language.
+
+  The `combined_digest` is used to ensure that none of the formatters overwrite each other. The
+  language implementation should run each formatter one at a time and pipe the resulting digest of
+  one formatter into the next."""
+  results: Tuple[FmtResult, ...]
+  combined_digest: Optional[Digest]
 
 
 @union
@@ -69,25 +76,30 @@ async def fmt(
   workspace: Workspace,
   union_membership: UnionMembership
 ) -> Fmt:
-  nested_results = await MultiGet(
-    Get[FmtResults](FormatTarget, target.adaptor)
+  aggregated_results = await MultiGet(
+    Get[AggregatedFmtResults](FormatTarget, target.adaptor)
     for target in targets
     if FormatTarget.is_formattable(target.adaptor, union_membership=union_membership)
   )
-  results = [result for results in nested_results for result in results]
+  individual_results = [
+    result
+    for aggregated_result in aggregated_results
+    for result in aggregated_result.results
+  ]
 
-  if not results:
+  if not individual_results:
     return Fmt(exit_code=0)
 
   # NB: this will fail if there are any conflicting changes, which we want to happen rather than
-  # silently having one result override the other.
-  # TODO(#8722): get this working with multiple formatters for the same language. Right now, the
-  #  rule will fail if formatters touch the same file.
+  # silently having one result override the other. In practicality, this should never happen due
+  # to our use of an aggregator rule for each distinct language.
   merged_formatted_digest = await Get[Digest](
-    DirectoriesToMerge(tuple(result.digest for result in results))
+    DirectoriesToMerge(
+      tuple(aggregated_result.combined_digest for aggregated_result in aggregated_results)
+    )
   )
   workspace.materialize_directory(DirectoryToMaterialize(merged_formatted_digest))
-  for result in results:
+  for result in individual_results:
     if result.stdout:
       console.print_stdout(result.stdout)
     if result.stderr:


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/8722.

### Solution

We tweak each formatter implementation to allow the language's aggregator rule to pass each formatter another formatter's prior result digest. If a prior result is given to a formatter, then it will operate against that digest; otherwise, it will operate on the original target's digest.

Then, we change the language aggregator rule to use a for loop, i.e. to operate one formatter at a time. The rule accumulates the results while feeding the prior formatter's digest into the new formatter.

### Result

Black and isort may safely modify the same file via `./pants fmt2`.