### PR TITLE
Typecheck `rules/core`, `testutil/engine/util.py`, and 30 more files

### DIFF
--- a/contrib/buildgen/src/python/pants/contrib/buildgen/BUILD
+++ b/contrib/buildgen/src/python/pants/contrib/buildgen/BUILD
@@ -7,6 +7,7 @@ python_library(
   dependencies=[
     ':build_file_manipulator',
   ],
+  tags = {"partially_type_checked"},
   provides=contrib_setup_py(
     name='pantsbuild.pants.contrib.buildgen',
     description='Automatic manipulation of BUILD dependencies based on source analysis.',

--- a/contrib/cpp/tests/python/pants_test/contrib/cpp/BUILD
+++ b/contrib/cpp/tests/python/pants_test/contrib/cpp/BUILD
@@ -17,9 +17,7 @@ python_tests(
 
 python_tests(
   name='cpp_toolchain',
-  sources=[
-    'test_cpp_toolchain.py',
-  ],
+  sources=['test_cpp_toolchain.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'contrib/cpp/src/python/pants/contrib/cpp/toolchain:toolchain',
@@ -27,4 +25,5 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
@@ -18,15 +18,17 @@ python_tests(
     'contrib/go/src/python/pants/contrib/go/subsystems',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
-    name='go_import_meta_tag_reader',
-    sources=['test_go_import_meta_tag_reader.py'],
-    dependencies=[
-      'contrib/go/src/python/pants/contrib/go/subsystems',
-    ]
+  name='go_import_meta_tag_reader',
+  sources=['test_go_import_meta_tag_reader.py'],
+  dependencies=[
+    'contrib/go/src/python/pants/contrib/go/subsystems',
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/BUILD
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/BUILD
@@ -1,9 +1,14 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+python_library(
+  sources=['googlejavaformat.py'],
+)
+
 contrib_plugin(
   name='plugin',
   dependencies=[
+    ':googlejavaformat',
     'src/python/pants/goal:task_registrar',
   ],
   distribution_name='pantsbuild.pants.contrib.googlejavaformat',

--- a/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/BUILD
+++ b/contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat/BUILD
@@ -1,14 +1,9 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(
-  sources=['googlejavaformat.py'],
-)
-
 contrib_plugin(
   name='plugin',
   dependencies=[
-    ':googlejavaformat',
     'src/python/pants/goal:task_registrar',
   ],
   distribution_name='pantsbuild.pants.contrib.googlejavaformat',

--- a/contrib/node/tests/python/pants_test/contrib/node/subsystems/BUILD
+++ b/contrib/node/tests/python/pants_test/contrib/node/subsystems/BUILD
@@ -8,7 +8,8 @@ python_tests(
     'contrib/node/src/python/pants/contrib/node/subsystems',
     'src/python/pants/testutil/base:context_utils',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -16,5 +17,6 @@ python_tests(
   sources=['test_package_managers.py'],
   dependencies=[
     'contrib/node/src/python/pants/contrib/node/subsystems',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/contrib/python/src/python/pants/contrib/python/checks/checker/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/checker/BUILD
@@ -19,7 +19,7 @@ python_library(
     'contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty:pycodestyle',
     'contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty:pyflakes',
     'contrib/python/src/python/pants/contrib/python/checks/checker/3rdparty:six',
-  ]
+  ],
 )
 
 python_binary(
@@ -27,5 +27,5 @@ python_binary(
   entry_point='pants.contrib.python.checks.checker.checker:main',
   dependencies=[
     ':checker',
-  ]
+  ],
 )

--- a/contrib/thrifty/src/python/pants/contrib/thrifty/BUILD
+++ b/contrib/thrifty/src/python/pants/contrib/thrifty/BUILD
@@ -12,6 +12,7 @@ contrib_plugin(
     ':thrifty',
     'src/python/pants/goal:task_registrar',
   ],
+  tags = {"partially_type_checked"},
   distribution_name='pantsbuild.pants.contrib.thrifty',
   description='Microsoft Thrifty thrift generator pants plugins.',
   additional_classifiers=[

--- a/src/python/pants/backend/project_info/rules/BUILD
+++ b/src/python/pants/backend/project_info/rules/BUILD
@@ -12,10 +12,11 @@ python_library(
     'src/python/pants/util:collections',
     'src/python/pants/util:memo',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
-  name='rules_tests',
+  name='tests',
   dependencies=[
     ':rules',
     'src/python/pants/testutil:console_rule_test_base',

--- a/src/python/pants/backend/project_info/rules/source_file_validator.py
+++ b/src/python/pants/backend/project_info/rules/source_file_validator.py
@@ -221,7 +221,7 @@ class MultiMatcher:
 async def validate(
   console: Console, hydrated_targets: HydratedTargets, validate_options: ValidateOptions
 ) -> Validate:
-  per_tgt_rmrs = await MultiGet(Get(RegexMatchResults, HydratedTarget, ht) for ht in hydrated_targets)
+  per_tgt_rmrs = await MultiGet(Get[RegexMatchResults](HydratedTarget, ht) for ht in hydrated_targets)
   regex_match_results = list(itertools.chain(*per_tgt_rmrs))
 
   detail_level = validate_options.values.detail_level
@@ -264,8 +264,7 @@ async def match_regexes_for_one_target(
   multi_matcher = source_file_validation.get_multi_matcher()
   rmrs = []
   if hasattr(hydrated_target.adaptor, 'sources'):
-    files_content = await Get(FilesContent,
-                              Digest, hydrated_target.adaptor.sources.snapshot.directory_digest)
+    files_content = await Get[FilesContent](Digest, hydrated_target.adaptor.sources.snapshot.directory_digest)
     for file_content in files_content:
       rmrs.append(multi_matcher.check_source_file(file_content.path, file_content.content))
   return RegexMatchResults(rmrs)

--- a/src/python/pants/backend/python/lint/BUILD
+++ b/src/python/pants/backend/python/lint/BUILD
@@ -8,4 +8,5 @@ python_library(
     'src/python/pants/engine:rules',
     'src/python/pants/rules/core',
   ],
+  tags = {"type_checked"},
 )

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -219,6 +219,7 @@ python_library(
     'src/python/pants/base:specs',
     'src/python/pants/rules/core:core',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(

--- a/src/python/pants/fs/BUILD
+++ b/src/python/pants/fs/BUILD
@@ -17,5 +17,5 @@ python_tests(
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil:console_rule_test_base',
     'src/python/pants/testutil/engine:util',
-  ]
+  ],
 )

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -27,4 +27,5 @@ python_tests(
   dependencies=[
     ':option',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/rules/core/BUILD
+++ b/src/python/pants/rules/core/BUILD
@@ -18,6 +18,7 @@ python_library(
     'src/python/pants/source',
     'src/python/pants/util:collections',
   ],
+  tags = {"type_checked"},
 )
 
 python_tests(

--- a/src/python/pants/rules/core/BUILD
+++ b/src/python/pants/rules/core/BUILD
@@ -37,7 +37,7 @@ python_tests(
     'src/python/pants/testutil:console_rule_test_base',
     'src/python/pants/testutil/engine:util',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
 )
 
 python_tests(

--- a/src/python/pants/rules/core/list_roots.py
+++ b/src/python/pants/rules/core/list_roots.py
@@ -32,7 +32,7 @@ async def all_roots(source_root_config: SourceRootConfig) -> AllSourceRoots:
     else:
       all_paths.add(f"**/{path}/")
 
-  snapshot = await Get(Snapshot, PathGlobs(include=tuple(all_paths)))
+  snapshot = await Get[Snapshot](PathGlobs(include=tuple(all_paths)))
 
   all_source_roots: Set[SourceRoot] = set()
 

--- a/src/python/pants/rules/core/list_targets.py
+++ b/src/python/pants/rules/core/list_targets.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import Union
+
 from pants.base.specs import Specs
 from pants.engine.addressable import BuildFileAddresses
 from pants.engine.console import Console
@@ -36,9 +38,10 @@ async def list_targets(console: Console, list_options: ListOptions, specs: Specs
   provides = list_options.values.provides
   provides_columns = list_options.values.provides_columns
   documented = list_options.values.documented
+  collection: Union[HydratedTargets, BuildFileAddresses]
   if provides or documented:
     # To get provides clauses or documentation, we need hydrated targets.
-    collection = await Get(HydratedTargets, Specs, specs)
+    collection = await Get[HydratedTargets](Specs, specs)
     if provides:
       extractors = dict(
           address=lambda target: target.address.spec,
@@ -68,7 +71,7 @@ async def list_targets(console: Console, list_options: ListOptions, specs: Specs
       print_fn = print_documented
   else:
     # Otherwise, we can use only addresses.
-    collection = await Get(BuildFileAddresses, Specs, specs)
+    collection = await Get[BuildFileAddresses](Specs, specs)
     print_fn = lambda address: address.spec
 
   with list_options.line_oriented(console) as print_stdout:

--- a/src/python/pants/rules/core/run.py
+++ b/src/python/pants/rules/core/run.py
@@ -33,10 +33,10 @@ async def run(
   bfa: BuildFileAddress,
 ) -> Run:
   target = bfa.to_address()
-  binary = await Get(CreatedBinary, Address, target)
+  binary = await Get[CreatedBinary](Address, target)
 
   with temporary_dir(root_dir=str(Path(build_root.path, ".pants.d")), cleanup=True) as tmpdir:
-    path_relative_to_build_root = Path(tmpdir).relative_to(build_root.path)
+    path_relative_to_build_root = str(Path(tmpdir).relative_to(build_root.path))
     workspace.materialize_directory(
       DirectoryToMaterialize(binary.digest, path_prefix=path_relative_to_build_root)
     )
@@ -44,7 +44,7 @@ async def run(
     console.write_stdout(f"Running target: {target}\n")
     full_path = str(Path(tmpdir, binary.binary_name))
     run_request = InteractiveProcessRequest(
-      argv=[full_path],
+      argv=(full_path,),
       run_in_workspace=True,
     )
 

--- a/src/python/pants/rules/core/strip_source_root.py
+++ b/src/python/pants/rules/core/strip_source_root.py
@@ -41,14 +41,12 @@ async def strip_source_root(
   if target_adaptor.type_alias == Files.alias():
     source_root = None
 
-  resulting_digest = await Get(
-    Digest,
+  resulting_digest = await Get[Digest](
     DirectoryWithPrefixToStrip(
-      directory_digest=digest,
-      prefix=source_root.path if source_root else ""
+      directory_digest=digest, prefix=source_root.path if source_root else ""
     )
   )
-  resulting_snapshot = await Get(Snapshot, Digest, resulting_digest)
+  resulting_snapshot = await Get[Snapshot](Digest, resulting_digest)
   return SourceRootStrippedSources(snapshot=resulting_snapshot)
 
 

--- a/src/python/pants/rules/core/test.py
+++ b/src/python/pants/rules/core/test.py
@@ -52,7 +52,7 @@ class AddressAndTestResult:
 
 @console_rule
 async def fast_test(console: Console, addresses: BuildFileAddresses) -> Test:
-  results = await MultiGet(Get(AddressAndTestResult, Address, addr.to_address()) for addr in addresses)
+  results = await MultiGet(Get[AddressAndTestResult](Address, addr.to_address()) for addr in addresses)
   did_any_fail = False
   filtered_results = [(x.address, x.test_result) for x in results if x.test_result is not None]
 
@@ -112,7 +112,7 @@ async def coordinator_of_tests(
   # NB: This has the effect of "casting" a TargetAdaptor to a member of the TestTarget union.
   # The adaptor will always be a member because of the union membership check above, but if
   # it were not it would fail at runtime with a useful error message.
-  result = await Get(TestResult, TestTarget, target.adaptor)
+  result = await Get[TestResult](TestTarget, target.adaptor)
   logger.info("Tests {}: {}".format(
     "succeeded" if result.status == Status.SUCCESS else "failed",
     target.address.reference(),

--- a/src/python/pants/testutil/engine/BUILD
+++ b/src/python/pants/testutil/engine/BUILD
@@ -28,4 +28,5 @@ python_library(
     'src/python/pants/engine:struct',
     'src/python/pants/util:objects',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -118,20 +118,14 @@ python_library(
   tags = {'partially_type_checked'},
 )
 
-python_library(
+python_binary(
   name = 's3_log_aggregator',
-  sources = ['s3_log_aggregator.py'],
+  source = 's3_log_aggregator.py',
+  entry_point = 'pants.util.s3_log_aggregator',
   dependencies = [
     '3rdparty/python:s3logparse'
   ],
-)
-
-python_binary(
-  name = 's3_log_aggregator_bin',
-  entry_point = 'pants.util.s3_log_aggregator',
-  dependencies = [
-    ':s3_log_aggregator'
-  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(

--- a/tests/python/pants_test/backend/jvm/subsystems/BUILD
+++ b/tests/python/pants_test/backend/jvm/subsystems/BUILD
@@ -12,6 +12,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil/subsystem',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -27,7 +28,7 @@ python_tests(
     'src/python/pants/backend/jvm/tasks/jvm_compile/zinc',
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
 )
 
 

--- a/tests/python/pants_test/backend/jvm/subsystems/test_shader.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_shader.py
@@ -141,7 +141,7 @@ class ShaderTest(unittest.TestCase):
                      Shading.create_relocate(from_pattern='com.foo.bar.**',
                                       shade_prefix='__my_prefix__.'))
 
-    self.assertEqual(('com.foo.bar.**', 'org.biz.baz.@1'.format('__my_prefix__.')),
+    self.assertEqual(('com.foo.bar.**', 'org.biz.baz.@1'),
                      Shading.create_relocate(from_pattern='com.foo.bar.**',
                                       shade_prefix='__my_prefix__.',
                                       shade_pattern='org.biz.baz.@1'))

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/BUILD
@@ -20,6 +20,7 @@ python_library(
     'testprojects/src/scala/org/pantsbuild/testproject:sharedsources_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:unicode_directory',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -7,6 +7,7 @@ python_library(
   dependencies = [
     'src/python/pants/util:contextutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -112,7 +112,8 @@ python_tests(
   dependencies = [
     ':pants_ignore_test_base',
     'src/python/pants/base:project_tree',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -120,7 +121,8 @@ python_library(
   sources = ['pants_ignore_test_base.py'],
   dependencies = [
     ':project_tree_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -150,7 +152,8 @@ python_library(
   sources = ['project_tree_test_base.py'],
   dependencies = [
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -224,4 +224,5 @@ python_tests(
   dependencies=[
     'src/python/pants/engine:objects',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -20,7 +20,7 @@ python_library(
 )
 
 python_tests(
-  name = 'test_legacy_engine',
+  name = 'legacy_engine',
   sources = ['test_legacy_engine.py'],
   dependencies = [
     ':engine_test_base',
@@ -31,7 +31,7 @@ python_tests(
 )
 
 python_tests(
-  name='test_round_engine',
+  name='round_engine',
   sources=['test_round_engine.py'],
   dependencies = [
     ':engine_test_base',
@@ -76,7 +76,7 @@ python_tests(
     'src/python/pants/testutil:test_base',
     'tests/python/pants_test/engine/examples:fs_test',
     'tests/python/pants_test/engine/examples:scheduler_inputs',
-  ]
+  ],
 )
 
 python_tests(
@@ -114,6 +114,7 @@ python_tests(
     'src/python/pants/testutil/engine:util',
     'src/python/pants/reporting',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -132,6 +133,7 @@ python_tests(
     'tests/python/pants_test/engine/examples:graph_test',
     'tests/python/pants_test/engine/examples:parsers',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -149,6 +151,7 @@ python_tests(
     'tests/python/pants_test/engine/examples:mapper_test',
     'tests/python/pants_test/engine/examples:parsers',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -176,7 +179,7 @@ python_tests(
     'tests/python/pants_test/engine/examples:parsers',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
 )
 
 python_tests(
@@ -191,7 +194,7 @@ python_tests(
     'src/python/pants/engine:scheduler',
     'tests/python/pants_test/engine/examples:scheduler_inputs',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
 )
 
 python_tests(
@@ -215,7 +218,8 @@ python_library(
     'src/python/pants/engine:parser',
     'src/python/pants/engine:scheduler',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -35,7 +35,7 @@ def fn_raises(x):
 
 
 @rule
-def nested_raise(x: B) -> A:
+def nested_raise(x: B) -> A:  # type: ignore[return]
   fn_raises(x)
 
 
@@ -48,7 +48,7 @@ class Fib:
 async def fib(n: int) -> Fib:
   if n < 2:
     return Fib(n)
-  x, y = tuple(await MultiGet([Get(Fib, int(n-2)), Get(Fib, int(n-1))]))
+  x, y = tuple(await MultiGet([Get[Fib](int(n-2)), Get[Fib](int(n-1))]))
   return Fib(x.val + y.val)
 
 
@@ -155,11 +155,11 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
     # Tests that when multiple distinct failures occur, they are each rendered.
 
     @rule
-    def d_from_b_nested_raise(b: B) -> D:
+    def d_from_b_nested_raise(b: B) -> D:  # type: ignore[return]
       fn_raises(b)
 
     @rule
-    def c_from_b_nested_raise(b: B) -> C:
+    def c_from_b_nested_raise(b: B) -> C:  # type: ignore[return]
       fn_raises(b)
 
     @rule

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -137,7 +137,7 @@ HydratedStructs = Collection[HydratedStruct]
 
 @rule
 async def unhydrated_structs(build_file_addresses: BuildFileAddresses) -> HydratedStructs:
-  tacs = await MultiGet(Get(HydratedStruct, Address, a) for a in build_file_addresses.addresses)
+  tacs = await MultiGet(Get[HydratedStruct](Address, a) for a in build_file_addresses.addresses)
   return HydratedStructs(tacs)
 
 

--- a/tests/python/pants_test/ivy/BUILD
+++ b/tests/python/pants_test/ivy/BUILD
@@ -7,7 +7,8 @@ python_tests(
   dependencies=[
     'src/python/pants/ivy',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -17,5 +18,6 @@ python_tests(
     'src/python/pants/ivy',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/java/BUILD
+++ b/tests/python/pants_test/java/BUILD
@@ -9,7 +9,8 @@ python_tests(
     'src/python/pants/java:executor',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/java/distribution/BUILD
+++ b/tests/python/pants_test/java/distribution/BUILD
@@ -11,6 +11,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil/subsystem',
   ],
+  tags = {"partially_type_checked"},
   timeout = 15,
 )
 

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -7,6 +7,7 @@ python_tests(
   dependencies = [
     'src/python/pants/reporting',
   ],
+  tags = {"partially_type_checked"},
   timeout = 10,
 )
 


### PR DESCRIPTION
Now that MyPy understands V2 goals, we can type `rules/core`, `engine/scheduler.py`, and `testutil/engine/util.py`. 

Brings the number of checked source files from 607 to 654. See https://docs.google.com/spreadsheets/d/1MKg82Fs3uIMOZDoWeNUBD-VirVkOzHU8Tte7oY6ypP0/edit#gid=1405325993 for what remains.

The only remaining major blocker for running MyPy over the whole codebase is getting MyPy to understand `meta.py` and `memo.py` so that we can check `pants/backend/native/subsystems`, which is a transitive dep for all of our Python backend and the `TestBase` and `PantsRunIntegrationTest` utils.