### PR TITLE
scalafmt-v2 goal using native-image

### DIFF
--- a/src/python/pants/backend/jvm/BUILD
+++ b/src/python/pants/backend/jvm/BUILD
@@ -30,6 +30,7 @@ python_library(
     ':ossrh_publication_metadata',
     ':repository',
     ':scala_artifact',
+    'src/python/pants/backend/jvm/rules',
     'src/python/pants/backend/jvm/subsystems:jar_dependency_management',
     'src/python/pants/backend/jvm/subsystems:shader',
     'src/python/pants/backend/jvm/targets:all',

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -9,6 +9,7 @@ from pants.backend.jvm.ossrh_publication_metadata import (
   Scm,
 )
 from pants.backend.jvm.repository import Repository as repo
+from pants.backend.jvm.rules.scalafmt import rules as scalafmt_rules
 from pants.backend.jvm.scala_artifact import ScalaArtifact
 from pants.backend.jvm.subsystems.jar_dependency_management import JarDependencyManagementSetup
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
@@ -228,3 +229,7 @@ def register_goals():
   task(name='test-jvm-prep-command', action=RunTestJvmPrepCommand).install('test', first=True)
   task(name='binary-jvm-prep-command', action=RunBinaryJvmPrepCommand).install('binary', first=True)
   task(name='compile-jvm-prep-command', action=RunCompileJvmPrepCommand).install('compile', first=True)
+
+
+def rules():
+  return [*scalafmt_rules()]

--- a/src/python/pants/backend/jvm/rules/BUILD
+++ b/src/python/pants/backend/jvm/rules/BUILD
@@ -1,0 +1,13 @@
+python_library(
+  dependencies=[
+    '3rdparty/python:dataclasses',
+    'src/python/pants/backend/jvm/subsystems:scalafmt',
+    'src/python/pants/binaries',
+    'src/python/pants/engine:console',
+    'src/python/pants/engine:fs',
+    'src/python/pants/engine:goal',
+    'src/python/pants/engine:isolated_process',
+    'src/python/pants/engine:rules',
+    'src/python/pants/engine:selectors',
+  ],
+)

--- a/src/python/pants/backend/jvm/rules/scalafmt.py
+++ b/src/python/pants/backend/jvm/rules/scalafmt.py
@@ -1,0 +1,66 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+
+from pants.backend.jvm.subsystems.scalafmt import ScalaFmtSubsystem
+from pants.binaries.binary_tool import BinaryToolFetchRequest
+from pants.engine.console import Console
+from pants.engine.fs import Snapshot
+from pants.engine.goal import Goal, GoalSubsystem
+from pants.engine.isolated_process import ExecuteProcessRequest
+from pants.engine.rules import console_rule, optionable_rule, rule
+
+
+@dataclass(frozen=True)
+class SingleFile:
+  snapshot: Snapshot
+
+
+@dataclass(frozen=True)
+class FileCollection:
+  snapshot: Snapshot
+
+
+@dataclass(frozen=True)
+class ScalaFmtNativeImage:
+  exe: SingleFile
+
+
+@dataclass(frozen=True)
+class ScalaFmtRequest:
+  config_file: SingleFile
+  input_files: FileCollection
+  scalafmt_tool: ScalaFmtNativeImage
+
+
+@dataclass(frozen=True)
+class ScalaFmtExeRequest:
+  exe_req: ExecuteProcessRequest
+
+
+@rule
+def make_scalafmt_exe_req(req: ScalaFmtRequest, scalafmt: ScalaFmtSubsystem) -> ScalaFmtExeRequest:
+  
+
+
+
+class ScalaFmt(Goal):
+  """???"""
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register('--???')
+
+
+@console_rule
+def scalafmt_v2(console: Console) -> ScalaFmt:
+  return ScalaFmt(exit_code=0)
+
+
+def rules():
+  return [
+    optionable_rule(ScalaFmtSubsystem),
+    scalafmt_v2,
+  ]

--- a/src/python/pants/backend/jvm/rules/scalafmt.py
+++ b/src/python/pants/backend/jvm/rules/scalafmt.py
@@ -2,24 +2,29 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
+from typing import Optional
 
 from pants.backend.jvm.subsystems.scalafmt import ScalaFmtSubsystem
 from pants.binaries.binary_tool import BinaryToolFetchRequest
 from pants.engine.console import Console
-from pants.engine.fs import Snapshot
+from pants.engine.fs import (
+  Digest,
+  DirectoriesToMerge,
+  DirectoryToMaterialize,
+  FileCollection,
+  ManyFileCollections,
+  PathGlobs,
+  SingleFile,
+  Snapshot,
+  Workspace,
+)
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.isolated_process import ExecuteProcessRequest
-from pants.engine.rules import console_rule, optionable_rule, rule
-
-
-@dataclass(frozen=True)
-class SingleFile:
-  snapshot: Snapshot
-
-
-@dataclass(frozen=True)
-class FileCollection:
-  snapshot: Snapshot
+from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.legacy.graph import HydratedTargets
+from pants.engine.rules import RootRule, console_rule, optionable_rule, rule
+from pants.engine.selectors import Get
+from pants.option.custom_types import dir_option
+from pants.util.collections import Enum
 
 
 @dataclass(frozen=True)
@@ -27,9 +32,34 @@ class ScalaFmtNativeImage:
   exe: SingleFile
 
 
+@rule
+async def extract_scalafmt_native_image(scalafmt: ScalaFmtSubsystem) -> ScalaFmtNativeImage:
+  zipped_snapshot = await Get[SingleFile](BinaryToolFetchRequest(scalafmt))
+  output_file = os.path.join(scalafmt.unzipped_inner_dir_platform_specific_name, 'scalafmt')
+  # TODO: create some class "HackyLocalExecuteProcessRequest" which automatically adds the PATH to
+  # the `env`, and uses
+  # `unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule`!
+  unzipped_result = await Get[ExecuteProcessResult](ExecuteProcessRequest(
+    argv=('unzip', str(zipped_snapshot.file_path)),
+    input_files=zipped_snapshot.digest,
+    description=f'Unzip the scalafmt native-image version {scalafmt.version()} from its release zip.',
+    output_files=(output_file,),
+    env={'PATH': os.environ['PATH']},
+  ))
+  chmod_plus_x_result = await Get[ExecuteProcessResult](ExecuteProcessRequest(
+    argv=('chmod', '+x', output_file),
+    input_files=unzipped_result.output_directory_digest,
+    description=f'Mark the scalafmt native-image version {scalafmt.version()} as executable!',
+    output_files=(output_file,),
+    env={'PATH': os.environ['PATH']},
+  ))
+  output_file = await Get[Snapshot](Digest, chmod_plus_x_result.output_directory_digest)
+  return ScalaFmtNativeImage(SingleFile(output_file))
+
+
 @dataclass(frozen=True)
 class ScalaFmtRequest:
-  config_file: SingleFile
+  config_file: Optional[SingleFile]
   input_files: FileCollection
   scalafmt_tool: ScalaFmtNativeImage
 
@@ -40,27 +70,128 @@ class ScalaFmtExeRequest:
 
 
 @rule
-def make_scalafmt_exe_req(req: ScalaFmtRequest, scalafmt: ScalaFmtSubsystem) -> ScalaFmtExeRequest:
-  
+async def make_scalafmt_exe_req(req: ScalaFmtRequest, scalafmt: ScalaFmtSubsystem) -> ScalaFmtExeRequest:
+  # Format the files.
+  prefix_args = ['-i']
+
+  digests_to_merge = [req.scalafmt_tool.exe.digest, req.input_files.digest]
+
+  if scalafmt.configuration:
+    config_file = SingleFile(await Get[Snapshot](PathGlobs([str(scalafmt.configuration)])))
+    digests_to_merge.append(config_file.digest)
+    prefix_args.extend(['--config', str(config_file.file_path)])
+
+  merged_input = await Get[Digest](DirectoriesToMerge(tuple(digests_to_merge)))
+
+  all_input_file_strs = [str(f) for f in req.input_files.file_paths]
+  argv = [
+    str(req.scalafmt_tool.exe.file_path),
+    *prefix_args,
+    *all_input_file_strs,
+  ]
+
+  return ScalaFmtExeRequest(ExecuteProcessRequest(
+    argv=tuple(argv),
+    input_files=merged_input,
+    description=f'Execute scalafmt for {len(all_input_file_strs)} sources!',
+    # TODO: some sort of macro or wrapper for:
+    # 1. where output files and input files are the same,
+    # 2. checking that the resulting Snapshot can be wrapped in a FileCollection,
+    # 3. and that the output files from expanding the digest match the input files!
+    output_files=tuple(all_input_file_strs),
+  ))
 
 
+@rule
+async def make_scalafmt_request(hts: HydratedTargets, scalafmt: ScalaFmtSubsystem) -> ScalaFmtRequest:
+  scala_libraries = [ht for ht in hts if ht.adaptor.type_alias == 'scala_library']
+  merged_source_files = await Get[FileCollection](ManyFileCollections(
+    FileCollection(ht.adaptor.sources.snapshot) for ht in scala_libraries))
 
-class ScalaFmt(Goal):
+  maybe_config_path = scalafmt.configuration
+  maybe_config_file = None
+  if maybe_config_path is not None:
+    maybe_config_file = SingleFile(await Get[Snapshot](PathGlobs([str(maybe_config_path)])))
+
+  assert scalafmt.use_native_image
+  scalafmt_tool = await Get[ScalaFmtNativeImage](ScalaFmtSubsystem, scalafmt)
+  return ScalaFmtRequest(
+    config_file=maybe_config_file,
+    input_files=merged_source_files,
+    scalafmt_tool=scalafmt_tool,
+  )
+
+
+@dataclass(frozen=True)
+class ScalaFmtResult:
+  edited_files: FileCollection
+  stdout: bytes
+  stderr: bytes
+
+
+@rule
+async def execute_scalafmt(req: ScalaFmtExeRequest) -> ScalaFmtResult:
+  exe_res = await Get[ExecuteProcessResult](ExecuteProcessRequest, req.exe_req)
+  snapshotted_output = await Get[Snapshot](Digest, exe_res.output_directory_digest)
+  return ScalaFmtResult(
+    FileCollection(snapshotted_output),
+    stdout=exe_res.stdout,
+    stderr=exe_res.stderr)
+
+
+class ScalaFmtOptions(GoalSubsystem):
   """???"""
+  name = 'scalafmt-v2'
 
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
-    register('--???')
+    register('--output-dir', type=dir_option, default=None, fingerprint=False,
+             help='If specified, write formatted scala files into this directory '
+                  'instead of overwriting the source files in the buildroot.')
+
+    register('--files-per-worker', type=int, fingerprint=False,
+             default=None,
+             help='Number of files to use per each scalafmt execution.')
+    register('--worker-count', type=int, fingerprint=False,
+             default=None,
+             help='Total number of parallel scalafmt threads or processes to run.')
+
+
+class ScalaFmt(Goal):
+  subsystem_cls = ScalaFmtOptions
 
 
 @console_rule
-def scalafmt_v2(console: Console) -> ScalaFmt:
+async def scalafmt_v2(
+    console: Console,
+    hts: HydratedTargets,
+    workspace: Workspace,
+    options: ScalaFmtOptions,
+) -> ScalaFmt:
+  result = await Get[ScalaFmtResult](HydratedTargets, hts)
+  console.print_stderr(f'formatted {len(result.edited_files.file_paths)} files!')
+  console.print_stderr(f'scalafmt stdout:\n')
+  # Ensure the only stdout we write is the same stdout as scalafmt itself, to be pipeline-friendly.
+  console.print_stdout(result.stdout.decode('utf-8'))
+  console.print_stderr(f'scalafmt stderr:\n')
+  console.print_stderr(result.stderr.decode('utf-8'))
+
+  workspace.materialize_directory(DirectoryToMaterialize(
+    directory_digest=result.edited_files.digest,
+    path_prefix=(options.values.output_dir or ''),
+  ))
+
   return ScalaFmt(exit_code=0)
 
 
 def rules():
   return [
     optionable_rule(ScalaFmtSubsystem),
+    extract_scalafmt_native_image,
+    make_scalafmt_exe_req,
+    make_scalafmt_request,
+    RootRule(ScalaFmtExeRequest),
+    execute_scalafmt,
     scalafmt_v2,
   ]

--- a/src/python/pants/backend/jvm/rules/scalafmt.py
+++ b/src/python/pants/backend/jvm/rules/scalafmt.py
@@ -1,8 +1,11 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import itertools
+import math
+import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import Iterable, List, Optional, Tuple, TypeVar
 
 from pants.backend.jvm.subsystems.scalafmt import ScalaFmtSubsystem
 from pants.binaries.binary_tool import BinaryToolFetchRequest
@@ -19,10 +22,10 @@ from pants.engine.fs import (
   Workspace,
 )
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult
+from pants.engine.isolated_process import ExecuteProcessRequest, ExecuteProcessResult, FallibleExecuteProcessResult
 from pants.engine.legacy.graph import HydratedTargets
 from pants.engine.rules import RootRule, console_rule, optionable_rule, rule
-from pants.engine.selectors import Get
+from pants.engine.selectors import Get, MultiGet
 from pants.option.custom_types import dir_option
 from pants.util.collections import Enum
 
@@ -57,16 +60,61 @@ async def extract_scalafmt_native_image(scalafmt: ScalaFmtSubsystem) -> ScalaFmt
   return ScalaFmtNativeImage(SingleFile(output_file))
 
 
+_T = TypeVar('_T')
+
+
+class _ParallelismStrategy(Enum):
+  files_per_worker = 'files-per-worker'
+  worker_count = 'worker-count'
+  none = 'none'
+
+  @staticmethod
+  def _split_by_files_per_worker(parameter: int, all_sources: List[_T]) -> List[List[_T]]:
+    return [
+      all_sources[i:i + parameter]
+      for i in range(0, len(all_sources), parameter)
+    ]
+
+  @staticmethod
+  def _split_by_worker_count(parameter: int, all_sources: List[_T]) -> List[List[_T]]:
+    sources_iterator = iter(all_sources)
+    return [
+      list(itertools.islice(sources_iterator, 0, math.ceil(len(all_sources) / parameter)))
+      for _ in range(0, parameter)
+    ]
+
+  def split_inputs(self, parameter: int, all_sources: Iterable[_T]) -> List[List[_T]]:
+    all_sources = list(all_sources)
+    return self.match({
+      _ParallelismStrategy.files_per_worker: lambda: self._split_by_files_per_worker(parameter, all_sources),
+      _ParallelismStrategy.worker_count: lambda: self._split_by_worker_count(parameter, all_sources),
+      _ParallelismStrategy.none: lambda: [all_sources],
+    })()
+
+  def make_parallelism(self, parameter: int) -> '_Parallelism':
+    return _Parallelism(self, parameter)
+
+
+@dataclass(frozen=True)
+class _Parallelism:
+  strategy: _ParallelismStrategy
+  parameter: int
+
+  def split_inputs(self, all_sources: Iterable[_T]) -> List[List[_T]]:
+    return self.strategy.split_inputs(self.parameter, all_sources)
+
+
 @dataclass(frozen=True)
 class ScalaFmtRequest:
   config_file: Optional[SingleFile]
   input_files: FileCollection
   scalafmt_tool: ScalaFmtNativeImage
+  parallelism: _Parallelism
 
 
 @dataclass(frozen=True)
 class ScalaFmtExeRequest:
-  exe_req: ExecuteProcessRequest
+  exe_reqs: Tuple[ExecuteProcessRequest, ...]
 
 
 @rule
@@ -84,27 +132,37 @@ async def make_scalafmt_exe_req(req: ScalaFmtRequest, scalafmt: ScalaFmtSubsyste
   merged_input = await Get[Digest](DirectoriesToMerge(tuple(digests_to_merge)))
 
   all_input_file_strs = [str(f) for f in req.input_files.file_paths]
-  argv = [
-    str(req.scalafmt_tool.exe.file_path),
-    *prefix_args,
-    *all_input_file_strs,
+
+  all_argvs_outputs: List[Tuple[List[str], List[str]]] = [
+    ([
+      str(req.scalafmt_tool.exe.file_path),
+      *prefix_args,
+      *inputs,
+    ], inputs)
+    for inputs in req.parallelism.split_inputs(all_input_file_strs)
   ]
 
-  return ScalaFmtExeRequest(ExecuteProcessRequest(
+  return ScalaFmtExeRequest(tuple(ExecuteProcessRequest(
     argv=tuple(argv),
     input_files=merged_input,
-    description=f'Execute scalafmt for {len(all_input_file_strs)} sources!',
+    description=f'Execute scalafmt for {len(outputs)} sources!',
     # TODO: some sort of macro or wrapper for:
     # 1. where output files and input files are the same,
     # 2. checking that the resulting Snapshot can be wrapped in a FileCollection,
     # 3. and that the output files from expanding the digest match the input files!
-    output_files=tuple(all_input_file_strs),
-  ))
+    output_files=tuple(outputs),
+  ) for argv, outputs in all_argvs_outputs))
+
+
+@dataclass(frozen=True)
+class ScalaFmtFormatRequest:
+  hts: HydratedTargets
+  parallelism: _Parallelism
 
 
 @rule
-async def make_scalafmt_request(hts: HydratedTargets, scalafmt: ScalaFmtSubsystem) -> ScalaFmtRequest:
-  scala_libraries = [ht for ht in hts if ht.adaptor.type_alias == 'scala_library']
+async def make_scalafmt_request(req: ScalaFmtFormatRequest, scalafmt: ScalaFmtSubsystem) -> ScalaFmtRequest:
+  scala_libraries = [ht for ht in req.hts if ht.adaptor.type_alias == 'scala_library']
   merged_source_files = await Get[FileCollection](ManyFileCollections(
     FileCollection(ht.adaptor.sources.snapshot) for ht in scala_libraries))
 
@@ -115,28 +173,38 @@ async def make_scalafmt_request(hts: HydratedTargets, scalafmt: ScalaFmtSubsyste
 
   assert scalafmt.use_native_image
   scalafmt_tool = await Get[ScalaFmtNativeImage](ScalaFmtSubsystem, scalafmt)
+
   return ScalaFmtRequest(
     config_file=maybe_config_file,
     input_files=merged_source_files,
     scalafmt_tool=scalafmt_tool,
+    parallelism=req.parallelism,
   )
 
 
 @dataclass(frozen=True)
 class ScalaFmtResult:
   edited_files: FileCollection
+  failure_exit_codes: Tuple[int, ...]
   stdout: bytes
   stderr: bytes
 
 
 @rule
 async def execute_scalafmt(req: ScalaFmtExeRequest) -> ScalaFmtResult:
-  exe_res = await Get[ExecuteProcessResult](ExecuteProcessRequest, req.exe_req)
-  snapshotted_output = await Get[Snapshot](Digest, exe_res.output_directory_digest)
+  exe_results = await MultiGet(Get[FallibleExecuteProcessResult](ExecuteProcessRequest, exe_req)
+                               for exe_req in req.exe_reqs)
+  merged_output_files = await Get[Digest](DirectoriesToMerge(tuple(
+    r.output_directory_digest for r in exe_results
+  )))
+  catted_stdout = b''.join(r.stdout for r in exe_results)
+  catted_stderr = b''.join(r.stderr for r in exe_results)
+  snapshotted_output = await Get[Snapshot](Digest, merged_output_files)
   return ScalaFmtResult(
     FileCollection(snapshotted_output),
-    stdout=exe_res.stdout,
-    stderr=exe_res.stderr)
+    failure_exit_codes=tuple(r.exit_code for r in exe_results if r.exit_code != 0),
+    stdout=catted_stdout,
+    stderr=catted_stderr)
 
 
 class ScalaFmtOptions(GoalSubsystem):
@@ -169,12 +237,22 @@ async def scalafmt_v2(
     workspace: Workspace,
     options: ScalaFmtOptions,
 ) -> ScalaFmt:
-  result = await Get[ScalaFmtResult](HydratedTargets, hts)
+
+  if options.values.files_per_worker is not None:
+    parallelism = _ParallelismStrategy.files_per_worker.make_parallelism(options.values.files_per_worker)
+  elif options.values.worker_count is not None:
+    parallelism = _ParallelismStrategy.worker_count.make_parallelism(options.values.worker_count)
+  else:
+    parallelism = _ParallelismStrategy.none.make_parallelism(0)
+
+  result = await Get[ScalaFmtResult](ScalaFmtFormatRequest(hts, parallelism))
   console.print_stderr(f'formatted {len(result.edited_files.file_paths)} files!')
-  console.print_stderr(f'scalafmt stdout:\n')
+  joined_exit_codes = ', '.join(str(rc) for rc in result.failure_exit_codes)
+  console.print_stderr(f'failed worker exit codes: [{joined_exit_codes}]')
+  console.print_stderr(f'scalafmt stdout:')
   # Ensure the only stdout we write is the same stdout as scalafmt itself, to be pipeline-friendly.
   console.print_stdout(result.stdout.decode('utf-8'))
-  console.print_stderr(f'scalafmt stderr:\n')
+  console.print_stderr(f'scalafmt stderr:')
   console.print_stderr(result.stderr.decode('utf-8'))
 
   workspace.materialize_directory(DirectoryToMaterialize(
@@ -190,6 +268,7 @@ def rules():
     optionable_rule(ScalaFmtSubsystem),
     extract_scalafmt_native_image,
     make_scalafmt_exe_req,
+    RootRule(ScalaFmtFormatRequest),
     make_scalafmt_request,
     RootRule(ScalaFmtExeRequest),
     execute_scalafmt,

--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -191,3 +191,14 @@ python_library(
   ],
   tags = {"partially_type_checked"},
 )
+
+python_library(
+  name='scalafmt',
+  sources=['scalafmt.py'],
+  dependencies=[
+    'src/python/pants/binaries',
+    'src/python/pants/engine:platform',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
+  ]
+)

--- a/src/python/pants/backend/jvm/subsystems/scalafmt.py
+++ b/src/python/pants/backend/jvm/subsystems/scalafmt.py
@@ -1,11 +1,18 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
+from pathlib import Path
+from typing import Optional
+
+from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.binaries.binary_tool import NativeTool
 from pants.binaries.binary_util import BinaryToolUrlGenerator
 from pants.engine.platform import Platform
+from pants.java.jar.jar_dependency import JarDependency
+from pants.option.custom_types import file_option
 from pants.util.dirutil import chmod_plus_x
-from pants.util.memo import memoized_method
+from pants.util.memo import memoized_method, memoized_staticproperty
 
 
 class ScalaFmtNativeUrlGenerator(BinaryToolUrlGenerator):
@@ -25,10 +32,19 @@ class ScalaFmtNativeUrlGenerator(BinaryToolUrlGenerator):
 class ScalaFmtSubsystem(JvmToolMixin, NativeTool):
   options_scope = 'scalafmt'
   default_version = '2.3.1'
+  default_fingerprint = 'ec219e20c604a324962c01de5621558fa08761ba63c5b455ec3acf34ff187d76'
+  default_size_bytes = 16616182
   archive_type = 'zip'
 
   def get_external_url_generator(self):
     return ScalaFmtNativeUrlGenerator()
+
+  @memoized_staticproperty
+  def unzipped_inner_dir_platform_specific_name() -> str:
+    return Platform.current.match({
+      Platform.darwin: 'scalafmt-macos',
+      Platform.linux: 'scalafmt-linux',
+    })
 
   @memoized_method
   def select(self):
@@ -37,11 +53,9 @@ class ScalaFmtSubsystem(JvmToolMixin, NativeTool):
     Also make sure to chmod +x the scalafmt executable, since the release zip doesn't do that.
     """
     extracted_dir = super().select()
-    inner_dir_name = Platform.current.match({
-      Platform.darwin: 'scalafmt-macos',
-      Platform.linux: 'scalafmt-linux',
-    })
-    output_file = os.path.join(extracted_dir, inner_dir_name, 'scalafmt')
+    output_file = os.path.join(extracted_dir,
+                               self.unzipped_inner_dir_platform_specific_name,
+                               'scalafmt')
     chmod_plus_x(output_file)
     return output_file
 
@@ -49,11 +63,20 @@ class ScalaFmtSubsystem(JvmToolMixin, NativeTool):
   def use_native_image(self) -> bool:
     return bool(self.get_options().use_native_image)
 
+  @property
+  def configuration(self) -> Optional[Path]:
+    maybe_file = self.get_options().configuration
+    if maybe_file is None:
+      return None
+    return Path(maybe_file)
+
   @classmethod
   def register_options(cls, register):
     super().register_options(register)
     register('--use-native-image', type=bool, advanced=True, fingerprint=False,
              help='Use a pre-compiled native-image for scalafmt.')
+    register('--configuration', advanced=True, type=file_option, default=None, fingerprint=True,
+              help='Path to scalafmt config file, if not specified default scalafmt config used')
 
     cls.register_jvm_tool(register,
                           'scalafmt',

--- a/src/python/pants/backend/jvm/subsystems/scalafmt.py
+++ b/src/python/pants/backend/jvm/subsystems/scalafmt.py
@@ -1,0 +1,63 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.binaries.binary_tool import NativeTool
+from pants.binaries.binary_util import BinaryToolUrlGenerator
+from pants.engine.platform import Platform
+from pants.util.dirutil import chmod_plus_x
+from pants.util.memo import memoized_method
+
+
+class ScalaFmtNativeUrlGenerator(BinaryToolUrlGenerator):
+
+  _DIST_URL_FMT = 'https://github.com/scalameta/scalafmt/releases/download/v{version}/scalafmt-{system_id}.zip'
+
+  _SYSTEM_ID = {
+    'mac': 'macos',
+    'linux': 'linux',
+  }
+
+  def generate_urls(self, version, host_platform):
+    system_id = self._SYSTEM_ID[host_platform.os_name]
+    return [self._DIST_URL_FMT.format(version=version, system_id=system_id)]
+
+
+class ScalaFmtSubsystem(JvmToolMixin, NativeTool):
+  options_scope = 'scalafmt'
+  default_version = '2.3.1'
+  archive_type = 'zip'
+
+  def get_external_url_generator(self):
+    return ScalaFmtNativeUrlGenerator()
+
+  @memoized_method
+  def select(self):
+    """Reach into the unzipped directory and return the scalafmt executable.
+
+    Also make sure to chmod +x the scalafmt executable, since the release zip doesn't do that.
+    """
+    extracted_dir = super().select()
+    inner_dir_name = Platform.current.match({
+      Platform.darwin: 'scalafmt-macos',
+      Platform.linux: 'scalafmt-linux',
+    })
+    output_file = os.path.join(extracted_dir, inner_dir_name, 'scalafmt')
+    chmod_plus_x(output_file)
+    return output_file
+
+  @property
+  def use_native_image(self) -> bool:
+    return bool(self.get_options().use_native_image)
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register('--use-native-image', type=bool, advanced=True, fingerprint=False,
+             help='Use a pre-compiled native-image for scalafmt.')
+
+    cls.register_jvm_tool(register,
+                          'scalafmt',
+                          classpath=[
+                          JarDependency(org='com.geirsson',
+                                        name='scalafmt-cli_2.11',
+                                        rev='1.5.1')])

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -702,6 +702,7 @@ python_library(
   sources = ['scalafmt.py'],
   dependencies = [
     ':rewrite_base',
+    'src/python/pants/backend/jvm/subsystems:scalafmt',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -1,14 +1,79 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
+import subprocess
 from abc import abstractmethod
+from typing import List, cast
 
+from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
 from pants.base.exceptions import TaskError
+from pants.base.workunit import WorkUnitLabel
+from pants.binaries.binary_tool import NativeTool
+from pants.binaries.binary_util import BinaryToolUrlGenerator
+from pants.engine.platform import Platform
 from pants.java.jar.jar_dependency import JarDependency
 from pants.option.custom_types import file_option
 from pants.task.fmt_task_mixin import FmtTaskMixin
 from pants.task.lint_task_mixin import LintTaskMixin
+from pants.util.dirutil import chmod_plus_x
+from pants.util.memo import memoized_method
+
+
+class ScalaFmtNativeUrlGenerator(BinaryToolUrlGenerator):
+
+  _DIST_URL_FMT = 'https://github.com/scalameta/scalafmt/releases/download/v{version}/scalafmt-{system_id}.zip'
+
+  _SYSTEM_ID = {
+    'mac': 'macos',
+    'linux': 'linux',
+  }
+
+  def generate_urls(self, version, host_platform):
+    system_id = self._SYSTEM_ID[host_platform.os_name]
+    return [self._DIST_URL_FMT.format(version=version, system_id=system_id)]
+
+
+class ScalaFmtSubsystem(JvmToolMixin, NativeTool):
+  options_scope = 'scalafmt'
+  default_version = '2.3.1'
+  archive_type = 'zip'
+
+  def get_external_url_generator(self):
+    return ScalaFmtNativeUrlGenerator()
+
+  @memoized_method
+  def select(self):
+    """Reach into the unzipped directory and return the scalafmt executable.
+
+    Also make sure to chmod +x the scalafmt executable, since the release zip doesn't do that.
+    """
+    extracted_dir = super().select()
+    inner_dir_name = Platform.current.match({
+      Platform.darwin: 'scalafmt-macos',
+      Platform.linux: 'scalafmt-linux',
+    })
+    output_file = os.path.join(extracted_dir, inner_dir_name, 'scalafmt')
+    chmod_plus_x(output_file)
+    return output_file
+
+  @property
+  def use_native_image(self) -> bool:
+    return cast(bool, self.get_options().use_native_image)
+
+  @classmethod
+  def register_options(cls, register):
+    super().register_options(register)
+    register('--use-native-image', type=bool, advanced=True, fingerprint=False,
+             help='Use a pre-compiled native-image for scalafmt.')
+
+    cls.register_jvm_tool(register,
+                          'scalafmt',
+                          classpath=[
+                          JarDependency(org='com.geirsson',
+                                        name='scalafmt-cli_2.11',
+                                        rev='1.5.1')])
 
 
 class ScalaFmt(RewriteBase):
@@ -19,18 +84,16 @@ class ScalaFmt(RewriteBase):
   """
 
   @classmethod
+  def subsystem_dependencies(cls):
+    return super().subsystem_dependencies() + (
+      ScalaFmtSubsystem.scoped(cls),
+    )
+
+  @classmethod
   def register_options(cls, register):
     super().register_options(register)
     register('--configuration', advanced=True, type=file_option, fingerprint=True,
               help='Path to scalafmt config file, if not specified default scalafmt config used')
-
-    cls.register_jvm_tool(register,
-                          'scalafmt',
-                          classpath=[
-                          JarDependency(org='com.geirsson',
-                                        name='scalafmt-cli_2.11',
-                                        rev='1.5.1')
-                          ])
 
   @classmethod
   def target_types(cls):
@@ -44,7 +107,23 @@ class ScalaFmt(RewriteBase):
   def implementation_version(cls):
     return super().implementation_version() + [('ScalaFmt', 5)]
 
+  @property
+  def _use_native_image(self) -> bool:
+    return ScalaFmtSubsystem.scoped_instance(self).use_native_image
+
+  def _native_image_path(self) -> str:
+    return ScalaFmtSubsystem.scoped_instance(self).select()
+
+  def _tool_classpath(self) -> List[str]:
+    subsystem = ScalaFmtSubsystem.scoped_instance(self)
+    return subsystem.tool_classpath_from_products(
+      self.context.products,
+      key='scalafmt',
+      scope=subsystem.options_scope)
+
   def invoke_tool(self, absolute_root, target_sources):
+    self.context.log.debug(f'scalafmt called with sources: {target_sources}')
+
     # If no config file is specified use default scalafmt config.
     config_file = self.get_options().configuration
     args = list(self.additional_args)
@@ -52,11 +131,21 @@ class ScalaFmt(RewriteBase):
       args.extend(['--config', config_file])
     args.extend([source for _target, source in target_sources])
 
-    return self.runjava(classpath=self.tool_classpath('scalafmt'),
-                        main='org.scalafmt.cli.Cli',
-                        args=args,
-                        workunit_name='scalafmt',
-                        jvm_options=self.get_options().jvm_options)
+    if self._use_native_image:
+      with self.context.new_workunit(name='scalafmt', labels=[WorkUnitLabel.COMPILER]) as workunit:
+        args = [self._native_image_path(), *args]
+        self.context.log.debug(f'executing scalafmt with native image with args: {args}')
+        return subprocess.run(
+          args=args,
+          stdout=workunit.output('stdout'),
+          stderr=workunit.output('stderr'),
+        ).returncode
+    else:
+      return self.runjava(classpath=self._tool_classpath(),
+                          main='org.scalafmt.cli.Cli',
+                          args=args,
+                          workunit_name='scalafmt',
+                          jvm_options=self.get_options().jvm_options)
 
   @property
   @abstractmethod

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -7,74 +7,15 @@ from abc import abstractmethod
 from typing import List
 
 from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
+from pants.backend.jvm.subsystems.scalafmt import ScalaFmtSubsystem
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
-from pants.binaries.binary_tool import NativeTool
-from pants.binaries.binary_util import BinaryToolUrlGenerator
-from pants.engine.platform import Platform
 from pants.java.jar.jar_dependency import JarDependency
 from pants.option.custom_types import file_option
 from pants.process.xargs import Xargs
 from pants.task.fmt_task_mixin import FmtTaskMixin
 from pants.task.lint_task_mixin import LintTaskMixin
-from pants.util.dirutil import chmod_plus_x
-from pants.util.memo import memoized_method
-
-
-class ScalaFmtNativeUrlGenerator(BinaryToolUrlGenerator):
-
-  _DIST_URL_FMT = 'https://github.com/scalameta/scalafmt/releases/download/v{version}/scalafmt-{system_id}.zip'
-
-  _SYSTEM_ID = {
-    'mac': 'macos',
-    'linux': 'linux',
-  }
-
-  def generate_urls(self, version, host_platform):
-    system_id = self._SYSTEM_ID[host_platform.os_name]
-    return [self._DIST_URL_FMT.format(version=version, system_id=system_id)]
-
-
-class ScalaFmtSubsystem(JvmToolMixin, NativeTool):
-  options_scope = 'scalafmt'
-  default_version = '2.3.1'
-  archive_type = 'zip'
-
-  def get_external_url_generator(self):
-    return ScalaFmtNativeUrlGenerator()
-
-  @memoized_method
-  def select(self):
-    """Reach into the unzipped directory and return the scalafmt executable.
-
-    Also make sure to chmod +x the scalafmt executable, since the release zip doesn't do that.
-    """
-    extracted_dir = super().select()
-    inner_dir_name = Platform.current.match({
-      Platform.darwin: 'scalafmt-macos',
-      Platform.linux: 'scalafmt-linux',
-    })
-    output_file = os.path.join(extracted_dir, inner_dir_name, 'scalafmt')
-    chmod_plus_x(output_file)
-    return output_file
-
-  @property
-  def use_native_image(self) -> bool:
-    return bool(self.get_options().use_native_image)
-
-  @classmethod
-  def register_options(cls, register):
-    super().register_options(register)
-    register('--use-native-image', type=bool, advanced=True, fingerprint=False,
-             help='Use a pre-compiled native-image for scalafmt.')
-
-    cls.register_jvm_tool(register,
-                          'scalafmt',
-                          classpath=[
-                          JarDependency(org='com.geirsson',
-                                        name='scalafmt-cli_2.11',
-                                        rev='1.5.1')])
 
 
 class ScalaFmt(RewriteBase):

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -1,7 +1,6 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os
 import subprocess
 from abc import abstractmethod
 from typing import List

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -6,13 +6,10 @@ import subprocess
 from abc import abstractmethod
 from typing import List
 
-from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.backend.jvm.subsystems.scalafmt import ScalaFmtSubsystem
 from pants.backend.jvm.tasks.rewrite_base import RewriteBase
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
-from pants.java.jar.jar_dependency import JarDependency
-from pants.option.custom_types import file_option
 from pants.process.xargs import Xargs
 from pants.task.fmt_task_mixin import FmtTaskMixin
 from pants.task.lint_task_mixin import LintTaskMixin
@@ -34,12 +31,6 @@ class ScalaFmt(RewriteBase):
     return super().subsystem_dependencies() + (
       ScalaFmtSubsystem.scoped(cls),
     )
-
-  @classmethod
-  def register_options(cls, register):
-    super().register_options(register)
-    register('--configuration', advanced=True, type=file_option, fingerprint=True,
-              help='Path to scalafmt config file, if not specified default scalafmt config used')
 
   @classmethod
   def target_types(cls):
@@ -86,10 +77,10 @@ class ScalaFmt(RewriteBase):
     self.context.log.debug(f'scalafmt called with sources: {target_sources}')
 
     # If no config file is specified, use default scalafmt config.
-    config_file = self.get_options().configuration
+    config_file = ScalaFmtSubsystem.scoped_instance(self).configuration
     prefix_args = list(self.additional_args)
     if config_file is not None:
-      prefix_args.extend(['--config', config_file])
+      prefix_args.extend(['--config', str(config_file)])
 
     all_source_paths = [source for _target, source in target_sources]
 

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -122,7 +122,6 @@ class ScalaFmt(RewriteBase):
       scope=subsystem.options_scope)
 
   def invoke_tool(self, current_workunit, absolute_root, target_sources):
-    self.context.run_tracker._threadlocal.current_workunit = current_workunit
     self.context.log.debug(f'scalafmt called with sources: {target_sources}')
 
     # If no config file is specified use default scalafmt config.

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -121,7 +121,8 @@ class ScalaFmt(RewriteBase):
       key='scalafmt',
       scope=subsystem.options_scope)
 
-  def invoke_tool(self, absolute_root, target_sources):
+  def invoke_tool(self, current_workunit, absolute_root, target_sources):
+    self.context.run_tracker._threadlocal.current_workunit = current_workunit
     self.context.log.debug(f'scalafmt called with sources: {target_sources}')
 
     # If no config file is specified use default scalafmt config.
@@ -132,7 +133,10 @@ class ScalaFmt(RewriteBase):
     args.extend([source for _target, source in target_sources])
 
     if self._use_native_image:
-      with self.context.new_workunit(name='scalafmt', labels=[WorkUnitLabel.COMPILER]) as workunit:
+      with self.context.run_tracker.new_workunit(
+          name='scalafmt',
+          labels=[WorkUnitLabel.COMPILER],
+      ) as workunit:
         args = [self._native_image_path(), *args]
         self.context.log.debug(f'executing scalafmt with native image with args: {args}')
         return subprocess.run(

--- a/src/python/pants/binaries/BUILD
+++ b/src/python/pants/binaries/BUILD
@@ -9,6 +9,8 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/engine:fs',
+    'src/python/pants/engine:rules',
+    'src/python/pants/engine:selectors',
     'src/python/pants/fs',
     'src/python/pants/net',
     'src/python/pants/option',

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -187,6 +187,14 @@ class RunTracker(Subsystem):
   def set_v2_console_rule_names(self, v2_console_rule_names):
     self._v2_console_rule_names = v2_console_rule_names
 
+  def get_current_workunit(self):
+    """Return the workunit associated with the current thread.
+
+    This can be used along with .register_thread() to ensure spawned threads have access to the
+    parent workunit that spawned them!
+    """
+    return self._threadlocal.current_workunit
+
   def register_thread(self, parent_workunit):
     """Register the parent workunit for all work in the calling thread.
 
@@ -383,7 +391,7 @@ class RunTracker(Subsystem):
 
     if stats_version not in cls.SUPPORTED_STATS_VERSIONS:
       raise ValueError("Invalid stats version")
-    
+
 
     auth_data = BasicAuth.global_instance().get_auth_for_provider(auth_provider)
     headers = cls._get_headers(stats_version=stats_version)
@@ -462,7 +470,7 @@ class RunTracker(Subsystem):
     else:
       stats.update({
         'self_timings': self.self_timings.get_all(),
-        'critical_path_timings': self.get_critical_path_timings().get_all(),        
+        'critical_path_timings': self.get_critical_path_timings().get_all(),
         'outcomes': self.outcomes,
       })
     return stats

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -17,6 +17,7 @@ from pants.base.build_root import BuildRoot
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.base.specs import Specs
+from pants.binaries.binary_tool import rules as binary_tool_rules
 from pants.build_graph.address import BuildFileAddress
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.remote_sources import RemoteSources
@@ -414,6 +415,7 @@ class EngineInitializer:
       create_graph_rules(address_mapper) +
       create_options_parsing_rules() +
       structs_rules() +
+      binary_tool_rules() +
       rules
     )
 

--- a/src/python/pants/process/xargs.py
+++ b/src/python/pants/process/xargs.py
@@ -2,7 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import errno
+import logging
 import subprocess
+
+
+logger = logging.getLogger(__name__)
 
 
 class Xargs:
@@ -40,11 +44,13 @@ class Xargs:
     :param list args: Extra arguments to pass to cmd.
     """
     all_args = list(args)
+    logger.debug(f'xargs all_args: {all_args}')
     try:
       return self._cmd(all_args)
     except OSError as e:
       if errno.E2BIG == e.errno:
         args1, args2 = self._split_args(all_args)
+        logger.debug(f'xargs split cmd line:\nargs1={args1},\nargs2={args2}!')
         result = self.execute(args1)
         if result != 0:
           return result

--- a/src/python/pants/process/xargs.py
+++ b/src/python/pants/process/xargs.py
@@ -45,13 +45,14 @@ class Xargs:
 
     :param list args: Extra arguments to pass to cmd.
     """
-    all_args = list(args)
-    logger.debug(f'xargs all_args: {all_args}')
+    splittable_args = list(args)
+    all_args_for_command_function = self._constant_args + [splittable_args]
+    logger.debug(f'xargs all_args_for_command_function: {all_args_for_command_function}')
     try:
-      return self._cmd(*(*self._constant_args, all_args))
+      return self._cmd(*all_args_for_command_function)
     except OSError as e:
       if errno.E2BIG == e.errno:
-        args1, args2 = self._split_args(all_args)
+        args1, args2 = self._split_args(splittable_args)
         logger.debug(f'xargs split cmd line:\nargs1={args1},\nargs2={args2}!')
         result = self.execute(args1)
         if result != 0:

--- a/src/python/pants/process/xargs.py
+++ b/src/python/pants/process/xargs.py
@@ -26,13 +26,15 @@ class Xargs:
       return subprocess.call(cmd + args, **kwargs)
     return cls(call)
 
-  def __init__(self, cmd):
+  def __init__(self, cmd, constant_args=None):
     """Creates an xargs engine that calls cmd with argument chunks.
 
     :param cmd: A function that can execute a command line in the form of a list of strings
       passed as its sole argument.
+    :param constant_args: Any positional arguments to be added to each invocation.
     """
     self._cmd = cmd
+    self._constant_args = constant_args or []
 
   def _split_args(self, args):
     half = len(args) // 2
@@ -46,7 +48,7 @@ class Xargs:
     all_args = list(args)
     logger.debug(f'xargs all_args: {all_args}')
     try:
-      return self._cmd(all_args)
+      return self._cmd(*(*self._constant_args, all_args))
     except OSError as e:
       if errno.E2BIG == e.errno:
         args1, args2 = self._split_args(all_args)

--- a/src/python/pants/testutil/base/context_utils.py
+++ b/src/python/pants/testutil/base/context_utils.py
@@ -49,6 +49,7 @@ class TestContext(Context):
 
     def __init__(self):
       self.logger = RunTrackerLogger(self)
+      self._cur_workunit = TestContext.DummyWorkUnit()
 
     class DummyArtifactCacheStats:
       def add_hits(self, cache_name, targets): pass
@@ -58,6 +59,16 @@ class TestContext(Context):
     artifact_cache_stats = DummyArtifactCacheStats()
 
     def report_target_info(self, scope, target, keys, val): pass
+
+    def get_current_workunit(self):
+      return self._cur_workunit
+
+    def register_thread(self, parent_workunit):
+      self._cur_workunit = parent_workunit
+
+    @contextmanager
+    def new_workunit(self, *args, **kwargs):
+      yield self.get_current_workunit()
 
 
   class TestLogger(logging.getLoggerClass()):  # type: ignore[misc] # MyPy does't understand this dynamic base class


### PR DESCRIPTION
**TODO:**
- [ ] split out the first commit (`BinaryToolBase` fetching into a `UrlToFetch`) into its own PR
- [ ] merge #8772 
- [ ] make this remote-friendly with `MultiPlatformExecuteProcessRequest`!

Test with, e.g. (note that this is *without* pantsd, and *with* a cached process execution => <6 seconds!):
```bash
dmcclanahan@tw-mbp-dmcclanahan: ~/tools/pants-v3 0:18:07
X> mkdir -vp ttt && ./pants -ldebug --v2 --no-v1 --scalafmt-use-native-image scalafmt-v2 --output-dir=ttt --worker-count=6 src/scala::
Scrubbed PYTHONPATH=/Users/dmcclanahan/tools/pants-v3/src/python: from the environment.
08:24:14 [DEBUG] pants.base.exception_sink:pid=64816: re-enabling faulthandler
08:24:14 [DEBUG] pants.build_graph.build_configuration:pid=64816: Target alias resources has already been registered. Overwriting!
08:24:15 [DEBUG] pants.base.project_tree:pid=64816: ProjectTree ignore_patterns: ['.*/', '/dist/', '/build-support/virtualenvs/', '/build-support/bin/native/src', '/.pants.d', '/dist']
08:24:16 [DEBUG] pants.init.target_roots_calculator:pid=64816: spec_roots are: Specs(dependencies=(DescendantAddresses(directory='src/scala'),), matcher=SpecsMatcher(tags=(), exclude_patterns=()))
08:24:16 [DEBUG] pants.init.target_roots_calculator:pid=64816: changed_request is: ChangedRequest(changes_since=None, diffspec=None, include_dependees='none', fast=False)
08:24:16 [DEBUG] pants.init.target_roots_calculator:pid=64816: owned_files are: []
08:24:16 [DEBUG] pants.base.exception_sink:pid=64816: overriding the global exiter with <pants.bin.local_pants_runner.LocalExiter object at 0x1b9192b5828> (from <pants.base.exiter.Exiter object at 0x10a8ba198>)
08:24:16 [DEBUG] pants.init.engine_initializer:pid=64816: requesting <class 'pants.backend.jvm.rules.scalafmt.ScalaFmt'> to satisfy execution of `scalafmt-v2` goal
08:24:16 [DEBUG] engine::scheduler: Launching 1 roots.
08:24:16 [DEBUG] pants.binaries.binary_util:pid=64816: self._allow_external_binary_tool_downloads: True
08:24:16 [DEBUG] pants.binaries.binary_util:pid=64816: external_url_generator: <pants.backend.jvm.subsystems.scalafmt.ScalaFmtNativeUrlGenerator object at 0x1b9193abe48>
formatted 20 files!
failed worker exit codes: []
scalafmt stdout:
Reformatting...
Reformatting...
Reformatting...
Reformatting...
Reformatting...
Reformatting...
Reformatting...

scalafmt stderr:

08:24:18 [DEBUG] engine::scheduler: Root Select((<pants.engine.console.Console object at 0x1b9192b5940>+OptionsBootstrapper(env_tuples=(('PANTS_DEV', '1'),), bootstrap_args=('-ldebug',), args=('/Users/dmcclanahan/tools/pants-v3/src/python/pants/bin/pants_loader.py', '-ldebug', '--v2', '--no-v1', '--scalafmt-use-native-image', 'scalafmt-v2', '--output-dir=ttt', '--worker-count=6', 'src/scala::'), config=_ChainedConfig(chained_configs=(<pants.option.config._SingleFileConfig object at 0x10c635f28>,)))+Specs(dependencies=(DescendantAddresses(directory='src/scala'),), matcher=SpecsMatcher(tags=(), exclude_patterns=()))+Workspace(_scheduler=<pants.engine.scheduler.SchedulerSession object at 0x1b91929cfd0>)), ScalaFmt) completed.
08:24:18 [DEBUG] pants.engine.scheduler:pid=64816: computed 1 nodes in 2.209556 seconds. there are 161 total nodes.
./pants -ldebug --v2 --no-v1 --scalafmt-use-native-image scalafmt-v2     3.63s user 0.97s system 77% cpu 5.930 total
``` 

### Problem

(_explain the context of the problem and why you're making this change. include
references to all relevant github issues._)

### Solution

(_describe the modifications you've made._)

### Result

(_describe how your changes affect the end-user behavior of the system. this section is
optional, and should generally be summarized in the title of the pull request._)