### PR TITLE
Add user-facing-name abstraction to Node and use it in v2 console UI

### DIFF
--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -570,7 +570,12 @@ impl<N: Node> InnerGraph<N> {
 
       if deps.peek().is_none() {
         // If the entry has no running deps, it is a leaf. Emit it.
-        res.insert(format!("{}", self.unsafe_entry_for_id(id).node()), duration);
+        let node = self.unsafe_entry_for_id(id).node();
+        let output = match node.user_facing_name() {
+          Some(s) => s,
+          None => format!("{}", node),
+        };
+        res.insert(output, duration);
         if res.len() >= k {
           break;
         }

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -38,6 +38,15 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
   /// If the node result is cacheable, return true.
   ///
   fn cacheable(&self) -> bool;
+
+  /// Nodes optionally have a user-facing name (distinct from their Debug and Display
+  /// implementations). This user-facing name is intended to provide high-level information
+  /// to end users of pants about what computation pants is currently doing. Not all
+  /// `Node`s need a user-facing name. For `Node`s derived from Python `@rule`s, the
+  /// user-facing name should be the same as the `name` annotation on the rule decorator.
+  fn user_facing_name(&self) -> Option<String> {
+    None
+  }
 }
 
 pub trait NodeError: Clone + Debug + Eq + Send {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -214,16 +214,14 @@ pub struct ExecuteProcessRequest {
 }
 
 impl ExecuteProcessRequest {
-  fn user_facing_name(&self) -> String {
+  fn command_representation(&self) -> String {
     let mut buf = String::new();
-    buf.push_str("Exec: [");
     for (i, item) in self.argv.iter().enumerate() {
       if i != 0 {
         buf.push(' ');
       }
       buf.push_str(&item);
     }
-    buf.push_str("]");
     buf
   }
 }
@@ -252,8 +250,18 @@ pub struct MultiPlatformExecuteProcessRequest(
 impl MultiPlatformExecuteProcessRequest {
   pub fn user_facing_name(&self) -> Option<String> {
     let mut buf = String::new();
+    buf.push_str("Exec(");
+    for (i, ((_, target_platform), _)) in self.0.iter().enumerate() {
+      let platform: String = (*target_platform).into();
+      if i != 0 {
+        buf.push(',');
+      }
+      buf.push_str(&platform);
+    }
+    buf.push_str("): ");
+
     for (_, epr) in self.0.iter() {
-      buf.push_str(&epr.user_facing_name())
+      buf.push_str(&epr.command_representation())
     }
     Some(buf)
   }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -213,6 +213,21 @@ pub struct ExecuteProcessRequest {
   pub is_nailgunnable: bool,
 }
 
+impl ExecuteProcessRequest {
+  fn user_facing_name(&self) -> String {
+    let mut buf = String::new();
+    buf.push_str("Exec: [");
+    for (i, item) in self.argv.iter().enumerate() {
+      if i != 0 {
+        buf.push(' ');
+      }
+      buf.push_str(&item);
+    }
+    buf.push_str("]");
+    buf
+  }
+}
+
 impl TryFrom<MultiPlatformExecuteProcessRequest> for ExecuteProcessRequest {
   type Error = String;
 
@@ -233,6 +248,16 @@ impl TryFrom<MultiPlatformExecuteProcessRequest> for ExecuteProcessRequest {
 pub struct MultiPlatformExecuteProcessRequest(
   pub BTreeMap<(Platform, Platform), ExecuteProcessRequest>,
 );
+
+impl MultiPlatformExecuteProcessRequest {
+  pub fn user_facing_name(&self) -> Option<String> {
+    let mut buf = String::new();
+    for (_, epr) in self.0.iter() {
+      buf.push_str(&epr.user_facing_name())
+    }
+    Some(buf)
+  }
+}
 
 impl From<ExecuteProcessRequest> for MultiPlatformExecuteProcessRequest {
   fn from(req: ExecuteProcessRequest) -> Self {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1292,7 +1292,11 @@ impl Node for NodeKey {
       NodeKey::Task(ref task) => task.get_display_info().map(|s| s.to_owned()),
       NodeKey::Snapshot(_) => Some(format!("{}", self)),
       NodeKey::MultiPlatformExecuteProcess(mp_epr) => mp_epr.0.user_facing_name(),
-      _ => None,
+      NodeKey::DigestFile(..) => None,
+      NodeKey::DownloadedFile(..) => None,
+      NodeKey::ReadLink(..) => None,
+      NodeKey::Scandir(..) => None,
+      NodeKey::Select(..) => None,
     }
   }
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1224,13 +1224,7 @@ impl Node for NodeKey {
 
     let (node_workunit_params, maybe_span_id) = if handle_workunits {
       let span_id = generate_random_64bit_string();
-      let maybe_display_info: Option<String> = match self {
-        NodeKey::Task(ref task) => task.get_display_info().map(|s| s.to_owned()),
-        NodeKey::Snapshot(_) => Some(format!("{}", self)),
-        _ => None,
-      };
-
-      let node_workunit_params = match maybe_display_info {
+      let node_workunit_params = match self.user_facing_name() {
         Some(ref node_name) => {
           let start_time = std::time::SystemTime::now();
           Some((node_name.clone(), start_time, span_id.clone()))
@@ -1290,6 +1284,14 @@ impl Node for NodeKey {
       // TODO Select nodes are made uncacheable as a workaround to #6146. Will be worked on in #6598
       &NodeKey::Select(_) => false,
       _ => true,
+    }
+  }
+
+  fn user_facing_name(&self) -> Option<String> {
+    match self {
+      NodeKey::Task(ref task) => task.get_display_info().map(|s| s.to_owned()),
+      NodeKey::Snapshot(_) => Some(format!("{}", self)),
+      _ => None,
     }
   }
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1291,6 +1291,7 @@ impl Node for NodeKey {
     match self {
       NodeKey::Task(ref task) => task.get_display_info().map(|s| s.to_owned()),
       NodeKey::Snapshot(_) => Some(format!("{}", self)),
+      NodeKey::MultiPlatformExecuteProcess(mp_epr) => mp_epr.0.user_facing_name(),
       _ => None,
     }
   }


### PR DESCRIPTION
This is a first chunk of work addressing some of the issues in https://github.com/pantsbuild/pants/issues/7509 . In this commit, we introduce the notion of a user-facing-name defined on a Node (distinct from the Display implementation), define one automatically for ExecuteProcessRequests (in a fairly naive way - we might want to display more information about EPRs later), and use it in the live-updating swim lanes display of the v2 console UI.