### PR TITLE
V2 console UI: fix bug with InteractiveProcessRequest

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -570,9 +570,11 @@ class SchedulerSession:
     self, request: 'InteractiveProcessRequest'
   ) -> 'InteractiveProcessResult':
     sched_pointer = self._scheduler._scheduler
+    session_pointer = self._session
 
     wrapped_result = self._scheduler._native.lib.run_local_interactive_process(
       sched_pointer,
+      session_pointer,
       self._scheduler._to_value(request)
     )
     result: 'InteractiveProcessResult' = self._scheduler._raise_or_return(wrapped_result)

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -918,51 +918,56 @@ pub extern "C" fn merge_directories(
 #[no_mangle]
 pub extern "C" fn run_local_interactive_process(
   scheduler_ptr: *mut Scheduler,
+  session_ptr: *mut Session,
   request: Handle,
 ) -> PyResult {
   use std::process;
 
   with_scheduler(scheduler_ptr, |scheduler| {
-    let types = &scheduler.core.types;
-    let construct_interactive_process_result = types.construct_interactive_process_result;
+    with_session(session_ptr, |session| {
+      session.with_console_ui_disabled(|| {
+        let types = &scheduler.core.types;
+        let construct_interactive_process_result = types.construct_interactive_process_result;
 
-    let value: Value = request.into();
+        let value: Value = request.into();
 
-    let argv: Vec<String> = externs::project_multi_strs(&value, "argv");
-    if argv.is_empty() {
-      return Err("Empty argv list not permitted".to_string());
-    }
+        let argv: Vec<String> = externs::project_multi_strs(&value, "argv");
+        if argv.is_empty() {
+          return Err("Empty argv list not permitted".to_string());
+        }
 
-    let mut command = process::Command::new(argv[0].clone());
-    for arg in argv[1..].iter() {
-      command.arg(arg);
-    }
+        let mut command = process::Command::new(argv[0].clone());
+        for arg in argv[1..].iter() {
+          command.arg(arg);
+        }
 
-    let env = externs::project_tuple_encoded_map(&value, "env")?;
-    for (key, value) in env.iter() {
-      command.env(key, value);
-    }
+        let env = externs::project_tuple_encoded_map(&value, "env")?;
+        for (key, value) in env.iter() {
+          command.env(key, value);
+        }
 
-    let run_in_workspace = externs::project_bool(&value, "run_in_workspace");
-    let maybe_tempdir = if run_in_workspace {
-      None
-    } else {
-      Some(TempDir::new().map_err(|err| format!("Error creating tempdir: {}", err))?)
-    };
+        let run_in_workspace = externs::project_bool(&value, "run_in_workspace");
+        let maybe_tempdir = if run_in_workspace {
+          None
+        } else {
+          Some(TempDir::new().map_err(|err| format!("Error creating tempdir: {}", err))?)
+        };
 
-    if let Some(ref tempdir) = maybe_tempdir {
-      command.current_dir(tempdir.path());
-    }
+        if let Some(ref tempdir) = maybe_tempdir {
+          command.current_dir(tempdir.path());
+        }
 
-    let mut subprocess = command.spawn().map_err(|e| e.to_string())?;
-    let exit_status = subprocess.wait().map_err(|e| e.to_string())?;
-    let code = exit_status.code().unwrap_or(-1);
+        let mut subprocess = command.spawn().map_err(|e| e.to_string())?;
+        let exit_status = subprocess.wait().map_err(|e| e.to_string())?;
+        let code = exit_status.code().unwrap_or(-1);
 
-    let output: Result<Value, String> = Ok(externs::unsafe_call(
-      &construct_interactive_process_result,
-      &[externs::store_i64(i64::from(code))],
-    ));
-    output
+        let output: Result<Value, String> = Ok(externs::unsafe_call(
+          &construct_interactive_process_result,
+          &[externs::store_i64(i64::from(code))],
+        ));
+        output
+      })
+    })
   })
   .into()
 }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -338,6 +338,7 @@ impl Scheduler {
     // This map keeps the k most relevant jobs in assigned possitions.
     // Keys are positions in the display (display workers) and the values are the actual jobs to print.
     let mut tasks_to_display = IndexMap::new();
+    let refresh_interval = Duration::from_millis(100);
 
     match session.maybe_display() {
       Some(display) => {
@@ -348,7 +349,7 @@ impl Scheduler {
         let unique_handle = LOGGER.register_engine_display(display.clone());
 
         let results = loop {
-          if let Ok(res) = receiver.recv_timeout(Duration::from_millis(100)) {
+          if let Ok(res) = receiver.recv_timeout(refresh_interval) {
             break res;
           } else {
             Scheduler::display_ongoing_tasks(
@@ -367,7 +368,7 @@ impl Scheduler {
         results
       }
       None => loop {
-        if let Ok(res) = receiver.recv_timeout(Duration::from_millis(100)) {
+        if let Ok(res) = receiver.recv_timeout(refresh_interval) {
           break res;
         }
       },

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -400,10 +400,12 @@ impl Scheduler {
       }
     }
 
-    for (i, id) in tasks_to_display.iter().enumerate() {
-      // TODO Maybe we want to print something else besides the ID here.
+    for (i, item) in tasks_to_display.iter().enumerate() {
+      let label = item.0;
+      let duration = item.1;
+      let duration_secs: f64 = (duration.as_millis() as f64) / 1000.0;
       let mut d = display.lock();
-      d.update(i.to_string(), format!("{:?}", id));
+      d.update(i.to_string(), format!("{:.2}s {}", duration_secs, label));
     }
 
     // If the number of ongoing tasks is less than the number of workers,

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -110,8 +110,6 @@ impl Session {
     &self.0.build_id
   }
 
-  //TODO Thsese two functions should eventually hook up intelligently to EngineDisplay
-  //instead of just naively printing to stdout/stderr.
   pub fn write_stdout(&self, msg: &str) {
     if let Some(display) = self.maybe_display() {
       let mut d = display.lock();
@@ -123,6 +121,23 @@ impl Session {
     if let Some(display) = self.maybe_display() {
       let mut d = display.lock();
       d.write_stderr(msg);
+    }
+  }
+
+  pub fn with_console_ui_disabled<F: FnOnce() -> T, T>(&self, f: F) -> T {
+    if let Some(display) = self.maybe_display() {
+      {
+        let mut d = display.lock();
+        d.suspend()
+      }
+      let output = f();
+      {
+        let mut d = display.lock();
+        d.unsuspend();
+      }
+      output
+    } else {
+      f()
     }
   }
 }

--- a/src/rust/engine/ui/src/display.rs
+++ b/src/rust/engine/ui/src/display.rs
@@ -64,7 +64,6 @@ pub struct EngineDisplay {
   action_map: BTreeMap<String, String>,
   logs: VecDeque<String>,
   printable_msgs: VecDeque<PrintableMsg>,
-  running: bool,
   cursor_start: (u16, u16),
   terminal_size: (u16, u16),
 }
@@ -86,7 +85,6 @@ impl EngineDisplay {
       // want to be able to fill the entire screen if resized much larger than when we started.
       logs: VecDeque::with_capacity(500),
       printable_msgs: VecDeque::with_capacity(500),
-      running: false,
       // N.B. This will cause the screen to clear - but with some improved position
       // tracking logic we could avoid screen clearing in favor of using the value
       // of `EngineDisplay::get_cursor_pos()` as initialization here. From there, the
@@ -138,11 +136,6 @@ impl EngineDisplay {
   // Gets the current terminal's width and height, if applicable.
   fn get_size() -> (u16, u16) {
     termion::terminal_size().unwrap_or((0, 0))
-  }
-
-  // Whether or not the EngineDisplay is running (whether .start() has been called).
-  pub fn is_running(&self) -> bool {
-    self.running
   }
 
   // Sets the terminal size per-render for signal-free resize detection.
@@ -286,7 +279,6 @@ impl EngineDisplay {
   // Starts the EngineDisplay at the current cursor position.
   pub fn start(&mut self) {
     let write_handle = termion::screen::AlternateScreen::from(stdout());
-    self.running = true;
     self.terminal = match write_handle.into_raw_mode() {
       Ok(t) => Console::Terminal(t),
       Err(_) => Console::Pipe(stdout()),
@@ -348,7 +340,6 @@ impl EngineDisplay {
   // to a static position, then prints all buffered stdout/stderr output.
   pub fn finish(&mut self) {
     self.render();
-    self.running = false;
     {
       self.terminal = Console::Uninitialized; //This forces the AlternateScreen to drop, restoring the original terminal state.
     }

--- a/src/rust/engine/ui/src/display.rs
+++ b/src/rust/engine/ui/src/display.rs
@@ -329,6 +329,21 @@ impl EngineDisplay {
     self.action_map.len()
   }
 
+  pub fn suspend(&mut self) {
+    {
+      self.terminal = Console::Uninitialized;
+    }
+    println!("{}", termion::cursor::Show);
+  }
+
+  pub fn unsuspend(&mut self) {
+    let write_handle = termion::screen::AlternateScreen::from(stdout());
+    self.terminal = match write_handle.into_raw_mode() {
+      Ok(t) => Console::Terminal(t),
+      Err(_) => Console::Pipe(stdout()),
+    };
+  }
+
   // Initiates one last screen render, then terminates the EngineDisplay and returns the cursor
   // to a static position, then prints all buffered stdout/stderr output.
   pub fn finish(&mut self) {


### PR DESCRIPTION
### Problem

When running goals that make use of InteractiveProcessRequest such as `run`, the terminal refreshing would cause any output from the running program to be erased when pants shut down the swim lanes display before exiting.

### Solution

I added some infrastructure to the InteractiveProcessRequest intrinsic that would grab a reference to the EngineDisplay and temporarily disable the interactive console while doing so. This way, any output from a program run with InteractiveProcessRequest would be left in the terminal scrollback like any other normal output.

I also cleaned up a few more small nits around EngineDisplay - namely, displaying the amount of time a node has been running in the swim lanes before rather than after the name of the node (so it doesn't get pushed off the side of the screen), and removing the `running` bool on that type, since nothing was actually using it.