### PR TITLE
Add HTTP engine intrinsic

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -266,3 +266,15 @@ resources(
   name='native_engine_shared_library',
   sources=['native_engine.so']
 )
+ 
+python_tests(
+  name = "tests",
+  sources = ["http_test.py"],
+  dependencies = [
+    ':http',
+    'src/python/pants/testutil:test_base',
+    'tests/python/pants_test:console_rule_test_base',
+    'tests/python/pants_test/engine:util'
+  ]
+)
+

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -22,6 +22,15 @@ python_library(
 )
 
 python_library(
+  name='http',
+  sources=['http.py'],
+  dependencies=[
+    ':goal',
+    ':selectors',
+  ]
+)
+
+python_library(
   name='addressable',
   sources=['addressable.py'],
   dependencies=[

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -239,6 +239,7 @@ python_library(
   dependencies=[
     ':native_engine_shared_library',
     ':fs',
+    ':http',
     ':interactive_runner',
     ':isolated_process',
     ':selectors',

--- a/src/python/pants/engine/http.py
+++ b/src/python/pants/engine/http.py
@@ -1,0 +1,18 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HttpResponse:
+  pass
+
+
+@dataclass(frozen=True)
+class MakeHttpRequest:
+  pass
+
+
+def create_http_rules():
+  return []

--- a/src/python/pants/engine/http.py
+++ b/src/python/pants/engine/http.py
@@ -2,17 +2,26 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from pants.engine.rules import RootRule
 
 
 @dataclass(frozen=True)
 class HttpResponse:
-  pass
+  url: str
+  response_code: Optional[int]
+  output_bytes: Optional[bytes]
+  headers: Tuple[Tuple[str, str], ...]
 
 
 @dataclass(frozen=True)
 class MakeHttpRequest:
-  pass
+  url: str
+  headers: Tuple[str, ...] = ()
 
 
 def create_http_rules():
-  return []
+  return [
+    RootRule(MakeHttpRequest),
+  ]

--- a/src/python/pants/engine/http.py
+++ b/src/python/pants/engine/http.py
@@ -19,6 +19,7 @@ class HttpResponse:
 class MakeHttpRequest:
   url: str
   headers: Tuple[str, ...] = ()
+  invalidation_token: str = ''
 
 
 def create_http_rules():

--- a/src/python/pants/engine/http_test.py
+++ b/src/python/pants/engine/http_test.py
@@ -1,0 +1,45 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.engine.http import HttpResponse, MakeHttpRequest
+from pants.util.contextutil import http_server, temporary_dir
+from http.server import BaseHTTPRequestHandler
+from pants.engine.rules import RootRule
+from pants.testutil.test_base import TestBase
+
+
+
+class HttpHandlerForTests(BaseHTTPRequestHandler):
+  response_text = b"www.pantsbuild.org"
+
+  def do_HEAD(self):
+    self.send_headers()
+
+  def do_GET(self):
+    self.send_headers()
+    self.wfile.write(self.response_text)
+
+  def send_headers(self):
+    code = 200 if self.path == "/CNAME" else 404
+    self.send_response(code)
+    self.send_header("Content-Type", "text/utf-8")
+    self.send_header("Content-Length", "{}".format(len(self.response_text)))
+    self.end_headers()
+
+class HttpIntrinsicTest(TestBase):
+
+  @classmethod
+  def rules(cls):
+    return super().rules() + [
+      RootRule(MakeHttpRequest),
+    ]
+
+  def test_basic(self):
+    with http_server(HttpHandlerForTests) as port:
+      url = f'http://localhost:{port}/'
+
+      req = MakeHttpRequest()
+      output, = self.scheduler.product_request(HttpResponse, subjects=[req])
+      print(f"output: {output}")
+      self.assertEqual(1, 2)
+

--- a/src/python/pants/engine/http_test.py
+++ b/src/python/pants/engine/http_test.py
@@ -37,13 +37,17 @@ class HttpHandlerForTests(BaseHTTPRequestHandler):
       code = 500
     elif self.path == "/redirect":
       code = 302
-      self.send_header("Location", "/valid-url")
     else:
       code = 404
     self.send_response(code)
-    self.send_header("Content-Type", "text/utf-8")
+
+    if self.path == "/redirect":
+      self.send_header("Location", "/valid-url")
     if self.path == "/broken-header":
       self.send_header(f"Content-Length", "deliberately-broken-header")
+
+    self.send_header("Content-Type", "text/utf-8")
+
     self.end_headers()
 
 
@@ -83,8 +87,7 @@ class HttpIntrinsicTest(TestBase):
 
   def test_302(self):
     with self.make_request_to_path("redirect") as (response, port):
-      print(response)
-      assert response.response_code == 444
+      assert response.url == f"http://localhost:{port}/valid-url"
 
   def test_404(self):
     with self.make_request_to_path("nothingtheserverknowsabout") as (response, port):

--- a/src/python/pants/engine/http_test.py
+++ b/src/python/pants/engine/http_test.py
@@ -1,45 +1,107 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.http import HttpResponse, MakeHttpRequest
-from pants.util.contextutil import http_server, temporary_dir
+from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler
-from pants.engine.rules import RootRule
-from pants.testutil.test_base import TestBase
+from typing import Iterator, Tuple
 
+from pants.engine.http import HttpResponse, MakeHttpRequest
+from pants.engine.rules import RootRule
+from pants.engine.scheduler import ExecutionError
+from pants.testutil.test_base import TestBase
+from pants.util.contextutil import http_server
 
 
 class HttpHandlerForTests(BaseHTTPRequestHandler):
-  response_text = b"www.pantsbuild.org"
-
-  def do_HEAD(self):
-    self.send_headers()
+  response_text = b"A valid HTTP response!"
+  not_found_text = b"Custom 404 page"
+  server_failure_text = b"500 internal server error"
 
   def do_GET(self):
     self.send_headers()
-    self.wfile.write(self.response_text)
+    if self.path == "/valid-url":
+      self.wfile.write(self.response_text)
+    elif self.path == "/deliberate500":
+      self.wfile.write(self.server_failure_text)
+    elif self.path == "/test-headers":
+      self.wfile.write(str(self.headers).encode())
+    elif self.path == "/redirect":
+      self.wfile.write(b"")
+    else:
+      self.wfile.write(self.not_found_text)
 
   def send_headers(self):
-    code = 200 if self.path == "/CNAME" else 404
+    if self.path == "/valid-url" or self.path == "/test-headers":
+      code = 200
+    elif self.path == "/deliberate500":
+      code = 500
+    elif self.path == "/redirect":
+      code = 302
+      self.send_header("Location", "/valid-url")
+    else:
+      code = 404
     self.send_response(code)
     self.send_header("Content-Type", "text/utf-8")
-    self.send_header("Content-Length", "{}".format(len(self.response_text)))
+    if self.path == "/broken-header":
+      self.send_header(f"Content-Length", "deliberately-broken-header")
     self.end_headers()
 
-class HttpIntrinsicTest(TestBase):
 
+class HttpIntrinsicTest(TestBase):
   @classmethod
   def rules(cls):
     return super().rules() + [
       RootRule(MakeHttpRequest),
     ]
 
-  def test_basic(self):
+  @contextmanager
+  def make_request_to_path(self, path: str, headers: Tuple[str, ...] = ()) -> Iterator[HttpResponse]:
     with http_server(HttpHandlerForTests) as port:
-      url = f'http://localhost:{port}/'
+      url = f'http://localhost:{port}/{path}'
+      request = MakeHttpRequest(url=url, headers=headers)
+      output = self.request_single_product(HttpResponse, request)
+      yield (output, port)
 
-      req = MakeHttpRequest()
-      output, = self.scheduler.product_request(HttpResponse, subjects=[req])
-      print(f"output: {output}")
-      self.assertEqual(1, 2)
+  def test_200(self):
+    with self.make_request_to_path("valid-url") as (response, port):
+      assert response.response_code == 200
+      assert response.output_bytes == b"A valid HTTP response!"
+      assert response.url == f'http://localhost:{port}/valid-url'
+      assert ('content-type', 'text/utf-8') in response.headers
 
+  def test_302(self):
+    with self.make_request_to_path("redirect") as (response, port):
+      print(response)
+      assert response.response_code == 444
+
+  def test_404(self):
+    with self.make_request_to_path("nothingtheserverknowsabout") as (response, port):
+      assert response.response_code == 404
+      assert response.output_bytes == b"Custom 404 page"
+      assert response.url == f'http://localhost:{port}/nothingtheserverknowsabout'
+
+  def test_500(self):
+    with self.make_request_to_path("deliberate500") as (response, port):
+      assert response.response_code == 500
+      assert response.output_bytes == b"500 internal server error"
+      assert response.url == f'http://localhost:{port}/deliberate500'
+
+  def test_broken_header(self):
+    with self.make_request_to_path("broken-header") as (response, port):
+      assert response.response_code is None
+
+  def test_custom_headers(self):
+    headers = ("X-My-Custom-Header", "custom-info", "X-Other-Header", "more-info")
+    with self.make_request_to_path("test-headers", headers=headers) as (response, port):
+      assert response.response_code == 200
+      output = response.output_bytes.decode()
+      assert "x-my-custom-header: custom-info" in output
+      assert "x-other-header: more-info" in output
+
+  def test_malformed_header_specification(self):
+    headers = ("X-My-Custom-Header", "custom-info", "X-Other-Header",)
+    with self.assertRaises(ExecutionError) as cm:
+      with self.make_request_to_path("test-headers", headers=headers) as (response, port):
+        pass
+    messages = cm.exception.end_user_messages()
+    assert messages == ["Error parsing field 'headers': odd number of parts"]

--- a/src/python/pants/engine/http_test.py
+++ b/src/python/pants/engine/http_test.py
@@ -128,11 +128,10 @@ class HttpIntrinsicTest(TestBase):
       request3 = MakeHttpRequest(url=f'http://localhost:{port}/one-url', invalidation_token='something-else')
       request4 = MakeHttpRequest(url=f'http://localhost:{port}/another-url', invalidation_token='some-token')
 
-      output1 = self.request_single_product(HttpResponse, request1)
-      output2 = self.request_single_product(HttpResponse, request2)
+      self.request_single_product(HttpResponse, request1)
+      self.request_single_product(HttpResponse, request2)
       assert CachingTestHandler.count == 1
-      output3 = self.request_single_product(HttpResponse, request3)
+      self.request_single_product(HttpResponse, request3)
       assert CachingTestHandler.count == 2
-      output4 = self.request_single_product(HttpResponse, request4)
+      self.request_single_product(HttpResponse, request4)
       assert CachingTestHandler.count == 3
-

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -32,6 +32,7 @@ from pants.engine.fs import (
   Snapshot,
   UrlToFetch,
 )
+from pants.engine.http import HttpResponse, MakeHttpRequest
 from pants.engine.interactive_runner import InteractiveProcessRequest, InteractiveProcessResult
 from pants.engine.isolated_process import (
   FallibleExecuteProcessResult,
@@ -562,6 +563,7 @@ class EngineTypes(NamedTuple):
   construct_process_result: Function
   construct_materialize_directories_results: Function
   construct_materialize_directory_result: Function
+  construct_http_response: Function
   address: TypeId
   path_globs: TypeId
   directories_to_merge: TypeId
@@ -580,6 +582,8 @@ class EngineTypes(NamedTuple):
   construct_interactive_process_result: Function
   interactive_process_request: TypeId
   interactive_process_result: TypeId
+  make_http_request: TypeId
+  make_http_response: TypeId
 
 
 class PyResult(NamedTuple):
@@ -925,6 +929,7 @@ class Native(metaclass=SingletonMetaclass):
         construct_process_result=func(FallibleExecuteProcessResult),
         construct_materialize_directories_results=func(MaterializeDirectoriesResult),
         construct_materialize_directory_result=func(MaterializeDirectoryResult),
+        construct_http_response=func(HttpResponse),
         address=ti(Address),
         path_globs=ti(PathGlobs),
         directories_to_merge=ti(DirectoriesToMerge),
@@ -943,6 +948,8 @@ class Native(metaclass=SingletonMetaclass):
         construct_interactive_process_result=func(InteractiveProcessResult),
         interactive_process_request=ti(InteractiveProcessRequest),
         interactive_process_result=ti(InteractiveProcessResult),
+        make_http_request=ti(MakeHttpRequest),
+        make_http_response=ti(HttpResponse),
     )
 
     scheduler_result = self.lib.scheduler_create(

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -583,7 +583,7 @@ class EngineTypes(NamedTuple):
   interactive_process_request: TypeId
   interactive_process_result: TypeId
   make_http_request: TypeId
-  make_http_response: TypeId
+  http_response: TypeId
 
 
 class PyResult(NamedTuple):
@@ -949,7 +949,7 @@ class Native(metaclass=SingletonMetaclass):
         interactive_process_request=ti(InteractiveProcessRequest),
         interactive_process_result=ti(InteractiveProcessResult),
         make_http_request=ti(MakeHttpRequest),
-        make_http_response=ti(HttpResponse),
+        http_response=ti(HttpResponse),
     )
 
     scheduler_result = self.lib.scheduler_create(

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -26,6 +26,7 @@ from pants.engine.build_files import create_graph_rules
 from pants.engine.console import Console
 from pants.engine.fs import Workspace, create_fs_rules
 from pants.engine.goal import Goal
+from pants.engine.http import create_http_rules
 from pants.engine.interactive_runner import InteractiveRunner, create_interactive_runner_rules
 from pants.engine.isolated_process import create_process_rules
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
@@ -414,6 +415,7 @@ class EngineInitializer:
       create_graph_rules(address_mapper) +
       create_options_parsing_rules() +
       structs_rules() +
+      create_http_rules() +
       rules
     )
 

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -184,7 +184,10 @@ pub fn project_tuple_encoded_map(
 ) -> Result<BTreeMap<String, String>, String> {
   let parts = project_multi_strs(&value, field);
   if parts.len() % 2 != 0 {
-    return Err("Error parsing env: odd number of parts".to_owned());
+    return Err(format!(
+      "Error parsing field '{}': odd number of parts",
+      field
+    ));
   }
   Ok(parts.into_iter().tuples::<(_, _)>().collect())
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1436,6 +1436,7 @@ impl Node for NodeKey {
       &NodeKey::Task(ref s) => s.task.cacheable,
       // TODO Select nodes are made uncacheable as a workaround to #6146. Will be worked on in #6598
       &NodeKey::Select(_) => false,
+      &NodeKey::HttpRequester(..) => false,
       _ => true,
     }
   }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -477,7 +477,6 @@ impl WrappedNode for HttpRequester {
       .send()
       .then(|result: Result<reqwest::r#async::Response, reqwest::Error>| match result {
         Ok(resp) => {
-          println!("RESULT IN RUST: {:?}", resp);
           let response_code = Some(resp.status().as_u16());
           let url = resp.url().as_str().to_string();
           let headers: Vec<(String, String)> = resp

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -167,6 +167,10 @@ impl Tasks {
         product: types.process_result,
         input: types.multi_platform_process_request,
       },
+      Intrinsic {
+        product: types.http_response,
+        input: types.make_http_request,
+      },
     ];
 
     for intrinsic in intrinsics {

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -34,5 +34,5 @@ pub struct Types {
   pub interactive_process_request: TypeId,
   pub interactive_process_result: TypeId,
   pub make_http_request: TypeId,
-  pub make_http_response: TypeId,
+  pub http_response: TypeId,
 }

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -14,6 +14,7 @@ pub struct Types {
   pub construct_process_result: Function,
   pub construct_materialize_directories_results: Function,
   pub construct_materialize_directory_result: Function,
+  pub construct_http_response: Function,
   pub address: TypeId,
   pub path_globs: TypeId,
   pub directories_to_merge: TypeId,
@@ -32,4 +33,6 @@ pub struct Types {
   pub construct_interactive_process_result: Function,
   pub interactive_process_request: TypeId,
   pub interactive_process_result: TypeId,
+  pub make_http_request: TypeId,
+  pub make_http_response: TypeId,
 }


### PR DESCRIPTION
### Problem

We need to be able to make HTTP requests in certain rules (generally making GET requests to some kind of HTTP API), and get information from them without breaking any pants abstractions.

### Solution

This commit adds an engine intrinsic that makes an HTTP GET request in the most straightforward way possible. It introduces a new type `HttpRequest` that wraps a URL to make a GET request against. This type can be used to request from the engine a `HttpResponse` type that contains the raw bytes (if any) from the request, as well as the HTTP response code from the request.

