### PR TITLE
Deprecate old style of passthrough args for isort, Pytest, and MyPy

### DIFF
--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -35,7 +35,7 @@ do
 done
 
 # If changes were made or issues found, output with leading whitespace trimmed.
-output="$(./pants --changed-parent="$(git_merge_base)" fmt.isort -- "${isort_args[@]}")"
+output="$(./pants --changed-parent="$(git_merge_base)" fmt --isort-args=\'"${isort_args[*]}"\')"
 echo "${output}" | grep -Eo '(ERROR).*$' && exit 1
 echo "${output}" | grep -Eo '(Fixing).*$'
 exit 0

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -15,6 +15,7 @@ from pants.backend.python.tasks.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks.resolve_requirements_task_base import ResolveRequirementsTaskBase
 from pants.base import hash_utils
 from pants.base.build_environment import get_buildroot
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target
@@ -271,6 +272,19 @@ class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
       config = get_config()
       if config:
         cmd.append(f'--config-file={os.path.join(get_buildroot(), config)}')
+      deprecated_conditional(
+        lambda: self.get_passthru_args(),
+        removal_version='1.26.0.dev3',
+        entity_description='Using the old style of passthrough args for MyPy',
+        hint_message="You passed arguments to MyPy through either the "
+                     "`--lint-mypy-passthrough-args` option or the style "
+                     "`./pants lint.mypy -- --python-version 3.7 --disallow-any-expr`. Instead, "
+                     "pass any arguments to MyPy like this: "
+                     "`./pants lint :: --mypy-args='--python-version 3.7 --disallow-any-expr'`.\n\n"
+                     "This change is meant to reduce confusion in how option scopes work with "
+                     "passthrough args and to prepare for MyPy eventually exclusively using the "
+                     "V2 implementation, which only supports `--mypy-args`.",
+      )
       cmd.extend(self.get_passthru_args())
       cmd.extend(self._mypy_subsystem.get_args())
       cmd.append(f'@{sources_list_path}')

--- a/src/docs/options.md
+++ b/src/docs/options.md
@@ -144,15 +144,15 @@ sign: `-ldebug` is the same as `--level=debug` (`-l` is a synonym for `--level`)
 must use an equals sign to set a value.
 
 There's a useful shorthand that can save some typing when setting multiple options for a single task:
-If you invoke a task explicitly on the command line then you can follow that task with unqualified
+if you invoke a task explicitly on the command line then you can follow that task with unqualified
 options in its scope. E.g., `./pants compile.rsc --no-incremental --name-hashing`
 instead of `./pants compile --no-compile-rsc-incremental --compile-rsc-name-hashing`.
 
 Note that this shorthand requires you to mention a specific task, not just a goal: `./pants compile.rsc`
-instead of just `./pants compile` as you would usually enter. All tasks in the `compile` goal will
-still be executed, not just `compile.rsc`, but the `.zinc` addition is a convenience to support shorthand options.
+instead of just `./pants compile` as you would usually enter. **All tasks in the `compile` goal will
+still be executed, not just `compile.rsc`**, but the `.zinc` addition is a convenience to support shorthand options.
 
-Of course this works when specifying multiple goals, e.g.,
+This works when specifying multiple goals, e.g.,
 
 `./pants compile.rsc --no-incremental --name-hashing test.junit --parallel-threads=4`
 

--- a/src/python/pants/backend/python/tasks/isort_run.py
+++ b/src/python/pants/backend/python/tasks/isort_run.py
@@ -10,6 +10,7 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.isort_prep import IsortPrep
 from pants.base.build_environment import get_buildroot
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.task.fmt_task_mixin import FmtTaskMixin
@@ -50,6 +51,19 @@ class IsortRun(FmtTaskMixin, Task):
 
       isort = self.context.products.get_data(IsortPrep.tool_instance_cls)
       isort_subsystem = IsortPrep.tool_subsystem_cls.global_instance()
+      deprecated_conditional(
+        lambda: self.get_passthru_args(),
+        removal_version='1.26.0.dev3',
+        entity_description='Using the old style of passthrough args for isort',
+        hint_message="You passed arguments to isort through either the "
+                     "`--fmt-isort-passthrough-args` option or the style "
+                     "`./pants fmt.isort -- --case-sensitive --trailing-comma`. Instead, pass any "
+                     "arguments to isort like this: `./pants fmt :: "
+                     "--isort-args='--case-sensitive --trailing-comma'`.\n\n"
+                     "This change is meant to reduce confusion in how option scopes work with "
+                     "passthrough args and to prepare for isort eventually exclusively using the "
+                     "V2 implementation, which only supports `--isort-args`.",
+      )
       args = [
         *self.get_passthru_args(), *isort_subsystem.get_args(), '--filter-files', *sources
       ]

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -22,6 +22,7 @@ from pants.backend.python.tasks.gather_sources import GatherSources
 from pants.backend.python.tasks.pytest_prep import PytestPrep
 from pants.backend.python.tasks.python_execution_task_base import ensure_interpreter_search_path_env
 from pants.base.build_environment import get_buildroot
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import ErrorWhileTesting, TaskError
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
 from pants.base.hash_utils import Sharder
@@ -657,6 +658,18 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
       if self.get_options().colors:
         args.extend(['--color', 'yes'])
 
+      deprecated_conditional(
+        lambda: self.get_passthru_args(),
+        removal_version='1.26.0.dev3',
+        entity_description='Using the old style of passthrough args for Pytest',
+        hint_message="You passed arguments to Pytest through either the "
+                     "`--test-pytest-passthrough-args` option or the style "
+                     "`./pants test.pytest -- -k FooTest --quiet`. Instead, pass any arguments to "
+                     "Pytest like this: `./pants test :: --pytest-args='-k FooTest --quiet'`.\n\n"
+                     "This change is meant to reduce confusion in how option scopes work with "
+                     "passthrough args and to prepare for Pytest eventually exclusively using the "
+                     "V2 implementation, which only supports `--pytest-args`.",
+      )
       args.extend([*self.get_passthru_args(), *PyTest.global_instance().get_args()])
 
       args.extend(test_args)


### PR DESCRIPTION
### Problem

Per https://docs.google.com/document/d/18-WFAYiktq3DAfOQPrnU5yaycT6V1K27yrnFPoGgTIA/edit, we decided in V2 that "pass-through args" —i.e. args that are passed directly to the underlying tool—should be passed through an `--args` option defined either on subsystem for the underlying tool or on the goal itself.

For example,

```
./pants fmt.isort -- --check-only -> ./pants fmt --isort-args='--check-only'
./pants run path/to:target -- arg1 arg2 -> ./pants run --args='arg1 arg2' path/to:target
```

This design works around V2 no longer having tasks and task-level scopes like `fmt.isort`. It has an added benefit of reducing confusion about how option scopes work, as the difference between `./pants fmt.isort -- arg1` vs. `./pants fmt -- arg1` is a common gotcha.

This new style is now implemented for Black, Isort, and Pytest, including being hooked up to the V1 tasks and the V2 rules. However, this means that V1 now has two ways of implementing pass through args.

### Solution

Deprecate the old `--pasthrough-args` option and the `-- arg1` style for Pytest, isort, and MyPy and point users to `--pytest-args`, `--isort-args`, and `--mypy-args`. 

### Remaining follow-ups

* Deprecate V1-style passthrough args for `./pants run` once we can add an option `--run-args` to the goal (blocked by `--run-cpp-args` and `--run-py-args` being removed)
* Deprecate the remaining tasks using V1-style passthrough args, which is mostly the Go plugin.
* Improve `./pants help` to mention subsystems linked to goals so that `./pants help fmt2` would mention, for example, that users can run `./pants help black` and `./pants help isort`.
    * This is meant to help with discoverability as we move options away from tasks towards distinct subsystems.