### PR TITLE
Support enums when displaying option help choices

### DIFF
--- a/src/python/pants/backend/docgen/tasks/BUILD
+++ b/src/python/pants/backend/docgen/tasks/BUILD
@@ -4,6 +4,7 @@
 python_library(
   dependencies = [
     ':resources',
+    '3rdparty/python:dataclasses',
     '3rdparty/python:docutils',
     '3rdparty/python:Markdown',
     '3rdparty/python:Pygments',

--- a/src/python/pants/backend/docgen/tasks/generate_pants_reference.py
+++ b/src/python/pants/backend/docgen/tasks/generate_pants_reference.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from dataclasses import asdict
 
 from pants.base.mustache import MustacheRenderer
 from pants.goal.goal import Goal
@@ -54,7 +55,7 @@ class GeneratePantsReference(Task):
           # We don't use _asdict(), because then .description wouldn't be available.
           'scope_info': si,
           # We do use _asdict() here, so our mustache library can do property expansion.
-          'help_info': help_info._asdict(),
+          'help_info': asdict(help_info),
         })
       return ret
 

--- a/src/python/pants/help/BUILD
+++ b/src/python/pants/help/BUILD
@@ -3,6 +3,7 @@
 
 python_library(
   dependencies=[
+    '3rdparty/python:dataclasses',
     '3rdparty/python:typing-extensions',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',

--- a/src/python/pants/help/BUILD
+++ b/src/python/pants/help/BUILD
@@ -10,6 +10,7 @@ python_library(
     'src/python/pants/goal',
     'src/python/pants/option',
     'src/python/pants/subsystem',
+    'src/python/pants/util:collections',
     'src/python/pants/util:memo',
   ],
   tags = {"partially_type_checked"},
@@ -24,6 +25,7 @@ python_tests(
     'src/python/pants/option',
     'src/python/pants/subsystem',
     'src/python/pants/task',
+    'src/python/pants/util:collections',
   ],
   tags = {'partially_type_checked'},
 )

--- a/src/python/pants/help/BUILD
+++ b/src/python/pants/help/BUILD
@@ -10,7 +10,6 @@ python_library(
     'src/python/pants/goal',
     'src/python/pants/option',
     'src/python/pants/subsystem',
-    'src/python/pants/util:collections',
     'src/python/pants/util:memo',
   ],
   tags = {"partially_type_checked"},
@@ -25,7 +24,6 @@ python_tests(
     'src/python/pants/option',
     'src/python/pants/subsystem',
     'src/python/pants/task',
-    'src/python/pants/util:collections',
   ],
   tags = {'partially_type_checked'},
 )

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -52,6 +52,5 @@ class OptionHelpFormatterTest(unittest.TestCase):
       DEBUG = 'debug'
     no_default = self.format_help_for_foo(typ=LogLevel, choices='info, debug')
     assert no_default.lstrip() == '--foo (one of: [info, debug] default: None)'
-
     default = self.format_help_for_foo(typ=LogLevel, choices='info, debug', default='info')
     assert default.lstrip() == '--foo (one of: [info, debug] default: info)'

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -3,7 +3,6 @@
 
 import unittest
 from dataclasses import replace
-from enum import Enum
 
 from pants.help.help_formatter import HelpFormatter
 from pants.help.help_info_extracter import OptionHelpInfo
@@ -44,13 +43,3 @@ class OptionHelpFormatterTest(unittest.TestCase):
   def test_format_help_choices(self):
     line = self.format_help_for_foo(typ=str, default='kiwi', choices='apple, banana, kiwi')
     assert line.lstrip() == '--foo (one of: [apple, banana, kiwi] default: kiwi)'
-
-  def test_format_help_choices_enum(self) -> None:
-    # We assume that help_info_extractor.py correctly parsed the Enum into this OptionHelpInfo
-    class LogLevel(Enum):
-      INFO = 'info'
-      DEBUG = 'debug'
-    no_default = self.format_help_for_foo(typ=LogLevel, choices='info, debug')
-    assert no_default.lstrip() == '--foo (one of: [info, debug] default: None)'
-    default = self.format_help_for_foo(typ=LogLevel, choices='info, debug', default='info')
-    assert default.lstrip() == '--foo (one of: [info, debug] default: info)'

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -6,11 +6,7 @@ from dataclasses import replace
 from enum import Enum
 
 from pants.help.help_formatter import HelpFormatter
-from pants.help.help_info_extracter import HelpInfoExtracter, OptionHelpInfo
-from pants.option.config import Config
-from pants.option.global_options import GlobalOptionsRegistrar
-from pants.option.option_tracker import OptionTracker
-from pants.option.parser import Parser
+from pants.help.help_info_extracter import OptionHelpInfo
 
 
 class OptionHelpFormatterTest(unittest.TestCase):
@@ -53,22 +49,8 @@ class OptionHelpFormatterTest(unittest.TestCase):
     class LogLevel(Enum):
       INFO = 'info'
       DEBUG = 'debug'
-    def do_test(args, kwargs, expected_help_message):
-      parser = Parser(env={}, config=Config.load([]),
-                      scope_info=GlobalOptionsRegistrar.get_scope_info(),
-                      parent_parser=None, option_tracker=OptionTracker())
-      parser.register(*args, **kwargs)
-      oshi = HelpInfoExtracter.get_option_scope_help_info_from_parser(parser).basic
-      self.assertEqual(1, len(oshi))
-      ohi = oshi[0]
-      lines = HelpFormatter(
-        scope='', show_recursive=False, show_advanced=False, color=False
-      ).format_option(ohi)
-      assert len(lines) == 2
-      line = lines[0]
-      assert line.lstrip() == expected_help_message
+    no_default = self.format_help_for_foo(typ=LogLevel, choices='info, debug')
+    assert no_default.lstrip() == '--foo (one of: [info, debug] default: None)'
 
-    do_test(['--foo'], {'type': LogLevel, 'default': LogLevel.DEBUG},
-            '--foo=<LogLevel> (one of: [info, debug] default: debug)')
-    do_test(['--foo'], {'type': LogLevel},
-            '--foo=<LogLevel> (one of: [info, debug] default: None)')
+    default = self.format_help_for_foo(typ=LogLevel, choices='info, debug', default='info')
+    assert default.lstrip() == '--foo (one of: [info, debug] default: info)'

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import unittest
+from dataclasses import replace
 
 from pants.help.help_formatter import HelpFormatter
 from pants.help.help_info_extracter import OptionHelpInfo
@@ -14,7 +15,7 @@ class OptionHelpFormatterTest(unittest.TestCase):
                          typ=bool, default=None, help='help for foo',
                          deprecated_message=None, removal_version=None, removal_hint=None,
                          choices=None)
-    ohi = ohi._replace(**kwargs)
+    ohi = replace(ohi, **kwargs)
     lines = HelpFormatter(
       scope='', show_recursive=False, show_advanced=False, color=False
     ).format_option(ohi)

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -46,6 +46,7 @@ class OptionHelpFormatterTest(unittest.TestCase):
     assert line.lstrip() == '--foo (one of: [apple, banana, kiwi] default: kiwi)'
 
   def test_format_help_choices_enum(self) -> None:
+    # We assume that help_info_extractor.py correctly parsed the Enum into this OptionHelpInfo
     class LogLevel(Enum):
       INFO = 'info'
       DEBUG = 'debug'

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -3,9 +3,14 @@
 
 import unittest
 from dataclasses import replace
+from enum import Enum
 
 from pants.help.help_formatter import HelpFormatter
-from pants.help.help_info_extracter import OptionHelpInfo
+from pants.help.help_info_extracter import HelpInfoExtracter, OptionHelpInfo
+from pants.option.config import Config
+from pants.option.global_options import GlobalOptionsRegistrar
+from pants.option.option_tracker import OptionTracker
+from pants.option.parser import Parser
 
 
 class OptionHelpFormatterTest(unittest.TestCase):
@@ -43,3 +48,27 @@ class OptionHelpFormatterTest(unittest.TestCase):
   def test_format_help_choices(self):
     line = self.format_help_for_foo(typ=str, default='kiwi', choices='apple, banana, kiwi')
     assert line.lstrip() == '--foo (one of: [apple, banana, kiwi] default: kiwi)'
+
+  def test_format_help_choices_enum(self) -> None:
+    class LogLevel(Enum):
+      INFO = 'info'
+      DEBUG = 'debug'
+    def do_test(args, kwargs, expected_help_message):
+      parser = Parser(env={}, config=Config.load([]),
+                      scope_info=GlobalOptionsRegistrar.get_scope_info(),
+                      parent_parser=None, option_tracker=OptionTracker())
+      parser.register(*args, **kwargs)
+      oshi = HelpInfoExtracter.get_option_scope_help_info_from_parser(parser).basic
+      self.assertEqual(1, len(oshi))
+      ohi = oshi[0]
+      lines = HelpFormatter(
+        scope='', show_recursive=False, show_advanced=False, color=False
+      ).format_option(ohi)
+      assert len(lines) == 2
+      line = lines[0]
+      assert line.lstrip() == expected_help_message
+
+    do_test(['--foo'], {'type': LogLevel, 'default': LogLevel.DEBUG},
+            '--foo=<LogLevel> (one of: [info, debug] default: debug)')
+    do_test(['--foo'], {'type': LogLevel},
+            '--foo=<LogLevel> (one of: [info, debug] default: None)')

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -108,7 +108,7 @@ class HelpInfoExtracter:
     return metavar
 
   @staticmethod
-  def compute_choices(kwargs):
+  def compute_choices(kwargs) -> Optional[str]:
     """Compute the option choices to display based on an Enum or list type."""
     typ = kwargs.get('type', [])
     if inspect.isclass(typ) and issubclass(typ, Enum):

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -3,11 +3,11 @@
 
 import inspect
 from dataclasses import dataclass
+from enum import Enum
 from typing import List, Optional, Type
 
 from pants.base import deprecated
 from pants.option.option_util import is_list_option
-from pants.util.collections import Enum
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -1,8 +1,9 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import inspect
 from dataclasses import dataclass
-from typing import List, Type
+from typing import List, Optional, Type
 
 from pants.base import deprecated
 from pants.option.option_util import is_list_option
@@ -36,10 +37,10 @@ class OptionHelpInfo:
   typ: Type
   default: str
   help: str
-  deprecated_message: str
-  removal_version: str
-  removal_hint: str
-  choices: List[str]
+  deprecated_message: Optional[str]
+  removal_version: Optional[str]
+  removal_hint: Optional[str]
+  choices: Optional[str]
 
   def comma_separated_display_args(self):
     return ', '.join(self.display_args)
@@ -109,13 +110,11 @@ class HelpInfoExtracter:
   @staticmethod
   def compute_choices(kwargs):
     """Compute the option choices to display based on an Enum or list type."""
-    choices = kwargs.get('choices', [])
-    if isinstance(choices, list):
-      values = (str(choice) for choice in choices)
-    elif issubclass(choices, Enum):
-      values = (choice.value for choice in choices)
+    typ = kwargs.get('type', [])
+    if inspect.isclass(typ) and issubclass(typ, Enum):
+      values = (choice.value for choice in typ)
     else:
-      raise ValueError(f'Type {type(choices)} not supported for option choices')
+      values = (str(choice) for choice in kwargs.get('choices', []))
     return ', '.join(values) or None
 
   def __init__(self, scope):

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -1,17 +1,16 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from collections import namedtuple
+from dataclasses import dataclass
+from typing import List, Type
 
 from pants.base import deprecated
 from pants.option.option_util import is_list_option
 from pants.util.collections import Enum
 
 
-class OptionHelpInfo(namedtuple('_OptionHelpInfo',
-    ['registering_class', 'display_args', 'scoped_cmd_line_args', 'unscoped_cmd_line_args',
-     'typ', 'default', 'help', 'deprecated_message', 'removal_version',
-     'removal_hint', 'choices'])):
+@dataclass(frozen=True)
+class OptionHelpInfo:
   """A container for help information for a single option.
 
   registering_class: The type that registered the option.
@@ -30,19 +29,33 @@ class OptionHelpInfo(namedtuple('_OptionHelpInfo',
   removal_hint: If deprecated: The removal hint message registered for this option.
   choices: If this option has a constrained list of choices, a csv list of the choices.
   """
+  registering_class: Type
+  display_args: List[str]
+  scoped_cmd_line_args: List[str]
+  unscoped_cmd_line_args: List[str]
+  typ: Type
+  default: str
+  help: str
+  deprecated_message: str
+  removal_version: str
+  removal_hint: str
+  choices: List[str]
 
   def comma_separated_display_args(self):
     return ', '.join(self.display_args)
 
 
-class OptionScopeHelpInfo(namedtuple('_OptionScopeHelpInfo',
-                                     ['scope', 'basic', 'recursive', 'advanced'])):
+@dataclass(frozen=True)
+class OptionScopeHelpInfo:
   """A container for help information for a scope of options.
 
   scope: The scope of the described options.
   basic|recursive|advanced: A list of OptionHelpInfo for the options in that group.
   """
-  pass
+  scope: str
+  basic: List[OptionHelpInfo]
+  recursive: List[OptionHelpInfo]
+  advanced: List[OptionHelpInfo]
 
 
 class HelpInfoExtracter:

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -71,7 +71,7 @@ class HelpInfoExtracter:
     return cls(parser.scope).get_option_scope_help_info(parser.option_registrations_iter())
 
   @staticmethod
-  def compute_default(kwargs):
+  def compute_default(kwargs) -> str:
     """Compute the default value to display in help for an option registered with these kwargs."""
     ranked_default = kwargs.get('default')
     typ = kwargs.get('type', str)
@@ -90,6 +90,8 @@ class HelpInfoExtracter:
         default_str = '{}'
     elif typ == str:
       default_str = "'{}'".format(default).replace('\n', ' ')
+    elif inspect.isclass(typ) and issubclass(typ, Enum):
+      default_str = default.value
     else:
       default_str = str(default)
     return default_str

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -8,6 +8,7 @@ from pants.option.config import Config
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.option_tracker import OptionTracker
 from pants.option.parser import Parser
+from pants.util.collections import Enum
 
 
 class HelpInfoExtracterTest(unittest.TestCase):
@@ -95,6 +96,14 @@ class HelpInfoExtracterTest(unittest.TestCase):
     self.assertEqual('999.99.9', ohi.removal_version)
     self.assertEqual('do not use this', ohi.removal_hint)
     self.assertIsNotNone(ohi.deprecated_message)
+
+  def test_enum(self):
+    class LogLevel(Enum):
+      INFO = 'info'
+      DEBUG = 'debug'
+    kwargs = {'choices': LogLevel}
+    ohi = HelpInfoExtracter('').get_option_help_info([], kwargs)
+    self.assertEqual(', '.join(e.value for e in LogLevel), ohi.choices)
 
   def test_grouping(self):
     def do_test(kwargs, expected_basic=False, expected_recursive=False, expected_advanced=False):

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -107,7 +107,7 @@ class HelpInfoExtracterTest(unittest.TestCase):
   def test_enum_choices(self) -> None:
     kwargs = {'type': LogLevel}
     ohi = HelpInfoExtracter('').get_option_help_info([], kwargs)
-    assert ', '.join(e.value for e in LogLevel) == ohi.choices
+    assert ohi.choices == 'info, debug'
 
   def test_grouping(self):
     def do_test(kwargs, expected_basic=False, expected_recursive=False, expected_advanced=False):

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -81,9 +81,9 @@ class HelpInfoExtracterTest(unittest.TestCase):
                       parent_parser=None, option_tracker=OptionTracker())
       parser.register(*args, **kwargs)
       oshi = HelpInfoExtracter.get_option_scope_help_info_from_parser(parser).basic
-      assert 1 == len(oshi)
+      assert len(oshi) == 1
       ohi = oshi[0]
-      assert expected_default == ohi.default
+      assert ohi.default == expected_default
 
     do_test(['--foo'], {'type': bool }, 'False')
     do_test(['--foo'], {'type': bool, 'default': True}, 'True')
@@ -105,7 +105,7 @@ class HelpInfoExtracterTest(unittest.TestCase):
     self.assertIsNotNone(ohi.deprecated_message)
 
   def test_choices(self) -> None:
-    kwargs={'choices' : ['info', 'debug']}
+    kwargs={'choices': ['info', 'debug']}
     ohi = HelpInfoExtracter('').get_option_help_info([], kwargs)
     assert ohi.choices == 'info, debug'
 

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -104,7 +104,12 @@ class HelpInfoExtracterTest(unittest.TestCase):
     self.assertEqual('do not use this', ohi.removal_hint)
     self.assertIsNotNone(ohi.deprecated_message)
 
-  def test_enum_choices(self) -> None:
+  def test_choices(self) -> None:
+    kwargs={'choices' : ['info', 'debug']}
+    ohi = HelpInfoExtracter('').get_option_help_info([], kwargs)
+    assert ohi.choices == 'info, debug'
+
+  def test_choices_enum(self) -> None:
     kwargs = {'type': LogLevel}
     ohi = HelpInfoExtracter('').get_option_help_info([], kwargs)
     assert ohi.choices == 'info, debug'

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -101,9 +101,9 @@ class HelpInfoExtracterTest(unittest.TestCase):
     class LogLevel(Enum):
       INFO = 'info'
       DEBUG = 'debug'
-    kwargs = {'choices': LogLevel}
+    kwargs = {'type': LogLevel, 'default': LogLevel.INFO}
     ohi = HelpInfoExtracter('').get_option_help_info([], kwargs)
-    self.assertEqual(', '.join(e.value for e in LogLevel), ohi.choices)
+    assert ', '.join(e.value for e in LogLevel) == ohi.choices
 
   def test_grouping(self):
     def do_test(kwargs, expected_basic=False, expected_recursive=False, expected_advanced=False):

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -97,7 +97,7 @@ class HelpInfoExtracterTest(unittest.TestCase):
     self.assertEqual('do not use this', ohi.removal_hint)
     self.assertIsNotNone(ohi.deprecated_message)
 
-  def test_enum(self):
+  def test_enum(self) -> None:
     class LogLevel(Enum):
       INFO = 'info'
       DEBUG = 'debug'

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import unittest
+from enum import Enum
 
 from pants.help.help_info_extracter import HelpInfoExtracter
 from pants.option.config import Config
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.option_tracker import OptionTracker
 from pants.option.parser import Parser
-from pants.util.collections import Enum
 
 
 class HelpInfoExtracterTest(unittest.TestCase):


### PR DESCRIPTION
### Problem

When an option is registered using an enum, choices are failed to be picked up. Relevant issue: #8819 

### Solution

- Helper function used to compute choices from lists as well as enums
- `OptionHelpInfo` and `OptionScopeHelpInfo` are migrated from named tuples to data classes 

### Result
Help messages for options registered with enums now display choices and the default value.

Before:
```
$ ./pants help-all --help-advanced | grep 'glob-expansion-failure'
Scrubbed PYTHONPATH=/Users/dherman/pants/src/python: from the environment.
  --glob-expansion-failure=<GlobMatchErrorBehavior> (default: GlobMatchErrorBehavior.warn)
```

After:
```
$ ./pants help-all --help-advanced | grep 'glob-expansion-failure'
Scrubbed PYTHONPATH=/Users/dherman/pants/src/python: from the environment.
  --glob-expansion-failure=<GlobMatchErrorBehavior> (one of: [ignore, warn, error] default: warn)
```