### PR TITLE
Provide input_files Digest to InteractiveRunner

### DIFF
--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Tuple
 
 from pants.base.exception_sink import ExceptionSink
+from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Digest
 from pants.engine.rules import RootRule
 
 
@@ -21,6 +22,7 @@ class InteractiveProcessResult:
 class InteractiveProcessRequest:
   argv: Tuple[str, ...]
   env: Tuple[str, ...] = ()
+  input_files: Digest = EMPTY_DIRECTORY_DIGEST
   run_in_workspace: bool = False
 
 

--- a/src/python/pants/engine/interactive_runner.py
+++ b/src/python/pants/engine/interactive_runner.py
@@ -25,6 +25,10 @@ class InteractiveProcessRequest:
   input_files: Digest = EMPTY_DIRECTORY_DIGEST
   run_in_workspace: bool = False
 
+  def __post_init__(self):
+    if self.input_files != EMPTY_DIRECTORY_DIGEST and self.run_in_workspace:
+      raise ValueError("InteractiveProessRequest should use the Workspace API to materialize any needed files when it runs in the workspace")
+
 
 @dataclass(frozen=True)
 class InteractiveRunner:

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -983,7 +983,7 @@ pub extern "C" fn run_local_interactive_process(
               session.workunit_store().clone(),
             );
 
-            let _ = scheduler.core.executor.spawn_on_io_pool(write_operation).wait()?;
+            scheduler.core.executor.spawn_on_io_pool(write_operation).wait()?;
           }
         }
 

--- a/src/rust/engine/engine_cffi/src/lib.rs
+++ b/src/rust/engine/engine_cffi/src/lib.rs
@@ -46,7 +46,7 @@ use engine::{
 };
 use futures::Future;
 use hashing::{Digest, EMPTY_DIGEST};
-use log::{error, Log};
+use log::{error, warn, Log};
 use logging::logger::LOGGER;
 use logging::{Destination, Logger};
 use rule_graph::{GraphMaker, RuleGraph};
@@ -970,7 +970,7 @@ pub extern "C" fn run_local_interactive_process(
         let digest: Digest = nodes::lift_digest(&input_files_value)?;
         if digest != EMPTY_DIGEST {
           if run_in_workspace {
-            return Err("When running an interactive process in the workspace, use the Workspace type to materialize files.".to_string());
+            warn!("Local interactive process should not attempt to materialize files when run in workspace");
           } else {
             let destination = match maybe_tempdir {
               Some(ref dir) => dir.path().to_path_buf(),


### PR DESCRIPTION
### Problem

When we use InteractiveRunner to run a process not in the workspace but rather in a random tempdir, we need some way to materialize files we might want to work with from a Digest.

### Solution
Add a new field `input_files: Digest` on `InteractiveProcessRequest` that works the same way as the analogous field on `ExecuteProcessRequest`, i.e. provision the working directory of the interactive process with the contents of the Digest.

The code deliberately throws an error rather than trying to write files to disk if we are trying to run the process in the workspace. We already have the `Workspace` abstraction for writing files there which we can use if we need to do this, and if we force rule-writers to use that abstraction only for touching files in the workspace we can introduce checks to try to mitigate people accidentally overwriting source files they shouldn't be.

