### PR TITLE
Report a deprecation for the option name rather than for the dest.

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/plugin_subsystem_base.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/plugin_subsystem_base.py
@@ -24,7 +24,8 @@ class PluginSubsystemBase(Subsystem):
     option_names = []
 
     def recording_register(*args, **kwargs):
-      option_names.append(Parser.parse_dest(*args, **kwargs))
+      _, dest = Parser.parse_name_and_dest(*args, **kwargs)
+      option_names.append(dest)
       register(*args, **kwargs)
 
     super().register_options(recording_register)

--- a/src/python/pants/testutil/option/fakes.py
+++ b/src/python/pants/testutil/option/fakes.py
@@ -51,7 +51,7 @@ class _FakeOptionValues(object):
 
 def _options_registration_function(defaults, fingerprintables):
   def register(*args, **kwargs):
-    option_name = Parser.parse_dest(*args, **kwargs)
+    _, option_dest = Parser.parse_name_and_dest(*args, **kwargs)
 
     default = kwargs.get('default')
     if default is None:
@@ -59,7 +59,7 @@ def _options_registration_function(defaults, fingerprintables):
         default = False
       if kwargs.get('type') == list:
         default = []
-    defaults[option_name] = RankedValue(RankedValue.HARDCODED, default)
+    defaults[option_dest] = RankedValue(RankedValue.HARDCODED, default)
 
     fingerprint = kwargs.get('fingerprint', False)
     if fingerprint:
@@ -67,7 +67,7 @@ def _options_registration_function(defaults, fingerprintables):
         val_type = kwargs.get('member_type', str)
       else:
         val_type = kwargs.get('type', str)
-      fingerprintables[option_name] = val_type
+      fingerprintables[option_dest] = val_type
 
   return register
 

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -605,6 +605,10 @@ class OptionsTest(TestBase):
     options = self._parse('./pants --int-choices=42 --int-choices=99')
     self.assertEqual([42, 99], options.for_global_scope().int_choices)
 
+  def test_parse_name_and_dest(self):
+    self.assertEqual(('thing', 'thing'), Parser.parse_name_and_dest('--thing'))
+    self.assertEqual(('thing', 'other_thing'), Parser.parse_name_and_dest('--thing', dest='other_thing'))
+
   def test_validation(self):
     def assertError(expected_error, *args, **kwargs):
       with self.assertRaises(expected_error):


### PR DESCRIPTION
### Problem

`--target-spec-file` is currently deprecated in favor of `--positional-arg-file`, but the deprecation was rendering as:
```
DeprecationWarning: DEPRECATED: option 'positional_arg_files' in global scope will be removed in version 1.25.0.dev2.
  Use --positional-arg-file instead
  self._bootstrap_inner()
```

This was because the `dest` of the option definition was used in the warning, rather than its original registration name.

### Solution

Use the original registration in deprecation messages.

### Result

A more helpful message is rendered:
```
DeprecationWarning: DEPRECATED: option 'target_spec_file' in global scope will be removed in version 1.25.0.dev2.
  Use --positional-arg-file instead
  main()
```