### PR TITLE
Get rid of working_directory field

### DIFF
--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -32,7 +32,6 @@ class ExecuteProcessRequest:
   argv: Tuple[str, ...]
   input_files: Digest
   description: str
-  working_directory: Optional[str]
   env: Tuple[str, ...]
   output_files: Tuple[str, ...]
   output_directories: Tuple[str, ...]
@@ -47,7 +46,6 @@ class ExecuteProcessRequest:
     *,
     input_files: Digest,
     description: str,
-    working_directory: Optional[str] = None,
     env: Optional[Dict[str, str]] = None,
     output_files: Optional[Tuple[str, ...]] = None,
     output_directories: Optional[Tuple[str, ...]] = None,
@@ -59,7 +57,6 @@ class ExecuteProcessRequest:
     self.argv = argv
     self.input_files = input_files
     self.description = description
-    self.working_directory = working_directory
     self.env = tuple(itertools.chain.from_iterable((env or {}).items()))
     self.output_files = output_files or ()
     self.output_directories = output_directories or ()

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -49,7 +49,6 @@ fn run_roundtrip(script_exit_code: i8) -> RoundtripResults {
       format!("{}", script_path.display()),
     ],
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("roland")].into_iter().collect(),
     output_directories: BTreeSet::new(),

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -175,12 +175,6 @@ pub struct ExecuteProcessRequest {
   ///
   pub env: BTreeMap<String, String>,
 
-  ///
-  /// A relative path to a directory existing in the `input_files` digest to execute the process
-  /// from. Defaults to the `input_files` root.
-  ///
-  pub working_directory: Option<RelativePath>,
-
   pub input_files: hashing::Digest,
 
   pub output_files: BTreeSet<PathBuf>,

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -258,11 +258,7 @@ impl CapturedWorkdir for CommandRunner {
   ) -> Result<Box<dyn Stream<Item = ChildOutput, Error = String> + Send>, String> {
     StreamedHermeticCommand::new(&req.argv[0])
       .args(&req.argv[1..])
-      .current_dir(if let Some(working_directory) = req.working_directory {
-        workdir_path.join(working_directory)
-      } else {
-        workdir_path.to_owned()
-      })
+      .current_dir(workdir_path.to_owned())
       .envs(&req.env)
       .stream()
       .map(|s| {

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -3,7 +3,7 @@ use testutil;
 
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, ExecuteProcessRequest,
-  FallibleExecuteProcessResult, Platform, RelativePath,
+  FallibleExecuteProcessResult, Platform,
 };
 use hashing::EMPTY_DIGEST;
 use spectral::{assert_that, string::StrAssertions};
@@ -23,7 +23,6 @@ fn stdout() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -53,7 +52,6 @@ fn stdout_and_stderr_and_exit_code() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/bash", "-c", "echo -n foo ; echo >&2 -n bar ; exit 1"]),
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -84,7 +82,6 @@ fn capture_exit_code_signal() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/bash", "-c", "kill $$"]),
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -118,7 +115,6 @@ fn env() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["/usr/bin/env"]),
     env: env.clone(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -158,7 +154,6 @@ fn env_is_deterministic() {
     ExecuteProcessRequest {
       argv: owned_string_vec(&["/usr/bin/env"]),
       env: env,
-      working_directory: None,
       input_files: EMPTY_DIGEST,
       output_files: BTreeSet::new(),
       output_directories: BTreeSet::new(),
@@ -182,7 +177,6 @@ fn binary_not_found() {
   run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&["echo", "-n", "foo"]),
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -201,7 +195,6 @@ fn output_files_none() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: owned_string_vec(&[&find_bash(), "-c", "exit 0"]),
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -233,7 +226,6 @@ fn output_files_one() {
       format!("echo -n {} > {}", TestData::roland().string(), "roland"),
     ],
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("roland")].into_iter().collect(),
     output_directories: BTreeSet::new(),
@@ -271,7 +263,6 @@ fn output_dirs() {
       ),
     ],
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("treats")].into_iter().collect(),
     output_directories: vec![PathBuf::from("cats")].into_iter().collect(),
@@ -308,7 +299,6 @@ fn output_files_many() {
       ),
     ],
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("cats/roland"), PathBuf::from("treats")]
       .into_iter()
@@ -347,7 +337,6 @@ fn output_files_execution_failure() {
       ),
     ],
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("roland")].into_iter().collect(),
     output_directories: BTreeSet::new(),
@@ -380,7 +369,6 @@ fn output_files_partial_output() {
       format!("echo -n {} > {}", TestData::roland().string(), "roland"),
     ],
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("roland"), PathBuf::from("susannah")]
       .into_iter()
@@ -415,7 +403,6 @@ fn output_overlapping_file_and_dir() {
       format!("echo -n {} > cats/roland", TestData::roland().string()),
     ],
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("cats/roland")].into_iter().collect(),
     output_directories: vec![PathBuf::from("cats")].into_iter().collect(),
@@ -448,7 +435,6 @@ fn jdk_symlink() {
   let result = run_command_locally(ExecuteProcessRequest {
     argv: vec!["/bin/cat".to_owned(), ".jdk/roland".to_owned()],
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -484,7 +470,6 @@ fn test_directory_preservation() {
         format!("echo -n {} > {}", TestData::roland().string(), "roland"),
       ],
       env: BTreeMap::new(),
-      working_directory: None,
       input_files: EMPTY_DIGEST,
       output_files: vec![PathBuf::from("roland")].into_iter().collect(),
       output_directories: BTreeSet::new(),
@@ -525,7 +510,6 @@ fn test_directory_preservation_error() {
     ExecuteProcessRequest {
       argv: vec!["doesnotexist".to_owned()],
       env: BTreeMap::new(),
-      working_directory: None,
       input_files: EMPTY_DIGEST,
       output_files: BTreeSet::new(),
       output_directories: BTreeSet::new(),
@@ -563,7 +547,6 @@ fn all_containing_directories_for_outputs_are_created() {
       ),
     ],
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: vec![PathBuf::from("cats/roland")].into_iter().collect(),
     output_directories: vec![PathBuf::from("birds/falcons")].into_iter().collect(),
@@ -596,7 +579,6 @@ fn output_empty_dir() {
       "/bin/mkdir falcons".to_string(),
     ],
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: vec![PathBuf::from("falcons")].into_iter().collect(),
@@ -643,7 +625,6 @@ fn local_only_scratch_files_materialized() {
     ExecuteProcessRequest {
       argv: vec![find_bash(), "-c".to_owned(), format!("echo -n ''")],
       env: BTreeMap::new(),
-      working_directory: None,
       input_files: EMPTY_DIGEST,
       output_files: vec![PathBuf::from("roland")].into_iter().collect(),
       output_directories: BTreeSet::new(),
@@ -682,7 +663,6 @@ fn timeout() {
       "/bin/sleep 0.2; /bin/echo -n 'European Burmese'".to_string(),
     ],
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -699,58 +679,6 @@ fn timeout() {
   let error_msg = String::from_utf8(result.stdout.to_vec()).unwrap();
   assert_that(&error_msg).contains("Exceeded timeout");
   assert_that(&error_msg).contains("sleepy-cat");
-}
-
-#[test]
-fn working_directory() {
-  let store_dir = TempDir::new().unwrap();
-  let executor = task_executor::Executor::new();
-  let store = Store::local_only(executor.clone(), store_dir.path()).unwrap();
-
-  // Prepare the store to contain /cats/roland, because the EPR needs to materialize it and then run
-  // from the ./cats directory.
-  executor
-    .block_on(store.store_file_bytes(TestData::roland().bytes(), false))
-    .expect("Error saving file bytes");
-  executor
-    .block_on(store.record_directory(&TestDirectory::containing_roland().directory(), true))
-    .expect("Error saving directory");
-  executor
-    .block_on(store.record_directory(&TestDirectory::nested().directory(), true))
-    .expect("Error saving directory");
-
-  let work_dir = TempDir::new().unwrap();
-  let result = run_command_locally_in_dir(
-    ExecuteProcessRequest {
-      argv: vec![find_bash(), "-c".to_owned(), "/bin/ls".to_string()],
-      env: BTreeMap::new(),
-      working_directory: Some(RelativePath::new("cats").unwrap()),
-      input_files: TestDirectory::nested().digest(),
-      output_files: BTreeSet::new(),
-      output_directories: BTreeSet::new(),
-      timeout: Duration::from_millis(100),
-      description: "confused-cat".to_string(),
-      unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: EMPTY_DIGEST,
-      jdk_home: None,
-      target_platform: Platform::None,
-      is_nailgunnable: false,
-    },
-    work_dir.path().to_owned(),
-    true,
-    Some(store),
-    Some(executor),
-  );
-
-  assert_eq!(
-    result.unwrap(),
-    FallibleExecuteProcessResult {
-      stdout: as_bytes("roland\n"),
-      stderr: as_bytes(""),
-      exit_code: 0,
-      output_directory: EMPTY_DIGEST,
-      execution_attempts: vec![],
-    }
-  );
 }
 
 fn run_command_locally(req: ExecuteProcessRequest) -> Result<FallibleExecuteProcessResult, String> {

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -54,7 +54,6 @@ fn construct_nailgun_server_request(
   ExecuteProcessRequest {
     argv: full_args,
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: hashing::EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -78,7 +77,6 @@ fn construct_nailgun_client_request(
     input_files,
     description,
     env: original_request_env,
-    working_directory,
     output_files,
     output_directories,
     timeout,
@@ -93,7 +91,6 @@ fn construct_nailgun_client_request(
     input_files,
     description,
     env: original_request_env,
-    working_directory,
     output_files,
     output_directories,
     timeout,
@@ -221,11 +218,7 @@ impl CapturedWorkdir for CommandRunner {
     let nailgun_name = CommandRunner::calculate_nailgun_name(&client_main_class);
     let nailgun_name2 = nailgun_name.clone();
     let nailgun_name3 = nailgun_name.clone();
-    let client_workdir = if let Some(working_directory) = &req.working_directory {
-      workdir_path.join(working_directory)
-    } else {
-      workdir_path.to_path_buf()
-    };
+    let client_workdir = workdir_path.to_path_buf();
 
     let jdk_home = req
       .jdk_home

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -35,7 +35,6 @@ fn mock_nailgunnable_request(jdk_home: Option<PathBuf>) -> ExecuteProcessRequest
   ExecuteProcessRequest {
     argv: vec![],
     env: Default::default(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: Default::default(),
     output_directories: Default::default(),

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -892,15 +892,6 @@ pub fn make_execute_request(
   output_directories.sort();
   command.set_output_directories(protobuf::RepeatedField::from_vec(output_directories));
 
-  if let Some(working_directory) = &req.working_directory {
-    command.set_working_directory(
-      working_directory
-        .to_str()
-        .map(str::to_owned)
-        .unwrap_or_else(|| panic!("Non-UTF8 working directory path: {:?}", working_directory)),
-    )
-  }
-
   if req.jdk_home.is_some() {
     // Ideally, the JDK would be brought along as part of the input directory, but we don't
     // currently have support for that. Scoot supports this property, and will symlink .jdk to a

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -56,7 +56,6 @@ fn local_only_scratch_files_ignored() {
     env: vec![("SOME".to_owned(), "value".to_owned())]
       .into_iter()
       .collect(),
-    working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
     output_files: vec!["path/to/file", "other/file"]
@@ -81,7 +80,6 @@ fn local_only_scratch_files_ignored() {
     env: vec![("SOME".to_owned(), "value".to_owned())]
       .into_iter()
       .collect(),
-    working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
     output_files: vec!["path/to/file", "other/file"]
@@ -115,7 +113,6 @@ fn make_execute_request() {
     env: vec![("SOME".to_owned(), "value".to_owned())]
       .into_iter()
       .collect(),
-    working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
     output_files: vec!["path/to/file", "other/file"]
@@ -199,7 +196,6 @@ fn make_execute_request_with_instance_name() {
     env: vec![("SOME".to_owned(), "value".to_owned())]
       .into_iter()
       .collect(),
-    working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
     output_files: vec!["path/to/file", "other/file"]
@@ -291,7 +287,6 @@ fn make_execute_request_with_cache_key_gen_version() {
     env: vec![("SOME".to_owned(), "value".to_owned())]
       .into_iter()
       .collect(),
-    working_directory: None,
     input_files: input_directory.digest(),
     // Intentionally poorly sorted:
     output_files: vec!["path/to/file", "other/file"]
@@ -386,7 +381,6 @@ fn make_execute_request_with_jdk() {
   let req = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "yo"]),
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: input_directory.digest(),
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -452,7 +446,6 @@ fn make_execute_request_with_jdk_and_extra_platform_properties() {
   let req = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "yo"]),
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: input_directory.digest(),
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -560,7 +553,6 @@ fn server_rejecting_execute_request_gives_error() {
           &ExecuteProcessRequest {
             argv: owned_string_vec(&["/bin/echo", "-n", "bar"]),
             env: BTreeMap::new(),
-            working_directory: None,
             input_files: EMPTY_DIGEST,
             output_files: BTreeSet::new(),
             output_directories: BTreeSet::new(),
@@ -1045,7 +1037,6 @@ fn timeout_after_sufficiently_delayed_getoperations() {
   let execute_request = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -1098,7 +1089,6 @@ fn dropped_request_cancels() {
   let execute_request = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -2279,7 +2269,6 @@ pub fn echo_foo_request() -> MultiPlatformExecuteProcessRequest {
   let req = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -2593,7 +2582,6 @@ fn cat_roland_request() -> MultiPlatformExecuteProcessRequest {
   let req = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/cat", "roland"]),
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: TestDirectory::containing_roland().digest(),
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
@@ -2612,7 +2600,6 @@ fn echo_roland_request() -> MultiPlatformExecuteProcessRequest {
   let req = ExecuteProcessRequest {
     argv: owned_string_vec(&["/bin/echo", "meoooow"]),
     env: BTreeMap::new(),
-    working_directory: None,
     input_files: EMPTY_DIGEST,
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),

--- a/src/rust/engine/process_execution/src/tests.rs
+++ b/src/rust/engine/process_execution/src/tests.rs
@@ -11,7 +11,6 @@ fn execute_process_request_equality() {
         |description: String, timeout: Duration, unsafe_local_only_files_because_we_favor_speed_over_correctness_for_this_rule: hashing::Digest| ExecuteProcessRequest {
             argv: vec![],
             env: BTreeMap::new(),
-            working_directory: None,
             input_files: hashing::EMPTY_DIGEST,
             output_files: BTreeSet::new(),
             output_directories: BTreeSet::new(),

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -33,7 +33,7 @@ use process_execution;
 
 use clap::{value_t, App, AppSettings, Arg};
 use hashing::{Digest, Fingerprint};
-use process_execution::{Context, ExecuteProcessRequestMetadata, Platform, RelativePath};
+use process_execution::{Context, ExecuteProcessRequestMetadata, Platform};
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryFrom;
 use std::iter::{FromIterator, Iterator};
@@ -321,15 +321,11 @@ fn main() {
     Digest(fingerprint, length)
   };
 
-  let working_directory = args
-    .value_of("working-directory")
-    .map(|path| RelativePath::new(path).expect("working-directory must be a relative path"));
   let is_nailgunnable: bool = args.value_of("use-nailgun").unwrap().parse().unwrap();
 
   let request = process_execution::ExecuteProcessRequest {
     argv,
     env,
-    working_directory,
     input_files,
     output_files,
     output_directories,

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -28,7 +28,7 @@ use fs::{
 };
 use hashing;
 use process_execution::{
-  self, ExecuteProcessRequest, MultiPlatformExecuteProcessRequest, Platform, RelativePath,
+  self, ExecuteProcessRequest, MultiPlatformExecuteProcessRequest, Platform,
 };
 use rule_graph;
 
@@ -411,15 +411,6 @@ impl MultiPlatformExecuteProcess {
   ) -> Result<ExecuteProcessRequest, String> {
     let env = externs::project_tuple_encoded_map(&value, "env")?;
 
-    let working_directory = {
-      let val = externs::project_str(&value, "working_directory");
-      if val.is_empty() {
-        None
-      } else {
-        Some(RelativePath::new(val.as_str())?)
-      }
-    };
-
     let digest = lift_digest(&externs::project_ignoring_type(&value, "input_files"))
       .map_err(|err| format!("Error parsing digest {}", err))?;
 
@@ -465,7 +456,6 @@ impl MultiPlatformExecuteProcess {
     Ok(process_execution::ExecuteProcessRequest {
       argv: externs::project_multi_strs(&value, "argv"),
       env,
-      working_directory,
       input_files: digest,
       output_files,
       output_directories,


### PR DESCRIPTION
### Problem

ExecuteProcesssRequest has a field called `working_directory` that no python code is actually using.

### Solution

Remove this field 