### PR TITLE
don't cache errored engine node results

### DIFF
--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -60,6 +60,12 @@ pub trait NodeError: Clone + Debug + Eq + Send {
   /// Creates an instance that represents that a Node dependency was cyclic along the given path.
   ///
   fn cyclic(path: Vec<String>) -> Self;
+
+  ///
+  /// If this error indicates an erroneous state of the underlying graph. A cyclic graph error
+  /// generated with Self::cyclic() will return true for this.
+  ///
+  fn indicates_that_the_graph_is_invalid(&self) -> bool;
 }
 
 ///

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -662,4 +662,8 @@ impl NodeError for TError {
   fn cyclic(_path: Vec<String>) -> Self {
     TError::Cyclic
   }
+
+  fn indicates_that_the_graph_is_invalid(&self) -> bool {
+    self == &TError::Cyclic
+  }
 }

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -287,6 +287,8 @@ pub enum Failure {
   /// A Node failed because a filesystem change invalidated it or its inputs.
   /// A root requestor should usually immediately retry their request.
   Invalidated,
+  /// A rule raised an exception about the graph being cyclic.
+  Cyclic(Value, String),
   /// A rule raised an exception.
   Throw(Value, String),
 }
@@ -296,8 +298,19 @@ impl fmt::Display for Failure {
     match self {
       Failure::Invalidated => write!(f, "Exhausted retries due to changed files."),
       Failure::Throw(exc, _) => write!(f, "{}", externs::val_to_str(exc)),
+      Failure::Cyclic(exc, _) => write!(f, "{}", externs::val_to_str(exc)),
     }
   }
+}
+
+pub fn cyclic_throw(msg: &str) -> Failure {
+  Failure::Cyclic(
+    externs::create_exception(msg),
+    format!(
+      "Traceback (no traceback):\n  <pants native internals>\nException: {}",
+      msg
+    ),
+  )
 }
 
 pub fn throw(msg: &str) -> Failure {

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -462,6 +462,7 @@ impl From<Result<Value, Failure>> for PyResult {
         let val = match f {
           f @ Failure::Invalidated => create_exception(&format!("{}", f)),
           Failure::Throw(exc, _) => exc,
+          Failure::Cyclic(exc, _) => exc,
         };
         PyResult {
           is_throw: true,


### PR DESCRIPTION
### Problem

We would like to avoid having the engine cache exceptions raised in `@rule`s, along with other failures when invoking engine intrinsics such as flaky process executions.

### Solution

- Add a method `NodeError::indicates_that_the_graph_is_invalid()` to mark cyclic graph errors which are unrecoverable.
- Add a new `EntryState::Erroneous` enum member, and use it `if error.indicates_that_the_graph_is_invalid()`.
- Rename `EntryState::NotStarted` to `EntryState::Dormant`, and add a `previous_error` field.

### Result

Raising an exception in an `@rule` is no longer cached!