### PR TITLE
add SingleFileExecutable to make it easier to consume Snapshots of executables

### DIFF
--- a/src/python/pants/backend/python/rules/download_pex_bin.py
+++ b/src/python/pants/backend/python/rules/download_pex_bin.py
@@ -20,7 +20,7 @@ class DownloadedPexBin(HermeticPex):
 
   @property
   def executable(self) -> str:
-    return str(self.exe.exe_filename)
+    return self.exe.exe_filename
 
   @property
   def directory_digest(self) -> Digest:

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -55,8 +55,8 @@ python_library(
     ':selectors',
     'src/python/pants/base:project_tree',
     'src/python/pants/option',
+    'src/python/pants/util:dirutil',
     'src/python/pants/util:meta',
-    'src/python/pants/util:strutil',
   ],
   tags = {'partially_type_checked'},
 )

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -56,6 +56,7 @@ python_library(
     'src/python/pants/base:project_tree',
     'src/python/pants/option',
     'src/python/pants/util:meta',
+    'src/python/pants/util:strutil',
   ],
   tags = {'partially_type_checked'},
 )

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -239,7 +239,6 @@ EMPTY_SNAPSHOT = Snapshot(
 )
 
 
-# FIXME: make pex and cloc rulesets produce this instead of doing snapshot.files[0]!
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class SingleFileExecutable:

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -10,9 +10,13 @@ from pants.engine.objects import Collection
 from pants.engine.rules import RootRule
 from pants.option.custom_types import GlobExpansionConjunction as GlobExpansionConjunction
 from pants.option.global_options import GlobMatchErrorBehavior
-from pants.util.dirutil import maybe_read_file, safe_delete, safe_file_dump
+from pants.util.dirutil import (
+  ensure_relative_file_name,
+  maybe_read_file,
+  safe_delete,
+  safe_file_dump,
+)
 from pants.util.meta import frozen_after_init
-from pants.util.strutil import ensure_relative_file_name
 
 
 if TYPE_CHECKING:

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -140,13 +140,11 @@ class SingleFileExecutableTest(TestBase):
     ))
     snapshot = self.request_single_product(Snapshot, input_files_content)
 
-    self.assertEquals(SingleFileExecutable(snapshot).exe_filename,
-                      './subdir/a.txt')
+    assert SingleFileExecutable(snapshot).exe_filename == './subdir/a.txt'
 
     input_files_content = InputFilesContent((
       FileContent(path='some_silly_file_name', content=b'test file contents'),
     ))
     snapshot = self.request_single_product(Snapshot, input_files_content)
 
-    self.assertEquals(SingleFileExecutable(snapshot).exe_filename,
-                      './some_silly_file_name')
+    assert SingleFileExecutable(snapshot).exe_filename == './some_silly_file_name'

--- a/src/python/pants/rules/core/cloc.py
+++ b/src/python/pants/rules/core/cloc.py
@@ -12,6 +12,7 @@ from pants.engine.fs import (
   FileContent,
   FilesContent,
   InputFilesContent,
+  SingleFileExecutable,
   Snapshot,
   UrlToFetch,
 )
@@ -25,8 +26,15 @@ from pants.engine.selectors import Get
 @dataclass(frozen=True)
 class DownloadedClocScript:
   """Cloc script as downloaded from the pantsbuild binaries repo."""
-  script_path: str
-  digest: Digest
+  exe: SingleFileExecutable
+
+  @property
+  def script_path(self) -> str:
+    return str(self.exe.exe_filename)
+
+  @property
+  def digest(self) -> Digest:
+    return self.exe.directory_digest
 
 
 #TODO(#7790) - We can't call this feature-complete with the v1 version of cloc
@@ -37,7 +45,7 @@ async def download_cloc_script() -> DownloadedClocScript:
   sha_256 = "2b23012b1c3c53bd6b9dd43cd6aa75715eed4feb2cb6db56ac3fbbd2dffeac9d"
   digest = Digest(sha_256, 546279)
   snapshot = await Get[Snapshot](UrlToFetch(url, digest))
-  return DownloadedClocScript(script_path=snapshot.files[0], digest=snapshot.directory_digest)
+  return DownloadedClocScript(SingleFileExecutable(snapshot))
 
 
 class CountLinesOfCodeOptions(GoalSubsystem):

--- a/src/python/pants/rules/core/cloc.py
+++ b/src/python/pants/rules/core/cloc.py
@@ -30,7 +30,7 @@ class DownloadedClocScript:
 
   @property
   def script_path(self) -> str:
-    return str(self.exe.exe_filename)
+    return self.exe.exe_filename
 
   @property
   def digest(self) -> Digest:

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -11,6 +11,7 @@ import threading
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
+from pathlib import Path
 from typing import (
   Any,
   Callable,
@@ -72,6 +73,17 @@ def fast_relpath_optional(path: str, start: str) -> Optional[str]:
     # the prefix is a directory.
     return path[pref_end+1:]
   return None
+
+
+def ensure_relative_file_name(path: Path) -> str:
+  """Return a string representing the `path`, with a leading './'.
+
+  This ensures that the returned string can be used as the executable file when executing a
+  subprocess, without putting the executable file on the PATH.
+  """
+  if path.is_absolute():
+    raise ValueError(f'path {path} is expected to be relative!')
+  return f'./{path}'
 
 
 def safe_mkdir(directory: str, clean: bool = False) -> None:

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -3,7 +3,6 @@
 
 import re
 import shlex
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 
@@ -128,14 +127,3 @@ def strip_prefix(string: str, prefix: str) -> str:
     return string[len(prefix):]
   else:
     return string
-
-
-def ensure_relative_file_name(path: Path) -> str:
-  """Return a string representing the `path`, with a leading './'.
-
-  This ensures that the returned string can be used as the executable file when executing a
-  subprocess, without putting the executable file on the PATH.
-  """
-  if path.is_absolute():
-    raise ValueError(f'path {path} is expected to be relative!')
-  return f'./{path}'

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -3,6 +3,7 @@
 
 import re
 import shlex
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 
@@ -127,3 +128,14 @@ def strip_prefix(string: str, prefix: str) -> str:
     return string[len(prefix):]
   else:
     return string
+
+
+def ensure_relative_file_name(path: Path) -> str:
+  """Return a string representing the `path`, with a leading './'.
+
+  This ensures that the returned string can be used as the executable file when executing a
+  subprocess, without putting the executable file on the PATH.
+  """
+  if path.is_absolute():
+    raise ValueError(f'path {path} is expected to be relative!')
+  return f'./{path}'

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -8,6 +8,7 @@ import unittest
 import unittest.mock
 from contextlib import contextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterator, Tuple, Union
 
 from pants.util import dirutil
@@ -18,6 +19,7 @@ from pants.util.dirutil import (
   _mkdtemp_unregister_cleaner,
   absolute_symlink,
   check_no_overlapping_paths,
+  ensure_relative_file_name,
   fast_relpath,
   get_basedir,
   longest_dir_prefix,
@@ -91,6 +93,20 @@ class DirutilTest(unittest.TestCase):
       fast_relpath('/a/b', '/a/baseball')
     with self.assertRaises(ValueError):
       fast_relpath('/a/baseball', '/a/b')
+
+  def test_ensure_relative_file_name(self) -> None:
+    path = Path('./subdir/a.txt')
+    assert str(path) == 'subdir/a.txt'
+    assert ensure_relative_file_name(path) == './subdir/a.txt'
+
+    path = Path('./a.txt')
+    assert ensure_relative_file_name(path) == './a.txt'
+
+    path = Path('some_exe')
+    assert ensure_relative_file_name(path) == './some_exe'
+
+    path = Path('./leading_slash')
+    assert ensure_relative_file_name(path) == './leading_slash'
 
   @strict_patch('atexit.register')
   @strict_patch('os.getpid')


### PR DESCRIPTION
### Problem

We use the same boilerplate in `cloc.py` and `download_pex_bin.py` to wrap a `Snapshot` consumed by a `UrlToFetch`, e.g.: https://github.com/pantsbuild/pants/blob/43ffe73ada2fcbc2571172193c30b906d2de944f/src/python/pants/backend/python/rules/download_pex_bin.py#L64-L65

### Solution

- Create `SingleFileExecutable` dataclass in `engine/fs.py`, which validates that the input has only one file, and has a convenience method `.exe_filename` to return a relative path to the wrapped executable which can be used in a hermetic process execution.
- Use `SingleFileExecutable` for both `cloc` and `pex`.

### Result

Along with #8859, this helps to simplify the experience of fetching an executable via `UrlToFetch`!