### PR TITLE
Fix type hints for decorators in memo.py and meta.py

### DIFF
--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -70,7 +70,7 @@ python_library(
   dependencies = [
     ':meta'
   ],
-  tags = {'partially_type_checked'},
+  tags = {'type_checked'},
 )
 
 python_library(

--- a/src/python/pants/util/memo.py
+++ b/src/python/pants/util/memo.py
@@ -6,12 +6,7 @@ import inspect
 from contextlib import contextmanager
 from typing import Any, Callable, Optional, TypeVar
 
-from pants.util.meta import P, classproperty, staticproperty
-
-
-# NB: We liberally ignore MyPy issues in the implementations of these decorators. This is because
-#  it would be hard to both type the implementation correctly and get the call sites of the
-#  decorators properly typed. We care far more about the latter use case.
+from pants.util.meta import T, classproperty, staticproperty
 
 
 FuncType = Callable[..., Any]
@@ -66,7 +61,7 @@ def per_instance(*args, **kwargs):
 
 
 def memoized(
-  func: Optional[F] = None, *, key_factory=equal_args, cache_factory=dict,
+  func: Optional[F] = None, key_factory=equal_args, cache_factory=dict,
 ) -> F:
   """Memoizes the results of a function call.
 
@@ -150,7 +145,7 @@ def memoized(
 
 
 def memoized_method(
-  func: Optional[F] = None, *, key_factory=per_instance, cache_factory=dict,
+  func: Optional[F] = None, key_factory=per_instance, cache_factory=dict,
 ) -> F:
   """A convenience wrapper for memoizing instance methods.
 
@@ -190,8 +185,8 @@ def memoized_method(
 
 
 def memoized_property(
-  func: Optional[Callable[..., P]] = None, *, key_factory=per_instance, cache_factory=dict,
-) -> P:
+  func: Optional[Callable[..., T]] = None, key_factory=per_instance, cache_factory=dict,
+) -> T:
   """A convenience wrapper for memoizing properties.
 
   Applied like so:
@@ -261,7 +256,7 @@ def memoized_property(
 
 
 def memoized_classmethod(
-  func: Optional[F] = None, *, key_factory=per_instance, cache_factory=dict,
+  func: Optional[F] = None, key_factory=per_instance, cache_factory=dict,
 ) -> F:
   return classmethod(  # type: ignore[return-value]
     memoized_method(func, key_factory=key_factory, cache_factory=cache_factory)
@@ -269,15 +264,15 @@ def memoized_classmethod(
 
 
 def memoized_classproperty(
-  func: Optional[Callable[..., P]] = None, *, key_factory=per_instance, cache_factory=dict,
-) -> P:
+  func: Optional[Callable[..., T]] = None, key_factory=per_instance, cache_factory=dict,
+) -> T:
   return classproperty(
     memoized_classmethod(func, key_factory=key_factory, cache_factory=cache_factory)
   )
 
 
 def memoized_staticmethod(
-  func: Optional[F] = None, *, key_factory=equal_args, cache_factory=dict,
+  func: Optional[F] = None, key_factory=equal_args, cache_factory=dict,
 ) -> F:
   return staticmethod(  # type: ignore[return-value]
     memoized(func, key_factory=key_factory, cache_factory=cache_factory)
@@ -285,16 +280,16 @@ def memoized_staticmethod(
 
 
 def memoized_staticproperty(
-  func: Optional[Callable[..., P]] = None, *, key_factory=equal_args, cache_factory=dict,
-) -> P:
+  func: Optional[Callable[..., T]] = None, key_factory=equal_args, cache_factory=dict,
+) -> T:
   return staticproperty(
     memoized_staticmethod(func, key_factory=key_factory, cache_factory=cache_factory)
   )
 
 
 def testable_memoized_property(
-  func: Optional[Callable[..., P]] = None, key_factory=per_instance, cache_factory=dict,
-) -> P:
+  func: Optional[Callable[..., T]] = None, key_factory=per_instance, cache_factory=dict,
+) -> T:
   """A variant of `memoized_property` that allows for setting of properties (for tests, etc)."""
   getter = memoized_method(func=func, key_factory=key_factory, cache_factory=cache_factory)
 

--- a/src/python/pants/util/memo.py
+++ b/src/python/pants/util/memo.py
@@ -4,8 +4,18 @@
 import functools
 import inspect
 from contextlib import contextmanager
+from typing import Any, Callable, Optional, TypeVar
 
-from pants.util.meta import classproperty, staticproperty
+from pants.util.meta import P, classproperty, staticproperty
+
+
+# NB: We liberally ignore MyPy issues in the implementations of these decorators. This is because
+#  it would be hard to both type the implementation correctly and get the call sites of the
+#  decorators properly typed. We care far more about the latter use case.
+
+
+FuncType = Callable[..., Any]
+F = TypeVar("F", bound=FuncType)
 
 
 # Used as a sentinel that disambiguates tuples passed in *args from coincidentally matching tuples
@@ -55,7 +65,9 @@ def per_instance(*args, **kwargs):
   return equal_args(*instance_and_rest, **kwargs)
 
 
-def memoized(func=None, key_factory=equal_args, cache_factory=dict):
+def memoized(
+  func: Optional[F] = None, *, key_factory=equal_args, cache_factory=dict,
+) -> F:
   """Memoizes the results of a function call.
 
   By default, exactly one result is memoized for each unique combination of function arguments.
@@ -99,7 +111,9 @@ def memoized(func=None, key_factory=equal_args, cache_factory=dict):
     # application forms.  Without this trick, ie: using a decorator class or nested decorator
     # function, the no-params application would have to be `@memoized()`.  It still can, but need
     # not be and a bare `@memoized` will work as well as a `@memoized()`.
-    return functools.partial(memoized, key_factory=key_factory, cache_factory=cache_factory)
+    return functools.partial(  # type: ignore[return-value]
+      memoized, key_factory=key_factory, cache_factory=cache_factory
+    )
 
   if not inspect.isfunction(func):
     raise ValueError('The @memoized decorator must be applied innermost of all decorators.')
@@ -120,22 +134,24 @@ def memoized(func=None, key_factory=equal_args, cache_factory=dict):
   def put(*args, **kwargs):
     key = key_func(*args, **kwargs)
     yield functools.partial(memoized_results.__setitem__, key)
-  memoize.put = put
+  memoize.put = put  # type: ignore[attr-defined]
 
   def forget(*args, **kwargs):
     key = key_func(*args, **kwargs)
     if key in memoized_results:
       del memoized_results[key]
-  memoize.forget = forget
+  memoize.forget = forget  # type: ignore[attr-defined]
 
   def clear():
     memoized_results.clear()
-  memoize.clear = clear
+  memoize.clear = clear  # type: ignore[attr-defined]
 
-  return memoize
+  return memoize  # type: ignore[return-value]
 
 
-def memoized_method(func=None, key_factory=per_instance, **kwargs):
+def memoized_method(
+  func: Optional[F] = None, *, key_factory=per_instance, cache_factory=dict
+) -> F:
   """A convenience wrapper for memoizing instance methods.
 
   Typically you'd expect a memoized instance method to hold a cached value per class instance;
@@ -168,10 +184,14 @@ def memoized_method(func=None, key_factory=per_instance, **kwargs):
   :raises: `ValueError` if the wrapper is applied to anything other than a function.
   :returns: A wrapped function that memoizes its results or else a function wrapper that does this.
   """
-  return memoized(func=func, key_factory=key_factory, **kwargs)
+  return memoized(
+    func=func, key_factory=key_factory, cache_factory=cache_factory
+  )
 
 
-def memoized_property(func=None, key_factory=per_instance, **kwargs):
+def memoized_property(
+  func: Optional[Callable[..., P]] = None, *, key_factory=per_instance, cache_factory=dict,
+) -> P:
   """A convenience wrapper for memoizing properties.
 
   Applied like so:
@@ -233,34 +253,57 @@ def memoized_property(func=None, key_factory=per_instance, **kwargs):
   :returns: A read-only property that memoizes its calculated value and un-caches its value when
             `del`ed.
   """
-  getter = memoized_method(func=func, key_factory=key_factory, **kwargs)
-  return property(fget=getter, fdel=lambda self: getter.forget(self))
+  getter = memoized_method(func=func, key_factory=key_factory, cache_factory=cache_factory)
+  return property(  # type: ignore[return-value]
+    fget=getter,
+    fdel=lambda self: getter.forget(self),  # type: ignore[attr-defined, no-any-return]
+  )
 
 
-def memoized_classmethod(*args, **kwargs):
-  return classmethod(memoized_method(*args, **kwargs))
+def memoized_classmethod(
+  func: Optional[F] = None, *, key_factory=per_instance, cache_factory=dict
+) -> F:
+  return classmethod(  # type: ignore[return-value]
+    memoized_method(func, key_factory=key_factory, cache_factory=cache_factory)
+  )
 
 
-def memoized_classproperty(*args, **kwargs):
-  return classproperty(memoized_classmethod(*args, **kwargs))
+def memoized_classproperty(
+  func: Optional[Callable[..., P]] = None, *, key_factory=per_instance, cache_factory=dict,
+) -> P:
+  return classproperty(
+    memoized_classmethod(func, key_factory=key_factory, cache_factory=cache_factory)
+  )
 
 
-def memoized_staticmethod(*args, **kwargs):
-  return staticmethod(memoized(*args, **kwargs))
+def memoized_staticmethod(
+  func: Optional[F] = None, *, key_factory=per_instance, cache_factory=dict,
+) -> F:
+  return staticmethod(  # type: ignore[return-value]
+    memoized(func, key_factory=key_factory, cache_factory=cache_factory)
+  )
 
 
-def memoized_staticproperty(*args, **kwargs):
-  return staticproperty(memoized_staticmethod(*args, **kwargs))
+def memoized_staticproperty(
+  func: Optional[Callable[..., P]] = None, *, key_factory=per_instance, cache_factory=dict,
+) -> P:
+  return staticproperty(
+    memoized_staticmethod(func, key_factory=key_factory, cache_factory=cache_factory)
+  )
 
 
-def testable_memoized_property(func=None, key_factory=per_instance, **kwargs):
+def testable_memoized_property(
+  func: Optional[Callable[..., P]] = None, key_factory=per_instance, cache_factory=dict,
+) -> P:
   """A variant of `memoized_property` that allows for setting of properties (for tests, etc)."""
-  getter = memoized_method(func=func, key_factory=key_factory, **kwargs)
+  getter = memoized_method(func=func, key_factory=key_factory, cache_factory=cache_factory)
 
   def setter(self, val):
     with getter.put(self) as putter:
       putter(val)
 
-  return property(fget=getter,
-                  fset=setter,
-                  fdel=lambda self: getter.forget(self))
+  return property(  # type: ignore[return-value]
+    fget=getter,
+    fset=setter,
+    fdel=lambda self: getter.forget(self),  # type: ignore[attr-defined, no-any-return]
+  )

--- a/src/python/pants/util/memo.py
+++ b/src/python/pants/util/memo.py
@@ -150,7 +150,7 @@ def memoized(
 
 
 def memoized_method(
-  func: Optional[F] = None, *, key_factory=per_instance, cache_factory=dict
+  func: Optional[F] = None, *, key_factory=per_instance, cache_factory=dict,
 ) -> F:
   """A convenience wrapper for memoizing instance methods.
 
@@ -261,7 +261,7 @@ def memoized_property(
 
 
 def memoized_classmethod(
-  func: Optional[F] = None, *, key_factory=per_instance, cache_factory=dict
+  func: Optional[F] = None, *, key_factory=per_instance, cache_factory=dict,
 ) -> F:
   return classmethod(  # type: ignore[return-value]
     memoized_method(func, key_factory=key_factory, cache_factory=cache_factory)
@@ -277,7 +277,7 @@ def memoized_classproperty(
 
 
 def memoized_staticmethod(
-  func: Optional[F] = None, *, key_factory=per_instance, cache_factory=dict,
+  func: Optional[F] = None, *, key_factory=equal_args, cache_factory=dict,
 ) -> F:
   return staticmethod(  # type: ignore[return-value]
     memoized(func, key_factory=key_factory, cache_factory=cache_factory)
@@ -285,7 +285,7 @@ def memoized_staticmethod(
 
 
 def memoized_staticproperty(
-  func: Optional[Callable[..., P]] = None, *, key_factory=per_instance, cache_factory=dict,
+  func: Optional[Callable[..., P]] = None, *, key_factory=equal_args, cache_factory=dict,
 ) -> P:
   return staticproperty(
     memoized_staticmethod(func, key_factory=key_factory, cache_factory=cache_factory)

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -6,6 +6,13 @@ from functools import wraps
 from typing import Any, Callable, Optional, Type, TypeVar, Union
 
 
+T = TypeVar("T")
+C = TypeVar("C")
+# This TypeVar is used to annotate property decorators. The decorator should take the parameter
+# func=Callable[..., P] and return P.
+P = TypeVar("P")
+
+
 class SingletonMetaclass(type):
   """When using this metaclass in your class definition, your class becomes a singleton. That is,
   every construction returns the same instance.
@@ -21,9 +28,6 @@ class SingletonMetaclass(type):
     if not hasattr(cls, 'instance'):
       cls.instance = super().__call__(*args, **kwargs)
     return cls.instance
-
-
-T = TypeVar("T")
 
 
 class ClassPropertyDescriptor:
@@ -54,7 +58,7 @@ with an @classproperty decorator."""
     return callable_field()
 
 
-def classproperty(func: Union[classmethod, staticmethod, Callable]) -> ClassPropertyDescriptor:
+def classproperty(func: Callable[..., P]) -> P:
   """Use as a decorator on a method definition to make it a class-level attribute.
 
   This decorator can be applied to a method, a classmethod, or a staticmethod. This decorator will
@@ -77,12 +81,17 @@ def classproperty(func: Union[classmethod, staticmethod, Callable]) -> ClassProp
   doc = func.__doc__
 
   if not isinstance(func, (classmethod, staticmethod)):
-    func = classmethod(func)
+    # MyPy complains about converting a Callable -> classmethod. We use a Callable in the first
+    # place because there is no typing.classmethod, i.e. a type that takes generic arguments, and
+    # we need to use TypeVars for the call sites of this decorator to work properly.
+    func = classmethod(func)  # type: ignore[assignment]
 
-  return ClassPropertyDescriptor(func, doc)
+  # If we properly annotated this function as returning a ClassPropertyDescriptor, then MyPy would
+  # no longer work correctly at call sites for this decorator.
+  return ClassPropertyDescriptor(func, doc)  # type: ignore[arg-type, return-value]
 
 
-def staticproperty(func: Union[staticmethod, Callable]) -> ClassPropertyDescriptor:
+def staticproperty(func: Callable[..., P]) -> P:
   """Use as a decorator on a method definition to make it a class-level attribute (without binding).
 
   This decorator can be applied to a method or a staticmethod. This decorator does not bind any
@@ -106,12 +115,17 @@ def staticproperty(func: Union[staticmethod, Callable]) -> ClassPropertyDescript
   doc = func.__doc__
 
   if not isinstance(func, staticmethod):
-    func = staticmethod(func)
+    # MyPy complains about converting a Callable -> staticmethod. We use a Callable in the first
+    # place because there is no typing.staticmethod, i.e. a type that takes generic arguments, and
+    # we need to use TypeVars for the call sites of this decorator to work properly.
+    func = staticmethod(func)  # type: ignore[assignment]
 
-  return ClassPropertyDescriptor(func, doc)
+  # If we properly annotated this function as returning a ClassPropertyDescriptor, then MyPy would
+  # no longer work correctly at call sites for this decorator.
+  return ClassPropertyDescriptor(func, doc)  # type: ignore[arg-type, return-value]
 
 
-def frozen_after_init(cls: Type[T]) -> Type[T]:
+def frozen_after_init(cls: Type[C]) -> Type[C]:
   """Class decorator to freeze any modifications to the object after __init__() is done.
 
   The primary use case is for @dataclasses who cannot use frozen=True due to the need for a custom


### PR DESCRIPTION
## Problem
All of our decorators like `@classproperty`, `@memoized_method`, and `@memoized_classproperty` did not work properly at call sites, which has been blocking the type hints project.

## Solution
We make a conscious tradeoff to have MyPy ignore the implementation of the decorators to instead have the correct type hints for call sites. Originally, we were focused on getting the type hints for the implementation to be correct. However, the call sites are what really matter for these decorators.

## Result
We can now use all of the decorators from `meta.py` and `memo.py` as expected, which unblocks the type hints project.

For example, MyPy now understands this:

```python
class Example:
  
   @classproperty
   def my_prop() -> str:
     return "I'm a class property!"
  
  
   @memoized_method
   def my_memoized_func(x: int) -> float
      return float(x)


assert Example.my_prop ==  "I'm a class property!"
assert isinstance(Example().my_memoized_func(2), float)
```
