### PR TITLE
stop treating python 4 as special

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -404,7 +404,7 @@ verify_commit: False
 
 
 [python-setup]
-interpreter_constraints: ["CPython>=3.6,<4"]
+interpreter_constraints: ["CPython>=3.6"]
 interpreter_cache_dir: %(pants_bootstrapdir)s/python_cache/interpreters
 resolver_cache_dir: %(pants_bootstrapdir)s/python_cache/requirements
 

--- a/src/python/pants/backend/native/subsystems/packaging/conan.py
+++ b/src/python/pants/backend/native/subsystems/packaging/conan.py
@@ -15,4 +15,4 @@ class Conan(PythonToolBase):
   # NB: Only versions of pylint below `2.0.0` support use in python 2.
   default_extra_requirements = ['pylint==1.9.3']
   default_entry_point = 'conans.conan'
-  default_interpreter_constraints = ['CPython>=2.7,<4']
+  default_interpreter_constraints = ['CPython>=2.7']

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -124,7 +124,7 @@ class TestResolveRequirements(TestBase):
 
   def test_interpreter_constraints(self) -> None:
     constraints = PexInterpreterConstraints(
-        constraint_set=("CPython>=2.7,<3", "CPython>=3.6,<4")
+        constraint_set=("CPython>=2.7,<3", "CPython>=3.6")
     )
     pex_info = self.create_pex_and_get_pex_info(interpreter_constraints=constraints)
     self.assertEqual(set(pex_info["interpreter_constraints"]), set(constraints.constraint_set))

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -24,7 +24,7 @@ class PythonSetup(Subsystem):
   def register_options(cls, register):
     super().register_options(register)
     register('--interpreter-constraints', advanced=True, fingerprint=True, type=list,
-             default=['CPython>=2.7,<3', 'CPython>=3.6,<4'],
+             default=['CPython>=2.7,<3', 'CPython>=3.6'],
              metavar='<requirement>',
              help="Constrain the selected Python interpreter.  Specify with requirement syntax, "
                   "e.g. 'CPython>=2.7,<3' (A CPython interpreter with version >=2.7 AND version <3)"
@@ -75,8 +75,8 @@ class PythonSetup(Subsystem):
                    "Python 3.6+. In preparation for this change, you should explicitly mark what "
                    "Python version(s) your project uses in your `pants.ini` under the section "
                    "`python-setup`.\n\nFor example, if you need to still support Python 2, set "
-                   "`interpreter_constraints` to `['CPython>=2.7,<3', 'CPython>=3.6<4']`. "
-                   "Otherwise, set the value to something like `['CPython>=3.6<4']`. See "
+                   "`interpreter_constraints` to `['CPython>=2.7,<3', 'CPython>=3.6']`. "
+                   "Otherwise, set the value to something like `['CPython>=3.6']`. See "
                    "https://www.pantsbuild.org/python_readme.html#configure-the-python-version "
                    "for more information on setting interpreter constraints."
     )

--- a/testprojects/src/python/interpreter_selection/BUILD
+++ b/testprojects/src/python/interpreter_selection/BUILD
@@ -8,7 +8,7 @@ python_library(
   name = 'echo_interpreter_version_lib',
   sources = ['echo_interpreter_version.py'],
   # Play with this to test interpreter selection in the pex machinery.
-  compatibility = ['CPython>=2.7,<4']
+  compatibility = ['CPython>=2.7']
 )
 
 python_binary(

--- a/testprojects/src/python/interpreter_selection/python_3_selection_testing/BUILD
+++ b/testprojects/src/python/interpreter_selection/python_3_selection_testing/BUILD
@@ -77,7 +77,7 @@ python_tests(
 python_binary(
   name='main_py23',
   source='main_py23.py',
-  compatibility=['CPython>2.7,<4'],
+  compatibility=['CPython>2.7'],
   dependencies=[
     ':lib_py23'
   ]
@@ -86,7 +86,7 @@ python_binary(
 python_library(
   name='lib_py23',
   sources=['lib_py23.py'],
-  compatibility=['CPython>2.7,<4']
+  compatibility=['CPython>2.7']
 )
 
 python_tests(
@@ -97,5 +97,5 @@ python_tests(
   dependencies=[
     ':main_py23'
   ],
-  compatibility=['CPython>2.7,<4']
+  compatibility=['CPython>2.7']
 )

--- a/testprojects/src/python/nested_runs/BUILD
+++ b/testprojects/src/python/nested_runs/BUILD
@@ -1,6 +1,6 @@
 python_binary(
   name="nested_runs",
   source="run_pants_with_pantsd.py",
-  compatibility=['CPython>=3.6,<4']
+  compatibility=['CPython>=3.6']
 )
 

--- a/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_interpreter_selection_integration.py
@@ -33,7 +33,7 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
 
   def _build_pex(self, binary_target, config=None, args=None, version=PY_27):
     # By default, Avoid some known-to-choke-on interpreters.
-    constraint = '["CPython>=3.6,<4"]' if version == PY_3 else '["CPython>=2.7,<3"]'
+    constraint = '["CPython>=3.6"]' if version == PY_3 else '["CPython>=2.7,<3"]'
     args = list(args) if args is not None else [
           f'--python-setup-interpreter-constraints={constraint}'
         ]
@@ -125,7 +125,7 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
         }
       }
       args = [
-          '--python-setup-interpreter-constraints=["CPython>=3.6,<4"]',
+          '--python-setup-interpreter-constraints=["CPython>=3.6"]',
         ]
       binary_name = 'echo_interpreter_version'
       binary_target = f'{self.testproject}:{binary_name}'

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -313,7 +313,7 @@ python_tests(
 python_tests(
   name = "py23-tests",
   sources = ["py23_test_source.py"],
-  compatibility = ['CPython>=2.7,<4'],
+  compatibility = ['CPython>=2.7'],
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -169,7 +169,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     with temporary_dir() as interpreters_cache:
       pants_ini_config = {
         'python-setup': {
-          'interpreter_constraints': ['CPython>=2.7,<4'],
+          'interpreter_constraints': ['CPython>=2.7'],
           'interpreter_cache_dir': interpreters_cache,
         },
         # NB: we pin Pytest to 4.6 to ensure Pytest still works with Python 2.
@@ -196,7 +196,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     with temporary_dir() as interpreters_cache:
       pants_ini_config = {
         'python-setup': {
-          'interpreter_constraints': ['CPython>=2.7,<4'],
+          'interpreter_constraints': ['CPython>=2.7'],
           'interpreter_cache_dir': interpreters_cache,
         }
       }

--- a/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
@@ -21,7 +21,7 @@ from pants.util.contextutil import temporary_dir
 class PythonRunIntegrationTest(PantsRunIntegrationTest):
   testproject = 'testprojects/src/python/interpreter_selection'
   py2_interpreter_constraint = 'CPython>=2.7,<3'
-  py3_interpreter_constraint = 'CPython>=3.6,<4'
+  py3_interpreter_constraint = 'CPython>=3.6'
 
   @classmethod
   def hermetic(cls):

--- a/tests/python/pants_test/backend/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/backend/python/test_interpreter_cache.py
@@ -81,7 +81,7 @@ class TestInterpreterCache(TestBase):
       with self._setup_cache(constraints=['CPython>=2.7,<3'],
                              search_paths=['<PEXRC>']) as (cache, _):
         self.assertIn(py27_path, {pi.binary for pi in cache.setup()})
-      with self._setup_cache(constraints=['CPython>=3.6,<4'],
+      with self._setup_cache(constraints=['CPython>=3.6'],
                              search_paths=['<PEXRC>']) as (cache, _):
         self.assertIn(py36_path, {pi.binary for pi in cache.setup()})
 


### PR DESCRIPTION
### Problem

CPython does not use semantic versioning. As such all releases may and
typically do break things from previous versions. Restricting the
interpreter to less python 4 is confusing and semantically meaningless.

### Solution

Don't impose an upper bound on cpython versions