### PR TITLE
Type check `build-support/bin/generate_travis_yml.py`

### DIFF
--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -77,6 +77,7 @@ python_binary(
   dependencies = [
     '3rdparty/python:PyYAML',
   ],
+  tags = {'type_checked'},
 )
 
 python_binary(


### PR DESCRIPTION
While we had added type hints from the start, it turns out that MyPy wasn't actually running against the script. We need to fix all the issues before being able to run MyPy against all targets by default.