### PR TITLE
Fix isort, Pytest, and MyPy options to be fingerprinted

### DIFF
--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -24,3 +24,8 @@ target(
     'contrib/thrifty/src/python/pants/contrib/thrifty:plugin',
   ]
 )
+
+files(
+  name = 'isort_cfg',
+  source = '.isort.cfg',
+)

--- a/contrib/mypy/src/python/pants/contrib/mypy/subsystems/subsystem.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/subsystems/subsystem.py
@@ -18,12 +18,12 @@ class MyPy(PythonToolBase):
   def register_options(cls, register):
     super().register_options(register)
     register(
-      '--args', type=list, member_type=str,
+      '--args', type=list, member_type=str, fingerprint=True,
       help="Arguments to pass directly to mypy, e.g. "
            "`--mypy-args=\"--python-version 3.7 --disallow-any-expr\"`",
     )
     register(
-      '--config', type=file_option,
+      '--config', type=file_option, fingerprint=True,
       help="Path to `mypy.ini` or alternative MyPy config file"
     )
 

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -5,3 +5,8 @@ files(
   name = '3rdparty_directory',
   sources = rglobs('3rdparty/*'),
 )
+
+files(
+  name = 'isort_cfg',
+  source = '.isort.cfg',
+)

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -18,12 +18,12 @@ class Isort(PythonToolBase):
   def register_options(cls, register):
     super().register_options(register)
     register(
-      '--args', type=list, member_type=str,
+      '--args', type=list, member_type=str, fingerprint=True,
       help="Arguments to pass directly to isort, e.g. "
            "`--isort-args=\"--case-sensitive --trailing-comma\"`",
     )
     register(
-      '--config', type=list, member_type=file_option,
+      '--config', type=list, member_type=file_option, fingerprint=True,
       help="Path to `isort.cfg` or alternative isort config file(s)"
     )
 

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -15,14 +15,15 @@ class PyTest(Subsystem):
   def register_options(cls, register):
     super().register_options(register)
     register(
-      '--args', type=list, member_type=str,
+      '--args', type=list, member_type=str, fingerprint=True,
       help="Arguments to pass directly to Pytest, e.g. `--pytest-args=\"-k test_foo --quiet\"`",
     )
-    register('--version', default='pytest>=4.6.6,<4.7',
-             help="Requirement string for Pytest.", fingerprint=True)
+    register('--version', default='pytest>=4.6.6,<4.7', fingerprint=True,
+             help="Requirement string for Pytest.")
     register(
       '--pytest-plugins',
       type=list,
+      fingerprint=True,
       default=[
         'pytest-timeout>=1.3.3,<1.4',
         'pytest-cov>=2.8.1,<3',
@@ -30,7 +31,6 @@ class PyTest(Subsystem):
         "more-itertools<6.0.0 ; python_version<'3'",
       ],
       help="Requirement strings for any plugins or additional requirements you'd like to use.",
-      fingerprint=True
     )
     register('--requirements', advanced=True, default='pytest>=4.6.6,<4.7',
              help='Requirements string for the pytest library.',

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -85,6 +85,8 @@ python_tests(
   name = 'isort_run_integration',
   sources = ['test_isort_run_integration.py'],
   dependencies = [
+    'contrib:isort_cfg',
+    'examples:isort_cfg',
     'src/python/pants/backend/python/tasks',
     'src/python/pants/testutil:int-test',
     'testprojects/tests/java/org/pantsbuild/testproject:dummies_directory',

--- a/tests/python/pants_test/backend/python/tasks/test_isort_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_isort_run_integration.py
@@ -9,11 +9,12 @@ class IsortRunIntegrationTest(PantsRunIntegrationTest):
 
   @ensure_daemon
   def test_isort_no_python_sources_should_noop(self):
-    command = ['-ldebug',
-               'fmt.isort',
-               'testprojects/tests/java/org/pantsbuild/testproject/dummies/::',
-               '--',
-               '--check-only']
+    command = [
+      '-ldebug',
+      'fmt.isort',
+      'testprojects/tests/java/org/pantsbuild/testproject/dummies/::',
+      "--isort-args='--check-only'",
+    ]
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
-    self.assertIn(IsortRun.NOOP_MSG_HAS_TARGET_BUT_NO_SOURCE, pants_run.stderr_data)
+    assert IsortRun.NOOP_MSG_HAS_TARGET_BUT_NO_SOURCE in pants_run.stderr_data


### PR DESCRIPTION
These subsystems recently got new options like `--args` that were accidentally not marked as having `fingerprint=True`. This was missed because in V2 `fingerprint=True` is irrelevant, but now that we've hooked these options up to V1 we need to fix this oversight.

We don't modify `black/subsystem.py` and `flake8/subsystem.py` because those are solely used by V2.