### PR TITLE
Refactor `option` and `subsystem` tests

### DIFF
--- a/src/python/pants/option/arg_splitter_test.py
+++ b/src/python/pants/option/arg_splitter_test.py
@@ -18,15 +18,15 @@ from pants.option.scope import ScopeInfo
 from pants.util.contextutil import pushd, temporary_dir
 
 
-def task(scope: str) -> ScopeInfo:
+def task(scope):
   return ScopeInfo(scope, ScopeInfo.TASK)
 
 
-def intermediate(scope: str) -> ScopeInfo:
+def intermediate(scope):
   return ScopeInfo(scope, ScopeInfo.INTERMEDIATE)
 
 
-def subsys(scope: str) -> ScopeInfo:
+def subsys(scope):
   return ScopeInfo(scope, ScopeInfo.SUBSYSTEM)
 
 

--- a/src/python/pants/option/arg_splitter_test.py
+++ b/src/python/pants/option/arg_splitter_test.py
@@ -4,6 +4,8 @@
 import os
 import shlex
 import unittest
+from functools import partial
+from typing import Dict, List, Optional
 
 from pants.option.arg_splitter import (
   ArgSplitter,
@@ -16,15 +18,15 @@ from pants.option.scope import ScopeInfo
 from pants.util.contextutil import pushd, temporary_dir
 
 
-def task(scope):
+def task(scope: str) -> ScopeInfo:
   return ScopeInfo(scope, ScopeInfo.TASK)
 
 
-def intermediate(scope):
+def intermediate(scope: str) -> ScopeInfo:
   return ScopeInfo(scope, ScopeInfo.INTERMEDIATE)
 
 
-def subsys(scope):
+def subsys(scope: str) -> ScopeInfo:
   return ScopeInfo(scope, ScopeInfo.SUBSYSTEM)
 
 
@@ -33,10 +35,20 @@ class ArgSplitterTest(unittest.TestCase):
                         subsys('jvm'), subsys('jvm.test.junit'),
                         subsys('reporting'), intermediate('test'), task('test.junit')]
 
-  def _split(self, args_str, expected_goals, expected_scope_to_flags, expected_positional_args,
-             expected_passthru=None, expected_passthru_owner=None,
-             expected_is_help=False, expected_help_advanced=False, expected_help_all=False,
-             expected_unknown_scopes=None):
+  def assert_valid_split(
+    self,
+    args_str: str,
+    *,
+    expected_goals: List[str],
+    expected_scope_to_flags: Dict[str, List[str]],
+    expected_positional_args: List[str],
+    expected_passthru: Optional[List[str]] = None,
+    expected_passthru_owner: Optional[str] = None,
+    expected_is_help: bool = False,
+    expected_help_advanced: bool = False,
+    expected_help_all: bool = False,
+    expected_unknown_scopes: Optional[List[str]] = None
+  ) -> None:
     expected_passthru = expected_passthru or []
     expected_unknown_scopes = expected_unknown_scopes or []
     splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
@@ -56,35 +68,11 @@ class ArgSplitterTest(unittest.TestCase):
                        splitter.help_request.all_scopes))
     self.assertEqual(expected_unknown_scopes, split_args.unknown_scopes)
 
-  def _split_help(self, args_str, expected_goals, expected_scope_to_flags, expected_target_specs,
-                  expected_help_advanced=False, expected_help_all=False):
-    self._split(args_str, expected_goals, expected_scope_to_flags, expected_target_specs,
-                expected_passthru=None, expected_passthru_owner=None,
-                expected_is_help=True,
-                expected_help_advanced=expected_help_advanced,
-                expected_help_all=expected_help_all)
-
-  def _split_version_request(self, args_str):
-    splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
-    splitter.split_args(shlex.split(args_str))
-    self.assertTrue(isinstance(splitter.help_request, VersionHelp))
-
-  def _split_unknown_goal(self, args_str, unknown_goals):
-    splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
-    result = splitter.split_args(shlex.split(args_str))
-    self.assertTrue(isinstance(splitter.help_request, UnknownGoalHelp))
-    self.assertSetEqual(set(unknown_goals), set(splitter.help_request.unknown_goals))
-    self.assertEqual(result.unknown_scopes, unknown_goals)
-
-  def _split_no_goal(self, args_str):
-    splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
-    splitter.split_args(shlex.split(args_str))
-    self.assertTrue(isinstance(splitter.help_request, NoGoalHelp))
-
-  def test_is_positional_arg(self):
-    def assert_positional(arg):
+  def test_is_positional_arg(self) -> None:
+    def assert_positional(arg: str) -> None:
       self.assertTrue(ArgSplitter.is_positional_arg(arg))
-    def assert_not_positional(arg):
+
+    def assert_not_positional(arg: str) -> None:
       self.assertFalse(ArgSplitter.is_positional_arg(arg))
 
     assert_positional('a/b/c')
@@ -98,140 +86,259 @@ class ArgSplitterTest(unittest.TestCase):
     assert_not_positional('foo')
     assert_not_positional('a_b_c')
 
-  def test_basic_arg_splitting(self):
+  def test_basic_arg_splitting(self) -> None:
     # Various flag combos.
-    self._split('./pants --compile-java-long-flag -f compile -g compile.java -x test.junit -i '
-                'src/java/org/pantsbuild/foo src/java/org/pantsbuild/bar:baz',
-                ['compile', 'test'],
-                {
-                  '': ['-f'],
-                  'compile.java': ['--long-flag', '-x'],
-                  'compile': ['-g'],
-                  'test.junit': ['-i']
-                },
-                ['src/java/org/pantsbuild/foo', 'src/java/org/pantsbuild/bar:baz'])
-    self._split('./pants -farg --fff=arg compile --gg-gg=arg-arg -g test.junit --iii '
-                '--compile-java-long-flag src/java/org/pantsbuild/foo src/java/org/pantsbuild/bar:baz',
-                ['compile', 'test'],
-                {
-                  '': ['-farg', '--fff=arg'],
-                  'compile': ['--gg-gg=arg-arg', '-g'],
-                  'test.junit': ['--iii'],
-                  'compile.java': ['--long-flag'],
-                },
-                ['src/java/org/pantsbuild/foo', 'src/java/org/pantsbuild/bar:baz'])
+    self.assert_valid_split(
+      './pants --compile-java-long-flag -f compile -g compile.java -x test.junit -i '
+      'src/java/org/pantsbuild/foo src/java/org/pantsbuild/bar:baz',
+      expected_goals=['compile', 'test'],
+      expected_scope_to_flags={
+        '': ['-f'],
+        'compile.java': ['--long-flag', '-x'],
+        'compile': ['-g'],
+        'test.junit': ['-i']
+      },
+      expected_positional_args=['src/java/org/pantsbuild/foo', 'src/java/org/pantsbuild/bar:baz'],
+    )
+    self.assert_valid_split(
+      './pants -farg --fff=arg compile --gg-gg=arg-arg -g test.junit --iii '
+      '--compile-java-long-flag src/java/org/pantsbuild/foo src/java/org/pantsbuild/bar:baz',
+      expected_goals=['compile', 'test'],
+      expected_scope_to_flags={
+        '': ['-farg', '--fff=arg'],
+        'compile': ['--gg-gg=arg-arg', '-g'],
+        'test.junit': ['--iii'],
+        'compile.java': ['--long-flag'],
+      },
+      expected_positional_args=['src/java/org/pantsbuild/foo', 'src/java/org/pantsbuild/bar:baz'],
+    )
 
-  def test_distinguish_goals_from_target_specs(self):
-    self._split('./pants compile test foo::', ['compile', 'test'],
-                {'': [], 'compile': [], 'test': []}, ['foo::'])
-    self._split('./pants compile test foo::', ['compile', 'test'],
-                {'': [], 'compile': [], 'test': []}, ['foo::'])
-    self._split('./pants compile test:test', ['compile'], {'': [], 'compile': []}, ['test:test'])
-    self._split('./pants test test:test', ['test'], {'': [], 'test': []}, ['test:test'])
-    self._split('./pants test ./test', ['test'], {'': [], 'test': []}, ['./test'])
-    self._split('./pants test //test', ['test'], {'': [], 'test': []}, ['//test'])
+  def test_distinguish_goals_from_positional_args(self) -> None:
+    self.assert_valid_split(
+      './pants compile test foo::',
+      expected_goals=['compile', 'test'],
+      expected_scope_to_flags={'': [], 'compile': [], 'test': []},
+      expected_positional_args=['foo::'],
+    )
+    self.assert_valid_split(
+      './pants compile test foo::',
+      expected_goals=['compile', 'test'],
+      expected_scope_to_flags={'': [], 'compile': [], 'test': []},
+      expected_positional_args=['foo::'],
+    )
+    self.assert_valid_split(
+      './pants compile test:test',
+      expected_goals=['compile'],
+      expected_scope_to_flags={'': [], 'compile': []},
+      expected_positional_args=['test:test'],
+    )
+    self.assert_valid_split(
+      './pants test test:test',
+      expected_goals=['test'],
+      expected_scope_to_flags={'': [], 'test': []},
+      expected_positional_args=['test:test'],
+    )
+    self.assert_valid_split(
+      './pants test ./test',
+      expected_goals=['test'],
+      expected_scope_to_flags={'': [], 'test': []},
+      expected_positional_args=['./test'],
+    )
+    self.assert_valid_split(
+      './pants test //test',
+      expected_goals=['test'],
+      expected_scope_to_flags={'': [], 'test': []},
+      expected_positional_args=['//test'],
+    )
 
-  def test_descoping_qualified_flags(self):
-    self._split('./pants compile test --compile-java-bar --no-test-junit-baz foo/bar',
-                ['compile', 'test'],
-                {'': [], 'compile': [], 'compile.java': ['--bar'], 'test': [],
-                 'test.junit': ['--no-baz']}, ['foo/bar'])
-
+  def test_descoping_qualified_flags(self) -> None:
+    self.assert_valid_split(
+      './pants compile test --compile-java-bar --no-test-junit-baz foo/bar',
+      expected_goals=['compile', 'test'],
+      expected_scope_to_flags={
+        '': [], 'compile': [], 'compile.java': ['--bar'], 'test': [], 'test.junit': ['--no-baz']
+      },
+      expected_positional_args=['foo/bar'],
+    )
     # Qualified flags don't count as explicit goals.
-    self._split('./pants compile --test-junit-bar foo/bar',
-                ['compile'],
-                {'': [], 'compile': [], 'test.junit': ['--bar']}, ['foo/bar'])
+    self.assert_valid_split(
+      './pants compile --test-junit-bar foo/bar',
+      expected_goals=['compile'],
+      expected_scope_to_flags={'': [], 'compile': [], 'test.junit': ['--bar']},
+      expected_positional_args=['foo/bar'],
+    )
 
-  def test_passthru_args(self):
-    self._split('./pants test foo/bar -- -t arg',
-                ['test'],
-                {'': [], 'test': []},
-                ['foo/bar'],
-                expected_passthru=['-t', 'arg'],
-                expected_passthru_owner='test')
-    self._split('./pants -farg --fff=arg compile --gg-gg=arg-arg -g test.junit --iii '
-                '--compile-java-long-flag src/java/org/pantsbuild/foo '
-                'src/java/org/pantsbuild/bar:baz '
-                '-- passthru1 passthru2',
-                ['compile', 'test'],
-                {
-                  '': ['-farg', '--fff=arg'],
-                  'compile': ['--gg-gg=arg-arg', '-g'],
-                  'compile.java': ['--long-flag'],
-                  'test.junit': ['--iii']
-                },
-                ['src/java/org/pantsbuild/foo', 'src/java/org/pantsbuild/bar:baz'],
-                expected_passthru=['passthru1', 'passthru2'],
-                expected_passthru_owner='test.junit')
+  def test_passthru_args(self) -> None:
+    self.assert_valid_split(
+      './pants test foo/bar -- -t arg',
+      expected_goals=['test'],
+      expected_scope_to_flags={'': [], 'test': []},
+      expected_positional_args=['foo/bar'],
+      expected_passthru=['-t', 'arg'],
+      expected_passthru_owner='test',
+    )
+    self.assert_valid_split(
+      './pants -farg --fff=arg compile --gg-gg=arg-arg -g test.junit --iii '
+      '--compile-java-long-flag src/java/org/pantsbuild/foo src/java/org/pantsbuild/bar:baz -- '
+      'passthru1 passthru2',
+      expected_goals=['compile', 'test'],
+      expected_scope_to_flags={
+        '': ['-farg', '--fff=arg'],
+        'compile': ['--gg-gg=arg-arg', '-g'],
+        'compile.java': ['--long-flag'],
+        'test.junit': ['--iii']
+      },
+      expected_positional_args=['src/java/org/pantsbuild/foo', 'src/java/org/pantsbuild/bar:baz'],
+      expected_passthru=['passthru1', 'passthru2'],
+      expected_passthru_owner='test.junit'
+    )
 
-  def test_subsystem_flags(self):
+  def test_subsystem_flags(self) -> None:
     # Global subsystem flag in global scope.
-    self._split('./pants --jvm-options=-Dbar=baz test foo:bar',
-                ['test'],
-                {'': [], 'jvm': ['--options=-Dbar=baz'], 'test': []}, ['foo:bar'])
+    self.assert_valid_split(
+      './pants --jvm-options=-Dbar=baz test foo:bar',
+      expected_goals=['test'],
+      expected_scope_to_flags={'': [], 'jvm': ['--options=-Dbar=baz'], 'test': []},
+      expected_positional_args=['foo:bar']
+    )
     # Qualified task subsystem flag in global scope.
-    self._split('./pants --jvm-test-junit-options=-Dbar=baz test foo:bar',
-                ['test'],
-                {'': [], 'jvm.test.junit': ['--options=-Dbar=baz'], 'test': []}, ['foo:bar'])
+    self.assert_valid_split(
+      './pants --jvm-test-junit-options=-Dbar=baz test foo:bar',
+      expected_goals=['test'],
+      expected_scope_to_flags={'': [], 'jvm.test.junit': ['--options=-Dbar=baz'], 'test': []},
+      expected_positional_args=['foo:bar']
+    )
     # Unqualified task subsystem flag in task scope.
     # Note that this exposes a small problem: You can't set an option on the cmd-line if that
     # option's name begins with any subsystem scope. For example, if test.junit has some option
     # named --jvm-foo, then it cannot be set on the cmd-line, because the ArgSplitter will assume
     # it's an option --foo on the jvm subsystem.
-    self._split('./pants test.junit --jvm-options=-Dbar=baz foo:bar',
-                ['test'],
-                {'': [], 'jvm.test.junit': ['--options=-Dbar=baz'], 'test.junit': []}, ['foo:bar'])
+    self.assert_valid_split(
+      './pants test.junit --jvm-options=-Dbar=baz foo:bar',
+      expected_goals=['test'],
+      expected_scope_to_flags={'': [], 'jvm.test.junit': ['--options=-Dbar=baz'], 'test.junit': []},
+      expected_positional_args=['foo:bar'])
     # Global-only flag in task scope.
-    self._split('./pants test.junit --reporting-template-dir=path foo:bar',
-                ['test'],
-                {'': [], 'reporting': ['--template-dir=path'], 'test.junit': []}, ['foo:bar'])
+    self.assert_valid_split(
+      './pants test.junit --reporting-template-dir=path foo:bar',
+      expected_goals=['test'],
+      expected_scope_to_flags={'': [], 'reporting': ['--template-dir=path'], 'test.junit': []},
+      expected_positional_args=['foo:bar']
+    )
 
-  def test_help_detection(self):
-    self._split_help('./pants', [], {'': []}, [])
-    self._split_help('./pants -f', [], {'': ['-f']}, [])
-    self._split_help('./pants help', [], {'': []}, [])
-    self._split_help('./pants -h', [], {'': []}, [])
-    self._split_help('./pants --help', [], {'': []}, [])
-    self._split_help('./pants help compile -x', ['compile'],
-                {'': [], 'compile': ['-x']}, [])
-    self._split_help('./pants help compile -x', ['compile'],
-                {'': [], 'compile': ['-x']}, [])
-    self._split_help('./pants compile -h', ['compile'],
-                {'': [], 'compile': []}, [])
-    self._split_help('./pants compile --help test', ['compile', 'test'],
-                {'': [], 'compile': [], 'test': []}, [])
-    self._split_help('./pants test src/foo/bar:baz -h', ['test'],
-                {'': [], 'test': []}, ['src/foo/bar:baz'])
+  def test_help_detection(self) -> None:
+    assert_help = partial(
+      self.assert_valid_split, expected_passthru=None, expected_passthru_owner=None, expected_is_help=True,
+    )
+    assert_help_no_arguments = partial(
+      assert_help, expected_goals=[], expected_scope_to_flags={'': []}, expected_positional_args=[],
+    )
+    assert_help_no_arguments('./pants')
+    assert_help_no_arguments('./pants help')
+    assert_help_no_arguments('./pants -h')
+    assert_help_no_arguments('./pants --help')
+    assert_help_no_arguments('./pants help-advanced', expected_help_advanced=True)
+    assert_help_no_arguments('./pants help --help-advanced', expected_help_advanced=True)
+    assert_help_no_arguments('./pants --help-advanced', expected_help_advanced=True)
+    assert_help_no_arguments('./pants --help --help-advanced', expected_help_advanced=True)
+    assert_help_no_arguments('./pants --help-advanced --help', expected_help_advanced=True)
+    assert_help_no_arguments('./pants help-all', expected_help_all=True)
+    assert_help_no_arguments('./pants --help-all', expected_help_all=True)
+    assert_help_no_arguments('./pants --help --help-all', expected_help_all=True)
+    assert_help_no_arguments(
+      './pants help-advanced --help-all', expected_help_advanced=True, expected_help_all=True,
+    )
+    assert_help_no_arguments(
+      './pants --help-all --help --help-advanced',
+      expected_help_advanced=True,
+      expected_help_all=True,
+    )
 
-    self._split_help('./pants help-advanced', [], {'': []}, [], True, False)
-    self._split_help('./pants help-all', [], {'': []}, [], False, True)
-    self._split_help('./pants --help-advanced', [], {'': []}, [], True, False)
-    self._split_help('./pants --help-all', [], {'': []}, [], False, True)
-    self._split_help('./pants --help --help-advanced', [], {'': []}, [], True, False)
-    self._split_help('./pants --help-advanced --help', [], {'': []}, [], True, False)
-    self._split_help('./pants --help --help-all', [], {'': []}, [], False, True)
-    self._split_help('./pants --help-all --help --help-advanced', [], {'': []}, [], True, True)
-    self._split_help('./pants help --help-advanced', [], {'': []}, [], True, False)
-    self._split_help('./pants help-advanced --help-all', [], {'': []}, [], True, True)
-    self._split_help('./pants compile --help-advanced test', ['compile', 'test'],
-                     {'': [], 'compile': [], 'test': []}, [], True, False)
-    self._split_help('./pants help-advanced compile', ['compile'],
-                     {'': [], 'compile': []}, [], True, False)
-    self._split_help('./pants compile help-all test --help', ['compile', 'test'],
-                     {'': [], 'compile': [], 'test': []}, [], False, True)
+    assert_help(
+      './pants -f',
+      expected_goals=[],
+      expected_scope_to_flags={'': ['-f']},
+      expected_positional_args=[],
+    )
+    assert_help(
+      './pants help compile -x',
+      expected_goals=['compile'],
+      expected_scope_to_flags={'': [], 'compile': ['-x']},
+      expected_positional_args=[],
+    )
+    assert_help(
+      './pants help compile -x',
+      expected_goals=['compile'],
+      expected_scope_to_flags={'': [], 'compile': ['-x']},
+      expected_positional_args=[],
+    )
+    assert_help(
+      './pants compile -h',
+      expected_goals=['compile'],
+      expected_scope_to_flags={'': [], 'compile': []},
+      expected_positional_args=[],
+    )
+    assert_help(
+      './pants compile --help test',
+      expected_goals=['compile', 'test'],
+      expected_scope_to_flags={'': [], 'compile': [], 'test': []},
+      expected_positional_args=[],
+    )
+    assert_help(
+      './pants test src/foo/bar:baz -h',
+      expected_goals=['test'],
+      expected_scope_to_flags={'': [], 'test': []},
+      expected_positional_args=['src/foo/bar:baz'],
+    )
 
-  def test_version_request_detection(self):
-    self._split_version_request('./pants -v')
-    self._split_version_request('./pants -V')
-    self._split_version_request('./pants --version')
+    assert_help(
+      './pants compile --help-advanced test',
+      expected_goals=['compile', 'test'],
+      expected_scope_to_flags={'': [], 'compile': [], 'test': []},
+      expected_positional_args=[],
+      expected_help_advanced=True,
+    )
+    assert_help(
+      './pants help-advanced compile',
+      expected_goals=['compile'],
+      expected_scope_to_flags={'': [], 'compile': []},
+      expected_positional_args=[],
+      expected_help_advanced=True,
+    )
+    assert_help(
+      './pants compile help-all test --help',
+      expected_goals=['compile', 'test'],
+      expected_scope_to_flags={'': [], 'compile': [], 'test': []},
+      expected_positional_args=[],
+      expected_help_all=True,
+    )
+
+  def test_version_request_detection(self) -> None:
+    def assert_version_request(args_str: str) -> None:
+      splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
+      splitter.split_args(shlex.split(args_str))
+      self.assertTrue(isinstance(splitter.help_request, VersionHelp))
+
+    assert_version_request('./pants -v')
+    assert_version_request('./pants -V')
+    assert_version_request('./pants --version')
     # A version request supercedes anything else.
-    self._split_version_request('./pants --version compile --foo --bar path/to/target')
+    assert_version_request('./pants --version compile --foo --bar path/to/target')
 
-  def test_unknown_goal_detection(self):
-    self._split_unknown_goal('./pants foo', ['foo'])
-    self._split_unknown_goal('./pants compile foo', ['foo'])
-    self._split_unknown_goal('./pants foo bar baz:qux', ['foo', 'bar'])
-    self._split_unknown_goal('./pants foo compile bar baz:qux', ['foo', 'bar'])
+  def test_unknown_goal_detection(self) -> None:
+    def assert_unknown_goal(args_str: str, unknown_goals: List[str]) -> None:
+      splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
+      result = splitter.split_args(shlex.split(args_str))
+      self.assertTrue(isinstance(splitter.help_request, UnknownGoalHelp))
+      self.assertSetEqual(set(unknown_goals), set(splitter.help_request.unknown_goals))
+      self.assertEqual(result.unknown_scopes, unknown_goals)
 
-  def test_no_goal_detection(self):
-    self._split_no_goal('./pants foo/bar:baz')
+    assert_unknown_goal('./pants foo', ['foo'])
+    assert_unknown_goal('./pants compile foo', ['foo'])
+    assert_unknown_goal('./pants foo bar baz:qux', ['foo', 'bar'])
+    assert_unknown_goal('./pants foo compile bar baz:qux', ['foo', 'bar'])
+
+  def test_no_goal_detection(self) -> None:
+    splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
+    splitter.split_args(shlex.split('./pants foo/bar:baz'))
+    self.assertTrue(isinstance(splitter.help_request, NoGoalHelp))

--- a/src/python/pants/option/config_test.py
+++ b/src/python/pants/option/config_test.py
@@ -10,7 +10,7 @@ from pants.util.contextutil import temporary_file, temporary_file_path
 
 class ConfigTest(unittest.TestCase):
 
-  def setUp(self):
+  def setUp(self) -> None:
     self.ini1_content = textwrap.dedent(
       """
       [DEFAULT]
@@ -62,7 +62,7 @@ class ConfigTest(unittest.TestCase):
       )
       self.assertEqual([ini1.name, ini2.name], self.config.sources())
 
-  def test_getstring(self):
+  def test_getstring(self) -> None:
     self.assertEqual('/a/b/42', self.config.get('a', 'path'))
     self.assertEqual('/a/b/42::foo', self.config.get('a', 'embed'))
     self.assertEqual('[1, 2, 3, 42]', self.config.get('a', 'list'))
@@ -73,21 +73,21 @@ Let it be known
 that.""",
       self.config.get('b', 'disclaimer'))
 
-    self._check_defaults(self.config.get, '')
-    self._check_defaults(self.config.get, '42')
+    def check_defaults(default: str) -> None:
+      assert self.config.get('c', 'fast') is None
+      assert self.config.get('c', 'preempt', None) is None
+      assert self.config.get('c', 'jake', default=default) == default
 
-  def test_default_section(self):
+    check_defaults('')
+    check_defaults('42')
+
+  def test_default_section(self) -> None:
     self.assertEqual('foo', self.config.get(Config.DEFAULT_SECTION, 'name'))
     self.assertEqual('foo', self.config.get(Config.DEFAULT_SECTION, 'name'))
 
-  def test_sections(self):
+  def test_sections(self) -> None:
     self.assertEqual(['a', 'b', 'defined_section'], self.config.sections())
 
-  def test_empty(self):
+  def test_empty(self) -> None:
     config = Config.load([])
     self.assertEqual([], config.sections())
-
-  def _check_defaults(self, accessor, default):
-    self.assertEqual(None, accessor('c', 'fast'))
-    self.assertEqual(None, accessor('c', 'preempt', None))
-    self.assertEqual(default, accessor('c', 'jake', default=default))

--- a/src/python/pants/option/enclosing_scopes_test.py
+++ b/src/python/pants/option/enclosing_scopes_test.py
@@ -1,13 +1,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import unittest
+
 from pants.option.parser_hierarchy import InvalidScopeError, all_enclosing_scopes, enclosing_scope
 from pants.option.scope import GLOBAL_SCOPE
-from pants.testutil.test_base import TestBase
 
 
-class TestEnclosingScopeTraversal(TestBase):
-  def test_enclosing_scope(self):
+class TestEnclosingScopeTraversal(unittest.TestCase):
+
+  def test_enclosing_scope(self) -> None:
     """The enclosing scope of any non-nested scope should be the global scope,
     and the enclosing scope of a nested scope should be the scope without its
     final component."""
@@ -15,7 +17,7 @@ class TestEnclosingScopeTraversal(TestBase):
     self.assertEqual(GLOBAL_SCOPE, enclosing_scope('scope'))
     self.assertEqual('base', enclosing_scope('base.subscope'))
 
-  def test_all_enclosing_scopes(self):
+  def test_all_enclosing_scopes(self) -> None:
     """`all_enclosing_scopes` should repeatedly apply `enclosing_scope` to any
     valid single- or multiple- component scope. `all_enclosing_scopes` should
     not yield the global scope if `allow_global=False`."""
@@ -37,7 +39,7 @@ class TestEnclosingScopeTraversal(TestBase):
     compound_scope_closure_no_global = list(all_enclosing_scopes(compound_scope, allow_global=False))
     self.assertEqual(compound_scope_closure_no_global, [compound_scope, base_scope])
 
-  def test_valid_invalid_scope(self):
+  def test_valid_invalid_scope(self) -> None:
     """Scopes with dashes or underscores are treated as a single component, and
     scopes with empty components raise an InvalidScopeError."""
     base_dashed_scope = 'base-scope'

--- a/src/python/pants/option/option_value_container_test.py
+++ b/src/python/pants/option/option_value_container_test.py
@@ -10,7 +10,7 @@ from pants.option.ranked_value import RankedValue
 
 class OptionValueContainerTest(unittest.TestCase):
 
-  def test_unknown_values(self):
+  def test_unknown_values(self) -> None:
     o = OptionValueContainer()
     o.foo = RankedValue(RankedValue.HARDCODED, 1)
     self.assertEqual(1, o.foo)
@@ -18,7 +18,7 @@ class OptionValueContainerTest(unittest.TestCase):
     with self.assertRaises(AttributeError):
       o.bar
 
-  def test_value_ranking(self):
+  def test_value_ranking(self) -> None:
     o = OptionValueContainer()
     o.foo = RankedValue(RankedValue.CONFIG, 11)
     self.assertEqual(11, o.foo)
@@ -33,7 +33,7 @@ class OptionValueContainerTest(unittest.TestCase):
     self.assertEqual(44, o.foo)
     self.assertEqual(RankedValue.FLAG, o.get_rank('foo'))
 
-  def test_is_flagged(self):
+  def test_is_flagged(self) -> None:
     o = OptionValueContainer()
 
     o.foo = RankedValue(RankedValue.NONE, 11)
@@ -48,7 +48,7 @@ class OptionValueContainerTest(unittest.TestCase):
     o.foo = RankedValue(RankedValue.FLAG, 11)
     self.assertTrue(o.is_flagged('foo'))
 
-  def test_indexing(self):
+  def test_indexing(self) -> None:
     o = OptionValueContainer()
     o.foo = RankedValue(RankedValue.CONFIG, 1)
     self.assertEqual(1, o['foo'])
@@ -61,7 +61,7 @@ class OptionValueContainerTest(unittest.TestCase):
     with self.assertRaises(AttributeError):
       o['bar']
 
-  def test_iterator(self):
+  def test_iterator(self) -> None:
     o = OptionValueContainer()
     o.a = RankedValue(RankedValue.FLAG, 3)
     o.b = RankedValue(RankedValue.FLAG, 2)
@@ -69,7 +69,7 @@ class OptionValueContainerTest(unittest.TestCase):
     names = list(iter(o))
     self.assertListEqual(['a', 'b', 'c'], names)
 
-  def test_copy(self):
+  def test_copy(self) -> None:
     # copy semantics can get hairy when overriding __setattr__/__getattr__, so we test them.
     o = OptionValueContainer()
     o.foo = RankedValue(RankedValue.FLAG, 1)
@@ -86,7 +86,7 @@ class OptionValueContainerTest(unittest.TestCase):
     o.bar['b'] = 222
     self.assertEqual({'a': 111, 'b': 222}, p.bar)
 
-  def test_deepcopy(self):
+  def test_deepcopy(self) -> None:
     # copy semantics can get hairy when overriding __setattr__/__getattr__, so we test them.
     o = OptionValueContainer()
     o.foo = RankedValue(RankedValue.FLAG, 1)

--- a/src/python/pants/option/option_value_container_test.py
+++ b/src/python/pants/option/option_value_container_test.py
@@ -83,7 +83,8 @@ class OptionValueContainerTest(unittest.TestCase):
     self.assertFalse(hasattr(p, 'baz'))  # Does not have attribute added after the copy.
 
     # Verify that it's a shallow copy by modifying a referent in o and reading it in p.
-    o.bar['b'] = 222
+    # TODO: add type hints to ranked_value.py and option_value_container.py so that this works.
+    o.bar['b'] = 222  # type: ignore[index]
     self.assertEqual({'a': 111, 'b': 222}, p.bar)
 
   def test_deepcopy(self) -> None:
@@ -100,5 +101,6 @@ class OptionValueContainerTest(unittest.TestCase):
     self.assertFalse(hasattr(p, 'baz'))  # Does not have attribute added after the copy.
 
     # Verify that it's a deep copy by modifying a referent in o and reading it in p.
-    o.bar['b'] = 222
+    # TODO: add type hints to ranked_value.py and option_value_container.py so that this works.
+    o.bar['b'] = 222  # type: ignore[index]
     self.assertEqual({'a': 111}, p.bar)

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -64,8 +64,8 @@ class Optionable(OptionableFactory, metaclass=ABCMeta):
   # Option values can be read from the deprecated scope, but a deprecation warning will be issued.
   # The deprecation warning becomes an error at the given Pants version (which must therefore be
   # a valid semver).
-  deprecated_options_scope = None
-  deprecated_options_scope_removal_version = None
+  deprecated_options_scope: Optional[str] = None
+  deprecated_options_scope_removal_version: Optional[str] = None
 
   _scope_name_component_re = re.compile(r'^(?:[a-z0-9])+(?:-(?:[a-z0-9])+)*$')
 

--- a/src/python/pants/option/optionable_test.py
+++ b/src/python/pants/option/optionable_test.py
@@ -20,7 +20,7 @@ class OptionableTest(unittest.TestCase):
       NoneScope()
 
     class NonStringScope(Optionable):
-      options_scope = 42
+      options_scope = 42  # type: ignore[assignment]
     with self.assertRaises(NotImplementedError):
       NonStringScope()
 

--- a/src/python/pants/option/optionable_test.py
+++ b/src/python/pants/option/optionable_test.py
@@ -7,7 +7,8 @@ from pants.option.optionable import Optionable
 
 
 class OptionableTest(unittest.TestCase):
-  def test_optionable(self):
+
+  def test_optionable(self) -> None:
     class NoScope(Optionable):
       pass
     with self.assertRaises(NotImplementedError):
@@ -34,11 +35,11 @@ class OptionableTest(unittest.TestCase):
       options_scope = 'good'
     self.assertEqual('good', Indirect.options_scope)
 
-  def test_is_valid_scope_name_component(self):
-    def check_true(s):
+  def test_is_valid_scope_name_component(self) -> None:
+    def check_true(s: str) -> None:
       self.assertTrue(Optionable.is_valid_scope_name_component(s))
 
-    def check_false(s):
+    def check_false(s: str) -> None:
       self.assertFalse(Optionable.is_valid_scope_name_component(s))
 
     check_true('foo')

--- a/src/python/pants/option/options_fingerprinter_test.py
+++ b/src/python/pants/option/options_fingerprinter_test.py
@@ -21,11 +21,11 @@ from pants.util.contextutil import temporary_dir
 
 class OptionsFingerprinterTest(TestBase):
 
-  def setUp(self):
+  def setUp(self) -> None:
     super().setUp()
     self.options_fingerprinter = OptionsFingerprinter(self.context().build_graph)
 
-  def test_fingerprint_dict(self):
+  def test_fingerprint_dict(self) -> None:
     d1 = {'b': 1, 'a': 2}
     d2 = {'a': 2, 'b': 1}
     d3 = {'a': 1, 'b': 2}
@@ -34,19 +34,19 @@ class OptionsFingerprinterTest(TestBase):
     self.assertEqual(fp1, fp2)
     self.assertNotEqual(fp1, fp3)
 
-  def test_fingerprint_dict_with_non_string_keys(self):
+  def test_fingerprint_dict_with_non_string_keys(self) -> None:
     d = {('a', 2): (3, 4)}
     fp = self.options_fingerprinter.fingerprint(dict_option, d)
     self.assertEqual(fp, '3852a094612ce1c22c08ee2ddcdc03d09e87ad97')
 
-  def test_fingerprint_list(self):
+  def test_fingerprint_list(self) -> None:
     l1 = [1, 2, 3]
     l2 = [1, 3, 2]
     fp1, fp2 = (self.options_fingerprinter.fingerprint(list_option, l)
                      for l in (l1, l2))
     self.assertNotEqual(fp1, fp2)
 
-  def test_fingerprint_target_spec(self):
+  def test_fingerprint_target_spec(self) -> None:
     specs = [':t1', ':t2']
     payloads = [Payload() for i in range(2)]
     for i, (s, p) in enumerate(zip(specs, payloads)):
@@ -59,7 +59,7 @@ class OptionsFingerprinterTest(TestBase):
     fp2 = fp_spec(s2)
     self.assertNotEqual(fp1, fp2)
 
-  def test_fingerprint_target_spec_list(self):
+  def test_fingerprint_target_spec_list(self) -> None:
     specs = [':t1', ':t2', ':t3']
     payloads = [Payload() for i in range(3)]
     for i, (s, p) in enumerate(zip(specs, payloads)):
@@ -74,7 +74,7 @@ class OptionsFingerprinterTest(TestBase):
     self.assertEqual(fp1, fp2)
     self.assertNotEqual(fp1, fp3)
 
-  def test_fingerprint_file(self):
+  def test_fingerprint_file(self) -> None:
     fp1, fp2, fp3 = (self.options_fingerprinter.fingerprint(file_option,
                                                             self.create_file(f, contents=c))
                      for (f, c) in (('foo/bar.config', 'blah blah blah'),
@@ -84,13 +84,13 @@ class OptionsFingerprinterTest(TestBase):
     self.assertNotEqual(fp1, fp3)
     self.assertNotEqual(fp2, fp3)
 
-  def test_fingerprint_file_outside_buildroot(self):
+  def test_fingerprint_file_outside_buildroot(self) -> None:
     with temporary_dir() as tmp:
       outside_buildroot = self.create_file(os.path.join(tmp, 'foobar'), contents='foobar')
       with self.assertRaises(ValueError):
         self.options_fingerprinter.fingerprint(file_option, outside_buildroot)
 
-  def test_fingerprint_file_list(self):
+  def test_fingerprint_file_list(self) -> None:
     f1, f2, f3 = (self.create_file(f, contents=c) for (f, c) in
                   (('foo/bar.config', 'blah blah blah'),
                    ('foo/bar.config', 'meow meow meow'),
@@ -101,26 +101,29 @@ class OptionsFingerprinterTest(TestBase):
     self.assertEqual(fp1, fp2)
     self.assertNotEqual(fp1, fp3)
 
-  def test_fingerprint_primitive(self):
+  def test_fingerprint_primitive(self) -> None:
     fp1, fp2 = (self.options_fingerprinter.fingerprint('', v) for v in ('foo', 5))
     self.assertNotEqual(fp1, fp2)
 
-  def test_fingerprint_unset_bool(self):
+  def test_fingerprint_unset_bool(self) -> None:
     fp1 = self.options_fingerprinter.fingerprint(UnsetBool, UnsetBool)
     fp2 = self.options_fingerprinter.fingerprint(UnsetBool, UnsetBool)
     self.assertEqual(fp1, fp2)
 
-  def test_fingerprint_dir(self):
+  def test_fingerprint_dir(self) -> None:
     d1 = self.create_dir('a')
     d2 = self.create_dir('b')
     d3 = self.create_dir('c')
 
-    f1, f2, f3, f4, f5 = (self.create_file(f, contents=c) for (f, c) in (
+    for f, c in [
       ('a/bar/bar.config', 'blah blah blah'),
       ('a/foo/foo.config', 'meow meow meow'),
       ('b/foo/foo.config', 'meow meow meow'),
       ('b/bar/bar.config', 'blah blah blah'),
-      ('c/bar/bar.config', 'blah meow blah')))
+      ('c/bar/bar.config', 'blah meow blah')
+    ]:
+      self.create_file(f, contents=c)
+
     dp1 = self.options_fingerprinter.fingerprint(dir_option, [d1])
     dp2 = self.options_fingerprinter.fingerprint(dir_option, [d1, d2])
     dp3 = self.options_fingerprinter.fingerprint(dir_option, [d2, d1])
@@ -132,7 +135,7 @@ class OptionsFingerprinterTest(TestBase):
     self.assertNotEqual(dp1, dp4)
     self.assertNotEqual(dp2, dp3)
 
-  def test_fingerprint_dict_with_files_order(self):
+  def test_fingerprint_dict_with_files_order(self) -> None:
     f1, f2 = (self.create_file(f, contents=c) for (f, c) in
       (('foo/bar.config', 'blah blah blah'),
       ('foo/bar.config', 'meow meow meow')))
@@ -140,7 +143,7 @@ class OptionsFingerprinterTest(TestBase):
     fp2 = self.options_fingerprinter.fingerprint(dict_with_files_option, {'properties': f"{f2},{f1}"})
     self.assertEqual(fp1, fp2)
 
-  def test_fingerprint_dict_with_files_content_change(self):
+  def test_fingerprint_dict_with_files_content_change(self) -> None:
     f1, f2 = (self.create_file(f, contents=c) for (f, c) in
       (('foo/bar.config', 'blah blah blah'),
       ('foo/bar.config', 'meow meow meow')))

--- a/src/python/pants/option/options_integration_test.py
+++ b/src/python/pants/option/options_integration_test.py
@@ -13,13 +13,13 @@ from pants.util.contextutil import temporary_dir
 class TestOptionsIntegration(PantsRunIntegrationTest):
 
   @classmethod
-  def hermetic(cls):
+  def hermetic(cls) -> bool:
     return True
 
-  def test_options_works_at_all(self):
+  def test_options_works_at_all(self) -> None:
     self.assert_success(self.run_pants(['options']))
 
-  def test_options_scope(self):
+  def test_options_scope(self) -> None:
     pants_run = self.run_pants(['options', '--no-colors', '--scope=options'])
     self.assert_success(pants_run)
     self.assertIn('options.scope = options', pants_run.stdout_data)
@@ -33,7 +33,7 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     self.assertNotIn('options.name = None', pants_run.stdout_data)
     self.assertIn('publish.jar.scm_push_attempts = ', pants_run.stdout_data)
 
-  def test_valid_json(self):
+  def test_valid_json(self) -> None:
     pants_run = self.run_pants(['options', '--output-format=json'])
     self.assert_success(pants_run)
     try:
@@ -44,7 +44,7 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     except ValueError:
       self.fail("Invalid JSON output")
 
-  def test_valid_json_with_history(self):
+  def test_valid_json_with_history(self) -> None:
     pants_run = self.run_pants(['options', '--output-format=json', '--show-history'])
     self.assert_success(pants_run)
     try:
@@ -58,14 +58,14 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     except ValueError:
       self.fail("Invalid JSON output")
 
-  def test_options_option(self):
+  def test_options_option(self) -> None:
     pants_run = self.run_pants(['options', '--no-colors', '--name=colors', '--no-skip-inherited'])
     self.assert_success(pants_run)
     self.assertIn('options.colors = ', pants_run.stdout_data)
     self.assertIn('unpack-jars.colors = ', pants_run.stdout_data)
     self.assertNotIn('options.scope = ', pants_run.stdout_data)
 
-  def test_options_only_overridden(self):
+  def test_options_only_overridden(self) -> None:
     pants_run = self.run_pants(['options', '--no-colors', '--only-overridden'])
     self.assert_success(pants_run)
     self.assertIn('options.only_overridden = True', pants_run.stdout_data)
@@ -73,7 +73,7 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     self.assertNotIn('from HARDCODED', pants_run.stdout_data)
     self.assertNotIn('from NONE', pants_run.stdout_data)
 
-  def test_options_rank(self):
+  def test_options_rank(self) -> None:
     pants_run = self.run_pants(['options', '--no-colors', '--rank=FLAG'])
     self.assert_success(pants_run)
     self.assertIn('options.rank = ', pants_run.stdout_data)
@@ -82,13 +82,13 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     self.assertNotIn('(from HARDCODED', pants_run.stdout_data)
     self.assertNotIn('(from NONE', pants_run.stdout_data)
 
-  def test_options_show_history(self):
+  def test_options_show_history(self) -> None:
     pants_run = self.run_pants(['options', '--no-colors', '--only-overridden', '--show-history'])
     self.assert_success(pants_run)
     self.assertIn('options.only_overridden = True', pants_run.stdout_data)
     self.assertIn('overrode False (from HARDCODED', pants_run.stdout_data)
 
-  def test_from_config(self):
+  def test_from_config(self) -> None:
     with temporary_dir(root_dir=os.path.abspath('.')) as tempdir:
       config_path = os.path.relpath(os.path.join(tempdir, 'config.ini'))
       with open(config_path, 'w+') as f:
@@ -104,7 +104,7 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
       self.assertIn('options.only_overridden = True', pants_run.stdout_data)
       self.assertIn(f'(from CONFIG in {config_path})', pants_run.stdout_data)
 
-  def test_options_deprecation_from_config(self):
+  def test_options_deprecation_from_config(self) -> None:
     with temporary_dir(root_dir=os.path.abspath('.')) as tempdir:
       config_path = os.path.relpath(os.path.join(tempdir, 'config.ini'))
       with open(config_path, 'w+') as f:
@@ -125,12 +125,11 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
       pants_run = self.run_pants([f'--pants-config-files={config_path}', 'options'])
       self.assert_success(pants_run)
 
-
       self.assertIn('dummy-options.normal_option', pants_run.stdout_data)
       self.assertIn('dummy-options.dummy_crufty_deprecated_but_still_functioning',
                     pants_run.stdout_data)
 
-  def test_from_config_invalid_section(self):
+  def test_from_config_invalid_section(self) -> None:
     with temporary_dir(root_dir=os.path.abspath('.')) as tempdir:
       config_path = os.path.relpath(os.path.join(tempdir, 'config.ini'))
       with open(config_path, 'w+') as f:
@@ -152,7 +151,7 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
       self.assertIn('ERROR] Invalid scope [invalid_scope]', pants_run.stderr_data)
       self.assertIn('ERROR] Invalid scope [another_invalid_scope]', pants_run.stderr_data)
 
-  def test_from_config_invalid_option(self):
+  def test_from_config_invalid_option(self) -> None:
     with temporary_dir(root_dir=os.path.abspath('.')) as tempdir:
       config_path = os.path.relpath(os.path.join(tempdir, 'config.ini'))
       with open(config_path, 'w+') as f:
@@ -170,7 +169,7 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
       self.assertIn("ERROR] Invalid option 'invalid_option' under [test.junit]",
                     pants_run.stderr_data)
 
-  def test_from_config_invalid_global_option(self):
+  def test_from_config_invalid_global_option(self) -> None:
     """
     This test can be interpreted in two ways:
       1. An invalid global option `invalid_global` will be caught.
@@ -197,7 +196,7 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
       self.assertIn("ERROR] Invalid option 'another_invalid_global' under [GLOBAL]",
                     pants_run.stderr_data)
 
-  def test_invalid_command_line_option_and_invalid_config(self):
+  def test_invalid_command_line_option_and_invalid_config(self) -> None:
     """
     Make sure invalid command line error will be thrown and exits.
     """
@@ -229,16 +228,16 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
       self.assertIn("ERROR] Invalid option 'bad_option' under [test.junit]", pants_run.stderr_data)
       self.assertIn("ERROR] Invalid scope [invalid_scope]", pants_run.stderr_data)
 
-  def test_command_line_option_unused_by_goals(self):
+  def test_command_line_option_unused_by_goals(self) -> None:
     self.assert_success(self.run_pants(['filter', '--bundle-jvm-archive=zip']))
     self.assert_failure(self.run_pants(['filter', '--jvm-invalid=zip']))
 
-  def test_non_recursive_quiet_no_output(self):
+  def test_non_recursive_quiet_no_output(self) -> None:
     pants_run = self.run_pants(['-q', 'compile'])
     self.assert_success(pants_run)
     self.assertEqual('', pants_run.stdout_data)
 
-  def test_skip_inherited(self):
+  def test_skip_inherited(self) -> None:
     pants_run = self.run_pants([
       '--no-colors', '--no-jvm-platform-validate-colors', '--test-junit-colors',
       '--unpack-jars-colors', '--no-resolve-ivy-colors', '--imports-ivy-imports-colors',
@@ -260,7 +259,7 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     self.assertNotIn('jvm-platform-validate.colors = False', lines)
     self.assertNotIn('resolve.ivy.colors = False', lines)
 
-  def test_pants_ignore_option(self):
+  def test_pants_ignore_option(self) -> None:
     with temporary_dir(root_dir=os.path.abspath('.')) as tempdir:
       config_path = os.path.relpath(os.path.join(tempdir, 'config.ini'))
       with open(config_path, 'w+') as f:
@@ -277,7 +276,7 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
         pants_run.stdout_data
       )
 
-  def test_pants_symlink_workdirs(self):
+  def test_pants_symlink_workdirs(self) -> None:
     with temporary_dir() as tmp_dir:
       symlink_workdir = f'{tmp_dir}/.pants.d'
       physical_workdir_base = f'{tmp_dir}/workdirs'
@@ -289,7 +288,7 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
       # Make sure symlink workdir is pointing to physical workdir
       self.assertTrue(os.readlink(symlink_workdir) == physical_workdir)
 
-      pants_run = self.run_pants_with_workdir(
+      self.run_pants_with_workdir(
         [f'--pants-physical-workdir-base={physical_workdir_base}', 'clean-all'], symlink_workdir)
       # Make sure both physical_workdir and symlink_workdir are empty after running clean-all
       self.assertTrue(not os.listdir(symlink_workdir) and not os.listdir(physical_workdir))

--- a/src/python/pants/option/quiet_option_integration_test.py
+++ b/src/python/pants/option/quiet_option_integration_test.py
@@ -8,12 +8,13 @@ from pants.util.contextutil import temporary_file
 
 
 class TestOptionsQuietIntegration(PantsRunIntegrationTest):
-  def test_pants_default_quietness(self):
+
+  def test_pants_default_quietness(self) -> None:
     pants_run = self.run_pants(['export'])
     self.assert_success(pants_run)
     json.loads(pants_run.stdout_data)
 
-  def test_pants_no_quiet_cli(self):
+  def test_pants_no_quiet_cli(self) -> None:
     pants_run = self.run_pants(['--no-quiet', 'export'])
     self.assert_success(pants_run)
 
@@ -21,7 +22,7 @@ class TestOptionsQuietIntegration(PantsRunIntegrationTest):
     with self.assertRaises(ValueError):
       json.loads(pants_run.stdout_data)
 
-  def test_pants_no_quiet_env(self):
+  def test_pants_no_quiet_env(self) -> None:
     pants_run = self.run_pants(['export'], extra_env={'PANTS_QUIET': 'FALSE'})
     self.assert_success(pants_run)
 
@@ -29,7 +30,7 @@ class TestOptionsQuietIntegration(PantsRunIntegrationTest):
     with self.assertRaises(ValueError):
       json.loads(pants_run.stdout_data)
 
-  def test_pants_no_quiet_output_file(self):
+  def test_pants_no_quiet_output_file(self) -> None:
     with temporary_file() as f:
       pants_run = self.run_pants(['--no-quiet', 'export', f'--output-file={f.name}'])
       self.assert_success(pants_run)

--- a/src/python/pants/subsystem/subsystem_test.py
+++ b/src/python/pants/subsystem/subsystem_test.py
@@ -50,36 +50,36 @@ def si(scope, subsystem_cls):
 
 
 class SubsystemTest(TestBase):
-  def setUp(self):
+  def setUp(self) -> None:
     DummySubsystem._options = DummyOptions()
     WorkunitSubscriptableSubsystem._options = DummyOptions()
 
-  def test_global_instance(self):
+  def test_global_instance(self) -> None:
     # Verify that we get the same instance back every time.
     global_instance = DummySubsystem.global_instance()
     self.assertIs(global_instance, DummySubsystem.global_instance())
 
-  def test_scoped_instance(self):
+  def test_scoped_instance(self) -> None:
     # Verify that we get the same instance back every time.
     task = DummyOptionable()
     task_instance = DummySubsystem.scoped_instance(task)
     self.assertIs(task_instance, DummySubsystem.scoped_instance(task))
 
-  def test_invalid_subsystem_class(self):
+  def test_invalid_subsystem_class(self) -> None:
     class NoScopeSubsystem(Subsystem):
       pass
     NoScopeSubsystem._options = DummyOptions()
     with self.assertRaises(NotImplementedError):
       NoScopeSubsystem.global_instance()
 
-  def test_scoping_simple(self):
+  def test_scoping_simple(self) -> None:
     self.assertEqual({si('dummy', DummySubsystem)}, DummySubsystem.known_scope_infos())
     self.assertEqual({si('scoped-dependent-subsystem', ScopedDependentSubsystem),
                       si('dummy', DummySubsystem),
                       si('dummy.scoped-dependent-subsystem', DummySubsystem)},
                      ScopedDependentSubsystem.known_scope_infos())
 
-  def test_scoping_tree(self):
+  def test_scoping_tree(self) -> None:
     class SubsystemB(Subsystem):
       options_scope = 'b'
 
@@ -93,7 +93,7 @@ class SubsystemTest(TestBase):
     self.assertEqual({si('dummy', DummySubsystem), si('a', SubsystemA), si('b', SubsystemB)},
                      SubsystemA.known_scope_infos())
 
-  def test_scoping_graph(self):
+  def test_scoping_graph(self) -> None:
     class SubsystemB(Subsystem):
       options_scope = 'b'
 
@@ -114,7 +114,7 @@ class SubsystemTest(TestBase):
     self.assertEqual({si('dummy', DummySubsystem), si('a', SubsystemA), si('b', SubsystemB)},
                      SubsystemA.known_scope_infos())
 
-  def test_option_class_cycle(self):
+  def test_option_class_cycle(self) -> None:
     class SubsystemC(Subsystem):
       options_scope = 'c'
 
@@ -141,7 +141,7 @@ class SubsystemTest(TestBase):
       with self.assertRaises(SubsystemClientMixin.CycleException):
         root.known_scope_infos()
 
-  def test_scoping_complex(self):
+  def test_scoping_complex(self) -> None:
     """
     Subsystem dep structure is (-s-> = scoped dep, -g-> = global dep):
 
@@ -199,13 +199,13 @@ class SubsystemTest(TestBase):
     }
     self.assertSetEqual(expected_known_scope_infos_d, set(SubsystemD.known_scope_infos()))
 
-  def test_uninitialized_global(self):
+  def test_uninitialized_global(self) -> None:
     Subsystem.reset()
     with self.assertRaisesRegexp(Subsystem.UninitializedSubsystemError,
                                  r'UninitializedSubsystem.*uninitialized-scope'):
       UninitializedSubsystem.global_instance()
 
-  def test_uninitialized_scoped_instance(self):
+  def test_uninitialized_scoped_instance(self) -> None:
     Subsystem.reset()
 
     class UninitializedOptional(Optionable):
@@ -216,7 +216,7 @@ class SubsystemTest(TestBase):
                                  r'UninitializedSubsystem.*uninitialized-scope'):
       UninitializedSubsystem.scoped_instance(optional)
 
-  def test_subsystem_dependencies_iter(self):
+  def test_subsystem_dependencies_iter(self) -> None:
     class SubsystemB(Subsystem):
       options_scope = 'b'
 
@@ -230,7 +230,7 @@ class SubsystemTest(TestBase):
     dep_scopes = {dep.options_scope for dep in SubsystemA.subsystem_dependencies_iter()}
     self.assertEqual({'b', 'dummy.a'}, dep_scopes)
 
-  def test_subsystem_closure_iter(self):
+  def test_subsystem_closure_iter(self) -> None:
     class SubsystemA(Subsystem):
       options_scope = 'a'
 
@@ -258,7 +258,7 @@ class SubsystemTest(TestBase):
     dep_scopes = {dep.options_scope for dep in SubsystemD.subsystem_closure_iter()}
     self.assertEqual({'c', 'a', 'b.c', 'b'}, dep_scopes)
 
-  def test_subsystem_closure_iter_cycle(self):
+  def test_subsystem_closure_iter_cycle(self) -> None:
     class SubsystemA(Subsystem):
       options_scope = 'a'
 
@@ -276,12 +276,12 @@ class SubsystemTest(TestBase):
     with self.assertRaises(SubsystemClientMixin.CycleException):
       list(SubsystemB.subsystem_closure_iter())
 
-  def test_get_streaming_workunit_callbacks(self):
+  def test_get_streaming_workunit_callbacks(self) -> None:
     import_str = "pants.subsystem.subsystem_test.WorkunitSubscriptableSubsystem"
     callables_list = Subsystem.get_streaming_workunit_callbacks([import_str])
     assert len(callables_list) == 1
 
-  def test_streaming_workunit_callbacks_bad_module(self):
+  def test_streaming_workunit_callbacks_bad_module(self) -> None:
     import_str = "nonexistent_module.AClassThatDoesntActuallyExist"
     with self.captured_logging(level = logging.WARNING) as captured:
       callables_list = Subsystem.get_streaming_workunit_callbacks([import_str])
@@ -290,7 +290,7 @@ class SubsystemTest(TestBase):
       assert len(callables_list) == 0
       assert "No module named 'nonexistent_module'" in warnings[0]
 
-  def test_streaming_workunit_callbacks_good_module_bad_class(self):
+  def test_streaming_workunit_callbacks_good_module_bad_class(self) -> None:
     import_str = "pants.subsystem.subsystem_test.ANonexistentClass"
     with self.captured_logging(level = logging.WARNING) as captured:
       callables_list = Subsystem.get_streaming_workunit_callbacks([import_str])
@@ -299,7 +299,7 @@ class SubsystemTest(TestBase):
       assert len(callables_list) == 0
       assert "module 'pants.subsystem.subsystem_test' has no attribute 'ANonexistentClass'" in warnings[0]
 
-  def test_streaming_workunit_callbacks_with_invalid_subsystem(self):
+  def test_streaming_workunit_callbacks_with_invalid_subsystem(self) -> None:
     import_str = "pants.subsystem.subsystem_test.DummySubsystem"
     with self.captured_logging(level = logging.WARNING) as captured:
       callables_list = Subsystem.get_streaming_workunit_callbacks([import_str])

--- a/src/python/pants/subsystem/subsystem_test.py
+++ b/src/python/pants/subsystem/subsystem_test.py
@@ -50,7 +50,7 @@ def si(scope, subsystem_cls):
 
 
 class SubsystemTest(TestBase):
-  def setUp(self) -> None:
+  def setUp(self):
     DummySubsystem._options = DummyOptions()
     WorkunitSubscriptableSubsystem._options = DummyOptions()
 
@@ -65,7 +65,7 @@ class SubsystemTest(TestBase):
     task_instance = DummySubsystem.scoped_instance(task)
     self.assertIs(task_instance, DummySubsystem.scoped_instance(task))
 
-  def test_invalid_subsystem_class(self) -> None:
+  def test_invalid_subsystem_class(self):
     class NoScopeSubsystem(Subsystem):
       pass
     NoScopeSubsystem._options = DummyOptions()


### PR DESCRIPTION
We'll need to make modifications soon to the `option` folder to unblock progress on transitioning V1 tasks to use V2-style passthrough args. 

Most of the option code is from the early days of Pants. It hasn't had much refactoring and instead has had many new features added on top. This PR takes a step back to try to deduplicate and modernize some of the test code, as prework for these upcoming changes.

A followup will refactor the src code.