### PR TITLE
Partially type check `TestBase` and 235 test files

### DIFF
--- a/src/python/pants/backend/python/lint/black/BUILD
+++ b/src/python/pants/backend/python/lint/black/BUILD
@@ -33,6 +33,6 @@ python_tests(
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 120,
 )

--- a/src/python/pants/backend/python/lint/flake8/BUILD
+++ b/src/python/pants/backend/python/lint/flake8/BUILD
@@ -34,6 +34,6 @@ python_tests(
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 210,
 )

--- a/src/python/pants/backend/python/lint/isort/BUILD
+++ b/src/python/pants/backend/python/lint/isort/BUILD
@@ -33,5 +33,5 @@ python_tests(
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )

--- a/src/python/pants/backend/python/rules/BUILD
+++ b/src/python/pants/backend/python/rules/BUILD
@@ -37,6 +37,7 @@ python_tests(
     'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 

--- a/src/python/pants/backend/python/rules/pex_test.py
+++ b/src/python/pants/backend/python/rules/pex_test.py
@@ -4,7 +4,7 @@
 import json
 import os.path
 import zipfile
-from typing import Dict, List
+from typing import Dict, Optional, cast
 
 from pants.backend.python.rules.download_pex_bin import download_pex_bin
 from pants.backend.python.rules.pex import (
@@ -54,7 +54,7 @@ class TestResolveRequirements(TestBase):
   def create_pex_and_get_all_data(self, *, requirements=PexRequirements(),
       entry_point=None,
       interpreter_constraints=PexInterpreterConstraints(),
-      input_files: Digest = None) -> (Dict, List[str]):
+      input_files: Optional[Digest] = None) -> Dict:
     request = CreatePex(
       output_filename="test.pex",
       requirements=requirements,
@@ -83,9 +83,13 @@ class TestResolveRequirements(TestBase):
   def create_pex_and_get_pex_info(
     self, *, requirements=PexRequirements(), entry_point=None,
     interpreter_constraints=PexInterpreterConstraints(),
-    input_files: Digest = None) -> Dict:
-    return self.create_pex_and_get_all_data(requirements=requirements, entry_point=entry_point, interpreter_constraints=interpreter_constraints,
-        input_files=input_files)['info']
+    input_files: Optional[Digest] = None) -> Dict:
+    return cast(Dict, self.create_pex_and_get_all_data(
+      requirements=requirements,
+      entry_point=entry_point,
+      interpreter_constraints=interpreter_constraints,
+      input_files=input_files
+    )['info'])
 
   def test_generic_pex_creation(self) -> None:
     input_files_content = InputFilesContent((

--- a/src/python/pants/fs/BUILD
+++ b/src/python/pants/fs/BUILD
@@ -18,4 +18,5 @@ python_tests(
     'src/python/pants/testutil:console_rule_test_base',
     'src/python/pants/testutil/engine:util',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/fs/fs_test.py
+++ b/src/python/pants/fs/fs_test.py
@@ -40,7 +40,7 @@ class MockWorkspaceGoal(Goal):
 
 @console_rule
 async def workspace_console_rule(console: Console, workspace: Workspace, msg: MessageToConsoleRule) -> MockWorkspaceGoal:
-  digest = await Get(Digest, InputFilesContent, msg.input_files_content)
+  digest = await Get[Digest](InputFilesContent, msg.input_files_content)
   output = workspace.materialize_directory(DirectoryToMaterialize(digest))
   console.print_stdout(output.output_paths[0], end='')
   return MockWorkspaceGoal(exit_code=0)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -49,7 +49,7 @@ from pants.engine.mapper import AddressMapper, ResolveError
 from pants.engine.parser import SymbolTable
 from pants.engine.platform import create_platform_rules
 from pants.engine.rules import RootRule, UnionMembership, rule
-from pants.engine.scheduler import Scheduler
+from pants.engine.scheduler import Scheduler, SchedulerSession
 from pants.engine.selectors import Get, Params
 from pants.init.options_initializer import BuildConfigInitializer, OptionsInitializer
 from pants.option.global_options import (
@@ -173,7 +173,9 @@ class LegacyGraphScheduler:
   build_file_aliases: Any
   goal_map: Any
 
-  def new_session(self, zipkin_trace_v2, build_id, v2_ui=False, should_report_workunits=False):
+  def new_session(
+    self, zipkin_trace_v2, build_id, v2_ui=False, should_report_workunits=False
+  ) -> "LegacyGraphSession":
     session = self.scheduler.new_session(zipkin_trace_v2, build_id, v2_ui, should_report_workunits)
     return LegacyGraphSession(session, self.build_file_aliases, self.goal_map)
 
@@ -181,7 +183,7 @@ class LegacyGraphScheduler:
 @dataclass(frozen=True)
 class LegacyGraphSession:
   """A thin wrapper around a SchedulerSession configured with @rules for a symbol table."""
-  scheduler_session: Any
+  scheduler_session: SchedulerSession
   build_file_aliases: Any
   goal_map: Any
 

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -34,6 +34,7 @@ python_tests(
     'src/python/pants/testutil/option',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(

--- a/src/python/pants/rules/core/BUILD
+++ b/src/python/pants/rules/core/BUILD
@@ -40,6 +40,7 @@ python_tests(
     'src/python/pants/testutil/engine:util',
     'src/python/pants/testutil/subsystem',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/src/python/pants/rules/core/fmt_test.py
+++ b/src/python/pants/rules/core/fmt_test.py
@@ -38,7 +38,7 @@ class FmtTest(TestBase):
       # TODO: this is not robust to set as an empty digest. Add a test util that provides
       #  some premade snapshots and possibly a generalized make_hydrated_target function.
       directory_digest=EMPTY_DIRECTORY_DIGEST,
-      files=("formatted.txt", "fake.txt") if include_sources else (),
+      files=tuple(["formatted.txt", "fake.txt"] if include_sources else []),
       dirs=()
     )
     return HydratedTarget(

--- a/src/python/pants/rules/core/run_test.py
+++ b/src/python/pants/rules/core/run_test.py
@@ -33,10 +33,10 @@ class RunTest(ConsoleRuleTestBase):
       target_name=address.target_name,
       rel_path=f'{address.spec_path}/BUILD'
     )
-    BuildRoot.path = self.build_root
+    BuildRoot().path = self.build_root
     res = run_rule(
       run.run,
-      rule_args=[console, workspace, interactive_runner, BuildRoot, bfa],
+      rule_args=[console, workspace, interactive_runner, BuildRoot(), bfa],
       mock_gets=[
         MockGet(
           product_type=CreatedBinary,

--- a/src/python/pants/rules/core/test_test.py
+++ b/src/python/pants/rules/core/test_test.py
@@ -12,14 +12,8 @@ from pants.engine.fs import EMPTY_DIRECTORY_DIGEST, Snapshot
 from pants.engine.legacy.graph import HydratedTarget
 from pants.engine.legacy.structs import PythonBinaryAdaptor, PythonTestsAdaptor
 from pants.engine.rules import UnionMembership
-from pants.rules.core.core_test_model import TestTarget
-from pants.rules.core.test import (
-  AddressAndTestResult,
-  Status,
-  TestResult,
-  coordinator_of_tests,
-  fast_test,
-)
+from pants.rules.core.core_test_model import Status, TestResult, TestTarget
+from pants.rules.core.test import AddressAndTestResult, coordinator_of_tests, fast_test
 from pants.source.wrapped_globs import EagerFilesetWithSpec
 from pants.testutil.engine.util import MockConsole, MockGet, run_rule
 from pants.testutil.test_base import TestBase
@@ -137,7 +131,7 @@ class TestTest(TestBase):
         # TODO: this is not robust to set as an empty digest. Add a test util that provides
         #  some premade snapshots and possibly a generalized make_hydrated_target function.
         directory_digest=EMPTY_DIRECTORY_DIGEST,
-        files=("test.py",) if include_sources else (),
+        files=tuple(["test.py"] if include_sources else []),
         dirs=()
       )
     )
@@ -147,7 +141,7 @@ class TestTest(TestBase):
       PythonBinaryAdaptor(type_alias='python_binary', sources=mocked_fileset)
     )
     with self.captured_logging(logging.INFO):
-      result = run_rule(
+      result: AddressAndTestResult = run_rule(
         coordinator_of_tests,
         rule_args=[
           HydratedTarget(address, target_adaptor, ()),

--- a/src/python/pants/subsystem/BUILD
+++ b/src/python/pants/subsystem/BUILD
@@ -17,4 +17,5 @@ python_tests(
     'src/python/pants/subsystem',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {'partially_type_checked'},
 )

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -7,6 +7,7 @@ from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from hashlib import sha1
 from itertools import repeat
+from typing import Optional
 
 from pants.base.exceptions import TaskError
 from pants.base.worker_pool import Work
@@ -58,7 +59,7 @@ class TaskBase(SubsystemClientMixin, Optionable, metaclass=ABCMeta):
 
   # We set this explicitly on the synthetic subclass, so that it shares a stable name with
   # its superclass, which is not necessary for regular use, but can be convenient in tests.
-  _stable_name = None
+  _stable_name: Optional[str] = None
 
   @classmethod
   def implementation_version(cls):

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -87,6 +87,7 @@ python_library(
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -98,6 +99,7 @@ python_library(
     'src/python/pants/init',
     'src/python/pants/util:meta',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -113,6 +115,7 @@ python_library(
     'src/python/pants/util:objects',
     ':test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(

--- a/src/python/pants/testutil/console_rule_test_base.py
+++ b/src/python/pants/testutil/console_rule_test_base.py
@@ -21,7 +21,7 @@ class ConsoleRuleTestBase(TestBase):
   :API: public
   """
 
-  _implicit_args = tuple(['--pants-config-files=[]'])
+  _implicit_args = ('--pants-config-files=[]',)
 
   @classproperty
   def goal_cls(cls):
@@ -62,16 +62,13 @@ class ConsoleRuleTestBase(TestBase):
 
     # Flush and capture console output.
     console.flush()
-    stdout = stdout.getvalue()
-    stderr = stderr.getvalue()
+    stdout_val = stdout.getvalue()
+    stderr_val = stderr.getvalue()
 
-    self.assertEqual(
-        exit_code,
-        actual_exit_code,
-        "Exited with {} (expected {}):\nstdout:\n{}\nstderr:\n{}".format(actual_exit_code, exit_code, stdout, stderr)
-      )
+    assert exit_code == actual_exit_code, \
+      f"Exited with {actual_exit_code} (expected {exit_code}):\nstdout:\n{stdout_val}\nstderr:\n{stderr_val}"
 
-    return stdout
+    return stdout_val
 
   def assert_entries(self, sep, *output, **kwargs):
     """Verifies the expected output text is flushed by the console task under test.

--- a/src/python/pants/testutil/engine/BUILD
+++ b/src/python/pants/testutil/engine/BUILD
@@ -8,7 +8,8 @@ python_library(
     'src/python/pants/goal',
     'src/python/pants/goal:task_registrar',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 

--- a/src/python/pants/testutil/jvm/BUILD
+++ b/src/python/pants/testutil/jvm/BUILD
@@ -19,6 +19,7 @@ python_library(
     'src/python/pants/java/jar',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -28,6 +29,7 @@ python_library(
     ':jvm_tool_task_test_base',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -36,6 +38,7 @@ python_library(
   dependencies=[
     ':nailgun_task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -47,4 +50,5 @@ python_library(
     'src/python/pants/testutil:task_test_base',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/src/python/pants/testutil/task_test_base.py
+++ b/src/python/pants/testutil/task_test_base.py
@@ -335,7 +335,7 @@ class DeclarativeTaskTestMixin:
     this_task: Task
     after_tasks: Tuple[Task, ...]
 
-  def invoke_tasks(self, target_closure=None, **context_kwargs) -> 'TaskInvocationResult':
+  def invoke_tasks(self, target_closure=None, **context_kwargs):
     """Create and execute the declaratively specified tasks in order.
 
     Create instances of and execute task types in `self.run_before_task_types()`, then
@@ -359,7 +359,7 @@ class DeclarativeTaskTestMixin:
       for_task_types=all_synthesized_task_types,
       **context_kwargs)
     if target_closure is not None:
-      self.assertEqual(set(target_closure), set(context.build_graph.targets()))
+      assert set(target_closure) == set(context.build_graph.targets())
 
     run_before_task_instances = [
       self._create_task(task_type, context)

--- a/src/python/pants/testutil/test_base.py
+++ b/src/python/pants/testutil/test_base.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from tempfile import mkdtemp
 from textwrap import dedent
-from typing import Any, Type, TypeVar, Union, cast
+from typing import Any, Optional, Type, TypeVar, Union, cast
 
 from pants.base.build_root import BuildRoot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
@@ -90,7 +90,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
   :API: public
   """
 
-  _scheduler = None
+  _scheduler: Optional[SchedulerSession] = None
   _local_store_dir = None
   _build_graph = None
   _address_mapper = None
@@ -408,7 +408,7 @@ class TestBase(unittest.TestCase, metaclass=ABCMeta):
     if self._scheduler is None:
       self._init_engine()
       self.post_scheduler_init()
-    return self._scheduler
+    return cast(SchedulerSession, self._scheduler)
 
   def post_scheduler_init(self):
     """Run after initializing the Scheduler, it will have the same lifetime"""

--- a/tests/python/pants_test/auth/BUILD
+++ b/tests/python/pants_test/auth/BUILD
@@ -6,5 +6,6 @@ python_tests(
     'src/python/pants/auth',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/codegen/antlr/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/antlr/java/BUILD
@@ -12,7 +12,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 

--- a/tests/python/pants_test/backend/codegen/antlr/python/BUILD
+++ b/tests/python/pants_test/backend/codegen/antlr/python/BUILD
@@ -11,7 +11,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 

--- a/tests/python/pants_test/backend/codegen/grpcio/BUILD
+++ b/tests/python/pants_test/backend/codegen/grpcio/BUILD
@@ -8,5 +8,6 @@ python_tests(
     'src/python/pants/base:build_environment',
     'src/python/pants/testutil:task_test_base',
   ],
-  sources=globs('*.py')
+  sources=globs('*.py'),
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/codegen/jaxb/BUILD
+++ b/tests/python/pants_test/backend/codegen/jaxb/BUILD
@@ -9,4 +9,5 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil/jvm:nailgun_task_test_base'
   ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/codegen/protobuf/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/protobuf/java/BUILD
@@ -13,7 +13,8 @@ python_tests(
     'src/python/pants/testutil:test_base',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 

--- a/tests/python/pants_test/backend/codegen/ragel/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/ragel/java/BUILD
@@ -8,4 +8,5 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/codegen/thrift/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/thrift/java/BUILD
@@ -9,5 +9,6 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/codegen/thrift/python/BUILD
+++ b/tests/python/pants_test/backend/codegen/thrift/python/BUILD
@@ -13,5 +13,6 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/codegen/wire/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/wire/java/BUILD
@@ -17,7 +17,8 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 

--- a/tests/python/pants_test/backend/docgen/targets/BUILD
+++ b/tests/python/pants_test/backend/docgen/targets/BUILD
@@ -10,5 +10,6 @@ python_tests(
     'src/python/pants/base:build_environment',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/docgen/tasks/BUILD
+++ b/tests/python/pants_test/backend/docgen/tasks/BUILD
@@ -13,9 +13,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
   ],
-  coverage = [
-    'pants.backend.docgen.tasks.markdown_to_html',
-  ]
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -26,9 +24,6 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:int-test',
     'testprojects/src/java/org/pantsbuild/testproject:page_directory',
-  ],
-  coverage = [
-    'pants.backend.docgen.tasks.markdown_to_html',
   ],
   tags = {'integration'},
 )

--- a/tests/python/pants_test/backend/graph_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/graph_info/tasks/BUILD
@@ -12,7 +12,8 @@ python_tests(
     'src/python/pants/backend/python/targets',
     'src/python/pants/base:build_environment',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -37,7 +38,8 @@ python_tests(
     'src/python/pants/backend/python/targets',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -49,6 +51,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -63,6 +66,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -78,6 +82,7 @@ python_tests(
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:console_rule_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -89,6 +94,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -98,7 +104,8 @@ python_tests(
     'src/python/pants/backend/graph_info/tasks',
     'src/python/pants/base:exceptions',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -120,6 +127,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -129,5 +137,6 @@ python_tests(
     'src/python/pants/backend/graph_info/tasks',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/graph_info/tasks/test_list_targets.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_list_targets.py
@@ -58,7 +58,7 @@ class ListTargetsTest(ConsoleRuleTestBase):
             """).strip() if provides else 'None'
 
     def create_library(path: str, *libs: Lib) -> None:
-      libs = libs or [Lib(os.path.basename(os.path.dirname(self.build_path(path))))]
+      libs = libs or (Lib(os.path.basename(os.path.dirname(self.build_path(path)))),)
       for lib in libs:
         target = f"java_library(name='{lib.name}', provides={lib.provides}, sources=[])\n"
         self.add_to_build_file(path, target)

--- a/tests/python/pants_test/backend/jvm/subsystems/BUILD
+++ b/tests/python/pants_test/backend/jvm/subsystems/BUILD
@@ -29,6 +29,7 @@ python_tests(
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil/subsystem',
   ],
+  tags = {"partially_type_checked"},
 )
 
 
@@ -45,7 +46,8 @@ python_tests(
     'src/python/pants/backend/jvm/tasks/jvm_compile/zinc',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -89,7 +91,8 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/targets/BUILD
+++ b/tests/python/pants_test/backend/jvm/targets/BUILD
@@ -7,7 +7,8 @@ python_tests(
   dependencies=[
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -39,7 +40,8 @@ python_tests(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -52,6 +54,7 @@ python_tests(
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -64,7 +67,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/source',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -77,7 +81,8 @@ python_tests(
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -87,5 +92,6 @@ python_tests(
     'src/python/pants/java/jar',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -20,7 +20,8 @@ python_tests(
     'src/python/pants/java/jar',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil/jvm:jvm_tool_task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -38,7 +39,8 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil/jvm:jvm_tool_task_test_base',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -58,7 +60,8 @@ python_tests(
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
     'src/python/pants/testutil/jvm:jvm_tool_task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -101,7 +104,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -117,7 +121,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -130,7 +135,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -158,7 +164,8 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:check_published_deps',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -178,7 +185,8 @@ python_tests(
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:file_test_util',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -191,7 +199,8 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:classpath_util',
     'src/python/pants/goal:products',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -209,6 +218,7 @@ python_tests(
     'src/python/pants/testutil/jvm:jvm_task_test_base',
     'src/python/pants/testutil/subsystem',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -224,6 +234,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -247,7 +258,8 @@ python_tests(
     'src/python/pants/java/jar',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -278,14 +290,13 @@ python_tests(
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
   name = 'coursier_resolve',
-  sources = [
-    'test_coursier_resolve.py',
-  ],
+  sources = ['test_coursier_resolve.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/jvm/subsystems:jar_dependency_management',
@@ -300,7 +311,8 @@ python_tests(
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -343,7 +355,8 @@ python_tests(
     'tests/python/pants_test/backend/jvm/tasks/ivy_utils_resources',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -365,6 +378,7 @@ python_tests(
     'src/python/pants/testutil:task_test_base',
     'src/python/pants/testutil/subsystem',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -382,6 +396,7 @@ python_tests(
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil:mock_logger',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -414,7 +429,8 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil/jvm:jar_task_test_base',
     'src/python/pants/testutil/jvm:jvm_tool_task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -501,7 +517,8 @@ python_library(
     'src/python/pants/backend/jvm/tasks:classpath_products',
     'src/python/pants/java/jar',
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -527,7 +544,8 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:jvm_dependency_usage',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -551,7 +569,8 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:jvm_platform_analysis',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -574,7 +593,8 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:run_jvm_prep_command',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -598,7 +618,8 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:jvm_task',
     'src/python/pants/testutil/jvm:jvm_task_test_base',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -610,7 +631,8 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:jvm_run',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil/jvm:jvm_task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -635,7 +657,8 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:jvmdoc_gen',
     'src/python/pants/base:exceptions',
     'src/python/pants/testutil/jvm:jvm_task_test_base'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 resources(
@@ -656,7 +679,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -669,7 +693,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -682,7 +707,8 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:prepare_services',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -709,6 +735,7 @@ python_tests(
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil/subsystem'
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -739,7 +766,8 @@ python_tests(
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -802,7 +830,8 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -831,6 +860,7 @@ python_tests(
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -858,4 +888,5 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil/jvm:jvm_tool_task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/jvm/tasks/coverage/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/coverage/BUILD
@@ -7,5 +7,6 @@ python_tests(
     'src/python/pants/backend/jvm/tasks/coverage',
     'src/python/pants/java/jar',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -11,6 +11,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -21,6 +22,7 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:classpath_products',
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -84,6 +84,7 @@ python_tests(
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil/subsystem',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(

--- a/tests/python/pants_test/backend/jvm/tasks/reports/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/reports/BUILD
@@ -14,5 +14,5 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:strutil',
     'tests/python/pants_test:test_infra',
-  ]
+  ],
 )

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
@@ -7,12 +7,8 @@ from pants.backend.jvm.artifact import Artifact
 from pants.backend.jvm.repository import Repository
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
-from pants.backend.jvm.tasks.classpath_products import (
-  ArtifactClasspathEntry,
-  ClasspathEntry,
-  ClasspathProducts,
-  MissingClasspathEntryError,
-)
+from pants.backend.jvm.tasks.classpath_entry import ArtifactClasspathEntry, ClasspathEntry
+from pants.backend.jvm.tasks.classpath_products import ClasspathProducts, MissingClasspathEntryError
 from pants.base.exceptions import TaskError
 from pants.build_graph.target import Target
 from pants.java.jar.exclude import Exclude

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_util.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_util.py
@@ -5,7 +5,8 @@ import os
 from collections import OrderedDict
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
-from pants.backend.jvm.tasks.classpath_products import ClasspathEntry, ClasspathProducts
+from pants.backend.jvm.tasks.classpath_entry import ClasspathEntry
+from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.java.jar.exclude import Exclude
 from pants.java.jar.jar_dependency_utils import M2Coordinate, ResolvedJar

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
@@ -108,7 +108,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
               ],
               sources=['w.java'],
             )
-        """.format(org=self.b_org, name=self.b_name)))
+        """))
 
     self.add_to_build_file('src/java/targets',
         dedent("""
@@ -121,7 +121,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
               excludes=[exclude(org='commons-lang', name='commons-lang')],
               sources=['w.java'],
             )
-        """.format(org=self.b_org, name=self.b_name)))
+        """))
 
     self.a = self.target('src/java/targets:a')
     self.b = self.target('src/java/targets:b')

--- a/tests/python/pants_test/backend/native/subsystems/BUILD
+++ b/tests/python/pants_test/backend/native/subsystems/BUILD
@@ -12,6 +12,6 @@ python_tests(
     'tests/python/pants_test/engine:scheduler_test_base',
     'src/python/pants/testutil/subsystem',
   ],
-  tags={'platform_specific_behavior'},
+  tags={'platform_specific_behavior', 'partially_type_checked'},
   timeout=120,
 )

--- a/tests/python/pants_test/backend/native/subsystems/test_libc_resolution.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_libc_resolution.py
@@ -1,9 +1,9 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.native.config.environment import Platform
 from pants.backend.native.subsystems.libc_dev import LibcDev
 from pants.backend.native.subsystems.utils.parse_search_dirs import ParseSearchDirs
+from pants.engine.platform import Platform
 from pants.testutil.subsystem.util import global_subsystem_instance, init_subsystems
 from pants.testutil.test_base import TestBase
 from pants_test.backend.native.util.platform_utils import platform_specific

--- a/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
+++ b/tests/python/pants_test/backend/native/subsystems/test_native_toolchain.py
@@ -6,7 +6,6 @@ import re
 import subprocess
 from contextlib import contextmanager
 
-from pants.backend.native.config.environment import Platform
 from pants.backend.native.register import rules as native_backend_rules
 from pants.backend.native.subsystems.binaries.gcc import GCC
 from pants.backend.native.subsystems.binaries.llvm import LLVM
@@ -18,7 +17,7 @@ from pants.backend.native.subsystems.native_toolchain import (
   LLVMCToolchain,
   NativeToolchain,
 )
-from pants.engine.platform import create_platform_rules
+from pants.engine.platform import Platform, create_platform_rules
 from pants.testutil.subsystem.util import global_subsystem_instance, init_subsystems
 from pants.testutil.test_base import TestBase
 from pants.util.contextutil import environment_as, pushd, temporary_dir

--- a/tests/python/pants_test/backend/native/tasks/BUILD
+++ b/tests/python/pants_test/backend/native/tasks/BUILD
@@ -4,7 +4,7 @@ python_tests(
     'src/python/pants/backend/native/targets',
     'src/python/pants/backend/native/tasks',
   ],
-  tags={'platform_specific_behavior'},
+  tags={'platform_specific_behavior', 'partially_type_checked'},
   timeout=280,
 )
 
@@ -17,4 +17,5 @@ python_library(
     'src/python/pants/backend/python/tasks',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -22,7 +22,8 @@ python_tests(
     'src/python/pants/backend/python:python_requirement',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -38,7 +39,8 @@ python_tests(
     'src/python/pants/subsystem',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -67,7 +69,8 @@ python_tests(
     'src/python/pants/util:osutil',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -96,7 +99,8 @@ python_tests(
     'src/python/pants/util:osutil',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -137,6 +141,7 @@ python_tests(
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -145,6 +150,7 @@ python_tests(
   dependencies = [
     'src/python/pants/backend/project_info/tasks:idea_plugin_gen',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -10,7 +10,8 @@ python_tests(
     'src/python/pants/backend/python/targets',
     'src/python/pants/base:build_environment',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -22,7 +23,8 @@ python_tests(
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -36,6 +38,7 @@ python_tests(
     'tests/python/pants_test:interpreter_selection_utils',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -60,5 +63,5 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:int-test',
-  ]
+  ],
 )

--- a/tests/python/pants_test/backend/python/subsystems/BUILD
+++ b/tests/python/pants_test/backend/python/subsystems/BUILD
@@ -9,5 +9,6 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil:pexrc_util',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/python/targets/BUILD
+++ b/tests/python/pants_test/backend/python/targets/BUILD
@@ -7,5 +7,6 @@ python_tests(
     'src/python/pants/backend/python:python_requirement',
     'src/python/pants/util:collections',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -11,7 +11,8 @@ python_library(
     'src/python/pants/subsystem',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -23,6 +24,7 @@ python_tests(
     'src/python/pants/backend/python/targets',
     'tests/python/pants_test/backend/python/tasks/util',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -53,6 +55,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -79,6 +82,7 @@ python_tests(
     'tests/python/pants_test:interpreter_selection_utils',
     ':python_task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -108,6 +112,7 @@ python_tests(
     'src/python/pants/testutil/subsystem',
     ':python_task_test_base',
   ],
+  tags = {"partially_type_checked"},
   timeout=480,
 )
 
@@ -138,6 +143,7 @@ python_tests(
     'src/python/pants/build_graph',
     ':python_task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -164,6 +170,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     ':python_task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -203,6 +210,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     ':python_task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -220,6 +228,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -235,6 +244,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -256,6 +266,7 @@ python_tests(
     'src/python/pants/testutil/subsystem',
     'tests/python/pants_test:interpreter_selection_utils',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -284,4 +295,5 @@ python_tests(
     'src/python/pants/util:collections',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/backend/python/tasks/native/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/native/BUILD
@@ -27,7 +27,7 @@ python_tests(
     'tests/python/pants_test:interpreter_selection_utils',
     'src/python/pants/testutil:task_test_base',
   ],
-  tags={'platform_specific_behavior'},
+  tags={'platform_specific_behavior', 'partially_type_checked'},
   timeout=600,
 )
 

--- a/tests/python/pants_test/backend/python/tasks/util/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/util/BUILD
@@ -1,3 +1,6 @@
+# Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 python_library(
   dependencies=[
     'src/python/pants/backend/native',
@@ -7,5 +10,6 @@ python_library(
     'src/python/pants/util:meta',
     'tests/python/pants_test/backend/python/tasks:python_task_test_base',
     'tests/python/pants_test/engine:scheduler_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -20,7 +20,8 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -42,7 +43,8 @@ python_tests(
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -51,7 +53,7 @@ python_library(
   dependencies = [
     'src/python/pants/testutil/base:context_utils',
     'tests/python/pants_test:deprecated_testinfra',
-  ]
+  ],
 )
 
 python_tests(
@@ -63,6 +65,7 @@ python_tests(
     'src/python/pants:version',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -83,7 +86,8 @@ python_tests(
   dependencies = [
     'src/python/pants/base:fingerprint_strategy',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -92,7 +96,8 @@ python_tests(
   dependencies = [
     'src/python/pants/base:generator',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -133,7 +138,8 @@ python_tests(
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -144,7 +150,8 @@ python_tests(
     'src/python/pants/backend/python:python_requirement',
     'src/python/pants/base:payload_field',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -162,7 +169,8 @@ python_tests(
   dependencies = [
     'src/python/pants/base:revision',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -172,7 +180,8 @@ python_tests(
     'src/python/pants/base:run_info',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/binaries/BUILD
+++ b/tests/python/pants_test/binaries/BUILD
@@ -10,5 +10,6 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -11,7 +11,8 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -54,7 +55,8 @@ python_tests(
     'src/python/pants/base:build_file',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -65,6 +67,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base'
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -103,7 +106,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -113,7 +117,8 @@ python_tests(
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -127,7 +132,8 @@ python_tests(
     'src/python/pants/source',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -137,7 +143,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/source',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -147,5 +154,6 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/task',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/build_graph/test_build_graph.py
+++ b/tests/python/pants_test/build_graph/test_build_graph.py
@@ -208,7 +208,7 @@ class BuildGraphTest(TestBase):
 
     def empty_gen():
       return
-      yield
+      yield  # type: ignore[misc] # MyPy complains that this is not reachable
     self.assertEqual([], BuildGraph.closure(empty_gen()))
 
   def test_closure_bfs(self):

--- a/tests/python/pants_test/build_graph/test_target_filter_subsystem.py
+++ b/tests/python/pants_test/build_graph/test_target_filter_subsystem.py
@@ -11,7 +11,9 @@ class TestTargetFilter(TaskTestBase):
 
   class DummyTask(Task):
     options_scope = 'dummy'
-    target_filtering_enabled = True
+    # TODO: MyPy doesn't understand when a class property was defined via a method with
+    # @classproperty and then is treated as a normal class var in a subclass.
+    target_filtering_enabled = True  # type: ignore[assignment]
 
     def execute(self):
       self.context.products.safe_create_data('task_targets', self.get_targets)

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -9,7 +9,8 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -22,7 +23,8 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -37,7 +39,8 @@ python_tests(
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/option',
     'src/python/pants/testutil:mock_logger',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -51,6 +54,7 @@ python_tests(
     'src/python/pants/cache:cache',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -62,6 +66,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(

--- a/tests/python/pants_test/core_tasks/BUILD
+++ b/tests/python/pants_test/core_tasks/BUILD
@@ -8,7 +8,8 @@ python_tests(
   dependencies=[
     'src/python/pants/core_tasks',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -44,7 +45,8 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:task_test_base',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -28,6 +28,7 @@ python_tests(
     'src/python/pants/engine:legacy_engine',
     'src/python/pants/testutil/base:context_utils',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -39,6 +40,7 @@ python_tests(
     'src/python/pants/task',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -60,7 +62,8 @@ python_tests(
     'src/python/pants/engine:nodes',
     'src/python/pants/testutil:test_base',
     'tests/python/pants_test/engine/examples:fs_test',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -77,6 +80,7 @@ python_tests(
     'tests/python/pants_test/engine/examples:fs_test',
     'tests/python/pants_test/engine/examples:scheduler_inputs',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -180,6 +184,7 @@ python_tests(
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -195,6 +200,7 @@ python_tests(
     'tests/python/pants_test/engine/examples:scheduler_inputs',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -13,7 +13,8 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil/engine:util',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -137,7 +138,8 @@ python_tests(
     'src/python/pants/init',
     'src/python/pants/testutil/engine:util',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -177,7 +179,8 @@ python_tests(
     'src/python/pants/init',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/engine:util',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -79,13 +79,13 @@ class CatExecutionRequest:
 @rule
 async def cat_files_process_result_concatted(cat_exe_req: CatExecutionRequest) -> Concatted:
   cat_bin = cat_exe_req.shell_cat
-  cat_files_snapshot = await Get(Snapshot, PathGlobs, cat_exe_req.path_globs)
+  cat_files_snapshot = await Get[Snapshot](PathGlobs, cat_exe_req.path_globs)
   process_request = ExecuteProcessRequest(
     argv=cat_bin.argv_from_snapshot(cat_files_snapshot),
     input_files=cat_files_snapshot.directory_digest,
     description='cat some files',
   )
-  cat_process_result = await Get(ExecuteProcessResult, ExecuteProcessRequest, process_request)
+  cat_process_result = await Get[ExecuteProcessResult](ExecuteProcessRequest, process_request)
   return Concatted(cat_process_result.stdout.decode())
 
 
@@ -121,8 +121,9 @@ async def get_javac_version_output(javac_version_command: JavacVersionExecutionR
     description=javac_version_command.description,
     input_files=EMPTY_DIRECTORY_DIGEST,
   )
-  javac_version_proc_result = await Get(
-    ExecuteProcessResult, ExecuteProcessRequest, javac_version_proc_req)
+  javac_version_proc_result = await Get[ExecuteProcessResult](
+    ExecuteProcessRequest, javac_version_proc_req,
+  )
 
   return JavacVersionOutput(javac_version_proc_result.stderr.decode())
 
@@ -172,7 +173,7 @@ async def javac_compile_process_result(javac_compile_req: JavacCompileRequest) -
   for java_file in java_files:
     if not java_file.endswith(".java"):
       raise ValueError(f"Can only compile .java files but got {java_file}")
-  sources_snapshot = await Get(Snapshot, PathGlobs, PathGlobs(java_files, ()))
+  sources_snapshot = await Get[Snapshot](PathGlobs, PathGlobs(java_files, ()))
   output_dirs = tuple({os.path.dirname(java_file) for java_file in java_files})
   process_request = ExecuteProcessRequest(
     argv=javac_compile_req.argv_from_source_snapshot(sources_snapshot),
@@ -180,7 +181,7 @@ async def javac_compile_process_result(javac_compile_req: JavacCompileRequest) -
     output_directories=output_dirs,
     description='javac compilation'
   )
-  javac_proc_result = await Get(ExecuteProcessResult, ExecuteProcessRequest, process_request)
+  javac_proc_result = await Get[ExecuteProcessResult](ExecuteProcessRequest, process_request)
 
   return JavacCompileResult(
     javac_proc_result.stdout.decode(),

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -81,7 +81,7 @@ class Example(Goal):
 
 @console_rule
 async def a_console_rule_generator(console: Console) -> Example:
-  a = await Get(A, str('a str!'))
+  a = await Get[A](str('a str!'))
   console.print_stdout(str(a))
   return Example(exit_code=0)
 
@@ -309,8 +309,8 @@ class RuleGraphTest(TestBase):
       pass
 
     @rule
-    async def d_from_a_and_suba(a: A, suba: SubA) -> D:
-      _ = await Get(A, C, C())  # noqa: F841
+    async def d_from_a_and_suba(a: A, suba: SubA) -> D:  # type: ignore[return]
+      _ = await Get[A](C, C())  # noqa: F841
 
     @rule
     def a_from_c(c: C) -> A:
@@ -510,8 +510,8 @@ class RuleGraphTest(TestBase):
     # they intend for the Get's parameter to be consumed in the subgraph. Anything else would
     # be surprising.
     @rule
-    async def a(sub_a: SubA) -> A:
-      _ = await Get(B, C())  # noqa: F841
+    async def a(sub_a: SubA) -> A:  # type: ignore[return]
+      _ = await Get[B](C())  # noqa: F841
 
     @rule
     def b_from_suba(suba: SubA) -> B:
@@ -799,8 +799,8 @@ class RuleGraphTest(TestBase):
 
   def test_get_simple(self):
     @rule
-    async def a() -> A:
-      _ = await Get(B, D, D())  # noqa: F841
+    async def a() -> A:  # type: ignore[return]
+      _ = await Get[B](D, D())  # noqa: F841
 
     @rule
     async def b_from_d(d: D) -> B:

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -33,7 +33,7 @@ def fn_raises(x):
 
 
 @rule
-def nested_raise(x: B) -> A:
+def nested_raise(x: B) -> A:  # type: ignore[return]
   fn_raises(x)
 
 
@@ -59,7 +59,7 @@ class D:
 
 @rule
 async def transitive_coroutine_rule(c: C) -> D:
-  b = await Get(B, C, c)
+  b = await Get[B](C, c)
   return D(b)
 
 
@@ -89,7 +89,7 @@ class UnionA:
 
 @rule
 def select_union_a(union_a: UnionA) -> A:
-  return union_a.a()
+  return union_a.a()  # type: ignore[no-any-return]
 
 
 class UnionB:
@@ -100,13 +100,13 @@ class UnionB:
 
 @rule
 def select_union_b(union_b: UnionB) -> A:
-  return union_b.a()
+  return union_b.a()  # type: ignore[no-any-return]
 
 
 # TODO: add GetMulti testing for unions!
 @rule
 async def a_union_test(union_wrapper: UnionWrapper) -> A:
-  union_a = await Get(A, UnionBase, union_wrapper.inner)
+  union_a = await Get[A](UnionBase, union_wrapper.inner)
   return union_a
 
 
@@ -116,7 +116,7 @@ class UnionX:
 
 @rule
 async def error_msg_test_rule(union_wrapper: UnionWrapper) -> UnionX:
-  union_x = await Get(UnionX, UnionWithNonMemberErrorMsg, union_wrapper.inner)
+  union_x = await Get[UnionX](UnionWithNonMemberErrorMsg, union_wrapper.inner)
   return union_x
 
 

--- a/tests/python/pants_test/goal/BUILD
+++ b/tests/python/pants_test/goal/BUILD
@@ -9,7 +9,8 @@ python_tests(
     'src/python/pants/goal:artifact_cache_stats',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -29,7 +30,8 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/init/BUILD
+++ b/tests/python/pants_test/init/BUILD
@@ -26,5 +26,5 @@ python_tests(
     'tests/python/pants_test:interpreter_selection_utils',
     'src/python/pants/testutil:test_base',
   ],
-  coverage = ['pants.init'],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/invalidation/BUILD
+++ b/tests/python/pants_test/invalidation/BUILD
@@ -20,7 +20,8 @@ python_tests(
     'src/python/pants/invalidation',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/java/BUILD
+++ b/tests/python/pants_test/java/BUILD
@@ -31,7 +31,8 @@ python_tests(
     '3rdparty/python:psutil',
     'src/python/pants/java:nailgun_executor',
     'src/python/pants/testutil:test_base'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -83,5 +84,6 @@ python_tests(
     'src/python/pants/java:util',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/java/junit/BUILD
+++ b/tests/python/pants_test/java/junit/BUILD
@@ -8,5 +8,6 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:xml_parser',
     'src/python/pants/testutil:test_base'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/jvm/BUILD
+++ b/tests/python/pants_test/jvm/BUILD
@@ -8,7 +8,8 @@ python_tests(
     'src/python/pants/backend/jvm:artifact',
     'src/python/pants/backend/jvm:repository',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/jvm/subsystems/BUILD
+++ b/tests/python/pants_test/jvm/subsystems/BUILD
@@ -7,5 +7,6 @@ python_tests(
   dependencies=[
     'src/python/pants/backend/jvm/subsystems:jvm',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/logging/BUILD
+++ b/tests/python/pants_test/logging/BUILD
@@ -3,9 +3,7 @@
 
 python_tests(
   name='test_native_engine_logging',
-  sources=[
-    'test_native_engine_logging.py'
-  ],
+  sources=['test_native_engine_logging.py'],
   dependencies=[
     'src/python/pants/testutil:int-test',
     'tests/python/pants_test/pantsd:pantsd_integration_test_base',
@@ -15,9 +13,7 @@ python_tests(
 
 python_tests(
   name='test_workunit_label',
-  sources=[
-    'test_workunit_label.py'
-  ],
+  sources=['test_workunit_label.py'],
   dependencies=[
     'src/python/pants/goal:run_tracker',
     'src/python/pants/testutil:int-test',

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -15,7 +15,8 @@ python_tests(
   dependencies = [
     ':test_deps',
     'src/python/pants/pantsd:process_manager',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -25,7 +26,8 @@ python_tests(
   dependencies = [
     ':test_deps',
     'src/python/pants/pantsd:watchman'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -35,7 +37,8 @@ python_tests(
   dependencies = [
     ':test_deps',
     'src/python/pants/pantsd:watchman_client'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -45,7 +48,8 @@ python_tests(
   dependencies = [
     ':test_deps',
     'src/python/pants/pantsd:pailgun_server'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -58,7 +62,8 @@ python_tests(
     'src/python/pants/pantsd:pants_daemon',
     'src/python/pants/pantsd/service:pants_service',
     'src/python/pants/util:contextutil',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_library(
@@ -99,5 +104,6 @@ python_tests(
     'tests/python/pants_test/pantsd:test_deps',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/pantsd:watchman_launcher'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/pantsd/service/BUILD
+++ b/tests/python/pants_test/pantsd/service/BUILD
@@ -8,7 +8,8 @@ python_tests(
   dependencies = [
     'tests/python/pants_test/pantsd:test_deps',
     'src/python/pants/pantsd/service:pants_service'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -18,7 +19,8 @@ python_tests(
   dependencies = [
     'tests/python/pants_test/pantsd:test_deps',
     'src/python/pants/pantsd/service:fs_event_service'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -28,5 +30,6 @@ python_tests(
   dependencies = [
     'tests/python/pants_test/pantsd:test_deps',
     'src/python/pants/pantsd/service:pailgun_service'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/process/BUILD
+++ b/tests/python/pants_test/process/BUILD
@@ -6,5 +6,6 @@ python_tests(
     'src/python/pants/process',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -37,6 +37,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -47,4 +48,5 @@ python_tests(
     'src/python/pants/reporting',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/source/BUILD
+++ b/tests/python/pants_test/source/BUILD
@@ -7,7 +7,8 @@ python_tests(
   dependencies = [
     'src/python/pants/source',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -18,7 +19,8 @@ python_tests(
     'src/python/pants/source:payload_fields',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -27,7 +29,8 @@ python_tests(
   dependencies = [
     'src/python/pants/source',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -38,5 +41,6 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/source',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/targets/BUILD
+++ b/tests/python/pants_test/targets/BUILD
@@ -6,6 +6,7 @@ python_library(
   dependencies = [
     'src/python/pants/testutil:test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -24,7 +25,8 @@ python_tests(
   dependencies = [
     ':base',
     'src/python/pants/build_graph',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -35,7 +37,8 @@ python_tests(
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -56,7 +59,8 @@ python_tests(
     ':base',
     'src/python/pants/backend/python/targets',
     'src/python/pants/build_graph',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -69,7 +73,8 @@ python_tests(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/build_graph',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -83,5 +88,6 @@ python_tests(
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base'
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/task/BUILD
+++ b/tests/python/pants_test/task/BUILD
@@ -7,7 +7,8 @@ python_tests(
   dependencies = [
     'src/python/pants/task',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -28,7 +29,8 @@ python_tests(
     'src/python/pants/task',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -43,6 +45,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -65,7 +68,8 @@ python_tests(
     'src/python/pants/task',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -75,7 +79,8 @@ python_tests(
     'src/python/pants/task',
     'src/python/pants/util:process_handler',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -85,4 +90,5 @@ python_tests(
     'src/python/pants/task',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {"partially_type_checked"},
 )

--- a/tests/python/pants_test/task/test_task.py
+++ b/tests/python/pants_test/task/test_task.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from typing import List, Tuple
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
@@ -57,7 +58,7 @@ class DummyTask(Task):
 
 
 class FakeTask(Task):
-  _impls = []
+  _impls: List[Tuple[str, int]] = []
 
   @classmethod
   def implementation_version(cls):
@@ -79,7 +80,7 @@ class FakeTask(Task):
 
 
 class OtherFakeTask(FakeTask):
-  _other_impls = []
+  _other_impls: List[Tuple[str, int]] = []
 
   @classmethod
   def supports_passthru_args(cls):
@@ -146,7 +147,9 @@ class TaskWithTransitiveSubsystemDependencies(Task):
 
 class TaskWithTargetFiltering(DummyTask):
   options_scope = 'task-with-target-filtering'
-  target_filtering_enabled = True
+  # TODO: MyPy doesn't understand when a class property was defined via a method with
+  # @classproperty and then is treated as a normal class var in a subclass.
+  target_filtering_enabled = True  # type: ignore[assignment]
 
 
 class TaskTest(TaskTestBase):

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -99,6 +99,7 @@ python_tests(
     'src/python/pants/util:meta',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -118,6 +119,7 @@ python_tests(
     'src/python/pants/util:objects',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(
@@ -127,6 +129,7 @@ python_tests(
     'src/python/pants/util:osutil',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {"partially_type_checked"},
 )
 
 python_tests(

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -57,7 +57,7 @@ class WithProp:
     return cls._value
 
   @staticproperty
-  def static_property():
+  def static_property():  # type: ignore[misc]  # MyPy expects methods to have `self` or `cls`
     "static_property docs"
     return 'static_property'
 
@@ -289,7 +289,7 @@ class FrozenAfterInitTest(unittest.TestCase):
 
     test = Test()
     with self.assertRaises(FrozenInstanceError):
-      test.x = 1
+      test.x = 1  # type: ignore[attr-defined]
 
   def test_init_still_works(self):
     @frozen_after_init
@@ -319,18 +319,18 @@ class FrozenAfterInitTest(unittest.TestCase):
     class Test:
 
       def __init__(self, x: int) -> None:
-        self.x: x
+        self.x = x
 
     test = Test(x=0)
     with self.assertRaises(FrozenInstanceError):
-      test.y = "abc"
+      test.y = "abc"  # type: ignore[attr-defined]
 
   def test_explicitly_call_setattr_after_init(self) -> None:
     @frozen_after_init
     class Test:
 
       def __init__(self, x: int) -> None:
-        self.x: x
+        self.x = x
 
     test = Test(x=0)
     with self.assertRaises(FrozenInstanceError):


### PR DESCRIPTION
Brings the number of checked files from 863 to 1100. This means that we now run MyPy over V2 tests.