### PR TITLE
Partially type check remaining 250 files

### DIFF
--- a/build-support/bin/mypy.py
+++ b/build-support/bin/mypy.py
@@ -33,7 +33,7 @@ def create_parser() -> argparse.ArgumentParser:
   parser.add_argument(
     "globs",
     nargs='*',
-    default=["build-support::", "contrib::", "src/python::", "tests/python::", "pants-plugins::"]
+    default=["build-support::", "contrib::", "src/python::", "tests/python::", "pants-plugins::"],
   )
   return parser
 

--- a/contrib/avro/tests/python/pants_test/contrib/avro/tasks/BUILD
+++ b/contrib/avro/tests/python/pants_test/contrib/avro/tasks/BUILD
@@ -10,6 +10,7 @@ python_tests(
     'src/python/pants/build_graph:build_graph',
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -19,5 +20,5 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'contrib/avro:avro_tests_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
 )

--- a/contrib/avro/tests/python/pants_test/contrib/avro/tasks/test_avro_gen.py
+++ b/contrib/avro/tests/python/pants_test/contrib/avro/tasks/test_avro_gen.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from textwrap import dedent
+from typing import List
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.testutil.jvm.nailgun_task_test_base import NailgunTaskTestBase
@@ -11,7 +12,7 @@ from pants.contrib.avro.tasks.avro_gen import AvroJavaGenTask
 
 
 class MockAvroJavaGenTest(AvroJavaGenTask):
-  _test_cmd_log = []  # List of lists for commands run by the task under test.
+  _test_cmd_log: List[List[str]] = []  # List of lists for commands run by the task under test.
 
   # Overide this method and record the command that would have been run.
   def _avro(self, args):

--- a/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/examples/BUILD
+++ b/contrib/awslambda/python/src/python/pants/contrib/awslambda/python/examples/BUILD
@@ -11,6 +11,7 @@ python_requirement_library(
 python_library(
   name='hello-lib',
   sources = ['hello_lib.py'],
+  tags = {'partially_type_checked'},
 )
 
 python_binary(
@@ -19,7 +20,8 @@ python_binary(
   dependencies=[
     ':pycountry',
     ':hello-lib',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_awslambda(

--- a/contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python/BUILD
+++ b/contrib/awslambda/python/tests/python/pants_test/contrib/awslambda/python/BUILD
@@ -8,6 +8,6 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:int-test',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout=120,
 )

--- a/contrib/buildgen/tests/python/pants_test/contrib/buildgen/BUILD
+++ b/contrib/buildgen/tests/python/pants_test/contrib/buildgen/BUILD
@@ -11,4 +11,5 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {'partially_type_checked'},
 )

--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/BUILD
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/BUILD
@@ -6,6 +6,7 @@ contrib_plugin(
   dependencies=[
     ':buildrefactor'
   ],
+  tags = {'partially_type_checked'},
   distribution_name='pantsbuild.pants.contrib.buildrefactor',
   description='Plugin to manipulate and refactor BUILD files and targets',
   register_goals=True,

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/BUILD
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/BUILD
@@ -19,7 +19,8 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 
@@ -33,7 +34,8 @@ python_tests(
     'src/python/pants/base:build_environment',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 
@@ -44,7 +46,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/tests/java/org/pantsbuild/testproject:buildrefactor_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
 )
 
 
@@ -55,5 +57,5 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/tests/java/org/pantsbuild/testproject:buildrefactor_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
 )

--- a/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/BUILD
+++ b/contrib/codeanalysis/tests/python/pants_test/contrib/codeanalysis/tasks/BUILD
@@ -9,6 +9,6 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'examples/src/java/org/pantsbuild/example:hello_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout=240,
 )

--- a/contrib/cpp/tests/python/pants_test/contrib/cpp/BUILD
+++ b/contrib/cpp/tests/python/pants_test/contrib/cpp/BUILD
@@ -12,7 +12,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:int-test',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
 )
 
 python_tests(

--- a/contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks/BUILD
+++ b/contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks/BUILD
@@ -8,7 +8,8 @@ python_tests(
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil/option',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -18,6 +19,6 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'contrib/errorprone:java_tests_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout=420,
 )

--- a/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/BUILD
+++ b/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/BUILD
@@ -8,7 +8,8 @@ python_tests(
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil/option',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -18,6 +19,6 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'contrib/findbugs:java_tests_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout=520,
 )

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
@@ -8,7 +8,8 @@ python_tests(
     'contrib/go/src/python/pants/contrib/go/subsystems',
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -39,6 +40,6 @@ python_tests(
     'contrib/go:examples_directory',
     'src/python/pants/testutil:int-test',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout=180,
 )

--- a/contrib/go/tests/python/pants_test/contrib/go/targets/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/targets/BUILD
@@ -7,7 +7,8 @@ python_library(
     'contrib/go/src/python/pants/contrib/go:plugin',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -17,5 +18,6 @@ python_tests(
     'contrib/go/src/python/pants/contrib/go/targets',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
@@ -19,7 +19,7 @@ class GoLocalSourceTestBase(ABC):
   def setUpClass(cls):
     if not issubclass(cls, TestBase):
       raise TypeError('Subclasses must mix in TestBase')
-    super().setUpClass()
+    super().setUpClass()  # type: ignore[misc]  # MyPy does not understand this mixin
 
   def setUp(self):
     super().setUp()

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
@@ -15,6 +15,7 @@ python_tests(
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {'partially_type_checked'},
   timeout=120,
 )
 
@@ -32,6 +33,6 @@ python_tests(
     'src/python/pants/testutil:file_test_util',
     'src/python/pants/testutil:int-test',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout=360,
 )

--- a/contrib/googlejavaformat/tests/python/pants_test/contrib/googlejavaformat/BUILD
+++ b/contrib/googlejavaformat/tests/python/pants_test/contrib/googlejavaformat/BUILD
@@ -1,3 +1,6 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 python_tests(
   dependencies = [
     'contrib/googlejavaformat/src/python/pants/contrib/googlejavaformat',
@@ -7,4 +10,5 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
   ],
+  tags = {'partially_type_checked'},
 )

--- a/contrib/jax_ws/tests/python/pants_test/contrib/jax_ws/tasks/BUILD
+++ b/contrib/jax_ws/tests/python/pants_test/contrib/jax_ws/tasks/BUILD
@@ -8,7 +8,8 @@ python_tests(
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil/option',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -19,6 +20,6 @@ python_tests(
     'src/python/pants/testutil:file_test_util',
     'contrib/jax_ws:wsdl_tests_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout=300,
 )

--- a/contrib/mypy/examples/src/python/mypy_plugin/BUILD
+++ b/contrib/mypy/examples/src/python/mypy_plugin/BUILD
@@ -5,14 +5,14 @@ python_requirement_library(
   name='django',
   requirements=[
     python_requirement('Django==2.2.5'),
-  ]
+  ],
 )
 
 python_requirement_library(
   name='django-stubs',
   requirements=[
     python_requirement('django-stubs==1.1.0'),
-  ]
+  ],
 )
 
 python_library(
@@ -21,6 +21,7 @@ python_library(
   dependencies=[
     ':django-stubs',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -30,6 +31,7 @@ python_library(
     ':django',
     ':settings',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(

--- a/contrib/mypy/examples/src/python/simple/BUILD
+++ b/contrib/mypy/examples/src/python/simple/BUILD
@@ -3,10 +3,11 @@
 
 python_library(
   name = 'valid',
-  source = 'valid.py'
+  source = 'valid.py',
+  tags = {'partially_type_checked'},
 )
 
 python_library(
   name = 'invalid',
-  source = 'invalid.py'
+  source = 'invalid.py',
 )

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/BUILD
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/BUILD
@@ -8,6 +8,7 @@ python_tests(
     'src/python/pants/testutil:task_test_base',
     'contrib/mypy/src/python/pants/contrib/mypy/tasks',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -17,6 +18,6 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'contrib/mypy:examples_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout = 120,
 )

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/test_mypy.py
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/test_mypy.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import logging
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.build_graph.target import Target
@@ -18,14 +18,14 @@ class MyPyWhitelistMechanismTest(TaskTestBase):
     return MypyTask
 
   def make_python_target(
-    self, spec: str, *, typed: bool = False, dependencies: Optional[List[Target]] = None
+    self, spec: str, *, typed: bool = False, dependencies: Optional[List[Target]] = None,
   ) -> Target:
-    kwargs = {}
+    kwargs: Dict[str, Any] = {}
     if typed:
       kwargs['tags'] = ['type_checked']
     if dependencies:
       kwargs['dependencies'] = dependencies
-    return self.make_target(spec, PythonLibrary, **kwargs)
+    return cast(Target, self.make_target(spec, PythonLibrary, **kwargs))
 
   def run_task_and_capture_warnings(
     self, *, target_roots: List[Target], enable_whitelist: bool = True
@@ -37,7 +37,7 @@ class MyPyWhitelistMechanismTest(TaskTestBase):
     task = self.create_task(context)
     with self.captured_logging(level=logging.WARNING) as captured:
       task.execute()
-    return captured.warnings()
+    return cast(List[str], captured.warnings())
 
   def assert_no_warning(self, captured_warnings: List[str]) -> None:
     self.assertFalse(captured_warnings)

--- a/contrib/node/examples/src/node/web-component-button/BUILD
+++ b/contrib/node/examples/src/node/web-component-button/BUILD
@@ -24,7 +24,7 @@ node_test(
   dependencies=[
     ':web-component-button'
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
 )
 
 # Contains non-transpiled codes including all subdirectories under node_modules dirctory.

--- a/contrib/node/tests/python/pants_test/contrib/node/targets/BUILD
+++ b/contrib/node/tests/python/pants_test/contrib/node/targets/BUILD
@@ -7,7 +7,8 @@ python_tests(
   dependencies=[
     'contrib/node/src/python/pants/contrib/node/targets:node_remote_module',
     'src/python/pants/testutil:test_base'
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -16,7 +17,8 @@ python_tests(
   dependencies=[
     'contrib/node/src/python/pants/contrib/node/targets:node_package',
     'src/python/pants/testutil:test_base'
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -25,5 +27,6 @@ python_tests(
   dependencies=[
     'contrib/node/src/python/pants/contrib/node/targets:node_module',
     'src/python/pants/testutil:test_base'
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
@@ -12,6 +12,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {'partially_type_checked'},
   timeout=30,
 )
 
@@ -25,6 +26,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {'partially_type_checked'},
   timeout=30
 )
 
@@ -38,7 +40,7 @@ python_tests(
     'src/python/pants/util:contextutil',
   ],
   timeout=480,
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -48,7 +50,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'contrib/node:examples_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -60,7 +62,7 @@ python_tests(
     'contrib/node:testprojects_directory',
   ],
   timeout=180,
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -71,7 +73,7 @@ python_tests(
     'contrib/node:examples_directory',
   ],
   timeout=180,
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -82,7 +84,7 @@ python_tests(
     'contrib/node:examples_directory',
   ],
   timeout=240,
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -97,7 +99,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -114,7 +117,8 @@ python_tests(
     'contrib/node/src/python/pants/contrib/node/subsystems/resolvers:node_preinstalled_module_resolver',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -125,7 +129,7 @@ python_tests(
     'contrib/node:examples_directory',
   ],
   timeout=180,
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -136,7 +140,7 @@ python_tests(
     'contrib/node:examples_directory',
   ],
   timeout=180,
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -153,5 +157,6 @@ python_tests(
     'contrib/node/src/python/pants/contrib/node/subsystems/resolvers:node_preinstalled_module_resolver',
     'src/python/pants/build_graph',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/checker/BUILD
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/checker/BUILD
@@ -8,6 +8,7 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil/option',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -18,5 +19,6 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil/option',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/checker/plugin_test_base.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/checker/plugin_test_base.py
@@ -4,17 +4,18 @@
 import copy
 import os
 import unittest
+from typing import Optional, Type
 
 from pants.testutil.option.fakes import create_options
 from pants.util.dirutil import safe_mkdtemp
 
-from pants.contrib.python.checks.checker.common import Nit, PythonFile
+from pants.contrib.python.checks.checker.common import CheckstylePlugin, Nit, PythonFile
 
 
 # TODO: Refactor this test suite to leverage the ConsoleTaskTestBase class
 # for proper integration testing (i.e. any test that runs task.execute()).
 class CheckstylePluginTestBase(unittest.TestCase):
-  plugin_type = None   # Subclasses must override.
+  plugin_type: Optional[Type[CheckstylePlugin]] = None   # Subclasses must override.
 
   @property
   def file_required(self):

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/checker/test_print_statements.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/checker/test_print_statements.py
@@ -28,8 +28,7 @@ class PrintStatementsTest(CheckstylePluginTestBase):
     """
     self.assertNoNits(statement)
 
-  # TODO(#7979): Rework tests so that we can run this with Python 2.
-  @unittest.skip
+  @unittest.skip(reason="#7979: Rework tests so that we can run this with Python 2.")
   def test_print_statement(self):
     statement = """
       print["I do what I want"]

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/BUILD
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/BUILD
@@ -8,5 +8,6 @@ python_tests(
     'src/python/pants/backend/python/subsystems',
     'contrib/python/src/python/pants/contrib/python/checks/tasks',
     'tests/python/pants_test/backend/python/tasks:python_task_test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
@@ -19,4 +19,5 @@ python_tests(
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/backend/python/tasks:python_task_test_base',
   ],
+  tags = {'partially_type_checked'},
 )

--- a/contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks/BUILD
+++ b/contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks/BUILD
@@ -8,6 +8,6 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'contrib/scalajs:examples_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout=270,
 )

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
@@ -8,7 +8,8 @@ python_tests(
     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:java_thrift_library_fingerprint_strategy',
     'src/python/pants/backend/codegen/thrift/java',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -25,6 +26,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil/jvm:nailgun_task_test_base'
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -35,7 +37,7 @@ python_tests(
     'contrib/scrooge:scala_tests_directory',
     'contrib/scrooge:thrift_tests_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout=270,
 )
 
@@ -46,7 +48,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'contrib/scrooge:thrift_tests_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout=240,
 )
 
@@ -61,6 +63,7 @@ python_tests(
     'src/python/pants/testutil:task_test_base',
     'src/python/pants/testutil:mock_logger',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -71,5 +74,6 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
@@ -2,8 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from functools import wraps
+from typing import Any, Callable, TypeVar
 
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
+
+
+FuncType = Callable[..., Any]
+F = TypeVar("F", bound=FuncType)
 
 
 class ThriftLinterTest(PantsRunIntegrationTest):
@@ -19,7 +24,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
   def thrift_test_target(cls, name):
     return f'{cls.thrift_folder_root}:{name}'
 
-  def rename_build_file(func):
+  def rename_build_file(func: F) -> F:
     """This decorator implements the TEST_BUILD pattern.
 
     Because these tests use files that intentionally should fail linting, the goal `./pants lint ::`
@@ -30,7 +35,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     def wrapper(self, *args, **kwargs):
       with self.file_renamed(self.thrift_folder_root, test_name='TEST_BUILD', real_name='BUILD'):
         func(self, *args, **kwargs)
-    return wrapper
+    return wrapper  # type: ignore[return-value]
 
   def run_pants(self, command, config=None, stdin_data=None, extra_env=None, **kwargs):
     full_config = {

--- a/contrib/thrifty/tests/python/pants_test/pants/contrib/thrifty/BUILD
+++ b/contrib/thrifty/tests/python/pants_test/pants/contrib/thrifty/BUILD
@@ -6,5 +6,5 @@ python_tests(
     'contrib/thrifty/src/python/pants/contrib/thrifty',
     'src/python/pants/testutil:task_test_base',
   ],
-  sources=globs('*.py'),
+  tags = {'partially_type_checked'},
 )

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -7,7 +7,8 @@ python_library(
   sources=['__main__.py'],
   dependencies=[
     'src/python/pants/bin',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -21,6 +22,7 @@ python_library(
     ':entry_point',
     ':version',
   ],
+  tags = {'partially_type_checked'},
   provides=pants_setup_py(
     name='pantsbuild.pants',
     description='A scalable build tool for large, complex, heterogeneous repos.',

--- a/src/python/pants/backend/awslambda/common/BUILD
+++ b/src/python/pants/backend/awslambda/common/BUILD
@@ -13,5 +13,6 @@ python_library(
     'src/python/pants/engine:selectors',
     'src/python/pants/engine/legacy:graph',
     'src/python/pants/rules/core',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/src/python/pants/backend/awslambda/python/BUILD
+++ b/src/python/pants/backend/awslambda/python/BUILD
@@ -17,7 +17,7 @@ python_library(
 )
 
 python_tests(
-  name='test',
+  name='tests',
   dependencies=[
     ':python',
     'src/python/pants/backend/python/rules',
@@ -33,7 +33,8 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 pants_plugin(

--- a/src/python/pants/backend/awslambda/python/examples/BUILD
+++ b/src/python/pants/backend/awslambda/python/examples/BUILD
@@ -11,6 +11,7 @@ python_requirement_library(
 python_library(
   name='hello-lib',
   sources = ['hello_lib.py'],
+  tags = {'partially_type_checked'},
 )
 
 python_awslambda(

--- a/src/python/pants/backend/project_info/rules/BUILD
+++ b/src/python/pants/backend/project_info/rules/BUILD
@@ -21,5 +21,6 @@ python_tests(
   dependencies=[
     ':rules',
     'src/python/pants/testutil:console_rule_test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/src/python/pants/backend/python/rules/BUILD
+++ b/src/python/pants/backend/python/rules/BUILD
@@ -48,6 +48,6 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/tests/python/pants:dummies_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 120,
 )

--- a/src/python/pants/backend/python/subsystems/BUILD
+++ b/src/python/pants/backend/python/subsystems/BUILD
@@ -31,4 +31,5 @@ python_tests(
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {'partially_type_checked'},
 )

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -59,6 +59,7 @@ python_binary(
   dependencies=[
     ':bin',
   ],
+  tags = {'partially_type_checked'},
   # We depend on twitter.common libraries that trigger pex warnings for not properly declaring their
   # dependency on setuptools (for namespace package support).
   emit_warnings=False,
@@ -90,6 +91,7 @@ python_binary(
     'contrib:plugins',
     'pants-plugins/src/python/internal_backend:plugins',
   ],
+  tags = {'partially_type_checked'},
   # We depend on twitter.common libraries that trigger pex warnings for not properly declaring their
   # dependency on setuptools (for namespace package support).
   emit_warnings=False,

--- a/src/python/pants/help/BUILD
+++ b/src/python/pants/help/BUILD
@@ -34,5 +34,5 @@ python_tests(
   dependencies=[
     'src/python/pants/testutil:int-test',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -45,6 +45,6 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/python:plugins_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout=90,
 )

--- a/src/python/pants/option/options_integration_test.py
+++ b/src/python/pants/option/options_integration_test.py
@@ -245,8 +245,8 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
       'options', '--skip-inherited', '--name=colors',
     ])
     self.assert_success(pants_run)
-    lines = (s.split('(', 1)[0] for s in pants_run.stdout_data.split('\n') if '(' in s)
-    lines = [s.strip() for s in lines]
+    unstripped_lines = (s.split('(', 1)[0] for s in pants_run.stdout_data.split('\n') if '(' in s)
+    lines = [s.strip() for s in unstripped_lines]
     # This should be included because it has no super-scopes.
     self.assertIn('colors = False', lines)
     # These should be included because they differ from the super-scope value.

--- a/src/python/pants/rules/core/BUILD
+++ b/src/python/pants/rules/core/BUILD
@@ -52,5 +52,5 @@ python_tests(
     'examples/src/scala/org/pantsbuild/example:hello_directory',
     'examples/src/resources/org/pantsbuild/example:hello_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -28,9 +28,7 @@ python_library(
 
 python_library(
   name = 'int-test-for-export',
-  sources = [
-    'pants_run_integration_test.py'
-  ],
+  sources = ['pants_run_integration_test.py'],
   dependencies = [
     '//:build_root',
     '//:pants_pex',
@@ -49,6 +47,7 @@ python_library(
     'src/python/pants/util:strutil',
     'src/python/pants:entry_point',
   ],
+  tags = {'partially_type_checked'},
 )
 
 target(

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -16,6 +16,7 @@ python_library(
     'src/python/pants/testutil/option',
     'src/python/pants/testutil/subsystem',
   ],
+  tags = {'partially_type_checked'},
   provides=pants_setup_py(
     name='pantsbuild.pants.testutil',
     description='Test support for writing Pants plugins.',

--- a/src/python/pants/util/process_handler.py
+++ b/src/python/pants/util/process_handler.py
@@ -3,8 +3,8 @@
 
 import io
 import multiprocessing
-import sys
 import subprocess
+import sys
 from abc import ABC, abstractmethod
 from typing import Optional
 

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -16,6 +16,7 @@ python_library(
     'tests/python/pants_test/option/util',
     'tests/python/pants_test/testutils:file_test_util',
   ],
+  tags = {'partially_type_checked'},
   provides=pants_setup_py(
     name='pantsbuild.pants.testinfra',
     description='Test support for writing Pants plugins.',
@@ -31,7 +32,8 @@ python_library(
   sources=['deprecated_testinfra.py'],
   dependencies = [
     'src/python/pants/base:deprecated',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -40,7 +42,8 @@ python_library(
   dependencies = [
     ':deprecated_testinfra',
     'src/python/pants/testutil:int-test-for-export',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 target(
@@ -57,7 +60,8 @@ python_library(
   dependencies = [
     'src/python/pants/base:deprecated',
     'src/python/pants/testutil:test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -66,7 +70,8 @@ python_library(
   dependencies = [
     ':deprecated_testinfra',
     'src/python/pants/testutil:console_rule_test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 
@@ -76,7 +81,8 @@ python_library(
   dependencies = [
     ':deprecated_testinfra',
     'src/python/pants/testutil:task_test_base',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -85,7 +91,8 @@ python_library(
   dependencies = [
     ':deprecated_testinfra',
     'src/python/pants/testutil:interpreter_selection_utils',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -97,5 +104,6 @@ python_tests(
     'src/python/pants/source',
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/subsystem',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/tests/python/pants_test/backend/codegen/antlr/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/antlr/java/BUILD
@@ -27,6 +27,6 @@ python_tests(
     'examples/src/java/org/pantsbuild/example:antlr3_directory',
     'examples/src/java/org/pantsbuild/example:antlr4_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 240,
 )

--- a/tests/python/pants_test/backend/codegen/antlr/python/BUILD
+++ b/tests/python/pants_test/backend/codegen/antlr/python/BUILD
@@ -25,5 +25,5 @@ python_tests(
     'testprojects/src/python:antlr_directory',
     'testprojects/src/antlr/python:test_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )

--- a/tests/python/pants_test/backend/codegen/protobuf/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/protobuf/java/BUILD
@@ -27,6 +27,6 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:proto-ordering_directory',
     'testprojects/src/protobuf/org/pantsbuild/testproject:import_from_buildroot_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 330,
 )

--- a/tests/python/pants_test/backend/codegen/wire/java/BUILD
+++ b/tests/python/pants_test/backend/codegen/wire/java/BUILD
@@ -32,6 +32,6 @@ python_tests(
     'src/python/pants/testutil:file_test_util',
     'examples/src/java/org/pantsbuild/example:wire_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 300,
 )

--- a/tests/python/pants_test/backend/docgen/tasks/BUILD
+++ b/tests/python/pants_test/backend/docgen/tasks/BUILD
@@ -25,5 +25,5 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/java/org/pantsbuild/testproject:page_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )

--- a/tests/python/pants_test/backend/graph_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/graph_info/tasks/BUILD
@@ -23,7 +23,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/python:python_targets_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -115,7 +115,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/python:python_targets_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/BUILD
+++ b/tests/python/pants_test/backend/jvm/BUILD
@@ -17,6 +17,6 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'examples/tests/java/org/pantsbuild/example:hello_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout=300
 )

--- a/tests/python/pants_test/backend/jvm/subsystems/BUILD
+++ b/tests/python/pants_test/backend/jvm/subsystems/BUILD
@@ -59,7 +59,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/scala/org/pantsbuild/testproject:custom_scala_platform_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout=500,
 )
 
@@ -75,7 +75,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:shading_directory',
     'testprojects/3rdparty:managed_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 370,
 )
 
@@ -109,6 +109,6 @@ python_tests(
     'testprojects/tests/java/org/pantsbuild/testproject:depman_directory',
     'testprojects/3rdparty:managed_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout=800,
 )

--- a/tests/python/pants_test/backend/jvm/targets/BUILD
+++ b/tests/python/pants_test/backend/jvm/targets/BUILD
@@ -29,7 +29,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/3rdparty:org_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -50,7 +50,7 @@ python_tests(
   dependencies = [
     'src/python/pants/testutil:int-test',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -72,7 +72,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/java/org/pantsbuild/testproject:bench_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 210,
 )
 
@@ -89,7 +89,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:manifest_directory',
   ],
   timeout=420,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -149,7 +149,7 @@ python_tests(
     'examples/src/java/org/pantsbuild/example:hello_directory',
     'testprojects/3rdparty:checkstyle_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 240,
 )
 
@@ -246,7 +246,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:intransitive_directory',
   ],
   timeout=300,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -270,7 +270,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:int-test',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -324,7 +324,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'examples/tests/scala/org/pantsbuild/example:hello_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -338,7 +338,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
   timeout = 240,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -413,7 +413,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:publish_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:publish_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 480,
 )
 
@@ -453,6 +453,7 @@ python_tests(
     'src/python/pants/testutil/subsystem',
     'src/python/pants/testutil:task_test_base',
   ],
+  tags = {'partially_type_checked'},
   timeout = 120,
 )
 
@@ -472,7 +473,7 @@ python_tests(
     'testprojects/tests/java/org/pantsbuild/testproject:timeout_directory',
     'testprojects/tests/java/org/pantsbuild/testproject:unicode_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 600
 )
 
@@ -493,7 +494,7 @@ python_tests(
     'testprojects/tests/java/org/pantsbuild/testproject:fail256_directory',
     'testprojects/tests/java/org/pantsbuild/testproject:workdirs_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 1240,
 )
 
@@ -507,7 +508,7 @@ python_tests(
     'testprojects/tests/java/org/pantsbuild/testproject:parallelclassesandmethods_directory',
     'testprojects/tests/java/org/pantsbuild/testproject:parallelmethods_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 540,
 )
 
@@ -532,7 +533,7 @@ python_tests(
     'testprojects/maven_layout:resource_collision_directory',
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 320,
 )
 
@@ -558,7 +559,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:nocache_directory',
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 460,
 )
 
@@ -583,7 +584,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:int-test',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -607,7 +608,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/java/org/pantsbuild/testproject:jvmprepcommand_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 250,
 )
 
@@ -646,7 +647,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:extra_jvm_options_directory',
     'testprojects/tests/java/org/pantsbuild/testproject:syntheticjar_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 360,
 )
 
@@ -749,7 +750,7 @@ python_tests(
     'testprojects/src/scala/org/pantsbuild/testproject:rsc_compat_directory',
   ],
   timeout=340,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -780,7 +781,7 @@ python_tests(
     'testprojects/src/scala/org/pantsbuild/testproject:unicode_directory',
   ],
   timeout=480,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -792,7 +793,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:provided_directory',
   ],
   timeout=720,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -803,7 +804,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:runtime_directory',
   ],
   timeout=600,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -817,7 +818,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:junit_directory',
   ],
   timeout=300,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -844,7 +845,7 @@ python_tests(
     'examples/src/java/org/pantsbuild/example:hello_directory',
     'testprojects/src/java/org/pantsbuild/testproject:exclude_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 300
 )
 
@@ -873,7 +874,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
     'testprojects/tests/java/org/pantsbuild/testproject:testjvms_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 360,
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -33,6 +33,7 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:int-test',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -43,7 +44,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:missingdirectdepswhitelist_directory',
     'testprojects/src/java/org/pantsbuild/testproject:missingjardepswhitelist_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout=540,
 )
 
@@ -58,7 +59,7 @@ python_tests(
     'testprojects/tests/scala/org/pantsbuild/testproject:non_exports_directory',
     'testprojects/src/thrift/org/pantsbuild:thrift_exports_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout=600,
 )
 
@@ -80,6 +81,6 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:dummies_directory',
     'testprojects/src/java/org/pantsbuild/testproject:missingjardepswhitelist_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout = 240,
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/base_compile_integration_test.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/base_compile_integration_test.py
@@ -4,6 +4,7 @@
 import os
 from collections import defaultdict
 from contextlib import contextmanager
+from typing import List
 
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.contextutil import temporary_dir
@@ -14,7 +15,7 @@ class BaseCompileIT(PantsRunIntegrationTest):
   :API: public
   """
 
-  _EXTRA_TASK_ARGS=[]
+  _EXTRA_TASK_ARGS: List[str] = []
 
   @contextmanager
   def do_test_compile(self, target, expected_files=None, iterations=2, expect_failure=False,

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -12,7 +12,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout=720,
 )
 
@@ -33,7 +33,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:printversion_directory',
     'testprojects/src/scala/org/pantsbuild/testproject:unicode_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout=600,
 )
 
@@ -55,7 +55,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
     'testprojects/tests/java/org/pantsbuild/testproject:matcher_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout=600,
 )
 
@@ -68,7 +68,7 @@ python_tests(
     'examples/src/java/org/pantsbuild/example:javac_directory',
   ],
   timeout = 530,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -96,4 +96,5 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:int-test',
   ],
+  tags = {'partially_type_checked'},
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
@@ -336,8 +336,16 @@ class CacheCompileIntegrationTest(BaseCompileIT):
         Compile({srcfile: "public final class A {}"}, config, 3),
     )
   
-  def _compile_spec(self, compiles: List[Compile], target_defs: List[str], target_names: List[str], target_to_compile: str, callback: Callable[[Compile, Dict[str, str]], None] = lambda cache_test_subdirs: None) -> None:
-    """Compiles a spec within the same workspace under multiple compilation configs, with a callback function."""
+  def _compile_spec(
+    self,
+    compiles: List[Compile],
+    target_defs: List[str],
+    target_names: List[str],
+    target_to_compile: str,
+    callback: Callable[[Compile, Dict[str, str]], None] = lambda _compile, _cache_test_subdirs: None,
+  ) -> None:
+    """Compiles a spec within the same workspace under multiple compilation configs, with a
+    callback function."""
 
     with temporary_dir() as cache_dir, \
         self.temporary_workdir() as workdir, \

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/javac/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/javac/BUILD
@@ -12,5 +12,5 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:publish_directory',
   ],
   timeout = 240,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/rsc/BUILD
@@ -9,6 +9,7 @@ python_library(
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -23,7 +24,7 @@ python_tests(
     'testprojects/src/scala/org/pantsbuild/testproject:mutual_directory',
   ],
   timeout = 660,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -36,7 +37,7 @@ python_tests(
     'testprojects/src/scala/org/pantsbuild/testproject:public_inference_directory',
   ],
   timeout = 800,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 
@@ -50,4 +51,5 @@ python_tests(
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'src/python/pants/testutil/subsystem',
   ],
+  tags = {'partially_type_checked'},
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
@@ -10,5 +10,5 @@ python_tests(
     'examples/src/scala/org/pantsbuild/example:scalac_directory',
   ],
   timeout = 640,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/BUILD
@@ -32,7 +32,7 @@ python_tests(
     'examples/src/java/org/pantsbuild/example:hello_directory',
   ],
   timeout = 900,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -43,5 +43,5 @@ python_tests(
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
   ],
   timeout = 900,
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration.py
@@ -1,6 +1,8 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from typing import List
+
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
 from pants_test.backend.jvm.tasks.jvm_compile.zinc.zinc_compile_integration_base import (
   BaseZincCompileIntegrationTest,
@@ -8,4 +10,4 @@ from pants_test.backend.jvm.tasks.jvm_compile.zinc.zinc_compile_integration_base
 
 
 class ZincCompileIntegration(BaseCompileIT, BaseZincCompileIntegrationTest):
-  _EXTRA_TASK_ARGS = []
+  _EXTRA_TASK_ARGS: List[str] = []

--- a/tests/python/pants_test/backend/jvm/tasks/reports/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/reports/BUILD
@@ -15,4 +15,5 @@ python_tests(
     'src/python/pants/util:strutil',
     'tests/python/pants_test:test_infra',
   ],
+  tags = {'partially_type_checked'},
 )

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -125,7 +125,7 @@ python_tests(
     'testprojects/tests/java/org/pantsbuild/testproject:testjvms_directory',
     ':resolve_jars_test_mixin',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 630,
 )
 
@@ -162,5 +162,5 @@ python_tests(
     'examples/src/scala/org/pantsbuild/example:hello_directory',
     'testprojects/src/python:antlr_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -51,7 +51,7 @@ python_tests(
     'examples/tests/python/example_test:hello_directory',
     'testprojects:pants_plugins_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
   timeout = 120,
 )
 
@@ -64,4 +64,5 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:int-test',
   ],
+  tags = {'partially_type_checked'},
 )

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -37,7 +37,7 @@ python_tests(
     'testprojects/src/python:python_distribution_directory',
     'testprojects/tests/python:example_test_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 180,
 )
 
@@ -68,7 +68,7 @@ python_tests(
     'tests/python/pants_test:interpreter_selection_utils',
     'testprojects/src/python:interpreter_selection_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout=240,
 )
 
@@ -93,7 +93,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/tests/java/org/pantsbuild/testproject:dummies_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -130,7 +130,7 @@ python_tests(
     'testprojects/tests/python/pants:constants_only_directory',
     'testprojects/tests/python/pants:timeout_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout=240,
 )
 
@@ -155,7 +155,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/python:python_distribution_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout=240
 )
 
@@ -180,7 +180,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/python:interpreter_selection_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout=120,
 )
 
@@ -196,7 +196,7 @@ python_tests(
     'testprojects/src/python:interpreter_selection_directory',
     'testprojects/src/python:print_env_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout=240
 )
 
@@ -279,7 +279,7 @@ python_tests(
     'examples/src/thrift/org/pantsbuild/example:precipitation_directory',
     'testprojects:pants_plugins_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout=240,
 )
 

--- a/tests/python/pants_test/backend/python/tasks/native/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/native/BUILD
@@ -47,6 +47,6 @@ python_tests(
     'tests/python/pants_test/engine:scheduler_test_base',
     'testprojects/src/python:python_distribution_directory',
   ],
-  tags={'platform_specific_behavior', 'integration'},
+  tags={'platform_specific_behavior', 'integration', 'partially_type_checked'},
   timeout=240,
 )

--- a/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/native/test_ctypes_integration.py
@@ -9,8 +9,8 @@ from functools import wraps
 from unittest import skip
 from zipfile import ZipFile
 
-from pants.backend.native.config.environment import Platform
 from pants.backend.native.subsystems.native_build_step import ToolchainVariant
+from pants.engine.platform import Platform
 from pants.option.scope import GLOBAL_SCOPE_CONFIG_SECTION
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
 from pants.util.collections import assert_single_element

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -31,7 +31,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/java/org/pantsbuild/testproject:phrases_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 530,
 )
 
@@ -54,6 +54,7 @@ python_library(
     'src/python/pants/testutil/base:context_utils',
     'tests/python/pants_test:deprecated_testinfra',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -215,7 +216,7 @@ python_tests(
     'src/python/pants/testutil:test_base',
     'src/python/pants/testutil/option',
   ],
-  tags={'platform_specific_behavior'},
+  tags={'platform_specific_behavior', 'partially_type_checked'},
 )
 
 python_tests(
@@ -228,7 +229,7 @@ python_tests(
     'testprojects/src/python:coordinated_runs_directory',
     'testprojects:pants_plugins_directory',
   ],
-  tags = {'platform_specific_behavior', 'integration'},
+  tags = {'platform_specific_behavior', 'integration', 'partially_type_checked'},
   # NB: This frequently times out, but due to hanging. So, we want to fail eagerly. See
   # https://github.com/pantsbuild/pants/issues/8127.
   timeout = 200,
@@ -241,6 +242,6 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/python:unicode_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 120,
 )

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -12,5 +12,5 @@ python_tests(
     'testprojects:pants_plugins_directory',
     'testprojects/src/python:nested_runs_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -33,7 +33,7 @@ python_tests(
   dependencies = [
     'src/python/pants/testutil:int-test',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 
@@ -80,7 +80,7 @@ python_tests(
     'testprojects/src/python:build_file_imports_function_directory',
     'testprojects/src/python:build_file_imports_module_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 75,
 )
 
@@ -94,7 +94,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:intransitive_directory',
     'testprojects/src/java/org/pantsbuild/testproject:runtime_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -88,6 +88,7 @@ python_tests(
     'src/python/pants/cache',
     'src/python/pants/testutil:test_base',
   ],
+  tags = {'partially_type_checked'},
   timeout = 90
 )
 
@@ -111,6 +112,6 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 600,
 )

--- a/tests/python/pants_test/core_tasks/BUILD
+++ b/tests/python/pants_test/core_tasks/BUILD
@@ -20,7 +20,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:int-test',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -31,7 +31,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'src/python/pants/testutil:int-test',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -56,6 +56,6 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/java/org/pantsbuild/testproject:aliases_directory'
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 270,
 )

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -8,6 +8,7 @@ python_library(
     'src/python/pants/testutil/engine:util',
     'tests/python/pants_test:deprecated_testinfra',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -16,7 +17,8 @@ python_library(
   dependencies = [
     'src/python/pants/testutil/engine:engine_test_base',
     'tests/python/pants_test:deprecated_testinfra',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -211,7 +213,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'examples/src/scala/org/pantsbuild/example:hello_directory',
   ],
-  tags={'integration'},
+  tags={'integration', 'partially_type_checked'},
 )
 
 python_library(

--- a/tests/python/pants_test/engine/examples/BUILD
+++ b/tests/python/pants_test/engine/examples/BUILD
@@ -14,7 +14,8 @@ python_library(
     'src/python/pants/engine:objects',
     'src/python/pants/engine:parser',
     'src/python/pants/util:memo',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 resources(

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -25,7 +25,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:phrases_directory',
     'testprojects/tests/python/pants:constants_only_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -36,7 +36,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/java/org/pantsbuild/testproject:bundle_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 480,
 )
 
@@ -56,7 +56,7 @@ python_tests(
     'testprojects/src/python:sources_directory',
     'testprojects/tests/scala/org/pantsbuild/testproject:cp-directories_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 600,
 )
 
@@ -67,7 +67,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/tests/python:owners_integration_target',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -77,7 +77,7 @@ python_tests(
     'tests/python/pants_test/pantsd:pantsd_integration_test_base',
     'examples/src/scala/org/pantsbuild/example:hello_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 270,
 )
 
@@ -90,7 +90,7 @@ python_tests(
     'examples/src/scala/org/pantsbuild/example:jvm_run_directory',
     'examples/tests/scala/org/pantsbuild/example:hello_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -100,7 +100,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'examples/src/scala/org/pantsbuild/example:hello_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 40,
 )
 
@@ -113,7 +113,7 @@ python_tests(
     'testprojects/src/python:sources_directory',
     'testprojects/tests/python/pants:file_sets_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -124,7 +124,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'examples/src/scala/org/pantsbuild/example:hello_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 180,
 )
 
@@ -154,7 +154,7 @@ python_tests(
     'testprojects/src/python:no_build_file_directory',
     'testprojects/src/python:sources_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 180,
 )
 
@@ -166,7 +166,7 @@ python_tests(
     'testprojects/tests/python/pants:build_parsing_directory',
     'testprojects/tests/java/org/pantsbuild:build_parsing_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 180,
 )
 

--- a/tests/python/pants_test/goal/BUILD
+++ b/tests/python/pants_test/goal/BUILD
@@ -46,6 +46,6 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:extra_jvm_options_directory',
     'testprojects/src/java/org/pantsbuild/testproject:unicode_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 180,
 )

--- a/tests/python/pants_test/goal/data/BUILD
+++ b/tests/python/pants_test/goal/data/BUILD
@@ -8,6 +8,7 @@ python_library(
     'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/base:workunit',
     'src/python/pants/goal:task_registrar',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 

--- a/tests/python/pants_test/invalidation/BUILD
+++ b/tests/python/pants_test/invalidation/BUILD
@@ -32,6 +32,6 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/tests/java/org/pantsbuild/testproject:strictdeps_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 480,
 )

--- a/tests/python/pants_test/java/BUILD
+++ b/tests/python/pants_test/java/BUILD
@@ -72,7 +72,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'examples/src/scala/org/pantsbuild/example:hello_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 270,
 )
 

--- a/tests/python/pants_test/java/distribution/BUILD
+++ b/tests/python/pants_test/java/distribution/BUILD
@@ -26,6 +26,6 @@ python_tests(
     'src/python/pants/testutil/subsystem',
     'testprojects/src/java/org/pantsbuild/testproject:printversion_directory'
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 300,
 )

--- a/tests/python/pants_test/jvm/BUILD
+++ b/tests/python/pants_test/jvm/BUILD
@@ -27,7 +27,8 @@ python_library(
   dependencies=[
     'src/python/pants/testutil/jvm:jvm_tool_task_test_base',
     'tests/python/pants_test:deprecated_testinfra',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -36,7 +37,8 @@ python_library(
   dependencies=[
     'src/python/pants/testutil/jvm:nailgun_task_test_base',
     'tests/python/pants_test:deprecated_testinfra',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -45,7 +47,8 @@ python_library(
   dependencies=[
     'src/python/pants/testutil/jvm:jar_task_test_base',
     'tests/python/pants_test:deprecated_testinfra',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -54,5 +57,6 @@ python_library(
   dependencies=[
     'src/python/pants/testutil/jvm:jvm_task_test_base',
     'tests/python/pants_test:deprecated_testinfra',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )

--- a/tests/python/pants_test/logging/BUILD
+++ b/tests/python/pants_test/logging/BUILD
@@ -8,7 +8,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'tests/python/pants_test/pantsd:pantsd_integration_test_base',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -19,5 +19,5 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'tests/python/pants_test/logging/data:plugin',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )

--- a/tests/python/pants_test/logging/data/BUILD
+++ b/tests/python/pants_test/logging/data/BUILD
@@ -8,6 +8,7 @@ python_library(
     'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/base:workunit',
     'src/python/pants/goal:task_registrar',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 

--- a/tests/python/pants_test/logging/test_workunit_label.py
+++ b/tests/python/pants_test/logging/test_workunit_label.py
@@ -1,7 +1,6 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import unittest
 from pathlib import Path
 
 from pants.testutil.pants_run_integration_test import PantsRunIntegrationTest
@@ -24,7 +23,6 @@ class WorkUnitLabelTest(PantsRunIntegrationTest):
     self.assert_failure(pants_run)
     self.assertIn("[non-existent-main-class]", pants_run.stdout_data)
 
-  @unittest.skip
   def test_workunit_label_ignore(self):
     pants_run = self.run_pants(
       [*self.load_plugin_cmdline, 'run-workunit-label-test', '--ignore-label']

--- a/tests/python/pants_test/option/util/BUILD
+++ b/tests/python/pants_test/option/util/BUILD
@@ -6,4 +6,5 @@ python_library(
     'src/python/pants/testutil/option',
     'tests/python/pants_test:deprecated_testinfra',
   ],
+  tags = {'partially_type_checked'},
 )

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -76,6 +76,7 @@ python_library(
     'src/python/pants/testutil:process_test_util',
     'src/python/pants/testutil:int-test',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -92,7 +93,7 @@ python_tests(
     'testprojects/src/python:nested_runs_directory',
     'testprojects/src/python:print_env_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 900
 )
 

--- a/tests/python/pants_test/projects/BUILD
+++ b/tests/python/pants_test/projects/BUILD
@@ -7,6 +7,7 @@ python_library(
   dependencies = [
     'src/python/pants/testutil:int-test',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_tests(
@@ -17,7 +18,7 @@ python_tests(
     'examples/src/antlr/org/pantsbuild/example:all_directories',
     'testprojects/src/antlr/python:all_directories',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 200,
 )
 
@@ -29,7 +30,7 @@ python_tests(
     'examples/src/java/org/pantsbuild/example:all_directories',
     'examples/tests/java/org/pantsbuild/example:all_directories',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 360,
 )
 
@@ -41,7 +42,7 @@ python_tests(
     'testprojects/src/java/org/pantsbuild/testproject:all_directories',
     'testprojects/tests/java/org/pantsbuild:all_directories',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 400,
 )
 
@@ -52,7 +53,7 @@ python_tests(
     ':projects_test_base',
     'testprojects/maven_layout:all_directories',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 300,
 )
 
@@ -64,7 +65,7 @@ python_tests(
     'examples/src/protobuf/org/pantsbuild/example:all_directories',
     'testprojects/src/protobuf/org/pantsbuild/testproject:all_directories',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 200,
 )
 
@@ -76,7 +77,7 @@ python_tests(
     'examples/src/python/example:all_directories',
     'examples/tests/python/example_test:all_directories',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -87,7 +88,7 @@ python_tests(
     'testprojects/src/python:all_directories',
     'testprojects/tests/python:all_directories',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 120,
 )
 
@@ -99,7 +100,7 @@ python_tests(
     'examples/src/scala/org/pantsbuild/example:all_directories',
     'examples/tests/scala/org/pantsbuild/example:all_directories',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 300,
 )
 
@@ -111,7 +112,7 @@ python_tests(
     'testprojects/src/scala/org/pantsbuild/testproject:all_directories',
     'testprojects/tests/scala/org/pantsbuild/testproject:all_directories',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 330,
 )
 
@@ -123,7 +124,7 @@ python_tests(
     'examples/src/thrift/org/pantsbuild/example:all_directories',
     'testprojects/src/thrift/org/pantsbuild:all_directories',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 300,
 )
 
@@ -134,6 +135,6 @@ python_tests(
     ':projects_test_base',
     'examples/src/wire/org/pantsbuild/example:all_directories',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 220,
 )

--- a/tests/python/pants_test/releases/BUILD
+++ b/tests/python/pants_test/releases/BUILD
@@ -9,5 +9,5 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'src/python/pants:reversion_file_with_dependencies',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -22,7 +22,7 @@ python_tests(
     'examples/src/java/org/pantsbuild/example:hello_directory',
     'examples/src/scala/org/pantsbuild/example:several_scala_targets_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 600,
 )
 

--- a/tests/python/pants_test/subsystem/BUILD
+++ b/tests/python/pants_test/subsystem/BUILD
@@ -8,4 +8,5 @@ python_library(
     'src/python/pants/testutil/subsystem',
     'tests/python/pants_test:deprecated_testinfra',
   ],
+  tags = {'partially_type_checked'},
 )

--- a/tests/python/pants_test/targets/BUILD
+++ b/tests/python/pants_test/targets/BUILD
@@ -16,7 +16,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:int-test',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -48,7 +48,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'testprojects/src/java/org/pantsbuild/testproject:bundle_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 300,
 )
 

--- a/tests/python/pants_test/task/BUILD
+++ b/tests/python/pants_test/task/BUILD
@@ -18,7 +18,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'tests/python/pants_test/task/echo_plugin:plugin',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(

--- a/tests/python/pants_test/task/echo_plugin/BUILD
+++ b/tests/python/pants_test/task/echo_plugin/BUILD
@@ -9,6 +9,7 @@ python_library(
     'src/python/pants/goal',
     'src/python/pants/goal:task_registrar',
     'src/python/pants/task',
-  ]
+  ],
+  tags = {'partially_type_checked'},
 )
 

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -8,7 +8,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'examples/src/scala/org/pantsbuild/example:styleissue_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 python_tests(
@@ -21,7 +21,7 @@ python_tests(
     'src/python/pants/testutil:int-test',
     'src/python/pants/testutil:git_util',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout=540,
 )
 
@@ -34,7 +34,7 @@ python_tests(
     'examples/src/java/org/pantsbuild/example:hello_directory',
     'examples/src/scala/org/pantsbuild/example:hello_directory',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
   timeout = 540,
 )
 
@@ -54,7 +54,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/testutil:int-test',
   ],
-  tags = {'integration'},
+  tags = {'integration', 'partially_type_checked'},
 )
 
 files(

--- a/tests/python/pants_test/testutils/BUILD
+++ b/tests/python/pants_test/testutils/BUILD
@@ -8,6 +8,7 @@ python_library(
     'src/python/pants/testutil:mock_logger',
     'tests/python/pants_test:deprecated_testinfra',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -19,6 +20,7 @@ python_library(
     'src/python/pants/testutil:file_test_util',
     'tests/python/pants_test:deprecated_testinfra',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -30,6 +32,7 @@ python_library(
     'src/python/pants/testutil:git_util',
     'tests/python/pants_test:deprecated_testinfra',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -41,6 +44,7 @@ python_library(
     'src/python/pants/testutil:process_test_util',
     'tests/python/pants_test:deprecated_testinfra',
   ],
+  tags = {'partially_type_checked'},
 )
 
 python_library(
@@ -52,4 +56,5 @@ python_library(
     'src/python/pants/testutil:pexrc_util',
     'tests/python/pants_test:deprecated_testinfra',
   ],
+  tags = {'partially_type_checked'},
 )


### PR DESCRIPTION
Brings the number of checked files from 1100 to 1352. Now, every Python file is checked by MyPy.

### Keeps `partially_type_checked` tag
Ideally, we'd be able to remove this tag and check just run `./pants lint ::`. However, `./pants lint ::` fails when using MyPy (which is why we have the `build-support/bin/mypy.py` script) and this would cause several precursor contrib tasks to run. For example, some tests would run that need Java 8, which prevents Pants devs from running MyPy unless they have Java 8.

This will need to be addressed either by changing `mypy.py` to disable all other backends or adding a V2 implementation of MyPy.