### PR TITLE
Fix `./pants lint2` for Black and isort

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -45,7 +45,6 @@ pythonpath: [
   ]
 
 backend_packages: +[
-    "pants.backend.python.lint.isort",
     "pants.backend.docgen",
     "pants.contrib.avro",
     "pants.contrib.awslambda.python",
@@ -71,6 +70,7 @@ backend_packages: +[
 backend_packages2: [
     "pants.backend.project_info",
     "pants.backend.python",
+    "pants.backend.python.lint.isort",
     "pants.backend.native",
     "internal_backend.rules_for_testing",
   ]

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -33,7 +33,7 @@ from pants.rules.core.lint import LintResult
 @dataclass(frozen=True)
 class BlackTarget:
   target: TargetAdaptor
-  prior_formatter_result_digest: Digest
+  prior_formatter_result_digest: Optional[Digest] = None  # unused by `lint`
 
 
 @dataclass(frozen=True)
@@ -101,7 +101,7 @@ async def create_black_request(
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> ExecuteProcessRequest:
   target = wrapped_target.target
-  sources_digest = wrapped_target.prior_formatter_result_digest
+  sources_digest = wrapped_target.prior_formatter_result_digest or target.sources.snapshot.directory_digest
   merged_input_files = await Get[Digest](
     DirectoriesToMerge(
       directories=(

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -70,33 +70,32 @@ class BlackIntegrationTest(TestBase):
     if config is not None:
       self.create_file(relpath="pyproject.toml", contents=config)
     input_snapshot = self.request_single_product(Snapshot, InputFilesContent(source_files))
-    target = BlackTarget(
-      TargetAdaptor(
-        sources=EagerFilesetWithSpec('test', {'globs': []}, snapshot=input_snapshot),
-        address=Address.parse("test:target"),
-      ),
-      prior_formatter_result_digest=input_snapshot.directory_digest,
+    target_adaptor = TargetAdaptor(
+      sources=EagerFilesetWithSpec('test', {'globs': []}, snapshot=input_snapshot),
+      address=Address.parse("test:target"),
     )
+    lint_target = BlackTarget(target_adaptor)
+    fmt_target = BlackTarget(target_adaptor, prior_formatter_result_digest=input_snapshot.directory_digest)
     black_subsystem = global_subsystem_instance(
       Black, options={Black.options_scope: {
         "config": "pyproject.toml" if config else None,
         "args": passthrough_args or [],
       }}
     )
+    python_subsystems = [
+      PythonNativeCode.global_instance(),
+      PythonSetup.global_instance(),
+      SubprocessEnvironment.global_instance(),
+    ]
     black_setup = self.request_single_product(
-      BlackSetup,
-      Params(
-        black_subsystem,
-        PythonNativeCode.global_instance(),
-        PythonSetup.global_instance(),
-        SubprocessEnvironment.global_instance(),
-      )
+      BlackSetup, Params(black_subsystem, *python_subsystems)
     )
-    fmt_and_lint_params = Params(
-      target, black_setup, PythonSetup.global_instance(), SubprocessEnvironment.global_instance()
+    lint_result = self.request_single_product(
+      LintResult, Params(lint_target, black_setup, *python_subsystems)
     )
-    lint_result = self.request_single_product(LintResult, fmt_and_lint_params)
-    fmt_result = self.request_single_product(FmtResult, fmt_and_lint_params)
+    fmt_result = self.request_single_product(
+      FmtResult, Params(fmt_target, black_setup, *python_subsystems)
+    )
     return lint_result, fmt_result
 
   def get_digest(self, source_files: List[FileContent]) -> Digest:

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -31,7 +31,7 @@ from pants.rules.core.lint import LintResult
 @dataclass(frozen=True)
 class IsortTarget:
   target: TargetAdaptor
-  prior_formatter_result_digest: Digest
+  prior_formatter_result_digest: Optional[Digest] = None  # unused by `lint`
 
 
 @dataclass(frozen=True)
@@ -91,7 +91,7 @@ async def create_isort_request(
   subprocess_encoding_environment: SubprocessEncodingEnvironment,
 ) -> ExecuteProcessRequest:
   target = wrapped_target.target
-  sources_digest = wrapped_target.prior_formatter_result_digest
+  sources_digest = wrapped_target.prior_formatter_result_digest or target.sources.snapshot.directory_digest
   merged_input_files = await Get[Digest](
     DirectoriesToMerge(
       directories=(


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/8823 broke `./pants lint2` for formatters like Black and Isort because `python_lint_target.py` was not passing the argument `prior_formatter_result_digest` to the constructors for `IsortTarget` and `BlackTarget`.

However, `prior_formatter_result_digest` is only relevant to `fmt2` and the lint logic should never have to deal with the argument.

So, here, we set the field to `Optional` with a default of `None`. `python_fmt_target.py` will ensure that the value is always set when formatting, whereas `python_lint_target.py` will ignore the value as before. This also updates tests to ensure that both code paths are tested. 