### PR TITLE
Add type hints to `option/` and `subsystem/`

### DIFF
--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -1,7 +1,7 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from typing import Tuple, cast
+from typing import Tuple
 
 from pants.base.deprecated import deprecated_conditional
 from pants.option.option_util import flatten_shlexed_list
@@ -61,7 +61,7 @@ class PyTest(Subsystem):
     opts = self.get_options()
 
     deprecated_conditional(
-      lambda: cast(bool, opts.is_default("version")),
+      lambda: opts.is_default("version"),
       removal_version="1.25.0.dev2",
       entity_description="Pants defaulting to a Python 2-compatible Pytest version",
       hint_message="Pants will soon start defaulting to Pytest 5.x, which no longer supports "

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -8,6 +8,7 @@ python_library(
     '3rdparty/python:python-Levenshtein',
     '3rdparty/python:PyYAML',
     '3rdparty/python:setuptools',
+    '3rdparty/python:typing-extensions',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:deprecated',

--- a/src/python/pants/option/arg_splitter_test.py
+++ b/src/python/pants/option/arg_splitter_test.py
@@ -18,15 +18,15 @@ from pants.option.scope import ScopeInfo
 from pants.util.contextutil import pushd, temporary_dir
 
 
-def task(scope):
+def task(scope: str) -> ScopeInfo:
   return ScopeInfo(scope, ScopeInfo.TASK)
 
 
-def intermediate(scope):
+def intermediate(scope: str) -> ScopeInfo:
   return ScopeInfo(scope, ScopeInfo.INTERMEDIATE)
 
 
-def subsys(scope):
+def subsys(scope: str) -> ScopeInfo:
   return ScopeInfo(scope, ScopeInfo.SUBSYSTEM)
 
 
@@ -329,9 +329,9 @@ class ArgSplitterTest(unittest.TestCase):
     def assert_unknown_goal(args_str: str, unknown_goals: List[str]) -> None:
       splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
       result = splitter.split_args(shlex.split(args_str))
-      self.assertTrue(isinstance(splitter.help_request, UnknownGoalHelp))
-      self.assertSetEqual(set(unknown_goals), set(splitter.help_request.unknown_goals))
-      self.assertEqual(result.unknown_scopes, unknown_goals)
+      assert isinstance(splitter.help_request, UnknownGoalHelp)
+      assert set(unknown_goals) == set(splitter.help_request.unknown_goals)
+      assert result.unknown_scopes == unknown_goals
 
     assert_unknown_goal('./pants foo', ['foo'])
     assert_unknown_goal('./pants compile foo', ['foo'])

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -4,6 +4,7 @@
 import os
 import re
 from enum import Enum
+from typing import Dict, Iterable, List, Pattern, Sequence
 
 from pants.option.errors import ParseError
 from pants.util.eval import parse_expression
@@ -19,12 +20,12 @@ class UnsetBool:
   :API: public
   """
 
-  def __init__(self):
+  def __init__(self) -> None:
     raise NotImplementedError('UnsetBool cannot be instantiated. It should only be used as a '
                               'sentinel type.')
 
 
-def dict_option(s):
+def dict_option(s: str) -> "DictValueComponent":
   """An option of type 'dict'.
 
   The value (on the command-line, in an env var or in the config file) must be eval'able to a dict.
@@ -34,7 +35,7 @@ def dict_option(s):
   return DictValueComponent.create(s)
 
 
-def list_option(s):
+def list_option(s: str) -> "ListValueComponent":
   """An option of type 'list'.
 
   The value (on the command-line, in an env var or in the config file) must be one of:
@@ -50,7 +51,7 @@ def list_option(s):
   return ListValueComponent.create(s)
 
 
-def target_option(s):
+def target_option(s: str) -> str:
   """Same type as 'str', but indicates a single target spec.
 
   :API: public
@@ -72,7 +73,7 @@ def target_list_option(s):
   return _convert(s, (list, tuple))
 
 
-def _normalize_directory_separators(s):
+def _normalize_directory_separators(s: str) -> str:
   """Coalesce runs of consecutive instances of `os.sep` in `s`, e.g. '//' -> '/' on POSIX.
 
   The engine will use paths or target addresses either to form globs or to string-match against, and
@@ -85,7 +86,7 @@ def _normalize_directory_separators(s):
   return os.path.normpath(s)
 
 
-def dir_option(s):
+def dir_option(s: str) -> str:
   """Same type as 'str', but indicates string represents a directory path.
 
   :API: public
@@ -93,7 +94,7 @@ def dir_option(s):
   return _normalize_directory_separators(s)
 
 
-def file_option(s):
+def file_option(s: str) -> str:
   """Same type as 'str', but indicates string represents a filepath.
 
   :API: public
@@ -147,7 +148,7 @@ class ListValueComponent:
   # If we do ever encounter them, we'll have to replace this with a real parser.
   @classmethod
   @memoized_method
-  def _get_modifier_expr_re(cls):
+  def _get_modifier_expr_re(cls) -> Pattern[str]:
     # Note that the regex consists of a positive lookbehind assertion for a ] or a ),
     # followed by a comma (possibly surrounded by whitespace), followed by a
     # positive lookahead assertion for [ or (.  The lookahead/lookbehind assertions mean that
@@ -155,23 +156,17 @@ class ListValueComponent:
     return re.compile(r'(?<=\]|\))\s*,\s*(?=[+-](?:\[|\())')
 
   @classmethod
-  def _split_modifier_expr(cls, s):
+  def _split_modifier_expr(cls, s: str) -> List[str]:
     # This check ensures that the first expression (before the first split point) is a modification.
     if s.startswith('+') or s.startswith('-'):
       return cls._get_modifier_expr_re().split(s)
-    else:
-      return [s]
+    return [s]
 
   @classmethod
-  def merge(cls, components):
+  def merge(cls, components: Iterable["ListValueComponent"]) -> "ListValueComponent":
     """Merges components into a single component, applying their actions appropriately.
 
-    This operation is associative:  M(M(a, b), c) == M(a, M(b, c)) == M(a, b, c).
-
-    :param list components: an iterable of instances of ListValueComponent.
-    :return: An instance representing the result of merging the components.
-    :rtype: `ListValueComponent`
-    """
+    This operation is associative:  M(M(a, b), c) == M(a, M(b, c)) == M(a, b, c)."""
     # Note that action of the merged component is MODIFY until the first REPLACE is encountered.
     # This guarantees associativity.
     action = cls.MODIFY
@@ -186,16 +181,16 @@ class ListValueComponent:
         appends.extend(component._appends)
         filters.extend(component._filters)
       else:
-        raise ParseError(f'Unknown action for list value: {component.action}')
+        raise ParseError(f'Unknown action for list value: {component._action}')
     return cls(action, appends, filters)
 
-  def __init__(self, action, appends, filters):
+  def __init__(self, action: str, appends: List, filters: List) -> None:
     self._action = action
     self._appends = appends
     self._filters = filters
 
   @property
-  def val(self):
+  def val(self) -> List:
     ret = list(self._appends)
     for x in self._filters:
       # Note: can't do ret.remove(x) because that only removes the first instance of x.
@@ -203,7 +198,7 @@ class ListValueComponent:
     return ret
 
   @classmethod
-  def create(cls, value):
+  def create(cls, value) -> "ListValueComponent":
     """Interpret value as either a list or something to extend another list with.
 
     Note that we accept tuple literals, but the internal value is always a list.
@@ -212,7 +207,6 @@ class ListValueComponent:
                   a string representation of a list or tuple (possibly prefixed by + or -
                   indicating modification instead of replacement), or any allowed member_type.
                   May also be a comma-separated sequence of modifications.
-    :rtype: `ListValueComponent`
     """
     if isinstance(value, bytes):
       value = value.decode()
@@ -223,8 +217,8 @@ class ListValueComponent:
         return cls.merge([cls.create(x) for x in comma_separated_exprs])
 
     action = cls.MODIFY
-    appends = []
-    filters = []
+    appends: Sequence[str] = []
+    filters: Sequence[str] = []
     if isinstance(value, cls):  # Ensure idempotency.
       action = value._action
       appends = value._appends
@@ -245,7 +239,7 @@ class ListValueComponent:
       appends = _convert(f'[{value}]', list)
     return cls(action, list(appends), list(filters))
 
-  def __repr__(self):
+  def __repr__(self) -> str:
     return f'{self._action} +{self._appends} -{self._filters}'
 
 
@@ -261,15 +255,10 @@ class DictValueComponent:
   EXTEND = 'EXTEND'
 
   @classmethod
-  def merge(cls, components):
+  def merge(cls, components: Iterable["DictValueComponent"]) -> "DictValueComponent":
     """Merges components into a single component, applying their actions appropriately.
 
-    This operation is associative:  M(M(a, b), c) == M(a, M(b, c)) == M(a, b, c).
-
-    :param list components: an iterable of instances of DictValueComponent.
-    :return: An instance representing the result of merging the components.
-    :rtype: `DictValueComponent`
-    """
+    This operation is associative:  M(M(a, b), c) == M(a, M(b, c)) == M(a, b, c)."""
     # Note that action of the merged component is EXTEND until the first REPLACE is encountered.
     # This guarantees associativity.
     action = cls.EXTEND
@@ -284,17 +273,16 @@ class DictValueComponent:
         raise ParseError(f'Unknown action for dict value: {component.action}')
     return cls(action, val)
 
-  def __init__(self, action, val):
+  def __init__(self, action: str, val: Dict) -> None:
     self.action = action
     self.val = val
 
   @classmethod
-  def create(cls, value):
+  def create(cls, value) -> "DictValueComponent":
     """Interpret value as either a dict or something to extend another dict with.
 
     :param value: The value to convert.  Can be an instance of DictValueComponent, a dict,
                   or a string representation (possibly prefixed by +) of a dict.
-    :rtype: `DictValueComponent`
     """
     if isinstance(value, bytes):
       value = value.decode()
@@ -314,7 +302,7 @@ class DictValueComponent:
       raise ParseError(f'Invalid dict value: {value}')
     return cls(action, dict(val))
 
-  def __repr__(self):
+  def __repr__(self) -> str:
     return f'{self.action} {self.val}'
 
 

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -7,44 +7,89 @@ from pants.option.scope import GLOBAL_SCOPE
 class OptionsError(Exception):
   """An options system-related error."""
 
+# -----------------------------------------------------------------------
+# Option registration errors
+# -----------------------------------------------------------------------
 
 class RegistrationError(OptionsError):
   """An error at option registration time."""
 
-  def __init__(self, msg, scope, option):
-    super().__init__(
-      '{} [option {} in {}].'.format(msg, option,
-      'global scope' if scope == GLOBAL_SCOPE else 'scope {}'.format(scope)))
+  def __init__(self, scope: str, option: str, **msg_format_args) -> None:
+    scope_str = 'global scope' if scope == GLOBAL_SCOPE else f'scope {scope}'
+    if self.__doc__ is None:
+      raise ValueError(
+        "Invalid RegistrationError definition. Please specify the error message in the docstring."
+      )
+    docstring = self.__doc__.format(**msg_format_args)
+    super().__init__(f'{docstring} [option {option} in {scope_str}].')
 
+
+class BooleanOptionNameWithNo(RegistrationError):
+  """"Boolean option names cannot start with --no."""
+
+
+class FrozenRegistration(RegistrationError):
+  """Cannot register an option on a scope after registering on any of its inner scopes."""
+
+
+class ImplicitValIsNone(RegistrationError):
+  """Implicit value cannot be None."""
+
+
+class InvalidKwarg(RegistrationError):
+  """Invalid registration kwarg {kwarg}."""
+
+
+class InvalidKwargNonGlobalScope(RegistrationError):
+  """Invalid registration kwarg {kwarg} on non-global scope."""
+
+
+class InvalidMemberType(RegistrationError):
+  """member_type {member_type} not allowed."""
+
+
+class MemberTypeNotAllowed(RegistrationError):
+  """member_type not allowed on option with type {type_}. It may only be specified if type=list."""
+
+
+class NoOptionNames(RegistrationError):
+  """No option names provided."""
+
+
+class OptionAlreadyRegistered(RegistrationError):
+  """An option with this name was already registered on this scope."""
+
+
+class OptionNameDash(RegistrationError):
+  """Option name must begin with a dash."""
+
+
+class OptionNameDoubleDash(RegistrationError):
+  """Long option name must begin with a double-dash."""
+
+
+class RecursiveSubsystemOption(RegistrationError):
+  """Subsystem option cannot specify 'recursive'. Subsystem options are always recursive."""
+
+
+class Shadowing(RegistrationError):
+  """Option shadows an option in {outer_scope}."""
+
+# -----------------------------------------------------------------------
+# Flag parsing errors
+# -----------------------------------------------------------------------
 
 class ParseError(OptionsError):
   """An error at flag parsing time."""
 
 
-# Subclasses of RegistrationError. The distinction between them is useful mainly for testing
-# that the error we get is the one we expect.
-# TODO: Similar thing for ParseError.
-def mk_registration_error(msg):
-  class Anon(RegistrationError):
-    def __init__(self, scope, option, **msg_format_args):
-      super().__init__(msg.format(**msg_format_args), scope, option)
-  return Anon
+class BooleanConversionError(ParseError):
+  """Indicates a value other than 'True' or 'False' when attempting to parse a bool."""
 
 
-BooleanOptionNameWithNo = mk_registration_error('Boolean option names cannot start with --no.')
-FrozenRegistration = mk_registration_error('Cannot register an option on a scope after registering '
-                                           'on any of its inner scopes.')
-ImplicitValIsNone = mk_registration_error('Implicit value cannot be None.')
-InvalidKwarg = mk_registration_error('Invalid registration kwarg {kwarg}.')
-InvalidKwargNonGlobalScope = mk_registration_error('Invalid registration kwarg {kwarg} on non-global scope.')
-InvalidMemberType = mk_registration_error('member_type {member_type} not allowed.')
-MemberTypeNotAllowed = mk_registration_error('member_type not allowed on option with type {type_}. '
-                                             'It may only be specified if type=list.')
-NoOptionNames = mk_registration_error('No option names provided.')
-OptionAlreadyRegistered = mk_registration_error('An option with this name was already registered '
-                                                'on this scope.')
-OptionNameDash = mk_registration_error('Option name must begin with a dash.')
-OptionNameDoubleDash = mk_registration_error('Long option name must begin with a double-dash.')
-RecursiveSubsystemOption = mk_registration_error("Subsystem option cannot specify 'recursive'. "
-                                                 "Subsystem options are always recursive.")
-Shadowing = mk_registration_error('Option shadows an option in {outer_scope}')
+class FromfileError(ParseError):
+  """Indicates a problem reading a value @fromfile."""
+
+
+class MutuallyExclusiveOptionError(ParseError):
+  """Raised when more than one option belonging to the same mutually exclusive group is specified."""

--- a/src/python/pants/option/option_util.py
+++ b/src/python/pants/option/option_util.py
@@ -2,17 +2,16 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import shlex
-from typing import Sequence, Tuple
+from typing import Sequence, Tuple, cast
 
 from pants.option.custom_types import dict_with_files_option, list_option
 
 
-def is_list_option(kwargs):
-  return (kwargs.get('action') == 'append' or kwargs.get('type') == list or
-          kwargs.get('type') == list_option)
+def is_list_option(kwargs) -> bool:
+  return cast(bool, kwargs.get('action') == 'append' or kwargs.get('type') in [list, list_option])
 
 
-def is_dict_option(kwargs):
+def is_dict_option(kwargs) -> bool:
   return kwargs.get('type') in (dict, dict_with_files_option)
 
 

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -4,7 +4,7 @@
 import functools
 import re
 from abc import ABC, ABCMeta, abstractmethod
-from typing import Optional
+from typing import Optional, Type
 
 from pants.engine.selectors import Get
 from pants.option.errors import OptionsError
@@ -27,7 +27,7 @@ class OptionableFactory(ABC):
 
   @property
   @abstractmethod
-  def optionable_cls(self):
+  def optionable_cls(self) -> Type["Optionable"]:
     """The Optionable class that is constructed by this OptionableFactory."""
 
   @property
@@ -75,15 +75,16 @@ class Optionable(OptionableFactory, metaclass=ABCMeta):
     return cls
 
   @classmethod
-  def is_valid_scope_name_component(cls, s):
+  def is_valid_scope_name_component(cls, s: str) -> bool:
     return cls._scope_name_component_re.match(s) is not None
 
   @classmethod
-  def validate_scope_name_component(cls, s):
+  def validate_scope_name_component(cls, s: str) -> None:
     if not cls.is_valid_scope_name_component(s):
-      raise OptionsError('Options scope "{}" is not valid:\n'
-                         'Replace in code with a new scope name consisting of dash-separated-words, '
-                         'with words consisting only of lower-case letters and digits.'.format(s))
+      raise OptionsError(
+        f'Options scope "{s}" is not valid:\nReplace in code with a new scope name consisting of '
+        f'dash-separated-words, with words consisting only of lower-case letters and digits.'
+      )
 
   @classmethod
   def get_scope_info(cls):
@@ -136,7 +137,7 @@ class Optionable(OptionableFactory, metaclass=ABCMeta):
     """
     cls.register_options(options.registration_function_for_optionable(cls))
 
-  def __init__(self):
+  def __init__(self) -> None:
     # Check that the instance's class defines options_scope.
     # Note: It is a bit odd to validate a class when instantiating an object of it. but checking
     # the class itself (e.g., via metaclass magic) turns out to be complicated, because

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -1,7 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import io
 import json
 import os
 import shlex
@@ -17,7 +16,6 @@ from packaging.version import Version
 
 from pants.base.deprecated import CodeRemovedError
 from pants.base.hash_utils import CoercingEncoder
-from pants.engine.fs import FileContent
 from pants.option.config import Config
 from pants.option.custom_types import UnsetBool, file_option, target_option
 from pants.option.errors import (
@@ -1530,17 +1528,3 @@ class OptionsTest(TestBase):
     single_warning_dummy1 = assert_single_element(w)
     self.assertEqual(single_warning_dummy1.category, DeprecationWarning)
     self.assertEqual('vv', vals1.foo)
-
-
-# TODO: Figure out why this testing is necessary.
-class OptionsTestStringPayloads(OptionsTest):
-  """Runs the same tests as OptionsTest, but backed with `Config.loads` vs `Config.load`."""
-
-  def _create_config_from_strings(self, config):
-    with io.BytesIO(b'') as fp:
-      self._write_config_to_file(fp, config)
-      fp.seek(0)
-      payload = fp.read()
-      return Config.load_file_contents(
-        config_payloads=[FileContent(path='blah', content=payload)],
-      )

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -2,10 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from dataclasses import dataclass
-from typing import Any, ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar, Optional, Type, cast
 
 from pants.option.option_value_container import OptionValueContainer
 
+
+if TYPE_CHECKING:
+  from pants.option.optionable import Optionable  # noqa: F401
 
 GLOBAL_SCOPE = ''
 GLOBAL_SCOPE_CONFIG_SECTION = 'GLOBAL'
@@ -20,15 +23,15 @@ class Scope:
 @dataclass(frozen=True, order=True)
 class ScopeInfo:
   """Information about a scope."""
-  scope: Scope
-  category: Any
-  optionable_cls: Optional[Any] = None
+  scope: str
+  category: str
+  optionable_cls: Optional[Type["Optionable"]] = None
   # A ScopeInfo may have a deprecated_scope (from its associated optionable_cls), which represents a
   # previous/deprecated name for a current/non-deprecated ScopeInfo. It may also be directly
   # deprecated via this `removal_version`, which allows for the deprecation of an entire scope,
   # including that of a SubsystemDependency (ie, deprecation of a dependency on a scoped Subsystem).
-  removal_version: Optional[Any] = None
-  removal_hint: Optional[Any] = None
+  removal_version: Optional[str] = None
+  removal_hint: Optional[str] = None
 
   # Symbolic constants for different categories of scope.
   GLOBAL: ClassVar[str] = 'GLOBAL'
@@ -39,18 +42,20 @@ class ScopeInfo:
   INTERMEDIATE: ClassVar[str] = 'INTERMEDIATE'  # Scope added automatically to fill out the scope hierarchy.
 
   @property
-  def description(self):
-    return self._optionable_cls_attr('get_description', lambda: '')()
+  def description(self) -> str:
+    return cast(str, self._optionable_cls_attr('get_description', lambda: '')())
 
   @property
-  def deprecated_scope(self):
-    return self._optionable_cls_attr('deprecated_options_scope')
+  def deprecated_scope(self) -> Optional[str]:
+    return cast(Optional[str], self._optionable_cls_attr('deprecated_options_scope'))
 
   @property
-  def deprecated_scope_removal_version(self):
-    return self._optionable_cls_attr('deprecated_options_scope_removal_version')
+  def deprecated_scope_removal_version(self) -> Optional[str]:
+    return cast(
+      Optional[str], self._optionable_cls_attr('deprecated_options_scope_removal_version'),
+    )
 
-  def _optionable_cls_attr(self, name, default=None):
+  def _optionable_cls_attr(self, name: str, default=None):
     return getattr(self.optionable_cls, name) if self.optionable_cls else default
 
 

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 from typing import Callable, Dict, Iterable, List, Optional, Tuple, Type, TypeVar, Union, cast
 
+from pants.option.option_value_container import OptionValueContainer
 from pants.option.optionable import Optionable
 from pants.option.options import Options
 from pants.option.scope import ScopeInfo
@@ -138,7 +139,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
       cls._options = None
     cls._scoped_instances = {}
 
-  def __init__(self, scope: str, scoped_options) -> None:
+  def __init__(self, scope: str, scoped_options: OptionValueContainer) -> None:
     """Note: A subsystem has no access to options in scopes other than its own.
 
     TODO: We'd like that to be true of Tasks some day. Subsystems will help with that.
@@ -161,14 +162,14 @@ class Subsystem(SubsystemClientMixin, Optionable):
     return self._scope
 
   @property
-  def options(self):
+  def options(self) -> OptionValueContainer:
     """Returns the option values for this subsystem's scope.
 
     :API: public
     """
     return self._scoped_options
 
-  def get_options(self):
+  def get_options(self) -> OptionValueContainer:
     """Returns the option values for this subsystem's scope.
 
     :API: public


### PR DESCRIPTION
The `option` and `subsystem` code is a core foundation for Pants. Adding type hints helps to ensure the code work, makes it easier to understand, and makes the call sites more informative.